### PR TITLE
fix: make asset modules available in JS when referenced from CSS and lazy JS

### DIFF
--- a/.changeset/fix-css-lazy-asset-resource.md
+++ b/.changeset/fix-css-lazy-asset-resource.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Make asset modules available in JS context when referenced from both CSS and a lazily compiled JS chunk.

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1748,6 +1748,15 @@ class NormalModule extends Module {
 			/** @type {string} */
 			(buildInfo.hash)
 		);
+		// Clear cached source types and re-compute so that changes in incoming
+		// connections (e.g. asset module newly referenced from JS via lazy
+		// compilation) are reflected in the hash and trigger code generation
+		// cache invalidation.
+		// https://github.com/webpack/webpack/issues/20800
+		this._sourceTypes = undefined;
+		for (const type of this.getSourceTypes()) {
+			hash.update(type);
+		}
 		/** @type {Generator} */
 		(this.generator).updateHash(hash, {
 			module: this,

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_15e922b2c97f47f17c54",
-  "btn-info_is-disabled": "_15e922b2c97f47f17c54",
-  "color-red": "--_15e922b2c97f47f17c54",
+  "btn--info_is-disabled_1": "_0dd29f73dea88606ae8e",
+  "btn-info_is-disabled": "_0dd29f73dea88606ae8e",
+  "color-red": "--_0dd29f73dea88606ae8e",
   "foo": "bar",
-  "foo_bar": "_15e922b2c97f47f17c54",
+  "foo_bar": "_0dd29f73dea88606ae8e",
   "my-btn-info_is-disabled": "value",
-  "simple": "_15e922b2c97f47f17c54",
+  "simple": "_0dd29f73dea88606ae8e",
 }
 `;
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_04a0a4472ff4d45a1166-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_04a0a4472ff4d45a1166-btn-info_is-disabled",
-  "color-red": "--_04a0a4472ff4d45a1166-color-red",
+  "btn--info_is-disabled_1": "_26658d651495575453a9-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_26658d651495575453a9-btn-info_is-disabled",
+  "color-red": "--_26658d651495575453a9-color-red",
   "foo": "bar",
-  "foo_bar": "_04a0a4472ff4d45a1166-foo_bar",
+  "foo_bar": "_26658d651495575453a9-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_04a0a4472ff4d45a1166-simple",
+  "simple": "_26658d651495575453a9-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "ba1a7d6d0bb21c7b0653-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "ba1a7d6d0bb21c7b0653-btn-info_is-disabled",
-  "color-red": "--ba1a7d6d0bb21c7b0653-color-red",
+  "btn--info_is-disabled_1": "_78c918141017246fe472-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_78c918141017246fe472-btn-info_is-disabled",
+  "color-red": "--_78c918141017246fe472-color-red",
   "foo": "bar",
-  "foo_bar": "ba1a7d6d0bb21c7b0653-foo_bar",
+  "foo_bar": "_78c918141017246fe472-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "ba1a7d6d0bb21c7b0653-simple",
+  "simple": "_78c918141017246fe472-simple",
 }
 `;
 
@@ -110,25 +110,25 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
-  "btn--info_is-disabled_1": "a02ad227dd548bb84a61",
-  "btn-info_is-disabled": "a02ad227dd548bb84a61",
-  "color-red": "--a02ad227dd548bb84a61",
+  "btn--info_is-disabled_1": "fd8953d7b68db99277a0",
+  "btn-info_is-disabled": "fd8953d7b68db99277a0",
+  "color-red": "--fd8953d7b68db99277a0",
   "foo": "bar",
-  "foo_bar": "a02ad227dd548bb84a61",
+  "foo_bar": "fd8953d7b68db99277a0",
   "my-btn-info_is-disabled": "value",
-  "simple": "a02ad227dd548bb84a61",
+  "simple": "fd8953d7b68db99277a0",
 }
 `;
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
 Object {
-  "btn--info_is-disabled_1": "_81378ae70e35838d73e5-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_81378ae70e35838d73e5-btn-info_is-disabled",
-  "color-red": "--_81378ae70e35838d73e5-color-red",
+  "btn--info_is-disabled_1": "_54bf27341e3b9f7be65e-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_54bf27341e3b9f7be65e-btn-info_is-disabled",
+  "color-red": "--_54bf27341e3b9f7be65e-color-red",
   "foo": "bar",
-  "foo_bar": "_81378ae70e35838d73e5-foo_bar",
+  "foo_bar": "_54bf27341e3b9f7be65e-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_81378ae70e35838d73e5-simple",
+  "simple": "_54bf27341e3b9f7be65e-simple",
 }
 `;
 
@@ -182,12 +182,12 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "_68c15c0000bcbbd61f4d-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_68c15c0000bcbbd61f4d-btn-info_is-disabled",
-  "color-red": "--_68c15c0000bcbbd61f4d-color-red",
+  "btn--info_is-disabled_1": "_31b7efe08dce677d1ef4-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_31b7efe08dce677d1ef4-btn-info_is-disabled",
+  "color-red": "--_31b7efe08dce677d1ef4-color-red",
   "foo": "bar",
-  "foo_bar": "_68c15c0000bcbbd61f4d-foo_bar",
+  "foo_bar": "_31b7efe08dce677d1ef4-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_68c15c0000bcbbd61f4d-simple",
+  "simple": "_31b7efe08dce677d1ef4-simple",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_15e922b2c97f47f17c54",
-  "btn-info_is-disabled": "_15e922b2c97f47f17c54",
-  "color-red": "--_15e922b2c97f47f17c54",
+  "btn--info_is-disabled_1": "_0dd29f73dea88606ae8e",
+  "btn-info_is-disabled": "_0dd29f73dea88606ae8e",
+  "color-red": "--_0dd29f73dea88606ae8e",
   "foo": "bar",
-  "foo_bar": "_15e922b2c97f47f17c54",
+  "foo_bar": "_0dd29f73dea88606ae8e",
   "my-btn-info_is-disabled": "value",
-  "simple": "_15e922b2c97f47f17c54",
+  "simple": "_0dd29f73dea88606ae8e",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_04a0a4472ff4d45a1166-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_04a0a4472ff4d45a1166-btn-info_is-disabled",
-  "color-red": "--_04a0a4472ff4d45a1166-color-red",
+  "btn--info_is-disabled_1": "_26658d651495575453a9-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_26658d651495575453a9-btn-info_is-disabled",
+  "color-red": "--_26658d651495575453a9-color-red",
   "foo": "bar",
-  "foo_bar": "_04a0a4472ff4d45a1166-foo_bar",
+  "foo_bar": "_26658d651495575453a9-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_04a0a4472ff4d45a1166-simple",
+  "simple": "_26658d651495575453a9-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "ba1a7d6d0bb21c7b0653-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "ba1a7d6d0bb21c7b0653-btn-info_is-disabled",
-  "color-red": "--ba1a7d6d0bb21c7b0653-color-red",
+  "btn--info_is-disabled_1": "_78c918141017246fe472-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_78c918141017246fe472-btn-info_is-disabled",
+  "color-red": "--_78c918141017246fe472-color-red",
   "foo": "bar",
-  "foo_bar": "ba1a7d6d0bb21c7b0653-foo_bar",
+  "foo_bar": "_78c918141017246fe472-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "ba1a7d6d0bb21c7b0653-simple",
+  "simple": "_78c918141017246fe472-simple",
 }
 `;
 
@@ -110,25 +110,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
-  "btn--info_is-disabled_1": "a02ad227dd548bb84a61",
-  "btn-info_is-disabled": "a02ad227dd548bb84a61",
-  "color-red": "--a02ad227dd548bb84a61",
+  "btn--info_is-disabled_1": "fd8953d7b68db99277a0",
+  "btn-info_is-disabled": "fd8953d7b68db99277a0",
+  "color-red": "--fd8953d7b68db99277a0",
   "foo": "bar",
-  "foo_bar": "a02ad227dd548bb84a61",
+  "foo_bar": "fd8953d7b68db99277a0",
   "my-btn-info_is-disabled": "value",
-  "simple": "a02ad227dd548bb84a61",
+  "simple": "fd8953d7b68db99277a0",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
 Object {
-  "btn--info_is-disabled_1": "_81378ae70e35838d73e5-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_81378ae70e35838d73e5-btn-info_is-disabled",
-  "color-red": "--_81378ae70e35838d73e5-color-red",
+  "btn--info_is-disabled_1": "_54bf27341e3b9f7be65e-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_54bf27341e3b9f7be65e-btn-info_is-disabled",
+  "color-red": "--_54bf27341e3b9f7be65e-color-red",
   "foo": "bar",
-  "foo_bar": "_81378ae70e35838d73e5-foo_bar",
+  "foo_bar": "_54bf27341e3b9f7be65e-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_81378ae70e35838d73e5-simple",
+  "simple": "_54bf27341e3b9f7be65e-simple",
 }
 `;
 
@@ -182,12 +182,12 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "_68c15c0000bcbbd61f4d-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_68c15c0000bcbbd61f4d-btn-info_is-disabled",
-  "color-red": "--_68c15c0000bcbbd61f4d-color-red",
+  "btn--info_is-disabled_1": "_31b7efe08dce677d1ef4-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_31b7efe08dce677d1ef4-btn-info_is-disabled",
+  "color-red": "--_31b7efe08dce677d1ef4-color-red",
   "foo": "bar",
-  "foo_bar": "_68c15c0000bcbbd61f4d-foo_bar",
+  "foo_bar": "_31b7efe08dce677d1ef4-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_68c15c0000bcbbd61f4d-simple",
+  "simple": "_31b7efe08dce677d1ef4-simple",
 }
 `;

--- a/test/hotCases/css/lazy-compilation-asset/file.txt
+++ b/test/hotCases/css/lazy-compilation-asset/file.txt
@@ -1,0 +1,1 @@
+asset-content

--- a/test/hotCases/css/lazy-compilation-asset/index.js
+++ b/test/hotCases/css/lazy-compilation-asset/index.js
@@ -1,0 +1,13 @@
+import "./style.css";
+
+it("should make asset available in both CSS and lazy JS chunk", (done) => {
+	const promise = import("./mod.js");
+	NEXT_DEFERRED(
+		require("../../update")(done, true, () => {
+			promise.then((mod) => {
+				expect(mod.default).toContain("file.txt");
+				done();
+			}, done);
+		})
+	);
+});

--- a/test/hotCases/css/lazy-compilation-asset/mod.js
+++ b/test/hotCases/css/lazy-compilation-asset/mod.js
@@ -1,0 +1,2 @@
+import file from "./file.txt";
+export default file;

--- a/test/hotCases/css/lazy-compilation-asset/style.css
+++ b/test/hotCases/css/lazy-compilation-asset/style.css
@@ -1,0 +1,3 @@
+.font {
+	src: url("./file.txt");
+}

--- a/test/hotCases/css/lazy-compilation-asset/test.filter.js
+++ b/test/hotCases/css/lazy-compilation-asset/test.filter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/css/lazy-compilation-asset/webpack.config.js
+++ b/test/hotCases/css/lazy-compilation-asset/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	output: {
+		cssFilename: "[name].css",
+		cssChunkFilename: "[name].css",
+		assetModuleFilename: "assets/[name][ext]"
+	},
+	experiments: {
+		css: true,
+		lazyCompilation: {
+			entries: false,
+			imports: true
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.txt$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	node: {
+		__dirname: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes #20800

When an asset module is referenced from both CSS (via url()) and a lazy JS chunk (via lazyCompilation), the module was missing from the JS context at runtime.

Root cause: NormalModule._sourceTypes was cached after first computation and never invalidated when incoming connections changed. Additionally, source types were not included in the module hash, so the code generation cache was not invalidated when types changed.

Fix:
- Add Module.invalidateSourceTypes() to clear cached source types when a module is not rebuilt but its connections may have changed
- Include source types in NormalModule.updateHash() so hash changes trigger code generation cache invalidation and HMR updates

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial