### PR TITLE
fix: set .name to "default" for anonymous default exports per ES spec

### DIFF
--- a/.changeset/fix-anonymous-default-export-name.md
+++ b/.changeset/fix-anonymous-default-export-name.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Set `.name` to `"default"` for anonymous default export functions and classes per ES spec

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -137,6 +137,13 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 							}
 						: undefined
 			);
+			dep.isAnonymousDefault =
+				node.type === "ArrowFunctionExpression" ||
+				((node.type === "FunctionDeclaration" ||
+					node.type === "FunctionExpression" ||
+					node.type === "ClassDeclaration" ||
+					node.type === "ClassExpression") &&
+					!node.id);
 			dep.loc = Object.create(
 				/** @type {DependencyLocation} */ (statement.loc)
 			);

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const ConcatenationScope = require("../ConcatenationScope");
+const InitFragment = require("../InitFragment");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
@@ -36,6 +37,7 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		this.rangeStatement = rangeStatement;
 		this.prefix = prefix;
 		this.declarationId = declarationId;
+		this.isAnonymousDefault = false;
 	}
 
 	get type() {
@@ -74,6 +76,7 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		write(this.rangeStatement);
 		write(this.prefix);
 		write(this.declarationId);
+		write(this.isAnonymousDefault);
 		super.serialize(context);
 	}
 
@@ -86,6 +89,7 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		this.rangeStatement = read();
 		this.prefix = read();
 		this.declarationId = read();
+		this.isAnonymousDefault = read();
 		super.deserialize(context);
 	}
 }
@@ -153,6 +157,18 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				dep.range[0] - 1,
 				`/* harmony default export */ ${dep.prefix}`
 			);
+
+			if (typeof declarationId !== "string" && dep.isAnonymousDefault) {
+				// Fix .name for anonymous default export function declarations
+				// see test/test262-cases/test/language/module-code/instn-named-bndng-dflt-fun-anon.js cspell:disable-line
+				initFragments.push(
+					new InitFragment(
+						`Reflect.defineProperty(${name}, "name", { value: "default", configurable: true });\n`,
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						2
+					)
+				);
+			}
 		} else {
 			/** @type {string} */
 			let content;
@@ -199,7 +215,17 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					dep.range[0] - 1,
 					`${content}(${dep.prefix}`
 				);
-				source.replace(dep.range[1], dep.rangeStatement[1] - 0.5, ");");
+				if (dep.isAnonymousDefault) {
+					// Fix .name for anonymous default export expressions
+					// see test/test262-cases/test/language/module-code/eval-export-dflt-cls-anon.js cspell:disable-line
+					source.replace(
+						dep.range[1],
+						dep.rangeStatement[1] - 0.5,
+						`);\nReflect.getOwnPropertyDescriptor(${name}, "name").writable || Reflect.defineProperty(${name}, "name", { value: "default", configurable: true });`
+					);
+				} else {
+					source.replace(dep.range[1], dep.rangeStatement[1] - 0.5, ");");
+				}
 				return;
 			}
 

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -853,10 +853,6 @@ const knownBugs = [
 
 	// Replacing `export default` will remove `default` name by spec, need to `static name = "default";` if doesn't exist
 	"expressions/class/elements/class-name-static-initializer-default-export.js",
-	"module-code/eval-export-dflt-cls-anon.js",
-	"module-code/eval-export-dflt-expr-cls-anon.js",
-	"module-code/eval-export-dflt-expr-fn-anon.js",
-	"module-code/eval-export-dflt-expr-gen-anon.js",
 
 	// improve test runner to keep dynamic import for such case
 	"expressions/dynamic-import/assign-expr-get-value-abrupt-throws.js",
@@ -894,9 +890,6 @@ const knownBugs = [
 
 	// Not a bug, we need to improve our test runner
 	"statements/async-function/evaluation-body.js",
-
-	"module-code/instn-named-bndng-dflt-gen-anon.js",
-	"module-code/instn-named-bndng-dflt-fun-anon.js",
 
 	// Do we need to call `Object.setPrototypeOf(__webpack_exports__, null);` for namespace imports and other things
 	"module-code/namespace/internals/get-own-property-str-found-init.js",
@@ -1008,10 +1001,6 @@ const knownBugs = [
 	"expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-circular.js",
 	"expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-circular.js",
 
-	"expressions/dynamic-import/eval-export-dflt-cls-anon.js",
-	"expressions/dynamic-import/eval-export-dflt-expr-cls-anon.js",
-	"expressions/dynamic-import/eval-export-dflt-expr-fn-anon.js",
-	"expressions/dynamic-import/eval-export-dflt-expr-gen-anon.js",
 	"expressions/dynamic-import/eval-self-once-script.js",
 	"expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js",
 	"expressions/dynamic-import/import-errored-module.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
`export default class {}` and `export default function() {}` should have `.name === "default"` per the ES specification. Webpack's renaming to `__WEBPACK_DEFAULT_EXPORT__` caused name inference to assign the wrong name.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No
