### PR TITLE
fix: prevent prototype pollution in cli.processArguments

### DIFF
--- a/.changeset/cli-prototype-pollution.md
+++ b/.changeset/cli-prototype-pollution.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reject `__proto__`, `constructor` and `prototype` path segments in `cli.processArguments` to prevent prototype pollution.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,7 +25,7 @@ const webpackSchema =
  * @property {string} path the path in the config
  */
 
-/** @typedef {"unknown-argument" | "unexpected-non-array-in-path" | "unexpected-non-object-in-path" | "multiple-values-unexpected" | "invalid-value"} ProblemType */
+/** @typedef {"unknown-argument" | "unexpected-non-array-in-path" | "unexpected-non-object-in-path" | "prototype-pollution-in-path" | "multiple-values-unexpected" | "invalid-value"} ProblemType */
 
 /** @typedef {string | number | boolean | RegExp} Value */
 
@@ -450,6 +450,14 @@ const cliAddedItems = new WeakMap();
 /** @typedef {string | number} Property */
 
 /**
+ * Whether a path segment would walk into the prototype chain.
+ * @param {string} name path segment
+ * @returns {boolean} true when the segment is unsafe to write through
+ */
+const isUnsafeKey = (name) =>
+	name === "__proto__" || name === "constructor" || name === "prototype";
+
+/**
  * Gets object and property.
  * @param {ObjectConfiguration} config configuration
  * @param {string} schemaPath path in the config
@@ -465,6 +473,14 @@ const getObjectAndProperty = (config, schemaPath, index = 0) => {
 	for (const part of parts) {
 		const isArray = part.endsWith("[]");
 		const name = isArray ? part.slice(0, -2) : part;
+		if (isUnsafeKey(name)) {
+			return {
+				problem: {
+					type: "prototype-pollution-in-path",
+					path: parts.slice(0, i).join(".")
+				}
+			};
+		}
 		let value = current[name];
 		if (isArray) {
 			if (value === undefined) {
@@ -510,6 +526,14 @@ const getObjectAndProperty = (config, schemaPath, index = 0) => {
 		}
 		current = value;
 		i++;
+	}
+	if (isUnsafeKey(property.endsWith("[]") ? property.slice(0, -2) : property)) {
+		return {
+			problem: {
+				type: "prototype-pollution-in-path",
+				path: parts.join(".")
+			}
+		};
 	}
 	const value = current[property];
 	if (property.endsWith("[]")) {

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -550,6 +550,48 @@ describe("Cli", () => {
 			]
 		`)
 		);
+
+		for (const key of ["__proto__", "constructor", "prototype"]) {
+			it(`should not pollute the prototype through a "${key}" path segment`, () => {
+				const args = {
+					"evil-flag": {
+						configs: [
+							{ type: "string", multiple: false, path: `${key}.polluted` }
+						],
+						simpleType: "string",
+						multiple: false
+					}
+				};
+				const config = {};
+				const problems = processArguments(args, config, {
+					"evil-flag": "PWNED"
+				});
+
+				expect({}.polluted).toBeUndefined();
+				expect(problems).toEqual([
+					expect.objectContaining({ type: "prototype-pollution-in-path" })
+				]);
+			});
+
+			it(`should not pollute the prototype through a trailing "${key}" path segment`, () => {
+				const args = {
+					"evil-flag": {
+						configs: [{ type: "string", multiple: false, path: key }],
+						simpleType: "string",
+						multiple: false
+					}
+				};
+				const config = {};
+				const problems = processArguments(args, config, {
+					"evil-flag": "PWNED"
+				});
+
+				expect({}.polluted).toBeUndefined();
+				expect(problems).toEqual([
+					expect.objectContaining({ type: "prototype-pollution-in-path" })
+				]);
+			});
+		}
 	});
 
 	describe("isColorSupported", () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -18931,6 +18931,7 @@ type ProblemType =
 	| "unknown-argument"
 	| "unexpected-non-array-in-path"
 	| "unexpected-non-object-in-path"
+	| "prototype-pollution-in-path"
 	| "multiple-values-unexpected"
 	| "invalid-value";
 declare interface ProcessAssetsAdditionalOptions {


### PR DESCRIPTION
Reject `__proto__`, `constructor` and `prototype` path segments when
walking the schema path so a crafted argument path can no longer write
through to Object.prototype.