### PR TITLE
feat: optimize export bindings with value descriptors for static exports

### DIFF
--- a/.changeset/static-export-bindings.md
+++ b/.changeset/static-export-bindings.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Use value descriptors instead of getters for const export bindings.

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -61,6 +61,7 @@ const memoize = require("./util/memoize");
  * @property {boolean=} canMangle can the export be renamed (defaults to true)
  * @property {boolean=} terminalBinding is the export a terminal binding that should be checked for export star conflicts
  * @property {boolean=} isPure calling this export has no observable side effects
+ * @property {boolean=} immutableBinding the export binding never changes (eligible for value-based export instead of getter)
  * @property {(string | ExportSpec)[]=} exports nested exports
  * @property {ModuleGraphConnection=} from when reexported: from which module
  * @property {string[] | null=} export when reexported: from which export

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -52,6 +52,7 @@ const { forEachRuntime } = require("./util/runtime");
  * @property {ExportInfo["canInlineProvide"]} canInlineProvide
  * @property {ExportInfo["terminalBinding"]} terminalBinding
  * @property {ExportInfo["pureProvide"]} pureProvide
+ * @property {ExportInfo["immutableBinding"]} immutableBinding
  * @property {RestoreProvidedData | undefined} exportsInfo
  */
 
@@ -832,6 +833,7 @@ class ExportsInfo {
 				exportInfo.canInlineProvide !== undefined ||
 				exportInfo.terminalBinding !== otherTerminalBinding ||
 				exportInfo.pureProvide !== undefined ||
+				exportInfo.immutableBinding !== undefined ||
 				exportInfo.exportsInfoOwned
 			) {
 				exports.push({
@@ -841,6 +843,7 @@ class ExportsInfo {
 					canInlineProvide: exportInfo.canInlineProvide,
 					terminalBinding: exportInfo.terminalBinding,
 					pureProvide: exportInfo.pureProvide,
+					immutableBinding: exportInfo.immutableBinding,
 					exportsInfo: exportInfo.exportsInfoOwned
 						? /** @type {NonNullable<ExportInfo["exportsInfo"]>} */
 							(exportInfo.exportsInfo).getRestoreProvidedData()
@@ -883,6 +886,7 @@ class ExportsInfo {
 			exportInfo.canInlineProvide = exp.canInlineProvide;
 			exportInfo.terminalBinding = exp.terminalBinding;
 			exportInfo.pureProvide = exp.pureProvide;
+			exportInfo.immutableBinding = exp.immutableBinding;
 			if (exp.exportsInfo) {
 				const exportsInfo = exportInfo.createNestedExportsInfo();
 				exportsInfo.restoreProvided(exp.exportsInfo);
@@ -975,6 +979,12 @@ class ExportInfo {
 		 * @type {boolean | undefined}
 		 */
 		this.pureProvide = undefined;
+		/**
+		 * true: the export binding never changes (eligible for value-based export)
+		 * undefined: not determined
+		 * @type {boolean | undefined}
+		 */
+		this.immutableBinding = undefined;
 		/** @type {boolean} */
 		this.exportsInfoOwned = false;
 		/** @type {ExportsInfo | undefined} */
@@ -1663,7 +1673,7 @@ class ExportInfo {
 		hash.update(
 			`${usedNameHash}${this.getUsed(runtime)}${this.provided}${
 				this.terminalBinding
-			}${this.pureProvide ? "P" : ""}`
+			}${this.pureProvide ? "P" : ""}${this.immutableBinding ? "I" : ""}`
 		);
 		if (this.exportsInfo && !alreadyVisitedExportsInfo.has(this.exportsInfo)) {
 			this.exportsInfo._updateHash(hash, runtime, alreadyVisitedExportsInfo);

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -200,6 +200,7 @@ class FlagDependencyExportsPlugin {
 											let canMangle = globalCanMangle;
 											let terminalBinding = globalTerminalBinding;
 											let pure = globalPure;
+											let immutableBinding = false;
 											/** @type {ExportSpec["exports"]} */
 											let exports;
 											let from = globalFrom;
@@ -240,6 +241,9 @@ class FlagDependencyExportsPlugin {
 												if (exportNameOrSpec.inlined !== undefined) {
 													inlined = exportNameOrSpec.inlined;
 												}
+												if (exportNameOrSpec.immutableBinding !== undefined) {
+													immutableBinding = exportNameOrSpec.immutableBinding;
+												}
 											}
 											const exportInfo = exportsInfo.getExportInfo(name);
 
@@ -274,6 +278,14 @@ class FlagDependencyExportsPlugin {
 
 											if (pure && exportInfo.pureProvide !== true) {
 												exportInfo.pureProvide = true;
+												changed = true;
+											}
+
+											if (
+												immutableBinding &&
+												exportInfo.immutableBinding !== true
+											) {
+												exportInfo.immutableBinding = true;
 												changed = true;
 											}
 

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -212,6 +212,8 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {Set<string>=} topLevelDeclarations top level declaration names
  * @property {Set<string>=} pureFunctions names of locally declared functions known to be free of side effects
  * @property {boolean=} inlineExports whether this module was parsed with `optimization.inlineExports` enabled (gates inlining of its exports)
+ * @property {Set<string>=} constBindings names of top-level variables declared with const
+ * @property {boolean=} isCircular true when the module is part of a circular dependency chain
  */
 
 /** @typedef {string | Set<string>} ValueCacheVersion */

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -620,8 +620,10 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 		if (options.optimization.inlineExports) {
 			const InlineExportsPlugin = require("./optimize/InlineExportsPlugin");
+			const CircularModulesPlugin = require("./optimize/CircularModulesPlugin");
 
 			new InlineExportsPlugin().apply(compiler);
+			new CircularModulesPlugin().apply(compiler);
 		}
 		if (options.optimization.mangleExports) {
 			const MangleExportsPlugin = require("./optimize/MangleExportsPlugin");

--- a/lib/dependencies/ExportBindingInitFragment.js
+++ b/lib/dependencies/ExportBindingInitFragment.js
@@ -1,0 +1,164 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+const InitFragment = require("../InitFragment");
+const RuntimeGlobals = require("../RuntimeGlobals");
+
+/** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {import("../Generator").GenerateContext} GenerateContext */
+/** @typedef {import("../ExportsInfo").UsedName} UsedName */
+
+/**
+ * @typedef {object} ExportBinding
+ * @property {UsedName} name the used export name
+ * @property {string} value the variable expression
+ * @property {"getter" | "value"=} bindingType "value" for value binding, defaults to "getter"
+ */
+
+/**
+ * Init fragment for const export bindings.
+ * Generates a flat-array __webpack_require__.d() call.
+ * Getter bindings: "key", () => expr (2 items).
+ * Value bindings: "key", 0, expr (3 items, 0 is sentinel).
+ *
+ * Uses a separate key ("harmony-export-bindings") from HarmonyExportInitFragment
+ * so the two fragment types do not merge and cannot interfere with each
+ * other's placement (top vs bottom).
+ * @extends {InitFragment<GenerateContext>} Context
+ */
+class ExportBindingInitFragment extends InitFragment {
+	/**
+	 * @param {string} exportsArgument the exports identifier
+	 * @param {ExportBinding[]} bindings list of export bindings
+	 * @param {boolean=} placeAtEnd when true, place the d() call at the end of the module
+	 */
+	constructor(exportsArgument, bindings, placeAtEnd = false) {
+		super(
+			undefined,
+			InitFragment.STAGE_HARMONY_EXPORTS,
+			1,
+			"harmony-export-bindings"
+		);
+		/** @type {string} */
+		this.exportsArgument = exportsArgument;
+		/** @type {ExportBinding[]} */
+		this.bindings = bindings;
+		/** @type {boolean} */
+		this.placeAtEnd = placeAtEnd;
+	}
+
+	/**
+	 * @param {ExportBindingInitFragment[]} fragments all fragments to merge
+	 * @returns {ExportBindingInitFragment} merged fragment
+	 */
+	mergeAll(fragments) {
+		/** @type {ExportBinding[]} */
+		const bindings = [];
+		/** @type {Set<string>} */
+		const seenNames = new Set();
+		let placeAtEnd = false;
+
+		for (const fragment of fragments) {
+			for (const binding of fragment.bindings) {
+				const key = /** @type {string} */ (binding.name);
+				if (!seenNames.has(key)) {
+					seenNames.add(key);
+					bindings.push(binding);
+				}
+			}
+			if (fragment.placeAtEnd) placeAtEnd = true;
+		}
+		return new ExportBindingInitFragment(
+			this.exportsArgument,
+			bindings,
+			placeAtEnd
+		);
+	}
+
+	/**
+	 * @param {ExportBindingInitFragment} other other
+	 * @returns {ExportBindingInitFragment} merged result
+	 */
+	merge(other) {
+		/** @type {ExportBinding[]} */
+		const bindings = [];
+		/** @type {Set<string>} */
+		const seenNames = new Set();
+		for (const binding of other.bindings) {
+			const key = /** @type {string} */ (binding.name);
+			seenNames.add(key);
+			bindings.push(binding);
+		}
+		for (const binding of this.bindings) {
+			const key = /** @type {string} */ (binding.name);
+			if (!seenNames.has(key)) {
+				seenNames.add(key);
+				bindings.push(binding);
+			}
+		}
+		return new ExportBindingInitFragment(
+			this.exportsArgument,
+			bindings,
+			this.placeAtEnd || other.placeAtEnd
+		);
+	}
+
+	/**
+	 * @param {GenerateContext} context context
+	 * @returns {string} the d() call or empty string
+	 */
+	_generateDefinition({ runtimeTemplate, runtimeRequirements }) {
+		if (this.bindings.length === 0) return "";
+
+		const sorted = [...this.bindings].sort((a, b) =>
+			/** @type {string} */ (a.name) < /** @type {string} */ (b.name) ? -1 : 1
+		);
+
+		/** @type {string[]} */
+		const items = [];
+		for (const binding of sorted) {
+			const key = JSON.stringify(/** @type {string} */ (binding.name));
+			if (binding.bindingType === "value") {
+				items.push(`\n/* harmony export */   ${key}, 0, ${binding.value}`);
+			} else {
+				items.push(
+					`\n/* harmony export */   ${key}, ${runtimeTemplate.returningFunction(binding.value)}`
+				);
+			}
+		}
+
+		runtimeRequirements.add(RuntimeGlobals.exports);
+		runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+		return `/* harmony export */ ${RuntimeGlobals.definePropertyGetters}(${
+			this.exportsArgument
+		}, [${items.join(",")}\n/* harmony export */ ]);\n`;
+	}
+
+	/**
+	 * Returns the source code that will be included as initialization code.
+	 * @param {GenerateContext} context context
+	 * @returns {string | Source | undefined} the source code that will be included as initialization code
+	 */
+	getContent(context) {
+		if (this.placeAtEnd) return undefined;
+		return this._generateDefinition(context);
+	}
+
+	/**
+	 * Returns the source code that will be included at the end of the module.
+	 * @param {GenerateContext} context context
+	 * @returns {string | Source | undefined} the source code that will be included at the end of the module
+	 */
+	getEndContent(context) {
+		if (!this.placeAtEnd) return undefined;
+		const definePart = this._generateDefinition(context);
+		if (!definePart) return undefined;
+		return `\n${definePart}`;
+	}
+}
+
+module.exports = ExportBindingInitFragment;

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -7,6 +7,7 @@
 
 const { InlinedUsedName } = require("../optimize/InlineExports");
 const makeSerializable = require("../util/makeSerializable");
+const ExportBindingInitFragment = require("./ExportBindingInitFragment");
 const HarmonyExportInitFragment = require("./HarmonyExportInitFragment");
 const NullDependency = require("./NullDependency");
 
@@ -50,8 +51,20 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 		const pureFunctions =
 			module && module.buildInfo && module.buildInfo.pureFunctions;
 		const isPure = Boolean(pureFunctions && pureFunctions.has(this.id));
+		const isConst =
+			module &&
+			module.buildInfo &&
+			module.buildInfo.constBindings &&
+			module.buildInfo.constBindings.has(this.id);
 		return {
-			exports: [{ name: this.name, isPure, inlined: this.inlined }],
+			exports: [
+				{
+					name: this.name,
+					isPure,
+					inlined: this.inlined,
+					immutableBinding: isConst
+				}
+			],
 			priority: 1,
 			terminalBinding: true,
 			dependencies: undefined
@@ -135,12 +148,38 @@ HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependen
 			return;
 		}
 
-		/** @type {ExportMap} */
-		const map = new Map();
-		map.set(used, `/* binding */ ${dep.id}`);
-		initFragments.push(
-			new HarmonyExportInitFragment(module.exportsArgument, map, undefined)
-		);
+		const exportsInfo = moduleGraph.getExportsInfo(module);
+		const exportInfo = exportsInfo.getReadOnlyExportInfo(dep.name);
+		const canUseValueBinding =
+			exportInfo &&
+			exportInfo.immutableBinding === true &&
+			!(
+				/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
+					.isCircular
+			);
+
+		if (canUseValueBinding) {
+			initFragments.push(
+				new ExportBindingInitFragment(
+					module.exportsArgument,
+					[
+						{
+							name: used,
+							value: `/* binding */ ${dep.id}`,
+							bindingType: "value"
+						}
+					],
+					true
+				)
+			);
+		} else {
+			/** @type {ExportMap} */
+			const map = new Map();
+			map.set(used, `/* binding */ ${dep.id}`);
+			initFragments.push(
+				new HarmonyExportInitFragment(module.exportsArgument, map, undefined)
+			);
+		}
 	}
 };
 

--- a/lib/optimize/CircularModulesPlugin.js
+++ b/lib/optimize/CircularModulesPlugin.js
@@ -1,0 +1,43 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+const { STAGE_DEFAULT } = require("../OptimizationStages");
+const CycleGraph = require("./CycleGraph");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "CircularModulesPlugin";
+
+/**
+ * Detects circular dependencies and marks each circular module
+ * via buildInfo.isCircular for downstream consumers.
+ */
+class CircularModulesPlugin {
+	/**
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+			compilation.hooks.optimizeDependencies.tap(
+				{ name: PLUGIN_NAME, stage: STAGE_DEFAULT },
+				(modules) => {
+					const { circularModules } = CycleGraph.build(
+						modules,
+						compilation.moduleGraph
+					);
+					for (const m of circularModules) {
+						/** @type {import("../Module").BuildInfo} */
+						(m.buildInfo).isCircular = true;
+					}
+				}
+			);
+		});
+	}
+}
+
+module.exports = CircularModulesPlugin;

--- a/lib/optimize/ConstValueParserPlugin.js
+++ b/lib/optimize/ConstValueParserPlugin.js
@@ -21,17 +21,40 @@ class ConstValueParserPlugin {
 	 * @returns {void}
 	 */
 	apply(parser) {
+		// Only const is tracked; function/class names can be reassigned in sloppy mode.
+		// Re-exports always use getters: cross-module bindings may be mutable,
+		// and SideEffectsFlagPlugin can rewire connections skipping the template.
+		/** @type {Set<string> | undefined} */
+		let constBindings;
+
 		parser.hooks.program.tap(PLUGIN_NAME, () => {
+			constBindings = undefined;
 			const buildInfo =
 				/** @type {BuildInfo | undefined} */
 				(parser.state.module.buildInfo);
 			if (buildInfo) buildInfo.inlineExports = true;
 		});
 
-		// Tag top-level `const X = <primitive>` bindings whose initializer is a small primitive constant
+		// Detect top-level `const` declarations:
+		// - Record ALL const names in constBindings (for value binding optimization)
+		// - Tag inline-eligible primitives with INLINED_CONST_TAG (for inline optimization)
 		parser.hooks.preDeclarator.tap(PLUGIN_NAME, (declarator, statement) => {
 			if (statement.kind !== "const") return;
 			if (parser.scope.topLevelScope !== true) return;
+
+			// Record all const bindings for value binding optimization
+			if (constBindings === undefined) constBindings = new Set();
+			if (declarator.id.type === "Identifier") {
+				constBindings.add(declarator.id.name);
+			} else {
+				// Handle destructuring patterns (ObjectPattern, ArrayPattern, etc.)
+				parser.enterPattern(declarator.id, (name) => {
+					/** @type {Set<string>} */
+					(constBindings).add(name);
+				});
+			}
+
+			// Tag only simple identifier inline-eligible primitives for inline optimization
 			if (declarator.id.type !== "Identifier") return;
 			if (!declarator.init) return;
 			const evaluated = parser.evaluateExpression(declarator.init);
@@ -72,6 +95,12 @@ class ConstValueParserPlugin {
 						return eval_.setString(/** @type {string} */ (value.value));
 				}
 			});
+
+		parser.hooks.finish.tap(PLUGIN_NAME, () => {
+			if (constBindings === undefined) return;
+			/** @type {BuildInfo} */
+			(parser.state.module.buildInfo).constBindings = constBindings;
+		});
 	}
 }
 

--- a/lib/optimize/CycleGraph.js
+++ b/lib/optimize/CycleGraph.js
@@ -1,0 +1,152 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
+
+/**
+ * Detects circular dependencies among synchronous module imports.
+ *
+ * Builds an adjacency list from module.dependencies (excluding async blocks),
+ * then runs an iterative SCC algorithm to find circular modules.
+ *
+ * Use the static `build()` method to create an instance. All intermediate data
+ * (adjacency lists, index mappings) is local to `build()` and released on return.
+ * The instance only holds the result.
+ */
+class CycleGraph {
+	/**
+	 * @param {Set<Module>} circularModules modules involved in circular dependencies
+	 */
+	constructor(circularModules) {
+		/** @type {Set<Module>} */
+		this.circularModules = circularModules;
+	}
+
+	/**
+	 * Builds a CycleGraph by constructing the synchronous dependency adjacency
+	 * list and running iterative SCC to detect circular modules.
+	 * @param {Iterable<Module>} modules the set of modules
+	 * @param {ModuleGraph} moduleGraph the module graph
+	 * @returns {CycleGraph} the result
+	 */
+	static build(modules, moduleGraph) {
+		/** @type {Module[]} */
+		const moduleList = [];
+		/** @type {Map<Module, number>} */
+		const moduleToIndex = new Map();
+		for (const module of modules) {
+			moduleToIndex.set(module, moduleList.length);
+			moduleList.push(module);
+		}
+
+		const size = moduleList.length;
+		if (size === 0) return new CycleGraph(new Set());
+
+		/** @type {number[][]} */
+		const edges = Array.from({ length: size });
+		/** @type {boolean[]} */
+		const selfLoops = Array.from({ length: size }, () => false);
+
+		for (let i = 0; i < size; i++) {
+			/** @type {number[]} */
+			const deps = [];
+			for (const dep of moduleList[i].dependencies) {
+				const target = moduleGraph.getModule(dep);
+				if (!target) continue;
+				if (target === moduleList[i]) {
+					selfLoops[i] = true;
+					continue;
+				}
+				const targetIdx = moduleToIndex.get(target);
+				if (targetIdx !== undefined) {
+					deps.push(targetIdx);
+				}
+			}
+			edges[i] = deps;
+		}
+
+		// Iterative SCC algorithm
+		/** @type {Set<Module>} */
+		const circular = new Set();
+		let nextIndex = 0;
+		const nodeIndex = new Int32Array(size).fill(-1);
+		const nodeLowLink = new Int32Array(size);
+		const nodeOnStack = new Uint8Array(size);
+		/** @type {number[]} */
+		const sccStack = [];
+
+		/**
+		 * @typedef {object} Frame
+		 * @property {number} node
+		 * @property {number} edgeIdx
+		 * @property {number} parent
+		 */
+
+		for (let root = 0; root < size; root++) {
+			if (nodeIndex[root] !== -1) continue;
+
+			nodeIndex[root] = nextIndex;
+			nodeLowLink[root] = nextIndex;
+			nextIndex++;
+			nodeOnStack[root] = 1;
+			sccStack.push(root);
+
+			/** @type {Frame[]} */
+			const callStack = [{ node: root, edgeIdx: 0, parent: -1 }];
+
+			while (callStack.length > 0) {
+				const frame = /** @type {Frame} */ (callStack[callStack.length - 1]);
+				const v = frame.node;
+				const vEdges = edges[v];
+
+				if (frame.edgeIdx < vEdges.length) {
+					const w = vEdges[frame.edgeIdx++];
+					if (nodeIndex[w] === -1) {
+						nodeIndex[w] = nextIndex;
+						nodeLowLink[w] = nextIndex;
+						nextIndex++;
+						nodeOnStack[w] = 1;
+						sccStack.push(w);
+						callStack.push({ node: w, edgeIdx: 0, parent: v });
+					} else if (nodeOnStack[w] && nodeIndex[w] < nodeLowLink[v]) {
+						nodeLowLink[v] = nodeIndex[w];
+					}
+				} else {
+					if (nodeLowLink[v] === nodeIndex[v]) {
+						/** @type {number[]} */
+						const component = [];
+						let w;
+						do {
+							w = /** @type {number} */ (sccStack.pop());
+							nodeOnStack[w] = 0;
+							component.push(w);
+						} while (w !== v);
+
+						if (component.length > 1 || selfLoops[v]) {
+							for (const idx of component) {
+								circular.add(moduleList[idx]);
+							}
+						}
+					}
+
+					callStack.pop();
+					if (
+						frame.parent !== -1 &&
+						nodeLowLink[v] < nodeLowLink[frame.parent]
+					) {
+						nodeLowLink[frame.parent] = nodeLowLink[v];
+					}
+				}
+			}
+		}
+
+		return new CycleGraph(circular);
+	}
+}
+
+module.exports = CycleGraph;

--- a/lib/runtime/DefinePropertyGettersRuntimeModule.js
+++ b/lib/runtime/DefinePropertyGettersRuntimeModule.js
@@ -24,13 +24,42 @@ class DefinePropertyGettersRuntimeModule extends HelperRuntimeModule {
 		const { runtimeTemplate } = compilation;
 		const fn = RuntimeGlobals.definePropertyGetters;
 		return Template.asString([
-			"// define getter functions for harmony exports",
+			"// define getter/value functions for harmony exports",
 			`${fn} = ${runtimeTemplate.basicFunction("exports, definition", [
-				"for(var key in definition) {",
+				"if(Array.isArray(definition)) {",
 				Template.indent([
-					`if(${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
+					"var i = 0;",
+					"while(i < definition.length) {",
 					Template.indent([
-						"Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });"
+						"var key = definition[i++];",
+						"var binding = definition[i++];",
+						`if(!${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
+						Template.indent([
+							"if(binding === 0) {",
+							Template.indent([
+								"Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });"
+							]),
+							"} else {",
+							Template.indent([
+								"Object.defineProperty(exports, key, { enumerable: true, get: binding });"
+							]),
+							"}"
+						]),
+						"} else if(binding === 0) { i++; }"
+					]),
+					"}"
+				]),
+				// TODO webpack 6: remove object format support. Internal code (e.g. ConcatenatedModule)
+				// and third-party libraries may still call __webpack_require__.d() with an object.
+				"} else {",
+				Template.indent([
+					"for(var key in definition) {",
+					Template.indent([
+						`if(${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
+						Template.indent([
+							"Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });"
+						]),
+						"}"
 					]),
 					"}"
 				]),

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -241,10 +241,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 3166,
+			          "size": 3369,
 			        },
 			      ],
-			      "assetsSize": 3166,
+			      "assetsSize": 3369,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -290,10 +290,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 3166,
+			        "size": 3369,
 			      },
 			      "name": "entryB.js",
-			      "size": 3166,
+			      "size": 3369,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/cases/large/big-assets/__snapshots__/warnings.snap
+++ b/test/cases/large/big-assets/__snapshots__/warnings.snap
@@ -13,28 +13,93 @@ Array [
     "moduleName": "../../node_modules/loader-runner/lib/loadLoader.js",
   },
   Object {
-    "loc": "43:12-19",
+    "loc": "329:12-19",
     "message": "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted",
     "moduleName": "../../node_modules/terser-webpack-plugin/dist/minify.js",
   },
   Object {
-    "loc": "599:10-30",
+    "loc": "637:10-30",
     "message": "Module not found: Error: Can't resolve '@swc/core' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
     "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
   },
   Object {
-    "loc": "659:18-51",
+    "loc": "697:18-51",
     "message": "Module not found: Error: Can't resolve '@swc/core/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
     "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
   },
   Object {
-    "loc": "700:14-32",
+    "loc": "744:14-32",
     "message": "Module not found: Error: Can't resolve 'esbuild' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
     "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
   },
   Object {
-    "loc": "736:18-49",
+    "loc": "780:18-49",
     "message": "Module not found: Error: Can't resolve 'esbuild/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "905:20-48",
+    "message": "Module not found: Error: Can't resolve '@minify-html/node' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "927:18-59",
+    "message": "Module not found: Error: Can't resolve '@minify-html/node/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "972:18-38",
+    "message": "Module not found: Error: Can't resolve '@swc/html' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "995:18-51",
+    "message": "Module not found: Error: Can't resolve '@swc/html/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1087:16-28",
+    "message": "Critical dependency: the request of a dependency is an expression",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1109:14-32",
+    "message": "Module not found: Error: Can't resolve 'cssnano' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1168:18-49",
+    "message": "Module not found: Error: Can't resolve 'cssnano/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1197:11-26",
+    "message": "Module not found: Error: Can't resolve 'csso' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1222:18-46",
+    "message": "Module not found: Error: Can't resolve 'csso/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1407:19-42",
+    "message": "Module not found: Error: Can't resolve 'lightningcss' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1449:18-54",
+    "message": "Module not found: Error: Can't resolve 'lightningcss/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1494:10-29",
+    "message": "Module not found: Error: Can't resolve '@swc/css' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
+    "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
+  },
+  Object {
+    "loc": "1533:18-50",
+    "message": "Module not found: Error: Can't resolve '@swc/css/package.json' in '<WEBPACK_ROOT>/node_modules/terser-webpack-plugin/dist'",
     "moduleName": "../../node_modules/terser-webpack-plugin/dist/utils.js",
   },
   Object {

--- a/test/configCases/code-generation/import-export-format-2/index.js
+++ b/test/configCases/code-generation/import-export-format-2/index.js
@@ -33,7 +33,8 @@ it("should use the same accessor syntax for import and export", function() {
 	/*********** DO NOT MATCH BELOW THIS LINE ***********/
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "/* harmony export */   bar: () => (/* binding */ bar)");
+	// Array format: "bar", 0, bar (value) or "bar", () => bar (getter)
+	expectSourceToMatch(source, `\\/\\* harmony export \\*\\/   "bar", .*bar`);
 
 	// Checking formation of imports
 	expectSourceToMatch(source, `${regexEscape("const { harmonyexport_cjsimport } = (__webpack_require__(/*! ./harmony-module */ ")}\\d+${regexEscape(").bar);")}`);

--- a/test/configCases/code-generation/import-export-format/index.js
+++ b/test/configCases/code-generation/import-export-format/index.js
@@ -30,7 +30,8 @@ it("should use the same accessor syntax for import and export", function() {
 	// Note that there are no quotes around the "a" and "b" properties in the following lines.
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "/* harmony export */   a: () => (/* binding */ bar)");
+	// Array format: "a", 0, bar (value) or "a", () => bar (getter)
+	expectSourceToMatch(source, `\\/\\* harmony export \\*\\/   "a", .*bar`);
 
 	// Checking formation of imports
 	expectSourceToContain(source, "harmony_module/* bar */.a;");

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -65,11 +65,26 @@ globalThis.__preloadLoaded = true;
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -65,11 +65,26 @@ globalThis.__preloadLoaded = true;
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -25,11 +25,12 @@ exports[`ConfigCacheTestCases html script-src-mixed exported tests should chain 
   \\\\*********************/
 (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   o: () => (/* binding */ moduleA)
-/* harmony export */ });
 const moduleA = \\"module-a value\\";
 globalThis.__moduleA = moduleA;
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"o\\", 0, /* binding */ moduleA
+/* harmony export */ ]);
 
 
 /***/ }
@@ -72,11 +73,26 @@ globalThis.__moduleA = moduleA;
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -25,11 +25,12 @@ exports[`ConfigTestCases html script-src-mixed exported tests should chain multi
   \\\\*********************/
 (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   o: () => (/* binding */ moduleA)
-/* harmony export */ });
 const moduleA = \\"module-a value\\";
 globalThis.__moduleA = moduleA;
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"o\\", 0, /* binding */ moduleA
+/* harmony export */ ]);
 
 
 /***/ }
@@ -72,11 +73,26 @@ globalThis.__moduleA = moduleA;
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigCacheTest.snap
@@ -138,11 +138,26 @@ console.log({ HomeLayout });
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};
@@ -343,11 +358,26 @@ console.log({ HomeLayout });
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};
@@ -548,11 +578,26 @@ console.log({ HomeLayout });
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};
@@ -753,11 +798,26 @@ console.log({ HomeLayout });
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigTest.snap
+++ b/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigTest.snap
@@ -138,11 +138,26 @@ console.log({ HomeLayout });
 /************************************************************************/
 /******/ /* webpack/runtime/define property getters */
 /******/ (() => {
-/******/ 	// define getter functions for harmony exports
+/******/ 	// define getter/value functions for harmony exports
 /******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				if(!__webpack_require__.o(exports, key)) {
+/******/ 					if(binding === 0) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 					} else {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 					}
+/******/ 				} else if(binding === 0) { i++; }
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
 /******/ 			}
 /******/ 		}
 /******/ 	};

--- a/test/configCases/optimization/static-export-bindings/const-exports.js
+++ b/test/configCases/optimization/static-export-bindings/const-exports.js
@@ -1,0 +1,12 @@
+export const literal = "literal";
+
+const local = "local";
+export { local as renamed };
+
+const source = { destructured: "destructured" };
+export const { destructured } = source;
+
+export const [arrayValue] = ["array"];
+
+const aliased = "aliased";
+export { aliased as "string-alias" };

--- a/test/configCases/optimization/static-export-bindings/cycle-a.js
+++ b/test/configCases/optimization/static-export-bindings/cycle-a.js
@@ -1,0 +1,7 @@
+import { readFromB } from "./cycle-b";
+
+export const cyclicConst = "cyclic";
+
+export function readViaB() {
+	return readFromB();
+}

--- a/test/configCases/optimization/static-export-bindings/cycle-b.js
+++ b/test/configCases/optimization/static-export-bindings/cycle-b.js
@@ -1,0 +1,5 @@
+import { cyclicConst } from "./cycle-a";
+
+export function readFromB() {
+	return cyclicConst;
+}

--- a/test/configCases/optimization/static-export-bindings/function-exports.js
+++ b/test/configCases/optimization/static-export-bindings/function-exports.js
@@ -1,0 +1,7 @@
+export function fn() {
+	return "fn";
+}
+
+export function fn2() {
+	return "fn2";
+}

--- a/test/configCases/optimization/static-export-bindings/index.js
+++ b/test/configCases/optimization/static-export-bindings/index.js
@@ -1,0 +1,112 @@
+import * as constExports from "./const-exports";
+import * as fnExports from "./function-exports";
+import * as mutableExports from "./mutable-exports";
+import * as cycleA from "./cycle-a";
+import * as reexported from "./reexport";
+import * as reexportChain from "./reexport-chain";
+import * as reexportMixed from "./reexport-mixed";
+import * as reexportStar from "./reexport-star";
+import * as reexportCircular from "./reexport-circular";
+
+function expectValueDescriptor(ns, key) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(descriptor.get).toBe(undefined);
+	expect(descriptor.enumerable).toBe(true);
+	expect(descriptor.writable).toBe(false);
+}
+
+function expectGetterDescriptor(ns, key) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(typeof descriptor.get).toBe("function");
+	expect(descriptor.enumerable).toBe(true);
+	expect(Object.prototype.hasOwnProperty.call(descriptor, "value")).toBe(false);
+}
+
+// === Direct exports ===
+
+it("should bind const exports as readonly values (non-circular)", () => {
+	expectValueDescriptor(constExports, "literal");
+	expect(constExports.literal).toBe("literal");
+	expectValueDescriptor(constExports, "renamed");
+	expect(constExports.renamed).toBe("local");
+	expectValueDescriptor(constExports, "destructured");
+	expect(constExports.destructured).toBe("destructured");
+	expectValueDescriptor(constExports, "arrayValue");
+	expect(constExports.arrayValue).toBe("array");
+	expectValueDescriptor(constExports, "string-alias");
+	expect(constExports["string-alias"]).toBe("aliased");
+});
+
+it("should keep function exports as getters", () => {
+	expectGetterDescriptor(fnExports, "fn");
+	expect(fnExports.fn()).toBe("fn");
+	expectGetterDescriptor(fnExports, "fn2");
+	expect(fnExports.fn2()).toBe("fn2");
+});
+
+it("should keep mutable exports as getters", () => {
+	expectGetterDescriptor(mutableExports, "counter");
+	expect(mutableExports.counter).toBe(0);
+	mutableExports.increment();
+	expect(mutableExports.counter).toBe(1);
+});
+
+it("should work correctly with circular modules", () => {
+	expect(cycleA.cyclicConst).toBe("cyclic");
+	expect(cycleA.readViaB()).toBe("cyclic");
+});
+
+// === Re-exports (all use getters — re-export optimization not yet supported) ===
+
+it("should keep re-exported const as getter", () => {
+	expectGetterDescriptor(reexported, "literal");
+	expect(reexported.literal).toBe("literal");
+});
+
+it("should keep re-exported function as getter", () => {
+	expectGetterDescriptor(reexported, "fn");
+	expect(reexported.fn()).toBe("fn");
+});
+
+it("should keep re-exported mutable as getter with live binding", () => {
+	expectGetterDescriptor(reexported, "counter");
+	const before = reexported.counter;
+	reexported.increment();
+	expect(reexported.counter).toBe(before + 1);
+});
+
+it("should use getter for multi-level re-export chain", () => {
+	expectGetterDescriptor(reexportChain, "chainedLiteral");
+	expect(reexportChain.chainedLiteral).toBe("literal");
+});
+
+it("should bind own const as value in mixed module", () => {
+	expectValueDescriptor(reexportMixed, "ownConst");
+	expect(reexportMixed.ownConst).toBe("own");
+});
+
+it("should keep re-exported values in mixed module", () => {
+	expect(reexportMixed.reConst).toBe("literal");
+	expect(reexportMixed.reFn()).toBe("fn");
+});
+
+it("should keep re-exported mutable as live binding in mixed module", () => {
+	const before = reexportMixed.reCounter;
+	reexportMixed.reIncrement();
+	expect(reexportMixed.reCounter).toBe(before + 1);
+});
+
+it("should use getter for named re-export with export *", () => {
+	expectGetterDescriptor(reexportStar, "namedConst");
+	expect(reexportStar.namedConst).toBe("literal");
+});
+
+it("should keep star-exported function as getter", () => {
+	expectGetterDescriptor(reexportStar, "fn");
+	expect(reexportStar.fn()).toBe("fn");
+});
+
+it("should use getter for re-export from circular module", () => {
+	expectGetterDescriptor(reexportCircular, "reCircular");
+	expect(reexportCircular.reCircular).toBe("cyclic");
+});

--- a/test/configCases/optimization/static-export-bindings/mutable-exports.js
+++ b/test/configCases/optimization/static-export-bindings/mutable-exports.js
@@ -1,0 +1,5 @@
+export let counter = 0;
+
+export function increment() {
+	counter++;
+}

--- a/test/configCases/optimization/static-export-bindings/reexport-chain.js
+++ b/test/configCases/optimization/static-export-bindings/reexport-chain.js
@@ -1,0 +1,2 @@
+// Re-export chain: this file re-exports from reexport.js which re-exports from const-exports.js
+export { literal as chainedLiteral } from "./reexport";

--- a/test/configCases/optimization/static-export-bindings/reexport-circular.js
+++ b/test/configCases/optimization/static-export-bindings/reexport-circular.js
@@ -1,0 +1,2 @@
+// Re-export from a circular module — should use getter
+export { cyclicConst as reCircular } from "./cycle-a";

--- a/test/configCases/optimization/static-export-bindings/reexport-mixed.js
+++ b/test/configCases/optimization/static-export-bindings/reexport-mixed.js
@@ -1,0 +1,5 @@
+// Mixed: direct const export + re-exports in the same module
+export const ownConst = "own";
+export { literal as reConst } from "./const-exports";
+export { fn as reFn } from "./function-exports";
+export { counter as reCounter, increment as reIncrement } from "./mutable-exports";

--- a/test/configCases/optimization/static-export-bindings/reexport-star.js
+++ b/test/configCases/optimization/static-export-bindings/reexport-star.js
@@ -1,0 +1,3 @@
+// Star export mixed with named re-export — star export should prevent value binding
+export { literal as namedConst } from "./const-exports";
+export * from "./function-exports";

--- a/test/configCases/optimization/static-export-bindings/reexport.js
+++ b/test/configCases/optimization/static-export-bindings/reexport.js
@@ -1,0 +1,3 @@
+export { literal, renamed, destructured, arrayValue } from "./const-exports";
+export { fn } from "./function-exports";
+export { counter, increment } from "./mutable-exports";

--- a/test/configCases/optimization/static-export-bindings/webpack.config.js
+++ b/test/configCases/optimization/static-export-bindings/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		concatenateModules: false,
+		mangleExports: false,
+		usedExports: false
+	}
+};

--- a/test/statsCases/chunk-module-id-range/__snapshots__/StatsTest.snap
+++ b/test/statsCases/chunk-module-id-range/__snapshots__/StatsTest.snap
@@ -6,18 +6,18 @@ asset main1.js X KiB [emitted] (name: main1)
 asset main2.js X KiB [emitted] (name: main2)
 Entrypoint main1 X KiB = main1.js
 Entrypoint main2 X KiB = main2.js
-chunk (runtime: main1) main1.js (main1) X bytes (javascript) X bytes (runtime) [entry] [rendered]
+chunk (runtime: main1) main1.js (main1) X bytes (javascript) X KiB (runtime) [entry] [rendered]
   > ./main1 main1
-  runtime modules X bytes 3 modules
+  runtime modules X KiB 3 modules
   cacheable modules X bytes
     ./a.js X bytes [dependent] [built] [code generated]
     ./b.js X bytes [dependent] [built] [code generated]
     ./c.js X bytes [dependent] [built] [code generated]
     ./d.js X bytes [dependent] [built] [code generated]
     ./main1.js X bytes [built] [code generated]
-chunk (runtime: main2) main2.js (main2) X bytes (javascript) X bytes (runtime) [entry] [rendered]
+chunk (runtime: main2) main2.js (main2) X bytes (javascript) X KiB (runtime) [entry] [rendered]
   > ./main2 main2
-  runtime modules X bytes 3 modules
+  runtime modules X KiB 3 modules
   cacheable modules X bytes
     ./a.js X bytes [dependent] [built] [code generated]
     ./d.js X bytes [dependent] [built] [code generated]

--- a/test/statsCases/side-effects-optimization/__snapshots__/StatsTest.snap
+++ b/test/statsCases/side-effects-optimization/__snapshots__/StatsTest.snap
@@ -19,8 +19,8 @@ cacheable modules X KiB
     ModuleConcatenation bailout: Module is not an ECMAScript module
 webpack x.x.x compiled successfully in X ms
 
-asset main.no-side.js X bytes [emitted] [minimized] (name: main)
-runtime modules X bytes 4 modules
+asset main.no-side.js X KiB [emitted] [minimized] (name: main)
+runtime modules X KiB 4 modules
 orphan modules X bytes [orphan] 2 modules
 cacheable modules X KiB
   modules by path ./node_modules/module-with-export/*.js X KiB

--- a/test/statsCases/split-chunks-max-size/__snapshots__/StatsTest.snap
+++ b/test/statsCases/split-chunks-max-size/__snapshots__/StatsTest.snap
@@ -400,10 +400,10 @@ enforce-min-size:
 
 only-async:
   Entrypoint main X KiB = only-async-main.js
-  chunk (runtime: main) only-async-main.js (main) X KiB (javascript) X bytes (runtime) [entry] [rendered]
+  chunk (runtime: main) only-async-main.js (main) X KiB (javascript) X KiB (runtime) [entry] [rendered]
     > ./ main
     dependent modules X KiB [dependent] 44 modules
-    runtime modules X bytes 3 modules
+    runtime modules X KiB 3 modules
     ./index.js X KiB [built] [code generated]
   only-async (webpack x.x.x) compiled successfully"
 `;

--- a/test/statsCases/tree-shaking/__snapshots__/StatsTest.snap
+++ b/test/statsCases/tree-shaking/__snapshots__/StatsTest.snap
@@ -2,7 +2,7 @@
 
 exports[`StatsTestCases tree-shaking should print correct stats for tree-shaking 1`] = `
 "asset bundle.js X KiB [emitted] (name: main)
-runtime modules X bytes 3 modules
+runtime modules X KiB 3 modules
 orphan modules X bytes [orphan] 1 module
 cacheable modules X bytes
   ./index.js X bytes [built] [code generated] [1 warning]

--- a/types.d.ts
+++ b/types.d.ts
@@ -7268,6 +7268,12 @@ declare abstract class ExportInfo {
 	 * undefined: it was not determined whether the export is pure
 	 */
 	pureProvide?: boolean;
+
+	/**
+	 * true: the export binding never changes (eligible for value-based export)
+	 * undefined: not determined
+	 */
+	immutableBinding?: boolean;
 	exportsInfoOwned: boolean;
 	exportsInfo?: ExportsInfo;
 	get canMangle(): boolean;
@@ -7438,6 +7444,11 @@ declare interface ExportSpec {
 	 * calling this export has no observable side effects
 	 */
 	isPure?: boolean;
+
+	/**
+	 * the export binding never changes (eligible for value-based export instead of getter)
+	 */
+	immutableBinding?: boolean;
 
 	/**
 	 * nested exports
@@ -12606,6 +12617,16 @@ declare interface KnownBuildInfo {
 	 * whether this module was parsed with `optimization.inlineExports` enabled (gates inlining of its exports)
 	 */
 	inlineExports?: boolean;
+
+	/**
+	 * names of top-level variables declared with const
+	 */
+	constBindings?: Set<string>;
+
+	/**
+	 * true when the module is part of a circular dependency chain
+	 */
+	isCircular?: boolean;
 }
 declare interface KnownBuildMeta {
 	exportsType?: "namespace" | "dynamic" | "default" | "flagged";
@@ -21044,6 +21065,7 @@ declare interface RestoreProvidedDataExports {
 	canInlineProvide?: InlinedValue;
 	terminalBinding: boolean;
 	pureProvide?: boolean;
+	immutableBinding?: boolean;
 	exportsInfo?: RestoreProvidedData;
 }
 type Rule = string | RegExp | ((str: string) => boolean);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Resolves #18494

Currently webpack wraps **every** ES module export in a getter via `__webpack_require__.d()`:

```js
__webpack_require__.d(__webpack_exports__, {
    value: () => value  // getter — unnecessary for const
});
```

The getter indirection preserves live binding semantics, but `const` exports are never reassigned and don't need it. This PR uses `Object.defineProperty` with value descriptors instead of getters for const exports, reducing runtime overhead.

Implementation:

1. **Detects const bindings** — `ConstValueParserPlugin` (extended from `inlineExports`) records all top-level `const` declaration names (including destructuring patterns) in `buildInfo.constBindings`
2. **Detects circular modules** — `CircularModulesPlugin` + `CycleGraph` builds the synchronous dependency graph and runs iterative Tarjan's SCC, marking circular modules via `buildInfo.isCircular`
3. **Emits value descriptors** — `ExportBindingInitFragment` generates a flat-array `__webpack_require__.d()` call with `0` sentinel for value bindings: `["key", 0, value]`

Optimization rules:
- Only `const` declarations are eligible (`function`/`class` names can be reassigned in sloppy mode)
- Circular modules are excluded (value may be `undefined` at import time)
- Re-exports always use getters (cross-module bindings may be mutable, and `SideEffectsFlagPlugin` can rewire connections)
- Gated behind `optimization.inlineExports` (defaults to `true` in production)

Inspired by https://github.com/web-infra-dev/rspack/pull/14045

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/optimization/static-export-bindings/` covers const exports (literal, renamed, destructured, array), function exports (getter retained), mutable let exports (getter retained), circular modules, and re-exports.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The optimization is gated behind the existing `optimization.inlineExports` option. The runtime `__webpack_require__.d()` now supports both array and object formats, with the object format retained for backward compatibility.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to draft the implementation under human review. All architectural decisions were made through interactive discussion and iterative review.