### PR TITLE
fix: avoid invalid __WEBPACK_DEFAULT_EXPORT__ access for anonymous de…

### DIFF
--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -173,6 +173,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 			/** @type {string} */
 			let content;
 			const name = ConcatenationScope.DEFAULT_EXPORT;
+			let nameAccess = name;
 			if (runtimeTemplate.supportsConst()) {
 				content = `/* harmony default export */ const ${name} = `;
 				if (concatenationScope) {
@@ -199,11 +200,12 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					.getExportsInfo(module)
 					.getUsedName("default", runtime);
 				if (used) {
+					nameAccess = `${exportsName}${propertyAccess(
+						typeof used === "string" ? [used] : used
+					)}`;
 					runtimeRequirements.add(RuntimeGlobals.exports);
 					// This is a little bit incorrect as TDZ is not correct, but we can't use const.
-					content = `/* harmony default export */ ${exportsName}${propertyAccess(
-						typeof used === "string" ? [used] : used
-					)} = `;
+					content = `/* harmony default export */ ${nameAccess} = `;
 				} else {
 					content = `/* unused harmony default export */ var ${name} = `;
 				}
@@ -221,7 +223,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					source.replace(
 						dep.range[1],
 						dep.rangeStatement[1] - 0.5,
-						`);\nReflect.getOwnPropertyDescriptor(${name}, "name").writable || Reflect.defineProperty(${name}, "name", { value: "default", configurable: true });`
+						`);\nReflect.getOwnPropertyDescriptor(${nameAccess}, "name").writable || Reflect.defineProperty(${nameAccess}, "name", { value: "default", configurable: true });`
 					);
 				} else {
 					source.replace(dep.range[1], dep.rangeStatement[1] - 0.5, ");");

--- a/test/configCases/parsing/anonymous-default-export-name-runtime-error/index.js
+++ b/test/configCases/parsing/anonymous-default-export-name-runtime-error/index.js
@@ -1,0 +1,7 @@
+import value from "./module";
+
+it("should support anonymous default export expressions without a local binding", async () => {
+	expect(typeof value).toBe("function");
+	expect(await value()).toBe("ok");
+	expect(value.name).toBe("default");
+});

--- a/test/configCases/parsing/anonymous-default-export-name-runtime-error/module.js
+++ b/test/configCases/parsing/anonymous-default-export-name-runtime-error/module.js
@@ -1,0 +1,1 @@
+export default async () => "ok";

--- a/test/configCases/parsing/anonymous-default-export-name-runtime-error/webpack.config.js
+++ b/test/configCases/parsing/anonymous-default-export-name-runtime-error/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	output: {
+		environment: {
+			const: false
+		}
+	},
+	optimization: {
+		concatenateModules: false,
+		minimize: false
+	}
+};


### PR DESCRIPTION
**Summary**
This PR fixes a runtime regression introduced by the anonymous default export `.name` handling added in `webpack@5.106.0`.
For anonymous default export expressions, webpack does not always emit a local `__WEBPACK_DEFAULT_EXPORT__` binding. In particular, when `output.environment.const` is `false` and the default export is emitted directly onto the exports object, the generated code looks like this:
```js
/* harmony default export */ __webpack_exports__["default"] = async () => {}
```
However, the new .name fix still unconditionally referenced __WEBPACK_DEFAULT_EXPORT__:
Reflect.getOwnPropertyDescriptor(__WEBPACK_DEFAULT_EXPORT__, "name").writable ||
Reflect.defineProperty(__WEBPACK_DEFAULT_EXPORT__, "name", {
  value: "default",
  configurable: true
});
In that code path, __WEBPACK_DEFAULT_EXPORT__ is not declared, which causes a runtime error:
ReferenceError: __WEBPACK_DEFAULT_EXPORT__ is not defined
This PR fixes the issue by tracking the actual emitted access path for the default export and applying the .name fix to that reference instead of always assuming a local __WEBPACK_DEFAULT_EXPORT__ binding exists.
What kind of change does this PR introduce?
This PR introduces a fix for a runtime regression in anonymous default export expression handling.
Did you add tests for your changes?
Yes.
This PR adds a regression test covering:
- an anonymous default export expression
- output.environment.const = false
- concatenateModules = false
The test verifies that:
- the generated bundle executes successfully
- the default export remains callable
- the returned value is correct
- the function name is "default"
Does this PR introduce a breaking change?
No.
This change only fixes an invalid emitted code path and restores expected runtime behavior.
If relevant, what needs to be documented once your changes are merged or what have you already documented?
No documentation changes are needed.
Use of AI
AI was used as an assistive tool for analysis and drafting. I manually reviewed the affected webpack code path, reproduced the issue locally, bisected it to `webpack@5.106.0`, implemented the fix, added the regression test, and verified the result by running the targeted test locally.