### PR TITLE
perf(Compilation): index asset -> chunks to speed up deleteAsset/renameAsset

### DIFF
--- a/.changeset/compilation-asset-chunk-reverse-index.md
+++ b/.changeset/compilation-asset-chunk-reverse-index.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up `Compilation.deleteAsset` and `Compilation.renameAsset` via a lazy reverse index from asset file name to containing chunks.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -5089,20 +5089,47 @@ This prevents using hashes of each other and should be avoided.`);
 		delete this.assets[file];
 		this.assets[newFile] = source;
 		this._buildAssetToChunkIndex();
-		this._renameAssetInIndex(
-			/** @type {Map<string, Set<Chunk>>} */
-			(this._assetToChunkIndex),
-			file,
-			newFile,
-			false
+		const index = /** @type {Map<string, Set<Chunk>>} */ (
+			this._assetToChunkIndex
 		);
-		this._renameAssetInIndex(
-			/** @type {Map<string, Set<Chunk>>} */
-			(this._assetToChunkAuxiliaryIndex),
-			file,
-			newFile,
-			true
+		const auxiliaryIndex = /** @type {Map<string, Set<Chunk>>} */ (
+			this._assetToChunkAuxiliaryIndex
 		);
+		const chunks = index.get(file);
+		const auxiliaryChunks = auxiliaryIndex.get(file);
+		if (chunks === undefined && auxiliaryChunks === undefined) {
+			// Not tracked in either index: chunk sets may have been mutated
+			// directly (bypassing emitAsset), so scan all chunks to stay correct.
+			for (const chunk of this.chunks) {
+				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
+				this._renameAssetInChunk(
+					chunk,
+					chunk.auxiliaryFiles,
+					auxiliaryIndex,
+					file,
+					newFile
+				);
+			}
+			return;
+		}
+		if (chunks !== undefined) {
+			index.delete(file);
+			for (const chunk of chunks) {
+				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
+			}
+		}
+		if (auxiliaryChunks !== undefined) {
+			auxiliaryIndex.delete(file);
+			for (const chunk of auxiliaryChunks) {
+				this._renameAssetInChunk(
+					chunk,
+					chunk.auxiliaryFiles,
+					auxiliaryIndex,
+					file,
+					newFile
+				);
+			}
+		}
 	}
 
 	// Lazily build the reverse index file -> chunks. emitAsset() invalidates
@@ -5136,25 +5163,20 @@ This prevents using hashes of each other and should be avoided.`);
 
 	/**
 	 * @private
-	 * @param {Map<string, Set<Chunk>>} index reverse index (files or auxiliaryFiles)
+	 * @param {Chunk} chunk the chunk owning the set
+	 * @param {Set<string>} set chunk.files or chunk.auxiliaryFiles
+	 * @param {Map<string, Set<Chunk>>} index matching reverse index
 	 * @param {string} file old file name
 	 * @param {string} newFile new file name
-	 * @param {boolean} auxiliary true to update chunk.auxiliaryFiles, false for chunk.files
 	 * @returns {void}
 	 */
-	_renameAssetInIndex(index, file, newFile, auxiliary) {
-		const chunks = index.get(file);
-		if (chunks === undefined) return;
-		index.delete(file);
-		for (const chunk of chunks) {
-			const set = auxiliary ? chunk.auxiliaryFiles : chunk.files;
-			// Only carry the rename to chunks that actually held the old name.
-			if (!set.delete(file)) continue;
-			set.add(newFile);
-			let target = index.get(newFile);
-			if (target === undefined) index.set(newFile, (target = new Set()));
-			target.add(chunk);
-		}
+	_renameAssetInChunk(chunk, set, index, file, newFile) {
+		// Only carry the rename to chunks that actually held the old name.
+		if (!set.delete(file)) return;
+		set.add(newFile);
+		let target = index.get(newFile);
+		if (target === undefined) index.set(newFile, (target = new Set()));
+		target.add(chunk);
 	}
 
 	/**
@@ -5194,15 +5216,24 @@ This prevents using hashes of each other and should be avoided.`);
 		const index = /** @type {Map<string, Set<Chunk>>} */ (
 			this._assetToChunkIndex
 		);
+		const auxiliaryIndex = /** @type {Map<string, Set<Chunk>>} */ (
+			this._assetToChunkAuxiliaryIndex
+		);
 		const chunks = index.get(file);
+		const auxiliaryChunks = auxiliaryIndex.get(file);
+		if (chunks === undefined && auxiliaryChunks === undefined) {
+			// Not tracked in either index: chunk sets may have been mutated
+			// directly (bypassing emitAsset), so scan all chunks to stay correct.
+			for (const chunk of this.chunks) {
+				chunk.files.delete(file);
+				chunk.auxiliaryFiles.delete(file);
+			}
+			return;
+		}
 		if (chunks !== undefined) {
 			for (const chunk of chunks) chunk.files.delete(file);
 			index.delete(file);
 		}
-		const auxiliaryIndex = /** @type {Map<string, Set<Chunk>>} */ (
-			this._assetToChunkAuxiliaryIndex
-		);
-		const auxiliaryChunks = auxiliaryIndex.get(file);
 		if (auxiliaryChunks !== undefined) {
 			for (const chunk of auxiliaryChunks) chunk.auxiliaryFiles.delete(file);
 			auxiliaryIndex.delete(file);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1260,6 +1260,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.assetsInfo = new Map();
 		/** @type {Map<string, Map<string, Set<string>>>} */
 		this._assetsRelatedIn = new Map();
+		/** @type {Map<string, Set<Chunk>> | undefined} */
+		this._assetToChunkIndex = undefined;
+		/** @type {Map<string, Set<Chunk>> | undefined} */
+		this._assetToChunkAuxiliaryIndex = undefined;
 		/** @type {Error[]} */
 		this.errors = [];
 		/** @type {Error[]} */
@@ -3266,6 +3270,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.additionalChunkAssets.length = 0;
 		this.assets = {};
 		this.assetsInfo.clear();
+		this._assetToChunkIndex = undefined;
+		this._assetToChunkAuxiliaryIndex = undefined;
 		this.moduleGraph.removeAllModuleAttributes();
 		this.moduleGraph.unfreeze();
 		this.moduleMemCaches2 = undefined;
@@ -5077,21 +5083,78 @@ This prevents using hashes of each other and should be avoided.`);
 		this._setAssetInfo(newFile, assetInfo);
 		delete this.assets[file];
 		this.assets[newFile] = source;
+		this._buildAssetToChunkIndex();
+		this._renameAssetInIndex(
+			/** @type {Map<string, Set<Chunk>>} */
+			(this._assetToChunkIndex),
+			file,
+			newFile,
+			false
+		);
+		this._renameAssetInIndex(
+			/** @type {Map<string, Set<Chunk>>} */
+			(this._assetToChunkAuxiliaryIndex),
+			file,
+			newFile,
+			true
+		);
+	}
+
+	// Lazily build the reverse index file -> chunks. Kept in sync by
+	// renameAsset/deleteAsset; direct chunk.files mutations after build are
+	// not observed.
+	/**
+	 * @private
+	 * @returns {void}
+	 */
+	_buildAssetToChunkIndex() {
+		if (this._assetToChunkIndex !== undefined) return;
+		/** @type {Map<string, Set<Chunk>>} */
+		const filesIndex = new Map();
+		/** @type {Map<string, Set<Chunk>>} */
+		const auxiliaryIndex = new Map();
 		for (const chunk of this.chunks) {
-			{
-				const size = chunk.files.size;
-				chunk.files.delete(file);
-				if (size !== chunk.files.size) {
-					chunk.files.add(newFile);
-				}
+			for (const file of chunk.files) {
+				let set = filesIndex.get(file);
+				if (set === undefined) filesIndex.set(file, (set = new Set()));
+				set.add(chunk);
 			}
-			{
-				const size = chunk.auxiliaryFiles.size;
+			for (const file of chunk.auxiliaryFiles) {
+				let set = auxiliaryIndex.get(file);
+				if (set === undefined) auxiliaryIndex.set(file, (set = new Set()));
+				set.add(chunk);
+			}
+		}
+		this._assetToChunkIndex = filesIndex;
+		this._assetToChunkAuxiliaryIndex = auxiliaryIndex;
+	}
+
+	/**
+	 * @private
+	 * @param {Map<string, Set<Chunk>>} index reverse index (files or auxiliaryFiles)
+	 * @param {string} file old file name
+	 * @param {string} newFile new file name
+	 * @param {boolean} auxiliary true to update chunk.auxiliaryFiles, false for chunk.files
+	 * @returns {void}
+	 */
+	_renameAssetInIndex(index, file, newFile, auxiliary) {
+		const chunks = index.get(file);
+		if (chunks === undefined) return;
+		for (const chunk of chunks) {
+			if (auxiliary) {
 				chunk.auxiliaryFiles.delete(file);
-				if (size !== chunk.auxiliaryFiles.size) {
-					chunk.auxiliaryFiles.add(newFile);
-				}
+				chunk.auxiliaryFiles.add(newFile);
+			} else {
+				chunk.files.delete(file);
+				chunk.files.add(newFile);
 			}
+		}
+		index.delete(file);
+		const existing = index.get(newFile);
+		if (existing === undefined) {
+			index.set(newFile, chunks);
+		} else {
+			for (const c of chunks) existing.add(c);
 		}
 	}
 
@@ -5128,11 +5191,22 @@ This prevents using hashes of each other and should be avoided.`);
 				}
 			}
 		}
-		// TODO If this becomes a performance problem
-		// store a reverse mapping from asset to chunk
-		for (const chunk of this.chunks) {
-			chunk.files.delete(file);
-			chunk.auxiliaryFiles.delete(file);
+		this._buildAssetToChunkIndex();
+		const index = /** @type {Map<string, Set<Chunk>>} */ (
+			this._assetToChunkIndex
+		);
+		const chunks = index.get(file);
+		if (chunks !== undefined) {
+			for (const chunk of chunks) chunk.files.delete(file);
+			index.delete(file);
+		}
+		const auxiliaryIndex = /** @type {Map<string, Set<Chunk>>} */ (
+			this._assetToChunkAuxiliaryIndex
+		);
+		const auxiliaryChunks = auxiliaryIndex.get(file);
+		if (auxiliaryChunks !== undefined) {
+			for (const chunk of auxiliaryChunks) chunk.auxiliaryFiles.delete(file);
+			auxiliaryIndex.delete(file);
 		}
 	}
 
@@ -5170,6 +5244,8 @@ This prevents using hashes of each other and should be avoided.`);
 			chunk.files.clear();
 			chunk.auxiliaryFiles.clear();
 		}
+		this._assetToChunkIndex = undefined;
+		this._assetToChunkAuxiliaryIndex = undefined;
 	}
 
 	createModuleAssets() {

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4924,6 +4924,10 @@ This prevents using hashes of each other and should be avoided.`);
 		}
 		this.assets[file] = source;
 		this._setAssetInfo(file, assetInfo, undefined);
+		// A new asset may be added to a chunk right after being emitted, so the
+		// reverse index (built lazily by deleteAsset/renameAsset) is now stale.
+		this._assetToChunkIndex = undefined;
+		this._assetToChunkAuxiliaryIndex = undefined;
 	}
 
 	/**
@@ -5100,9 +5104,9 @@ This prevents using hashes of each other and should be avoided.`);
 		);
 	}
 
-	// Lazily build the reverse index file -> chunks. Kept in sync by
-	// renameAsset/deleteAsset; direct chunk.files mutations after build are
-	// not observed.
+	// Lazily build the reverse index file -> chunks. emitAsset() invalidates
+	// it, so chunk.files / chunk.auxiliaryFiles entries added alongside a newly
+	// emitted asset are always picked up on the next rebuild.
 	/**
 	 * @private
 	 * @returns {void}
@@ -5140,21 +5144,15 @@ This prevents using hashes of each other and should be avoided.`);
 	_renameAssetInIndex(index, file, newFile, auxiliary) {
 		const chunks = index.get(file);
 		if (chunks === undefined) return;
-		for (const chunk of chunks) {
-			if (auxiliary) {
-				chunk.auxiliaryFiles.delete(file);
-				chunk.auxiliaryFiles.add(newFile);
-			} else {
-				chunk.files.delete(file);
-				chunk.files.add(newFile);
-			}
-		}
 		index.delete(file);
-		const existing = index.get(newFile);
-		if (existing === undefined) {
-			index.set(newFile, chunks);
-		} else {
-			for (const c of chunks) existing.add(c);
+		for (const chunk of chunks) {
+			const set = auxiliary ? chunk.auxiliaryFiles : chunk.files;
+			// Only carry the rename to chunks that actually held the old name.
+			if (!set.delete(file)) continue;
+			set.add(newFile);
+			let target = index.get(newFile);
+			if (target === undefined) index.set(newFile, (target = new Set()));
+			target.add(chunk);
 		}
 	}
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4902,6 +4902,11 @@ This prevents using hashes of each other and should be avoided.`);
 	 * @returns {void}
 	 */
 	emitAsset(file, source, assetInfo = {}) {
+		// A file may be attached to a chunk right after any emit (including the
+		// re-emit path for assets shared across chunks in createChunkAssets), so
+		// the lazily-built reverse index is stale after every emitAsset.
+		this._assetToChunkIndex = undefined;
+		this._assetToChunkAuxiliaryIndex = undefined;
 		if (this.assets[file]) {
 			if (!isSourceEqual(this.assets[file], source)) {
 				this.errors.push(
@@ -4924,10 +4929,6 @@ This prevents using hashes of each other and should be avoided.`);
 		}
 		this.assets[file] = source;
 		this._setAssetInfo(file, assetInfo, undefined);
-		// A new asset may be added to a chunk right after being emitted, so the
-		// reverse index (built lazily by deleteAsset/renameAsset) is now stale.
-		this._assetToChunkIndex = undefined;
-		this._assetToChunkAuxiliaryIndex = undefined;
 	}
 
 	/**

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3164,9 +3164,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 							loaders
 								? `${
 										modules.length
-								  } x ${moduleType} with ${this.requestShortener.shorten(
+									} x ${moduleType} with ${this.requestShortener.shorten(
 										loaders
-								  )}`
+									)}`
 								: `${modules.length} x ${moduleType}`
 						}`
 					);
@@ -3618,7 +3618,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 														`BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
 	Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
 	Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.`
-												  )
+													)
 												: Object.freeze(this.assets)
 										);
 
@@ -5385,8 +5385,8 @@ This prevents using hashes of each other and should be avoided.`);
 									(typeof file === "string"
 										? file
 										: typeof filenameTemplate === "string"
-										? filenameTemplate
-										: "");
+											? filenameTemplate
+											: "");
 
 								this.errors.push(new ChunkRenderError(chunk, filename, err));
 								inTry = false;
@@ -5408,7 +5408,7 @@ This prevents using hashes of each other and should be avoided.`);
 										? {
 												...pathAndInfo.info,
 												...fileManifest.info
-										  }
+											}
 										: pathAndInfo.info;
 								}
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1455,9 +1455,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						typeof console.profileEnd === "function"
 					) {
 						console.profileEnd(
-							`[${name}] ${
-								/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]
-							}`
+							`[${name}] ${/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]}`
 						);
 					}
 					if (logEntries === undefined) {
@@ -5099,6 +5097,21 @@ This prevents using hashes of each other and should be avoided.`);
 		);
 		const chunks = index.get(file);
 		const auxiliaryChunks = auxiliaryIndex.get(file);
+		if (chunks === undefined && auxiliaryChunks === undefined) {
+			// Not tracked in either index: chunk sets may have been mutated
+			// directly (bypassing emitAsset), so scan all chunks to stay correct.
+			for (const chunk of this.chunks) {
+				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
+				this._renameAssetInChunk(
+					chunk,
+					chunk.auxiliaryFiles,
+					auxiliaryIndex,
+					file,
+					newFile
+				);
+			}
+			return;
+		}
 		if (chunks !== undefined) {
 			index.delete(file);
 			for (const chunk of chunks) {
@@ -5108,23 +5121,6 @@ This prevents using hashes of each other and should be avoided.`);
 		if (auxiliaryChunks !== undefined) {
 			auxiliaryIndex.delete(file);
 			for (const chunk of auxiliaryChunks) {
-				this._renameAssetInChunk(
-					chunk,
-					chunk.auxiliaryFiles,
-					auxiliaryIndex,
-					file,
-					newFile
-				);
-			}
-		}
-		// The index can miss chunks whose files/auxiliaryFiles were mutated
-		// directly (bypassing emitAsset) after it was built; sweep the rest.
-		// _renameAssetInChunk guards on Set#delete, so non-holders stay untouched.
-		for (const chunk of this.chunks) {
-			if (chunks === undefined || !chunks.has(chunk)) {
-				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
-			}
-			if (auxiliaryChunks === undefined || !auxiliaryChunks.has(chunk)) {
 				this._renameAssetInChunk(
 					chunk,
 					chunk.auxiliaryFiles,
@@ -5225,6 +5221,15 @@ This prevents using hashes of each other and should be avoided.`);
 		);
 		const chunks = index.get(file);
 		const auxiliaryChunks = auxiliaryIndex.get(file);
+		if (chunks === undefined && auxiliaryChunks === undefined) {
+			// Not tracked in either index: chunk sets may have been mutated
+			// directly (bypassing emitAsset), so scan all chunks to stay correct.
+			for (const chunk of this.chunks) {
+				chunk.files.delete(file);
+				chunk.auxiliaryFiles.delete(file);
+			}
+			return;
+		}
 		if (chunks !== undefined) {
 			for (const chunk of chunks) chunk.files.delete(file);
 			index.delete(file);
@@ -5232,14 +5237,6 @@ This prevents using hashes of each other and should be avoided.`);
 		if (auxiliaryChunks !== undefined) {
 			for (const chunk of auxiliaryChunks) chunk.auxiliaryFiles.delete(file);
 			auxiliaryIndex.delete(file);
-		}
-		// The index can miss chunks whose files/auxiliaryFiles were mutated
-		// directly (bypassing emitAsset) after it was built; sweep the rest.
-		for (const chunk of this.chunks) {
-			if (chunks === undefined || !chunks.has(chunk)) chunk.files.delete(file);
-			if (auxiliaryChunks === undefined || !auxiliaryChunks.has(chunk)) {
-				chunk.auxiliaryFiles.delete(file);
-			}
 		}
 	}
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1455,7 +1455,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						typeof console.profileEnd === "function"
 					) {
 						console.profileEnd(
-							`[${name}] ${/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]}`
+							`[${name}] ${
+								/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]
+							}`
 						);
 					}
 					if (logEntries === undefined) {
@@ -3162,9 +3164,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 							loaders
 								? `${
 										modules.length
-									} x ${moduleType} with ${this.requestShortener.shorten(
+								  } x ${moduleType} with ${this.requestShortener.shorten(
 										loaders
-									)}`
+								  )}`
 								: `${modules.length} x ${moduleType}`
 						}`
 					);
@@ -3616,7 +3618,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 														`BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
 	Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
 	Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.`
-													)
+												  )
 												: Object.freeze(this.assets)
 										);
 
@@ -5097,21 +5099,6 @@ This prevents using hashes of each other and should be avoided.`);
 		);
 		const chunks = index.get(file);
 		const auxiliaryChunks = auxiliaryIndex.get(file);
-		if (chunks === undefined && auxiliaryChunks === undefined) {
-			// Not tracked in either index: chunk sets may have been mutated
-			// directly (bypassing emitAsset), so scan all chunks to stay correct.
-			for (const chunk of this.chunks) {
-				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
-				this._renameAssetInChunk(
-					chunk,
-					chunk.auxiliaryFiles,
-					auxiliaryIndex,
-					file,
-					newFile
-				);
-			}
-			return;
-		}
 		if (chunks !== undefined) {
 			index.delete(file);
 			for (const chunk of chunks) {
@@ -5121,6 +5108,23 @@ This prevents using hashes of each other and should be avoided.`);
 		if (auxiliaryChunks !== undefined) {
 			auxiliaryIndex.delete(file);
 			for (const chunk of auxiliaryChunks) {
+				this._renameAssetInChunk(
+					chunk,
+					chunk.auxiliaryFiles,
+					auxiliaryIndex,
+					file,
+					newFile
+				);
+			}
+		}
+		// The index can miss chunks whose files/auxiliaryFiles were mutated
+		// directly (bypassing emitAsset) after it was built; sweep the rest.
+		// _renameAssetInChunk guards on Set#delete, so non-holders stay untouched.
+		for (const chunk of this.chunks) {
+			if (chunks === undefined || !chunks.has(chunk)) {
+				this._renameAssetInChunk(chunk, chunk.files, index, file, newFile);
+			}
+			if (auxiliaryChunks === undefined || !auxiliaryChunks.has(chunk)) {
 				this._renameAssetInChunk(
 					chunk,
 					chunk.auxiliaryFiles,
@@ -5221,15 +5225,6 @@ This prevents using hashes of each other and should be avoided.`);
 		);
 		const chunks = index.get(file);
 		const auxiliaryChunks = auxiliaryIndex.get(file);
-		if (chunks === undefined && auxiliaryChunks === undefined) {
-			// Not tracked in either index: chunk sets may have been mutated
-			// directly (bypassing emitAsset), so scan all chunks to stay correct.
-			for (const chunk of this.chunks) {
-				chunk.files.delete(file);
-				chunk.auxiliaryFiles.delete(file);
-			}
-			return;
-		}
 		if (chunks !== undefined) {
 			for (const chunk of chunks) chunk.files.delete(file);
 			index.delete(file);
@@ -5237,6 +5232,14 @@ This prevents using hashes of each other and should be avoided.`);
 		if (auxiliaryChunks !== undefined) {
 			for (const chunk of auxiliaryChunks) chunk.auxiliaryFiles.delete(file);
 			auxiliaryIndex.delete(file);
+		}
+		// The index can miss chunks whose files/auxiliaryFiles were mutated
+		// directly (bypassing emitAsset) after it was built; sweep the rest.
+		for (const chunk of this.chunks) {
+			if (chunks === undefined || !chunks.has(chunk)) chunk.files.delete(file);
+			if (auxiliaryChunks === undefined || !auxiliaryChunks.has(chunk)) {
+				chunk.auxiliaryFiles.delete(file);
+			}
 		}
 	}
 
@@ -5382,8 +5385,8 @@ This prevents using hashes of each other and should be avoided.`);
 									(typeof file === "string"
 										? file
 										: typeof filenameTemplate === "string"
-											? filenameTemplate
-											: "");
+										? filenameTemplate
+										: "");
 
 								this.errors.push(new ChunkRenderError(chunk, filename, err));
 								inTry = false;
@@ -5405,7 +5408,7 @@ This prevents using hashes of each other and should be avoided.`);
 										? {
 												...pathAndInfo.info,
 												...fileManifest.info
-											}
+										  }
 										: pathAndInfo.info;
 								}
 

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -97,5 +97,38 @@ describe("Compilation", () => {
 			expect(chunk.files.has("late.js")).toBe(false);
 			expect(chunk.files.has("renamed.js")).toBe(true);
 		});
+
+		it("unseal drops the cached reverse index", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunk.files.add("a.js");
+			// Build the index.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			expect(compilation._assetToChunkIndex).toBeDefined();
+
+			compilation.unseal();
+
+			expect(compilation._assetToChunkIndex).toBeUndefined();
+			expect(compilation._assetToChunkAuxiliaryIndex).toBeUndefined();
+		});
+
+		it("renameAsset skips chunks that no longer hold the file (stale index)", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunk.files.add("a.js");
+			// Build the index so it records a.js -> chunk.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			// Drop the file from the chunk directly, making the cached index stale.
+			chunk.files.delete("a.js");
+
+			compilation.renameAsset("a.js", "b.js");
+
+			expect(chunk.files.has("a.js")).toBe(false);
+			expect(chunk.files.has("b.js")).toBe(false);
+		});
 	});
 });

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const webpack = require("../lib/index");
+
+const createCompilation = () => {
+	const compiler = webpack({ mode: "none", entry: "./nope.js" });
+	const params = compiler.newCompilationParams();
+	return compiler.createCompilation(params);
+};
+
+describe("Compilation", () => {
+	describe("deleteAsset / renameAsset reverse index", () => {
+		it("deleteAsset removes the file from chunk.files and chunk.auxiliaryFiles", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunk.files.add("a.js");
+			compilation.emitAsset("a.aux.js", new RawSource("// aux"));
+			chunk.auxiliaryFiles.add("a.aux.js");
+
+			compilation.deleteAsset("a.js");
+			compilation.deleteAsset("a.aux.js");
+
+			expect(chunk.files.has("a.js")).toBe(false);
+			expect(chunk.auxiliaryFiles.has("a.aux.js")).toBe(false);
+			expect(compilation.getAsset("a.js")).toBeUndefined();
+			expect(compilation.getAsset("a.aux.js")).toBeUndefined();
+		});
+
+		it("renameAsset renames the file in chunk.files and chunk.auxiliaryFiles", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunk.files.add("a.js");
+			compilation.emitAsset("a.aux.js", new RawSource("// aux"));
+			chunk.auxiliaryFiles.add("a.aux.js");
+
+			compilation.renameAsset("a.js", "b.js");
+			compilation.renameAsset("a.aux.js", "b.aux.js");
+
+			expect(chunk.files.has("a.js")).toBe(false);
+			expect(chunk.files.has("b.js")).toBe(true);
+			expect(chunk.auxiliaryFiles.has("a.aux.js")).toBe(false);
+			expect(chunk.auxiliaryFiles.has("b.aux.js")).toBe(true);
+		});
+
+		it("renameAsset does not add the new name to chunks that did not hold the old name", () => {
+			const compilation = createCompilation();
+			const holder = compilation.addChunk("holder");
+			const other = compilation.addChunk("other");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			holder.files.add("a.js");
+
+			compilation.renameAsset("a.js", "b.js");
+
+			expect(holder.files.has("b.js")).toBe(true);
+			expect(other.files.has("b.js")).toBe(false);
+			expect(other.files.has("a.js")).toBe(false);
+		});
+
+		// emitAsset must invalidate the lazily-built reverse index, otherwise a
+		// delete after an early index build would leave a stale chunk.files entry.
+		it("deleteAsset cleans chunks for assets added after the index was built", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+
+			// Force the reverse index to be built (and cached) early.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+
+			// Emit and attach a new asset after the index already exists.
+			compilation.emitAsset("late.js", new RawSource("// late"));
+			chunk.files.add("late.js");
+			compilation.emitAsset("late.aux.js", new RawSource("// late aux"));
+			chunk.auxiliaryFiles.add("late.aux.js");
+
+			compilation.deleteAsset("late.js");
+			compilation.deleteAsset("late.aux.js");
+
+			expect(chunk.files.has("late.js")).toBe(false);
+			expect(chunk.auxiliaryFiles.has("late.aux.js")).toBe(false);
+		});
+
+		it("renameAsset cleans chunks for assets added after the index was built", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+
+			compilation.emitAsset("late.js", new RawSource("// late"));
+			chunk.files.add("late.js");
+
+			compilation.renameAsset("late.js", "renamed.js");
+
+			expect(chunk.files.has("late.js")).toBe(false);
+			expect(chunk.files.has("renamed.js")).toBe(true);
+		});
+	});
+});

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -114,6 +114,27 @@ describe("Compilation", () => {
 			expect(compilation._assetToChunkAuxiliaryIndex).toBeUndefined();
 		});
 
+		it("deleteAsset cleans every chunk for an asset shared via re-emit", () => {
+			const compilation = createCompilation();
+			const chunkA = compilation.addChunk("a");
+			const chunkB = compilation.addChunk("b");
+			const source = new RawSource("// shared");
+			compilation.emitAsset("shared.js", source);
+			chunkA.files.add("shared.js");
+			// Build the index while it only knows about chunkA.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			// chunkB re-emits the same file (same content -> emitAsset early-return)
+			// then attaches it; emitAsset must still invalidate the index.
+			compilation.emitAsset("shared.js", source);
+			chunkB.files.add("shared.js");
+
+			compilation.deleteAsset("shared.js");
+
+			expect(chunkA.files.has("shared.js")).toBe(false);
+			expect(chunkB.files.has("shared.js")).toBe(false);
+		});
+
 		it("renameAsset skips chunks that no longer hold the file (stale index)", () => {
 			const compilation = createCompilation();
 			const chunk = compilation.addChunk("a");

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -180,5 +180,48 @@ describe("Compilation", () => {
 			expect(chunk.files.has("standalone.js")).toBe(false);
 			expect(chunk.files.has("renamed.js")).toBe(true);
 		});
+
+		it("deleteAsset sweeps chunks the index missed (incomplete index)", () => {
+			const compilation = createCompilation();
+			const chunkA = compilation.addChunk("a");
+			const chunkB = compilation.addChunk("b");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunkA.files.add("a.js");
+			compilation.emitAsset("a.aux.js", new RawSource("// aux"));
+			chunkA.auxiliaryFiles.add("a.aux.js");
+			// Build the index while only chunkA holds the files.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			// Attach the already-indexed names to chunkB directly (no emitAsset),
+			// leaving the cached index incomplete for these files.
+			chunkB.files.add("a.js");
+			chunkB.auxiliaryFiles.add("a.aux.js");
+
+			compilation.deleteAsset("a.js");
+			compilation.deleteAsset("a.aux.js");
+
+			expect(chunkA.files.has("a.js")).toBe(false);
+			expect(chunkB.files.has("a.js")).toBe(false);
+			expect(chunkA.auxiliaryFiles.has("a.aux.js")).toBe(false);
+			expect(chunkB.auxiliaryFiles.has("a.aux.js")).toBe(false);
+		});
+
+		it("renameAsset sweeps chunks the index missed (incomplete index)", () => {
+			const compilation = createCompilation();
+			const chunkA = compilation.addChunk("a");
+			const chunkB = compilation.addChunk("b");
+			compilation.emitAsset("a.js", new RawSource("// a"));
+			chunkA.files.add("a.js");
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			chunkB.files.add("a.js");
+
+			compilation.renameAsset("a.js", "b.js");
+
+			expect(chunkA.files.has("a.js")).toBe(false);
+			expect(chunkA.files.has("b.js")).toBe(true);
+			expect(chunkB.files.has("a.js")).toBe(false);
+			expect(chunkB.files.has("b.js")).toBe(true);
+		});
 	});
 });

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -151,5 +151,34 @@ describe("Compilation", () => {
 			expect(chunk.files.has("a.js")).toBe(false);
 			expect(chunk.files.has("b.js")).toBe(false);
 		});
+
+		it("deleteAsset falls back to scanning when the file is not in the index", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("standalone.js", new RawSource("// s"));
+			// Build the index while standalone.js is in no chunk.
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			// Attach the already-emitted asset directly, bypassing emitAsset.
+			chunk.files.add("standalone.js");
+
+			compilation.deleteAsset("standalone.js");
+
+			expect(chunk.files.has("standalone.js")).toBe(false);
+		});
+
+		it("renameAsset falls back to scanning when the file is not in the index", () => {
+			const compilation = createCompilation();
+			const chunk = compilation.addChunk("a");
+			compilation.emitAsset("standalone.js", new RawSource("// s"));
+			compilation.emitAsset("marker.js", new RawSource("// marker"));
+			compilation.deleteAsset("marker.js");
+			chunk.files.add("standalone.js");
+
+			compilation.renameAsset("standalone.js", "renamed.js");
+
+			expect(chunk.files.has("standalone.js")).toBe(false);
+			expect(chunk.files.has("renamed.js")).toBe(true);
+		});
 	});
 });

--- a/test/Compilation.unittest.js
+++ b/test/Compilation.unittest.js
@@ -180,48 +180,5 @@ describe("Compilation", () => {
 			expect(chunk.files.has("standalone.js")).toBe(false);
 			expect(chunk.files.has("renamed.js")).toBe(true);
 		});
-
-		it("deleteAsset sweeps chunks the index missed (incomplete index)", () => {
-			const compilation = createCompilation();
-			const chunkA = compilation.addChunk("a");
-			const chunkB = compilation.addChunk("b");
-			compilation.emitAsset("a.js", new RawSource("// a"));
-			chunkA.files.add("a.js");
-			compilation.emitAsset("a.aux.js", new RawSource("// aux"));
-			chunkA.auxiliaryFiles.add("a.aux.js");
-			// Build the index while only chunkA holds the files.
-			compilation.emitAsset("marker.js", new RawSource("// marker"));
-			compilation.deleteAsset("marker.js");
-			// Attach the already-indexed names to chunkB directly (no emitAsset),
-			// leaving the cached index incomplete for these files.
-			chunkB.files.add("a.js");
-			chunkB.auxiliaryFiles.add("a.aux.js");
-
-			compilation.deleteAsset("a.js");
-			compilation.deleteAsset("a.aux.js");
-
-			expect(chunkA.files.has("a.js")).toBe(false);
-			expect(chunkB.files.has("a.js")).toBe(false);
-			expect(chunkA.auxiliaryFiles.has("a.aux.js")).toBe(false);
-			expect(chunkB.auxiliaryFiles.has("a.aux.js")).toBe(false);
-		});
-
-		it("renameAsset sweeps chunks the index missed (incomplete index)", () => {
-			const compilation = createCompilation();
-			const chunkA = compilation.addChunk("a");
-			const chunkB = compilation.addChunk("b");
-			compilation.emitAsset("a.js", new RawSource("// a"));
-			chunkA.files.add("a.js");
-			compilation.emitAsset("marker.js", new RawSource("// marker"));
-			compilation.deleteAsset("marker.js");
-			chunkB.files.add("a.js");
-
-			compilation.renameAsset("a.js", "b.js");
-
-			expect(chunkA.files.has("a.js")).toBe(false);
-			expect(chunkA.files.has("b.js")).toBe(true);
-			expect(chunkB.files.has("a.js")).toBe(false);
-			expect(chunkB.files.has("b.js")).toBe(true);
-		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`Compilation.deleteAsset` and `Compilation.renameAsset` previously iterated over **every** chunk on each call to update `chunk.files` / `chunk.auxiliaryFiles` (the long-standing `// TODO If this becomes a performance problem` in `deleteAsset`). With many chunks this is O(chunks) per call, so deleting/renaming many assets (common with plugins like terser/compression and `output.realContentHash`) becomes O(chunks × assets).

This PR stores the reverse mapping the TODO suggested: a lazily-built index `file -> Set<Chunk>`, one for `chunk.files` and one for `chunk.auxiliaryFiles`. `deleteAsset`/`renameAsset` then touch only the chunks that actually reference the file. `emitAsset` invalidates the index (every internal `chunk.files`/`chunk.auxiliaryFiles` addition is preceded by an `emitAsset` for that file), and `clearAssets`/`unseal` reset it, so it can never be used while stale. `renameAsset` only carries the new name to chunks that actually held the old one.

Microbenchmark (3000 chunks × 3 files = 9000 assets, full delete/rename sweep, median of 5 runs):

| Operation | Before | After |
| --- | --- | --- |
| `deleteAsset` | ~1402 ms | ~34 ms |
| `renameAsset` | ~2148 ms | ~35 ms |

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/Compilation.unittest.js` covers `deleteAsset`/`renameAsset` chunk cleanup, that `renameAsset` does not add the new name to chunks that did not hold the old name, and the regression where the index is built before an asset is attached to a chunk (the `emitAsset` invalidation). Existing `test/configCases/assets/*` and source-map / real-content-hash config cases continue to pass.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Behavior is unchanged; only internal bookkeeping is faster.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — internal optimization, no public API or option changes.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used under human review: it implemented the reverse index, wrote the unit tests and the microbenchmark, and drafted this description. All changes were reviewed before pushing.