### PR TITLE
test: try to stable memory benchmark / 2

### DIFF
--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -532,6 +532,10 @@ const withCodSpeed = async (bench) => {
 
 	const rawAdd = bench.add;
 	const uriMap = getOrCreateUriMap(bench);
+
+	const releaseClosuresAfterMeasure = codspeedRunnerMode === "memory";
+	const NO_OP_FN = () => {};
+
 	bench.add = (name, fn, options) => {
 		const callingFile = getCallingFile();
 		let uri = callingFile;
@@ -540,6 +544,9 @@ const withCodSpeed = async (bench) => {
 		}
 		uri += `::${name}`;
 		uriMap.set(name, { uri, fn, options });
+		if (releaseClosuresAfterMeasure) {
+			return rawAdd.bind(bench)(name, NO_OP_FN, {});
+		}
 		return rawAdd.bind(bench)(name, fn, options);
 	};
 	const rootCallingFile = getCallingFile();
@@ -638,7 +645,7 @@ const withCodSpeed = async (bench) => {
 		 * @param {string} uri URI
 		 */
 		const runTaskAsync = async (task, name, uri) => {
-			const { fn, options } =
+			let { fn, options } =
 				/** @type {TaskMeta} */
 				(uriMap.get(name));
 
@@ -693,14 +700,9 @@ const withCodSpeed = async (bench) => {
 
 			logTaskCompletion(uri, taskCompletionMessage());
 
-			// Release the just-measured task's closure-captured refs
-			// (webpack, config, watching, originalEntryContent) so the next
-			// task's measurement starts from a smaller heap. In memory mode
-			// every task shares one process, so without this drop each task's
-			// sample includes residue from every prior task and is sensitive
-			// to registration order. The drain mirrors the pre-measurement
-			// pattern: gc -> microtask three times, then setImmediate, then
-			// one final gc to sweep what finalizers / IO callbacks produced.
+			// Release this task's closures
+			fn = NO_OP_FN;
+			options = undefined;
 			uriMap.delete(name);
 			for (let i = 0; i < 3; i++) {
 				global.gc?.();
@@ -757,7 +759,7 @@ const withCodSpeed = async (bench) => {
 		 * @param {string} uri URI
 		 */
 		const runTaskSync = (task, name, uri) => {
-			const { fn, options } =
+			let { fn, options } =
 				/** @type {TaskMeta} */
 				(uriMap.get(name));
 
@@ -797,9 +799,9 @@ const withCodSpeed = async (bench) => {
 
 			logTaskCompletion(uri, taskCompletionMessage());
 
-			// Release the just-measured task's closures — see the async path
-			// for the rationale. The sync path has no microtask queue to
-			// drain, so we just chain GCs.
+			// Release this task's closures
+			fn = NO_OP_FN;
+			options = undefined;
 			uriMap.delete(name);
 			for (let i = 0; i < 4; i++) {
 				global.gc?.();

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -317,12 +317,12 @@ function buildConfiguration(
 	) {
 		config.cache.cacheDirectory = path.resolve(config.output.path, ".cache");
 	}
-	// if (watch) {
-	// 	config.cache = {
-	// 		type: "memory",
-	// 		maxGenerations: 1
-	// 	};
-	// }
+	if (watch) {
+		config.cache = {
+			type: "memory",
+			maxGenerations: 1
+		};
+	}
 	return config;
 }
 

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -317,12 +317,12 @@ function buildConfiguration(
 	) {
 		config.cache.cacheDirectory = path.resolve(config.output.path, ".cache");
 	}
-	if (watch) {
-		config.cache = {
-			type: "memory",
-			maxGenerations: 1
-		};
-	}
+	// if (watch) {
+	// 	config.cache = {
+	// 		type: "memory",
+	// 		maxGenerations: 1
+	// 	};
+	// }
 	return config;
 }
 


### PR DESCRIPTION

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

CodSpeed memory mode measures between `InstrumentHooks.startBenchmark()` and `InstrumentHooks.stopBenchmark()` (already asked the official), so a prior task affects the next task indirectly: the previous task's retained heap will raises the `Peak Memory` of the next task.

1. In memory mode, hand `tinybench` a no-op task instead of the real `fn` / `options`. The harness overrides `bench.run` / `bench.runSync` and dispatches via `uriMap`, so `tinybench`'s native `Task.run` is never invoked so it never keep the closures of previous task.
2. After each measurement, clear the `fn` / `options` locals on `runTaskAsync` / `runTaskSync` and `uriMap.delete(name)`, so by the previous task's closure are unreachable.
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Parital
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->