### PR TITLE
fix: preserve `using` declaration initializers in inner graph

### DIFF
--- a/.changeset/using-inner-graph.md
+++ b/.changeset/using-inner-graph.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Preserve `using` declaration initializers when the inner graph optimization is enabled.

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -29,6 +29,7 @@ const InnerGraph = require("./InnerGraph");
 const { topLevelSymbolTag } = InnerGraph;
 
 const PLUGIN_NAME = "InnerGraphPlugin";
+const impureVariableDeclarationKinds = new Set(["using", "await using"]);
 
 class InnerGraphPlugin {
 	/**
@@ -200,8 +201,9 @@ class InnerGraphPlugin {
 						}
 					});
 
-					parser.hooks.preDeclarator.tap(PLUGIN_NAME, (decl, _statement) => {
+					parser.hooks.preDeclarator.tap(PLUGIN_NAME, (decl, statement) => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (impureVariableDeclarationKinds.has(statement.kind)) return;
 						if (
 							parser.scope.topLevelScope === true &&
 							decl.init &&

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1066,15 +1066,7 @@ const knownProductionBuildBugs = [
 	"module-code/instn-star-props-nrml.js",
 	"module-code/namespace/internals/get-nested-namespace-props-nrml.js",
 	// Production concatenation orders eager import after defer
-	"import/import-defer/evaluation-sync/module-imported-defer-and-eager.js",
-	// Production inner graph drops using initializers
-	"statements/using/Symbol.dispose-getter.js",
-	"statements/using/gets-initializer-Symbol.dispose-property-once.js",
-	"statements/using/initializer-disposed-at-end-of-block.js",
-	"statements/using/initializer-disposed-at-end-of-forstatement.js",
-	"statements/using/multiple-resources-disposed-in-reverse-order.js",
-	"statements/using/puts-initializer-on-top-of-disposableresourcestack-multiple-bindings.js",
-	"statements/using/puts-initializer-on-top-of-disposableresourcestack-subsequent-usings.js"
+	"import/import-defer/evaluation-sync/module-imported-defer-and-eager.js"
 ];
 /* cspell:enable */
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

We should consider `using` declarations as side effect statement in the inner graph so their initializers are not replaced with null expressions.


Error output:
```js
var resource = {
	disposed: false,
	get [Symbol.dispose]() {
		return function () {
			this.disposed = true;
		};
	}
};

{
	using _ = (/* unused pure expression or super */ null && (resource));
}
```

Expected output:
``` js
var resource = {
	disposed: false,
	get [Symbol.dispose]() {
		return function () {
			this.disposed = true;
		};
	}
};

{
	using _ = resource;
}
```
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Existing test262 spec test.
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Partial
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->