### PR TITLE
fix: spec-compliant defer namespace [[Set]] and identity

### DIFF
--- a/.changeset/defer-import-spec-compliant-set-and-identity.md
+++ b/.changeset/defer-import-spec-compliant-set-and-identity.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Make `import defer * as ns` more spec-compliant: `ns.x = value` no longer triggers module evaluation (per the TC39 import-defer `[[Set]]` algorithm), and the deferred namespace is now a distinct object from the eager namespace, with the same Deferred Module Namespace Exotic Object shared across defer-import call sites for the same module.

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -413,6 +413,27 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					return true;
 				}
 			);
+		// Per the TC39 import-defer spec, [[Set]] on a Module Namespace
+		// Exotic Object returns false without triggering evaluation. The
+		// default expressionMemberChain path produces `<importVar>.a.foo`
+		// whose `.a` getter eagerly requires (and thus evaluates) the
+		// deferred module. For top-level `ns.foo = value`, walk only the
+		// bare `ns` identifier so it gets replaced with the deferred
+		// namespace proxy (whose set trap returns false), and leave the
+		// `.foo = value` part as plain code.
+		parser.hooks.assignMemberChain
+			.for(harmonySpecifierTag)
+			.tap(PLUGIN_NAME, (expression, members) => {
+				const settings = /** @type {HarmonySettings} */ (parser.currentTagData);
+				if (!ImportPhaseUtils.isDefer(settings.phase)) return;
+				if (expression.operator !== "=") return;
+				if (members.length !== 1) return;
+				const left = /** @type {MemberExpression} */ (expression.left);
+				if (left.object.type !== "Identifier") return;
+				parser.walkExpression(expression.right);
+				parser.walkExpression(left.object);
+				return true;
+			});
 		const { hotAcceptCallback, hotAcceptWithoutCallback } =
 			HotModuleReplacementPlugin.getParserHooks(parser);
 		hotAcceptCallback.tap(PLUGIN_NAME, (expr, requests) => {

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1422,6 +1422,13 @@ class JavascriptModulesPlugin {
 			// is evaluated.
 			buf.push("// The deferred module cache");
 			buf.push("var __webpack_module_deferred_exports__ = {};");
+			// Per the TC39 import-defer spec, every defer-import call site for
+			// the same module must yield the same Deferred Module Namespace
+			// Exotic Object (and a distinct one from any eager namespace).
+			// Cache the deferred namespace proxy here so calls from different
+			// files share identity.
+			buf.push("// The deferred namespace cache");
+			buf.push("var __webpack_module_deferred_namespace_cache__ = {};");
 			buf.push("");
 		}
 

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -127,19 +127,25 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			// same object. Cache the Proxy / fake namespace per-moduleId so
 			// repeated calls (including across files) share identity.
 			//
-			// Key by `(moduleId, shapeMode)` so different exports-type
-			// shapes (e.g. one importer treats a CJS module as
-			// "default-with-named", another as "namespace") get distinct
-			// cache entries. Bit 16 (`createFakeNamespaceObject`'s
-			// "return value when it's Promise-like" flag added by
+			// Bit 16 (`createFakeNamespaceObject`'s "return value when
+			// it's Promise-like" flag added by
 			// `RuntimeTemplate.moduleNamespacePromise` for dynamic
-			// imports) is masked off because it does not change the
-			// output shape produced here, so static defer (mode 8) and
-			// dynamic `await import.defer` (mode 8 | 16) for the same
-			// module still share identity.
-			"var shapeMode = mode & ~16;",
+			// imports) is irrelevant for deferred namespaces — the value
+			// passed into `createFakeNamespaceObject` here is always the
+			// resolved module exports (after unwrapping the async-module
+			// export symbol when present), never a Promise. Strip it
+			// once so all downstream behavior, the cache key, and the
+			// `createFakeNamespaceObject` call below see the same shape
+			// mode. This keeps static defer (mode 8) and dynamic
+			// `await import.defer` (mode 8 | 16) sharing the same
+			// Deferred Module Namespace object, while still keying by
+			// `(moduleId, mode)` so distinct exports-type shapes
+			// (e.g. one importer treats a CJS module as
+			// "default-with-named", another as "namespace") get
+			// distinct cache entries.
+			"mode &= ~16;",
 			"var byMode = __webpack_module_deferred_namespace_cache__[moduleId];",
-			"if (byMode && byMode[shapeMode] !== undefined) return byMode[shapeMode];",
+			"if (byMode && byMode[mode] !== undefined) return byMode[mode];",
 			"if (!byMode) byMode = __webpack_module_deferred_namespace_cache__[moduleId] = {};",
 			"var cachedModule = __webpack_module_cache__[moduleId];",
 			"if (cachedModule && cachedModule.error === undefined && !(mode & 8)) {",
@@ -148,7 +154,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 				hasAsync
 					? `if (${RuntimeGlobals.asyncModuleExportSymbol} in exports) exports = exports[${RuntimeGlobals.asyncModuleExportSymbol}];`
 					: "",
-				`return byMode[shapeMode] = ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
+				`return byMode[mode] = ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
 			]),
 			"}",
 			"",
@@ -306,7 +312,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			]),
 			"}",
 			// we don't fully emulate ES Module semantics in this Proxy to align with normal webpack esm namespace object.
-			"return byMode[shapeMode] = new Proxy(ns_target, handler);"
+			"return byMode[mode] = new Proxy(ns_target, handler);"
 		])};`;
 	}
 }

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -126,8 +126,21 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			// referenced from multiple defer-import sites must yield the
 			// same object. Cache the Proxy / fake namespace per-moduleId so
 			// repeated calls (including across files) share identity.
-			"var cached = __webpack_module_deferred_namespace_cache__[moduleId];",
-			"if (cached !== undefined) return cached;",
+			//
+			// Key by `(moduleId, shapeMode)` so different exports-type
+			// shapes (e.g. one importer treats a CJS module as
+			// "default-with-named", another as "namespace") get distinct
+			// cache entries. Bit 16 (`createFakeNamespaceObject`'s
+			// "return value when it's Promise-like" flag added by
+			// `RuntimeTemplate.moduleNamespacePromise` for dynamic
+			// imports) is masked off because it does not change the
+			// output shape produced here, so static defer (mode 8) and
+			// dynamic `await import.defer` (mode 8 | 16) for the same
+			// module still share identity.
+			"var shapeMode = mode & ~16;",
+			"var byMode = __webpack_module_deferred_namespace_cache__[moduleId];",
+			"if (byMode && byMode[shapeMode] !== undefined) return byMode[shapeMode];",
+			"if (!byMode) byMode = __webpack_module_deferred_namespace_cache__[moduleId] = {};",
 			"var cachedModule = __webpack_module_cache__[moduleId];",
 			"if (cachedModule && cachedModule.error === undefined && !(mode & 8)) {",
 			Template.indent([
@@ -135,7 +148,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 				hasAsync
 					? `if (${RuntimeGlobals.asyncModuleExportSymbol} in exports) exports = exports[${RuntimeGlobals.asyncModuleExportSymbol}];`
 					: "",
-				`return __webpack_module_deferred_namespace_cache__[moduleId] = ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
+				`return byMode[shapeMode] = ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
 			]),
 			"}",
 			"",
@@ -293,7 +306,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			]),
 			"}",
 			// we don't fully emulate ES Module semantics in this Proxy to align with normal webpack esm namespace object.
-			"return __webpack_module_deferred_namespace_cache__[moduleId] = new Proxy(ns_target, handler);"
+			"return byMode[shapeMode] = new Proxy(ns_target, handler);"
 		])};`;
 	}
 }

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -121,15 +121,21 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			? "init?.();"
 			: "if (init) init();";
 		return `${fn} = ${runtimeTemplate.basicFunction("moduleId, mode", [
+			// Per the TC39 import-defer spec, deferred namespaces are
+			// distinct from their eager counterparts and the same module
+			// referenced from multiple defer-import sites must yield the
+			// same object. Cache the Proxy / fake namespace per-moduleId so
+			// repeated calls (including across files) share identity.
+			"var cached = __webpack_module_deferred_namespace_cache__[moduleId];",
+			"if (cached !== undefined) return cached;",
 			"var cachedModule = __webpack_module_cache__[moduleId];",
-			"if (cachedModule && cachedModule.error === undefined) {",
+			"if (cachedModule && cachedModule.error === undefined && !(mode & 8)) {",
 			Template.indent([
 				"var exports = cachedModule.exports;",
 				hasAsync
 					? `if (${RuntimeGlobals.asyncModuleExportSymbol} in exports) exports = exports[${RuntimeGlobals.asyncModuleExportSymbol}];`
 					: "",
-				"if (mode & 8) return exports;",
-				`return ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
+				`return __webpack_module_deferred_namespace_cache__[moduleId] = ${RuntimeGlobals.createFakeNamespaceObject}(exports, mode);`
 			]),
 			"}",
 			"",
@@ -287,7 +293,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			]),
 			"}",
 			// we don't fully emulate ES Module semantics in this Proxy to align with normal webpack esm namespace object.
-			"return new Proxy(ns_target, handler);"
+			"return __webpack_module_deferred_namespace_cache__[moduleId] = new Proxy(ns_target, handler);"
 		])};`;
 	}
 }

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -166,9 +166,23 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 				"init = null;",
 				"if (mode & 8 || mode & 4 && ns.__esModule && typeof ns === 'object') {",
 				Template.indent([
-					"delete handler.defineProperty;",
-					"delete handler.deleteProperty;",
-					"delete handler.set;",
+					// Drop only the read-side traps after init: with the
+					// resolved namespace's own keys mirrored onto
+					// `ns_target` below, the default `Reflect` behavior
+					// returns the right values via the live-binding
+					// getters, so we no longer need to intercept `get` /
+					// `has` / `ownKeys` / `getOwnPropertyDescriptor`.
+					//
+					// The mutation traps (`set`, `deleteProperty`,
+					// `defineProperty`) are kept because per the TC39
+					// import-defer spec, `[[Set]]` / `[[Delete]]` /
+					// `[[DefineOwnProperty]]` on a Deferred Module
+					// Namespace Exotic Object never succeed — and the
+					// proxy target itself remains extensible
+					// (architecturally we cannot freeze it up-front),
+					// so without these traps `ns.notExported = "x"`
+					// after evaluation would silently create a property
+					// on the target instead of returning false.
 					"delete handler.get;",
 					"delete handler.has;",
 					"delete handler.ownKeys;",

--- a/test/configCases/defer-import/identity-across-call-sites/dep.js
+++ b/test/configCases/defer-import/identity-across-call-sites/dep.js
@@ -1,0 +1,2 @@
+export const value = 42;
+export default "default-value";

--- a/test/configCases/defer-import/identity-across-call-sites/index.js
+++ b/test/configCases/defer-import/identity-across-call-sites/index.js
@@ -1,0 +1,22 @@
+import * as eager from "./dep.js";
+import defer * as deferred1 from "./dep.js";
+import defer * as deferred2 from "./dep.js";
+import { ns as deferredFromOtherFile } from "./reexport.js";
+
+it("shares the deferred namespace across call sites in the same file", () => {
+	expect(deferred1).toBe(deferred2);
+});
+
+it("shares the deferred namespace across files", () => {
+	expect(deferred1).toBe(deferredFromOtherFile);
+});
+
+it("keeps the deferred namespace distinct from the eager namespace", () => {
+	expect(deferred1).not.toBe(eager);
+	expect(deferred1.value).toBe(eager.value);
+});
+
+it("shares the deferred namespace between static defer and dynamic import.defer (mode bit 16)", async () => {
+	const dynamic = await import.defer("./dep.js");
+	expect(dynamic).toBe(deferred1);
+});

--- a/test/configCases/defer-import/identity-across-call-sites/reexport.js
+++ b/test/configCases/defer-import/identity-across-call-sites/reexport.js
@@ -1,0 +1,3 @@
+import defer * as deferredNs from "./dep.js";
+
+export const ns = deferredNs;

--- a/test/configCases/defer-import/identity-across-call-sites/test.filter.js
+++ b/test/configCases/defer-import/identity-across-call-sites/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsAsync = require("../../../helpers/supportsAsync");
+
+module.exports = () => supportsAsync();

--- a/test/configCases/defer-import/identity-across-call-sites/webpack.config.js
+++ b/test/configCases/defer-import/identity-across-call-sites/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	optimization: {
+		concatenateModules: false
+	},
+	experiments: {
+		deferImport: true
+	}
+};

--- a/test/configCases/defer-import/same-module/index.js
+++ b/test/configCases/defer-import/same-module/index.js
@@ -3,7 +3,10 @@ import defer * as mod2 from "./module.js";
 
 it("should generate different runtime code for the same module", () => {
 	expect(mod1.default).toBe(mod2.default);
-	expect(mod1).toBe(mod2);
+	// Per the TC39 import-defer spec, the deferred namespace is a
+	// distinct Deferred Module Namespace Exotic Object, separate from
+	// the eager namespace of the same module.
+	expect(mod1).not.toBe(mod2);
 	// Test itself + module
 	expect(Object.keys(__webpack_modules__).length).toBe(2);
 });

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/dep.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/dep.js
@@ -1,0 +1,3 @@
+globalThis.evaluations = (globalThis.evaluations || 0) + 1;
+
+export let exported = 1;

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
@@ -28,3 +28,23 @@ it("evaluates when reading a property", () => {
 	expect(ns.exported).toBe(1);
 	expect(globalThis.evaluations).toBe(1);
 });
+
+it("`[[Set]]` keeps returning false after evaluation", () => {
+	// After evaluation the proxy switches to forwarding reads via the
+	// underlying target, but `[[Set]]` on a Module Namespace Exotic
+	// Object must still always fail. Without an explicit `set` trap a
+	// dangling assignment would silently create a property on
+	// `ns_target`.
+	expect(() => {
+		"use strict";
+
+		ns.exported = "ignored";
+	}).toThrow(TypeError);
+	expect(() => {
+		"use strict";
+
+		ns.notExported = "ignored";
+	}).toThrow(TypeError);
+	expect("notExported" in ns).toBe(false);
+	expect(ns.exported).toBe(1);
+});

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
@@ -1,0 +1,30 @@
+import defer * as ns from "./dep.js";
+
+it("does not evaluate the deferred module on `import defer`", () => {
+	expect(globalThis.evaluations).toBe(undefined);
+});
+
+it("does not evaluate when assigning to an exported namespace property", () => {
+	// Per the TC39 import-defer spec, `[[Set]]` on a Module Namespace
+	// Exotic Object returns false without triggering evaluation.
+	expect(() => {
+		"use strict";
+
+		ns.exported = "ignored";
+	}).toThrow(TypeError);
+	expect(globalThis.evaluations).toBe(undefined);
+});
+
+it("does not evaluate when assigning to a non-exported namespace property", () => {
+	expect(() => {
+		"use strict";
+
+		ns.notExported = "ignored";
+	}).toThrow(TypeError);
+	expect(globalThis.evaluations).toBe(undefined);
+});
+
+it("evaluates when reading a property", () => {
+	expect(ns.exported).toBe(1);
+	expect(globalThis.evaluations).toBe(1);
+});

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/test.filter.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/webpack.config.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	optimization: {
+		concatenateModules: false
+	},
+	experiments: {
+		deferImport: true
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -772,14 +772,12 @@ const knownBugs = [
 	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-return.js",
 	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-throw.js",
 	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-sequence.js",
-	// Bugs with defer
+	// `#mark in obj` requires the deferred namespace target to report
+	// `isExtensible() === false` to throw a TypeError. webpack's proxy
+	// target is mutable until init runs and cannot be frozen up-front
+	// because the underlying module's exports aren't yet known.
 	"import/import-defer/evaluation-triggers/ignore-private-name-access.js",
-	"import/import-defer/evaluation-triggers/ignore-set-string-exported.js",
-	"import/import-defer/evaluation-triggers/ignore-set-string-not-exported.js",
-	"import/import-defer/evaluation-triggers/trigger-exported-string-delete.js",
-	"import/import-defer/evaluation-triggers/trigger-not-exported-string-delete.js",
 	// Bugs with defer and evaluation
-	"import/import-defer/deferred-namespace-object/identity.js",
 	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
 	"import/import-defer/errors/get-self-while-evaluating-async/main.js",
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
@@ -1051,7 +1049,11 @@ const knownProductionBuildBugs = [
 	"module-code/instn-star-props-nrml.js",
 	"module-code/namespace/internals/get-nested-namespace-props-nrml.js",
 	// Production concatenation orders eager import after defer
-	"import/import-defer/evaluation-sync/module-imported-defer-and-eager.js"
+	"import/import-defer/evaluation-sync/module-imported-defer-and-eager.js",
+	// Production concatenation inlines a re-exported deferred namespace as
+	// the eager namespace of the underlying module, so cross-file deferred
+	// namespaces are no longer the same object as the local Proxy.
+	"import/import-defer/deferred-namespace-object/identity.js"
 ];
 /* cspell:enable */
 


### PR DESCRIPTION
`ns.foo = value` previously generated `<importVar>.a.foo = value`
whose `.a` getter eagerly required the deferred module, violating
the TC39 import-defer `[[Set]]` algorithm. Tap `assignMemberChain`
for `harmonySpecifierTag` to walk only the bare `ns` identifier so
it resolves to the deferred-namespace proxy (whose `set` trap
returns false without triggering evaluation), and leave the
`.foo = value` assignment as plain code.

Cache the deferred-namespace proxy per-`moduleId` in a new global
`__webpack_module_deferred_namespace_cache__`, and stop the
`__webpack_require__.z` cached-module fast path from short-circuiting
to the underlying exports for namespace-mode imports. This keeps
the deferred and eager namespaces as distinct objects (per spec)
and shares one Deferred Module Namespace Exotic Object across all
defer-import call sites for the same module.