### PR TITLE
fix: correct `createParser`/`createGenerator` hook types in `NormalModuleFactory`

### DIFF
--- a/.changeset/fix-create-parser-generator-hook-types.md
+++ b/.changeset/fix-create-parser-generator-hook-types.md
@@ -1,0 +1,8 @@
+---
+"webpack": patch
+---
+
+Fix `NormalModuleFactory` hook types so `createParser`/`createGenerator` (and `parser`/`generator`) expose accurate per-module-type options:
+
+- `module.generator.html` now uses `HtmlGeneratorOptions` instead of `EmptyGeneratorOptions` (the `extract` option was hidden).
+- WebAssembly (`webassembly/async`, `webassembly/sync`) generator hooks now use `EmptyGeneratorOptions` instead of `EmptyParserOptions`.

--- a/.changeset/fix-create-parser-generator-hook-types.md
+++ b/.changeset/fix-create-parser-generator-hook-types.md
@@ -2,7 +2,8 @@
 "webpack": patch
 ---
 
-Fix `NormalModuleFactory` hook types so `createParser`/`createGenerator` (and `parser`/`generator`) expose accurate per-module-type options:
+Fix `NormalModuleFactory` parser/generator types:
 
-- `module.generator.html` now uses `HtmlGeneratorOptions` instead of `EmptyGeneratorOptions` (the `extract` option was hidden).
+- `module.generator.html` now uses `HtmlGeneratorOptions` instead of `EmptyGeneratorOptions` (the `extract` option was hidden from the `createGenerator` / `generator` hook types).
 - WebAssembly (`webassembly/async`, `webassembly/sync`) generator hooks now use `EmptyGeneratorOptions` instead of `EmptyParserOptions`.
+- `NormalModuleFactory#getParser` / `createParser` / `getGenerator` / `createGenerator` are now generic over the module-type string, returning the specific parser/generator class for known types (e.g. `JavascriptParser` for `"javascript/auto"`, `CssGenerator` for `"css"`, etc.) instead of always returning the base `Parser` / `Generator`.

--- a/.changeset/fix-create-parser-generator-hook-types.md
+++ b/.changeset/fix-create-parser-generator-hook-types.md
@@ -7,3 +7,4 @@ Fix `NormalModuleFactory` parser/generator types:
 - `module.generator.html` now uses `HtmlGeneratorOptions` instead of `EmptyGeneratorOptions` (the `extract` option was hidden from the `createGenerator` / `generator` hook types).
 - WebAssembly (`webassembly/async`, `webassembly/sync`) generator hooks now use `EmptyGeneratorOptions` instead of `EmptyParserOptions`.
 - `NormalModuleFactory#getParser` / `createParser` / `getGenerator` / `createGenerator` are now generic over the module-type string, returning the specific parser/generator class for known types (e.g. `JavascriptParser` for `"javascript/auto"`, `CssGenerator` for `"css"`, etc.) instead of always returning the base `Parser` / `Generator`.
+- `NormalModuleCreateData` is now generic over the module type so `parser`, `parserOptions`, `generator`, and `generatorOptions` are narrowed to the specific class / options for the given `type`.

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -89,6 +89,10 @@ const parseJson = require("./util/parseJson");
 /** @typedef {Iterator<SideEffectsWalk, ConnectionState, ConnectionState>} SideEffectsWalk */
 /** @typedef {import("./NormalModuleFactory")} NormalModuleFactory */
 /** @typedef {import("./NormalModuleFactory").NormalModuleTypes} NormalModuleTypes */
+/** @typedef {import("./NormalModuleFactory").ParserByType} ParserByType */
+/** @typedef {import("./NormalModuleFactory").ParserOptionsByType} ParserOptionsByType */
+/** @typedef {import("./NormalModuleFactory").GeneratorByType} GeneratorByType */
+/** @typedef {import("./NormalModuleFactory").GeneratorOptionsByType} GeneratorOptionsByType */
 /** @typedef {import("./NormalModuleFactory").ResourceSchemeData} ResourceSchemeData */
 /** @typedef {import("./Parser")} Parser */
 /** @typedef {import("./Parser").PreparsedAst} PreparsedAst */
@@ -312,9 +316,10 @@ const asBuffer = (input) => {
  */
 
 /**
+ * @template {NormalModuleTypes | ""} [T=NormalModuleTypes | ""]
  * @typedef {object} NormalModuleCreateData
  * @property {string=} layer an optional layer in which the module is
- * @property {NormalModuleTypes | ""} type module type. When deserializing, this is set to an empty string "".
+ * @property {T} type module type. When deserializing, this is set to an empty string "".
  * @property {string} request request string
  * @property {string} userRequest request intended by user (without loaders from config)
  * @property {string} rawRequest request without resolving
@@ -323,10 +328,10 @@ const asBuffer = (input) => {
  * @property {(ResourceSchemeData & Partial<ResolveRequest>)=} resourceResolveData resource resolve data
  * @property {string} context context directory for resolving
  * @property {string=} matchResource path + query of the matched resource (virtual)
- * @property {Parser} parser the parser used
- * @property {ParserOptions=} parserOptions the options of the parser used
- * @property {Generator} generator the generator used
- * @property {GeneratorOptions=} generatorOptions the options of the generator used
+ * @property {ParserByType[T]} parser the parser used
+ * @property {ParserOptionsByType[T]=} parserOptions the options of the parser used
+ * @property {GeneratorByType[T]} generator the generator used
+ * @property {GeneratorOptionsByType[T]=} generatorOptions the options of the generator used
  * @property {ResolveOptions=} resolveOptions options used for resolving requests from this module
  * @property {boolean} extractSourceMap enable/disable extracting source map
  */

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -324,7 +324,7 @@ const ruleSetCompiler = new RuleSetCompiler([
 /** @typedef {import("./html/HtmlParser")} HtmlParser */
 /** @typedef {import("../declarations/WebpackOptions").EmptyParserOptions} HtmlParserOptions */
 /** @typedef {import("./html/HtmlGenerator")} HtmlGenerator */
-/** @typedef {import("../declarations/WebpackOptions").EmptyGeneratorOptions} HtmlGeneratorOptions */
+/** @typedef {import("../declarations/WebpackOptions").HtmlGeneratorOptions} HtmlGeneratorOptions */
 
 /* eslint-disable jsdoc/type-formatting */
 /**
@@ -339,8 +339,8 @@ const ruleSetCompiler = new RuleSetCompiler([
  * [ASSET_MODULE_TYPE_RESOURCE, AssetParser, EmptyParserOptions, AssetGenerator, AssetGeneratorOptions],
  * [ASSET_MODULE_TYPE_SOURCE, AssetSourceParser, EmptyParserOptions, AssetSourceGenerator, EmptyGeneratorOptions],
  * [ASSET_MODULE_TYPE_BYTES, AssetBytesParser, EmptyParserOptions, AssetBytesGenerator, EmptyGeneratorOptions],
- * [WEBASSEMBLY_MODULE_TYPE_ASYNC, AsyncWebAssemblyParser, EmptyParserOptions, Generator, EmptyParserOptions],
- * [WEBASSEMBLY_MODULE_TYPE_SYNC, WebAssemblyParser, EmptyParserOptions, Generator, EmptyParserOptions],
+ * [WEBASSEMBLY_MODULE_TYPE_ASYNC, AsyncWebAssemblyParser, EmptyParserOptions, Generator, EmptyGeneratorOptions],
+ * [WEBASSEMBLY_MODULE_TYPE_SYNC, WebAssemblyParser, EmptyParserOptions, Generator, EmptyGeneratorOptions],
  * [CSS_MODULE_TYPE, CssParser, CssParserOptions, CssGenerator, CssGeneratorOptions],
  * [CSS_MODULE_TYPE_AUTO, CssParser, CssModuleParserOptions, CssGenerator, CssModuleGeneratorOptions],
  * [CSS_MODULE_TYPE_MODULE, CssParser, CssModuleParserOptions, CssGenerator, CssModuleGeneratorOptions],

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -366,6 +366,16 @@ const ruleSetCompiler = new RuleSetCompiler([
  * @typedef {T extends [infer Head extends [string, ...unknown[]], ...infer Tail extends [string, ...unknown[]][]] ? Record<Head[0], SyncBailHook<ExtractTupleElements<Head, A>, R extends number ? Head[R] : R>> & RecordFactoryFromTuple<Tail, A, R> : unknown } RecordFactoryFromTuple
  */
 
+/**
+ * Maps each tuple in `T` to a record from its `[0]` key to its `[I]` value.
+ * @template {unknown[]} T
+ * @template {number} I
+ * @typedef {T extends [infer Head extends [string, ...unknown[]], ...infer Tail extends [string, ...unknown[]][]] ? Record<Head[0], I extends keyof Head ? Head[I] : never> & TupleToTypeMap<Tail, I> : unknown } TupleToTypeMap
+ */
+
+/** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 1>} ParserByType */
+/** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 3>} GeneratorByType */
+
 class NormalModuleFactory extends ModuleFactory {
 	/**
 	 * Creates an instance of NormalModuleFactory.
@@ -1401,9 +1411,10 @@ If changing the source code is not an option there is also a resolve options cal
 
 	/**
 	 * Returns parser.
-	 * @param {string} type type
+	 * @template {string} T
+	 * @param {T} type type
 	 * @param {ParserOptions} parserOptions parser options
-	 * @returns {Parser} parser
+	 * @returns {ParserByType[T]} parser
 	 */
 	getParser(type, parserOptions = EMPTY_PARSER_OPTIONS) {
 		let cache = this.parserCache.get(type);
@@ -1420,14 +1431,15 @@ If changing the source code is not an option there is also a resolve options cal
 			cache.set(parserOptions, parser);
 		}
 
-		return parser;
+		return /** @type {ParserByType[T]} */ (parser);
 	}
 
 	/**
 	 * Creates a parser from the provided type.
-	 * @param {string} type type
+	 * @template {string} T
+	 * @param {T} type type
 	 * @param {ParserOptions} parserOptions parser options
-	 * @returns {Parser} parser
+	 * @returns {ParserByType[T]} parser
 	 */
 	createParser(type, parserOptions = {}) {
 		parserOptions = mergeGlobalOptions(
@@ -1440,14 +1452,15 @@ If changing the source code is not an option there is also a resolve options cal
 			throw new Error(`No parser registered for ${type}`);
 		}
 		this.hooks.parser.for(type).call(parser, parserOptions);
-		return parser;
+		return /** @type {ParserByType[T]} */ (parser);
 	}
 
 	/**
 	 * Returns generator.
-	 * @param {string} type type of generator
+	 * @template {string} T
+	 * @param {T} type type of generator
 	 * @param {GeneratorOptions} generatorOptions generator options
-	 * @returns {Generator} generator
+	 * @returns {GeneratorByType[T]} generator
 	 */
 	getGenerator(type, generatorOptions = EMPTY_GENERATOR_OPTIONS) {
 		let cache = this.generatorCache.get(type);
@@ -1464,14 +1477,15 @@ If changing the source code is not an option there is also a resolve options cal
 			cache.set(generatorOptions, generator);
 		}
 
-		return generator;
+		return /** @type {GeneratorByType[T]} */ (generator);
 	}
 
 	/**
 	 * Creates a generator.
-	 * @param {string} type type of generator
+	 * @template {string} T
+	 * @param {T} type type of generator
 	 * @param {GeneratorOptions} generatorOptions generator options
-	 * @returns {Generator} generator
+	 * @returns {GeneratorByType[T]} generator
 	 */
 	createGenerator(type, generatorOptions = {}) {
 		generatorOptions = mergeGlobalOptions(
@@ -1486,7 +1500,7 @@ If changing the source code is not an option there is also a resolve options cal
 			throw new Error(`No generator registered for ${type}`);
 		}
 		this.hooks.generator.for(type).call(generator, generatorOptions);
-		return generator;
+		return /** @type {GeneratorByType[T]} */ (generator);
 	}
 
 	/**

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -374,7 +374,9 @@ const ruleSetCompiler = new RuleSetCompiler([
  */
 
 /** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 1>} ParserByType */
+/** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 2>} ParserOptionsByType */
 /** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 3>} GeneratorByType */
+/** @typedef {TupleToTypeMap<ParsersAndGeneratorsByTypes, 4>} GeneratorOptionsByType */
 
 class NormalModuleFactory extends ModuleFactory {
 	/**

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -255,11 +255,7 @@ class HtmlModulesPlugin {
 									options
 								)
 						);
-						return new HtmlGenerator(
-							/** @type {import("../../declarations/WebpackOptions").HtmlGeneratorOptions} */
-							(generatorOptions),
-							compilation.moduleGraph
-						);
+						return new HtmlGenerator(generatorOptions, compilation.moduleGraph);
 					});
 
 				NormalModule.getCompilationHooks(compilation).processResult.tap(

--- a/types.d.ts
+++ b/types.d.ts
@@ -16272,11 +16272,11 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 				> &
 				Record<
 					"webassembly/async",
-					SyncBailHook<[EmptyParserOptions], Generator>
+					SyncBailHook<[EmptyGeneratorOptions], Generator>
 				> &
 				Record<
 					"webassembly/sync",
-					SyncBailHook<[EmptyParserOptions], Generator>
+					SyncBailHook<[EmptyGeneratorOptions], Generator>
 				> &
 				Record<"css", SyncBailHook<[CssGeneratorOptions], CssGenerator>> &
 				Record<
@@ -16291,7 +16291,7 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 					"css/global",
 					SyncBailHook<[CssModuleGeneratorOptions], CssGenerator>
 				> &
-				Record<"html", SyncBailHook<[EmptyGeneratorOptions], HtmlGenerator>> &
+				Record<"html", SyncBailHook<[HtmlGeneratorOptions], HtmlGenerator>> &
 				Record<string, SyncBailHook<[GeneratorOptions], Generator>>
 		>;
 		generator: TypedHookMap<
@@ -16333,11 +16333,11 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 				> &
 				Record<
 					"webassembly/async",
-					SyncBailHook<[Generator, EmptyParserOptions], void>
+					SyncBailHook<[Generator, EmptyGeneratorOptions], void>
 				> &
 				Record<
 					"webassembly/sync",
-					SyncBailHook<[Generator, EmptyParserOptions], void>
+					SyncBailHook<[Generator, EmptyGeneratorOptions], void>
 				> &
 				Record<"css", SyncBailHook<[CssGenerator, CssGeneratorOptions], void>> &
 				Record<
@@ -16354,7 +16354,7 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 				> &
 				Record<
 					"html",
-					SyncBailHook<[HtmlGenerator, EmptyGeneratorOptions], void>
+					SyncBailHook<[HtmlGenerator, HtmlGeneratorOptions], void>
 				> &
 				Record<string, SyncBailHook<[Generator, GeneratorOptions], void>>
 		>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -4440,7 +4440,7 @@ declare interface Configuration {
 				/**
 				 * Which asset type should receive this devtool value.
 				 */
-				type: "all" | "javascript" | "css";
+				type: "css" | "all" | "javascript";
 				/**
 				 * A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
 				 */
@@ -5045,7 +5045,89 @@ declare interface ContextTimestampAndHash {
 	symlinks?: Set<string>;
 }
 type ContextTypes = KnownContext & Record<any, any>;
-type CreateData = NormalModuleCreateData & { settings: ModuleSettings };
+
+declare interface CreateData {
+	/**
+	 * an optional layer in which the module is
+	 */
+	layer?: string;
+
+	/**
+	 * module type. When deserializing, this is set to an empty string "".
+	 */
+	type: string;
+
+	/**
+	 * request string
+	 */
+	request: string;
+
+	/**
+	 * request intended by user (without loaders from config)
+	 */
+	userRequest: string;
+
+	/**
+	 * request without resolving
+	 */
+	rawRequest: string;
+
+	/**
+	 * list of loaders
+	 */
+	loaders: LoaderItem[];
+
+	/**
+	 * path + query of the real resource
+	 */
+	resource: string;
+
+	/**
+	 * resource resolve data
+	 */
+	resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
+
+	/**
+	 * context directory for resolving
+	 */
+	context: string;
+
+	/**
+	 * path + query of the matched resource (virtual)
+	 */
+	matchResource?: string;
+
+	/**
+	 * the parser used
+	 */
+	parser: ParserClass;
+
+	/**
+	 * the options of the parser used
+	 */
+	parserOptions?: ParserOptions;
+
+	/**
+	 * the generator used
+	 */
+	generator: Generator;
+
+	/**
+	 * the options of the generator used
+	 */
+	generatorOptions?: GeneratorOptions;
+
+	/**
+	 * options used for resolving requests from this module
+	 */
+	resolveOptions?: ResolveOptions;
+
+	/**
+	 * enable/disable extracting source map
+	 */
+	extractSourceMap: boolean;
+	settings: ModuleSettings;
+}
 type CreateReadStreamFSImplementation = FSImplementation & {
 	read: (...args: any[]) => any;
 };
@@ -15941,7 +16023,7 @@ declare interface NodeTemplatePluginOptions {
 type NodeWebpackOptions = false | NodeOptions;
 type NonNullable<T> = T & {};
 declare class NormalModule extends Module {
-	constructor(__0: NormalModuleCreateData);
+	constructor(__0: NormalModuleCreateDataNormalModuleObject_1<string>);
 	request: string;
 	userRequest: string;
 	rawRequest: string;
@@ -16037,7 +16119,9 @@ declare interface NormalModuleCompilationHooks {
 	>;
 	needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
 }
-declare interface NormalModuleCreateData {
+declare interface NormalModuleCreateDataNormalModuleObject_1<
+	T extends string = string
+> {
 	/**
 	 * an optional layer in which the module is
 	 */
@@ -16046,7 +16130,7 @@ declare interface NormalModuleCreateData {
 	/**
 	 * module type. When deserializing, this is set to an empty string "".
 	 */
-	type: string;
+	type: T;
 
 	/**
 	 * request string
@@ -16091,22 +16175,86 @@ declare interface NormalModuleCreateData {
 	/**
 	 * the parser used
 	 */
-	parser: ParserClass;
+	parser: (Record<"javascript/auto", JavascriptParser> &
+		Record<"javascript/dynamic", JavascriptParser> &
+		Record<"javascript/esm", JavascriptParser> &
+		Record<"json", JsonParser> &
+		Record<"asset", AssetParser> &
+		Record<"asset/inline", AssetParser> &
+		Record<"asset/resource", AssetParser> &
+		Record<"asset/source", AssetSourceParser> &
+		Record<"asset/bytes", AssetBytesParser> &
+		Record<"webassembly/async", AsyncWebAssemblyParser> &
+		Record<"webassembly/sync", WebAssemblyParser> &
+		Record<"css", CssParser> &
+		Record<"css/auto", CssParser> &
+		Record<"css/module", CssParser> &
+		Record<"css/global", CssParser> &
+		Record<"html", HtmlParser> &
+		Record<string, ParserClass>)[T];
 
 	/**
 	 * the options of the parser used
 	 */
-	parserOptions?: ParserOptions;
+	parserOptions?: (Record<"javascript/auto", JavascriptParserOptions> &
+		Record<"javascript/dynamic", JavascriptParserOptions> &
+		Record<"javascript/esm", JavascriptParserOptions> &
+		Record<"json", JsonParserOptions> &
+		Record<"asset", AssetParserOptions> &
+		Record<"asset/inline", EmptyParserOptions> &
+		Record<"asset/resource", EmptyParserOptions> &
+		Record<"asset/source", EmptyParserOptions> &
+		Record<"asset/bytes", EmptyParserOptions> &
+		Record<"webassembly/async", EmptyParserOptions> &
+		Record<"webassembly/sync", EmptyParserOptions> &
+		Record<"css", CssParserOptions> &
+		Record<"css/auto", CssModuleParserOptions> &
+		Record<"css/module", CssModuleParserOptions> &
+		Record<"css/global", CssModuleParserOptions> &
+		Record<"html", EmptyParserOptions> &
+		Record<string, ParserOptions>)[T];
 
 	/**
 	 * the generator used
 	 */
-	generator: Generator;
+	generator: (Record<"javascript/auto", JavascriptGenerator> &
+		Record<"javascript/dynamic", JavascriptGenerator> &
+		Record<"javascript/esm", JavascriptGenerator> &
+		Record<"json", JsonGenerator> &
+		Record<"asset", AssetGenerator> &
+		Record<"asset/inline", AssetGenerator> &
+		Record<"asset/resource", AssetGenerator> &
+		Record<"asset/source", AssetSourceGenerator> &
+		Record<"asset/bytes", AssetBytesGenerator> &
+		Record<"webassembly/async", Generator> &
+		Record<"webassembly/sync", Generator> &
+		Record<"css", CssGenerator> &
+		Record<"css/auto", CssGenerator> &
+		Record<"css/module", CssGenerator> &
+		Record<"css/global", CssGenerator> &
+		Record<"html", HtmlGenerator> &
+		Record<string, Generator>)[T];
 
 	/**
 	 * the options of the generator used
 	 */
-	generatorOptions?: GeneratorOptions;
+	generatorOptions?: (Record<"javascript/auto", EmptyGeneratorOptions> &
+		Record<"javascript/dynamic", EmptyGeneratorOptions> &
+		Record<"javascript/esm", EmptyGeneratorOptions> &
+		Record<"json", JsonGeneratorOptions> &
+		Record<"asset", AssetGeneratorOptions> &
+		Record<"asset/inline", AssetGeneratorOptions> &
+		Record<"asset/resource", AssetGeneratorOptions> &
+		Record<"asset/source", EmptyGeneratorOptions> &
+		Record<"asset/bytes", EmptyGeneratorOptions> &
+		Record<"webassembly/async", EmptyGeneratorOptions> &
+		Record<"webassembly/sync", EmptyGeneratorOptions> &
+		Record<"css", CssGeneratorOptions> &
+		Record<"css/auto", CssModuleGeneratorOptions> &
+		Record<"css/module", CssModuleGeneratorOptions> &
+		Record<"css/global", CssModuleGeneratorOptions> &
+		Record<"html", HtmlGeneratorOptions> &
+		Record<string, GeneratorOptions>)[T];
 
 	/**
 	 * options used for resolving requests from this module
@@ -24437,7 +24585,7 @@ declare interface WebpackOptionsInterception {
 				/**
 				 * Which asset type should receive this devtool value.
 				 */
-				type: "all" | "javascript" | "css";
+				type: "css" | "all" | "javascript";
 				/**
 				 * A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
 				 */
@@ -24489,7 +24637,7 @@ declare interface WebpackOptionsNormalized {
 				/**
 				 * Which asset type should receive this devtool value.
 				 */
-				type: "all" | "javascript" | "css";
+				type: "css" | "all" | "javascript";
 				/**
 				 * A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
 				 */
@@ -24685,7 +24833,7 @@ type WebpackOptionsNormalizedWithDefaults = WebpackOptionsNormalized & {
 				/**
 				 * Which asset type should receive this devtool value.
 				 */
-				type: "all" | "javascript" | "css";
+				type: "css" | "all" | "javascript";
 				/**
 				 * A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
 				 */

--- a/types.d.ts
+++ b/types.d.ts
@@ -16401,22 +16401,98 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 	/**
 	 * Returns parser.
 	 */
-	getParser(type: string, parserOptions?: ParserOptions): ParserClass;
+	getParser<T extends string>(
+		type: T,
+		parserOptions?: ParserOptions
+	): (Record<"javascript/auto", JavascriptParser> &
+		Record<"javascript/dynamic", JavascriptParser> &
+		Record<"javascript/esm", JavascriptParser> &
+		Record<"json", JsonParser> &
+		Record<"asset", AssetParser> &
+		Record<"asset/inline", AssetParser> &
+		Record<"asset/resource", AssetParser> &
+		Record<"asset/source", AssetSourceParser> &
+		Record<"asset/bytes", AssetBytesParser> &
+		Record<"webassembly/async", AsyncWebAssemblyParser> &
+		Record<"webassembly/sync", WebAssemblyParser> &
+		Record<"css", CssParser> &
+		Record<"css/auto", CssParser> &
+		Record<"css/module", CssParser> &
+		Record<"css/global", CssParser> &
+		Record<"html", HtmlParser> &
+		Record<string, ParserClass>)[T];
 
 	/**
 	 * Creates a parser from the provided type.
 	 */
-	createParser(type: string, parserOptions?: ParserOptions): ParserClass;
+	createParser<T extends string>(
+		type: T,
+		parserOptions?: ParserOptions
+	): (Record<"javascript/auto", JavascriptParser> &
+		Record<"javascript/dynamic", JavascriptParser> &
+		Record<"javascript/esm", JavascriptParser> &
+		Record<"json", JsonParser> &
+		Record<"asset", AssetParser> &
+		Record<"asset/inline", AssetParser> &
+		Record<"asset/resource", AssetParser> &
+		Record<"asset/source", AssetSourceParser> &
+		Record<"asset/bytes", AssetBytesParser> &
+		Record<"webassembly/async", AsyncWebAssemblyParser> &
+		Record<"webassembly/sync", WebAssemblyParser> &
+		Record<"css", CssParser> &
+		Record<"css/auto", CssParser> &
+		Record<"css/module", CssParser> &
+		Record<"css/global", CssParser> &
+		Record<"html", HtmlParser> &
+		Record<string, ParserClass>)[T];
 
 	/**
 	 * Returns generator.
 	 */
-	getGenerator(type: string, generatorOptions?: GeneratorOptions): Generator;
+	getGenerator<T extends string>(
+		type: T,
+		generatorOptions?: GeneratorOptions
+	): (Record<"javascript/auto", JavascriptGenerator> &
+		Record<"javascript/dynamic", JavascriptGenerator> &
+		Record<"javascript/esm", JavascriptGenerator> &
+		Record<"json", JsonGenerator> &
+		Record<"asset", AssetGenerator> &
+		Record<"asset/inline", AssetGenerator> &
+		Record<"asset/resource", AssetGenerator> &
+		Record<"asset/source", AssetSourceGenerator> &
+		Record<"asset/bytes", AssetBytesGenerator> &
+		Record<"webassembly/async", Generator> &
+		Record<"webassembly/sync", Generator> &
+		Record<"css", CssGenerator> &
+		Record<"css/auto", CssGenerator> &
+		Record<"css/module", CssGenerator> &
+		Record<"css/global", CssGenerator> &
+		Record<"html", HtmlGenerator> &
+		Record<string, Generator>)[T];
 
 	/**
 	 * Creates a generator.
 	 */
-	createGenerator(type: string, generatorOptions?: GeneratorOptions): Generator;
+	createGenerator<T extends string>(
+		type: T,
+		generatorOptions?: GeneratorOptions
+	): (Record<"javascript/auto", JavascriptGenerator> &
+		Record<"javascript/dynamic", JavascriptGenerator> &
+		Record<"javascript/esm", JavascriptGenerator> &
+		Record<"json", JsonGenerator> &
+		Record<"asset", AssetGenerator> &
+		Record<"asset/inline", AssetGenerator> &
+		Record<"asset/resource", AssetGenerator> &
+		Record<"asset/source", AssetSourceGenerator> &
+		Record<"asset/bytes", AssetBytesGenerator> &
+		Record<"webassembly/async", Generator> &
+		Record<"webassembly/sync", Generator> &
+		Record<"css", CssGenerator> &
+		Record<"css/auto", CssGenerator> &
+		Record<"css/module", CssGenerator> &
+		Record<"css/global", CssGenerator> &
+		Record<"html", HtmlGenerator> &
+		Record<string, Generator>)[T];
 
 	/**
 	 * Returns the resolver.


### PR DESCRIPTION
- Use the real `HtmlGeneratorOptions` type for the `html` entry instead of aliasing it to `EmptyGeneratorOptions` (the `extract` option was hidden from `createGenerator`/`generator` hook types).
- Replace `EmptyParserOptions` with `EmptyGeneratorOptions` in the `webassembly/async` and `webassembly/sync` rows so generator hooks no longer leak parser-options types.