### PR TITLE
refactor: carry css @import inheritance on CssImportDependency

### DIFF
--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -361,67 +361,24 @@ class CssModulesPlugin {
 							const exportType =
 								/** @type {CssParser} */
 								(createData.parser).options.exportType;
-							if (resolveData.dependencies.length > 0) {
-								// When CSS is imported from CSS there is only one dependency
-								const dependency = resolveData.dependencies[0];
+							// When CSS is imported from CSS there is only one dependency
+							const dependency =
+								resolveData.dependencies.length > 0
+									? resolveData.dependencies[0]
+									: undefined;
 
-								if (dependency instanceof CssImportDependency) {
-									const parent =
-										/** @type {CssModule} */
-										(compilation.moduleGraph.getParentModule(dependency));
-
-									if (parent instanceof CssModule) {
-										/** @type {Inheritance | undefined} */
-										let inheritance;
-
-										if (
-											parent.cssLayer !== undefined ||
-											parent.supports ||
-											parent.media
-										) {
-											if (!inheritance) {
-												inheritance = [];
-											}
-
-											inheritance.push([
-												parent.cssLayer,
-												parent.supports,
-												parent.media
-											]);
-										}
-
-										if (parent.inheritance) {
-											if (!inheritance) {
-												inheritance = [];
-											}
-
-											inheritance.push(...parent.inheritance);
-										}
-
-										return new CssModule(
-											/** @type {CssModuleCreateData} */
-											({
-												...createData,
-												cssLayer: dependency.layer,
-												supports: dependency.supports,
-												media: dependency.media,
-												inheritance,
-												exportType: parent.exportType || exportType
-											})
-										);
-									}
-
-									return new CssModule(
-										/** @type {CssModuleCreateData} */
-										({
-											...createData,
-											cssLayer: dependency.layer,
-											supports: dependency.supports,
-											media: dependency.media,
-											exportType
-										})
-									);
-								}
+							if (dependency instanceof CssImportDependency) {
+								return new CssModule(
+									/** @type {CssModuleCreateData} */
+									({
+										...createData,
+										cssLayer: dependency.layer,
+										supports: dependency.supports,
+										media: dependency.media,
+										inheritance: dependency.inheritance,
+										exportType: dependency.exportType || exportType
+									})
+								);
 							}
 
 							return new CssModule(

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -38,6 +38,7 @@ const walkCssTokens = require("./walkCssTokens");
 /** @typedef {import("../../declarations/WebpackOptions").CssAutoOrModuleParserOptions} CssAutoOrModuleParserOptions */
 /** @typedef {import("../../declarations/WebpackOptions").CssModuleParserOptions} CssModuleParserOptions */
 /** @typedef {import("./CssModule")} CssModule */
+/** @typedef {import("./CssModule").Inheritance} Inheritance */
 
 /** @typedef {[number, number]} Range */
 /** @typedef {{ line: number, column: number }} Position */
@@ -913,19 +914,30 @@ class CssParser extends Parser {
 
 			const { line: sl, column: sc } = locConverter.get(start);
 			const { line: el, column: ec } = locConverter.get(newline);
+			const parent = /** @type {CssModule} */ (module);
+			/** @type {Inheritance | undefined} */
+			let inheritance;
+			if (parent.cssLayer !== undefined || parent.supports || parent.media) {
+				inheritance = [[parent.cssLayer, parent.supports, parent.media]];
+			}
+			if (parent.inheritance) {
+				if (!inheritance) inheritance = [];
+				inheritance.push(...parent.inheritance);
+			}
 			const dep = new CssImportDependency(
 				url,
 				[start, newline],
 				mode === "local" || mode === "global" ? mode : undefined,
 				layer,
 				supports && supports.length > 0 ? supports : undefined,
-				media && media.length > 0 ? media : undefined
+				media && media.length > 0 ? media : undefined,
+				inheritance,
+				parent.exportType
 			);
 			dep.setLoc(sl, sc, el, ec);
 			module.addDependency(dep);
 			// `text`/`css-style-sheet` parents inline the import's rendered CSS at build time, so register it as a code-generation dependency to have the imported subtree generated first.
-			const exportType = /** @type {import("./CssModule")} */ (module)
-				.exportType;
+			const exportType = parent.exportType;
 			if (exportType === "text" || exportType === "css-style-sheet") {
 				module.addCodeGenerationDependency(dep);
 			}

--- a/lib/dependencies/CssImportDependency.js
+++ b/lib/dependencies/CssImportDependency.js
@@ -9,8 +9,10 @@ const makeSerializable = require("../util/makeSerializable");
 const ModuleDependency = require("./ModuleDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
+/** @typedef {import("../../declarations/WebpackOptions").CssParserExportType} CssParserExportType */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").CssDependencyTemplateContext} DependencyTemplateContext */
+/** @typedef {import("../css/CssModule").Inheritance} Inheritance */
 /** @typedef {import("../css/CssParser").Range} Range */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
@@ -25,14 +27,27 @@ class CssImportDependency extends ModuleDependency {
 	 * @param {string=} layer layer
 	 * @param {string=} supports list of supports conditions
 	 * @param {string=} media list of media conditions
+	 * @param {Inheritance=} inheritance layer/supports/media chain inherited from the importing module
+	 * @param {CssParserExportType=} exportType exportType inherited from the importing module
 	 */
-	constructor(request, range, mode, layer, supports, media) {
+	constructor(
+		request,
+		range,
+		mode,
+		layer,
+		supports,
+		media,
+		inheritance,
+		exportType
+	) {
 		super(request);
 		this.range = range;
 		this.mode = mode;
 		this.layer = layer;
 		this.supports = supports;
 		this.media = media;
+		this.inheritance = inheritance;
+		this.exportType = exportType;
 	}
 
 	get type() {
@@ -88,6 +103,8 @@ class CssImportDependency extends ModuleDependency {
 		write(this.layer);
 		write(this.supports);
 		write(this.media);
+		write(this.inheritance);
+		write(this.exportType);
 		super.serialize(context);
 	}
 
@@ -102,6 +119,8 @@ class CssImportDependency extends ModuleDependency {
 		this.layer = read();
 		this.supports = read();
 		this.media = read();
+		this.inheritance = read();
+		this.exportType = read();
 		super.deserialize(context);
 	}
 }


### PR DESCRIPTION
Precompute the imported module's cssLayer/supports/media inheritance
chain and inherited exportType on CssImportDependency at parse time,
so createModuleClass builds the CssModule without a
moduleGraph.getParentModule lookup.