### PR TITLE
fix: support dotted absolute URL schemes

### DIFF
--- a/.changeset/ten-bobcats-bake.md
+++ b/.changeset/ten-bobcats-bake.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Allow absolute URL specifiers with `.` in their scheme to be parsed correctly.

--- a/lib/util/URLAbsoluteSpecifier.js
+++ b/lib/util/URLAbsoluteSpecifier.js
@@ -15,6 +15,7 @@ const aUpperCaseCharCode = "A".charCodeAt(0);
 const zUpperCaseCharCode = "Z".charCodeAt(0);
 const _0CharCode = "0".charCodeAt(0);
 const _9CharCode = "9".charCodeAt(0);
+const dotCharCode = ".".charCodeAt(0);
 const plusCharCode = "+".charCodeAt(0);
 const hyphenCharCode = "-".charCodeAt(0);
 const colonCharCode = ":".charCodeAt(0);
@@ -45,6 +46,7 @@ function getScheme(specifier) {
 		(ch >= aLowerCaseCharCode && ch <= zLowerCaseCharCode) ||
 		(ch >= aUpperCaseCharCode && ch <= zUpperCaseCharCode) ||
 		(ch >= _0CharCode && ch <= _9CharCode) ||
+		ch === dotCharCode ||
 		ch === plusCharCode ||
 		ch === hyphenCharCode
 	) {

--- a/test/URLAbsoluteSpecifier.unittest.js
+++ b/test/URLAbsoluteSpecifier.unittest.js
@@ -39,6 +39,14 @@ const samples = [
 		expected: "my+data"
 	},
 	{
+		specifier: "my.data:image/jpg;base64",
+		expected: "my.data"
+	},
+	{
+		specifier: "My.Data+Ext:image/jpg;base64",
+		expected: "my.data+ext"
+	},
+	{
 		specifier: "my-data/next:image/",
 		expected: undefined
 	},


### PR DESCRIPTION

**Repo:** webpack/webpack (⭐ 64000)
**Type:** bugfix
**Files changed:** 3
**Lines:** +15/-0

## What
This change updates webpack's absolute URL specifier parser so it accepts `.` inside URL schemes, which RFC 3986 allows. It adds focused unit coverage for dotted and mixed dotted-plus schemes and includes a patch changeset for release notes.

## Why
`lib/util/URLAbsoluteSpecifier.js` documented RFC 3986 behavior but rejected valid schemes such as `my.data:` because `.` was missing from the allowed scheme characters. That creates incorrect behavior for consumers using absolute specifiers with dotted custom schemes. The patch aligns the implementation with the RFC and locks the behavior down with a regression test.

## Testing
Attempted: `yarn test:unit --runTestsByPath test/URLAbsoluteSpecifier.unittest.js`  
Result: could not run because `node_modules/jest-cli/bin/jest` is missing in this checkout.  
Sanity check run locally with `node` against `lib/util/URLAbsoluteSpecifier.js`, confirming `my.data:` and `My.Data+Ext:` now parse correctly while Windows paths still do not.

## Risk
Low - this widens scheme parsing to match the RFC and is covered by targeted regression tests.
