### PR TITLE
 feat(html): support async template function in module.parser.html.template

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -9,9 +9,9 @@ const querystring = require("querystring");
 const { getContext, runLoaders } = require("loader-runner");
 const {
 	AsyncSeriesBailHook,
+	AsyncSeriesWaterfallHook,
 	HookMap,
-	SyncHook,
-	SyncWaterfallHook
+	SyncHook
 } = require("tapable");
 const {
 	CachedSource,
@@ -711,7 +711,7 @@ const asBuffer = (input) => {
  * @property {SyncHook<[NormalModule]>} beforeSnapshot
  * @property {DeprecatedReadResourceForScheme} readResourceForScheme
  * @property {HookMap<AsyncSeriesBailHook<[AnyLoaderContext], string | Buffer | null>>} readResource
- * @property {SyncWaterfallHook<[Result, NormalModule]>} processResult
+ * @property {AsyncSeriesWaterfallHook<[Result, NormalModule]>} processResult
  * @property {AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>} needBuild
  */
 
@@ -796,7 +796,7 @@ class NormalModule extends Module {
 				readResource: new HookMap(
 					() => new AsyncSeriesBailHook(["loaderContext"])
 				),
-				processResult: new SyncWaterfallHook(["result", "module"]),
+				processResult: new AsyncSeriesWaterfallHook(["result", "module"]),
 				needBuild: new AsyncSeriesBailHook(["module", "context"])
 			};
 			compilationHooksMap.set(
@@ -1469,50 +1469,54 @@ class NormalModule extends Module {
 				});
 				return callback(error);
 			}
-			const result = hooks.processResult.call(
+			hooks.processResult.callAsync(
 				/** @type {Result} */
 				(result_),
-				this
+				this,
+				(processErr, result) => {
+					if (processErr) return callback(new ModuleBuildError(processErr));
+					const resolved = /** @type {Result} */ (result);
+					const source = resolved[0];
+					const sourceMap = resolved.length >= 1 ? resolved[1] : null;
+					const extraInfo = resolved.length >= 2 ? resolved[2] : null;
+
+					if (!Buffer.isBuffer(source) && typeof source !== "string") {
+						const currentLoader = this.getCurrentLoader(loaderContext, 0);
+						const err = new Error(
+							`Final loader (${
+								currentLoader
+									? compilation.runtimeTemplate.requestShortener.shorten(
+											currentLoader.loader
+										)
+									: "unknown"
+							}) didn't return a Buffer or String`
+						);
+						const error = new ModuleBuildError(err);
+						return callback(error);
+					}
+
+					const isBinaryModule =
+						this.generatorOptions && this.generatorOptions.binary !== undefined
+							? this.generatorOptions.binary
+							: this.binary;
+
+					this._source = this.createSource(
+						options.context,
+						isBinaryModule ? asBuffer(source) : asString(source),
+						sourceMap,
+						compilation.compiler.root
+					);
+					if (this._sourceSizes !== undefined) this._sourceSizes.clear();
+					/** @type {PreparsedAst | null} */
+					this._ast =
+						typeof extraInfo === "object" &&
+						extraInfo !== null &&
+						extraInfo.webpackAST !== undefined
+							? extraInfo.webpackAST
+							: null;
+					return callback();
+				}
 			);
-			const source = result[0];
-			const sourceMap = result.length >= 1 ? result[1] : null;
-			const extraInfo = result.length >= 2 ? result[2] : null;
-
-			if (!Buffer.isBuffer(source) && typeof source !== "string") {
-				const currentLoader = this.getCurrentLoader(loaderContext, 0);
-				const err = new Error(
-					`Final loader (${
-						currentLoader
-							? compilation.runtimeTemplate.requestShortener.shorten(
-									currentLoader.loader
-								)
-							: "unknown"
-					}) didn't return a Buffer or String`
-				);
-				const error = new ModuleBuildError(err);
-				return callback(error);
-			}
-
-			const isBinaryModule =
-				this.generatorOptions && this.generatorOptions.binary !== undefined
-					? this.generatorOptions.binary
-					: this.binary;
-
-			this._source = this.createSource(
-				options.context,
-				isBinaryModule ? asBuffer(source) : asString(source),
-				sourceMap,
-				compilation.compiler.root
-			);
-			if (this._sourceSizes !== undefined) this._sourceSizes.clear();
-			/** @type {PreparsedAst | null} */
-			this._ast =
-				typeof extraInfo === "object" &&
-				extraInfo !== null &&
-				extraInfo.webpackAST !== undefined
-					? extraInfo.webpackAST
-					: null;
-			return callback();
 		};
 
 		const buildInfo = /** @type {BuildInfo} */ (this.buildInfo);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -293,9 +293,9 @@ class HtmlModulesPlugin {
 						return new HtmlGenerator(generatorOptions, compilation.moduleGraph);
 					});
 
-				NormalModule.getCompilationHooks(compilation).processResult.tap(
+				NormalModule.getCompilationHooks(compilation).processResult.tapPromise(
 					PLUGIN_NAME,
-					(result, module) => {
+					async (result, module) => {
 						if (module.type === HTML_MODULE_TYPE) {
 							const [source, ...rest] = result;
 							// `applyTemplate` is a no-op unless `module.parser.html.template`
@@ -304,7 +304,10 @@ class HtmlModulesPlugin {
 							// and the generator's render base in sync.
 							const parser = /** @type {HtmlParser} */ (module.parser);
 
-							return [parser.applyTemplate(removeBOM(source), module), ...rest];
+							return [
+								await parser.applyTemplate(removeBOM(source), module),
+								...rest
+							];
 						}
 
 						return result;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -787,7 +787,7 @@ class HtmlParser extends Parser {
 	 * `module.originalSource()`) stay in agreement.
 	 * @param {string | Buffer} source the original source
 	 * @param {NormalModule} module the html module
-	 * @returns {string | Buffer | Promise<string | Buffer>} the transformed source
+	 * @returns {string | Buffer | Promise<string>} the transformed source
 	 */
 	applyTemplate(source, module) {
 		if (!this.template) return source;
@@ -833,9 +833,7 @@ class HtmlParser extends Parser {
 					)
 			}
 		);
-		if (typeof transformed === "string" || Buffer.isBuffer(transformed)) {
-			return transformed;
-		}
+		if (typeof transformed === "string") return transformed;
 		if (transformed instanceof Promise) {
 			return transformed.then((result) => {
 				if (typeof result !== "string") {

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -46,7 +46,7 @@ const buildHtmlAst = require("./buildHtmlAst");
  * @property {(warning: Error | string) => void} emitWarning report a non-fatal warning on the module
  * @property {(error: Error | string) => void} emitError report an error on the module
  */
-/** @typedef {(source: string, context: HtmlTemplateContext) => string} HtmlTemplateFunction */
+/** @typedef {(source: string, context: HtmlTemplateContext) => string | Promise<string>} HtmlTemplateFunction */
 
 const HORIZONTAL_TAB = "\u0009".charCodeAt(0);
 const NEWLINE = "\u000A".charCodeAt(0);
@@ -787,7 +787,7 @@ class HtmlParser extends Parser {
 	 * `module.originalSource()`) stay in agreement.
 	 * @param {string | Buffer} source the original source
 	 * @param {NormalModule} module the html module
-	 * @returns {string | Buffer} the transformed source
+	 * @returns {string | Buffer | Promise<string | Buffer>} the transformed source
 	 */
 	applyTemplate(source, module) {
 		if (!this.template) return source;
@@ -833,12 +833,22 @@ class HtmlParser extends Parser {
 					)
 			}
 		);
-		if (typeof transformed !== "string") {
-			throw new Error(
-				"The `template` html parser option must return a string."
-			);
+		if (typeof transformed === "string" || Buffer.isBuffer(transformed)) {
+			return transformed;
 		}
-		return transformed;
+		if (transformed instanceof Promise) {
+			return transformed.then((result) => {
+				if (typeof result !== "string") {
+					throw new Error(
+						"The `template` html parser option must return a string or Promise<string>."
+					);
+				}
+				return result;
+			});
+		}
+		throw new Error(
+			"The `template` html parser option must return a string or Promise<string>."
+		);
 	}
 
 	/**

--- a/test/configCases/html/parser-template-async/__snapshots__/warnings.snap
+++ b/test/configCases/html/parser-template-async/__snapshots__/warnings.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`warnings 1`] = `
+Array [
+  Object {
+    "message": "async template warning",
+    "moduleName": "./page.html",
+  },
+]
+`;

--- a/test/configCases/html/parser-template-async/index.js
+++ b/test/configCases/html/parser-template-async/index.js
@@ -1,0 +1,8 @@
+import page from "./page.html";
+
+it("should support an async template function", () => {
+	expect(page).toContain("<title>Hello async</title>");
+	expect(page).not.toContain("{{title}}");
+	expect(page).not.toContain('src="./image.png"');
+	expect(page).toMatch(/<img src="[^"]+\.png" alt="image">/);
+});

--- a/test/configCases/html/parser-template-async/page.html
+++ b/test/configCases/html/parser-template-async/page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{title}}</title></head>
+<body>
+<img src="{{image}}" alt="image">
+</body>
+</html>

--- a/test/configCases/html/parser-template-async/webpack.config.js
+++ b/test/configCases/html/parser-template-async/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	module: {
+		parser: {
+			html: {
+				template: async (source, { resource, addDependency, emitWarning }) => {
+					await Promise.resolve();
+					addDependency(resource);
+					emitWarning("async template warning");
+					return source
+						.replace(/\{\{title\}\}/g, "Hello async")
+						.replace(/\{\{image\}\}/g, "./image.png");
+				}
+			}
+		}
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -9149,7 +9149,10 @@ declare interface HtmlGeneratorOptions {
 }
 declare abstract class HtmlParser extends ParserClass {
 	magicCommentContext: ContextImport;
-	template?: (source: string, context: HtmlTemplateContext) => string;
+	template?: (
+		source: string,
+		context: HtmlTemplateContext
+	) => string | Promise<string>;
 	sourcesByTag: Record<string, Record<string, SourceItem>>;
 	anyTagSources?: Record<string, SourceItem>;
 
@@ -9160,7 +9163,10 @@ declare abstract class HtmlParser extends ParserClass {
 	 * dependency offsets against it) and the generator (which renders from
 	 * `module.originalSource()`) stay in agreement.
 	 */
-	applyTemplate(source: string | Buffer, module: NormalModule): string | Buffer;
+	applyTemplate(
+		source: string | Buffer,
+		module: NormalModule
+	): string | Buffer | Promise<string | Buffer>;
 }
 
 /**
@@ -9199,7 +9205,10 @@ declare interface HtmlParserOptions {
 	/**
 	 * Transform the raw source before the html parser extracts dependencies. Receives the source string and a context (`{ module, resource }`) and must return the html string to parse. Useful for compiling a templating language (Handlebars, EJS, Eta, …) to html so that URLs the template emits are still picked up as webpack dependencies. Runs synchronously.
 	 */
-	template?: (source: string, context: HtmlTemplateContext) => string;
+	template?: (
+		source: string,
+		context: HtmlTemplateContext
+	) => string | Promise<string>;
 }
 declare interface HtmlTemplateContext {
 	/**
@@ -16355,7 +16364,7 @@ declare interface NormalModuleCompilationHooks {
 	readResource: HookMap<
 		AsyncSeriesBailHook<[AnyLoaderContext], null | string | Buffer>
 	>;
-	processResult: SyncWaterfallHook<
+	processResult: AsyncSeriesWaterfallHook<
 		[
 			[
 				string | Buffer,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The `module.parser.html.template` option only supported synchronous functions. This adds `Promise<string>` return support, closing the html-loader `preprocessor` async parity gap.

Implemented by converting the per-module `processResult` hook from `SyncWaterfallHook` to `AsyncSeriesWaterfallHook`. Existing sync tappers (CSS, JS, TypeScript) are unaffected — `.tap()` callbacks remain valid on an async waterfall hook. A minor per-module async overhead applies to all module types; benchmarks should be checked.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/configCases/html/parser-template-async/`. Covers async URL injection, `addDependency`, and `emitWarning` called after `await`.

**Does this PR introduce a breaking change?**

No. Sync templates continue to work unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

`module.parser.html.template` docs should note it now accepts `async` functions / `Promise<string>`.

**Use of AI**
partial