### PR TITLE
ci: pin test262 job to Node.js 26.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "latest"
+          # Pinned; revert to "latest" once https://github.com/nodejs/node/issues/63715 is resolved
+          node-version: "26.2.0"
           cache: yarn
 
       - run: yarn --frozen-lockfile


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The test262 CI job ran on Node.js `latest`, which currently breaks due to https://github.com/nodejs/node/issues/63715. This pins the job to Node.js `26.2.0` to keep CI green, with a comment to revert once the upstream issue is resolved.

**What kind of change does this PR introduce?**

ci

**Did you add tests for your changes?**

n/a

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes