### PR TITLE
refactor: move weak flag from Dependency to ModuleDependency

### DIFF
--- a/.changeset/move-weak-flag-to-module-dependency.md
+++ b/.changeset/move-weak-flag-to-module-dependency.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Move the `weak` flag from `Dependency` to `ModuleDependency`, where it's actually set.

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -117,10 +117,7 @@ class Dependency {
 		this._parentDependenciesBlock = undefined;
 		/** @type {number} */
 		this._parentDependenciesBlockIndex = -1;
-		// TODO check if this can be moved into ModuleDependency
-		/** @type {boolean} */
-		this.weak = false;
-		// TODO check if this can be moved into ModuleDependency
+		// stays on base: also set on ContextDependency, which is not a ModuleDependency
 		/** @type {boolean | undefined} */
 		this.optional = false;
 		this._locSL = 0;
@@ -343,7 +340,6 @@ class Dependency {
 	 * @param {ObjectSerializerContext} context context
 	 */
 	serialize({ write }) {
-		write(this.weak);
 		write(this.optional);
 		write(this._locSL);
 		write(this._locSC);
@@ -358,7 +354,6 @@ class Dependency {
 	 * @param {ObjectDeserializerContext} context context
 	 */
 	deserialize({ read }) {
-		this.weak = read();
 		this.optional = read();
 		this._locSL = read();
 		this._locSC = read();

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -262,7 +262,8 @@ class ModuleGraph {
 			dependency,
 			module,
 			undefined,
-			dependency.weak,
+			// weak is defined on ModuleDependency; undefined for other dependency kinds
+			/** @type {{ weak?: boolean }} */ (dependency).weak,
 			dependency.getCondition(this)
 		);
 		const connections = this._getModuleGraphModule(module).incomingConnections;

--- a/lib/dependencies/ContextDependencyTemplateAsId.js
+++ b/lib/dependencies/ContextDependencyTemplateAsId.js
@@ -31,7 +31,7 @@ class ContextDependencyTemplateAsId extends ContextDependency.Template {
 			module,
 			chunkGraph,
 			request: /** @type {string} */ (dep.request),
-			weak: dep.weak,
+			weak: /** @type {{ weak?: boolean }} */ (dep).weak,
 			runtimeRequirements
 		});
 

--- a/lib/dependencies/ModuleDependency.js
+++ b/lib/dependencies/ModuleDependency.js
@@ -30,6 +30,8 @@ class ModuleDependency extends Dependency {
 		this.range = undefined;
 		/** @type {undefined | string} */
 		this._context = undefined;
+		/** @type {boolean} */
+		this.weak = false;
 	}
 
 	/**
@@ -84,6 +86,7 @@ class ModuleDependency extends Dependency {
 		write(this._context);
 		write(this.range);
 		write(this.sourceOrder);
+		write(this.weak);
 		super.serialize(context);
 	}
 
@@ -98,6 +101,7 @@ class ModuleDependency extends Dependency {
 		this._context = read();
 		this.range = read();
 		this.sourceOrder = read();
+		this.weak = read();
 		super.deserialize(context);
 	}
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -5007,8 +5007,8 @@ declare interface ContextHash {
 	symlinks?: Set<string>;
 }
 type ContextMode =
-	| "weak"
 	| "eager"
+	| "weak"
 	| "lazy"
 	| "lazy-once"
 	| "sync"
@@ -5787,7 +5787,6 @@ declare interface DependenciesBlockLike {
 }
 declare class Dependency {
 	constructor();
-	weak: boolean;
 	optional?: boolean;
 
 	/**
@@ -12236,7 +12235,7 @@ declare interface JavascriptParserOptions {
 	/**
 	 * Specifies global mode for dynamic import.
 	 */
-	dynamicImportMode?: "weak" | "eager" | "lazy" | "lazy-once";
+	dynamicImportMode?: "eager" | "weak" | "lazy" | "lazy-once";
 
 	/**
 	 * Specifies global prefetch for dynamic import.
@@ -14889,6 +14888,7 @@ declare class ModuleDependency extends Dependency {
 	userRequest: string;
 	sourceOrder?: number;
 	range?: [number, number];
+	weak: boolean;
 	static Template: typeof DependencyTemplate;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];


### PR DESCRIPTION
weak is only set on ModuleDependency subclasses, so move it there; optional
stays on the base because ContextDependency (not a ModuleDependency) uses it.

https://claude.ai/code/session_01W3cXrpZRvyKD3D6sLUqoCz