### PR TITLE
docs(AGENTS): tighten PR-template brevity and add perf/memory guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,10 @@ JSDoc on exported symbols stays as-is — that's the type contract, not commenta
 
 Reviewers have repeatedly flagged paragraph-long comments as a blocker; this rule applies on every commit, not just the first one.
 
+## Performance and memory
+
+webpack is a bundler — users measure it on build time and peak heap, and every line in `lib/` runs once per module (or per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so user code holding `Stats` doesn't keep the whole graph pinned (#15521 is a worked example of getting this wrong).
+
 ## Auto-generated files
 
 > [!REQUIRED]
@@ -261,6 +265,8 @@ webpack uses an **org-wide** PR template from [`webpack/.github`](https://github
 
 The template is mandatory for **every** PR — including PRs the user only asked you to "verify", "check", "test", "add a small assertion to", or otherwise framed as quick or one-off work. Task framing does not change PR-template requirements. The size of the diff does not change PR-template requirements. There is no "this one's too small for the template" carve-out.
 
+**Keep every answer short — ideally one sentence, at most two or three.** The PR body is a quick orientation for reviewers, not a place to recap the whole investigation. No multi-paragraph essays, no bench tables, no code blocks, no walkthroughs of intermediate iterations or reverts. If something needs a longer explanation, drop it into a reply on the relevant inline review thread, link to a discussion issue, or let the squash-merge commit body carry it (the PR body itself becomes that commit body on merge — keep it short anyway). A reviewer should be able to read the entire PR body in well under 30 seconds; if yours takes longer, trim it.
+
 Titles are plain text, not HTML — use raw `<`, `>`, and other special characters directly. Never HTML-entity-encode them (`&lt;`, `&gt;`, `&amp;`) thinking GitHub will render the entities; it will not, the title will literally display the entity codes. Compare against the titles of recent webpack PRs as a sanity check.
 
 Common ways agents get this wrong — all of them are PR-blocking:
@@ -312,14 +318,14 @@ Paste the body **inside** the fenced block below — only the lines between the 
 Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->
 ```
 
-Required answer per section:
+Required answer per section — **one sentence each is the target, two or three the absolute maximum**:
 
-- **Summary** — motivation and what problem is solved; link the related issue (`Closes #…` / `Fixes #…`).
-- **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
-- **Did you add tests for your changes?** — yes/no + which test files.
-- **Does this PR introduce a breaking change?** — yes/no + migration path if yes.
-- **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
-- **Use of AI** — required. State that Claude Code was used and how (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
+- **Summary** — one sentence on motivation (what problem / use case / gap) and one on what changed; link the issue (`Closes #…` / `Fixes #…`) if there is one. Phrase it for whatever change type this is — "broken / fixed" only fits `fix` PRs; `feat`/`refactor`/`perf`/`docs` should describe the missing capability or rationale instead. No bench tables, no code blocks, no narrative of intermediate attempts.
+- **What kind of change does this PR introduce?** — a single word: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
+- **Did you add tests for your changes?** — yes/no + the test file name. One line.
+- **Does this PR introduce a breaking change?** — yes/no, plus a one-sentence migration note if yes.
+- **If relevant, what needs to be documented…** — one-line list or write `n/a`.
+- **Use of AI** — required, one or two sentences. State that Claude Code was used and the broad role (e.g. "Claude Code drafted the implementation under human review"). Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
 
 #### After opening the PR — wait for Copilot review
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Two `AGENTS.md` additions, both nudging contributors toward "less is more": (1) make the PR-template brevity rule explicit so agent-authored bodies stop running multi-paragraph with bench tables and intermediate-iteration recaps; (2) add a short "Performance and memory" section reminding contributors that every line in `lib/` runs once per module (or per module × runtime) on user builds, so weigh the time/memory cost of every change. #15521 is cited as a worked counter-example.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

n/a — docs-only.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — change is in `AGENTS.md` itself.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code drafted the wording under human review, after the human flagged that agent PR bodies were running too long and that perf/memory awareness should be a first-class rule.