### PR TITLE
fix: explicit hashed properties in CssGenerator for robust caching

### DIFF
--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -716,6 +716,11 @@ class CssGenerator extends Generator {
 	updateHash(hash, { module }) {
 		hash.update(/** @type {boolean} */ (this._esModule).toString());
 		hash.update(/** @type {boolean} */ (this._exportsOnly).toString());
+		const exportType = /** @type {CssModule} */ (module).exportType || "link";
+		hash.update(exportType);
+		if (this.options.exportsConvention) {
+			hash.update(this.options.exportsConvention.toString());
+		}
 	}
 }
 

--- a/test/configCases/contenthash/css-generator-options/test.config.js
+++ b/test/configCases/contenthash/css-generator-options/test.config.js
@@ -16,7 +16,7 @@ module.exports = {
 		return [`./css${i}/${async}`, `./${bundle}`];
 	},
 	afterExecute: () => {
-		expect(allBundles.size).toBe(7);
+		expect(allBundles.size).toBe(9);
 		expect(allCss.size).toBe(7);
 	}
 };

--- a/test/configCases/contenthash/css-generator-options/webpack.config.js
+++ b/test/configCases/contenthash/css-generator-options/webpack.config.js
@@ -145,5 +145,43 @@ module.exports = [
 				}
 			]
 		}
+	},
+	{
+		...common,
+		output: {
+			filename: "bundle7.[contenthash].js",
+			chunkFilename: "css7/[name].[contenthash].js",
+			cssChunkFilename: "css7/[name].[contenthash].css"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					generator: {
+						exportType: "style"
+					}
+				}
+			]
+		}
+	},
+	{
+		...common,
+		output: {
+			filename: "bundle8.[contenthash].js",
+			chunkFilename: "css8/[name].[contenthash].js",
+			cssChunkFilename: "css8/[name].[contenthash].css"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					generator: {
+						exportType: "css-style-sheet"
+					}
+				}
+			]
+		}
 	}
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes a silent cache invalidation bug in `CssGenerator`. 
Previously, `updateHash` only checked `_esModule` and `_exportsOnly`. It missed `exportType` and `exportsConvention`, which meant changing those options didn't update the `contenthash`, causing stale builds. Added them to the hash stream.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. Added `exportType: "style"` and `"css-style-sheet"` configurations to the existing `css-generator-options` tests to verify hash stability.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

No.
