### PR TITLE
feat: support CommonJS reexports via Object.defineProperty descriptors

### DIFF
--- a/.changeset/cjs-define-property-reexport.md
+++ b/.changeset/cjs-define-property-reexport.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Support CommonJS reexports via `Object.defineProperty` value descriptors.
+Support CommonJS reexports via `Object.defineProperty` value and getter descriptors.

--- a/.changeset/cjs-define-property-reexport.md
+++ b/.changeset/cjs-define-property-reexport.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support CommonJS reexports via `Object.defineProperty` value descriptors.

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -67,6 +67,9 @@ class CommonJsExportRequireDependency extends ModuleDependency {
 		this.resultUsed = resultUsed;
 		/** @type {undefined | boolean} */
 		this.asiSafe = undefined;
+		// true when the reexport is a lazy `{ get: () => require(...) }` accessor
+		// (as produced by `Object.defineProperty`) rather than an eager value.
+		this.getter = false;
 	}
 
 	get type() {
@@ -361,6 +364,7 @@ class CommonJsExportRequireDependency extends ModuleDependency {
 		write(this.names);
 		write(this.ids);
 		write(this.resultUsed);
+		write(this.getter);
 		super.serialize(context);
 	}
 
@@ -377,6 +381,7 @@ class CommonJsExportRequireDependency extends ModuleDependency {
 		this.names = read();
 		this.ids = read();
 		this.resultUsed = read();
+		this.getter = read();
 		super.deserialize(context);
 	}
 }
@@ -463,21 +468,30 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 				return;
 			case "Object.defineProperty": {
 				// `Object.defineProperty(exports, "name", { value: require("...") })`
+				// or the lazy getter form `{ get: () => require("...") }` used by
+				// barrel files (e.g. webpack's own `lib/index.js`).
 				const valueRange = /** @type {Range} */ (dep.valueRange);
 				if (!used) {
+					// A lazy getter never runs `require` until accessed, so an unused
+					// one can be dropped entirely; an eager value must keep side effects.
 					source.replace(
 						dep.range[0],
 						dep.range[1] - 1,
-						`/* unused reexport */ ${requireExpr}`
+						dep.getter
+							? "/* unused reexport */ 0"
+							: `/* unused reexport */ ${requireExpr}`
 					);
 					return;
 				}
+				const descriptor = dep.getter
+					? "enumerable: true, get: () => ("
+					: "value: (";
 				source.replace(
 					dep.range[0],
 					valueRange[0] - 1,
 					`Object.defineProperty(${base}${propertyAccess(
 						used.slice(0, -1)
-					)}, ${JSON.stringify(used[used.length - 1])}, { value: (`
+					)}, ${JSON.stringify(used[used.length - 1])}, { ${descriptor}`
 				);
 				source.replace(valueRange[0], valueRange[1] - 1, requireExpr);
 				source.replace(valueRange[1], dep.range[1] - 1, ") })");

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -461,8 +461,28 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 						: `/* unused reexport */ ${requireExpr}`
 				);
 				return;
-			case "Object.defineProperty":
-				throw new Error("TODO");
+			case "Object.defineProperty": {
+				// `Object.defineProperty(exports, "name", { value: require("...") })`
+				const valueRange = /** @type {Range} */ (dep.valueRange);
+				if (!used) {
+					source.replace(
+						dep.range[0],
+						dep.range[1] - 1,
+						`/* unused reexport */ ${requireExpr}`
+					);
+					return;
+				}
+				source.replace(
+					dep.range[0],
+					valueRange[0] - 1,
+					`Object.defineProperty(${base}${propertyAccess(
+						used.slice(0, -1)
+					)}, ${JSON.stringify(used[used.length - 1])}, { value: (`
+				);
+				source.replace(valueRange[0], valueRange[1] - 1, requireExpr);
+				source.replace(valueRange[1], dep.range[1] - 1, ") })");
+				return;
+			}
 			default:
 				throw new Error("Unexpected type");
 		}

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -60,6 +60,50 @@ const getValueOfPropertyDescription = (expr) => {
 };
 
 /**
+ * Extracts the re-exportable expression from a property descriptor, handling
+ * both the eager `{ value: <expr> }` form and the lazy
+ * `{ get: () => <expr> }` / `{ get() { return <expr>; } }` accessor form used
+ * by barrel files (e.g. webpack's own `lib/index.js`).
+ * @param {Expression} expr property descriptor expression
+ * @returns {{ expr: Expression, getter: boolean } | undefined} the value expression and whether it is a lazy getter
+ */
+const getReexportOfPropertyDescriptor = (expr) => {
+	if (expr.type !== "ObjectExpression") return;
+	for (const property of expr.properties) {
+		if (property.type === "SpreadElement" || property.computed) continue;
+		const key = property.key;
+		if (key.type !== "Identifier") continue;
+		if (key.name === "value") {
+			return {
+				expr: /** @type {Expression} */ (property.value),
+				getter: false
+			};
+		}
+		if (key.name === "get") {
+			const fn = property.value;
+			if (
+				fn.type !== "FunctionExpression" &&
+				fn.type !== "ArrowFunctionExpression"
+			) {
+				continue;
+			}
+			// Arrow with expression body: `() => require("./x")`.
+			if (fn.body.type !== "BlockStatement") {
+				return { expr: /** @type {Expression} */ (fn.body), getter: true };
+			}
+			// Function body must be exactly `return <expr>;`.
+			if (
+				fn.body.body.length === 1 &&
+				fn.body.body[0].type === "ReturnStatement" &&
+				fn.body.body[0].argument
+			) {
+				return { expr: fn.body.body[0].argument, getter: true };
+			}
+		}
+	}
+};
+
+/**
  * The purpose of this function is to check whether an expression is a truthy literal or not. This is
  * useful when parsing CommonJS exports, because CommonJS modules can export any value, including falsy
  * values like `null` and `false`. However, exports should only be created if the exported value is truthy.
@@ -295,20 +339,23 @@ class CommonJsExportsParserPlugin {
 				if (typeof property !== "string") return;
 				enableStructuredExports();
 				const descArg = expr.arguments[2];
-				const valueExpr = getValueOfPropertyDescription(descArg);
 				// Handle reexporting: `Object.defineProperty(exports, "x", { value: require("./y")[.z] })`
-				if (property !== "__esModule" && valueExpr) {
-					const requireCall = parseRequireCall(parser, valueExpr);
-					if (requireCall && requireCall.argument.isString()) {
+				// and the lazy getter form `{ get: () => require("./y")[.z] }`.
+				if (property !== "__esModule") {
+					const reexport = getReexportOfPropertyDescriptor(descArg);
+					const requireCall =
+						reexport && parseRequireCall(parser, reexport.expr);
+					if (reexport && requireCall && requireCall.argument.isString()) {
 						const dep = new CommonJsExportRequireDependency(
 							/** @type {Range} */ (expr.range),
-							/** @type {Range} */ (valueExpr.range),
+							/** @type {Range} */ (reexport.expr.range),
 							`Object.defineProperty(${exportsArg.identifier})`,
 							[property],
 							/** @type {string} */ (requireCall.argument.string),
 							requireCall.ids,
 							false
 						);
+						dep.getter = reexport.getter;
 						dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 						dep.optional = Boolean(parser.scope.inTry);
 						parser.state.module.addDependency(dep);
@@ -323,7 +370,7 @@ class CommonJsExportsParserPlugin {
 					/** @type {StatementPath} */
 					(parser.statementPath).length === 1,
 					[property],
-					valueExpr
+					getValueOfPropertyDescription(descArg)
 				);
 				const dep = new CommonJsExportsDependency(
 					/** @type {Range} */ (expr.range),

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -63,42 +63,47 @@ const getValueOfPropertyDescription = (expr) => {
  * Extracts the re-exportable expression from a property descriptor, handling
  * both the eager `{ value: <expr> }` form and the lazy
  * `{ get: () => <expr> }` / `{ get() { return <expr>; } }` accessor form used
- * by barrel files (e.g. webpack's own `lib/index.js`).
+ * by barrel files (e.g. webpack's own `lib/index.js`). A `set` accessor cannot
+ * be reproduced by the rewritten descriptor, so descriptors with a setter are
+ * left to the generic handler (which keeps the descriptor verbatim).
  * @param {Expression} expr property descriptor expression
  * @returns {{ expr: Expression, getter: boolean } | undefined} the value expression and whether it is a lazy getter
  */
 const getReexportOfPropertyDescriptor = (expr) => {
 	if (expr.type !== "ObjectExpression") return;
+	/** @type {Expression | undefined} */
+	let valueExpr;
+	/** @type {Expression | undefined} */
+	let getFn;
 	for (const property of expr.properties) {
 		if (property.type === "SpreadElement" || property.computed) continue;
 		const key = property.key;
 		if (key.type !== "Identifier") continue;
+		// A setter would be silently dropped by the rewrite — bail out.
+		if (key.name === "set") return;
 		if (key.name === "value") {
-			return {
-				expr: /** @type {Expression} */ (property.value),
-				getter: false
-			};
+			valueExpr = /** @type {Expression} */ (property.value);
+		} else if (key.name === "get") {
+			getFn = /** @type {Expression} */ (property.value);
 		}
-		if (key.name === "get") {
-			const fn = property.value;
-			if (
-				fn.type !== "FunctionExpression" &&
-				fn.type !== "ArrowFunctionExpression"
-			) {
-				continue;
-			}
-			// Arrow with expression body: `() => require("./x")`.
-			if (fn.body.type !== "BlockStatement") {
-				return { expr: /** @type {Expression} */ (fn.body), getter: true };
-			}
-			// Function body must be exactly `return <expr>;`.
-			if (
-				fn.body.body.length === 1 &&
-				fn.body.body[0].type === "ReturnStatement" &&
-				fn.body.body[0].argument
-			) {
-				return { expr: fn.body.body[0].argument, getter: true };
-			}
+	}
+	if (valueExpr) return { expr: valueExpr, getter: false };
+	if (
+		getFn &&
+		(getFn.type === "FunctionExpression" ||
+			getFn.type === "ArrowFunctionExpression")
+	) {
+		// Arrow with expression body: `() => require("./x")`.
+		if (getFn.body.type !== "BlockStatement") {
+			return { expr: /** @type {Expression} */ (getFn.body), getter: true };
+		}
+		// Function body must be exactly `return <expr>;`.
+		if (
+			getFn.body.body.length === 1 &&
+			getFn.body.body[0].type === "ReturnStatement" &&
+			getFn.body.body[0].argument
+		) {
+			return { expr: getFn.body.body[0].argument, getter: true };
 		}
 	}
 };

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -295,11 +295,35 @@ class CommonJsExportsParserPlugin {
 				if (typeof property !== "string") return;
 				enableStructuredExports();
 				const descArg = expr.arguments[2];
+				const valueExpr = getValueOfPropertyDescription(descArg);
+				// Handle reexporting: `Object.defineProperty(exports, "x", { value: require("./y")[.z] })`
+				if (property !== "__esModule" && valueExpr) {
+					const requireCall = parseRequireCall(parser, valueExpr);
+					if (requireCall && requireCall.argument.isString()) {
+						const dep = new CommonJsExportRequireDependency(
+							/** @type {Range} */ (expr.range),
+							/** @type {Range} */ (valueExpr.range),
+							`Object.defineProperty(${exportsArg.identifier})`,
+							[property],
+							/** @type {string} */ (requireCall.argument.string),
+							requireCall.ids,
+							false
+						);
+						dep.loc = /** @type {DependencyLocation} */ (expr.loc);
+						dep.optional = Boolean(parser.scope.inTry);
+						parser.state.module.addDependency(dep);
+						/** @type {BuildMeta} */ (
+							parser.state.module.buildMeta
+						).treatAsCommonJs = true;
+
+						return true;
+					}
+				}
 				checkNamespace(
 					/** @type {StatementPath} */
 					(parser.statementPath).length === 1,
 					[property],
-					getValueOfPropertyDescription(descArg)
+					valueExpr
 				);
 				const dep = new CommonJsExportsDependency(
 					/** @type {Range} */ (expr.range),

--- a/test/cases/cjs-tree-shaking/reexports-define-property/add-to-counter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/add-to-counter.js
@@ -1,0 +1,5 @@
+const counter = require("./counter");
+counter.value++;
+
+exports.abc = 42;
+exports.abcUsed = __webpack_exports_info__.abc.used;

--- a/test/cases/cjs-tree-shaking/reexports-define-property/counter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/counter.js
@@ -1,0 +1,1 @@
+exports.value = 0;

--- a/test/cases/cjs-tree-shaking/reexports-define-property/index.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/index.js
@@ -16,7 +16,17 @@ it("should reexport a reexported module via Object.defineProperty value", () => 
 	expect(require("./reexport-reexport-define?3").reexport3.abc).toBe("abc");
 });
 
-it("should keep executing reexported modules even when unused", () => {
+it("should reexport a deeply nested property via Object.defineProperty value", () => {
+	expect(require("./reexport-nested?1").nested).toBe("nested-value");
+});
+
+it("should reexport via a lazy Object.defineProperty getter (arrow, function, method)", () => {
+	expect(require("./reexport-getter-define?1").getter1.abc).toBe("abc");
+	expect(require("./reexport-getter-define?2").getter2).toBe("abc");
+	expect(require("./reexport-getter-define?3").getter3.abc).toBe("abc");
+});
+
+it("should keep executing eager (value) reexported modules even when unused", () => {
 	const counter = require("./counter");
 	counter.value = 0;
 	Object.defineProperty(exports, "unused1", {
@@ -30,4 +40,22 @@ it("should keep executing reexported modules even when unused", () => {
 		expect(require("./add-to-counter?1").abcUsed).toBe(false);
 		expect(require("./add-to-counter?2").abcUsed).toBe(false);
 	}
+});
+
+it("should not execute a reexported module until the getter is accessed", () => {
+	const counter = require("./counter");
+	counter.value = 0;
+	const m = require("./reexport-lazy-getter");
+	// the require ran, but the lazy getter has not been accessed yet
+	expect(counter.value).toBe(0);
+	// accessing the getter triggers the underlying require
+	expect(m.lazy.abc).toBe(42);
+	expect(counter.value).toBe(1);
+});
+
+it("should never execute a module behind an unused getter reexport", () => {
+	const counter = require("./counter");
+	counter.value = 0;
+	require("./reexport-unused-getter");
+	expect(counter.value).toBe(0);
 });

--- a/test/cases/cjs-tree-shaking/reexports-define-property/index.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/index.js
@@ -53,6 +53,14 @@ it("should not execute a reexported module until the getter is accessed", () => 
 	expect(counter.value).toBe(1);
 });
 
+it("should preserve the setter when a get/set descriptor wraps a reexport", () => {
+	const m = require("./reexport-getter-setter?1");
+	expect(m.value).toBe("abc"); // getter returns the reexported value
+	m.value = "written"; // setter must still exist (would throw if dropped)
+	expect(m.getLastSet()).toBe("written");
+	expect(m.value).toBe("abc"); // getter is unaffected by the write
+});
+
 it("should never execute a module behind an unused getter reexport", () => {
 	const counter = require("./counter");
 	counter.value = 0;

--- a/test/cases/cjs-tree-shaking/reexports-define-property/index.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/index.js
@@ -1,0 +1,33 @@
+it("should reexport a whole module via Object.defineProperty value (exports, module.exports, this)", () => {
+	expect(require("./reexport-whole-define?1").module1.abc).toBe("abc");
+	expect(require("./reexport-whole-define?2").module2.abc).toBe("abc");
+	expect(require("./reexport-whole-define?3").module3.abc).toBe("abc");
+});
+
+it("should reexport an imported property via Object.defineProperty value (exports, module.exports, this)", () => {
+	expect(require("./reexport-property-define?1").property1).toBe("abc");
+	expect(require("./reexport-property-define?2").property2).toBe("abc");
+	expect(require("./reexport-property-define?3").property3).toBe("abc");
+});
+
+it("should reexport a reexported module via Object.defineProperty value", () => {
+	expect(require("./reexport-reexport-define?1").reexport1.abc).toBe("abc");
+	expect(require("./reexport-reexport-define?2").reexport2.abc).toBe("abc");
+	expect(require("./reexport-reexport-define?3").reexport3.abc).toBe("abc");
+});
+
+it("should keep executing reexported modules even when unused", () => {
+	const counter = require("./counter");
+	counter.value = 0;
+	Object.defineProperty(exports, "unused1", {
+		value: require("./add-to-counter?1")
+	});
+	Object.defineProperty(exports, "unused2", {
+		value: require("./add-to-counter?2").abc
+	});
+	expect(counter.value).toBe(2);
+	if (process.env.NODE_ENV === "production") {
+		expect(require("./add-to-counter?1").abcUsed).toBe(false);
+		expect(require("./add-to-counter?2").abcUsed).toBe(false);
+	}
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/lazy-counter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/lazy-counter.js
@@ -1,0 +1,3 @@
+require("./counter").value++;
+
+exports.abc = 42;

--- a/test/cases/cjs-tree-shaking/reexports-define-property/module.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/module.js
@@ -1,0 +1,2 @@
+exports.abc = "abc";
+exports.def = "def";

--- a/test/cases/cjs-tree-shaking/reexports-define-property/nested.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/nested.js
@@ -1,0 +1,1 @@
+exports.outer = { inner: "nested-value" };

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-getter-define.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-getter-define.js
@@ -1,0 +1,19 @@
+// Arrow getter, whole module.
+Object.defineProperty(exports, "getter1", {
+	enumerable: true,
+	get: () => require("./module?dg1" + __resourceQuery)
+});
+// Function-expression getter, property access.
+Object.defineProperty(module.exports, "getter2", {
+	enumerable: true,
+	get: function () {
+		return require("./module?dg2" + __resourceQuery).abc;
+	}
+});
+// Method-shorthand getter on `this`.
+Object.defineProperty(this, "getter3", {
+	enumerable: true,
+	get() {
+		return require("./module?dg3" + __resourceQuery);
+	}
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-getter-setter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-getter-setter.js
@@ -1,0 +1,12 @@
+let lastSet;
+
+// A get/set descriptor: the getter re-exports a required value, but the setter
+// must be preserved (it cannot be reproduced by the reexport rewrite).
+Object.defineProperty(exports, "value", {
+	get: () => require("./module?gs" + __resourceQuery).abc,
+	set: v => {
+		lastSet = v;
+	}
+});
+
+exports.getLastSet = () => lastSet;

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-lazy-getter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-lazy-getter.js
@@ -1,0 +1,4 @@
+Object.defineProperty(exports, "lazy", {
+	enumerable: true,
+	get: () => require("./lazy-counter")
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-nested.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-nested.js
@@ -1,0 +1,3 @@
+Object.defineProperty(exports, "nested", {
+	value: require("./nested?dn" + __resourceQuery).outer.inner
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-property-define.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-property-define.js
@@ -1,0 +1,9 @@
+Object.defineProperty(exports, "property1", {
+	value: require("./module?dpe1" + __resourceQuery).abc
+});
+Object.defineProperty(module.exports, "property2", {
+	value: require("./module?dpe2" + __resourceQuery).abc
+});
+Object.defineProperty(this, "property3", {
+	value: require("./module?dpe3" + __resourceQuery).abc
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-reexport-define.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-reexport-define.js
@@ -1,0 +1,9 @@
+Object.defineProperty(exports, "reexport1", {
+	value: require("./reexport-whole-define?dx1" + __resourceQuery).module1
+});
+Object.defineProperty(module.exports, "reexport2", {
+	value: require("./reexport-whole-define?dx2" + __resourceQuery).module2
+});
+Object.defineProperty(this, "reexport3", {
+	value: require("./reexport-whole-define?dx3" + __resourceQuery).module3
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-unused-getter.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-unused-getter.js
@@ -1,0 +1,4 @@
+Object.defineProperty(exports, "neverUsed", {
+	enumerable: true,
+	get: () => require("./lazy-counter?unused")
+});

--- a/test/cases/cjs-tree-shaking/reexports-define-property/reexport-whole-define.js
+++ b/test/cases/cjs-tree-shaking/reexports-define-property/reexport-whole-define.js
@@ -1,0 +1,9 @@
+Object.defineProperty(exports, "module1", {
+	value: require("./module?dwe1" + __resourceQuery)
+});
+Object.defineProperty(module.exports, "module2", {
+	value: require("./module?dwe2" + __resourceQuery)
+});
+Object.defineProperty(this, "module3", {
+	value: require("./module?dwe3" + __resourceQuery)
+});

--- a/test/configCases/library/reexport-define-property-module/PluginA.js
+++ b/test/configCases/library/reexport-define-property-module/PluginA.js
@@ -1,0 +1,5 @@
+module.exports = class PluginA {
+	apply() {
+		return "A";
+	}
+};

--- a/test/configCases/library/reexport-define-property-module/barrel.js
+++ b/test/configCases/library/reexport-define-property-module/barrel.js
@@ -1,0 +1,14 @@
+// A CommonJS barrel exposing submodules the way webpack's own `lib/index.js`
+// does: eager `value` re-exports next to lazy `get` accessors. Consumed below
+// through static ESM named imports.
+Object.defineProperty(exports, "PluginA", {
+	value: require("./PluginA")
+});
+Object.defineProperty(exports, "lazyValue", {
+	enumerable: true,
+	get: () => require("./util").value
+});
+Object.defineProperty(exports, "util", {
+	enumerable: true,
+	get: () => require("./util")
+});

--- a/test/configCases/library/reexport-define-property-module/index.js
+++ b/test/configCases/library/reexport-define-property-module/index.js
@@ -1,0 +1,10 @@
+import { PluginA, lazyValue, util } from "./barrel";
+
+it("should statically named-import value and getter reexports from a CJS barrel", () => {
+	expect(new PluginA().apply()).toBe("A");
+	expect(lazyValue).toBe(42);
+	expect(util.helper()).toBe("helper");
+	expect(util.value).toBe(42);
+});
+
+export { PluginA, lazyValue, util };

--- a/test/configCases/library/reexport-define-property-module/util.js
+++ b/test/configCases/library/reexport-define-property-module/util.js
@@ -1,0 +1,2 @@
+exports.value = 42;
+exports.helper = () => "helper";

--- a/test/configCases/library/reexport-define-property-module/webpack.config.js
+++ b/test/configCases/library/reexport-define-property-module/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	// Keep export names stable so named imports resolve by their source names.
+	optimization: { mangleExports: false },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		library: { type: "module" }
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/test/configCases/library/reexport-define-property/PluginA.js
+++ b/test/configCases/library/reexport-define-property/PluginA.js
@@ -1,0 +1,5 @@
+module.exports = class PluginA {
+	apply() {
+		return "A";
+	}
+};

--- a/test/configCases/library/reexport-define-property/PluginB.js
+++ b/test/configCases/library/reexport-define-property/PluginB.js
@@ -1,0 +1,3 @@
+module.exports = function PluginB() {
+	return "B";
+};

--- a/test/configCases/library/reexport-define-property/barrel.js
+++ b/test/configCases/library/reexport-define-property/barrel.js
@@ -1,0 +1,15 @@
+// Mirrors how webpack's own `lib/index.js` exposes submodules: a barrel that
+// defines each named export as a non-enumerable `value` re-export.
+Object.defineProperty(exports, "PluginA", {
+	value: require("./PluginA")
+});
+Object.defineProperty(exports, "PluginB", {
+	value: require("./PluginB")
+});
+Object.defineProperty(exports, "util", {
+	value: require("./util")
+});
+// Single nested property re-export.
+Object.defineProperty(exports, "value", {
+	value: require("./util").value
+});

--- a/test/configCases/library/reexport-define-property/index.js
+++ b/test/configCases/library/reexport-define-property/index.js
@@ -1,0 +1,18 @@
+const lib = require("./barrel");
+
+it("should reexport whole submodules via Object.defineProperty value", () => {
+	expect(new lib.PluginA().apply()).toBe("A");
+	expect(lib.PluginB()).toBe("B");
+	expect(lib.util.helper()).toBe("helper");
+	expect(lib.util.value).toBe(42);
+});
+
+it("should reexport a single nested property via Object.defineProperty value", () => {
+	expect(lib.value).toBe(42);
+});
+
+it("should define the reexports as non-enumerable, read-only properties", () => {
+	const desc = Object.getOwnPropertyDescriptor(lib, "PluginB");
+	expect(desc.enumerable).toBe(false);
+	expect(desc.writable).toBe(false);
+});

--- a/test/configCases/library/reexport-define-property/util.js
+++ b/test/configCases/library/reexport-define-property/util.js
@@ -1,0 +1,3 @@
+exports.helper = () => "helper";
+exports.value = 42;
+exports.unused = "unused";

--- a/test/configCases/library/reexport-define-property/webpack.config.js
+++ b/test/configCases/library/reexport-define-property/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	// Keep export names stable so the test can assert on them by name.
+	optimization: { mangleExports: false },
+	output: {
+		library: { type: "commonjs-module" }
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The `Object.defineProperty` branch of `CommonJsExportRequireDependency` was an unimplemented `throw new Error("TODO")`, so `Object.defineProperty(exports, name, { value: require("...") })` re-exports were never treated as structured re-exports (no exports analysis, no tree-shaking). This PR detects and implements them, including the lazy `{ get: () => require("...") }` / `{ get() { return require("...") } }` barrel form used by webpack's own `lib/index.js`. Lazy getters keep their deferred semantics in the generated code, and a `{ get, set }` descriptor keeps its setter (it falls back to the generic handler rather than silently dropping it).

**What kind of change does this PR introduce?**

feat (plus a related fix for the get/set descriptor case).

**Did you add tests for your changes?**

Yes — `test/cases/cjs-tree-shaking/reexports-define-property/` (value/getter/get+set forms across the `exports`/`module.exports`/`this` bases, nested ids, laziness, unused) and two library cases: `test/configCases/library/reexport-define-property/` (CommonJS output) and `test/configCases/library/reexport-define-property-module/` (ESM `library.type: "module"` output, statically named-importing value and getter reexports from a CommonJS barrel).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — internal exports-analysis optimization, no public API or config change.

**Use of AI**

Yes — implemented with Claude Code (Anthropic). All changes were reviewed, run, and tested locally before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tprbu7T8nKkms2TTmn6jpM)_