### PR TITLE
fix: respect falsy boolean options in ProgressPlugin and ManifestPlugin

### DIFF
--- a/.changeset/fix-plugin-falsy-defaults.md
+++ b/.changeset/fix-plugin-falsy-defaults.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `||` default value handling in ProgressPlugin and ManifestPlugin that incorrectly overrode user-provided falsy values (e.g. `modules: false`, `entries: false`, `entrypoints: false`).

--- a/lib/ManifestPlugin.js
+++ b/lib/ManifestPlugin.js
@@ -73,7 +73,8 @@ class ManifestPlugin {
 			);
 		});
 
-		const entrypoints = this.options.entrypoints || true;
+		const entrypoints =
+			this.options.entrypoints !== undefined ? this.options.entrypoints : true;
 		const serialize =
 			this.options.serialize ||
 			((manifest) => JSON.stringify(manifest, null, 2));

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -175,18 +175,16 @@ class ProgressPlugin {
 		/** @type {ProgressPluginOptions} */
 		this.options = options;
 
-		this.profile = options.profile || DEFAULT_OPTIONS.profile;
-		this.handler = options.handler;
-		this.modulesCount = options.modulesCount || DEFAULT_OPTIONS.modulesCount;
-		this.dependenciesCount =
-			options.dependenciesCount || DEFAULT_OPTIONS.dependenciesCount;
-		this.showEntries = options.entries || DEFAULT_OPTIONS.entries;
-		this.showModules = options.modules || DEFAULT_OPTIONS.modules;
-		this.showDependencies =
-			options.dependencies || DEFAULT_OPTIONS.dependencies;
-		this.showActiveModules =
-			options.activeModules || DEFAULT_OPTIONS.activeModules;
-		this.percentBy = options.percentBy || DEFAULT_OPTIONS.percentBy;
+		const merged = { ...DEFAULT_OPTIONS, ...options };
+		this.profile = merged.profile;
+		this.handler = merged.handler;
+		this.modulesCount = merged.modulesCount;
+		this.dependenciesCount = merged.dependenciesCount;
+		this.showEntries = merged.entries;
+		this.showModules = merged.modules;
+		this.showDependencies = merged.dependencies;
+		this.showActiveModules = merged.activeModules;
+		this.percentBy = merged.percentBy;
 	}
 
 	/**

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -262,6 +262,22 @@ describe("ProgressPlugin", () => {
 		});
 	});
 
+	it("should respect falsy boolean options", () => {
+		const plugin = new webpack.ProgressPlugin({
+			modules: false,
+			dependencies: false,
+			entries: false,
+			activeModules: false,
+			profile: false
+		});
+
+		expect(plugin.showModules).toBe(false);
+		expect(plugin.showDependencies).toBe(false);
+		expect(plugin.showEntries).toBe(false);
+		expect(plugin.showActiveModules).toBe(false);
+		expect(plugin.profile).toBe(false);
+	});
+
 	it("should get the custom handler text from the log", () => {
 		const compiler = createSimpleCompilerWithCustomHandler();
 


### PR DESCRIPTION
**Summary**
The `||` operator used for default values incorrectly overrode user-provided falsy values like `modules: false` or `entries: false` with the truthy defaults. Use object spread for ProgressPlugin and explicit `!== undefined` check for ManifestPlugin to preserve user intent.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing