### PR TITLE
refactor: use minimizer-webpack-plugin as default minimizer

### DIFF
--- a/.changeset/migrate-to-minimizer-webpack-plugin.md
+++ b/.changeset/migrate-to-minimizer-webpack-plugin.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Switch the default minimizer to minimizer-webpack-plugin.

--- a/.changeset/migrate-to-minimizer-webpack-plugin.md
+++ b/.changeset/migrate-to-minimizer-webpack-plugin.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Switch the default minimizer to minimizer-webpack-plugin.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -2090,8 +2090,8 @@ const applyOptimizationDefaults = (
 	A(optimization, "minimizer", () => [
 		{
 			apply: (compiler) => {
-				// Lazy load the Terser plugin
-				const TerserPlugin = require("terser-webpack-plugin");
+				// Lazy load the minimizer plugin
+				const TerserPlugin = require("minimizer-webpack-plugin");
 
 				new TerserPlugin({
 					terserOptions: {

--- a/package.json
+++ b/package.json
@@ -105,10 +105,10 @@
     "graceful-fs": "^4.2.11",
     "loader-runner": "^4.3.2",
     "mime-db": "^1.54.0",
+    "minimizer-webpack-plugin": "^5.6.1",
     "neo-async": "^2.6.2",
     "schema-utils": "^4.3.3",
     "tapable": "^2.3.0",
-    "terser-webpack-plugin": "^5.5.0",
     "watchpack": "^2.5.1",
     "webpack-sources": "^3.5.0"
   },

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -100,7 +100,7 @@ const describeCases = (config) => {
 								}
 								if (options.optimization.minimizer === undefined) {
 									options.optimization.minimizer = [
-										new (require("terser-webpack-plugin"))({
+										new (require("minimizer-webpack-plugin"))({
 											parallel: false
 										})
 									];

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -101,7 +101,7 @@ const describeCases = (config) => {
 							testConfig = require(testConfigPath);
 						}
 
-						const TerserPlugin = require("terser-webpack-plugin");
+						const TerserPlugin = require("minimizer-webpack-plugin");
 
 						const terserForTesting = new TerserPlugin({
 							parallel: false

--- a/test/configCases/assets/delete-asset/webpack.config.js
+++ b/test/configCases/assets/delete-asset/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 const { BannerPlugin, Compilation } = require("../../../../");
 
 /** @type {import("../../../../").Configuration} */
@@ -43,7 +43,7 @@ module.exports = {
 							compilation.getAsset("chunk_js.bundle0.js.map")
 						).toBeDefined();
 						expect(compilation.getAsset("LICENSES.txt")).toBeDefined();
-						// TODO: terser-webpack-plugin should set related info
+						// TODO: minimizer-webpack-plugin should set related info
 						compilation.updateAsset(
 							"chunk_js.bundle0.js",
 							compilation.assets["chunk_js.bundle0.js"],

--- a/test/configCases/plugins/source-map-dev-tool-plugin-append-function/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin-append-function/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 const webpack = require("../../../../");
 
 /** @type {import("../../../../types").Configuration} */

--- a/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 const webpack = require("../../../../");
 
 /** @type {import("../../../../").Configuration} */

--- a/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 const webpack = require("../../../../");
 
 /** @type {import("../../../../").Configuration} */

--- a/test/configCases/plugins/terser-plugin/webpack.config.js
+++ b/test/configCases/plugins/terser-plugin/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/statsCases/custom-terser/webpack.config.js
+++ b/test/statsCases/custom-terser/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const TerserPlugin = require("terser-webpack-plugin");
+const TerserPlugin = require("minimizer-webpack-plugin");
 
 /** @type {import("../../../").Configuration} */
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,6 +7159,16 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minimizer-webpack-plugin@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz#289922a4c96c4ed1ddb76b8a00bd8074e89a2f7f"
+  integrity sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jest-worker "^27.4.5"
+    schema-utils "^4.3.0"
+    terser "^5.31.1"
+
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
@@ -8937,16 +8947,6 @@ term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
-
-terser-webpack-plugin@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz#8e7caad248183ab9e91ff08a83b0fc9f0439c3c3"
-  integrity sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.25"
-    jest-worker "^27.4.5"
-    schema-utils "^4.3.0"
-    terser "^5.31.1"
 
 terser@^5.15.1, terser@^5.31.1, terser@^5.32.0, terser@^5.46.2:
   version "5.48.0"


### PR DESCRIPTION
Replace terser-webpack-plugin with its renamed successor
minimizer-webpack-plugin (same default terser-based minifier,
terserOptions still supported) in defaults and tests.