### PR TITLE
fix: remove unnecessary __webpack_require__ in ESM library output

### DIFF
--- a/.changeset/fix-unnecessary-webpack-require.md
+++ b/.changeset/fix-unnecessary-webpack-require.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Remove unnecessary `__webpack_require__` runtime helpers in ESM library output with multi-module chunks.

--- a/lib/dependencies/HarmonyExportInitFragment.js
+++ b/lib/dependencies/HarmonyExportInitFragment.js
@@ -161,9 +161,6 @@ class HarmonyExportInitFragment extends InitFragment {
 	 * @returns {string | Source | undefined} the source code that will be included as initialization code
 	 */
 	getContent({ runtimeTemplate, runtimeRequirements }) {
-		runtimeRequirements.add(RuntimeGlobals.exports);
-		runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-
 		const unusedPart =
 			this.unusedExports.size > 1
 				? `/* unused harmony exports ${joinIterableWithComma(
@@ -184,12 +181,14 @@ class HarmonyExportInitFragment extends InitFragment {
 				)}: ${runtimeTemplate.returningFunction(value)}`
 			);
 		}
-		const definePart =
-			this.exportMap.size > 0
-				? `/* harmony export */ ${RuntimeGlobals.definePropertyGetters}(${
-						this.exportsArgument
-					}, {${definitions.join(",")}\n/* harmony export */ });\n`
-				: "";
+		let definePart = "";
+		if (this.exportMap.size > 0) {
+			runtimeRequirements.add(RuntimeGlobals.exports);
+			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+			definePart = `/* harmony export */ ${RuntimeGlobals.definePropertyGetters}(${
+				this.exportsArgument
+			}, {${definitions.join(",")}\n/* harmony export */ });\n`;
+		}
 		return `${definePart}${unusedPart}`;
 	}
 }

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -111,24 +111,15 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 
 			// `ModuleLibraryPlugin` stashes the on-demand exports source via
 			// `onDemandExportsGeneration` and only re-emits it when the
-			// module is wrapped in an IIFE/factory. When a single concatenated
-			// entry is inlined directly, the stashed source — and the
+			// module is wrapped in an IIFE/factory. When the entry is
+			// inlined directly, the stashed source — and the
 			// `definePropertyGetters` / `requireScope` runtime helpers it
 			// pulled in — never make it into the output. Drop those helpers
-			// from the chunk's set in that simple shape so the bundle stays
-			// clean.
+			// from the chunk's set so the bundle stays clean.
 			compilation.hooks.additionalChunkRuntimeRequirements.tap(
 				PLUGIN_NAME,
 				(chunk, set, { chunkGraph, codeGenerationResults }) => {
 					if (!set.has(RuntimeGlobals.definePropertyGetters)) return;
-
-					// Only handle the simple "single concatenated entry"
-					// shape. Anything else (additional modules, multiple
-					// entries, sibling runtime chunks, or chunk-level
-					// requirements that disable inline startup) forces the
-					// module through factory/IIFE rendering, which re-emits
-					// the source.
-					if (chunkGraph.getNumberOfChunkModules(chunk) !== 1) return;
 					if (chunkGraph.getNumberOfEntryModules(chunk) !== 1) return;
 					if (chunkGraph.hasChunkEntryDependentChunks(chunk)) return;
 					if (
@@ -140,8 +131,6 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 					) {
 						return;
 					}
-					// Anyone tapping `inlineInRuntimeBailout` may force factory
-					// rendering at render time, so conservatively bail out.
 					if (javascriptHooks.inlineInRuntimeBailout.isUsed()) return;
 
 					const [module] = chunkGraph.getChunkEntryModulesIterable(chunk);
@@ -153,14 +142,6 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 					) {
 						return;
 					}
-					// If the generated source references any
-					// `__webpack_require__.<helper>` (the on-demand `.d(...)`
-					// is stashed, but `.r(__webpack_exports__)` from the ESM
-					// compat flag, namespace objects, deferred externals, ...
-					// stay in the result) the helpers and the require scope
-					// they live in are still needed. The dot in the substring
-					// avoids matching the bare `"__webpack_require__"` string
-					// literals that some test fixtures include.
 					const codeGenResult = codeGenerationResults.get(
 						module,
 						chunk.runtime
@@ -174,9 +155,34 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 						return;
 					}
 
+					// Check whether any other module in the chunk still needs
+					// the helpers we want to remove.
+					let otherNeedsDefine = false;
+					let otherNeedsExports = false;
+					let otherNeedsRequireScope = false;
+					for (const m of chunkGraph.getChunkModulesIterable(chunk)) {
+						if (m === module) continue;
+						const requirements = chunkGraph.getModuleRuntimeRequirements(
+							m,
+							chunk.runtime
+						);
+						if (!requirements) continue;
+						if (requirements.has(RuntimeGlobals.definePropertyGetters)) {
+							otherNeedsDefine = true;
+						}
+						if (requirements.has(RuntimeGlobals.exports)) {
+							otherNeedsExports = true;
+						}
+						if (requirements.has(RuntimeGlobals.requireScope)) {
+							otherNeedsRequireScope = true;
+						}
+						if (otherNeedsDefine) break;
+					}
+
+					if (otherNeedsDefine) return;
 					set.delete(RuntimeGlobals.definePropertyGetters);
-					set.delete(RuntimeGlobals.exports);
-					set.delete(RuntimeGlobals.requireScope);
+					if (!otherNeedsExports) set.delete(RuntimeGlobals.exports);
+					if (!otherNeedsRequireScope) set.delete(RuntimeGlobals.requireScope);
 				}
 			);
 		});

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
@@ -3,29 +3,6 @@
 exports[`ConfigCacheTestCases html script-src-classic exported tests should emit IIFE-wrapped chunks for <script type=module src> too (still valid as ES modules) 1`] = `
 "/******/ (() => { // webpackBootstrap
 /******/ 	\\"use strict\\";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/define property getters */
-/******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 				}
-/******/ 			}
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
-/******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-/******/ 	})();
-/******/ 	
-/************************************************************************/
-var __webpack_exports__ = {};
 /*!*************************!*\\\\
   !*** ./module-entry.js ***!
   \\\\*************************/

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
@@ -3,29 +3,6 @@
 exports[`ConfigTestCases html script-src-classic exported tests should emit IIFE-wrapped chunks for <script type=module src> too (still valid as ES modules) 1`] = `
 "/******/ (() => { // webpackBootstrap
 /******/ 	\\"use strict\\";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/define property getters */
-/******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 				}
-/******/ 			}
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
-/******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-/******/ 	})();
-/******/ 	
-/************************************************************************/
-var __webpack_exports__ = {};
 /*!*************************!*\\\\
   !*** ./module-entry.js ***!
   \\\\*************************/

--- a/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
@@ -1,30 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ConfigCacheTestCases html script-src exported tests should bundle <script type=module src> through ESM resolution alongside classic scripts 1`] = `
-"/******/ // The require scope
-/******/ var __webpack_require__ = {};
-/******/ 
-/************************************************************************/
-/******/ /* webpack/runtime/define property getters */
-/******/ (() => {
-/******/ 	// define getter functions for harmony exports
-/******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 			}
-/******/ 		}
-/******/ 	};
-/******/ })();
-/******/ 
-/******/ /* webpack/runtime/hasOwnProperty shorthand */
-/******/ (() => {
-/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-/******/ })();
-/******/ 
-/************************************************************************/
-var __webpack_exports__ = {};
-/*!*************************!*\\\\
+"/*!*************************!*\\\\
   !*** ./module-entry.js ***!
   \\\\*************************/
 /* unused harmony export value */

--- a/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
@@ -1,30 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ConfigTestCases html script-src exported tests should bundle <script type=module src> through ESM resolution alongside classic scripts 1`] = `
-"/******/ // The require scope
-/******/ var __webpack_require__ = {};
-/******/ 
-/************************************************************************/
-/******/ /* webpack/runtime/define property getters */
-/******/ (() => {
-/******/ 	// define getter functions for harmony exports
-/******/ 	__webpack_require__.d = (exports, definition) => {
-/******/ 		for(var key in definition) {
-/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 			}
-/******/ 		}
-/******/ 	};
-/******/ })();
-/******/ 
-/******/ /* webpack/runtime/hasOwnProperty shorthand */
-/******/ (() => {
-/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-/******/ })();
-/******/ 
-/************************************************************************/
-var __webpack_exports__ = {};
-/*!*************************!*\\\\
+"/*!*************************!*\\\\
   !*** ./module-entry.js ***!
   \\\\*************************/
 /* unused harmony export value */

--- a/test/configCases/library/module-useless-export-requirement/entry4.js
+++ b/test/configCases/library/module-useless-export-requirement/entry4.js
@@ -1,0 +1,43 @@
+import concat from "./concat";
+import "./style.css";
+
+const getFile = () => {
+	const fs = __non_webpack_require__("fs");
+	return fs.readFileSync(__filename, "utf-8");
+};
+
+const stripModuleMarkers = (content) =>
+	content.split(/^;\/\/ /m)[0];
+
+const RuntimeGlobals_Exports = "__webpack_exports__";
+const RuntimeGlobals_Require = "__webpack_require__";
+const exportsReg = new RegExp(
+	"var\\s+" + RuntimeGlobals_Exports + "\\s*="
+);
+const definePropertyGettersReg = new RegExp(
+	RuntimeGlobals_Require + "\\.d\\s*="
+);
+const hasOwnPropertyReg = new RegExp(
+	RuntimeGlobals_Require + "\\.o\\s*="
+);
+const requireScopeReg = new RegExp(
+	"var\\s+" + RuntimeGlobals_Require + "\\s*=\\s*\\{"
+);
+const isNoConcat = /-no-concat\.mjs$/.test(__filename);
+
+it("should not emit __webpack_require__ helpers with CSS modules", () => {
+	const content = stripModuleMarkers(getFile());
+	expect(concat).toBe("concat");
+
+	if (isNoConcat) {
+		expect(content).toMatch(exportsReg);
+	} else {
+		expect(content).not.toMatch(exportsReg);
+		expect(content).not.toMatch(definePropertyGettersReg);
+		expect(content).not.toMatch(hasOwnPropertyReg);
+		expect(content).not.toMatch(requireScopeReg);
+	}
+});
+
+export { concat };
+export default "foo";

--- a/test/configCases/library/module-useless-export-requirement/style.css
+++ b/test/configCases/library/module-useless-export-requirement/style.css
@@ -1,0 +1,1 @@
+.main { color: red; }

--- a/test/configCases/library/module-useless-export-requirement/webpack.config.js
+++ b/test/configCases/library/module-useless-export-requirement/webpack.config.js
@@ -18,7 +18,6 @@ const common = {
 	}
 };
 
-/** @type {Configuration[]} */
 const configs = [
 	{
 		name: "entry1",

--- a/test/configCases/library/module-useless-export-requirement/webpack.config.js
+++ b/test/configCases/library/module-useless-export-requirement/webpack.config.js
@@ -34,16 +34,25 @@ const configs = [
 		optimization: {
 			avoidEntryIife: false
 		}
+	},
+	{
+		name: "entry4",
+		entry: "./entry4.js",
+		css: true
 	}
 ];
 
 module.exports = configs.reduce(
 	/** @type {(result: EXPECTED_ANY, config: EXPECTED_ANY) => Configuration[]} */ (
 		result,
-		{ name, entry, optimization }
+		{ name, entry, optimization, css }
 	) => {
+		const extra = css
+			? { experiments: { ...common.experiments, css: true } }
+			: {};
 		result.push({
 			...common,
+			...extra,
 			optimization: {
 				...optimization,
 				concatenateModules: true
@@ -54,6 +63,7 @@ module.exports = configs.reduce(
 		});
 		result.push({
 			...common,
+			...extra,
 			optimization: {
 				...optimization,
 				concatenateModules: false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

When an ESM library chunk (`output.library.type = "module"`) contains non-JS modules (CSS via `experiments.css`, `MiniCssExtractPlugin`, asset modules, etc.) alongside a concatenated entry, `__webpack_require__` runtime helpers (`var __webpack_require__ = {}`, `__webpack_require__.d`, `__webpack_require__.o`) are emitted even though they are never referenced in the output.

Root cause: `ModuleLibraryPlugin`'s cleanup hook bailed out when `getNumberOfChunkModules(chunk) !== 1`, but CSS/asset modules increase the count without actually needing those JS helpers.

Two fixes:

1. **`HarmonyExportInitFragment.getContent()`** — only add `definePropertyGetters` and `exports` runtime requirements when `exportMap` is non-empty. Previously these were added unconditionally even when the fragment produced no output.

2. **`ModuleLibraryPlugin` cleanup hook** — replace the coarse `getNumberOfChunkModules !== 1` guard with a per-module check: iterate chunk modules and only retain helpers that another module actually requires.

Fixes #21029

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. Added `entry4.js` + `style.css` to the existing `test/configCases/library/module-useless-export-requirement/` test case, covering the ESM library + CSS module combination. Updated 4 HTML snapshot files that previously contained the unnecessary helpers.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. This only removes dead runtime code from the output.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate the root cause, draft the implementation, and write the test case, under human review.