### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-announcement.yml
+++ b/.github/workflows/release-announcement.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/webpack/webpack/security/code-scanning/30](https://github.com/webpack/webpack/security/code-scanning/30)

Add an explicit `permissions` block with least privilege to the workflow.  
For this workflow, `gh release view` and `actions/checkout` only require read access to repository contents, so `contents: read` is sufficient and does not change behavior.

Best single fix:
- Edit `.github/workflows/release-announcement.yml`.
- Add a root-level `permissions:` block after the triggers (`on:`) and before `jobs:`.
- Set:
  - `contents: read`

No imports, methods, or extra definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
