### PR TITLE
docs: PR template applies to every PR, regardless of task framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,10 @@ Do **NOT** add `Co-authored-by` lines — unrecognized co-author emails also bre
 
 webpack uses an **org-wide** PR template from [`webpack/.github`](https://github.com/webpack/.github/blob/main/.github/pull_request_template.md). The GitHub web UI prefills it; the GitHub API / MCP / `gh pr create` path does **not**, so you must paste the template yourself when opening a PR programmatically. Every PR body must contain **every** section below, in this order, with the labels spelled exactly as written. If a section truly does not apply, write `n/a` under it. Do not delete sections, do not reorder, do not strip the HTML comment hints, and do not substitute a different template (e.g. `## Summary` / `## Test plan`).
 
+The template is mandatory for **every** PR — including PRs the user only asked you to "verify", "check", "test", "add a small assertion to", or otherwise framed as quick or one-off work. Task framing does not change PR-template requirements. The size of the diff does not change PR-template requirements. There is no "this one's too small for the template" carve-out.
+
+Titles are plain text, not HTML — use raw `<`, `>`, and other special characters directly. Never HTML-entity-encode them (`&lt;`, `&gt;`, `&amp;`) thinking GitHub will render the entities; it will not, the title will literally display the entity codes. Compare against the titles of recent webpack PRs as a sanity check.
+
 Common ways agents get this wrong — all of them are PR-blocking:
 
 - Writing `## Summary` and `## Test plan` headings instead of the bold-labelled sections below (`**Summary**`, `**What kind of change does this PR introduce?**`, …).
@@ -259,7 +263,9 @@ Common ways agents get this wrong — all of them are PR-blocking:
 
 Before every `create_pull_request` and every `update_pull_request` call, diff the body you are about to send against the template below. If any section is missing, add it before sending.
 
-If a PR already exists (e.g. it was opened from the GitHub web UI before you joined the task, or a human edited the body), agents must verify the body still matches the template before each push, and call `update_pull_request` to re-paste any missing section. Treat the PR body the same way you treat the commit message: every push is also a chance to fix a drifted PR body.
+If a PR already exists — opened from the GitHub web UI before you joined the task, edited by a human, **or auto-created by a webhook from your push** (webpack/webpack has this setup; pushing a new branch immediately opens a PR whose body is just the commit message, which never matches the template) — agents must verify the body still matches the template before each push, and call `update_pull_request` to re-paste any missing section. Treat the PR body the same way you treat the commit message: every push is also a chance to fix a drifted PR body.
+
+Push and template are inseparable. After every `git push` of a new branch, your very next action must be a `list_pull_requests` (filtered by `head: <owner>:<branch>`) followed by `update_pull_request` to install the full template. Do not wait for a reviewer (human, Copilot, CodSpeed, codecov, anything) to flag the missing template — the auto-created body never matches the template and an empty-template PR is PR-blocking. The same applies to follow-up pushes if the body ever drifts.
 
 Paste the body **inside** the fenced block below — only the lines between the ` ```markdown ` opener and the closing ` ``` ` (do **not** include the fence lines themselves; pasting them would render your whole PR body as a code block). Then fill in answers directly under each label:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Codify two lessons from agent failures observed on PR #21007:

1. **The PR template is mandatory for every PR**, including ones the user only asked the agent to "verify", "check", "test", or "add a small assertion to". Task framing and diff size do not change the template requirement. The current AGENTS.md doesn't say this explicitly, so agents read tasks like "just verify X" as exempt from the template flow.
2. **webpack/webpack auto-opens a PR via webhook** on every new-branch push, with the commit message as the body — which never matches the template. The current AGENTS.md mentions the "PR already exists" case in passing but doesn't pin down that the agent's *very next action after `git push`* must be `list_pull_requests` + `update_pull_request` to install the template, before any reviewer (human or bot) sees the empty-template PR.

Also adds a short note that PR titles are plain text — `<`, `>`, and `&` belong in the title raw, never as `&lt;`, `&gt;`, `&amp;`. Another concrete agent-failure-mode from PR #21007, where the title displayed `&lt;link&gt;` instead of `<link>`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs — AGENTS.md only; no code changes.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

n/a — docs-only.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — this PR *is* the documentation update.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used under human review. The maintainer flagged repeated agent failures around the PR template (treating "just verify"/"just add a test" tasks as exempt; missing the webhook auto-created PR body; HTML-entity-encoding `<` in the title). Claude Code drafted the AGENTS.md additions to capture those failure modes as explicit, prescriptive rules. The change was reviewed before being committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzPdGW1YRTPWpDqLiUgue9)_