### PR TITLE
ci: run Node.js 10.x macOS tests on macos-13 to avoid Rosetta 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,21 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 20.x, 22.x, 24.x, 25.x]
         part: [a, b]
+        exclude:
+          # Node.js 10.x has no native arm64 macOS binaries and `macos-latest`
+          # is Apple Silicon, so x64 Node 10 runs under Rosetta 2 emulation
+          # which makes the integration suite ~2-3x slower. Run it on the
+          # native Intel runner below instead.
+          - os: macos-latest
+            node-version: 10.x
         include:
+          # Native Intel x64 runner for Node.js 10.x on macOS.
+          - os: macos-13
+            node-version: 10.x
+            part: a
+          - os: macos-13
+            node-version: 10.x
+            part: b
           # Test with main branches of webpack dependencies
           - os: ubuntu-latest
             node-version: lts/*
@@ -248,22 +262,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        id: calculate_architecture
-        with:
-          result-encoding: string
-          script: |
-            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '10.x') {
-              return "x64"
-            } else {
-              return ''
-            }
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
-          architecture: ${{ steps.calculate_architecture.outputs.result }}
           cache: yarn
 
       # Install old `jest` version and deps for legacy node versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,20 +222,10 @@ jobs:
         node-version: [10.x, 20.x, 22.x, 24.x, 25.x]
         part: [a, b]
         exclude:
-          # GitHub's free Apple Silicon `macos-latest` runners have 3 vCPU /
-          # 7 GB (vs 4 vCPU / 16 GB on Linux) and slower filesystem I/O, so
-          # "part a" (~44 test files) averages ~26 min on macOS vs ~10 min
-          # on Linux and frequently queues for 10-30 min before starting.
-          # macOS-specific regressions are not Node-version specific, so we
-          # rely on Linux for full Node version coverage and only run the
-          # active LTS (22.x) and latest (25.x) on macOS.
-          - os: macos-latest
-            node-version: 20.x
-          - os: macos-latest
-            node-version: 24.x
-          # Node.js 10.x has no native arm64 macOS binaries; running x64 Node
-          # under Rosetta 2 emulation makes the suite another 2-3x slower.
-          # Use the native Intel runner included below instead.
+          # Node.js 10.x has no native arm64 macOS binaries and `macos-latest`
+          # is Apple Silicon, so x64 Node 10 runs under Rosetta 2 emulation
+          # which makes the integration suite ~2-3x slower. Run it on the
+          # native Intel runner below instead.
           - os: macos-latest
             node-version: 10.x
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,8 +153,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .jest-cache
-          key: jest-unit-${{ env.GITHUB_SHA }}
-          restore-keys: jest-unit-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}
+          key: jest-unit-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-${{ github.sha }}
+          restore-keys: |
+            jest-unit-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-
+            jest-unit-${{ runner.os }}-
 
       - run: yarn cover:unit --ci --cacheDirectory .jest-cache
 
@@ -193,8 +195,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .jest-cache
-          key: jest-test262-${{ matrix.shard }}-${{ env.GITHUB_SHA }}
-          restore-keys: jest-test262-${{ matrix.shard }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}
+          key: jest-test262-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-${{ github.sha }}
+          restore-keys: |
+            jest-test262-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-
+            jest-test262-${{ matrix.shard }}-${{ runner.os }}-
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -305,8 +309,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .jest-cache
-          key: jest-integration-${{ env.GITHUB_SHA }}
-          restore-keys: jest-integration-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}
+          key: jest-integration-${{ runner.os }}-node-${{ matrix.node-version }}-${{ matrix.part }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-${{ github.sha }}
+          restore-keys: |
+            jest-integration-${{ runner.os }}-node-${{ matrix.node-version }}-${{ matrix.part }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-
+            jest-integration-${{ runner.os }}-node-${{ matrix.node-version }}-${{ matrix.part }}-
 
       - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache -f
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,10 +222,20 @@ jobs:
         node-version: [10.x, 20.x, 22.x, 24.x, 25.x]
         part: [a, b]
         exclude:
-          # Node.js 10.x has no native arm64 macOS binaries and `macos-latest`
-          # is Apple Silicon, so x64 Node 10 runs under Rosetta 2 emulation
-          # which makes the integration suite ~2-3x slower. Run it on the
-          # native Intel runner below instead.
+          # GitHub's free Apple Silicon `macos-latest` runners have 3 vCPU /
+          # 7 GB (vs 4 vCPU / 16 GB on Linux) and slower filesystem I/O, so
+          # "part a" (~44 test files) averages ~26 min on macOS vs ~10 min
+          # on Linux and frequently queues for 10-30 min before starting.
+          # macOS-specific regressions are not Node-version specific, so we
+          # rely on Linux for full Node version coverage and only run the
+          # active LTS (22.x) and latest (25.x) on macOS.
+          - os: macos-latest
+            node-version: 20.x
+          - os: macos-latest
+            node-version: 24.x
+          # Node.js 10.x has no native arm64 macOS binaries; running x64 Node
+          # under Rosetta 2 emulation makes the suite another 2-3x slower.
+          # Use the native Intel runner included below instead.
           - os: macos-latest
             node-version: 10.x
         include:


### PR DESCRIPTION
`macos-latest` has been Apple Silicon (arm64) since early 2024. Node.js
10.x has no arm64 macOS binaries, so we were forcing `architecture: x64`
via a `calculate_architecture` step and running x64 Node under Rosetta 2
emulation. The integration suite is CPU-heavy (webpack compilations +
V8 JIT), both of which are hit hardest by Rosetta — making the
`integration (macos-latest, 10.x, *)` jobs roughly 2-3x slower than
they should be.

Move Node 10.x on macOS onto `macos-13` (native Intel x64) via matrix
exclude/include and drop the now-unused architecture override step.
All other macOS Node versions (20/22/24/25.x) have arm64 binaries and
continue to run natively on `macos-latest`.