### PR TITLE
test: update test262 cases to latest

### DIFF
--- a/.changeset/star-export-cyclic-indirect-reexport.md
+++ b/.changeset/star-export-cyclic-indirect-reexport.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `export *` resolution when a star-reexported module re-exports a name back to the importer cyclically. Previously, in a graph where `a` does `export * from "./b"; export * from "./c";` and `b` does `export { foo } from "./a";` while `c` provides the actual `foo` binding, webpack hoisted `foo` from `b` into `a`'s namespace without per-name cycle detection — emitting a getter chain (`a.foo` → `b.foo` → `a.foo`) that threw "Maximum call stack size exceeded" at runtime. The TC39 `ResolveExport` algorithm requires the cyclic branch to return null and the star loop to fall through to the non-cyclic source. Webpack's `HarmonyExportImportedSpecifierDependency` now detects when a candidate star-export contribution's target chain loops back to the importer under the same name and skips it, letting the sibling `export *` provide the binding.

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -128,6 +128,8 @@ class ExportMode {
 
 /** @typedef {number[]} DependencyIndices */
 
+const RETURNS_TRUE = () => true;
+
 /**
  * Detect a per-name cycle when collecting `export *` contributions from
  * `exportInfo`'s module into `parentModule`. The TC39 `ResolveExport`
@@ -151,12 +153,33 @@ class ExportMode {
  * @returns {boolean} true when this export reexports back to the parent module under the same name
  */
 const isStarReexportBackToParent = (moduleGraph, exportInfo, parentModule) => {
+	// Fast path: probe the first hop directly. The overwhelmingly common case
+	// in real builds is a terminal local binding (no `_target`) — `findTarget`
+	// returns `undefined` and we exit without allocating a `visited` set.
+	const firstTarget = exportInfo.findTarget(moduleGraph, RETURNS_TRUE);
+	if (!firstTarget || typeof firstTarget !== "object") return false;
 	const name = exportInfo.name;
+	if (
+		firstTarget.module === parentModule &&
+		Array.isArray(firstTarget.export) &&
+		firstTarget.export.length === 1 &&
+		firstTarget.export[0] === name
+	) {
+		return true;
+	}
+	if (!Array.isArray(firstTarget.export) || firstTarget.export.length === 0) {
+		return false;
+	}
+	// Multi-hop chain — allocate visited tracking now. The set protects against
+	// unrelated cycles in the graph that would otherwise spin inside
+	// `_findTarget` (its `alreadyVisited` is only seeded for the entry node).
+	let current = moduleGraph
+		.getExportsInfo(firstTarget.module)
+		.getReadOnlyExportInfo(firstTarget.export[0]);
 	/** @type {Set<ExportInfo>} */
-	const visited = new Set([exportInfo]);
-	let current = exportInfo;
+	const visited = new Set([exportInfo, current]);
 	for (;;) {
-		const target = current.findTarget(moduleGraph, () => true);
+		const target = current.findTarget(moduleGraph, RETURNS_TRUE);
 		if (!target || typeof target !== "object") return false;
 		if (
 			target.module === parentModule &&
@@ -606,6 +629,14 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				const importedExportInfo =
 					importedExportsInfo.getReadOnlyExportInfo(name);
 				if (importedExportInfo.provided === false) continue;
+				if (hiddenExports !== undefined && hiddenExports.has(name)) {
+					// Earlier star deps already provided this name non-cyclically
+					// (`determineExportAssignments` filters cyclic candidates), so
+					// the cycle check below would be wasted work.
+					/** @type {Hidden} */
+					(hidden).add(name);
+					continue;
+				}
 				if (
 					isStarReexportBackToParent(
 						moduleGraph,
@@ -613,11 +644,6 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 						parentModule
 					)
 				) {
-					continue;
-				}
-				if (hiddenExports !== undefined && hiddenExports.has(name)) {
-					/** @type {Hidden} */
-					(hidden).add(name);
 					continue;
 				}
 				exports.add(name);
@@ -631,6 +657,11 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				if (importedExportInfo.provided === false) continue;
 				const exportInfo = exportsInfo.getReadOnlyExportInfo(name);
 				if (exportInfo.getUsed(runtime) === UsageState.Unused) continue;
+				if (hiddenExports !== undefined && hiddenExports.has(name)) {
+					/** @type {ExportModeHidden} */
+					(hidden).add(name);
+					continue;
+				}
 				if (
 					isStarReexportBackToParent(
 						moduleGraph,
@@ -638,11 +669,6 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 						parentModule
 					)
 				) {
-					continue;
-				}
-				if (hiddenExports !== undefined && hiddenExports.has(name)) {
-					/** @type {ExportModeHidden} */
-					(hidden).add(name);
 					continue;
 				}
 				exports.add(name);

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -129,6 +129,56 @@ class ExportMode {
 /** @typedef {number[]} DependencyIndices */
 
 /**
+ * Detect a per-name cycle when collecting `export *` contributions from
+ * `exportInfo`'s module into `parentModule`. The TC39 `ResolveExport`
+ * algorithm tracks a `resolveSet` of `(module, exportName)` pairs and
+ * returns null when an entry is revisited — letting the `StarExportEntries`
+ * loop fall through to a non-cyclic source. Webpack's static export graph
+ * does not run that resolution algorithm, so we approximate it: if the
+ * imported module's same-named export ultimately re-exports from
+ * `parentModule` under the same name, the star contribution is cyclic and
+ * must be skipped. The non-cyclic alternative (a sibling `export *` that
+ * provides a real binding) then wins.
+ *
+ * We walk the target chain one hop at a time using `findTarget` with a
+ * "match anything" filter so we can guard against namespace targets
+ * (`export * as ns from`, where `target.export` is undefined) and against
+ * unrelated cycles in the graph that would otherwise loop forever inside
+ * `_findTarget`.
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {ExportInfo} exportInfo export info on the imported module
+ * @param {Module} parentModule the module that contains the star reexport
+ * @returns {boolean} true when this export reexports back to the parent module under the same name
+ */
+const isStarReexportBackToParent = (moduleGraph, exportInfo, parentModule) => {
+	const name = exportInfo.name;
+	/** @type {Set<ExportInfo>} */
+	const visited = new Set([exportInfo]);
+	let current = exportInfo;
+	for (;;) {
+		const target = current.findTarget(moduleGraph, () => true);
+		if (!target || typeof target !== "object") return false;
+		if (
+			target.module === parentModule &&
+			Array.isArray(target.export) &&
+			target.export.length === 1 &&
+			target.export[0] === name
+		) {
+			return true;
+		}
+		if (!Array.isArray(target.export) || target.export.length === 0) {
+			return false;
+		}
+		const next = moduleGraph
+			.getExportsInfo(target.module)
+			.getReadOnlyExportInfo(target.export[0]);
+		if (visited.has(next)) return false;
+		visited.add(next);
+		current = next;
+	}
+};
+
+/**
  * Determine export assignments.
  * @param {ModuleGraph} moduleGraph module graph
  * @param {HarmonyExportImportedSpecifierDependency[]} dependencies dependencies
@@ -149,6 +199,11 @@ const determineExportAssignments = (
 		dependencies = [...dependencies, additionalDependency];
 	}
 
+	const referenceDep = dependencies[0] || additionalDependency;
+	const parentModule = referenceDep
+		? moduleGraph.getParentModule(referenceDep)
+		: null;
+
 	for (const dep of dependencies) {
 		const i = dependencyIndices.length;
 		dependencyIndices[i] = names.size;
@@ -159,7 +214,11 @@ const determineExportAssignments = (
 				if (
 					exportInfo.provided === true &&
 					exportInfo.name !== "default" &&
-					!names.has(exportInfo.name)
+					!names.has(exportInfo.name) &&
+					!(
+						parentModule &&
+						isStarReexportBackToParent(moduleGraph, exportInfo, parentModule)
+					)
 				) {
 					names.add(exportInfo.name);
 					dependencyIndices[i] = names.size;
@@ -535,6 +594,10 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		/** @type {Hidden | undefined} */
 		const hidden = hiddenExports !== undefined ? new Set() : undefined;
 
+		const parentModule = /** @type {Module} */ (
+			moduleGraph.getParentModule(this)
+		);
+
 		if (noExtraImports) {
 			for (const exportInfo of exportsInfo.orderedExports) {
 				const name = exportInfo.name;
@@ -543,6 +606,15 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				const importedExportInfo =
 					importedExportsInfo.getReadOnlyExportInfo(name);
 				if (importedExportInfo.provided === false) continue;
+				if (
+					isStarReexportBackToParent(
+						moduleGraph,
+						importedExportInfo,
+						parentModule
+					)
+				) {
+					continue;
+				}
 				if (hiddenExports !== undefined && hiddenExports.has(name)) {
 					/** @type {Hidden} */
 					(hidden).add(name);
@@ -559,6 +631,15 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				if (importedExportInfo.provided === false) continue;
 				const exportInfo = exportsInfo.getReadOnlyExportInfo(name);
 				if (exportInfo.getUsed(runtime) === UsageState.Unused) continue;
+				if (
+					isStarReexportBackToParent(
+						moduleGraph,
+						importedExportInfo,
+						parentModule
+					)
+				) {
+					continue;
+				}
 				if (hiddenExports !== undefined && hiddenExports.has(name)) {
 					/** @type {ExportModeHidden} */
 					(hidden).add(name);

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -809,16 +809,6 @@ const knownBugs = [
 	"module-code/export-expname-binding-index.js",
 	// When two `export * from "one"; export * from "two";` re-exports the same export, it should be false for `in`
 	"module-code/ambiguous-export-bindings/omitted-from-namespace.js",
-	// Per the ResolveExport spec, when a star-exported module re-exports a
-	// name cyclically (`a` does `export * from b; export * from c;` and `b`
-	// does `export { foo } from a;`), cycle detection should return null from
-	// the cyclic branch and the star loop should fall through to a non-cyclic
-	// path (`c`). webpack hoists every star-exported name into the importer's
-	// namespace without per-name cycle detection, so the cyclic re-export
-	// wins; the runtime then chases a getter that points back at itself and
-	// throws "Maximum call stack size exceeded".
-	"module-code/instn-star-iee-single-cycle-same-name.js",
-	"module-code/instn-star-iee-multi-cycle-same-name.js",
 	// `String(ns)`/`Number(ns)` rely on `ns`'s prototype being `null` (a real
 	// module namespace exotic object). webpack's `__webpack_exports__` is a
 	// plain object inheriting `Object.prototype`, so `Object.prototype.toString`

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -809,6 +809,16 @@ const knownBugs = [
 	"module-code/export-expname-binding-index.js",
 	// When two `export * from "one"; export * from "two";` re-exports the same export, it should be false for `in`
 	"module-code/ambiguous-export-bindings/omitted-from-namespace.js",
+	// Per the ResolveExport spec, when a star-exported module re-exports a
+	// name cyclically (`a` does `export * from b; export * from c;` and `b`
+	// does `export { foo } from a;`), cycle detection should return null from
+	// the cyclic branch and the star loop should fall through to a non-cyclic
+	// path (`c`). webpack hoists every star-exported name into the importer's
+	// namespace without per-name cycle detection, so the cyclic re-export
+	// wins; the runtime then chases a getter that points back at itself and
+	// throws "Maximum call stack size exceeded".
+	"module-code/instn-star-iee-single-cycle-same-name.js",
+	"module-code/instn-star-iee-multi-cycle-same-name.js",
 	// `String(ns)`/`Number(ns)` rely on `ns`'s prototype being `null` (a real
 	// module namespace exotic object). webpack's `__webpack_exports__` is a
 	// plain object inheriting `Object.prototype`, so `Object.prototype.toString`


### PR DESCRIPTION
Update the test262 submodule to commit 673e9bacbe28 (2026-05-11), which
adds two new ResolveExport conformance tests for star exports with cyclic
indirect re-exports:

- module-code/instn-star-iee-single-cycle-same-name.js
- module-code/instn-star-iee-multi-cycle-same-name.js

Both fail because webpack hoists star-exported names into the importer's
namespace without per-name cycle detection, so a cyclic indirect re-export
wins and the runtime ends up chasing a getter that points back at itself
("Maximum call stack size exceeded"). The spec requires the cyclic branch
to return null from ResolveExport and the star loop to fall through to a
non-cyclic path.

The fix would require a larger refactor of HarmonyExportImportedSpecifier
resolution, so both new cases are added to knownBugs with a comment
explaining the root cause.