### PR TITLE
fix: stable shared module ids and runtime-chunk emission order

### DIFF
--- a/.changeset/five-jars-join.md
+++ b/.changeset/five-jars-join.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Stable shared module ids and runtime-chunk emission order.

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
+const { compareModulesById } = require("../util/comparators");
 const {
 	parseVersionRuntimeCode,
 	rangeToStringRuntimeCode,
@@ -71,12 +72,14 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 				);
 			}
 		};
+		const byId = compareModulesById(chunkGraph);
 		for (const chunk of /** @type {Chunk} */ (
 			this.chunk
 		).getAllReferencedChunks()) {
-			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+			const modules = chunkGraph.getOrderedChunkModulesIterableBySourceType(
 				chunk,
-				"consume-shared"
+				"consume-shared",
+				byId
 			);
 			if (!modules) continue;
 			addModules(
@@ -88,9 +91,10 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 		for (const chunk of /** @type {Chunk} */ (
 			this.chunk
 		).getAllInitialChunks()) {
-			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+			const modules = chunkGraph.getOrderedChunkModulesIterableBySourceType(
 				chunk,
-				"consume-shared"
+				"consume-shared",
+				byId
 			);
 			if (!modules) continue;
 			addModules(modules, chunk, initialConsumes);

--- a/lib/sharing/ProvideSharedModule.js
+++ b/lib/sharing/ProvideSharedModule.js
@@ -54,7 +54,7 @@ class ProvideSharedModule extends Module {
 	 * @returns {string} a unique identifier of the module
 	 */
 	identifier() {
-		return `provide module (${this._shareScope}) ${this._name}@${this._version} = ${this._request}`;
+		return `provide module (${this._shareScope}) ${this._name}@${this._version}|${this._request}`;
 	}
 
 	/**

--- a/test/SharingUtil.unittest.js
+++ b/test/SharingUtil.unittest.js
@@ -1,6 +1,33 @@
 "use strict";
 
+const ProvideSharedModule = require("../lib/sharing/ProvideSharedModule");
 const { normalizeVersion } = require("../lib/sharing/utils");
+const { makePathsRelative } = require("../lib/util/identifier");
+
+describe("ProvideSharedModule identifier", () => {
+	it("normalizes the request path across different build roots", () => {
+		const a = new ProvideSharedModule(
+			"default",
+			"x",
+			"1.0.0",
+			"/runner-a/project/node_modules/x/index.js",
+			true
+		).identifier();
+		const b = new ProvideSharedModule(
+			"default",
+			"x",
+			"1.0.0",
+			"/runner-b/project/node_modules/x/index.js",
+			true
+		).identifier();
+		// After makePathsRelative the two identifiers must match so that
+		// DeterministicModuleIdsPlugin assigns the same id for the same
+		// shared module regardless of the absolute project root.
+		expect(makePathsRelative("/runner-a/project", a)).toBe(
+			makePathsRelative("/runner-b/project", b)
+		);
+	});
+});
 
 describe("normalize dep version", () => {
 	const commonInvalid = [

--- a/test/configCases/sharing/consume-shared-stable-runtime/a.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/sharing/consume-shared-stable-runtime/b.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/sharing/consume-shared-stable-runtime/c.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/test/configCases/sharing/consume-shared-stable-runtime/d.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/d.js
@@ -1,0 +1,1 @@
+module.exports = "d";

--- a/test/configCases/sharing/consume-shared-stable-runtime/index.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/index.js
@@ -1,0 +1,11 @@
+import a from "./a";
+import b from "./b";
+import c from "./c";
+import d from "./d";
+
+it("should load every consumed share", () => {
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(c).toBe("c");
+	expect(d).toBe("d");
+});

--- a/test/configCases/sharing/consume-shared-stable-runtime/test.config.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/test.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const findOutputFiles = require("../../../helpers/findOutputFiles");
+
+module.exports = {
+	findBundle(i, options) {
+		const runtime = findOutputFiles(options, /^runtime\.js$/)[0];
+		const src = fs.readFileSync(
+			path.join(options.output.path, runtime),
+			"utf8"
+		);
+
+		const block = /var moduleToHandlerMapping = \{([\s\S]*?)^[^\n]*?\};/m.exec(
+			src
+		);
+		expect(block).not.toBeNull();
+		const ids = [...block[1].matchAll(/^[^\n]*?\b(\d+):\s*\(\)/gm)].map((m) =>
+			Number(m[1])
+		);
+		expect(ids.length).toBeGreaterThan(0);
+
+		const sorted = [...ids].sort((a, b) => a - b);
+		expect(ids).toEqual(sorted);
+
+		return [`./${runtime}`, `./${findOutputFiles(options, /^main\.js$/)[0]}`];
+	}
+};

--- a/test/configCases/sharing/consume-shared-stable-runtime/test.config.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/test.config.js
@@ -4,6 +4,8 @@ const fs = require("fs");
 const path = require("path");
 const findOutputFiles = require("../../../helpers/findOutputFiles");
 
+const regex = /^[^\n]*?\b(\d+):\s*\(\)/gm;
+
 module.exports = {
 	findBundle(i, options) {
 		const runtime = findOutputFiles(options, /^runtime\.js$/)[0];
@@ -16,9 +18,14 @@ module.exports = {
 			src
 		);
 		expect(block).not.toBeNull();
-		const ids = [...block[1].matchAll(/^[^\n]*?\b(\d+):\s*\(\)/gm)].map((m) =>
-			Number(m[1])
-		);
+
+		const ids = [];
+		let match;
+
+		while ((match = regex.exec(block[1])) !== null) {
+			ids.push(Number(match[1]));
+		}
+
 		expect(ids.length).toBeGreaterThan(0);
 
 		const sorted = [...ids].sort((a, b) => a - b);

--- a/test/configCases/sharing/consume-shared-stable-runtime/webpack.config.js
+++ b/test/configCases/sharing/consume-shared-stable-runtime/webpack.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		moduleIds: "deterministic",
+		runtimeChunk: "single",
+		minimize: false
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"./a": { eager: true },
+				"./b": { eager: true },
+				"./c": { eager: true },
+				"./d": { eager: true }
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Makes shared-module runtime output stable across builds. `ProvideSharedModule.identifier()` now separates the request path with `|` so `makePathsRelative` can strip the build root (previously, differing absolute paths across CI runners produced different module IDs). `ConsumeSharedRuntimeModule` now emits `moduleToHandlerMapping` entries in id-sorted order via `getOrderedChunkModulesIterableBySourceType`, instead of chunk-graph insertion order. Together these prevent spurious content-hash churn on otherwise-identical rebuilds. Fixes #20852.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
  A fix.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing that I am aware of
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
I used AI to help me with the tests.
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->