### PR TITLE
fix: avoid ProvidePlugin injection for local const require bindings

### DIFF
--- a/.changeset/nice-peaches-smell.md
+++ b/.changeset/nice-peaches-smell.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Avoid `ProvidePlugin` injection for local CommonJS require bindings that use the same variable name.

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -732,6 +732,7 @@ class CommonJsImportsParserPlugin {
 				// chain), so we have to assume the whole exports object is used.
 				binding.dep.referencedExports = null;
 			}
+			return true;
 		});
 
 		parser.hooks.expressionMemberChain

--- a/test/configCases/plugins/provide-plugin-require-binding/index.js
+++ b/test/configCases/plugins/provide-plugin-require-binding/index.js
@@ -1,0 +1,14 @@
+const process = require("./process");
+const originalCwd = process.cwd;
+
+process.cwd = () => `${originalCwd()}/provided`;
+
+const nodePolyfills = {
+	process
+};
+
+it("should not provide for a const require binding with the same name", () => {
+	expect(nodePolyfills.process.cwd()).toBe("/cwd/provided");
+});
+
+export default nodePolyfills;

--- a/test/configCases/plugins/provide-plugin-require-binding/process.js
+++ b/test/configCases/plugins/provide-plugin-require-binding/process.js
@@ -1,0 +1,1 @@
+exports.cwd = () => "/cwd";

--- a/test/configCases/plugins/provide-plugin-require-binding/webpack.config.js
+++ b/test/configCases/plugins/provide-plugin-require-binding/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const ProvidePlugin = require("../../../../").ProvidePlugin;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new ProvidePlugin({
+			process: "./process"
+		})
+	],
+	optimization: {
+		concatenateModules: true
+	}
+};


### PR DESCRIPTION
**Summary**

Fix a parser interaction introduced by the CommonJS `const NAME = require(LITERAL)` binding tracking.

When a local const require binding has the same name as a `ProvidePlugin` definition, for example:

```js
const process = require("process");
process.cwd();
```

with:

```js
new ProvidePlugin({
  process: "process"
});
```

webpack could still fall through from the local require-binding hook to the `ProvidePlugin` hook for `process`. That caused webpack to emit both a provided dependency declaration and the local const binding in the same scope, eventually failing with:

```text
Identifier 'process' has already been declared
```

This change returns `true` after handling bare reads of tagged CommonJS require bindings, so the local binding is treated as handled and does not trigger same-name free variable hooks.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. Added a regression test in `test/configCases/plugins/provide-plugin-require-binding` covering a local `const process = require(...)` binding together with `ProvidePlugin({ process })` and module concatenation enabled.

Validated with:

```sh
yarn test:base --testMatch "<rootDir>/test/ConfigTestCases.basictest.js" --runInBand --testNamePattern "provide-plugin-require-binding"
yarn test:base --testMatch "<rootDir>/test/TestCasesNormal.basictest.js" --runInBand --testNamePattern "cjs-tree-shaking.*require-member-access"
yarn test:base --testMatch "<rootDir>/test/ConfigTestCases.basictest.js" --runInBand --testNamePattern "plugins.*provide-plugin"
```

**Does this PR introduce a breaking change?**

No.

This only prevents a local `const NAME = require(...)` binding from falling through to same-name free variable hooks after webpack has already handled that local binding. Existing `ProvidePlugin` behavior for actual free variables is unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are needed. This is a bug fix for parser behavior.

**Use of AI**

AI assistance was used to help investigate the regression, identify the parser fallback path, draft the minimal code change, and prepare the PR description. The generated code and text were reviewed and validated by a human before submission, following webpack's AI usage policy.