### PR TITLE
refactor: clean up CssGenerator

### DIFF
--- a/.changeset/refactor-css-generator.md
+++ b/.changeset/refactor-css-generator.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Refactor CssGenerator: rename `_cssSourceToJsStringLiteral` to `_cssToJsLiteral` and remove unused parameters, hoist shared variables to eliminate duplicate declarations, flatten nested source map wrapping logic, and extract repeated type annotations into typedefs

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -53,6 +53,9 @@ const memoize = require("../util/memoize");
 /** @typedef {import("../Module").RuntimeRequirements} RuntimeRequirements */
 /** @typedef {import("../../declarations/WebpackOptions").CssParserExportType} CssParserExportType */
 
+/** @typedef {{ line: number, column: number }} SourcePosition */
+/** @typedef {Map<string, SourcePosition>} ExportLocsMap */
+
 const getPropertyName = memoize(() => require("../util/property"));
 const getCssModulesPlugin = memoize(() => require("./CssModulesPlugin"));
 
@@ -64,7 +67,7 @@ const getCssModulesPlugin = memoize(() => require("./CssModulesPlugin"));
  * in the original CSS. Lines without an associated export are left
  * unmapped — devtools simply shows them as part of the bundled JS.
  * @param {string} generatedJs the generated JS string
- * @param {Map<string, { line: number, column: number }>} exportLocs map of export names to CSS source location
+ * @param {ExportLocsMap} exportLocs map of export names to CSS source location
  * @param {string} cssContent original CSS source content
  * @param {string} sourceName source identifier to use in the map
  * @returns {RawSourceMap} a v3 RawSourceMap
@@ -91,9 +94,7 @@ const buildExportsSourceMap = (
 	/** @type {(import("../util/createMappings").LineMappings)[]} */
 	const perLine = lines.map(() => null);
 	for (const [exportName, genLine] of lineByExport) {
-		const pos = /** @type {{ line: number, column: number }} */ (
-			exportLocs.get(exportName)
-		);
+		const pos = /** @type {SourcePosition} */ (exportLocs.get(exportName));
 		// Source-map V3 uses 0-based lines and 0-based columns. webpack's
 		// dependency `loc` uses 1-based lines and 0-based columns, so subtract
 		// one from the line.
@@ -314,27 +315,17 @@ class CssGenerator extends Generator {
 	}
 
 	/**
-	 * Convert a CSS Source to a JS string literal Source.
-	 *
-	 * The CSS is embedded as a single JS string. To still let DevTools
-	 * resolve the original sources when the string is applied at runtime —
-	 * `<style>` injection, `CSSStyleSheet`, or any consumer of the exported
-	 * text — we append an inline `sourceMappingURL` data URI to the CSS
-	 * content itself. The surrounding module emit is later wrapped in a
-	 * single `OriginalSource` in `generate()` so the bundle's JS source map
-	 * carries the full generated wrapper as `sourcesContent`.
+	 * Serialize a CSS Source into a JS string literal with an optional
+	 * inline `sourceMappingURL` data URI so DevTools can resolve the
+	 * original sources at runtime.
 	 * @param {Source} cssSource the CSS source
-	 * @param {NormalModule} module the module
-	 * @param {GenerateContext} generateContext context for generate
+	 * @param {import("../../declarations/WebpackOptions").DevTool | undefined} devtool the devtool option
 	 * @returns {Source} a Source representing a JS string literal
 	 */
-	_cssSourceToJsStringLiteral(cssSource, module, generateContext) {
+	_cssToJsLiteral(cssSource, devtool) {
 		const { source, map } = cssSource.sourceAndMap();
 		let content = /** @type {string} */ (source);
 		if (map) {
-			const devtool =
-				generateContext.runtimeTemplate.compilation.options.devtool;
-			// Honour `nosources-*` devtools the same way SourceMapDevToolPlugin does for external maps
 			const inlineMap =
 				typeof devtool === "string" && devtool.includes("nosources")
 					? { ...map, sourcesContent: undefined }
@@ -466,6 +457,11 @@ class CssGenerator extends Generator {
 
 		switch (generateContext.type) {
 			case JAVASCRIPT_TYPE: {
+				const compilation = generateContext.runtimeTemplate.compilation;
+				const devtool = compilation.options.devtool;
+				const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
+					.isCSSModule;
+
 				const generateContentCode = () => {
 					switch (exportType) {
 						case "style": {
@@ -482,11 +478,7 @@ class CssGenerator extends Generator {
 							if (generateContext.concatenationScope) {
 								return new ConcatSource(
 									"__webpack_css_styles__.push(",
-									this._cssSourceToJsStringLiteral(
-										cssSource,
-										module,
-										generateContext
-									),
+									this._cssToJsLiteral(cssSource, devtool),
 									");"
 								);
 							}
@@ -495,11 +487,7 @@ class CssGenerator extends Generator {
 
 							return new ConcatSource(
 								`${RuntimeGlobals.cssInjectStyle}(${JSON.stringify(moduleId || "")}, `,
-								this._cssSourceToJsStringLiteral(
-									cssSource,
-									module,
-									generateContext
-								),
+								this._cssToJsLiteral(cssSource, devtool),
 								");"
 							);
 						}
@@ -532,11 +520,7 @@ class CssGenerator extends Generator {
 						);
 
 						let jsLiteral = cssSource
-							? this._cssSourceToJsStringLiteral(
-									cssSource,
-									module,
-									generateContext
-								)
+							? this._cssToJsLiteral(cssSource, devtool)
 							: new RawSource('""');
 
 						if (importCode.length > 0) {
@@ -610,8 +594,6 @@ class CssGenerator extends Generator {
 						}
 					};
 
-					const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
-						.isCSSModule;
 					/** @type {Source | null} */
 					const defaultExport = generateJSDefaultExport();
 
@@ -748,50 +730,40 @@ class CssGenerator extends Generator {
 						source.add("\n");
 					}
 				}
-				// Wrap the entire generated module emit so the bundle's JS source
-				// map shows the full wrapper (`__webpack_require__.r(...)`,
-				// `cssInjectStyle(...)`, `new CSSStyleSheet()`,
-				// `module.exports = { className: "hash" }` for CSS modules, etc.)
-				// under the CSS module's identifier. Use the shortened readable
-				// identifier so the source name is relative to the compilation
-				// context (matching how regular JS modules appear as
-				// `webpack:///./module.js` rather than absolute paths).
-				//
-				// For link-type modules without any JS emit (plain CSS imports
-				// loaded via <link>) skip the wrap since there's nothing to map.
-				//
-				// When we know the source position of each class-name export
-				// (from `cssData.exportLocs`) we emit a `SourceMapSource` whose
-				// mappings point each export line in the generated JS back to
-				// the corresponding selector in the original CSS — same shape
-				// css-loader emits for CSS modules consumed in JS. Without
-				// per-export positions we fall back to `OriginalSource`, which
-				// only embeds the generated JS as `sourcesContent`.
-				const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
-					.isCSSModule;
-				if (exportType !== "link" || isCSSModule || cssData.exports.size > 0) {
-					const compilation = generateContext.runtimeTemplate.compilation;
-					const generatedJs = /** @type {string} */ (source.source());
-					const sourceName = module.readableIdentifier(
-						compilation.requestShortener
-					);
+				// For link-type modules without any JS emit, skip source wrapping
+				if (
+					exportType === "link" &&
+					!isCSSModule &&
+					cssData.exports.size === 0
+				) {
+					return source;
+				}
+
+				const generatedJs = /** @type {string} */ (source.source());
+				const sourceName = module.readableIdentifier(
+					compilation.requestShortener
+				);
+
+				// When per-export source positions are available, emit a
+				// SourceMapSource mapping each export line back to its CSS
+				// selector; otherwise fall back to OriginalSource.
+				if (
+					/** @type {ExportLocsMap} */
+					(cssData.exportLocs).size > 0
+				) {
 					const cssOriginal = module.originalSource();
-					if (
-						cssData.exportLocs &&
-						cssData.exportLocs.size > 0 &&
-						cssOriginal
-					) {
+					if (cssOriginal) {
 						const sourceMap = buildExportsSourceMap(
 							generatedJs,
-							cssData.exportLocs,
+							/** @type {ExportLocsMap} */
+							(cssData.exportLocs),
 							/** @type {string} */ (cssOriginal.source()),
 							sourceName
 						);
 						return new SourceMapSource(generatedJs, sourceName, sourceMap);
 					}
-					return new OriginalSource(generatedJs, sourceName);
 				}
-				return source;
+				return new OriginalSource(generatedJs, sourceName);
 			}
 			case CSS_TYPE: {
 				if (


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
- Rename _cssSourceToJsStringLiteral to _cssToJsLiteral, remove unused module parameter, narrow generateContext to just devtool
- Hoist isCSSModule, compilation, devtool to JAVASCRIPT_TYPE case top to eliminate duplicate declarations
- Flatten source map wrapping with early return, remove redundant exportLocs truthy check
- Extract repeated type annotations into SourcePosition and ExportLocsMap typedefs

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactor

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing