### PR TITLE
perf: guard isDeferred() behind experiments.deferImport in ConcatenatedModule

### DIFF
--- a/.changeset/good-flies-say.md
+++ b/.changeset/good-flies-say.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+perf: guard isDeferred() behind experiments.deferImport in ConcatenatedModule

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2355,7 +2355,7 @@ ${defineGetters}`
 							interopNamespaceObject2Name: undefined,
 							interopDefaultAccessUsed: false,
 							interopDefaultAccessName: undefined,
-							deferred: moduleGraph.isDeferred(info.module),
+							deferred: this.compilation.options.experiments.deferImport ? moduleGraph.isDeferred(info.module) : false,
 							deferredNamespaceObjectName: undefined,
 							deferredNamespaceObjectUsed: false
 						};
@@ -2406,7 +2406,8 @@ ${defineGetters}`
 						`${chunkGraph.getModuleId(info.module)}|${runtimeConditionToString(
 							info.runtimeCondition
 						)}|${info.nonDeferAccess ? "1" : "0"}|${
-							chunkGraph.moduleGraph.isDeferred(info.module) ? "1" : "0"
+							(this.compilation.options.experiments.deferImport &&
+								chunkGraph.moduleGraph.isDeferred(info.module)) ? "1" : "0"
 						}`
 					);
 					break;


### PR DESCRIPTION
## perf: guard `isDeferred()` behind `experiments.deferImport` in `ConcatenatedModule`

### What this PR does

Adds a missing guard around two `moduleGraph.isDeferred()` calls in `ConcatenatedModule` so they are skipped entirely when `experiments.deferImport` is not enabled — which is the default for every webpack project.

---

### Background

We run a large Next.js monorepo with ~10 Module Federation remotes. Each remote is registered via `ContainerReferencePlugin` → `ExternalsPlugin`, which creates an `ExternalModule` per remote in the webpack module graph.

During a production build, `ModuleConcatenationPlugin` scope-hoists modules into `ConcatenatedModule` instances. Each remote's `ExternalModule` is not eligible for scope-hoisting, so it ends up as a `type: "external"` entry in the concatenation list — one entry per remote, per `ConcatenatedModule`, per runtime.

During code generation, `ConcatenatedModule._getModulesWithInfo()` builds the info map for each of these entries and hits this line for every one:

```js
// lib/optimize/ConcatenatedModule.js
deferred: moduleGraph.isDeferred(info.module),
```

And separately, `updateHash()` hits:

```js
chunkGraph.moduleGraph.isDeferred(info.module) ? "1" : "0"
```

---

### Why this is expensive

`moduleGraph.isDeferred()` is not a simple flag check. It walks **all incoming connections** of the module:

```js
isDeferred(module) {
  if (this.isAsync(module)) return false;
  const connections = this.getIncomingConnections(module); // ← full traversal
  for (const connection of connections) {
    if (!(connection.dependency instanceof HarmonyImportDependency)) continue;
    if (ImportPhaseUtils.isDefer(connection.dependency.phase)) return true;
  }
  return false;
}
```

In a large module graph with many external modules (federated remotes, CDN externals, Node.js externals), this traversal is called:
- once per external entry per `ConcatenatedModule` during code generation
- once again per external entry during hashing

In our build: ~10 federated remotes each appearing as externals across many `ConcatenatedModule` instances. The result was a sustained 2-minute stall between consecutive `optimizeChunkModules` calls, and a **~9 minute total build time increase** — all from traversals that were guaranteed to return `false`.

---

### Why these traversals always return `false`

The `deferImport` experiment controls whether the JS parser ever emits a `HarmonyImportDependency` with `phase = ImportPhase.Defer`. When `experiments.deferImport` is `false` (the default):

```js
// lib/config/defaults.js
D(experiments, "deferImport", false);
```

`HarmonyImportDependencyParserPlugin` is initialised with:

```js
createGetImportPhase(deferImport=false, sourceImport=false)
// → always returns ImportPhase.Evaluation
// → no dependency ever gets phase = ImportPhase.Defer
```

This means `ImportPhaseUtils.isDefer(connection.dependency.phase)` can **never** return `true` for any connection in the graph. The full `getIncomingConnections()` traversal in `isDeferred()` is therefore guaranteed to return `false` — making every call unconditionally redundant.

---

### The inconsistency

`ModuleConcatenationPlugin` already correctly guards its own `isDeferred()` call:

```js
// lib/optimize/ModuleConcatenationPlugin.js:243 — CORRECTLY guarded
const deferEnabled = compilation.options.experiments.deferImport;
if (deferEnabled && moduleGraph.isDeferred(module)) {
  setInnerBailoutReason(module, "Module is deferred");
  canBeInner = false;
}
```

The same guard was not applied in `ConcatenatedModule` where `isDeferred()` is also called — introduced as part of the same `deferImport` feature.

---

### The fix

Apply the same guard that already exists in `ModuleConcatenationPlugin`:

**`_getModulesWithInfo()` (~line 2357):**
```js
// before
deferred: moduleGraph.isDeferred(info.module),

// after
deferred: this.compilation.options.experiments.deferImport
  ? moduleGraph.isDeferred(info.module)
  : false,
```

**`updateHash()` (~line 2408):**
```js
// before
chunkGraph.moduleGraph.isDeferred(info.module) ? "1" : "0"

// after
(this.compilation.options.experiments.deferImport &&
  chunkGraph.moduleGraph.isDeferred(info.module)) ? "1" : "0"
```

---

### Correctness

- When `deferImport` is `false`: `isDeferred()` is bypassed. Semantically identical — the parser never emitted a deferred phase dependency, so the result is a mathematical certainty of `false`.
- When `deferImport` is `true`: behaviour is **completely unchanged**. The guard passes through to `isDeferred()` exactly as before.

**Note on `updateHash()`:** changing the hash string for external modules when `deferImport` is `false` will invalidate existing build caches on upgrade. Happy to defer this fix to a separate PR or a major version if preferred — the `_getModulesWithInfo()` fix alone accounts for the significant build time regression.

---

### Build evidence

## Before CPU Profile
<img width="1728" height="978" alt="Screenshot 2026-06-04 at 12 04 11 PM" src="https://github.com/user-attachments/assets/eddc597e-992a-4054-a7d8-5e8e597e8f56" />

## After CPU Profile
<img width="1728" height="978" alt="Screenshot 2026-06-04 at 12 05 06 PM" src="https://github.com/user-attachments/assets/ee4387be-f9ef-4885-8964-7294d7623dca" />

Total build time saved after patch: ~11 minutes

---

### Impact

- **No behavioral change** for any project using `experiments.deferImport: true`
- **Significant build time reduction** for all projects not using the `deferImport` experiment — i.e. every webpack project running with default configuration that has external modules inside scope-hoisted bundles