### PR TITLE
fix: map link-type CSS module class exports in JS source map

### DIFF
--- a/.changeset/css-link-fine-grained-mappings.md
+++ b/.changeset/css-link-fine-grained-mappings.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Map each generated CSS-module class export line in the JS bundle back to its selector position in the original CSS file (e.g. `btn: "..."` → `.btn { ... }`), rather than only embedding the generated wrapper as `sourcesContent`. Brings JS source-map fidelity for the built-in CSS feature in line with what `css-loader` produces.

--- a/.changeset/css-link-source-map.md
+++ b/.changeset/css-link-source-map.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Wrap the JS emit of CSS modules with `exportType: "link"` (the default) in an `OriginalSource` so the bundle's JS source map maps the generated `module.exports = { className: "hash" }` lines back to the CSS module's identifier, matching the behaviour of other CSS export types.

--- a/lib/DependencyTemplate.js
+++ b/lib/DependencyTemplate.js
@@ -52,6 +52,7 @@
  * @typedef {object} CssData
  * @property {boolean} esModule whether export __esModule
  * @property {Map<string, string>} exports the css exports
+ * @property {Map<string, { line: number, column: number }>=} exportLocs source position (line is 1-based, column is 0-based) of each export's defining identifier in the original CSS, used to emit fine-grained JS-to-CSS source mappings
  */
 
 /** @typedef {DependencyTemplateContext & CssDependencyTemplateContextExtras} CssDependencyTemplateContext */

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -9,7 +9,8 @@ const {
 	ConcatSource,
 	OriginalSource,
 	RawSource,
-	ReplaceSource
+	ReplaceSource,
+	SourceMapSource
 } = require("webpack-sources");
 const { UsageState } = require("../ExportsInfo");
 const Generator = require("../Generator");
@@ -53,6 +54,90 @@ const memoize = require("../util/memoize");
 
 const getPropertyName = memoize(() => require("../util/property"));
 const getCssModulesPlugin = memoize(() => require("./CssModulesPlugin"));
+
+const VLQ_BASE64 =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Encodes a signed integer as a base64 VLQ string per the source-map V3 spec.
+ * @param {number} value signed integer to encode
+ * @returns {string} base64 VLQ encoded value
+ */
+const encodeVLQ = (value) => {
+	let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+	let result = "";
+	do {
+		let digit = vlq & 0x1f;
+		vlq >>>= 5;
+		if (vlq > 0) digit |= 0x20;
+		result += VLQ_BASE64[digit];
+	} while (vlq > 0);
+	return result;
+};
+
+/** @typedef {import("webpack-sources").RawSourceMap} RawSourceMap */
+
+/**
+ * Build a v3 source map that maps each line in `generatedJs` containing a
+ * known CSS-class export entry back to the corresponding selector position
+ * in the original CSS. Lines without an associated export are left
+ * unmapped — devtools simply shows them as part of the bundled JS.
+ * @param {string} generatedJs the generated JS string
+ * @param {Map<string, { line: number, column: number }>} exportLocs map of export names to CSS source location
+ * @param {string} cssContent original CSS source content
+ * @param {string} sourceName source identifier to use in the map
+ * @returns {RawSourceMap} a v3 RawSourceMap
+ */
+const buildExportsSourceMap = (
+	generatedJs,
+	exportLocs,
+	cssContent,
+	sourceName
+) => {
+	const lines = generatedJs.split("\n");
+	const lineMappings = lines.map(() => "");
+
+	const lineByExport = new Map();
+	for (const [exportName] of exportLocs) {
+		const needle = `${JSON.stringify(exportName)}:`;
+		for (let i = 0; i < lines.length; i++) {
+			if (lines[i].includes(needle)) {
+				lineByExport.set(exportName, i);
+				break;
+			}
+		}
+	}
+
+	let prevSrcLine = 0;
+	let prevSrcCol = 0;
+	const ordered = [...lineByExport.entries()].sort((a, b) => a[1] - b[1]);
+	for (const [exportName, genLine] of ordered) {
+		const pos = /** @type {{ line: number, column: number }} */ (
+			exportLocs.get(exportName)
+		);
+		// Source-map V3 uses 0-based lines and 0-based columns. webpack's
+		// dependency `loc` uses 1-based lines and 0-based columns, so subtract
+		// one from the line.
+		const srcLine = pos.line - 1;
+		const srcCol = pos.column;
+		lineMappings[genLine] =
+			encodeVLQ(0) +
+			encodeVLQ(0) +
+			encodeVLQ(srcLine - prevSrcLine) +
+			encodeVLQ(srcCol - prevSrcCol);
+		prevSrcLine = srcLine;
+		prevSrcCol = srcCol;
+	}
+
+	return {
+		version: 3,
+		file: "",
+		sources: [sourceName],
+		sourcesContent: [cssContent],
+		names: [],
+		mappings: lineMappings.join(";")
+	};
+};
 
 class CssGenerator extends Generator {
 	/**
@@ -309,7 +394,8 @@ class CssGenerator extends Generator {
 		/** @type {CssData} */
 		const cssData = {
 			esModule: /** @type {boolean} */ (this._esModule),
-			exports: new Map()
+			exports: new Map(),
+			exportLocs: new Map()
 		};
 
 		this.sourceModule(module, initFragments, source, {
@@ -588,26 +674,48 @@ class CssGenerator extends Generator {
 						source.add("\n");
 					}
 				}
-				// Wrap the entire generated module emit as a single OriginalSource
-				// so the bundle's JS source map shows the full wrapper
-				// (`__webpack_require__.r(module.exports = ...)`,
+				// Wrap the entire generated module emit so the bundle's JS source
+				// map shows the full wrapper (`__webpack_require__.r(...)`,
 				// `cssInjectStyle(...)`, `new CSSStyleSheet()`,
 				// `module.exports = { className: "hash" }` for CSS modules, etc.)
-				// as sourcesContent under the CSS module's identifier — same shape
-				// css-loader emits for CSS modules consumed in JS. Use the
-				// shortened readable identifier so the source name is relative
-				// to the compilation context (matching how regular JS modules
-				// appear as `webpack:///./module.js` rather than absolute paths).
+				// under the CSS module's identifier. Use the shortened readable
+				// identifier so the source name is relative to the compilation
+				// context (matching how regular JS modules appear as
+				// `webpack:///./module.js` rather than absolute paths).
+				//
 				// For link-type modules without any JS emit (plain CSS imports
 				// loaded via <link>) skip the wrap since there's nothing to map.
+				//
+				// When we know the source position of each class-name export
+				// (from `cssData.exportLocs`) we emit a `SourceMapSource` whose
+				// mappings point each export line in the generated JS back to
+				// the corresponding selector in the original CSS — same shape
+				// css-loader emits for CSS modules consumed in JS. Without
+				// per-export positions we fall back to `OriginalSource`, which
+				// only embeds the generated JS as `sourcesContent`.
 				const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
 					.isCSSModule;
 				if (exportType !== "link" || isCSSModule || cssData.exports.size > 0) {
 					const compilation = generateContext.runtimeTemplate.compilation;
-					return new OriginalSource(
-						/** @type {string} */ (source.source()),
-						module.readableIdentifier(compilation.requestShortener)
+					const generatedJs = /** @type {string} */ (source.source());
+					const sourceName = module.readableIdentifier(
+						compilation.requestShortener
 					);
+					const cssOriginal = module.originalSource();
+					if (
+						cssData.exportLocs &&
+						cssData.exportLocs.size > 0 &&
+						cssOriginal
+					) {
+						const sourceMap = buildExportsSourceMap(
+							generatedJs,
+							cssData.exportLocs,
+							/** @type {string} */ (cssOriginal.source()),
+							sourceName
+						);
+						return new SourceMapSource(generatedJs, sourceName, sourceMap);
+					}
+					return new OriginalSource(generatedJs, sourceName);
 				}
 				return source;
 			}

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -588,16 +588,21 @@ class CssGenerator extends Generator {
 						source.add("\n");
 					}
 				}
-				// For non-link exportTypes, wrap the entire generated module emit
-				// as a single OriginalSource so the bundle's JS source map shows
-				// the full wrapper (`__webpack_require__.r(module.exports = ...)`,
-				// `cssInjectStyle(...)`, `new CSSStyleSheet()`, etc.) as
-				// sourcesContent under the CSS module's identifier — same shape
+				// Wrap the entire generated module emit as a single OriginalSource
+				// so the bundle's JS source map shows the full wrapper
+				// (`__webpack_require__.r(module.exports = ...)`,
+				// `cssInjectStyle(...)`, `new CSSStyleSheet()`,
+				// `module.exports = { className: "hash" }` for CSS modules, etc.)
+				// as sourcesContent under the CSS module's identifier — same shape
 				// css-loader emits for CSS modules consumed in JS. Use the
 				// shortened readable identifier so the source name is relative
 				// to the compilation context (matching how regular JS modules
 				// appear as `webpack:///./module.js` rather than absolute paths).
-				if (exportType !== "link") {
+				// For link-type modules without any JS emit (plain CSS imports
+				// loaded via <link>) skip the wrap since there's nothing to map.
+				const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
+					.isCSSModule;
+				if (exportType !== "link" || isCSSModule || cssData.exports.size > 0) {
 					const compilation = generateContext.runtimeTemplate.compilation;
 					return new OriginalSource(
 						/** @type {string} */ (source.source()),

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -27,6 +27,7 @@ const Template = require("../Template");
 const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 
+const { encodeMappings } = require("../util/createMappings");
 const memoize = require("../util/memoize");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -55,26 +56,6 @@ const memoize = require("../util/memoize");
 const getPropertyName = memoize(() => require("../util/property"));
 const getCssModulesPlugin = memoize(() => require("./CssModulesPlugin"));
 
-const VLQ_BASE64 =
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-/**
- * Encodes a signed integer as a base64 VLQ string per the source-map V3 spec.
- * @param {number} value signed integer to encode
- * @returns {string} base64 VLQ encoded value
- */
-const encodeVLQ = (value) => {
-	let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
-	let result = "";
-	do {
-		let digit = vlq & 0x1f;
-		vlq >>>= 5;
-		if (vlq > 0) digit |= 0x20;
-		result += VLQ_BASE64[digit];
-	} while (vlq > 0);
-	return result;
-};
-
 /** @typedef {import("webpack-sources").RawSourceMap} RawSourceMap */
 
 /**
@@ -95,7 +76,6 @@ const buildExportsSourceMap = (
 	sourceName
 ) => {
 	const lines = generatedJs.split("\n");
-	const lineMappings = lines.map(() => "");
 
 	const lineByExport = new Map();
 	for (const [exportName] of exportLocs) {
@@ -108,25 +88,21 @@ const buildExportsSourceMap = (
 		}
 	}
 
-	let prevSrcLine = 0;
-	let prevSrcCol = 0;
-	const ordered = [...lineByExport.entries()].sort((a, b) => a[1] - b[1]);
-	for (const [exportName, genLine] of ordered) {
+	/** @type {(import("../util/createMappings").LineMappings)[]} */
+	const perLine = lines.map(() => null);
+	for (const [exportName, genLine] of lineByExport) {
 		const pos = /** @type {{ line: number, column: number }} */ (
 			exportLocs.get(exportName)
 		);
 		// Source-map V3 uses 0-based lines and 0-based columns. webpack's
 		// dependency `loc` uses 1-based lines and 0-based columns, so subtract
 		// one from the line.
-		const srcLine = pos.line - 1;
-		const srcCol = pos.column;
-		lineMappings[genLine] =
-			encodeVLQ(0) +
-			encodeVLQ(0) +
-			encodeVLQ(srcLine - prevSrcLine) +
-			encodeVLQ(srcCol - prevSrcCol);
-		prevSrcLine = srcLine;
-		prevSrcCol = srcCol;
+		perLine[genLine] = {
+			generatedColumn: 0,
+			sourceIndex: 0,
+			originalLine: pos.line - 1,
+			originalColumn: pos.column
+		};
 	}
 
 	return {
@@ -135,7 +111,7 @@ const buildExportsSourceMap = (
 		sources: [sourceName],
 		sourcesContent: [cssContent],
 		names: [],
-		mappings: lineMappings.join(";")
+		mappings: encodeMappings(perLine)
 	};
 };
 

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -618,10 +618,24 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 			const allNames = new Set([...usedNames, ...names]);
 			const unescaped = getCssParser().unescapeIdentifier(value);
 
+			const depLocStart =
+				dep.loc &&
+				/** @type {{ start?: { line: number, column: number } }} */ (dep.loc)
+					.start;
 			for (const used of allNames) {
 				if (dep.exportMode === CssIcssExportDependency.EXPORT_MODE.ONCE) {
 					if (cssData.exports.has(used)) return;
 					cssData.exports.set(used, unescaped);
+					if (
+						depLocStart &&
+						cssData.exportLocs &&
+						!cssData.exportLocs.has(used)
+					) {
+						cssData.exportLocs.set(used, {
+							line: depLocStart.line,
+							column: depLocStart.column
+						});
+					}
 				} else {
 					const originalValue =
 						dep.exportMode === CssIcssExportDependency.EXPORT_MODE.REPLACE
@@ -632,6 +646,19 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 						used,
 						`${originalValue ? `${originalValue}${unescaped ? " " : ""}` : ""}${unescaped}`
 					);
+					// Record the source location once per export (use the first
+					// occurrence — for APPEND/REPLACE this corresponds to the
+					// first selector seen, which is a reasonable anchor).
+					if (
+						depLocStart &&
+						cssData.exportLocs &&
+						!cssData.exportLocs.has(used)
+					) {
+						cssData.exportLocs.set(used, {
+							line: depLocStart.line,
+							column: depLocStart.column
+						});
+					}
 				}
 			}
 		} else if (

--- a/lib/util/createMappings.js
+++ b/lib/util/createMappings.js
@@ -1,0 +1,118 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+/**
+ * Utilities for building V3 source-map `mappings` strings without pulling in a
+ * full source-map library. The shape of the input is intentionally minimal —
+ * one slot per generated line, each holding zero, one, or many segments — so
+ * call sites that have a "one mapping per line" structure (like the CSS-module
+ * exports emit in `lib/css/CssGenerator.js`) can build mappings directly,
+ * while richer call sites can pass arrays of segments.
+ *
+ * This intentionally mirrors the shape of an API that would fit in
+ * `webpack-sources` itself; if a public encoder lands there, this file's
+ * implementation can be swapped out for re-exports without changing the
+ * call sites.
+ */
+
+const VLQ_BASE64 =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Encode a signed integer as a base64 VLQ string per the source-map V3 spec.
+ * @param {number} value signed integer to encode
+ * @returns {string} base64 VLQ encoded value
+ */
+const encodeVLQ = (value) => {
+	let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+	let result = "";
+	do {
+		let digit = vlq & 0x1f;
+		vlq >>>= 5;
+		if (vlq > 0) digit |= 0x20;
+		result += VLQ_BASE64[digit];
+	} while (vlq > 0);
+	return result;
+};
+
+/**
+ * @typedef {object} MappingSegment
+ * @property {number=} generatedColumn 0-based generated column (defaults to 0)
+ * @property {number=} sourceIndex index into the surrounding source map's `sources` array; omit for a generated-only segment
+ * @property {number=} originalLine 0-based line in the original source (required when `sourceIndex` is set)
+ * @property {number=} originalColumn 0-based column in the original source (required when `sourceIndex` is set)
+ * @property {number=} nameIndex index into the surrounding source map's `names` array
+ */
+
+/** @typedef {null | MappingSegment | MappingSegment[]} LineMappings */
+
+/**
+ * Encode a V3 source-map `mappings` string from a per-generated-line
+ * description of segments.
+ *
+ * Each entry of `lines` describes the mappings for one generated line:
+ *
+ * - `null` (or `undefined`) — the line has no mappings.
+ * - a single `MappingSegment` — convenience for the common "one mapping at
+ * column 0" case.
+ * - `MappingSegment[]` — multiple segments on the same line.
+ *
+ * Lines are joined with `;`, segments within a line with `,`. All numeric
+ * fields are encoded as deltas relative to the previous emitted segment, per
+ * the V3 spec.
+ * @param {LineMappings[]} lines per-generated-line mapping segments
+ * @returns {string} VLQ-encoded V3 mappings string
+ */
+const encodeMappings = (lines) => {
+	let prevSourceIndex = 0;
+	let prevOriginalLine = 0;
+	let prevOriginalColumn = 0;
+	let prevNameIndex = 0;
+
+	const encodedLines = [];
+
+	for (const line of lines) {
+		if (line === null || line === undefined) {
+			encodedLines.push("");
+			continue;
+		}
+
+		const segments = Array.isArray(line) ? line : [line];
+		let prevGeneratedColumn = 0;
+		const encodedSegments = [];
+
+		for (const segment of segments) {
+			const generatedColumn = segment.generatedColumn || 0;
+			let encoded = encodeVLQ(generatedColumn - prevGeneratedColumn);
+			prevGeneratedColumn = generatedColumn;
+
+			if (segment.sourceIndex !== undefined) {
+				const originalLine = /** @type {number} */ (segment.originalLine);
+				const originalColumn = /** @type {number} */ (segment.originalColumn);
+				encoded += encodeVLQ(segment.sourceIndex - prevSourceIndex);
+				encoded += encodeVLQ(originalLine - prevOriginalLine);
+				encoded += encodeVLQ(originalColumn - prevOriginalColumn);
+				prevSourceIndex = segment.sourceIndex;
+				prevOriginalLine = originalLine;
+				prevOriginalColumn = originalColumn;
+
+				if (segment.nameIndex !== undefined) {
+					encoded += encodeVLQ(segment.nameIndex - prevNameIndex);
+					prevNameIndex = segment.nameIndex;
+				}
+			}
+
+			encodedSegments.push(encoded);
+		}
+
+		encodedLines.push(encodedSegments.join(","));
+	}
+
+	return encodedLines.join(";");
+};
+
+module.exports.encodeMappings = encodeMappings;
+module.exports.encodeVLQ = encodeVLQ;

--- a/lib/util/createMappings.js
+++ b/lib/util/createMappings.js
@@ -12,10 +12,10 @@
  * exports emit in `lib/css/CssGenerator.js`) can build mappings directly,
  * while richer call sites can pass arrays of segments.
  *
- * This intentionally mirrors the shape of an API that would fit in
- * `webpack-sources` itself; if a public encoder lands there, this file's
- * implementation can be swapped out for re-exports without changing the
- * call sites.
+ * TODO move this encoder into `webpack-sources` and replace the body of this
+ * file with re-exports. The public shape (`encodeVLQ`, `encodeMappings(lines)`,
+ * `MappingSegment`, `LineMappings`) is intended to match what would land
+ * upstream so call sites don't have to change.
  */
 
 const VLQ_BASE64 =

--- a/test/configCases/source-map/css-modules-link-fine-grained-mappings/index.js
+++ b/test/configCases/source-map/css-modules-link-fine-grained-mappings/index.js
@@ -1,0 +1,69 @@
+import * as styles from "./style.module.css";
+
+it("should map each generated CSS-module export line back to its selector in the original CSS", () => {
+	const fs = require("fs");
+	const path = require("path");
+	const { SourceMapConsumer } = require("source-map");
+
+	expect(typeof styles.btn).toBe("string");
+	expect(typeof styles.card).toBe("string");
+	expect(typeof styles.alert).toBe("string");
+
+	const bundlePath = path.join(__dirname, "bundle0.js");
+	const mapPath = path.join(__dirname, "bundle0.js.map");
+	const bundleSource = fs.readFileSync(bundlePath, "utf-8");
+	const sourceMap = JSON.parse(fs.readFileSync(mapPath, "utf-8"));
+
+	expect(sourceMap.sources).toEqual(
+		expect.arrayContaining([expect.stringMatching(/style\.module\.css$/)])
+	);
+
+	const cssIndex = sourceMap.sources.findIndex(s =>
+		/style\.module\.css$/.test(s)
+	);
+	expect(cssIndex).toBeGreaterThanOrEqual(0);
+
+	// The CSS source content should be embedded — i.e. the original CSS, not the generated JS wrapper.
+	const cssContent = sourceMap.sourcesContent[cssIndex];
+	expect(cssContent).toMatch(/\.btn\s*\{/);
+	expect(cssContent).toMatch(/\.card\s*\{/);
+	expect(cssContent).toMatch(/\.alert\s*\{/);
+
+	const cssLines = cssContent.split("\n");
+	const findCssLine = selector => {
+		for (let i = 0; i < cssLines.length; i++) {
+			if (cssLines[i].includes(selector)) return i + 1; // 1-based for source-map consumer
+		}
+		throw new Error(`selector ${selector} not found in CSS`);
+	};
+
+	const bundleLines = bundleSource.split("\n");
+	const findBundleLine = needle => {
+		for (let i = 0; i < bundleLines.length; i++) {
+			if (bundleLines[i].includes(needle)) return i + 1;
+		}
+		throw new Error(`needle ${needle} not found in bundle`);
+	};
+
+	const consumer = new SourceMapConsumer(sourceMap);
+	try {
+		const expectations = [
+			{ exportName: "btn", selector: ".btn" },
+			{ exportName: "card", selector: ".card" },
+			{ exportName: "alert", selector: ".alert" }
+		];
+		for (const { exportName, selector } of expectations) {
+			const generatedLine = findBundleLine(`"${exportName}":`);
+			const original = consumer.originalPositionFor({
+				line: generatedLine,
+				column: 0
+			});
+			expect(original.source).toBeDefined();
+			expect(original.source).toMatch(/style\.module\.css$/);
+			const expectedLine = findCssLine(selector);
+			expect(original.line).toBe(expectedLine);
+		}
+	} finally {
+		consumer.destroy && consumer.destroy();
+	}
+});

--- a/test/configCases/source-map/css-modules-link-fine-grained-mappings/style.module.css
+++ b/test/configCases/source-map/css-modules-link-fine-grained-mappings/style.module.css
@@ -1,0 +1,13 @@
+.btn {
+	color: red;
+}
+
+/* a comment line */
+
+.card {
+	padding: 10px;
+}
+
+.alert {
+	background: yellow;
+}

--- a/test/configCases/source-map/css-modules-link-fine-grained-mappings/webpack.config.js
+++ b/test/configCases/source-map/css-modules-link-fine-grained-mappings/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: "source-map",
+	entry: "./index.js",
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/source-map/css-modules-link-source-map/index.js
+++ b/test/configCases/source-map/css-modules-link-source-map/index.js
@@ -1,0 +1,28 @@
+import * as styles from "./style.module.css";
+
+it("should map link-type CSS module class exports in the JS source map", () => {
+	const fs = require("fs");
+	const path = require("path");
+
+	expect(typeof styles.btn).toBe("string");
+	expect(typeof styles.card).toBe("string");
+
+	const sourceMap = JSON.parse(
+		fs.readFileSync(path.join(__dirname, "bundle0.js.map"), "utf-8")
+	);
+
+	expect(sourceMap).toHaveProperty("version", 3);
+	expect(Array.isArray(sourceMap.sources)).toBe(true);
+
+	// The CSS module's generated JS (`module.exports = { btn: "...", card: "..." }`)
+	// should be wrapped as an OriginalSource and appear in the source map under
+	// the module's readable identifier.
+	const cssSource = sourceMap.sources.find(s =>
+		/style\.module\.css$/.test(s)
+	);
+	expect(cssSource).toBeDefined();
+
+	// The mapping must reference real generated JS positions, not be empty.
+	expect(typeof sourceMap.mappings).toBe("string");
+	expect(sourceMap.mappings.length).toBeGreaterThan(0);
+});

--- a/test/configCases/source-map/css-modules-link-source-map/index.js
+++ b/test/configCases/source-map/css-modules-link-source-map/index.js
@@ -14,13 +14,20 @@ it("should map link-type CSS module class exports in the JS source map", () => {
 	expect(sourceMap).toHaveProperty("version", 3);
 	expect(Array.isArray(sourceMap.sources)).toBe(true);
 
-	// The CSS module's generated JS (`module.exports = { btn: "...", card: "..." }`)
-	// should be wrapped as an OriginalSource and appear in the source map under
-	// the module's readable identifier.
-	const cssSource = sourceMap.sources.find(s =>
+	// The CSS module's generated JS export wrapper should appear in the
+	// source map under the module's readable identifier.
+	const cssSourceIndex = sourceMap.sources.findIndex(s =>
 		/style\.module\.css$/.test(s)
 	);
-	expect(cssSource).toBeDefined();
+	expect(cssSourceIndex).toBeGreaterThanOrEqual(0);
+
+	// `sourcesContent` must carry a non-empty entry for that source —
+	// without it the entry in `sources` would be unresolvable. The exact
+	// content (original CSS vs. generated JS wrapper) depends on whether
+	// the CSS module emits class exports; either way it must be non-empty.
+	expect(Array.isArray(sourceMap.sourcesContent)).toBe(true);
+	expect(typeof sourceMap.sourcesContent[cssSourceIndex]).toBe("string");
+	expect(sourceMap.sourcesContent[cssSourceIndex].length).toBeGreaterThan(0);
 
 	// The mapping must reference real generated JS positions, not be empty.
 	expect(typeof sourceMap.mappings).toBe("string");

--- a/test/configCases/source-map/css-modules-link-source-map/style.module.css
+++ b/test/configCases/source-map/css-modules-link-source-map/style.module.css
@@ -1,0 +1,7 @@
+.btn {
+	color: red;
+}
+
+.card {
+	padding: 10px;
+}

--- a/test/configCases/source-map/css-modules-link-source-map/webpack.config.js
+++ b/test/configCases/source-map/css-modules-link-source-map/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: "source-map",
+	entry: "./index.js",
+	experiments: {
+		css: true
+	}
+};

--- a/test/createMappings.unittest.js
+++ b/test/createMappings.unittest.js
@@ -1,5 +1,6 @@
 "use strict";
 
+// cspell:disable -- VLQ-encoded source-map mappings strings below
 const { encodeMappings, encodeVLQ } = require("../lib/util/createMappings");
 
 describe("encodeVLQ", () => {
@@ -105,3 +106,4 @@ describe("encodeMappings", () => {
 		expect(result).toBe("AAAAA;AACAC");
 	});
 });
+// cspell:enable

--- a/test/createMappings.unittest.js
+++ b/test/createMappings.unittest.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const { encodeMappings, encodeVLQ } = require("../lib/util/createMappings");
+
+describe("encodeVLQ", () => {
+	const cases = [
+		[0, "A"],
+		[1, "C"],
+		[-1, "D"],
+		[15, "e"],
+		[16, "gB"],
+		[-16, "hB"],
+		[123456, "gkxH"]
+	];
+
+	for (const [input, expected] of cases) {
+		it(`encodes ${input} -> ${expected}`, () => {
+			expect(encodeVLQ(input)).toBe(expected);
+		});
+	}
+});
+
+describe("encodeMappings", () => {
+	it("returns the empty string for an empty input", () => {
+		expect(encodeMappings([])).toBe("");
+	});
+
+	it("emits a single semicolon per skipped line", () => {
+		expect(encodeMappings([null, null, null])).toBe(";;");
+	});
+
+	it("encodes a single segment per line", () => {
+		const result = encodeMappings([
+			null,
+			{
+				generatedColumn: 0,
+				sourceIndex: 0,
+				originalLine: 0,
+				originalColumn: 0
+			},
+			null,
+			{
+				generatedColumn: 0,
+				sourceIndex: 0,
+				originalLine: 4,
+				originalColumn: 0
+			}
+		]);
+		expect(result).toBe(";AAAA;;AAIA");
+	});
+
+	it("emits relative deltas across lines", () => {
+		const result = encodeMappings([
+			{ sourceIndex: 0, originalLine: 0, originalColumn: 0 },
+			{ sourceIndex: 0, originalLine: 1, originalColumn: 0 },
+			{ sourceIndex: 0, originalLine: 5, originalColumn: 2 }
+		]);
+		expect(result).toBe("AAAA;AACA;AAIE");
+	});
+
+	it("supports multiple segments on the same line", () => {
+		const result = encodeMappings([
+			[
+				{
+					generatedColumn: 0,
+					sourceIndex: 0,
+					originalLine: 0,
+					originalColumn: 0
+				},
+				{
+					generatedColumn: 4,
+					sourceIndex: 0,
+					originalLine: 0,
+					originalColumn: 4
+				}
+			]
+		]);
+		expect(result).toBe("AAAA,IAAI");
+	});
+
+	it("supports an unmapped generated-only segment", () => {
+		const result = encodeMappings([
+			[{ generatedColumn: 0 }, { generatedColumn: 8 }]
+		]);
+		expect(result).toBe("A,Q");
+	});
+
+	it("supports a name index", () => {
+		const result = encodeMappings([
+			{
+				generatedColumn: 0,
+				sourceIndex: 0,
+				originalLine: 0,
+				originalColumn: 0,
+				nameIndex: 0
+			},
+			{
+				generatedColumn: 0,
+				sourceIndex: 0,
+				originalLine: 1,
+				originalColumn: 0,
+				nameIndex: 1
+			}
+		]);
+		expect(result).toBe("AAAAA;AACAC");
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -4970,6 +4970,11 @@ declare interface CssData {
 	 * the css exports
 	 */
 	exports: Map<string, string>;
+
+	/**
+	 * source position (line is 1-based, column is 0-based) of each export's defining identifier in the original CSS, used to emit fine-grained JS-to-CSS source mappings
+	 */
+	exportLocs?: Map<string, { line: number; column: number }>;
 }
 declare abstract class CssGenerator extends Generator {
 	options: CssModuleGeneratorOptions;


### PR DESCRIPTION
The JS code emitted for CSS modules with the default `exportType: "link"`
(`module.exports = { className: "hash", ... }`) was returned as a bare
ConcatSource without the OriginalSource wrap that other export types
receive. As a result, the generated lines were missing from the bundle's
JS source map — no `sources` entry, no mappings — making them appear as
unmapped output. Wrap the emit so the source map carries the generated
wrapper as sourcesContent under the CSS module's identifier, matching
the behaviour of `style`, `text`, and `css-style-sheet` export types.