### PR TITLE
fix: invalidate incremental cache when CSS-only asset becomes JS-referenced

### DIFF
--- a/.changeset/fix-css-lazy-asset-incremental-cache.md
+++ b/.changeset/fix-css-lazy-asset-incremental-cache.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Make CSS-referenced asset available in lazy JS chunk during incremental rebuilds.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -545,7 +545,7 @@ const unsafeCacheDependencies = new WeakMap();
 /** @type {WeakMap<ModuleWithRestoreFromUnsafeCache, UnsafeCacheData>} */
 const unsafeCacheData = new WeakMap();
 
-/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], assetOriginTypes?: Set<string> }} References */
+/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], originTypes?: Set<string> }} References */
 /** @typedef {Map<Module, WeakTupleMap<EXPECTED_ANY[], EXPECTED_ANY>>} ModuleMemCaches */
 
 class Compilation {
@@ -2897,14 +2897,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		let statChanged = 0;
 		let statNew = 0;
 		/**
-		 * Asset source types (AssetGenerator.getTypes) depend on incoming origin
-		 * module types (CSS vs JS), not outgoing connections. Track them so
-		 * memCache2 invalidates when a CSS-only asset becomes JS-referenced. #20800
+		 * Signature of incoming origin types for modules whose source types depend on them (e.g. assets referenced from CSS vs JS); tracked so memCache2 invalidates when it changes. #20800
 		 * @param {Module} module module
-		 * @returns {Set<string> | undefined} incoming origin source-type signature, or undefined for non-asset modules
+		 * @returns {Set<string> | undefined} incoming origin type signature, or undefined when source types don't depend on incoming connections
 		 */
-		const computeAssetOriginTypes = (module) => {
-			if (!module.type.startsWith("asset")) return undefined;
+		const computeOriginTypes = (module) => {
+			if (!module.getSourceTypesDependOnIncomingConnections()) return undefined;
 			const types = new Set();
 			for (const { originModule } of moduleGraph.getIncomingConnections(
 				module
@@ -2952,7 +2950,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				id,
 				modules,
 				blocks,
-				assetOriginTypes: computeAssetOriginTypes(module)
+				originTypes: computeOriginTypes(module)
 			};
 		};
 		/**
@@ -2962,12 +2960,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		 * @param {string | number} references.id id
 		 * @param {Map<Module, string | number | undefined>=} references.modules modules
 		 * @param {(string | number | null)[]=} references.blocks blocks
-		 * @param {Set<string>=} references.assetOriginTypes asset origin source-type signature
+		 * @param {Set<string>=} references.originTypes incoming origin type signature
 		 * @returns {boolean} ok?
 		 */
 		const compareReferences = (
 			module,
-			{ id, modules, blocks, assetOriginTypes }
+			{ id, modules, blocks, originTypes }
 		) => {
 			if (id !== chunkGraph.getModuleId(module)) return false;
 			if (modules !== undefined) {
@@ -2992,13 +2990,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				}
 				if (i !== blocks.length) return false;
 			}
-			if (assetOriginTypes !== undefined) {
+			if (originTypes !== undefined) {
 				const current =
 					/** @type {Set<string>} */
-					(computeAssetOriginTypes(module));
-				if (current.size !== assetOriginTypes.size) return false;
+					(computeOriginTypes(module));
+				if (current.size !== originTypes.size) return false;
 				for (const type of current) {
-					if (!assetOriginTypes.has(type)) return false;
+					if (!originTypes.has(type)) return false;
 				}
 			}
 			return true;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -545,7 +545,7 @@ const unsafeCacheDependencies = new WeakMap();
 /** @type {WeakMap<ModuleWithRestoreFromUnsafeCache, UnsafeCacheData>} */
 const unsafeCacheData = new WeakMap();
 
-/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[] }} References */
+/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], assetOriginTypes?: Set<string> }} References */
 /** @typedef {Map<Module, WeakTupleMap<EXPECTED_ANY[], EXPECTED_ANY>>} ModuleMemCaches */
 
 class Compilation {
@@ -2897,6 +2897,23 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		let statChanged = 0;
 		let statNew = 0;
 		/**
+		 * Asset source types (AssetGenerator.getTypes) depend on incoming origin
+		 * module types (CSS vs JS), not outgoing connections. Track them so
+		 * memCache2 invalidates when a CSS-only asset becomes JS-referenced. #20800
+		 * @param {Module} module module
+		 * @returns {Set<string> | undefined} incoming origin source-type signature, or undefined for non-asset modules
+		 */
+		const computeAssetOriginTypes = (module) => {
+			if (!module.type.startsWith("asset")) return undefined;
+			const types = new Set();
+			for (const { originModule } of moduleGraph.getIncomingConnections(
+				module
+			)) {
+				if (originModule) types.add(originModule.type.split("/", 1)[0]);
+			}
+			return types;
+		};
+		/**
 		 * Compute references.
 		 * @param {Module} module module
 		 * @returns {References} references
@@ -2931,7 +2948,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					queue.push.apply(queue, block.blocks);
 				}
 			}
-			return { id, modules, blocks };
+			return {
+				id,
+				modules,
+				blocks,
+				assetOriginTypes: computeAssetOriginTypes(module)
+			};
 		};
 		/**
 		 * Compares references.
@@ -2940,9 +2962,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		 * @param {string | number} references.id id
 		 * @param {Map<Module, string | number | undefined>=} references.modules modules
 		 * @param {(string | number | null)[]=} references.blocks blocks
+		 * @param {Set<string>=} references.assetOriginTypes asset origin source-type signature
 		 * @returns {boolean} ok?
 		 */
-		const compareReferences = (module, { id, modules, blocks }) => {
+		const compareReferences = (
+			module,
+			{ id, modules, blocks, assetOriginTypes }
+		) => {
 			if (id !== chunkGraph.getModuleId(module)) return false;
 			if (modules !== undefined) {
 				for (const [module, id] of modules) {
@@ -2965,6 +2991,15 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					queue.push.apply(queue, block.blocks);
 				}
 				if (i !== blocks.length) return false;
+			}
+			if (assetOriginTypes !== undefined) {
+				const current =
+					/** @type {Set<string>} */
+					(computeAssetOriginTypes(module));
+				if (current.size !== assetOriginTypes.size) return false;
+				for (const type of current) {
+					if (!assetOriginTypes.has(type)) return false;
+				}
 			}
 			return true;
 		};

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -108,6 +108,7 @@ const { isSourceEqual } = require("./util/source");
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
 /** @typedef {import("./Module").ValueCacheVersions} ValueCacheVersions */
 /** @typedef {import("./Module").RuntimeRequirements} RuntimeRequirements */
+/** @typedef {import("./Module").SourceTypes} SourceTypes */
 /** @typedef {import("./NormalModule").NormalModuleCompilationHooks} NormalModuleCompilationHooks */
 /** @typedef {import("./Module").FactoryMeta} FactoryMeta */
 /** @typedef {import("./Module").CodeGenerationResult} CodeGenerationResult */
@@ -545,7 +546,7 @@ const unsafeCacheDependencies = new WeakMap();
 /** @type {WeakMap<ModuleWithRestoreFromUnsafeCache, UnsafeCacheData>} */
 const unsafeCacheData = new WeakMap();
 
-/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], originTypes?: Set<string> }} References */
+/** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], sourceTypes?: SourceTypes }} References */
 /** @typedef {Map<Module, WeakTupleMap<EXPECTED_ANY[], EXPECTED_ANY>>} ModuleMemCaches */
 
 class Compilation {
@@ -2897,21 +2898,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		let statChanged = 0;
 		let statNew = 0;
 		/**
-		 * Signature of incoming origin types for modules whose source types depend on them (e.g. assets referenced from CSS vs JS); tracked so memCache2 invalidates when it changes. #20800
-		 * @param {Module} module module
-		 * @returns {Set<string> | undefined} incoming origin type signature, or undefined when source types don't depend on incoming connections
-		 */
-		const computeOriginTypes = (module) => {
-			if (!module.getSourceTypesDependOnIncomingConnections()) return undefined;
-			const types = new Set();
-			for (const { originModule } of moduleGraph.getIncomingConnections(
-				module
-			)) {
-				if (originModule) types.add(originModule.type.split("/", 1)[0]);
-			}
-			return types;
-		};
-		/**
 		 * Compute references.
 		 * @param {Module} module module
 		 * @returns {References} references
@@ -2950,7 +2936,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				id,
 				modules,
 				blocks,
-				originTypes: computeOriginTypes(module)
+				sourceTypes: module.getReferencedSourceTypes()
 			};
 		};
 		/**
@@ -2960,12 +2946,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		 * @param {string | number} references.id id
 		 * @param {Map<Module, string | number | undefined>=} references.modules modules
 		 * @param {(string | number | null)[]=} references.blocks blocks
-		 * @param {Set<string>=} references.originTypes incoming origin type signature
+		 * @param {SourceTypes=} references.sourceTypes connection-dependent source types
 		 * @returns {boolean} ok?
 		 */
 		const compareReferences = (
 			module,
-			{ id, modules, blocks, originTypes }
+			{ id, modules, blocks, sourceTypes }
 		) => {
 			if (id !== chunkGraph.getModuleId(module)) return false;
 			if (modules !== undefined) {
@@ -2990,14 +2976,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				}
 				if (i !== blocks.length) return false;
 			}
-			if (originTypes !== undefined) {
-				const current =
-					/** @type {Set<string>} */
-					(computeOriginTypes(module));
-				if (current.size !== originTypes.size) return false;
-				for (const type of current) {
-					if (!originTypes.has(type)) return false;
-				}
+			// getReferencedSourceTypes() returns interned type sets, compare by reference. #20800
+			if (
+				sourceTypes !== undefined &&
+				module.getReferencedSourceTypes() !== sourceTypes
+			) {
+				return false;
 			}
 			return true;
 		};

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -79,6 +79,13 @@ class Generator {
 		throw new AbstractMethodError();
 	}
 
+	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		return false;
+	}
+
 	/* istanbul ignore next */
 	/**
 	 * Returns the estimated size for the requested source type.

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1077,6 +1077,13 @@ class Module extends DependenciesBlock {
 	}
 
 	/**
+	 * @returns {boolean} whether getSourceTypes() depends on the module's incoming connections
+	 */
+	getSourceTypesDependOnIncomingConnections() {
+		return false;
+	}
+
+	/**
 	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
 	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
 	 * added or changed over time by generators and do not need to be handled or detected here.

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1077,10 +1077,11 @@ class Module extends DependenciesBlock {
 	}
 
 	/**
-	 * @returns {boolean} whether getSourceTypes() depends on the module's incoming connections
+	 * Freshly recomputed source types when they depend on incoming connections, for chunk-graph cache invalidation; undefined otherwise. #20800
+	 * @returns {SourceTypes | undefined} source types or undefined
 	 */
-	getSourceTypesDependOnIncomingConnections() {
-		return false;
+	getReferencedSourceTypes() {
+		return undefined;
 	}
 
 	/**

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -2016,7 +2016,7 @@ class NormalModule extends Module {
 	getReferencedSourceTypes() {
 		const generator = /** @type {Generator} */ (this.generator);
 		// Bypass the _sourceTypes cache: it may be stale when the module is not rebuilt.
-		return generator && generator.getTypesDependOnIncomingConnections()
+		return generator.getTypesDependOnIncomingConnections()
 			? generator.getTypes(this)
 			: undefined;
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -2010,12 +2010,15 @@ class NormalModule extends Module {
 	}
 
 	/**
-	 * @returns {boolean} whether getSourceTypes() depends on the module's incoming connections
+	 * Freshly recomputed source types when they depend on incoming connections, for chunk-graph cache invalidation; undefined otherwise. #20800
+	 * @returns {SourceTypes | undefined} source types or undefined
 	 */
-	getSourceTypesDependOnIncomingConnections() {
-		return this.generator
-			? this.generator.getTypesDependOnIncomingConnections()
-			: false;
+	getReferencedSourceTypes() {
+		const generator = /** @type {Generator} */ (this.generator);
+		// Bypass the _sourceTypes cache: it may be stale when the module is not rebuilt.
+		return generator && generator.getTypesDependOnIncomingConnections()
+			? generator.getTypes(this)
+			: undefined;
 	}
 
 	/**

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -2010,6 +2010,15 @@ class NormalModule extends Module {
 	}
 
 	/**
+	 * @returns {boolean} whether getSourceTypes() depends on the module's incoming connections
+	 */
+	getSourceTypesDependOnIncomingConnections() {
+		return this.generator
+			? this.generator.getTypesDependOnIncomingConnections()
+			: false;
+	}
+
+	/**
 	 * Generates code and runtime requirements for this module.
 	 * @param {CodeGenerationContext} context context for code generation
 	 * @returns {CodeGenerationResult} result

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -737,6 +737,13 @@ class AssetGenerator extends Generator {
 	}
 
 	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		return true;
+	}
+
+	/**
 	 * Returns the estimated size for the requested source type.
 	 * @param {NormalModule} module the module
 	 * @param {SourceType=} type source type

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/file.txt
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/file.txt
@@ -1,0 +1,1 @@
+asset-content

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/index.js
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/index.js
@@ -1,0 +1,13 @@
+import "./style.css";
+
+it("should make asset available in both CSS and lazy JS chunk with incremental cache", (done) => {
+	const promise = import("./mod.js");
+	NEXT_DEFERRED(
+		require("../../update")(done, true, () => {
+			promise.then((mod) => {
+				expect(mod.default).toContain("file.txt");
+				done();
+			}, done);
+		})
+	);
+});

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/mod.js
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/mod.js
@@ -1,0 +1,2 @@
+import file from "./file.txt";
+export default file;

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/style.css
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/style.css
@@ -1,0 +1,3 @@
+.font {
+	src: url("./file.txt");
+}

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/test.filter.js
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/test.filter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/css/lazy-compilation-asset-cache-unaffected/webpack.config.js
+++ b/test/hotCases/css/lazy-compilation-asset-cache-unaffected/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		cssFilename: "[name].css",
+		cssChunkFilename: "[name].css",
+		assetModuleFilename: "assets/[name][ext]"
+	},
+	experiments: {
+		css: true,
+		cacheUnaffected: true,
+		lazyCompilation: {
+			entries: false,
+			imports: true
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.txt$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/test/watchCases/css/asset-referenced-from-css-and-js/0/file.txt
+++ b/test/watchCases/css/asset-referenced-from-css-and-js/0/file.txt
@@ -1,0 +1,1 @@
+asset-content

--- a/test/watchCases/css/asset-referenced-from-css-and-js/0/index.js
+++ b/test/watchCases/css/asset-referenced-from-css-and-js/0/index.js
@@ -1,0 +1,6 @@
+import "./style.css";
+
+it("should emit the asset referenced only from CSS", () => {
+	const asset = STATS_JSON.assets.find((a) => /file\.txt$/.test(a.name));
+	expect(asset).toBeDefined();
+});

--- a/test/watchCases/css/asset-referenced-from-css-and-js/0/style.css
+++ b/test/watchCases/css/asset-referenced-from-css-and-js/0/style.css
@@ -1,0 +1,3 @@
+.font {
+	src: url("./file.txt");
+}

--- a/test/watchCases/css/asset-referenced-from-css-and-js/1/index.js
+++ b/test/watchCases/css/asset-referenced-from-css-and-js/1/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+// Now the asset is also referenced from JS; on the incremental rebuild the
+// asset module is not rebuilt, so the JS source type must still be added. #20800
+import file from "./file.txt";
+
+it("should make the CSS-referenced asset available from JS after rebuild", () => {
+	expect(file).toContain("file.txt");
+});

--- a/test/watchCases/css/asset-referenced-from-css-and-js/webpack.config.js
+++ b/test/watchCases/css/asset-referenced-from-css-and-js/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		filename: "bundle.js",
+		cssFilename: "[name].css",
+		assetModuleFilename: "assets/[name][ext]"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.txt$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	experiments: {
+		css: true,
+		cacheUnaffected: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -8547,6 +8547,7 @@ declare class Generator {
 	 * Returns the source types available for this module.
 	 */
 	getTypes(module: NormalModule): ReadonlySet<string>;
+	getTypesDependOnIncomingConnections(): boolean;
 
 	/**
 	 * Returns the estimated size for the requested source type.
@@ -14617,6 +14618,7 @@ declare class Module extends DependenciesBlock {
 	 * Returns the source types this module can generate.
 	 */
 	getSourceTypes(): ReadonlySet<string>;
+	getSourceTypesDependOnIncomingConnections(): boolean;
 
 	/**
 	 * Basic source types are high-level categories like javascript, css, webassembly, etc.

--- a/types.d.ts
+++ b/types.d.ts
@@ -14618,7 +14618,11 @@ declare class Module extends DependenciesBlock {
 	 * Returns the source types this module can generate.
 	 */
 	getSourceTypes(): ReadonlySet<string>;
-	getSourceTypesDependOnIncomingConnections(): boolean;
+
+	/**
+	 * Freshly recomputed source types when they depend on incoming connections, for chunk-graph cache invalidation; undefined otherwise. #20800
+	 */
+	getReferencedSourceTypes(): undefined | ReadonlySet<string>;
 
 	/**
 	 * Basic source types are high-level categories like javascript, css, webassembly, etc.


### PR DESCRIPTION
Asset source types come from incoming origin module types (CSS vs JS),
which moduleMemCaches2 did not track. A CSS-only asset later referenced
from a lazily compiled JS chunk was treated as unchanged, so its cached
CSS-only code generation was reused and __webpack_require__ threw at
runtime. Track the asset origin-type signature in computeReferences so the
cache is invalidated. Adds a hot test under incremental cacheUnaffected.