### PR TITLE
Fix global library exports for array entries

### DIFF
--- a/.changeset/global-library-array-entries.md
+++ b/.changeset/global-library-array-entries.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix global library exports for array entries.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -287,6 +287,11 @@ module.exports.makeNamespaceObject = "__webpack_require__.r";
 module.exports.makeOptimizedDeferredNamespaceObject = "__webpack_require__.zO";
 
 /**
+ * entry modules should merge exports into the same exports object
+ */
+module.exports.mergeEntryExports = "merge-entry-exports";
+
+/**
  * the internal module object
  */
 module.exports.module = "module";

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1115,6 +1115,9 @@ class JavascriptModulesPlugin {
 			/** @type {Map<Module, Source> | false} */
 			let renamedInlinedModule = false;
 			let inlinedInIIFE = false;
+			const mergeEntryExports = runtimeRequirements.has(
+				RuntimeGlobals.mergeEntryExports
+			);
 
 			if (avoidEntryIife) {
 				renamedInlinedModule = this._getRenamedInlineModule(
@@ -1189,13 +1192,17 @@ class JavascriptModulesPlugin {
 						footer = "\n";
 					}
 					if (exports) {
-						if (m !== lastInlinedModule) {
+						if (m.exportsArgument !== RuntimeGlobals.exports) {
+							startupSource.add(
+								`${runtimeTemplate.renderLet()} ${m.exportsArgument} = ${
+									m !== lastInlinedModule && !mergeEntryExports
+										? "{}"
+										: RuntimeGlobals.exports
+								};\n`
+							);
+						} else if (m !== lastInlinedModule && !mergeEntryExports) {
 							startupSource.add(
 								`${runtimeTemplate.renderLet()} ${m.exportsArgument} = {};\n`
-							);
-						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
-							startupSource.add(
-								`${runtimeTemplate.renderLet()} ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
 							);
 						}
 					}
@@ -1482,6 +1489,20 @@ class JavascriptModulesPlugin {
 				const runtimeRequirements =
 					chunkGraph.getTreeRuntimeRequirements(chunk);
 				buf2.push("// Load entry module and return exports");
+				const mergeEntryExports = runtimeRequirements.has(
+					RuntimeGlobals.mergeEntryExports
+				);
+				const exportsDecl = runtimeTemplate.renderLet();
+				if (mergeEntryExports) {
+					buf2.push(`${exportsDecl} ${RuntimeGlobals.exports} = {};`);
+				}
+
+				/** @type {(exportsExpression: string) => string[]} */
+				const mergeEntryExportsCode = (exportsExpression) => [
+					`var __webpack_entry_exports__ = ${exportsExpression};`,
+					`for(var __webpack_i__ in __webpack_entry_exports__) ${RuntimeGlobals.exports}[__webpack_i__] = __webpack_entry_exports__[__webpack_i__];`,
+					`if(__webpack_entry_exports__.__esModule) Object.defineProperty(${RuntimeGlobals.exports}, "__esModule", { value: true });`
+				];
 
 				/** @type {EntryModuleWithChunkGroup[]} */
 				const jsEntries = [];
@@ -1593,25 +1614,40 @@ class JavascriptModulesPlugin {
 					// value), or by other downstream codegen. Always declare
 					// with `let` (or `var` if `let` is unsupported) so
 					// reassignment is allowed.
-					const exportsDecl = runtimeTemplate.renderLet();
 					if (chunks.length > 0) {
+						const exportsExpression = `${
+							RuntimeGlobals.onChunksLoaded
+						}(undefined, ${JSON.stringify(
+							chunks.map((c) => c.id)
+						)}, ${runtimeTemplate.returningFunction(
+							`${RuntimeGlobals.require}(${moduleIdExpr})`
+						)})`;
 						buf2.push(
-							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.onChunksLoaded
-							}(undefined, ${JSON.stringify(
-								chunks.map((c) => c.id)
-							)}, ${runtimeTemplate.returningFunction(
-								`${RuntimeGlobals.require}(${moduleIdExpr})`
-							)})`
+							...(mergeEntryExports
+								? mergeEntryExportsCode(exportsExpression)
+								: [
+										`${
+											i === 0
+												? `${exportsDecl} ${RuntimeGlobals.exports} = `
+												: ""
+										}${exportsExpression}`
+									])
 						);
 					} else if (useRequire) {
+						const exportsExpression = `${RuntimeGlobals.require}(${moduleIdExpr})`;
 						buf2.push(
-							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.require
-							}(${moduleIdExpr});`
+							...(mergeEntryExports
+								? mergeEntryExportsCode(exportsExpression)
+								: [
+										`${
+											i === 0
+												? `${exportsDecl} ${RuntimeGlobals.exports} = `
+												: ""
+										}${exportsExpression};`
+									])
 						);
 					} else {
-						if (i === 0) {
+						if (i === 0 && !mergeEntryExports) {
 							buf2.push(`${exportsDecl} ${RuntimeGlobals.exports} = {};`);
 						}
 						const needThisAsExports = entryRuntimeRequirements.has(
@@ -1624,7 +1660,8 @@ class JavascriptModulesPlugin {
 							requireScopeUsed ||
 							entryRuntimeRequirements.has(RuntimeGlobals.exports)
 						) {
-							const exportsArg = i === 0 ? RuntimeGlobals.exports : "{}";
+							const exportsArg =
+								i === 0 || mergeEntryExports ? RuntimeGlobals.exports : "{}";
 							args.push("0", exportsArg);
 							if (requireScopeUsed) {
 								args.push(RuntimeGlobals.require);

--- a/lib/library/AbstractLibraryPlugin.js
+++ b/lib/library/AbstractLibraryPlugin.js
@@ -84,8 +84,10 @@ class AbstractLibraryPlugin {
 								: compilation.outputOptions.library
 						);
 						if (options !== false) {
-							const dep = deps[deps.length - 1];
-							if (dep) {
+							const entryDeps = this.shouldProcessAllEntryModules(options)
+								? deps
+								: deps.slice(-1);
+							for (const dep of entryDeps) {
 								const module = compilation.moduleGraph.getModule(dep);
 								if (module) {
 									this.finishEntryModule(module, name, {
@@ -252,6 +254,15 @@ class AbstractLibraryPlugin {
 		const AbstractMethodError = require("../errors/AbstractMethodError");
 
 		throw new AbstractMethodError();
+	}
+
+	/**
+	 * Returns true when every entry dependency should be handled as a library entry.
+	 * @param {T} options preprocessed library options
+	 * @returns {boolean} true, when all entry modules should be processed
+	 */
+	shouldProcessAllEntryModules(options) {
+		return false;
 	}
 
 	/**

--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -170,6 +170,18 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 	}
 
 	/**
+	 * Returns true when every entry dependency should be handled as a library entry.
+	 * @param {T} options preprocessed library options
+	 * @returns {boolean} true, when all entry modules should be processed
+	 */
+	shouldProcessAllEntryModules(options) {
+		return (
+			this.unnamed === "static" ||
+			(options.name ? this.named === "copy" : this.unnamed === "copy")
+		);
+	}
+
+	/**
 	 * Finish entry module.
 	 * @param {Module} module the exporting entry module
 	 * @param {string} entryName the name of the entrypoint
@@ -428,8 +440,14 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 	 * @param {LibraryContext<T>} libraryContext context
 	 * @returns {void}
 	 */
-	runtimeRequirements(chunk, set, libraryContext) {
+	runtimeRequirements(chunk, set, { options }) {
 		set.add(RuntimeGlobals.exports);
+		if (
+			this.unnamed === "static" ||
+			(options.name ? this.named === "copy" : this.unnamed === "copy")
+		) {
+			set.add(RuntimeGlobals.mergeEntryExports);
+		}
 	}
 
 	/**

--- a/test/configCases/library/global-multi-entry/a.js
+++ b/test/configCases/library/global-multi-entry/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/configCases/library/global-multi-entry/b.js
+++ b/test/configCases/library/global-multi-entry/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/library/global-multi-entry/index.js
+++ b/test/configCases/library/global-multi-entry/index.js
@@ -1,0 +1,13 @@
+it("should expose exports from all entry modules", function (done) {
+	setTimeout(function () {
+		expect(global.a).toBe("a");
+		expect(global.b).toBe("b");
+		expect(global.c).toBe("c");
+		delete global.a;
+		delete global.b;
+		delete global.c;
+		done();
+	}, 1);
+});
+
+export const c = "c";

--- a/test/configCases/library/global-multi-entry/webpack.config.js
+++ b/test/configCases/library/global-multi-entry/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: ["./a.js", "./b.js", "./index.js"],
+	output: {
+		libraryTarget: "global"
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -146,6 +146,11 @@ declare class AbstractLibraryPlugin<T> {
 	parseOptions(library: LibraryOptions): T;
 
 	/**
+	 * Returns true when every entry dependency should be handled as a library entry.
+	 */
+	shouldProcessAllEntryModules(options: T): boolean;
+
+	/**
 	 * Finish entry module.
 	 */
 	finishEntryModule(
@@ -25566,6 +25571,7 @@ declare namespace exports {
 		export let makeDeferredNamespaceObject: "__webpack_require__.z";
 		export let makeNamespaceObject: "__webpack_require__.r";
 		export let makeOptimizedDeferredNamespaceObject: "__webpack_require__.zO";
+		export let mergeEntryExports: "merge-entry-exports";
 		export let module: "module";
 		export let moduleCache: "__webpack_require__.c";
 		export let moduleFactories: "__webpack_require__.m";


### PR DESCRIPTION
﻿<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #15936. Array entries with unnamed global library output now merge each entry module's exports before copying them to the global target.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, `test/configCases/library/global-multi-entry` covers unnamed global library output from multiple entry modules.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI assistance was used to inspect the issue, draft the patch, and run the local validation commands recorded here.
