### PR TITLE
feat: support webpackIgnore magic comment in HTML modules

### DIFF
--- a/.changeset/html-modules-webpack-ignore.md
+++ b/.changeset/html-modules-webpack-ignore.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support the `webpackIgnore: true` magic comment in HTML modules. Placing `<!-- webpackIgnore: true -->` immediately before a tag tells webpack not to resolve any of that tag's `src`/`href`/`srcset`/… URLs and leave them untouched in the output, matching the behavior already provided by `html-loader`.

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -4,12 +4,19 @@
 
 "use strict";
 
+const vm = require("vm");
 const Parser = require("../Parser");
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
+const CommentCompilationWarning = require("../errors/CommentCompilationWarning");
 const ModuleDependencyError = require("../errors/ModuleDependencyError");
+const UnsupportedFeatureWarning = require("../errors/UnsupportedFeatureWarning");
 const WebpackError = require("../errors/WebpackError");
 const LocConverter = require("../util/LocConverter");
+const {
+	createMagicCommentContext,
+	webpackCommentRegExp
+} = require("../util/magicComment");
 const walkHtmlTokens = require("./walkHtmlTokens");
 
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
@@ -722,6 +729,11 @@ const DEFAULT_SOURCES = new Map([
 ]);
 
 class HtmlParser extends Parser {
+	constructor() {
+		super();
+		this.magicCommentContext = createMagicCommentContext();
+	}
+
 	/**
 	 * Parses the provided source and updates the parser state.
 	 * @param {string | Buffer | PreparsedAst} source the source to parse
@@ -745,8 +757,85 @@ class HtmlParser extends Parser {
 		/** @type {{ nameStart: number, nameEnd: number, valueStart: number, valueEnd: number }[]} */
 		const pendingAttributes = [];
 
+		/**
+		 * Tracks the `webpackIgnore` value from the most recent comment that
+		 * appears before the next tag. Reset whenever a tag is emitted or a
+		 * comment without a `webpackIgnore` value is encountered.
+		 * @type {boolean | undefined}
+		 */
+		let pendingWebpackIgnore;
+
+		const magicCommentContext = this.magicCommentContext;
+
 		// TODO implement full HTML parser (WASM)
 		walkHtmlTokens(source, 0, {
+			comment: (input, start, end) => {
+				// Strip the `<!--` prefix and `-->` suffix; tolerate truncated
+				// comments at EOF (the tokenizer flushes any open comment with
+				// the buffer end as `end`).
+				const contentStart = start + 4;
+				const contentEnd =
+					end >= contentStart + 3 &&
+					input.charCodeAt(end - 1) === 0x3e /* > */ &&
+					input.charCodeAt(end - 2) === 0x2d /* - */ &&
+					input.charCodeAt(end - 3) === 0x2d /* - */
+						? end - 3
+						: end;
+				if (contentEnd <= contentStart) {
+					pendingWebpackIgnore = undefined;
+					return end;
+				}
+				const value = input.slice(contentStart, contentEnd);
+				if (!webpackCommentRegExp.test(value)) {
+					pendingWebpackIgnore = undefined;
+					return end;
+				}
+				/** @type {Record<string, EXPECTED_ANY>} */
+				let options;
+				try {
+					options = vm.runInContext(
+						`(function(){return {${value}};})()`,
+						magicCommentContext
+					);
+				} catch (err) {
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					module.addWarning(
+						new CommentCompilationWarning(
+							`Compilation error while processing magic comment(-s): /*${value}*/: ${
+								/** @type {Error} */ (err).message
+							}`,
+							{
+								start: { line: sl, column: sc },
+								end: { line: el, column: ec }
+							}
+						)
+					);
+					pendingWebpackIgnore = undefined;
+					return end;
+				}
+				if (options.webpackIgnore === undefined) {
+					pendingWebpackIgnore = undefined;
+					return end;
+				}
+				if (typeof options.webpackIgnore !== "boolean") {
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					module.addWarning(
+						new UnsupportedFeatureWarning(
+							`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
+							{
+								start: { line: sl, column: sc },
+								end: { line: el, column: ec }
+							}
+						)
+					);
+					pendingWebpackIgnore = undefined;
+					return end;
+				}
+				pendingWebpackIgnore = options.webpackIgnore;
+				return end;
+			},
 			attribute: (
 				input,
 				nameStart,
@@ -761,7 +850,17 @@ class HtmlParser extends Parser {
 					? valueEnd + 1
 					: valueEnd;
 			},
+			closeTag: (input, start, end) => {
+				pendingWebpackIgnore = undefined;
+				return end;
+			},
 			openTag: (input, start, end, nameStart, nameEnd) => {
+				const ignore = pendingWebpackIgnore === true;
+				pendingWebpackIgnore = undefined;
+				if (ignore) {
+					pendingAttributes.length = 0;
+					return end;
+				}
 				const elementName = input.slice(nameStart, nameEnd).toLowerCase();
 				const sources = DEFAULT_SOURCES.get(elementName);
 

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -770,21 +770,25 @@ class HtmlParser extends Parser {
 		// TODO implement full HTML parser (WASM)
 		walkHtmlTokens(source, 0, {
 			comment: (input, start, end) => {
-				// Strip the `<!--` prefix and `-->` suffix; tolerate truncated
-				// comments at EOF (the tokenizer flushes any open comment with
-				// the buffer end as `end`).
-				const contentStart = start + 4;
-				const contentEnd =
-					end >= contentStart + 3 &&
-					input.charCodeAt(end - 1) === 0x3e /* > */ &&
-					input.charCodeAt(end - 2) === 0x2d /* - */ &&
-					input.charCodeAt(end - 3) === 0x2d /* - */
-						? end - 3
-						: end;
-				if (contentEnd <= contentStart) {
+				// Only proper `<!-- ... -->` comments carry magic comments.
+				// `walkHtmlTokens` also dispatches this callback for bogus
+				// comments such as `<!DOCTYPE …>` and `<?…>`, which must not
+				// be parsed as magic comments.
+				if (
+					end - start < 7 ||
+					input.charCodeAt(start) !== 0x3c /* < */ ||
+					input.charCodeAt(start + 1) !== 0x21 /* ! */ ||
+					input.charCodeAt(start + 2) !== 0x2d /* - */ ||
+					input.charCodeAt(start + 3) !== 0x2d /* - */ ||
+					input.charCodeAt(end - 1) !== 0x3e /* > */ ||
+					input.charCodeAt(end - 2) !== 0x2d /* - */ ||
+					input.charCodeAt(end - 3) !== 0x2d /* - */
+				) {
 					pendingWebpackIgnore = undefined;
 					return end;
 				}
+				const contentStart = start + 4;
+				const contentEnd = end - 3;
 				const value = input.slice(contentStart, contentEnd);
 				if (!webpackCommentRegExp.test(value)) {
 					pendingWebpackIgnore = undefined;

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
@@ -32,6 +32,9 @@ exports[`ConfigCacheTestCases html webpack-ignore exported tests should support 
 
 <!-- webpackIgnore: 1 -->
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
+
+<!? webpackIgnore: true ?>
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"bogus-comment-not-magic\\">
 </body>
 </html>
 "

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html webpack-ignore exported tests should support webpackIgnore magic comment in html modules 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>webpackIgnore</title></head>
+<body>
+<!-- Resolved: no comment -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"resolved\\">
+
+<!-- webpackIgnore: true -->
+<img src=\\"./ignored.png\\" alt=\\"ignored\\">
+
+<!-- webpackIgnore: false -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"resolved-explicit-false\\">
+
+<!--  webpackIgnore:   true  -->
+<img src=\\"./still-ignored.png\\" srcset=\\"./still-ignored.png 2x\\" alt=\\"ignored-with-srcset\\">
+
+<!-- webpackIgnore: true -->
+<!-- a regular comment overrides the webpackIgnore -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"overridden\\">
+
+<!-- not-a-magic-comment -->
+<!-- webpackIgnore: true -->
+<img src=\\"./still-ignored2.png\\" alt=\\"ignored-last-wins\\">
+
+<!-- webpackIgnore: true -->
+<div>
+	<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"nested-not-ignored\\">
+</div>
+
+<!-- webpackIgnore: 1 -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html webpack-ignore exported tests should support webpackIgnore magic comment in html modules 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>webpackIgnore</title></head>
+<body>
+<!-- Resolved: no comment -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"resolved\\">
+
+<!-- webpackIgnore: true -->
+<img src=\\"./ignored.png\\" alt=\\"ignored\\">
+
+<!-- webpackIgnore: false -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"resolved-explicit-false\\">
+
+<!--  webpackIgnore:   true  -->
+<img src=\\"./still-ignored.png\\" srcset=\\"./still-ignored.png 2x\\" alt=\\"ignored-with-srcset\\">
+
+<!-- webpackIgnore: true -->
+<!-- a regular comment overrides the webpackIgnore -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"overridden\\">
+
+<!-- not-a-magic-comment -->
+<!-- webpackIgnore: true -->
+<img src=\\"./still-ignored2.png\\" alt=\\"ignored-last-wins\\">
+
+<!-- webpackIgnore: true -->
+<div>
+	<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"nested-not-ignored\\">
+</div>
+
+<!-- webpackIgnore: 1 -->
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
@@ -32,6 +32,9 @@ exports[`ConfigTestCases html webpack-ignore exported tests should support webpa
 
 <!-- webpackIgnore: 1 -->
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
+
+<!? webpackIgnore: true ?>
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"bogus-comment-not-magic\\">
 </body>
 </html>
 "

--- a/test/configCases/html/webpack-ignore/index.js
+++ b/test/configCases/html/webpack-ignore/index.js
@@ -1,0 +1,29 @@
+import page from "./page.html";
+
+it("should support webpackIgnore magic comment in html modules", () => {
+	expect(typeof page).toBe("string");
+	// Resolved URLs are rewritten to a hashed asset filename without the
+	// leading "./".
+	expect(page).toMatch(/<img src="[a-f0-9]+\.png" alt="resolved">/);
+	expect(page).toMatch(
+		/<img src="[a-f0-9]+\.png" alt="resolved-explicit-false">/
+	);
+	expect(page).toMatch(/<img src="[a-f0-9]+\.png" alt="overridden">/);
+	// Nested img inside an ignored parent must still be processed.
+	expect(page).toMatch(
+		/<img src="[a-f0-9]+\.png" alt="nested-not-ignored">/
+	);
+	// Ignored URLs remain unchanged in the output.
+	expect(page).toContain('<img src="./ignored.png" alt="ignored">');
+	expect(page).toContain(
+		'<img src="./still-ignored.png" srcset="./still-ignored.png 2x" alt="ignored-with-srcset">'
+	);
+	expect(page).toContain(
+		'<img src="./still-ignored2.png" alt="ignored-last-wins">'
+	);
+	// Non-boolean webpackIgnore should not ignore; original src is replaced.
+	expect(page).toMatch(
+		/<img src="[a-f0-9]+\.png" alt="warning-non-boolean">/
+	);
+	expect(page).toMatchSnapshot();
+});

--- a/test/configCases/html/webpack-ignore/index.js
+++ b/test/configCases/html/webpack-ignore/index.js
@@ -25,5 +25,10 @@ it("should support webpackIgnore magic comment in html modules", () => {
 	expect(page).toMatch(
 		/<img src="[a-f0-9]+\.png" alt="warning-non-boolean">/
 	);
+	// A "bogus comment" (e.g. `<? … ?>`) must not be parsed as a magic
+	// comment even if its body happens to contain `webpackIgnore`.
+	expect(page).toMatch(
+		/<img src="[a-f0-9]+\.png" alt="bogus-comment-not-magic">/
+	);
 	expect(page).toMatchSnapshot();
 });

--- a/test/configCases/html/webpack-ignore/page.html
+++ b/test/configCases/html/webpack-ignore/page.html
@@ -29,5 +29,8 @@
 
 <!-- webpackIgnore: 1 -->
 <img src="./image.png" alt="warning-non-boolean">
+
+<!? webpackIgnore: true ?>
+<img src="./image.png" alt="bogus-comment-not-magic">
 </body>
 </html>

--- a/test/configCases/html/webpack-ignore/page.html
+++ b/test/configCases/html/webpack-ignore/page.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head><title>webpackIgnore</title></head>
+<body>
+<!-- Resolved: no comment -->
+<img src="./image.png" alt="resolved">
+
+<!-- webpackIgnore: true -->
+<img src="./ignored.png" alt="ignored">
+
+<!-- webpackIgnore: false -->
+<img src="./image.png" alt="resolved-explicit-false">
+
+<!--  webpackIgnore:   true  -->
+<img src="./still-ignored.png" srcset="./still-ignored.png 2x" alt="ignored-with-srcset">
+
+<!-- webpackIgnore: true -->
+<!-- a regular comment overrides the webpackIgnore -->
+<img src="./image.png" alt="overridden">
+
+<!-- not-a-magic-comment -->
+<!-- webpackIgnore: true -->
+<img src="./still-ignored2.png" alt="ignored-last-wins">
+
+<!-- webpackIgnore: true -->
+<div>
+	<img src="./image.png" alt="nested-not-ignored">
+</div>
+
+<!-- webpackIgnore: 1 -->
+<img src="./image.png" alt="warning-non-boolean">
+</body>
+</html>

--- a/test/configCases/html/webpack-ignore/warnings.js
+++ b/test/configCases/html/webpack-ignore/warnings.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [/`webpackIgnore` expected a boolean, but received: 1\./];

--- a/test/configCases/html/webpack-ignore/webpack.config.js
+++ b/test/configCases/html/webpack-ignore/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	experiments: {
+		html: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -8833,7 +8833,9 @@ declare abstract class HtmlGenerator extends Generator {
 		generateContext: GenerateContext
 	): null | Source;
 }
-declare abstract class HtmlParser extends ParserClass {}
+declare abstract class HtmlParser extends ParserClass {
+	magicCommentContext: ContextImport;
+}
 
 /**
  * Options for building http resources.


### PR DESCRIPTION
Adds support for `<!-- webpackIgnore: true -->` placed before an HTML
element to skip URL resolution for that element's sources, mirroring
the behavior provided by html-loader. The comment value is parsed with
the same magic-comment context used by JS/CSS parsers; non-boolean
values emit an UnsupportedFeatureWarning.