### PR TITLE
fix: link import bindings inside `define` callbacks (#17063)

### DIFF
--- a/.changeset/fix-import-binding-in-define.md
+++ b/.changeset/fix-import-binding-in-define.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Link import bindings used inside `define(...)` callbacks in ES modules. Previously, `HarmonyDetectionParserPlugin` skipped walking the arguments of `define` calls in harmony modules, so references to imported bindings inside an inline AMD `define` factory (e.g. `define(function () { console.log(foo); })`) were not rewritten to their imported references and could cause `ReferenceError` at runtime. Inner graph usage analysis is also fixed for the related pattern `const fn = function () { foo; }; define(fn);`.

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -92,6 +92,19 @@ module.exports = class HarmonyDetectionParserPlugin {
 			}
 		};
 
+		/**
+		 * Walks call arguments so import bindings used inside callbacks are
+		 * still tracked, then skips default AMD/CommonJS handling.
+		 * @param {import("estree").CallExpression} expr call expression
+		 * @returns {boolean | undefined} true if in harmony
+		 */
+		const walkArgumentsAndSkipInHarmony = (expr) => {
+			if (HarmonyExports.isEnabled(parser.state)) {
+				if (expr.arguments) parser.walkExpressions(expr.arguments);
+				return true;
+			}
+		};
+
 		const nonHarmonyIdentifiers = ["define", "exports"];
 		for (const identifier of nonHarmonyIdentifiers) {
 			parser.hooks.evaluateTypeof
@@ -100,7 +113,14 @@ module.exports = class HarmonyDetectionParserPlugin {
 			parser.hooks.typeof.for(identifier).tap(PLUGIN_NAME, skipInHarmony);
 			parser.hooks.evaluate.for(identifier).tap(PLUGIN_NAME, nullInHarmony);
 			parser.hooks.expression.for(identifier).tap(PLUGIN_NAME, skipInHarmony);
-			parser.hooks.call.for(identifier).tap(PLUGIN_NAME, skipInHarmony);
+			parser.hooks.call
+				.for(identifier)
+				.tap(
+					PLUGIN_NAME,
+					identifier === "define"
+						? walkArgumentsAndSkipInHarmony
+						: skipInHarmony
+				);
 		}
 	}
 };

--- a/test/cases/parsing/issue-17063/index.js
+++ b/test/cases/parsing/issue-17063/index.js
@@ -1,0 +1,55 @@
+import foo, { named } from "./lib";
+
+// The bug we are testing is purely about static analysis: webpack's
+// HarmonyDetectionParserPlugin was skipping the arguments of `define`
+// calls in ES modules, so import bindings used inside the callback
+// were not rewritten to their imported references.
+//
+// To exercise the rewriting we need to actually call `define(...)` so
+// the parser's call hook fires and walks the argument expressions. We
+// briefly install a no-op `define` on the realm's global, capture the
+// callbacks via assignment-in-argument, then remove `define` again so
+// other tests in the suite still see it as undefined. The
+// `Function("return this")()` polyfill is used in place of `globalThis`
+// for Node 10 compatibility.
+var __globalThis = Function("return this")();
+var __hadDefine = Object.prototype.hasOwnProperty.call(__globalThis, "define");
+var __previousDefine = __globalThis.define;
+__globalThis.define = function () {};
+
+var cbDefault;
+var cbNamed;
+var cbBoth;
+
+define((cbDefault = function () {
+	return foo;
+}));
+
+define((cbNamed = function () {
+	return named;
+}));
+
+define("named-module", ["./lib"], (cbBoth = function (lib) {
+	// Reference both the AMD-style argument and the harmony import binding.
+	return [foo, named, lib && lib.default];
+}));
+
+if (__hadDefine) {
+	__globalThis.define = __previousDefine;
+} else {
+	delete __globalThis.define;
+}
+
+it("should link default import binding inside `define` callback (issue #17063)", function () {
+	expect(cbDefault()).toBe(42);
+});
+
+it("should link named import binding inside `define` callback (issue #17063)", function () {
+	expect(cbNamed()).toBe("named-value");
+});
+
+it("should link import bindings inside `define(name, deps, fn)` callback (issue #17063)", function () {
+	var result = cbBoth(undefined);
+	expect(result[0]).toBe(42);
+	expect(result[1]).toBe("named-value");
+});

--- a/test/cases/parsing/issue-17063/lib.js
+++ b/test/cases/parsing/issue-17063/lib.js
@@ -1,0 +1,2 @@
+export default 42;
+export const named = "named-value";

--- a/test/configCases/inner-graph/issue-17063/module.js
+++ b/test/configCases/inner-graph/issue-17063/module.js
@@ -1,0 +1,26 @@
+import { x, y } from "./dependency";
+
+// `x` is referenced inside an inline `define` callback. Without the fix
+// for issue #17063, webpack's `HarmonyDetectionParserPlugin` skipped
+// walking the arguments of `define(...)` calls in ES modules, so the
+// reference to `x` would never be tracked and tree-shaking would drop
+// it from `./dependency`.
+function useX() {
+	define(function () {
+		return x;
+	});
+}
+
+// `callback` is a top-level function expression that closes over `y`.
+// innerGraph only treats `y` as used when `callback` itself is referenced
+// at top level — and the only reference is via `define(callback)`, which
+// the buggy code also skipped.
+const callback = function () {
+	return y;
+};
+
+function useY() {
+	define(callback);
+}
+
+export { useX, useY };

--- a/test/configCases/inner-graph/issue-17063/webpack.config.js
+++ b/test/configCases/inner-graph/issue-17063/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const createTestCases = require("../_helpers/createTestCases");
+
+module.exports = createTestCases({
+	useX: {
+		usedExports: ["useX"],
+		expect: {
+			"./dependency": ["x"]
+		}
+	},
+	useY: {
+		usedExports: ["useY"],
+		expect: {
+			"./dependency": ["y"]
+		}
+	},
+	both: {
+		usedExports: ["useX", "useY"],
+		expect: {
+			"./dependency": ["x", "y"]
+		}
+	}
+});


### PR DESCRIPTION
`HarmonyDetectionParserPlugin` short-circuited `hooks.call.for("define")`
in harmony modules, which skipped walking the arguments of `define(...)`
calls. As a result, references to imported bindings inside an inline AMD
factory (e.g. `define(function () { console.log(foo); })`) were never
rewritten, causing `ReferenceError` at runtime. The same omission also
hid usages from inner graph, so patterns like `const fn = () => foo;
define(fn);` would tree-shake `foo` away.

Walk the call arguments before skipping the default AMD/CommonJS
handling so the harmony parser sees those references.

fixes #17063
fixes #20542