### PR TITLE
refactor(html): switch HtmlParser to AST-based walk

### DIFF
--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -915,6 +915,7 @@ class HtmlParser extends Parser {
 
 		const magicCommentContext = this.magicCommentContext;
 
+		// TODO implement full HTML parser (WASM)
 		const doc = buildHtmlAst(source);
 
 		/**
@@ -1118,10 +1119,7 @@ class HtmlParser extends Parser {
 					return;
 				}
 
-				const request = `data:text/css;base64,${Buffer.from(
-					cssContent,
-					"utf8"
-				).toString("base64")}`;
+				const request = `data:text/css,${encodeURIComponent(cssContent)}`;
 
 				const { line: sl, column: sc } = locConverter.get(contentStart);
 				const { line: el, column: ec } = locConverter.get(contentEnd);
@@ -1164,10 +1162,7 @@ class HtmlParser extends Parser {
 
 				if (type === "stylesheet-inline") {
 					if (attributeValue.trim() === "") continue;
-					const request = `data:text/css;base64,${Buffer.from(
-						attributeValue,
-						"utf8"
-					).toString("base64")}`;
+					const request = `data:text/css,${encodeURIComponent(attributeValue)}`;
 					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
 					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
 					const dep = new HtmlInlineStyleDependency(request, [

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -24,7 +24,7 @@ const {
 	createMagicCommentContext,
 	webpackCommentRegExp
 } = require("../util/magicComment");
-const walkHtmlTokens = require("./walkHtmlTokens");
+const buildHtmlAst = require("./buildHtmlAst");
 
 /** @typedef {import("../../declarations/WebpackOptions").HtmlParserOptions} HtmlParserOptions */
 /** @typedef {import("../Module")} Module */
@@ -118,14 +118,6 @@ const parseSrc = (input) => {
 
 	return [[value, start, end]];
 };
-
-// HTML `<style>` content is rawtext: it ends at the first `</style>`
-// where the tag name is followed by whitespace, `>` or `/`. The
-// lookahead (rather than a consuming character class) keeps the match
-// from running past the first `>` into a later tag — the
-// `[^>]*` only consumes any (rarely-seen) end-tag attributes before the
-// closing `>` of the end tag itself.
-const STYLE_END_REGEXP = /<\/style(?=[\s/>])[^>]*>/gi;
 
 // (Don't use \s, to avoid matching non-breaking space)
 // eslint-disable-next-line no-control-regex
@@ -889,74 +881,6 @@ class HtmlParser extends Parser {
 			.digest("hex")
 			.slice(0, 8);
 
-		/** @typedef {{ nameStart: number, nameEnd: number, valueStart: number, valueEnd: number }} AttrToken */
-
-		/** @type {AttrToken[]} */
-		const pendingAttributes = [];
-
-		/**
-		 * Reconciles the rewritten `<script>` tag's `type` attribute with the
-		 * emitted chunk's actual format. Used by both the `<script src>` and
-		 * inline `<script>` paths so the two stay in sync.
-		 * @param {AttrToken | undefined} typeAttr existing `type` attribute, if any
-		 * @param {number} nameEnd position right after `<script` (for inserts)
-		 * @param {"script" | "script-module"} type chunk type decided by the parser
-		 * @param {string} input full source string
-		 * @returns {void}
-		 */
-		const reconcileScriptTypeAttr = (typeAttr, nameEnd, type, input) => {
-			if (outputModule && type === "script") {
-				// Chunk is an ES module; upgrade the tag.
-				if (typeAttr && typeAttr.valueStart !== -1) {
-					module.addPresentationalDependency(
-						new ConstDependency("module", [
-							typeAttr.valueStart,
-							typeAttr.valueEnd
-						])
-					);
-				} else {
-					module.addPresentationalDependency(
-						new ConstDependency(' type="module"', nameEnd)
-					);
-				}
-			} else if (!outputModule && type === "script-module" && typeAttr) {
-				// Chunk is a classic IIFE; drop `type="module"` so the
-				// browser doesn't load it under module semantics.
-				let attrEnd;
-				if (typeAttr.valueStart === -1) {
-					attrEnd = typeAttr.nameEnd;
-				} else if (
-					input[typeAttr.valueEnd] === '"' ||
-					input[typeAttr.valueEnd] === "'"
-				) {
-					attrEnd = typeAttr.valueEnd + 1;
-				} else {
-					attrEnd = typeAttr.valueEnd;
-				}
-				// Consume one leading whitespace char so we don't leave a
-				// double space between `<script` and the next attribute.
-				let attrStart = typeAttr.nameStart;
-				if (
-					attrStart > 0 &&
-					isASCIIWhitespace(input.charCodeAt(attrStart - 1))
-				) {
-					attrStart -= 1;
-				}
-				module.addPresentationalDependency(
-					new ConstDependency("", [attrStart, attrEnd])
-				);
-			}
-		};
-
-		// Inline `<script>` body extraction is deferred to the matching
-		// `closeTag` event so the walker's script-data state machine
-		// (including its escaped/double-escaped sub-states) decides where
-		// the body ends. This is the spec-compliant way to find the close
-		// — a plain `</script>` regex would split too early inside
-		// `<!--<script>…</script>-->` patterns.
-		/** @type {null | { contentStart: number, attrs: Map<string, string>, typeAttr: AttrToken | undefined, nameEnd: number }} */
-		let pendingInlineScript = null;
-
 		// Script src / modulepreload references are collected per-type
 		// during the walk; HtmlModulesPlugin later turns them into real
 		// entries. `script` and `script-module` entries are chained via a
@@ -991,32 +915,86 @@ class HtmlParser extends Parser {
 
 		const magicCommentContext = this.magicCommentContext;
 
-		// TODO implement full HTML parser (WASM)
-		walkHtmlTokens(source, 0, {
-			comment: (input, start, end) => {
-				// Only proper `<!-- ... -->` comments carry magic comments.
-				// `walkHtmlTokens` also dispatches this callback for bogus
-				// comments such as `<!DOCTYPE …>` and `<?…>`, which must not
-				// be parsed as magic comments.
+		const doc = buildHtmlAst(source);
+
+		/**
+		 * @param {import("./buildHtmlAst").HtmlAttribute | undefined} typeAttr type attribute
+		 * @param {number} nameEnd end offset of the attribute name
+		 * @param {string} type type of the script
+		 * @param {string} input source string
+		 */
+		const reconcileScriptTypeAttr = (typeAttr, nameEnd, type, input) => {
+			if (outputModule && type === "script") {
+				// Chunk is an ES module; upgrade the tag.
+				if (typeAttr && typeAttr.valueStart !== -1) {
+					module.addPresentationalDependency(
+						new ConstDependency("module", [
+							typeAttr.valueStart,
+							typeAttr.valueEnd
+						])
+					);
+				} else {
+					module.addPresentationalDependency(
+						new ConstDependency(' type="module"', nameEnd)
+					);
+				}
+			} else if (!outputModule && type === "script-module" && typeAttr) {
+				// Chunk is a classic IIFE; drop `type="module"` so the
+				// browser doesn't load it under module semantics.
+				let attrEnd;
+				if (typeAttr.valueStart === -1) {
+					attrEnd = typeAttr.nameEnd;
+				} else if (
+					input[typeAttr.valueEnd] === '"' ||
+					input[typeAttr.valueEnd] === "'"
+				) {
+					attrEnd = typeAttr.valueEnd + 1;
+				} else {
+					attrEnd = typeAttr.valueEnd;
+				}
+				let attrStart = typeAttr.nameStart;
 				if (
-					end - start < 7 ||
-					input.charCodeAt(start) !== 0x3c /* < */ ||
-					input.charCodeAt(start + 1) !== 0x21 /* ! */ ||
-					input.charCodeAt(start + 2) !== 0x2d /* - */ ||
-					input.charCodeAt(start + 3) !== 0x2d /* - */ ||
-					input.charCodeAt(end - 1) !== 0x3e /* > */ ||
-					input.charCodeAt(end - 2) !== 0x2d /* - */ ||
-					input.charCodeAt(end - 3) !== 0x2d /* - */
+					attrStart > 0 &&
+					isASCIIWhitespace(input.charCodeAt(attrStart - 1))
+				) {
+					attrStart -= 1;
+				}
+				module.addPresentationalDependency(
+					new ConstDependency("", [attrStart, attrEnd])
+				);
+			}
+		};
+
+		/**
+		 * @param {import("./buildHtmlAst").HtmlNode[]} children children
+		 * @returns {void}
+		 */
+		const walkChildren = (children) => {
+			for (const child of children) walkNode(child);
+			pendingWebpackIgnore = undefined;
+		};
+
+		/** @param {import("./buildHtmlAst").HtmlNode} node AST node */
+		const walkNode = (node) => {
+			if (node.type === "comment") {
+				// Only proper `<!-- ... -->` comments carry magic comments.
+				if (
+					node.end - node.start < 7 ||
+					source.charCodeAt(node.start) !== 0x3c ||
+					source.charCodeAt(node.start + 1) !== 0x21 ||
+					source.charCodeAt(node.start + 2) !== 0x2d ||
+					source.charCodeAt(node.start + 3) !== 0x2d ||
+					source.charCodeAt(node.end - 1) !== 0x3e ||
+					source.charCodeAt(node.end - 2) !== 0x2d ||
+					source.charCodeAt(node.end - 3) !== 0x2d
 				) {
 					pendingWebpackIgnore = undefined;
-					return end;
+					return;
 				}
-				const contentStart = start + 4;
-				const contentEnd = end - 3;
-				const value = input.slice(contentStart, contentEnd);
+				const value = node.data;
 				if (!webpackCommentRegExp.test(value)) {
 					pendingWebpackIgnore = undefined;
-					return end;
+					return;
 				}
 				/** @type {Record<string, EXPECTED_ANY>} */
 				let options;
@@ -1026,8 +1004,8 @@ class HtmlParser extends Parser {
 						magicCommentContext
 					);
 				} catch (err) {
-					const { line: sl, column: sc } = locConverter.get(start);
-					const { line: el, column: ec } = locConverter.get(end);
+					const { line: sl, column: sc } = locConverter.get(node.start);
+					const { line: el, column: ec } = locConverter.get(node.end);
 					module.addWarning(
 						new CommentCompilationWarning(
 							`Compilation error while processing magic comment(-s): /*${value}*/: ${
@@ -1040,15 +1018,15 @@ class HtmlParser extends Parser {
 						)
 					);
 					pendingWebpackIgnore = undefined;
-					return end;
+					return;
 				}
 				if (options.webpackIgnore === undefined) {
 					pendingWebpackIgnore = undefined;
-					return end;
+					return;
 				}
 				if (typeof options.webpackIgnore !== "boolean") {
-					const { line: sl, column: sc } = locConverter.get(start);
-					const { line: el, column: ec } = locConverter.get(end);
+					const { line: sl, column: sc } = locConverter.get(node.start);
+					const { line: el, column: ec } = locConverter.get(node.end);
 					module.addWarning(
 						new UnsupportedFeatureWarning(
 							`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
@@ -1059,259 +1037,187 @@ class HtmlParser extends Parser {
 						)
 					);
 					pendingWebpackIgnore = undefined;
-					return end;
+					return;
 				}
 				pendingWebpackIgnore = options.webpackIgnore;
-				return end;
-			},
-			attribute: (
-				input,
-				nameStart,
-				nameEnd,
-				valueStart,
-				valueEnd,
-				quoteType
-			) => {
-				pendingAttributes.push({ nameStart, nameEnd, valueStart, valueEnd });
-				if (valueStart === -1) return nameEnd;
-				return quoteType !== walkHtmlTokens.QUOTE_NONE
-					? valueEnd + 1
-					: valueEnd;
-			},
-			closeTag: (input, start, end, nameStart, nameEnd) => {
+				return;
+			}
+
+			if (node.type === "doctype") {
 				pendingWebpackIgnore = undefined;
-				if (pendingInlineScript) {
-					const elName = input.slice(nameStart, nameEnd).toLowerCase();
-					if (elName === "script") {
-						const ps = pendingInlineScript;
-						pendingInlineScript = null;
-						const contentStart = ps.contentStart;
-						const contentEnd = start; // start of `</script>`
-						const jsContent = input.slice(contentStart, contentEnd);
-						if (jsContent.trim() === "") return end;
+				return;
+			}
 
-						// Base64-encode the JS body so the data URI round-trips
-						// arbitrary JavaScript text, including non-ASCII source
-						// (`decodeDataURI` decodes non-base64 bodies as ASCII,
-						// which would corrupt Unicode string literals or
-						// identifiers).
-						const request = `data:text/javascript;base64,${Buffer.from(
-							jsContent,
-							"utf8"
-						).toString("base64")}`;
+			if (node.type === "text") {
+				return;
+			}
 
-						const useEsmEntry = isModuleScript(ps.attrs);
-						const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
-						/** @type {"script" | "script-module"} */
-						const type = useEsmEntry ? "script-module" : "script";
-						const { line: sl, column: sc } = locConverter.get(contentStart);
-						const { line: el, column: ec } = locConverter.get(contentEnd);
-						const dep = new HtmlInlineScriptDependency(
-							request,
-							ps.nameEnd,
-							[contentStart, contentEnd],
-							entryName,
-							useEsmEntry ? "esm" : "commonjs"
-						);
-						dep.setLoc(sl, sc, el, ec);
-						module.addPresentationalDependency(dep);
-						reconcileScriptTypeAttr(ps.typeAttr, ps.nameEnd, type, input);
-						const collection =
-							type === "script" ? scriptEntries : scriptModuleEntries;
-						collection.push({ request, entryName, type });
+			if (node.type !== "element") return;
+
+			const ignore = pendingWebpackIgnore === true;
+			pendingWebpackIgnore = undefined;
+
+			if (ignore) {
+				walkChildren(node.children);
+				return;
+			}
+
+			const elementName = node.tagName;
+			const attrs = node.attributes;
+
+			/** @type {Map<string, string> | undefined} */
+			let attributesMap;
+			const getAttributesMap = () => {
+				if (attributesMap) return attributesMap;
+				attributesMap = new Map();
+				for (const attr of attrs) {
+					attributesMap.set(attr.name, attr.value);
+				}
+				return attributesMap;
+			};
+
+			if (elementName === "style") {
+				/** @type {string | undefined} */
+				let typeValue;
+				for (const attr of attrs) {
+					if (attr.name === "type") {
+						typeValue = attr.value;
+						break;
 					}
 				}
-				return end;
-			},
-			openTag: (input, start, end, nameStart, nameEnd) => {
-				const ignore = pendingWebpackIgnore === true;
-				pendingWebpackIgnore = undefined;
-				if (ignore) {
-					// For `<script>` and `<style>` we don't emit a dependency,
-					// but we must NOT advance past the close tag either: the
-					// walker is already in script-data/rawtext state for
-					// those tags and will consume the body and emit the
-					// matching `closeTag` itself. Returning a position past
-					// `</script>`/`</style>` would leave the walker stuck in
-					// rawtext mode, swallowing later markup.
-					pendingAttributes.length = 0;
-					return end;
+
+				const trimmedType =
+					typeValue !== undefined ? typeValue.trim().toLowerCase() : "";
+				if (
+					typeValue !== undefined &&
+					trimmedType !== "" &&
+					trimmedType !== "text/css"
+				) {
+					walkChildren(node.children);
+					return;
 				}
-				const elementName = input.slice(nameStart, nameEnd).toLowerCase();
 
-				// `<style>` is rawtext: capture the inline CSS and hand it to
-				// the CSS pipeline as a virtual `data:text/css` module with
-				// `exportType: "text"`. We use the regex only to discover the
-				// `</style>` position so we can slice the body; the walker is
-				// already in rawtext state for `<style>` and will emit the
-				// matching `closeTag` event itself, so we must return `end`
-				// (the position right after the opening tag's `>`) rather
-				// than advancing past `</style>`. Only `<style>` tags whose
-				// `type` attribute is absent, empty, or `text/css` are
-				// processed; other types are left untouched.
-				if (elementName === "style") {
-					/** @type {string | undefined} */
-					let typeValue;
-					for (const attr of pendingAttributes) {
-						const attrName = input
-							.slice(attr.nameStart, attr.nameEnd)
-							.toLowerCase();
-						if (attrName === "type") {
-							typeValue =
-								attr.valueStart !== -1
-									? input.slice(attr.valueStart, attr.valueEnd)
-									: "";
-							break;
-						}
+				if (!css) {
+					walkChildren(node.children);
+					return;
+				}
+
+				let contentStart = node.tagEnd;
+				let contentEnd = node.tagEnd;
+				for (const child of node.children) {
+					if (child.type === "text") {
+						contentStart = child.start;
+						contentEnd = child.end;
+						break;
 					}
-					pendingAttributes.length = 0;
+				}
 
-					STYLE_END_REGEXP.lastIndex = end;
-					const closeMatch = STYLE_END_REGEXP.exec(input);
-					if (!closeMatch) return end;
-					const contentStart = end;
-					const contentEnd = closeMatch.index;
+				const cssContent = source.slice(contentStart, contentEnd);
+				if (cssContent.trim() === "") {
+					walkChildren(node.children);
+					return;
+				}
 
-					const trimmedType =
-						typeValue !== undefined ? typeValue.trim().toLowerCase() : "";
-					if (
-						typeValue !== undefined &&
-						trimmedType !== "" &&
-						trimmedType !== "text/css"
-					) {
-						return end;
-					}
+				const request = `data:text/css;base64,${Buffer.from(
+					cssContent,
+					"utf8"
+				).toString("base64")}`;
 
-					// Inline-style processing requires the CSS pipeline; when
-					// `experiments.css` is off, leave the body alone — the
-					// walker is in rawtext mode for `<style>` and will skip
-					// over the body to the matching `</style>` itself.
-					if (!css) {
-						return end;
-					}
+				const { line: sl, column: sc } = locConverter.get(contentStart);
+				const { line: el, column: ec } = locConverter.get(contentEnd);
+				const dep = new HtmlInlineStyleDependency(request, [
+					contentStart,
+					contentEnd
+				]);
+				dep.setLoc(sl, sc, el, ec);
+				module.addDependency(dep);
+				module.addCodeGenerationDependency(dep);
+				walkChildren(node.children);
+				return;
+			}
 
-					const cssContent = input.slice(contentStart, contentEnd);
-					if (cssContent.trim() === "") {
-						return end;
-					}
+			const tagSources = this.sourcesByTag[elementName] || this.anyTagSources;
+			if (!tagSources && elementName !== "script") {
+				walkChildren(node.children);
+				return;
+			}
 
-					// Base64-encode the CSS body so the data URI round-trips
-					// arbitrary CSS text including non-ASCII (`decodeDataURI`
-					// decodes non-base64 bodies as ASCII, which would corrupt
-					// Unicode in selectors, `content`, custom properties, …).
+			for (const attr of tagSources ? attrs : []) {
+				const sourceItem = tagSources[attr.name];
+				if (!sourceItem) continue;
+
+				const attributeValue = attr.value;
+				if (!attributeValue) continue;
+
+				if (
+					typeof sourceItem.filter === "function" &&
+					!sourceItem.filter(getAttributesMap())
+				) {
+					continue;
+				}
+
+				const type =
+					typeof sourceItem.type === "function"
+						? sourceItem.type(getAttributesMap(), css)
+						: sourceItem.type;
+				const parse = type === "srcset" ? parseSrcset : parseSrc;
+
+				if (type === "stylesheet-inline") {
+					if (attributeValue.trim() === "") continue;
 					const request = `data:text/css;base64,${Buffer.from(
-						cssContent,
+						attributeValue,
 						"utf8"
 					).toString("base64")}`;
-
-					const { line: sl, column: sc } = locConverter.get(contentStart);
-					const { line: el, column: ec } = locConverter.get(contentEnd);
+					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
+					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
 					const dep = new HtmlInlineStyleDependency(request, [
-						contentStart,
-						contentEnd
+						attr.valueStart,
+						attr.valueEnd
 					]);
 					dep.setLoc(sl, sc, el, ec);
 					module.addDependency(dep);
 					module.addCodeGenerationDependency(dep);
-					return end;
+					continue;
 				}
 
-				// Per-tag bucket — already contains the any-tag entries when
-				// the user supplied any (merged in at build time). For tags
-				// missing from the table, fall back to the bare any-tag
-				// bucket so unknown tags like `<custom-elem>` still match
-				// user any-tag rules. When both are undefined, only
-				// `<script>` keeps going for the inline-script handler.
-				const tagSources = this.sourcesByTag[elementName] || this.anyTagSources;
-				if (!tagSources && elementName !== "script") {
-					pendingAttributes.length = 0;
-					return end;
+				/** @type {ParsedSource[] | undefined} */
+				let parsedAttributeValue;
+
+				try {
+					parsedAttributeValue = parse(attributeValue);
+				} catch (err) {
+					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
+					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
+
+					module.addError(
+						new ModuleDependencyError(
+							module,
+							new WebpackError(
+								`Bad value for attribute "${attr.name}" on element "${elementName}": ${
+									/** @type {Error} */ (err).message
+								}`
+							),
+							{
+								start: { line: sl, column: sc },
+								end: { line: el, column: ec }
+							}
+						)
+					);
 				}
 
-				/** @type {Map<string, string> | undefined} */
-				let attributesMap;
-				const getAttributesMap = () => {
-					if (attributesMap) return attributesMap;
-					attributesMap = new Map();
-					for (const attr of pendingAttributes) {
-						const name = input
-							.slice(attr.nameStart, attr.nameEnd)
-							.toLowerCase();
-						const value =
-							attr.valueStart !== -1
-								? input.slice(attr.valueStart, attr.valueEnd)
-								: "";
-						attributesMap.set(name, value);
-					}
-					return attributesMap;
-				};
+				if (!parsedAttributeValue) continue;
 
-				// Skip the attribute loop entirely when there are no
-				// applicable sources (only path here is a `<script>` with
-				// no source extraction configured — we still want the
-				// inline-script handler below).
-				for (const attr of tagSources ? pendingAttributes : []) {
-					const attributeName = input
-						.slice(attr.nameStart, attr.nameEnd)
-						.toLowerCase();
-					// Single property read — any-tag entries were folded into
-					// `tagSources` at build time.
-					const sourceItem = tagSources[attributeName];
-
-					if (!sourceItem) continue;
-
-					// TODO(html-entities): We should ideally decode entities here using
-					// `walkHtmlTokens.decodeHtmlEntities(input.slice(...))` so that URLs
-					// like `image.png?a=1&amp;b=2` are correctly resolved as `&`.
-					// However, doing so currently breaks `srcset` parsing tests (e.g. `errors.js`)
-					// which explicitly expect whitespace entities like `&#x9;` to NOT be decoded
-					// before the srcset parser runs. A follow-up PR should implement selective
-					// decoding for specific URL attributes.
-					const attributeValue =
-						attr.valueStart !== -1
-							? input.slice(attr.valueStart, attr.valueEnd)
-							: "";
-
-					if (!attributeValue) continue;
-
-					if (
-						typeof sourceItem.filter === "function" &&
-						!sourceItem.filter(getAttributesMap())
-					) {
-						continue;
-					}
-
-					// Polymorphic defaults (e.g. `<link href>`, `<script src>`)
-					// pick a type based on the element's other attributes
-					// (`rel`, `type`); user-supplied sources have a static
-					// `type` string.
-					const type =
-						typeof sourceItem.type === "function"
-							? sourceItem.type(getAttributesMap(), css)
-							: sourceItem.type;
-					// `src` and `srcset` both produce plain asset URLs;
-					// they differ only in how the attribute value is
-					// parsed. Everything else uses `parseSrc`.
-					const parse = type === "srcset" ? parseSrcset : parseSrc;
-
-					// `stylesheet-inline` shortcut: the attribute value IS
-					// CSS text, not a URL. Bundle it through the CSS
-					// pipeline as a virtual `data:text/css` module and
-					// let `HtmlInlineStyleDependency` replace the attribute
-					// value with the processed CSS at render time.
-					if (type === "stylesheet-inline") {
-						if (attributeValue.trim() === "") continue;
-						// Base64 (not URL) so non-ASCII CSS round-trips — see
-						// the inline-`<style>` body handler above.
-						const request = `data:text/css;base64,${Buffer.from(
-							attributeValue,
-							"utf8"
-						).toString("base64")}`;
-						const { line: sl, column: sc } = locConverter.get(attr.valueStart);
-						const { line: el, column: ec } = locConverter.get(attr.valueEnd);
-						const dep = new HtmlInlineStyleDependency(request, [
-							attr.valueStart,
-							attr.valueEnd
+				for (const parsedSource of parsedAttributeValue) {
+					const [value, innerStart, innerEnd] = parsedSource;
+					if (value.startsWith("#")) continue;
+					const sourceStart = attr.valueStart + innerStart;
+					const sourceEnd = attr.valueStart + innerEnd;
+					const { line: sl, column: sc } = locConverter.get(sourceStart);
+					const { line: el, column: ec } = locConverter.get(sourceEnd);
+					if (type === "src" || type === "srcset") {
+						const dep = new HtmlSourceDependency(value, [
+							sourceStart,
+							sourceEnd
 						]);
 						dep.setLoc(sl, sc, el, ec);
 						module.addDependency(dep);
@@ -1319,180 +1225,106 @@ class HtmlParser extends Parser {
 						continue;
 					}
 
-					/** @type {ParsedSource[] | undefined} */
-					let parsedAttributeValue;
-
-					try {
-						parsedAttributeValue = parse(attributeValue);
-					} catch (err) {
-						const { line: sl, column: sc } = locConverter.get(attr.valueStart);
-						const { line: el, column: ec } = locConverter.get(attr.valueEnd);
-
-						module.addError(
-							new ModuleDependencyError(
-								module,
-								new WebpackError(
-									`Bad value for attribute "${attributeName}" on element "${elementName}": ${
-										/** @type {Error} */ (err).message
-									}`
-								),
-								{
-									start: { line: sl, column: sc },
-									end: { line: el, column: ec }
-								}
-							)
-						);
+					const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+					const willBeModuleScript =
+						type === "script-module" || (outputModule && type === "script");
+					/** @type {"script" | "script-module" | "modulepreload" | "stylesheet"} */
+					const elementKind =
+						type === "modulepreload"
+							? "modulepreload"
+							: type === "stylesheet"
+								? "stylesheet"
+								: willBeModuleScript
+									? "script-module"
+									: "script";
+					const entryCategory =
+						type === "stylesheet"
+							? "css-import"
+							: type === "script-module" || type === "modulepreload"
+								? "esm"
+								: undefined;
+					const dep = new HtmlScriptSrcDependency(
+						value,
+						[sourceStart, sourceEnd],
+						entryName,
+						entryCategory,
+						elementKind,
+						node.start,
+						node.tagEnd
+					);
+					dep.setLoc(sl, sc, el, ec);
+					module.addPresentationalDependency(dep);
+					if (
+						elementName === "script" &&
+						(type === "script" || type === "script-module")
+					) {
+						const typeAttr = attrs.find((a) => a.name === "type");
+						reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
 					}
-
-					if (!parsedAttributeValue) continue;
-
-					for (const parsedSource of parsedAttributeValue) {
-						const [value, innerStart, innerEnd] = parsedSource;
-						if (value.startsWith("#")) continue;
-						const sourceStart = attr.valueStart + innerStart;
-						const sourceEnd = attr.valueStart + innerEnd;
-						const { line: sl, column: sc } = locConverter.get(sourceStart);
-						const { line: el, column: ec } = locConverter.get(sourceEnd);
-						if (type === "src" || type === "srcset") {
-							const dep = new HtmlSourceDependency(value, [
-								sourceStart,
-								sourceEnd
-							]);
-							dep.setLoc(sl, sc, el, ec);
-							module.addDependency(dep);
-							module.addCodeGenerationDependency(dep);
-							continue;
-						}
-
-						// Entry types: script, script-module, modulepreload, stylesheet.
-						const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
-						// Under `output.module` the emitted chunks are ESM, so the
-						// sibling tags the template generates for runtime/split
-						// chunks must be `<script type="module">` — for any
-						// `type: "script"` source, whether a native `<script>` or a
-						// custom element. Reflect that in `elementKind`. (The
-						// originating tag's own `type` attribute is rewritten in
-						// place only for a native `<script>` — see the
-						// ConstDependency below; a custom element's attributes are
-						// the user's to own.)
-						const willBeModuleScript =
-							type === "script-module" || (outputModule && type === "script");
-						/** @type {"script" | "script-module" | "modulepreload" | "stylesheet"} */
-						const elementKind =
-							type === "modulepreload"
-								? "modulepreload"
+					const collection =
+						type === "script"
+							? scriptEntries
+							: type === "script-module"
+								? scriptModuleEntries
 								: type === "stylesheet"
-									? "stylesheet"
-									: willBeModuleScript
-										? "script-module"
-										: "script";
-						// `stylesheet` chunks are bundled through the CSS pipeline —
-						// a non-"url" category lets the default `.css` rule win over
-						// `dependency: "url"`. `script-module` / `modulepreload`
-						// resolve as ESM; classic `script` follows the default
-						// (commonjs/url) resolution.
-						const entryCategory =
-							type === "stylesheet"
-								? "css-import"
-								: type === "script-module" || type === "modulepreload"
-									? "esm"
-									: undefined;
-						const dep = new HtmlScriptSrcDependency(
-							value,
-							[sourceStart, sourceEnd],
-							entryName,
-							entryCategory,
-							elementKind,
-							start,
-							end
-						);
-						dep.setLoc(sl, sc, el, ec);
-						module.addPresentationalDependency(dep);
-						// Reconcile the rewritten `<script>` tag's `type` attribute
-						// with the chunk's actual format — see `reconcileScriptTypeAttr`.
-						if (
-							elementName === "script" &&
-							(type === "script" || type === "script-module")
-						) {
-							/** @type {AttrToken | undefined} */
-							let typeAttr;
-							for (const a of pendingAttributes) {
-								if (
-									input.slice(a.nameStart, a.nameEnd).toLowerCase() === "type"
-								) {
-									typeAttr = a;
-									break;
-								}
-							}
-							reconcileScriptTypeAttr(typeAttr, nameEnd, type, input);
-						}
-						const collection =
-							type === "script"
-								? scriptEntries
-								: type === "script-module"
-									? scriptModuleEntries
-									: type === "stylesheet"
-										? stylesheetEntries
-										: modulePreloadEntries;
-						collection.push({ request: value, entryName, type });
-					}
+									? stylesheetEntries
+									: modulePreloadEntries;
+					collection.push({ request: value, entryName, type });
 				}
+			}
 
-				// `<script>` is rawtext (the "script data state" in the HTML
-				// tokenizer): its body must never be reparsed as HTML,
-				// regardless of whether the tag has a `src` attribute. The
-				// walker is already in script-data state for `<script>` and
-				// will emit the matching `closeTag` event itself, so we
-				// return `end` and defer body extraction to the closeTag
-				// callback (which gets the spec-correct `</script>` position
-				// even in escaped/double-escaped script-data sub-states).
-				// When the tag has no `src` and its body is non-empty, the
-				// closeTag handler bundles the inline JS as its own entry —
-				// the same pipeline that processes `<script src>` — by
-				// issuing a `data:text/javascript;base64,...` virtual request
-				// and adding a dependency that rewrites the tag to
-				// `<script src="…">` at render time. Only `<script>` tags
-				// whose `type` attribute is absent, empty, or a recognized
-				// JS mimetype are processed as JS; other types (e.g.
-				// `application/ld+json`, `importmap`) are left untouched.
-				if (elementName === "script") {
-					const attrs = getAttributesMap();
-					// Use attribute presence, not value: a `<script src>` with
-					// an empty or valueless `src` still ignores its inline
-					// body in the browser, so we must not bundle the body.
-					const hasSrc = attrs.has("src");
+			if (elementName === "script") {
+				const scriptAttrs = getAttributesMap();
+				const hasSrc = scriptAttrs.has("src");
 
-					/** @type {AttrToken | undefined} */
-					let typeAttr;
-					for (const a of pendingAttributes) {
-						if (input.slice(a.nameStart, a.nameEnd).toLowerCase() === "type") {
-							typeAttr = a;
+				if (!hasSrc && isExecutableJsScript(scriptAttrs)) {
+					let contentStart = node.tagEnd;
+					let contentEnd = node.tagEnd;
+					for (const child of node.children) {
+						if (child.type === "text") {
+							contentStart = child.start;
+							contentEnd = child.end;
 							break;
 						}
 					}
-					pendingAttributes.length = 0;
 
-					if (hasSrc || !isExecutableJsScript(attrs)) {
-						// `<script src>` body is ignored by the browser, and
-						// non-JS `<script type>` (e.g. importmap, JSON-LD)
-						// passes through unchanged. Either way the walker
-						// consumes the body and emits the close tag itself.
-						return end;
+					const jsContent = source.slice(contentStart, contentEnd);
+					if (jsContent.trim() !== "") {
+						const request = `data:text/javascript;base64,${Buffer.from(
+							jsContent,
+							"utf8"
+						).toString("base64")}`;
+
+						const useEsmEntry = isModuleScript(scriptAttrs);
+						const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+						/** @type {"script" | "script-module"} */
+						const type = useEsmEntry ? "script-module" : "script";
+						const { line: sl, column: sc } = locConverter.get(contentStart);
+						const { line: el, column: ec } = locConverter.get(contentEnd);
+						const dep = new HtmlInlineScriptDependency(
+							request,
+							node.nameEnd,
+							[contentStart, contentEnd],
+							entryName,
+							useEsmEntry ? "esm" : "commonjs"
+						);
+						dep.setLoc(sl, sc, el, ec);
+						module.addPresentationalDependency(dep);
+
+						const typeAttr = attrs.find((a) => a.name === "type");
+						reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
+
+						const collection =
+							type === "script" ? scriptEntries : scriptModuleEntries;
+						collection.push({ request, entryName, type });
 					}
-
-					pendingInlineScript = {
-						contentStart: end,
-						attrs,
-						typeAttr,
-						nameEnd
-					};
-					return end;
 				}
-
-				pendingAttributes.length = 0;
-				return end;
 			}
-		});
+
+			walkChildren(node.children);
+		};
+
+		for (const child of doc.children) walkNode(child);
 
 		const buildInfo = /** @type {BuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1119,7 +1119,7 @@ class HtmlParser extends Parser {
 					return;
 				}
 
-				const request = `data:text/css,${encodeURIComponent(cssContent)}`;
+				const request = `data:text/css;base64,${Buffer.from(cssContent, "utf8").toString("base64")}`;
 
 				const { line: sl, column: sc } = locConverter.get(contentStart);
 				const { line: el, column: ec } = locConverter.get(contentEnd);

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1162,7 +1162,7 @@ class HtmlParser extends Parser {
 
 				if (type === "stylesheet-inline") {
 					if (attributeValue.trim() === "") continue;
-					const request = `data:text/css,${encodeURIComponent(attributeValue)}`;
+					const request = `data:text/css;base64,${Buffer.from(attributeValue, "utf8").toString("base64")}`;
 					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
 					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
 					const dep = new HtmlInlineStyleDependency(request, [

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -920,7 +920,7 @@ class HtmlParser extends Parser {
 
 		/**
 		 * @param {import("./buildHtmlAst").HtmlAttribute | undefined} typeAttr type attribute
-		 * @param {number} nameEnd end offset of the attribute name
+		 * @param {number} nameEnd end offset of the tag name
 		 * @param {string} type type of the script
 		 * @param {string} input source string
 		 */

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -316,12 +316,14 @@ const buildHtmlAst = (source) => {
 
 		while (idx < activeFormattingElements.length) {
 			formattingElement = activeFormattingElements[idx];
+			// No attributes on the clone (see adoptionAgencyAlgorithm): the
+			// original still owns those spans, so copying them double-emits.
 			/** @type {HtmlElement} */
 			const clone = {
 				type: "element",
 				tagName: formattingElement.tagName,
 				namespace: formattingElement.namespace,
-				attributes: [...formattingElement.attributes],
+				attributes: [],
 				children: [],
 				selfClosing: formattingElement.selfClosing,
 				start,
@@ -379,12 +381,14 @@ const buildHtmlAst = (source) => {
 		activeFormattingElements.splice(fmtIdx, 1);
 		openElements.splice(formattingElementIdx, 1);
 
+		// No attributes on the clone: the original is still in the tree and
+		// owns those source spans, so copying them would double-emit the dependency.
 		/** @type {HtmlElement} */
 		const clone = {
 			type: "element",
 			tagName: formattingElement.tagName,
 			namespace: formattingElement.namespace,
-			attributes: [...formattingElement.attributes],
+			attributes: [],
 			children: furthestBlock.children,
 			selfClosing: formattingElement.selfClosing,
 			start: furthestBlock.start,

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -204,13 +204,29 @@ const buildHtmlAst = (source) => {
 	/** @type {HtmlAttribute[]} */
 	const pendingAttrs = [];
 
+	// Append node, merging into a trailing text node when both sides are text.
+	/**
+	 * @param {HtmlNode[]} children target children array
+	 * @param {HtmlNode} node the node to append
+	 */
+	const appendChild = (children, node) => {
+		const last =
+			children.length > 0 ? children[children.length - 1] : undefined;
+		if (node.type === "text" && last && last.type === "text") {
+			/** @type {HtmlText} */ (last).data += node.data;
+			/** @type {HtmlText} */ (last).end = node.end;
+			return;
+		}
+		children.push(node);
+	};
+
 	/**
 	 * Inserts a node into the appropriate parent, handling Foster Parenting.
 	 * @param {HtmlNode} node the node to insert
 	 */
 	const insertNode = (node) => {
 		if (openElements.length === 0) {
-			doc.children.push(node);
+			appendChild(doc.children, node);
 			return;
 		}
 		const parent = openElements[openElements.length - 1];
@@ -246,7 +262,7 @@ const buildHtmlAst = (source) => {
 			}
 		}
 
-		parent.children.push(node);
+		appendChild(parent.children, node);
 	};
 
 	/**
@@ -309,7 +325,9 @@ const buildHtmlAst = (source) => {
 				children: [],
 				selfClosing: formattingElement.selfClosing,
 				start,
-				end: start
+				end: start,
+				tagEnd: formattingElement.tagEnd,
+				nameEnd: formattingElement.nameEnd
 			};
 			insertNode(clone);
 			openElements.push(clone);
@@ -370,7 +388,9 @@ const buildHtmlAst = (source) => {
 			children: furthestBlock.children,
 			selfClosing: formattingElement.selfClosing,
 			start: furthestBlock.start,
-			end
+			end,
+			tagEnd: formattingElement.tagEnd,
+			nameEnd: formattingElement.nameEnd
 		};
 		// TODO: In strict WHATWG, furthestBlock should be moved to a new parent.
 		// For now, leaving it inside simplifies the AST logic while satisfying our current use case.
@@ -461,23 +481,15 @@ const buildHtmlAst = (source) => {
 				input.charCodeAt(start + 3) === 0x2d &&
 				input.charCodeAt(end - 1) === 0x3e &&
 				input.charCodeAt(end - 2) === 0x2d &&
-			input.charCodeAt(end - 3) === 0x2d
-			) {
-				insertNode({
-					type: "comment",
-					data: input.slice(contentStart, contentEnd),
-					start,
-					end
-				});
-			} else {
-				// Bogus comment (DOCTYPE, PI, etc.) — still add as comment
-				insertNode({
-					type: "comment",
-					data: input.slice(start, end),
-					start,
-					end
-				});
-			}
+				input.charCodeAt(end - 3) === 0x2d;
+			insertNode({
+				type: "comment",
+				data: isProper
+					? input.slice(contentStart, contentEnd)
+					: input.slice(start, end),
+				start,
+				end
+			});
 			return end;
 		},
 		text: (input, start, end) => {
@@ -551,7 +563,9 @@ const buildHtmlAst = (source) => {
 						children: [],
 						selfClosing: true,
 						start,
-						end
+						end,
+						tagEnd: end,
+						nameEnd: start
 					};
 					activeFormattingElements.push(marker);
 				}

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -152,6 +152,8 @@ const TABLE_ALLOWED_CHILDREN = new Set([
  * @property {boolean} selfClosing
  * @property {number} start
  * @property {number} end
+ * @property {number} tagEnd end offset of the opening tag (after `>`)
+ * @property {number} nameEnd end offset of the tag name
  */
 
 /**
@@ -186,12 +188,8 @@ const TABLE_ALLOWED_CHILDREN = new Set([
 /** @typedef {HtmlElement | HtmlText | HtmlComment | HtmlDoctype} HtmlNode */
 
 /**
- * Builds a WHATWG-aligned AST from an HTML source string.
- * Uses walkHtmlTokens as the tokenizer and constructs a tree
- * following the simplified tree construction algorithm from the
- * WHATWG HTML spec (modeled after SWC's swc_html_parser).
  * @param {string} source HTML source
- * @returns {HtmlDocument} the document AST
+ * @returns {HtmlDocument} document AST
  */
 const buildHtmlAst = (source) => {
 	/** @type {HtmlDocument} */
@@ -382,10 +380,9 @@ const buildHtmlAst = (source) => {
 	};
 
 	/**
-	 * Auto-close elements that should be implicitly closed when
-	 * encountering a new start tag.
-	 * @param {string} tagName the incoming tag name (lowercase)
-	 * @param {number} start the start offset of the incoming tag
+	 * @param {string} tagName tag name
+	 * @param {number} start start offset
+	 * @returns {void}
 	 */
 	const implicitlyCloseElements = (tagName, start) => {
 		// Auto-close <p> when a block-level element is opened inside it
@@ -398,42 +395,39 @@ const buildHtmlAst = (source) => {
 					openElements.splice(i);
 					break;
 				}
-				// Don't cross non-phrasing boundaries
 				if (!isPhrasingContent(openElements[i].tagName)) break;
 			}
 		}
 
-		// Auto-close same-name elements (e.g. <li> inside <li>)
+		// Auto-close same-name elements (e.g. <li> inside <li>).
 		if (SELF_CLOSING_PAIRS.has(tagName)) {
 			const top =
 				openElements.length > 0 ? openElements[openElements.length - 1] : null;
 			if (top && top.tagName === tagName) {
-				const popped = openElements.pop();
-				if (popped) popped.end = start;
+				const popped = /** @type {HtmlElement} */ (openElements.pop());
+				popped.end = start;
 			}
 		}
 	};
 
 	/**
 	 * @param {string} name tag name
-	 * @returns {boolean} true if the element is phrasing content
+	 * @returns {boolean} whether it is phrasing content
 	 */
 	const isPhrasingContent = (name) =>
 		!P_CLOSING_ELEMENTS.has(name) || name === "p";
 
 	/**
-	 * Determines the namespace for a tag based on its parent context.
-	 * @param {string} tagName the tag name
-	 * @returns {number} namespace constant
+	 * @param {string} tagName tag name
+	 * @returns {number} namespace
 	 */
 	const getNamespace = (tagName) => {
 		if (tagName === "svg") return NS_SVG;
 		if (tagName === "math") return NS_MATHML;
-		// Inherit parent namespace for foreign content children
+		// Inherit parent namespace; HTML integration points (<foreignObject>, <desc>) reset to HTML.
 		if (openElements.length > 0) {
 			const parentNs = openElements[openElements.length - 1].namespace;
 			if (parentNs !== NS_HTML) {
-				// HTML integration points switch back to HTML
 				const parentTag = openElements[openElements.length - 1].tagName;
 				if (parentNs === NS_SVG && parentTag === "foreignobject") {
 					return NS_HTML;
@@ -457,8 +451,9 @@ const buildHtmlAst = (source) => {
 		comment: (input, start, end) => {
 			const contentStart = start + 4; // after <!--
 			const contentEnd = end - 3; // before -->
-			// Only treat proper <!-- --> comments as comments
-			if (
+			// walkHtmlTokens also fires this for bogus comments (<!DOCTYPE>, <?...>).
+			// Proper <!-- --> comments get their inner text; bogus ones store the raw token.
+			const isProper =
 				end - start >= 7 &&
 				input.charCodeAt(start) === 0x3c &&
 				input.charCodeAt(start + 1) === 0x21 &&
@@ -466,7 +461,7 @@ const buildHtmlAst = (source) => {
 				input.charCodeAt(start + 3) === 0x2d &&
 				input.charCodeAt(end - 1) === 0x3e &&
 				input.charCodeAt(end - 2) === 0x2d &&
-				input.charCodeAt(end - 3) === 0x2d
+			input.charCodeAt(end - 3) === 0x2d
 			) {
 				insertNode({
 					type: "comment",
@@ -524,7 +519,9 @@ const buildHtmlAst = (source) => {
 				children: [],
 				selfClosing: isVoid,
 				start,
-				end
+				end,
+				tagEnd: end,
+				nameEnd
 			};
 
 			pendingAttrs.length = 0;

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -372,4 +372,24 @@ describe("buildHtmlAst Edge Cases", () => {
 		expect(ast.children).toHaveLength(1);
 		expect(ast.children[0].tagName).toBe("div");
 	});
+
+	it("should not duplicate an attribute span when a formatting element is cloned", () => {
+		// <a> is reopened around <div> by the adoption agency algorithm; the
+		// clone must not reuse the original's href source span, or the parser
+		// would emit two dependencies for the same position.
+		const ast = buildHtmlAst("<a href=x.png><div>y</a>");
+		/** @type {string[]} */
+		const spans = [];
+		const collect = (node) => {
+			if (node.type !== "element") return;
+			for (const attr of node.attributes) {
+				if (attr.valueStart !== -1) {
+					spans.push(`${attr.valueStart},${attr.valueEnd}`);
+				}
+			}
+			for (const child of node.children) collect(child);
+		};
+		for (const child of ast.children) collect(child);
+		expect(spans).toEqual([...new Set(spans)]);
+	});
 });

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -1,5 +1,19 @@
 "use strict";
 
+jest.mock("../lib/html/walkHtmlTokens", () => {
+	const actual = jest.requireActual("../lib/html/walkHtmlTokens");
+	const mockWalkHtmlTokens = jest.fn((input, pos, callbacks) => {
+		if (input === "MOCK_ADJACENT_TEXT") {
+			callbacks.text(input, 0, 5);
+			callbacks.text(input, 5, 13);
+			return 13;
+		}
+		return actual(input, pos, callbacks);
+	});
+	Object.assign(mockWalkHtmlTokens, actual);
+	return mockWalkHtmlTokens;
+});
+
 const buildHtmlAst = require("../lib/html/buildHtmlAst");
 
 describe("buildHtmlAst", () => {
@@ -89,10 +103,10 @@ describe("buildHtmlAst", () => {
 	});
 
 	it("should merge adjacent text nodes", () => {
-		const ast = buildHtmlAst("hello world");
+		const ast = buildHtmlAst("MOCK_ADJACENT_TEXT");
 		expect(ast.children).toHaveLength(1);
 		expect(ast.children[0].type).toBe("text");
-		expect(ast.children[0].data).toBe("hello world");
+		expect(ast.children[0].data).toBe("MOCK_ADJACENT");
 	});
 
 	it("should detect SVG namespace", () => {
@@ -216,6 +230,17 @@ describe("buildHtmlAst", () => {
 		expect(input.attributes[1].value).toBe("hello");
 	});
 
+	it("should handle all attribute quote styles", () => {
+		const ast = buildHtmlAst("<input a=\"1\" b='2' c=3 disabled>");
+		const input = ast.children[0];
+		expect(input.attributes.map((attr) => attr.value)).toEqual([
+			"1",
+			"2",
+			"3",
+			""
+		]);
+	});
+
 	it("should parse raw-text elements correctly", () => {
 		const ast = buildHtmlAst("<script>var a = 1 < 2;</script>");
 		const script = ast.children[0];
@@ -293,6 +318,35 @@ describe("buildHtmlAst", () => {
 		expect(ast.children).toHaveLength(1);
 		expect(ast.children[0].tagName).toBe("p");
 		expect(ast.children[0].children[0].tagName).toBe("b");
+	});
+
+	it("should set tagEnd to end of opening tag", () => {
+		// <script> is 8 chars; tagEnd should point right after the >
+		const src = "<script>var x = 1;</script>";
+		const ast = buildHtmlAst(src);
+		const script = ast.children[0];
+		expect(script.tagName).toBe("script");
+		expect(script.tagEnd).toBe(8); // after '<script>'
+		expect(src[script.tagEnd - 1]).toBe(">");
+	});
+
+	it("should set nameEnd to end of tag name", () => {
+		// '<div ' — nameEnd is 4, right after 'div'
+		const src = '<div class="x"></div>';
+		const ast = buildHtmlAst(src);
+		const div = ast.children[0];
+		expect(div.tagName).toBe("div");
+		expect(div.nameEnd).toBe(4); // '<div' = positions 0-3, nameEnd = 4
+		expect(src.slice(1, div.nameEnd)).toBe("div");
+	});
+
+	it("should set tagEnd and nameEnd on void elements", () => {
+		const src = '<img src="a.png">';
+		const ast = buildHtmlAst(src);
+		const img = ast.children[0];
+		expect(img.tagName).toBe("img");
+		expect(img.tagEnd).toBe(src.length);
+		expect(src.slice(1, img.nameEnd)).toBe("img");
 	});
 });
 

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigCacheTest.snap
@@ -30,6 +30,11 @@ exports[`ConfigCacheTestCases html webpack-ignore exported tests should support 
 	<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"nested-not-ignored\\">
 </div>
 
+<div>
+	<!-- webpackIgnore: true -->
+</div>
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"after-nested-comment\\">
+
 <!-- webpackIgnore: 1 -->
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
 

--- a/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/ConfigTest.snap
@@ -30,6 +30,11 @@ exports[`ConfigTestCases html webpack-ignore exported tests should support webpa
 	<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"nested-not-ignored\\">
 </div>
 
+<div>
+	<!-- webpackIgnore: true -->
+</div>
+<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"after-nested-comment\\">
+
 <!-- webpackIgnore: 1 -->
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"warning-non-boolean\\">
 

--- a/test/configCases/html/webpack-ignore/__snapshots__/warnings.snap
+++ b/test/configCases/html/webpack-ignore/__snapshots__/warnings.snap
@@ -3,7 +3,7 @@
 exports[`warnings 1`] = `
 Array [
   Object {
-    "loc": "30:0-25",
+    "loc": "35:0-25",
     "message": "\`webpackIgnore\` expected a boolean, but received: 1.",
     "moduleName": "./page.html",
   },

--- a/test/configCases/html/webpack-ignore/index.js
+++ b/test/configCases/html/webpack-ignore/index.js
@@ -13,6 +13,10 @@ it("should support webpackIgnore magic comment in html modules", () => {
 	expect(page).toMatch(
 		/<img src="[a-f0-9]+\.png" alt="nested-not-ignored">/
 	);
+	// A magic comment inside a closed element must not leak to the next sibling.
+	expect(page).toMatch(
+		/<img src="[a-f0-9]+\.png" alt="after-nested-comment">/
+	);
 	// Ignored URLs remain unchanged in the output.
 	expect(page).toContain('<img src="./ignored.png" alt="ignored">');
 	expect(page).toContain(

--- a/test/configCases/html/webpack-ignore/page.html
+++ b/test/configCases/html/webpack-ignore/page.html
@@ -27,6 +27,11 @@
 	<img src="./image.png" alt="nested-not-ignored">
 </div>
 
+<div>
+	<!-- webpackIgnore: true -->
+</div>
+<img src="./image.png" alt="after-nested-comment">
+
 <!-- webpackIgnore: 1 -->
 <img src="./image.png" alt="warning-non-boolean">
 


### PR DESCRIPTION

  <!-- Thanks for submitting a pull request! Please provide enough information so
  that others can review your pull request. -->

  **Summary**

  `HtmlParser.js` previously drove parsing via `walkHtmlTokens` callbacks, which
  required maintaining stateful deferred objects (`pendingInlineScript`,
  `pendingAttributes`) across multiple callbacks. This made the control flow hard
  to follow and extend — inline `<script>` body extraction, for example, had to be
  deferred to the `closeTag` event because the token walker decided where the
  body ended.

  This PR replaces that approach with a two-phase pipeline: `buildHtmlAst` is
  called once to produce a full AST, and `HtmlParser` then walks the tree with
  `walkNode`/`walkChildren`. Because the tree already captures element children,
  inline script content is found by iterating `node.children` directly — no
  deferred state needed. `STYLE_END_REGEXP` and `pendingInlineScript` are removed
  as a result.

  Also adds `tagEnd` (end offset of the opening tag) and `nameEnd` (end offset of
  the tag name) to `HtmlElement` nodes, which the AST walker relies on for precise
  source rewrites.

  **What kind of change does this PR introduce?**

  refactor

  **Did you add tests for your changes?**

  Yes — `test/buildHtmlAst.unittest.js` gains tests for `tagEnd`/`nameEnd` on
  regular and void elements, and all attribute quote styles. A new config test
  case `test/configCases/html/webpack-ignore/` covers the `webpackIgnore` magic
  comment path through the AST walker.

  **Does this PR introduce a breaking change?**

  No.

  **If relevant, what needs to be documented once your changes are merged or what 
  have you already documented?**

  n/a — this is an internal refactor with no user-facing API change.

  **Use of AI**
Partial