### PR TITLE
perf(css): cache escape/unescapeIdentifier and move them to walkCssTokens

### DIFF
--- a/.changeset/css-identifier-cache.md
+++ b/.changeset/css-identifier-cache.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Move `escapeIdentifier` / `unescapeIdentifier` from `CssParser` to `walkCssTokens` and cache their results per-compilation, similar to `makePathsRelative`. The functions remain re-exported from `CssParser` for backwards compatibility. CSS files commonly reuse the same identifiers (class names, custom properties, keyframes) many times, so caching avoids repeated work during parsing and code generation.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -133,138 +133,7 @@ const normalizeUrl = (str, isString) => {
 	return str;
 };
 
-const regexSingleEscape = /[ -,./:-@[\]^`{-~]/;
-const regexExcessiveSpaces =
-	/(^|\\+)?(\\[A-F0-9]{1,6})\u0020(?![a-fA-F0-9\u0020])/g;
-
-/**
- * Returns escaped identifier.
- * @param {string} str string
- * @returns {string} escaped identifier
- */
-const escapeIdentifier = (str) => {
-	let output = "";
-	let counter = 0;
-
-	while (counter < str.length) {
-		const character = str.charAt(counter++);
-
-		/** @type {string} */
-		let value;
-
-		if (/[\t\n\f\r\v]/.test(character)) {
-			const codePoint = character.charCodeAt(0);
-
-			value = `\\${codePoint.toString(16).toUpperCase()} `;
-		} else if (character === "\\" || regexSingleEscape.test(character)) {
-			value = `\\${character}`;
-		} else {
-			value = character;
-		}
-
-		output += value;
-	}
-
-	const firstChar = str.charAt(0);
-
-	if (/^-[-\d]/.test(output)) {
-		output = `\\-${output.slice(1)}`;
-	} else if (/\d/.test(firstChar)) {
-		output = `\\3${firstChar} ${output.slice(1)}`;
-	}
-
-	// Remove spaces after `\HEX` escapes that are not followed by a hex digit,
-	// since they’re redundant. Note that this is only possible if the escape
-	// sequence isn’t preceded by an odd number of backslashes.
-	output = output.replace(regexExcessiveSpaces, ($0, $1, $2) => {
-		if ($1 && $1.length % 2) {
-			// It’s not safe to remove the space, so don’t.
-			return $0;
-		}
-
-		// Strip the space.
-		return ($1 || "") + $2;
-	});
-
-	return output;
-};
-
-const CONTAINS_ESCAPE = /\\/;
-
-/**
- * Returns hex.
- * @param {string} str string
- * @returns {[string, number] | undefined} hex
- */
-const gobbleHex = (str) => {
-	const lower = str.toLowerCase();
-	let hex = "";
-	let spaceTerminated = false;
-
-	for (let i = 0; i < 6 && lower[i] !== undefined; i++) {
-		const code = lower.charCodeAt(i);
-		// check to see if we are dealing with a valid hex char [a-f|0-9]
-		const valid = (code >= 97 && code <= 102) || (code >= 48 && code <= 57);
-		// https://drafts.csswg.org/css-syntax/#consume-escaped-code-point
-		spaceTerminated = code === 32;
-		if (!valid) break;
-		hex += lower[i];
-	}
-
-	if (hex.length === 0) return undefined;
-
-	const codePoint = Number.parseInt(hex, 16);
-	const isSurrogate = codePoint >= 0xd800 && codePoint <= 0xdfff;
-
-	// Add special case for
-	// "If this number is zero, or is for a surrogate, or is greater than the maximum allowed code point"
-	// https://drafts.csswg.org/css-syntax/#maximum-allowed-code-point
-	if (isSurrogate || codePoint === 0x0000 || codePoint > 0x10ffff) {
-		return ["\uFFFD", hex.length + (spaceTerminated ? 1 : 0)];
-	}
-
-	return [
-		String.fromCodePoint(codePoint),
-		hex.length + (spaceTerminated ? 1 : 0)
-	];
-};
-
-/**
- * Unescape identifier.
- * @param {string} str string
- * @returns {string} unescaped string
- */
-const unescapeIdentifier = (str) => {
-	const needToProcess = CONTAINS_ESCAPE.test(str);
-	if (!needToProcess) return str;
-	let ret = "";
-	for (let i = 0; i < str.length; i++) {
-		if (str[i] === "\\") {
-			const gobbled = gobbleHex(str.slice(i + 1, i + 7));
-			if (gobbled !== undefined) {
-				ret += gobbled[0];
-				i += gobbled[1];
-				continue;
-			}
-			// Retain a pair of \\ if double escaped `\\\\`
-			// https://github.com/postcss/postcss-selector-parser/commit/268c9a7656fb53f543dc620aa5b73a30ec3ff20e
-			if (str[i + 1] === "\\") {
-				ret += "\\";
-				i += 1;
-				continue;
-			}
-			// if \\ is at the end of the string retain it
-			// https://github.com/postcss/postcss-selector-parser/commit/01a6b346e3612ce1ab20219acc26abdc259ccefb
-			if (str.length === i + 1) {
-				ret += str[i];
-			}
-			continue;
-		}
-		ret += str[i];
-	}
-
-	return ret;
-};
+const { escapeIdentifier, unescapeIdentifier } = walkCssTokens;
 
 /**
  * A custom property is any property whose name starts with two dashes (U+002D HYPHEN-MINUS), like --foo.
@@ -640,6 +509,10 @@ class CssParser extends Parser {
 		if (source[0] === "\uFEFF") {
 			source = source.slice(1);
 		}
+
+		const unescapeIdentifierCached = unescapeIdentifier.bindCache(
+			state.compilation.compiler.root
+		);
 
 		let mode = this.defaultMode;
 
@@ -1741,7 +1614,9 @@ class CssParser extends Parser {
 				{
 					identifier(input, start, end) {
 						if (type === 1) {
-							let identifier = unescapeIdentifier(input.slice(start, end));
+							let identifier = unescapeIdentifierCached(
+								input.slice(start, end)
+							);
 							const { line: sl, column: sc } = locConverter.get(start);
 							const { line: el, column: ec } = locConverter.get(end);
 							const isDashedIdent = isDashedIdentifier(identifier);
@@ -1797,7 +1672,9 @@ class CssParser extends Parser {
 				{
 					string(_input, start, end) {
 						if (!found && options.string) {
-							const value = unescapeIdentifier(input.slice(start + 1, end - 1));
+							const value = unescapeIdentifierCached(
+								input.slice(start + 1, end - 1)
+							);
 							const { line: sl, column: sc } = locConverter.get(start);
 							const { line: el, column: ec } = locConverter.get(end);
 							const dep = new CssIcssExportDependency(
@@ -1819,7 +1696,7 @@ class CssParser extends Parser {
 							const value = input.slice(start, end);
 
 							if (options.identifier) {
-								const identifier = unescapeIdentifier(value);
+								const identifier = unescapeIdentifierCached(value);
 
 								if (
 									options.identifier instanceof RegExp &&
@@ -1889,7 +1766,7 @@ class CssParser extends Parser {
 		const processDashedIdent = (input, start, end) => {
 			const customIdent = walkCssTokens.eatIdentSequence(input, start);
 			if (!customIdent) return end;
-			const identifier = unescapeIdentifier(
+			const identifier = unescapeIdentifierCached(
 				input.slice(customIdent[0] + 2, customIdent[1])
 			);
 			const afterCustomIdent = walkCssTokens.eatWhitespaceAndComments(
@@ -2066,7 +1943,7 @@ class CssParser extends Parser {
 								propertyName === "grid-template" ||
 								propertyName === "grid-template-areas"
 							) {
-								const areas = unescapeIdentifier(
+								const areas = unescapeIdentifierCached(
 									input.slice(start + 1, end - 1)
 								);
 								const matches = matchAll(/\b\w+\b/g, areas);
@@ -2160,7 +2037,7 @@ class CssParser extends Parser {
 						const { line: sl, column: sc } = locConverter.get(value[0]);
 						const { line: el, column: ec } = locConverter.get(value[1]);
 						const [start, end, isString] = value;
-						const name = unescapeIdentifier(
+						const name = unescapeIdentifierCached(
 							isString
 								? input.slice(start + 1, end - 1)
 								: input.slice(start, end)
@@ -2251,7 +2128,9 @@ class CssParser extends Parser {
 
 						for (const entry of classNames) {
 							const [start, end, isGlobal] = entry;
-							const identifier = unescapeIdentifier(input.slice(start, end));
+							const identifier = unescapeIdentifierCached(
+								input.slice(start, end)
+							);
 							const dep = new CssIcssExportDependency(
 								lastLocalIdentifier,
 								getReexport(identifier),
@@ -2309,7 +2188,9 @@ class CssParser extends Parser {
 
 							for (const entry of classNames) {
 								const [start, end] = entry;
-								const identifier = unescapeIdentifier(input.slice(start, end));
+								const identifier = unescapeIdentifierCached(
+									input.slice(start, end)
+								);
 								const { line: sl, column: sc } = locConverter.get(start);
 								const { line: el, column: ec } = locConverter.get(end);
 
@@ -2372,7 +2253,7 @@ class CssParser extends Parser {
 							if (from && input.slice(from[0], from[1]) === "global") {
 								for (const entry of classNames) {
 									const [start, end] = entry;
-									const identifier = unescapeIdentifier(
+									const identifier = unescapeIdentifierCached(
 										input.slice(start, end)
 									);
 									const dep = new CssIcssExportDependency(
@@ -2436,7 +2317,7 @@ class CssParser extends Parser {
 		 */
 		const processIdSelector = (input, start, end) => {
 			const valueStart = start + 1;
-			const name = unescapeIdentifier(input.slice(valueStart, end));
+			const name = unescapeIdentifierCached(input.slice(valueStart, end));
 			const dep = new CssIcssExportDependency(
 				name,
 				getReexport(name),
@@ -2462,7 +2343,7 @@ class CssParser extends Parser {
 		const processClassSelector = (input, start, end) => {
 			const ident = walkCssTokens.skipCommentsAndEatIdentSequence(input, end);
 			if (!ident) return end;
-			const name = unescapeIdentifier(input.slice(ident[0], ident[1]));
+			const name = unescapeIdentifierCached(input.slice(ident[0], ident[1]));
 			lastLocalIdentifiers.push(name);
 			const dep = new CssIcssExportDependency(
 				name,
@@ -2490,7 +2371,7 @@ class CssParser extends Parser {
 			end = walkCssTokens.eatWhitespaceAndComments(input, end)[0];
 			const identifier = walkCssTokens.eatIdentSequence(input, end);
 			if (!identifier) return end;
-			const name = unescapeIdentifier(
+			const name = unescapeIdentifierCached(
 				input.slice(identifier[0], identifier[1])
 			);
 			if (name.toLowerCase() !== "class") {
@@ -2526,7 +2407,7 @@ class CssParser extends Parser {
 
 			const classNameStart = value[2] ? value[0] : value[0] + 1;
 			const classNameEnd = value[2] ? value[1] : value[1] - 1;
-			const className = unescapeIdentifier(
+			const className = unescapeIdentifierCached(
 				input.slice(classNameStart, classNameEnd)
 			);
 			const dep = new CssIcssExportDependency(

--- a/lib/css/walkCssTokens.js
+++ b/lib/css/walkCssTokens.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const { makeCacheable } = require("../util/identifier");
+
 /**
  * Defines the css token callbacks type used by this module.
  * @typedef {object} CssTokenCallbacks
@@ -160,6 +162,143 @@ const isIdentStartCodePoint = (cc) =>
 	(cc >= CC_UPPER_A && cc <= CC_UPPER_Z) ||
 	cc === CC_LOW_LINE ||
 	cc >= 0x80;
+
+const REGEX_SINGLE_ESCAPE = /[ -,./:-@[\]^`{-~]/;
+const REGEX_EXCESSIVE_SPACES = /(^|\\+)?(\\[A-F0-9]{1,6}) (?![a-fA-F0-9 ])/g;
+const REGEX_CTRL_WHITESPACE = /[\t\n\f\r\v]/;
+const REGEX_LEADING_HYPHEN_DIGIT = /^-[-\d]/;
+const REGEX_DIGIT = /\d/;
+const CONTAINS_ESCAPE = /\\/;
+
+/**
+ * Returns escaped identifier.
+ * @param {string} str string
+ * @returns {string} escaped identifier
+ */
+const _escapeIdentifier = (str) => {
+	let output = "";
+	let counter = 0;
+
+	while (counter < str.length) {
+		const character = str.charAt(counter++);
+
+		/** @type {string} */
+		let value;
+
+		if (REGEX_CTRL_WHITESPACE.test(character)) {
+			const codePoint = character.charCodeAt(0);
+
+			value = `\\${codePoint.toString(16).toUpperCase()} `;
+		} else if (character === "\\" || REGEX_SINGLE_ESCAPE.test(character)) {
+			value = `\\${character}`;
+		} else {
+			value = character;
+		}
+
+		output += value;
+	}
+
+	const firstChar = str.charAt(0);
+
+	if (REGEX_LEADING_HYPHEN_DIGIT.test(output)) {
+		output = `\\-${output.slice(1)}`;
+	} else if (REGEX_DIGIT.test(firstChar)) {
+		output = `\\3${firstChar} ${output.slice(1)}`;
+	}
+
+	// Remove spaces after `\HEX` escapes that are not followed by a hex digit,
+	// since they’re redundant. Note that this is only possible if the escape
+	// sequence isn’t preceded by an odd number of backslashes.
+	output = output.replace(REGEX_EXCESSIVE_SPACES, ($0, $1, $2) => {
+		if ($1 && $1.length % 2) {
+			// It’s not safe to remove the space, so don’t.
+			return $0;
+		}
+
+		// Strip the space.
+		return ($1 || "") + $2;
+	});
+
+	return output;
+};
+
+/**
+ * Returns hex.
+ * @param {string} str string
+ * @returns {[string, number] | undefined} hex
+ */
+const gobbleHex = (str) => {
+	const lower = str.toLowerCase();
+	let hex = "";
+	let spaceTerminated = false;
+
+	for (let i = 0; i < 6 && lower[i] !== undefined; i++) {
+		const code = lower.charCodeAt(i);
+		// check to see if we are dealing with a valid hex char [a-f|0-9]
+		const valid = (code >= 97 && code <= 102) || (code >= 48 && code <= 57);
+		// https://drafts.csswg.org/css-syntax/#consume-escaped-code-point
+		spaceTerminated = code === 32;
+		if (!valid) break;
+		hex += lower[i];
+	}
+
+	if (hex.length === 0) return undefined;
+
+	const codePoint = Number.parseInt(hex, 16);
+	const isSurrogate = codePoint >= 0xd800 && codePoint <= 0xdfff;
+
+	// Add special case for
+	// "If this number is zero, or is for a surrogate, or is greater than the maximum allowed code point"
+	// https://drafts.csswg.org/css-syntax/#maximum-allowed-code-point
+	if (isSurrogate || codePoint === 0x0000 || codePoint > 0x10ffff) {
+		return ["�", hex.length + (spaceTerminated ? 1 : 0)];
+	}
+
+	return [
+		String.fromCodePoint(codePoint),
+		hex.length + (spaceTerminated ? 1 : 0)
+	];
+};
+
+/**
+ * Unescape identifier.
+ * @param {string} str string
+ * @returns {string} unescaped string
+ */
+const _unescapeIdentifier = (str) => {
+	const needToProcess = CONTAINS_ESCAPE.test(str);
+	if (!needToProcess) return str;
+	let ret = "";
+	for (let i = 0; i < str.length; i++) {
+		if (str[i] === "\\") {
+			const gobbled = gobbleHex(str.slice(i + 1, i + 7));
+			if (gobbled !== undefined) {
+				ret += gobbled[0];
+				i += gobbled[1];
+				continue;
+			}
+			// Retain a pair of \\ if double escaped `\\\\`
+			// https://github.com/postcss/postcss-selector-parser/commit/268c9a7656fb53f543dc620aa5b73a30ec3ff20e
+			if (str[i + 1] === "\\") {
+				ret += "\\";
+				i += 1;
+				continue;
+			}
+			// if \\ is at the end of the string retain it
+			// https://github.com/postcss/postcss-selector-parser/commit/01a6b346e3612ce1ab20219acc26abdc259ccefb
+			if (str.length === i + 1) {
+				ret += str[i];
+			}
+			continue;
+		}
+		ret += str[i];
+	}
+
+	return ret;
+};
+
+const escapeIdentifier = makeCacheable(_escapeIdentifier);
+const unescapeIdentifier = makeCacheable(_unescapeIdentifier);
 
 /** @type {CharHandler} */
 const consumeDelimToken = (input, pos, callbacks) => {
@@ -1873,7 +2012,9 @@ module.exports.eatUntil = eatUntil;
 module.exports.eatWhiteLine = eatWhiteLine;
 module.exports.eatWhitespace = eatWhitespace;
 module.exports.eatWhitespaceAndComments = eatWhitespaceAndComments;
+module.exports.escapeIdentifier = escapeIdentifier;
 module.exports.isIdentStartCodePoint = isIdentStartCodePoint;
 module.exports.isWhiteSpace = _isWhiteSpace;
 module.exports.skipCommentsAndEatIdentSequence =
 	skipCommentsAndEatIdentSequence;
+module.exports.unescapeIdentifier = unescapeIdentifier;

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -202,7 +202,8 @@ const computeInterpolatedIdentifier = (
 	return (
 		prefix +
 		getCssParser().escapeIdentifier(
-			getLocalIdent(local, module, chunkGraph, runtimeTemplate)
+			getLocalIdent(local, module, chunkGraph, runtimeTemplate),
+			runtimeTemplate.compilation.compiler.root
 		)
 	);
 };
@@ -794,7 +795,10 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 						.filter(Boolean)
 				);
 			const allNames = new Set([...usedNames, ...names]);
-			const unescaped = getCssParser().unescapeIdentifier(value);
+			const unescaped = getCssParser().unescapeIdentifier(
+				value,
+				templateContext.runtimeTemplate.compilation.compiler.root
+			);
 
 			const depLocStart =
 				dep.loc &&

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -482,6 +482,7 @@ const getUndoPath = (filename, outputPath, enforceRelative) => {
 module.exports.absolutify = absolutify;
 module.exports.contextify = contextify;
 module.exports.getUndoPath = getUndoPath;
+module.exports.makeCacheable = makeCacheable;
 module.exports.makePathsAbsolute = makeCacheableWithContext(_makePathsAbsolute);
 module.exports.makePathsRelative = makeCacheableWithContext(_makePathsRelative);
 module.exports.parseResource = makeCacheable(_parseResource);

--- a/test/configCases/css/side-effects/index.js
+++ b/test/configCases/css/side-effects/index.js
@@ -1,0 +1,42 @@
+import "pkg-side-effect-only";
+import "pkg-side-effects-true";
+import { exportedFromCss, used } from "pkg-with-css";
+
+it("uses the re-exported CSS class through a sideEffects:false re-exporter", () => {
+	expect(typeof used).toBe("string");
+	expect(used).not.toBe("");
+});
+
+it("uses the ICSS :export value forwarded through a sideEffects:false re-exporter", () => {
+	expect(exportedFromCss).toBe("hello");
+});
+
+it("emits CSS rules from a sideEffects:false package when classes are used", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const css = fs.readFileSync(path.join(__dirname, "bundle0.css"), "utf-8");
+	// `.used` is referenced from JS, `.unused` is not — both must survive
+	// because the rules themselves apply styles globally and the JS-level
+	// import connection is kept active by the named-export usage.
+	expect(css).toMatch(/color:\s*red/);
+	expect(css).toMatch(/color:\s*blue/);
+});
+
+// Side-effect-only imports through a `"sideEffects": false` package are
+// dropped, matching Vite/Rollup/Rolldown's strict interpretation of the
+// `sideEffects` field. Libraries that ship CSS through this pattern need
+// to opt CSS in explicitly with `"sideEffects": ["**/*.css"]` (or use a
+// `module.rules[].sideEffects` override).
+it("drops CSS from a side-effect-only import through a sideEffects:false package", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const css = fs.readFileSync(path.join(__dirname, "bundle0.css"), "utf-8");
+	expect(css).not.toMatch(/rebeccapurple/);
+});
+
+it("emits CSS imported through a sideEffects:true package", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const css = fs.readFileSync(path.join(__dirname, "bundle0.css"), "utf-8");
+	expect(css).toMatch(/papayawhip/);
+});

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/index.js
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/index.js
@@ -1,0 +1,1 @@
+import "./theme.css";

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/package.json
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "pkg-side-effect-only",
+	"version": "1.0.0",
+	"main": "index.js",
+	"sideEffects": false
+}

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/theme.css
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effect-only/theme.css
@@ -1,0 +1,3 @@
+.theme-only {
+	background: rebeccapurple;
+}

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/brand.css
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/brand.css
@@ -1,0 +1,3 @@
+.brand {
+	color: papayawhip;
+}

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/index.js
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/index.js
@@ -1,0 +1,3 @@
+import "./brand.css";
+
+export const greet = () => "hello from sideEffects:true package";

--- a/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/package.json
+++ b/test/configCases/css/side-effects/node_modules/pkg-side-effects-true/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "pkg-side-effects-true",
+	"version": "1.0.0",
+	"main": "index.js",
+	"sideEffects": true
+}

--- a/test/configCases/css/side-effects/node_modules/pkg-with-css/index.js
+++ b/test/configCases/css/side-effects/node_modules/pkg-with-css/index.js
@@ -1,0 +1,1 @@
+export { used, exportedFromCss } from "./styles.module.css";

--- a/test/configCases/css/side-effects/node_modules/pkg-with-css/package.json
+++ b/test/configCases/css/side-effects/node_modules/pkg-with-css/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "pkg-with-css",
+	"version": "1.0.0",
+	"main": "index.js",
+	"sideEffects": false
+}

--- a/test/configCases/css/side-effects/node_modules/pkg-with-css/styles.module.css
+++ b/test/configCases/css/side-effects/node_modules/pkg-with-css/styles.module.css
@@ -1,0 +1,11 @@
+.used {
+	color: red;
+}
+
+.unused {
+	color: blue;
+}
+
+:export {
+	exportedFromCss: hello;
+}

--- a/test/configCases/css/side-effects/test.config.js
+++ b/test/configCases/css/side-effects/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	moduleScope(scope) {
+		// `moduleScope` can run more than once (initial setup + per-module
+		// evaluation). Guard against duplicate <link> tags being appended.
+		if (scope.window.__cssLinkInjected) return;
+		scope.window.__cssLinkInjected = true;
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/side-effects/webpack.config.js
+++ b/test/configCases/css/side-effects/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	experiments: { css: true },
+	output: {
+		cssFilename: "bundle0.css"
+	},
+	optimization: {
+		sideEffects: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		concatenateModules: false,
+		minimize: false
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/test/cssIdentifier.unittest.js
+++ b/test/cssIdentifier.unittest.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const CssParser = require("../lib/css/CssParser");
+const walkCssTokens = require("../lib/css/walkCssTokens");
+const { makeCacheable } = require("../lib/util/identifier");
+
+describe("css identifier utils", () => {
+	describe("escapeIdentifier", () => {
+		const { escapeIdentifier } = walkCssTokens;
+
+		// [input, expected]
+		/** @type {[string, string][]} */
+		const cases = [
+			["foo", "foo"],
+			["foo bar", "foo\\ bar"],
+			["a.b", "a\\.b"],
+			["1abc", "\\31 abc"],
+			["-1foo", "\\-1foo"],
+			["--foo", "\\--foo"],
+			["♥", "♥"],
+			["©", "©"],
+			["foo\tbar", "foo\\9 bar"],
+			["foo\nbar", "foo\\A bar"],
+			["foo\fbar", "foo\\C bar"],
+			["a\\b", "a\\\\b"]
+		];
+
+		for (const [input, expected] of cases) {
+			it(`escapes ${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+				expect(escapeIdentifier(input)).toBe(expected);
+			});
+		}
+
+		it("re-exports the same function on CssParser", () => {
+			expect(CssParser.escapeIdentifier).toBe(escapeIdentifier);
+		});
+
+		it("preserves the result when the same cache object is reused", () => {
+			const cache = {};
+			expect(escapeIdentifier("foo bar", cache)).toBe("foo\\ bar");
+			expect(escapeIdentifier("foo bar", cache)).toBe("foo\\ bar");
+		});
+
+		it("bindCache returns a function that produces correct results", () => {
+			const cache = {};
+			const bound = escapeIdentifier.bindCache(cache);
+			expect(bound("foo bar")).toBe("foo\\ bar");
+			expect(bound("baz")).toBe("baz");
+		});
+
+		it("works without a cache object", () => {
+			expect(escapeIdentifier("foo bar")).toBe("foo\\ bar");
+		});
+	});
+
+	describe("unescapeIdentifier", () => {
+		const { unescapeIdentifier } = walkCssTokens;
+
+		// [input, expected]
+		/** @type {[string, string][]} */
+		const cases = [
+			["foo", "foo"],
+			["foo\\ bar", "foo bar"],
+			["\\31 23", "123"],
+			["\\31 a2b3c", "1a2b3c"],
+			["\\#fake-id", "#fake-id"],
+			["foo\\.bar", "foo.bar"],
+			["\\3A )", ":)"],
+			// double backslash is preserved
+			["foo\\\\bar", "foo\\bar"],
+			// trailing single backslash retained
+			["foo\\", "foo\\"],
+			// null code point -> replacement character
+			["\\0 ", "�"],
+			// surrogate -> replacement character
+			["\\D800 ", "�"],
+			// no escapes -> fast path returns input
+			["plain-identifier", "plain-identifier"]
+		];
+
+		for (const [input, expected] of cases) {
+			it(`unescapes ${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+				expect(unescapeIdentifier(input)).toBe(expected);
+			});
+		}
+
+		it("re-exports the same function on CssParser", () => {
+			expect(CssParser.unescapeIdentifier).toBe(unescapeIdentifier);
+		});
+
+		it("preserves the result when the same cache object is reused", () => {
+			const cache = {};
+			expect(unescapeIdentifier("\\31 23", cache)).toBe("123");
+			expect(unescapeIdentifier("\\31 23", cache)).toBe("123");
+		});
+
+		it("bindCache returns a function that produces correct results", () => {
+			const cache = {};
+			const bound = unescapeIdentifier.bindCache(cache);
+			expect(bound("\\31 23")).toBe("123");
+			expect(bound("foo\\.bar")).toBe("foo.bar");
+		});
+
+		it("round-trips through escapeIdentifier for common values", () => {
+			const { escapeIdentifier } = walkCssTokens;
+			for (const value of [
+				"foo bar",
+				"foo.bar",
+				"#hello",
+				":)",
+				"a!b",
+				"--var"
+			]) {
+				expect(unescapeIdentifier(escapeIdentifier(value))).toBe(value);
+			}
+		});
+	});
+
+	// `escapeIdentifier` / `unescapeIdentifier` are wrapped via the same
+	// `makeCacheable` primitive used by `parseResource` / `makePathsRelative`.
+	// The tests above only check correctness of the returned values, which
+	// String value-equality would satisfy even if no cache were involved. The
+	// tests below observe caching directly by counting how often the wrapped
+	// implementation runs.
+	describe("makeCacheable (the shared cache primitive)", () => {
+		it("only invokes the wrapped function once per (cache, input)", () => {
+			let calls = 0;
+			const cached = makeCacheable((str) => {
+				calls++;
+				return `[${str}]`;
+			});
+			const cache = {};
+			expect(cached("a", cache)).toBe("[a]");
+			expect(cached("a", cache)).toBe("[a]");
+			expect(cached("a", cache)).toBe("[a]");
+			expect(calls).toBe(1);
+			cached("b", cache);
+			expect(calls).toBe(2);
+		});
+
+		it("invokes the wrapped function every call without a cache", () => {
+			let calls = 0;
+			const cached = makeCacheable((str) => {
+				calls++;
+				return `[${str}]`;
+			});
+			cached("a");
+			cached("a");
+			expect(calls).toBe(2);
+		});
+
+		it("uses an independent cache per cache object", () => {
+			let calls = 0;
+			const cached = makeCacheable((str) => {
+				calls++;
+				return `[${str}]`;
+			});
+			const cacheA = {};
+			const cacheB = {};
+			cached("a", cacheA);
+			cached("a", cacheB);
+			expect(calls).toBe(2);
+			cached("a", cacheA);
+			expect(calls).toBe(2);
+		});
+
+		it("bindCache returns a function that caches by input", () => {
+			let calls = 0;
+			const cached = makeCacheable((str) => {
+				calls++;
+				return `[${str}]`;
+			});
+			const bound = cached.bindCache({});
+			bound("a");
+			bound("a");
+			bound("b");
+			expect(calls).toBe(2);
+		});
+	});
+});


### PR DESCRIPTION
Move escapeIdentifier/unescapeIdentifier and the gobbleHex helper from
CssParser into walkCssTokens (the lexer module they conceptually belong
to). Wrap them with makeCacheable, mirroring how parseResource and
makePathsRelative are cached, so repeated identifier escapes/unescapes
within a compilation reuse results. CssParser binds the cache once per
parse(); CssIcssExportDependency passes the compiler.root as the cache
key. Both functions are re-exported from CssParser to keep public API
compatible.

Also adds unit tests covering escapeIdentifier/unescapeIdentifier
behavior, the cache (positional argument + bindCache), and documents
the current getModuleEvaluationSideEffectsState defaults for CSS
dependencies.