### PR TITLE
ci: trigger webpack-doc-kit release workflow on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,15 +55,20 @@ jobs:
     steps:
       - name: Trigger webpack-doc-kit release
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        env:
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
         with:
           github-token: ${{ secrets.DISPATCH_TOKEN }}
           script: |
+            const packages = JSON.parse(process.env.PUBLISHED_PACKAGES);
+            const pkg = packages.find(p => p.name === "webpack");
+            if (!pkg) throw new Error("webpack package not found in published packages");
             await github.rest.actions.createWorkflowDispatch({
               owner: "webpack",
               repo: "webpack-doc-kit",
               workflow_id: "release.yml",
               ref: "main",
               inputs: {
-                tag: "v" + ${{ needs.release.outputs.publishedPackages }}[0].version,
+                tag: "v" + pkg.version,
               },
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -46,3 +47,23 @@ jobs:
     if: needs.release.outputs.published == 'true'
     uses: ./.github/workflows/release-announcement.yml
     secrets: inherit
+
+  trigger-webpack-doc-kit:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger webpack-doc-kit release
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          github-token: ${{ secrets.DISPATCH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: "webpack",
+              repo: "webpack-doc-kit",
+              workflow_id: "release.yml",
+              ref: "main",
+              inputs: {
+                tag: "v" + ${{ needs.release.outputs.publishedPackages }}[0].version,
+              },
+            });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

After each webpack release, automatically trigger the webpack-doc-kit release workflow so documentation stays in sync .

**What kind of change does this PR introduce?**

CI

**Did you add tests for your changes?**

No, this is a CI workflow change.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

NA

**Use of AI**

No