### PR TITLE
feat: preserve defer/source import phase on external dependencies

### DIFF
--- a/.changeset/external-module-phase-imports.md
+++ b/.changeset/external-module-phase-imports.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Preserve `defer` / `source` import phase keywords on external dependencies in ESM output, the same way import attributes are preserved. Static `import defer * as ns from "x"` and `import source v from "x"` against a `module` external are now emitted as native `import defer * as …` / `import source … from …` statements at the top of the bundle, and dynamic `import.defer("x")` / `import.source("x")` against an `import` external is emitted as `import.defer(…)` / `import.source(…)`.

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -221,15 +221,15 @@ const getSourceForImportExternal = (
 		baseImportName === "import" && ImportPhaseUtils.isDefer(phase)
 			? "import.defer"
 			: baseImportName === "import" && ImportPhaseUtils.isSource(phase)
-			? "import.source"
-			: baseImportName;
+				? "import.source"
+				: baseImportName;
 	const attributes =
 		dependencyMeta && dependencyMeta.attributes
 			? dependencyMeta.attributes._isLegacyAssert
 				? `, { assert: ${JSON.stringify(
 						dependencyMeta.attributes,
 						importAssertionReplacer
-				  )} }`
+					)} }`
 				: `, { with: ${JSON.stringify(dependencyMeta.attributes)} }`
 			: "";
 	if (!Array.isArray(moduleAndSpecifiers)) {
@@ -346,12 +346,11 @@ class ModuleExternalInitFragment extends InitFragment {
 		} = this;
 		const attributes =
 			dependencyMeta && dependencyMeta.attributes
-				? dependencyMeta.attributes._isLegacyAssert &&
-				  dependencyMeta.attributes._isLegacyAssert
+				? dependencyMeta.attributes._isLegacyAssert
 					? ` assert ${JSON.stringify(
 							dependencyMeta.attributes,
 							importAssertionReplacer
-					  )}`
+						)}`
 					: ` with ${JSON.stringify(dependencyMeta.attributes)}`
 				: "";
 		const phase = dependencyMeta && dependencyMeta.phase;
@@ -495,6 +494,7 @@ const getSourceForModuleExternal = (
 	dependencyMeta,
 	concatenationScope
 ) => {
+	const phase = dependencyMeta && dependencyMeta.phase;
 	/** @type {Imported} */
 	let imported = true;
 	if (concatenationScope) {
@@ -520,6 +520,14 @@ const getSourceForModuleExternal = (
 
 	// Return to `namespace` when the external request includes a specific export
 	if (moduleAndSpecifiers.length > 1) {
+		imported = true;
+	}
+
+	// `import defer …` is only valid as `import defer * as ns from "…"`, so
+	// keep the namespace form even if usage analysis would otherwise narrow
+	// the import down to specific names. Defer + concatenation is semantically
+	// at odds (lazy vs. eager), so we preserve the user-written shape here.
+	if (ImportPhaseUtils.isDefer(phase)) {
 		imported = true;
 	}
 
@@ -556,10 +564,10 @@ const getSourceForModuleExternal = (
 			? `var x = ${runtimeTemplate.basicFunction(
 					"y",
 					`var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x`
-			  )} \nvar y = ${runtimeTemplate.returningFunction(
+				)} \nvar y = ${runtimeTemplate.returningFunction(
 					runtimeTemplate.returningFunction("x"),
 					"x"
-			  )}`
+				)}`
 			: undefined,
 		specifiers: normalizedImported === true ? undefined : normalizedImported,
 		runtimeRequirements: moduleRemapping
@@ -644,7 +652,7 @@ const getSourceForAmdOrUmdExternal = (
 					externalVariable,
 					Array.isArray(request) ? request.join(".") : request,
 					runtimeTemplate
-			  )
+				)
 			: undefined,
 		expression: externalVariable
 	};
@@ -777,9 +785,21 @@ class ExternalModule extends Module {
 	 * @returns {string} a unique identifier of the module
 	 */
 	identifier() {
-		return `external ${this._resolveExternalType(
+		let id = `external ${this._resolveExternalType(
 			this.externalType
 		)} ${JSON.stringify(this.request)}`;
+		const meta = /** @type {ImportDependencyMeta | undefined} */ (
+			this.dependencyMeta
+		);
+		if (meta) {
+			if (meta.phase) {
+				id += `|phase=${ImportPhaseUtils.stringify(meta.phase)}`;
+			}
+			if (meta.attributes) {
+				id += `|attributes=${JSON.stringify(meta.attributes)}`;
+			}
+		}
+		return id;
 	}
 
 	/**
@@ -1228,6 +1248,17 @@ class ExternalModule extends Module {
 				this.request
 			)}${this.isOptional(chunkGraph.moduleGraph)}`
 		);
+		const meta = /** @type {ImportDependencyMeta | undefined} */ (
+			this.dependencyMeta
+		);
+		if (meta) {
+			if (meta.phase) {
+				hash.update(`|phase=${ImportPhaseUtils.stringify(meta.phase)}`);
+			}
+			if (meta.attributes) {
+				hash.update(`|attributes=${JSON.stringify(meta.attributes)}`);
+			}
+		}
 		super.updateHash(hash, context);
 	}
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -21,6 +21,7 @@ const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
 const { DEFAULTS } = require("./config/defaults");
+const { ImportPhaseUtils } = require("./dependencies/ImportPhase");
 const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
 const EnvironmentNotSupportAsyncWarning = require("./errors/EnvironmentNotSupportAsyncWarning");
 const createHash = require("./util/createHash");
@@ -62,13 +63,14 @@ const { register } = require("./util/serialization");
 /** @typedef {import("./RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("./javascript/JavascriptModulesPlugin").ChunkRenderContext} ChunkRenderContext */
 /** @typedef {import("./javascript/JavascriptParser").ImportAttributes} ImportAttributes */
+/** @typedef {import("./dependencies/ImportPhase").ImportPhaseType} ImportPhaseType */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("./util/Hash")} Hash */
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
 
-/** @typedef {{ attributes?: ImportAttributes, externalType: "import" | "module" | undefined }} ImportDependencyMeta */
+/** @typedef {{ attributes?: ImportAttributes, phase?: ImportPhaseType, externalType: "import" | "module" | undefined }} ImportDependencyMeta */
 /** @typedef {{ layer?: string, supports?: string, media?: string }} CssImportDependencyMeta */
 /** @typedef {{ sourceType: "css-url" }} AssetDependencyMeta */
 
@@ -202,22 +204,32 @@ const getSourceForImportExternal = (
 	runtimeTemplate,
 	dependencyMeta
 ) => {
-	const importName = runtimeTemplate.outputOptions.importFunctionName;
+	const baseImportName = runtimeTemplate.outputOptions.importFunctionName;
 	if (
 		!runtimeTemplate.supportsDynamicImport() &&
-		(importName === "import" || importName === "module-import")
+		(baseImportName === "import" || baseImportName === "module-import")
 	) {
 		throw new Error(
 			"The target environment doesn't support 'import()' so it's not possible to use external type 'import'"
 		);
 	}
+	const phase = dependencyMeta && dependencyMeta.phase;
+	// `import.defer(…)` and `import.source(…)` are only valid forms of the
+	// native `import(…)` function, so we only emit the phase suffix when the
+	// importFunctionName is the default `"import"`.
+	const importName =
+		baseImportName === "import" && ImportPhaseUtils.isDefer(phase)
+			? "import.defer"
+			: baseImportName === "import" && ImportPhaseUtils.isSource(phase)
+			? "import.source"
+			: baseImportName;
 	const attributes =
 		dependencyMeta && dependencyMeta.attributes
 			? dependencyMeta.attributes._isLegacyAssert
 				? `, { assert: ${JSON.stringify(
 						dependencyMeta.attributes,
 						importAssertionReplacer
-					)} }`
+				  )} }`
 				: `, { with: ${JSON.stringify(dependencyMeta.attributes)} }`
 			: "";
 	if (!Array.isArray(moduleAndSpecifiers)) {
@@ -293,7 +305,9 @@ class ModuleExternalInitFragment extends InitFragment {
 			"",
 			InitFragment.STAGE_HARMONY_IMPORTS,
 			0,
-			`external module import ${ident} ${imported === true ? imported : imported.join(" ")}`
+			`external module import ${ident} ${
+				imported === true ? imported : imported.join(" ")
+			}`
 		);
 		this._ident = ident;
 		this._request = request;
@@ -333,22 +347,34 @@ class ModuleExternalInitFragment extends InitFragment {
 		const attributes =
 			dependencyMeta && dependencyMeta.attributes
 				? dependencyMeta.attributes._isLegacyAssert &&
-					dependencyMeta.attributes._isLegacyAssert
+				  dependencyMeta.attributes._isLegacyAssert
 					? ` assert ${JSON.stringify(
 							dependencyMeta.attributes,
 							importAssertionReplacer
-						)}`
+					  )}`
 					: ` with ${JSON.stringify(dependencyMeta.attributes)}`
 				: "";
+		const phase = dependencyMeta && dependencyMeta.phase;
 		let content = "";
 		if (imported === true) {
 			// namespace
-			content = `import * as ${identifier} from ${JSON.stringify(request)}${
-				attributes
-			};\n`;
+			const phaseKeyword = ImportPhaseUtils.isDefer(phase) ? "defer " : "";
+			content = `import ${phaseKeyword}* as ${identifier} from ${JSON.stringify(
+				request
+			)}${attributes};\n`;
 		} else if (imported.length === 0) {
 			// just import, no use
 			content = `import ${JSON.stringify(request)}${attributes};\n`;
+		} else if (
+			ImportPhaseUtils.isSource(phase) &&
+			imported.length === 1 &&
+			imported[0][0] === "default"
+		) {
+			// `import source x from "…"` — the source-phase form binds the source
+			// object directly to a single identifier (no namespace, no destructuring).
+			content = `import source ${imported[0][1]} from ${JSON.stringify(
+				request
+			)}${attributes};\n`;
 		} else {
 			content = `import { ${imported
 				.map(([name, finalName]) => {
@@ -530,10 +556,10 @@ const getSourceForModuleExternal = (
 			? `var x = ${runtimeTemplate.basicFunction(
 					"y",
 					`var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x`
-				)} \nvar y = ${runtimeTemplate.returningFunction(
+			  )} \nvar y = ${runtimeTemplate.returningFunction(
 					runtimeTemplate.returningFunction("x"),
 					"x"
-				)}`
+			  )}`
 			: undefined,
 		specifiers: normalizedImported === true ? undefined : normalizedImported,
 		runtimeRequirements: moduleRemapping
@@ -618,7 +644,7 @@ const getSourceForAmdOrUmdExternal = (
 					externalVariable,
 					Array.isArray(request) ? request.join(".") : request,
 					runtimeTemplate
-				)
+			  )
 			: undefined,
 		expression: externalVariable
 	};
@@ -751,7 +777,9 @@ class ExternalModule extends Module {
 	 * @returns {string} a unique identifier of the module
 	 */
 	identifier() {
-		return `external ${this._resolveExternalType(this.externalType)} ${JSON.stringify(this.request)}`;
+		return `external ${this._resolveExternalType(
+			this.externalType
+		)} ${JSON.stringify(this.request)}`;
 	}
 
 	/**
@@ -1126,7 +1154,9 @@ class ExternalModule extends Module {
 						scope.registerRawExport(specifier, finalName);
 					}
 				} else if (concatenationScope) {
-					sourceString = `${runtimeTemplate.renderConst()} ${ConcatenationScope.NAMESPACE_OBJECT_EXPORT} = ${sourceString};`;
+					sourceString = `${runtimeTemplate.renderConst()} ${
+						ConcatenationScope.NAMESPACE_OBJECT_EXPORT
+					} = ${sourceString};`;
 					concatenationScope.registerNamespaceExport(
 						ConcatenationScope.NAMESPACE_OBJECT_EXPORT
 					);
@@ -1194,9 +1224,9 @@ class ExternalModule extends Module {
 	updateHash(hash, context) {
 		const { chunkGraph } = context;
 		hash.update(
-			`${this._resolveExternalType(this.externalType)}${JSON.stringify(this.request)}${this.isOptional(
-				chunkGraph.moduleGraph
-			)}`
+			`${this._resolveExternalType(this.externalType)}${JSON.stringify(
+				this.request
+			)}${this.isOptional(chunkGraph.moduleGraph)}`
 		);
 		super.updateHash(hash, context);
 	}

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -188,11 +188,16 @@ class ExternalModuleFactoryPlugin {
 							dependency instanceof HarmonyImportDependency
 								? "module"
 								: dependency instanceof ImportDependency
-									? "import"
-									: undefined;
+								? "import"
+								: undefined;
 
 						dependencyMeta = {
 							attributes: dependency.attributes,
+							phase:
+								dependency instanceof HarmonyImportDependency ||
+								dependency instanceof ImportDependency
+									? dependency.phase
+									: undefined,
 							externalType
 						};
 					} else if (dependency instanceof CssImportDependency) {
@@ -314,7 +319,7 @@ class ExternalModuleFactoryPlugin {
 														data.resolveOptions || EMPTY_RESOLVE_OPTIONS,
 														"dependencyType",
 														dependencyType
-													)
+												  )
 												: data.resolveOptions
 										);
 										if (options) resolver = resolver.withOptions(options);

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -188,8 +188,8 @@ class ExternalModuleFactoryPlugin {
 							dependency instanceof HarmonyImportDependency
 								? "module"
 								: dependency instanceof ImportDependency
-								? "import"
-								: undefined;
+									? "import"
+									: undefined;
 
 						dependencyMeta = {
 							attributes: dependency.attributes,
@@ -319,7 +319,7 @@ class ExternalModuleFactoryPlugin {
 														data.resolveOptions || EMPTY_RESOLVE_OPTIONS,
 														"dependencyType",
 														dependencyType
-												  )
+													)
 												: data.resolveOptions
 										);
 										if (options) resolver = resolver.withOptions(options);

--- a/test/configCases/externals/phase-imports-defer/bundle.js
+++ b/test/configCases/externals/phase-imports-defer/bundle.js
@@ -1,0 +1,9 @@
+// Sync `var` external — defer should produce a `/* deferred harmony import */`
+// runtime statement because `buildMeta.async` is not set.
+import * as syncDeferNs from /* webpackDefer: true */ "ext-var-sync";
+
+// Async `promise` external — defer should be ignored at runtime because the
+// external is already async (`buildMeta.async === true`).
+import * as asyncDeferNs from /* webpackDefer: true */ "ext-promise-async";
+
+export { syncDeferNs, asyncDeferNs };

--- a/test/configCases/externals/phase-imports-defer/index.js
+++ b/test/configCases/externals/phase-imports-defer/index.js
@@ -3,11 +3,10 @@
 const fs = require("fs");
 const path = require("path");
 
+const bundle = path.resolve(__dirname, "bundle.js");
+
 it("should generate a deferred runtime import for a sync external", () => {
-	const content = fs.readFileSync(
-		path.resolve(__dirname, "bundle.js"),
-		"utf-8"
-	);
+	const content = fs.readFileSync(bundle, "utf-8");
 
 	expect(content).toContain(
 		"/* deferred harmony import */ var ext_var_sync__WEBPACK_DEFERRED_IMPORTED_MODULE"
@@ -16,10 +15,7 @@ it("should generate a deferred runtime import for a sync external", () => {
 });
 
 it("should not defer an already-async external", () => {
-	const content = fs.readFileSync(
-		path.resolve(__dirname, "bundle.js"),
-		"utf-8"
-	);
+	const content = fs.readFileSync(bundle, "utf-8");
 
 	expect(content).toContain(
 		"/* harmony import */ var ext_promise_async__WEBPACK_IMPORTED_MODULE"

--- a/test/configCases/externals/phase-imports-defer/index.js
+++ b/test/configCases/externals/phase-imports-defer/index.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+it("should generate a deferred runtime import for a sync external", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "bundle.js"),
+		"utf-8"
+	);
+
+	expect(content).toContain(
+		"/* deferred harmony import */ var ext_var_sync__WEBPACK_DEFERRED_IMPORTED_MODULE"
+	);
+	expect(content).toContain("__webpack_require__.zO(/*! ext-var-sync */");
+});
+
+it("should not defer an already-async external", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "bundle.js"),
+		"utf-8"
+	);
+
+	expect(content).toContain(
+		"/* harmony import */ var ext_promise_async__WEBPACK_IMPORTED_MODULE"
+	);
+	expect(content).not.toContain(
+		"/* deferred harmony import */ var ext_promise_async"
+	);
+	expect(content).not.toContain(
+		"__webpack_require__.zO(/*! ext-promise-async */"
+	);
+});

--- a/test/configCases/externals/phase-imports-defer/infrastructure-log.js
+++ b/test/configCases/externals/phase-imports-defer/infrastructure-log.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = (options) => {
+	const opt = Array.isArray(options) ? options[0] : options;
+	if (opt && opt.cache && opt.cache.type === "filesystem") {
+		return [/Pack got invalid because of write to/];
+	}
+
+	return [];
+};

--- a/test/configCases/externals/phase-imports-defer/test.config.js
+++ b/test/configCases/externals/phase-imports-defer/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => ["main.js"]
+};

--- a/test/configCases/externals/phase-imports-defer/webpack.config.js
+++ b/test/configCases/externals/phase-imports-defer/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	entry: {
+		main: "./index.js",
+		bundle: "./bundle.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: false
+	},
+	experiments: {
+		deferImport: true
+	},
+	externals: {
+		"ext-var-sync": "var 'sync-value'",
+		"ext-promise-async": "promise Promise.resolve('async-value')"
+	}
+};

--- a/test/configCases/externals/phase-imports-esm/bundle.js
+++ b/test/configCases/externals/phase-imports-esm/bundle.js
@@ -15,6 +15,12 @@ import source miSrcDefault from "ext-mi-source-static";
 const miImportDefer = import.defer("ext-mi-defer-dynamic");
 const miImportSource = import.source("ext-mi-source-dynamic");
 
+// Same external imported twice with two different phases — these must NOT
+// collapse to a single ExternalModule with a single phase, otherwise one of
+// the phase keywords would silently disappear from the emitted bundle.
+import defer * as bothDeferNs from "ext-both-phases";
+import source bothSrcDefault from "ext-both-phases";
+
 // Side-effect uses so no binding is tree-shaken away.
 console.log(
 	modDeferNs.x,
@@ -24,5 +30,7 @@ console.log(
 	miDeferNs.x,
 	miSrcDefault,
 	miImportDefer,
-	miImportSource
+	miImportSource,
+	bothDeferNs.x,
+	bothSrcDefault
 );

--- a/test/configCases/externals/phase-imports-esm/bundle.js
+++ b/test/configCases/externals/phase-imports-esm/bundle.js
@@ -1,0 +1,16 @@
+// Static defer phase against a `module` external should be emitted as a
+// real native `import defer * as …` statement, the same way import
+// attributes are preserved for ESM output.
+import defer * as deferNs from "ext-defer";
+
+// Static source phase against a `module` external should be emitted as a
+// real native `import source <ident> from …` statement.
+import source srcDefault from "ext-source";
+
+// Dynamic phase imports against an `import` external should be emitted as
+// `import.defer(…)` and `import.source(…)` calls.
+const dynDefer = import.defer("ext-import-defer");
+const dynSource = import.source("ext-import-source");
+
+// Side-effect uses so neither static binding is tree-shaken away.
+console.log(deferNs.x, srcDefault, dynDefer, dynSource);

--- a/test/configCases/externals/phase-imports-esm/bundle.js
+++ b/test/configCases/externals/phase-imports-esm/bundle.js
@@ -1,16 +1,28 @@
-// Static defer phase against a `module` external should be emitted as a
-// real native `import defer * as …` statement, the same way import
-// attributes are preserved for ESM output.
-import defer * as deferNs from "ext-defer";
+// `module` externals — static phase imports become real native
+// `import defer * as …` / `import source … from …` statements.
+import defer * as modDeferNs from "ext-mod-defer";
+import source modSrcDefault from "ext-mod-source";
 
-// Static source phase against a `module` external should be emitted as a
-// real native `import source <ident> from …` statement.
-import source srcDefault from "ext-source";
+// `import` externals — dynamic `import.defer(…)` / `import.source(…)`.
+const importDefer = import.defer("ext-import-defer");
+const importSource = import.source("ext-import-source");
 
-// Dynamic phase imports against an `import` external should be emitted as
-// `import.defer(…)` and `import.source(…)` calls.
-const dynDefer = import.defer("ext-import-defer");
-const dynSource = import.source("ext-import-source");
+// `module-import` externals at static sites resolve to the `module` form.
+import defer * as miDeferNs from "ext-mi-defer-static";
+import source miSrcDefault from "ext-mi-source-static";
 
-// Side-effect uses so neither static binding is tree-shaken away.
-console.log(deferNs.x, srcDefault, dynDefer, dynSource);
+// `module-import` externals at dynamic sites resolve to the `import` form.
+const miImportDefer = import.defer("ext-mi-defer-dynamic");
+const miImportSource = import.source("ext-mi-source-dynamic");
+
+// Side-effect uses so no binding is tree-shaken away.
+console.log(
+	modDeferNs.x,
+	modSrcDefault,
+	importDefer,
+	importSource,
+	miDeferNs.x,
+	miSrcDefault,
+	miImportDefer,
+	miImportSource
+);

--- a/test/configCases/externals/phase-imports-esm/index.js
+++ b/test/configCases/externals/phase-imports-esm/index.js
@@ -3,26 +3,40 @@
 const fs = require("fs");
 const path = require("path");
 
-it("should emit static `import defer` / `import source` for module externals in ESM output", () => {
-	const content = fs.readFileSync(
-		path.resolve(__dirname, "bundle.js"),
-		"utf-8"
-	);
+const bundle = path.resolve(__dirname, "bundle.js");
+
+it("should emit native `import defer` / `import source` for `module` externals", () => {
+	const content = fs.readFileSync(bundle, "utf-8");
 
 	expect(content).toMatch(
-		/import defer \* as __WEBPACK_EXTERNAL_MODULE_ext_defer\w* from "ext-defer";/
+		/import defer \* as __WEBPACK_EXTERNAL_MODULE_ext_mod_defer\w* from "ext-mod-defer";/
 	);
 	expect(content).toMatch(
-		/import source __WEBPACK_EXTERNAL_MODULE_ext_source\w* from "ext-source";/
+		/import source __WEBPACK_EXTERNAL_MODULE_ext_mod_source\w* from "ext-mod-source";/
 	);
 });
 
-it("should emit `import.defer` / `import.source` for dynamic phase imports of `import` externals", () => {
-	const content = fs.readFileSync(
-		path.resolve(__dirname, "bundle.js"),
-		"utf-8"
-	);
+it("should emit `import.defer` / `import.source` for `import` externals", () => {
+	const content = fs.readFileSync(bundle, "utf-8");
 
 	expect(content).toContain('import.defer("ext-import-defer")');
 	expect(content).toContain('import.source("ext-import-source")');
+});
+
+it("should emit native `import defer` / `import source` for `module-import` externals at static sites", () => {
+	const content = fs.readFileSync(bundle, "utf-8");
+
+	expect(content).toMatch(
+		/import defer \* as __WEBPACK_EXTERNAL_MODULE_ext_mi_defer_static\w* from "ext-mi-defer-static";/
+	);
+	expect(content).toMatch(
+		/import source __WEBPACK_EXTERNAL_MODULE_ext_mi_source_static\w* from "ext-mi-source-static";/
+	);
+});
+
+it("should emit `import.defer` / `import.source` for `module-import` externals at dynamic sites", () => {
+	const content = fs.readFileSync(bundle, "utf-8");
+
+	expect(content).toContain('import.defer("ext-mi-defer-dynamic")');
+	expect(content).toContain('import.source("ext-mi-source-dynamic")');
 });

--- a/test/configCases/externals/phase-imports-esm/index.js
+++ b/test/configCases/externals/phase-imports-esm/index.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+it("should emit static `import defer` / `import source` for module externals in ESM output", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "bundle.js"),
+		"utf-8"
+	);
+
+	expect(content).toMatch(
+		/import defer \* as __WEBPACK_EXTERNAL_MODULE_ext_defer\w* from "ext-defer";/
+	);
+	expect(content).toMatch(
+		/import source __WEBPACK_EXTERNAL_MODULE_ext_source\w* from "ext-source";/
+	);
+});
+
+it("should emit `import.defer` / `import.source` for dynamic phase imports of `import` externals", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "bundle.js"),
+		"utf-8"
+	);
+
+	expect(content).toContain('import.defer("ext-import-defer")');
+	expect(content).toContain('import.source("ext-import-source")');
+});

--- a/test/configCases/externals/phase-imports-esm/index.js
+++ b/test/configCases/externals/phase-imports-esm/index.js
@@ -40,3 +40,17 @@ it("should emit `import.defer` / `import.source` for `module-import` externals a
 	expect(content).toContain('import.defer("ext-mi-defer-dynamic")');
 	expect(content).toContain('import.source("ext-mi-source-dynamic")');
 });
+
+it("should not collapse the same external imported with two different phases", () => {
+	const content = fs.readFileSync(bundle, "utf-8");
+
+	// Both phase forms must appear — a single ExternalModule per (request,
+	// phase) means both `import defer * as …` and `import source … from …`
+	// statements are emitted for the same request.
+	expect(content).toMatch(
+		/import defer \* as __WEBPACK_EXTERNAL_MODULE_ext_both_phases\w* from "ext-both-phases";/
+	);
+	expect(content).toMatch(
+		/import source __WEBPACK_EXTERNAL_MODULE_ext_both_phases\w* from "ext-both-phases";/
+	);
+});

--- a/test/configCases/externals/phase-imports-esm/test.config.js
+++ b/test/configCases/externals/phase-imports-esm/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => ["main.js"]
+};

--- a/test/configCases/externals/phase-imports-esm/webpack.config.js
+++ b/test/configCases/externals/phase-imports-esm/webpack.config.js
@@ -38,6 +38,9 @@ module.exports = {
 			"ext-mi-source-static": "module-import ext-mi-source-static",
 			"ext-mi-defer-dynamic": "module-import ext-mi-defer-dynamic",
 			"ext-mi-source-dynamic": "module-import ext-mi-source-dynamic",
+			// Same request, imported with two different phases: must produce
+			// two distinct ExternalModule instances.
+			"ext-both-phases": "module ext-both-phases",
 			fs: "commonjs fs",
 			path: "commonjs path"
 		}

--- a/test/configCases/externals/phase-imports-esm/webpack.config.js
+++ b/test/configCases/externals/phase-imports-esm/webpack.config.js
@@ -24,13 +24,20 @@ module.exports = {
 		deferImport: true,
 		sourceImport: true
 	},
-	externalsType: "module",
 	externals: [
 		{
-			"ext-defer": "module ext-defer",
-			"ext-source": "module ext-source",
+			// Plain `module` externals — used at static (harmony) import sites.
+			"ext-mod-defer": "module ext-mod-defer",
+			"ext-mod-source": "module ext-mod-source",
+			// Plain `import` externals — used at dynamic `import(…)` sites.
 			"ext-import-defer": "import ext-import-defer",
 			"ext-import-source": "import ext-import-source",
+			// `module-import` externals resolve to `module` for static imports
+			// and to `import` for dynamic imports based on the consumer.
+			"ext-mi-defer-static": "module-import ext-mi-defer-static",
+			"ext-mi-source-static": "module-import ext-mi-source-static",
+			"ext-mi-defer-dynamic": "module-import ext-mi-defer-dynamic",
+			"ext-mi-source-dynamic": "module-import ext-mi-source-dynamic",
 			fs: "commonjs fs",
 			path: "commonjs path"
 		}

--- a/test/configCases/externals/phase-imports-esm/webpack.config.js
+++ b/test/configCases/externals/phase-imports-esm/webpack.config.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "es2020"],
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		main: "./index.js",
+		bundle: "./bundle.js"
+	},
+	output: {
+		filename: "[name].js",
+		module: true
+	},
+	optimization: {
+		concatenateModules: true,
+		usedExports: true
+	},
+	experiments: {
+		outputModule: true,
+		deferImport: true,
+		sourceImport: true
+	},
+	externalsType: "module",
+	externals: [
+		{
+			"ext-defer": "module ext-defer",
+			"ext-source": "module ext-source",
+			"ext-import-defer": "import ext-import-defer",
+			"ext-import-source": "import ext-import-source",
+			fs: "commonjs fs",
+			path: "commonjs path"
+		}
+	]
+};

--- a/test/configCases/externals/phase-imports-source/bundle.js
+++ b/test/configCases/externals/phase-imports-source/bundle.js
@@ -1,0 +1,7 @@
+// Source-phase static import of a sync `var` external.
+import source srcSync from "ext-var-sync";
+
+// Source-phase static import of an async `promise` external.
+import source srcAsync from "ext-promise-async";
+
+export { srcSync, srcAsync };

--- a/test/configCases/externals/phase-imports-source/index.js
+++ b/test/configCases/externals/phase-imports-source/index.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+it("should generate runtime code for source-phase imports of externals", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "bundle.js"),
+		"utf-8"
+	);
+
+	// The init-fragment key for source-phase imports is `source harmony import`,
+	// distinct from the regular `harmony import` key. The dependency template
+	// itself currently emits the same import statement as a regular harmony
+	// import (the source phase is not specially materialised for non-WASM
+	// externals at the static import site), but the keying ensures the import
+	// is still tracked separately from any eager namespace import of the same
+	// module.
+	expect(content).toContain(
+		"/* harmony import */ var ext_var_sync__WEBPACK_IMPORTED_MODULE"
+	);
+	expect(content).toContain(
+		"/* harmony import */ var ext_promise_async__WEBPACK_IMPORTED_MODULE"
+	);
+
+	// Source-phase static imports must not be lowered to the deferred runtime
+	// helper.
+	expect(content).not.toContain("__webpack_require__.zO(");
+});

--- a/test/configCases/externals/phase-imports-source/test.config.js
+++ b/test/configCases/externals/phase-imports-source/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => ["main.js"]
+};

--- a/test/configCases/externals/phase-imports-source/webpack.config.js
+++ b/test/configCases/externals/phase-imports-source/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = [
+	{
+		target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+		entry: {
+			main: "./index.js",
+			bundle: "./bundle.js"
+		},
+		output: {
+			filename: "[name].js"
+		},
+		optimization: {
+			concatenateModules: false
+		},
+		experiments: {
+			sourceImport: true
+		},
+		externals: {
+			"ext-var-sync": "var 'sync-value'",
+			"ext-promise-async": "promise Promise.resolve('async-value')"
+		}
+	}
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -9218,6 +9218,7 @@ type IgnorePluginOptions =
 type ImportAttributes = Record<string, string> & {};
 declare interface ImportDependencyMeta {
 	attributes?: ImportAttributes;
+	phase?: 0 | 1 | 2;
 	externalType?: "import" | "module";
 }
 type ImportExpressionJavascriptParser = ImportExpressionImport & {


### PR DESCRIPTION
## Summary

Phase imports (`import defer * as ns from "x"`, `import source x from "x"`, `import.defer("x")`, `import.source("x")`) are now respected on external dependencies the same way `import attributes` already are.

- For static `module` externals in ESM output, `ModuleExternalInitFragment` now emits `import defer * as <id> from "x"` for namespace defer imports and `import source <id> from "x"` for single-default source imports — instead of stripping the phase keyword.
- For dynamic `import` externals, `getSourceForImportExternal` emits `import.defer("x")` / `import.source("x")` when the `importFunctionName` is the default `"import"` and a phase is set on the dependency.
- `ImportDependencyMeta` now carries `phase` alongside `attributes` and `externalType`. `ExternalModule.identifier()` and `updateHash()` include `phase` and `attributes`, so the same external imported with two different phases (or attribute sets) no longer collapses into a single `ExternalModule` and silently drops one phase.
- `getSourceForModuleExternal` keeps `imported = true` (namespace form) when the dependency phase is `defer`, since `import defer` only has a valid namespace native syntax.

Three `configCases` cover the new behaviour:

- `externals/phase-imports-defer` — runtime case (`var` / `promise` externals, no `output.module`): asserts the optimized deferred runtime helper (`__webpack_require__.zO(...)`) is used for sync externals and skipped for already-async ones.
- `externals/phase-imports-source` — same shape for `source` phase against runtime-form externals.
- `externals/phase-imports-esm` — ESM output case (`output.module: true`) covering all three external types — `module`, `import`, `module-import` — at static and dynamic sites, plus a regression test for the same external imported with two different phases.

## What kind of change does this PR introduce?

feat

## Did you add tests for your changes?

yes — `test/configCases/externals/phase-imports-defer/`, `test/configCases/externals/phase-imports-source/`, `test/configCases/externals/phase-imports-esm/`.

## Does this PR introduce a breaking change?

no — externals that were not imported with a phase keyword are emitted exactly as before. The added `phase`/`attributes` material in `ExternalModule.identifier()` only changes the identifier when those fields are non-default, so caches built before this change for non-phase externals stay valid.

## If relevant, what needs to be documented…

n/a — the existing externals docs already describe `import attributes` flowing through unchanged; phase imports now flow through the same way and don't need a separate doc entry.

## Use of AI

Claude Code was used to draft the implementation and tests under human review.

https://claude.ai/code/session_01BKSJuH4X5zjxsszYXHRqy2