### PR TITLE
perf: extract anonymous default export .name fix-up into runtime helper

### DIFF
--- a/.changeset/anonymous-default-export-runtime-helper.md
+++ b/.changeset/anonymous-default-export-runtime-helper.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Extract anonymous default export `.name` fix-up into a shared runtime helper (`__webpack_require__.dn`), replacing repeated inline `Object.defineProperty` / `Object.getOwnPropertyDescriptor` calls with a single short call per module to reduce output size.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -392,6 +392,11 @@ module.exports.runtimeId = "__webpack_require__.j";
 module.exports.scriptNonce = "__webpack_require__.nc";
 
 /**
+ * set .name to "default" for anonymous default exports per ES spec
+ */
+module.exports.setAnonymousDefaultName = "__webpack_require__.dn";
+
+/**
  * an object with all share scopes
  */
 module.exports.shareScopeMap = "__webpack_require__.S";

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -34,6 +34,7 @@ const OnChunksLoadedRuntimeModule = require("./runtime/OnChunksLoadedRuntimeModu
 const PublicPathRuntimeModule = require("./runtime/PublicPathRuntimeModule");
 const RelativeUrlRuntimeModule = require("./runtime/RelativeUrlRuntimeModule");
 const RuntimeIdRuntimeModule = require("./runtime/RuntimeIdRuntimeModule");
+const SetAnonymousDefaultNameRuntimeModule = require("./runtime/SetAnonymousDefaultNameRuntimeModule");
 const SystemContextRuntimeModule = require("./runtime/SystemContextRuntimeModule");
 const ToBinaryRuntimeModule = require("./runtime/ToBinaryRuntimeModule");
 const ShareRuntimeModule = require("./sharing/ShareRuntimeModule");
@@ -79,6 +80,7 @@ const GLOBALS_ON_REQUIRE = [
 	RuntimeGlobals.shareScopeMap,
 	RuntimeGlobals.initializeSharing,
 	RuntimeGlobals.loadScript,
+	RuntimeGlobals.setAnonymousDefaultName,
 	RuntimeGlobals.systemContext,
 	RuntimeGlobals.onChunksLoaded,
 	RuntimeGlobals.makeOptimizedDeferredNamespaceObject,
@@ -235,6 +237,15 @@ class RuntimePlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new CompatGetDefaultExportRuntimeModule()
+					);
+					return true;
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.setAnonymousDefaultName)
+				.tap(PLUGIN_NAME, (chunk) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new SetAnonymousDefaultNameRuntimeModule()
 					);
 					return true;
 				});

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -143,18 +143,17 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				);
 			}
 
+			const used = concatenationScope
+				? undefined
+				: moduleGraph.getExportsInfo(module).getUsedName("default", runtime);
+
 			if (concatenationScope) {
 				concatenationScope.registerExport("default", name);
-			} else {
-				const used = moduleGraph
-					.getExportsInfo(module)
-					.getUsedName("default", runtime);
-				if (used) {
-					/** @type {ExportMap} */
-					const map = new Map();
-					map.set(used, `/* export default binding */ ${name}`);
-					initFragments.push(new HarmonyExportInitFragment(exportsName, map));
-				}
+			} else if (used) {
+				/** @type {ExportMap} */
+				const map = new Map();
+				map.set(used, `/* export default binding */ ${name}`);
+				initFragments.push(new HarmonyExportInitFragment(exportsName, map));
 			}
 
 			source.replace(
@@ -163,12 +162,17 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				`/* harmony default export */ ${dep.prefix}`
 			);
 
-			if (typeof declarationId !== "string" && dep.isAnonymousDefault) {
+			if (
+				typeof declarationId !== "string" &&
+				dep.isAnonymousDefault &&
+				(concatenationScope || used)
+			) {
 				// Fix .name for anonymous default export function declarations
 				// see test/test262-cases/test/language/module-code/instn-named-bndng-dflt-fun-anon.js cspell:disable-line
+				runtimeRequirements.add(RuntimeGlobals.setAnonymousDefaultName);
 				initFragments.push(
 					new InitFragment(
-						`Object.defineProperty(${name}, "name", { value: "default", configurable: true });\n`,
+						`${RuntimeGlobals.setAnonymousDefaultName}(${name});\n`,
 						InitFragment.STAGE_HARMONY_EXPORTS,
 						2
 					)
@@ -178,6 +182,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 			/** @type {string} */
 			let content;
 			let name = ConcatenationScope.DEFAULT_EXPORT;
+			let defaultIsUsed = Boolean(concatenationScope);
 			if (runtimeTemplate.supportsConst()) {
 				content = `/* harmony default export */ const ${name} = `;
 				if (concatenationScope) {
@@ -187,6 +192,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 						.getExportsInfo(module)
 						.getUsedName("default", runtime);
 					if (used) {
+						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
 						/** @type {ExportMap} */
 						const map = new Map();
@@ -204,6 +210,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					.getExportsInfo(module)
 					.getUsedName("default", runtime);
 				if (used) {
+					defaultIsUsed = true;
 					runtimeRequirements.add(RuntimeGlobals.exports);
 					// This is a little bit incorrect as TDZ is not correct, but we can't use const.
 					// No local `__WEBPACK_DEFAULT_EXPORT__` binding is created in this path,
@@ -224,13 +231,14 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					dep.range[0] - 1,
 					`${content}(${dep.prefix}`
 				);
-				if (dep.isAnonymousDefault) {
+				if (dep.isAnonymousDefault && defaultIsUsed) {
 					// Fix .name for anonymous default export expressions
 					// see test/test262-cases/test/language/module-code/eval-export-dflt-cls-anon.js cspell:disable-line
+					runtimeRequirements.add(RuntimeGlobals.setAnonymousDefaultName);
 					source.replace(
 						dep.range[1],
 						dep.rangeStatement[1] - 0.5,
-						`);\n(Object.getOwnPropertyDescriptor(${name}, "name") || {}).writable || Object.defineProperty(${name}, "name", { value: "default", configurable: true });`
+						`);\n${RuntimeGlobals.setAnonymousDefaultName}(${name});`
 					);
 				} else {
 					source.replace(dep.range[1], dep.rangeStatement[1] - 0.5, ");");

--- a/lib/runtime/SetAnonymousDefaultNameRuntimeModule.js
+++ b/lib/runtime/SetAnonymousDefaultNameRuntimeModule.js
@@ -1,0 +1,35 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
+const HelperRuntimeModule = require("./HelperRuntimeModule");
+
+/** @typedef {import("../Compilation")} Compilation */
+
+class SetAnonymousDefaultNameRuntimeModule extends HelperRuntimeModule {
+	constructor() {
+		super("set anonymous default export name");
+	}
+
+	/**
+	 * Generates runtime code for this runtime module.
+	 * @returns {string | null} runtime code
+	 */
+	generate() {
+		const compilation = /** @type {Compilation} */ (this.compilation);
+		const { runtimeTemplate } = compilation;
+		const fn = RuntimeGlobals.setAnonymousDefaultName;
+		return Template.asString([
+			"// set .name for anonymous default exports per ES spec",
+			`${fn} = ${runtimeTemplate.basicFunction("x", [
+				'(Object.getOwnPropertyDescriptor(x, "name") || {}).writable || Object.defineProperty(x, "name", { value: "default", configurable: true });'
+			])};`
+		]);
+	}
+}
+
+module.exports = SetAnonymousDefaultNameRuntimeModule;

--- a/test/statsCases/import-with-invalid-options-comments/__snapshots__/StatsTest.snap
+++ b/test/statsCases/import-with-invalid-options-comments/__snapshots__/StatsTest.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`StatsTestCases import-with-invalid-options-comments should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules X KiB 12 modules
+"runtime modules X KiB 13 modules
 cacheable modules X bytes
   ./index.js X bytes [built] [code generated]
   ./chunk.js X bytes [built] [code generated] [3 warnings]

--- a/types.d.ts
+++ b/types.d.ts
@@ -24469,6 +24469,7 @@ declare namespace exports {
 		export let returnExportsFromRuntime: "return-exports-from-runtime";
 		export let runtimeId: "__webpack_require__.j";
 		export let scriptNonce: "__webpack_require__.nc";
+		export let setAnonymousDefaultName: "__webpack_require__.dn";
 		export let shareScopeMap: "__webpack_require__.S";
 		export let startup: "__webpack_require__.x";
 		export let startupEntrypoint: "__webpack_require__.X";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
perf: https://github.com/webpack/webpack/pull/20796

Move the inline `Object.defineProperty` / `Object.getOwnPropertyDescriptor` calls for anonymous default export `.name` fix-up into a shared runtime module (`__webpack_require__.dn`). This avoids repeating ~140 bytes of unmangleable code per anonymous default export and replaces each with a ~25-byte call, significantly reducing output size in projects with many such exports.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
perf

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing