### PR TITLE
fix: expose exports from all library entry modules

### DIFF
--- a/.changeset/fix-library-array-entry-exports.md
+++ b/.changeset/fix-library-array-entry-exports.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Expose exports from all array entry modules in library output.

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1128,6 +1128,21 @@ class JavascriptModulesPlugin {
 					Boolean(chunkModules)
 				);
 			}
+			const hasLibrary = [
+				...chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk)
+			].some(([, entrypoint]) => {
+				const library =
+					/** @type {Entrypoint} */
+					(entrypoint).options.library !== undefined
+						? /** @type {Entrypoint} */
+							(entrypoint).options.library
+						: runtimeTemplate.compilation.outputOptions.library;
+				return library !== undefined;
+			});
+			const useSharedEntryExports =
+				hasLibrary &&
+				inlinedModules.size > 1 &&
+				runtimeRequirements.has(RuntimeGlobals.exports);
 
 			for (const m of inlinedModules) {
 				const runtimeRequirements = chunkGraph.getModuleRuntimeRequirements(
@@ -1189,7 +1204,13 @@ class JavascriptModulesPlugin {
 						footer = "\n";
 					}
 					if (exports) {
-						if (m !== lastInlinedModule) {
+						if (useSharedEntryExports) {
+							if (m.exportsArgument !== RuntimeGlobals.exports) {
+								startupSource.add(
+									`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
+								);
+							}
+						} else if (m !== lastInlinedModule) {
 							startupSource.add(`var ${m.exportsArgument} = {};\n`);
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
 							startupSource.add(
@@ -1491,6 +1512,39 @@ class JavascriptModulesPlugin {
 						continue;
 					}
 				}
+				const hasLibrary = jsEntries.some(([, entrypoint]) => {
+					const library =
+						/** @type {Entrypoint} */
+						(entrypoint).options.library !== undefined
+							? /** @type {Entrypoint} */
+								(entrypoint).options.library
+							: runtimeTemplate.compilation.outputOptions.library;
+					return library !== undefined;
+				});
+				const mergeEntryExports =
+					hasLibrary &&
+					jsEntries.length > 1 &&
+					runtimeRequirements.has(RuntimeGlobals.exports);
+				let entryExportsDeclared = false;
+				/**
+				 * @param {string} expression expression returning entry exports
+				 * @returns {void}
+				 */
+				const mergeEntryExportsExpression = (expression) => {
+					if (!entryExportsDeclared) {
+						buf2.push(`var ${RuntimeGlobals.exports} = {};`);
+						entryExportsDeclared = true;
+					}
+					buf2.push(`var __webpack_entry_exports__ = ${expression};`);
+					buf2.push("if(__webpack_entry_exports__) {");
+					buf2.push(
+						`for(var __webpack_i__ in __webpack_entry_exports__) ${RuntimeGlobals.exports}[__webpack_i__] = __webpack_entry_exports__[__webpack_i__];`
+					);
+					buf2.push(
+						`if(__webpack_entry_exports__.__esModule) Object.defineProperty(${RuntimeGlobals.exports}, "__esModule", { value: true });`
+					);
+					buf2.push("}");
+				};
 				let i = jsEntries.length;
 				for (const [entryModule, entrypoint] of jsEntries) {
 					const chunks =
@@ -1582,23 +1636,32 @@ class JavascriptModulesPlugin {
 					}
 
 					if (chunks.length > 0) {
-						buf2.push(
-							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.onChunksLoaded
-							}(undefined, ${JSON.stringify(
-								chunks.map((c) => c.id)
-							)}, ${runtimeTemplate.returningFunction(
-								`${RuntimeGlobals.require}(${moduleIdExpr})`
-							)})`
-						);
+						const expression = `${RuntimeGlobals.onChunksLoaded}(undefined, ${JSON.stringify(
+							chunks.map((c) => c.id)
+						)}, ${runtimeTemplate.returningFunction(
+							`${RuntimeGlobals.require}(${moduleIdExpr})`
+						)})`;
+						if (mergeEntryExports) {
+							mergeEntryExportsExpression(expression);
+						} else {
+							buf2.push(
+								`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${expression};`
+							);
+						}
 					} else if (useRequire) {
-						buf2.push(
-							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.require
-							}(${moduleIdExpr});`
-						);
+						const expression = `${RuntimeGlobals.require}(${moduleIdExpr})`;
+						if (mergeEntryExports) {
+							mergeEntryExportsExpression(expression);
+						} else {
+							buf2.push(
+								`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${expression};`
+							);
+						}
 					} else {
-						if (i === 0) buf2.push(`var ${RuntimeGlobals.exports} = {};`);
+						if (!entryExportsDeclared && (mergeEntryExports || i === 0)) {
+							buf2.push(`var ${RuntimeGlobals.exports} = {};`);
+							entryExportsDeclared = true;
+						}
 						const needThisAsExports = entryRuntimeRequirements.has(
 							RuntimeGlobals.thisAsExports
 						);
@@ -1609,7 +1672,8 @@ class JavascriptModulesPlugin {
 							requireScopeUsed ||
 							entryRuntimeRequirements.has(RuntimeGlobals.exports)
 						) {
-							const exportsArg = i === 0 ? RuntimeGlobals.exports : "{}";
+							const exportsArg =
+								mergeEntryExports || i === 0 ? RuntimeGlobals.exports : "{}";
 							args.push("0", exportsArg);
 							if (requireScopeUsed) {
 								args.push(RuntimeGlobals.require);

--- a/lib/library/AbstractLibraryPlugin.js
+++ b/lib/library/AbstractLibraryPlugin.js
@@ -84,8 +84,7 @@ class AbstractLibraryPlugin {
 								: compilation.outputOptions.library
 						);
 						if (options !== false) {
-							const dep = deps[deps.length - 1];
-							if (dep) {
+							for (const dep of deps) {
 								const module = compilation.moduleGraph.getModule(dep);
 								if (module) {
 									this.finishEntryModule(module, name, {

--- a/test/configCases/library/issue-15936-array-entry-exports/a.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/configCases/library/issue-15936-array-entry-exports/b.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/library/issue-15936-array-entry-exports/c.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/configCases/library/issue-15936-array-entry-exports/index.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/index.js
@@ -1,0 +1,5 @@
+it("should expose exports from all array entry modules", () => {
+	expect(globalThis.a).toBe("a");
+	expect(globalThis.b).toBe("b");
+	expect(globalThis.c).toBe("c");
+});

--- a/test/configCases/library/issue-15936-array-entry-exports/test.config.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	afterExecute() {
+		delete globalThis.a;
+		delete globalThis.b;
+		delete globalThis.c;
+	}
+};

--- a/test/configCases/library/issue-15936-array-entry-exports/webpack.config.js
+++ b/test/configCases/library/issue-15936-array-entry-exports/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: ["./a.js", "./b.js", "./c.js", "./index.js"],
+	output: {
+		library: {
+			type: "global"
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #15936.

Array entries with `output.library` currently expose only the final entry module exports. This marks each array entry module as used by the library and makes startup share the library exports object so all entry exports are exposed.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. Added a library config case covering array entry exports.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI assistance helped inspect the startup and library code paths and draft the first patch. I reviewed, adjusted, tested, and verified the change locally.