### PR TITLE
fix: render inlined export in module lib with unknown re-export

### DIFF
--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -443,6 +443,7 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 				}
 			}
 
+			// The exports of entry module are never inlined
 			const usedName =
 				/** @type {string} */
 				(exportInfo.getUsedName(originalName, chunk.runtime));

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -13,6 +13,7 @@ const Template = require("../Template");
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("../optimize/ConcatenatedModule");
+const { InlinedUsedName } = require("../optimize/InlineExports");
 const { propertyAccess } = require("../util/property");
 const { getEntryRuntime, getRuntimeKey } = require("../util/runtime");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
@@ -269,7 +270,7 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		const result = new ConcatSource(source);
 		/** @type {Set<string>} */
 		const moduleRequests = new Set();
-		/** @type {Map<string, string>} */
+		/** @type {Map<string, string | InlinedUsedName>} */
 		const unknownProvidedExports = new Map();
 
 		/**
@@ -311,10 +312,9 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 								continue;
 							}
 							const originalName = exportInfo.name;
-							// Library exports are marked canInlineUse=No, so inlining is prevented here
-							const usedName = /** @type {string | false} */ (
-								exportInfo.getUsedName(originalName, runtime)
-							);
+							const usedName =
+								/** @type {string | InlinedUsedName | false} */
+								(exportInfo.getUsedName(originalName, runtime));
 
 							if (!alreadyRenderedExports.has(originalName) && usedName) {
 								unknownProvidedExports.set(originalName, usedName);
@@ -334,7 +334,13 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		for (const [origin, used] of unknownProvidedExports) {
 			exports.push([
 				origin,
-				`${RuntimeGlobals.exports}${propertyAccess([used])}`
+				used instanceof InlinedUsedName
+					? used.render(
+							Template.toNormalComment(
+								`inlined export ${propertyAccess([origin])}`
+							)
+						)
+					: `${RuntimeGlobals.exports}${propertyAccess([used])}`
 			]);
 		}
 

--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -141,7 +141,7 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 									/** @type {ExportInfoName[]} */
 									const handledNames = [];
 									for (const exportInfo of exportsInfo.orderedExports) {
-										// Library exports are marked canInlineUse=No (in AssignLibraryPlugin)
+										// The exports of `ExternalModule` are never inlined
 										const used = /** @type {string | false} */ (
 											exportInfo.getUsedName(undefined, chunk.runtime)
 										);

--- a/test/configCases/inline-exports/module-reexport-inlined-const/a.js
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/a.js
@@ -1,0 +1,3 @@
+export * from "fs";
+export * from "./b";
+export const c = 3333333;

--- a/test/configCases/inline-exports/module-reexport-inlined-const/b.js
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/b.js
@@ -1,0 +1,1 @@
+export const b = "1";

--- a/test/configCases/inline-exports/module-reexport-inlined-const/external.mjs
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/external.mjs
@@ -1,0 +1,3 @@
+export const a = "external-a"
+export const b = "external-b"
+export const c = "external-c"

--- a/test/configCases/inline-exports/module-reexport-inlined-const/index.js
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/index.js
@@ -1,0 +1,12 @@
+export * from "./a";
+import fs from "fs";
+import path from "path";
+
+const generated = /** @type {string} */ (fs.readFileSync(__filename, "utf-8"));
+
+it("should render inlined re-exported const as a literal in the library surface", () => {
+	expect(generated).not.toMatch(/\{"value":\{"kind":/);
+	expect(generated).toMatch(
+		/export const b = \(\/\* inlined export \.b \*\/"1"\);/
+	);
+});

--- a/test/configCases/inline-exports/module-reexport-inlined-const/test.js
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/test.js
@@ -1,0 +1,1 @@
+export * from "./a";

--- a/test/configCases/inline-exports/module-reexport-inlined-const/webpack.config.js
+++ b/test/configCases/inline-exports/module-reexport-inlined-const/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "production",
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		}
+	},
+	experiments: {
+		outputModule: true
+	},
+	externals: {
+		external: "./external.mjs"
+	},
+	optimization: {
+		concatenateModules: true,
+		inlineExports: true,
+		minimize: false
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-webpack-plugin",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(
+								path.resolve(__dirname, "./external.mjs")
+							);
+							compilation.emitAsset(
+								"external.mjs",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem
 does the pull request solve? -->

**What kind of change does this PR introduce?**

Follow-up of https://github.com/webpack/webpack/pull/20973.

When output module library, the entry module have both unknown reexport and known exports which were inlined, we should render the inlined value directly.


**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or
what have you already documented?**

n/a

**Use of AI**

Partial