### PR TITLE
fix: extend incremental-cache invalidation to css, html and asset source/inline modules

### DIFF
--- a/.changeset/extend-incremental-cache-source-types.md
+++ b/.changeset/extend-incremental-cache-source-types.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix stale incremental cache for css, html and asset/source/inline modules.

--- a/lib/asset/AssetBytesGenerator.js
+++ b/lib/asset/AssetBytesGenerator.js
@@ -162,6 +162,13 @@ class AssetSourceGenerator extends Generator {
 	}
 
 	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		return true;
+	}
+
+	/**
 	 * Returns the estimated size for the requested source type.
 	 * @param {NormalModule} module the module
 	 * @param {SourceType=} type source type

--- a/lib/asset/AssetSourceGenerator.js
+++ b/lib/asset/AssetSourceGenerator.js
@@ -161,6 +161,13 @@ class AssetSourceGenerator extends Generator {
 	}
 
 	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		return true;
+	}
+
+	/**
 	 * Returns the estimated size for the requested source type.
 	 * @param {NormalModule} module the module
 	 * @param {SourceType=} type source type

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -918,6 +918,13 @@ class CssGenerator extends Generator {
 	}
 
 	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		return true;
+	}
+
+	/**
 	 * Returns the estimated size for the requested source type.
 	 * @param {NormalModule} module the module
 	 * @param {SourceType=} type source type

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -195,6 +195,14 @@ class HtmlGenerator extends Generator {
 	}
 
 	/**
+	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
+	 */
+	getTypesDependOnIncomingConnections() {
+		// Only a fixed extract short-circuits `_shouldExtract`; otherwise it reads `_isEntryModule` (incoming connections).
+		return this.options.extract !== true && this.options.extract !== false;
+	}
+
+	/**
 	 * Returns the estimated size for the requested source type.
 	 * @param {NormalModule} module the module
 	 * @param {SourceType=} type source type

--- a/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/file.txt
+++ b/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/file.txt
@@ -1,0 +1,1 @@
+asset-bytes-content

--- a/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/index.js
+++ b/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/index.js
@@ -1,0 +1,6 @@
+import "./style.css";
+
+it("should compile with the asset/bytes referenced only from CSS", () => {
+	const asset = STATS_JSON.assets.find((a) => /\.css$/.test(a.name));
+	expect(asset).toBeDefined();
+});

--- a/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/style.css
+++ b/test/watchCases/css/asset-bytes-referenced-from-css-and-js/0/style.css
@@ -1,0 +1,3 @@
+.font {
+	src: url("./file.txt");
+}

--- a/test/watchCases/css/asset-bytes-referenced-from-css-and-js/1/index.js
+++ b/test/watchCases/css/asset-bytes-referenced-from-css-and-js/1/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+import file from "./file.txt";
+
+it("should expose asset/bytes content to JS after incremental rebuild", () => {
+	const text = new TextDecoder("utf-8").decode(file);
+	expect(text).toContain("asset-bytes-content");
+});

--- a/test/watchCases/css/asset-bytes-referenced-from-css-and-js/webpack.config.js
+++ b/test/watchCases/css/asset-bytes-referenced-from-css-and-js/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		cssFilename: "[name].css"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.txt$/,
+				type: "asset/bytes"
+			}
+		]
+	},
+	experiments: {
+		css: true,
+		cacheUnaffected: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/test/watchCases/css/asset-source-referenced-from-css-and-js/0/file.txt
+++ b/test/watchCases/css/asset-source-referenced-from-css-and-js/0/file.txt
@@ -1,0 +1,1 @@
+asset-source-content

--- a/test/watchCases/css/asset-source-referenced-from-css-and-js/0/index.js
+++ b/test/watchCases/css/asset-source-referenced-from-css-and-js/0/index.js
@@ -1,0 +1,5 @@
+import "./style.css";
+
+it("should compile with the asset/source referenced only from CSS", () => {
+	expect(true).toBe(true);
+});

--- a/test/watchCases/css/asset-source-referenced-from-css-and-js/0/style.css
+++ b/test/watchCases/css/asset-source-referenced-from-css-and-js/0/style.css
@@ -1,0 +1,3 @@
+.font {
+	src: url("./file.txt");
+}

--- a/test/watchCases/css/asset-source-referenced-from-css-and-js/1/index.js
+++ b/test/watchCases/css/asset-source-referenced-from-css-and-js/1/index.js
@@ -1,0 +1,6 @@
+import "./style.css";
+import content from "./file.txt";
+
+it("should expose asset/source content to JS after incremental rebuild", () => {
+	expect(content).toContain("asset-source-content");
+});

--- a/test/watchCases/css/asset-source-referenced-from-css-and-js/webpack.config.js
+++ b/test/watchCases/css/asset-source-referenced-from-css-and-js/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		cssFilename: "[name].css"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.txt$/,
+				type: "asset/source"
+			}
+		]
+	},
+	experiments: {
+		css: true,
+		cacheUnaffected: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/test/watchCases/css/css-module-referenced-from-css-and-js/0/index.js
+++ b/test/watchCases/css/css-module-referenced-from-css-and-js/0/index.js
@@ -1,0 +1,5 @@
+import "./style.css";
+
+it("should compile with the css module referenced only from CSS", () => {
+	expect(true).toBe(true);
+});

--- a/test/watchCases/css/css-module-referenced-from-css-and-js/0/shared.module.css
+++ b/test/watchCases/css/css-module-referenced-from-css-and-js/0/shared.module.css
@@ -1,0 +1,3 @@
+.foo {
+	color: red;
+}

--- a/test/watchCases/css/css-module-referenced-from-css-and-js/0/style.css
+++ b/test/watchCases/css/css-module-referenced-from-css-and-js/0/style.css
@@ -1,0 +1,1 @@
+@import "./shared.module.css";

--- a/test/watchCases/css/css-module-referenced-from-css-and-js/1/index.js
+++ b/test/watchCases/css/css-module-referenced-from-css-and-js/1/index.js
@@ -1,0 +1,6 @@
+import "./style.css";
+import * as styles from "./shared.module.css";
+
+it("should expose css module locals to JS after incremental rebuild", () => {
+	expect(styles.foo).toBeTruthy();
+});

--- a/test/watchCases/css/css-module-referenced-from-css-and-js/webpack.config.js
+++ b/test/watchCases/css/css-module-referenced-from-css-and-js/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		cssFilename: "[name].css"
+	},
+	experiments: {
+		css: true,
+		cacheUnaffected: true
+	}
+};

--- a/test/watchCases/css/html-module-incremental-cache/0/index.js
+++ b/test/watchCases/css/html-module-incremental-cache/0/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should emit the HTML module", () => {
+	const htmlAsset = STATS_JSON.assets.find((a) => /\.html$/.test(a.name));
+	expect(htmlAsset).toBeDefined();
+});

--- a/test/watchCases/css/html-module-incremental-cache/0/page.html
+++ b/test/watchCases/css/html-module-incremental-cache/0/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>page</title>
+</head>
+<body>
+<p>hi</p>
+</body>
+</html>

--- a/test/watchCases/css/html-module-incremental-cache/1/index.js
+++ b/test/watchCases/css/html-module-incremental-cache/1/index.js
@@ -1,0 +1,9 @@
+import "./page.html";
+
+const marker = "changed";
+
+it("should keep the HTML module available after an incremental rebuild", () => {
+	expect(marker).toBe("changed");
+	const htmlAsset = STATS_JSON.assets.find((a) => /\.html$/.test(a.name));
+	expect(htmlAsset).toBeDefined();
+});

--- a/test/watchCases/css/html-module-incremental-cache/webpack.config.js
+++ b/test/watchCases/css/html-module-incremental-cache/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	cache: {
+		type: "memory",
+		cacheUnaffected: true
+	},
+	output: {
+		htmlFilename: "[name].html"
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	experiments: {
+		html: true,
+		css: true,
+		cacheUnaffected: true
+	},
+	node: {
+		__dirname: false
+	}
+};


### PR DESCRIPTION
**Summary**

Follow-up to #21100 (fixes the remaining part of #20800). That PR fixed the incremental-cache staleness only for `AssetGenerator` (asset/resource). Auditing every `getTypes()` implementation shows `CssGenerator`, `HtmlGenerator`, `AssetSourceGenerator` (asset/source) and `AssetBytesGenerator` (asset/inline) also derive their source types from incoming connections, so they had the same bug: when such a module is not rebuilt but a new JS importer appears, `moduleMemCaches2` treated it as unchanged, reused the stale code generation, and `__webpack_require__` threw `Cannot find module`. This overrides `getTypesDependOnIncomingConnections()` for those generators (HTML only when `extract` is auto, mirroring `_shouldExtract`).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/watchCases/css/css-module-referenced-from-css-and-js` and `test/watchCases/css/asset-source-referenced-from-css-and-js` (both fail without the fix with `Cannot find module`).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to audit the `getTypes()` implementations, implement the generator flags, and write the watch reproductions; all results were reviewed and verified by running the tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_0139zj94VmY5y29NyS3GhbiX)_