### PR TITLE
fix: CJS tree-shaking drops exports accessed before deferred require

### DIFF
--- a/.changeset/fix-cjs-deferred-require-tree-shaking.md
+++ b/.changeset/fix-cjs-deferred-require-tree-shaking.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+CommonJS tree-shaking no longer drops exports accessed before a deferred require binding.

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -53,7 +53,7 @@ const RequireResolveHeaderDependency = require("./RequireResolveHeaderDependency
  * member-access references on `NAME` to the `CommonJsRequireDependency`
  * created for the `require()` call.
  * @typedef {object} RequireBindingData
- * @property {RawReferencedExports} referencedExports mutable list shared with the dependency; pushed to as `NAME.x.y` accesses are walked
+ * @property {RawReferencedExports | null} referencedExports mutable list shared with the dependency; pushed to as `NAME.x.y` accesses are walked; null means the whole namespace is used
  * @property {InstanceType<typeof import("./CommonJsRequireDependency")> | null} dep dependency for the `require()` call (assigned during walk)
  */
 
@@ -727,10 +727,13 @@ class CommonJsImportsParserPlugin {
 			const binding =
 				/** @type {RequireBindingData} */
 				(parser.currentTagData);
-			if (binding && binding.dep) {
+			if (binding) {
 				// `NAME` is read as a value (not as the object of a static member
 				// chain), so we have to assume the whole exports object is used.
-				binding.dep.referencedExports = null;
+				binding.referencedExports = null;
+				if (binding.dep) {
+					binding.dep.referencedExports = null;
+				}
 			}
 			return true;
 		});
@@ -741,8 +744,8 @@ class CommonJsImportsParserPlugin {
 				const binding =
 					/** @type {RequireBindingData} */
 					(parser.currentTagData);
-				if (binding && binding.dep && binding.dep.referencedExports) {
-					binding.dep.referencedExports.push(members);
+				if (binding && binding.referencedExports) {
+					binding.referencedExports.push(members);
 				}
 				// Returning truthy suppresses the parser's fallback chain (which
 				// would otherwise walk `NAME` as a bare expression and trigger our
@@ -756,13 +759,16 @@ class CommonJsImportsParserPlugin {
 				const binding =
 					/** @type {RequireBindingData} */
 					(parser.currentTagData);
-				if (binding && binding.dep && binding.dep.referencedExports) {
+				if (binding && binding.referencedExports) {
 					if (members.length === 0) {
 						// `NAME(...)` — calling the require result directly; the
 						// whole exports object is observable.
-						binding.dep.referencedExports = null;
+						binding.referencedExports = null;
+						if (binding.dep) {
+							binding.dep.referencedExports = null;
+						}
 					} else {
-						binding.dep.referencedExports.push(members);
+						binding.referencedExports.push(members);
 					}
 				}
 				if (expr.arguments) parser.walkExpressions(expr.arguments);

--- a/test/cases/cjs-tree-shaking/require-member-access-deferred/impl.js
+++ b/test/cases/cjs-tree-shaking/require-member-access-deferred/impl.js
@@ -1,0 +1,8 @@
+// Simulates whatwg-url/lib/URL-impl.js
+exports.implementation = class URLImpl {
+	constructor(args) {
+		this.href = args[0];
+	}
+};
+exports.unused = "should be tree-shaken";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-member-access-deferred/index.js
+++ b/test/cases/cjs-tree-shaking/require-member-access-deferred/index.js
@@ -1,0 +1,12 @@
+it("should not tree-shake exports accessed via a deferred require binding", () => {
+	const { interface: URL } = require("./wrapper");
+	const u = new URL("https://example.com/");
+	expect(u._impl).toBeTruthy();
+	expect(u._impl.href).toBe("https://example.com/");
+});
+
+it("should still tree-shake unused exports from the deferred module", () => {
+	const Impl = require("./impl");
+	// "implementation" is used (via wrapper.js), "unused" is not
+	expect(Impl.usedExports).toEqual(["implementation", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/require-member-access-deferred/test.filter.js
+++ b/test/cases/cjs-tree-shaking/require-member-access-deferred/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/require-member-access-deferred/wrapper.js
+++ b/test/cases/cjs-tree-shaking/require-member-access-deferred/wrapper.js
@@ -1,0 +1,17 @@
+// Simulates whatwg-url/lib/URL.js pattern: function bodies reference
+// `Impl` which is declared at the bottom (deferred require for circular deps).
+exports.setup = (obj, constructorArgs) => {
+	obj._impl = new Impl.implementation(constructorArgs);
+	return obj;
+};
+
+class URL {
+	constructor(url) {
+		return exports.setup(Object.create(URL.prototype), [url]);
+	}
+}
+
+exports.interface = URL;
+
+// Deferred require at the bottom of the file (handles circular dependencies)
+const Impl = require("./impl");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #21122. The `const NAME = require(LITERAL)` binding optimization (#21003) missed member accesses appearing lexically before the declaration (e.g. inside hoisted function bodies — the pattern webidl2js generates for whatwg-url). The hooks guarded pushes behind `binding.dep &&` which is null until the `require()` call is walked, but function bodies above are walked first. Fixed by operating directly on `binding.referencedExports` (the shared array that the dep later receives) instead of going through `binding.dep`.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/cases/cjs-tree-shaking/require-member-access-deferred`, reproducing the deferred-require pattern from whatwg-url/webidl2js.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to trace the root cause through the parser's walk phases and author the fix under human review and direction.