### PR TITLE
perf: guard isDeferred() behind experiments.deferImport in ConcatenatedModule

### DIFF
--- a/.changeset/good-flies-say.md
+++ b/.changeset/good-flies-say.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+perf: guard isDeferred() behind experiments.deferImport in ConcatenatedModule

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2355,7 +2355,7 @@ ${defineGetters}`
 							interopNamespaceObject2Name: undefined,
 							interopDefaultAccessUsed: false,
 							interopDefaultAccessName: undefined,
-							deferred: moduleGraph.isDeferred(info.module),
+							deferred: this.compilation.options.experiments.deferImport ? moduleGraph.isDeferred(info.module) : false,
 							deferredNamespaceObjectName: undefined,
 							deferredNamespaceObjectUsed: false
 						};
@@ -2406,7 +2406,8 @@ ${defineGetters}`
 						`${chunkGraph.getModuleId(info.module)}|${runtimeConditionToString(
 							info.runtimeCondition
 						)}|${info.nonDeferAccess ? "1" : "0"}|${
-							chunkGraph.moduleGraph.isDeferred(info.module) ? "1" : "0"
+							(this.compilation.options.experiments.deferImport &&
+								chunkGraph.moduleGraph.isDeferred(info.module)) ? "1" : "0"
 						}`
 					);
 					break;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2355,7 +2355,9 @@ ${defineGetters}`
 							interopNamespaceObject2Name: undefined,
 							interopDefaultAccessUsed: false,
 							interopDefaultAccessName: undefined,
-							deferred: this.compilation.options.experiments.deferImport ? moduleGraph.isDeferred(info.module) : false,
+							deferred: this.compilation.options.experiments.deferImport
+								? moduleGraph.isDeferred(info.module)
+								: false,
 							deferredNamespaceObjectName: undefined,
 							deferredNamespaceObjectUsed: false
 						};
@@ -2406,8 +2408,10 @@ ${defineGetters}`
 						`${chunkGraph.getModuleId(info.module)}|${runtimeConditionToString(
 							info.runtimeCondition
 						)}|${info.nonDeferAccess ? "1" : "0"}|${
-							(this.compilation.options.experiments.deferImport &&
-								chunkGraph.moduleGraph.isDeferred(info.module)) ? "1" : "0"
+							this.compilation.options.experiments.deferImport &&
+							chunkGraph.moduleGraph.isDeferred(info.module)
+								? "1"
+								: "0"
 						}`
 					);
 					break;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

In large builds with many external modules (for example, Module Federation remotes and CDN externals), ConcatenatedModule unconditionally calls moduleGraph.isDeferred() for every type: "external" entry during code generation and hash generation.

moduleGraph.isDeferred() walks all incoming connections of a module. When experiments.deferImport is disabled (the default), the result is guaranteed to be false, making these traversals unnecessary. In large applications this can result in a significant amount of redundant work.

ModuleConcatenationPlugin already avoids this overhead by guarding its isDeferred() check behind deferEnabled:

// ModuleConcatenationPlugin.js
if (deferEnabled && moduleGraph.isDeferred(module)) { ... }

The same guard was missing in ConcatenatedModule._getModulesWithInfo() and ConcatenatedModule.updateHash().

This change adds the missing guard, avoiding unnecessary graph traversals when deferImport is disabled while preserving the existing behavior when it is enabled.

In a real-world Next.js application using Module Federation with approximately 10 remotes, build profiling attributed roughly 11 minutes of build time to these redundant traversals.

Before CPU Profile
<img width="3456" height="1956" alt="image" src="https://github.com/user-attachments/assets/e230f4cd-cf01-4db2-9c66-1d75ea331141" />

After CPU Profile
<img width="3456" height="1956" alt="image" src="https://github.com/user-attachments/assets/37edfc63-d214-478b-9c40-68a5b6506a8d" />


**What kind of change does this PR introduce?**

`perf`

This change does not alter functionality. It only skips work that is provably unnecessary when experiments.deferImport is disabled.

**Did you add tests for your changes?**

No additional tests were added.

The behavior when experiments.deferImport: true remains unchanged. This change only replaces a computed false result with an explicit false when deferImport is disabled.

**Does this PR introduce a breaking change?**

No runtime behavior changes are introduced.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are required.

**Use of AI**

partial