### PR TITLE
fix: tree-shake CommonJS exports through `const NAME = require(LITERAL)` bindings

### DIFF
--- a/.changeset/cjs-require-binding-tree-shake.md
+++ b/.changeset/cjs-require-binding-tree-shake.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Tree-shake CommonJS modules imported through a `const NAME = require(LITERAL)` binding when only static members of `NAME` are read. Previously webpack treated every export of such modules as referenced (because the bare `require()` dependency reports `EXPORTS_OBJECT_REFERENCED`), so unused `exports.x = ...` assignments remained in the bundle even with `usedExports` enabled. The parser now forwards `NAME.x` / `NAME.x()` / `NAME["x"]` accesses to the underlying `CommonJsRequireDependency` as referenced exports, falling back to the full exports object the moment `NAME` is read in any other context (passed by value, destructured later, accessed with a dynamic key, …). This brings the binding form to parity with the existing destructuring form (`const { x } = require(...)`).

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -54,7 +54,7 @@ const RequireResolveHeaderDependency = require("./RequireResolveHeaderDependency
  * created for the `require()` call.
  * @typedef {object} RequireBindingData
  * @property {RawReferencedExports} referencedExports mutable list shared with the dependency; pushed to as `NAME.x.y` accesses are walked
- * @property {import("./CommonJsRequireDependency") | null} dep dependency for the `require()` call (assigned during walk)
+ * @property {InstanceType<typeof import("./CommonJsRequireDependency")> | null} dep dependency for the `require()` call (assigned during walk)
  */
 
 /** @type {WeakMap<CallExpression, RequireBindingData>} */

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -48,6 +48,22 @@ const RequireResolveHeaderDependency = require("./RequireResolveHeaderDependency
  * @property {string} context
  */
 
+/**
+ * Per-`const NAME = require(LITERAL)` binding state used to forward
+ * member-access references on `NAME` to the `CommonJsRequireDependency`
+ * created for the `require()` call.
+ * @typedef {object} RequireBindingData
+ * @property {RawReferencedExports} referencedExports mutable list shared with the dependency; pushed to as `NAME.x.y` accesses are walked
+ * @property {import("./CommonJsRequireDependency") | null} dep dependency for the `require()` call (assigned during walk)
+ */
+
+/** @type {WeakMap<CallExpression, RequireBindingData>} */
+const requireBindingData = new WeakMap();
+
+const REQUIRE_BINDING_TAG = Symbol(
+	"CommonJsImportsParserPlugin require binding"
+);
+
 const PLUGIN_NAME = "CommonJsImportsParserPlugin";
 
 /**
@@ -152,10 +168,18 @@ const createRequireCallHandler = (parser, options, getContext) => {
 	 */
 	const processRequireItem = (expr, param) => {
 		if (param.isString()) {
-			const referencedExports = getRequireReferencedExportsFromDestructuring(
+			let referencedExports = getRequireReferencedExportsFromDestructuring(
 				parser,
 				expr
 			);
+			const binding = requireBindingData.get(
+				/** @type {CallExpression} */ (expr)
+			);
+			if (binding && !referencedExports) {
+				// `const NAME = require(LITERAL)` — let later member-access walks
+				// on `NAME` populate the dependency's referenced exports.
+				referencedExports = binding.referencedExports;
+			}
 			const dep = new CommonJsRequireDependency(
 				/** @type {string} */ (param.string),
 				/** @type {Range} */ (param.range),
@@ -163,6 +187,7 @@ const createRequireCallHandler = (parser, options, getContext) => {
 				referencedExports,
 				/** @type {Range} */ (expr.range)
 			);
+			if (binding) binding.dep = dep;
 			dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 			dep.optional = Boolean(parser.scope.inTry);
 			parser.state.current.addDependency(dep);
@@ -660,6 +685,88 @@ class CommonJsImportsParserPlugin {
 		parser.hooks.callMemberChainOfCallMemberChain
 			.for("module.require")
 			.tap(PLUGIN_NAME, callChainHandler);
+		// #endregion
+
+		// #region Require bound to a const variable
+		// Track `const NAME = require(LITERAL)` so that static member accesses on
+		// `NAME` (e.g. `NAME.foo`, `NAME.foo()`) are forwarded to the same
+		// `CommonJsRequireDependency` as referenced exports — enabling tree
+		// shaking of CommonJS modules that are imported into a named binding
+		// rather than destructured.
+		parser.hooks.preDeclarator.tap(PLUGIN_NAME, (declarator, statement) => {
+			if (statement.kind !== "const") return;
+			if (declarator.id.type !== "Identifier") return;
+			if (!declarator.init || declarator.init.type !== "CallExpression") {
+				return;
+			}
+			const init = declarator.init;
+			if (
+				init.callee.type !== "Identifier" ||
+				init.callee.name !== "require" ||
+				init.arguments.length !== 1
+			) {
+				return;
+			}
+			const arg = init.arguments[0];
+			if (arg.type !== "Literal" || typeof arg.value !== "string") return;
+			// Only attach binding state when `require` resolves to the free
+			// `require` (i.e. it isn't shadowed in the current scope).
+			const requireInfo = parser.getFreeInfoFromVariable("require");
+			if (!requireInfo || requireInfo.name !== "require") return;
+			/** @type {RequireBindingData} */
+			const binding = {
+				referencedExports: [],
+				dep: null
+			};
+			requireBindingData.set(init, binding);
+			parser.tagVariable(declarator.id.name, REQUIRE_BINDING_TAG, binding);
+			return true;
+		});
+
+		parser.hooks.expression.for(REQUIRE_BINDING_TAG).tap(PLUGIN_NAME, () => {
+			const binding =
+				/** @type {RequireBindingData} */
+				(parser.currentTagData);
+			if (binding && binding.dep) {
+				// `NAME` is read as a value (not as the object of a static member
+				// chain), so we have to assume the whole exports object is used.
+				binding.dep.referencedExports = null;
+			}
+		});
+
+		parser.hooks.expressionMemberChain
+			.for(REQUIRE_BINDING_TAG)
+			.tap(PLUGIN_NAME, (_expr, members) => {
+				const binding =
+					/** @type {RequireBindingData} */
+					(parser.currentTagData);
+				if (binding && binding.dep && binding.dep.referencedExports) {
+					binding.dep.referencedExports.push(members);
+				}
+				// Returning truthy suppresses the parser's fallback chain (which
+				// would otherwise walk `NAME` as a bare expression and trigger our
+				// `expression` hook above, marking the whole namespace as used).
+				return true;
+			});
+
+		parser.hooks.callMemberChain
+			.for(REQUIRE_BINDING_TAG)
+			.tap(PLUGIN_NAME, (expr, members) => {
+				const binding =
+					/** @type {RequireBindingData} */
+					(parser.currentTagData);
+				if (binding && binding.dep && binding.dep.referencedExports) {
+					if (members.length === 0) {
+						// `NAME(...)` — calling the require result directly; the
+						// whole exports object is observable.
+						binding.dep.referencedExports = null;
+					} else {
+						binding.dep.referencedExports.push(members);
+					}
+				}
+				if (expr.arguments) parser.walkExpressions(expr.arguments);
+				return true;
+			});
 		// #endregion
 
 		// #region Require.resolve

--- a/test/cases/cjs-tree-shaking/require-member-access/index.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/index.js
@@ -1,28 +1,48 @@
-it("should tree-shake CommonJS exports through a const binding (call form)", () => {
+it("should tree-shake CommonJS exports when accessed via a member call", () => {
 	const m = require("./module");
-	expect(m.a).toBe("a");
+	expect(m.a()).toBe("a");
 	expect(m.usedExports).toEqual(["a", "usedExports"]);
 });
 
-it("should tree-shake CommonJS exports through a const binding (property form)", () => {
+it("should tree-shake CommonJS exports when accessed as a property", () => {
 	const m = require("./module");
 	const a = m.a;
 	const u = m.usedExports;
-	expect(a).toBe("a");
+	expect(a()).toBe("a");
 	expect(u).toEqual(["a", "usedExports"]);
 });
 
-it("should tree-shake CommonJS exports through static string-literal access", () => {
+it("should tree-shake CommonJS exports when accessed with a string literal", () => {
 	const m = require("./module");
-	expect(m["a"]).toBe("a");
+	expect(m["a"]()).toBe("a");
 	expect(m.usedExports).toEqual(["a", "usedExports"]);
 });
 
-it("should bail out when the require result is read as a value", () => {
+it("should bail out when the require result is read as a value (spread)", () => {
 	const m = require("./module-rest");
 	// Spreading the namespace forces every export to remain reachable.
 	const all = { ...m };
 	expect(all.a).toBe("a");
 	expect(all.b).toBe("b");
 	expect(all.usedExports).toBe(true);
+});
+
+it("should bail out when the require result is accessed with a dynamic key", () => {
+	const m = require("./module-rest");
+	const key = "a";
+	expect(m[key]).toBe("a");
+	// Dynamic-key access cannot be statically tracked, so every export must
+	// remain reachable.
+	expect(m.usedExports).toBe(true);
+});
+
+it("should bail out when the require result is called directly", () => {
+	const m = require("./module-call");
+	expect(m()).toBe("direct-call");
+	// Calling the namespace itself means the whole exports object is observable;
+	// every attached property must still be reachable.
+	expect(m.x).toBe("x");
+	// `module.exports = fn` already prevents named-export tracking, so usage
+	// reports `null` ("no specific usage tracked").
+	expect(m.usedExports).toBe(null);
 });

--- a/test/cases/cjs-tree-shaking/require-member-access/index.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/index.js
@@ -1,0 +1,28 @@
+it("should tree-shake CommonJS exports through a const binding (call form)", () => {
+	const m = require("./module");
+	expect(m.a).toBe("a");
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should tree-shake CommonJS exports through a const binding (property form)", () => {
+	const m = require("./module");
+	const a = m.a;
+	const u = m.usedExports;
+	expect(a).toBe("a");
+	expect(u).toEqual(["a", "usedExports"]);
+});
+
+it("should tree-shake CommonJS exports through static string-literal access", () => {
+	const m = require("./module");
+	expect(m["a"]).toBe("a");
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should bail out when the require result is read as a value", () => {
+	const m = require("./module-rest");
+	// Spreading the namespace forces every export to remain reachable.
+	const all = { ...m };
+	expect(all.a).toBe("a");
+	expect(all.b).toBe("b");
+	expect(all.usedExports).toBe(true);
+});

--- a/test/cases/cjs-tree-shaking/require-member-access/module-call.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/module-call.js
@@ -1,0 +1,6 @@
+const fn = function () {
+	return "direct-call";
+};
+fn.x = "x";
+fn.usedExports = __webpack_exports_info__.usedExports;
+module.exports = fn;

--- a/test/cases/cjs-tree-shaking/require-member-access/module-rest.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/module-rest.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-member-access/module.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/module.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-member-access/module.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/module.js
@@ -1,3 +1,5 @@
-exports.a = "a";
+exports.a = function a() {
+	return "a";
+};
 exports.b = "b";
 exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-member-access/test.filter.js
+++ b/test/cases/cjs-tree-shaking/require-member-access/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/configCases/issues/issue-14054/index.js
+++ b/test/configCases/issues/issue-14054/index.js
@@ -1,0 +1,30 @@
+const utils = require("./utils");
+const allUsed = require("./utils-fullref");
+
+it("should run the used CommonJS export", () => {
+	expect(utils.foo()).toBe(["USED", "FOO", "MARKER"].join("_"));
+});
+
+it("should keep all exports when the require result is read directly", () => {
+	// Reading `allUsed` itself (not through a static member) must keep every
+	// export reachable — Object.keys is a side-effecting use of the namespace.
+	expect(Object.keys(allUsed).sort()).toEqual(["bar", "foo"]);
+});
+
+it("should tree-shake unused CommonJS exports when only static members are accessed", () => {
+	const fs = require("fs");
+	const content = fs.readFileSync(__filename, "utf-8");
+	// Build marker strings at runtime so the assertion source itself does not
+	// embed the patterns we are about to look up.
+	const usedFoo = ["USED", "FOO", "MARKER"].join("_");
+	const unusedBar = ["UNUSED", "BAR", "MARKER"].join("_");
+	const unusedBaz = ["UNUSED", "BAZ", "MARKER"].join("_");
+	const fullrefFoo = ["FULLREF", "FOO", "MARKER"].join("_");
+	const fullrefBar = ["FULLREF", "BAR", "MARKER"].join("_");
+	expect(content.includes(usedFoo)).toBe(true);
+	expect(content.includes(unusedBar)).toBe(false);
+	expect(content.includes(unusedBaz)).toBe(false);
+	// Counter-test: when the require result is read directly, exports are kept.
+	expect(content.includes(fullrefFoo)).toBe(true);
+	expect(content.includes(fullrefBar)).toBe(true);
+});

--- a/test/configCases/issues/issue-14054/utils-fullref.js
+++ b/test/configCases/issues/issue-14054/utils-fullref.js
@@ -1,0 +1,7 @@
+exports.foo = function foo() {
+	return "FULLREF_FOO_MARKER";
+};
+
+exports.bar = function bar() {
+	return "FULLREF_BAR_MARKER";
+};

--- a/test/configCases/issues/issue-14054/utils.js
+++ b/test/configCases/issues/issue-14054/utils.js
@@ -1,0 +1,11 @@
+exports.foo = function foo() {
+	return "USED_FOO_MARKER";
+};
+
+exports.bar = function bar() {
+	return "UNUSED_BAR_MARKER";
+};
+
+exports.baz = function baz() {
+	return "UNUSED_BAZ_MARKER";
+};

--- a/test/configCases/issues/issue-14054/webpack.config.js
+++ b/test/configCases/issues/issue-14054/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		minimize: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
Closes #14054.

Previously webpack treated every export of a CommonJS module as referenced
when the module was imported via a named binding (`const utils =
require("./utils")`) — the bare `CommonJsRequireDependency` reports
`EXPORTS_OBJECT_REFERENCED` because it can't see how `utils` is later
used. Only the destructuring form (`const { foo } = require("./utils")`)
was actually tree-shakeable.

CommonJsImportsParserPlugin now tags the declared binding and forwards
later static member accesses on it — `utils.foo`, `utils.foo()`,
`utils["foo"]` — to the same `CommonJsRequireDependency` as referenced
exports. The moment `utils` is read in any other context (passed by
value, spread, destructured later, accessed with a dynamic key, called
directly), the dependency is restored to `EXPORTS_OBJECT_REFERENCED` so
no usage is silently dropped.