### PR TITLE
test: re-enable passing top-level-await import resolution test262 cases

### DIFF
--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1082,9 +1082,7 @@ const knownBugs = [
 	"module-code/top-level-await/module-import-rejection.js",
 	"module-code/top-level-await/module-import-rejection-body.js",
 	"module-code/top-level-await/await-dynamic-import-rejection.js",
-	"module-code/top-level-await/module-import-rejection-tick.js",
-	"module-code/top-level-await/module-import-resolution.js",
-	"module-code/top-level-await/module-import-unwrapped.js"
+	"module-code/top-level-await/module-import-rejection-tick.js"
 ];
 
 const knownProductionBuildBugs = [


### PR DESCRIPTION
module-import-resolution.js and module-import-unwrapped.js no longer hit
the unhandled-rejection limitation that affects the sibling rejection
tests; they now pass in both development and production, so drop them
from the knownBugs skip list.

https://claude.ai/code/session_01TmfUF7GPwhxx4yLTdt9FtF