### PR TITLE
test: cover live-binding edge cases for static export bindings

### DIFF
--- a/test/configCases/optimization/static-export-bindings/const-default.js
+++ b/test/configCases/optimization/static-export-bindings/const-default.js
@@ -1,0 +1,3 @@
+// `export { const as default }` is immutable -> eligible for value binding
+const constDefault = "const-default";
+export { constDefault as default };

--- a/test/configCases/optimization/static-export-bindings/default-binding.js
+++ b/test/configCases/optimization/static-export-bindings/default-binding.js
@@ -1,0 +1,6 @@
+// `export { x as default }` is a live binding (unlike `export default <expr>`)
+let mutableDefault = 0;
+export function bumpDefault() {
+	mutableDefault++;
+}
+export { mutableDefault as default };

--- a/test/configCases/optimization/static-export-bindings/index.js
+++ b/test/configCases/optimization/static-export-bindings/index.js
@@ -7,6 +7,11 @@ import * as reexportChain from "./reexport-chain";
 import * as reexportMixed from "./reexport-mixed";
 import * as reexportStar from "./reexport-star";
 import * as reexportCircular from "./reexport-circular";
+import * as defaultBinding from "./default-binding";
+import * as constDefault from "./const-default";
+import * as starMutable from "./star-mutable";
+import * as selfConst from "./self-const";
+import * as mutableForms from "./mutable-forms";
 
 function expectValueDescriptor(ns, key) {
 	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
@@ -109,4 +114,64 @@ it("should keep star-exported function as getter", () => {
 it("should use getter for re-export from circular module", () => {
 	expectGetterDescriptor(reexportCircular, "reCircular");
 	expect(reexportCircular.reCircular).toBe("cyclic");
+});
+
+// === Live-binding edge cases ===
+
+it("should keep `export { let as default }` as a live binding", () => {
+	expectGetterDescriptor(defaultBinding, "default");
+	expect(defaultBinding.default).toBe(0);
+	defaultBinding.bumpDefault();
+	expect(defaultBinding.default).toBe(1);
+});
+
+it("should bind `export { const as default }` as a value", () => {
+	expectValueDescriptor(constDefault, "default");
+	expect(constDefault.default).toBe("const-default");
+});
+
+it("should keep mutable binding live through `export *`", () => {
+	expectGetterDescriptor(starMutable, "counter");
+	const before = starMutable.counter;
+	starMutable.increment();
+	expect(starMutable.counter).toBe(before + 1);
+});
+
+it("should keep mutable binding live through a two-hop re-export chain", () => {
+	expectGetterDescriptor(reexportChain, "chainedCounter");
+	const before = reexportChain.chainedCounter;
+	reexportChain.chainedIncrement();
+	expect(reexportChain.chainedCounter).toBe(before + 1);
+});
+
+it("should fall back to getter for const in a self-cycle and read correctly", () => {
+	expectGetterDescriptor(selfConst, "selfConst");
+	expect(selfConst.selfConst).toBe("self");
+	expect(selfConst.readSelf()).toBe("self");
+});
+
+it("should observe every mutation form (assign, compound, update) as live", () => {
+	expect(mutableForms.viaAssign).toBe(1);
+	expect(mutableForms.viaCompound).toBe(1);
+	expect(mutableForms.viaUpdate).toBe(1);
+	mutableForms.mutateAll();
+	expect(mutableForms.viaAssign).toBe(10);
+	expect(mutableForms.viaCompound).toBe(6);
+	expect(mutableForms.viaUpdate).toBe(2);
+});
+
+it("should enumerate value-bound and getter exports together", () => {
+	expect(Object.keys(mutableForms).sort()).toEqual([
+		"mutateAll",
+		"viaAssign",
+		"viaCompound",
+		"viaUpdate"
+	]);
+	expect(Object.keys(constExports).sort()).toEqual([
+		"arrayValue",
+		"destructured",
+		"literal",
+		"renamed",
+		"string-alias"
+	]);
 });

--- a/test/configCases/optimization/static-export-bindings/mutable-forms.js
+++ b/test/configCases/optimization/static-export-bindings/mutable-forms.js
@@ -1,0 +1,10 @@
+// Various mutation forms on exported `let` must all stay observable as live bindings
+export let viaAssign = 1;
+export let viaCompound = 1;
+export let viaUpdate = 1;
+
+export function mutateAll() {
+	viaAssign = 10;
+	viaCompound += 5;
+	viaUpdate++;
+}

--- a/test/configCases/optimization/static-export-bindings/reexport-chain.js
+++ b/test/configCases/optimization/static-export-bindings/reexport-chain.js
@@ -1,2 +1,4 @@
 // Re-export chain: this file re-exports from reexport.js which re-exports from const-exports.js
 export { literal as chainedLiteral } from "./reexport";
+// A mutable binding re-exported through two hops must stay live
+export { counter as chainedCounter, increment as chainedIncrement } from "./reexport";

--- a/test/configCases/optimization/static-export-bindings/self-const.js
+++ b/test/configCases/optimization/static-export-bindings/self-const.js
@@ -1,0 +1,8 @@
+// Self-cycle: const must fall back to a getter so reading via the namespace works
+import * as self from "./self-const";
+
+export const selfConst = "self";
+
+export function readSelf() {
+	return self.selfConst;
+}

--- a/test/configCases/optimization/static-export-bindings/star-mutable.js
+++ b/test/configCases/optimization/static-export-bindings/star-mutable.js
@@ -1,0 +1,2 @@
+// `export *` of a mutable binding must stay live
+export * from "./mutable-exports";


### PR DESCRIPTION
Add cases probing the const value-binding optimization and live-binding
semantics: export { let as default } (live) vs export { const as default }
(value), mutable bindings through export * and a two-hop re-export chain,
const in a self-cycle (getter fallback), all mutation forms, and namespace
enumeration mixing value and getter exports.