### PR TITLE
Improve ChunkLoadError message for loaded chunks

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -188,7 +188,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 																"if(installedChunkData !== 0) installedChunks[chunkId] = undefined;",
 																"if(installedChunkData) {",
 																Template.indent([
-																	"var errorType = event && (event.type === 'load' ? 'missing' : event.type);",
+																	"var errorType = event && (event.type === 'load' ? 'loaded but not executed' : event.type);",
 																	"var realSrc = event && event.target && event.target.src;",
 																	"error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';",
 																	"error.name = 'ChunkLoadError';",
@@ -326,7 +326,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 										"if(waitingUpdateResolves[chunkId]) {",
 										Template.indent([
 											"waitingUpdateResolves[chunkId] = undefined",
-											"var errorType = event && (event.type === 'load' ? 'missing' : event.type);",
+											"var errorType = event && (event.type === 'load' ? 'loaded but not executed' : event.type);",
 											"var realSrc = event && event.target && event.target.src;",
 											"error.message = 'Loading hot update chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';",
 											"error.name = 'ChunkLoadError';",


### PR DESCRIPTION
**Summary**

This PR improves the `ChunkLoadError` message for cases where the script `load` event fires, but the chunk is still not registered as loaded.

Previously, webpack reported this case as `missing`, which can be misleading because the chunk script may have loaded successfully but failed during parsing, evaluation, or execution. This change updates the message to `loaded but not executed` to make the failure reason easier to understand while debugging.

Related to #16618

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No tests have been added yet. This is a small runtime error-message improvement, and I would appreciate maintainer guidance on the preferred test location or whether an existing runtime test should be updated.

**Does this PR introduce a breaking change?**

No. This only changes the wording of the `ChunkLoadError` type/message for this specific load-event case.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are required at this time.

**Use of AI**

I used AI assistance for learning support while understanding the issue discussion and navigating the webpack codebase. I manually reviewed the relevant file, made the code change myself, checked the diff, and verified it with `git diff --check` before submission. AI was not used to generate unreviewed code.