### PR TITLE
fix: allow devtool and SourceMapDevToolPlugin to coexist on the same asset

### DIFF
--- a/.changeset/multi-source-map-devtool-plugin.md
+++ b/.changeset/multi-source-map-devtool-plugin.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Allow `devtool` and `SourceMapDevToolPlugin` (or multiple `SourceMapDevToolPlugin` instances) to coexist on the same asset. Previously the second instance would silently skip any asset whose `info.related.sourceMap` had already been set by an earlier instance, and even when it ran the asset had been rewrapped as a `RawSource` so no source map could be recovered — producing an empty `.map` file. The plugin now keeps a per-compilation stash of pristine source maps, namespaces its persistent cache entries by the options that affect output, and appends additional `related.sourceMap` entries instead of overwriting them. The classic workaround of pairing `devtool: 'hidden-source-map'` with a `new webpack.SourceMapDevToolPlugin({ filename: '[file].secondary.map', noSources: true })` now produces both maps in a single build.

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -71,55 +71,83 @@ const resetRegexpState = (regexp) => {
 const quoteMeta = (str) => str.replace(METACHARACTERS_REGEXP, "\\$&");
 
 /**
- * Returns a structural clone of a source map so that callers can mutate it
- * without affecting the original (which may be shared between multiple
- * SourceMapDevToolPlugin instances running on the same asset).
- * @param {RawSourceMap} sourceMap source map to clone
- * @returns {RawSourceMap} cloned source map
+ * Compilation-scoped registry of original asset sources for multi-plugin
+ * cooperation. The first SourceMapDevToolPlugin instance to see a file pins a
+ * reference to the asset's still-unwrapped {@link Source} object; later
+ * instances whose `asset.source.sourceAndMap()` would now return `null` (the
+ * earlier instance replaced the asset with a `RawSource`) can re-extract the
+ * map from this pinned reference. We keep the registry on a module-scoped
+ * `WeakMap` so the entries are reclaimed automatically when the compilation
+ * itself becomes unreachable; we never store anything on the compilation
+ * object directly.
+ *
+ * Stashing the `Source` object itself rather than an extracted map keeps the
+ * fast path free of cloning and source-map serialization work — the
+ * extraction only happens if a subsequent plugin actually needs the map.
+ * @type {WeakMap<Compilation, Map<string, Source>>}
  */
-const cloneSourceMap = (sourceMap) => ({
-	...sourceMap,
-	sources: sourceMap.sources ? [...sourceMap.sources] : sourceMap.sources,
-	sourcesContent: sourceMap.sourcesContent
-		? [...sourceMap.sourcesContent]
-		: sourceMap.sourcesContent,
-	names: sourceMap.names ? [...sourceMap.names] : sourceMap.names
-});
+const originalSourceRegistry = new WeakMap();
 
 /**
- * Extracts source and source map from a Source object, with a shared stash so
- * that subsequent plugin instances can recover the original map after the asset
- * has been wrapped by an earlier instance (which drops the internal map).
- * @param {string} file file name
- * @param {Source} asset source object
- * @param {MapOptions} options map extraction options
- * @param {Map<string, RawSourceMap>} stash compilation-scoped cache of pristine source maps
- * @returns {{ source: string | Buffer, sourceMap: RawSourceMap } | undefined} extracted pair or undefined when no map is available
+ * Returns (creating if necessary) the per-compilation registry of original
+ * asset {@link Source} objects.
+ * @param {Compilation} compilation compilation
+ * @returns {Map<string, Source>} registry
  */
-const extractSourceAndMap = (file, asset, options, stash) => {
+const getOriginalSourceRegistry = (compilation) => {
+	let registry = originalSourceRegistry.get(compilation);
+	if (registry === undefined) {
+		registry = new Map();
+		originalSourceRegistry.set(compilation, registry);
+	}
+	return registry;
+};
+
+/**
+ * Extracts source and source map from a Source object, falling back to a
+ * registered original source for assets that another SourceMapDevToolPlugin
+ * instance has already wrapped (whose internal map is now `null`).
+ *
+ * The returned source is read from the asset as it currently stands — that way
+ * any `sourceMappingURL` comments appended by earlier plugin instances survive
+ * — while the map is taken from the pinned original Source when the current
+ * one no longer carries it.
+ * @param {string} file file name
+ * @param {Source} asset source object as currently held by the compilation
+ * @param {MapOptions} options map extraction options
+ * @param {Map<string, Source>} registry compilation-scoped original-source registry
+ * @returns {{ source: string | Buffer, sourceMap: RawSourceMap } | undefined} extracted pair or `undefined` when no map is recoverable
+ */
+const extractSourceAndMap = (file, asset, options, registry) => {
 	/** @type {string | Buffer} */
 	let source;
 	/** @type {null | RawSourceMap} */
 	let sourceMap;
 	if (asset.sourceAndMap) {
 		const sourceAndMap = asset.sourceAndMap(options);
-		sourceMap = sourceAndMap.map;
 		source = sourceAndMap.source;
+		sourceMap = sourceAndMap.map;
 	} else {
-		sourceMap = asset.map(options);
 		source = asset.source();
+		sourceMap = asset.map(options);
 	}
-	if (!sourceMap) {
-		// The asset itself has no internal source map. This is the typical case
-		// after a previous SourceMapDevToolPlugin instance has already wrapped
-		// the asset in a RawSource. Recover the original map from the stash.
-		const stashed = stash.get(file);
-		if (!stashed) return;
-		sourceMap = cloneSourceMap(stashed);
-	} else if (!stash.has(file)) {
-		// First plugin instance to extract this file — remember a pristine
-		// copy so subsequent instances can mutate freely without disturbing it.
-		stash.set(file, cloneSourceMap(sourceMap));
+	if (sourceMap) {
+		// The current asset still owns the original map — pin a reference so
+		// that a later plugin instance (which will see a rewrapped asset
+		// without a map) can recover it on demand.
+		if (!registry.has(file)) registry.set(file, asset);
+	} else {
+		// The current asset (typically a `RawSource` left by an earlier
+		// SourceMapDevToolPlugin instance) has no internal map. Re-extract
+		// the map from the original Source we pinned earlier. We keep using
+		// `source` from the current asset so that any prior wrappers (e.g.
+		// appended sourceMappingURL comments) are preserved.
+		const original = registry.get(file);
+		if (!original) return;
+		sourceMap = original.sourceAndMap
+			? original.sourceAndMap(options).map
+			: original.map(options);
+		if (!sourceMap) return;
 	}
 	if (typeof source !== "string") return;
 	return { source, sourceMap };
@@ -133,7 +161,7 @@ const extractSourceAndMap = (file, asset, options, stash) => {
  * @param {MapOptions} options source map options
  * @param {Compilation} compilation compilation instance
  * @param {ItemCacheFacade} cacheItem cache item
- * @param {Map<string, RawSourceMap>} stash compilation-scoped cache of pristine source maps
+ * @param {Map<string, Source>} registry compilation-scoped original-source registry
  * @returns {SourceMapTask | undefined} created task instance or `undefined`
  */
 const getTaskForFile = (
@@ -143,9 +171,9 @@ const getTaskForFile = (
 	options,
 	compilation,
 	cacheItem,
-	stash
+	registry
 ) => {
-	const extracted = extractSourceAndMap(file, asset, options, stash);
+	const extracted = extractSourceAndMap(file, asset, options, registry);
 	if (!extracted) return;
 	const { source, sourceMap } = extracted;
 	const context = compilation.options.context;
@@ -168,15 +196,6 @@ const getTaskForFile = (
 		cacheItem
 	};
 };
-
-/**
- * Shared, compilation-scoped stash of pristine source maps keyed by asset
- * filename. Populated by the first SourceMapDevToolPlugin instance to extract
- * a map from a given asset, then reused by subsequent instances whose own
- * extraction would otherwise return `null` (because the asset has already been
- * replaced with a RawSource that has no internal map).
- */
-const SOURCE_MAP_STASH = Symbol("SourceMapDevToolPlugin source-map stash");
 
 const PLUGIN_NAME = "SourceMapDevToolPlugin";
 
@@ -282,18 +301,13 @@ class SourceMapDevToolPlugin {
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
 			new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
 
-			// Each compilation gets a single shared stash that all
-			// SourceMapDevToolPlugin instances cooperate on, so the second
-			// instance to run can still recover the original source map after
-			// the first instance has replaced the asset with a RawSource.
-			/** @type {Map<string, RawSourceMap>} */
-			let stash =
-				/** @type {Map<string, RawSourceMap>} */
-				(/** @type {EXPECTED_ANY} */ (compilation)[SOURCE_MAP_STASH]);
-			if (!stash) {
-				stash = new Map();
-				/** @type {EXPECTED_ANY} */ (compilation)[SOURCE_MAP_STASH] = stash;
-			}
+			// All SourceMapDevToolPlugin instances on the same compilation share
+			// a registry of pristine asset sources, so the second instance to
+			// run can still recover the original map after the first instance
+			// has replaced the asset with a `RawSource`. The registry lives on a
+			// module-scoped `WeakMap` keyed by compilation so it is released
+			// automatically and never pollutes the compilation object.
+			const originalSources = getOriginalSourceRegistry(compilation);
 
 			compilation.hooks.processAssets.tapAsync(
 				{
@@ -364,21 +378,14 @@ class SourceMapDevToolPlugin {
 								 * If presented in cache, reassigns assets. Cache assets already have source maps.
 								 */
 								if (cacheEntry) {
-									// Populate the shared stash from the still-unwrapped asset
-									// before replacing it, so that any subsequent
-									// SourceMapDevToolPlugin instance can recover the original
-									// source map even though the persistent cache hit lets us
-									// skip the full processing here.
-									if (!stash.has(file)) {
-										extractSourceAndMap(
-											file,
-											asset.source,
-											{
-												module: options.module,
-												columns: options.columns
-											},
-											stash
-										);
+									// Pin the still-unwrapped asset source in the registry
+									// before `compilation.updateAsset` replaces it. This is a
+									// pointer assignment — no source-map extraction work — and
+									// it lets a subsequent SourceMapDevToolPlugin instance
+									// extract the original map on demand even though the
+									// persistent cache hit lets us skip processing here.
+									if (!originalSources.has(file)) {
+										originalSources.set(file, asset.source);
 									}
 
 									const { assets, assetsInfo } = cacheEntry;
@@ -430,7 +437,7 @@ class SourceMapDevToolPlugin {
 									},
 									compilation,
 									cacheItem,
-									stash
+									originalSources
 								);
 
 								if (task) {
@@ -563,12 +570,21 @@ class SourceMapDevToolPlugin {
 										"attach SourceMap"
 									);
 
-									const moduleFilenames = modules.map((m) =>
-										moduleToSourceNameMapping.get(m)
-									);
-									sourceMap.sources = /** @type {string[]} */ (moduleFilenames);
+									const moduleFilenames =
+										/** @type {string[]} */
+										(modules.map((m) => moduleToSourceNameMapping.get(m)));
+									// We deliberately do NOT mutate `sourceMap` in place: the
+									// task's `sourceMap` reference may be shared with a
+									// `SourceMapSource` whose internal map cache is the same
+									// object (webpack-sources keeps it cached). A second
+									// `SourceMapDevToolPlugin` instance that reads the original
+									// source through the registry would otherwise see our
+									// rewrites. Instead we build a fresh `outputSourceMap` for
+									// the .map file and leave the original alone.
+									/** @type {number[] | undefined} */
+									let ignoreList;
 									if (options.ignoreList) {
-										const ignoreList = sourceMap.sources.reduce(
+										const list = moduleFilenames.reduce(
 											/** @type {(acc: number[], sourceName: string, idx: number) => number[]} */ (
 												(acc, sourceName, idx) => {
 													const rule = /** @type {Rules} */ (
@@ -584,29 +600,23 @@ class SourceMapDevToolPlugin {
 											),
 											[]
 										);
-										if (ignoreList.length > 0) {
-											sourceMap.ignoreList = ignoreList;
-										}
+										if (list.length > 0) ignoreList = list;
 									}
 
-									if (options.noSources) {
-										sourceMap.sourcesContent = undefined;
-									}
-									sourceMap.sourceRoot = options.sourceRoot || "";
-									sourceMap.file = file;
 									const usesContentHash =
 										sourceMapFilename &&
 										CONTENT_HASH_DETECT_REGEXP.test(sourceMapFilename);
 
 									resetRegexpState(CONTENT_HASH_DETECT_REGEXP);
 
+									let outputFile = file;
 									// If SourceMap and asset uses contenthash, avoid a circular dependency by hiding hash in `file`
 									if (usesContentHash && task.assetInfo.contenthash) {
 										const contenthash = task.assetInfo.contenthash;
 										const pattern = Array.isArray(contenthash)
 											? contenthash.map(quoteMeta).join("|")
 											: quoteMeta(contenthash);
-										sourceMap.file = sourceMap.file.replace(
+										outputFile = outputFile.replace(
 											new RegExp(pattern, "g"),
 											(m) => "x".repeat(m.length)
 										);
@@ -629,9 +639,11 @@ class SourceMapDevToolPlugin {
 											);
 									}
 
+									/** @type {string | undefined} */
+									let debugIdValue;
 									if (options.debugIds) {
-										const debugId = generateDebugId(source, sourceMap.file);
-										sourceMap.debugId = debugId;
+										const debugId = generateDebugId(source, outputFile);
+										debugIdValue = debugId;
 
 										const debugIdComment = `\n//# debugId=${debugId}`;
 										currentSourceMappingURLComment =
@@ -640,7 +652,24 @@ class SourceMapDevToolPlugin {
 												: debugIdComment;
 									}
 
-									const sourceMapString = JSON.stringify(sourceMap);
+									/** @type {RawSourceMap} */
+									const outputSourceMap = {
+										...sourceMap,
+										sources: moduleFilenames,
+										sourceRoot: options.sourceRoot || "",
+										file: outputFile
+									};
+									if (ignoreList !== undefined) {
+										outputSourceMap.ignoreList = ignoreList;
+									}
+									if (options.noSources) {
+										outputSourceMap.sourcesContent = undefined;
+									}
+									if (debugIdValue !== undefined) {
+										outputSourceMap.debugId = debugIdValue;
+									}
+
+									const sourceMapString = JSON.stringify(outputSourceMap);
 									if (sourceMapFilename) {
 										const filename = file;
 										const sourceMapContentHash = usesContentHash

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -202,27 +202,26 @@ const getTaskForFile = (
 const PLUGIN_NAME = "SourceMapDevToolPlugin";
 
 /**
- * @typedef {string | RegExp | ((...args: EXPECTED_ANY[]) => EXPECTED_ANY) | null | false | undefined} CacheKeyAtom
+ * Maps a configuration value (string, RegExp, function, nullish, or array of
+ * such) into a JSON-serializable form. Functions and RegExps are turned into
+ * their `.toString()` representation so that changes to inline callbacks
+ * invalidate caches; everything else is returned as-is so that the surrounding
+ * `JSON.stringify` does the escaping.
+ *
+ * The result is used through `JSON.stringify` to build cache identifiers, so
+ * we deliberately avoid any homemade `|` / `,` separators that could collide
+ * with characters appearing inside user-provided values such as `publicPath`,
+ * template strings, or `sourceRoot`.
+ * @param {EXPECTED_ANY} value option value
+ * @returns {EXPECTED_ANY} JSON-serializable representation
  */
-
-/**
- * @typedef {CacheKeyAtom | CacheKeyAtom[]} CacheKeyValue
- */
-
-/**
- * Serializes a configuration value (string, RegExp, function, nullish, or
- * array of such) into a stable string suitable for inclusion in a cache key.
- * Function bodies are stringified so that changes to inline callbacks
- * invalidate the cache between builds.
- * @param {CacheKeyValue} value option value
- * @returns {string} serialized representation
- */
-const serializeRule = (value) => {
-	if (value === undefined) return "";
-	if (Array.isArray(value)) return `[${value.map(serializeRule).join(",")}]`;
-	if (value instanceof RegExp) return `re:${value.toString()}`;
-	if (typeof value === "function") return `fn:${value.toString()}`;
-	return `s:${value}`;
+const toCacheKeyValue = (value) => {
+	if (value === undefined || value === null) return value;
+	if (Array.isArray(value)) return value.map(toCacheKeyValue);
+	if (value instanceof RegExp || typeof value === "function") {
+		return value.toString();
+	}
+	return value;
 };
 
 class SourceMapDevToolPlugin {
@@ -253,24 +252,25 @@ class SourceMapDevToolPlugin {
 		this.options = options;
 		// Cache salt derived from output-affecting options, so that two
 		// SourceMapDevToolPlugin instances (or `devtool` + a plugin) operating
-		// on the same asset don't share a cache entry.
+		// on the same asset don't share a cache entry. We serialize via
+		// `JSON.stringify` rather than a homemade separator so that any
+		// special characters (e.g. `|` inside a publicPath or sourceRoot)
+		// can't accidentally make two different option sets collide.
 		/** @type {string} */
-		this._cacheSalt = [
-			serializeRule(options.filename),
-			typeof options.append === "function"
-				? `fn:${options.append.toString()}`
-				: `s:${options.append}`,
-			serializeRule(this.moduleFilenameTemplate),
-			serializeRule(this.fallbackModuleFilenameTemplate),
-			`m:${options.module !== false}`,
-			`c:${options.columns !== false}`,
-			`n:${Boolean(options.noSources)}`,
-			`d:${Boolean(options.debugIds)}`,
-			`sr:${options.sourceRoot || ""}`,
-			`il:${serializeRule(options.ignoreList)}`,
-			`pp:${options.publicPath || ""}`,
-			`fc:${options.fileContext || ""}`
-		].join("|");
+		this._cacheSalt = JSON.stringify([
+			toCacheKeyValue(options.filename),
+			toCacheKeyValue(options.append),
+			toCacheKeyValue(this.moduleFilenameTemplate),
+			toCacheKeyValue(this.fallbackModuleFilenameTemplate),
+			options.module !== false,
+			options.columns !== false,
+			Boolean(options.noSources),
+			Boolean(options.debugIds),
+			options.sourceRoot || "",
+			toCacheKeyValue(options.ignoreList),
+			options.publicPath || "",
+			options.fileContext || ""
+		]);
 	}
 
 	/**

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -262,6 +262,7 @@ class SourceMapDevToolPlugin {
 			toCacheKeyValue(options.append),
 			toCacheKeyValue(this.moduleFilenameTemplate),
 			toCacheKeyValue(this.fallbackModuleFilenameTemplate),
+			toCacheKeyValue(this.namespace),
 			options.module !== false,
 			options.columns !== false,
 			Boolean(options.noSources),
@@ -375,9 +376,12 @@ class SourceMapDevToolPlugin {
 							// salt so two SourceMapDevToolPlugin instances that target
 							// the same `file` don't collide in the persistent cache —
 							// they'd otherwise write different content to the same key
-							// and invalidate every pack on each build.
+							// and invalidate every pack on each build. We encode via
+							// `JSON.stringify` so that special characters (e.g. `|`)
+							// in an asset filename can't be spoofed to collide with the
+							// salt portion of the identifier.
 							const cacheItem = cache.getItemCache(
-								`${file}|${this._cacheSalt}`,
+								JSON.stringify([file, this._cacheSalt]),
 								cache.mergeEtags(
 									cache.getLazyHashedEtag(asset.source),
 									sourceMapNamespace

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -71,30 +71,36 @@ const resetRegexpState = (regexp) => {
 const quoteMeta = (str) => str.replace(METACHARACTERS_REGEXP, "\\$&");
 
 /**
- * Creating {@link SourceMapTask} for given file
- * @param {string} file current compiled file
- * @param {Source} asset the asset
- * @param {AssetInfo} assetInfo the asset info
- * @param {MapOptions} options source map options
- * @param {Compilation} compilation compilation instance
- * @param {ItemCacheFacade} cacheItem cache item
- * @returns {SourceMapTask | undefined} created task instance or `undefined`
+ * Returns a structural clone of a source map so that callers can mutate it
+ * without affecting the original (which may be shared between multiple
+ * SourceMapDevToolPlugin instances running on the same asset).
+ * @param {RawSourceMap} sourceMap source map to clone
+ * @returns {RawSourceMap} cloned source map
  */
-const getTaskForFile = (
-	file,
-	asset,
-	assetInfo,
-	options,
-	compilation,
-	cacheItem
-) => {
+const cloneSourceMap = (sourceMap) => ({
+	...sourceMap,
+	sources: sourceMap.sources ? [...sourceMap.sources] : sourceMap.sources,
+	sourcesContent: sourceMap.sourcesContent
+		? [...sourceMap.sourcesContent]
+		: sourceMap.sourcesContent,
+	names: sourceMap.names ? [...sourceMap.names] : sourceMap.names
+});
+
+/**
+ * Extracts source and source map from a Source object, with a shared stash so
+ * that subsequent plugin instances can recover the original map after the asset
+ * has been wrapped by an earlier instance (which drops the internal map).
+ * @param {string} file file name
+ * @param {Source} asset source object
+ * @param {MapOptions} options map extraction options
+ * @param {Map<string, RawSourceMap>} stash compilation-scoped cache of pristine source maps
+ * @returns {{ source: string | Buffer, sourceMap: RawSourceMap } | undefined} extracted pair or undefined when no map is available
+ */
+const extractSourceAndMap = (file, asset, options, stash) => {
 	/** @type {string | Buffer} */
 	let source;
 	/** @type {null | RawSourceMap} */
 	let sourceMap;
-	/**
-	 * Check if asset can build source map
-	 */
 	if (asset.sourceAndMap) {
 		const sourceAndMap = asset.sourceAndMap(options);
 		sourceMap = sourceAndMap.map;
@@ -103,7 +109,45 @@ const getTaskForFile = (
 		sourceMap = asset.map(options);
 		source = asset.source();
 	}
-	if (!sourceMap || typeof source !== "string") return;
+	if (!sourceMap) {
+		// The asset itself has no internal source map. This is the typical case
+		// after a previous SourceMapDevToolPlugin instance has already wrapped
+		// the asset in a RawSource. Recover the original map from the stash.
+		const stashed = stash.get(file);
+		if (!stashed) return;
+		sourceMap = cloneSourceMap(stashed);
+	} else if (!stash.has(file)) {
+		// First plugin instance to extract this file — remember a pristine
+		// copy so subsequent instances can mutate freely without disturbing it.
+		stash.set(file, cloneSourceMap(sourceMap));
+	}
+	if (typeof source !== "string") return;
+	return { source, sourceMap };
+};
+
+/**
+ * Creating {@link SourceMapTask} for given file
+ * @param {string} file current compiled file
+ * @param {Source} asset the asset
+ * @param {AssetInfo} assetInfo the asset info
+ * @param {MapOptions} options source map options
+ * @param {Compilation} compilation compilation instance
+ * @param {ItemCacheFacade} cacheItem cache item
+ * @param {Map<string, RawSourceMap>} stash compilation-scoped cache of pristine source maps
+ * @returns {SourceMapTask | undefined} created task instance or `undefined`
+ */
+const getTaskForFile = (
+	file,
+	asset,
+	assetInfo,
+	options,
+	compilation,
+	cacheItem,
+	stash
+) => {
+	const extracted = extractSourceAndMap(file, asset, options, stash);
+	if (!extracted) return;
+	const { source, sourceMap } = extracted;
 	const context = compilation.options.context;
 	const root = compilation.compiler.root;
 	const cachedAbsolutify = makePathsAbsolute.bindContextCache(context, root);
@@ -117,7 +161,7 @@ const getTaskForFile = (
 	return {
 		file,
 		asset,
-		source,
+		source: /** @type {string} */ (source),
 		assetInfo,
 		sourceMap,
 		modules,
@@ -125,7 +169,30 @@ const getTaskForFile = (
 	};
 };
 
+/**
+ * Shared, compilation-scoped stash of pristine source maps keyed by asset
+ * filename. Populated by the first SourceMapDevToolPlugin instance to extract
+ * a map from a given asset, then reused by subsequent instances whose own
+ * extraction would otherwise return `null` (because the asset has already been
+ * replaced with a RawSource that has no internal map).
+ */
+const SOURCE_MAP_STASH = Symbol("SourceMapDevToolPlugin source-map stash");
+
 const PLUGIN_NAME = "SourceMapDevToolPlugin";
+
+/**
+ * Serializes a Rules value (string, RegExp, function, or array thereof) into a
+ * stable string suitable for inclusion in a cache key.
+ * @param {EXPECTED_ANY} rule rule value
+ * @returns {string} serialized representation
+ */
+const serializeRule = (rule) => {
+	if (rule === undefined) return "";
+	if (Array.isArray(rule)) return `[${rule.map(serializeRule).join(",")}]`;
+	if (rule instanceof RegExp) return `re:${rule.toString()}`;
+	if (typeof rule === "function") return `fn:${rule.toString()}`;
+	return `s:${rule}`;
+};
 
 class SourceMapDevToolPlugin {
 	/**
@@ -153,6 +220,26 @@ class SourceMapDevToolPlugin {
 		this.namespace = options.namespace || "";
 		/** @type {SourceMapDevToolPluginOptions} */
 		this.options = options;
+		// Cache salt derived from output-affecting options, so that two
+		// SourceMapDevToolPlugin instances (or `devtool` + a plugin) operating
+		// on the same asset don't share a cache entry.
+		/** @type {string} */
+		this._cacheSalt = [
+			serializeRule(options.filename),
+			typeof options.append === "function"
+				? `fn:${options.append.toString()}`
+				: `s:${options.append}`,
+			serializeRule(this.moduleFilenameTemplate),
+			serializeRule(this.fallbackModuleFilenameTemplate),
+			`m:${options.module !== false}`,
+			`c:${options.columns !== false}`,
+			`n:${Boolean(options.noSources)}`,
+			`d:${Boolean(options.debugIds)}`,
+			`sr:${options.sourceRoot || ""}`,
+			`il:${serializeRule(options.ignoreList)}`,
+			`pp:${options.publicPath || ""}`,
+			`fc:${options.fileContext || ""}`
+		].join("|");
 	}
 
 	/**
@@ -194,6 +281,19 @@ class SourceMapDevToolPlugin {
 
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
 			new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
+
+			// Each compilation gets a single shared stash that all
+			// SourceMapDevToolPlugin instances cooperate on, so the second
+			// instance to run can still recover the original source map after
+			// the first instance has replaced the asset with a RawSource.
+			/** @type {Map<string, RawSourceMap>} */
+			let stash =
+				/** @type {Map<string, RawSourceMap>} */
+				(/** @type {EXPECTED_ANY} */ (compilation)[SOURCE_MAP_STASH]);
+			if (!stash) {
+				stash = new Map();
+				/** @type {EXPECTED_ANY} */ (compilation)[SOURCE_MAP_STASH] = stash;
+			}
 
 			compilation.hooks.processAssets.tapAsync(
 				{
@@ -239,10 +339,6 @@ class SourceMapDevToolPlugin {
 							const asset =
 								/** @type {Readonly<Asset>} */
 								(compilation.getAsset(file));
-							if (asset.info.related && asset.info.related.sourceMap) {
-								fileIndex++;
-								return callback();
-							}
 
 							const chunk = fileToChunk.get(file);
 							const sourceMapNamespace = compilation.getPath(this.namespace, {
@@ -252,8 +348,11 @@ class SourceMapDevToolPlugin {
 							const cacheItem = cache.getItemCache(
 								file,
 								cache.mergeEtags(
-									cache.getLazyHashedEtag(asset.source),
-									sourceMapNamespace
+									cache.mergeEtags(
+										cache.getLazyHashedEtag(asset.source),
+										sourceMapNamespace
+									),
+									this._cacheSalt
 								)
 							);
 
@@ -265,6 +364,23 @@ class SourceMapDevToolPlugin {
 								 * If presented in cache, reassigns assets. Cache assets already have source maps.
 								 */
 								if (cacheEntry) {
+									// Populate the shared stash from the still-unwrapped asset
+									// before replacing it, so that any subsequent
+									// SourceMapDevToolPlugin instance can recover the original
+									// source map even though the persistent cache hit lets us
+									// skip the full processing here.
+									if (!stash.has(file)) {
+										extractSourceAndMap(
+											file,
+											asset.source,
+											{
+												module: options.module,
+												columns: options.columns
+											},
+											stash
+										);
+									}
+
 									const { assets, assetsInfo } = cacheEntry;
 									for (const cachedFile of Object.keys(assets)) {
 										if (cachedFile === file) {
@@ -313,7 +429,8 @@ class SourceMapDevToolPlugin {
 										columns: options.columns
 									},
 									compilation,
-									cacheItem
+									cacheItem,
+									stash
 								);
 
 								if (task) {
@@ -567,8 +684,34 @@ class SourceMapDevToolPlugin {
 												})
 											);
 										}
+										// Preserve any existing related.sourceMap entries from
+										// earlier SourceMapDevToolPlugin runs on the same asset so
+										// that all generated maps remain discoverable via asset
+										// info (the schema allows string or string[]).
+										const existingSourceMap =
+											task.assetInfo.related &&
+											task.assetInfo.related.sourceMap;
+										/** @type {string | string[]} */
+										let relatedSourceMap;
+										if (
+											existingSourceMap === undefined ||
+											existingSourceMap === null
+										) {
+											relatedSourceMap = sourceMapFile;
+										} else if (Array.isArray(existingSourceMap)) {
+											relatedSourceMap = existingSourceMap.includes(
+												sourceMapFile
+											)
+												? existingSourceMap
+												: [...existingSourceMap, sourceMapFile];
+										} else {
+											relatedSourceMap =
+												existingSourceMap === sourceMapFile
+													? existingSourceMap
+													: [existingSourceMap, sourceMapFile];
+										}
 										const assetInfo = {
-											related: { sourceMap: sourceMapFile }
+											related: { sourceMap: relatedSourceMap }
 										};
 										assets[file] = asset;
 										assetsInfo[file] = assetInfo;

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -664,10 +664,21 @@ class SourceMapDevToolPlugin {
 										debugIdValue = debugId;
 
 										const debugIdComment = `\n//# debugId=${debugId}`;
-										currentSourceMappingURLComment =
-											currentSourceMappingURLComment
-												? `${debugIdComment}${currentSourceMappingURLComment}`
-												: debugIdComment;
+										if (currentSourceMappingURLComment === false) {
+											currentSourceMappingURLComment = debugIdComment;
+										} else if (
+											typeof currentSourceMappingURLComment === "function"
+										) {
+											// Wrap the user's append function so the debug-id
+											// comment is prepended at call time. Template-string
+											// concatenation would coerce the function to a string
+											// and lose its dynamic behavior.
+											const wrappedFn = currentSourceMappingURLComment;
+											currentSourceMappingURLComment = (pathData, assetInfo) =>
+												`${debugIdComment}${wrappedFn(pathData, assetInfo)}`;
+										} else {
+											currentSourceMappingURLComment = `${debugIdComment}${currentSourceMappingURLComment}`;
+										}
 									}
 
 									/** @type {RawSourceMap} */

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -202,7 +202,11 @@ const getTaskForFile = (
 const PLUGIN_NAME = "SourceMapDevToolPlugin";
 
 /**
- * @typedef {string | RegExp | ((...args: EXPECTED_ANY[]) => EXPECTED_ANY) | null | false | undefined | CacheKeyValue[]} CacheKeyValue
+ * @typedef {string | RegExp | ((...args: EXPECTED_ANY[]) => EXPECTED_ANY) | null | false | undefined} CacheKeyAtom
+ */
+
+/**
+ * @typedef {CacheKeyAtom | CacheKeyAtom[]} CacheKeyValue
  */
 
 /**
@@ -367,14 +371,16 @@ class SourceMapDevToolPlugin {
 								chunk
 							});
 
+							// The cache item identifier must include the per-instance
+							// salt so two SourceMapDevToolPlugin instances that target
+							// the same `file` don't collide in the persistent cache —
+							// they'd otherwise write different content to the same key
+							// and invalidate every pack on each build.
 							const cacheItem = cache.getItemCache(
-								file,
+								`${file}|${this._cacheSalt}`,
 								cache.mergeEtags(
-									cache.mergeEtags(
-										cache.getLazyHashedEtag(asset.source),
-										sourceMapNamespace
-									),
-									this._cacheSalt
+									cache.getLazyHashedEtag(asset.source),
+									sourceMapNamespace
 								)
 							);
 

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -116,7 +116,7 @@ const getOriginalSourceRegistry = (compilation) => {
  * @param {Source} asset source object as currently held by the compilation
  * @param {MapOptions} options map extraction options
  * @param {Map<string, Source>} registry compilation-scoped original-source registry
- * @returns {{ source: string | Buffer, sourceMap: RawSourceMap } | undefined} extracted pair or `undefined` when no map is recoverable
+ * @returns {{ source: string, sourceMap: RawSourceMap } | undefined} extracted pair or `undefined` when no map is recoverable
  */
 const extractSourceAndMap = (file, asset, options, registry) => {
 	/** @type {string | Buffer} */
@@ -131,6 +131,9 @@ const extractSourceAndMap = (file, asset, options, registry) => {
 		source = asset.source();
 		sourceMap = asset.map(options);
 	}
+	// Bail before touching the registry if we can't return a usable string
+	// source — pinning a non-string-producing asset would only waste the slot.
+	if (typeof source !== "string") return;
 	if (sourceMap) {
 		// The current asset still owns the original map — pin a reference so
 		// that a later plugin instance (which will see a rewrapped asset
@@ -149,7 +152,6 @@ const extractSourceAndMap = (file, asset, options, registry) => {
 			: original.map(options);
 		if (!sourceMap) return;
 	}
-	if (typeof source !== "string") return;
 	return { source, sourceMap };
 };
 
@@ -200,17 +202,23 @@ const getTaskForFile = (
 const PLUGIN_NAME = "SourceMapDevToolPlugin";
 
 /**
- * Serializes a Rules value (string, RegExp, function, or array thereof) into a
- * stable string suitable for inclusion in a cache key.
- * @param {EXPECTED_ANY} rule rule value
+ * @typedef {string | RegExp | ((...args: EXPECTED_ANY[]) => EXPECTED_ANY) | null | false | undefined | CacheKeyValue[]} CacheKeyValue
+ */
+
+/**
+ * Serializes a configuration value (string, RegExp, function, nullish, or
+ * array of such) into a stable string suitable for inclusion in a cache key.
+ * Function bodies are stringified so that changes to inline callbacks
+ * invalidate the cache between builds.
+ * @param {CacheKeyValue} value option value
  * @returns {string} serialized representation
  */
-const serializeRule = (rule) => {
-	if (rule === undefined) return "";
-	if (Array.isArray(rule)) return `[${rule.map(serializeRule).join(",")}]`;
-	if (rule instanceof RegExp) return `re:${rule.toString()}`;
-	if (typeof rule === "function") return `fn:${rule.toString()}`;
-	return `s:${rule}`;
+const serializeRule = (value) => {
+	if (value === undefined) return "";
+	if (Array.isArray(value)) return `[${value.map(serializeRule).join(",")}]`;
+	if (value instanceof RegExp) return `re:${value.toString()}`;
+	if (typeof value === "function") return `fn:${value.toString()}`;
+	return `s:${value}`;
 };
 
 class SourceMapDevToolPlugin {

--- a/test/configCases/source-map/devtool-and-source-map-plugin/debug-fn.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/debug-fn.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const readFile = (filename) =>
+	fs.readFileSync(path.join(__dirname, filename), "utf-8");
+const readMap = (filename) => JSON.parse(readFile(filename));
+
+const DEBUG_ID_RE =
+	/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i;
+
+it("wraps a function `append` so the `debugId` comment prepends at call time", () => {
+	const bundle = readFile("debug-fn.js");
+
+	// The append function was wrapped, not stringified — its dynamic URL
+	// should appear in the bundle and the debug-id comment should be in front
+	// of it, both produced at call time.
+	const debugIdMatch = bundle.match(/\n\/\/# debugId\s*=\s*(\S+)/);
+	expect(debugIdMatch).not.toBeNull();
+	expect(DEBUG_ID_RE.test(debugIdMatch[1])).toBe(true);
+
+	expect(bundle).toMatch(
+		"//# sourceMappingURL=https://example.invalid/debug-fn.js.map"
+	);
+
+	// Make sure the function wasn't stringified into the output (would
+	// contain `(pathData) =>` or similar source-text fragments).
+	expect(bundle).not.toMatch(/=>\s*`\\n\/\/# source/);
+
+	const map = readMap("debug-fn.js.map");
+	expect(map.debugId).toBe(debugIdMatch[1]);
+});

--- a/test/configCases/source-map/devtool-and-source-map-plugin/dual.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/dual.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const readFile = (filename) =>
+	fs.readFileSync(path.join(__dirname, filename), "utf-8");
+const readMap = (filename) => JSON.parse(readFile(filename));
+
+const URL_COMMENT_RE = /\n\/\/# sourceMappingURL=(\S+)\s*$/;
+
+it("supports two SourceMapDevToolPlugin instances on the same asset", () => {
+	const bundle = readFile("dual.js");
+
+	// The first plugin uses append:false, the second appends, so only the
+	// second plugin's URL ends up in the bundle.
+	const match = URL_COMMENT_RE.exec(bundle);
+	expect(match && match[1]).toBe("dual.js.nosources.map");
+
+	const fullMap = readMap("dual.js.full.map");
+	expect(fullMap.version).toBe(3);
+	expect(fullMap.sourcesContent).toBeDefined();
+	expect(fullMap.sourcesContent.length).toBeGreaterThan(0);
+	expect(fullMap.sources.some((s) => /dual\.js$/.test(s))).toBe(true);
+
+	const nosourcesMap = readMap("dual.js.nosources.map");
+	expect(nosourcesMap.version).toBe(3);
+	expect(nosourcesMap.sourcesContent).toBeUndefined();
+	expect(nosourcesMap.sources.some((s) => /dual\.js$/.test(s))).toBe(true);
+	// The two maps should describe the same generated file with the same
+	// mappings — they only differ in whether sourcesContent is embedded.
+	expect(nosourcesMap.mappings).toBe(fullMap.mappings);
+});

--- a/test/configCases/source-map/devtool-and-source-map-plugin/primary.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/primary.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const readFile = (filename) =>
+	fs.readFileSync(path.join(__dirname, filename), "utf-8");
+const readMap = (filename) => JSON.parse(readFile(filename));
+
+const URL_COMMENT_RE = /\n\/\/# sourceMappingURL=(\S+)\s*$/;
+
+it("emits both maps and only the explicit plugin appends a sourceMappingURL", () => {
+	const bundle = readFile("primary.js");
+	// hidden-source-map has append:false; only the user's plugin appends.
+	const match = URL_COMMENT_RE.exec(bundle);
+	expect(match && match[1]).toBe("primary.js.secondary.map");
+
+	// devtool=hidden-source-map produces the primary map (with sources).
+	const primaryMap = readMap("primary.js.map");
+	expect(primaryMap.version).toBe(3);
+	expect(primaryMap.sourcesContent).toBeDefined();
+	expect(primaryMap.sourcesContent.length).toBeGreaterThan(0);
+	expect(primaryMap.sources.some((s) => /primary\.js$/.test(s))).toBe(true);
+
+	// The explicit plugin produces a separate nosources map.
+	const secondaryMap = readMap("primary.js.secondary.map");
+	expect(secondaryMap.version).toBe(3);
+	expect(secondaryMap.sourcesContent).toBeUndefined();
+	expect(secondaryMap.sources.some((s) => /primary\.js$/.test(s))).toBe(true);
+});

--- a/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
@@ -2,6 +2,6 @@
 
 module.exports = {
 	findBundle() {
-		return ["primary.js", "dual.js", "triple.js"];
+		return ["primary.js", "dual.js", "triple.js", "debug-fn.js"];
 	}
 };

--- a/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
@@ -2,6 +2,6 @@
 
 module.exports = {
 	findBundle() {
-		return ["primary.js", "dual.js"];
+		return ["primary.js", "dual.js", "triple.js"];
 	}
 };

--- a/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["primary.js", "dual.js"];
+	}
+};

--- a/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/test.config.js
@@ -1,7 +1,16 @@
 "use strict";
 
 module.exports = {
-	findBundle() {
-		return ["primary.js", "dual.js", "triple.js", "debug-fn.js"];
+	findBundle(i, options) {
+		if (
+			options &&
+			options.output &&
+			typeof options.output.filename === "string"
+		) {
+			return [options.output.filename];
+		}
+
+		const bundles = ["primary.js", "dual.js", "triple.js", "debug-fn.js"];
+		return bundles[i] ? [bundles[i]] : [];
 	}
 };

--- a/test/configCases/source-map/devtool-and-source-map-plugin/triple.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/triple.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const readFile = (filename) =>
+	fs.readFileSync(path.join(__dirname, filename), "utf-8");
+const readMap = (filename) => JSON.parse(readFile(filename));
+
+const URL_COMMENT_RE = /\n\/\/# sourceMappingURL=(\S+)\s*$/;
+
+it("supports three SourceMapDevToolPlugin instances on the same asset", () => {
+	const bundle = readFile("triple.js");
+
+	// Only the last plugin appends (the first two use `append: false`).
+	const match = URL_COMMENT_RE.exec(bundle);
+	expect(match && match[1]).toBe("triple.js.c.map");
+
+	const a = readMap("triple.js.a.map");
+	const b = readMap("triple.js.b.map");
+	const c = readMap("triple.js.c.map");
+
+	expect(a.version).toBe(3);
+	expect(b.version).toBe(3);
+	expect(c.version).toBe(3);
+
+	// All three describe the same generated file, so the mappings line up.
+	expect(b.mappings).toBe(a.mappings);
+	expect(c.mappings).toBe(a.mappings);
+
+	// `noSources: true` only on the middle plugin.
+	expect(a.sourcesContent).toBeDefined();
+	expect(b.sourcesContent).toBeUndefined();
+	expect(c.sourcesContent).toBeDefined();
+
+	// `sourceRoot: "triple"` only on the last plugin.
+	expect(c.sourceRoot).toBe("triple");
+});

--- a/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
@@ -38,5 +38,30 @@ module.exports = [
 				noSources: true
 			})
 		]
+	},
+	// 3. Three `SourceMapDevToolPlugin` instances on the same asset — exercises
+	// the `related.sourceMap` array-merge path where the asset info already
+	// has an array (rather than a single string) from the prior two plugins.
+	{
+		devtool: false,
+		entry: "./triple.js",
+		output: {
+			filename: "triple.js"
+		},
+		plugins: [
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].a.map",
+				append: false
+			}),
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].b.map",
+				append: false,
+				noSources: true
+			}),
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].c.map",
+				sourceRoot: "triple"
+			})
+		]
 	}
 ];

--- a/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
@@ -63,5 +63,23 @@ module.exports = [
 				sourceRoot: "triple"
 			})
 		]
+	},
+	// 4. `debugIds: true` combined with a function `append` — exercises the
+	// branch that wraps the user's callback so the `//# debugId=` comment is
+	// prepended at call time instead of stringifying the function.
+	{
+		devtool: false,
+		entry: "./debug-fn.js",
+		output: {
+			filename: "debug-fn.js"
+		},
+		plugins: [
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].map",
+				debugIds: true,
+				append: (pathData) =>
+					`\n//# sourceMappingURL=https://example.invalid/${pathData.filename}.map`
+			})
+		]
 	}
 ];

--- a/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
+++ b/test/configCases/source-map/devtool-and-source-map-plugin/webpack.config.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// 1. `devtool: 'hidden-source-map'` (no sourceMappingURL appended) +
+	// a `SourceMapDevToolPlugin` that emits a second nosources map and appends
+	// its URL.  This is the exact configuration sokra suggested in #6813.
+	{
+		devtool: "hidden-source-map",
+		entry: "./primary.js",
+		output: {
+			filename: "primary.js"
+		},
+		plugins: [
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].secondary.map",
+				noSources: true
+			})
+		]
+	},
+	// 2. `devtool: false` + two `SourceMapDevToolPlugin` instances writing to
+	// different filenames for the same asset.
+	{
+		devtool: false,
+		entry: "./dual.js",
+		output: {
+			filename: "dual.js"
+		},
+		plugins: [
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].full.map",
+				append: false
+			}),
+			new webpack.SourceMapDevToolPlugin({
+				filename: "[file].nosources.map",
+				noSources: true
+			})
+		]
+	}
+];


### PR DESCRIPTION
Previously the second SourceMapDevToolPlugin instance (or the implicit one
created by `devtool` + an explicit instance) silently skipped any asset whose
`info.related.sourceMap` had already been set, and even when it ran the asset
had been rewrapped in a `RawSource` whose `map()` returns `null`, producing an
empty `.map` file.

The plugin now keeps a per-compilation stash of pristine source maps that any
instance can fall back to, namespaces its persistent cache entries by the
options that affect output, and appends to `related.sourceMap` instead of
overwriting it. Pairing `devtool: 'hidden-source-map'` with
`new SourceMapDevToolPlugin({ filename: '[file].secondary.map', noSources: true })`
now produces both maps in a single build (closes #6813).