### PR TITLE
test: try to stable memory benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,6 +61,8 @@ jobs:
   benchmark-memory:
     strategy:
       fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -98,3 +100,4 @@ jobs:
         env:
           LAST_COMMIT: 1
           NEGATIVE_FILTER: on-schedule
+          SHARD: ${{ matrix.shard }}

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -692,6 +692,26 @@ const withCodSpeed = async (bench) => {
 			await bench.teardown?.(task, "run");
 
 			logTaskCompletion(uri, taskCompletionMessage());
+
+			// Release the just-measured task's closure-captured refs
+			// (webpack, config, watching, originalEntryContent) so the next
+			// task's measurement starts from a smaller heap. In memory mode
+			// every task shares one process, so without this drop each task's
+			// sample includes residue from every prior task and is sensitive
+			// to registration order. The drain mirrors the pre-measurement
+			// pattern: gc -> microtask three times, then setImmediate, then
+			// one final gc to sweep what finalizers / IO callbacks produced.
+			uriMap.delete(name);
+			for (let i = 0; i < 3; i++) {
+				global.gc?.();
+				await new Promise((resolve) => {
+					queueMicrotask(() => resolve(undefined));
+				});
+			}
+			await new Promise((resolve) => {
+				setImmediate(resolve);
+			});
+			global.gc?.();
 		};
 
 		/**
@@ -776,6 +796,14 @@ const withCodSpeed = async (bench) => {
 			bench.teardown?.(task, "run");
 
 			logTaskCompletion(uri, taskCompletionMessage());
+
+			// Release the just-measured task's closures — see the async path
+			// for the rationale. The sync path has no microtask queue to
+			// drain, so we just chain GCs.
+			uriMap.delete(name);
+			for (let i = 0; i < 4; i++) {
+				global.gc?.();
+			}
 		};
 
 		/**


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem
 does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The CodSpeed memory job reports large swings (±20–95% on rebuild scenarios)
across PRs that touch no allocation-rate code, because all ~28 tasks share
one Node process and each measured task inherits the prior tasks' retained
closures (`webpack`, the unique `config`, `watching`, `originalEntryContent`,
 `next`) plus their old-gen residue. This PR shards the memory job 4-ways
(matching the simulation job) and drops each task's closure-captured refs
right after measurement so the next task starts from a smaller, more
deterministic heap.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert,
 docs or describe it if you did not find a suitable kind of change. -->

ci.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge
your changes unless you add tests. -->

No — this only touches the benchmark harness and CI workflow; the existing
CodSpeed runs validate stability.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and
a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or
what have you already documented?**

<!-- List all the information that needs to be added to the documentation
after merge that has already been documented in this PR. -->

n/a.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy
(https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull
Request may be closed due to irresponsible use of AI. -->

Yes.