### PR TITLE
refactor: move Module.hot to NormalModule

### DIFF
--- a/.changeset/move-hot-flag-to-normal-module.md
+++ b/.changeset/move-hot-flag-to-normal-module.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Move the `hot` flag from `Module` to `NormalModule`, where it's actually read and written.

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -938,7 +938,7 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 						applyImportMetaHot(parser);
 					});
 				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module) => {
-					module.hot = true;
+					if (module instanceof NormalModule) module.hot = true;
 					return module;
 				});
 

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -300,10 +300,6 @@ class Module extends DependenciesBlock {
 		/** @type {boolean} */
 		this.useSimpleSourceMap = false;
 
-		// Is in hot context, i.e. HotModuleReplacementPlugin.js enabled
-		// TODO do we need hot here?
-		/** @type {boolean} */
-		this.hot = false;
 		// Info from Build
 		/** @type {Error[] | undefined} */
 		this._warnings = undefined;
@@ -1302,7 +1298,6 @@ class Module extends DependenciesBlock {
 		write(this.factoryMeta);
 		write(this.useSourceMap);
 		write(this.useSimpleSourceMap);
-		write(this.hot);
 		write(
 			this._warnings !== undefined && this._warnings.length === 0
 				? undefined
@@ -1333,7 +1328,6 @@ class Module extends DependenciesBlock {
 		this.factoryMeta = read();
 		this.useSourceMap = read();
 		this.useSimpleSourceMap = read();
-		this.hot = read();
 		this._warnings = read();
 		this._errors = read();
 		this.buildMeta = read();

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -863,6 +863,10 @@ class NormalModule extends Module {
 		/** @type {NormalModuleCreateData['extractSourceMap']} */
 		this.extractSourceMap = extractSourceMap;
 
+		// Set by HotModuleReplacementPlugin via NormalModuleFactory's `module` hook
+		/** @type {boolean} */
+		this.hot = false;
+
 		// Info from Build
 		/** @type {Error | null} */
 		this.error = null;
@@ -2239,6 +2243,7 @@ class NormalModule extends Module {
 		write(this._lastSuccessfulBuildMeta);
 		write(this._forceBuild);
 		write(this._codeGeneratorData);
+		write(this.hot);
 		super.serialize(context);
 	}
 
@@ -2281,6 +2286,7 @@ class NormalModule extends Module {
 		this._lastSuccessfulBuildMeta = read();
 		this._forceBuild = read();
 		this._codeGeneratorData = read();
+		this.hot = read();
 		super.deserialize(context);
 	}
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -14191,7 +14191,6 @@ declare class Module extends DependenciesBlock {
 	factoryMeta?: FactoryMeta;
 	useSourceMap: boolean;
 	useSimpleSourceMap: boolean;
-	hot: boolean;
 	buildMeta?: BuildMeta;
 	buildInfo?: BuildInfo;
 	presentationalDependencies?: Dependency[];
@@ -16138,6 +16137,7 @@ declare class NormalModule extends Module {
 	matchResource?: string;
 	loaders: LoaderItem[];
 	extractSourceMap: boolean;
+	hot: boolean;
 	error: null | Error;
 	getResource(): null | string;
 


### PR DESCRIPTION
The flag is only written by HMR through `NormalModuleFactory.hooks.module`
and only read by `NormalModule`/`CssModule`/`CssGenerator`, so move it to
`NormalModule` and guard the HMR setter with an instanceof check. Other
base-`Module` subclasses (ContextModule, ExternalModule, RawModule,
RuntimeModule, ConsumeSharedModule) no longer carry the property.