### PR TITLE
fix: prevent webpackPrefetch/Preload from leaking across same-named chunks

### DIFF
--- a/.changeset/prefetch-chunk-name-collision.md
+++ b/.changeset/prefetch-chunk-name-collision.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Stop `webpackPrefetch` / `webpackPreload` magic comments from leaking across `import()` call sites that share a `webpackChunkName`. When two imports targeted the same named chunk and only one of them set `webpackPrefetch: true`, the prefetch directive was applied from every parent chunk that referenced the named chunk. Prefetch and preload orders are now resolved per `import()` call site instead of from the shared chunk group's accumulated options.

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -794,26 +794,21 @@ class Chunk {
 		for (const group of this.groupsIterable) {
 			if (group.chunks[group.chunks.length - 1] === this) {
 				for (const childGroup of group.childrenIterable) {
-					for (const key of Object.keys(childGroup.options)) {
-						if (key.endsWith("Order")) {
-							const name = key.slice(0, key.length - "Order".length);
-							let list = lists.get(name);
-							if (list === undefined) {
-								list = [];
-								lists.set(name, list);
-							}
-							list.push({
-								order:
-									/** @type {number} */
-									(
-										childGroup.options[
-											/** @type {keyof ChunkGroupOptions} */
-											(key)
-										]
-									),
-								group: childGroup
-							});
+					const edgeOptions = group.getChildOrderOptions(
+						childGroup,
+						chunkGraph
+					);
+					for (const key of Object.keys(edgeOptions)) {
+						const name = key.slice(0, key.length - "Order".length);
+						let list = lists.get(name);
+						if (list === undefined) {
+							list = [];
+							lists.set(name, list);
 						}
+						list.push({
+							order: edgeOptions[key],
+							group: childGroup
+						});
 					}
 				}
 			}
@@ -852,9 +847,8 @@ class Chunk {
 		const list = [];
 		for (const group of this.groupsIterable) {
 			for (const childGroup of group.childrenIterable) {
-				const order =
-					/** @type {number} */
-					(childGroup.options[/** @type {keyof ChunkGroupOptions} */ (type)]);
+				const edgeOptions = group.getChildOrderOptions(childGroup, chunkGraph);
+				const order = edgeOptions[type];
 				if (order === undefined) continue;
 				list.push({
 					order,

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -545,6 +545,53 @@ class ChunkGroup {
 	}
 
 	/**
+	 * Aggregates per-block `*Order` options for the blocks that bridge this
+	 * chunk group to the given child chunk group. `*Order` options are tied to
+	 * the originating `import()` call and must not be sourced from the child's
+	 * shared options, otherwise a webpackPrefetch/Preload directive from one
+	 * parent would leak into other parents that share the child by name.
+	 * @param {ChunkGroup} childGroup the child chunk group
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {Record<string, number>} merged `*Order` options for the edge from this group to `childGroup`
+	 */
+	getChildOrderOptions(childGroup, chunkGraph) {
+		/** @type {Record<string, number>} */
+		const result = Object.create(null);
+		let bridged = false;
+		for (const block of childGroup.blocksIterable) {
+			const rootModule = /** @type {Module} */ (block.getRootBlock());
+			if (!chunkGraph.isModuleInChunkGroup(rootModule, this)) continue;
+			bridged = true;
+			const opts = block.groupOptions;
+			if (!opts) continue;
+			for (const key of Object.keys(opts)) {
+				if (!key.endsWith("Order")) continue;
+				const value =
+					/** @type {number} */
+					(opts[/** @type {keyof ChunkGroupOptions} */ (key)]);
+				if (typeof value !== "number") continue;
+				if (result[key] === undefined || value > result[key]) {
+					result[key] = value;
+				}
+			}
+		}
+		// Fall back to the child's own options only when no block bridges
+		// this edge (e.g. a chunk group created by APIs that don't go through
+		// an AsyncDependenciesBlock). Otherwise we'd reintroduce the leak.
+		if (!bridged) {
+			for (const key of Object.keys(childGroup.options)) {
+				if (!key.endsWith("Order")) continue;
+				const value =
+					childGroup.options[/** @type {keyof ChunkGroupOptions} */ (key)];
+				if (typeof value === "number") {
+					result[key] = value;
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
 	 * Groups child chunk groups by their `*Order` options and sorts each group
 	 * by descending order and deterministic chunk-group comparison.
 	 * @param {ModuleGraph} moduleGraph the module graph
@@ -555,22 +602,17 @@ class ChunkGroup {
 		/** @type {Map<string, { order: number, group: ChunkGroup }[]>} */
 		const lists = new Map();
 		for (const childGroup of this._children) {
-			for (const key of Object.keys(childGroup.options)) {
-				if (key.endsWith("Order")) {
-					const name = key.slice(0, key.length - "Order".length);
-					let list = lists.get(name);
-					if (list === undefined) {
-						lists.set(name, (list = []));
-					}
-					list.push({
-						order:
-							/** @type {number} */
-							(
-								childGroup.options[/** @type {keyof ChunkGroupOptions} */ (key)]
-							),
-						group: childGroup
-					});
+			const edgeOptions = this.getChildOrderOptions(childGroup, chunkGraph);
+			for (const key of Object.keys(edgeOptions)) {
+				const name = key.slice(0, key.length - "Order".length);
+				let list = lists.get(name);
+				if (list === undefined) {
+					lists.set(name, (list = []));
 				}
+				list.push({
+					order: edgeOptions[key],
+					group: childGroup
+				});
 			}
 		}
 		/** @type {Record<string, ChunkGroup[]>} */

--- a/test/configCases/web/prefetch-chunk-name-collision/a.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/a.js
@@ -1,0 +1,11 @@
+__webpack_public_path__ = "https://example.com/path/";
+
+it("entry a should prefetch the shared chunk at startup", () => {
+	const prefetchLinks = document.head._children.filter(
+		(node) => node._type === "link" && node.rel === "prefetch"
+	);
+	expect(prefetchLinks).toHaveLength(1);
+	expect(prefetchLinks[0].href).toBe("https://example.com/path/shared.js");
+	// The import is what registered the prefetch directive at compile time.
+	import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared");
+});

--- a/test/configCases/web/prefetch-chunk-name-collision/a.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/a.js
@@ -1,11 +1,16 @@
 __webpack_public_path__ = "https://example.com/path/";
 
+// The import below only needs to exist for the parser to register the
+// prefetch directive. Wrapping it in unreachable code prevents the
+// JSONP runtime from arming a long chunkLoadTimeout in the test harness.
+if (Math.random() < -1) {
+	import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared");
+}
+
 it("entry a should prefetch the shared chunk at startup", () => {
 	const prefetchLinks = document.head._children.filter(
 		(node) => node._type === "link" && node.rel === "prefetch"
 	);
 	expect(prefetchLinks).toHaveLength(1);
 	expect(prefetchLinks[0].href).toBe("https://example.com/path/shared.js");
-	// The import is what registered the prefetch directive at compile time.
-	import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared");
 });

--- a/test/configCases/web/prefetch-chunk-name-collision/b.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/b.js
@@ -1,0 +1,13 @@
+__webpack_public_path__ = "https://example.com/path/";
+
+it("entry b should not prefetch the shared chunk because webpackPrefetch is not set", () => {
+	// Entry a (run before this) already added one prefetch link at startup.
+	// Without the fix from issue #12393, entry b would also have added a
+	// prefetch link because the named "shared" chunk group accumulated
+	// prefetchOrder from entry a's block.
+	const prefetchLinks = document.head._children.filter(
+		(node) => node._type === "link" && node.rel === "prefetch"
+	);
+	expect(prefetchLinks).toHaveLength(1);
+	import(/* webpackChunkName: "shared" */ "./shared");
+});

--- a/test/configCases/web/prefetch-chunk-name-collision/b.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/b.js
@@ -1,5 +1,12 @@
 __webpack_public_path__ = "https://example.com/path/";
 
+// The import below only needs to exist for the parser to associate this
+// entry with the same named chunk group. Wrapping it in unreachable code
+// prevents the JSONP runtime from arming a long chunkLoadTimeout.
+if (Math.random() < -1) {
+	import(/* webpackChunkName: "shared" */ "./shared");
+}
+
 it("entry b should not prefetch the shared chunk because webpackPrefetch is not set", () => {
 	// Entry a (run before this) already added one prefetch link at startup.
 	// Without the fix from issue #12393, entry b would also have added a
@@ -9,5 +16,4 @@ it("entry b should not prefetch the shared chunk because webpackPrefetch is not 
 		(node) => node._type === "link" && node.rel === "prefetch"
 	);
 	expect(prefetchLinks).toHaveLength(1);
-	import(/* webpackChunkName: "shared" */ "./shared");
 });

--- a/test/configCases/web/prefetch-chunk-name-collision/shared.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/shared.js
@@ -1,0 +1,1 @@
+module.exports = "shared";

--- a/test/configCases/web/prefetch-chunk-name-collision/test.config.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./a.js", "./b.js"];
+	}
+};

--- a/test/configCases/web/prefetch-chunk-name-collision/webpack.config.js
+++ b/test/configCases/web/prefetch-chunk-name-collision/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: {
+		a: "./a.js",
+		b: "./b.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].js"
+	},
+	performance: {
+		hints: false
+	},
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/statsCases/prefetch-chunk-name-collision/__snapshots__/StatsTest.snap
+++ b/test/statsCases/prefetch-chunk-name-collision/__snapshots__/StatsTest.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsTestCases prefetch-chunk-name-collision should print correct stats for prefetch-chunk-name-collision 1`] = `
+"Entrypoint a X KiB = a.js
+  prefetch: shared.js (name: shared)
+Entrypoint b X KiB = b.js
+chunk (runtime: b) b.js (b) X bytes (javascript) X KiB (runtime) >{804}< [entry] [rendered]
+chunk (runtime: a, b) shared.js (shared) X bytes <{199}> <{996}> [rendered]
+chunk (runtime: a) a.js (a) X bytes (javascript) X KiB (runtime) >{804}< (prefetch: {804}) [entry] [rendered]"
+`;

--- a/test/statsCases/prefetch-chunk-name-collision/a.js
+++ b/test/statsCases/prefetch-chunk-name-collision/a.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared");

--- a/test/statsCases/prefetch-chunk-name-collision/b.js
+++ b/test/statsCases/prefetch-chunk-name-collision/b.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: "shared" */ "./shared");

--- a/test/statsCases/prefetch-chunk-name-collision/shared.js
+++ b/test/statsCases/prefetch-chunk-name-collision/shared.js
@@ -1,0 +1,1 @@
+module.exports = "shared";

--- a/test/statsCases/prefetch-chunk-name-collision/webpack.config.js
+++ b/test/statsCases/prefetch-chunk-name-collision/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		a: "./a",
+		b: "./b"
+	},
+	stats: {
+		all: false,
+		chunkRelations: true,
+		chunks: true,
+		entrypoints: true,
+		chunkGroupChildren: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -2531,6 +2531,18 @@ declare abstract class ChunkGroup {
 	compareTo(chunkGraph: ChunkGraph, otherGroup: ChunkGroup): 0 | 1 | -1;
 
 	/**
+	 * Aggregates per-block `*Order` options for the blocks that bridge this
+	 * chunk group to the given child chunk group. `*Order` options are tied to
+	 * the originating `import()` call and must not be sourced from the child's
+	 * shared options, otherwise a webpackPrefetch/Preload directive from one
+	 * parent would leak into other parents that share the child by name.
+	 */
+	getChildOrderOptions(
+		childGroup: ChunkGroup,
+		chunkGraph: ChunkGraph
+	): Record<string, number>;
+
+	/**
 	 * Groups child chunk groups by their `*Order` options and sorts each group
 	 * by descending order and deterministic chunk-group comparison.
 	 */


### PR DESCRIPTION
When two `import()` calls used the same `webpackChunkName` but only one
specified `webpackPrefetch` (or `webpackPreload`), the directive was
applied to every parent chunk that referenced the named chunk. This
happened because `*Order` options were accumulated on the shared chunk
group's options, losing the per-call-site origin.

Resolve `*Order` options per parent→child edge by inspecting the blocks
that bridge the edge instead of the child chunk group's accumulated
options. Closes #12393.