### PR TITLE
fix: extend value binding to export default expressions

### DIFF
--- a/.changeset/export-default-value-binding.md
+++ b/.changeset/export-default-value-binding.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Extend value binding optimization to export default expressions.

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -61,15 +61,12 @@ class HarmonyExportExpressionDependency extends NullDependency {
 			pureFunctions && pureFunctions.has(DEFAULT_EXPORT_NAME)
 		);
 
-		// Expression default (`export default expr`) generates a const binding;
-		// declaration default (`export default function/class`) is mutable.
-		const isImmutable = !this.declarationId;
 		return {
 			exports: [
 				{
 					name: DEFAULT_EXPORT_NAME,
 					isPure: isPure || undefined,
-					immutableBinding: isImmutable || undefined
+					immutableBinding: true
 				}
 			],
 			priority: 1,

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -10,6 +10,7 @@ const InitFragment = require("../InitFragment");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
+const ExportBindingInitFragment = require("./ExportBindingInitFragment");
 const HarmonyExportInitFragment = require("./HarmonyExportInitFragment");
 const NullDependency = require("./NullDependency");
 
@@ -60,11 +61,16 @@ class HarmonyExportExpressionDependency extends NullDependency {
 			pureFunctions && pureFunctions.has(DEFAULT_EXPORT_NAME)
 		);
 
+		// Expression default (`export default expr`) generates a const binding;
+		// declaration default (`export default function/class`) is mutable.
+		const isImmutable = !this.declarationId;
 		return {
 			exports: [
-				isPure
-					? { name: DEFAULT_EXPORT_NAME, isPure: true }
-					: DEFAULT_EXPORT_NAME
+				{
+					name: DEFAULT_EXPORT_NAME,
+					isPure: isPure || undefined,
+					immutableBinding: isImmutable || undefined
+				}
 			],
 			priority: 1,
 			terminalBinding: true,
@@ -210,10 +216,36 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					if (used) {
 						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
-						/** @type {ExportMap} */
-						const map = new Map();
-						map.set(used, name);
-						initFragments.push(new HarmonyExportInitFragment(exportsName, map));
+						const exportsInfo = moduleGraph.getExportsInfo(module);
+						const exportInfo =
+							exportsInfo.getReadOnlyExportInfo(DEFAULT_EXPORT_NAME);
+						const canUseValueBinding =
+							exportInfo &&
+							exportInfo.immutableBinding === true &&
+							/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
+								.isCircular === false;
+						if (canUseValueBinding) {
+							initFragments.push(
+								new ExportBindingInitFragment(
+									exportsName,
+									[
+										{
+											name: used,
+											value: `/* export default binding */ ${name}`,
+											bindingType: "value"
+										}
+									],
+									true
+								)
+							);
+						} else {
+							/** @type {ExportMap} */
+							const map = new Map();
+							map.set(used, name);
+							initFragments.push(
+								new HarmonyExportInitFragment(exportsName, map)
+							);
+						}
 					} else {
 						content = `/* unused harmony default export */ var ${name} = `;
 					}

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -153,10 +153,8 @@ HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependen
 		const canUseValueBinding =
 			exportInfo &&
 			exportInfo.immutableBinding === true &&
-			!(
-				/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
-					.isCircular
-			);
+			/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
+				.isCircular === false;
 
 		if (canUseValueBinding) {
 			initFragments.push(

--- a/lib/optimize/CircularModulesPlugin.js
+++ b/lib/optimize/CircularModulesPlugin.js
@@ -30,9 +30,9 @@ class CircularModulesPlugin {
 						modules,
 						compilation.moduleGraph
 					);
-					for (const m of circularModules) {
+					for (const m of modules) {
 						/** @type {import("../Module").BuildInfo} */
-						(m.buildInfo).isCircular = true;
+						(m.buildInfo).isCircular = circularModules.has(m);
 					}
 				}
 			);

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -20,12 +20,13 @@ exports[`ConfigCacheTestCases html modulepreload-esm exported tests should emit 
   \\\\********************/
 (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   A: () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
 const value = \\"preload module\\";
 globalThis.__preloadLoaded = true;
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (value);
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"A\\", 0, /* export default binding */ __WEBPACK_DEFAULT_EXPORT__
+/* harmony export */ ]);
 
 
 /***/ }

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -20,12 +20,13 @@ exports[`ConfigTestCases html modulepreload-esm exported tests should emit modul
   \\\\********************/
 (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   A: () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
 const value = \\"preload module\\";
 globalThis.__preloadLoaded = true;
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (value);
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"A\\", 0, /* export default binding */ __WEBPACK_DEFAULT_EXPORT__
+/* harmony export */ ]);
 
 
 /***/ }

--- a/test/configCases/optimization/static-export-bindings/default-expr.js
+++ b/test/configCases/optimization/static-export-bindings/default-expr.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/optimization/static-export-bindings/default-fn-anon.js
+++ b/test/configCases/optimization/static-export-bindings/default-fn-anon.js
@@ -1,0 +1,1 @@
+export default function() { return "default-anon"; }

--- a/test/configCases/optimization/static-export-bindings/default-fn-decl.js
+++ b/test/configCases/optimization/static-export-bindings/default-fn-decl.js
@@ -1,0 +1,1 @@
+export default function fn() { return "default-fn"; }

--- a/test/configCases/optimization/static-export-bindings/index.js
+++ b/test/configCases/optimization/static-export-bindings/index.js
@@ -9,6 +9,9 @@ import * as reexportStar from "./reexport-star";
 import * as reexportCircular from "./reexport-circular";
 import * as defaultBinding from "./default-binding";
 import * as constDefault from "./const-default";
+import * as defaultExpr from "./default-expr";
+import * as defaultFnDecl from "./default-fn-decl";
+import * as defaultFnAnon from "./default-fn-anon";
 import * as starMutable from "./star-mutable";
 import * as selfConst from "./self-const";
 import * as mutableForms from "./mutable-forms";
@@ -128,6 +131,21 @@ it("should keep `export { let as default }` as a live binding", () => {
 it("should bind `export { const as default }` as a value", () => {
 	expectValueDescriptor(constDefault, "default");
 	expect(constDefault.default).toBe("const-default");
+});
+
+it("should bind `export default expression` as a value", () => {
+	expectValueDescriptor(defaultExpr, "default");
+	expect(defaultExpr.default).toBe(42);
+});
+
+it("should keep `export default function fn(){}` as getter", () => {
+	expectGetterDescriptor(defaultFnDecl, "default");
+	expect(defaultFnDecl.default()).toBe("default-fn");
+});
+
+it("should keep `export default function(){}` as getter", () => {
+	expectGetterDescriptor(defaultFnAnon, "default");
+	expect(defaultFnAnon.default()).toBe("default-anon");
 });
 
 it("should keep mutable binding live through `export *`", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21021. That PR applied value binding optimization only to `HarmonyExportSpecifierDependency` (named exports). This PR extends it to `HarmonyExportExpressionDependency` for `export default expression` which generates `const __WEBPACK_DEFAULT_EXPORT__` — an immutable binding eligible for value descriptors.

Also hardens the `isCircular` check: uses `=== false` instead of `!isCircular`, so `undefined` (when `CircularModulesPlugin` hasn't run) prevents the optimization rather than allowing it. `CircularModulesPlugin` now explicitly sets `isCircular` to `false` for non-circular modules.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — added `default-expr.js`, `default-fn-decl.js`, `default-fn-anon.js` test cases in `test/configCases/optimization/static-export-bindings/`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to draft the implementation under human review. All architectural decisions were made through interactive discussion.