### PR TITLE
test: increase integration test coverage for core module plugins

### DIFF
--- a/test/configCases/contenthash/css-generator-options-string/index.js
+++ b/test/configCases/contenthash/css-generator-options-string/index.js
@@ -1,0 +1,3 @@
+it("should compile", async () => {
+	await import("./style.module.css");
+});

--- a/test/configCases/contenthash/css-generator-options-string/style.module.css
+++ b/test/configCases/contenthash/css-generator-options-string/style.module.css
@@ -1,0 +1,7 @@
+.class-a {
+  color: red;
+}
+
+.class-b {
+  color: blue;
+}

--- a/test/configCases/contenthash/css-generator-options-string/test.config.js
+++ b/test/configCases/contenthash/css-generator-options-string/test.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const findOutputFiles = require("../../../helpers/findOutputFiles");
+
+const allCss = new Set();
+const allBundles = new Set();
+
+module.exports = {
+	findBundle(i, options) {
+		const bundle = findOutputFiles(options, new RegExp(`^bundle${i}`))[0];
+		const async = findOutputFiles(options, /\.js/, `css${i}`);
+		if (bundle) {
+			const m = /\.([^.]+)\./.exec(bundle);
+			if (m) allBundles.add(m[1]);
+		}
+		const cssFiles = findOutputFiles(options, /^.*\.[^.]*\.css$/, `css${i}`);
+		if (cssFiles.length > 0) {
+			allCss.add(cssFiles[0]);
+		}
+
+		return [`./css${i}/${async}`, `./${bundle}`];
+	},
+	afterExecute: () => {
+		expect(allBundles.size).toBe(2);
+		expect(allCss.size).toBe(1);
+	}
+};

--- a/test/configCases/contenthash/css-generator-options-string/webpack.config.js
+++ b/test/configCases/contenthash/css-generator-options-string/webpack.config.js
@@ -1,0 +1,54 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+const common = {
+	target: "web",
+	optimization: {
+		realContentHash: false
+	},
+	experiments: {
+		css: true
+	}
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		...common,
+		output: {
+			filename: "bundle0.[contenthash].js",
+			chunkFilename: "css0/[name].[contenthash].js",
+			cssChunkFilename: "css0/[name].[contenthash].css"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					generator: {
+						exportType: "text"
+					}
+				}
+			]
+		}
+	},
+	{
+		...common,
+		output: {
+			filename: "bundle1.[contenthash].js",
+			chunkFilename: "css1/[name].[contenthash].js",
+			cssChunkFilename: "css1/[name].[contenthash].css"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					generator: {
+						exportType: "css-style-sheet"
+					}
+				}
+			]
+		}
+	}
+];

--- a/test/configCases/externals/concatenated-module-externals/index.js
+++ b/test/configCases/externals/concatenated-module-externals/index.js
@@ -1,0 +1,6 @@
+import { doSomethingWithFs, existsSync } from "./lib.js";
+
+it("should map external imports in a concatenated module", function() {
+	expect(typeof doSomethingWithFs).toBe("function");
+	expect(typeof existsSync).toBe("function");
+});

--- a/test/configCases/externals/concatenated-module-externals/lib.js
+++ b/test/configCases/externals/concatenated-module-externals/lib.js
@@ -1,0 +1,4 @@
+export { existsSync } from "fs";
+export function doSomethingWithFs() {
+	return 1;
+}

--- a/test/configCases/externals/concatenated-module-externals/test.filter.js
+++ b/test/configCases/externals/concatenated-module-externals/test.filter.js
@@ -1,5 +1,6 @@
 "use strict";
 
 module.exports = function filter() {
-	return /^v(20|22|24)/.test(process.version);
+	const major = Number(process.versions.node.split(".")[0]);
+	return major >= 20;
 };

--- a/test/configCases/externals/concatenated-module-externals/test.filter.js
+++ b/test/configCases/externals/concatenated-module-externals/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function filter() {
+	return /^v(20|22|24)/.test(process.version);
+};

--- a/test/configCases/externals/concatenated-module-externals/webpack.config.js
+++ b/test/configCases/externals/concatenated-module-externals/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "async-node",
+	externalsType: "module",
+	externals: {
+		fs: "module fs"
+	},
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	}
+};

--- a/test/configCases/plugins/normal-module-replacement-plugin/after-absolute.js
+++ b/test/configCases/plugins/normal-module-replacement-plugin/after-absolute.js
@@ -1,0 +1,2 @@
+"use strict";
+module.exports = "dummy";

--- a/test/configCases/plugins/normal-module-replacement-plugin/index.js
+++ b/test/configCases/plugins/normal-module-replacement-plugin/index.js
@@ -16,6 +16,11 @@ it("should use NormalModuleReplacementPlugin for function replacement (afterReso
 });
 
 it("should use NormalModuleReplacementPlugin for relative path replacement (afterResolve)", function () {
-    const result = require("./after-relative.js");
-    expect(result).toBe("replaced-after-resolve");
+	const result = require("./after-relative.js");
+	expect(result).toBe("replaced-after-resolve");
+});
+
+it("should use NormalModuleReplacementPlugin for absolute path replacement (afterResolve)", function () {
+	const result = require("./after-absolute.js");
+	expect(result).toBe("replaced-after-resolve");
 });

--- a/test/configCases/plugins/normal-module-replacement-plugin/webpack.config.js
+++ b/test/configCases/plugins/normal-module-replacement-plugin/webpack.config.js
@@ -18,6 +18,10 @@ module.exports = {
 				result.createData.resource = path.join(dir, "after.js");
 			}
 		}),
-		new NormalModuleReplacementPlugin(/[/\\]after-relative\.js$/, "./after.js")
+		new NormalModuleReplacementPlugin(/[/\\]after-relative\.js$/, "./after.js"),
+		new NormalModuleReplacementPlugin(
+			/(?<!\.)[/\\]after-absolute\.js$/,
+			path.resolve(__dirname, "./after.js")
+		)
 	]
 };


### PR DESCRIPTION
**Summary**

This PR systematically increases the end-to-end integration test coverage (`configCases`) targeting untested code paths and hooks within three core Webpack plugins: `NormalModuleReplacementPlugin`, `CssModulesPlugin`, and `ExternalsPlugin`. 

Specifically, it resolves a deeply-buried coverage miss in `NormalModuleReplacementPlugin`. Previously, the fallback logic inside the `afterResolve` hook was unreachable during testing because absolute paths were intercepted entirely by the initial `beforeResolve` hook. By utilizing a negative lookbehind `/(?<!\.)[/\\]after-absolute\.js$/` and resolving to a direct dummy file asset, we successfully bypass `beforeResolve` and accurately trigger the missing branch.

### Coverage Impact (NormalModuleReplacementPlugin)

**Before (Fallback logic skipped):**
```text
----------------------------------|---------|----------|---------|---------|-------------------
File                              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------------|---------|----------|---------|---------|-------------------
 NormalModuleReplacementPlugin.js |   81.81 |    53.84 |     100 |   81.81 | 55-62             
----------------------------------|---------|----------|---------|---------|-------------------
```

**After (Successfully targeted `afterResolve` replacement):**
<img width="1600" height="880" alt="image" src="https://github.com/user-attachments/assets/6abb2f52-8656-4fd8-9338-b03221a36651" />

*(Similarly, `CssModulesPlugin` custom exportType parsing and `ExternalsPlugin` ESM re-export concatenation edge-cases are now structurally covered in the core `configCases` test suite).*

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes. I added 3 specific integration scenarios under `/test/configCases/` targeting the missing hooks directly within the Webpack compilation lifecycle.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

No 
