### PR TITLE
test: cover :import/:export across initial and async chunks

### DIFF
--- a/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigCacheTest.snap
@@ -22,26 +22,31 @@ Array [
 	border-color: orange;
 }
 
-
-/*# sourceMappingURL=bundle0.css.map*/",
-  "/*!*************************************!*\\\\
-  !*** css ./shared-vars.modules.css ***!
-  \\\\*************************************/
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
 
 /*!**************************************!*\\\\
-  !*** css ./initial-vars.modules.css ***!
+  !*** css ./chain-middle.modules.css ***!
   \\\\**************************************/
 
-/*!*********************************!*\\\\
-  !*** css ./initial.modules.css ***!
-  \\\\*********************************/
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
 
 
-
-.initial_modules_css-initial {
-	color: red;
-	background: blue;
-	border-color: orange;
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
 }
 
 
@@ -66,6 +71,33 @@ Array [
 	border-color: orange;
 }
 
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
 
 /*# sourceMappingURL=bundle0.css.map*/",
   "/*!*************************************!*\\\\
@@ -86,6 +118,327 @@ Array [
 	color: red;
 	background: blue;
 	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
 }
 
 

--- a/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css pseudo-import-export-chunks exported tests should resolve :import/:export in the initial chunk 1`] = `
+Array [
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+]
+`;

--- a/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigTest.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css pseudo-import-export-chunks exported tests should resolve :import/:export in the initial chunk 1`] = `
+Array [
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+]
+`;

--- a/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/pseudo-import-export-chunks/__snapshots__/ConfigTest.snap
@@ -22,26 +22,31 @@ Array [
 	border-color: orange;
 }
 
-
-/*# sourceMappingURL=bundle0.css.map*/",
-  "/*!*************************************!*\\\\
-  !*** css ./shared-vars.modules.css ***!
-  \\\\*************************************/
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
 
 /*!**************************************!*\\\\
-  !*** css ./initial-vars.modules.css ***!
+  !*** css ./chain-middle.modules.css ***!
   \\\\**************************************/
 
-/*!*********************************!*\\\\
-  !*** css ./initial.modules.css ***!
-  \\\\*********************************/
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
 
 
-
-.initial_modules_css-initial {
-	color: red;
-	background: blue;
-	border-color: orange;
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
 }
 
 
@@ -66,6 +71,33 @@ Array [
 	border-color: orange;
 }
 
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
 
 /*# sourceMappingURL=bundle0.css.map*/",
   "/*!*************************************!*\\\\
@@ -86,6 +118,327 @@ Array [
 	color: red;
 	background: blue;
 	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/",
+  "/*!*************************************!*\\\\
+  !*** css ./shared-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./initial-vars.modules.css ***!
+  \\\\**************************************/
+
+/*!*********************************!*\\\\
+  !*** css ./initial.modules.css ***!
+  \\\\*********************************/
+
+
+
+.initial_modules_css-initial {
+	color: red;
+	background: blue;
+	border-color: orange;
+}
+
+/*!************************************!*\\\\
+  !*** css ./chain-base.modules.css ***!
+  \\\\************************************/
+
+/*!**************************************!*\\\\
+  !*** css ./chain-middle.modules.css ***!
+  \\\\**************************************/
+
+
+.chain-middle_modules_css_1811-chain-middle {
+	color: hotpink;
+}
+
+/*!*************************************!*\\\\
+  !*** css ./custom-vars.modules.css ***!
+  \\\\*************************************/
+
+/*!****************************************!*\\\\
+  !*** css ./initial-custom.modules.css ***!
+  \\\\****************************************/
+
+
+.initial-custom_modules_css-initial-custom {
+	--initial-custom_modules_css-scoped-color: tomato;
+	color: var(--initial-custom_modules_css-scoped-color);
 }
 
 

--- a/test/configCases/css/pseudo-import-export-chunks/async-a.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-a.modules.css
@@ -1,0 +1,11 @@
+:import("./async-only-vars.modules.css") {
+	_tone: tone;
+}
+
+:export {
+	tone: _tone;
+}
+
+.async-a {
+	color: _tone;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-b.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-b.modules.css
@@ -1,0 +1,11 @@
+:import("./async-only-vars.modules.css") {
+	_tone: tone;
+}
+
+:export {
+	tone: _tone;
+}
+
+.async-b {
+	background: _tone;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-custom.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-custom.modules.css
@@ -1,0 +1,16 @@
+:import("./custom-vars.modules.css") {
+	_color: --my-color;
+	_bg: --my-bg;
+}
+
+:export {
+	--async-color: _color;
+	--async-bg: _bg;
+}
+
+.async-custom {
+	--scoped-color: _color;
+	--scoped-bg: _bg;
+	color: var(--scoped-color);
+	background: var(--scoped-bg);
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-different.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-different.modules.css
@@ -1,0 +1,11 @@
+:import("./async-vars.modules.css") {
+	_border: border-color;
+}
+
+:export {
+	border: _border;
+}
+
+.async-different {
+	border-color: _border;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-mixed.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-mixed.modules.css
@@ -1,0 +1,17 @@
+:import("./shared-vars.modules.css") {
+	_primary: primary-color;
+}
+
+:import("./async-vars.modules.css") {
+	_border: border-color;
+}
+
+:export {
+	primary: _primary;
+	border: _border;
+}
+
+.async-mixed {
+	color: _primary;
+	border-color: _border;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-only-vars.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-only-vars.modules.css
@@ -1,0 +1,3 @@
+:export {
+	tone: cyan;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-shared.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-shared.modules.css
@@ -1,0 +1,14 @@
+:import("./shared-vars.modules.css") {
+	_primary: primary-color;
+	_secondary: secondary-color;
+}
+
+:export {
+	primary: _primary;
+	secondary: _secondary;
+}
+
+.async-shared {
+	color: _primary;
+	background: _secondary;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/async-vars.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/async-vars.modules.css
@@ -1,0 +1,3 @@
+:export {
+	border-color: purple;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/chain-base.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/chain-base.modules.css
@@ -1,0 +1,3 @@
+:export {
+	base-color: hotpink;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/chain-end.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/chain-end.modules.css
@@ -1,0 +1,11 @@
+:import("./chain-middle.modules.css") {
+	_mid: mid-color;
+}
+
+:export {
+	end-color: _mid;
+}
+
+.chain-end {
+	color: _mid;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/chain-middle.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/chain-middle.modules.css
@@ -1,0 +1,11 @@
+:import("./chain-base.modules.css") {
+	_base: base-color;
+}
+
+:export {
+	mid-color: _base;
+}
+
+.chain-middle {
+	color: _base;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/custom-vars.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/custom-vars.modules.css
@@ -1,0 +1,4 @@
+:export {
+	--my-color: tomato;
+	--my-bg: gold;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/index.js
+++ b/test/configCases/css/pseudo-import-export-chunks/index.js
@@ -1,4 +1,6 @@
 import * as initial from "./initial.modules.css";
+import * as initialChain from "./chain-middle.modules.css";
+import * as initialCustom from "./initial-custom.modules.css";
 
 it("should resolve :import/:export in the initial chunk", () => {
 	expect(initial).toEqual(
@@ -41,6 +43,110 @@ it("should resolve :import/:export when async chunk imports a different module t
 				nsObj({
 					border: "purple",
 					"async-different": "async-different_modules_css-async-different"
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});
+
+it("should resolve a chained :import/:export re-export through the initial chunk", () => {
+	expect(initialChain).toEqual(
+		nsObj({
+			"mid-color": "hotpink",
+			"chain-middle": expect.stringMatching(
+				/^chain-middle_modules_css(?:_[\da-f]+)?-chain-middle$/
+			)
+		})
+	);
+});
+
+it("should resolve a chained :import/:export re-export when the chain end is in an async chunk", (done) => {
+	import("./chain-end.modules.css").then((module) => {
+		try {
+			expect(module).toEqual(
+				nsObj({
+					"end-color": "hotpink",
+					"chain-end": expect.stringMatching(
+						/^chain-end_modules_css(?:_[\da-f]+)?-chain-end$/
+					)
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});
+
+it("should resolve :import/:export with custom properties (--foo) in the initial chunk", () => {
+	expect(initialCustom).toEqual(
+		nsObj({
+			"--initial-color": "tomato",
+			"initial-custom": "initial-custom_modules_css-initial-custom",
+			"scoped-color": "--initial-custom_modules_css-scoped-color"
+		})
+	);
+});
+
+it("should resolve :import/:export with custom properties (--foo) in an async chunk", (done) => {
+	import("./async-custom.modules.css").then((module) => {
+		try {
+			expect(module).toEqual(
+				nsObj({
+					"--async-color": "tomato",
+					"--async-bg": "gold",
+					"async-custom": "async-custom_modules_css-async-custom",
+					"scoped-color": "--async-custom_modules_css-scoped-color",
+					"scoped-bg": "--async-custom_modules_css-scoped-bg"
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});
+
+it("should resolve :import/:export when two async chunks import the same async-only module", (done) => {
+	Promise.all([
+		import("./async-a.modules.css"),
+		import("./async-b.modules.css")
+	]).then(([a, b]) => {
+		try {
+			expect(a).toEqual(
+				nsObj({
+					tone: "cyan",
+					"async-a": "async-a_modules_css-async-a"
+				})
+			);
+			expect(b).toEqual(
+				nsObj({
+					tone: "cyan",
+					"async-b": "async-b_modules_css-async-b"
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});
+
+it("should resolve :import/:export when an async chunk mixes shared and async-only modules", (done) => {
+	import("./async-mixed.modules.css").then((module) => {
+		try {
+			expect(module).toEqual(
+				nsObj({
+					primary: "red",
+					border: "purple",
+					"async-mixed": "async-mixed_modules_css-async-mixed"
 				})
 			);
 		} catch (e) {

--- a/test/configCases/css/pseudo-import-export-chunks/index.js
+++ b/test/configCases/css/pseudo-import-export-chunks/index.js
@@ -1,0 +1,52 @@
+import * as initial from "./initial.modules.css";
+
+it("should resolve :import/:export in the initial chunk", () => {
+	expect(initial).toEqual(
+		nsObj({
+			primary: "red",
+			secondary: "blue",
+			border: "orange",
+			initial: "initial_modules_css-initial"
+		})
+	);
+
+	const links = Array.from(document.getElementsByTagName("link"));
+	const css = links.map((link) => link.sheet.css);
+
+	expect(css).toMatchSnapshot();
+});
+
+it("should resolve :import/:export when async chunk imports the same module as the initial chunk", (done) => {
+	import("./async-shared.modules.css").then((module) => {
+		try {
+			expect(module).toEqual(
+				nsObj({
+					primary: "red",
+					secondary: "blue",
+					"async-shared": "async-shared_modules_css-async-shared"
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});
+
+it("should resolve :import/:export when async chunk imports a different module than the initial chunk", (done) => {
+	import("./async-different.modules.css").then((module) => {
+		try {
+			expect(module).toEqual(
+				nsObj({
+					border: "purple",
+					"async-different": "async-different_modules_css-async-different"
+				})
+			);
+		} catch (e) {
+			done(e);
+			return;
+		}
+		done();
+	}, done);
+});

--- a/test/configCases/css/pseudo-import-export-chunks/initial-custom.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/initial-custom.modules.css
@@ -1,0 +1,12 @@
+:import("./custom-vars.modules.css") {
+	_color: --my-color;
+}
+
+:export {
+	--initial-color: _color;
+}
+
+.initial-custom {
+	--scoped-color: _color;
+	color: var(--scoped-color);
+}

--- a/test/configCases/css/pseudo-import-export-chunks/initial-vars.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/initial-vars.modules.css
@@ -1,0 +1,3 @@
+:export {
+	border-color: orange;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/initial.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/initial.modules.css
@@ -1,0 +1,20 @@
+:import("./shared-vars.modules.css") {
+	_primary: primary-color;
+	_secondary: secondary-color;
+}
+
+:import("./initial-vars.modules.css") {
+	_border: border-color;
+}
+
+:export {
+	primary: _primary;
+	secondary: _secondary;
+	border: _border;
+}
+
+.initial {
+	color: _primary;
+	background: _secondary;
+	border-color: _border;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/shared-vars.modules.css
+++ b/test/configCases/css/pseudo-import-export-chunks/shared-vars.modules.css
@@ -1,0 +1,4 @@
+:export {
+	primary-color: red;
+	secondary-color: blue;
+}

--- a/test/configCases/css/pseudo-import-export-chunks/test.config.js
+++ b/test/configCases/css/pseudo-import-export-chunks/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return [
+			"async-shared_modules_css.chunk.js",
+			"async-different_modules_css.chunk.js",
+			"bundle0.js"
+		];
+	},
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/pseudo-import-export-chunks/test.config.js
+++ b/test/configCases/css/pseudo-import-export-chunks/test.config.js
@@ -5,6 +5,11 @@ module.exports = {
 		return [
 			"async-shared_modules_css.chunk.js",
 			"async-different_modules_css.chunk.js",
+			"chain-end_modules_css.chunk.js",
+			"async-custom_modules_css.chunk.js",
+			"async-a_modules_css.chunk.js",
+			"async-b_modules_css.chunk.js",
+			"async-mixed_modules_css.chunk.js",
 			"bundle0.js"
 		];
 	},

--- a/test/configCases/css/pseudo-import-export-chunks/webpack.config.js
+++ b/test/configCases/css/pseudo-import-export-chunks/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	output: {
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
Add a configCase exercising CSS modules where :import/:export pseudo
selectors are used in both the initial chunk and an async chunk, with
both shared and unique imported modules to verify each case is handled
correctly.

https://claude.ai/code/session_01PaDCpYiKErmanNcZwrW9Zt