### PR TITLE
fix: use compiler context for CSS modules hash to avoid collisions

### DIFF
--- a/.changeset/fix-css-module-hash-collision.md
+++ b/.changeset/fix-css-module-hash-collision.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Use compiler context instead of module context for CSS modules local ident hashing to avoid hash collisions when files with the same name exist in different directories.

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -55,7 +55,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		(generator.options.localIdentName);
 	const relativeResourcePath = makePathsRelative(
 		/** @type {string} */
-		(module.context),
+		(runtimeTemplate.compilation.compiler.context),
 		/** @type {string} */
 		(module.getResource()),
 		runtimeTemplate.compilation.compiler.root

--- a/test/configCases/css/css-modules-hash-collision/f1/style.module.css
+++ b/test/configCases/css/css-modules-hash-collision/f1/style.module.css
@@ -1,0 +1,3 @@
+.xxx {
+	background: green;
+}

--- a/test/configCases/css/css-modules-hash-collision/f2/style.module.css
+++ b/test/configCases/css/css-modules-hash-collision/f2/style.module.css
@@ -1,0 +1,3 @@
+.xxx {
+	background: red;
+}

--- a/test/configCases/css/css-modules-hash-collision/index.js
+++ b/test/configCases/css/css-modules-hash-collision/index.js
@@ -1,0 +1,8 @@
+import * as f1 from "./f1/style.module.css";
+import * as f2 from "./f2/style.module.css";
+
+it("should generate unique hashed class names for same-named classes in different directories", () => {
+	expect(f1.xxx).toBeDefined();
+	expect(f2.xxx).toBeDefined();
+	expect(f1.xxx).not.toBe(f2.xxx);
+});

--- a/test/configCases/css/css-modules-hash-collision/webpack.config.js
+++ b/test/configCases/css/css-modules-hash-collision/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	experiments: {
+		css: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.module\.css$/i,
+				type: "css/module"
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
fixes https://github.com/webpack/webpack/issues/20795

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial