### PR TITLE
test: fail on missing per-kind snapshot instead of auto write

### DIFF
--- a/test/harness/snapshot/index.js
+++ b/test/harness/snapshot/index.js
@@ -121,7 +121,7 @@ const matchKindSnapshot = function (caseDir, kind, received) {
 		getActiveSnapshotState() || expect.getState().snapshotState;
 
 	const kindState = new SnapshotState(snapshotPath, {
-		updateSnapshot: parentState._updateSnapshot,
+		updateSnapshot: parentState._updateSnapshot === "all" ? "all" : "none",
 		snapshotFormat: parentState.snapshotFormat,
 		expand: parentState.expand,
 		prettierPath: parentState._prettierPath,


### PR DESCRIPTION
  <!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

  **Summary**

Improve local development DX. Previously a local compile error silently wrote `errors.snap` and passed; now a missing snapshot fails (like CI) unless you regenerate it with -u.

  <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
  <!-- Try to link to an open issue for more information. -->
  <!-- Any other information related to changes. -->
  <!-- In addition to that please answer these questions: -->

  **What kind of change does this PR introduce?**


`matchKindSnapshot` built the per-kind `SnapshotState` with `updateSnapshot: parentState._updateSnapshot`, which is `"new"` in a normal local run. Under `"new"`, a missing `errors.snap`/`warnings.snap` is silently written and the test passes on its first run, so a newly introduced compile error/warning is only caught in CI (where the mode is `"none"`).

This forces the mode to `"none"` unless snapshots are explicitly being updated (`-u` → `"all"`). A missing or changed per-kind snapshot now fails in local runs too; recording or refreshing one requires `yarn jest -u`.

Before: running a test locally that hit a compilation error passed, silently auto-generating `errors.snap`.

<img width="2458" height="708" alt="5c4d1d2c-bcd3-4756-a117-9e12c6e43905" src="https://github.com/user-attachments/assets/b8c3a306-0a92-4ab9-ad7e-018fc891c8ef" />

After: such a test now fails when the snapshot is missing (matching CI behavior), unless you run with `-u` to generate it.

<img width="2678" height="686" alt="81bd8fed-8095-4ae4-b45a-718b34b65dbc" src="https://github.com/user-attachments/assets/ddd018df-2463-4249-952f-aa48d43ec419" />

  <!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind
  of change. -->

cc @xiaoxiaojx 

  **Did you add tests for your changes?**

  <!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Existing

  **Does this PR introduce a breaking change?**

  <!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Nothing

  **If relevant, what needs to be documented once your changes are merged or what have you already documented?**

  <!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

  n/a

  **Use of AI**

  <!-- If you have used AI, please state so here. Explain how you used it.
  Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due
  to irresponsible use of AI. -->
Partial