### PR TITLE
preserve @charset in CSS modules with exportType "text"

### DIFF
--- a/.changeset/css-modules-text-export-charset.md
+++ b/.changeset/css-modules-text-export-charset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is now prepended to the exported text at build time. When a text module imports another text module, the inner `@charset` directives are kept (CSS parsers honor only the first one at byte 0 and ignore the rest).
+Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is prepended at build time. When a text module imports another text module, the import's `@charset` prefix is sliced off using a build-time-computed length so the final output contains a single `@charset` directive at byte 0.

--- a/.changeset/css-modules-text-export-charset.md
+++ b/.changeset/css-modules-text-export-charset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is now prepended to the exported text, and any duplicate `@charset` from concatenated text imports is stripped.
+Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is now prepended to the exported text at build time. When a text module imports another text module, the inner `@charset` directives are kept (CSS parsers honor only the first one at byte 0 and ignore the rest).

--- a/.changeset/css-modules-text-export-charset.md
+++ b/.changeset/css-modules-text-export-charset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is prepended at build time. When a text module imports another text module, the import's `@charset` prefix is sliced off using a build-time-computed length so the final output contains a single `@charset` directive at byte 0.
+Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is prepended at build time, walking through text imports to handle the transitive case where a module has no local `@charset` but inherits one from an imported text module. When a text module imports another text module, the import's `@charset` prefix is sliced off using a build-time-computed length so the final output contains a single `@charset` directive at byte 0.

--- a/.changeset/css-modules-text-export-charset.md
+++ b/.changeset/css-modules-text-export-charset.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Preserve `@charset` at-rule when CSS modules use `exportType: "text"`. The charset is now prepended to the exported text, and any duplicate `@charset` from concatenated text imports is stripped.

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -489,17 +489,9 @@ class CssGenerator extends Generator {
 									"])"
 								);
 							} else {
-								// Strip leading @charset from text imports so it is not duplicated when this module's own @charset is prepended below.
-								const concatParts =
-									exportType === "text"
-										? importCode.map((part) => ({
-												expr: `(${part.expr}).replace(/^@charset\\s+"[^"]*";\\s*/, "")`
-											}))
-										: importCode;
-
 								jsLiteral = new ConcatSource(
 									`${generateContext.runtimeTemplate.concatenation(
-										...concatParts
+										...importCode
 									)} + `,
 									jsLiteral
 								);

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -489,9 +489,17 @@ class CssGenerator extends Generator {
 									"])"
 								);
 							} else {
+								// Strip leading @charset from text imports so it is not duplicated when this module's own @charset is prepended below.
+								const concatParts =
+									exportType === "text"
+										? importCode.map((part) => ({
+												expr: `(${part.expr}).replace(/^@charset\\s+"[^"]*";\\s*/, "")`
+											}))
+										: importCode;
+
 								jsLiteral = new ConcatSource(
 									`${generateContext.runtimeTemplate.concatenation(
-										...importCode
+										...concatParts
 									)} + `,
 									jsLiteral
 								);
@@ -499,7 +507,7 @@ class CssGenerator extends Generator {
 						}
 
 						if (
-							exportType === "css-style-sheet" &&
+							(exportType === "css-style-sheet" || exportType === "text") &&
 							typeof (/** @type {BuildInfo} */ (module.buildInfo).charset) !==
 								"undefined"
 						) {

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -146,6 +146,42 @@ class CssGenerator extends Generator {
 	}
 
 	/**
+	 * Returns the `@charset` that will appear at the start of this module's
+	 * default export, walking through text imports when the module has no
+	 * local `@charset` of its own.
+	 * @param {NormalModule} module the module
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @param {WeakSet<NormalModule>=} visited cycle guard
+	 * @returns {string | undefined} the effective charset
+	 */
+	_getEffectiveCharset(module, moduleGraph, visited = new WeakSet()) {
+		if (!module || visited.has(module)) return undefined;
+		const exportType = /** @type {CssModule} */ (module).exportType;
+		if (exportType !== "text" && exportType !== "css-style-sheet") {
+			return undefined;
+		}
+		visited.add(module);
+		const own =
+			module.buildInfo && /** @type {BuildInfo} */ (module.buildInfo).charset;
+		if (own !== undefined) return own;
+		if (exportType !== "text") return undefined;
+		for (const dep of module.dependencies) {
+			if (dep instanceof CssImportDependency) {
+				const depModule = /** @type {NormalModule} */ (
+					moduleGraph.getModule(dep)
+				);
+				const inherited = this._getEffectiveCharset(
+					depModule,
+					moduleGraph,
+					visited
+				);
+				if (inherited !== undefined) return inherited;
+			}
+		}
+		return undefined;
+	}
+
+	/**
 	 * Generate JavaScript code that requires and concatenates all CSS imports
 	 * @param {NormalModule} module the module to generate CSS text for
 	 * @param {GenerateContext} generateContext the generate context
@@ -156,10 +192,9 @@ class CssGenerator extends Generator {
 		const { moduleGraph, concatenationScope } = generateContext;
 		/** @type {{ expr: string, type: CssParserExportType }[]} */
 		const parts = [];
-		const ownCharset =
-			/** @type {CssModule} */ (module).exportType === "text" &&
-			module.buildInfo
-				? /** @type {BuildInfo} */ (module.buildInfo).charset
+		const ownEffectiveCharset =
+			/** @type {CssModule} */ (module).exportType === "text"
+				? this._getEffectiveCharset(module, moduleGraph)
 				: undefined;
 
 		// Iterate through module.dependencies to maintain source order
@@ -169,16 +204,19 @@ class CssGenerator extends Generator {
 				// When this text module prepends its own @charset, slice off the
 				// imported text module's leading `@charset "..";\n` (whose length
 				// is known at build time) so the final output has a single
-				// @charset directive at byte 0.
-				const depCharset =
-					ownCharset !== undefined &&
+				// @charset directive at byte 0. The dep's effective charset
+				// covers the transitive case where the dep itself has no local
+				// @charset but inherits one from a text module it imports.
+				const depEffectiveCharset =
+					ownEffectiveCharset !== undefined &&
 					getDefaultExport &&
-					depModule.exportType === "text" &&
-					depModule.buildInfo
-						? /** @type {BuildInfo} */ (depModule.buildInfo).charset
+					depModule.exportType === "text"
+						? this._getEffectiveCharset(depModule, moduleGraph)
 						: undefined;
 				const charsetPrefixLen =
-					depCharset !== undefined ? `@charset "${depCharset}";\n`.length : 0;
+					depEffectiveCharset !== undefined
+						? `@charset "${depEffectiveCharset}";\n`.length
+						: 0;
 
 				if (
 					concatenationScope &&
@@ -527,13 +565,13 @@ class CssGenerator extends Generator {
 							}
 						}
 
-						if (
-							(exportType === "css-style-sheet" || exportType === "text") &&
-							typeof (/** @type {BuildInfo} */ (module.buildInfo).charset) !==
-								"undefined"
-						) {
+						const effectiveCharset =
+							exportType === "css-style-sheet" || exportType === "text"
+								? this._getEffectiveCharset(module, generateContext.moduleGraph)
+								: undefined;
+						if (effectiveCharset !== undefined) {
 							jsLiteral = new ConcatSource(
-								`'@charset "${/** @type {BuildInfo} */ (module.buildInfo).charset}";\\n' + `,
+								`'@charset "${effectiveCharset}";\\n' + `,
 								jsLiteral
 							);
 						}

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -156,11 +156,29 @@ class CssGenerator extends Generator {
 		const { moduleGraph, concatenationScope } = generateContext;
 		/** @type {{ expr: string, type: CssParserExportType }[]} */
 		const parts = [];
+		const ownCharset =
+			/** @type {CssModule} */ (module).exportType === "text" &&
+			module.buildInfo
+				? /** @type {BuildInfo} */ (module.buildInfo).charset
+				: undefined;
 
 		// Iterate through module.dependencies to maintain source order
 		for (const dep of module.dependencies) {
 			if (dep instanceof CssImportDependency) {
 				const depModule = /** @type {CssModule} */ (moduleGraph.getModule(dep));
+				// When this text module prepends its own @charset, slice off the
+				// imported text module's leading `@charset "..";\n` (whose length
+				// is known at build time) so the final output has a single
+				// @charset directive at byte 0.
+				const depCharset =
+					ownCharset !== undefined &&
+					getDefaultExport &&
+					depModule.exportType === "text" &&
+					depModule.buildInfo
+						? /** @type {BuildInfo} */ (depModule.buildInfo).charset
+						: undefined;
+				const charsetPrefixLen =
+					depCharset !== undefined ? `@charset "${depCharset}";\n`.length : 0;
 
 				if (
 					concatenationScope &&
@@ -168,12 +186,19 @@ class CssGenerator extends Generator {
 				) {
 					generateContext.runtimeRequirements.add(RuntimeGlobals.require);
 					if (getDefaultExport) {
-						parts.push({
-							expr: concatenationScope.createModuleReference(depModule, {
+						const baseExpr = concatenationScope.createModuleReference(
+							depModule,
+							{
 								ids: ["default"],
 								call: false,
 								directImport: false
-							}),
+							}
+						);
+						parts.push({
+							expr:
+								charsetPrefixLen > 0
+									? `(${baseExpr}).slice(${charsetPrefixLen})`
+									: baseExpr,
 							type: /** @type {CssParserExportType} */ (depModule.exportType)
 						});
 					}
@@ -190,8 +215,12 @@ class CssGenerator extends Generator {
 						generateContext.runtimeRequirements.add(
 							RuntimeGlobals.compatGetDefaultExport
 						);
+						const baseExpr = `(${RuntimeGlobals.compatGetDefaultExport}(${importVar})() || "")`;
 						parts.push({
-							expr: `(${RuntimeGlobals.compatGetDefaultExport}(${importVar})() || "")`,
+							expr:
+								charsetPrefixLen > 0
+									? `${baseExpr}.slice(${charsetPrefixLen})`
+									: baseExpr,
 							type: /** @type {CssParserExportType} */ (depModule.exportType)
 						});
 					} else {

--- a/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
@@ -49,7 +49,8 @@ Array [
 `;
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
-"/*!*******************************************************!*\\\\
+"@charset \\"UTF-8\\";
+/*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
 
@@ -119,7 +120,8 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 `;
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
-"/*!*******************************************************!*\\\\
+"@charset \\"UTF-8\\";
+/*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
 

--- a/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
@@ -50,6 +50,8 @@ Array [
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
 "@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -59,6 +61,7 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -78,6 +81,8 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
+@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -87,6 +92,7 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -121,6 +127,7 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
 "@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -130,6 +137,7 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/

--- a/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
@@ -177,6 +177,60 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 `;
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 5`] = `
+"@charset \\"UTF-8\\";
+/*!***********************************************************!*\\\\
+  !*** css ./leaf-with-charset.text.css (exportType: text) ***!
+  \\\\***********************************************************/
+
+
+.leaf-with-charset {
+	color: red;
+}
+
+/*!*********************************************************!*\\\\
+  !*** css ./inherit-charset.text.css (exportType: text) ***!
+  \\\\*********************************************************/
+
+.inherit-charset {
+	color: red;
+}
+
+/*!**************************************************!*\\\\
+  !*** css ./styles-7.text.css (exportType: text) ***!
+  \\\\**************************************************/
+
+
+
+.class-7 {
+	color: red;
+}
+
+"
+`;
+
+exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 6`] = `
+"@charset \\"UTF-8\\";
+/*!***********************************************************!*\\\\
+  !*** css ./leaf-with-charset.text.css (exportType: text) ***!
+  \\\\***********************************************************/
+
+
+.leaf-with-charset {
+	color: red;
+}
+
+/*!*********************************************************!*\\\\
+  !*** css ./inherit-charset.text.css (exportType: text) ***!
+  \\\\*********************************************************/
+
+.inherit-charset {
+	color: red;
+}
+
+"
+`;
+
+exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 7`] = `
 Array [
   "/*!********************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: style) ***!

--- a/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigCacheTest.snap
@@ -50,8 +50,6 @@ Array [
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
 "@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -61,7 +59,6 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -81,8 +78,6 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
-@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -92,7 +87,6 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -127,7 +121,6 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 
 exports[`ConfigCacheTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
 "@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -137,7 +130,6 @@ exports[`ConfigCacheTestCases css charset exported tests should handle \`@charse
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/

--- a/test/configCases/css/charset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigTest.snap
@@ -49,7 +49,8 @@ Array [
 `;
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
-"/*!*******************************************************!*\\\\
+"@charset \\"UTF-8\\";
+/*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
 
@@ -119,7 +120,8 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 `;
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
-"/*!*******************************************************!*\\\\
+"@charset \\"UTF-8\\";
+/*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
 

--- a/test/configCases/css/charset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigTest.snap
@@ -177,6 +177,60 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 `;
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 5`] = `
+"@charset \\"UTF-8\\";
+/*!***********************************************************!*\\\\
+  !*** css ./leaf-with-charset.text.css (exportType: text) ***!
+  \\\\***********************************************************/
+
+
+.leaf-with-charset {
+	color: red;
+}
+
+/*!*********************************************************!*\\\\
+  !*** css ./inherit-charset.text.css (exportType: text) ***!
+  \\\\*********************************************************/
+
+.inherit-charset {
+	color: red;
+}
+
+/*!**************************************************!*\\\\
+  !*** css ./styles-7.text.css (exportType: text) ***!
+  \\\\**************************************************/
+
+
+
+.class-7 {
+	color: red;
+}
+
+"
+`;
+
+exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 6`] = `
+"@charset \\"UTF-8\\";
+/*!***********************************************************!*\\\\
+  !*** css ./leaf-with-charset.text.css (exportType: text) ***!
+  \\\\***********************************************************/
+
+
+.leaf-with-charset {
+	color: red;
+}
+
+/*!*********************************************************!*\\\\
+  !*** css ./inherit-charset.text.css (exportType: text) ***!
+  \\\\*********************************************************/
+
+.inherit-charset {
+	color: red;
+}
+
+"
+`;
+
+exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 7`] = `
 Array [
   "/*!********************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: style) ***!

--- a/test/configCases/css/charset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigTest.snap
@@ -50,6 +50,8 @@ Array [
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
 "@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -59,6 +61,7 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -78,6 +81,8 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
+@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -87,6 +92,7 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -121,6 +127,7 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
 "@charset \\"UTF-8\\";
+@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -130,6 +137,7 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
+@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/

--- a/test/configCases/css/charset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/charset/__snapshots__/ConfigTest.snap
@@ -50,8 +50,6 @@ Array [
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 2`] = `
 "@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -61,7 +59,6 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -81,8 +78,6 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
-@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -92,7 +87,6 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/
@@ -127,7 +121,6 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 
 exports[`ConfigTestCases css charset exported tests should handle \`@charset\` at-rule 3`] = `
 "@charset \\"UTF-8\\";
-@charset \\"UTF-8\\";
 /*!*******************************************************!*\\\\
   !*** css ./import-nested.text.css (exportType: text) ***!
   \\\\*******************************************************/
@@ -137,7 +130,6 @@ exports[`ConfigTestCases css charset exported tests should handle \`@charset\` a
 	color: red;
 }
 
-@charset \\"UTF-8\\";
 /*!***************************************************************!*\\\\
   !*** css ./import-nested.text.css?foo=bar (exportType: text) ***!
   \\\\***************************************************************/

--- a/test/configCases/css/charset/index.js
+++ b/test/configCases/css/charset/index.js
@@ -5,6 +5,8 @@ import text from "./styles-4.text.css";
 import textImport from "./import.text.css";
 import styleSheet from "./styles-5.css-style-sheet.css";
 import "./styles-6.style.css";
+import textInherited from "./styles-7.text.css";
+import textInheritedDirect from "./inherit-charset.text.css";
 
 it("should handle `@charset` at-rule", () => {
 	const links = document.getElementsByTagName("link");
@@ -19,6 +21,15 @@ it("should handle `@charset` at-rule", () => {
 	expect(text).toMatchSnapshot();
 	expect(textImport).toMatchSnapshot();
 	expect(styleSheet._cssText).toMatchSnapshot();
+	expect(textInherited).toMatchSnapshot();
+	expect(textInheritedDirect).toMatchSnapshot();
+	// styles-7 has its own @charset and imports a module that inherits its @charset.
+	// inherit-charset has no own @charset but imports one with @charset.
+	// In both, the final text must contain exactly one `@charset` directive at byte 0.
+	expect(textInherited.match(/@charset/g)).toEqual(["@charset"]);
+	expect(textInheritedDirect.match(/@charset/g)).toEqual(["@charset"]);
+	expect(textInherited.startsWith('@charset "UTF-8";\n')).toBe(true);
+	expect(textInheritedDirect.startsWith('@charset "UTF-8";\n')).toBe(true);
 
 	const styles = window.document.getElementsByTagName("style");
 	const css2 = [];

--- a/test/configCases/css/charset/inherit-charset.text.css
+++ b/test/configCases/css/charset/inherit-charset.text.css
@@ -1,0 +1,5 @@
+@import "./leaf-with-charset.text.css";
+
+.inherit-charset {
+	color: red;
+}

--- a/test/configCases/css/charset/leaf-with-charset.text.css
+++ b/test/configCases/css/charset/leaf-with-charset.text.css
@@ -1,0 +1,5 @@
+@charset "UTF-8";
+
+.leaf-with-charset {
+	color: red;
+}

--- a/test/configCases/css/charset/styles-7.text.css
+++ b/test/configCases/css/charset/styles-7.text.css
@@ -1,0 +1,7 @@
+@charset "UTF-8";
+
+@import "./inherit-charset.text.css";
+
+.class-7 {
+	color: red;
+}


### PR DESCRIPTION
The charset extracted by the parser was only re-added for "css-style-sheet"
exports, so "text" exports lost it. Prepend the charset to the exported
text and strip leading @charset from concatenated text imports to avoid
duplicate directives in the resulting string.