### PR TITLE
fix(css): resolve [hash]/[fullhash] in publicPath for url() references

### DIFF
--- a/.changeset/css-publicpath-hash.md
+++ b/.changeset/css-publicpath-hash.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve `[hash]`/`[fullhash]` placeholders in `output.publicPath` (including function publicPaths that reference `pathData.hash`) when generating `url()` references for `experiments.css`. Previously these produced broken URLs containing `undefined` or an un-substituted `[hash]` placeholder because the compilation hash was not yet available at code generation time.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 test/statsCases/** eol=lf
 test/hotCases/** eol=lf
+test/configCases/css/public-path/*.js eol=lf
 examples/* eol=lf
 bin/* eol=lf
 *.svg eol=lf

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -129,12 +129,14 @@ class RuntimeModule extends Module {
 		hash.update(this.name);
 		hash.update(`${this.stage}`);
 		try {
-			if (this.fullHash || this.dependentHash) {
-				// Do not use getGeneratedCode here, because i. e. compilation hash might be not
-				// ready at this point. We will cache it later instead.
-				hash.update(/** @type {string} */ (this.generate()));
-			} else {
-				hash.update(/** @type {string} */ (this.getGeneratedCode()));
+			const code =
+				this.fullHash || this.dependentHash
+					? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
+						// ready at this point. We will cache it later instead.
+						this.generate()
+					: this.getGeneratedCode();
+			if (code !== null && code !== undefined) {
+				hash.update(code);
 			}
 		} catch (err) {
 			hash.update(/** @type {Error} */ (err).message);

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -398,11 +398,13 @@ class AssetGenerator extends Generator {
 				compilation.outputOptions.publicPath === "auto"
 					? CssUrlDependency.PUBLIC_PATH_AUTO
 					: compilation.getAssetPath(compilation.outputOptions.publicPath, {
-							hash: compilation.hash || CssUrlDependency.PUBLIC_PATH_FULL_HASH,
+							hash:
+								compilation.hash ||
+								`${CssUrlDependency.PUBLIC_PATH_FULL_HASH}0__`,
 							hashWithLength: (length) =>
 								compilation.hash
 									? compilation.hash.slice(0, length)
-									: `${CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH}${length}__`
+									: `${CssUrlDependency.PUBLIC_PATH_FULL_HASH}${length}__`
 						});
 
 			assetPath = path + filename;

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -398,7 +398,11 @@ class AssetGenerator extends Generator {
 				compilation.outputOptions.publicPath === "auto"
 					? CssUrlDependency.PUBLIC_PATH_AUTO
 					: compilation.getAssetPath(compilation.outputOptions.publicPath, {
-							hash: compilation.hash
+							hash: compilation.hash || CssUrlDependency.PUBLIC_PATH_FULL_HASH,
+							hashWithLength: (length) =>
+								compilation.hash
+									? compilation.hash.slice(0, length)
+									: `${CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH}${length}__`
 						});
 
 			assetPath = path + filename;

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -44,8 +44,6 @@ const removeBOM = require("../util/removeBOM");
 const CssGenerator = require("./CssGenerator");
 const CssParser = require("./CssParser");
 
-const publicPathAutoRegex = new RegExp(CssUrlDependency.PUBLIC_PATH_AUTO, "g");
-
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../Chunk")} Chunk */
@@ -72,6 +70,7 @@ const publicPathAutoRegex = new RegExp(CssUrlDependency.PUBLIC_PATH_AUTO, "g");
  * @property {RuntimeTemplate} runtimeTemplate the runtime template
  * @property {string} uniqueName the unique name
  * @property {string} undoPath undo path to css file
+ * @property {string=} hash compilation hash
  * @property {CssModule[]} modules modules
  */
 
@@ -83,6 +82,7 @@ const publicPathAutoRegex = new RegExp(CssUrlDependency.PUBLIC_PATH_AUTO, "g");
  * @property {CodeGenerationResults=} codeGenerationResults results of code generation
  * @property {RuntimeTemplate} runtimeTemplate the runtime template
  * @property {string} undoPath undo path to css file
+ * @property {string=} hash compilation hash
  * @property {WeakMap<Source, ModuleFactoryCacheEntry>} moduleFactoryCache moduleFactoryCache
  * @property {Source} moduleSourceContent content
  */
@@ -98,6 +98,7 @@ const publicPathAutoRegex = new RegExp(CssUrlDependency.PUBLIC_PATH_AUTO, "g");
  * Defines the module factory cache entry type used by this module.
  * @typedef {object} ModuleFactoryCacheEntry
  * @property {string} undoPath - The undo path to the CSS file
+ * @property {string | undefined} hash - The compilation hash
  * @property {Inheritance} inheritance - The inheritance chain
  * @property {CachedSource} source - The cached source
  */
@@ -577,6 +578,7 @@ class CssModulesPlugin {
 										codeGenerationResults,
 										uniqueName: compilation.outputOptions.uniqueName,
 										undoPath,
+										hash,
 										modules,
 										runtimeTemplate
 									},
@@ -906,7 +908,8 @@ class CssModulesPlugin {
 	 * @returns {Source | null} css module source
 	 */
 	static renderModule(module, renderContext, hooks) {
-		const { undoPath, moduleFactoryCache, moduleSourceContent } = renderContext;
+		const { undoPath, hash, moduleFactoryCache, moduleSourceContent } =
+			renderContext;
 		const cacheEntry = moduleFactoryCache.get(moduleSourceContent);
 
 		/** @type {Inheritance} */
@@ -920,6 +923,7 @@ class CssModulesPlugin {
 		if (
 			cacheEntry &&
 			cacheEntry.undoPath === undoPath &&
+			cacheEntry.hash === hash &&
 			cacheEntry.inheritance.length === inheritance.length &&
 			cacheEntry.inheritance.every(([layer, supports, media], i) => {
 				const item = inheritance[i];
@@ -935,18 +939,72 @@ class CssModulesPlugin {
 			const moduleSourceCode =
 				/** @type {string} */
 				(moduleSourceContent.source());
-			publicPathAutoRegex.lastIndex = 0;
-			/** @type {Source} */
-			let moduleSource = new ReplaceSource(moduleSourceContent);
-			/** @type {null | RegExpExecArray} */
-			let match;
-			while ((match = publicPathAutoRegex.exec(moduleSourceCode))) {
-				/** @type {ReplaceSource} */ (moduleSource).replace(
-					match.index,
-					match.index + match[0].length - 1,
-					undoPath
-				);
+			const replaceSource = new ReplaceSource(moduleSourceContent);
+
+			const autoPlaceholder = CssUrlDependency.PUBLIC_PATH_AUTO;
+			const autoPlaceholderLen = autoPlaceholder.length;
+			for (
+				let idx = moduleSourceCode.indexOf(autoPlaceholder);
+				idx !== -1;
+				idx = moduleSourceCode.indexOf(
+					autoPlaceholder,
+					idx + autoPlaceholderLen
+				)
+			) {
+				replaceSource.replace(idx, idx + autoPlaceholderLen - 1, undoPath);
 			}
+
+			if (hash) {
+				const lengthPrefix = CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH;
+				const lengthPrefixLen = lengthPrefix.length;
+				const sourceLen = moduleSourceCode.length;
+				let idx = moduleSourceCode.indexOf(lengthPrefix);
+				while (idx !== -1) {
+					let digitEnd = idx + lengthPrefixLen;
+					while (digitEnd < sourceLen) {
+						const cc = moduleSourceCode.charCodeAt(digitEnd);
+						if (cc < 48 || cc > 57) break;
+						digitEnd++;
+					}
+					let nextSearch;
+					if (
+						digitEnd > idx + lengthPrefixLen &&
+						digitEnd + 1 < sourceLen &&
+						moduleSourceCode.charCodeAt(digitEnd) === 95 &&
+						moduleSourceCode.charCodeAt(digitEnd + 1) === 95
+					) {
+						const length = Number.parseInt(
+							moduleSourceCode.slice(idx + lengthPrefixLen, digitEnd),
+							10
+						);
+						replaceSource.replace(idx, digitEnd + 1, hash.slice(0, length));
+						nextSearch = digitEnd + 2;
+					} else {
+						nextSearch = idx + lengthPrefixLen;
+					}
+					idx = moduleSourceCode.indexOf(lengthPrefix, nextSearch);
+				}
+
+				const fullHashPlaceholder = CssUrlDependency.PUBLIC_PATH_FULL_HASH;
+				const fullHashPlaceholderLen = fullHashPlaceholder.length;
+				for (
+					let hashIdx = moduleSourceCode.indexOf(fullHashPlaceholder);
+					hashIdx !== -1;
+					hashIdx = moduleSourceCode.indexOf(
+						fullHashPlaceholder,
+						hashIdx + fullHashPlaceholderLen
+					)
+				) {
+					replaceSource.replace(
+						hashIdx,
+						hashIdx + fullHashPlaceholderLen - 1,
+						hash
+					);
+				}
+			}
+
+			/** @type {Source} */
+			let moduleSource = replaceSource;
 
 			for (let i = 0; i < inheritance.length; i++) {
 				const layer = inheritance[i][0];
@@ -987,6 +1045,7 @@ class CssModulesPlugin {
 			moduleFactoryCache.set(moduleSourceContent, {
 				inheritance,
 				undoPath,
+				hash,
 				source
 			});
 		}
@@ -1010,7 +1069,8 @@ class CssModulesPlugin {
 			codeGenerationResults,
 			modules,
 			runtimeTemplate,
-			chunkGraph
+			chunkGraph,
+			hash
 		},
 		hooks
 	) {
@@ -1040,6 +1100,7 @@ class CssModulesPlugin {
 					module,
 					{
 						undoPath,
+						hash,
 						chunk,
 						chunkGraph,
 						codeGenerationResults,

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -955,12 +955,12 @@ class CssModulesPlugin {
 			}
 
 			if (hash) {
-				const lengthPrefix = CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH;
-				const lengthPrefixLen = lengthPrefix.length;
+				const hashPrefix = CssUrlDependency.PUBLIC_PATH_FULL_HASH;
+				const hashPrefixLen = hashPrefix.length;
 				const sourceLen = moduleSourceCode.length;
-				let idx = moduleSourceCode.indexOf(lengthPrefix);
+				let idx = moduleSourceCode.indexOf(hashPrefix);
 				while (idx !== -1) {
-					let digitEnd = idx + lengthPrefixLen;
+					let digitEnd = idx + hashPrefixLen;
 					while (digitEnd < sourceLen) {
 						const cc = moduleSourceCode.charCodeAt(digitEnd);
 						if (cc < 48 || cc > 57) break;
@@ -968,38 +968,25 @@ class CssModulesPlugin {
 					}
 					let nextSearch;
 					if (
-						digitEnd > idx + lengthPrefixLen &&
+						digitEnd > idx + hashPrefixLen &&
 						digitEnd + 1 < sourceLen &&
 						moduleSourceCode.charCodeAt(digitEnd) === 95 &&
 						moduleSourceCode.charCodeAt(digitEnd + 1) === 95
 					) {
 						const length = Number.parseInt(
-							moduleSourceCode.slice(idx + lengthPrefixLen, digitEnd),
+							moduleSourceCode.slice(idx + hashPrefixLen, digitEnd),
 							10
 						);
-						replaceSource.replace(idx, digitEnd + 1, hash.slice(0, length));
+						replaceSource.replace(
+							idx,
+							digitEnd + 1,
+							length === 0 ? hash : hash.slice(0, length)
+						);
 						nextSearch = digitEnd + 2;
 					} else {
-						nextSearch = idx + lengthPrefixLen;
+						nextSearch = idx + hashPrefixLen;
 					}
-					idx = moduleSourceCode.indexOf(lengthPrefix, nextSearch);
-				}
-
-				const fullHashPlaceholder = CssUrlDependency.PUBLIC_PATH_FULL_HASH;
-				const fullHashPlaceholderLen = fullHashPlaceholder.length;
-				for (
-					let hashIdx = moduleSourceCode.indexOf(fullHashPlaceholder);
-					hashIdx !== -1;
-					hashIdx = moduleSourceCode.indexOf(
-						fullHashPlaceholder,
-						hashIdx + fullHashPlaceholderLen
-					)
-				) {
-					replaceSource.replace(
-						hashIdx,
-						hashIdx + fullHashPlaceholderLen - 1,
-						hash
-					);
+					idx = moduleSourceCode.indexOf(hashPrefix, nextSearch);
 				}
 			}
 

--- a/lib/dependencies/CssUrlDependency.js
+++ b/lib/dependencies/CssUrlDependency.js
@@ -192,9 +192,6 @@ CssUrlDependency.Template = class CssUrlDependencyTemplate extends (
 makeSerializable(CssUrlDependency, "webpack/lib/dependencies/CssUrlDependency");
 
 CssUrlDependency.PUBLIC_PATH_AUTO = "__WEBPACK_CSS_PUBLIC_PATH_AUTO__";
-CssUrlDependency.PUBLIC_PATH_FULL_HASH =
-	"__WEBPACK_CSS_PUBLIC_PATH_FULL_HASH__";
-CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH =
-	"__WEBPACK_CSS_PUBLIC_PATH_FULL_HASH_WITH_LENGTH_";
+CssUrlDependency.PUBLIC_PATH_FULL_HASH = "__WEBPACK_CSS_PUBLIC_PATH_FULL_HASH_";
 
 module.exports = CssUrlDependency;

--- a/lib/dependencies/CssUrlDependency.js
+++ b/lib/dependencies/CssUrlDependency.js
@@ -192,5 +192,9 @@ CssUrlDependency.Template = class CssUrlDependencyTemplate extends (
 makeSerializable(CssUrlDependency, "webpack/lib/dependencies/CssUrlDependency");
 
 CssUrlDependency.PUBLIC_PATH_AUTO = "__WEBPACK_CSS_PUBLIC_PATH_AUTO__";
+CssUrlDependency.PUBLIC_PATH_FULL_HASH =
+	"__WEBPACK_CSS_PUBLIC_PATH_FULL_HASH__";
+CssUrlDependency.PUBLIC_PATH_FULL_HASH_WITH_LENGTH =
+	"__WEBPACK_CSS_PUBLIC_PATH_FULL_HASH_WITH_LENGTH_";
 
 module.exports = CssUrlDependency;

--- a/test/configCases/css/public-path/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/public-path/__snapshots__/ConfigCacheTest.snap
@@ -678,42 +678,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -726,42 +726,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -774,42 +774,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -822,42 +822,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -870,42 +870,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 ",

--- a/test/configCases/css/public-path/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/public-path/__snapshots__/ConfigCacheTest.snap
@@ -678,42 +678,234 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/undefined/same_root.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/undefined/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/undefined/same_root.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigCacheTestCases css public-path exported tests should work 16`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigCacheTestCases css public-path exported tests should work 17`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigCacheTestCases css public-path exported tests should work 18`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigCacheTestCases css public-path exported tests should work 19`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
 }
 
 ",

--- a/test/configCases/css/public-path/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/public-path/__snapshots__/ConfigTest.snap
@@ -678,42 +678,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -726,42 +726,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -774,42 +774,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -822,42 +822,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5153a23401faf/c9e192c015437a21dea1.svg);
 }
 
 ",
@@ -870,42 +870,42 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/f1264fe5/c9e192c015437a21dea1.svg);
 }
 
 ",

--- a/test/configCases/css/public-path/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/public-path/__snapshots__/ConfigTest.snap
@@ -678,42 +678,234 @@ Array [
   !*** css ./style.css ***!
   \\\\***********************/
 .class-1 {
-	background-image: url(https://webpack.js.org/undefined/same_root.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
 }
 
 .class-2 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-3 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-4 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-5 {
-	background-image: url(https://webpack.js.org/undefined/styles/nested/nested_dir.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
 }
 
 /*!******************************!*\\\\
   !*** css ./nested/style.css ***!
   \\\\******************************/
 .class-5 {
-	background-image: url(https://webpack.js.org/undefined/same_root.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
 }
 
 .class-6 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-7 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
 }
 
 .class-8 {
-	background-image: url(https://webpack.js.org/undefined/c9e192c015437a21dea1.svg);
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigTestCases css public-path exported tests should work 16`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigTestCases css public-path exported tests should work 17`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigTestCases css public-path exported tests should work 18`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b91e6fd89903a/c9e192c015437a21dea1.svg);
+}
+
+",
+]
+`;
+
+exports[`ConfigTestCases css public-path exported tests should work 19`] = `
+Array [
+  "/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.class-1 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-2 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-3 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-4 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/styles/nested/nested_dir.svg);
+}
+
+/*!******************************!*\\\\
+  !*** css ./nested/style.css ***!
+  \\\\******************************/
+.class-5 {
+	background-image: url(https://webpack.js.org/1706b30b/same_root.svg);
+}
+
+.class-6 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-7 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
+}
+
+.class-8 {
+	background-image: url(https://webpack.js.org/1706b30b/c9e192c015437a21dea1.svg);
 }
 
 ",

--- a/test/configCases/css/public-path/webpack.config.js
+++ b/test/configCases/css/public-path/webpack.config.js
@@ -17,12 +17,15 @@ const publicPaths = [
 	"./",
 	"../static/",
 	"./static/",
-	// TODO BUG
 	/**
 	 * @param {PathData} pathData path data
 	 * @returns {string} public path
 	 */
-	(pathData) => `https://webpack.js.org/${pathData.hash}/`
+	(pathData) => `https://webpack.js.org/${pathData.hash}/`,
+	"https://webpack.js.org/[fullhash]/",
+	"https://webpack.js.org/[fullhash:8]/",
+	() => "https://webpack.js.org/[fullhash]/",
+	() => "https://webpack.js.org/[fullhash:8]/"
 ];
 
 /** @type {import("../../../../").Configuration[]} */

--- a/types.d.ts
+++ b/types.d.ts
@@ -2684,6 +2684,11 @@ declare interface ChunkRenderContextCssModulesPlugin {
 	undoPath: string;
 
 	/**
+	 * compilation hash
+	 */
+	hash?: string;
+
+	/**
 	 * moduleFactoryCache
 	 */
 	moduleFactoryCache: WeakMap<Source, ModuleFactoryCacheEntry>;
@@ -14209,6 +14214,11 @@ declare interface ModuleFactoryCacheEntry {
 	undoPath: string;
 
 	/**
+	 * - The compilation hash
+	 */
+	hash?: string;
+
+	/**
 	 * - The inheritance chain
 	 */
 	inheritance: [CssLayer, Supports, Media][];
@@ -19093,6 +19103,11 @@ declare interface RenderContextCssModulesPlugin {
 	 * undo path to css file
 	 */
 	undoPath: string;
+
+	/**
+	 * compilation hash
+	 */
+	hash?: string;
 
 	/**
 	 * modules


### PR DESCRIPTION
experiments.css code-generates asset URLs during the codeGeneration
phase, before compilation.hash is computed. When output.publicPath was
a function that referenced pathData.hash (or a string containing
[hash]/[fullhash]), the hash was undefined at that point so url()
references were emitted with "undefined" or an un-substituted [hash]
placeholder.

Substitute a placeholder token for the hash during code generation and
replace it with the real compilation hash in CssModulesPlugin.renderModule
once the hash is known. hashWithLength is also plumbed through to
support [fullhash:N] truncation.

https://claude.ai/code/session_01LPU9TnJW4mam4PgL6dVrtq