### PR TITLE
fix: dedup symlink targets in FileSystemInfo context-hash walk

### DIFF
--- a/.changeset/dedup-context-symlink-walk.md
+++ b/.changeset/dedup-context-symlink-walk.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip already-visited symlink targets when resolving context hashes so cyclic symlink graphs no longer overflow the queue.

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -3875,6 +3875,8 @@ class FileSystemInfo {
 		/** @type {string[]} */
 		const hashes = [];
 		let safeTime = 0;
+		// Skip already-visited symlink targets so cyclic pnpm/peer-variant graphs terminate (#21084).
+		const seen = new Set(entry.symlinks);
 		processAsyncTree(
 			/** @type {NonNullable<ContextHash["symlinks"]>} */ (entry.symlinks),
 			10,
@@ -3887,7 +3889,12 @@ class FileSystemInfo {
 							safeTime = Math.max(safeTime, entry.safeTime);
 						}
 						if (entry.symlinks !== undefined) {
-							for (const target of entry.symlinks) push(target);
+							for (const target of entry.symlinks) {
+								if (!seen.has(target)) {
+									seen.add(target);
+									push(target);
+								}
+							}
 						}
 					}
 					callback();
@@ -3997,6 +4004,8 @@ class FileSystemInfo {
 	_resolveContextHash(entry, callback) {
 		/** @type {string[]} */
 		const hashes = [];
+		// Skip already-visited symlink targets so cyclic pnpm/peer-variant graphs terminate (#21084).
+		const seen = new Set(entry.symlinks);
 		processAsyncTree(
 			/** @type {NonNullable<ContextHash["symlinks"]>} */ (entry.symlinks),
 			10,
@@ -4006,7 +4015,12 @@ class FileSystemInfo {
 					if (hash) {
 						hashes.push(hash.hash);
 						if (hash.symlinks !== undefined) {
-							for (const target of hash.symlinks) push(target);
+							for (const target of hash.symlinks) {
+								if (!seen.has(target)) {
+									seen.add(target);
+									push(target);
+								}
+							}
 						}
 					}
 					callback();
@@ -4170,6 +4184,8 @@ class FileSystemInfo {
 		/** @type {string[]} */
 		const tsHashes = [];
 		let safeTime = 0;
+		// Skip already-visited symlink targets so cyclic pnpm/peer-variant graphs terminate (#21084).
+		const seen = new Set(entry.symlinks);
 		processAsyncTree(
 			/** @type {NonNullable<ContextHash["symlinks"]>} */ (entry.symlinks),
 			10,
@@ -4183,7 +4199,12 @@ class FileSystemInfo {
 							safeTime = Math.max(safeTime, entry.safeTime);
 						}
 						if (entry.symlinks !== undefined) {
-							for (const target of entry.symlinks) push(target);
+							for (const target of entry.symlinks) {
+								if (!seen.has(target)) {
+									seen.add(target);
+									push(target);
+								}
+							}
 						}
 					}
 					callback();

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -499,6 +499,28 @@ ${details(snapshot)}`)
 				}
 			);
 		});
+
+		// #21084: a cyclic symlink graph (e.g. pnpm peer-variant back-edges) used
+		// to re-push already-visited targets forever, overflowing the context
+		// queue. The walk must visit each target once and terminate.
+		it("should terminate on a cyclic symlink graph", (done) => {
+			const fs = createFs();
+			fs.mkdirSync("/path/cycle/a", { recursive: true });
+			fs.mkdirSync("/path/cycle/b", { recursive: true });
+			fs.writeFileSync("/path/cycle/a/file.txt", "Hello A");
+			fs.writeFileSync("/path/cycle/b/file.txt", "Hello B");
+			// Relative targets, matching pnpm's symlink layout, so they resolve
+			// back into the cycle instead of being mangled by `join`.
+			fs.symlinkSync("../b", "/path/cycle/a/link", "dir");
+			fs.symlinkSync("../a", "/path/cycle/b/link", "dir");
+
+			const fsInfo = createFsInfo(fs);
+			fsInfo.getContextHash("/path/cycle/a", (err, hash) => {
+				if (err) return done(err);
+				expect(typeof hash).toBe("string");
+				done();
+			});
+		});
 	});
 
 	// Reproduces the type-lie discussed in webpack/webpack#16886:


### PR DESCRIPTION
Cyclic symlink graphs (pnpm peer-variant back-edges) caused the context
resolution queue in processAsyncTree to re-push already-visited targets
indefinitely, overflowing V8's array limit (RangeError: Invalid array length).

Add a per-walk visited Set keyed on the target path in _resolveContextTimestamp,
_resolveContextHash, and _resolveContextTsh so each real directory is visited at
most once and the walk terminates. Closes #21084.