### PR TITLE
fix: re-export `ModuleNotFoundError` from `lib/ModuleNotFoundError`

### DIFF
--- a/.changeset/reexport-module-not-found-error.md
+++ b/.changeset/reexport-module-not-found-error.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Re-export `ModuleNotFoundError` from `webpack/lib/ModuleNotFoundError` for backward compatibility with old plugins that import it from that path. This re-export will be removed in webpack 6.

--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -1,0 +1,10 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+// TODO remove in webpack 6
+// Some old plugins use `require("webpack/lib/ModuleNotFoundError")`, in webpack@6 developer should migrate to `compiler.webpack.ModuleNotFoundError`
+module.exports = require("./errors/ModuleNotFoundError");


### PR DESCRIPTION
Some old plugins use `require("webpack/lib/ModuleNotFoundError")` directly.
Add a re-export at the legacy path, mirroring how `lib/WebpackError.js`
re-exports `./errors/WebpackError`. Marked with a TODO to remove in webpack@6.

Refs #20985