### PR TITLE
fix: CSS @import should inherit parent's exportType over parser config

### DIFF
--- a/.changeset/fix-css-import-inherit-parent-export-type.md
+++ b/.changeset/fix-css-import-inherit-parent-export-type.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+CSS @import now inherits the parent module's exportType, so a file configured as "text" correctly creates a style tag when @imported by a "style" parent.

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -405,7 +405,7 @@ class CssModulesPlugin {
 												supports: dependency.supports,
 												media: dependency.media,
 												inheritance,
-												exportType: exportType || parent.exportType
+												exportType: parent.exportType || exportType
 											})
 										);
 									}

--- a/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
@@ -152,35 +152,13 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 4`] = `
 "@charset \\"UTF-8\\";
-/*!*******************************************************!*\\\\
-  !*** css ./import-nested.text.css (exportType: text) ***!
-  \\\\*******************************************************/
-
-
 .import-nested {
 	color: red;
-}
-
-/*!***************************************************************!*\\\\
-  !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
-  \\\\***************************************************************/
-
-
-.import-nested {
+}.import-nested {
 	color: red;
-}
-
-/*!************************************************!*\\\\
-  !*** css ./import.text.css (exportType: text) ***!
-  \\\\************************************************/
-
-
-
-.import {
+}.import {
 	color: red;
-}
-
-/*!************************************************************************!*\\\\
+}/*!************************************************************************!*\\\\
   !*** css ./styles-5.css-style-sheet.css (exportType: css-style-sheet) ***!
   \\\\************************************************************************/
 
@@ -195,6 +173,37 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 5`] = `
 Array [
+  "/*!********************************************************!*\\\\
+  !*** css ./import-nested.text.css (exportType: style) ***!
+  \\\\********************************************************/
+@charset \\"UTF-8\\";
+
+.import-nested {
+	color: red;
+}
+
+",
+  "/*!****************************************************************!*\\\\
+  !*** css ./import-nested.text.css?foo=bar (exportType: style) ***!
+  \\\\****************************************************************/
+@charset \\"UTF-8\\";
+
+.import-nested {
+	color: red;
+}
+
+",
+  "/*!*************************************************!*\\\\
+  !*** css ./import.text.css (exportType: style) ***!
+  \\\\*************************************************/
+@charset \\"UTF-8\\";
+
+
+.import {
+	color: red;
+}
+
+",
   "/*!****************************************************!*\\\\
   !*** css ./styles-6.style.css (exportType: style) ***!
   \\\\****************************************************/

--- a/test/configCases/css/charset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigTest.snap
@@ -152,35 +152,13 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 4`] = `
 "@charset \\"UTF-8\\";
-/*!*******************************************************!*\\\\
-  !*** css ./import-nested.text.css (exportType: text) ***!
-  \\\\*******************************************************/
-
-
 .import-nested {
 	color: red;
-}
-
-/*!***************************************************************!*\\\\
-  !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
-  \\\\***************************************************************/
-
-
-.import-nested {
+}.import-nested {
 	color: red;
-}
-
-/*!************************************************!*\\\\
-  !*** css ./import.text.css (exportType: text) ***!
-  \\\\************************************************/
-
-
-
-.import {
+}.import {
 	color: red;
-}
-
-/*!************************************************************************!*\\\\
+}/*!************************************************************************!*\\\\
   !*** css ./styles-5.css-style-sheet.css (exportType: css-style-sheet) ***!
   \\\\************************************************************************/
 
@@ -195,6 +173,37 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 5`] = `
 Array [
+  "/*!********************************************************!*\\\\
+  !*** css ./import-nested.text.css (exportType: style) ***!
+  \\\\********************************************************/
+@charset \\"UTF-8\\";
+
+.import-nested {
+	color: red;
+}
+
+",
+  "/*!****************************************************************!*\\\\
+  !*** css ./import-nested.text.css?foo=bar (exportType: style) ***!
+  \\\\****************************************************************/
+@charset \\"UTF-8\\";
+
+.import-nested {
+	color: red;
+}
+
+",
+  "/*!*************************************************!*\\\\
+  !*** css ./import.text.css (exportType: style) ***!
+  \\\\*************************************************/
+@charset \\"UTF-8\\";
+
+
+.import {
+	color: red;
+}
+
+",
   "/*!****************************************************!*\\\\
   !*** css ./styles-6.style.css (exportType: style) ***!
   \\\\****************************************************/

--- a/test/configCases/css/export-type-style-and-text-import/base.css
+++ b/test/configCases/css/export-type-style-and-text-import/base.css
@@ -1,0 +1,3 @@
+.base-class {
+	color: red;
+}

--- a/test/configCases/css/export-type-style-and-text-import/index.js
+++ b/test/configCases/css/export-type-style-and-text-import/index.js
@@ -1,0 +1,27 @@
+import { "wrapper-style-class" as wrapperStyleClass } from "./wrapper-style.css";
+import textContent from "./base.css";
+
+it("should export correct class name for wrapper-style.css", () => {
+	expect(wrapperStyleClass).toBe("wrapper-style_css-wrapper-style-class");
+});
+
+it("should export text content for base.css", () => {
+	expect(typeof textContent).toBe("string");
+	expect(textContent).toContain("color: red");
+});
+
+it("should create a style tag for wrapper-style.css own content", () => {
+	const allCSS = Array.from(
+		window.document.getElementsByTagName("style")
+	).map(s => s.textContent);
+
+	expect(allCSS.some(c => c.includes("padding: 10px"))).toBe(true);
+});
+
+it("should create a style tag for base.css when @imported by a style-type parent even though base.css itself is text-type", () => {
+	const allCSS = Array.from(
+		window.document.getElementsByTagName("style")
+	).map(s => s.textContent);
+
+	expect(allCSS.some(c => c.includes("color: red"))).toBe(true);
+});

--- a/test/configCases/css/export-type-style-and-text-import/webpack.config.js
+++ b/test/configCases/css/export-type-style-and-text-import/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{
+				test: /wrapper-style\.css$/,
+				type: "css/module",
+				parser: {
+					exportType: "style"
+				}
+			},
+			{
+				test: /base\.css$/,
+				type: "css/module",
+				parser: {
+					exportType: "text"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/export-type-style-and-text-import/wrapper-style.css
+++ b/test/configCases/css/export-type-style-and-text-import/wrapper-style.css
@@ -1,0 +1,5 @@
+@import url(./base.css);
+
+.wrapper-style-class {
+	padding: 10px;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
fix: CSS @import should inherit parent's exportType over parser config

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing