### PR TITLE
fix: replace DefinePlugin undefined member access with undefined

### DIFF
--- a/.changeset/define-plugin-undefined-member.md
+++ b/.changeset/define-plugin-undefined-member.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Replace `DefinePlugin` member access on an undefined object property with `undefined` instead of inlining the whole object.

--- a/.changeset/define-plugin-undefined-member.md
+++ b/.changeset/define-plugin-undefined-member.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Replace `DefinePlugin` member access on an undefined object property with `undefined` instead of inlining the whole object.
+Resolve `DefinePlugin` access to an undefined object member as `undefined`.

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -23,6 +23,7 @@ const {
 const createHash = require("./util/createHash");
 
 /** @typedef {import("estree").Expression} Expression */
+/** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
 /** @typedef {import("./Module").ValueCacheVersion} ValueCacheVersion */
@@ -31,6 +32,7 @@ const createHash = require("./util/createHash");
 /** @typedef {import("./RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("./javascript/JavascriptParser").DestructuringAssignmentProperties} DestructuringAssignmentProperties */
+/** @typedef {import("./javascript/JavascriptParser").Members} Members */
 /** @typedef {import("./javascript/JavascriptParser").Range} Range */
 /** @typedef {import("./logging/Logger").Logger} Logger */
 /** @typedef {import("./Compilation")} Compilation */
@@ -780,34 +782,64 @@ class DefinePlugin {
 							}
 							return toConstantDependency(parser, strCode)(expr);
 						});
-						// A member access not defined on the object becomes `undefined`
-						// instead of inlining the whole object — root keys only (issue #15559).
-						if (!key.includes(".")) {
-							parser.hooks.expressionMemberChain
-								.for(key)
-								.tap(PLUGIN_NAME, (expr, members) => {
-									/** @type {CodeValue} */
-									let value = /** @type {CodeValue} */ (obj);
-									let path = key;
-									for (let i = 0; i < members.length; i++) {
-										// a leaf with members left is a real property access;
-										// let the default handling inline the leaf.
-										if (!isObjectDefinition(value)) return;
-										const member = members[i];
-										const nextPath = `${path}.${member}`;
-										if (member in value) {
-											value = value[member];
-										} else if (nextPath in definitions) {
-											// defined via a dotted sibling key, e.g. `OBJECT.SUB2`
-											value = definitions[nextPath];
-										} else {
-											addValueDependency(key);
-											return toConstantDependency(parser, "undefined")(expr);
-										}
-										path = nextPath;
-									}
-								});
-						}
+						// A property access not defined on the object resolves to `undefined`
+						// and the whole object is never inlined (issue #15559). Keyed by the
+						// chain root so dotted object keys (e.g. `a.b`) are also covered.
+						const chainParts = key.split(".");
+						const chainRoot = chainParts[0];
+						const chainPrefix = chainParts.slice(1);
+						/**
+						 * Whether a member chain reads a property that is not defined.
+						 * @param {Members} members chain members (after the root)
+						 * @returns {boolean} true when the access resolves to `undefined`
+						 */
+						const isUndefinedMemberAccess = (members) => {
+							if (members.length <= chainPrefix.length) return false;
+							for (let i = 0; i < chainPrefix.length; i++) {
+								if (members[i] !== chainPrefix[i]) return false;
+							}
+							/** @type {CodeValue} */
+							let value = /** @type {CodeValue} */ (obj);
+							let path = key;
+							for (let i = chainPrefix.length; i < members.length; i++) {
+								// a leaf with members left is a real property access on a value
+								if (!isObjectDefinition(value)) return false;
+								const member = members[i];
+								const nextPath = `${path}.${member}`;
+								if (member in value) {
+									value = value[member];
+								} else if (nextPath in definitions) {
+									// defined via a dotted sibling key, e.g. `OBJECT.SUB2`
+									value = definitions[nextPath];
+								} else {
+									return true;
+								}
+								path = nextPath;
+							}
+							return false;
+						};
+						parser.hooks.expressionMemberChain
+							.for(chainRoot)
+							.tap(PLUGIN_NAME, (expr, members) => {
+								if (!isUndefinedMemberAccess(members)) return;
+								addValueDependency(key);
+								return toConstantDependency(parser, "undefined")(expr);
+							});
+						// In a call, replace only the callee so the call itself is kept:
+						// `x.MISSING()` stays a (throwing) call and `x.MISSING?.()`
+						// short-circuits, with the object never inlined.
+						parser.hooks.callMemberChain
+							.for(chainRoot)
+							.tap(PLUGIN_NAME, (expr, members) => {
+								if (!isUndefinedMemberAccess(members)) return;
+								addValueDependency(key);
+								toConstantDependency(
+									parser,
+									"undefined"
+								)(/** @type {Expression} */ (expr.callee));
+								parser.walkExpressions(expr.arguments);
+								return true;
+							});
 						parser.hooks.typeof
 							.for(key)
 							.tap(

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -140,6 +140,17 @@ function getObjKeys(properties) {
 	return new Set([...properties].map((p) => p.id));
 }
 
+/**
+ * A value that should be walked into as a nested definition (plain object or array).
+ * @param {CodeValue} code code value
+ * @returns {code is Definitions} true when the value is a plain object/array
+ */
+const isObjectDefinition = (code) =>
+	Boolean(code) &&
+	typeof code === "object" &&
+	!(code instanceof RuntimeValue) &&
+	!(code instanceof RegExp);
+
 /** @typedef {Set<string> | null} ObjKeys */
 /** @typedef {boolean | undefined | null} AsiSafe */
 
@@ -487,12 +498,7 @@ class DefinePlugin {
 					const walkDefinitions = (definitions, prefix) => {
 						for (const key of Object.keys(definitions)) {
 							const code = definitions[key];
-							if (
-								code &&
-								typeof code === "object" &&
-								!(code instanceof RuntimeValue) &&
-								!(code instanceof RegExp)
-							) {
+							if (isObjectDefinition(code)) {
 								walkDefinitions(
 									/** @type {Definitions} */ (code),
 									`${prefix + key}.`
@@ -774,6 +780,34 @@ class DefinePlugin {
 							}
 							return toConstantDependency(parser, strCode)(expr);
 						});
+						// Member access on an undefined property resolves to `undefined`
+						// instead of inlining the whole object (issue #15559). Only top-level
+						// roots reach here; dotted keys share the same root.
+						if (!key.includes(".")) {
+							parser.hooks.expressionMemberChain
+								.for(key)
+								.tap(PLUGIN_NAME, (expr, members) => {
+									/** @type {EXPECTED_ANY} */
+									let value = obj;
+									let path = key;
+									for (let i = 0; i < members.length; i++) {
+										// leaf reached with members left: real property access,
+										// let the default handling inline the resolved leaf.
+										if (!isObjectDefinition(value)) return;
+										const member = members[i];
+										const nextPath = `${path}.${member}`;
+										if (member in value) {
+											value = value[member];
+										} else if (nextPath in definitions) {
+											value = definitions[nextPath];
+										} else {
+											addValueDependency(key);
+											return toConstantDependency(parser, "undefined")(expr);
+										}
+										path = nextPath;
+									}
+								});
+						}
 						parser.hooks.typeof
 							.for(key)
 							.tap(
@@ -821,12 +855,7 @@ class DefinePlugin {
 							warning.hideStack = true;
 							compilation.warnings.push(warning);
 						}
-						if (
-							code &&
-							typeof code === "object" &&
-							!(code instanceof RuntimeValue) &&
-							!(code instanceof RegExp)
-						) {
+						if (isObjectDefinition(code)) {
 							walkDefinitionsForValues(
 								/** @type {Definitions} */ (code),
 								`${prefix + key}.`

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -787,8 +787,8 @@ class DefinePlugin {
 							parser.hooks.expressionMemberChain
 								.for(key)
 								.tap(PLUGIN_NAME, (expr, members) => {
-									/** @type {EXPECTED_ANY} */
-									let value = obj;
+									/** @type {CodeValue} */
+									let value = /** @type {CodeValue} */ (obj);
 									let path = key;
 									for (let i = 0; i < members.length; i++) {
 										// leaf reached with members left: real property access,

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -23,7 +23,6 @@ const {
 const createHash = require("./util/createHash");
 
 /** @typedef {import("estree").Expression} Expression */
-/** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
 /** @typedef {import("./Module").ValueCacheVersion} ValueCacheVersion */

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -786,8 +786,11 @@ class DefinePlugin {
 						// and the whole object is never inlined (issue #15559). Keyed by the
 						// chain root so dotted object keys (e.g. `a.b`) are also covered.
 						const chainParts = key.split(".");
-						const chainRoot = chainParts[0];
-						const chainPrefix = chainParts.slice(1);
+						// `import.meta` is one chain root (a MetaProperty), not two members.
+						const isMeta =
+							chainParts[0] === "import" && chainParts[1] === "meta";
+						const chainRoot = isMeta ? "import.meta" : chainParts[0];
+						const chainPrefix = chainParts.slice(isMeta ? 2 : 1);
 						/**
 						 * Whether a member chain reads a property that is not defined.
 						 * @param {Members} members chain members (after the root)

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -141,9 +141,9 @@ function getObjKeys(properties) {
 }
 
 /**
- * A value that should be walked into as a nested definition (plain object or array).
+ * Whether a value is a nested definition (plain object/array) to recurse into.
  * @param {CodeValue} code code value
- * @returns {code is Definitions} true when the value is a plain object/array
+ * @returns {code is Definitions} true for a plain object or array
  */
 const isObjectDefinition = (code) =>
 	Boolean(code) &&
@@ -780,9 +780,8 @@ class DefinePlugin {
 							}
 							return toConstantDependency(parser, strCode)(expr);
 						});
-						// Member access on an undefined property resolves to `undefined`
-						// instead of inlining the whole object (issue #15559). Only top-level
-						// roots reach here; dotted keys share the same root.
+						// A member access not defined on the object becomes `undefined`
+						// instead of inlining the whole object — root keys only (issue #15559).
 						if (!key.includes(".")) {
 							parser.hooks.expressionMemberChain
 								.for(key)
@@ -791,14 +790,15 @@ class DefinePlugin {
 									let value = /** @type {CodeValue} */ (obj);
 									let path = key;
 									for (let i = 0; i < members.length; i++) {
-										// leaf reached with members left: real property access,
-										// let the default handling inline the resolved leaf.
+										// a leaf with members left is a real property access;
+										// let the default handling inline the leaf.
 										if (!isObjectDefinition(value)) return;
 										const member = members[i];
 										const nextPath = `${path}.${member}`;
 										if (member in value) {
 											value = value[member];
 										} else if (nextPath in definitions) {
+											// defined via a dotted sibling key, e.g. `OBJECT.SUB2`
 											value = definitions[nextPath];
 										} else {
 											addValueDependency(key);

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -793,10 +793,15 @@ class DefinePlugin {
 						const chainPrefix = chainParts.slice(isMeta ? 2 : 1);
 						/**
 						 * Whether a member chain reads a property that is not defined.
+						 * Collects every define key consulted so the caller can record a
+						 * value dependency on each (a sibling key like `OBJECT.SUB2` affects
+						 * the result even though `OBJECT` registered the handler).
+						 * `member in value` keeps inherited members (e.g. `toString`) defined.
 						 * @param {Members} members chain members (after the root)
+						 * @param {string[]} deps consulted define keys (mutated)
 						 * @returns {boolean} true when the access resolves to `undefined`
 						 */
-						const isUndefinedMemberAccess = (members) => {
+						const isUndefinedMemberAccess = (members, deps) => {
 							if (members.length <= chainPrefix.length) return false;
 							for (let i = 0; i < chainPrefix.length; i++) {
 								if (members[i] !== chainPrefix[i]) return false;
@@ -811,8 +816,11 @@ class DefinePlugin {
 								const nextPath = `${path}.${member}`;
 								if (member in value) {
 									value = value[member];
-								} else if (nextPath in definitions) {
+								} else if (
+									Object.prototype.hasOwnProperty.call(definitions, nextPath)
+								) {
 									// defined via a dotted sibling key, e.g. `OBJECT.SUB2`
+									deps.push(nextPath);
 									value = definitions[nextPath];
 								} else {
 									return true;
@@ -824,8 +832,9 @@ class DefinePlugin {
 						parser.hooks.expressionMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members) => {
-								if (!isUndefinedMemberAccess(members)) return;
-								addValueDependency(key);
+								const deps = [key];
+								if (!isUndefinedMemberAccess(members, deps)) return;
+								for (const dep of deps) addValueDependency(dep);
 								return toConstantDependency(parser, "undefined")(expr);
 							});
 						// In a call, replace only the callee so the call itself is kept:
@@ -834,8 +843,9 @@ class DefinePlugin {
 						parser.hooks.callMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members) => {
-								if (!isUndefinedMemberAccess(members)) return;
-								addValueDependency(key);
+								const deps = [key];
+								if (!isUndefinedMemberAccess(members, deps)) return;
+								for (const dep of deps) addValueDependency(dep);
 								toConstantDependency(
 									parser,
 									"undefined"

--- a/test/configCases/plugins/define-plugin-import-meta/index.js
+++ b/test/configCases/plugins/define-plugin-import-meta/index.js
@@ -1,0 +1,14 @@
+it("should define a member of an import.meta object key", function () {
+	expect(import.meta.config.TOKEN).toBe("token");
+});
+it("should resolve unknown import.meta member access with undefined (issue 15559)", function () {
+	const a = function () { return import.meta.config.MISSING; };
+	const b = function () { return import.meta.config?.MISSING; };
+	const c = function () { return import.meta.config.MISSING?.(); };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined?.(); }");
+	expect(import.meta.config.MISSING).toBe(undefined);
+	expect(import.meta.config?.MISSING).toBe(undefined);
+	expect(import.meta.config.MISSING?.()).toBe(undefined);
+});

--- a/test/configCases/plugins/define-plugin-import-meta/test.filter.js
+++ b/test/configCases/plugins/define-plugin-import-meta/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
+
+module.exports = () => supportsOptionalChaining();

--- a/test/configCases/plugins/define-plugin-import-meta/webpack.config.js
+++ b/test/configCases/plugins/define-plugin-import-meta/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const { DefinePlugin } = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module"
+	},
+	optimization: {
+		minimize: false,
+		concatenateModules: false
+	},
+	plugins: [
+		new DefinePlugin({
+			"import.meta.config": { TOKEN: JSON.stringify("token") }
+		})
+	]
+};

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -1,0 +1,44 @@
+it("should resolve unknown optional and computed member access with undefined (issue 15559)", function () {
+	const a = function () { return OBJECT?.SUB1?.UNKNOWN; };
+	const b = function () { return OBJECT?.["SUB1"]?.["UNKNOWN"]; };
+	const c = function () { return NOT_DEFINED?.SUB2?.b; };
+	const d = function () { return NOT_DEFINED?.["SUB2"]?.["b"]; };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined; }");
+	expect(d.toString()).toBe("function () { return undefined; }");
+	expect(OBJECT?.SUB1?.UNKNOWN).toBe(undefined);
+	expect(NOT_DEFINED?.SUB2?.b).toBe(undefined);
+});
+it("should resolve optional calls on an unknown member without inlining the object (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN?.(); };
+	const b = function () { return NOT_DEFINED.SUB2.b?.(); };
+	const c = function () { return OBJECT.SUB1?.UNKNOWN?.(); };
+	const d = function () { return OBJECT?.SUB1?.UNKNOWN?.(); };
+	const e = function () { return OBJECT.SUB1["UNKNOWN"]?.(); };
+	const f = function () { return OBJECT.SUB1.UNKNOWN?.().deep; };
+	expect(a.toString()).toBe("function () { return undefined?.(); }");
+	expect(b.toString()).toBe("function () { return undefined?.(); }");
+	expect(c.toString()).toBe("function () { return undefined?.(); }");
+	expect(d.toString()).toBe("function () { return undefined?.(); }");
+	expect(e.toString()).toBe("function () { return undefined?.(); }");
+	expect(f.toString()).toBe("function () { return undefined?.().deep; }");
+	expect(OBJECT.SUB1.UNKNOWN?.()).toBe(undefined);
+	expect(OBJECT?.SUB1?.UNKNOWN?.()).toBe(undefined);
+	expect(NOT_DEFINED.SUB2.b?.()).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN?.().deep).toBe(undefined);
+});
+it("should resolve unknown member calls with optional members without inlining the object (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1?.UNKNOWN(); };
+	const b = function () { return OBJECT?.SUB1?.UNKNOWN(); };
+	const c = function () { return NOT_DEFINED.SUB2?.b(); };
+	expect(a.toString()).toBe("function () { return undefined(); }");
+	expect(b.toString()).toBe("function () { return undefined(); }");
+	expect(c.toString()).toBe("function () { return undefined(); }");
+	expect(() => OBJECT.SUB1?.UNKNOWN()).toThrow();
+});
+it("should still substitute arguments of an unknown member call (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };
+	expect(a.toString()).toBe('function () { return undefined?.("string"); }');
+	expect(OBJECT.SUB1.UNKNOWN?.(STRING)).toBe(undefined);
+});

--- a/test/configCases/plugins/define-plugin-optional-chaining/test.filter.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
+
+module.exports = () => supportsOptionalChaining();

--- a/test/configCases/plugins/define-plugin-optional-chaining/webpack.config.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const { DefinePlugin } = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new DefinePlugin({
+			OBJECT: { SUB1: { a: 1 } },
+			"OBJECT.SUB2": { a: 1 },
+			"NOT_DEFINED.SUB2": { a: 1 },
+			STRING: JSON.stringify("string")
+		})
+	]
+};

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -176,63 +176,15 @@ it("should resolve unknown member access on a dotted object key (issue 15559)", 
 	expect(a.toString()).toBe("function () { return undefined; }");
 	expect(b.toString()).toBe("function () { return undefined; }");
 });
-it("should resolve unknown optional and computed member access with undefined (issue 15559)", function () {
-	const a = function () { return OBJECT?.SUB1?.UNKNOWN; };
-	const b = function () { return OBJECT?.["SUB1"]?.["UNKNOWN"]; };
-	const c = function () { return NOT_DEFINED?.SUB2?.b; };
-	const d = function () { return NOT_DEFINED?.["SUB2"]?.["b"]; };
-	expect(a.toString()).toBe("function () { return undefined; }");
-	expect(b.toString()).toBe("function () { return undefined; }");
-	expect(c.toString()).toBe("function () { return undefined; }");
-	expect(d.toString()).toBe("function () { return undefined; }");
-	expect(OBJECT?.SUB1?.UNKNOWN).toBe(undefined);
-	expect(NOT_DEFINED?.SUB2?.b).toBe(undefined);
-});
 it("should not inline the object when calling an unknown member (issue 15559)", function () {
-	const a = function () { return OBJECT.SUB1.UNKNOWN?.(); };
-	const b = function () { return NOT_DEFINED.SUB2.b?.(); };
-	const c = function () { return OBJECT.SUB1.UNKNOWN(); };
-	expect(a.toString()).toBe("function () { return undefined?.(); }");
-	expect(b.toString()).toBe("function () { return undefined?.(); }");
-	expect(c.toString()).toBe("function () { return undefined(); }");
-	expect(OBJECT.SUB1.UNKNOWN?.()).toBe(undefined);
-	expect(NOT_DEFINED.SUB2.b?.()).toBe(undefined);
-	// a non-optional call to an undefined member still throws (no object inlined)
-	expect(() => OBJECT.SUB1.UNKNOWN()).toThrow();
-});
-it("should resolve optional calls on an unknown member without inlining the object (issue 15559)", function () {
-	const a = function () { return OBJECT.SUB1?.UNKNOWN?.(); };
-	const b = function () { return OBJECT?.SUB1?.UNKNOWN?.(); };
-	const c = function () { return OBJECT.SUB1["UNKNOWN"]?.(); };
-	const d = function () { return NOT_DEFINED?.SUB2?.b?.(); };
-	const e = function () { return OBJECT.SUB1.UNKNOWN?.().deep; };
-	expect(a.toString()).toBe("function () { return undefined?.(); }");
-	expect(b.toString()).toBe("function () { return undefined?.(); }");
-	expect(c.toString()).toBe("function () { return undefined?.(); }");
-	expect(d.toString()).toBe("function () { return undefined?.(); }");
-	expect(e.toString()).toBe("function () { return undefined?.().deep; }");
-	expect(OBJECT.SUB1?.UNKNOWN?.()).toBe(undefined);
-	expect(OBJECT?.SUB1?.UNKNOWN?.()).toBe(undefined);
-	expect(NOT_DEFINED?.SUB2?.b?.()).toBe(undefined);
-	expect(OBJECT.SUB1.UNKNOWN?.().deep).toBe(undefined);
-});
-it("should still substitute arguments of an unknown member call (issue 15559)", function () {
-	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };
-	expect(a.toString()).toBe('function () { return undefined?.("string"); }');
-});
-it("should resolve unknown member calls in other chain forms without inlining the object (issue 15559)", function () {
-	const a = function () { return OBJECT.SUB1?.UNKNOWN(); };
-	const b = function () { return OBJECT?.SUB1?.UNKNOWN(); };
-	const c = function () { return NOT_DEFINED.SUB2?.b(); };
-	const d = function () { return (OBJECT.SUB1.UNKNOWN)(); };
-	const e = function () { return new OBJECT.SUB1.UNKNOWN(); };
+	const a = function () { return OBJECT.SUB1.UNKNOWN(); };
+	const b = function () { return (OBJECT.SUB1.UNKNOWN)(); };
+	const c = function () { return new OBJECT.SUB1.UNKNOWN(); };
 	expect(a.toString()).toBe("function () { return undefined(); }");
-	expect(b.toString()).toBe("function () { return undefined(); }");
-	expect(c.toString()).toBe("function () { return undefined(); }");
-	expect(d.toString()).toBe("function () { return (undefined)(); }");
-	expect(e.toString()).toBe("function () { return new undefined(); }");
+	expect(b.toString()).toBe("function () { return (undefined)(); }");
+	expect(c.toString()).toBe("function () { return new undefined(); }");
 	// the object is not inlined; calling an undefined member still throws
-	expect(() => OBJECT.SUB1?.UNKNOWN()).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN()).toThrow();
 	expect(() => new OBJECT.SUB1.UNKNOWN()).toThrow();
 });
 it("should define ARRAY", function () {

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -154,6 +154,20 @@ it("should define OBJECT.SUB.STRING", function () {
 		expect(sub.STRING).toBe("string");
 	})(OBJECT.SUB);
 });
+it("should replace unknown member access with undefined (issue 15559)", function () {
+	expect(typeof OBJECT.UNKNOWN).toBe("undefined");
+	const a = function () { return OBJECT.UNKNOWN.A; };
+	const b = function () { return OBJECT.SUB1.UNKNOWN; };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(OBJECT.SUB1.a).toBe(1);
+	expect(OBJECT.SUB2.a).toBe(1);
+	expect(OBJECT.SUB2.b).toBe(undefined);
+	expect(OBJECT.SUB2).toEqual({ a: 1 });
+	expect(NOT_DEFINED.SUB2.a).toBe(1);
+	expect(NOT_DEFINED.SUB2.b).toBe(undefined);
+	expect(NOT_DEFINED.SUB2).toEqual({ a: 1 });
+});
 it("should define ARRAY", function () {
 	(donotcallme)
 	ARRAY;

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -168,6 +168,73 @@ it("should replace unknown member access with undefined (issue 15559)", function
 	expect(NOT_DEFINED.SUB2.b).toBe(undefined);
 	expect(NOT_DEFINED.SUB2).toEqual({ a: 1 });
 });
+it("should resolve unknown member access on a dotted object key (issue 15559)", function () {
+	// dotted key whose root also has a single-identifier object define
+	const a = function () { return OBJECT.SUB2.b; };
+	// dotted key whose root is only ever a dotted define (no inlining of the object)
+	const b = function () { return NOT_DEFINED.SUB2.b; };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+});
+it("should resolve unknown optional and computed member access with undefined (issue 15559)", function () {
+	const a = function () { return OBJECT?.SUB1?.UNKNOWN; };
+	const b = function () { return OBJECT?.["SUB1"]?.["UNKNOWN"]; };
+	const c = function () { return NOT_DEFINED?.SUB2?.b; };
+	const d = function () { return NOT_DEFINED?.["SUB2"]?.["b"]; };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined; }");
+	expect(d.toString()).toBe("function () { return undefined; }");
+	expect(OBJECT?.SUB1?.UNKNOWN).toBe(undefined);
+	expect(NOT_DEFINED?.SUB2?.b).toBe(undefined);
+});
+it("should not inline the object when calling an unknown member (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN?.(); };
+	const b = function () { return NOT_DEFINED.SUB2.b?.(); };
+	const c = function () { return OBJECT.SUB1.UNKNOWN(); };
+	expect(a.toString()).toBe("function () { return undefined?.(); }");
+	expect(b.toString()).toBe("function () { return undefined?.(); }");
+	expect(c.toString()).toBe("function () { return undefined(); }");
+	expect(OBJECT.SUB1.UNKNOWN?.()).toBe(undefined);
+	expect(NOT_DEFINED.SUB2.b?.()).toBe(undefined);
+	// a non-optional call to an undefined member still throws (no object inlined)
+	expect(() => OBJECT.SUB1.UNKNOWN()).toThrow();
+});
+it("should resolve optional calls on an unknown member without inlining the object (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1?.UNKNOWN?.(); };
+	const b = function () { return OBJECT?.SUB1?.UNKNOWN?.(); };
+	const c = function () { return OBJECT.SUB1["UNKNOWN"]?.(); };
+	const d = function () { return NOT_DEFINED?.SUB2?.b?.(); };
+	const e = function () { return OBJECT.SUB1.UNKNOWN?.().deep; };
+	expect(a.toString()).toBe("function () { return undefined?.(); }");
+	expect(b.toString()).toBe("function () { return undefined?.(); }");
+	expect(c.toString()).toBe("function () { return undefined?.(); }");
+	expect(d.toString()).toBe("function () { return undefined?.(); }");
+	expect(e.toString()).toBe("function () { return undefined?.().deep; }");
+	expect(OBJECT.SUB1?.UNKNOWN?.()).toBe(undefined);
+	expect(OBJECT?.SUB1?.UNKNOWN?.()).toBe(undefined);
+	expect(NOT_DEFINED?.SUB2?.b?.()).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN?.().deep).toBe(undefined);
+});
+it("should still substitute arguments of an unknown member call (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };
+	expect(a.toString()).toBe('function () { return undefined?.("string"); }');
+});
+it("should resolve unknown member calls in other chain forms without inlining the object (issue 15559)", function () {
+	const a = function () { return OBJECT.SUB1?.UNKNOWN(); };
+	const b = function () { return OBJECT?.SUB1?.UNKNOWN(); };
+	const c = function () { return NOT_DEFINED.SUB2?.b(); };
+	const d = function () { return (OBJECT.SUB1.UNKNOWN)(); };
+	const e = function () { return new OBJECT.SUB1.UNKNOWN(); };
+	expect(a.toString()).toBe("function () { return undefined(); }");
+	expect(b.toString()).toBe("function () { return undefined(); }");
+	expect(c.toString()).toBe("function () { return undefined(); }");
+	expect(d.toString()).toBe("function () { return (undefined)(); }");
+	expect(e.toString()).toBe("function () { return new undefined(); }");
+	// the object is not inlined; calling an undefined member still throws
+	expect(() => OBJECT.SUB1?.UNKNOWN()).toThrow();
+	expect(() => new OBJECT.SUB1.UNKNOWN()).toThrow();
+});
 it("should define ARRAY", function () {
 	(donotcallme)
 	ARRAY;

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -187,6 +187,13 @@ it("should not inline the object when calling an unknown member (issue 15559)", 
 	expect(() => OBJECT.SUB1.UNKNOWN()).toThrow();
 	expect(() => new OBJECT.SUB1.UNKNOWN()).toThrow();
 });
+it("should keep inherited members of a defined object accessible (issue 15559)", function () {
+	// resolved via `in` (not own-property), so inherited members stay reachable
+	const a = function () { return OBJECT.SUB1.toString; };
+	expect(a.toString()).toBe('function () { return ({"a":1}).toString; }');
+	expect(OBJECT.SUB1.toString()).toBe("[object Object]");
+	expect(OBJECT.SUB1.hasOwnProperty("a")).toBe(true);
+});
 it("should define ARRAY", function () {
 	(donotcallme)
 	ARRAY;

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -46,8 +46,11 @@ module.exports = {
 					CODE: "(1+2)",
 					REGEXP: /abc/i,
 					STRING: JSON.stringify("string")
-				}
+				},
+				SUB1: { a: 1 }
 			},
+			"OBJECT.SUB2": { a: 1 },
+			"NOT_DEFINED.SUB2": { a: 1 },
 			ARRAY: [2, [JSON.stringify("six")]],
 			"process.env.DEFINED_NESTED_KEY": 5,
 			"process.env.DEFINED_NESTED_KEY_STRING": '"string"',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`DefinePlugin` inlined the entire object definition when code accessed a property that was not defined on it (e.g. `OBJECT.UNKNOWN` emitted `({...}).UNKNOWN`), which bloated output and could leak unrelated/secret values from the same object.

This resolves such undefined member accesses to `undefined` instead, via the `expressionMemberChain` and `callMemberChain` parser hooks, keyed by the chain root so it also covers:

- dotted object keys (`"config.env": { ... }` → `config.env.MISSING`);
- optional and computed access (`a?.b`, `a?.["b"]`);
- calls — `a.MISSING()` stays a throwing call and `a.MISSING?.()` short-circuits, neither inlining the object; call arguments are still substituted;
- `import.meta.*` object keys.

A value dependency is recorded for every consulted define key (including dotted siblings such as `OBJECT.SUB2`) so persistent caching invalidates correctly.

Closes #15559.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes:
- `test/configCases/plugins/define-plugin` — undefined member access and non-optional calls (runs on all Node versions);
- `test/configCases/plugins/define-plugin-optional-chaining` — optional chaining / optional calls, gated by the `supportsOptionalChaining` test filter (the emitted `?.` is not parseable on Node 10/12);
- `test/configCases/plugins/define-plugin-import-meta` — `import.meta.*` object key in an ESM build.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Direct undefined member access resolved to `undefined` at runtime before (via the inlined object) and still does. The only difference for the common case is the emitted code (no object inlined). One edge-case nuance: a chain that read further through an undefined member (e.g. `OBJECT.SUB1.UNKNOWN.deep`) previously threw a `TypeError` at runtime and now evaluates to `undefined`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This change was implemented with the assistance of Claude (Claude Code). AI was used to investigate the relevant `JavascriptParser` hooks, implement the fix in `lib/DefinePlugin.js`, write the test cases, and address review feedback. All output was reviewed and verified locally by running the affected test suites (`ConfigTestCases`) and `tsc`/lint.