### PR TITLE
refactor: tighten CreateData type in NormalModuleFactory

### DIFF
--- a/.changeset/normal-module-factory-create-data-type.md
+++ b/.changeset/normal-module-factory-create-data-type.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Tighten the `CreateData` typedef in `NormalModuleFactory`. `CreateData` now represents the fully-populated value passed to the `createModule`, `module`, and `createModuleClass` hooks (`NormalModuleCreateData & { settings: ModuleSettings }`), while `ResolveData.createData` is typed as `Partial<CreateData>` to reflect the empty initial state. Plugins tapping those hooks no longer need to cast individual fields away from optional.

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -69,7 +69,7 @@ const {
  */
 
 /** @typedef {Pick<RuleSetRule, "type" | "sideEffects" | "parser" | "generator" | "resolve" | "layer" | "extractSourceMap">} ModuleSettings */
-/** @typedef {Partial<NormalModuleCreateData & { settings: ModuleSettings }>} CreateData */
+/** @typedef {NormalModuleCreateData & { settings: ModuleSettings }} CreateData */
 
 /**
  * Defines the resolve data type used by this module.
@@ -82,7 +82,7 @@ const {
  * @property {ImportAttributes=} attributes
  * @property {ModuleDependency[]} dependencies
  * @property {string} dependencyType
- * @property {CreateData} createData
+ * @property {Partial<CreateData>} createData
  * @property {FileSystemDependencies} fileDependencies
  * @property {FileSystemDependencies} missingDependencies
  * @property {FileSystemDependencies} contextDependencies
@@ -493,7 +493,9 @@ class NormalModuleFactory extends ModuleFactory {
 						// Ignored
 						if (result === false) return callback();
 
-						const createData = resolveData.createData;
+						const createData =
+							/** @type {CreateData} */
+							(resolveData.createData);
 
 						this.hooks.createModule.callAsync(
 							createData,
@@ -506,18 +508,12 @@ class NormalModuleFactory extends ModuleFactory {
 
 									// TODO webpack 6 make it required and move javascript/wasm/asset properties to own module
 									createdModule = this.hooks.createModuleClass
-										.for(
-											/** @type {ModuleSettings} */
-											(createData.settings).type
-										)
+										.for(createData.settings.type)
 										.call(createData, resolveData);
 
 									if (!createdModule) {
 										createdModule = /** @type {Module} */ (
-											new NormalModule(
-												/** @type {NormalModuleCreateData} */
-												(createData)
-											)
+											new NormalModule(createData)
 										);
 									}
 								}

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -26,7 +26,6 @@ const memoize = require("../util/memoize");
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
 /** @typedef {import("../NormalModule")} NormalModule */
-/** @typedef {import("../NormalModule").NormalModuleCreateData} NormalModuleCreateData */
 
 /**
  * Returns definition.
@@ -98,10 +97,7 @@ class AssetModulesPlugin {
 						.for(type)
 						.tap(PLUGIN_NAME, (createData, _resolveData) => {
 							// TODO create the module via new AssetModule with its own properties
-							const module = new NormalModule(
-								/** @type {NormalModuleCreateData} */
-								(createData)
-							);
+							const module = new NormalModule(createData);
 							if (this.options.sideEffectFree) {
 								module.factoryMeta = { sideEffectFree: true };
 							}

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -27,7 +27,6 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../ModuleGraphConnection")} ModuleGraphConnection */
-/** @typedef {import("../NormalModuleFactory").ModuleSettings} ModuleSettings */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 
@@ -134,7 +133,7 @@ class SideEffectsFlagPlugin {
 					return module;
 				});
 				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {
-					const settings = /** @type {ModuleSettings} */ (data.settings);
+					const settings = data.settings;
 					if (typeof settings.sideEffects === "boolean") {
 						if (module.factoryMeta === undefined) {
 							module.factoryMeta = {};

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -356,15 +356,9 @@ class ConsumeSharedPlugin {
 						) {
 							return Promise.resolve();
 						}
-						const options = resolvedConsumes.get(
-							/** @type {string} */ (resource)
-						);
+						const options = resolvedConsumes.get(resource);
 						if (options !== undefined) {
-							return createConsumeSharedModule(
-								context,
-								/** @type {string} */ (resource),
-								options
-							);
+							return createConsumeSharedModule(context, resource, options);
 						}
 						return Promise.resolve();
 					}

--- a/lib/sharing/ProvideSharedPlugin.js
+++ b/lib/sharing/ProvideSharedPlugin.js
@@ -169,7 +169,7 @@ class ProvideSharedPlugin {
 				normalModuleFactory.hooks.module.tap(
 					PLUGIN_NAME,
 					(module, { resource, resourceResolveData }, resolveData) => {
-						if (resolvedProvideMap.has(/** @type {string} */ (resource))) {
+						if (resolvedProvideMap.has(resource)) {
 							return module;
 						}
 						const { request } = resolveData;
@@ -179,7 +179,7 @@ class ProvideSharedPlugin {
 								provideSharedModule(
 									request,
 									config,
-									/** @type {string} */ (resource),
+									resource,
 									resourceResolveData
 								);
 								resolveData.cacheable = false;
@@ -189,12 +189,12 @@ class ProvideSharedPlugin {
 							if (request.startsWith(prefix)) {
 								const remainder = request.slice(prefix.length);
 								provideSharedModule(
-									/** @type {string} */ (resource),
+									resource,
 									{
 										...config,
 										shareKey: config.shareKey + remainder
 									},
-									/** @type {string} */ (resource),
+									resource,
 									resourceResolveData
 								);
 								resolveData.cacheable = false;

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -216,8 +216,7 @@ class AsyncWebAssemblyModulesPlugin {
 						PLUGIN_NAME,
 						(createData, resolveData) =>
 							new AsyncWasmModule({
-								.../** @type {NormalModuleCreateData & { type: string }} */
-								(createData),
+								...createData,
 								phase: resolveData.phase
 							})
 					);

--- a/types.d.ts
+++ b/types.d.ts
@@ -5022,6 +5022,7 @@ declare interface ContextTimestampAndHash {
 	symlinks?: Set<string>;
 }
 type ContextTypes = KnownContext & Record<any, any>;
+type CreateData = NormalModuleCreateData & { settings: ModuleSettings };
 type CreateReadStreamFSImplementation = FSImplementation & {
 	read: (...args: any[]) => any;
 };
@@ -16104,21 +16105,8 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		factorize: AsyncSeriesBailHook<[ResolveData], undefined | Module>;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], false | void>;
 		afterResolve: AsyncSeriesBailHook<[ResolveData], false | void>;
-		createModule: AsyncSeriesBailHook<
-			[
-				Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
-				ResolveData
-			],
-			void | Module
-		>;
-		module: SyncWaterfallHook<
-			[
-				Module,
-				Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
-				ResolveData
-			],
-			Module
-		>;
+		createModule: AsyncSeriesBailHook<[CreateData, ResolveData], void | Module>;
+		module: SyncWaterfallHook<[Module, CreateData, ResolveData], Module>;
 		createParser: TypedHookMap<
 			Record<
 				"javascript/auto",
@@ -16346,13 +16334,7 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 				Record<string, SyncBailHook<[Generator, GeneratorOptions], void>>
 		>;
 		createModuleClass: HookMap<
-			SyncBailHook<
-				[
-					Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
-					ResolveData
-				],
-				void | Module
-			>
+			SyncBailHook<[CreateData, ResolveData], void | Module>
 		>;
 	}>;
 	resolverFactory: ResolverFactory;
@@ -19836,7 +19818,7 @@ declare interface ResolveData {
 	attributes?: ImportAttributes;
 	dependencies: ModuleDependency[];
 	dependencyType: string;
-	createData: Partial<NormalModuleCreateData & { settings: ModuleSettings }>;
+	createData: Partial<CreateData>;
 	fileDependencies: LazySet<string>;
 	missingDependencies: LazySet<string>;
 	contextDependencies: LazySet<string>;


### PR DESCRIPTION
CreateData now describes the fully-populated value passed to the
createModule, module, and createModuleClass hooks
(NormalModuleCreateData & { settings: ModuleSettings }), while
ResolveData.createData is typed as Partial<CreateData> to reflect the
empty initial state filled in by the bulk Object.assign during resolve.
Drops the now-redundant ModuleSettings and NormalModuleCreateData
casts at the construction site.