### PR TITLE
perf: use webpack-sources 3.4 buffers() to avoid concat on hashing

### DIFF
--- a/.changeset/webpack-sources-buffers.md
+++ b/.changeset/webpack-sources-buffers.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Bump `webpack-sources` to `^3.4.1` and feed asset bytes into hashes via the new `Source.prototype.buffers()` API. For large `ConcatSource`/`ReplaceSource` outputs this avoids the intermediate `Buffer.concat` that `source.buffer()` performs, removing a peak-memory spike equal to the source's total size on each hashed asset (`AssetGenerator.getFullContentHash`, `CssIcssExportDependency` content hashing, and `RealContentHashPlugin`). A small benchmark on a 64 MiB `ConcatSource` shows ~64 MiB lower peak external memory and ~45% faster hashing.

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -29,6 +29,7 @@ const createHash = require("../util/createHash");
 const { makePathsRelative } = require("../util/identifier");
 const memoize = require("../util/memoize");
 const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { updateHashFromSource } = require("../util/source");
 
 const getMimeTypes = memoize(() => require("../util/mimeTypes"));
 
@@ -259,7 +260,7 @@ class AssetGenerator extends Generator {
 		const source = module.originalSource();
 
 		if (source) {
-			hash.update(source.buffer());
+			updateHashFromSource(hash, source);
 		}
 
 		if (module.error) {

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -14,6 +14,7 @@ const { makePathsRelative } = require("../util/identifier");
 const makeSerializable = require("../util/makeSerializable");
 const memoize = require("../util/memoize");
 const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { updateHashFromSource } = require("../util/source");
 const CssIcssImportDependency = require("./CssIcssImportDependency");
 const NullDependency = require("./NullDependency");
 
@@ -104,7 +105,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		const source = module.originalSource();
 
 		if (source) {
-			hash.update(source.buffer());
+			updateHashFromSource(hash, source);
 		}
 
 		if (module.error) {

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -46,24 +46,76 @@ const addToList = (itemOrItems, list) => {
 };
 
 /**
- * Map and deduplicate buffers.
+ * Compares two non-empty buffer chunk arrays for byte-equality without
+ * allocating a concatenated buffer.
+ * @param {Buffer[]} a first chunk array
+ * @param {Buffer[]} b second chunk array
+ * @returns {boolean} true if the concatenations are byte-equal
+ */
+const bufferArraysEqual = (a, b) => {
+	let aIdx = 0;
+	let aOff = 0;
+	let bIdx = 0;
+	let bOff = 0;
+	while (aIdx < a.length && bIdx < b.length) {
+		const aBuf = a[aIdx];
+		const bBuf = b[bIdx];
+		const len = Math.min(aBuf.length - aOff, bBuf.length - bOff);
+		if (aBuf.compare(bBuf, bOff, bOff + len, aOff, aOff + len) !== 0) {
+			return false;
+		}
+		aOff += len;
+		bOff += len;
+		if (aOff === aBuf.length) {
+			aIdx++;
+			aOff = 0;
+		}
+		if (bOff === bBuf.length) {
+			bIdx++;
+			bOff = 0;
+		}
+	}
+	return aIdx === a.length && bIdx === b.length;
+};
+
+/**
+ * Map sources to their buffer chunks and deduplicate by total byte content,
+ * grouping by total length first to avoid full comparisons.
  * @template T
  * @param {T[]} input list
- * @param {(item: T) => Buffer} fn map function
- * @returns {Buffer[]} buffers without duplicates
+ * @param {(item: T) => Source} fn map function returning a Source
+ * @returns {Buffer[][]} unique chunk arrays
  */
-const mapAndDeduplicateBuffers = (input, fn) => {
-	// Buffer.equals compares size first so this should be efficient enough
-	// If it becomes a performance problem we can use a map and group by size
-	// instead of looping over all assets.
-	/** @type {Buffer[]} */
+const mapAndDeduplicateSourceBuffers = (input, fn) => {
+	/** @type {Map<number, Buffer[][]>} */
+	const bySize = new Map();
+	/** @type {Buffer[][]} */
 	const result = [];
-	outer: for (const value of input) {
-		const buf = fn(value);
-		for (const other of result) {
-			if (buf.equals(other)) continue outer;
+	for (const value of input) {
+		const source = fn(value);
+		// TODO webpack 6: drop the `buffers` check, require webpack-sources >= 3.4
+		// and call `source.buffers()` unconditionally.
+		const chunks =
+			typeof source.buffers === "function"
+				? source.buffers()
+				: [source.buffer()];
+		let total = 0;
+		for (const c of chunks) total += c.length;
+		const sameSize = bySize.get(total);
+		if (sameSize) {
+			let duplicate = false;
+			for (const other of sameSize) {
+				if (bufferArraysEqual(chunks, other)) {
+					duplicate = true;
+					break;
+				}
+			}
+			if (duplicate) continue;
+			sameSize.push(chunks);
+		} else {
+			bySize.set(total, [chunks]);
 		}
-		result.push(buf);
+		result.push(chunks);
 	}
 	return result;
 };
@@ -437,24 +489,34 @@ ${referencingAssets
 									: computeNewContent(asset)
 							)
 						);
-						const assetsContent = mapAndDeduplicateBuffers(assets, (asset) => {
-							if (/** @type {Hashes} */ (asset.ownHashes).has(oldHash)) {
-								return asset.newSourceWithoutOwn
-									? asset.newSourceWithoutOwn.buffer()
-									: asset.source.buffer();
+						const uniqueChunkArrays = mapAndDeduplicateSourceBuffers(
+							assets,
+							(asset) => {
+								if (/** @type {Hashes} */ (asset.ownHashes).has(oldHash)) {
+									return asset.newSourceWithoutOwn || asset.source;
+								}
+								return asset.newSource || asset.source;
 							}
-							return asset.newSource
-								? asset.newSource.buffer()
-								: asset.source.buffer();
-						});
-						let newHash = hooks.updateHash.call(assetsContent, oldHash);
+						);
+						/** @type {string | undefined} */
+						let newHash;
+						// Only materialize the public `Buffer[]` (one entry per unique
+						// asset) when something is tapped; otherwise the hot path feeds
+						// chunks into the hash directly, avoiding per-asset Buffer.concat.
+						if (hooks.updateHash.isUsed()) {
+							const assetsContent = uniqueChunkArrays.map((chunks) =>
+								chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)
+							);
+							newHash =
+								hooks.updateHash.call(assetsContent, oldHash) || undefined;
+						}
 						if (!newHash) {
 							const hash = createHash(this._hashFunction);
 							if (compilation.outputOptions.hashSalt) {
 								hash.update(compilation.outputOptions.hashSalt);
 							}
-							for (const content of assetsContent) {
-								hash.update(content);
+							for (const chunks of uniqueChunkArrays) {
+								for (const c of chunks) hash.update(c);
 							}
 							const digest = hash.digest(this._hashDigest);
 							newHash = digest.slice(0, oldHash.length);

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -96,6 +96,7 @@ const mapAndDeduplicateSourceBuffers = (input, fn) => {
 		// TODO webpack 6: drop the `buffers` check, require webpack-sources >= 3.4
 		// and call `source.buffers()` unconditionally.
 		const chunks =
+			// TODO remove in webpack 6, this is protection against authors who directly use `webpack-sources` outdated version
 			typeof source.buffers === "function"
 				? source.buffers()
 				: [source.buffer()];

--- a/lib/util/source.js
+++ b/lib/util/source.js
@@ -62,6 +62,7 @@ const isSourceEqual = (a, b) => {
 	return result;
 };
 
+// TODO remove in webpack 6, this is protection against authors who directly use `webpack-sources` outdated version
 /**
  * Feeds the Source's content into a Hash without forcing a single
  * concatenated Buffer. Uses webpack-sources >= 3.4.0 `buffers()` when

--- a/lib/util/source.js
+++ b/lib/util/source.js
@@ -6,6 +6,7 @@
 "use strict";
 
 /** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {import("./Hash")} Hash */
 
 /** @type {WeakMap<Source, WeakMap<Source, boolean>>} */
 const equalityCache = new WeakMap();
@@ -61,4 +62,23 @@ const isSourceEqual = (a, b) => {
 	return result;
 };
 
+/**
+ * Feeds the Source's content into a Hash without forcing a single
+ * concatenated Buffer. Uses webpack-sources >= 3.4.0 `buffers()` when
+ * available so `ConcatSource` can stream its children directly.
+ * @param {Hash} hash hash to update
+ * @param {Source} source source whose bytes are appended
+ * @returns {void}
+ */
+const updateHashFromSource = (hash, source) => {
+	// TODO webpack 6: drop the `buffers` check, require webpack-sources >= 3.4
+	// and call `source.buffers()` unconditionally.
+	if (typeof source.buffers === "function") {
+		for (const buf of source.buffers()) hash.update(buf);
+	} else {
+		hash.update(source.buffer());
+	}
+};
+
 module.exports.isSourceEqual = isSourceEqual;
+module.exports.updateHashFromSource = updateHashFromSource;

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "tapable": "^2.3.0",
     "terser-webpack-plugin": "^5.5.0",
     "watchpack": "^2.5.1",
-    "webpack-sources": "^3.3.4"
+    "webpack-sources": "^3.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",

--- a/types.d.ts
+++ b/types.d.ts
@@ -21807,6 +21807,7 @@ declare class Source {
 	constructor();
 	source(): SourceValue;
 	buffer(): Buffer;
+	buffers(): Buffer[];
 	size(): number;
 	map(options?: MapOptions): null | RawSourceMap;
 	sourceAndMap(options?: MapOptions): SourceAndMap;
@@ -21833,6 +21834,11 @@ declare interface SourceLike {
 	 * buffer
 	 */
 	buffer?: () => Buffer;
+
+	/**
+	 * buffers
+	 */
+	buffers?: () => Buffer[];
 
 	/**
 	 * size

--- a/yarn.lock
+++ b/yarn.lock
@@ -9769,10 +9769,10 @@ webpack-merge@^6.0.1:
     flat "^5.0.2"
     wildcard "^2.0.1"
 
-webpack-sources@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.3.4.tgz#a338b95eb484ecc75fbb196cbe8a2890618b4891"
-  integrity sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==
+webpack-sources@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.4.1.tgz#009d110999ebd9fb3a6fa8d32eec6f84d940e65d"
+  integrity sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Bumps webpack-sources to ^3.4.1 and feeds Source bytes into hashes via
the new Source.prototype.buffers() API. For ConcatSource/ReplaceSource
outputs this removes the intermediate Buffer.concat that source.buffer()
performs, eliminating a peak-memory spike equal to the source's total
size on each hashed asset:

- lib/util/source.js: add updateHashFromSource(hash, source) helper
  that prefers buffers() and falls back for older sources.
- lib/asset/AssetGenerator.js: use the helper in getFullContentHash.
- lib/dependencies/CssIcssExportDependency.js: same for [contenthash]
  in CSS ident generation.
- lib/optimize/RealContentHashPlugin.js: replace mapAndDeduplicateBuffers
  with mapAndDeduplicateSourceBuffers + bufferArraysEqual so dedup and
  hashing both work on chunk arrays without concatenation.

Quick measurement on a 64 MiB ConcatSource:
  buffer()  path: ~121 ms, +64 MiB peak external memory
  buffers() path:  ~64 ms,   0 MiB peak external memory