### PR TITLE
fix: correctly parse '#' in absolute path directory names (fixes #16819)

### DIFF
--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -375,21 +375,22 @@ const _parseResource = (str) => {
 	const queryStart = str.indexOf("?");
 	let fragmentStart = str.indexOf("#");
 
-	if (fragmentStart >= 0) {
-		if (str.startsWith("/") || WINDOWS_ABS_PATH_REGEXP.test(str)) {
-			for (;;) {
-				const nextSlash = str.indexOf("/", fragmentStart + 1);
-				const nextBackslash = str.indexOf("\\", fragmentStart + 1);
-				if (
-					(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
-					(nextBackslash !== -1 &&
-						(queryStart === -1 || nextBackslash < queryStart))
-				) {
-					fragmentStart = str.indexOf("#", fragmentStart + 1);
-					if (fragmentStart === -1) break;
-				} else {
-					break;
-				}
+	if (
+		fragmentStart >= 0 &&
+		(str.startsWith("/") || WINDOWS_ABS_PATH_REGEXP.test(str))
+	) {
+		for (;;) {
+			const nextSlash = str.indexOf("/", fragmentStart + 1);
+			const nextBackslash = str.indexOf("\\", fragmentStart + 1);
+			if (
+				(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
+				(nextBackslash !== -1 &&
+					(queryStart === -1 || nextBackslash < queryStart))
+			) {
+				fragmentStart = str.indexOf("#", fragmentStart + 1);
+				if (fragmentStart === -1) break;
+			} else {
+				break;
 			}
 		}
 	}

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -373,7 +373,26 @@ const _parseResource = (str) => {
 	/** @type {ParsedResource} */
 	const result = { resource: str, path: "", query: "", fragment: "" };
 	const queryStart = str.indexOf("?");
-	const fragmentStart = str.indexOf("#");
+	let fragmentStart = str.indexOf("#");
+
+	if (fragmentStart >= 0) {
+		if (str.startsWith("/") || WINDOWS_ABS_PATH_REGEXP.test(str)) {
+			for (;;) {
+				const nextSlash = str.indexOf("/", fragmentStart + 1);
+				const nextBackslash = str.indexOf("\\", fragmentStart + 1);
+				if (
+					(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
+					(nextBackslash !== -1 &&
+						(queryStart === -1 || nextBackslash < queryStart))
+				) {
+					fragmentStart = str.indexOf("#", fragmentStart + 1);
+					if (fragmentStart === -1) break;
+				} else {
+					break;
+				}
+			}
+		}
+	}
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -120,3 +120,30 @@ describe("util/identifier", () => {
 		}
 	});
 });
+
+describe("parseResource", () => {
+	/** @type {[string, string, string, string][]} */
+	const cases = [
+		["path#hash?query", "path", "?query", "#hash"],
+		["path?query#hash", "path", "?query", "#hash"],
+		["/home/user/test#folder/file.js", "/home/user/test#folder/file.js", "", ""],
+		["C:\\Users\\test#folder\\file.js", "C:\\Users\\test#folder\\file.js", "", ""],
+		[
+			"/home/user/test#folder/file.js?query#frag",
+			"/home/user/test#folder/file.js",
+			"?query",
+			"#frag"
+		],
+		["path/to/file.js#frag", "path/to/file.js", "", "#frag"],
+		["/abs/path/file.js#fragment", "/abs/path/file.js", "", "#fragment"],
+		["C:\\abs\\path\\file.js#fragment", "C:\\abs\\path\\file.js", "", "#fragment"]
+	];
+	for (const [input, path, query, fragment] of cases) {
+		it(input, () => {
+			const result = identifierUtil.parseResource(input);
+			expect(result.path).toBe(path);
+			expect(result.query).toBe(query);
+			expect(result.fragment).toBe(fragment);
+		});
+	}
+});


### PR DESCRIPTION
Following enhanced-resolve#473 which introduced the `\0#` escape workaround, this PR implements automatic detection for `#` in absolute paths to resolve #16819.

### The Problem
When a project is located in a directory containing `#` (e.g. `/home/user/test#project/` or `C:\my#project\`), webpack incorrectly treats `#` as a fragment identifier, causing resolution failures and `UnhandledSchemeError`.

### The Fix
In `_parseResource`, if the path is absolute and a `/` or `\` exists after the `#` before any query string, the `#` is treated as part of the directory name. Fragments cannot have path separators after them, so this detection is mathematically sound.

### Tests Added
- Linux absolute path with `#` in directory name
- Windows absolute path with `#` in directory name  
- Mixed case with query and fragment after `#` directory
- Regression: real fragment on absolute path still detected correctly
- Regression: relative paths with `#` fragments unchanged