### PR TITLE
fix: parse `#` in absolute path directory names as part of the path

### DIFF
--- a/.changeset/parse-resource-hash-in-absolute-path.md
+++ b/.changeset/parse-resource-hash-in-absolute-path.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Treat `#` in an absolute path's directory name as part of the path rather than a fragment separator, so projects in directories like `/home/user/proj#1` resolve correctly.
+Treat `#` in an absolute path's directory name as part of the path rather than a fragment separator. `parseResource` and resolver requests now correctly handle absolute paths containing `#`, so projects in directories like `/home/user/proj#1` (and tools like webpack-dev-server that build absolute entry requests with query strings) resolve correctly.

--- a/.changeset/parse-resource-hash-in-absolute-path.md
+++ b/.changeset/parse-resource-hash-in-absolute-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Treat `#` in an absolute path's directory name as part of the path rather than a fragment separator, so projects in directories like `/home/user/proj#1` resolve correctly.

--- a/.changeset/parse-resource-hash-in-absolute-path.md
+++ b/.changeset/parse-resource-hash-in-absolute-path.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Treat `#` in an absolute path's directory name as part of the path rather than a fragment separator. `parseResource` and resolver requests now correctly handle absolute paths containing `#`, so projects in directories like `/home/user/proj#1` (and tools like webpack-dev-server that build absolute entry requests with query strings) resolve correctly.
+Escape `#` characters that appear inside a path-shaped request's directory portion before passing the request to the resolver, so projects located in directories like `/home/user/proj#1` (and tools like webpack-dev-server that build entry requests with query strings) resolve correctly. The escape only kicks in when the request contains both a `#` in the path portion and a `?` query string — paths without a query keep their existing semantics.

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -31,6 +31,7 @@ const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const { cachedCleverMerge, cachedSetProperty } = require("./util/cleverMerge");
 const { join } = require("./util/fs");
 const {
+	escapeHashInAbsolutePath,
 	parseResource,
 	parseResourceWithoutFragment
 } = require("./util/identifier");
@@ -917,7 +918,7 @@ class NormalModuleFactory extends ModuleFactory {
 						this.resolveResource(
 							contextInfo,
 							context,
-							unresolvedResource,
+							escapeHashInAbsolutePath(unresolvedResource),
 							normalResolver,
 							resolveContext,
 							(err, _resolvedResource, resolvedResourceResolveData) => {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -31,7 +31,7 @@ const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const { cachedCleverMerge, cachedSetProperty } = require("./util/cleverMerge");
 const { join } = require("./util/fs");
 const {
-	escapeHashInAbsolutePath,
+	escapeHashInPathRequest,
 	parseResource,
 	parseResourceWithoutFragment
 } = require("./util/identifier");
@@ -918,7 +918,7 @@ class NormalModuleFactory extends ModuleFactory {
 						this.resolveResource(
 							contextInfo,
 							context,
-							escapeHashInAbsolutePath(unresolvedResource),
+							escapeHashInPathRequest(unresolvedResource),
 							normalResolver,
 							resolveContext,
 							(err, _resolvedResource, resolvedResourceResolveData) => {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -482,31 +482,42 @@ const getUndoPath = (filename, outputPath, enforceRelative) => {
 const HASH_REGEXP = /#/g;
 
 /**
- * Escape `#` characters that appear inside an absolute path's directory portion
+ * Escape `#` characters that appear inside a path request's directory portion
  * with the `\0#` escape recognized by enhanced-resolve, so a project located at
- * a path like `/home/user/proj#1/` resolves correctly. A `#` that is followed
- * only by the filename (no further path separator before any query) is left
- * alone so that explicit fragment requests like `/abs/path/file.js#fragment`
- * still behave the same.
+ * a path like `/home/user/proj#1/` (or `./proj#1/`) resolves correctly. Applies
+ * to absolute paths (Unix or Windows) and relative paths (starting with `./` or
+ * `../`). Only triggers when a query string is present, because that is the case
+ * where the resolver's parseIdentifier fails (without a `?`, the resolver
+ * handles directory `#` via its own fallback). A `#` after the last path
+ * separator is left alone so that explicit fragment requests like
+ * `/abs/path/file.js#fragment` still behave the same. Bare module specifiers
+ * are not touched.
  * @param {string} request request to potentially escape
  * @returns {string} request with directory `#` characters escaped
  */
-const escapeHashInAbsolutePath = (request) => {
-	if (
-		request.length === 0 ||
-		(request.charCodeAt(0) !== 47 /* "/" */ &&
-			!WINDOWS_ABS_PATH_REGEXP.test(request))
-	) {
-		return request;
-	}
-	const hashStart = request.indexOf("#");
-	if (hashStart < 0) return request;
+const escapeHashInPathRequest = (request) => {
+	if (request.length === 0) return request;
 	const queryStart = request.indexOf("?");
-	const pathEnd = queryStart >= 0 ? queryStart : request.length;
-	if (hashStart >= pathEnd) return request;
+	if (queryStart < 0) return request;
+	const hashStart = request.indexOf("#");
+	if (hashStart < 0 || hashStart >= queryStart) return request;
+	const c0 = request.charCodeAt(0);
+	const isAbsolute =
+		c0 === 47 /* "/" */ || WINDOWS_ABS_PATH_REGEXP.test(request);
+	let isRelative = false;
+	if (!isAbsolute && c0 === 46 /* "." */) {
+		const c1 = request.charCodeAt(1);
+		if (c1 === 47 || c1 === 92 /* "/" or "\" */) {
+			isRelative = true;
+		} else if (c1 === 46 /* "." */) {
+			const c2 = request.charCodeAt(2);
+			if (c2 === 47 || c2 === 92) isRelative = true;
+		}
+	}
+	if (!isAbsolute && !isRelative) return request;
 	const lastSep = Math.max(
-		request.lastIndexOf("/", pathEnd - 1),
-		request.lastIndexOf("\\", pathEnd - 1)
+		request.lastIndexOf("/", queryStart - 1),
+		request.lastIndexOf("\\", queryStart - 1)
 	);
 	if (hashStart >= lastSep) return request;
 	const pathPart = request.slice(0, lastSep);
@@ -515,7 +526,7 @@ const escapeHashInAbsolutePath = (request) => {
 
 module.exports.absolutify = absolutify;
 module.exports.contextify = contextify;
-module.exports.escapeHashInAbsolutePath = escapeHashInAbsolutePath;
+module.exports.escapeHashInPathRequest = escapeHashInPathRequest;
 module.exports.getUndoPath = getUndoPath;
 module.exports.makePathsAbsolute = makeCacheableWithContext(_makePathsAbsolute);
 module.exports.makePathsRelative = makeCacheableWithContext(_makePathsRelative);

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -373,27 +373,7 @@ const _parseResource = (str) => {
 	/** @type {ParsedResource} */
 	const result = { resource: str, path: "", query: "", fragment: "" };
 	const queryStart = str.indexOf("?");
-	let fragmentStart = str.indexOf("#");
-
-	// `#` in an absolute filesystem path's directory name (e.g. `/home/user/proj#1/file.js`)
-	// is part of the path, not a fragment marker. A real fragment has no path separator
-	// after it before any query, so a `#` followed by `/` or `\` within the path portion
-	// must be part of the path.
-	if (
-		fragmentStart >= 0 &&
-		(str.charCodeAt(0) === 47 /* "/" */ || WINDOWS_ABS_PATH_REGEXP.test(str))
-	) {
-		const pathEnd = queryStart >= 0 ? queryStart : str.length;
-		if (fragmentStart < pathEnd) {
-			const lastSep = Math.max(
-				str.lastIndexOf("/", pathEnd - 1),
-				str.lastIndexOf("\\", pathEnd - 1)
-			);
-			if (fragmentStart < lastSep) {
-				fragmentStart = str.indexOf("#", lastSep + 1);
-			}
-		}
-	}
+	const fragmentStart = str.indexOf("#");
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {
@@ -499,8 +479,43 @@ const getUndoPath = (filename, outputPath, enforceRelative) => {
 			: append;
 };
 
+const HASH_REGEXP = /#/g;
+
+/**
+ * Escape `#` characters that appear inside an absolute path's directory portion
+ * with the `\0#` escape recognized by enhanced-resolve, so a project located at
+ * a path like `/home/user/proj#1/` resolves correctly. A `#` that is followed
+ * only by the filename (no further path separator before any query) is left
+ * alone so that explicit fragment requests like `/abs/path/file.js#fragment`
+ * still behave the same.
+ * @param {string} request request to potentially escape
+ * @returns {string} request with directory `#` characters escaped
+ */
+const escapeHashInAbsolutePath = (request) => {
+	if (
+		request.length === 0 ||
+		(request.charCodeAt(0) !== 47 /* "/" */ &&
+			!WINDOWS_ABS_PATH_REGEXP.test(request))
+	) {
+		return request;
+	}
+	const hashStart = request.indexOf("#");
+	if (hashStart < 0) return request;
+	const queryStart = request.indexOf("?");
+	const pathEnd = queryStart >= 0 ? queryStart : request.length;
+	if (hashStart >= pathEnd) return request;
+	const lastSep = Math.max(
+		request.lastIndexOf("/", pathEnd - 1),
+		request.lastIndexOf("\\", pathEnd - 1)
+	);
+	if (hashStart >= lastSep) return request;
+	const pathPart = request.slice(0, lastSep);
+	return pathPart.replace(HASH_REGEXP, "\0#") + request.slice(lastSep);
+};
+
 module.exports.absolutify = absolutify;
 module.exports.contextify = contextify;
+module.exports.escapeHashInAbsolutePath = escapeHashInAbsolutePath;
 module.exports.getUndoPath = getUndoPath;
 module.exports.makePathsAbsolute = makeCacheableWithContext(_makePathsAbsolute);
 module.exports.makePathsRelative = makeCacheableWithContext(_makePathsRelative);

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -373,7 +373,27 @@ const _parseResource = (str) => {
 	/** @type {ParsedResource} */
 	const result = { resource: str, path: "", query: "", fragment: "" };
 	const queryStart = str.indexOf("?");
-	const fragmentStart = str.indexOf("#");
+	let fragmentStart = str.indexOf("#");
+
+	// `#` in an absolute filesystem path's directory name (e.g. `/home/user/proj#1/file.js`)
+	// is part of the path, not a fragment marker. A real fragment has no path separator
+	// after it before any query, so a `#` followed by `/` or `\` within the path portion
+	// must be part of the path.
+	if (
+		fragmentStart >= 0 &&
+		(str.charCodeAt(0) === 47 /* "/" */ || WINDOWS_ABS_PATH_REGEXP.test(str))
+	) {
+		const pathEnd = queryStart >= 0 ? queryStart : str.length;
+		if (fragmentStart < pathEnd) {
+			const lastSep = Math.max(
+				str.lastIndexOf("/", pathEnd - 1),
+				str.lastIndexOf("\\", pathEnd - 1)
+			);
+			if (fragmentStart < lastSep) {
+				fragmentStart = str.indexOf("#", lastSep + 1);
+			}
+		}
+	}
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -479,7 +479,7 @@ const getUndoPath = (filename, outputPath, enforceRelative) => {
 			: append;
 };
 
-const HASH_REGEXP = /#/g;
+const HASH_REGEXP = /(?<!\0)#/g;
 
 /**
  * Escape `#` characters that appear inside a path request's directory portion
@@ -491,7 +491,8 @@ const HASH_REGEXP = /#/g;
  * handles directory `#` via its own fallback). A `#` after the last path
  * separator is left alone so that explicit fragment requests like
  * `/abs/path/file.js#fragment` still behave the same. Bare module specifiers
- * are not touched.
+ * are not touched. Already-escaped `\0#` sequences are preserved so the
+ * explicit opt-out remains stable.
  * @param {string} request request to potentially escape
  * @returns {string} request with directory `#` characters escaped
  */

--- a/test/configCases/parsing/issue-16819-#-in-path-#/index.js
+++ b/test/configCases/parsing/issue-16819-#-in-path-#/index.js
@@ -1,0 +1,3 @@
+it("should resolve absolute entry paths containing '#' in a directory name", () => {
+	expect(1 + 1).toBe(2);
+});

--- a/test/configCases/parsing/issue-16819-#-in-path-#/webpack.config.js
+++ b/test/configCases/parsing/issue-16819-#-in-path-#/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const path = require("path");
+
+// Reproduces https://github.com/webpack/webpack/issues/16819: webpack-dev-server
+// adds entries as absolute paths with query strings, and when the project lives
+// in a directory containing `#` (e.g. `/home/user/proj#1/`), webpack incorrectly
+// split the path at the first `#`, failing to resolve.
+module.exports = {
+	entry: `${path.join(__dirname, "index.js")}?protocol=ws&port=8080`
+};

--- a/test/configCases/parsing/issue-16819-#-in-path-#/webpack.config.js
+++ b/test/configCases/parsing/issue-16819-#-in-path-#/webpack.config.js
@@ -5,7 +5,8 @@ const path = require("path");
 // Reproduces https://github.com/webpack/webpack/issues/16819: webpack-dev-server
 // adds entries as absolute paths with query strings, and when the project lives
 // in a directory containing `#` (e.g. `/home/user/proj#1/`), webpack incorrectly
-// split the path at the first `#`, failing to resolve.
+// splits the path at the first `#`, failing to resolve.
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	entry: `${path.join(__dirname, "index.js")}?protocol=ws&port=8080`
 };

--- a/test/configCases/parsing/issue-16819-relative-#/#dir/index.js
+++ b/test/configCases/parsing/issue-16819-relative-#/#dir/index.js
@@ -1,0 +1,3 @@
+it("should resolve relative entry paths containing '#' in a directory name", () => {
+	expect(1 + 1).toBe(2);
+});

--- a/test/configCases/parsing/issue-16819-relative-#/webpack.config.js
+++ b/test/configCases/parsing/issue-16819-relative-#/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// Companion to issue-16819-#-in-path-#: same project layout, but the entry is
+// expressed as a relative request with a query string. Without escaping, the
+// resolver mis-splits `#` in the directory portion and fails.
+module.exports = {
+	entry: "./#dir/index.js?protocol=ws&port=8080"
+};

--- a/test/configCases/parsing/issue-16819-relative-#/webpack.config.js
+++ b/test/configCases/parsing/issue-16819-relative-#/webpack.config.js
@@ -3,6 +3,7 @@
 // Companion to issue-16819-#-in-path-#: same project layout, but the entry is
 // expressed as a relative request with a query string. Without escaping, the
 // resolver mis-splits `#` in the directory portion and fails.
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	entry: "./#dir/index.js?protocol=ws&port=8080"
 };

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -144,7 +144,16 @@ describe("util/identifier", () => {
 				"#fragment"
 			],
 			["./relative/file#fragment", "./relative/file", "", "#fragment"],
-			["module#fragment", "module", "", "#fragment"]
+			["module#fragment", "module", "", "#fragment"],
+			// https://github.com/webpack/webpack/issues/16819 — webpack-dev-server
+			// adds entries as absolute paths with query strings when serving from a
+			// project directory containing `#` (e.g. `~/projects/f#/webpack`).
+			[
+				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
+				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js",
+				"?protocol=ws%3A&hostname=0.0.0.0&port=8080&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
+				""
+			]
 		];
 		for (const [input, path, query, fragment] of cases) {
 			it(JSON.stringify(input), () => {

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -90,27 +90,41 @@ describe("util/identifier", () => {
 		}
 	});
 
-	describe("escapeHashInAbsolutePath", () => {
+	describe("escapeHashInPathRequest", () => {
 		// [input, expected]
 		/** @type {[string, string][]} */
 		const cases = [
 			["", ""],
-			["./relative/file.js", "./relative/file.js"],
-			["./relative/with#hash/file.js", "./relative/with#hash/file.js"],
-			["module-name", "module-name"],
-			["/abs/path/file.js", "/abs/path/file.js"],
-			["/abs/path/file.js#fragment", "/abs/path/file.js#fragment"],
-			["/abs/path/file.js?query", "/abs/path/file.js?query"],
-			["/abs/path/file.js?query#frag", "/abs/path/file.js?query#frag"],
-			["/home/user/proj#1/file.js", "/home/user/proj\0#1/file.js"],
-			["/home/user/proj#1/file.js?q=1", "/home/user/proj\0#1/file.js?q=1"],
+			// without a query, the resolver handles directory `#` itself, so
+			// nothing is escaped
+			["/home/user/proj#1/file.js", "/home/user/proj#1/file.js"],
+			["./proj#1/file.js", "./proj#1/file.js"],
 			[
-				"/home/user/proj#1/file.js#fragment",
-				"/home/user/proj\0#1/file.js#fragment"
+				"./resourceFragment/index#/some/fragment",
+				"./resourceFragment/index#/some/fragment"
 			],
+			["/abs/path/file.js#fragment", "/abs/path/file.js#fragment"],
+			// bare module specifiers are not touched
+			["module-name?q=1", "module-name?q=1"],
+			["module-name#fragment?q=1", "module-name#fragment?q=1"],
+			["@scope/pkg#frag?q=1", "@scope/pkg#frag?q=1"],
+			// path + query without `#` → unchanged
+			["/abs/path/file.js?query", "/abs/path/file.js?query"],
+			["./rel/file.js?query", "./rel/file.js?query"],
+			// `#` after query is a real fragment, not escaped
+			["/abs/path/file.js?query#frag", "/abs/path/file.js?query#frag"],
+			// `#` after last path separator (before query) is a fragment, not escaped
+			["/abs/path/file.js#frag?q=1", "/abs/path/file.js#frag?q=1"],
+			["./rel/file.js#frag?q=1", "./rel/file.js#frag?q=1"],
+			// `#` in directory portion with query → escaped
+			["/home/user/proj#1/file.js?q=1", "/home/user/proj\0#1/file.js?q=1"],
 			["/home/user/a#b/c#d/file.js?q=1", "/home/user/a\0#b/c\0#d/file.js?q=1"],
 			["C:\\Users\\proj#1\\file.js?q=1", "C:\\Users\\proj\0#1\\file.js?q=1"],
-			["C:/Users/proj#1/file.js", "C:/Users/proj\0#1/file.js"],
+			["C:/Users/proj#1/file.js?q=1", "C:/Users/proj\0#1/file.js?q=1"],
+			["./rel/with#hash/file.js?q=1", "./rel/with\0#hash/file.js?q=1"],
+			["../parent#dir/file.js?q=1", "../parent\0#dir/file.js?q=1"],
+			["./a#b/c#d/file.js?q=1", "./a\0#b/c\0#d/file.js?q=1"],
+			[".\\rel#dir\\file.js?q=1", ".\\rel\0#dir\\file.js?q=1"],
 			// the exact request webpack-dev-server produces for issue #16819
 			[
 				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080",
@@ -119,7 +133,7 @@ describe("util/identifier", () => {
 		];
 		for (const [input, expected] of cases) {
 			it(JSON.stringify(input), () => {
-				expect(identifierUtil.escapeHashInAbsolutePath(input)).toBe(expected);
+				expect(identifierUtil.escapeHashInPathRequest(input)).toBe(expected);
 			});
 		}
 	});

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -90,78 +90,36 @@ describe("util/identifier", () => {
 		}
 	});
 
-	describe("parseResource", () => {
-		// [input, expectedPath, expectedQuery, expectedFragment]
-		/** @type {[string, string, string, string][]} */
+	describe("escapeHashInAbsolutePath", () => {
+		// [input, expected]
+		/** @type {[string, string][]} */
 		const cases = [
-			["path#hash?query", "path", "", "#hash?query"],
-			["path?query#hash", "path", "?query", "#hash"],
-			["path", "path", "", ""],
-			["path#fragment", "path", "", "#fragment"],
-			["path?query", "path", "?query", ""],
+			["", ""],
+			["./relative/file.js", "./relative/file.js"],
+			["./relative/with#hash/file.js", "./relative/with#hash/file.js"],
+			["module-name", "module-name"],
+			["/abs/path/file.js", "/abs/path/file.js"],
+			["/abs/path/file.js#fragment", "/abs/path/file.js#fragment"],
+			["/abs/path/file.js?query", "/abs/path/file.js?query"],
+			["/abs/path/file.js?query#frag", "/abs/path/file.js?query#frag"],
+			["/home/user/proj#1/file.js", "/home/user/proj\0#1/file.js"],
+			["/home/user/proj#1/file.js?q=1", "/home/user/proj\0#1/file.js?q=1"],
 			[
-				"/home/user/test#folder/file.js",
-				"/home/user/test#folder/file.js",
-				"",
-				""
+				"/home/user/proj#1/file.js#fragment",
+				"/home/user/proj\0#1/file.js#fragment"
 			],
+			["/home/user/a#b/c#d/file.js?q=1", "/home/user/a\0#b/c\0#d/file.js?q=1"],
+			["C:\\Users\\proj#1\\file.js?q=1", "C:\\Users\\proj\0#1\\file.js?q=1"],
+			["C:/Users/proj#1/file.js", "C:/Users/proj\0#1/file.js"],
+			// the exact request webpack-dev-server produces for issue #16819
 			[
-				"C:\\Users\\test#folder\\file.js",
-				"C:\\Users\\test#folder\\file.js",
-				"",
-				""
-			],
-			["C:/Users/test#folder/file.js", "C:/Users/test#folder/file.js", "", ""],
-			[
-				"/home/user/test#folder/file.js?protocol=ws&port=8080",
-				"/home/user/test#folder/file.js",
-				"?protocol=ws&port=8080",
-				""
-			],
-			[
-				"/home/user/test#folder/file.js?query=1#fragment",
-				"/home/user/test#folder/file.js",
-				"?query=1",
-				"#fragment"
-			],
-			[
-				"/home/user/test#a/test#b/file.js",
-				"/home/user/test#a/test#b/file.js",
-				"",
-				""
-			],
-			[
-				"/home/user/test#a/test#b/file.js#fragment",
-				"/home/user/test#a/test#b/file.js",
-				"",
-				"#fragment"
-			],
-			["/abs/path/file.js#fragment", "/abs/path/file.js", "", "#fragment"],
-			[
-				"C:\\abs\\path\\file.js#fragment",
-				"C:\\abs\\path\\file.js",
-				"",
-				"#fragment"
-			],
-			["./relative/file#fragment", "./relative/file", "", "#fragment"],
-			["module#fragment", "module", "", "#fragment"],
-			// https://github.com/webpack/webpack/issues/16819 — webpack-dev-server
-			// adds entries as absolute paths with query strings when serving from a
-			// project directory containing `#` (e.g. `~/projects/f#/webpack`).
-			[
-				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js",
-				"?protocol=ws%3A&hostname=0.0.0.0&port=8080&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-				""
+				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080",
+				"/home/felix/projects/f\0#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080"
 			]
 		];
-		for (const [input, path, query, fragment] of cases) {
+		for (const [input, expected] of cases) {
 			it(JSON.stringify(input), () => {
-				const result = identifierUtil.parseResource(input);
-				expect(result.path).toBe(path);
-				expect(result.query).toBe(query);
-				expect(result.fragment).toBe(fragment);
-				expect(result.resource).toBe(input);
+				expect(identifierUtil.escapeHashInAbsolutePath(input)).toBe(expected);
 			});
 		}
 	});

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -90,6 +90,73 @@ describe("util/identifier", () => {
 		}
 	});
 
+	describe("parseResource", () => {
+		// [input, expectedPath, expectedQuery, expectedFragment]
+		/** @type {[string, string, string, string][]} */
+		const cases = [
+			["path#hash?query", "path", "", "#hash?query"],
+			["path?query#hash", "path", "?query", "#hash"],
+			["path", "path", "", ""],
+			["path#fragment", "path", "", "#fragment"],
+			["path?query", "path", "?query", ""],
+			[
+				"/home/user/test#folder/file.js",
+				"/home/user/test#folder/file.js",
+				"",
+				""
+			],
+			[
+				"C:\\Users\\test#folder\\file.js",
+				"C:\\Users\\test#folder\\file.js",
+				"",
+				""
+			],
+			["C:/Users/test#folder/file.js", "C:/Users/test#folder/file.js", "", ""],
+			[
+				"/home/user/test#folder/file.js?protocol=ws&port=8080",
+				"/home/user/test#folder/file.js",
+				"?protocol=ws&port=8080",
+				""
+			],
+			[
+				"/home/user/test#folder/file.js?query=1#fragment",
+				"/home/user/test#folder/file.js",
+				"?query=1",
+				"#fragment"
+			],
+			[
+				"/home/user/test#a/test#b/file.js",
+				"/home/user/test#a/test#b/file.js",
+				"",
+				""
+			],
+			[
+				"/home/user/test#a/test#b/file.js#fragment",
+				"/home/user/test#a/test#b/file.js",
+				"",
+				"#fragment"
+			],
+			["/abs/path/file.js#fragment", "/abs/path/file.js", "", "#fragment"],
+			[
+				"C:\\abs\\path\\file.js#fragment",
+				"C:\\abs\\path\\file.js",
+				"",
+				"#fragment"
+			],
+			["./relative/file#fragment", "./relative/file", "", "#fragment"],
+			["module#fragment", "module", "", "#fragment"]
+		];
+		for (const [input, path, query, fragment] of cases) {
+			it(JSON.stringify(input), () => {
+				const result = identifierUtil.parseResource(input);
+				expect(result.path).toBe(path);
+				expect(result.query).toBe(query);
+				expect(result.fragment).toBe(fragment);
+				expect(result.resource).toBe(input);
+			});
+		}
+	});
+
 	describe("parseResourceWithoutFragment", () => {
 		// [input, expectedPath, expectedQuery]
 		/** @type {[string, string, string][]} */

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -129,7 +129,14 @@ describe("util/identifier", () => {
 			[
 				"/home/felix/projects/f#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080",
 				"/home/felix/projects/f\0#/webpack/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=8080"
-			]
+			],
+			// pre-escaped `\0#` is preserved (explicit opt-out remains stable)
+			["/home/user/proj\0#1/file.js?q=1", "/home/user/proj\0#1/file.js?q=1"],
+			[
+				"/home/user/proj\0#a/raw#b/file.js?q=1",
+				"/home/user/proj\0#a/raw\0#b/file.js?q=1"
+			],
+			["./proj\0#1/file.js?q=1", "./proj\0#1/file.js?q=1"]
 		];
 		for (const [input, expected] of cases) {
 			it(JSON.stringify(input), () => {


### PR DESCRIPTION
When an absolute path contains `#` followed by a path separator (e.g.
`/home/user/proj#1/file.js`), treat the `#` as part of the directory
name rather than a fragment marker. A real fragment cannot have a path
separator after it before any query, so this disambiguation is sound
and preserves existing fragment behavior for paths like
`/abs/path/file.js#fragment`.

fixes #16819
fixes https://github.com/webpack/webpack/pull/20877