### PR TITLE
test: lock chunk filenames stay verbatim for scoped names

### DIFF
--- a/test/configCases/entry/scoped-name/chunk.js
+++ b/test/configCases/entry/scoped-name/chunk.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/entry/scoped-name/index.js
+++ b/test/configCases/entry/scoped-name/index.js
@@ -1,0 +1,4 @@
+it("should not URL-encode '@' in chunk filenames", () =>
+	import(/* webpackChunkName: "@scope/chunk" */ "./chunk").then(r =>
+		expect(r).toEqual(expect.objectContaining({ default: 42 }))
+	));

--- a/test/configCases/entry/scoped-name/test.config.js
+++ b/test/configCases/entry/scoped-name/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(i, options) {
+		const bundle = "./@scope/app.js";
+		const chunk = path.join(options.output.path, "chunks/@scope/chunk.js");
+		if (!fs.existsSync(chunk)) {
+			throw new Error(
+				`Expected chunk to be emitted verbatim at ${chunk} (no URL-encoding of '@'); see https://github.com/jantimon/html-webpack-plugin/issues/1771`
+			);
+		}
+		return [bundle];
+	}
+};

--- a/test/configCases/entry/scoped-name/webpack.config.js
+++ b/test/configCases/entry/scoped-name/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		"@scope/app": "./index.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "chunks/[name].js"
+	}
+};


### PR DESCRIPTION
Regression test ensuring webpack does not URL-encode '@' (or other
special characters) in entry names or webpackChunkName values. Mirrors
the concern raised in jantimon/html-webpack-plugin#1771 against the
plugin and pins the expected webpack-side behavior.