### PR TITLE
feat: support cross-module pure detection in inner graph

### DIFF
--- a/.changeset/inner-graph-cross-module-pure.md
+++ b/.changeset/inner-graph-cross-module-pure.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Allow tree-shaking unused calls to `/*#__NO_SIDE_EFFECTS__*/`-annotated (pure) exports across module boundaries.

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -60,6 +60,7 @@ const memoize = require("./util/memoize");
  * @property {ExportInfoName} name the name of the export
  * @property {boolean=} canMangle can the export be renamed (defaults to true)
  * @property {boolean=} terminalBinding is the export a terminal binding that should be checked for export star conflicts
+ * @property {boolean=} isPure calling this export has no observable side effects
  * @property {(string | ExportSpec)[]=} exports nested exports
  * @property {ModuleGraphConnection=} from when reexported: from which module
  * @property {string[] | null=} export when reexported: from which export
@@ -79,6 +80,7 @@ const memoize = require("./util/memoize");
  * @property {number=} priority when reexported: with which priority
  * @property {boolean=} canMangle can the export be renamed (defaults to true)
  * @property {boolean=} terminalBinding are the exports terminal bindings that should be checked for export star conflicts
+ * @property {boolean=} isPure calling these exports has no observable side effects
  * @property {Module[]=} dependencies module on which the result depends on
  */
 

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -48,6 +48,7 @@ const { forEachRuntime } = require("./util/runtime");
  * @property {ExportInfo["provided"]} provided
  * @property {ExportInfo["canMangleProvide"]} canMangleProvide
  * @property {ExportInfo["terminalBinding"]} terminalBinding
+ * @property {ExportInfo["pureProvide"]} pureProvide
  * @property {RestoreProvidedData | undefined} exportsInfo
  */
 
@@ -819,6 +820,7 @@ class ExportsInfo {
 				exportInfo.provided !== otherProvided ||
 				exportInfo.canMangleProvide !== otherCanMangleProvide ||
 				exportInfo.terminalBinding !== otherTerminalBinding ||
+				exportInfo.pureProvide !== undefined ||
 				exportInfo.exportsInfoOwned
 			) {
 				exports.push({
@@ -826,6 +828,7 @@ class ExportsInfo {
 					provided: exportInfo.provided,
 					canMangleProvide: exportInfo.canMangleProvide,
 					terminalBinding: exportInfo.terminalBinding,
+					pureProvide: exportInfo.pureProvide,
 					exportsInfo: exportInfo.exportsInfoOwned
 						? /** @type {NonNullable<ExportInfo["exportsInfo"]>} */
 							(exportInfo.exportsInfo).getRestoreProvidedData()
@@ -866,6 +869,7 @@ class ExportsInfo {
 			exportInfo.provided = exp.provided;
 			exportInfo.canMangleProvide = exp.canMangleProvide;
 			exportInfo.terminalBinding = exp.terminalBinding;
+			exportInfo.pureProvide = exp.pureProvide;
 			if (exp.exportsInfo) {
 				const exportsInfo = exportInfo.createNestedExportsInfo();
 				exportsInfo.restoreProvided(exp.exportsInfo);
@@ -936,6 +940,13 @@ class ExportInfo {
 		 * @type {boolean | undefined}
 		 */
 		this.canMangleUse = initFrom ? initFrom.canMangleUse : undefined;
+		/**
+		 * Only specific export info can be pure, so other_export_info.pure is always undefined.
+		 * true: calling the export has no observable side effects
+		 * undefined: it was not determined whether the export is pure
+		 * @type {boolean | undefined}
+		 */
+		this.pureProvide = undefined;
 		/** @type {boolean} */
 		this.exportsInfoOwned = false;
 		/** @type {ExportsInfo | undefined} */
@@ -1603,7 +1614,7 @@ class ExportInfo {
 		hash.update(
 			`${this._usedName || this.name}${this.getUsed(runtime)}${this.provided}${
 				this.terminalBinding
-			}`
+			}${this.pureProvide ? "P" : ""}`
 		);
 		if (this.exportsInfo && !alreadyVisitedExportsInfo.has(this.exportsInfo)) {
 			this.exportsInfo._updateHash(hash, runtime, alreadyVisitedExportsInfo);

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -166,6 +166,7 @@ class FlagDependencyExportsPlugin {
 								const globalPriority = exportDesc.priority;
 								const globalTerminalBinding =
 									exportDesc.terminalBinding || false;
+								const globalPure = exportDesc.isPure || false;
 								const exportDeps = exportDesc.dependencies;
 								if (exportDesc.hideExports) {
 									for (const name of exportDesc.hideExports) {
@@ -198,6 +199,7 @@ class FlagDependencyExportsPlugin {
 											let name;
 											let canMangle = globalCanMangle;
 											let terminalBinding = globalTerminalBinding;
+											let pure = globalPure;
 											/** @type {ExportSpec["exports"]} */
 											let exports;
 											let from = globalFrom;
@@ -227,6 +229,9 @@ class FlagDependencyExportsPlugin {
 												if (exportNameOrSpec.terminalBinding !== undefined) {
 													terminalBinding = exportNameOrSpec.terminalBinding;
 												}
+												if (exportNameOrSpec.isPure !== undefined) {
+													pure = exportNameOrSpec.isPure;
+												}
 												if (exportNameOrSpec.hidden !== undefined) {
 													hidden = exportNameOrSpec.hidden;
 												}
@@ -251,6 +256,11 @@ class FlagDependencyExportsPlugin {
 
 											if (terminalBinding && !exportInfo.terminalBinding) {
 												exportInfo.terminalBinding = true;
+												changed = true;
+											}
+
+											if (pure && exportInfo.pureProvide !== true) {
+												exportInfo.pureProvide = true;
 												changed = true;
 											}
 

--- a/lib/JavascriptMetaInfoPlugin.js
+++ b/lib/JavascriptMetaInfoPlugin.js
@@ -10,7 +10,7 @@ const {
 	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("./ModuleTypeConstants");
-const InnerGraph = require("./optimize/InnerGraph");
+const { getInnerGraph } = require("./optimize/InnerGraph");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
@@ -28,6 +28,7 @@ class JavascriptMetaInfoPlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				const innerGraph = getInnerGraph(compilation);
 				/**
 				 * Handles the hook callback for this code path.
 				 * @param {JavascriptParser} parser the parser
@@ -39,11 +40,11 @@ class JavascriptMetaInfoPlugin {
 							/** @type {BuildInfo} */
 							(parser.state.module.buildInfo);
 						buildInfo.moduleConcatenationBailout = "eval()";
-						const currentSymbol = InnerGraph.getTopLevelSymbol(parser.state);
+						const currentSymbol = innerGraph.getTopLevelSymbol(parser.state);
 						if (currentSymbol) {
-							InnerGraph.addUsage(parser.state, null, currentSymbol);
+							innerGraph.addUsage(parser.state, null, currentSymbol);
 						} else {
-							InnerGraph.bailout(parser.state);
+							innerGraph.bailout(parser.state);
 						}
 					});
 					parser.hooks.finish.tap(PLUGIN_NAME, () => {

--- a/lib/JavascriptMetaInfoPlugin.js
+++ b/lib/JavascriptMetaInfoPlugin.js
@@ -10,7 +10,7 @@ const {
 	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("./ModuleTypeConstants");
-const { getInnerGraph } = require("./optimize/InnerGraph");
+const { getInnerGraphUtils } = require("./optimize/InnerGraph");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
@@ -28,7 +28,7 @@ class JavascriptMetaInfoPlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
-				const innerGraph = getInnerGraph(compilation);
+				const innerGraph = getInnerGraphUtils(compilation);
 				/**
 				 * Handles the hook callback for this code path.
 				 * @param {JavascriptParser} parser the parser

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -210,6 +210,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {string=} charset for css modules (charset at-rule)
  * @property {JsonData=} jsonData for json modules
  * @property {Set<string>=} topLevelDeclarations top level declaration names
+ * @property {Set<string>=} pureFunctions names of locally declared functions known to be free of side effects
  */
 
 /** @typedef {string | Set<string>} ValueCacheVersion */

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -8,7 +8,7 @@
 const CompatibilityPlugin = require("../CompatibilityPlugin");
 const WebpackError = require("../errors/WebpackError");
 const { getImportAttributes } = require("../javascript/JavascriptParser");
-const InnerGraph = require("../optimize/InnerGraph");
+const { getInnerGraph } = require("../optimize/InnerGraph");
 const ConstDependency = require("./ConstDependency");
 const HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");
 const HarmonyExportHeaderDependency = require("./HarmonyExportHeaderDependency");
@@ -156,7 +156,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			);
 			dep.loc.index = -1;
 			parser.state.current.addDependency(dep);
-			InnerGraph.addVariableUsage(
+			getInnerGraph(parser.state.compilation).addVariableUsage(
 				parser,
 				node.type.endsWith("Declaration") &&
 					/** @type {FunctionDeclaration | ClassDeclaration} */ (node).id
@@ -187,7 +187,11 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				const harmonyNamedExports = (parser.state.harmonyNamedExports =
 					parser.state.harmonyNamedExports || new Set());
 				harmonyNamedExports.add(name);
-				InnerGraph.addVariableUsage(parser, id, name);
+				getInnerGraph(parser.state.compilation).addVariableUsage(
+					parser,
+					id,
+					name
+				);
 				const dep = settings
 					? new HarmonyExportImportedSpecifierDependency(
 							settings.source,

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -8,7 +8,7 @@
 const CompatibilityPlugin = require("../CompatibilityPlugin");
 const WebpackError = require("../errors/WebpackError");
 const { getImportAttributes } = require("../javascript/JavascriptParser");
-const { getInnerGraph } = require("../optimize/InnerGraph");
+const { getInnerGraphUtils } = require("../optimize/InnerGraph");
 const ConstDependency = require("./ConstDependency");
 const HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");
 const HarmonyExportHeaderDependency = require("./HarmonyExportHeaderDependency");
@@ -156,7 +156,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			);
 			dep.loc.index = -1;
 			parser.state.current.addDependency(dep);
-			getInnerGraph(parser.state.compilation).addVariableUsage(
+			getInnerGraphUtils(parser.state.compilation).addVariableUsage(
 				parser,
 				node.type.endsWith("Declaration") &&
 					/** @type {FunctionDeclaration | ClassDeclaration} */ (node).id
@@ -187,7 +187,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				const harmonyNamedExports = (parser.state.harmonyNamedExports =
 					parser.state.harmonyNamedExports || new Set());
 				harmonyNamedExports.add(name);
-				getInnerGraph(parser.state.compilation).addVariableUsage(
+				getInnerGraphUtils(parser.state.compilation).addVariableUsage(
 					parser,
 					id,
 					name

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -13,6 +13,8 @@ const { propertyAccess } = require("../util/property");
 const HarmonyExportInitFragment = require("./HarmonyExportInitFragment");
 const NullDependency = require("./NullDependency");
 
+const DEFAULT_EXPORT_NAME = "default";
+
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
@@ -51,8 +53,19 @@ class HarmonyExportExpressionDependency extends NullDependency {
 	 * @returns {ExportsSpec | undefined} export names
 	 */
 	getExports(moduleGraph) {
+		const module = moduleGraph.getParentModule(this);
+		const pureFunctions =
+			module && module.buildInfo && module.buildInfo.pureFunctions;
+		const isPure = Boolean(
+			pureFunctions && pureFunctions.has(DEFAULT_EXPORT_NAME)
+		);
+
 		return {
-			exports: ["default"],
+			exports: [
+				isPure
+					? { name: DEFAULT_EXPORT_NAME, isPure: true }
+					: DEFAULT_EXPORT_NAME
+			],
 			priority: 1,
 			terminalBinding: true,
 			dependencies: undefined
@@ -145,10 +158,12 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 
 			const used = concatenationScope
 				? undefined
-				: moduleGraph.getExportsInfo(module).getUsedName("default", runtime);
+				: moduleGraph
+						.getExportsInfo(module)
+						.getUsedName(DEFAULT_EXPORT_NAME, runtime);
 
 			if (concatenationScope) {
-				concatenationScope.registerExport("default", name);
+				concatenationScope.registerExport(DEFAULT_EXPORT_NAME, name);
 			} else if (used) {
 				/** @type {ExportMap} */
 				const map = new Map();
@@ -186,11 +201,11 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 			if (runtimeTemplate.supportsConst()) {
 				content = `/* harmony default export */ const ${name} = `;
 				if (concatenationScope) {
-					concatenationScope.registerExport("default", name);
+					concatenationScope.registerExport(DEFAULT_EXPORT_NAME, name);
 				} else {
 					const used = moduleGraph
 						.getExportsInfo(module)
-						.getUsedName("default", runtime);
+						.getUsedName(DEFAULT_EXPORT_NAME, runtime);
 					if (used) {
 						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
@@ -204,11 +219,11 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				}
 			} else if (concatenationScope) {
 				content = `/* harmony default export */ var ${name} = `;
-				concatenationScope.registerExport("default", name);
+				concatenationScope.registerExport(DEFAULT_EXPORT_NAME, name);
 			} else {
 				const used = moduleGraph
 					.getExportsInfo(module)
-					.getUsedName("default", runtime);
+					.getUsedName(DEFAULT_EXPORT_NAME, runtime);
 				if (used) {
 					defaultIsUsed = true;
 					runtimeRequirements.add(RuntimeGlobals.exports);

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -42,8 +42,12 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 	 * @returns {ExportsSpec | undefined} export names
 	 */
 	getExports(moduleGraph) {
+		const module = moduleGraph.getParentModule(this);
+		const pureFunctions =
+			module && module.buildInfo && module.buildInfo.pureFunctions;
+		const isPure = Boolean(pureFunctions && pureFunctions.has(this.id));
 		return {
-			exports: [this.name],
+			exports: [isPure ? { name: this.name, isPure: true } : this.name],
 			priority: 1,
 			terminalBinding: true,
 			dependencies: undefined

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -11,7 +11,7 @@ const {
 	VariableInfo,
 	getImportAttributes
 } = require("../javascript/JavascriptParser");
-const InnerGraph = require("../optimize/InnerGraph");
+const { getInnerGraph } = require("../optimize/InnerGraph");
 const AppendOnlyStackedSet = require("../util/AppendOnlyStackedSet");
 const ConstDependency = require("./ConstDependency");
 const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
@@ -263,7 +263,10 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			);
 			dep.loc = /** @type {DependencyLocation} */ (expression.loc);
 			parser.state.module.addDependency(dep);
-			InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
+			getInnerGraph(parser.state.compilation).onUsage(
+				parser.state,
+				(e) => (dep.usedByExports = e)
+			);
 			return true;
 		});
 		parser.hooks.collectDestructuringAssignmentProperties.tap(
@@ -307,7 +310,10 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				dep.call = parser.scope.inTaggedTemplateTag;
 				parser.state.module.addDependency(dep);
-				InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
+				getInnerGraph(parser.state.compilation).onUsage(
+					parser.state,
+					(e) => (dep.usedByExports = e)
+				);
 				return true;
 			});
 		parser.hooks.expressionMemberChain
@@ -355,7 +361,10 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					);
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
-					InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
+					getInnerGraph(parser.state.compilation).onUsage(
+						parser.state,
+						(e) => (dep.usedByExports = e)
+					);
 					return true;
 				}
 			);
@@ -409,7 +418,10 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
 					if (args) parser.walkExpressions(args);
-					InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
+					getInnerGraph(parser.state.compilation).onUsage(
+						parser.state,
+						(e) => (dep.usedByExports = e)
+					);
 					return true;
 				}
 			);

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -11,7 +11,7 @@ const {
 	VariableInfo,
 	getImportAttributes
 } = require("../javascript/JavascriptParser");
-const { getInnerGraph } = require("../optimize/InnerGraph");
+const { getInnerGraphUtils } = require("../optimize/InnerGraph");
 const AppendOnlyStackedSet = require("../util/AppendOnlyStackedSet");
 const ConstDependency = require("./ConstDependency");
 const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
@@ -263,7 +263,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			);
 			dep.loc = /** @type {DependencyLocation} */ (expression.loc);
 			parser.state.module.addDependency(dep);
-			getInnerGraph(parser.state.compilation).onUsage(
+			getInnerGraphUtils(parser.state.compilation).onUsage(
 				parser.state,
 				(e) => (dep.usedByExports = e)
 			);
@@ -310,7 +310,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				dep.call = parser.scope.inTaggedTemplateTag;
 				parser.state.module.addDependency(dep);
-				getInnerGraph(parser.state.compilation).onUsage(
+				getInnerGraphUtils(parser.state.compilation).onUsage(
 					parser.state,
 					(e) => (dep.usedByExports = e)
 				);
@@ -361,7 +361,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					);
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
-					getInnerGraph(parser.state.compilation).onUsage(
+					getInnerGraphUtils(parser.state.compilation).onUsage(
 						parser.state,
 						(e) => (dep.usedByExports = e)
 					);
@@ -418,7 +418,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
 					if (args) parser.walkExpressions(args);
-					getInnerGraph(parser.state.compilation).onUsage(
+					getInnerGraphUtils(parser.state.compilation).onUsage(
 						parser.state,
 						(e) => (dep.usedByExports = e)
 					);

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -151,11 +151,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
 	 */
 	getCondition(moduleGraph) {
-		return getDependencyUsedByExportsCondition(
-			this,
-			this.usedByExports,
-			moduleGraph
-		);
+		return getDependencyUsedByExportsCondition(this, moduleGraph);
 	}
 
 	/**

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -60,11 +60,7 @@ class URLDependency extends ModuleDependency {
 	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
 	 */
 	getCondition(moduleGraph) {
-		return getDependencyUsedByExportsCondition(
-			this,
-			this.usedByExports,
-			moduleGraph
-		);
+		return getDependencyUsedByExportsCondition(this, moduleGraph);
 	}
 
 	/**

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5180,27 +5180,6 @@ class JavascriptParser extends Parser {
 					return pureFlag;
 				});
 
-			case "CallExpression": {
-				const pureFlag =
-					/** @type {Range} */ (expr.range)[0] - commentsStartPos > 12 &&
-					this.getComments([
-						commentsStartPos,
-						/** @type {Range} */ (expr.range)[0]
-					]).some(
-						(comment) =>
-							comment.type === "Block" &&
-							CompilerHintNotationRegExp.Pure.test(comment.value)
-					);
-				if (!pureFlag) return false;
-				commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
-				return expr.arguments.every((arg) => {
-					if (arg.type === "SpreadElement") return false;
-					const pureFlag = this.isPure(arg, commentsStartPos);
-					commentsStartPos = /** @type {Range} */ (arg.range)[1];
-					return pureFlag;
-				});
-			}
-
 			case "NewExpression": {
 				const pureFlag =
 					/** @type {Range} */ (expr.range)[0] - commentsStartPos > 12 &&

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5180,6 +5180,27 @@ class JavascriptParser extends Parser {
 					return pureFlag;
 				});
 
+			case "CallExpression": {
+				const pureFlag =
+					/** @type {Range} */ (expr.range)[0] - commentsStartPos > 12 &&
+					this.getComments([
+						commentsStartPos,
+						/** @type {Range} */ (expr.range)[0]
+					]).some(
+						(comment) =>
+							comment.type === "Block" &&
+							CompilerHintNotationRegExp.Pure.test(comment.value)
+					);
+				if (!pureFlag) return false;
+				commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
+				return expr.arguments.every((arg) => {
+					if (arg.type === "SpreadElement") return false;
+					const pureFlag = this.isPure(arg, commentsStartPos);
+					commentsStartPos = /** @type {Range} */ (arg.range)[1];
+					return pureFlag;
+				});
+			}
+
 			case "NewExpression": {
 				const pureFlag =
 					/** @type {Range} */ (expr.range)[0] - commentsStartPos > 12 &&

--- a/lib/optimize/InnerGraph.js
+++ b/lib/optimize/InnerGraph.js
@@ -8,6 +8,7 @@
 const { UsageState } = require("../ExportsInfo");
 const JavascriptParser = require("../javascript/JavascriptParser");
 
+/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").GetConditionFn} GetConditionFn */
 /** @typedef {import("../Module")} Module */
@@ -15,11 +16,12 @@ const JavascriptParser = require("../javascript/JavascriptParser");
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
+/** @typedef {boolean | ((compilation: Compilation, module: Module) => boolean)} PureCondition */
 /** @typedef {Set<string | TopLevelSymbol>} InnerGraphValueSet */
 /** @typedef {InnerGraphValueSet | true} InnerGraphValue */
 /** @typedef {TopLevelSymbol | null} InnerGraphKey */
 /** @typedef {Map<InnerGraphKey, InnerGraphValue | undefined>} InnerGraph */
-/** @typedef {(value: boolean | Set<string> | undefined) => void} UsageCallback */
+/** @typedef {(value: boolean | Set<string> | undefined, module: Module) => void} UsageCallback */
 
 /**
  * Defines the state object type used by this module.
@@ -30,244 +32,78 @@ const JavascriptParser = require("../javascript/JavascriptParser");
  */
 
 /** @typedef {false | StateObject} State */
+/** @typedef {string | TopLevelSymbol | true} Usage */
+/** @typedef {Set<string> | boolean} UsedByExports */
+/** @typedef {Dependency & { usedByExports: UsedByExports | undefined }} DependencyWithUsedByExports */
 
 class TopLevelSymbol {
 	/**
 	 * Creates an instance of TopLevelSymbol.
 	 * @param {string} name name of the variable
+	 * @param {PureCondition=} pure pure condition
 	 */
-	constructor(name) {
+	constructor(name, pure = false) {
 		/** @type {string} */
 		this.name = name;
+
+		/** @type {boolean} */
+		this.conditional = false;
+		/** @type {boolean} */
+		this._pure = false;
+		/** @type {((compilation: Compilation, module: Module) => boolean) | undefined} */
+		this.pureFn = undefined;
+
+		this.setPure(pure);
+	}
+
+	/**
+	 * Sets the pure condition
+	 * @param {PureCondition} pure pure condition
+	 * @returns {void}
+	 */
+	setPure(pure) {
+		this.conditional = typeof pure === "function";
+		this._pure = pure === true;
+		this.pureFn = typeof pure === "function" ? pure : undefined;
+	}
+
+	/**
+	 * @param {Compilation} compilation compilation
+	 * @param {Module} module module
+	 * @returns {boolean} if the symbol is pure
+	 */
+	isPure(compilation, module) {
+		if (!this.conditional) return this._pure;
+
+		const pureFn =
+			/** @type {(compilation: Compilation, module: Module) => boolean} */ (
+				this.pureFn
+			);
+		return pureFn(compilation, module);
 	}
 }
 
 module.exports.TopLevelSymbol = TopLevelSymbol;
 
-/** @type {WeakMap<ParserState, State>} */
-const parserStateMap = new WeakMap();
 const topLevelSymbolTag = Symbol("top level symbol");
 
-/**
- * Returns state.
- * @param {ParserState} parserState parser state
- * @returns {State | undefined} state
- */
-function getState(parserState) {
-	return parserStateMap.get(parserState);
-}
+/** @type {WeakMap<Compilation, InnerGraphUtils>} */
+const innerGraphByCompilation = new WeakMap();
 
 /**
- * Processes the provided state.
- * @param {ParserState} state parser state
- * @param {TopLevelSymbol | null} symbol the symbol, or null for all symbols
- * @param {Usage} usage usage data
- * @returns {void}
+ * @typedef {object} InnerGraphUtils
+ * @property {(parserState: ParserState) => void} enable
+ * @property {(parserState: ParserState) => void} bailout
+ * @property {(parserState: ParserState) => boolean} isEnabled
+ * @property {(parserState: ParserState, symbol: TopLevelSymbol | null, usage: Usage) => void} addUsage
+ * @property {(parserState: ParserState, onUsageCallback: UsageCallback) => void} onUsage
+ * @property {(parserState: ParserState, symbol: TopLevelSymbol | undefined) => void} setTopLevelSymbol
+ * @property {(parserState: ParserState) => TopLevelSymbol | void} getTopLevelSymbol
+ * @property {(parser: JavascriptParser, name: string, pure?: PureCondition) => TopLevelSymbol | undefined} tagTopLevelSymbol
+ * @property {(parser: JavascriptParser, name: string, usage: Usage) => void} addVariableUsage
+ * @property {(module: Module) => void} inferDependencyUsage
+ * @property {(module: Module) => void} release
  */
-module.exports.addUsage = (state, symbol, usage) => {
-	const innerGraphState = getState(state);
-
-	if (innerGraphState) {
-		const { innerGraph } = innerGraphState;
-		const info = innerGraph.get(symbol);
-		if (usage === true) {
-			innerGraph.set(symbol, true);
-		} else if (info === undefined) {
-			innerGraph.set(symbol, new Set([usage]));
-		} else if (info !== true) {
-			info.add(usage);
-		}
-	}
-};
-
-/** @typedef {string | TopLevelSymbol | true} Usage */
-
-/**
- * Processes the provided parser.
- * @param {JavascriptParser} parser the parser
- * @param {string} name name of variable
- * @param {Usage} usage usage data
- * @returns {void}
- */
-module.exports.addVariableUsage = (parser, name, usage) => {
-	const symbol =
-		/** @type {TopLevelSymbol} */ (
-			parser.getTagData(name, topLevelSymbolTag)
-		) || module.exports.tagTopLevelSymbol(parser, name);
-	if (symbol) {
-		module.exports.addUsage(parser.state, symbol, usage);
-	}
-};
-
-/**
- * Processes the provided parser state.
- * @param {ParserState} parserState parser state
- * @returns {void}
- */
-module.exports.bailout = (parserState) => {
-	parserStateMap.set(parserState, false);
-};
-
-/**
- * Processes the provided parser state.
- * @param {ParserState} parserState parser state
- * @returns {void}
- */
-module.exports.enable = (parserState) => {
-	const state = parserStateMap.get(parserState);
-	if (state === false) {
-		return;
-	}
-	parserStateMap.set(parserState, {
-		innerGraph: new Map(),
-		currentTopLevelSymbol: undefined,
-		usageCallbackMap: new Map()
-	});
-};
-
-/** @typedef {Set<string> | boolean} UsedByExports */
-
-/**
- * Usage callback map.
- * @param {Dependency} dependency the dependency
- * @param {UsedByExports | undefined} usedByExports usedByExports info
- * @param {ModuleGraph} moduleGraph moduleGraph
- * @returns {null | false | GetConditionFn} function to determine if the connection is active
- */
-module.exports.getDependencyUsedByExportsCondition = (
-	dependency,
-	usedByExports,
-	moduleGraph
-) => {
-	if (usedByExports === false) return false;
-	if (usedByExports !== true && usedByExports !== undefined) {
-		const selfModule =
-			/** @type {Module} */
-			(moduleGraph.getParentModule(dependency));
-		const exportsInfo = moduleGraph.getExportsInfo(selfModule);
-		return (_connections, runtime) => {
-			for (const exportName of usedByExports) {
-				if (exportsInfo.getUsed(exportName, runtime) !== UsageState.Unused) {
-					return true;
-				}
-			}
-			return false;
-		};
-	}
-	return null;
-};
-
-/**
- * Returns usage data.
- * @param {ParserState} state parser state
- * @returns {TopLevelSymbol | void} usage data
- */
-module.exports.getTopLevelSymbol = (state) => {
-	const innerGraphState = getState(state);
-
-	if (innerGraphState) {
-		return innerGraphState.currentTopLevelSymbol;
-	}
-};
-
-/**
- * Processes the provided state.
- * @param {ParserState} state parser state
- * @returns {void}
- */
-module.exports.inferDependencyUsage = (state) => {
-	const innerGraphState = getState(state);
-
-	if (!innerGraphState) {
-		return;
-	}
-
-	const { innerGraph, usageCallbackMap } = innerGraphState;
-	/** @type {Map<InnerGraphKey, InnerGraphValueSet | undefined>} */
-	const processed = new Map();
-	// flatten graph to terminal nodes (string, undefined or true)
-	const nonTerminal = new Set(innerGraph.keys());
-	while (nonTerminal.size > 0) {
-		for (const key of nonTerminal) {
-			/** @type {InnerGraphValue} */
-			let newSet = new Set();
-			let isTerminal = true;
-			const value = innerGraph.get(key);
-			let alreadyProcessed = processed.get(key);
-			if (alreadyProcessed === undefined) {
-				/** @type {InnerGraphValueSet} */
-				alreadyProcessed = new Set();
-				processed.set(key, alreadyProcessed);
-			}
-			if (value !== true && value !== undefined) {
-				for (const item of value) {
-					alreadyProcessed.add(item);
-				}
-				for (const item of value) {
-					if (typeof item === "string") {
-						newSet.add(item);
-					} else {
-						const itemValue = innerGraph.get(item);
-						if (itemValue === true) {
-							newSet = true;
-							break;
-						}
-						if (itemValue !== undefined) {
-							for (const i of itemValue) {
-								if (i === key) continue;
-								if (alreadyProcessed.has(i)) continue;
-								newSet.add(i);
-								if (typeof i !== "string") {
-									isTerminal = false;
-								}
-							}
-						}
-					}
-				}
-				if (newSet === true) {
-					innerGraph.set(key, true);
-				} else if (newSet.size === 0) {
-					innerGraph.set(key, undefined);
-				} else {
-					innerGraph.set(key, newSet);
-				}
-			}
-			if (isTerminal) {
-				nonTerminal.delete(key);
-
-				// For the global key, merge with all other keys
-				if (key === null) {
-					const globalValue = innerGraph.get(null);
-					if (globalValue) {
-						for (const [key, value] of innerGraph) {
-							if (key !== null && value !== true) {
-								if (globalValue === true) {
-									innerGraph.set(key, true);
-								} else {
-									const newSet = new Set(value);
-									for (const item of globalValue) {
-										newSet.add(item);
-									}
-									innerGraph.set(key, newSet);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	/** @type {Map<Dependency, true | Set<string>>} */
-	for (const [symbol, callbacks] of usageCallbackMap) {
-		const usage = /** @type {true | Set<string> | undefined} */ (
-			innerGraph.get(symbol)
-		);
-		for (const callback of callbacks) {
-			callback(usage === undefined ? false : usage);
-		}
-	}
-};
 
 /**
  * Returns false, when unused. Otherwise true.
@@ -277,107 +113,368 @@ module.exports.inferDependencyUsage = (state) => {
  * @param {RuntimeSpec} runtime runtime
  * @returns {boolean} false, when unused. Otherwise true
  */
-module.exports.isDependencyUsedByExports = (
+function isDependencyUsedByExports(
 	dependency,
 	usedByExports,
 	moduleGraph,
 	runtime
-) => {
+) {
 	if (usedByExports === false) return false;
 	if (usedByExports !== true && usedByExports !== undefined) {
 		const selfModule =
 			/** @type {Module} */
 			(moduleGraph.getParentModule(dependency));
 		const exportsInfo = moduleGraph.getExportsInfo(selfModule);
-		let used = false;
 		for (const exportName of usedByExports) {
 			if (exportsInfo.getUsed(exportName, runtime) !== UsageState.Unused) {
-				used = true;
+				return true;
 			}
 		}
-		if (!used) return false;
+		return false;
 	}
 	return true;
+}
+
+/**
+ * Returns dependency condition
+ * @param {Dependency} dependency the dependency
+ * @param {ModuleGraph} moduleGraph moduleGraph
+ * @returns {null | false | GetConditionFn} function to determine if the connection is active
+ */
+module.exports.getDependencyUsedByExportsCondition = (
+	dependency,
+	moduleGraph
+) => {
+	switch (
+		/** @type {DependencyWithUsedByExports} */ (dependency).usedByExports
+	) {
+		case false:
+			return false;
+		case true:
+			return null;
+		default:
+			return (_connections, runtime) =>
+				isDependencyUsedByExports(
+					dependency,
+					/** @type {DependencyWithUsedByExports} */ (dependency).usedByExports,
+					moduleGraph,
+					runtime
+				);
+	}
 };
 
 /**
- * Returns true, when enabled.
- * @param {ParserState} parserState parser state
- * @returns {boolean} true, when enabled
+ * Returns the InnerGraph utils scoped to a single compilation.
+ * @param {Compilation} compilation the compilation
+ * @returns {InnerGraphUtils} utils
  */
-module.exports.isEnabled = (parserState) => {
-	const state = parserStateMap.get(parserState);
-	return Boolean(state);
-};
+module.exports.getInnerGraph = (compilation) => {
+	let utils = innerGraphByCompilation.get(compilation);
+	if (utils) return utils;
 
-/**
- * Processes the provided state.
- * @param {ParserState} state parser state
- * @param {UsageCallback} onUsageCallback on usage callback
- */
-module.exports.onUsage = (state, onUsageCallback) => {
-	const innerGraphState = getState(state);
+	/** @type {WeakMap<Module, State>} */
+	const stateByModule = new WeakMap();
 
-	if (innerGraphState) {
-		const { usageCallbackMap, currentTopLevelSymbol } = innerGraphState;
-		if (currentTopLevelSymbol) {
-			let callbacks = usageCallbackMap.get(currentTopLevelSymbol);
+	/**
+	 * @param {ParserState} parserState parser state
+	 * @returns {State | undefined} state
+	 */
+	function getState(parserState) {
+		return stateByModule.get(parserState.module);
+	}
 
-			if (callbacks === undefined) {
-				/** @type {Set<UsageCallback>} */
-				callbacks = new Set();
-				usageCallbackMap.set(currentTopLevelSymbol, callbacks);
-			}
-
-			callbacks.add(onUsageCallback);
-		} else {
-			onUsageCallback(true);
+	/**
+	 * @param {ParserState} parserState parser state
+	 * @returns {void}
+	 */
+	function enable(parserState) {
+		const state = stateByModule.get(parserState.module);
+		if (state === false) {
+			return;
 		}
-	} else {
-		onUsageCallback(undefined);
+		stateByModule.set(parserState.module, {
+			innerGraph: new Map(),
+			currentTopLevelSymbol: undefined,
+			usageCallbackMap: new Map()
+		});
 	}
+
+	/**
+	 * @param {ParserState} parserState parser state
+	 * @returns {void}
+	 */
+	function bailout(parserState) {
+		stateByModule.set(parserState.module, false);
+	}
+
+	/**
+	 * @param {ParserState} parserState parser state
+	 * @returns {boolean} true, when enabled
+	 */
+	function isEnabled(parserState) {
+		return Boolean(stateByModule.get(parserState.module));
+	}
+
+	/**
+	 * @param {ParserState} state parser state
+	 * @param {TopLevelSymbol | null} symbol the symbol, or null for all symbols
+	 * @param {Usage} usage usage data
+	 * @returns {void}
+	 */
+	function addUsage(state, symbol, usage) {
+		const innerGraphState = getState(state);
+
+		if (innerGraphState) {
+			const { innerGraph } = innerGraphState;
+			const info = innerGraph.get(symbol);
+			if (usage === true) {
+				innerGraph.set(symbol, true);
+			} else if (info === undefined) {
+				innerGraph.set(symbol, new Set([usage]));
+			} else if (info !== true) {
+				info.add(usage);
+			}
+		}
+	}
+
+	/**
+	 * @param {JavascriptParser} parser the parser
+	 * @param {string} name name of variable
+	 * @param {Usage} usage usage data
+	 * @returns {void}
+	 */
+	function addVariableUsage(parser, name, usage) {
+		const symbol =
+			/** @type {TopLevelSymbol} */ (
+				parser.getTagData(name, topLevelSymbolTag)
+			) || tagTopLevelSymbol(parser, name);
+		if (symbol) {
+			addUsage(parser.state, symbol, usage);
+		}
+	}
+
+	/**
+	 * @param {ParserState} state parser state
+	 * @returns {TopLevelSymbol | void} usage data
+	 */
+	function getTopLevelSymbol(state) {
+		const innerGraphState = getState(state);
+
+		if (innerGraphState) {
+			return innerGraphState.currentTopLevelSymbol;
+		}
+	}
+
+	/**
+	 * @param {ParserState} state parser state
+	 * @param {TopLevelSymbol | undefined} symbol the symbol
+	 */
+	function setTopLevelSymbol(state, symbol) {
+		const innerGraphState = getState(state);
+
+		if (innerGraphState) {
+			innerGraphState.currentTopLevelSymbol = symbol;
+		}
+	}
+
+	/**
+	 * @param {ParserState} state parser state
+	 * @param {UsageCallback} onUsageCallback on usage callback
+	 */
+	function onUsage(state, onUsageCallback) {
+		const innerGraphState = getState(state);
+
+		if (innerGraphState) {
+			const { usageCallbackMap, currentTopLevelSymbol } = innerGraphState;
+			if (currentTopLevelSymbol) {
+				let callbacks = usageCallbackMap.get(currentTopLevelSymbol);
+
+				if (callbacks === undefined) {
+					/** @type {Set<UsageCallback>} */
+					callbacks = new Set();
+					usageCallbackMap.set(currentTopLevelSymbol, callbacks);
+				}
+
+				callbacks.add(onUsageCallback);
+			} else {
+				onUsageCallback(true, state.module);
+			}
+		} else {
+			onUsageCallback(undefined, state.module);
+		}
+	}
+
+	/**
+	 * @param {JavascriptParser} parser parser
+	 * @param {string} name name of variable
+	 * @param {PureCondition=} pure pure condition
+	 * @returns {TopLevelSymbol | undefined} symbol
+	 */
+	function tagTopLevelSymbol(parser, name, pure) {
+		const innerGraphState = getState(parser.state);
+		if (!innerGraphState) return;
+
+		parser.defineVariable(name);
+
+		const existingTag = /** @type {TopLevelSymbol} */ (
+			parser.getTagData(name, topLevelSymbolTag)
+		);
+		if (existingTag) {
+			if (pure !== undefined) {
+				existingTag.setPure(pure);
+			}
+			return existingTag;
+		}
+
+		const symbol = new TopLevelSymbol(name, pure);
+		parser.tagVariable(
+			name,
+			topLevelSymbolTag,
+			symbol,
+			JavascriptParser.VariableInfoFlags.Normal
+		);
+		return symbol;
+	}
+
+	/**
+	 * @param {Module} module module
+	 * @returns {void}
+	 */
+	function inferDependencyUsage(module) {
+		const innerGraphState = stateByModule.get(module);
+
+		if (!innerGraphState) {
+			return;
+		}
+
+		const { innerGraph, usageCallbackMap } = innerGraphState;
+		/** @type {Map<InnerGraphKey, InnerGraphValueSet | undefined>} */
+		const processed = new Map();
+		// flatten graph to terminal nodes (string, undefined or true)
+		const nonTerminal = new Set(innerGraph.keys());
+		while (nonTerminal.size > 0) {
+			for (const key of nonTerminal) {
+				if (key !== null && !key.isPure(compilation, module)) {
+					innerGraph.set(key, true);
+					nonTerminal.delete(key);
+					continue;
+				}
+
+				/** @type {InnerGraphValue} */
+				let newSet = new Set();
+				let isTerminal = true;
+				const value = innerGraph.get(key);
+				let alreadyProcessed = processed.get(key);
+				if (alreadyProcessed === undefined) {
+					/** @type {InnerGraphValueSet} */
+					alreadyProcessed = new Set();
+					processed.set(key, alreadyProcessed);
+				}
+				if (value !== true && value !== undefined) {
+					for (const item of value) {
+						alreadyProcessed.add(item);
+					}
+					for (const item of value) {
+						if (typeof item === "string") {
+							newSet.add(item);
+						} else if (!item.isPure(compilation, module)) {
+							newSet = true;
+							break;
+						} else {
+							const itemValue = innerGraph.get(item);
+							if (itemValue === true) {
+								newSet = true;
+								break;
+							}
+							if (itemValue !== undefined) {
+								for (const i of itemValue) {
+									if (i === key) continue;
+									if (alreadyProcessed.has(i)) continue;
+									newSet.add(i);
+									if (typeof i !== "string") {
+										isTerminal = false;
+									}
+								}
+							}
+						}
+					}
+					if (newSet === true) {
+						innerGraph.set(key, true);
+					} else if (newSet.size === 0) {
+						innerGraph.set(key, undefined);
+					} else {
+						innerGraph.set(key, newSet);
+					}
+				}
+				if (isTerminal) {
+					nonTerminal.delete(key);
+
+					// For the global key, merge with all other keys
+					if (key === null) {
+						const globalValue = innerGraph.get(null);
+						if (globalValue) {
+							for (const [key, value] of innerGraph) {
+								if (key !== null && value !== true) {
+									if (globalValue === true) {
+										innerGraph.set(key, true);
+									} else {
+										const newSet = new Set(value);
+										for (const item of globalValue) {
+											newSet.add(item);
+										}
+										innerGraph.set(key, newSet);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/** @type {Map<Dependency, true | Set<string>>} */
+		for (const [symbol, callbacks] of usageCallbackMap) {
+			const usage = symbol.isPure(compilation, module)
+				? /** @type {true | Set<string> | undefined} */ (innerGraph.get(symbol))
+				: true;
+
+			for (const callback of callbacks) {
+				callback(usage === undefined ? false : usage, module);
+			}
+		}
+	}
+
+	/**
+	 * @param {Module} module module
+	 * @returns {void}
+	 */
+	function release(module) {
+		stateByModule.delete(module);
+	}
+
+	utils = {
+		enable,
+		bailout,
+		isEnabled,
+		addUsage,
+		addVariableUsage,
+		getTopLevelSymbol,
+		setTopLevelSymbol,
+		onUsage,
+		tagTopLevelSymbol,
+		inferDependencyUsage,
+		release
+	};
+	innerGraphByCompilation.set(compilation, utils);
+	return utils;
 };
 
 /**
- * Processes the provided state.
- * @param {ParserState} state parser state
- * @param {TopLevelSymbol | undefined} symbol the symbol
+ * Usage callback map.
+ * @param {Dependency} dependency the dependency
+ * @param {UsedByExports | undefined} usedByExports usedByExports info
+ * @param {ModuleGraph} moduleGraph moduleGraph
+ * @returns {null | false | GetConditionFn} function to determine if the connection is active
  */
-module.exports.setTopLevelSymbol = (state, symbol) => {
-	const innerGraphState = getState(state);
-
-	if (innerGraphState) {
-		innerGraphState.currentTopLevelSymbol = symbol;
-	}
-};
-
-/**
- * Returns symbol.
- * @param {JavascriptParser} parser parser
- * @param {string} name name of variable
- * @returns {TopLevelSymbol | undefined} symbol
- */
-module.exports.tagTopLevelSymbol = (parser, name) => {
-	const innerGraphState = getState(parser.state);
-	if (!innerGraphState) return;
-
-	parser.defineVariable(name);
-
-	const existingTag = /** @type {TopLevelSymbol} */ (
-		parser.getTagData(name, topLevelSymbolTag)
-	);
-	if (existingTag) {
-		return existingTag;
-	}
-
-	const symbol = new TopLevelSymbol(name);
-	parser.tagVariable(
-		name,
-		topLevelSymbolTag,
-		symbol,
-		JavascriptParser.VariableInfoFlags.Normal
-	);
-	return symbol;
-};
 
 module.exports.topLevelSymbolTag = topLevelSymbolTag;

--- a/lib/optimize/InnerGraph.js
+++ b/lib/optimize/InnerGraph.js
@@ -146,7 +146,7 @@ module.exports.getDependencyUsedByExportsCondition = (
 	moduleGraph
 ) => {
 	switch (
-		/** @type {DependencyWithUsedByExports} */ (dependency).usedByExports
+		/** @type {DependencyWithUsedByExports}  */ (dependency).usedByExports
 	) {
 		case false:
 			return false;
@@ -168,19 +168,19 @@ module.exports.getDependencyUsedByExportsCondition = (
  * @param {Compilation} compilation the compilation
  * @returns {InnerGraphUtils} utils
  */
-module.exports.getInnerGraph = (compilation) => {
+module.exports.getInnerGraphUtils = (compilation) => {
 	let utils = innerGraphByCompilation.get(compilation);
 	if (utils) return utils;
 
 	/** @type {WeakMap<Module, State>} */
-	const stateByModule = new WeakMap();
+	const states = new WeakMap();
 
 	/**
 	 * @param {ParserState} parserState parser state
 	 * @returns {State | undefined} state
 	 */
 	function getState(parserState) {
-		return stateByModule.get(parserState.module);
+		return states.get(parserState.module);
 	}
 
 	/**
@@ -188,11 +188,11 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @returns {void}
 	 */
 	function enable(parserState) {
-		const state = stateByModule.get(parserState.module);
+		const state = states.get(parserState.module);
 		if (state === false) {
 			return;
 		}
-		stateByModule.set(parserState.module, {
+		states.set(parserState.module, {
 			innerGraph: new Map(),
 			currentTopLevelSymbol: undefined,
 			usageCallbackMap: new Map()
@@ -204,7 +204,7 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @returns {void}
 	 */
 	function bailout(parserState) {
-		stateByModule.set(parserState.module, false);
+		states.set(parserState.module, false);
 	}
 
 	/**
@@ -212,7 +212,7 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @returns {boolean} true, when enabled
 	 */
 	function isEnabled(parserState) {
-		return Boolean(stateByModule.get(parserState.module));
+		return Boolean(states.get(parserState.module));
 	}
 
 	/**
@@ -308,7 +308,7 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @param {JavascriptParser} parser parser
 	 * @param {string} name name of variable
 	 * @param {PureCondition=} pure pure condition
-	 * @returns {TopLevelSymbol | undefined} symbol
+	 * @returns {TopLevelSymbol=} symbol
 	 */
 	function tagTopLevelSymbol(parser, name, pure) {
 		const innerGraphState = getState(parser.state);
@@ -341,7 +341,7 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @returns {void}
 	 */
 	function inferDependencyUsage(module) {
-		const innerGraphState = stateByModule.get(module);
+		const innerGraphState = states.get(module);
 
 		if (!innerGraphState) {
 			return;
@@ -449,7 +449,7 @@ module.exports.getInnerGraph = (compilation) => {
 	 * @returns {void}
 	 */
 	function release(module) {
-		stateByModule.delete(module);
+		states.delete(module);
 	}
 
 	utils = {

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -10,9 +10,14 @@ const {
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
+const {
+	harmonySpecifierTag
+} = require("../dependencies/HarmonyImportDependencyParserPlugin");
+const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 const PureExpressionDependency = require("../dependencies/PureExpressionDependency");
-const InnerGraph = require("./InnerGraph");
+const { getInnerGraph, topLevelSymbolTag } = require("./InnerGraph");
 
+/** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("estree").ClassDeclaration} ClassDeclaration */
 /** @typedef {import("estree").ClassExpression} ClassExpression */
 /** @typedef {import("estree").Expression} Expression */
@@ -21,13 +26,15 @@ const InnerGraph = require("./InnerGraph");
 /** @typedef {import("estree").Node} Node */
 /** @typedef {import("estree").VariableDeclarator} VariableDeclarator */
 /** @typedef {import("../../declarations/WebpackOptions").JavascriptParserOptions} JavascriptParserOptions */
+/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("./InnerGraph").TopLevelSymbol} TopLevelSymbol */
-
-const { topLevelSymbolTag } = InnerGraph;
 
 const PLUGIN_NAME = "InnerGraphPlugin";
 const impureVariableDeclarationKinds = new Set(["using", "await using"]);
@@ -43,11 +50,23 @@ class InnerGraphPlugin {
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const logger = compilation.getLogger("webpack.InnerGraphPlugin");
+				const innerGraph = getInnerGraph(compilation);
 
 				compilation.dependencyTemplates.set(
 					PureExpressionDependency,
 					new PureExpressionDependency.Template()
 				);
+
+				/**
+				 * Adds pure dependency added after parsing, with parents set so it survives persistent caching.
+				 * @param {Module} module module
+				 * @param {Dependency} dep pure dependency
+				 * @returns {void}
+				 */
+				const addPureDependency = (module, dep) => {
+					compilation.moduleGraph.setParents(dep, module, module, -1);
+					module.addDependency(dep);
+				};
 
 				/**
 				 * Handles the hook callback for this code path.
@@ -61,7 +80,7 @@ class InnerGraphPlugin {
 					 * @param {Expression} sup sup
 					 */
 					const onUsageSuper = (sup) => {
-						InnerGraph.onUsage(parser.state, (usedByExports) => {
+						innerGraph.onUsage(parser.state, (usedByExports, module) => {
 							switch (usedByExports) {
 								case undefined:
 								case true:
@@ -73,7 +92,7 @@ class InnerGraphPlugin {
 									);
 									dep.loc = /** @type {DependencyLocation} */ (sup.loc);
 									dep.usedByExports = usedByExports;
-									parser.state.module.addDependency(dep);
+									addPureDependency(module, dep);
 									break;
 								}
 							}
@@ -81,21 +100,14 @@ class InnerGraphPlugin {
 					};
 
 					parser.hooks.program.tap(PLUGIN_NAME, () => {
-						InnerGraph.enable(parser.state);
+						innerGraph.enable(parser.state);
 
 						statementWithTopLevelSymbol = new WeakMap();
 						statementPurePart = new WeakMap();
 						classWithTopLevelSymbol = new WeakMap();
 						declWithTopLevelSymbol = new WeakMap();
 						pureDeclarators = new WeakSet();
-					});
-
-					parser.hooks.finish.tap(PLUGIN_NAME, () => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
-
-						logger.time("infer dependency usage");
-						InnerGraph.inferDependencyUsage(parser.state);
-						logger.timeAggregate("infer dependency usage");
+						pureConditionByCallExpr = new WeakMap();
 					});
 
 					// During prewalking the following datastructures are filled with
@@ -120,73 +132,146 @@ class InnerGraphPlugin {
 					/** @type {WeakSet<VariableDeclarator>} */
 					let pureDeclarators = new WeakSet();
 
+					/** @type {WeakMap<CallExpression, (compilation: Compilation, module: Module) => boolean>} */
+					let pureConditionByCallExpr = new WeakMap();
+
+					parser.hooks.isPure.for("CallExpression").tap(
+						{
+							name: PLUGIN_NAME,
+							stage: -10
+						},
+						(expression) => {
+							const expr = /** @type {CallExpression} */ (expression);
+							const callee = expr.callee;
+							/** @type {Node} */
+							let root;
+							/** @type {string[]} */
+							let chainMembers;
+							if (callee.type === "Identifier") {
+								root = callee;
+								chainMembers = [];
+							} else if (callee.type === "MemberExpression") {
+								const chain = parser.extractMemberExpressionChain(callee);
+								// optional chaining short-circuits and breaks straight purity
+								if (chain.membersOptionals.some(Boolean)) return;
+								root = /** @type {Node} */ (chain.object);
+								// extractMemberExpressionChain returns members in reverse
+								chainMembers = [...chain.members].reverse();
+							} else {
+								return;
+							}
+							if (root.type !== "Identifier") return;
+							const harmonySettings =
+								/** @type {{ source: string, ids: string[] } | undefined} */ (
+									parser.getTagData(root.name, harmonySpecifierTag)
+								);
+							if (!harmonySettings) return;
+							const ids = [...harmonySettings.ids, ...chainMembers];
+							if (ids.length === 0) return;
+							let pos = /** @type {Range} */ (callee.range)[1];
+							for (const arg of expr.arguments) {
+								if (arg.type === "SpreadElement") return;
+								if (!parser.isPure(arg, pos)) return;
+								pos = /** @type {Range} */ (arg.range)[1];
+							}
+							const source = harmonySettings.source;
+							pureConditionByCallExpr.set(expr, (compilation, module) => {
+								const moduleGraph = compilation.moduleGraph;
+								for (const dep of module.dependencies) {
+									if (
+										dep instanceof HarmonyImportSideEffectDependency &&
+										dep.request === source
+									) {
+										const m = moduleGraph.getModule(dep);
+										if (!m) return false;
+										const exportInfo = moduleGraph
+											.getExportsInfo(m)
+											.getReadOnlyExportInfoRecursive(ids);
+										if (!exportInfo) return false;
+										const target = exportInfo.getTarget(moduleGraph);
+										const final =
+											target && target.export
+												? moduleGraph
+														.getExportsInfo(target.module)
+														.getReadOnlyExportInfoRecursive(target.export)
+												: exportInfo;
+										return final !== undefined && final.pureProvide === true;
+									}
+								}
+								return false;
+							});
+						}
+					);
+
 					// The following hooks are used during prewalking:
 
 					parser.hooks.preStatement.tap(PLUGIN_NAME, (statement) => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (!innerGraph.isEnabled(parser.state)) return;
 
 						if (
 							parser.scope.topLevelScope === true &&
 							statement.type === "FunctionDeclaration"
 						) {
 							const name = statement.id ? statement.id.name : "*default*";
-							const symbol =
-								/** @type {TopLevelSymbol} */
-								(InnerGraph.tagTopLevelSymbol(parser, name));
+							const symbol = /** @type {TopLevelSymbol} */ (
+								innerGraph.tagTopLevelSymbol(
+									parser,
+									name,
+									parser.isPure(
+										statement,
+										/** @type {Range} */ (statement.range)[0]
+									)
+								)
+							);
 							statementWithTopLevelSymbol.set(statement, symbol);
 							return true;
 						}
 					});
 
 					parser.hooks.blockPreStatement.tap(PLUGIN_NAME, (statement) => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (!innerGraph.isEnabled(parser.state)) return;
 
 						if (parser.scope.topLevelScope === true) {
-							if (
-								statement.type === "ClassDeclaration" &&
-								parser.isPure(
+							if (statement.type === "ClassDeclaration") {
+								const name = statement.id ? statement.id.name : "*default*";
+								const pure = parser.isPure(
 									statement,
 									/** @type {Range} */ (statement.range)[0]
-								)
-							) {
-								const name = statement.id ? statement.id.name : "*default*";
+								);
 								const symbol = /** @type {TopLevelSymbol} */ (
-									InnerGraph.tagTopLevelSymbol(parser, name)
+									innerGraph.tagTopLevelSymbol(parser, name, pure)
 								);
 								classWithTopLevelSymbol.set(statement, symbol);
 								return true;
 							}
 							if (statement.type === "ExportDefaultDeclaration") {
 								const name = "*default*";
+								const decl = statement.declaration;
+								/** @type {boolean | ((compilation: Compilation, module: Module) => boolean)} */
+								let pure = parser.isPure(
+									decl,
+									/** @type {Range} */ (statement.range)[0]
+								);
+								if (!pure && decl.type === "CallExpression") {
+									const deferred = pureConditionByCallExpr.get(decl);
+									if (deferred) pure = deferred;
+								}
 								const symbol =
 									/** @type {TopLevelSymbol} */
-									(InnerGraph.tagTopLevelSymbol(parser, name));
-								const decl = statement.declaration;
+									(innerGraph.tagTopLevelSymbol(parser, name, pure));
 								if (
-									(decl.type === "ClassExpression" ||
-										decl.type === "ClassDeclaration") &&
-									parser.isPure(
-										/** @type {ClassExpression | ClassDeclaration} */
-										(decl),
-										/** @type {Range} */
-										(decl.range)[0]
-									)
+									decl.type === "ClassExpression" ||
+									decl.type === "ClassDeclaration"
 								) {
 									classWithTopLevelSymbol.set(
 										/** @type {ClassExpression | ClassDeclaration} */
 										(decl),
 										symbol
 									);
-								} else if (
-									parser.isPure(
-										/** @type {Expression} */
-										(decl),
-										/** @type {Range} */
-										(statement.range)[0]
-									)
-								) {
+								} else {
 									statementWithTopLevelSymbol.set(statement, symbol);
 									if (
+										pure &&
 										!decl.type.endsWith("FunctionExpression") &&
 										!decl.type.endsWith("Declaration") &&
 										decl.type !== "Literal"
@@ -203,7 +288,7 @@ class InnerGraphPlugin {
 					});
 
 					parser.hooks.preDeclarator.tap(PLUGIN_NAME, (decl, statement) => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (!innerGraph.isEnabled(parser.state)) return;
 						if (impureVariableDeclarationKinds.has(statement.kind)) return;
 						if (
 							parser.scope.topLevelScope === true &&
@@ -218,28 +303,28 @@ class InnerGraphPlugin {
 							) {
 								return;
 							}
-							if (
-								decl.init.type === "ClassExpression" &&
-								parser.isPure(
-									decl.init,
-									/** @type {Range} */ (decl.id.range)[1]
-								)
-							) {
+							/** @type {boolean | ((compilation: Compilation, module: Module) => boolean)} */
+							let pure = parser.isPure(
+								decl.init,
+								/** @type {Range} */ (decl.id.range)[1]
+							);
+							if (!pure && decl.init.type === "CallExpression") {
+								const deferred = pureConditionByCallExpr.get(decl.init);
+								if (deferred) pure = deferred;
+							}
+
+							if (decl.init.type === "ClassExpression") {
 								const symbol =
 									/** @type {TopLevelSymbol} */
-									(InnerGraph.tagTopLevelSymbol(parser, name));
+									(innerGraph.tagTopLevelSymbol(parser, name, pure));
 								classWithTopLevelSymbol.set(decl.init, symbol);
-							} else if (
-								parser.isPure(
-									decl.init,
-									/** @type {Range} */ (decl.id.range)[1]
-								)
-							) {
+							} else {
 								const symbol =
 									/** @type {TopLevelSymbol} */
-									(InnerGraph.tagTopLevelSymbol(parser, name));
+									(innerGraph.tagTopLevelSymbol(parser, name, pure));
 								declWithTopLevelSymbol.set(decl, symbol);
 								if (
+									pure &&
 									!decl.init.type.endsWith("FunctionExpression") &&
 									decl.init.type !== "Literal"
 								) {
@@ -266,16 +351,16 @@ class InnerGraphPlugin {
 					// The following hooks are called during walking:
 
 					parser.hooks.statement.tap(PLUGIN_NAME, (statement) => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (!innerGraph.isEnabled(parser.state)) return;
 						if (parser.scope.topLevelScope === true) {
-							InnerGraph.setTopLevelSymbol(parser.state, undefined);
+							innerGraph.setTopLevelSymbol(parser.state, undefined);
 
 							const symbol = statementWithTopLevelSymbol.get(statement);
 							if (symbol) {
-								InnerGraph.setTopLevelSymbol(parser.state, symbol);
+								innerGraph.setTopLevelSymbol(parser.state, symbol);
 								const purePart = statementPurePart.get(statement);
 								if (purePart) {
-									InnerGraph.onUsage(parser.state, (usedByExports) => {
+									innerGraph.onUsage(parser.state, (usedByExports, module) => {
 										switch (usedByExports) {
 											case undefined:
 											case true:
@@ -288,7 +373,7 @@ class InnerGraphPlugin {
 													/** @type {DependencyLocation} */
 													(statement.loc);
 												dep.usedByExports = usedByExports;
-												parser.state.module.addDependency(dep);
+												addPureDependency(module, dep);
 												break;
 											}
 										}
@@ -301,7 +386,7 @@ class InnerGraphPlugin {
 					parser.hooks.classExtendsExpression.tap(
 						PLUGIN_NAME,
 						(expr, statement) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
+							if (!innerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
 								const symbol = classWithTopLevelSymbol.get(statement);
 								if (
@@ -313,7 +398,7 @@ class InnerGraphPlugin {
 											: /** @type {Range} */ (statement.range)[0]
 									)
 								) {
-									InnerGraph.setTopLevelSymbol(parser.state, symbol);
+									innerGraph.setTopLevelSymbol(parser.state, symbol);
 									onUsageSuper(expr);
 								}
 							}
@@ -323,11 +408,11 @@ class InnerGraphPlugin {
 					parser.hooks.classBodyElement.tap(
 						PLUGIN_NAME,
 						(element, classDefinition) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
+							if (!innerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
 								const symbol = classWithTopLevelSymbol.get(classDefinition);
 								if (symbol) {
-									InnerGraph.setTopLevelSymbol(parser.state, undefined);
+									innerGraph.setTopLevelSymbol(parser.state, undefined);
 								}
 							}
 						}
@@ -336,7 +421,7 @@ class InnerGraphPlugin {
 					parser.hooks.classBodyValue.tap(
 						PLUGIN_NAME,
 						(expression, element, classDefinition) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
+							if (!innerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
 								const symbol = classWithTopLevelSymbol.get(classDefinition);
 								if (symbol) {
@@ -349,29 +434,32 @@ class InnerGraphPlugin {
 												: /** @type {Range} */ (element.range)[0]
 										)
 									) {
-										InnerGraph.setTopLevelSymbol(parser.state, symbol);
+										innerGraph.setTopLevelSymbol(parser.state, symbol);
 										if (element.type !== "MethodDefinition" && element.static) {
-											InnerGraph.onUsage(parser.state, (usedByExports) => {
-												switch (usedByExports) {
-													case undefined:
-													case true:
-														return;
-													default: {
-														const dep = new PureExpressionDependency(
-															/** @type {Range} */ (expression.range)
-														);
-														dep.loc =
-															/** @type {DependencyLocation} */
-															(expression.loc);
-														dep.usedByExports = usedByExports;
-														parser.state.module.addDependency(dep);
-														break;
+											innerGraph.onUsage(
+												parser.state,
+												(usedByExports, module) => {
+													switch (usedByExports) {
+														case undefined:
+														case true:
+															return;
+														default: {
+															const dep = new PureExpressionDependency(
+																/** @type {Range} */ (expression.range)
+															);
+															dep.loc =
+																/** @type {DependencyLocation} */
+																(expression.loc);
+															dep.usedByExports = usedByExports;
+															addPureDependency(module, dep);
+															break;
+														}
 													}
 												}
-											});
+											);
 										}
 									} else {
-										InnerGraph.setTopLevelSymbol(parser.state, undefined);
+										innerGraph.setTopLevelSymbol(parser.state, undefined);
 									}
 								}
 							}
@@ -379,11 +467,11 @@ class InnerGraphPlugin {
 					);
 
 					parser.hooks.declarator.tap(PLUGIN_NAME, (decl, _statement) => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (!innerGraph.isEnabled(parser.state)) return;
 						const symbol = declWithTopLevelSymbol.get(decl);
 
 						if (symbol) {
-							InnerGraph.setTopLevelSymbol(parser.state, symbol);
+							innerGraph.setTopLevelSymbol(parser.state, symbol);
 							if (pureDeclarators.has(decl)) {
 								if (
 									/** @type {ClassExpression} */
@@ -393,7 +481,7 @@ class InnerGraphPlugin {
 										onUsageSuper(decl.init.superClass);
 									}
 								} else {
-									InnerGraph.onUsage(parser.state, (usedByExports) => {
+									innerGraph.onUsage(parser.state, (usedByExports, module) => {
 										switch (usedByExports) {
 											case undefined:
 											case true:
@@ -407,7 +495,7 @@ class InnerGraphPlugin {
 												);
 												dep.loc = /** @type {DependencyLocation} */ (decl.loc);
 												dep.usedByExports = usedByExports;
-												parser.state.module.addDependency(dep);
+												addPureDependency(module, dep);
 												break;
 											}
 										}
@@ -419,7 +507,7 @@ class InnerGraphPlugin {
 									decl.init
 								)
 							);
-							InnerGraph.setTopLevelSymbol(parser.state, undefined);
+							innerGraph.setTopLevelSymbol(parser.state, undefined);
 							return true;
 						} else if (
 							decl.id.type === "Identifier" &&
@@ -428,7 +516,7 @@ class InnerGraphPlugin {
 							classWithTopLevelSymbol.has(decl.init)
 						) {
 							parser.walkExpression(decl.init);
-							InnerGraph.setTopLevelSymbol(parser.state, undefined);
+							innerGraph.setTopLevelSymbol(parser.state, undefined);
 							return true;
 						}
 					});
@@ -439,10 +527,10 @@ class InnerGraphPlugin {
 							const topLevelSymbol = /** @type {TopLevelSymbol} */ (
 								parser.currentTagData
 							);
-							const currentTopLevelSymbol = InnerGraph.getTopLevelSymbol(
+							const currentTopLevelSymbol = innerGraph.getTopLevelSymbol(
 								parser.state
 							);
-							InnerGraph.addUsage(
+							innerGraph.addUsage(
 								parser.state,
 								topLevelSymbol,
 								currentTopLevelSymbol || true
@@ -451,7 +539,7 @@ class InnerGraphPlugin {
 					parser.hooks.assign
 						.for(topLevelSymbolTag)
 						.tap(PLUGIN_NAME, (expr) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
+							if (!innerGraph.isEnabled(parser.state)) return;
 							if (expr.operator === "=") return true;
 						});
 				};
@@ -462,8 +550,12 @@ class InnerGraphPlugin {
 					.for(JAVASCRIPT_MODULE_TYPE_ESM)
 					.tap(PLUGIN_NAME, handler);
 
-				compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
-					logger.timeAggregateEnd("infer dependency usage");
+				compilation.hooks.finishModules.tap(PLUGIN_NAME, (modules) => {
+					logger.time("infer dependency usage");
+					for (const module of modules) {
+						innerGraph.inferDependencyUsage(module);
+					}
+					logger.timeEnd("infer dependency usage");
 				});
 			}
 		);

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -15,7 +15,7 @@ const {
 } = require("../dependencies/HarmonyImportDependencyParserPlugin");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 const PureExpressionDependency = require("../dependencies/PureExpressionDependency");
-const { getInnerGraph, topLevelSymbolTag } = require("./InnerGraph");
+const { getInnerGraphUtils, topLevelSymbolTag } = require("./InnerGraph");
 
 /** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("estree").ClassDeclaration} ClassDeclaration */
@@ -50,7 +50,7 @@ class InnerGraphPlugin {
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const logger = compilation.getLogger("webpack.InnerGraphPlugin");
-				const innerGraph = getInnerGraph(compilation);
+				const innerGraph = getInnerGraphUtils(compilation);
 
 				compilation.dependencyTemplates.set(
 					PureExpressionDependency,

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -25,6 +25,7 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("../Module")} Module */
+/** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../ModuleGraphConnection")} ModuleGraphConnection */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
@@ -83,6 +84,8 @@ const hasNoSideEffectsNotation = (parser, start, end) => {
 };
 
 const PLUGIN_NAME = "SideEffectsFlagPlugin";
+
+const notSideEffectsTag = Symbol("NoSideEffects");
 
 class SideEffectsFlagPlugin {
 	/**
@@ -285,21 +288,31 @@ class SideEffectsFlagPlugin {
 					 * @returns {void}
 					 */
 					const applyNoSideEffectsNotationHandler = (parser) => {
-						/** @type {Set<string>} */
-						let noSideEffectsFnNames;
+						/** @type {Set<string> | undefined} */
+						let pureFunctions;
 
 						parser.hooks.program.tap(PLUGIN_NAME, () => {
-							noSideEffectsFnNames = new Set();
+							pureFunctions = undefined;
 						});
+
+						/**
+						 * @param {string} name function name
+						 */
+						const markPure = (name) => {
+							parser.tagVariable(name, notSideEffectsTag, {});
+							if (pureFunctions === undefined) pureFunctions = new Set();
+							pureFunctions.add(name);
+						};
 
 						// Detect on function declarations
 						// Covers:
 						// 	1. function foo
 						//  2. export function foo
 						//  3. export default function foo
+						// 	4. export default function / export default () => {} (anonymous)
 						parser.hooks.preStatement.tap(PLUGIN_NAME, (statement) => {
 							if (parser.scope.topLevelScope !== true) return;
-							if (statement.type !== "FunctionDeclaration" || !statement.id) {
+							if (statement.type !== "FunctionDeclaration") {
 								return;
 							}
 							const commentsStart = parser.prevStatement
@@ -312,7 +325,7 @@ class SideEffectsFlagPlugin {
 									/** @type {Range} */ (statement.range)[0]
 								)
 							) {
-								noSideEffectsFnNames.add(statement.id.name);
+								markPure(statement.id ? statement.id.name : "default");
 							}
 						});
 
@@ -343,25 +356,59 @@ class SideEffectsFlagPlugin {
 								);
 							}
 							if (hasAnnotation) {
-								noSideEffectsFnNames.add(decl.id.name);
+								markPure(decl.id.name);
 							}
 						});
 
-						// Mark calls to annotated functions as pure
+						// Mark calls as pure when the callee is an annotated
+						// function or the call is preceded by /* @__PURE__ */
 						parser.hooks.isPure
 							.for("CallExpression")
 							.tap(PLUGIN_NAME, (expression, commentsStartPos) => {
 								const expr = /** @type {CallExpression} */ (expression);
-								if (expr.callee.type !== "Identifier") return;
-								if (!noSideEffectsFnNames.has(expr.callee.name)) return;
-								commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
-								for (const arg of expr.arguments) {
-									if (arg.type === "SpreadElement") return;
-									if (!parser.isPure(arg, commentsStartPos)) return;
-									commentsStartPos = /** @type {Range} */ (arg.range)[1];
+								const hasPureComment =
+									/** @type {Range} */ (expr.range)[0] - commentsStartPos >
+										12 &&
+									parser
+										.getComments([
+											commentsStartPos,
+											/** @type {Range} */ (expr.range)[0]
+										])
+										.some(
+											(comment) =>
+												comment.type === "Block" &&
+												CompilerHintNotationRegExp.Pure.test(comment.value)
+										);
+								if (!hasPureComment) {
+									const noSideEffectsMatch =
+										expr.callee.type === "Identifier" &&
+										parser.getTagData(expr.callee.name, notSideEffectsTag);
+									if (!noSideEffectsMatch) return false;
 								}
-								return true;
+								commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
+								return expr.arguments.every((arg) => {
+									if (arg.type === "SpreadElement") return false;
+									const pure = parser.isPure(arg, commentsStartPos);
+									commentsStartPos = /** @type {Range} */ (arg.range)[1];
+									return pure;
+								});
 							});
+
+						parser.hooks.finish.tap(PLUGIN_NAME, () => {
+							if (pureFunctions === undefined || pureFunctions.size === 0) {
+								return;
+							}
+							const buildInfo = /** @type {BuildInfo} */ (
+								parser.state.module.buildInfo
+							);
+							if (buildInfo.pureFunctions) {
+								for (const fn of pureFunctions) {
+									buildInfo.pureFunctions.add(fn);
+								}
+							} else {
+								buildInfo.pureFunctions = pureFunctions;
+							}
+						});
 					};
 
 					for (const key of [

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -360,30 +360,13 @@ class SideEffectsFlagPlugin {
 							}
 						});
 
-						// Mark calls as pure when the callee is an annotated
-						// function or the call is preceded by /* @__PURE__ */
 						parser.hooks.isPure
 							.for("CallExpression")
 							.tap(PLUGIN_NAME, (expression, commentsStartPos) => {
 								const expr = /** @type {CallExpression} */ (expression);
-								const hasPureComment =
-									/** @type {Range} */ (expr.range)[0] - commentsStartPos >
-										12 &&
-									parser
-										.getComments([
-											commentsStartPos,
-											/** @type {Range} */ (expr.range)[0]
-										])
-										.some(
-											(comment) =>
-												comment.type === "Block" &&
-												CompilerHintNotationRegExp.Pure.test(comment.value)
-										);
-								if (!hasPureComment) {
-									const noSideEffectsMatch =
-										expr.callee.type === "Identifier" &&
-										parser.getTagData(expr.callee.name, notSideEffectsTag);
-									if (!noSideEffectsMatch) return false;
+								if (expr.callee.type !== "Identifier") return;
+								if (!parser.getTagData(expr.callee.name, notSideEffectsTag)) {
+									return;
 								}
 								commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
 								return expr.arguments.every((arg) => {

--- a/lib/url/URLParserPlugin.js
+++ b/lib/url/URLParserPlugin.js
@@ -15,7 +15,7 @@ const CommentCompilationWarning = require("../errors/CommentCompilationWarning")
 const UnsupportedFeatureWarning = require("../errors/UnsupportedFeatureWarning");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { approve } = require("../javascript/JavascriptParserHelpers");
-const InnerGraph = require("../optimize/InnerGraph");
+const { getInnerGraph } = require("../optimize/InnerGraph");
 
 /** @typedef {import("estree").MemberExpression} MemberExpression */
 /** @typedef {import("estree").NewExpression} NewExpressionNode */
@@ -189,7 +189,10 @@ class URLParserPlugin {
 				);
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				parser.state.current.addDependency(dep);
-				InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
+				getInnerGraph(parser.state.compilation).onUsage(
+					parser.state,
+					(e) => (dep.usedByExports = e)
+				);
 				return true;
 			}
 

--- a/lib/url/URLParserPlugin.js
+++ b/lib/url/URLParserPlugin.js
@@ -15,7 +15,7 @@ const CommentCompilationWarning = require("../errors/CommentCompilationWarning")
 const UnsupportedFeatureWarning = require("../errors/UnsupportedFeatureWarning");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { approve } = require("../javascript/JavascriptParserHelpers");
-const { getInnerGraph } = require("../optimize/InnerGraph");
+const { getInnerGraphUtils } = require("../optimize/InnerGraph");
 
 /** @typedef {import("estree").MemberExpression} MemberExpression */
 /** @typedef {import("estree").NewExpression} NewExpressionNode */
@@ -189,7 +189,7 @@ class URLParserPlugin {
 				);
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				parser.state.current.addDependency(dep);
-				getInnerGraph(parser.state.compilation).onUsage(
+				getInnerGraphUtils(parser.state.compilation).onUsage(
 					parser.state,
 					(e) => (dep.usedByExports = e)
 				);

--- a/test/configCases/inner-graph/cross-module-pure-namespace-import/index.js
+++ b/test/configCases/inner-graph/cross-module-pure-namespace-import/index.js
@@ -1,0 +1,16 @@
+import * as ns from "./pure-source";
+
+const pure1 = ns.pureExport1(1);
+const pure2 = ns.pureExport2(1);
+const pure3 = ns.pureExport3(1);
+const pure4 = ns.pureExport4(1);
+const pure5 = ns.pureExport5(1);
+const pureDefault = ns.default(1);
+
+const impure = ns.impureExport(2);
+
+it("should compile successfully", () => {
+	expect(ns.usedExportsOfPureSource.sort()).toEqual(
+		["impureExport", "usedExportsOfPureSource"].sort()
+	);
+});

--- a/test/configCases/inner-graph/cross-module-pure-namespace-import/pure-source.js
+++ b/test/configCases/inner-graph/cross-module-pure-namespace-import/pure-source.js
@@ -1,0 +1,36 @@
+/*#__NO_SIDE_EFFECTS__*/
+export function pureExport1(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export default function pureDefaultExport(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export const pureExport2 = (x) => {
+	return x;
+};
+
+export var pureExport3 = /*#__NO_SIDE_EFFECTS__*/ (x) => {
+	return x;
+};
+
+/*#__NO_SIDE_EFFECTS__*/
+function fn4(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+const pureExport5 = (x) => {
+	return x;
+};
+
+export const impureExport = (x) => {
+	return x;
+};
+
+export const usedExportsOfPureSource = __webpack_exports_info__.usedExports;
+
+export { fn4 as pureExport4, pureExport5 };

--- a/test/configCases/inner-graph/cross-module-pure-namespace-import/webpack.config.js
+++ b/test/configCases/inner-graph/cross-module-pure-namespace-import/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "cross-module-pure-namespace-import without module concatenation",
+		mode: "production",
+		optimization: {
+			concatenateModules: false
+		}
+	},
+	{
+		name: "cross-module-pure-namespace-import with module concatenation",
+		mode: "production"
+	}
+];

--- a/test/configCases/inner-graph/cross-module-pure-normal/index.js
+++ b/test/configCases/inner-graph/cross-module-pure-normal/index.js
@@ -1,0 +1,24 @@
+import pureDefaultExport, {
+	pureExport1,
+	impureExport,
+	pureExport2,
+	pureExport3,
+	pureExport4,
+	pureExport5,
+	usedExportsOfPureSource
+} from "./pure-source";
+
+const pure1 = pureExport1(1);
+const pure2 = pureExport2(1);
+const pure3 = pureExport3(1);
+const pure4 = pureExport4(1);
+const pure5 = pureExport5(1);
+const pureDefault = pureDefaultExport(1);
+
+const impure = impureExport(2);
+
+it("should compile successfully", () => {
+	expect(usedExportsOfPureSource.sort()).toEqual(
+		["impureExport", "usedExportsOfPureSource"].sort()
+	);
+});

--- a/test/configCases/inner-graph/cross-module-pure-normal/pure-source.js
+++ b/test/configCases/inner-graph/cross-module-pure-normal/pure-source.js
@@ -1,0 +1,36 @@
+/*#__NO_SIDE_EFFECTS__*/
+export function pureExport1(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export default function pureDefaultExport(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export const pureExport2 = (x) => {
+	return x;
+};
+
+export var pureExport3 = /*#__NO_SIDE_EFFECTS__*/ (x) => {
+	return x;
+};
+
+/*#__NO_SIDE_EFFECTS__*/
+function fn4(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+const pureExport5 = (x) => {
+	return x;
+};
+
+export const impureExport = (x) => {
+	return x;
+};
+
+export const usedExportsOfPureSource = __webpack_exports_info__.usedExports;
+
+export { fn4 as pureExport4, pureExport5 };

--- a/test/configCases/inner-graph/cross-module-pure-normal/webpack.config.js
+++ b/test/configCases/inner-graph/cross-module-pure-normal/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "cross-module-pure-normal without module concatenation",
+		mode: "production",
+		optimization: {
+			concatenateModules: false
+		}
+	},
+	{
+		name: "cross-module-pure-normal with module concatenation",
+		mode: "production"
+	}
+];

--- a/test/configCases/inner-graph/cross-module-pure-reexport-target/index.js
+++ b/test/configCases/inner-graph/cross-module-pure-reexport-target/index.js
@@ -1,0 +1,23 @@
+import pureDefaultExport, {
+	pureExport1,
+	impureExport,
+	pureExport2,
+	pureExport3,
+	usedExportsOfPureSource
+} from "./reexport-1";
+import { pure, pureExport4 } from "./reexport-2";
+
+const pure1 = pureExport1(1);
+const pure2 = pureExport2(1);
+const pure3 = pureExport3(1);
+const pure4 = pureExport4(1);
+const pure5 = pure.pureExport5(1);
+const pureDefault = pureDefaultExport(1);
+
+const impure = impureExport(2);
+
+it("should compile successfully", () => {
+	expect(usedExportsOfPureSource.sort()).toEqual(
+		["impureExport", "usedExportsOfPureSource"].sort()
+	);
+});

--- a/test/configCases/inner-graph/cross-module-pure-reexport-target/pure-source.js
+++ b/test/configCases/inner-graph/cross-module-pure-reexport-target/pure-source.js
@@ -1,0 +1,36 @@
+/*#__NO_SIDE_EFFECTS__*/
+export function pureExport1(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export default function pureDefaultExport(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export const pureExport2 = (x) => {
+	return x;
+};
+
+export var pureExport3 = /*#__NO_SIDE_EFFECTS__*/ (x) => {
+	return x;
+};
+
+/*#__NO_SIDE_EFFECTS__*/
+function fn4(x) {
+	return x;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+const pureExport5 = (x) => {
+	return x;
+};
+
+export const impureExport = (x) => {
+	return x;
+};
+
+export const usedExportsOfPureSource = __webpack_exports_info__.usedExports;
+
+export { fn4 as pureExport4, pureExport5 };

--- a/test/configCases/inner-graph/cross-module-pure-reexport-target/reexport-1.js
+++ b/test/configCases/inner-graph/cross-module-pure-reexport-target/reexport-1.js
@@ -1,0 +1,2 @@
+export * from "./pure-source";
+export { default } from "./pure-source";

--- a/test/configCases/inner-graph/cross-module-pure-reexport-target/reexport-2.js
+++ b/test/configCases/inner-graph/cross-module-pure-reexport-target/reexport-2.js
@@ -1,0 +1,2 @@
+export * as pure from "./pure-source";
+export { pureExport4 } from "./pure-source";

--- a/test/configCases/inner-graph/cross-module-pure-reexport-target/webpack.config.js
+++ b/test/configCases/inner-graph/cross-module-pure-reexport-target/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "cross-module-pure-reexport-target without module concatenation",
+		mode: "production",
+		optimization: {
+			concatenateModules: false
+		}
+	},
+	{
+		name: "cross-module-pure-reexport-target with module concatenation",
+		mode: "production"
+	}
+];

--- a/test/configCases/inner-graph/default-pure-expression/module.js
+++ b/test/configCases/inner-graph/default-pure-expression/module.js
@@ -1,0 +1,7 @@
+import { a, b } from "dep";
+
+// pure export default expression: statementPurePart path
+export default /*#__PURE__*/ a();
+
+// pure declarator, independent usage
+export const other = /*#__PURE__*/ b();

--- a/test/configCases/inner-graph/default-pure-expression/webpack.config.js
+++ b/test/configCases/inner-graph/default-pure-expression/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const createTestCases = require("../_helpers/createTestCases");
+
+// pure default expression drops its import unless the default export is used
+module.exports = createTestCases({
+	nothing: {
+		usedExports: [],
+		expect: {
+			dep: []
+		}
+	},
+	default: {
+		usedExports: ["default"],
+		expect: {
+			dep: ["a"]
+		}
+	},
+	other: {
+		usedExports: ["other"],
+		expect: {
+			dep: ["b"]
+		}
+	},
+	all: {
+		usedExports: ["default", "other"],
+		expect: {
+			dep: ["a", "b"]
+		}
+	}
+});

--- a/test/configCases/inner-graph/impure-symbol/module.js
+++ b/test/configCases/inner-graph/impure-symbol/module.js
@@ -1,0 +1,17 @@
+import { pureCall, impureCall, classPureCall, classImpureCall } from "dep";
+
+// pure class declaration: dropped when unused
+export class PureClass {
+	method() {
+		classPureCall();
+	}
+}
+
+// impure class declaration (side effect in extends): always kept
+export class ImpureClass extends classImpureCall() {}
+
+// pure declarator: dropped when unused
+export const usedPureConst = /*#__PURE__*/ pureCall();
+
+// impure declarator: always kept
+export const impureConst = impureCall();

--- a/test/configCases/inner-graph/impure-symbol/webpack.config.js
+++ b/test/configCases/inner-graph/impure-symbol/webpack.config.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const createTestCases = require("../_helpers/createTestCases");
+
+// impure top-level symbols stay; pure ones drop unless their export is used
+module.exports = createTestCases({
+	nothing: {
+		usedExports: [],
+		expect: {
+			dep: ["impureCall", "classImpureCall"]
+		}
+	},
+	PureClass: {
+		usedExports: ["PureClass"],
+		expect: {
+			dep: ["impureCall", "classImpureCall", "classPureCall"]
+		}
+	},
+	ImpureClass: {
+		usedExports: ["ImpureClass"],
+		expect: {
+			dep: ["impureCall", "classImpureCall"]
+		}
+	},
+	usedPureConst: {
+		usedExports: ["usedPureConst"],
+		expect: {
+			dep: ["impureCall", "classImpureCall", "pureCall"]
+		}
+	},
+	all: {
+		usedExports: ["PureClass", "ImpureClass", "usedPureConst", "impureConst"],
+		expect: {
+			dep: ["impureCall", "classImpureCall", "classPureCall", "pureCall"]
+		}
+	}
+});

--- a/test/watchCases/inner-graph/pure-dependency/0/consumer.js
+++ b/test/watchCases/inner-graph/pure-dependency/0/consumer.js
@@ -1,0 +1,3 @@
+import { ua } from "./lib";
+
+export default ua;

--- a/test/watchCases/inner-graph/pure-dependency/0/dep.js
+++ b/test/watchCases/inner-graph/pure-dependency/0/dep.js
@@ -1,0 +1,3 @@
+export function a() {}
+export function b() {}
+export const __usedExports = __webpack_exports_info__.usedExports;

--- a/test/watchCases/inner-graph/pure-dependency/0/index.js
+++ b/test/watchCases/inner-graph/pure-dependency/0/index.js
@@ -1,0 +1,13 @@
+import consumed from "./consumer";
+import { __usedExports } from "./dep";
+
+it(`should keep pure deps correct after incremental rebuild (step ${WATCH_STEP})`, () => {
+	expect(consumed).toBe(undefined);
+	// lib.js is unchanged across steps (cache-restored); only the consumer switches
+	// which pure export it uses, so the persisted pure deps must re-drive tree-shaking
+	expect(__usedExports.sort()).toEqual(
+		WATCH_STEP === "0"
+			? ["__usedExports", "a"]
+			: ["__usedExports", "b"]
+	);
+});

--- a/test/watchCases/inner-graph/pure-dependency/0/lib.js
+++ b/test/watchCases/inner-graph/pure-dependency/0/lib.js
@@ -1,0 +1,5 @@
+import { a, b } from "./dep";
+
+// pure deps added in finishModules; must persist when lib.js is cache-restored
+export const ua = /*#__PURE__*/ a();
+export const ub = /*#__PURE__*/ b();

--- a/test/watchCases/inner-graph/pure-dependency/1/consumer.js
+++ b/test/watchCases/inner-graph/pure-dependency/1/consumer.js
@@ -1,0 +1,3 @@
+import { ub } from "./lib";
+
+export default ub;

--- a/test/watchCases/inner-graph/pure-dependency/webpack.config.js
+++ b/test/watchCases/inner-graph/pure-dependency/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		concatenateModules: false,
+		minimize: false
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -25455,7 +25455,9 @@ declare namespace exports {
 						moduleGraphConnection: ModuleGraphConnection,
 						runtime: RuntimeSpec
 				  ) => ConnectionState);
-			export let getInnerGraph: (compilation: Compilation) => InnerGraphUtils;
+			export let getInnerGraphUtils: (
+				compilation: Compilation
+			) => InnerGraphUtils;
 			export { TopLevelSymbol, topLevelSymbolTag };
 		}
 		export {

--- a/types.d.ts
+++ b/types.d.ts
@@ -7243,6 +7243,13 @@ declare abstract class ExportInfo {
 	 * undefined: it was not determined if it can be mangled
 	 */
 	canMangleUse?: boolean;
+
+	/**
+	 * Only specific export info can be pure, so other_export_info.pure is always undefined.
+	 * true: calling the export has no observable side effects
+	 * undefined: it was not determined whether the export is pure
+	 */
+	pureProvide?: boolean;
 	exportsInfoOwned: boolean;
 	exportsInfo?: ExportsInfo;
 	get canMangle(): boolean;
@@ -7407,6 +7414,11 @@ declare interface ExportSpec {
 	 * is the export a terminal binding that should be checked for export star conflicts
 	 */
 	terminalBinding?: boolean;
+
+	/**
+	 * calling this export has no observable side effects
+	 */
+	isPure?: boolean;
 
 	/**
 	 * nested exports
@@ -7623,6 +7635,11 @@ declare interface ExportsSpec {
 	 * are the exports terminal bindings that should be checked for export star conflicts
 	 */
 	terminalBinding?: boolean;
+
+	/**
+	 * calling these exports has no observable side effects
+	 */
+	isPure?: boolean;
 
 	/**
 	 * module on which the result depends on
@@ -9669,6 +9686,40 @@ declare class InitFragment<GenerateContext> {
 	static STAGE_PROVIDES: number;
 	static STAGE_ASYNC_DEPENDENCIES: number;
 	static STAGE_ASYNC_HARMONY_IMPORTS: number;
+}
+declare interface InnerGraphUtils {
+	enable: (parserState: ParserState) => void;
+	bailout: (parserState: ParserState) => void;
+	isEnabled: (parserState: ParserState) => boolean;
+	addUsage: (
+		parserState: ParserState,
+		symbol: null | TopLevelSymbol,
+		usage: Usage
+	) => void;
+	onUsage: (
+		parserState: ParserState,
+		onUsageCallback: (
+			value: undefined | boolean | Set<string>,
+			module: Module
+		) => void
+	) => void;
+	setTopLevelSymbol: (
+		parserState: ParserState,
+		symbol?: TopLevelSymbol
+	) => void;
+	getTopLevelSymbol: (parserState: ParserState) => void | TopLevelSymbol;
+	tagTopLevelSymbol: (
+		parser: JavascriptParser,
+		name: string,
+		pure?: boolean | ((compilation: Compilation, module: Module) => boolean)
+	) => undefined | TopLevelSymbol;
+	addVariableUsage: (
+		parser: JavascriptParser,
+		name: string,
+		usage: Usage
+	) => void;
+	inferDependencyUsage: (module: Module) => void;
+	release: (module: Module) => void;
 }
 
 /**
@@ -12475,6 +12526,11 @@ declare interface KnownBuildInfo {
 	 * top level declaration names
 	 */
 	topLevelDeclarations?: Set<string>;
+
+	/**
+	 * names of locally declared functions known to be free of side effects
+	 */
+	pureFunctions?: Set<string>;
 }
 declare interface KnownBuildMeta {
 	exportsType?: "namespace" | "dynamic" | "default" | "flagged";
@@ -19002,6 +19058,9 @@ declare interface ProvidesConfig {
 declare interface ProvidesObject {
 	[index: string]: string | ProvidesConfig;
 }
+type PureCondition =
+	| boolean
+	| ((compilation: Compilation, module: Module) => boolean);
 declare interface RawChunkGroupOptions {
 	preloadOrder?: number;
 	prefetchOrder?: number;
@@ -20887,6 +20946,7 @@ declare interface RestoreProvidedDataExports {
 	provided?: null | boolean;
 	canMangleProvide?: boolean;
 	terminalBinding: boolean;
+	pureProvide?: boolean;
 	exportsInfo?: RestoreProvidedData;
 }
 type Rule = string | RegExp | ((str: string) => boolean);
@@ -24009,8 +24069,19 @@ declare class TopLevelSymbol {
 	/**
 	 * Creates an instance of TopLevelSymbol.
 	 */
-	constructor(name: string);
+	constructor(
+		name: string,
+		pure?: boolean | ((compilation: Compilation, module: Module) => boolean)
+	);
 	name: string;
+	conditional: boolean;
+	pureFn?: (compilation: Compilation, module: Module) => boolean;
+
+	/**
+	 * Sets the pure condition
+	 */
+	setPure(pure: PureCondition): void;
+	isPure(compilation: Compilation, module: Module): boolean;
 }
 
 /**
@@ -25374,21 +25445,8 @@ declare namespace exports {
 	}
 	export namespace optimize {
 		export namespace InnerGraph {
-			export let addUsage: (
-				state: ParserState,
-				symbol: null | TopLevelSymbol,
-				usage: Usage
-			) => void;
-			export let addVariableUsage: (
-				parser: JavascriptParser,
-				name: string,
-				usage: Usage
-			) => void;
-			export let bailout: (parserState: ParserState) => void;
-			export let enable: (parserState: ParserState) => void;
 			export let getDependencyUsedByExportsCondition: (
 				dependency: Dependency,
-				usedByExports: undefined | boolean | Set<string>,
 				moduleGraph: ModuleGraph
 			) =>
 				| null
@@ -25397,29 +25455,7 @@ declare namespace exports {
 						moduleGraphConnection: ModuleGraphConnection,
 						runtime: RuntimeSpec
 				  ) => ConnectionState);
-			export let getTopLevelSymbol: (
-				state: ParserState
-			) => void | TopLevelSymbol;
-			export let inferDependencyUsage: (state: ParserState) => void;
-			export let isDependencyUsedByExports: (
-				dependency: Dependency,
-				usedByExports: undefined | boolean | Set<string>,
-				moduleGraph: ModuleGraph,
-				runtime: RuntimeSpec
-			) => boolean;
-			export let isEnabled: (parserState: ParserState) => boolean;
-			export let onUsage: (
-				state: ParserState,
-				onUsageCallback: (value?: boolean | Set<string>) => void
-			) => void;
-			export let setTopLevelSymbol: (
-				state: ParserState,
-				symbol?: TopLevelSymbol
-			) => void;
-			export let tagTopLevelSymbol: (
-				parser: JavascriptParser,
-				name: string
-			) => undefined | TopLevelSymbol;
+			export let getInnerGraph: (compilation: Compilation) => InnerGraphUtils;
 			export { TopLevelSymbol, topLevelSymbolTag };
 		}
 		export {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->


Refactors the InnerGraph tree-shaking utility so purity can be tracked across module boundaries, not just
within a single module.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**


***TL;DR***

A `/*#__NO_SIDE_EFFECTS__*/` annotation in one module is now honored by call sites in other modules — not
just within the file it was declared in.
Example

```js
// pure.js
/*#__NO_SIDE_EFFECTS__*/
export function pureFn(x) { return x; }

// index.js
import { pureFn } from "./pure";

const r = pureFn(1);   // result never read
```

Before this PR, `pureFn` shows up in `usedExports` because the `/*#__NO_SIDE_EFFECTS__*/` hint stayed inside
`pure.js` and never reached the importer, so the call site `pureFn(1)` was treated as a usage with `sideEffects`.
After this PR, `pureFn` export can be tree-shaken.

How the optimization works:

1. Producer records purity locally. While parsing `pure.js`, the parser sees the
`/*#__NO_SIDE_EFFECTS__*/` and writes the name into
`module.buildInfo.pureFunctions`. At this point the purity is just a per-module fact.

2. Purity is lifted onto the export descriptor. When `HarmonyExportSpecifierDependency /
HarmonyExportExpressionDependency` build their `ExportsSpec`, they consult
`buildInfo.pureFunctions` and emit `{ name: "pureFn", isPure: true }`. This is the
only channel that crosses the module boundary.

3. `FlagDependencyExportsPlugin` propagates `isPure` to ExportInfo and the
 new `isPure` flag is copied onto the matching `ExportInfo`.

4. Importer tags the local binding with a deferred pure predicate. When `index.js` is parsed, the inner graph
 creates a `TopLevelSymbol` for the imported `pureFn` and its `pure` field is a function for purpose of `deferring` instead of definite `true`. The deferral matters because the importing module may not yet be parsed.

5. Per-compilation state. `Inner-graph` state is now scoped to the Compilation
(`getInnerGraph(compilation)`) and keyed by `Module`, which is what lets step 4 reach into another module's
`ExportsInfo` from inside the importer's graph.

6. Inference resolves the call. When `inferDependencyUsage` walks the importer's graph, it reaches the
`pureFn(1)` call, asks the symbol `isPure(compilation, module)`, gets *true*, so propagate pure-symbol usage through the inner graph.


<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Partial
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->