### PR TITLE
feat: support async code generation in Generator and Module

### DIFF
--- a/.changeset/075-async-code-generation.md
+++ b/.changeset/075-async-code-generation.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Allow Generator.generate() and Module.codeGeneration() to return a Promise.

--- a/.changeset/async-code-generation.md
+++ b/.changeset/async-code-generation.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support async code generation in Generator and Module. `Generator.generate()` and `Module.codeGeneration()` can now return a Promise, enabling post-generation processing such as CSS minimization via multi-process workers after a module's source type is generated.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3889,43 +3889,64 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		);
 		cache.get((err, cachedResult) => {
 			if (err) return callback(/** @type {WebpackError} */ (err));
-			/** @type {CodeGenerationResult} */
-			let result;
-			if (!cachedResult) {
-				try {
-					codeGenerated = true;
-					this.codeGeneratedModules.add(module);
-					result = module.codeGeneration({
-						chunkGraph,
-						moduleGraph,
-						dependencyTemplates,
-						runtimeTemplate,
-						runtime,
-						runtimes,
-						codeGenerationResults: results,
-						compilation: this
-					});
-				} catch (err) {
-					errors.push(
-						new CodeGenerationError(module, /** @type {Error} */ (err))
-					);
-					result = cachedResult = {
-						sources: new Map(),
-						runtimeRequirements: null
-					};
+
+			/**
+			 * @param {CodeGenerationResult} result result
+			 */
+			const finish = (result) => {
+				for (const runtime of runtimes) {
+					results.add(module, runtime, result);
 				}
-			} else {
-				result = cachedResult;
-			}
-			for (const runtime of runtimes) {
-				results.add(module, runtime, result);
-			}
-			if (!cachedResult) {
-				cache.store(result, (err) =>
-					callback(/** @type {WebpackError} */ (err), codeGenerated)
-				);
-			} else {
+				if (!cachedResult) {
+					cache.store(result, (err) =>
+						callback(/** @type {WebpackError} */ (err), codeGenerated)
+					);
+				} else {
+					callback(null, codeGenerated);
+				}
+			};
+
+			if (cachedResult) return finish(cachedResult);
+
+			codeGenerated = true;
+			this.codeGeneratedModules.add(module);
+
+			/**
+			 * @param {Error} err error from code generation
+			 */
+			const handleError = (err) => {
+				errors.push(new CodeGenerationError(module, err));
+				/** @type {CodeGenerationResult} */
+				const errResult = {
+					sources: new Map(),
+					runtimeRequirements: null
+				};
+				for (const runtime of runtimes) {
+					results.add(module, runtime, errResult);
+				}
+				// Don't cache error results — errors must be
+				// regenerated on the next compilation
 				callback(null, codeGenerated);
+			};
+
+			try {
+				const result = module.codeGeneration({
+					chunkGraph,
+					moduleGraph,
+					dependencyTemplates,
+					runtimeTemplate,
+					runtime,
+					runtimes,
+					codeGenerationResults: results,
+					compilation: this
+				});
+				if (result instanceof Promise) {
+					result.then(finish, handleError);
+				} else {
+					finish(result);
+				}
+			} catch (err) {
+				handleError(/** @type {Error} */ (err));
 			}
 		});
 	}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -76,6 +76,7 @@ const {
 	createFakeHook,
 	soonFrozenObjectDeprecation
 } = require("./util/deprecation");
+const isPromise = require("./util/isPromise");
 const processAsyncTree = require("./util/processAsyncTree");
 const { getRuntimeKey } = require("./util/runtime");
 const { isSourceEqual } = require("./util/source");
@@ -4117,12 +4118,30 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		// without a cache backend, skip building the cache keys — the module
 		// identifier strings are large (concatenated modules join all inner ids)
 		if (!this._codeGenerationCache.isEnabled()) {
-			/** @type {CodeGenerationResult} */
-			let result;
+			/**
+			 * @param {CodeGenerationResult} result result
+			 */
+			const finish = (result) => {
+				for (const runtime of runtimes) {
+					results.add(module, runtime, result);
+				}
+				callback(null, codeGenerated);
+			};
+			/**
+			 * @param {Error} err error from code generation
+			 */
+			const handleError = (err) => {
+				errors.push(new CodeGenerationError(module, err));
+				finish({
+					sources: new Map(),
+					runtimeRequirements: null,
+					data: undefined
+				});
+			};
 			try {
 				codeGenerated = true;
 				this.codeGeneratedModules.add(module);
-				result = module.codeGeneration({
+				const result = module.codeGeneration({
 					chunkGraph,
 					moduleGraph,
 					dependencyTemplates,
@@ -4132,20 +4151,15 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 					codeGenerationResults: results,
 					compilation: this
 				});
+				if (isPromise(result)) {
+					result.then(finish, handleError);
+				} else {
+					finish(result);
+				}
 			} catch (err) {
-				errors.push(
-					new CodeGenerationError(module, /** @type {Error} */ (err))
-				);
-				result = {
-					sources: new Map(),
-					runtimeRequirements: null,
-					data: undefined
-				};
+				handleError(/** @type {Error} */ (err));
 			}
-			for (const runtime of runtimes) {
-				results.add(module, runtime, result);
-			}
-			return callback(null, codeGenerated);
+			return;
 		}
 		const cache = new MultiItemCache(
 			runtimes.map((runtime) =>
@@ -4157,44 +4171,65 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		);
 		cache.get((err, cachedResult) => {
 			if (err) return callback(/** @type {WebpackError} */ (err));
-			/** @type {CodeGenerationResult} */
-			let result;
-			if (!cachedResult) {
-				try {
-					codeGenerated = true;
-					this.codeGeneratedModules.add(module);
-					result = module.codeGeneration({
-						chunkGraph,
-						moduleGraph,
-						dependencyTemplates,
-						runtimeTemplate,
-						runtime,
-						runtimes,
-						codeGenerationResults: results,
-						compilation: this
-					});
-				} catch (err) {
-					errors.push(
-						new CodeGenerationError(module, /** @type {Error} */ (err))
-					);
-					result = cachedResult = {
-						sources: new Map(),
-						runtimeRequirements: null,
-						data: undefined
-					};
+
+			/**
+			 * @param {CodeGenerationResult} result result
+			 */
+			const finish = (result) => {
+				for (const runtime of runtimes) {
+					results.add(module, runtime, result);
 				}
-			} else {
-				result = cachedResult;
-			}
-			for (const runtime of runtimes) {
-				results.add(module, runtime, result);
-			}
-			if (!cachedResult) {
-				cache.store(result, (err) =>
-					callback(/** @type {WebpackError} */ (err), codeGenerated)
-				);
-			} else {
+				if (!cachedResult) {
+					cache.store(result, (err) =>
+						callback(/** @type {WebpackError} */ (err), codeGenerated)
+					);
+				} else {
+					callback(null, codeGenerated);
+				}
+			};
+
+			if (cachedResult) return finish(cachedResult);
+
+			codeGenerated = true;
+			this.codeGeneratedModules.add(module);
+
+			/**
+			 * @param {Error} err error from code generation
+			 */
+			const handleError = (err) => {
+				errors.push(new CodeGenerationError(module, err));
+				/** @type {CodeGenerationResult} */
+				const errResult = {
+					sources: new Map(),
+					runtimeRequirements: null,
+					data: undefined
+				};
+				for (const runtime of runtimes) {
+					results.add(module, runtime, errResult);
+				}
+				// Don't cache error results — errors must be
+				// regenerated on the next compilation
 				callback(null, codeGenerated);
+			};
+
+			try {
+				const result = module.codeGeneration({
+					chunkGraph,
+					moduleGraph,
+					dependencyTemplates,
+					runtimeTemplate,
+					runtime,
+					runtimes,
+					codeGenerationResults: results,
+					compilation: this
+				});
+				if (isPromise(result)) {
+					result.then(finish, handleError);
+				} else {
+					finish(result);
+				}
+			} catch (err) {
+				handleError(/** @type {Error} */ (err));
 			}
 		});
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1343,7 +1343,7 @@ module.exports = webpackEmptyAsyncContext;`;
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		const { chunkGraph, compilation } = context;

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1601,7 +1601,7 @@ module.exports = webpackEmptyAsyncContext;`;
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		const { chunkGraph, compilation } = context;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -1092,7 +1092,7 @@ class ExternalModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		runtimeTemplate,

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -1296,7 +1296,7 @@ class ExternalModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		runtimeTemplate,

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -8,6 +8,7 @@
 const { JAVASCRIPT_TYPE } = require("./ModuleSourceTypeConstants");
 
 /** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {Source | null | Promise<Source | null>} GenerateResult */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./CodeGenerationResults")} CodeGenerationResults */
 /** @typedef {import("./ConcatenationScope")} ConcatenationScope */
@@ -99,7 +100,7 @@ class Generator {
 	 * @abstract
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,
@@ -186,7 +187,7 @@ class ByTypeGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const type = generateContext.type;

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -8,6 +8,7 @@
 const { JAVASCRIPT_TYPE } = require("./ModuleSourceTypeConstants");
 
 /** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {Source | null | Promise<Source | null>} GenerateResult */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./CodeGenerationResults")} CodeGenerationResults */
 /** @typedef {import("./ConcatenationScope")} ConcatenationScope */
@@ -106,7 +107,7 @@ class Generator {
 	 * @abstract
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,
@@ -194,7 +195,7 @@ class ByTypeGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const type = generateContext.type;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1119,7 +1119,9 @@ class Module extends DependenciesBlock {
 			runtimes: [],
 			codeGenerationResults: undefined
 		};
-		const sources = this.codeGeneration(codeGenContext).sources;
+		const sources =
+			/** @type {CodeGenerationResult} */
+			(this.codeGeneration(codeGenContext)).sources;
 
 		return /** @type {Source} */ (
 			type
@@ -1179,7 +1181,7 @@ class Module extends DependenciesBlock {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		// Best override this method

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -17,6 +17,7 @@ const { JAVASCRIPT_TYPES } = require("./ModuleSourceTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const { first } = require("./util/SetHelpers");
 const { compareChunksById } = require("./util/comparators");
+const isPromise = require("./util/isPromise");
 const makeSerializable = require("./util/makeSerializable");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -1103,7 +1104,13 @@ class Module extends DependenciesBlock {
 			runtimes: [],
 			codeGenerationResults: undefined
 		};
-		const sources = this.codeGeneration(codeGenContext).sources;
+		const codeGenResult = this.codeGeneration(codeGenContext);
+		if (isPromise(codeGenResult)) {
+			throw new Error(
+				"Module.source() does not support async codeGeneration(). Use Compilation.codeGenerationResults instead."
+			);
+		}
+		const sources = codeGenResult.sources;
 
 		return /** @type {Source} */ (
 			type
@@ -1163,7 +1170,7 @@ class Module extends DependenciesBlock {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		// Best override this method

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1994,7 +1994,7 @@ class NormalModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -2021,6 +2021,8 @@ class NormalModule extends Module {
 
 		/** @type {Sources} */
 		const sources = new Map();
+		/** @type {Promise<void>[] | undefined} */
+		let promises;
 		for (const type of sourceTypes || chunkGraph.getModuleSourceTypes(this)) {
 			// TODO webpack@6 make generateError required
 			const generator =
@@ -2056,8 +2058,15 @@ class NormalModule extends Module {
 						type
 					});
 
-			if (source) {
-				sources.set(type, new CachedSource(source));
+			if (source instanceof Promise) {
+				if (promises === undefined) promises = [];
+				promises.push(
+					source.then((s) => {
+						if (s) sources.set(type, new CachedSource(s));
+					})
+				);
+			} else if (source) {
+				sources.set(type, new CachedSource(/** @type {Source} */ (source)));
 			}
 		}
 
@@ -2067,6 +2076,11 @@ class NormalModule extends Module {
 			runtimeRequirements,
 			data: this._codeGeneratorData
 		};
+
+		if (promises !== undefined) {
+			return Promise.all(promises).then(() => resultEntry);
+		}
+
 		return resultEntry;
 	}
 

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -54,6 +54,7 @@ const {
 	contextify,
 	contextifySourceUrl
 } = require("./util/identifier");
+const isPromise = require("./util/isPromise");
 const makeSerializable = require("./util/makeSerializable");
 const memoize = require("./util/memoize");
 const parseJson = require("./util/parseJson");
@@ -1835,7 +1836,7 @@ class NormalModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -1862,6 +1863,8 @@ class NormalModule extends Module {
 
 		/** @type {Sources} */
 		const sources = new Map();
+		/** @type {Promise<void>[] | undefined} */
+		let promises;
 		for (const type of sourceTypes || chunkGraph.getModuleSourceTypes(this)) {
 			// TODO webpack@6 make generateError required
 			const generator =
@@ -1897,8 +1900,15 @@ class NormalModule extends Module {
 						type
 					});
 
-			if (source) {
-				sources.set(type, new CachedSource(source));
+			if (isPromise(source)) {
+				if (promises === undefined) promises = [];
+				promises.push(
+					source.then((s) => {
+						if (s) sources.set(type, new CachedSource(s));
+					})
+				);
+			} else if (source) {
+				sources.set(type, new CachedSource(/** @type {Source} */ (source)));
 			}
 		}
 
@@ -1909,6 +1919,11 @@ class NormalModule extends Module {
 			data: this._codeGeneratorData,
 			hash: undefined
 		};
+
+		if (promises !== undefined) {
+			return Promise.all(promises).then(() => resultEntry);
+		}
+
 		return resultEntry;
 	}
 

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -129,7 +129,7 @@ class RawModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -133,7 +133,7 @@ class RawModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -168,7 +168,7 @@ class RuntimeModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -401,7 +401,9 @@ class Template {
 					codeGenerationResults
 				});
 				if (!codeGenResult) continue;
-				runtimeSource = codeGenResult.sources.get("runtime");
+				runtimeSource =
+					/** @type {import("./Module").CodeGenerationResult} */
+					(codeGenResult).sources.get("runtime");
 			}
 			if (runtimeSource) {
 				source.add(`${Template.toNormalComment(module.identifier())}\n`);

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -8,6 +8,7 @@
 const { ConcatSource, PrefixSource } = require("webpack-sources");
 const { WEBPACK_MODULE_TYPE_RUNTIME } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
+const isPromise = require("./util/isPromise");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
@@ -431,6 +432,11 @@ class Template {
 					runtimes: [renderContext.chunk.runtime],
 					codeGenerationResults
 				});
+				if (isPromise(codeGenResult)) {
+					throw new Error(
+						"Template.renderRuntimeModules() does not support async codeGeneration(). Use Compilation.codeGenerationResults instead."
+					);
+				}
 				if (!codeGenResult) continue;
 				runtimeSource = codeGenResult.sources.get("runtime");
 			}

--- a/lib/asset/AssetBytesGenerator.js
+++ b/lib/asset/AssetBytesGenerator.js
@@ -22,6 +22,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -43,7 +44,7 @@ class AssetSourceGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/AssetBytesGenerator.js
+++ b/lib/asset/AssetBytesGenerator.js
@@ -22,6 +22,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -44,7 +45,7 @@ class AssetBytesGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -47,6 +47,7 @@ const getMimeTypes = memoize(() => require("../util/mimeTypes"));
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").NameForCondition} NameForCondition */
@@ -547,7 +548,7 @@ class AssetGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -52,6 +52,7 @@ const getMimeTypes = memoize(() => require("../util/mimeTypes"));
 /** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").NameForCondition} NameForCondition */
@@ -596,7 +597,7 @@ class AssetGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/asset/AssetSourceGenerator.js
+++ b/lib/asset/AssetSourceGenerator.js
@@ -22,6 +22,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -43,7 +44,7 @@ class AssetSourceGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/AssetSourceGenerator.js
+++ b/lib/asset/AssetSourceGenerator.js
@@ -22,6 +22,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -44,7 +45,7 @@ class AssetSourceGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/RawDataUrlModule.js
+++ b/lib/asset/RawDataUrlModule.js
@@ -122,7 +122,7 @@ class RawDataUrlModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		if (this.url === undefined) {

--- a/lib/asset/WebManifestGenerator.js
+++ b/lib/asset/WebManifestGenerator.js
@@ -18,6 +18,7 @@ const AssetGenerator = require("./AssetGenerator");
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
@@ -115,7 +116,7 @@ class WebManifestGenerator extends AssetGenerator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		if (!module.originalSource()) return new RawSource("");

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -157,7 +157,7 @@ class ContainerEntryModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ moduleGraph, chunkGraph, runtimeTemplate }) {
 		/** @type {Sources} */

--- a/lib/container/FallbackModule.js
+++ b/lib/container/FallbackModule.js
@@ -143,7 +143,7 @@ class FallbackModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
 		const ids = this.dependencies.map((dep) =>

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -187,7 +187,7 @@ class RemoteModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ moduleGraph, chunkGraph }) {
 		const module = moduleGraph.getModule(this.dependencies[0]);

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -45,6 +45,7 @@ const {
 /** @typedef {import("../DependencyTemplate").CssData} CssData */
 /** @typedef {import("../DependencyTemplate").CssDependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
@@ -469,7 +470,7 @@ class CssGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const exportType = /** @type {CssModule} */ (module).exportType || "link";
@@ -823,7 +824,7 @@ class CssGenerator extends Generator {
 	 * @param {Error} error the error
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generateError(error, module, generateContext) {
 		switch (generateContext.type) {

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -58,6 +58,7 @@ const URL_SCHEME_REGEXP = /^(?:data|https?):/;
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../DependencyTemplate").CssDependencyTemplateContext} CssDependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
@@ -278,7 +279,7 @@ class CssGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const exportType = /** @type {CssModule} */ (module).exportType || "link";

--- a/lib/dll/DelegatedModule.js
+++ b/lib/dll/DelegatedModule.js
@@ -159,7 +159,7 @@ class DelegatedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
 		const dep = /** @type {DelegatedSourceDependency} */ (this.dependencies[0]);

--- a/lib/dll/DelegatedModule.js
+++ b/lib/dll/DelegatedModule.js
@@ -165,7 +165,7 @@ class DelegatedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
 		const dep = /** @type {DelegatedSourceDependency} */ (this.dependencies[0]);

--- a/lib/dll/DllModule.js
+++ b/lib/dll/DllModule.js
@@ -97,7 +97,7 @@ class DllModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/dll/DllModule.js
+++ b/lib/dll/DllModule.js
@@ -98,7 +98,7 @@ class DllModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -341,7 +341,7 @@ class LazyCompilationProxyModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph, moduleGraph }) {
 		/** @type {Sources} */

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -359,7 +359,7 @@ class LazyCompilationProxyModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph, moduleGraph }) {
 		/** @type {Sources} */

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -25,6 +25,7 @@ const { PUBLIC_PATH_AUTO } = require("../util/publicPathPlaceholder");
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -381,7 +382,7 @@ class HtmlGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -163,6 +163,7 @@ const metaIsCsp = (attrs) => {
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
@@ -1317,7 +1318,7 @@ class HtmlGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();

--- a/lib/javascript/JavascriptGenerator.js
+++ b/lib/javascript/JavascriptGenerator.js
@@ -19,6 +19,7 @@ const HarmonyCompatibilityDependency = require("../dependencies/HarmonyCompatibi
 /** @typedef {import("../DependencyTemplate")} DependencyTemplate */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
@@ -255,7 +256,7 @@ class JavascriptGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();

--- a/lib/javascript/JavascriptGenerator.js
+++ b/lib/javascript/JavascriptGenerator.js
@@ -21,6 +21,7 @@ const HarmonyCompatibilityDependency = require("../dependencies/HarmonyCompatibi
 /** @typedef {import("../DependencyTemplate")} DependencyTemplate */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
@@ -301,7 +302,7 @@ class JavascriptGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();

--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -16,6 +16,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 /** @typedef {import("../../declarations/WebpackOptions").JsonGeneratorOptions} JsonGeneratorOptions */
 /** @typedef {import("../ExportsInfo")} ExportsInfo */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
@@ -173,7 +174,7 @@ class JsonGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -16,6 +16,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 /** @typedef {import("../../declarations/WebpackOptions").JsonGeneratorOptions} JsonGeneratorOptions */
 /** @typedef {import("../ExportsInfo")} ExportsInfo */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
@@ -194,7 +195,7 @@ class JsonGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(
 		module,

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1371,7 +1371,7 @@ class ConcatenatedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -1406,8 +1406,10 @@ class ConcatenatedModule extends Module {
 
 		// Generate source code and analyse scopes
 		// Prepare a ReplaceSource for the final source
+		/** @type {Promise<void>[] | undefined} */
+		let analysisPromises;
 		for (const info of moduleToInfoMap.values()) {
-			this._analyseModule(
+			const result = this._analyseModule(
 				moduleToInfoMap,
 				info,
 				dependencyTemplates,
@@ -1420,73 +1422,392 @@ class ConcatenatedModule extends Module {
 				(codeGenerationResults),
 				allUsedNames
 			);
+			if (result instanceof Promise) {
+				if (analysisPromises === undefined) analysisPromises = [];
+				analysisPromises.push(result);
+			}
 		}
 
-		// Updated Top level declarations are created by renaming
-		/** @type {TopLevelDeclarations} */
-		const topLevelDeclarations = new Set();
+		/**
+		 * @returns {CodeGenerationResult} the code generation result
+		 */
+		const continueCodeGeneration = () => {
+			// Updated Top level declarations are created by renaming
+			/** @type {TopLevelDeclarations} */
+			const topLevelDeclarations = new Set();
 
-		// List of additional names in scope for module references
-		/** @type {Map<string, ScopeInfo>} */
-		const usedNamesInScopeInfo = new Map();
+			// List of additional names in scope for module references
+			/** @type {Map<string, ScopeInfo>} */
+			const usedNamesInScopeInfo = new Map();
 
-		// Set of already checked scopes
-		/** @type {Set<Scope>} */
-		const ignoredScopes = new Set();
+			// Set of already checked scopes
+			/** @type {Set<Scope>} */
+			const ignoredScopes = new Set();
 
-		// get all global names
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				// ignore symbols from moduleScope
-				if (info.moduleScope) {
-					ignoredScopes.add(info.moduleScope);
-				}
+			// get all global names
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					// ignore symbols from moduleScope
+					if (info.moduleScope) {
+						ignoredScopes.add(info.moduleScope);
+					}
 
-				// The super class expression in class scopes behaves weird
-				// We get ranges of all super class expressions to make
-				// renaming to work correctly
-				/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
-				/** @type {WeakMap<Scope, ClassInfo[]>} */
-				const superClassCache = new WeakMap();
-				/**
-				 * @param {Scope} scope scope
-				 * @returns {ClassInfo[]} result
-				 */
-				const getSuperClassExpressions = (scope) => {
-					const cacheEntry = superClassCache.get(scope);
-					if (cacheEntry !== undefined) return cacheEntry;
-					/** @type {ClassInfo[]} */
-					const superClassExpressions = [];
-					for (const childScope of scope.childScopes) {
-						if (childScope.type !== "class") continue;
-						const block = childScope.block;
-						if (
-							(block.type === "ClassDeclaration" ||
-								block.type === "ClassExpression") &&
-							block.superClass
-						) {
-							superClassExpressions.push({
-								range: /** @type {Range} */ (block.superClass.range),
-								variables: childScope.variables
-							});
+					// The super class expression in class scopes behaves weird
+					// We get ranges of all super class expressions to make
+					// renaming to work correctly
+					/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
+					/** @type {WeakMap<Scope, ClassInfo[]>} */
+					const superClassCache = new WeakMap();
+					/**
+					 * @param {Scope} scope scope
+					 * @returns {ClassInfo[]} result
+					 */
+					const getSuperClassExpressions = (scope) => {
+						const cacheEntry = superClassCache.get(scope);
+						if (cacheEntry !== undefined) return cacheEntry;
+						/** @type {ClassInfo[]} */
+						const superClassExpressions = [];
+						for (const childScope of scope.childScopes) {
+							if (childScope.type !== "class") continue;
+							const block = childScope.block;
+							if (
+								(block.type === "ClassDeclaration" ||
+									block.type === "ClassExpression") &&
+								block.superClass
+							) {
+								superClassExpressions.push({
+									range: /** @type {Range} */ (block.superClass.range),
+									variables: childScope.variables
+								});
+							}
+						}
+						superClassCache.set(scope, superClassExpressions);
+						return superClassExpressions;
+					};
+
+					// add global symbols
+					if (info.globalScope) {
+						for (const reference of info.globalScope.through) {
+							const name = reference.identifier.name;
+							if (ConcatenationScope.isModuleReference(name)) {
+								const match = ConcatenationScope.matchModuleReference(name);
+								if (!match) continue;
+								const referencedInfo = modulesWithInfo[match.index];
+								if (referencedInfo.type === "reference") {
+									throw new Error(
+										"Module reference can't point to a reference"
+									);
+								}
+								const binding = getFinalBinding(
+									moduleGraph,
+									referencedInfo,
+									match.ids,
+									moduleToInfoMap,
+									runtime,
+									requestShortener,
+									runtimeTemplate,
+									neededNamespaceObjects,
+									false,
+									match.deferredImport,
+									/** @type {BuildMeta} */
+									(info.module.buildMeta).strictHarmonyModule,
+									true
+								);
+								if (!binding.ids) continue;
+								const { usedNames, alreadyCheckedScopes } =
+									getUsedNamesInScopeInfo(
+										usedNamesInScopeInfo,
+										binding.info.module.identifier(),
+										"name" in binding ? binding.name : ""
+									);
+								for (const expr of getSuperClassExpressions(reference.from)) {
+									if (
+										expr.range[0] <=
+											/** @type {Range} */ (reference.identifier.range)[0] &&
+										expr.range[1] >=
+											/** @type {Range} */ (reference.identifier.range)[1]
+									) {
+										for (const variable of expr.variables) {
+											usedNames.add(variable.name);
+										}
+									}
+								}
+								addScopeSymbols(
+									reference.from,
+									usedNames,
+									alreadyCheckedScopes,
+									ignoredScopes
+								);
+							} else {
+								allUsedNames.add(name);
+							}
 						}
 					}
-					superClassCache.set(scope, superClassExpressions);
-					return superClassExpressions;
-				};
+				}
+			}
 
-				// add global symbols
-				if (info.globalScope) {
-					for (const reference of info.globalScope.through) {
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewName = (name, info, references) => {
+				const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
+					usedNamesInScopeInfo,
+					info.module.identifier(),
+					name
+				);
+				if (allUsedNames.has(name) || usedNames.has(name)) {
+					for (const ref of references) {
+						addScopeSymbols(
+							ref.from,
+							usedNames,
+							alreadyCheckedScopes,
+							ignoredScopes
+						);
+					}
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						usedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					info.internalNames.set(name, newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewNameForSpecifier = (name, info, references) => {
+				const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
+					getUsedNamesInScopeInfo(
+						usedNamesInScopeInfo,
+						info.module.identifier(),
+						name
+					);
+				/** @type {UsedNames} */
+				const referencesUsedNames = new Set();
+				for (const ref of references) {
+					addScopeSymbols(
+						ref.from,
+						referencesUsedNames,
+						alreadyCheckedScopes,
+						ignoredScopes
+					);
+				}
+				if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						new Set([...moduleUsedNames, ...referencesUsedNames]),
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			// generate names for symbols
+			for (const info of moduleToInfoMap.values()) {
+				const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
+					usedNamesInScopeInfo,
+					info.module.identifier(),
+					""
+				);
+				switch (info.type) {
+					case "concatenated": {
+						const variables = /** @type {Scope} */ (info.moduleScope).variables;
+						for (const variable of variables) {
+							const name = variable.name;
+							const references = getAllReferences(variable);
+							const newName = _findNewName(name, info, references);
+							if (newName) {
+								const source = /** @type {ReplaceSource} */ (info.source);
+								const allIdentifiers = new Set([
+									...references.map((r) => r.identifier),
+									...variable.identifiers
+								]);
+								for (const identifier of allIdentifiers) {
+									const r = /** @type {Range} */ (identifier.range);
+									const path = getPathInAst(
+										/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
+										(info.ast),
+										identifier
+									);
+									if (path && path.length > 1) {
+										const maybeProperty =
+											path[1].type === "AssignmentPattern" &&
+											path[1].left === path[0]
+												? path[2]
+												: path[1];
+										if (
+											maybeProperty.type === "Property" &&
+											maybeProperty.shorthand
+										) {
+											source.insert(r[1], `: ${newName}`);
+											continue;
+										}
+									}
+									source.replace(r[0], r[1] - 1, newName);
+								}
+							} else {
+								allUsedNames.add(name);
+								info.internalNames.set(name, name);
+								topLevelDeclarations.add(name);
+							}
+						}
+						/** @type {string} */
+						let namespaceObjectName;
+						if (info.namespaceExportSymbol) {
+							namespaceObjectName =
+								/** @type {string} */
+								(info.internalNames.get(info.namespaceExportSymbol));
+						} else {
+							namespaceObjectName = findNewName(
+								"namespaceObject",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(namespaceObjectName);
+						}
+						info.namespaceObjectName = namespaceObjectName;
+						topLevelDeclarations.add(namespaceObjectName);
+						break;
+					}
+					case "external": {
+						const externalName = findNewName(
+							"",
+							allUsedNames,
+							namespaceObjectUsedNames,
+							info.module.readableIdentifier(requestShortener)
+						);
+						allUsedNames.add(externalName);
+						info.name = externalName;
+						topLevelDeclarations.add(externalName);
+
+						if (info.deferred) {
+							const externalName = findNewName(
+								"deferred",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalName);
+							info.deferredName = externalName;
+							topLevelDeclarations.add(externalName);
+
+							const externalNameInterop = findNewName(
+								"deferredNamespaceObject",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalNameInterop);
+							info.deferredNamespaceObjectName = externalNameInterop;
+							topLevelDeclarations.add(externalNameInterop);
+						}
+						break;
+					}
+				}
+				const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
+				if (buildMeta.exportsType !== "namespace") {
+					const externalNameInterop = findNewName(
+						"namespaceObject",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObjectName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (
+					buildMeta.exportsType === "default" &&
+					buildMeta.defaultObject !== "redirect" &&
+					info.interopNamespaceObject2Used
+				) {
+					const externalNameInterop = findNewName(
+						"namespaceObject2",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObject2Name = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
+					const externalNameInterop = findNewName(
+						"default",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopDefaultAccessName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+			}
+
+			// Find and replace references to modules
+			for (const info of moduleToInfoMap.values()) {
+				if (info.type === "concatenated") {
+					const globalScope = /** @type {Scope} */ (info.globalScope);
+					// group references by name
+					/** @type {Map<string, Reference[]>} */
+					const referencesByName = new Map();
+					for (const reference of globalScope.through) {
 						const name = reference.identifier.name;
-						if (ConcatenationScope.isModuleReference(name)) {
-							const match = ConcatenationScope.matchModuleReference(name);
-							if (!match) continue;
+						if (!referencesByName.has(name)) {
+							referencesByName.set(name, []);
+						}
+						/** @type {Reference[]} */
+						(referencesByName.get(name)).push(reference);
+					}
+					for (const [name, references] of referencesByName) {
+						const match = ConcatenationScope.matchModuleReference(name);
+						if (match) {
 							const referencedInfo = modulesWithInfo[match.index];
 							if (referencedInfo.type === "reference") {
 								throw new Error("Module reference can't point to a reference");
 							}
-							const binding = getFinalBinding(
+							const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
+								referencedInfo
+							).concatenationScope;
+							const exportId = match.ids[0];
+							const specifier =
+								concatenationScope && concatenationScope.getRawExport(exportId);
+							if (specifier) {
+								const newName = _findNewNameForSpecifier(
+									specifier,
+									info,
+									references
+								);
+								const initFragmentChanged =
+									newName &&
+									concatenatedModuleInfo.call(
+										{
+											rawExportMap: new Map([
+												[exportId, /** @type {string} */ (newName)]
+											])
+										},
+										/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
+									);
+								if (initFragmentChanged) {
+									concatenationScope.setRawExportMap(exportId, newName);
+								}
+							}
+							const finalName = getFinalName(
 								moduleGraph,
 								referencedInfo,
 								match.ids,
@@ -1495,694 +1816,398 @@ class ConcatenatedModule extends Module {
 								requestShortener,
 								runtimeTemplate,
 								neededNamespaceObjects,
-								false,
+								match.call,
 								match.deferredImport,
+								!match.directImport,
+								/** @type {BuildMeta} */
+								(info.module.buildMeta).strictHarmonyModule,
+								match.asiSafe
+							);
+
+							for (const reference of references) {
+								const r = /** @type {Range} */ (reference.identifier.range);
+								const source = /** @type {ReplaceSource} */ (info.source);
+								// range is extended by 2 chars to cover the appended "._"
+								source.replace(r[0], r[1] + 1, finalName);
+							}
+						}
+					}
+				}
+			}
+
+			// Map with all root exposed used exports
+			/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
+			const exportsMap = new Map();
+
+			// Set with all root exposed unused exports
+			/** @type {Set<string>} */
+			const unusedExports = new Set();
+			// Set with all root exposed exports that were substituted with inlined literals
+			/** @type {Set<string>} */
+			const inlinedExports = new Set();
+
+			const rootInfo =
+				/** @type {ConcatenatedModuleInfo} */
+				(moduleToInfoMap.get(this.rootModule));
+			const strictHarmonyModule =
+				/** @type {BuildMeta} */
+				(rootInfo.module.buildMeta).strictHarmonyModule;
+			const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
+			/** @type {Record<string, string>} */
+			const exportsFinalName = {};
+			for (const exportInfo of exportsInfo.orderedExports) {
+				const name = exportInfo.name;
+				if (exportInfo.provided === false) continue;
+				const used = exportInfo.getUsedName(undefined, runtime);
+				if (!used) {
+					unusedExports.add(name);
+					continue;
+				}
+				if (used instanceof InlinedUsedName) {
+					inlinedExports.add(name);
+					continue;
+				}
+				exportsMap.set(used, (requestShortener) => {
+					try {
+						const finalName = getFinalName(
+							moduleGraph,
+							rootInfo,
+							[name],
+							moduleToInfoMap,
+							runtime,
+							requestShortener,
+							runtimeTemplate,
+							neededNamespaceObjects,
+							false,
+							false,
+							false,
+							strictHarmonyModule,
+							true
+						);
+						exportsFinalName[used] = finalName;
+						return `/* ${
+							exportInfo.isReexport() ? "reexport" : "binding"
+						} */ ${finalName}`;
+					} catch (err) {
+						/** @type {Error} */
+						(err).message +=
+							`\nwhile generating the root export '${name}' (used name: '${used}')`;
+						throw err;
+					}
+				});
+			}
+
+			const result = new ConcatSource();
+
+			// add harmony compatibility flag (must be first because of possible circular dependencies)
+			let shouldAddHarmonyFlag = false;
+			const rootExportsInfo = moduleGraph.getExportsInfo(this);
+			if (
+				rootExportsInfo.otherExportsInfo.getUsed(runtime) !==
+					UsageState.Unused ||
+				rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
+					UsageState.Unused
+			) {
+				shouldAddHarmonyFlag = true;
+			}
+
+			// define exports
+			if (exportsMap.size > 0) {
+				/** @type {string[]} */
+				const definitions = [];
+				for (const [key, value] of exportsMap) {
+					definitions.push(
+						`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
+							value(requestShortener)
+						)}`
+					);
+				}
+
+				runtimeRequirements.add(RuntimeGlobals.exports);
+				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+
+				if (shouldAddHarmonyFlag) {
+					result.add("// ESM COMPAT FLAG\n");
+					result.add(
+						runtimeTemplate.defineEsModuleFlagStatement({
+							exportsArgument: this.exportsArgument,
+							runtimeRequirements
+						})
+					);
+				}
+
+				const exportsSource =
+					"\n// EXPORTS\n" +
+					`${RuntimeGlobals.definePropertyGetters}(${
+						this.exportsArgument
+					}, {${definitions.join(",")}\n});\n`;
+
+				const { onDemandExportsGeneration } =
+					ConcatenatedModule.getCompilationHooks(this.compilation);
+
+				if (
+					!onDemandExportsGeneration.call(
+						this,
+						runtimes,
+						exportsSource,
+						exportsFinalName
+					)
+				) {
+					result.add(exportsSource);
+				}
+			}
+
+			// list unused exports
+			if (unusedExports.size > 0) {
+				result.add(
+					`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
+				);
+			}
+
+			// list inlined exports
+			if (inlinedExports.size > 0) {
+				result.add(
+					`\n// INLINED EXPORTS: ${joinIterableWithComma(inlinedExports)}\n`
+				);
+			}
+
+			// generate namespace objects
+			/** @type {Map<ConcatenatedModuleInfo, string>} */
+			const namespaceObjectSources = new Map();
+			for (const info of neededNamespaceObjects) {
+				if (info.namespaceExportSymbol) continue;
+				/** @type {string[]} */
+				const nsObj = [];
+				const exportsInfo = moduleGraph.getExportsInfo(info.module);
+				for (const exportInfo of exportsInfo.orderedExports) {
+					if (exportInfo.provided === false) continue;
+					const usedName = exportInfo.getUsedName(undefined, runtime);
+					if (usedName) {
+						// TODO: Replace with the inlined value directly at the call site
+						if (usedName instanceof InlinedUsedName) {
+							nsObj.push(
+								`\n  ${propertyName(exportInfo.name)}: ${runtimeTemplate.returningFunction(
+									usedName.render(
+										Template.toNormalComment(
+											`inlined export ${propertyAccess(exportInfo.name)}`
+										)
+									)
+								)}`
+							);
+						} else {
+							const finalName = getFinalName(
+								moduleGraph,
+								info,
+								[exportInfo.name],
+								moduleToInfoMap,
+								runtime,
+								requestShortener,
+								runtimeTemplate,
+								neededNamespaceObjects,
+								false,
+								false,
+								undefined,
 								/** @type {BuildMeta} */
 								(info.module.buildMeta).strictHarmonyModule,
 								true
 							);
-							if (!binding.ids) continue;
-							const { usedNames, alreadyCheckedScopes } =
-								getUsedNamesInScopeInfo(
-									usedNamesInScopeInfo,
-									binding.info.module.identifier(),
-									"name" in binding ? binding.name : ""
-								);
-							for (const expr of getSuperClassExpressions(reference.from)) {
-								if (
-									expr.range[0] <=
-										/** @type {Range} */ (reference.identifier.range)[0] &&
-									expr.range[1] >=
-										/** @type {Range} */ (reference.identifier.range)[1]
-								) {
-									for (const variable of expr.variables) {
-										usedNames.add(variable.name);
-									}
-								}
-							}
-							addScopeSymbols(
-								reference.from,
-								usedNames,
-								alreadyCheckedScopes,
-								ignoredScopes
+							nsObj.push(
+								`\n  ${propertyName(usedName)}: ${runtimeTemplate.returningFunction(
+									finalName
+								)}`
 							);
-						} else {
-							allUsedNames.add(name);
 						}
 					}
 				}
-			}
-		}
-
-		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
-		 */
-		const _findNewName = (name, info, references) => {
-			const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				name
-			);
-			if (allUsedNames.has(name) || usedNames.has(name)) {
-				for (const ref of references) {
-					addScopeSymbols(
-						ref.from,
-						usedNames,
-						alreadyCheckedScopes,
-						ignoredScopes
-					);
+				const name = info.namespaceObjectName;
+				const defineGetters =
+					nsObj.length > 0
+						? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
+								","
+							)}\n});\n`
+						: "";
+				if (nsObj.length > 0) {
+					runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
 				}
-				const newName = findNewName(
-					name,
-					allUsedNames,
-					usedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(newName);
-				info.internalNames.set(name, newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
-
-		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
-		 */
-		const _findNewNameForSpecifier = (name, info, references) => {
-			const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
-				getUsedNamesInScopeInfo(
-					usedNamesInScopeInfo,
-					info.module.identifier(),
-					name
-				);
-			/** @type {UsedNames} */
-			const referencesUsedNames = new Set();
-			for (const ref of references) {
-				addScopeSymbols(
-					ref.from,
-					referencesUsedNames,
-					alreadyCheckedScopes,
-					ignoredScopes
-				);
-			}
-			if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
-				const newName = findNewName(
-					name,
-					allUsedNames,
-					new Set([...moduleUsedNames, ...referencesUsedNames]),
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
-
-		// generate names for symbols
-		for (const info of moduleToInfoMap.values()) {
-			const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				""
-			);
-			switch (info.type) {
-				case "concatenated": {
-					const variables = /** @type {Scope} */ (info.moduleScope).variables;
-					for (const variable of variables) {
-						const name = variable.name;
-						const references = getAllReferences(variable);
-						const newName = _findNewName(name, info, references);
-						if (newName) {
-							const source = /** @type {ReplaceSource} */ (info.source);
-							const allIdentifiers = new Set([
-								...references.map((r) => r.identifier),
-								...variable.identifiers
-							]);
-							for (const identifier of allIdentifiers) {
-								const r = /** @type {Range} */ (identifier.range);
-								const path = getPathInAst(
-									/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
-									(info.ast),
-									identifier
-								);
-								if (path && path.length > 1) {
-									const maybeProperty =
-										path[1].type === "AssignmentPattern" &&
-										path[1].left === path[0]
-											? path[2]
-											: path[1];
-									if (
-										maybeProperty.type === "Property" &&
-										maybeProperty.shorthand
-									) {
-										source.insert(r[1], `: ${newName}`);
-										continue;
-									}
-								}
-								source.replace(r[0], r[1] - 1, newName);
-							}
-						} else {
-							allUsedNames.add(name);
-							info.internalNames.set(name, name);
-							topLevelDeclarations.add(name);
-						}
-					}
-					/** @type {string} */
-					let namespaceObjectName;
-					if (info.namespaceExportSymbol) {
-						namespaceObjectName =
-							/** @type {string} */
-							(info.internalNames.get(info.namespaceExportSymbol));
-					} else {
-						namespaceObjectName = findNewName(
-							"namespaceObject",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(namespaceObjectName);
-					}
-					info.namespaceObjectName = namespaceObjectName;
-					topLevelDeclarations.add(namespaceObjectName);
-					break;
-				}
-				case "external": {
-					const externalName = findNewName(
-						"",
-						allUsedNames,
-						namespaceObjectUsedNames,
-						info.module.readableIdentifier(requestShortener)
-					);
-					allUsedNames.add(externalName);
-					info.name = externalName;
-					topLevelDeclarations.add(externalName);
-
-					if (info.deferred) {
-						const externalName = findNewName(
-							"deferred",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(externalName);
-						info.deferredName = externalName;
-						topLevelDeclarations.add(externalName);
-
-						const externalNameInterop = findNewName(
-							"deferredNamespaceObject",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(externalNameInterop);
-						info.deferredNamespaceObjectName = externalNameInterop;
-						topLevelDeclarations.add(externalNameInterop);
-					}
-					break;
-				}
-			}
-			const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
-			if (buildMeta.exportsType !== "namespace") {
-				const externalNameInterop = findNewName(
-					"namespaceObject",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObjectName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (
-				buildMeta.exportsType === "default" &&
-				buildMeta.defaultObject !== "redirect" &&
-				info.interopNamespaceObject2Used
-			) {
-				const externalNameInterop = findNewName(
-					"namespaceObject2",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObject2Name = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
-				const externalNameInterop = findNewName(
-					"default",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopDefaultAccessName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-		}
-
-		// Find and replace references to modules
-		for (const info of moduleToInfoMap.values()) {
-			if (info.type === "concatenated") {
-				const globalScope = /** @type {Scope} */ (info.globalScope);
-				// group references by name
-				/** @type {Map<string, Reference[]>} */
-				const referencesByName = new Map();
-				for (const reference of globalScope.through) {
-					const name = reference.identifier.name;
-					if (!referencesByName.has(name)) {
-						referencesByName.set(name, []);
-					}
-					/** @type {Reference[]} */
-					(referencesByName.get(name)).push(reference);
-				}
-				for (const [name, references] of referencesByName) {
-					const match = ConcatenationScope.matchModuleReference(name);
-					if (match) {
-						const referencedInfo = modulesWithInfo[match.index];
-						if (referencedInfo.type === "reference") {
-							throw new Error("Module reference can't point to a reference");
-						}
-						const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
-							referencedInfo
-						).concatenationScope;
-						const exportId = match.ids[0];
-						const specifier =
-							concatenationScope && concatenationScope.getRawExport(exportId);
-						if (specifier) {
-							const newName = _findNewNameForSpecifier(
-								specifier,
-								info,
-								references
-							);
-							const initFragmentChanged =
-								newName &&
-								concatenatedModuleInfo.call(
-									{
-										rawExportMap: new Map([
-											[exportId, /** @type {string} */ (newName)]
-										])
-									},
-									/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
-								);
-							if (initFragmentChanged) {
-								concatenationScope.setRawExportMap(exportId, newName);
-							}
-						}
-						const finalName = getFinalName(
-							moduleGraph,
-							referencedInfo,
-							match.ids,
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							match.call,
-							match.deferredImport,
-							!match.directImport,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							match.asiSafe
-						);
-
-						for (const reference of references) {
-							const r = /** @type {Range} */ (reference.identifier.range);
-							const source = /** @type {ReplaceSource} */ (info.source);
-							// range is extended by 2 chars to cover the appended "._"
-							source.replace(r[0], r[1] + 1, finalName);
-						}
-					}
-				}
-			}
-		}
-
-		// Map with all root exposed used exports
-		/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
-		const exportsMap = new Map();
-
-		// Set with all root exposed unused exports
-		/** @type {Set<string>} */
-		const unusedExports = new Set();
-		// Set with all root exposed exports that were substituted with inlined literals
-		/** @type {Set<string>} */
-		const inlinedExports = new Set();
-
-		const rootInfo =
-			/** @type {ConcatenatedModuleInfo} */
-			(moduleToInfoMap.get(this.rootModule));
-		const strictHarmonyModule =
-			/** @type {BuildMeta} */
-			(rootInfo.module.buildMeta).strictHarmonyModule;
-		const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
-		/** @type {Record<string, string>} */
-		const exportsFinalName = {};
-		for (const exportInfo of exportsInfo.orderedExports) {
-			const name = exportInfo.name;
-			if (exportInfo.provided === false) continue;
-			const used = exportInfo.getUsedName(undefined, runtime);
-			if (!used) {
-				unusedExports.add(name);
-				continue;
-			}
-			if (used instanceof InlinedUsedName) {
-				inlinedExports.add(name);
-				continue;
-			}
-			exportsMap.set(used, (requestShortener) => {
-				try {
-					const finalName = getFinalName(
-						moduleGraph,
-						rootInfo,
-						[name],
-						moduleToInfoMap,
-						runtime,
-						requestShortener,
-						runtimeTemplate,
-						neededNamespaceObjects,
-						false,
-						false,
-						false,
-						strictHarmonyModule,
-						true
-					);
-					exportsFinalName[used] = finalName;
-					return `/* ${
-						exportInfo.isReexport() ? "reexport" : "binding"
-					} */ ${finalName}`;
-				} catch (err) {
-					/** @type {Error} */
-					(err).message +=
-						`\nwhile generating the root export '${name}' (used name: '${used}')`;
-					throw err;
-				}
-			});
-		}
-
-		const result = new ConcatSource();
-
-		// add harmony compatibility flag (must be first because of possible circular dependencies)
-		let shouldAddHarmonyFlag = false;
-		const rootExportsInfo = moduleGraph.getExportsInfo(this);
-		if (
-			rootExportsInfo.otherExportsInfo.getUsed(runtime) !== UsageState.Unused ||
-			rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
-				UsageState.Unused
-		) {
-			shouldAddHarmonyFlag = true;
-		}
-
-		// define exports
-		if (exportsMap.size > 0) {
-			/** @type {string[]} */
-			const definitions = [];
-			for (const [key, value] of exportsMap) {
-				definitions.push(
-					`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
-						value(requestShortener)
-					)}`
-				);
-			}
-
-			runtimeRequirements.add(RuntimeGlobals.exports);
-			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-
-			if (shouldAddHarmonyFlag) {
-				result.add("// ESM COMPAT FLAG\n");
-				result.add(
-					runtimeTemplate.defineEsModuleFlagStatement({
-						exportsArgument: this.exportsArgument,
-						runtimeRequirements
-					})
-				);
-			}
-
-			const exportsSource =
-				"\n// EXPORTS\n" +
-				`${RuntimeGlobals.definePropertyGetters}(${
-					this.exportsArgument
-				}, {${definitions.join(",")}\n});\n`;
-
-			const { onDemandExportsGeneration } =
-				ConcatenatedModule.getCompilationHooks(this.compilation);
-
-			if (
-				!onDemandExportsGeneration.call(
-					this,
-					runtimes,
-					exportsSource,
-					exportsFinalName
-				)
-			) {
-				result.add(exportsSource);
-			}
-		}
-
-		// list unused exports
-		if (unusedExports.size > 0) {
-			result.add(
-				`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
-			);
-		}
-
-		// list inlined exports
-		if (inlinedExports.size > 0) {
-			result.add(
-				`\n// INLINED EXPORTS: ${joinIterableWithComma(inlinedExports)}\n`
-			);
-		}
-
-		// generate namespace objects
-		/** @type {Map<ConcatenatedModuleInfo, string>} */
-		const namespaceObjectSources = new Map();
-		for (const info of neededNamespaceObjects) {
-			if (info.namespaceExportSymbol) continue;
-			/** @type {string[]} */
-			const nsObj = [];
-			const exportsInfo = moduleGraph.getExportsInfo(info.module);
-			for (const exportInfo of exportsInfo.orderedExports) {
-				if (exportInfo.provided === false) continue;
-				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (usedName) {
-					// TODO: Replace with the inlined value directly at the call site
-					if (usedName instanceof InlinedUsedName) {
-						nsObj.push(
-							`\n  ${propertyName(exportInfo.name)}: ${runtimeTemplate.returningFunction(
-								usedName.render(
-									Template.toNormalComment(
-										`inlined export ${propertyAccess(exportInfo.name)}`
-									)
-								)
-							)}`
-						);
-					} else {
-						const finalName = getFinalName(
-							moduleGraph,
-							info,
-							[exportInfo.name],
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							false,
-							false,
-							undefined,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							true
-						);
-						nsObj.push(
-							`\n  ${propertyName(usedName)}: ${runtimeTemplate.returningFunction(
-								finalName
-							)}`
-						);
-					}
-				}
-			}
-			const name = info.namespaceObjectName;
-			const defineGetters =
-				nsObj.length > 0
-					? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
-							","
-						)}\n});\n`
-					: "";
-			if (nsObj.length > 0) {
-				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-			}
-			namespaceObjectSources.set(
-				info,
-				`
+				namespaceObjectSources.set(
+					info,
+					`
 // NAMESPACE OBJECT: ${info.module.readableIdentifier(requestShortener)}
 var ${name} = {};
 ${RuntimeGlobals.makeNamespaceObject}(${name});
 ${defineGetters}`
-			);
-			runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
-		}
-
-		// define required namespace objects (must be before evaluation modules)
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				const source = namespaceObjectSources.get(info);
-				if (!source) continue;
-				result.add(source);
+				);
+				runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
 			}
 
-			if (info.type === "external" && info.deferred) {
-				const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
-				const loader = getOptimizedDeferredModule(
-					moduleId,
-					info.module.getExportsType(
-						moduleGraph,
-						/** @type {BuildMeta} */
-						(this.rootModule.buildMeta).strictHarmonyModule
-					),
-					// an async module will opt-out of the concat module optimization.
-					[],
-					runtimeRequirements
-				);
-				runtimeRequirements.add(RuntimeGlobals.require);
-				result.add(
-					`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(
-						requestShortener
-					)}\nvar ${info.deferredName} = ${loader};`
-				);
-				if (info.deferredNamespaceObjectUsed) {
-					runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
-					result.add(
-						`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
-							RuntimeGlobals.makeDeferredNamespaceObject
-						}(${JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						)}, ${getMakeDeferredNamespaceModeFromExportsType(
-							info.module.getExportsType(moduleGraph, strictHarmonyModule)
-						)});`
-					);
+			// define required namespace objects (must be before evaluation modules)
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					const source = namespaceObjectSources.get(info);
+					if (!source) continue;
+					result.add(source);
 				}
-			}
-		}
 
-		/** @type {InitFragment<ChunkRenderContext>[]} */
-		const chunkInitFragments = [];
-
-		// evaluate modules in order
-		for (const rawInfo of modulesWithInfo) {
-			/** @type {undefined | string} */
-			let name;
-			let isConditional = false;
-			const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
-			switch (info.type) {
-				case "concatenated": {
-					result.add(
-						`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
+				if (info.type === "external" && info.deferred) {
+					const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
+					const loader = getOptimizedDeferredModule(
+						moduleId,
+						info.module.getExportsType(
+							moduleGraph,
+							/** @type {BuildMeta} */
+							(this.rootModule.buildMeta).strictHarmonyModule
+						),
+						// an async module will opt-out of the concat module optimization.
+						[],
+						runtimeRequirements
 					);
-					result.add(/** @type {ReplaceSource} */ (info.source));
-					if (info.chunkInitFragments) {
-						for (const f of info.chunkInitFragments) chunkInitFragments.push(f);
-					}
-					if (info.runtimeRequirements) {
-						for (const r of info.runtimeRequirements) {
-							runtimeRequirements.add(r);
-						}
-					}
-					name = info.namespaceObjectName;
-					break;
-				}
-				case "external": {
-					// deferred case is handled in the "const info of modulesWithInfo" loop above
-					if (!info.deferred) {
+					runtimeRequirements.add(RuntimeGlobals.require);
+					result.add(
+						`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(
+							requestShortener
+						)}\nvar ${info.deferredName} = ${loader};`
+					);
+					if (info.deferredNamespaceObjectUsed) {
+						runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
 						result.add(
-							`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
-								requestShortener
-							)}\n`
+							`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
+								RuntimeGlobals.makeDeferredNamespaceObject
+							}(${JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							)}, ${getMakeDeferredNamespaceModeFromExportsType(
+								info.module.getExportsType(moduleGraph, strictHarmonyModule)
+							)});`
 						);
-						runtimeRequirements.add(RuntimeGlobals.require);
-						const { runtimeCondition } =
+					}
+				}
+			}
+
+			/** @type {InitFragment<ChunkRenderContext>[]} */
+			const chunkInitFragments = [];
+
+			// evaluate modules in order
+			for (const rawInfo of modulesWithInfo) {
+				/** @type {undefined | string} */
+				let name;
+				let isConditional = false;
+				const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
+				switch (info.type) {
+					case "concatenated": {
+						result.add(
+							`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
+						);
+						result.add(/** @type {ReplaceSource} */ (info.source));
+						if (info.chunkInitFragments) {
+							for (const f of info.chunkInitFragments) {
+								chunkInitFragments.push(f);
+							}
+						}
+						if (info.runtimeRequirements) {
+							for (const r of info.runtimeRequirements) {
+								runtimeRequirements.add(r);
+							}
+						}
+						name = info.namespaceObjectName;
+						break;
+					}
+					case "external": {
+						// deferred case is handled in the "const info of modulesWithInfo" loop above
+						if (!info.deferred) {
+							result.add(
+								`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
+									requestShortener
+								)}\n`
+							);
+							runtimeRequirements.add(RuntimeGlobals.require);
+							const { runtimeCondition } =
+								/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
+								(rawInfo);
+							const condition = runtimeTemplate.runtimeConditionExpression({
+								chunkGraph,
+								runtimeCondition,
+								runtime,
+								runtimeRequirements
+							});
+							if (condition !== "true") {
+								isConditional = true;
+								result.add(`if (${condition}) {\n`);
+							}
+							const moduleId = JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							);
+							// External module bindings may be wrapped in
+							// runtime-condition `if` blocks but referenced outside,
+							// so they must remain function-scoped (`var`).
+							result.add(
+								`var ${info.name} = __webpack_require__(${moduleId});`
+							);
+							name = info.name;
+						}
+						// If a module is deferred in other places, but used as non-deferred here,
+						// the module itself will be emitted as mod_deferred (in the case "external"),
+						// we need to emit an extra import declaration to evaluate it in order.
+						const { nonDeferAccess } =
 							/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
 							(rawInfo);
-						const condition = runtimeTemplate.runtimeConditionExpression({
-							chunkGraph,
-							runtimeCondition,
-							runtime,
-							runtimeRequirements
-						});
-						if (condition !== "true") {
-							isConditional = true;
-							result.add(`if (${condition}) {\n`);
+						if (info.deferred && nonDeferAccess) {
+							result.add(
+								`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(
+									requestShortener
+								)})\nvar ${info.name} = ${info.deferredName}.a;`
+							);
 						}
-						const moduleId = JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						);
-						// External module bindings may be wrapped in
-						// runtime-condition `if` blocks but referenced outside,
-						// so they must remain function-scoped (`var`).
-						result.add(`var ${info.name} = __webpack_require__(${moduleId});`);
-						name = info.name;
+						break;
 					}
-					// If a module is deferred in other places, but used as non-deferred here,
-					// the module itself will be emitted as mod_deferred (in the case "external"),
-					// we need to emit an extra import declaration to evaluate it in order.
-					const { nonDeferAccess } =
-						/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
-						(rawInfo);
-					if (info.deferred && nonDeferAccess) {
-						result.add(
-							`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(
-								requestShortener
-							)})\nvar ${info.name} = ${info.deferredName}.a;`
-						);
+					default: {
+						// @ts-expect-error never is expected here
+						const type = info.type;
+						throw new Error(`Unsupported concatenation entry type ${type}`);
 					}
-					break;
 				}
-				default:
-					// @ts-expect-error never is expected here
-					throw new Error(`Unsupported concatenation entry type ${info.type}`);
+				if (info.interopNamespaceObjectUsed) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						`\nvar ${info.interopNamespaceObjectName} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2);`
+					);
+				}
+				if (info.interopNamespaceObject2Used) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						`\nvar ${info.interopNamespaceObject2Name} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name});`
+					);
+				}
+				if (info.interopDefaultAccessUsed) {
+					runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
+					result.add(
+						`\nvar ${info.interopDefaultAccessName} = /*#__PURE__*/${RuntimeGlobals.compatGetDefaultExport}(${name});`
+					);
+				}
+				if (isConditional) {
+					result.add("\n}");
+				}
 			}
-			if (info.interopNamespaceObjectUsed) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					`\nvar ${info.interopNamespaceObjectName} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2);`
-				);
-			}
-			if (info.interopNamespaceObject2Used) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					`\nvar ${info.interopNamespaceObject2Name} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name});`
-				);
-			}
-			if (info.interopDefaultAccessUsed) {
-				runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
-				result.add(
-					`\nvar ${info.interopDefaultAccessName} = /*#__PURE__*/${RuntimeGlobals.compatGetDefaultExport}(${name});`
-				);
-			}
-			if (isConditional) {
-				result.add("\n}");
-			}
-		}
 
-		/** @type {CodeGenerationResultData} */
-		const data = new Map();
-		if (chunkInitFragments.length > 0) {
-			data.set("chunkInitFragments", chunkInitFragments);
-		}
-		data.set("topLevelDeclarations", topLevelDeclarations);
+			/** @type {CodeGenerationResultData} */
+			const data = new Map();
+			if (chunkInitFragments.length > 0) {
+				data.set("chunkInitFragments", chunkInitFragments);
+			}
+			data.set("topLevelDeclarations", topLevelDeclarations);
 
-		/** @type {CodeGenerationResult} */
-		const resultEntry = {
-			sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
-			data,
-			runtimeRequirements
+			/** @type {CodeGenerationResult} */
+			const resultEntry = {
+				sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
+				data,
+				runtimeRequirements
+			};
+
+			return resultEntry;
 		};
 
-		return resultEntry;
+		if (analysisPromises !== undefined) {
+			return Promise.all(analysisPromises).then(continueCodeGeneration);
+		}
+		return continueCodeGeneration();
 	}
 
 	/**
@@ -2196,6 +2221,7 @@ ${defineGetters}`
 	 * @param {RuntimeSpec[]} runtimes runtimes
 	 * @param {CodeGenerationResults} codeGenerationResults codeGenerationResults
 	 * @param {UsedNames} usedNames used names
+	 * @returns {void | Promise<void>} void or promise for async modules
 	 */
 	_analyseModule(
 		modulesMap,
@@ -2219,6 +2245,68 @@ ${defineGetters}`
 					usedNames
 				);
 
+				/**
+				 * @param {import("../Module").CodeGenerationResult} codeGenResult result
+				 */
+				const processResult = (codeGenResult) => {
+					const source =
+						/** @type {Source} */
+						(codeGenResult.sources.get(JAVASCRIPT_TYPE));
+					const data = codeGenResult.data;
+					const chunkInitFragments = data && data.get("chunkInitFragments");
+					const code = source.source().toString();
+
+					/** @type {Program} */
+					let ast;
+
+					try {
+						({ ast } = JavascriptParser._parse(
+							code,
+							{
+								sourceType: "module",
+								ranges: true
+							},
+							JavascriptParser._getModuleParseFunction(this.compilation, m)
+						));
+					} catch (_err) {
+						const err =
+							/** @type {Error & { loc?: { line: number, column: number } }} */
+							(_err);
+						if (
+							err.loc &&
+							typeof err.loc === "object" &&
+							typeof err.loc.line === "number"
+						) {
+							const lineNumber = err.loc.line;
+							const lines = code.split("\n");
+							err.message += `\n| ${lines
+								.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
+								.join("\n| ")}`;
+						}
+						throw err;
+					}
+					const scopeManager = eslintScope.analyze(ast, {
+						ecmaVersion: 6,
+						sourceType: "module",
+						optimistic: true,
+						ignoreEval: true,
+						impliedStrict: true
+					});
+					const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
+					const moduleScope = globalScope.childScopes[0];
+					const resultSource = new ReplaceSource(source);
+					info.runtimeRequirements =
+						/** @type {ReadOnlyRuntimeRequirements} */
+						(codeGenResult.runtimeRequirements);
+					info.ast = ast;
+					info.internalSource = source;
+					info.source = resultSource;
+					info.chunkInitFragments = chunkInitFragments;
+					info.globalScope = globalScope;
+					info.moduleScope = moduleScope;
+					info.concatenationScope = concatenationScope;
+				};
+
 				// TODO cache codeGeneration results
 				const codeGenResult = m.codeGeneration({
 					dependencyTemplates,
@@ -2231,62 +2319,15 @@ ${defineGetters}`
 					codeGenerationResults,
 					sourceTypes: JAVASCRIPT_TYPES
 				});
-				const source =
-					/** @type {Source} */
-					(codeGenResult.sources.get(JAVASCRIPT_TYPE));
-				const data = codeGenResult.data;
-				const chunkInitFragments = data && data.get("chunkInitFragments");
-				const code = source.source().toString();
-
-				/** @type {Program} */
-				let ast;
-
-				try {
-					({ ast } = JavascriptParser._parse(
-						code,
-						{
-							sourceType: "module",
-							ranges: true
-						},
-						JavascriptParser._getModuleParseFunction(this.compilation, m)
-					));
-				} catch (_err) {
-					const err =
-						/** @type {Error & { loc?: { line: number, column: number } }} */
-						(_err);
-					if (
-						err.loc &&
-						typeof err.loc === "object" &&
-						typeof err.loc.line === "number"
-					) {
-						const lineNumber = err.loc.line;
-						const lines = code.split("\n");
-						err.message += `\n| ${lines
-							.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
-							.join("\n| ")}`;
-					}
-					throw err;
+				if (codeGenResult instanceof Promise) {
+					return codeGenResult.then(processResult).catch((err) => {
+						/** @type {Error} */
+						(err).message +=
+							`\nwhile analyzing module ${m.identifier()} for concatenation`;
+						throw err;
+					});
 				}
-				const scopeManager = eslintScope.analyze(ast, {
-					ecmaVersion: 6,
-					sourceType: "module",
-					optimistic: true,
-					ignoreEval: true,
-					impliedStrict: true
-				});
-				const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
-				const moduleScope = globalScope.childScopes[0];
-				const resultSource = new ReplaceSource(source);
-				info.runtimeRequirements =
-					/** @type {ReadOnlyRuntimeRequirements} */
-					(codeGenResult.runtimeRequirements);
-				info.ast = ast;
-				info.internalSource = source;
-				info.source = resultSource;
-				info.chunkInitFragments = chunkInitFragments;
-				info.globalScope = globalScope;
-				info.moduleScope = moduleScope;
-				info.concatenationScope = concatenationScope;
+				processResult(codeGenResult);
 			} catch (err) {
 				/** @type {Error} */
 				(err).message +=

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -54,6 +54,7 @@ const {
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const { makePathsRelative } = require("../util/identifier");
+const isPromise = require("../util/isPromise");
 const makeSerializable = require("../util/makeSerializable");
 const memoize = require("../util/memoize");
 const { propertyAccess, propertyName } = require("../util/property");
@@ -1675,7 +1676,7 @@ class ConcatenatedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -1739,8 +1740,10 @@ class ConcatenatedModule extends Module {
 
 		// #region [1] ANALYSE: run each inner module's own codeGeneration; a
 		// non-wrapped body is parsed and scope-analysed so [3] can rename its locals
+		/** @type {Promise<void>[] | undefined} */
+		let analysisPromises;
 		for (const info of moduleToInfoMap.values()) {
-			this._analyseModule(
+			const result = this._analyseModule(
 				moduleToInfoMap,
 				info,
 				dependencyTemplates,
@@ -1753,870 +1756,799 @@ class ConcatenatedModule extends Module {
 				(codeGenerationResults),
 				allUsedNames
 			);
-		}
-		// #endregion
-
-		/**
-		 * Lazily allocates a decoupled namespace object for a concatenated module
-		 * whose exports are mangled, so an escaping whole-namespace value still
-		 * exposes the original export names. Returns undefined when no export is
-		 * mangled (the regular namespace object can be used as-is).
-		 * @param {ConcatenatedModuleInfo | ExternalModuleInfo} info module info
-		 * @returns {string | undefined} the escape namespace object name
-		 */
-		const getEscapeNamespaceObjectName = (info) => {
-			// Only a hoisted member's namespaceExportSymbol is a real variable
-			// holding the original names; a wrapped one reuses the field for its
-			// `X_namespaceFn()` call, which exposes the mangled keys
-			if (
-				info.type === "concatenated" &&
-				!info.wrapped &&
-				info.namespaceExportSymbol
-			) {
-				return undefined;
-			}
-
-			// Deferred external modules keep their special deferred namespace object
-			// and are rendered through a different path that wouldn't emit ours.
-			if (info.type === "external" && info.deferred) {
-				return undefined;
-			}
-			// Only real ES module namespaces are decoupled; non-harmony modules use
-			// their interop/fake namespace object as before.
-			const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
-			if (!buildMeta || buildMeta.exportsType !== "namespace") return undefined;
-			if (info.escapeNamespaceObjectName !== undefined) {
-				return info.escapeNamespaceObjectName;
-			}
-			const exportsInfo = moduleGraph.getExportsInfo(info.module);
-			let mangled = false;
-			for (const exportInfo of exportsInfo.orderedExports) {
-				if (exportInfo.provided === false) continue;
-				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (!usedName || usedName instanceof InlinedUsedName) continue;
-				if (usedName[usedName.length - 1] !== exportInfo.name) {
-					mangled = true;
-					break;
-				}
-			}
-			if (!mangled) return undefined;
-			const name = findNewName(
-				"namespaceObject",
-				allUsedNames,
-				/** @type {UsedNames} */ (new Set()),
-				info.module.readableIdentifier(requestShortener)
-			);
-			allUsedNames.add(name);
-			topLevelDeclarations.add(name);
-			info.escapeNamespaceObjectName = name;
-			neededEscapeNamespaceObjects.add(info);
-			return name;
-		};
-
-		// #region [2] RESERVE: the free globals of every analysed body. Claiming
-		// them up front is what lets [3] rename without shadowing any of them
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				if (info.wrapped) {
-					// The body is emitted verbatim and never renamed, so every identifier
-					// in it is claimed: its declarations must not shadow a name [3]
-					// generates, and its free globals must not be captured by one.
-					for (const name of findIdentifiers(
-						/** @type {Source} */ (info.internalSource)
-					)) {
-						allUsedNames.add(name);
-					}
-					// A wrapped body has no scope analysis, so its references are found
-					// textually. They still have to be resolved here: binding one is what
-					// flags the interop objects it needs, and [3] allocates their names.
-					/** @type {Set<string>} */
-					const visitedReferences = new Set();
-					for (const reference of ConcatenationScope.findModuleReferences(
-						/** @type {Source} */ (info.internalSource)
-					)) {
-						if (visitedReferences.has(reference.name)) continue;
-						visitedReferences.add(reference.name);
-						const match = ConcatenationScope.matchModuleReference(
-							reference.name
-						);
-						if (!match) continue;
-						const referencedInfo = modulesWithInfo[match.index];
-						if (referencedInfo.type === "reference") {
-							throw new Error("Module reference can't point to a reference");
-						}
-						if (
-							match.mangleableNamespace &&
-							match.ids.length === 0 &&
-							getEscapeNamespaceObjectName(referencedInfo) !== undefined
-						) {
-							continue;
-						}
-						getFinalBinding(
-							moduleGraph,
-							referencedInfo,
-							match.ids,
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							match.call,
-							match.deferredImport,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							match.asiSafe,
-							match.moduleExportsAccess
-						);
-					}
-				} else {
-					// ignore symbols from moduleScope
-					if (info.moduleScope) {
-						ignoredScopes.add(info.moduleScope);
-					}
-
-					// The super class expression in class scopes behaves weird
-					// We get ranges of all super class expressions to make
-					// renaming to work correctly
-					/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
-					/** @type {WeakMap<Scope, ClassInfo[]>} */
-					const superClassCache = new WeakMap();
-					/**
-					 * @param {Scope} scope scope
-					 * @returns {ClassInfo[]} result
-					 */
-					const getSuperClassExpressions = (scope) => {
-						const cacheEntry = superClassCache.get(scope);
-						if (cacheEntry !== undefined) return cacheEntry;
-						/** @type {ClassInfo[]} */
-						const superClassExpressions = [];
-						for (const childScope of scope.childScopes) {
-							if (childScope.type !== "class") continue;
-							const block = childScope.block;
-							if (
-								(block.type === "ClassDeclaration" ||
-									block.type === "ClassExpression") &&
-								block.superClass
-							) {
-								superClassExpressions.push({
-									range: /** @type {Range} */ (block.superClass.range),
-									variables: childScope.variables
-								});
-							}
-						}
-						superClassCache.set(scope, superClassExpressions);
-						return superClassExpressions;
-					};
-
-					// add global symbols
-					if (info.globalScope) {
-						for (const reference of info.globalScope.through) {
-							const name = reference.identifier.name;
-							if (ConcatenationScope.isModuleReference(name)) {
-								const match = ConcatenationScope.matchModuleReference(name);
-								if (!match) continue;
-								const referencedInfo = modulesWithInfo[match.index];
-								if (referencedInfo.type === "reference") {
-									throw new Error(
-										"Module reference can't point to a reference"
-									);
-								}
-								// An escaping mangled namespace resolves to its own decoupled
-								// namespace object (a unique top-level name), so it neither needs
-								// the regular namespace object nor super-class scope handling.
-								if (
-									match.mangleableNamespace &&
-									match.ids.length === 0 &&
-									getEscapeNamespaceObjectName(referencedInfo) !== undefined
-								) {
-									continue;
-								}
-								const binding = getFinalBinding(
-									moduleGraph,
-									referencedInfo,
-									match.ids,
-									moduleToInfoMap,
-									runtime,
-									requestShortener,
-									runtimeTemplate,
-									neededNamespaceObjects,
-									false,
-									match.deferredImport,
-									/** @type {BuildMeta} */
-									(info.module.buildMeta).strictHarmonyModule,
-									true,
-									match.moduleExportsAccess
-								);
-								if (!binding.ids) continue;
-								const { usedNames, alreadyCheckedScopes } =
-									getUsedNamesInScopeInfo(
-										usedNamesInScopeInfo,
-										binding.info.module.identifier(),
-										"name" in binding ? binding.name : ""
-									);
-								for (const expr of getSuperClassExpressions(reference.from)) {
-									if (
-										expr.range[0] <=
-											/** @type {Range} */ (reference.identifier.range)[0] &&
-										expr.range[1] >=
-											/** @type {Range} */ (reference.identifier.range)[1]
-									) {
-										for (const variable of expr.variables) {
-											usedNames.add(variable.name);
-										}
-									}
-								}
-								addScopeSymbols(
-									reference.from,
-									usedNames,
-									alreadyCheckedScopes,
-									ignoredScopes
-								);
-							} else {
-								allUsedNames.add(name);
-								freeNames.add(name);
-							}
-						}
-					}
-				}
+			if (isPromise(result)) {
+				if (analysisPromises === undefined) analysisPromises = [];
+				analysisPromises.push(result);
 			}
 		}
 		// #endregion
 
 		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
+		 * @returns {CodeGenerationResult} the code generation result
 		 */
-		const _findNewName = (name, info, references) => {
-			const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				name
-			);
-			if (allUsedNames.has(name) || usedNames.has(name)) {
-				for (const ref of references) {
-					addScopeSymbols(
-						ref.from,
-						usedNames,
-						alreadyCheckedScopes,
-						ignoredScopes
-					);
+		const continueCodeGeneration = () => {
+			/**
+			 * Lazily allocates a decoupled namespace object for a concatenated module
+			 * whose exports are mangled, so an escaping whole-namespace value still
+			 * exposes the original export names. Returns undefined when no export is
+			 * mangled (the regular namespace object can be used as-is).
+			 * @param {ConcatenatedModuleInfo | ExternalModuleInfo} info module info
+			 * @returns {string | undefined} the escape namespace object name
+			 */
+			const getEscapeNamespaceObjectName = (info) => {
+				// Only a hoisted member's namespaceExportSymbol is a real variable
+				// holding the original names; a wrapped one reuses the field for its
+				// `X_namespaceFn()` call, which exposes the mangled keys
+				if (
+					info.type === "concatenated" &&
+					!info.wrapped &&
+					info.namespaceExportSymbol
+				) {
+					return undefined;
 				}
-				const newName = findNewName(
-					name,
+
+				// Deferred external modules keep their special deferred namespace object
+				// and are rendered through a different path that wouldn't emit ours.
+				if (info.type === "external" && info.deferred) {
+					return undefined;
+				}
+				// Only real ES module namespaces are decoupled; non-harmony modules use
+				// their interop/fake namespace object as before.
+				const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
+				if (!buildMeta || buildMeta.exportsType !== "namespace") {
+					return undefined;
+				}
+				if (info.escapeNamespaceObjectName !== undefined) {
+					return info.escapeNamespaceObjectName;
+				}
+				const exportsInfo = moduleGraph.getExportsInfo(info.module);
+				let mangled = false;
+				for (const exportInfo of exportsInfo.orderedExports) {
+					if (exportInfo.provided === false) continue;
+					const usedName = exportInfo.getUsedName(undefined, runtime);
+					if (!usedName || usedName instanceof InlinedUsedName) continue;
+					if (usedName[usedName.length - 1] !== exportInfo.name) {
+						mangled = true;
+						break;
+					}
+				}
+				if (!mangled) return undefined;
+				const name = findNewName(
+					"namespaceObject",
 					allUsedNames,
-					usedNames,
+					/** @type {UsedNames} */ (new Set()),
 					info.module.readableIdentifier(requestShortener)
 				);
-				allUsedNames.add(newName);
-				info.internalNames.set(name, newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
+				allUsedNames.add(name);
+				topLevelDeclarations.add(name);
+				info.escapeNamespaceObjectName = name;
+				neededEscapeNamespaceObjects.add(info);
+				return name;
+			};
 
-		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
-		 */
-		const _findNewNameForSpecifier = (name, info, references) => {
-			const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
-				getUsedNamesInScopeInfo(
+			// #region [2] RESERVE: the free globals of every analysed body. Claiming
+			// them up front is what lets [3] rename without shadowing any of them
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					if (info.wrapped) {
+						// The body is emitted verbatim and never renamed, so every identifier
+						// in it is claimed: its declarations must not shadow a name [3]
+						// generates, and its free globals must not be captured by one.
+						for (const name of findIdentifiers(
+							/** @type {Source} */ (info.internalSource)
+						)) {
+							allUsedNames.add(name);
+						}
+						// A wrapped body has no scope analysis, so its references are found
+						// textually. They still have to be resolved here: binding one is what
+						// flags the interop objects it needs, and [3] allocates their names.
+						/** @type {Set<string>} */
+						const visitedReferences = new Set();
+						for (const reference of ConcatenationScope.findModuleReferences(
+							/** @type {Source} */ (info.internalSource)
+						)) {
+							if (visitedReferences.has(reference.name)) continue;
+							visitedReferences.add(reference.name);
+							const match = ConcatenationScope.matchModuleReference(
+								reference.name
+							);
+							if (!match) continue;
+							const referencedInfo = modulesWithInfo[match.index];
+							if (referencedInfo.type === "reference") {
+								throw new Error("Module reference can't point to a reference");
+							}
+							if (
+								match.mangleableNamespace &&
+								match.ids.length === 0 &&
+								getEscapeNamespaceObjectName(referencedInfo) !== undefined
+							) {
+								continue;
+							}
+							getFinalBinding(
+								moduleGraph,
+								referencedInfo,
+								match.ids,
+								moduleToInfoMap,
+								runtime,
+								requestShortener,
+								runtimeTemplate,
+								neededNamespaceObjects,
+								match.call,
+								match.deferredImport,
+								/** @type {BuildMeta} */
+								(info.module.buildMeta).strictHarmonyModule,
+								match.asiSafe,
+								match.moduleExportsAccess
+							);
+						}
+					} else {
+						// ignore symbols from moduleScope
+						if (info.moduleScope) {
+							ignoredScopes.add(info.moduleScope);
+						}
+
+						// The super class expression in class scopes behaves weird
+						// We get ranges of all super class expressions to make
+						// renaming to work correctly
+						/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
+						/** @type {WeakMap<Scope, ClassInfo[]>} */
+						const superClassCache = new WeakMap();
+						/**
+						 * @param {Scope} scope scope
+						 * @returns {ClassInfo[]} result
+						 */
+						const getSuperClassExpressions = (scope) => {
+							const cacheEntry = superClassCache.get(scope);
+							if (cacheEntry !== undefined) return cacheEntry;
+							/** @type {ClassInfo[]} */
+							const superClassExpressions = [];
+							for (const childScope of scope.childScopes) {
+								if (childScope.type !== "class") continue;
+								const block = childScope.block;
+								if (
+									(block.type === "ClassDeclaration" ||
+										block.type === "ClassExpression") &&
+									block.superClass
+								) {
+									superClassExpressions.push({
+										range: /** @type {Range} */ (block.superClass.range),
+										variables: childScope.variables
+									});
+								}
+							}
+							superClassCache.set(scope, superClassExpressions);
+							return superClassExpressions;
+						};
+
+						// add global symbols
+						if (info.globalScope) {
+							for (const reference of info.globalScope.through) {
+								const name = reference.identifier.name;
+								if (ConcatenationScope.isModuleReference(name)) {
+									const match = ConcatenationScope.matchModuleReference(name);
+									if (!match) continue;
+									const referencedInfo = modulesWithInfo[match.index];
+									if (referencedInfo.type === "reference") {
+										throw new Error(
+											"Module reference can't point to a reference"
+										);
+									}
+									// An escaping mangled namespace resolves to its own decoupled
+									// namespace object (a unique top-level name), so it neither needs
+									// the regular namespace object nor super-class scope handling.
+									if (
+										match.mangleableNamespace &&
+										match.ids.length === 0 &&
+										getEscapeNamespaceObjectName(referencedInfo) !== undefined
+									) {
+										continue;
+									}
+									const binding = getFinalBinding(
+										moduleGraph,
+										referencedInfo,
+										match.ids,
+										moduleToInfoMap,
+										runtime,
+										requestShortener,
+										runtimeTemplate,
+										neededNamespaceObjects,
+										false,
+										match.deferredImport,
+										/** @type {BuildMeta} */
+										(info.module.buildMeta).strictHarmonyModule,
+										true,
+										match.moduleExportsAccess
+									);
+									if (!binding.ids) continue;
+									const { usedNames, alreadyCheckedScopes } =
+										getUsedNamesInScopeInfo(
+											usedNamesInScopeInfo,
+											binding.info.module.identifier(),
+											"name" in binding ? binding.name : ""
+										);
+									for (const expr of getSuperClassExpressions(reference.from)) {
+										if (
+											expr.range[0] <=
+												/** @type {Range} */ (reference.identifier.range)[0] &&
+											expr.range[1] >=
+												/** @type {Range} */ (reference.identifier.range)[1]
+										) {
+											for (const variable of expr.variables) {
+												usedNames.add(variable.name);
+											}
+										}
+									}
+									addScopeSymbols(
+										reference.from,
+										usedNames,
+										alreadyCheckedScopes,
+										ignoredScopes
+									);
+								} else {
+									allUsedNames.add(name);
+									freeNames.add(name);
+								}
+							}
+						}
+					}
+				}
+			}
+			// #endregion
+
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewName = (name, info, references) => {
+				const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
 					usedNamesInScopeInfo,
 					info.module.identifier(),
 					name
 				);
-			/** @type {UsedNames} */
-			const referencesUsedNames = new Set();
-			for (const ref of references) {
-				addScopeSymbols(
-					ref.from,
-					referencesUsedNames,
-					alreadyCheckedScopes,
-					ignoredScopes
-				);
-			}
-			if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
-				const newName = findNewName(
-					name,
-					allUsedNames,
-					new Set([...moduleUsedNames, ...referencesUsedNames]),
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
-
-		// #region [3] RENAME: rename every module-scope variable inside its
-		// ReplaceSource, then allocate the generated names (wrapper accessor,
-		// namespace object, interop helpers, external import variable)
-		for (const info of moduleToInfoMap.values()) {
-			const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				""
-			);
-			switch (info.type) {
-				case "concatenated": {
-					if (info.wrapped) {
-						// A wrapped module declares exactly one shared-scope name: the
-						// lazy wrapper accessor holding its body. [2] claimed every
-						// identifier of that body, so findNewName avoids the ones that
-						// would shadow the accessor from inside it.
-						const namespaceFnName = findNewName(
-							"namespaceFn",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
+				if (allUsedNames.has(name) || usedNames.has(name)) {
+					for (const ref of references) {
+						addScopeSymbols(
+							ref.from,
+							usedNames,
+							alreadyCheckedScopes,
+							ignoredScopes
 						);
-						allUsedNames.add(namespaceFnName);
-						topLevelDeclarations.add(namespaceFnName);
-						info.namespaceFnName = namespaceFnName;
-						// Every reference — `require()` and ESM import alike — reads the
-						// live exports object through the accessor, so the namespace is
-						// the call itself, not a variable. Not a declared name.
-						info.namespaceObjectName = `${namespaceFnName}()`;
-					} else {
-						const variables = /** @type {Scope} */ (info.moduleScope).variables;
-						for (const variable of variables) {
-							const name = variable.name;
-							const references = getAllReferences(variable);
-							const newName = _findNewName(name, info, references);
-							if (newName) {
-								const source = /** @type {ReplaceSource} */ (info.source);
-								/** @type {Set<Identifier>} */
-								const allIdentifiers = new Set();
-								for (const r of references) allIdentifiers.add(r.identifier);
-								for (const identifier of variable.identifiers) {
-									allIdentifiers.add(identifier);
-								}
-								for (const identifier of allIdentifiers) {
-									const r = /** @type {Range} */ (identifier.range);
-									const path = getPathInAst(
-										/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
-										(info.ast),
-										identifier
-									);
-									if (path && path.length > 1) {
-										const maybeProperty =
-											path[1].type === "AssignmentPattern" &&
-											path[1].left === path[0]
-												? path[2]
-												: path[1];
-										if (
-											maybeProperty.type === "Property" &&
-											maybeProperty.shorthand
-										) {
-											source.insert(r[1], `: ${newName}`);
-											continue;
-										}
-									}
-									source.replace(r[0], r[1] - 1, newName);
-								}
-							} else {
-								allUsedNames.add(name);
-								info.internalNames.set(name, name);
-								topLevelDeclarations.add(name);
-							}
-						}
-						/** @type {string} */
-						let namespaceObjectName;
-						if (info.namespaceExportSymbol) {
-							namespaceObjectName =
-								/** @type {string} */
-								(info.internalNames.get(info.namespaceExportSymbol));
-						} else {
-							namespaceObjectName = findNewName(
-								"namespaceObject",
+					}
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						usedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					info.internalNames.set(name, newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewNameForSpecifier = (name, info, references) => {
+				const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
+					getUsedNamesInScopeInfo(
+						usedNamesInScopeInfo,
+						info.module.identifier(),
+						name
+					);
+				/** @type {UsedNames} */
+				const referencesUsedNames = new Set();
+				for (const ref of references) {
+					addScopeSymbols(
+						ref.from,
+						referencesUsedNames,
+						alreadyCheckedScopes,
+						ignoredScopes
+					);
+				}
+				if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						new Set([...moduleUsedNames, ...referencesUsedNames]),
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			// #region [3] RENAME: rename every module-scope variable inside its
+			// ReplaceSource, then allocate the generated names (wrapper accessor,
+			// namespace object, interop helpers, external import variable)
+			for (const info of moduleToInfoMap.values()) {
+				const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
+					usedNamesInScopeInfo,
+					info.module.identifier(),
+					""
+				);
+				switch (info.type) {
+					case "concatenated": {
+						if (info.wrapped) {
+							// A wrapped module declares exactly one shared-scope name: the
+							// lazy wrapper accessor holding its body. [2] claimed every
+							// identifier of that body, so findNewName avoids the ones that
+							// would shadow the accessor from inside it.
+							const namespaceFnName = findNewName(
+								"namespaceFn",
 								allUsedNames,
 								namespaceObjectUsedNames,
 								info.module.readableIdentifier(requestShortener)
 							);
-							allUsedNames.add(namespaceObjectName);
+							allUsedNames.add(namespaceFnName);
+							topLevelDeclarations.add(namespaceFnName);
+							info.namespaceFnName = namespaceFnName;
+							// Every reference — `require()` and ESM import alike — reads the
+							// live exports object through the accessor, so the namespace is
+							// the call itself, not a variable. Not a declared name.
+							info.namespaceObjectName = `${namespaceFnName}()`;
+						} else {
+							const variables = /** @type {Scope} */ (info.moduleScope)
+								.variables;
+							for (const variable of variables) {
+								const name = variable.name;
+								const references = getAllReferences(variable);
+								const newName = _findNewName(name, info, references);
+								if (newName) {
+									const source = /** @type {ReplaceSource} */ (info.source);
+									/** @type {Set<Identifier>} */
+									const allIdentifiers = new Set();
+									for (const r of references) allIdentifiers.add(r.identifier);
+									for (const identifier of variable.identifiers) {
+										allIdentifiers.add(identifier);
+									}
+									for (const identifier of allIdentifiers) {
+										const r = /** @type {Range} */ (identifier.range);
+										const path = getPathInAst(
+											/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
+											(info.ast),
+											identifier
+										);
+										if (path && path.length > 1) {
+											const maybeProperty =
+												path[1].type === "AssignmentPattern" &&
+												path[1].left === path[0]
+													? path[2]
+													: path[1];
+											if (
+												maybeProperty.type === "Property" &&
+												maybeProperty.shorthand
+											) {
+												source.insert(r[1], `: ${newName}`);
+												continue;
+											}
+										}
+										source.replace(r[0], r[1] - 1, newName);
+									}
+								} else {
+									allUsedNames.add(name);
+									info.internalNames.set(name, name);
+									topLevelDeclarations.add(name);
+								}
+							}
+							/** @type {string} */
+							let namespaceObjectName;
+							if (info.namespaceExportSymbol) {
+								namespaceObjectName =
+									/** @type {string} */
+									(info.internalNames.get(info.namespaceExportSymbol));
+							} else {
+								namespaceObjectName = findNewName(
+									"namespaceObject",
+									allUsedNames,
+									namespaceObjectUsedNames,
+									info.module.readableIdentifier(requestShortener)
+								);
+								allUsedNames.add(namespaceObjectName);
+							}
+							info.namespaceObjectName = namespaceObjectName;
+							topLevelDeclarations.add(namespaceObjectName);
 						}
-						info.namespaceObjectName = namespaceObjectName;
-						topLevelDeclarations.add(namespaceObjectName);
+						break;
 					}
-					break;
-				}
-				case "external": {
-					const externalName = findNewName(
-						"",
-						allUsedNames,
-						namespaceObjectUsedNames,
-						info.module.readableIdentifier(requestShortener)
-					);
-					allUsedNames.add(externalName);
-					info.name = externalName;
-					topLevelDeclarations.add(externalName);
-
-					if (info.wrapped) {
-						const namespaceFnName = findNewName(
-							"namespaceFn",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(namespaceFnName);
-						info.namespaceFnName = namespaceFnName;
-						topLevelDeclarations.add(namespaceFnName);
-					}
-
-					if (info.deferred) {
+					case "external": {
 						const externalName = findNewName(
-							"deferred",
+							"",
 							allUsedNames,
 							namespaceObjectUsedNames,
 							info.module.readableIdentifier(requestShortener)
 						);
 						allUsedNames.add(externalName);
-						info.deferredName = externalName;
+						info.name = externalName;
 						topLevelDeclarations.add(externalName);
 
-						const externalNameInterop = findNewName(
-							"deferredNamespaceObject",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(externalNameInterop);
-						info.deferredNamespaceObjectName = externalNameInterop;
-						topLevelDeclarations.add(externalNameInterop);
-					}
-					break;
-				}
-			}
-			const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
-			if (buildMeta.exportsType !== "namespace") {
-				const externalNameInterop = findNewName(
-					"namespaceObject",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObjectName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (
-				buildMeta.exportsType === "default" &&
-				buildMeta.defaultObject !== "redirect" &&
-				info.interopNamespaceObject2Used
-			) {
-				const externalNameInterop = findNewName(
-					"namespaceObject2",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObject2Name = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
-				const externalNameInterop = findNewName(
-					"default",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopDefaultAccessName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-		}
-		// #endregion
-
-		// #region [4] LINK: resolve each cross-module reference token to the final
-		// name picked in [3] and patch it in. Must run after [3] — a reference can
-		// only be resolved once its target has been named
-		for (const info of moduleToInfoMap.values()) {
-			if (info.type !== "concatenated") continue;
-			if (!info.wrapped) {
-				const globalScope = /** @type {Scope} */ (info.globalScope);
-				// group references by name
-				/** @type {Map<string, Reference[]>} */
-				const referencesByName = new Map();
-				for (const reference of globalScope.through) {
-					const name = reference.identifier.name;
-					let references = referencesByName.get(name);
-					if (references === undefined) {
-						referencesByName.set(name, (references = []));
-					}
-					references.push(reference);
-				}
-				for (const [name, references] of referencesByName) {
-					const match = ConcatenationScope.matchModuleReference(name);
-					if (match) {
-						const referencedInfo = modulesWithInfo[match.index];
-						if (referencedInfo.type === "reference") {
-							throw new Error("Module reference can't point to a reference");
-						}
-						const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
-							referencedInfo
-						).concatenationScope;
-						const exportId = match.ids[0];
-						const specifier =
-							concatenationScope && concatenationScope.getRawExport(exportId);
-						if (specifier) {
-							const newName = _findNewNameForSpecifier(
-								specifier,
-								info,
-								references
+						if (info.wrapped) {
+							const namespaceFnName = findNewName(
+								"namespaceFn",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
 							);
-							const initFragmentChanged =
-								newName &&
-								concatenatedModuleInfo.call(
-									{
-										rawExportMap: new Map([
-											[exportId, /** @type {string} */ (newName)]
-										])
-									},
-									/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
+							allUsedNames.add(namespaceFnName);
+							info.namespaceFnName = namespaceFnName;
+							topLevelDeclarations.add(namespaceFnName);
+						}
+
+						if (info.deferred) {
+							const externalName = findNewName(
+								"deferred",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalName);
+							info.deferredName = externalName;
+							topLevelDeclarations.add(externalName);
+
+							const externalNameInterop = findNewName(
+								"deferredNamespaceObject",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalNameInterop);
+							info.deferredNamespaceObjectName = externalNameInterop;
+							topLevelDeclarations.add(externalNameInterop);
+						}
+						break;
+					}
+				}
+				const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
+				if (buildMeta.exportsType !== "namespace") {
+					const externalNameInterop = findNewName(
+						"namespaceObject",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObjectName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (
+					buildMeta.exportsType === "default" &&
+					buildMeta.defaultObject !== "redirect" &&
+					info.interopNamespaceObject2Used
+				) {
+					const externalNameInterop = findNewName(
+						"namespaceObject2",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObject2Name = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
+					const externalNameInterop = findNewName(
+						"default",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopDefaultAccessName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+			}
+			// #endregion
+
+			// #region [4] LINK: resolve each cross-module reference token to the final
+			// name picked in [3] and patch it in. Must run after [3] — a reference can
+			// only be resolved once its target has been named
+			for (const info of moduleToInfoMap.values()) {
+				if (info.type !== "concatenated") continue;
+				if (!info.wrapped) {
+					const globalScope = /** @type {Scope} */ (info.globalScope);
+					// group references by name
+					/** @type {Map<string, Reference[]>} */
+					const referencesByName = new Map();
+					for (const reference of globalScope.through) {
+						const name = reference.identifier.name;
+						let references = referencesByName.get(name);
+						if (references === undefined) {
+							referencesByName.set(name, (references = []));
+						}
+						references.push(reference);
+					}
+					for (const [name, references] of referencesByName) {
+						const match = ConcatenationScope.matchModuleReference(name);
+						if (match) {
+							const referencedInfo = modulesWithInfo[match.index];
+							if (referencedInfo.type === "reference") {
+								throw new Error("Module reference can't point to a reference");
+							}
+							const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
+								referencedInfo
+							).concatenationScope;
+							const exportId = match.ids[0];
+							const specifier =
+								concatenationScope && concatenationScope.getRawExport(exportId);
+							if (specifier) {
+								const newName = _findNewNameForSpecifier(
+									specifier,
+									info,
+									references
 								);
-							if (initFragmentChanged) {
-								concatenationScope.setRawExportMap(exportId, newName);
+								const initFragmentChanged =
+									newName &&
+									concatenatedModuleInfo.call(
+										{
+											rawExportMap: new Map([
+												[exportId, /** @type {string} */ (newName)]
+											])
+										},
+										/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
+									);
+								if (initFragmentChanged) {
+									concatenationScope.setRawExportMap(exportId, newName);
+								}
+							}
+							// A whole-namespace value that escapes: when the module's exports
+							// are mangled, point it at a decoupled namespace object that keeps
+							// the original names so untracked access keeps working.
+							const escapeName =
+								match.mangleableNamespace && match.ids.length === 0
+									? getEscapeNamespaceObjectName(referencedInfo)
+									: undefined;
+							const finalName =
+								escapeName !== undefined
+									? escapeName
+									: getFinalName(
+											moduleGraph,
+											referencedInfo,
+											match.ids,
+											moduleToInfoMap,
+											runtime,
+											requestShortener,
+											runtimeTemplate,
+											neededNamespaceObjects,
+											match.call,
+											match.deferredImport,
+											!match.directImport,
+											/** @type {BuildMeta} */
+											(info.module.buildMeta).strictHarmonyModule,
+											match.asiSafe,
+											match.moduleExportsAccess
+										);
+
+							for (const reference of references) {
+								const r = /** @type {Range} */ (reference.identifier.range);
+								const source = /** @type {ReplaceSource} */ (info.source);
+								// range is extended by 2 chars to cover the appended "._"
+								source.replace(r[0], r[1] + 1, finalName);
 							}
 						}
-						// A whole-namespace value that escapes: when the module's exports
-						// are mangled, point it at a decoupled namespace object that keeps
-						// the original names so untracked access keeps working.
-						const escapeName =
-							match.mangleableNamespace && match.ids.length === 0
-								? getEscapeNamespaceObjectName(referencedInfo)
-								: undefined;
-						const finalName =
-							escapeName !== undefined
-								? escapeName
-								: getFinalName(
-										moduleGraph,
-										referencedInfo,
-										match.ids,
-										moduleToInfoMap,
-										runtime,
-										requestShortener,
-										runtimeTemplate,
-										neededNamespaceObjects,
-										match.call,
-										match.deferredImport,
-										!match.directImport,
-										/** @type {BuildMeta} */
-										(info.module.buildMeta).strictHarmonyModule,
-										match.asiSafe,
-										match.moduleExportsAccess
-									);
-
-						for (const reference of references) {
-							const r = /** @type {Range} */ (reference.identifier.range);
-							const source = /** @type {ReplaceSource} */ (info.source);
-							// range is extended by 2 chars to cover the appended "._"
-							source.replace(r[0], r[1] + 1, finalName);
+					}
+				} else {
+					// Wrapped bodies are not re-parsed: find their reference tokens
+					// textually. [2] scanned the same source, so this reuses its result.
+					/** @type {Map<string, string>} */
+					const finalNames = new Map();
+					const source = /** @type {ReplaceSource} */ (info.source);
+					for (const reference of ConcatenationScope.findModuleReferences(
+						/** @type {Source} */ (info.internalSource)
+					)) {
+						let finalName = finalNames.get(reference.name);
+						if (finalName === undefined) {
+							const match = ConcatenationScope.matchModuleReference(
+								reference.name
+							);
+							if (!match) continue;
+							const referencedInfo = modulesWithInfo[match.index];
+							if (referencedInfo.type === "reference") {
+								throw new Error("Module reference can't point to a reference");
+							}
+							// Same escaping whole-namespace rule as the hoisted branch above: a
+							// wrapped target resolves to its `X_namespaceFn()` exports object,
+							// whose keys are the mangled ones.
+							const escapeName =
+								match.mangleableNamespace && match.ids.length === 0
+									? getEscapeNamespaceObjectName(referencedInfo)
+									: undefined;
+							finalName =
+								escapeName !== undefined
+									? escapeName
+									: getFinalName(
+											moduleGraph,
+											referencedInfo,
+											match.ids,
+											moduleToInfoMap,
+											runtime,
+											requestShortener,
+											runtimeTemplate,
+											neededNamespaceObjects,
+											match.call,
+											match.deferredImport,
+											!match.directImport,
+											/** @type {BuildMeta} */
+											(info.module.buildMeta).strictHarmonyModule,
+											match.asiSafe,
+											match.moduleExportsAccess
+										);
+							finalNames.set(reference.name, finalName);
 						}
+						// token end is extended by 2 chars to cover the appended "._"
+						source.replace(reference.start, reference.end + 1, finalName);
 					}
 				}
-			} else {
-				// Wrapped bodies are not re-parsed: find their reference tokens
-				// textually. [2] scanned the same source, so this reuses its result.
-				/** @type {Map<string, string>} */
-				const finalNames = new Map();
-				const source = /** @type {ReplaceSource} */ (info.source);
-				for (const reference of ConcatenationScope.findModuleReferences(
-					/** @type {Source} */ (info.internalSource)
-				)) {
-					let finalName = finalNames.get(reference.name);
-					if (finalName === undefined) {
-						const match = ConcatenationScope.matchModuleReference(
-							reference.name
-						);
-						if (!match) continue;
-						const referencedInfo = modulesWithInfo[match.index];
-						if (referencedInfo.type === "reference") {
-							throw new Error("Module reference can't point to a reference");
-						}
-						// Same escaping whole-namespace rule as the hoisted branch above: a
-						// wrapped target resolves to its `X_namespaceFn()` exports object,
-						// whose keys are the mangled ones.
-						const escapeName =
-							match.mangleableNamespace && match.ids.length === 0
-								? getEscapeNamespaceObjectName(referencedInfo)
-								: undefined;
-						finalName =
-							escapeName !== undefined
-								? escapeName
-								: getFinalName(
-										moduleGraph,
-										referencedInfo,
-										match.ids,
-										moduleToInfoMap,
-										runtime,
-										requestShortener,
-										runtimeTemplate,
-										neededNamespaceObjects,
-										match.call,
-										match.deferredImport,
-										!match.directImport,
-										/** @type {BuildMeta} */
-										(info.module.buildMeta).strictHarmonyModule,
-										match.asiSafe,
-										match.moduleExportsAccess
-									);
-						finalNames.set(reference.name, finalName);
-					}
-					// token end is extended by 2 chars to cover the appended "._"
-					source.replace(reference.start, reference.end + 1, finalName);
-				}
 			}
-		}
-		// #endregion
+			// #endregion
 
-		// #region [5] COLLECT EXPORTS: split the root module's exports into used /
-		// unused / inlined. Used ones stay thunks — resolving one can still
-		// register a namespace object, which [7] must see
-		// Map with all root exposed used exports
-		/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
-		const exportsMap = new Map();
+			// #region [5] COLLECT EXPORTS: split the root module's exports into used /
+			// unused / inlined. Used ones stay thunks — resolving one can still
+			// register a namespace object, which [7] must see
+			// Map with all root exposed used exports
+			/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
+			const exportsMap = new Map();
 
-		// Set with all root exposed unused exports
-		/** @type {Set<string>} */
-		const unusedExports = new Set();
-		// Set with all root exposed exports that were substituted with inlined literals
-		/** @type {Set<string>} */
-		const inlinedExports = new Set();
+			// Set with all root exposed unused exports
+			/** @type {Set<string>} */
+			const unusedExports = new Set();
+			// Set with all root exposed exports that were substituted with inlined literals
+			/** @type {Set<string>} */
+			const inlinedExports = new Set();
 
-		const rootInfo =
-			/** @type {ConcatenatedModuleInfo} */
-			(moduleToInfoMap.get(this.rootModule));
-		const strictHarmonyModule =
-			/** @type {BuildMeta} */
-			(rootInfo.module.buildMeta).strictHarmonyModule;
-		const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
-		/** @type {Record<string, string>} */
-		const exportsFinalName = {};
-		for (const exportInfo of exportsInfo.orderedExports) {
-			const name = exportInfo.name;
-			if (exportInfo.provided === false) continue;
-			const used = exportInfo.getUsedName(undefined, runtime);
-			if (!used) {
-				unusedExports.add(name);
-				continue;
-			}
-			if (used instanceof InlinedUsedName) {
-				inlinedExports.add(name);
-				continue;
-			}
-			exportsMap.set(used, (requestShortener) => {
-				try {
-					const finalName = getFinalName(
-						moduleGraph,
-						rootInfo,
-						[name],
-						moduleToInfoMap,
-						runtime,
-						requestShortener,
-						runtimeTemplate,
-						neededNamespaceObjects,
-						false,
-						false,
-						false,
-						strictHarmonyModule,
-						true
-					);
-					exportsFinalName[used] = finalName;
-					return `/* ${
-						exportInfo.isReexport() ? "reexport" : "binding"
-					} */ ${finalName}`;
-				} catch (err) {
-					/** @type {Error} */
-					(err).message +=
-						`\nwhile generating the root export '${name}' (used name: '${used}')`;
-					throw err;
-				}
-			});
-		}
-		// #endregion
-
-		// #region [6] EMIT EXPORTS: first thing in the output — the exports getters
-		// must exist before any body runs, so circular importers see them
-		const result = new ConcatSource();
-
-		// add harmony compatibility flag (must be first because of possible circular dependencies)
-		let shouldAddHarmonyFlag = false;
-		const rootExportsInfo = moduleGraph.getExportsInfo(this);
-		if (
-			rootExportsInfo.otherExportsInfo.getUsed(runtime) !== UsageState.Unused ||
-			rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
-				UsageState.Unused
-		) {
-			shouldAddHarmonyFlag = true;
-		}
-
-		// define exports
-		if (exportsMap.size > 0) {
-			/** @type {string[]} */
-			const definitions = [];
-			for (const [key, value] of exportsMap) {
-				definitions.push(
-					`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
-						value(requestShortener)
-					)}`
-				);
-			}
-
-			runtimeRequirements.add(RuntimeGlobals.exports);
-			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-
-			if (shouldAddHarmonyFlag) {
-				result.add("// ESM COMPAT FLAG\n");
-				result.add(
-					runtimeTemplate.defineEsModuleFlagStatement({
-						exportsArgument: this.exportsArgument,
-						runtimeRequirements
-					})
-				);
-			}
-
-			const exportsSource =
-				"\n// EXPORTS\n" +
-				`${RuntimeGlobals.definePropertyGetters}(${
-					this.exportsArgument
-				}, {${definitions.join(",")}\n});\n`;
-
-			const { onDemandExportsGeneration } =
-				ConcatenatedModule.getCompilationHooks(this.compilation);
-
-			if (
-				!onDemandExportsGeneration.call(
-					this,
-					runtimes,
-					exportsSource,
-					exportsFinalName
-				)
-			) {
-				result.add(exportsSource);
-			}
-		}
-
-		// list unused exports
-		if (unusedExports.size > 0) {
-			result.add(
-				`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
-			);
-		}
-
-		// list inlined exports
-		if (inlinedExports.size > 0) {
-			result.add(
-				`\n// INLINED EXPORTS: ${joinIterableWithComma(inlinedExports)}\n`
-			);
-		}
-		// #endregion
-
-		// #region [7] BUILD NS: namespace object sources are built as strings here
-		// and emitted by [8]; an external's is emitted next to its import variable
-		// or accessor instead, which is defined later.
-		//
-		// generate decoupled namespace objects for escaping mangled namespaces:
-		// same getters as the regular namespace object, but keyed by the original
-		// export names so untracked access by name keeps working. Done before the
-		// regular namespace objects so any nested namespace they pull in is built.
-		/** @type {Map<ConcatenatedModuleInfo | ExternalModuleInfo, string>} */
-		const escapeNamespaceObjectSources = new Map();
-		for (const info of neededEscapeNamespaceObjects) {
-			/** @type {string[]} */
-			const nsObj = [];
-			const exportsInfo = moduleGraph.getExportsInfo(info.module);
+			const rootInfo =
+				/** @type {ConcatenatedModuleInfo} */
+				(moduleToInfoMap.get(this.rootModule));
+			const strictHarmonyModule =
+				/** @type {BuildMeta} */
+				(rootInfo.module.buildMeta).strictHarmonyModule;
+			const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
+			/** @type {Record<string, string>} */
+			const exportsFinalName = {};
 			for (const exportInfo of exportsInfo.orderedExports) {
+				const name = exportInfo.name;
 				if (exportInfo.provided === false) continue;
-				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (!usedName) continue;
-				if (usedName instanceof InlinedUsedName) {
-					nsObj.push(
-						`\n  ${propertyName(
-							exportInfo.name
-						)}: ${runtimeTemplate.returningFunction(
-							usedName.render(
-								Template.toNormalComment(
-									`inlined export ${propertyAccess([exportInfo.name])}`
-								)
-							)
+				const used = exportInfo.getUsedName(undefined, runtime);
+				if (!used) {
+					unusedExports.add(name);
+					continue;
+				}
+				if (used instanceof InlinedUsedName) {
+					inlinedExports.add(name);
+					continue;
+				}
+				exportsMap.set(used, (requestShortener) => {
+					try {
+						const finalName = getFinalName(
+							moduleGraph,
+							rootInfo,
+							[name],
+							moduleToInfoMap,
+							runtime,
+							requestShortener,
+							runtimeTemplate,
+							neededNamespaceObjects,
+							false,
+							false,
+							false,
+							strictHarmonyModule,
+							true
+						);
+						exportsFinalName[used] = finalName;
+						return `/* ${
+							exportInfo.isReexport() ? "reexport" : "binding"
+						} */ ${finalName}`;
+					} catch (err) {
+						/** @type {Error} */
+						(err).message +=
+							`\nwhile generating the root export '${name}' (used name: '${used}')`;
+						throw err;
+					}
+				});
+			}
+			// #endregion
+
+			// #region [6] EMIT EXPORTS: first thing in the output — the exports getters
+			// must exist before any body runs, so circular importers see them
+			const result = new ConcatSource();
+
+			// add harmony compatibility flag (must be first because of possible circular dependencies)
+			let shouldAddHarmonyFlag = false;
+			const rootExportsInfo = moduleGraph.getExportsInfo(this);
+			if (
+				rootExportsInfo.otherExportsInfo.getUsed(runtime) !==
+					UsageState.Unused ||
+				rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
+					UsageState.Unused
+			) {
+				shouldAddHarmonyFlag = true;
+			}
+
+			// define exports
+			if (exportsMap.size > 0) {
+				/** @type {string[]} */
+				const definitions = [];
+				for (const [key, value] of exportsMap) {
+					definitions.push(
+						`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
+							value(requestShortener)
 						)}`
 					);
-				} else {
-					// External (non-concatenated) modules are accessed through their
-					// import variable; concatenated ones resolve to an internal binding.
-					const finalName =
-						info.type === "external"
-							? `${getExternalModuleExpr(info)}${propertyAccess([usedName])}`
-							: getFinalName(
-									moduleGraph,
-									info,
-									[exportInfo.name],
-									moduleToInfoMap,
-									runtime,
-									requestShortener,
-									runtimeTemplate,
-									neededNamespaceObjects,
-									false,
-									false,
-									undefined,
-									/** @type {BuildMeta} */
-									(info.module.buildMeta).strictHarmonyModule,
-									true
-								);
-					nsObj.push(
-						`\n  ${propertyName(
-							exportInfo.name
-						)}: ${runtimeTemplate.returningFunction(finalName)}`
+				}
+
+				runtimeRequirements.add(RuntimeGlobals.exports);
+				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+
+				if (shouldAddHarmonyFlag) {
+					result.add("// ESM COMPAT FLAG\n");
+					result.add(
+						runtimeTemplate.defineEsModuleFlagStatement({
+							exportsArgument: this.exportsArgument,
+							runtimeRequirements
+						})
 					);
 				}
-			}
-			const name = /** @type {string} */ (info.escapeNamespaceObjectName);
-			const defineGetters =
-				nsObj.length > 0
-					? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
-							","
-						)}\n});\n`
-					: "";
-			if (nsObj.length > 0) {
-				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-			}
-			escapeNamespaceObjectSources.set(
-				info,
-				`
-// NAMESPACE OBJECT (decoupled): ${info.module.readableIdentifier(
-					requestShortener
-				)}
-var ${name} = {};
-${RuntimeGlobals.makeNamespaceObject}(${name});
-${defineGetters}`
-			);
-			runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
-		}
 
-		// generate namespace objects
-		/** @type {Map<ConcatenatedModuleInfo, string>} */
-		const namespaceObjectSources = new Map();
-		for (const info of neededNamespaceObjects) {
-			if (
-				info.namespaceExportSymbol ||
-				// Skip constructing namespace object generated for wrapped module
-				info.wrapped
-			) {
-				continue;
+				const exportsSource =
+					"\n// EXPORTS\n" +
+					`${RuntimeGlobals.definePropertyGetters}(${
+						this.exportsArgument
+					}, {${definitions.join(",")}\n});\n`;
+
+				const { onDemandExportsGeneration } =
+					ConcatenatedModule.getCompilationHooks(this.compilation);
+
+				if (
+					!onDemandExportsGeneration.call(
+						this,
+						runtimes,
+						exportsSource,
+						exportsFinalName
+					)
+				) {
+					result.add(exportsSource);
+				}
 			}
-			/** @type {string[]} */
-			const nsObj = [];
-			const exportsInfo = moduleGraph.getExportsInfo(info.module);
-			for (const exportInfo of exportsInfo.orderedExports) {
-				if (exportInfo.provided === false) continue;
-				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (usedName) {
-					// TODO: Replace with the inlined value directly at the call site
+
+			// list unused exports
+			if (unusedExports.size > 0) {
+				result.add(
+					`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
+				);
+			}
+
+			// list inlined exports
+			if (inlinedExports.size > 0) {
+				result.add(
+					`\n// INLINED EXPORTS: ${joinIterableWithComma(inlinedExports)}\n`
+				);
+			}
+			// #endregion
+
+			// #region [7] BUILD NS: namespace object sources are built as strings here
+			// and emitted by [8]; an external's is emitted next to its import variable
+			// or accessor instead, which is defined later.
+			//
+			// generate decoupled namespace objects for escaping mangled namespaces:
+			// same getters as the regular namespace object, but keyed by the original
+			// export names so untracked access by name keeps working. Done before the
+			// regular namespace objects so any nested namespace they pull in is built.
+			/** @type {Map<ConcatenatedModuleInfo | ExternalModuleInfo, string>} */
+			const escapeNamespaceObjectSources = new Map();
+			for (const info of neededEscapeNamespaceObjects) {
+				/** @type {string[]} */
+				const nsObj = [];
+				const exportsInfo = moduleGraph.getExportsInfo(info.module);
+				for (const exportInfo of exportsInfo.orderedExports) {
+					if (exportInfo.provided === false) continue;
+					const usedName = exportInfo.getUsedName(undefined, runtime);
+					if (!usedName) continue;
 					if (usedName instanceof InlinedUsedName) {
 						nsObj.push(
 							`\n  ${propertyName(
@@ -2630,357 +2562,451 @@ ${defineGetters}`
 							)}`
 						);
 					} else {
-						const finalName = getFinalName(
-							moduleGraph,
-							info,
-							[exportInfo.name],
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							false,
-							false,
-							undefined,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							true
-						);
+						// External (non-concatenated) modules are accessed through their
+						// import variable; concatenated ones resolve to an internal binding.
+						const finalName =
+							info.type === "external"
+								? `${getExternalModuleExpr(info)}${propertyAccess([usedName])}`
+								: getFinalName(
+										moduleGraph,
+										info,
+										[exportInfo.name],
+										moduleToInfoMap,
+										runtime,
+										requestShortener,
+										runtimeTemplate,
+										neededNamespaceObjects,
+										false,
+										false,
+										undefined,
+										/** @type {BuildMeta} */
+										(info.module.buildMeta).strictHarmonyModule,
+										true
+									);
 						nsObj.push(
 							`\n  ${propertyName(
-								usedName
+								exportInfo.name
 							)}: ${runtimeTemplate.returningFunction(finalName)}`
 						);
 					}
 				}
+				const name = /** @type {string} */ (info.escapeNamespaceObjectName);
+				const defineGetters =
+					nsObj.length > 0
+						? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
+								","
+							)}\n});\n`
+						: "";
+				if (nsObj.length > 0) {
+					runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+				}
+				escapeNamespaceObjectSources.set(
+					info,
+					`
+	// NAMESPACE OBJECT (decoupled): ${info.module.readableIdentifier(
+		requestShortener
+	)}
+	var ${name} = {};
+	${RuntimeGlobals.makeNamespaceObject}(${name});
+	${defineGetters}`
+				);
+				runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
 			}
-			const name = info.namespaceObjectName;
-			const defineGetters =
-				nsObj.length > 0
-					? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
-							","
-						)}\n});\n`
-					: "";
-			if (nsObj.length > 0) {
-				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+
+			// generate namespace objects
+			/** @type {Map<ConcatenatedModuleInfo, string>} */
+			const namespaceObjectSources = new Map();
+			for (const info of neededNamespaceObjects) {
+				if (
+					info.namespaceExportSymbol ||
+					// Skip constructing namespace object generated for wrapped module
+					info.wrapped
+				) {
+					continue;
+				}
+				/** @type {string[]} */
+				const nsObj = [];
+				const exportsInfo = moduleGraph.getExportsInfo(info.module);
+				for (const exportInfo of exportsInfo.orderedExports) {
+					if (exportInfo.provided === false) continue;
+					const usedName = exportInfo.getUsedName(undefined, runtime);
+					if (usedName) {
+						// TODO: Replace with the inlined value directly at the call site
+						if (usedName instanceof InlinedUsedName) {
+							nsObj.push(
+								`\n  ${propertyName(
+									exportInfo.name
+								)}: ${runtimeTemplate.returningFunction(
+									usedName.render(
+										Template.toNormalComment(
+											`inlined export ${propertyAccess([exportInfo.name])}`
+										)
+									)
+								)}`
+							);
+						} else {
+							const finalName = getFinalName(
+								moduleGraph,
+								info,
+								[exportInfo.name],
+								moduleToInfoMap,
+								runtime,
+								requestShortener,
+								runtimeTemplate,
+								neededNamespaceObjects,
+								false,
+								false,
+								undefined,
+								/** @type {BuildMeta} */
+								(info.module.buildMeta).strictHarmonyModule,
+								true
+							);
+							nsObj.push(
+								`\n  ${propertyName(
+									usedName
+								)}: ${runtimeTemplate.returningFunction(finalName)}`
+							);
+						}
+					}
+				}
+				const name = info.namespaceObjectName;
+				const defineGetters =
+					nsObj.length > 0
+						? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
+								","
+							)}\n});\n`
+						: "";
+				if (nsObj.length > 0) {
+					runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+				}
+				namespaceObjectSources.set(
+					info,
+					`
+	// NAMESPACE OBJECT: ${info.module.readableIdentifier(requestShortener)}
+	var ${name} = {};
+	${RuntimeGlobals.makeNamespaceObject}(${name});
+	${defineGetters}`
+				);
+				runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
 			}
-			namespaceObjectSources.set(
-				info,
-				`
-// NAMESPACE OBJECT: ${info.module.readableIdentifier(requestShortener)}
-var ${name} = {};
-${RuntimeGlobals.makeNamespaceObject}(${name});
-${defineGetters}`
+			// #endregion
+
+			// #region [8] DEFINE: define required namespace objects and wrapper
+			// (must be before evaluation modules — a cycle member calls another's
+			// accessor before that module's own position in the order)
+
+			// wrapper accessors are only called later, so their definitions may be
+			// emitted in a stable order of their own instead of concatenation order
+			/** @type {(ConcatenatedModuleInfo | ExternalModuleInfo)[]} */
+			const wrappedInfos = [];
+			for (const info of modulesWithInfo) {
+				if (
+					(info.type === "concatenated" || info.type === "external") &&
+					info.wrapped
+				) {
+					wrappedInfos.push(info);
+				}
+			}
+			const compareWrappedModules = compareModulesByFullName(
+				runtimeTemplate.compilation.compiler
 			);
-			runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
-		}
-		// #endregion
+			wrappedInfos.sort((a, b) => compareWrappedModules(a.module, b.module));
 
-		// #region [8] DEFINE: define required namespace objects and wrapper
-		// (must be before evaluation modules — a cycle member calls another's
-		// accessor before that module's own position in the order)
-
-		// wrapper accessors are only called later, so their definitions may be
-		// emitted in a stable order of their own instead of concatenation order
-		/** @type {(ConcatenatedModuleInfo | ExternalModuleInfo)[]} */
-		const wrappedInfos = [];
-		for (const info of modulesWithInfo) {
-			if (
-				(info.type === "concatenated" || info.type === "external") &&
-				info.wrapped
-			) {
-				wrappedInfos.push(info);
-			}
-		}
-		const compareWrappedModules = compareModulesByFullName(
-			runtimeTemplate.compilation.compiler
-		);
-		wrappedInfos.sort((a, b) => compareWrappedModules(a.module, b.module));
-
-		for (const info of wrappedInfos) {
-			if (info.type === "concatenated") {
-				runtimeRequirements.add(RuntimeGlobals.concatenationWrap);
-				result.add(
-					`\n// MODULE: ${info.module.readableIdentifier(
-						requestShortener
-					)}\nvar ${info.namespaceFnName} = /*#__PURE__*/${
-						RuntimeGlobals.concatenationWrap
-					}(function(${info.module.moduleArgument}, ${
-						info.module.exportsArgument
-					}) {\n`
-				);
-				result.add(/** @type {ReplaceSource} */ (info.source));
-				// A generated body (json, asset, html) binds its value to a local
-				// instead of writing exports; hand that local to the accessor. The
-				// name is verbatim: a wrapped body is not scope-analysed, so it keeps
-				// the reserved symbol the generator registered.
-				result.add(
-					info.namespaceExportSymbol
-						? `\n${info.module.moduleArgument}.exports = ${info.namespaceExportSymbol};\n});\n`
-						: "\n});\n"
-				);
-				// its getters call the accessor lazily, so this may sit right after it
-				const escapeSource = escapeNamespaceObjectSources.get(info);
-				if (escapeSource) result.add(escapeSource);
-			} else if (info.type === "external") {
-				runtimeRequirements.add(RuntimeGlobals.require);
-				const { runtimeCondition } = info;
-				const condition = runtimeTemplate.runtimeConditionExpression({
-					chunkGraph,
-					runtimeCondition,
-					runtime,
-					runtimeRequirements
-				});
-				const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
-				const body =
-					condition === "true"
-						? `return ${RuntimeGlobals.require}(${moduleId});`
-						: `if (${condition}) return ${RuntimeGlobals.require}(${moduleId});`;
-				result.add(
-					`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
-						requestShortener
-					)}\nvar ${info.namespaceFnName} = ${runtimeTemplate.basicFunction(
-						"",
-						body
-					)};\n`
-				);
-				const escapeSource = escapeNamespaceObjectSources.get(info);
-				if (escapeSource) result.add(escapeSource);
-			}
-		}
-
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				if (!info.wrapped) {
-					const source = namespaceObjectSources.get(info);
-					if (source) result.add(source);
-					const escapeSource = escapeNamespaceObjectSources.get(
-						/** @type {ConcatenatedModuleInfo} */ (info)
+			for (const info of wrappedInfos) {
+				if (info.type === "concatenated") {
+					runtimeRequirements.add(RuntimeGlobals.concatenationWrap);
+					result.add(
+						`\n// MODULE: ${info.module.readableIdentifier(
+							requestShortener
+						)}\nvar ${info.namespaceFnName} = /*#__PURE__*/${
+							RuntimeGlobals.concatenationWrap
+						}(function(${info.module.moduleArgument}, ${
+							info.module.exportsArgument
+						}) {\n`
 					);
+					result.add(/** @type {ReplaceSource} */ (info.source));
+					// A generated body (json, asset, html) binds its value to a local
+					// instead of writing exports; hand that local to the accessor. The
+					// name is verbatim: a wrapped body is not scope-analysed, so it keeps
+					// the reserved symbol the generator registered.
+					result.add(
+						info.namespaceExportSymbol
+							? `\n${info.module.moduleArgument}.exports = ${info.namespaceExportSymbol};\n});\n`
+							: "\n});\n"
+					);
+					// its getters call the accessor lazily, so this may sit right after it
+					const escapeSource = escapeNamespaceObjectSources.get(info);
+					if (escapeSource) result.add(escapeSource);
+				} else if (info.type === "external") {
+					runtimeRequirements.add(RuntimeGlobals.require);
+					const { runtimeCondition } = info;
+					const condition = runtimeTemplate.runtimeConditionExpression({
+						chunkGraph,
+						runtimeCondition,
+						runtime,
+						runtimeRequirements
+					});
+					const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
+					const body =
+						condition === "true"
+							? `return ${RuntimeGlobals.require}(${moduleId});`
+							: `if (${condition}) return ${RuntimeGlobals.require}(${moduleId});`;
+					result.add(
+						`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
+							requestShortener
+						)}\nvar ${info.namespaceFnName} = ${runtimeTemplate.basicFunction(
+							"",
+							body
+						)};\n`
+					);
+					const escapeSource = escapeNamespaceObjectSources.get(info);
 					if (escapeSource) result.add(escapeSource);
 				}
-			} else if (info.type === "external" && info.deferred) {
-				const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
-				const loader = getOptimizedDeferredModule(
-					moduleId,
-					getExportsType(
-						moduleGraph,
-						info,
-						/** @type {BuildMeta} */
-						(this.rootModule.buildMeta).strictHarmonyModule
-					),
-					// an async module will opt-out of the concat module optimization.
-					[],
-					// A closure member absorbed into this concatenation shares this
-					// module's runtime id (and thus its `evaluating` flag); resolve it
-					// to that id instead of the member's now-absent standalone id.
-					getDeferredCycleModuleIds(
-						getDeferredCycleModules(moduleGraph, info.module),
-						(mod) =>
-							moduleToInfoMap.has(mod)
-								? chunkGraph.getModuleId(this)
-								: chunkGraph.getModuleId(mod)
-					),
-					runtimeRequirements
-				);
-				runtimeRequirements.add(RuntimeGlobals.require);
-				result.add(
-					`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(
-						requestShortener
-					)}\nvar ${info.deferredName} = ${loader};`
-				);
-				if (info.deferredNamespaceObjectUsed) {
-					runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
-					result.add(
-						`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
-							RuntimeGlobals.makeDeferredNamespaceObject
-						}(${JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						)}, ${getMakeDeferredNamespaceModeFromExportsType(
-							getExportsType(moduleGraph, info, strictHarmonyModule)
-						)});`
+			}
+
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					if (!info.wrapped) {
+						const source = namespaceObjectSources.get(info);
+						if (source) result.add(source);
+						const escapeSource = escapeNamespaceObjectSources.get(
+							/** @type {ConcatenatedModuleInfo} */ (info)
+						);
+						if (escapeSource) result.add(escapeSource);
+					}
+				} else if (info.type === "external" && info.deferred) {
+					const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
+					const loader = getOptimizedDeferredModule(
+						moduleId,
+						getExportsType(
+							moduleGraph,
+							info,
+							/** @type {BuildMeta} */
+							(this.rootModule.buildMeta).strictHarmonyModule
+						),
+						// an async module will opt-out of the concat module optimization.
+						[],
+						// A closure member absorbed into this concatenation shares this
+						// module's runtime id (and thus its `evaluating` flag); resolve it
+						// to that id instead of the member's now-absent standalone id.
+						getDeferredCycleModuleIds(
+							getDeferredCycleModules(moduleGraph, info.module),
+							(mod) =>
+								moduleToInfoMap.has(mod)
+									? chunkGraph.getModuleId(this)
+									: chunkGraph.getModuleId(mod)
+						),
+						runtimeRequirements
 					);
+					runtimeRequirements.add(RuntimeGlobals.require);
+					result.add(
+						`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(
+							requestShortener
+						)}\nvar ${info.deferredName} = ${loader};`
+					);
+					if (info.deferredNamespaceObjectUsed) {
+						runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
+						result.add(
+							`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
+								RuntimeGlobals.makeDeferredNamespaceObject
+							}(${JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							)}, ${getMakeDeferredNamespaceModeFromExportsType(
+								getExportsType(moduleGraph, info, strictHarmonyModule)
+							)});`
+						);
+					}
 				}
 			}
-		}
 
-		// #endregion
+			// #endregion
 
-		// #region [9] EVALUATE: emit the bodies in concatenation order and collect
-		// what they need — runtime requirements, chunk init fragments, interop
-		/** @type {InitFragment<ChunkRenderContext>[]} */
-		const chunkInitFragments = [];
+			// #region [9] EVALUATE: emit the bodies in concatenation order and collect
+			// what they need — runtime requirements, chunk init fragments, interop
+			/** @type {InitFragment<ChunkRenderContext>[]} */
+			const chunkInitFragments = [];
 
-		for (const rawInfo of modulesWithInfo) {
-			/** @type {undefined | string} */
-			let name;
-			let isConditional = false;
-			const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
-			switch (info.type) {
-				case "concatenated": {
-					name = info.namespaceObjectName;
-					// wrapped bodies are emitted above, evaluated at their call sites
-					if (info.wrapped && info.eager) {
-						// This slot is the module's place in evaluation order; calling from
-						// the importing body would run it too late.
-						result.add(
-							`\n;// ${info.module.readableIdentifier(
-								requestShortener
-							)}\n${info.namespaceFnName}();\n`
-						);
-					} else if (!info.wrapped) {
-						result.add(
-							`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
-						);
-						result.add(/** @type {ReplaceSource} */ (info.source));
-					}
-
-					if (info.chunkInitFragments) {
-						for (const f of info.chunkInitFragments) chunkInitFragments.push(f);
-					}
-					if (info.runtimeRequirements) {
-						for (const r of info.runtimeRequirements) {
-							// Wrapped module supplies module/exports/this itself
-							if (
-								info.wrapped &&
-								(r === RuntimeGlobals.module ||
-									r === RuntimeGlobals.exports ||
-									r === RuntimeGlobals.thisAsExports)
-							) {
-								continue;
-							}
-							runtimeRequirements.add(r);
+			for (const rawInfo of modulesWithInfo) {
+				/** @type {undefined | string} */
+				let name;
+				let isConditional = false;
+				const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
+				switch (info.type) {
+					case "concatenated": {
+						name = info.namespaceObjectName;
+						// wrapped bodies are emitted above, evaluated at their call sites
+						if (info.wrapped && info.eager) {
+							// This slot is the module's place in evaluation order; calling from
+							// the importing body would run it too late.
+							result.add(
+								`\n;// ${info.module.readableIdentifier(
+									requestShortener
+								)}\n${info.namespaceFnName}();\n`
+							);
+						} else if (!info.wrapped) {
+							result.add(
+								`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
+							);
+							result.add(/** @type {ReplaceSource} */ (info.source));
 						}
-					}
 
-					break;
-				}
-				case "external": {
-					name = getExternalModuleExpr(info);
-					// deferred and wrapped cases are handled in the "const info of modulesWithInfo" loop above
-					if (!info.deferred && !info.wrapped) {
-						result.add(
-							`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
-								requestShortener
-							)}\n`
-						);
-						runtimeRequirements.add(RuntimeGlobals.require);
-						const { runtimeCondition } =
+						if (info.chunkInitFragments) {
+							for (const f of info.chunkInitFragments) {
+								chunkInitFragments.push(f);
+							}
+						}
+						if (info.runtimeRequirements) {
+							for (const r of info.runtimeRequirements) {
+								// Wrapped module supplies module/exports/this itself
+								if (
+									info.wrapped &&
+									(r === RuntimeGlobals.module ||
+										r === RuntimeGlobals.exports ||
+										r === RuntimeGlobals.thisAsExports)
+								) {
+									continue;
+								}
+								runtimeRequirements.add(r);
+							}
+						}
+
+						break;
+					}
+					case "external": {
+						name = getExternalModuleExpr(info);
+						// deferred and wrapped cases are handled in the "const info of modulesWithInfo" loop above
+						if (!info.deferred && !info.wrapped) {
+							result.add(
+								`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
+									requestShortener
+								)}\n`
+							);
+							runtimeRequirements.add(RuntimeGlobals.require);
+							const { runtimeCondition } =
+								/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
+								(rawInfo);
+							const condition = runtimeTemplate.runtimeConditionExpression({
+								chunkGraph,
+								runtimeCondition,
+								runtime,
+								runtimeRequirements
+							});
+							if (condition !== "true") {
+								isConditional = true;
+								result.add(`if (${condition}) {\n`);
+							}
+							const moduleId = JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							);
+							// External module bindings may be wrapped in
+							// runtime-condition `if` blocks but referenced outside,
+							// so they must remain function-scoped (`var`).
+							result.add(
+								`var ${info.name} = __webpack_require__(${moduleId});`
+							);
+
+							// Decoupled namespace object for an escaping mangled external
+							// module must come after its import variable is defined.
+							const escapeSource = escapeNamespaceObjectSources.get(info);
+							if (escapeSource) result.add(escapeSource);
+						} else if (info.wrapped && info.eager) {
+							result.add(
+								`\n;// EXTERNAL MODULE: ${info.module.readableIdentifier(
+									requestShortener
+								)}\n${info.namespaceFnName}();\n`
+							);
+						}
+						// If a module is deferred in other places, but used as non-deferred here,
+						// the module itself will be emitted as mod_deferred (in the case "external"),
+						// we need to emit an extra import declaration to evaluate it in order.
+						const { nonDeferAccess } =
 							/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
 							(rawInfo);
-						const condition = runtimeTemplate.runtimeConditionExpression({
-							chunkGraph,
-							runtimeCondition,
-							runtime,
-							runtimeRequirements
-						});
-						if (condition !== "true") {
-							isConditional = true;
-							result.add(`if (${condition}) {\n`);
+						if (info.deferred && nonDeferAccess && !info.wrapped) {
+							result.add(
+								`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(
+									requestShortener
+								)})\nvar ${info.name} = ${info.deferredName}.a;`
+							);
 						}
-						const moduleId = JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						);
-						// External module bindings may be wrapped in
-						// runtime-condition `if` blocks but referenced outside,
-						// so they must remain function-scoped (`var`).
-						result.add(`var ${info.name} = __webpack_require__(${moduleId});`);
-
-						// Decoupled namespace object for an escaping mangled external
-						// module must come after its import variable is defined.
-						const escapeSource = escapeNamespaceObjectSources.get(info);
-						if (escapeSource) result.add(escapeSource);
-					} else if (info.wrapped && info.eager) {
-						result.add(
-							`\n;// EXTERNAL MODULE: ${info.module.readableIdentifier(
-								requestShortener
-							)}\n${info.namespaceFnName}();\n`
-						);
+						break;
 					}
-					// If a module is deferred in other places, but used as non-deferred here,
-					// the module itself will be emitted as mod_deferred (in the case "external"),
-					// we need to emit an extra import declaration to evaluate it in order.
-					const { nonDeferAccess } =
-						/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
-						(rawInfo);
-					if (info.deferred && nonDeferAccess && !info.wrapped) {
-						result.add(
-							`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(
-								requestShortener
-							)})\nvar ${info.name} = ${info.deferredName}.a;`
-						);
+					default: {
+						const { type } = /** @type {{ type: string }} */ (info);
+						throw new Error(`Unsupported concatenation entry type ${type}`);
 					}
-					break;
 				}
-				default:
-					// @ts-expect-error never is expected here
-					throw new Error(`Unsupported concatenation entry type ${info.type}`);
+				// Building a wrapped module's interop object here would evaluate its body
+				// at the top level and break require() cycles, so defer it behind a
+				// hoisted function. The memo lives on the function object: it keeps the
+				// identity stable without claiming a second top-level name.
+				/**
+				 * @param {string} interopName interop variable name
+				 * @param {string} expr interop object expression
+				 * @returns {string} the declaration
+				 */
+				const declareInterop = (interopName, expr) =>
+					info.wrapped
+						? `\nfunction ${interopName}() { return ${interopName}.c || (${interopName}.c = ${expr}); }`
+						: `\nvar ${interopName} = /*#__PURE__*/${expr};`;
+				if (info.interopNamespaceObjectUsed) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						declareInterop(
+							/** @type {string} */ (info.interopNamespaceObjectName),
+							`${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2)`
+						)
+					);
+				}
+				if (info.interopNamespaceObject2Used) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						declareInterop(
+							/** @type {string} */ (info.interopNamespaceObject2Name),
+							`${RuntimeGlobals.createFakeNamespaceObject}(${name})`
+						)
+					);
+				}
+				if (info.interopDefaultAccessUsed) {
+					runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
+					result.add(
+						declareInterop(
+							/** @type {string} */ (info.interopDefaultAccessName),
+							`${RuntimeGlobals.compatGetDefaultExport}(${name})`
+						)
+					);
+				}
+				if (isConditional) {
+					result.add("\n}");
+				}
 			}
-			// Building a wrapped module's interop object here would evaluate its body
-			// at the top level and break require() cycles, so defer it behind a
-			// hoisted function. The memo lives on the function object: it keeps the
-			// identity stable without claiming a second top-level name.
-			/**
-			 * @param {string} interopName interop variable name
-			 * @param {string} expr interop object expression
-			 * @returns {string} the declaration
-			 */
-			const declareInterop = (interopName, expr) =>
-				info.wrapped
-					? `\nfunction ${interopName}() { return ${interopName}.c || (${interopName}.c = ${expr}); }`
-					: `\nvar ${interopName} = /*#__PURE__*/${expr};`;
-			if (info.interopNamespaceObjectUsed) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					declareInterop(
-						/** @type {string} */ (info.interopNamespaceObjectName),
-						`${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2)`
-					)
-				);
-			}
-			if (info.interopNamespaceObject2Used) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					declareInterop(
-						/** @type {string} */ (info.interopNamespaceObject2Name),
-						`${RuntimeGlobals.createFakeNamespaceObject}(${name})`
-					)
-				);
-			}
-			if (info.interopDefaultAccessUsed) {
-				runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
-				result.add(
-					declareInterop(
-						/** @type {string} */ (info.interopDefaultAccessName),
-						`${RuntimeGlobals.compatGetDefaultExport}(${name})`
-					)
-				);
-			}
-			if (isConditional) {
-				result.add("\n}");
-			}
-		}
-		// #endregion
+			// #endregion
 
-		// #region [10] RESULT: topLevelDeclarations and freeNames let consumers
-		// (mangling, an outer concatenation) reason about this source unparsed
-		/** @type {CodeGenerationResultData} */
-		const data = new Map();
-		if (chunkInitFragments.length > 0) {
-			data.set("chunkInitFragments", chunkInitFragments);
-		}
-		data.set("topLevelDeclarations", topLevelDeclarations);
-		data.set("freeNames", freeNames);
+			// #region [10] RESULT: topLevelDeclarations and freeNames let consumers
+			// (mangling, an outer concatenation) reason about this source unparsed
+			/** @type {CodeGenerationResultData} */
+			const data = new Map();
+			if (chunkInitFragments.length > 0) {
+				data.set("chunkInitFragments", chunkInitFragments);
+			}
+			data.set("topLevelDeclarations", topLevelDeclarations);
+			data.set("freeNames", freeNames);
 
-		/** @type {CodeGenerationResult} */
-		const resultEntry = {
-			sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
-			data,
-			runtimeRequirements
+			/** @type {CodeGenerationResult} */
+			const resultEntry = {
+				sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
+				data,
+				runtimeRequirements
+			};
+			// #endregion
+
+			return resultEntry;
 		};
-		// #endregion
 
-		return resultEntry;
+		if (analysisPromises !== undefined) {
+			return Promise.all(analysisPromises).then(continueCodeGeneration);
+		}
+		return continueCodeGeneration();
 	}
 
 	/**
@@ -2994,6 +3020,7 @@ ${defineGetters}`
 	 * @param {RuntimeSpec[]} runtimes runtimes
 	 * @param {CodeGenerationResults} codeGenerationResults codeGenerationResults
 	 * @param {UsedNames} usedNames used names
+	 * @returns {void | Promise<void>} void or promise when an inner module generates async
 	 */
 	_analyseModule(
 		modulesMap,
@@ -3020,6 +3047,21 @@ ${defineGetters}`
 					usedNames
 				);
 				info.concatenationScope = concatenationScope;
+				/**
+				 * @param {import("../Module").CodeGenerationResult} codeGenResult result
+				 */
+				const processWrappedResult = (codeGenResult) => {
+					const source =
+						/** @type {Source} */
+						(codeGenResult.sources.get(JAVASCRIPT_TYPE));
+					const data = codeGenResult.data;
+					info.runtimeRequirements =
+						/** @type {ReadOnlyRuntimeRequirements} */
+						(codeGenResult.runtimeRequirements);
+					info.internalSource = source;
+					info.source = new ReplaceSource(source);
+					info.chunkInitFragments = data && data.get("chunkInitFragments");
+				};
 				const codeGenResult = m.codeGeneration({
 					dependencyTemplates,
 					runtimeTemplate,
@@ -3031,16 +3073,10 @@ ${defineGetters}`
 					codeGenerationResults,
 					sourceTypes: JAVASCRIPT_TYPES
 				});
-				const source =
-					/** @type {Source} */
-					(codeGenResult.sources.get(JAVASCRIPT_TYPE));
-				const data = codeGenResult.data;
-				info.runtimeRequirements =
-					/** @type {ReadOnlyRuntimeRequirements} */
-					(codeGenResult.runtimeRequirements);
-				info.internalSource = source;
-				info.source = new ReplaceSource(source);
-				info.chunkInitFragments = data && data.get("chunkInitFragments");
+				if (isPromise(codeGenResult)) {
+					return codeGenResult.then(processWrappedResult);
+				}
+				processWrappedResult(codeGenResult);
 			} else {
 				try {
 					// Create a concatenation scope to track and capture information
@@ -3049,6 +3085,76 @@ ${defineGetters}`
 						info,
 						usedNames
 					);
+
+					/**
+					 * @param {import("../Module").CodeGenerationResult} codeGenResult result
+					 */
+					const processResult = (codeGenResult) => {
+						const source =
+							/** @type {Source} */
+							(codeGenResult.sources.get(JAVASCRIPT_TYPE));
+						const data = codeGenResult.data;
+						const chunkInitFragments = data && data.get("chunkInitFragments");
+						const code = source.source().toString();
+
+						/** @type {Program} */
+						let ast;
+
+						try {
+							const { experiments } = this.compilation.options;
+
+							({ ast } = JavascriptParser._parse(
+								code,
+								{
+									sourceType: "module",
+									ranges: true,
+									// generated code contains phase imports when the experiments are on
+									importPhases: Boolean(
+										experiments.deferImport || experiments.sourceImport
+									)
+								},
+								JavascriptParser._getModuleParseFunction(this.compilation, m)
+							));
+						} catch (_err) {
+							const err =
+								/** @type {Error & { loc?: { line: number, column: number } }} */
+								(_err);
+							if (
+								err.loc &&
+								typeof err.loc === "object" &&
+								typeof err.loc.line === "number"
+							) {
+								const lineNumber = err.loc.line;
+								const lines = code.split("\n");
+								err.message += `\n| ${lines
+									.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
+									.join("\n| ")}`;
+							}
+							throw err;
+						}
+						const scopeManager = eslintScope.analyze(ast, {
+							ecmaVersion: 6,
+							sourceType: "module",
+							optimistic: true,
+							ignoreEval: true,
+							impliedStrict: true
+						});
+						const globalScope = /** @type {Scope} */ (
+							scopeManager.acquire(ast)
+						);
+						const moduleScope = globalScope.childScopes[0];
+						const resultSource = new ReplaceSource(source);
+						info.runtimeRequirements =
+							/** @type {ReadOnlyRuntimeRequirements} */
+							(codeGenResult.runtimeRequirements);
+						info.ast = ast;
+						info.internalSource = source;
+						info.source = resultSource;
+						info.chunkInitFragments = chunkInitFragments;
+						info.globalScope = globalScope;
+						info.moduleScope = moduleScope;
+						info.concatenationScope = concatenationScope;
+					};
 
 					// Not cached: Compilation memoizes the outer codeGeneration per
 					// (module, runtime), so inner generation never recomputes usefully.
@@ -3063,68 +3169,15 @@ ${defineGetters}`
 						codeGenerationResults,
 						sourceTypes: JAVASCRIPT_TYPES
 					});
-					const source =
-						/** @type {Source} */
-						(codeGenResult.sources.get(JAVASCRIPT_TYPE));
-					const data = codeGenResult.data;
-					const chunkInitFragments = data && data.get("chunkInitFragments");
-					const code = source.source().toString();
-
-					/** @type {Program} */
-					let ast;
-
-					try {
-						const { experiments } = this.compilation.options;
-
-						({ ast } = JavascriptParser._parse(
-							code,
-							{
-								sourceType: "module",
-								ranges: true,
-								// generated code contains phase imports when the experiments are on
-								importPhases: Boolean(
-									experiments.deferImport || experiments.sourceImport
-								)
-							},
-							JavascriptParser._getModuleParseFunction(this.compilation, m)
-						));
-					} catch (_err) {
-						const err =
-							/** @type {Error & { loc?: { line: number, column: number } }} */
-							(_err);
-						if (
-							err.loc &&
-							typeof err.loc === "object" &&
-							typeof err.loc.line === "number"
-						) {
-							const lineNumber = err.loc.line;
-							const lines = code.split("\n");
-							err.message += `\n| ${lines
-								.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
-								.join("\n| ")}`;
-						}
-						throw err;
+					if (isPromise(codeGenResult)) {
+						return codeGenResult.then(processResult).catch((err) => {
+							/** @type {Error} */
+							(err).message +=
+								`\nwhile analyzing module ${m.identifier()} for concatenation`;
+							throw err;
+						});
 					}
-					const scopeManager = eslintScope.analyze(ast, {
-						ecmaVersion: 6,
-						sourceType: "module",
-						optimistic: true,
-						ignoreEval: true,
-						impliedStrict: true
-					});
-					const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
-					const moduleScope = globalScope.childScopes[0];
-					const resultSource = new ReplaceSource(source);
-					info.runtimeRequirements =
-						/** @type {ReadOnlyRuntimeRequirements} */
-						(codeGenResult.runtimeRequirements);
-					info.ast = ast;
-					info.internalSource = source;
-					info.source = resultSource;
-					info.chunkInitFragments = chunkInitFragments;
-					info.globalScope = globalScope;
-					info.moduleScope = moduleScope;
-					info.concatenationScope = concatenationScope;
+					processResult(codeGenResult);
 				} catch (err) {
 					/** @type {Error} */
 					(err).message +=

--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -260,7 +260,7 @@ class ConsumeSharedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ chunkGraph, runtimeTemplate }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.shareScopeMap]);

--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -261,7 +261,7 @@ class ConsumeSharedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ chunkGraph, runtimeTemplate }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.shareScopeMap]);

--- a/lib/sharing/ProvideSharedModule.js
+++ b/lib/sharing/ProvideSharedModule.js
@@ -137,7 +137,7 @@ class ProvideSharedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.initializeSharing]);

--- a/lib/sharing/ProvideSharedModule.js
+++ b/lib/sharing/ProvideSharedModule.js
@@ -142,7 +142,7 @@ class ProvideSharedModule extends Module {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.initializeSharing]);

--- a/lib/util/isPromise.js
+++ b/lib/util/isPromise.js
@@ -1,0 +1,18 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+/**
+ * Duck-type check for Promise-like values (same realm or not).
+ * @param {unknown} value value that may be async
+ * @returns {value is Promise<EXPECTED_ANY>} true when value is Promise-like
+ */
+const isPromise = (value) =>
+	Boolean(value) &&
+	typeof value === "object" &&
+	typeof (/** @type {{ then?: unknown }} */ (value).then) === "function";
+
+module.exports = isPromise;

--- a/lib/wasm-async/AsyncWebAssemblyGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyGenerator.js
@@ -11,6 +11,7 @@ const { WEBASSEMBLY_TYPES } = require("../ModuleSourceTypeConstants");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
 /** @typedef {import("../NormalModule")} NormalModule */
@@ -59,7 +60,7 @@ class AsyncWebAssemblyGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		return /** @type {Source} */ (module.originalSource());

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -16,6 +16,7 @@ const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDe
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("./AsyncWebAssemblyModulesPlugin").AsyncWasmModuleClass} AsyncWasmModule */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -56,7 +57,7 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -16,6 +16,7 @@ const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDe
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("./AsyncWasmModule")} AsyncWasmModule */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -56,7 +57,7 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/wasm-sync/WebAssemblyGenerator.js
+++ b/lib/wasm-sync/WebAssemblyGenerator.js
@@ -17,6 +17,7 @@ const WebAssemblyUtils = require("./WebAssemblyUtils");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
@@ -456,7 +457,7 @@ class WebAssemblyGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, { moduleGraph, runtime }) {
 		const bin =

--- a/lib/wasm-sync/WebAssemblyGenerator.js
+++ b/lib/wasm-sync/WebAssemblyGenerator.js
@@ -17,6 +17,7 @@ const WebAssemblyUtils = require("./WebAssemblyUtils");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
@@ -457,7 +458,7 @@ class WebAssemblyGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, { moduleGraph, runtime }) {
 		const bin =

--- a/lib/wasm-sync/WebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-sync/WebAssemblyJavascriptGenerator.js
@@ -18,6 +18,7 @@ const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDe
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").GenerateResult} GenerateResult */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -47,7 +48,7 @@ class WebAssemblyJavascriptGenerator extends Generator {
 	 * Generates generated code for this runtime module.
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {GenerateResult} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/test/Template.unittest.js
+++ b/test/Template.unittest.js
@@ -42,4 +42,41 @@ describe("Template", () => {
 		expect(content).toContain("// keep this line comment");
 		expect(content).toContain("/* keep */");
 	});
+
+	it("should reject async codeGeneration in renderRuntimeModules", () => {
+		/**
+		 * @param {() => unknown} codeGeneration codeGeneration implementation
+		 * @returns {import("webpack-sources").Source} rendered source
+		 */
+		const render = (codeGeneration) =>
+			Template.renderRuntimeModules(
+				[
+					/** @type {import("../lib/RuntimeModule")} */
+					(
+						/** @type {unknown} */ ({
+							identifier: () => "runtime-module",
+							codeGeneration
+						})
+					)
+				],
+				/** @type {EXPECTED_ANY} */ ({
+					chunk: { runtime: undefined },
+					chunkGraph: {},
+					dependencyTemplates: {},
+					moduleGraph: {},
+					runtimeTemplate: {}
+				})
+			);
+
+		expect(() => render(() => Promise.resolve({ sources: new Map() }))).toThrow(
+			/does not support async codeGeneration/
+		);
+		expect(() =>
+			render(() => ({
+				// eslint-disable-next-line unicorn/no-thenable
+				then: (/** @type {(value: unknown) => void} */ resolve) =>
+					resolve({ sources: new Map() })
+			}))
+		).toThrow(/does not support async codeGeneration/);
+	});
 });

--- a/test/configCases/code-generation/async-generate-error/__snapshots__/errors.snap
+++ b/test/configCases/code-generation/async-generate-error/__snapshots__/errors.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`errors 1`] = `
+Array [
+  Object {
+    "message": "async code generation failed",
+    "moduleName": "./error-module.js",
+  },
+]
+`;

--- a/test/configCases/code-generation/async-generate-error/__snapshots__/errors.snap
+++ b/test/configCases/code-generation/async-generate-error/__snapshots__/errors.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`errors 1`] = `
+Array [
+  "async code generation failed",
+]
+`;

--- a/test/configCases/code-generation/async-generate-error/error-module.js
+++ b/test/configCases/code-generation/async-generate-error/error-module.js
@@ -1,0 +1,3 @@
+export function getValue() {
+	return 42;
+}

--- a/test/configCases/code-generation/async-generate-error/index.js
+++ b/test/configCases/code-generation/async-generate-error/index.js
@@ -1,0 +1,9 @@
+it("should report async code generation error in stats", () => {
+	const errors = __STATS__.errors;
+	expect(errors).toHaveLength(1);
+	expect(errors[0].message).toMatch(/async code generation failed/);
+});
+
+it("should still build entry without errors", () => {
+	expect(1 + 1).toBe(2);
+});

--- a/test/configCases/code-generation/async-generate-error/test.filter.js
+++ b/test/configCases/code-generation/async-generate-error/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Async code generation errors are intentionally not cached,
+// so this test is incompatible with the cache test runner.
+module.exports = (config) => !config.cache;

--- a/test/configCases/code-generation/async-generate-error/webpack.config.js
+++ b/test/configCases/code-generation/async-generate-error/webpack.config.js
@@ -1,0 +1,44 @@
+"use strict";
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+/** @typedef {import("../../../../lib/NormalModule")} NormalModule */
+
+class AsyncCodeGenErrorPlugin {
+	/**
+	 * @param {Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("AsyncCodeGenErrorPlugin", (compilation) => {
+			compilation.hooks.succeedModule.tap(
+				"AsyncCodeGenErrorPlugin",
+				(module) => {
+					const normalModule = /** @type {NormalModule} */ (
+						/** @type {unknown} */ (module)
+					);
+					if (!normalModule.resource) return;
+					if (!normalModule.resource.includes("error-module")) return;
+
+					normalModule.codeGeneration = () =>
+						Promise.reject(new Error("async code generation failed"));
+				}
+			);
+		});
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		bundle0: "./index.js",
+		error: "./error-module.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [new AsyncCodeGenErrorPlugin()],
+	optimization: {
+		emitOnErrors: true,
+		concatenateModules: false,
+		inlineExports: false
+	}
+};

--- a/test/configCases/code-generation/async-generate/async-module.css
+++ b/test/configCases/code-generation/async-generate/async-module.css
@@ -1,0 +1,3 @@
+.test-class {
+	color: red;
+}

--- a/test/configCases/code-generation/async-generate/async-module.js
+++ b/test/configCases/code-generation/async-generate/async-module.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/code-generation/async-generate/index.js
+++ b/test/configCases/code-generation/async-generate/index.js
@@ -1,0 +1,7 @@
+import { value } from "./async-module";
+import { derived } from "./sync-module";
+
+it("should handle async code generation", () => {
+	expect(value).toBe(42);
+	expect(derived).toBe(43);
+});

--- a/test/configCases/code-generation/async-generate/index.js
+++ b/test/configCases/code-generation/async-generate/index.js
@@ -1,0 +1,12 @@
+import { value } from "./async-module";
+import { derived } from "./sync-module";
+import cssText from "./async-module.css";
+
+it("should handle async code generation", () => {
+	expect(value).toBe(42);
+	expect(derived).toBe(43);
+});
+
+it("should handle async CssModule code generation", () => {
+	expect(cssText).toMatch(/color:\s*red/);
+});

--- a/test/configCases/code-generation/async-generate/sync-module.js
+++ b/test/configCases/code-generation/async-generate/sync-module.js
@@ -1,0 +1,2 @@
+import { value } from "./async-module";
+export const derived = value + 1;

--- a/test/configCases/code-generation/async-generate/webpack.config.js
+++ b/test/configCases/code-generation/async-generate/webpack.config.js
@@ -1,0 +1,65 @@
+"use strict";
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+/** @typedef {import("../../../../lib/NormalModule")} NormalModule */
+
+class AsyncCodeGenPlugin {
+	/**
+	 * @param {{ wrapGenerator?: boolean }} options options
+	 */
+	constructor(options = {}) {
+		this.wrapGenerator = options.wrapGenerator || false;
+	}
+
+	/**
+	 * @param {Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("AsyncCodeGenPlugin", (compilation) => {
+			compilation.hooks.succeedModule.tap("AsyncCodeGenPlugin", (module) => {
+				const normalModule = /** @type {NormalModule} */ (
+					/** @type {unknown} */ (module)
+				);
+				if (!normalModule.resource) return;
+				if (!normalModule.resource.includes("async-module")) return;
+
+				if (this.wrapGenerator && normalModule.generator) {
+					const origGen = normalModule.generator;
+					const wrappedGen = Object.create(origGen);
+					/** @type {typeof origGen.generate} */
+					wrappedGen.generate = function generate(mod, ctx) {
+						const result = origGen.generate(mod, ctx);
+						return Promise.resolve(result);
+					};
+					normalModule.generator = wrappedGen;
+				} else {
+					const origCodeGen = normalModule.codeGeneration.bind(normalModule);
+					normalModule.codeGeneration = (context) =>
+						Promise.resolve(origCodeGen(context));
+				}
+			});
+		});
+	}
+}
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		// Generator.generate() returns Promise<Source>
+		// Tests NormalModule promise collection and Compilation async dispatch
+		plugins: [new AsyncCodeGenPlugin({ wrapGenerator: true })],
+		optimization: { concatenateModules: false }
+	},
+	{
+		// Module.codeGeneration() returns Promise<CodeGenerationResult>
+		// Tests Compilation._codeGenerationModule async dispatch
+		plugins: [new AsyncCodeGenPlugin({ wrapGenerator: false })],
+		optimization: { concatenateModules: false }
+	},
+	{
+		// Inner module's codeGeneration() returns Promise inside ConcatenatedModule
+		// Tests ConcatenatedModule._analyseModule async path
+		plugins: [new AsyncCodeGenPlugin({ wrapGenerator: false })],
+		optimization: { concatenateModules: true }
+	}
+];

--- a/test/configCases/code-generation/async-generate/webpack.config.js
+++ b/test/configCases/code-generation/async-generate/webpack.config.js
@@ -1,0 +1,97 @@
+"use strict";
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+/** @typedef {import("../../../../lib/NormalModule")} NormalModule */
+
+class AsyncCodeGenPlugin {
+	/**
+	 * @param {{ wrapGenerator?: boolean }} options options
+	 */
+	constructor(options = {}) {
+		this.wrapGenerator = options.wrapGenerator || false;
+	}
+
+	/**
+	 * @param {Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("AsyncCodeGenPlugin", (compilation) => {
+			compilation.hooks.succeedModule.tap("AsyncCodeGenPlugin", (module) => {
+				const normalModule = /** @type {NormalModule} */ (
+					/** @type {unknown} */ (module)
+				);
+				if (!normalModule.resource) return;
+				if (!normalModule.resource.includes("async-module")) return;
+
+				if (this.wrapGenerator && normalModule.generator) {
+					const origGen = normalModule.generator;
+					const wrappedGen = Object.create(origGen);
+					/** @type {typeof origGen.generate} */
+					wrappedGen.generate = function generate(mod, ctx) {
+						const result = origGen.generate(mod, ctx);
+						return Promise.resolve(result);
+					};
+					normalModule.generator = wrappedGen;
+				} else {
+					const origCodeGen = normalModule.codeGeneration.bind(normalModule);
+					normalModule.codeGeneration = (context) =>
+						Promise.resolve(origCodeGen(context));
+				}
+			});
+		});
+	}
+}
+
+/**
+ * @param {object} options options
+ * @param {boolean=} options.wrapGenerator wrap Generator.generate
+ * @param {boolean=} options.concatenateModules enable concatenation
+ * @param {string=} options.name config name
+ * @returns {import("../../../../").Configuration} webpack configuration
+ */
+function createConfig({ wrapGenerator, concatenateModules, name }) {
+	return {
+		name,
+		target: "web",
+		mode: "development",
+		devtool: false,
+		plugins: [new AsyncCodeGenPlugin({ wrapGenerator })],
+		optimization: {
+			concatenateModules: Boolean(concatenateModules),
+			usedExports: false
+		},
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					parser: {
+						exportType: "text"
+					}
+				}
+			]
+		},
+		experiments: {
+			css: true
+		}
+	};
+}
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	createConfig({
+		name: "async-generate",
+		wrapGenerator: true,
+		concatenateModules: false
+	}),
+	createConfig({
+		name: "async-codeGeneration",
+		wrapGenerator: false,
+		concatenateModules: false
+	}),
+	createConfig({
+		name: "async-generate-css-concat",
+		wrapGenerator: true,
+		concatenateModules: true
+	})
+];

--- a/test/isPromise.unittest.js
+++ b/test/isPromise.unittest.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const isPromise = require("../lib/util/isPromise");
+
+describe("isPromise", () => {
+	it("should accept native Promises", () => {
+		expect(isPromise(Promise.resolve(1))).toBe(true);
+		expect(isPromise(new Promise(() => {}))).toBe(true);
+	});
+
+	it("should accept Promise-like values", () => {
+		// eslint-disable-next-line unicorn/no-thenable
+		expect(isPromise({ then() {} })).toBe(true);
+	});
+
+	it("should reject values that are not Promise-like", () => {
+		expect(isPromise(null)).toBe(false);
+		expect(isPromise(undefined)).toBe(false);
+		expect(isPromise(0)).toBe(false);
+		expect(isPromise("then")).toBe(false);
+		expect(isPromise({})).toBe(false);
+		// eslint-disable-next-line unicorn/no-thenable
+		expect(isPromise({ then: 1 })).toBe(false);
+		expect(isPromise(() => {})).toBe(false);
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -5286,7 +5286,7 @@ declare abstract class CssGenerator extends Generator {
 		error: Error,
 		module: NormalModule,
 		generateContext: GenerateContext
-	): null | Source;
+	): GenerateResult;
 }
 
 /**
@@ -8524,6 +8524,7 @@ declare interface GenerateContext {
 	 */
 	getData?: () => CodeGenerationResultData;
 }
+type GenerateResult = null | Source | Promise<null | Source>;
 declare interface GeneratedSourceInfo {
 	/**
 	 * generated line
@@ -8556,7 +8557,7 @@ declare class Generator {
 	/**
 	 * Generates generated code for this runtime module.
 	 */
-	generate(module: NormalModule, __1: GenerateContext): null | Source;
+	generate(module: NormalModule, __1: GenerateContext): GenerateResult;
 
 	/**
 	 * Returns the reason this module cannot be concatenated, when one exists.
@@ -14658,7 +14659,9 @@ declare class Module extends DependenciesBlock {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 */
-	codeGeneration(context: CodeGenerationContext): CodeGenerationResult;
+	codeGeneration(
+		context: CodeGenerationContext
+	): CodeGenerationResult | Promise<CodeGenerationResult>;
 
 	/**
 	 * Returns true if the module can be placed in the chunk.

--- a/types.d.ts
+++ b/types.d.ts
@@ -9245,6 +9245,7 @@ declare interface GenerateContext {
 	 */
 	getData?: () => CodeGenerationResultData;
 }
+type GenerateResult = null | Source | Promise<null | Source>;
 declare interface GeneratedSourceInfo {
 	/**
 	 * generated line
@@ -9278,7 +9279,7 @@ declare class Generator {
 	/**
 	 * Generates generated code for this runtime module.
 	 */
-	generate(module: NormalModule, __1: GenerateContext): null | Source;
+	generate(module: NormalModule, __1: GenerateContext): GenerateResult;
 
 	/**
 	 * Returns the reason this module cannot be concatenated, when one exists.
@@ -16661,7 +16662,9 @@ declare class Module extends DependenciesBlock {
 	/**
 	 * Generates code and runtime requirements for this module.
 	 */
-	codeGeneration(context: CodeGenerationContext): CodeGenerationResult;
+	codeGeneration(
+		context: CodeGenerationContext
+	): CodeGenerationResult | Promise<CodeGenerationResult>;
 
 	/**
 	 * Returns true if the module can be placed in the chunk.


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Support async code generation in Generator and Module. `Generator.generate()` and `Module.codeGeneration()` can now return a Promise, enabling post-generation processing such as CSS minimization via multi-process workers after a module's source type is generated.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feat

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compilation code generation and concatenation ordering; mistakes could affect every build, though sync behavior is preserved and errors are isolated.
> 
> **Overview**
> **Async code generation** is now supported end-to-end: `Generator.generate()` may return a `Promise<Source | null>`, and `Module.codeGeneration()` may return a `Promise<CodeGenerationResult>`. A shared `isPromise` helper detects thenables.
> 
> **Compilation** awaits promises in both cached and uncached code-gen paths, maps rejections to `CodeGenerationError`, and **does not cache** failed async results so errors can be retried on the next build.
> 
> **NormalModule** collects per–source-type async `generate()` results via `Promise.all` before returning. **ConcatenatedModule** defers its rename/link/emit pipeline until inner `codeGeneration` promises from analysis finish.
> 
> **Sync-only call sites** (`Module.source()`, `Template.renderRuntimeModules()`) throw if they hit async `codeGeneration`, directing callers to `Compilation.codeGenerationResults`.
> 
> Types and JSDoc are updated across generators and modules; config-case and unit tests cover happy paths, concatenation/CSS, and async error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febd141faa3f7e10183a8eda2d064751c6d5c4d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->