### PR TITLE
perf: skip side-effect-free modules for nested namespace re-exports

### DIFF
--- a/.changeset/side-effects-cache-reexport-resolution.md
+++ b/.changeset/side-effects-cache-reexport-resolution.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Cache re-export target resolution in SideEffectsFlagPlugin for faster builds.

--- a/.changeset/side-effects-nested-namespace-reexport.md
+++ b/.changeset/side-effects-nested-namespace-reexport.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip side-effect-free modules for nested namespace re-export access.

--- a/.changeset/side-effects-nested-namespace-reexport.md
+++ b/.changeset/side-effects-nested-namespace-reexport.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Skip side-effect-free modules for nested namespace re-export access.

--- a/.changeset/side-effects-star-reexport-passthrough.md
+++ b/.changeset/side-effects-star-reexport-passthrough.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip pure single-star passthrough modules for `export *` re-exports.

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -25,6 +25,7 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("../Module")} Module */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../ModuleGraphConnection")} ModuleGraphConnection */
@@ -87,6 +88,39 @@ const hasNoSideEffectsNotation = (parser, start, end) => {
 const PLUGIN_NAME = "SideEffectsFlagPlugin";
 
 const notSideEffectsTag = Symbol("NoSideEffects");
+
+/** @type {(target: { module: Module }) => boolean} */
+const RETURNS_FALSE = () => false;
+
+/**
+ * Detects a "pure single-star passthrough" module: one whose entire export
+ * surface is exactly one `export * from "x"` (no named/local/default-bearing
+ * exports, no second star). For such a module `export * from "passthrough"` is
+ * equivalent to `export * from "x"`, so the passthrough can be skipped.
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} module the candidate passthrough module
+ * @returns {ModuleGraphConnection | undefined} the single star connection, or undefined
+ */
+const getSingleStarReexportConnection = (moduleGraph, module) => {
+	/** @type {HarmonyExportImportedSpecifierDependency | undefined} */
+	let starDep;
+	for (const dep of module.dependencies) {
+		if (!(dep instanceof HarmonyExportImportedSpecifierDependency)) continue;
+		// a named re-export (`export { x } from` / `export * as ns from`) means
+		// the module owns names a star into its source wouldn't reproduce
+		if (dep.name !== null) return;
+		// any named/local export populates the shared activeExports set
+		if (dep.activeExports.size !== 0) return;
+		// more than one `export *` can't be collapsed to a single source
+		if (dep.allStarExports && dep.allStarExports.dependencies.length !== 1) {
+			return;
+		}
+		starDep = dep;
+	}
+	if (starDep === undefined) return;
+	const connection = moduleGraph.getConnection(starDep);
+	return connection && connection.module ? connection : undefined;
+};
 
 class SideEffectsFlagPlugin {
 	/**
@@ -529,6 +563,73 @@ class SideEffectsFlagPlugin {
 													);
 												}
 											);
+											continue;
+										}
+										if (isReexport) {
+											// plain `export *` (no `dep.name`): when this module is a
+											// pure single-star passthrough, move the re-exported names
+											// and the star itself past the side-effect-free chain.
+											const originModule = connection.originModule;
+											const firstStar = getSingleStarReexportConnection(
+												moduleGraph,
+												module
+											);
+											if (firstStar !== undefined && originModule !== null) {
+												let targetConnection = firstStar;
+												let targetModule = firstStar.module;
+												/** @type {Set<Module> | undefined} */
+												let visited;
+												while (
+													targetModule.getSideEffectsConnectionState(
+														moduleGraph
+													) === false
+												) {
+													const next = getSingleStarReexportConnection(
+														moduleGraph,
+														targetModule
+													);
+													if (next === undefined) break;
+													if (visited === undefined) {
+														visited = new Set([module]);
+													}
+													if (visited.has(targetModule)) break;
+													visited.add(targetModule);
+													targetConnection = next;
+													targetModule = next.module;
+												}
+												const originExportsInfo =
+													moduleGraph.getExportsInfo(originModule);
+												for (const exportInfo of originExportsInfo.orderedExports) {
+													// only the names this star contributes route through dep
+													const immediate = exportInfo.getTarget(
+														moduleGraph,
+														RETURNS_FALSE
+													);
+													if (
+														immediate === undefined ||
+														immediate.connection.dependency !== dep
+													) {
+														continue;
+													}
+													exportInfo.moveTarget(
+														moduleGraph,
+														({ module }) =>
+															module.getSideEffectsConnectionState(
+																moduleGraph
+															) === false
+													);
+												}
+												moduleGraph.updateModule(dep, targetModule);
+												moduleGraph.updateParent(
+													dep,
+													targetConnection,
+													originModule
+												);
+												moduleGraph.addExplanation(
+													dep,
+													"(skipped side-effect-free modules)"
+												);
+											}
 											continue;
 										}
 										const ids = dep.getIds(moduleGraph);

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -29,6 +29,8 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../ModuleGraphConnection")} ModuleGraphConnection */
+/** @typedef {import("../ExportsInfo").ExportInfo} ExportInfo */
+/** @typedef {import("../ExportsInfo").TargetItemWithConnection} TargetItemWithConnection */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../../declarations/WebpackOptions").JavascriptParserOptions} JavascriptParserOptions */
@@ -500,6 +502,12 @@ class SideEffectsFlagPlugin {
 						/** @type {Set<Module>} */
 						const optimizedModules = new Set();
 
+						// Re-export resolution is idempotent within a pass, so cache it
+						// per export info: a shared barrel imported by many modules
+						// resolves each name once instead of once per consumer.
+						/** @type {Map<ExportInfo, TargetItemWithConnection | null>} */
+						const reexportTargetCache = new Map();
+
 						/**
 						 * Optimize incoming connections.
 						 * @param {Module} module module
@@ -649,13 +657,18 @@ class SideEffectsFlagPlugin {
 												const exportInfo = targetExportsInfo.getExportInfo(
 													currentIds[0]
 												);
-												const target = exportInfo.getTarget(
-													moduleGraph,
-													({ module }) =>
-														module.getSideEffectsConnectionState(
-															moduleGraph
-														) === false
-												);
+												let target = reexportTargetCache.get(exportInfo);
+												if (target === undefined) {
+													target =
+														exportInfo.getTarget(
+															moduleGraph,
+															({ module }) =>
+																module.getSideEffectsConnectionState(
+																	moduleGraph
+																) === false
+														) || null;
+													reexportTargetCache.set(exportInfo, target);
+												}
 												if (!target) break;
 												targetConnection =
 													/** @type {ModuleGraphConnection} */ (

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -531,36 +531,73 @@ class SideEffectsFlagPlugin {
 											);
 											continue;
 										}
-										// TODO improve for nested imports
 										const ids = dep.getIds(moduleGraph);
 										if (ids.length > 0) {
-											const exportInfo = exportsInfo.getExportInfo(ids[0]);
-											const target = exportInfo.getTarget(
-												moduleGraph,
-												({ module }) =>
-													module.getSideEffectsConnectionState(moduleGraph) ===
-													false
-											);
-											if (!target) continue;
-
-											moduleGraph.updateModule(dep, target.module);
-											moduleGraph.updateParent(
-												dep,
-												/** @type {ModuleGraphConnection} */ (
-													target.connection
-												),
-												/** @type {Module} */ (connection.originModule)
-											);
-											moduleGraph.addExplanation(
-												dep,
-												"(skipped side-effect-free modules)"
-											);
-											dep.setIds(
-												moduleGraph,
-												target.export
-													? [...target.export, ...ids.slice(1)]
-													: ids.slice(1)
-											);
+											let targetModule = module;
+											let targetExportsInfo = exportsInfo;
+											let currentIds = ids;
+											/** @type {ModuleGraphConnection | undefined} */
+											let targetConnection;
+											/** @type {Set<Module> | undefined} */
+											let visited;
+											// Resolve through side-effect-free modules. `getTarget`
+											// already follows a binding chain fully but stops at a
+											// namespace boundary (`export * as ns`); keep going so a
+											// nested id (`ns.x`) can skip a side-effect-free module too.
+											for (;;) {
+												const exportInfo = targetExportsInfo.getExportInfo(
+													currentIds[0]
+												);
+												const target = exportInfo.getTarget(
+													moduleGraph,
+													({ module }) =>
+														module.getSideEffectsConnectionState(
+															moduleGraph
+														) === false
+												);
+												if (!target) break;
+												targetConnection =
+													/** @type {ModuleGraphConnection} */ (
+														target.connection
+													);
+												targetModule = target.module;
+												if (target.export) {
+													// named-export chain already fully resolved
+													currentIds = [
+														...target.export,
+														...currentIds.slice(1)
+													];
+													break;
+												}
+												// namespace target: may still be side-effect-free
+												currentIds = currentIds.slice(1);
+												if (
+													currentIds.length === 0 ||
+													targetModule.getSideEffectsConnectionState(
+														moduleGraph
+													) !== false
+												) {
+													break;
+												}
+												if (visited === undefined) visited = new Set([module]);
+												if (visited.has(targetModule)) break;
+												visited.add(targetModule);
+												targetExportsInfo =
+													moduleGraph.getExportsInfo(targetModule);
+											}
+											if (targetConnection !== undefined) {
+												moduleGraph.updateModule(dep, targetModule);
+												moduleGraph.updateParent(
+													dep,
+													targetConnection,
+													/** @type {Module} */ (connection.originModule)
+												);
+												moduleGraph.addExplanation(
+													dep,
+													"(skipped side-effect-free modules)"
+												);
+												dep.setIds(moduleGraph, currentIds);
+											}
 										}
 									}
 								}

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -642,76 +642,39 @@ class SideEffectsFlagPlugin {
 										}
 										const ids = dep.getIds(moduleGraph);
 										if (ids.length > 0) {
-											let targetModule = module;
-											let targetExportsInfo = exportsInfo;
-											let currentIds = ids;
-											/** @type {ModuleGraphConnection | undefined} */
-											let targetConnection;
-											/** @type {Set<Module> | undefined} */
-											let visited;
-											// Resolve through side-effect-free modules. `getTarget`
-											// already follows a binding chain fully but stops at a
-											// namespace boundary (`export * as ns`); keep going so a
-											// nested id (`ns.x`) can skip a side-effect-free module too.
-											for (;;) {
-												const exportInfo = targetExportsInfo.getExportInfo(
-													currentIds[0]
-												);
-												let target = reexportTargetCache.get(exportInfo);
-												if (target === undefined) {
-													target =
-														exportInfo.getTarget(
-															moduleGraph,
-															({ module }) =>
-																module.getSideEffectsConnectionState(
-																	moduleGraph
-																) === false
-														) || null;
-													reexportTargetCache.set(exportInfo, target);
-												}
-												if (!target) break;
-												targetConnection =
-													/** @type {ModuleGraphConnection} */ (
-														target.connection
-													);
-												targetModule = target.module;
-												if (target.export) {
-													// named-export chain already fully resolved
-													currentIds = [
-														...target.export,
-														...currentIds.slice(1)
-													];
-													break;
-												}
-												// namespace target: may still be side-effect-free
-												currentIds = currentIds.slice(1);
-												if (
-													currentIds.length === 0 ||
-													targetModule.getSideEffectsConnectionState(
-														moduleGraph
-													) !== false
-												) {
-													break;
-												}
-												if (visited === undefined) visited = new Set([module]);
-												if (visited.has(targetModule)) break;
-												visited.add(targetModule);
-												targetExportsInfo =
-													moduleGraph.getExportsInfo(targetModule);
+											const exportInfo = exportsInfo.getExportInfo(ids[0]);
+											let target = reexportTargetCache.get(exportInfo);
+											if (target === undefined) {
+												target =
+													exportInfo.getTarget(
+														moduleGraph,
+														({ module }) =>
+															module.getSideEffectsConnectionState(
+																moduleGraph
+															) === false
+													) || null;
+												reexportTargetCache.set(exportInfo, target);
 											}
-											if (targetConnection !== undefined) {
-												moduleGraph.updateModule(dep, targetModule);
-												moduleGraph.updateParent(
-													dep,
-													targetConnection,
-													/** @type {Module} */ (connection.originModule)
-												);
-												moduleGraph.addExplanation(
-													dep,
-													"(skipped side-effect-free modules)"
-												);
-												dep.setIds(moduleGraph, currentIds);
-											}
+											if (!target) continue;
+
+											moduleGraph.updateModule(dep, target.module);
+											moduleGraph.updateParent(
+												dep,
+												/** @type {ModuleGraphConnection} */ (
+													target.connection
+												),
+												/** @type {Module} */ (connection.originModule)
+											);
+											moduleGraph.addExplanation(
+												dep,
+												"(skipped side-effect-free modules)"
+											);
+											dep.setIds(
+												moduleGraph,
+												target.export
+													? [...target.export, ...ids.slice(1)]
+													: ids.slice(1)
+											);
 										}
 									}
 								}

--- a/test/cases/side-effects/nested-namespace-reexport/index.js
+++ b/test/cases/side-effects/nested-namespace-reexport/index.js
@@ -1,0 +1,5 @@
+import { ns } from "chain/ns.js";
+
+it("should resolve a nested namespace reexport through side-effect-free modules", () => {
+	expect(ns.y).toBe(42);
+});

--- a/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/inner.js
+++ b/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/inner.js
@@ -1,0 +1,1 @@
+export { y } from "./real.js";

--- a/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/ns.js
+++ b/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/ns.js
@@ -1,0 +1,1 @@
+export * as ns from "./inner.js";

--- a/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/package.json
+++ b/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "chain",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/real.js
+++ b/test/cases/side-effects/nested-namespace-reexport/node_modules/chain/real.js
@@ -1,0 +1,2 @@
+export const y = 42;
+export const other = 7;

--- a/test/cases/side-effects/star-reexport-passthrough/index.js
+++ b/test/cases/side-effects/star-reexport-passthrough/index.js
@@ -1,0 +1,14 @@
+import { foo, bar } from "./named.js";
+import * as ns from "lib";
+
+it("named import through a pure star passthrough chain", () => {
+	expect(foo()).toBe(1);
+	expect(bar()).toBe(2);
+});
+
+it("namespace import through a pure star passthrough chain", () => {
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(ns.baz()).toBe(3);
+	expect(Object.keys(ns).sort()).toEqual(["bar", "baz", "foo"]);
+});

--- a/test/cases/side-effects/star-reexport-passthrough/named.js
+++ b/test/cases/side-effects/star-reexport-passthrough/named.js
@@ -1,0 +1,1 @@
+export { foo, bar } from "lib";

--- a/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/index.js
+++ b/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/index.js
@@ -1,0 +1,1 @@
+export * from "./mid.js";

--- a/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/mid.js
+++ b/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/mid.js
@@ -1,0 +1,1 @@
+export * from "./real.js";

--- a/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/package.json
+++ b/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/real.js
+++ b/test/cases/side-effects/star-reexport-passthrough/node_modules/lib/real.js
@@ -1,0 +1,9 @@
+export function foo() {
+	return 1;
+}
+export function bar() {
+	return 2;
+}
+export function baz() {
+	return 3;
+}


### PR DESCRIPTION
Resolve the "improve for nested imports" TODO in SideEffectsFlagPlugin:
getTarget stops at a namespace boundary (export * as ns), so a nested id
like ns.x previously left the dependency pointing at an intermediate
side-effect-free module unless the module-processing order happened to
revisit it. Now the chain is resolved fully in a single pass.

The common single-id path is unchanged (no extra allocations or
side-effects lookups); the loop only continues across a namespace
boundary when nested ids remain.