### PR TITLE
ci: stabilize CodSpeed memory benchmark measurements

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,6 +61,8 @@ jobs:
   benchmark-memory:
     strategy:
       fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -83,6 +85,12 @@ jobs:
 
       - run: yarn link webpack --frozen-lockfile
 
+      - name: Check Memory Status
+        run: >
+          node -e 'const os=require("os");
+          const toGb=b=>(b/1024**3).toFixed(2)+" GB";
+          console.log(`--- Memory Status ---\nTotal: ${toGb(os.totalmem())}\nFree:  ${toGb(os.freemem())}\nUsed:  ${toGb(os.totalmem()-os.freemem())}`)'
+
       - name: Run memory benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
@@ -92,3 +100,4 @@ jobs:
         env:
           LAST_COMMIT: 1
           NEGATIVE_FILTER: on-schedule
+          SHARD: ${{ matrix.shard }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,8 +61,6 @@ jobs:
   benchmark-memory:
     strategy:
       fail-fast: false
-      matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -100,4 +98,3 @@ jobs:
         env:
           LAST_COMMIT: 1
           NEGATIVE_FILTER: on-schedule
-          SHARD: ${{ matrix.shard }}

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -785,8 +785,64 @@ const withCodSpeed = async (bench) => {
 		 */
 		const finalizeSyncRun = () => finalizeBenchRun();
 
+		/**
+		 * Run a task's full lifecycle once with no instrumentation. Used as a
+		 * global prime pass for memory mode so module loads, V8 hidden-class
+		 * transitions, and inline-cache fills happen before any measurement —
+		 * removing the cross-task order-dependence that causes the same
+		 * benchmark to report different allocation counts across PRs.
+		 * @param {Task} task task
+		 * @returns {Promise<void>}
+		 */
+		const primeTaskAsync = async (task) => {
+			const meta = uriMap.get(task.name);
+			if (!meta) return;
+			await meta.options?.beforeAll?.call(task, "warmup");
+			try {
+				await iterationAsync(task, task.name);
+			} finally {
+				await meta.options?.afterAll?.call(task, "warmup");
+			}
+		};
+
+		/**
+		 * Sync version of primeTaskAsync.
+		 * @param {Task} task task
+		 */
+		const primeTaskSync = (task) => {
+			const meta = uriMap.get(task.name);
+			if (!meta) return;
+			meta.options?.beforeAll?.call(task, "warmup");
+			try {
+				iteration(task, task.name);
+			} finally {
+				meta.options?.afterAll?.call(task, "warmup");
+			}
+		};
+
 		bench.run = async () => {
 			setupBenchRun();
+
+			if (codspeedRunnerMode === "memory") {
+				console.log(
+					`[CodSpeed] memory mode: priming ${bench.tasks.length} tasks before measurement.`
+				);
+				for (const task of bench.tasks) {
+					await primeTaskAsync(task);
+				}
+				// Drain heap accumulated by the prime pass so it can't leak
+				// into the first measurement.
+				for (let i = 0; i < 4; i++) {
+					global.gc?.();
+					await new Promise((resolve) => {
+						queueMicrotask(() => resolve(undefined));
+					});
+				}
+				await new Promise((resolve) => {
+					setImmediate(resolve);
+				});
+				global.gc?.();
+			}
 
 			for (const task of bench.tasks) {
 				const uri = getTaskUri(bench, task.name, rootCallingFile);
@@ -798,6 +854,18 @@ const withCodSpeed = async (bench) => {
 
 		bench.runSync = () => {
 			setupBenchRun();
+
+			if (codspeedRunnerMode === "memory") {
+				console.log(
+					`[CodSpeed] memory mode: priming ${bench.tasks.length} tasks before measurement.`
+				);
+				for (const task of bench.tasks) {
+					primeTaskSync(task);
+				}
+				for (let i = 0; i < 4; i++) {
+					global.gc?.();
+				}
+			}
 
 			for (const task of bench.tasks) {
 				const uri = getTaskUri(bench, task.name, rootCallingFile);

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -545,10 +545,20 @@ const withCodSpeed = async (bench) => {
 	const rootCallingFile = getCallingFile();
 
 	if (codspeedRunnerMode === "simulation" || codspeedRunnerMode === "memory") {
+		// Memory mode counts allocations in the instrumented region. With `--no-opt`
+		// (required by CodSpeed analysis mode), JIT stabilization isn't a factor,
+		// so 2 warmup runs are enough to populate require.cache, webpack lazy
+		// singletons, and V8 hidden classes. More warmup just bloats the heap with
+		// garbage that the pre-measurement drain has to clean up, raising the
+		// chance of an in-measurement GC and introducing variance across PRs that
+		// would otherwise touch identical code paths.
+		const warmupIterations =
+			codspeedRunnerMode === "memory" ? 2 : bench.iterations - 1;
+
 		const setupBenchRun = () => {
 			setupCore();
 			console.log(
-				`[CodSpeed] running with @codspeed/tinybench (${codspeedRunnerMode} mode)`
+				`[CodSpeed] running with @codspeed/tinybench (${codspeedRunnerMode} mode, ${warmupIterations} warmup iterations)`
 			);
 		};
 		const finalizeBenchRun = () => {
@@ -647,21 +657,29 @@ const withCodSpeed = async (bench) => {
 				// polluted by module loading, lazy webpack init, and JIT shape transitions.
 				const samples = [];
 
-				while (samples.length < bench.iterations - 1) {
+				while (samples.length < warmupIterations) {
 					samples.push(await iterationAsync(task, name));
 				}
 			}
 
 			await options?.beforeEach?.call(task, "run");
 			await mongoMeasurement.start(uri);
-			// Two GCs + microtask drain: a single major GC can leave promoted-but-
-			// unreachable objects pending finalization, which would otherwise be
-			// attributed to the measured sample (especially under massif).
-			global.gc?.();
-			global.gc?.();
+			// Drain heap before the instrumented region so allocations from the
+			// warmup runs aren't attributed to the measured sample (especially
+			// under massif). One GC can leave promoted-but-unreachable objects
+			// pending finalization; finalizers themselves can allocate. Loop:
+			// GC -> microtask drain -> GC, repeated, then a final setImmediate
+			// drain so any pending IO callbacks settle before measurement.
+			for (let i = 0; i < 3; i++) {
+				global.gc?.();
+				await new Promise((resolve) => {
+					queueMicrotask(() => resolve(undefined));
+				});
+			}
 			await new Promise((resolve) => {
 				setImmediate(resolve);
 			});
+			global.gc?.();
 			await wrapWithInstrumentHooksAsync(wrapFunctionWithFrame(fn, true), uri);
 			await mongoMeasurement.stop(uri);
 			await options?.afterEach?.call(task, "run");
@@ -733,17 +751,19 @@ const withCodSpeed = async (bench) => {
 				// Custom warmup — see the async path for rationale.
 				const samples = [];
 
-				while (samples.length < bench.iterations - 1) {
+				while (samples.length < warmupIterations) {
 					samples.push(iteration(task, name));
 				}
 			}
 
 			options?.beforeEach?.call(task, "run");
 
-			// Two GCs so finalization doesn't leak allocations into the measured
-			// sample (sync path has no microtask queue to drain).
-			global.gc?.();
-			global.gc?.();
+			// Multiple GC passes so finalization (and any allocations finalizers
+			// trigger) doesn't leak into the measured sample. The sync path has no
+			// microtask queue to drain, so we just chain GCs.
+			for (let i = 0; i < 4; i++) {
+				global.gc?.();
+			}
 			wrapWithInstrumentHooks(wrapFunctionWithFrame(fn, false), uri);
 
 			options?.afterEach?.call(task, "run");

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -667,9 +667,11 @@ const withCodSpeed = async (bench) => {
 			// Drain heap before the instrumented region so allocations from the
 			// warmup runs aren't attributed to the measured sample (especially
 			// under massif). One GC can leave promoted-but-unreachable objects
-			// pending finalization; finalizers themselves can allocate. Loop:
-			// GC -> microtask drain -> GC, repeated, then a final setImmediate
-			// drain so any pending IO callbacks settle before measurement.
+			// pending finalization; finalizers themselves can allocate. Loop
+			// `gc -> microtask` three times so each GC's finalizers get a chance
+			// to run and any garbage they produce is collected on the next pass,
+			// then drain pending IO with `setImmediate`, then one final GC to
+			// catch anything the IO callbacks left behind.
 			for (let i = 0; i < 3; i++) {
 				global.gc?.();
 				await new Promise((resolve) => {
@@ -786,11 +788,19 @@ const withCodSpeed = async (bench) => {
 		const finalizeSyncRun = () => finalizeBenchRun();
 
 		/**
-		 * Run a task's full lifecycle once with no instrumentation. Used as a
-		 * global prime pass for memory mode so module loads, V8 hidden-class
-		 * transitions, and inline-cache fills happen before any measurement —
-		 * removing the cross-task order-dependence that causes the same
-		 * benchmark to report different allocation counts across PRs.
+		 * Run a task's per-task hooks plus one un-instrumented iteration. Used
+		 * as a global prime pass for memory mode so module loads, V8
+		 * hidden-class transitions, and inline-cache fills happen before any
+		 * measurement — removing the cross-task order-dependence that causes
+		 * the same benchmark to report different allocation counts across PRs.
+		 *
+		 * Intentionally skipped here: bench-level `setup` / `teardown`,
+		 * `beforeEach` / `afterEach`, `mongoMeasurement.start/stop`, and
+		 * `InstrumentHooks.startBenchmark/stopBenchmark`. Those belong to the
+		 * measurement loop and would either double-instrument or skew the
+		 * measured run if invoked here. `beforeAll` / `afterAll` are included
+		 * because they own setup/teardown that the iteration itself depends on
+		 * (e.g. the watch task opens its watcher in `beforeAll`).
 		 * @param {Task} task task
 		 * @returns {Promise<void>}
 		 */
@@ -806,7 +816,8 @@ const withCodSpeed = async (bench) => {
 		};
 
 		/**
-		 * Sync version of primeTaskAsync.
+		 * Sync version of primeTaskAsync — see that docstring for what is and
+		 * isn't included.
 		 * @param {Task} task task
 		 */
 		const primeTaskSync = (task) => {


### PR DESCRIPTION
## Summary

CodSpeed memory mode reported different allocation counts across PRs that touched identical code paths, producing false-positive regressions. The instability has two root causes that this PR addresses without sharding the `benchmark-memory` job:

1. **Cross-task order dependence in a single Node process.** Memory mode counts allocations between `InstrumentHooks.startBenchmark()` / `stopBenchmark()`. Whether V8 work (lazy module loading, hidden-class transitions, inline-cache fills) happens inside the instrumented region depends on which task ran earlier. PR A could allocate hidden class `HX` during task 3's measurement; PR B could allocate it during task 2's. CodSpeed sees that drift as a regression even when the code under test allocated identically.

   Fix: before the measurement loop, run a **global prime pass** that invokes every registered task's per-task hooks plus one un-instrumented iteration. By measurement time every task has been touched once, so module loads and V8 shape transitions cannot be attributed to any individual measurement. After the prime pass, drain the heap aggressively (`(gc + microtask) × 4 → setImmediate → gc`) so prime-pass allocations don't leak into the first measurement.

2. **Insufficient pre-measurement drain.** The previous drain was two `gc()` calls plus one `setImmediate`. Finalizers themselves can allocate, and one drain pass can leave them pending.

   Fix: replace with `(gc + microtask) × 3 → setImmediate → gc` so each GC's finalizers get a chance to run and any garbage they produce is collected on the next pass. Sync path chains four `gc()` calls (no microtask queue to await).

Per-task warmup is also reduced from `iterations - 1 = 7` to `2` for memory mode. With `--no-opt` (forced by CodSpeed analysis mode) JIT stabilization isn't a factor; the global prime pass + 2 per-task warmups are enough to converge inline caches without piling up garbage that the drain has to clean up.

A `Check Memory Status` diagnostic step is added to the `benchmark-memory` job to match the time job, so runner-level memory pressure can be inspected in CI logs.

## What kind of change does this PR introduce?

ci

## Did you add tests for your changes?

n/a — this is a CI / benchmark-harness change. The existing benchmark suite (`test/BenchmarkTestCases.benchmark.mjs`, run by the `Benchmarks` workflow) is the test for this change. The signal is whether CodSpeed memory numbers stabilize across PRs after this lands.

## Does this PR introduce a breaking change?

No. Only `.github/workflows/benchmarks.yml` and `test/BenchmarkTestCases.benchmark.mjs` are touched; no public API or runtime behavior changes.

## If relevant, what needs to be documented (`README.md`, `webpack.js.org`, `webpack-cli` etc.)?

n/a

## Use of AI

Claude Code drafted this change under human review. The investigation (reading the `benchmark-memory` workflow, the `withCodSpeed` wrapper, and the CodSpeed analysis-mode V8-flag requirements), the fix design (global prime pass + drain hardening + warmup reduction), the implementation, and the response to Copilot's review comments were produced by Claude Code; the maintainer reviewed and ran the changes.