### PR TITLE
test(html): assert `<link>` precedes `<script>` for JS-imported CSS

### DIFF
--- a/test/configCases/html/css-imported-from-js/test.js
+++ b/test/configCases/html/css-imported-from-js/test.js
@@ -40,6 +40,16 @@ it("should emit a <link rel=stylesheet> for the entry chunk's CSS file, copying 
 	expect(linkTag).not.toContain("defer");
 	expect(linkTag).not.toContain("integrity");
 
+	// The `<link>` must precede the `<script>` so the browser starts the
+	// stylesheet download before the script download — otherwise scripts
+	// race ahead and the stylesheet's render-blocking arrival is pushed
+	// out (the html-webpack-plugin#1813 concern, applied to JS-imported
+	// CSS in HTML entries).
+	const scriptIdx = extracted.indexOf("<script");
+	const linkIdx = extracted.indexOf('<link rel="stylesheet"');
+	expect(linkIdx).toBeGreaterThan(-1);
+	expect(linkIdx).toBeLessThan(scriptIdx);
+
 	// The referenced files actually exist on disk.
 	expect(() => readFile(scriptMatch[1])).not.toThrow();
 	const css = readFile(hrefMatch[1]);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Pins the [html-webpack-plugin#1813](https://github.com/jantimon/html-webpack-plugin/issues/1813) invariant for the `experiments.html` + `experiments.css` path: when JS in an HTML entry imports CSS, the emitted `<link rel="stylesheet">` must precede the `<script>` so browsers start the stylesheet download before the script download.

The behaviour already works — it was added in #21002 (`HtmlScriptSrcDependency` inserts CSS siblings before JS siblings, and the entry chunk's own CSS is folded into the CSS group so its `<link>` lands before the entry `<script>`). Three of the four `test/configCases/html/css-*` cases that landed alongside that change have an explicit `linkIdx < scriptIdx` assertion (`css-split-chunks-order`, `css-mixed-link-and-js-import`, `css-runtime-and-split-chunks`); the `css-imported-from-js` case — which is the most direct exercise of the html-webpack-plugin#1813 concern — only had the snapshot.

This PR adds the matching explicit assertion so the requirement is documented in code, not only captured implicitly by the snapshot.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test — adds an assertion to an existing test case; no production code changes.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/html/css-imported-from-js/test.js` now explicitly asserts the `<link>` precedes the `<script>`, matching the pattern used by the other three `test/configCases/html/css-*` cases.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used under human review. It read the linked issue, traced the existing ordering logic in `lib/dependencies/HtmlScriptSrcDependency.js` and the four `test/configCases/html/css-*` cases, identified that `css-imported-from-js` was the only one of the four lacking an explicit order assertion, and drafted the assertion. The change was reviewed and run locally before being committed.