### PR TITLE
fix: reject path traversal in chunk names from node_modules

### DIFF
--- a/.changeset/fix-chunk-name-path-traversal.md
+++ b/.changeset/fix-chunk-name-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Prevent asset path traversal via malicious chunk names in dependencies.

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -339,6 +339,19 @@ class ImportParserPlugin {
 								/** @type {DependencyLocation} */ (expr.loc)
 							)
 						);
+					} else if (
+						importOptions.webpackChunkName.includes("..") &&
+						/[\\/]node_modules[\\/]/.test(parser.state.module.resource || "")
+					) {
+						// cspell:ignore GHSA
+						// supply-chain path traversal (GHSA-x9gq-59m7-268r)
+						// TODO webpack 6 make this a build error
+						parser.state.module.addWarning(
+							new UnsupportedFeatureWarning(
+								'`webpackChunkName` must not contain ".." (path traversal).',
+								/** @type {DependencyLocation} */ (expr.loc)
+							)
+						);
 					} else {
 						chunkName = importOptions.webpackChunkName;
 					}

--- a/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const UnsupportedFeatureWarning = require("../errors/UnsupportedFeatureWarning");
 const RequireEnsureDependenciesBlock = require("./RequireEnsureDependenciesBlock");
 const RequireEnsureDependency = require("./RequireEnsureDependency");
 const RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
@@ -39,9 +40,25 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 				case 4: {
 					const chunkNameExpr = parser.evaluateExpression(expr.arguments[3]);
 					if (!chunkNameExpr.isString()) return;
-					chunkName =
+					const chunkNameValue =
 						/** @type {string} */
 						(chunkNameExpr.string);
+					if (
+						chunkNameValue.includes("..") &&
+						/[\\/]node_modules[\\/]/.test(parser.state.module.resource || "")
+					) {
+						// cspell:ignore GHSA
+						// supply-chain path traversal (GHSA-x9gq-59m7-268r)
+						// TODO webpack 6 make this a build error
+						parser.state.module.addWarning(
+							new UnsupportedFeatureWarning(
+								'require.ensure chunk name must not contain ".." (path traversal).',
+								/** @type {DependencyLocation} */ (expr.loc)
+							)
+						);
+					} else {
+						chunkName = chunkNameValue;
+					}
 				}
 				// falls through
 				case 3: {
@@ -51,9 +68,24 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 					if (!errorExpression && !chunkName) {
 						const chunkNameExpr = parser.evaluateExpression(expr.arguments[2]);
 						if (!chunkNameExpr.isString()) return;
-						chunkName =
+						const chunkNameValue2 =
 							/** @type {string} */
 							(chunkNameExpr.string);
+						if (
+							chunkNameValue2.includes("..") &&
+							/[\\/]node_modules[\\/]/.test(parser.state.module.resource || "")
+						) {
+							// supply-chain path traversal (GHSA-x9gq-59m7-268r)
+							// TODO webpack 6 make this a build error
+							parser.state.module.addWarning(
+								new UnsupportedFeatureWarning(
+									'require.ensure chunk name must not contain ".." (path traversal).',
+									/** @type {DependencyLocation} */ (expr.loc)
+								)
+							);
+						} else {
+							chunkName = chunkNameValue2;
+						}
 					}
 				}
 				// falls through

--- a/test/configCases/errors/chunk-name-path-traversal-import/__snapshots__/warnings.snap
+++ b/test/configCases/errors/chunk-name-path-traversal-import/__snapshots__/warnings.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`warnings 1`] = `
+Array [
+  "\`webpackChunkName\` must not contain \\"..\\" (path traversal).",
+]
+`;

--- a/test/configCases/errors/chunk-name-path-traversal-import/index.js
+++ b/test/configCases/errors/chunk-name-path-traversal-import/index.js
@@ -1,0 +1,3 @@
+it("should warn on path traversal in webpackChunkName from node_modules", () => {
+	require("malicious-dep");
+});

--- a/test/configCases/errors/chunk-name-path-traversal-import/node_modules/malicious-dep/index.js
+++ b/test/configCases/errors/chunk-name-path-traversal-import/node_modules/malicious-dep/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return import(/* webpackChunkName: "../escaped" */ "./payload.js");
+};

--- a/test/configCases/errors/chunk-name-path-traversal-import/node_modules/malicious-dep/payload.js
+++ b/test/configCases/errors/chunk-name-path-traversal-import/node_modules/malicious-dep/payload.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/configCases/errors/chunk-name-path-traversal-import/test.config.js
+++ b/test/configCases/errors/chunk-name-path-traversal-import/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/errors/chunk-name-path-traversal-import/webpack.config.js
+++ b/test/configCases/errors/chunk-name-path-traversal-import/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	output: {
+		filename: "[name].js"
+	}
+};

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/__snapshots__/warnings.snap
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/__snapshots__/warnings.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`warnings 1`] = `
+Array [
+  "require.ensure chunk name must not contain \\"..\\" (path traversal).",
+]
+`;

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/index.js
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/index.js
@@ -1,0 +1,3 @@
+it("should warn on path traversal in require.ensure chunk name from node_modules", () => {
+	require("malicious-dep");
+});

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/node_modules/malicious-dep/index.js
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/node_modules/malicious-dep/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	require.ensure([], () => require("./payload.js"), "../escaped");
+};

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/node_modules/malicious-dep/payload.js
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/node_modules/malicious-dep/payload.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/test.config.js
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/errors/chunk-name-path-traversal-require-ensure/webpack.config.js
+++ b/test/configCases/errors/chunk-name-path-traversal-require-ensure/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	output: {
+		filename: "[name].js"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes GHSA-x9gq-59m7-268r. A `webpackChunkName` magic comment or `require.ensure` chunk-name argument containing `..` in a dependency under `node_modules` can cause webpack to write chunks outside `output.path`, enabling a supply-chain path traversal attack. This adds a check at parse time in `ImportParserPlugin` and `RequireEnsureDependenciesBlockParserPlugin` that emits a build error when a chunk name from `node_modules` contains `..`. User-authored code is not affected — webpack intentionally allows user-controlled entry/chunk names to write outside `output.path` (see `test/configCases/entry/weird-names` and `test/configCases/entry/weird-names2`), so the guard is scoped to `node_modules` only.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/errors/chunk-name-path-traversal-import` and `test/configCases/errors/chunk-name-path-traversal-require-ensure`, each with a simulated malicious dependency under `node_modules/`.

**Does this PR introduce a breaking change?**

No — only `node_modules` code using `..` in chunk names (which has no legitimate use case) is rejected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to analyze the vulnerability, trace the attack surface, write the fix, and author the tests under human review and direction.