### PR TITLE
fix: support no-expression template literals in computed member access

### DIFF
--- a/.changeset/fuzzy-pigs-hide.md
+++ b/.changeset/fuzzy-pigs-hide.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Support no-expression template literals in computed member access (e.g. ``import.meta[`url`]``).

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -4215,10 +4215,10 @@ class JavascriptParser extends Parser {
 		if (expression.object.type === "MemberExpression") {
 			// optimize the case where expression.object is a MemberExpression too.
 			// we can keep info here when calling walkMemberExpression directly
-			const property =
-				/** @type {Identifier} */
-				(expression.property).name ||
-				`${/** @type {Literal} */ (expression.property).value}`;
+			// Read the property from `members` (already extracted by
+			// extractMemberExpressionChain) since the AST node may be a
+			// TemplateLiteral, which has neither .name nor .value.
+			const property = members[members.length - 1];
 			name = name.slice(0, -property.length - 1);
 			members.pop();
 			const result = this.callHooksForInfo(
@@ -5434,9 +5434,20 @@ class JavascriptParser extends Parser {
 		const memberRanges = [];
 		while (expr.type === "MemberExpression") {
 			if (expr.computed) {
-				if (expr.property.type !== "Literal") break;
-				members.push(`${expr.property.value}`); // the literal
-				memberRanges.push(/** @type {Range} */ (expr.object.range)); // the range of the expression fragment before the literal
+				const prop = expr.property;
+				if (prop.type === "Literal") {
+					members.push(`${prop.value}`); // the literal
+				} else if (
+					prop.type === "TemplateLiteral" &&
+					prop.expressions.length === 0 &&
+					typeof prop.quasis[0].value.cooked === "string"
+				) {
+					// `[`url`]` is statically a string just like `["url"]`
+					members.push(prop.quasis[0].value.cooked);
+				} else {
+					break;
+				}
+				memberRanges.push(/** @type {Range} */ (expr.object.range)); // the range of the expression fragment before the property
 			} else {
 				if (expr.property.type !== "Identifier") break;
 				members.push(expr.property.name); // the identifier

--- a/test/configCases/parsing/import-meta-computed/index.js
+++ b/test/configCases/parsing/import-meta-computed/index.js
@@ -1,0 +1,9 @@
+it("should support computed property access with literal string on import.meta", () => {
+	const url = import.meta.url;
+	expect(import.meta["url"]).toBe(url);
+});
+
+it("should support computed property access with template string on import.meta", () => {
+	const url = import.meta.url;
+	expect(import.meta[`url`]).toBe(url);
+});

--- a/test/configCases/parsing/import-meta-computed/webpack.config.js
+++ b/test/configCases/parsing/import-meta-computed/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	target: "node"
+};


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/pull/20607