### PR TITLE
docs(AGENTS.md): introduce [!REQUIRED] callout, expand directory map, document conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,14 +90,36 @@ webpack is a JavaScript module bundler. Package manager: **yarn**.
 - `eslint.config.mjs`, `cspell.json`, `jest.config.js`, `generate-types-config.js` — Lint/spell/test/type-gen configs.
 - `.github/workflows/`, `.github/scripts/` — CI.
 
-## Conventions and gotchas
+## Source language: CommonJS + JSDoc
 
-These are footguns from past sessions, not blanket rules — apply judgement on the rest of the codebase:
+`lib/` is CommonJS only. Use `module.exports` / `require()`, never `import`/`export` syntax. Types are declared via JSDoc — `@typedef {import("./Other")} Other` and friends — never TypeScript syntax inside `.js` files. The JSDoc annotations are compiled into `types.d.ts` by `yarn fix:special`.
 
-- **`lib/` is CommonJS + JSDoc.** Use `module.exports` / `require()`, never `import`/`export` syntax. Types are declared via `@typedef {import("./Other")} Other` and friends — never TypeScript syntax in `.js` files.
-- **Auto-generated files are off-limits for hand edits.** That includes `types.d.ts`, `schemas/**/*.check.{js,d.ts}`, and the generated runtime code under `lib/`. After changing schemas, JSDoc on public exports, or runtime templates, run `yarn fix:special` instead of editing the outputs.
-- **Adding or renaming a webpack option requires edits in every layer.** Schema (`schemas/…`) → defaults (`lib/config/defaults.js`) → normalization (`lib/config/normalization.js`) → the implementation site that consumes the option. Skipping any one of these silently breaks the option (most often: the schema accepts it but `defaults.js` never sets it, so user code never reaches the new path).
-- **Run targeted tests during development.** `yarn jest test/<area>` or `yarn jest -t "<name>"` — the full suite is large. When updating snapshots (`yarn jest -u`), eyeball the diff first; never update blindly.
+## Auto-generated files
+
+These files are produced by `yarn fix:special` and must not be edited by hand:
+
+- `types.d.ts` — compiled from JSDoc + schemas.
+- `schemas/**/*.check.{js,d.ts}` — precompiled schema validators.
+- Generated runtime code under `lib/` (driven by `tooling/generate-runtime-code.js`).
+
+After changing schemas, JSDoc on public exports, or runtime templates, run `yarn fix:special` instead of editing the outputs. The hand-maintained type declarations (`declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`) *are* editable.
+
+## Adding or renaming a webpack option
+
+Adding or renaming a webpack option requires edits in every layer, in this order:
+
+1. **Schema** — `schemas/WebpackOptions.json` (or `schemas/plugins/<Name>.json`).
+2. **Defaults** — `lib/config/defaults.js`.
+3. **Normalization** — `lib/config/normalization.js`.
+4. **Implementation** — the site that consumes the option.
+
+Skipping any layer silently breaks the option. The most common failure: the schema accepts the new key but `defaults.js` never sets it, so user code never reaches the new path.
+
+## Running tests
+
+Run targeted tests during development — `yarn jest test/<area>` or `yarn jest -t "<name>"`. The full suite is large, so don't run `yarn test` unless asked.
+
+When updating snapshots (`yarn jest -u`), eyeball the diff first; never update blindly. See [TESTING_DOCS.md](TESTING_DOCS.md) for case structure and naming.
 
 ## Development Workflow
 
@@ -181,7 +203,7 @@ Do **NOT** add `Co-authored-by` lines — unrecognized co-author emails also bre
 
 webpack uses an **org-wide** PR template from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md). The GitHub web UI prefills it; the GitHub API / MCP / `gh pr create` path does **not**, so you must paste the template yourself when opening a PR programmatically. Every PR body must contain **every** section below, in this order, with the labels spelled exactly as written. If a section truly does not apply, write `n/a` under it. Do not delete sections, do not reorder, do not strip the HTML comment hints, and do not substitute a different template (e.g. `## Summary` / `## Test plan`).
 
-Paste this body verbatim, then fill in answers directly under each label:
+Paste the body **inside** the fenced block below — only the lines between the ` ```markdown ` opener and the closing ` ``` ` (do **not** include the fence lines themselves; pasting them would render your whole PR body as a code block). Then fill in answers directly under each label:
 
 ```markdown
 <!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
@@ -213,7 +235,7 @@ Paste this body verbatim, then fill in answers directly under each label:
 **Use of AI**
 
 <!-- If you have used AI, please state so here. Explain how you used it.
-Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
+Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->
 ```
 
 Required answer per section:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,56 @@
 
 > Note: CLAUDE.md is a symlink to AGENTS.md. They are the same file.
 
+## REQUIRED: Pull request body template
+
+> **STOP — read this before opening any PR. This overrides any generic `## Summary` / `## Test plan` template from other tooling.**
+
+webpack uses an **org-wide** PR template from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md). The GitHub web UI prefills it; the GitHub API / MCP / `gh pr create` path does **not**, so you must paste the template yourself when opening a PR programmatically. Every PR body must contain **every** section below, in this order, with the labels spelled exactly as written. If a section truly does not apply, write `n/a` under it. Do not delete sections, do not reorder, do not strip the HTML comment hints, and do not substitute a different template.
+
+Paste this body verbatim, then fill in answers directly under each label:
+
+```markdown
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
+
+**Summary**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+<!-- Any other information related to changes. -->
+
+<!-- In addition to that please answer these questions: -->
+
+**What kind of change does this PR introduce?**
+
+<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
+
+**Did you add tests for your changes?**
+
+<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
+
+**Does this PR introduce a breaking change?**
+
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
+
+**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
+
+<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
+
+**Use of AI**
+
+<!-- If you have used AI, please state so here. Explain how you used it.
+Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
+```
+
+Required answer per section:
+
+- **Summary** — motivation and what problem is solved; link the related issue (`Closes #…` / `Fixes #…`).
+- **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
+- **Did you add tests for your changes?** — yes/no + which test files.
+- **Does this PR introduce a breaking change?** — yes/no + migration path if yes.
+- **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
+- **Use of AI** — required. State that Claude Code was used and how (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
+
 ## Project Overview
 
 webpack is a JavaScript module bundler. Package manager: **yarn**.
@@ -92,13 +142,4 @@ Do **NOT** add `Co-authored-by` lines — unrecognized co-author emails also bre
 
 #### Pull request body
 
-webpack uses an **org-wide** PR template from the [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md) repository (there is no template file inside `webpack/webpack`). When opening a PR, fill **every** section of that template, in order, keeping the headings exactly as written:
-
-- **Summary** — motivation and what problem is solved; link the related issue.
-- **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
-- **Did you add tests for your changes?** — yes/no + which test files.
-- **Does this PR introduce a breaking change?** — yes/no + migration path if yes.
-- **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
-- **Use of AI** — required. State that Claude Code was used and how (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
-
-Do not delete sections, do not reorder, do not strip the HTML comment hints — write the answer directly under each heading. If a section truly does not apply, write `n/a` under it.
+See **[REQUIRED: Pull request body template](#required-pull-request-body-template)** at the top of this file. Paste the template body verbatim and fill every section before calling `create_pull_request` / `gh pr create`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,55 +2,9 @@
 
 > Note: CLAUDE.md is a symlink to AGENTS.md. They are the same file.
 
-## REQUIRED: Pull request body template
+## Conventions in this guide
 
-> **STOP — read this before opening any PR. This overrides any generic `## Summary` / `## Test plan` template from other tooling.**
-
-webpack uses an **org-wide** PR template from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md). The GitHub web UI prefills it; the GitHub API / MCP / `gh pr create` path does **not**, so you must paste the template yourself when opening a PR programmatically. Every PR body must contain **every** section below, in this order, with the labels spelled exactly as written. If a section truly does not apply, write `n/a` under it. Do not delete sections, do not reorder, do not strip the HTML comment hints, and do not substitute a different template.
-
-Paste this body verbatim, then fill in answers directly under each label:
-
-```markdown
-<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
-
-**Summary**
-
-<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
-<!-- Try to link to an open issue for more information. -->
-<!-- Any other information related to changes. -->
-
-<!-- In addition to that please answer these questions: -->
-
-**What kind of change does this PR introduce?**
-
-<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
-
-**Did you add tests for your changes?**
-
-<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
-
-**Does this PR introduce a breaking change?**
-
-<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
-
-**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
-
-<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
-
-**Use of AI**
-
-<!-- If you have used AI, please state so here. Explain how you used it.
-Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
-```
-
-Required answer per section:
-
-- **Summary** — motivation and what problem is solved; link the related issue (`Closes #…` / `Fixes #…`).
-- **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
-- **Did you add tests for your changes?** — yes/no + which test files.
-- **Does this PR introduce a breaking change?** — yes/no + migration path if yes.
-- **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
-- **Use of AI** — required. State that Claude Code was used and how (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
+A `> [!REQUIRED]` callout placed immediately under a heading marks that whole section as **mandatory**: follow it exactly, do not paraphrase, do not skip, do not substitute a similar-looking convention from other tooling. Sections without the callout are normal guidance — apply judgement.
 
 ## Project Overview
 
@@ -124,6 +78,8 @@ If any `lib/` file's exports (public API) were modified, also run `yarn fix:spec
 
 #### Commit author identity (required for CLA)
 
+> [!REQUIRED]
+
 EasyCLA matches the **commit author email** to a GitHub account with a signed CLA. A commit using an unrecognized author email such as `claude-bot@users.noreply.github.com`, `noreply@anthropic.com`, or any other email not associated with the requester's GitHub account and signed CLA will fail the CLA check and block the PR.
 
 Before the first commit of a task, set the author to the GitHub account that requested the work — never to a bot identity. Resolve the identity in this order:
@@ -142,4 +98,50 @@ Do **NOT** add `Co-authored-by` lines — unrecognized co-author emails also bre
 
 #### Pull request body
 
-See **[REQUIRED: Pull request body template](#required-pull-request-body-template)** at the top of this file. Paste the template body verbatim and fill every section before calling `create_pull_request` / `gh pr create`.
+> [!REQUIRED]
+
+webpack uses an **org-wide** PR template from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md). The GitHub web UI prefills it; the GitHub API / MCP / `gh pr create` path does **not**, so you must paste the template yourself when opening a PR programmatically. Every PR body must contain **every** section below, in this order, with the labels spelled exactly as written. If a section truly does not apply, write `n/a` under it. Do not delete sections, do not reorder, do not strip the HTML comment hints, and do not substitute a different template (e.g. `## Summary` / `## Test plan`).
+
+Paste this body verbatim, then fill in answers directly under each label:
+
+```markdown
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
+
+**Summary**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+<!-- Any other information related to changes. -->
+
+<!-- In addition to that please answer these questions: -->
+
+**What kind of change does this PR introduce?**
+
+<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
+
+**Did you add tests for your changes?**
+
+<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
+
+**Does this PR introduce a breaking change?**
+
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
+
+**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
+
+<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
+
+**Use of AI**
+
+<!-- If you have used AI, please state so here. Explain how you used it.
+Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
+```
+
+Required answer per section:
+
+- **Summary** — motivation and what problem is solved; link the related issue (`Closes #…` / `Fixes #…`).
+- **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
+- **Did you add tests for your changes?** — yes/no + which test files.
+- **Does this PR introduce a breaking change?** — yes/no + migration path if yes.
+- **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
+- **Use of AI** — required. State that Claude Code was used and how (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,94 @@ A `> [!REQUIRED]` callout placed immediately under a heading marks that whole se
 
 webpack is a JavaScript module bundler. Package manager: **yarn**.
 
-- `lib/` — Main source code
-- `lib/javascript/` — JavaScript modules parsing and generation
-- `lib/css/` — CSS modules parsing and generation
-- `schemas/` — JSON schemas for webpack options
-- `test/` — All tests
-- `examples/` — Usage examples for webpack features and configuration options
-- `.changeset/` — Changeset files for releases
-- `types.d.ts` — Auto-generated type definitions (do not edit manually)
-- `package.json` — All available commands (defined in `scripts`)
+**Source**
+
+- `lib/` — Main source code (CommonJS only; types declared via JSDoc `@typedef`).
+  - `lib/asset/` — Asset modules (images, fonts, raw files).
+  - `lib/async-modules/` — Top-level await.
+  - `lib/cache/` — Filesystem and memory caches.
+  - `lib/config/` — Config defaults, normalization, target presets.
+  - `lib/container/` — Module Federation.
+  - `lib/css/` — CSS Modules, CSS parsing and generation.
+  - `lib/debug/` — Debug helpers.
+  - `lib/dependencies/` — `Dependency` classes and their templates (HarmonyImport, CommonJsRequire, RequireContext, …).
+  - `lib/dll/` — DllPlugin / DllReferencePlugin.
+  - `lib/electron/`, `lib/node/`, `lib/web/`, `lib/webworker/` — Target-specific runtime templates.
+  - `lib/errors/` — Error class hierarchy.
+  - `lib/esm/` — ESM-specific output (e.g. `import.meta`).
+  - `lib/hmr/` — Hot Module Replacement plugins.
+  - `lib/html/` — Experimental HTML support.
+  - `lib/ids/` — Module/chunk id assignment plugins.
+  - `lib/javascript/` — JavaScript parsing (acorn), generation, exports analysis.
+  - `lib/json/` — JSON modules.
+  - `lib/library/` — UMD/AMD/ESM/CommonJS library output formats.
+  - `lib/logging/` — Logger API and console formatting.
+  - `lib/optimize/` — Optimization plugins (`SplitChunksPlugin`, `ConcatenatedModule`, …).
+  - `lib/performance/` — Asset/entrypoint size hints.
+  - `lib/prefetch/` — Prefetch/preload plugins.
+  - `lib/rules/` — `module.rules` matching engine.
+  - `lib/runtime/` — Runtime modules emitted into bundles (chunk loaders, public-path, …).
+  - `lib/schemes/` — Custom URL scheme handlers (`data:`, `http:`, …).
+  - `lib/serialization/` — Persistent cache serialization.
+  - `lib/sharing/` — Shared modules / Module Federation runtime.
+  - `lib/stats/` — Stats output (default printer, JSON factories).
+  - `lib/url/` — `new URL(asset, import.meta.url)` references.
+  - `lib/util/` — Utility helpers.
+  - `lib/wasm/`, `lib/wasm-async/`, `lib/wasm-sync/` — WebAssembly module support.
+- `hot/` — Runtime code shipped to browsers for HMR (browser-side, not Node tooling).
+- `bin/` — `webpack` CLI entry point.
+- `tooling/` — Repo-internal build scripts (runtime/wasm code generators, hash-debug tool); invoked by `yarn fix:special`.
+- `assembly/` — WebAssembly source for the hash function.
+- `setup/` — One-time setup scripts.
+
+**Schemas (the source of truth for webpack's config API)**
+
+- `schemas/WebpackOptions.json` — top-level webpack options schema.
+- `schemas/plugins/*.json` — per-plugin option schemas (`BannerPlugin`, `IgnorePlugin`, `ProgressPlugin`, `SourceMapDevToolPlugin`, …).
+- `schemas/_container.json`, `schemas/_sharing.json` — Module Federation sub-schemas.
+
+**Tests** — see [TESTING_DOCS.md](TESTING_DOCS.md) for naming and how to run a single case.
+
+- `test/cases/` — Default-config compilation cases.
+- `test/configCases/` — Cases with explicit `webpack.config.js`.
+- `test/watchCases/` — Watch-mode incremental cases.
+- `test/hotCases/` — HMR runtime cases.
+- `test/statsCases/` — Stats output snapshots.
+- `test/typesCases/` — TypeScript type assertions against `types.d.ts`.
+- `test/test262-cases/` — JavaScript spec compliance (test262).
+- `test/memoryLimitCases/`, `test/benchmarkCases/` — Heap-bounded and perf cases.
+- `test/__snapshots__/`, `test/fixtures/`, `test/helpers/`, `test/harness/` — Snapshots and shared utilities.
+
+**Examples & changesets**
+
+- `examples/` — Usage examples (build with `yarn build:examples`).
+- `.changeset/` — Pending changeset files for the next release.
+
+**Auto-generated — do not edit by hand; regenerate via `yarn fix:special`**
+
+- `types.d.ts` — Compiled from JSDoc + schemas.
+- `schemas/**/*.check.{js,d.ts}` — Precompiled schema validators.
+- Generated runtime code under `lib/` (driven by `tooling/generate-runtime-code.js`).
+
+**Hand-maintained type declarations (these _are_ editable)**
+
+- `declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`.
+
+**Configuration**
+
+- `package.json` — All commands (defined in `scripts`).
+- `tsconfig*.json` — TypeScript configs (one per surface: `lib`, `hot`, types tests, validation, benchmarks).
+- `eslint.config.mjs`, `cspell.json`, `jest.config.js`, `generate-types-config.js` — Lint/spell/test/type-gen configs.
+- `.github/workflows/`, `.github/scripts/` — CI.
+
+## Conventions and gotchas
+
+These are footguns from past sessions, not blanket rules — apply judgement on the rest of the codebase:
+
+- **`lib/` is CommonJS + JSDoc.** Use `module.exports` / `require()`, never `import`/`export` syntax. Types are declared via `@typedef {import("./Other")} Other` and friends — never TypeScript syntax in `.js` files.
+- **Auto-generated files are off-limits for hand edits.** That includes `types.d.ts`, `schemas/**/*.check.{js,d.ts}`, and the generated runtime code under `lib/`. After changing schemas, JSDoc on public exports, or runtime templates, run `yarn fix:special` instead of editing the outputs.
+- **Adding or renaming a webpack option requires edits in every layer.** Schema (`schemas/…`) → defaults (`lib/config/defaults.js`) → normalization (`lib/config/normalization.js`) → the implementation site that consumes the option. Skipping any one of these silently breaks the option (most often: the schema accepts it but `defaults.js` never sets it, so user code never reaches the new path).
+- **Run targeted tests during development.** `yarn jest test/<area>` or `yarn jest -t "<name>"` — the full suite is large. When updating snapshots (`yarn jest -u`), eyeball the diff first; never update blindly.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ These files are produced by `yarn fix:special` and must not be edited by hand:
 - `schemas/**/*.check.{js,d.ts}` — precompiled schema validators.
 - Generated runtime code under `lib/` (driven by `tooling/generate-runtime-code.js`).
 
-After changing schemas, JSDoc on public exports, or runtime templates, run `yarn fix:special` instead of editing the outputs. The hand-maintained type declarations (`declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`) *are* editable.
+After changing schemas, JSDoc on public exports, or runtime templates, run `yarn fix:special` instead of editing the outputs. The hand-maintained type declarations (`declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`) _are_ editable.
 
 ## Adding or renaming a webpack option
 

--- a/cspell.json
+++ b/cspell.json
@@ -312,6 +312,7 @@
     "webmake",
     "webpack",
     "webpack's",
+    "webworker",
     "Xarray",
     "Xexports",
     "Xfactory",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Improve `AGENTS.md` (and `CLAUDE.md` via the symlink) so future contributors — and AI sessions in particular — follow the project's existing rules more reliably. Four changes:

1. **Introduce a `> [!REQUIRED]` callout convention.** Define it in a new "Conventions in this guide" section near the top of the file, then apply it to the two existing sections that guard non-recoverable failure modes — "Commit author identity (required for CLA)" and "Pull request body". Future required rules can be marked in place by adding the callout immediately under their heading, without relocating content.
2. **Embed the verbatim org-wide PR body template.** The GitHub web UI prefills it from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md), but the API / MCP / `gh pr create` path does not, which is why several recent `claude/*` PRs landed with a wrong template. Embedding the body locally (with a clarified instruction on what to copy) removes that failure mode.
3. **Expand the directory map** from 9 lines to a deep tree covering all 36 `lib/` subdirectories, plus `hot/`, `bin/`, `tooling/`, `assembly/`, `setup/`, the schemas layout, the `test/*` case categories, auto-generated outputs, hand-maintained type declarations, and config files.
4. **Document four conventions as standalone H2 sections** — "Source language: CommonJS + JSDoc", "Auto-generated files", "Adding or renaming a webpack option", and "Running tests".

Also addresses the Copilot review on this PR: the stale PR description (now rewritten), the fenced-block copy hazard (clarified), and the "due inresponsible" → "due to irresponsible" typo in the embedded AI-policy comment (one-line departure from upstream verbatim, but the comment is invisible at PR-render time).

No related issue.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation-only change to `AGENTS.md` (`CLAUDE.md` is a symlink to it). No code paths touched.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the change *is* the documentation update. Future required rules in `AGENTS.md` can be marked in place by adding `> [!REQUIRED]` immediately under their heading; no relocation needed.

**Use of AI**

Claude Code drafted this change end-to-end (proposed the `> [!REQUIRED]` convention, embedded the verbatim org-wide template body, expanded the directory map, split conventions into standalone sections, and addressed the Copilot review) under human review.