### PR TITLE
fix: prevent PURE comment leaking across ObjectExpression properties in isPure

### DIFF
--- a/.changeset/ispure-more-expression-types.md
+++ b/.changeset/ispure-more-expression-types.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Improve tree-shaking by handling more expression types in `isPure`: `ArrayExpression`, `ObjectExpression`, `NewExpression`, `ChainExpression`, `UnaryExpression` (safe operators), `MetaProperty` and `TaggedTemplateExpression`.
+Improve tree-shaking by handling more expression types in `isPure`: `ArrayExpression`, `ObjectExpression`, `NewExpression`, `ChainExpression`, `UnaryExpression` (safe operators), `MetaProperty`, `TaggedTemplateExpression` and `BinaryExpression` (strict equality).

--- a/.changeset/ispure-more-expression-types.md
+++ b/.changeset/ispure-more-expression-types.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Improve tree-shaking by handling more expression types in `isPure`: `ArrayExpression`, `ObjectExpression` and `NewExpression`.
+Improve tree-shaking by handling more expression types in `isPure`: `ArrayExpression`, `ObjectExpression`, `NewExpression`, `ChainExpression`, `UnaryExpression` (safe operators), `MetaProperty` and `TaggedTemplateExpression`.

--- a/.changeset/ispure-more-expression-types.md
+++ b/.changeset/ispure-more-expression-types.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Improve tree-shaking by handling more expression types in `isPure`: `ArrayExpression`, `ObjectExpression`, `NewExpression`, `ChainExpression`, `UnaryExpression` (safe operators), `MetaProperty`, `TaggedTemplateExpression` and `BinaryExpression` (strict equality).
+Improve tree-shaking in `isPure`: handle more expression types (`ArrayExpression`, `ObjectExpression`, `NewExpression`, `ChainExpression`, `UnaryExpression` (safe operators), `MetaProperty`, `TaggedTemplateExpression`, `BinaryExpression` (strict equality)), prevent `/*#__PURE__*/` comments from leaking across `ObjectExpression` properties, and detect PURE comments inside `TemplateLiteral` interpolations.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5057,6 +5057,27 @@ class JavascriptParser extends Parser {
 				});
 			}
 
+			case "ChainExpression":
+				return this.isPure(expr.expression, commentsStartPos);
+
+			case "UnaryExpression":
+				// Safe unary operators: they do not invoke user code on their
+				// operand (`typeof` never throws even for undeclared identifiers,
+				// `void` and `!` coerce via ToBoolean which is side-effect free).
+				// Other operators (`+`, `-`, `~`, `delete`) fall through to the
+				// generic evaluator which can still recognize literal cases.
+				if (
+					expr.operator === "typeof" ||
+					expr.operator === "void" ||
+					expr.operator === "!"
+				) {
+					return this.isPure(expr.argument, commentsStartPos);
+				}
+				break;
+
+			case "MetaProperty":
+				return true;
+
 			case "ConditionalExpression":
 				return (
 					this.isPure(expr.test, commentsStartPos) &&
@@ -5121,6 +5142,26 @@ class JavascriptParser extends Parser {
 					if (arg.type === "SpreadElement") return false;
 					const pureFlag = this.isPure(arg, commentsStartPos);
 					commentsStartPos = /** @type {Range} */ (arg.range)[1];
+					return pureFlag;
+				});
+			}
+
+			case "TaggedTemplateExpression": {
+				const pureFlag =
+					/** @type {Range} */ (expr.range)[0] - commentsStartPos > 12 &&
+					this.getComments([
+						commentsStartPos,
+						/** @type {Range} */ (expr.range)[0]
+					]).some(
+						(comment) =>
+							comment.type === "Block" &&
+							/^\s*(?:#|@)__PURE__\s*$/.test(comment.value)
+					);
+				if (!pureFlag) return false;
+				commentsStartPos = /** @type {Range} */ (expr.tag.range)[1];
+				return expr.quasi.expressions.every((e) => {
+					const pureFlag = this.isPure(e, commentsStartPos);
+					commentsStartPos = /** @type {Range} */ (e.range)[1];
 					return pureFlag;
 				});
 			}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5039,7 +5039,6 @@ class JavascriptParser extends Parser {
 			case "ObjectExpression": {
 				return expr.properties.every((property) => {
 					if (property.type === "SpreadElement") return false;
-					const end = /** @type {Range} */ (property.key.range)[1];
 
 					if (
 						property.computed &&
@@ -5051,9 +5050,9 @@ class JavascriptParser extends Parser {
 					const pureFlag = this.isPure(
 						/** @type {Exclude<Property["value"], AssignmentPattern | ObjectPattern | ArrayPattern | RestElement>} */
 						(property.value),
-						end
+						/** @type {Range} */ (property.key.range)[1]
 					);
-					commentsStartPos = end;
+					commentsStartPos = /** @type {Range} */ (property.range)[1];
 					return pureFlag;
 				});
 			}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5078,6 +5078,21 @@ class JavascriptParser extends Parser {
 			case "MetaProperty":
 				return true;
 
+			case "BinaryExpression":
+				// Strict (in)equality compares without coercion and never invokes
+				// user code on its operands, so the result is pure iff both sides
+				// are pure. All other binary operators may invoke `valueOf` /
+				// `toString` / `[Symbol.hasInstance]` / Proxy traps and fall through
+				// to the generic evaluator, which can still recognize the cases
+				// where both sides evaluate to known primitive literals.
+				if (expr.operator === "===" || expr.operator === "!==") {
+					return (
+						this.isPure(expr.left, commentsStartPos) &&
+						this.isPure(expr.right, /** @type {Range} */ (expr.left.range)[1])
+					);
+				}
+				break;
+
 			case "ConditionalExpression":
 				return (
 					this.isPure(expr.test, commentsStartPos) &&

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5010,9 +5010,15 @@ class JavascriptParser extends Parser {
 				});
 			}
 			case "TemplateLiteral":
-				return expr.expressions.every((expr) =>
-					this.isPure(expr, /** @type {Range} */ (expr.range)[0])
-				);
+				// Thread `commentsStartPos` through the interpolations so a
+				// /*#__PURE__*/ comment that sits inside `${ ... }` (or before
+				// the first interpolation) is part of the scanned range when
+				// the inner expression's purity is evaluated.
+				return expr.expressions.every((e) => {
+					const pureFlag = this.isPure(e, commentsStartPos);
+					commentsStartPos = /** @type {Range} */ (e.range)[1];
+					return pureFlag;
+				});
 			case "FunctionDeclaration":
 			case "FunctionExpression":
 			case "ArrowFunctionExpression":

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5067,11 +5067,17 @@ class JavascriptParser extends Parser {
 				return this.isPure(expr.expression, commentsStartPos);
 
 			case "UnaryExpression":
-				// Safe unary operators: they do not invoke user code on their
-				// operand (`typeof` never throws even for undeclared identifiers,
-				// `void` and `!` coerce via ToBoolean which is side-effect free).
-				// Other operators (`+`, `-`, `~`, `delete`) fall through to the
-				// generic evaluator which can still recognize literal cases.
+				// Safe unary operators — produce their result without invoking
+				// user code on the operand:
+				//   - `typeof` returns a type tag and never throws, even for
+				//     undeclared identifiers; no coercion.
+				//   - `void` evaluates the operand and discards it, returning
+				//     `undefined`; pure iff the operand is pure.
+				//   - `!` coerces via ToBoolean, which is defined to not call
+				//     any user code (objects → true, etc.).
+				// Other operators (`+`, `-`, `~`, `delete`) fall through to
+				// the generic evaluator which can still recognize literal
+				// cases (e.g. `-1`, `+5`).
 				if (
 					expr.operator === "typeof" ||
 					expr.operator === "void" ||

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5155,7 +5155,7 @@ class JavascriptParser extends Parser {
 					]).some(
 						(comment) =>
 							comment.type === "Block" &&
-							/^\s*(?:#|@)__PURE__\s*$/.test(comment.value)
+							CompilerHintNotationRegExp.Pure.test(comment.value)
 					);
 				if (!pureFlag) return false;
 				commentsStartPos = /** @type {Range} */ (expr.callee.range)[1];
@@ -5176,7 +5176,7 @@ class JavascriptParser extends Parser {
 					]).some(
 						(comment) =>
 							comment.type === "Block" &&
-							/^\s*(?:#|@)__PURE__\s*$/.test(comment.value)
+							CompilerHintNotationRegExp.Pure.test(comment.value)
 					);
 				if (!pureFlag) return false;
 				commentsStartPos = /** @type {Range} */ (expr.tag.range)[1];

--- a/test/configCases/inner-graph/pure-expressions-extended/module.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/module.js
@@ -1,0 +1,7 @@
+import { a, b, c, d, e } from "dep";
+
+export const chained = /*#__PURE__*/ a?.();
+export const tagged = /*#__PURE__*/ b`hello ${"world"}`;
+export const negated = !c;
+export const typed = typeof d;
+export const voided = void e;

--- a/test/configCases/inner-graph/pure-expressions-extended/module.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/module.js
@@ -1,7 +1,9 @@
-import { a, b, c, d, e } from "dep";
+import { a, b, c, d, e, f, g } from "dep";
 
 export const chained = /*#__PURE__*/ a?.();
 export const tagged = /*#__PURE__*/ b`hello ${"world"}`;
 export const negated = !c;
 export const typed = typeof d;
 export const voided = void e;
+export const eqStrict = f === undefined;
+export const neStrict = g !== null;

--- a/test/configCases/inner-graph/pure-expressions-extended/module.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/module.js
@@ -1,4 +1,4 @@
-import { a, b, c, d, e, f, g } from "dep";
+import { a, b, c, d, e, f, g, h } from "dep";
 
 export const chained = /*#__PURE__*/ a?.();
 export const tagged = /*#__PURE__*/ b`hello ${"world"}`;
@@ -7,3 +7,4 @@ export const typed = typeof d;
 export const voided = void e;
 export const eqStrict = f === undefined;
 export const neStrict = g !== null;
+export const tplPure = `wrap ${/*#__PURE__*/ h()}`;

--- a/test/configCases/inner-graph/pure-expressions-extended/test.filter.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
+
+module.exports = () => supportsOptionalChaining();

--- a/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
@@ -39,10 +39,30 @@ module.exports = createTestCases({
 			dep: ["e"]
 		}
 	},
-	all: {
-		usedExports: ["chained", "tagged", "negated", "typed", "voided"],
+	eqStrict: {
+		usedExports: ["eqStrict"],
 		expect: {
-			dep: ["a", "b", "c", "d", "e"]
+			dep: ["f"]
+		}
+	},
+	neStrict: {
+		usedExports: ["neStrict"],
+		expect: {
+			dep: ["g"]
+		}
+	},
+	all: {
+		usedExports: [
+			"chained",
+			"tagged",
+			"negated",
+			"typed",
+			"voided",
+			"eqStrict",
+			"neStrict"
+		],
+		expect: {
+			dep: ["a", "b", "c", "d", "e", "f", "g"]
 		}
 	}
 });

--- a/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const createTestCases = require("../_helpers/createTestCases");
+
+module.exports = createTestCases({
+	nothing: {
+		usedExports: [],
+		expect: {
+			dep: []
+		}
+	},
+	chained: {
+		usedExports: ["chained"],
+		expect: {
+			dep: ["a"]
+		}
+	},
+	tagged: {
+		usedExports: ["tagged"],
+		expect: {
+			dep: ["b"]
+		}
+	},
+	negated: {
+		usedExports: ["negated"],
+		expect: {
+			dep: ["c"]
+		}
+	},
+	typed: {
+		usedExports: ["typed"],
+		expect: {
+			dep: ["d"]
+		}
+	},
+	voided: {
+		usedExports: ["voided"],
+		expect: {
+			dep: ["e"]
+		}
+	},
+	all: {
+		usedExports: ["chained", "tagged", "negated", "typed", "voided"],
+		expect: {
+			dep: ["a", "b", "c", "d", "e"]
+		}
+	}
+});

--- a/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
+++ b/test/configCases/inner-graph/pure-expressions-extended/webpack.config.js
@@ -51,6 +51,12 @@ module.exports = createTestCases({
 			dep: ["g"]
 		}
 	},
+	tplPure: {
+		usedExports: ["tplPure"],
+		expect: {
+			dep: ["h"]
+		}
+	},
 	all: {
 		usedExports: [
 			"chained",
@@ -59,10 +65,11 @@ module.exports = createTestCases({
 			"typed",
 			"voided",
 			"eqStrict",
-			"neStrict"
+			"neStrict",
+			"tplPure"
 		],
 		expect: {
-			dep: ["a", "b", "c", "d", "e", "f", "g"]
+			dep: ["a", "b", "c", "d", "e", "f", "g", "h"]
 		}
 	}
 });

--- a/test/configCases/inner-graph/pure-expressions-object-leak/module.js
+++ b/test/configCases/inner-graph/pure-expressions-object-leak/module.js
@@ -1,0 +1,10 @@
+import { a, b, c } from "dep";
+
+// A PURE annotation attached to a preceding property's value must not leak
+// into a later property's computed key check. Without the fix, `Boolean(b)`
+// is treated as pure (because the comment before `Boolean(a)` falls into the
+// scanned range) and the whole object is wrongly considered pure.
+export const leak = {
+	first: /*#__PURE__*/ Boolean(a),
+	[Boolean(b)]: c
+};

--- a/test/configCases/inner-graph/pure-expressions-object-leak/webpack.config.js
+++ b/test/configCases/inner-graph/pure-expressions-object-leak/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const createTestCases = require("../_helpers/createTestCases");
+
+module.exports = createTestCases({
+	nothing: {
+		usedExports: [],
+		expect: {
+			dep: ["a", "b", "c"]
+		}
+	},
+	leak: {
+		usedExports: ["leak"],
+		expect: {
+			dep: ["a", "b", "c"]
+		}
+	}
+});


### PR DESCRIPTION
Advance commentsStartPos to the end of the full property (property.range[1])
between iterations, instead of the end of the key. Otherwise a /*#__PURE__*/
comment attached to an earlier property's value is still in the scanned range
when checking a later property's computed key, which could make a non-pure
computed key wrongly appear pure and incorrectly mark the whole object pure.