### PR TITLE
fix: include missing generator options in updateHash for persistent cache correctness

### DIFF
--- a/.changeset/fix-generator-updatehash-completeness.md
+++ b/.changeset/fix-generator-updatehash-completeness.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Include missing generator options in hash to ensure persistent cache invalidation when configuration changes (CssGenerator `exportsOnly`, JsonGenerator `JSONParse`, WebAssemblyGenerator `mangleImports`).

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -705,6 +705,7 @@ class CssGenerator extends Generator {
 	 */
 	updateHash(hash, { module }) {
 		hash.update(/** @type {boolean} */ (this._esModule).toString());
+		hash.update(/** @type {boolean} */ (this._exportsOnly).toString());
 	}
 }
 

--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -16,6 +16,8 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 /** @typedef {import("../../declarations/WebpackOptions").JsonGeneratorOptions} JsonGeneratorOptions */
 /** @typedef {import("../ExportsInfo")} ExportsInfo */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
+/** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../Module").ConcatenationBailoutReasonContext} ConcatenationBailoutReasonContext */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
@@ -236,6 +238,17 @@ class JsonGenerator extends Generator {
 	 */
 	generateError(error, module, generateContext) {
 		return new RawSource(`throw new Error(${JSON.stringify(error.message)});`);
+	}
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash that will be modified
+	 * @param {UpdateHashContext} updateHashContext context for updating hash
+	 */
+	updateHash(hash, updateHashContext) {
+		if (this.options.JSONParse) {
+			hash.update("json-parse");
+		}
 	}
 }
 

--- a/lib/wasm-sync/WebAssemblyGenerator.js
+++ b/lib/wasm-sync/WebAssemblyGenerator.js
@@ -17,11 +17,13 @@ const WebAssemblyUtils = require("./WebAssemblyUtils");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../Generator").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").SourceType} SourceType */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../NormalModule")} NormalModule */
+/** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./WebAssemblyUtils").UsedWasmDependency} UsedWasmDependency */
 /** @typedef {import("@webassemblyjs/ast").Instruction} Instruction */
@@ -541,6 +543,17 @@ class WebAssemblyGenerator extends Generator {
 	 */
 	generateError(error, module, generateContext) {
 		return new RawSource(error.message);
+	}
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash that will be modified
+	 * @param {UpdateHashContext} updateHashContext context for updating hash
+	 */
+	updateHash(hash, updateHashContext) {
+		if (this.options.mangleImports) {
+			hash.update("mangle-imports");
+		}
 	}
 }
 

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_8ee4d8b938ce15d40534",
-  "btn-info_is-disabled": "_8ee4d8b938ce15d40534",
-  "color-red": "--_8ee4d8b938ce15d40534",
+  "btn--info_is-disabled_1": "_15e922b2c97f47f17c54",
+  "btn-info_is-disabled": "_15e922b2c97f47f17c54",
+  "color-red": "--_15e922b2c97f47f17c54",
   "foo": "bar",
-  "foo_bar": "_8ee4d8b938ce15d40534",
+  "foo_bar": "_15e922b2c97f47f17c54",
   "my-btn-info_is-disabled": "value",
-  "simple": "_8ee4d8b938ce15d40534",
+  "simple": "_15e922b2c97f47f17c54",
 }
 `;
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "f0e5e7b8779254ec04d4-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "f0e5e7b8779254ec04d4-btn-info_is-disabled",
-  "color-red": "--f0e5e7b8779254ec04d4-color-red",
+  "btn--info_is-disabled_1": "_04a0a4472ff4d45a1166-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_04a0a4472ff4d45a1166-btn-info_is-disabled",
+  "color-red": "--_04a0a4472ff4d45a1166-color-red",
   "foo": "bar",
-  "foo_bar": "f0e5e7b8779254ec04d4-foo_bar",
+  "foo_bar": "_04a0a4472ff4d45a1166-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "f0e5e7b8779254ec04d4-simple",
+  "simple": "_04a0a4472ff4d45a1166-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "d5c602f0c8fdc09fea74-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "d5c602f0c8fdc09fea74-btn-info_is-disabled",
-  "color-red": "--d5c602f0c8fdc09fea74-color-red",
+  "btn--info_is-disabled_1": "ba1a7d6d0bb21c7b0653-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "ba1a7d6d0bb21c7b0653-btn-info_is-disabled",
+  "color-red": "--ba1a7d6d0bb21c7b0653-color-red",
   "foo": "bar",
-  "foo_bar": "d5c602f0c8fdc09fea74-foo_bar",
+  "foo_bar": "ba1a7d6d0bb21c7b0653-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "d5c602f0c8fdc09fea74-simple",
+  "simple": "ba1a7d6d0bb21c7b0653-simple",
 }
 `;
 
@@ -110,25 +110,25 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
-  "btn--info_is-disabled_1": "_8ee4d8b938ce15d40534",
-  "btn-info_is-disabled": "_8ee4d8b938ce15d40534",
-  "color-red": "--_8ee4d8b938ce15d40534",
+  "btn--info_is-disabled_1": "a02ad227dd548bb84a61",
+  "btn-info_is-disabled": "a02ad227dd548bb84a61",
+  "color-red": "--a02ad227dd548bb84a61",
   "foo": "bar",
-  "foo_bar": "_8ee4d8b938ce15d40534",
+  "foo_bar": "a02ad227dd548bb84a61",
   "my-btn-info_is-disabled": "value",
-  "simple": "_8ee4d8b938ce15d40534",
+  "simple": "a02ad227dd548bb84a61",
 }
 `;
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
 Object {
-  "btn--info_is-disabled_1": "f0e5e7b8779254ec04d4-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "f0e5e7b8779254ec04d4-btn-info_is-disabled",
-  "color-red": "--f0e5e7b8779254ec04d4-color-red",
+  "btn--info_is-disabled_1": "_81378ae70e35838d73e5-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_81378ae70e35838d73e5-btn-info_is-disabled",
+  "color-red": "--_81378ae70e35838d73e5-color-red",
   "foo": "bar",
-  "foo_bar": "f0e5e7b8779254ec04d4-foo_bar",
+  "foo_bar": "_81378ae70e35838d73e5-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "f0e5e7b8779254ec04d4-simple",
+  "simple": "_81378ae70e35838d73e5-simple",
 }
 `;
 
@@ -182,12 +182,12 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "d5c602f0c8fdc09fea74-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "d5c602f0c8fdc09fea74-btn-info_is-disabled",
-  "color-red": "--d5c602f0c8fdc09fea74-color-red",
+  "btn--info_is-disabled_1": "_68c15c0000bcbbd61f4d-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_68c15c0000bcbbd61f4d-btn-info_is-disabled",
+  "color-red": "--_68c15c0000bcbbd61f4d-color-red",
   "foo": "bar",
-  "foo_bar": "d5c602f0c8fdc09fea74-foo_bar",
+  "foo_bar": "_68c15c0000bcbbd61f4d-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "d5c602f0c8fdc09fea74-simple",
+  "simple": "_68c15c0000bcbbd61f4d-simple",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_8ee4d8b938ce15d40534",
-  "btn-info_is-disabled": "_8ee4d8b938ce15d40534",
-  "color-red": "--_8ee4d8b938ce15d40534",
+  "btn--info_is-disabled_1": "_15e922b2c97f47f17c54",
+  "btn-info_is-disabled": "_15e922b2c97f47f17c54",
+  "color-red": "--_15e922b2c97f47f17c54",
   "foo": "bar",
-  "foo_bar": "_8ee4d8b938ce15d40534",
+  "foo_bar": "_15e922b2c97f47f17c54",
   "my-btn-info_is-disabled": "value",
-  "simple": "_8ee4d8b938ce15d40534",
+  "simple": "_15e922b2c97f47f17c54",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "f0e5e7b8779254ec04d4-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "f0e5e7b8779254ec04d4-btn-info_is-disabled",
-  "color-red": "--f0e5e7b8779254ec04d4-color-red",
+  "btn--info_is-disabled_1": "_04a0a4472ff4d45a1166-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_04a0a4472ff4d45a1166-btn-info_is-disabled",
+  "color-red": "--_04a0a4472ff4d45a1166-color-red",
   "foo": "bar",
-  "foo_bar": "f0e5e7b8779254ec04d4-foo_bar",
+  "foo_bar": "_04a0a4472ff4d45a1166-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "f0e5e7b8779254ec04d4-simple",
+  "simple": "_04a0a4472ff4d45a1166-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "d5c602f0c8fdc09fea74-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "d5c602f0c8fdc09fea74-btn-info_is-disabled",
-  "color-red": "--d5c602f0c8fdc09fea74-color-red",
+  "btn--info_is-disabled_1": "ba1a7d6d0bb21c7b0653-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "ba1a7d6d0bb21c7b0653-btn-info_is-disabled",
+  "color-red": "--ba1a7d6d0bb21c7b0653-color-red",
   "foo": "bar",
-  "foo_bar": "d5c602f0c8fdc09fea74-foo_bar",
+  "foo_bar": "ba1a7d6d0bb21c7b0653-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "d5c602f0c8fdc09fea74-simple",
+  "simple": "ba1a7d6d0bb21c7b0653-simple",
 }
 `;
 
@@ -110,25 +110,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
-  "btn--info_is-disabled_1": "_8ee4d8b938ce15d40534",
-  "btn-info_is-disabled": "_8ee4d8b938ce15d40534",
-  "color-red": "--_8ee4d8b938ce15d40534",
+  "btn--info_is-disabled_1": "a02ad227dd548bb84a61",
+  "btn-info_is-disabled": "a02ad227dd548bb84a61",
+  "color-red": "--a02ad227dd548bb84a61",
   "foo": "bar",
-  "foo_bar": "_8ee4d8b938ce15d40534",
+  "foo_bar": "a02ad227dd548bb84a61",
   "my-btn-info_is-disabled": "value",
-  "simple": "_8ee4d8b938ce15d40534",
+  "simple": "a02ad227dd548bb84a61",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
 Object {
-  "btn--info_is-disabled_1": "f0e5e7b8779254ec04d4-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "f0e5e7b8779254ec04d4-btn-info_is-disabled",
-  "color-red": "--f0e5e7b8779254ec04d4-color-red",
+  "btn--info_is-disabled_1": "_81378ae70e35838d73e5-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_81378ae70e35838d73e5-btn-info_is-disabled",
+  "color-red": "--_81378ae70e35838d73e5-color-red",
   "foo": "bar",
-  "foo_bar": "f0e5e7b8779254ec04d4-foo_bar",
+  "foo_bar": "_81378ae70e35838d73e5-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "f0e5e7b8779254ec04d4-simple",
+  "simple": "_81378ae70e35838d73e5-simple",
 }
 `;
 
@@ -182,12 +182,12 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "d5c602f0c8fdc09fea74-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "d5c602f0c8fdc09fea74-btn-info_is-disabled",
-  "color-red": "--d5c602f0c8fdc09fea74-color-red",
+  "btn--info_is-disabled_1": "_68c15c0000bcbbd61f4d-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_68c15c0000bcbbd61f4d-btn-info_is-disabled",
+  "color-red": "--_68c15c0000bcbbd61f4d-color-red",
   "foo": "bar",
-  "foo_bar": "d5c602f0c8fdc09fea74-foo_bar",
+  "foo_bar": "_68c15c0000bcbbd61f4d-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "d5c602f0c8fdc09fea74-simple",
+  "simple": "_68c15c0000bcbbd61f4d-simple",
 }
 `;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes https://github.com/webpack/webpack/pull/20801#pullrequestreview-4091742773

CssGenerator was missing `exportsOnly`, JsonGenerator was missing `JSONParse`, and WebAssemblyGenerator was missing `mangleImports` in their updateHash methods. This could cause stale cached code generation results when these options change between builds with filesystem cache.

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial