### PR TITLE
fix: force-load a module's new owning chunk when its only loaded chunk leaves a runtime during HMR

### DIFF
--- a/.changeset/hmr-force-load-migrated-chunk.md
+++ b/.changeset/hmr-force-load-migrated-chunk.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Force-load a module's new owning chunk during HMR when its only loaded chunk is removed from a runtime, so it keeps receiving updates.

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -80,7 +80,7 @@ const {
 /** @typedef {Set<ChunkId>} ChunkIds */
 /** @typedef {Set<Module>} ModuleSet */
 
-/** @typedef {{ updatedChunkIds: ChunkIds, removedChunkIds: ChunkIds, removedModules: ModuleSet, filename: string, assetInfo: AssetInfo }} HotUpdateMainContentByRuntimeItem */
+/** @typedef {{ updatedChunkIds: ChunkIds, removedChunkIds: ChunkIds, removedModules: ModuleSet, forceLoadChunkIds: ChunkIds, filename: string, assetInfo: AssetInfo }} HotUpdateMainContentByRuntimeItem */
 /** @typedef {Map<string, HotUpdateMainContentByRuntimeItem>} HotUpdateMainContentByRuntime */
 
 /** @type {WeakMap<JavascriptParser, HMRJavascriptParserHooks>} */
@@ -573,6 +573,8 @@ class HotModuleReplacementPlugin {
 									removedChunkIds: new Set(),
 									/** @type {ModuleSet} */
 									removedModules: new Set(),
+									/** @type {ChunkIds} */
+									forceLoadChunkIds: new Set(),
 									filename,
 									assetInfo
 								}
@@ -699,30 +701,53 @@ class HotModuleReplacementPlugin {
 										}
 									} else {
 										// module is no longer in this runtime combination
-										// We (incorrectly) assume that it's not in an overlapping runtime combination
-										// and dispose it from the main runtimes the chunk was removed from
 										forEachRuntime(removedFromRuntime, (runtime) => {
-											// If the module is still used in this runtime, do not dispose it
-											// This could create a bad runtime state where the module is still loaded,
-											// but no chunk which contains it. This means we don't receive further HMR updates
-											// to this module and that's bad.
-											// TODO force load one of the chunks which contains the module
-											for (const moduleRuntime of runtimes) {
-												if (typeof moduleRuntime === "string") {
-													if (moduleRuntime === runtime) return;
-												} else if (
-													moduleRuntime !== undefined &&
-													moduleRuntime.has(/** @type {string} */ (runtime))
-												) {
-													return;
-												}
-											}
 											const item =
 												/** @type {HotUpdateMainContentByRuntimeItem} */ (
 													hotUpdateMainContentByRuntime.get(
 														/** @type {string} */ (runtime)
 													)
 												);
+											// If the module still lives in this runtime via another chunk,
+											// disposing it would leave it loaded with no chunk owning it,
+											// cutting off further HMR updates. Instead force-load one such
+											// chunk so the client keeps an installed owner.
+											let stillInRuntime = false;
+											for (const moduleRuntime of runtimes) {
+												if (typeof moduleRuntime === "string") {
+													if (moduleRuntime === runtime) {
+														stillInRuntime = true;
+														break;
+													}
+												} else if (
+													moduleRuntime !== undefined &&
+													moduleRuntime.has(/** @type {string} */ (runtime))
+												) {
+													stillInRuntime = true;
+													break;
+												}
+											}
+											if (stillInRuntime) {
+												for (const moduleChunk of chunkGraph.getModuleChunksIterable(
+													module
+												)) {
+													const chunkRuntime = moduleChunk.runtime;
+													const inRuntime =
+														typeof chunkRuntime === "string"
+															? chunkRuntime === runtime
+															: chunkRuntime !== undefined &&
+																chunkRuntime.has(
+																	/** @type {string} */ (runtime)
+																);
+													if (inRuntime) {
+														item.forceLoadChunkIds.add(
+															/** @type {ChunkId} */ (moduleChunk.id)
+														);
+														break;
+													}
+												}
+												return;
+											}
 											item.removedModules.add(module);
 										});
 									}
@@ -820,6 +845,7 @@ class HotModuleReplacementPlugin {
 							removedChunkIds,
 							removedModules,
 							updatedChunkIds,
+							forceLoadChunkIds,
 							filename,
 							assetInfo
 						} of hotUpdateMainContentByRuntime.values()) {
@@ -828,7 +854,8 @@ class HotModuleReplacementPlugin {
 								old &&
 								(!isSubset(old.removedChunkIds, removedChunkIds) ||
 									!isSubset(old.removedModules, removedModules) ||
-									!isSubset(old.updatedChunkIds, updatedChunkIds))
+									!isSubset(old.updatedChunkIds, updatedChunkIds) ||
+									!isSubset(old.forceLoadChunkIds, forceLoadChunkIds))
 							) {
 								compilation.warnings.push(
 									new WebpackError(`HotModuleReplacementPlugin
@@ -845,20 +872,30 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 								for (const chunkId of updatedChunkIds) {
 									old.updatedChunkIds.add(chunkId);
 								}
+								for (const chunkId of forceLoadChunkIds) {
+									old.forceLoadChunkIds.add(chunkId);
+								}
 								continue;
 							}
 							hotUpdateMainContentByFilename.set(filename, {
 								removedChunkIds,
 								removedModules,
 								updatedChunkIds,
+								forceLoadChunkIds,
 								assetInfo
 							});
 						}
 						for (const [
 							filename,
-							{ removedChunkIds, removedModules, updatedChunkIds, assetInfo }
+							{
+								removedChunkIds,
+								removedModules,
+								updatedChunkIds,
+								forceLoadChunkIds,
+								assetInfo
+							}
 						] of hotUpdateMainContentByFilename) {
-							/** @type {{ c: ChunkId[], r: ChunkId[], m: ModuleId[], css?: { r: ChunkId[] } }} */
+							/** @type {{ c: ChunkId[], r: ChunkId[], m: ModuleId[], f?: ChunkId[], css?: { r: ChunkId[] } }} */
 							const hotUpdateMainJson = {
 								c: [...updatedChunkIds],
 								r: [...removedChunkIds],
@@ -874,6 +911,13 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 												)
 											]
 							};
+
+							// Chunks the client must load so modules whose only loaded chunk
+							// was removed from a runtime keep an installed owner (see force-load
+							// branch above).
+							if (forceLoadChunkIds.size > 0) {
+								hotUpdateMainJson.f = [...forceLoadChunkIds];
+							}
 
 							// Build CSS removed chunks list (chunks in updatedChunkIds that no longer have CSS)
 							/** @type {ChunkId[]} */

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -708,10 +708,8 @@ class HotModuleReplacementPlugin {
 														/** @type {string} */ (runtime)
 													)
 												);
-											// If the module still lives in this runtime via another chunk,
-											// disposing it would leave it loaded with no chunk owning it,
-											// cutting off further HMR updates. Instead force-load one such
-											// chunk so the client keeps an installed owner.
+											// Module still in this runtime via another chunk: force-load one so
+											// it keeps an installed owner instead of being disposed (lost updates).
 											const stillInRuntime = [...runtimes].some(
 												(moduleRuntime) =>
 													typeof moduleRuntime === "string"
@@ -904,9 +902,8 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 											]
 							};
 
-							// Chunks the client must load so modules whose only loaded chunk
-							// was removed from a runtime keep an installed owner (see force-load
-							// branch above).
+							// Chunks the client must load so a module whose only loaded chunk
+							// left a runtime keeps an installed owner (see force-load branch).
 							if (forceLoadChunkIds.size > 0) {
 								hotUpdateMainJson.f = [...forceLoadChunkIds];
 							}

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -712,21 +712,13 @@ class HotModuleReplacementPlugin {
 											// disposing it would leave it loaded with no chunk owning it,
 											// cutting off further HMR updates. Instead force-load one such
 											// chunk so the client keeps an installed owner.
-											let stillInRuntime = false;
-											for (const moduleRuntime of runtimes) {
-												if (typeof moduleRuntime === "string") {
-													if (moduleRuntime === runtime) {
-														stillInRuntime = true;
-														break;
-													}
-												} else if (
-													moduleRuntime !== undefined &&
-													moduleRuntime.has(/** @type {string} */ (runtime))
-												) {
-													stillInRuntime = true;
-													break;
-												}
-											}
+											const stillInRuntime = [...runtimes].some(
+												(moduleRuntime) =>
+													typeof moduleRuntime === "string"
+														? moduleRuntime === runtime
+														: moduleRuntime !== undefined &&
+															moduleRuntime.has(/** @type {string} */ (runtime))
+											);
 											if (stillInRuntime) {
 												for (const moduleChunk of chunkGraph.getModuleChunksIterable(
 													module

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -286,7 +286,8 @@ module.exports = function () {
 								promises,
 								currentUpdateApplyHandlers,
 								updatedModules,
-								update.css
+								update.css,
+								update.f
 							);
 							return promises;
 						}, [])

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -457,22 +457,6 @@ module.exports = function () {
 				currentUpdateChunks[chunkId] = false;
 			}
 		});
-		// Force-load full chunks that now own modules whose previously loaded chunk
-		// was removed from this runtime, so the client keeps receiving their updates.
-		if (forceLoadChunks && $ensureChunkHandlers$) {
-			forceLoadChunks.forEach(function (chunkId) {
-				if (
-					!(
-						$hasOwnProperty$($installedChunks$, chunkId) &&
-						$installedChunks$[chunkId] !== undefined
-					)
-				) {
-					Object.keys($ensureChunkHandlers$).forEach(function (key) {
-						$ensureChunkHandlers$[key](chunkId, promises);
-					});
-				}
-			});
-		}
 		if ($ensureChunkHandlers$) {
 			$ensureChunkHandlers$.$key$Hmr = function (chunkId, promises) {
 				if (
@@ -484,6 +468,17 @@ module.exports = function () {
 					currentUpdateChunks[chunkId] = true;
 				}
 			};
+			// Force-load full chunks that now own modules whose previously loaded
+			// chunk was removed from this runtime, so the client keeps an installed
+			// owner and still receives their updates. Ensure handlers skip already
+			// installed chunks, so no extra guard is needed here.
+			if (forceLoadChunks) {
+				forceLoadChunks.forEach(function (chunkId) {
+					Object.keys($ensureChunkHandlers$).forEach(function (key) {
+						$ensureChunkHandlers$[key](chunkId, promises);
+					});
+				});
+			}
 		}
 	};
 };

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -468,10 +468,8 @@ module.exports = function () {
 					currentUpdateChunks[chunkId] = true;
 				}
 			};
-			// Force-load full chunks that now own modules whose previously loaded
-			// chunk was removed from this runtime, so the client keeps an installed
-			// owner and still receives their updates. Ensure handlers skip already
-			// installed chunks, so no extra guard is needed here.
+			// Force-load chunks that now own modules orphaned by a removed chunk;
+			// ensure handlers skip already-installed chunks, so no guard is needed.
 			if (forceLoadChunks) {
 				forceLoadChunks.forEach(function (chunkId) {
 					Object.keys($ensureChunkHandlers$).forEach(function (key) {

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -434,7 +434,9 @@ module.exports = function () {
 		removedModules,
 		promises,
 		applyHandlers,
-		updatedModulesList
+		updatedModulesList,
+		css,
+		forceLoadChunks
 	) {
 		applyHandlers.push(applyHandler);
 		currentUpdateChunks = {};
@@ -455,6 +457,22 @@ module.exports = function () {
 				currentUpdateChunks[chunkId] = false;
 			}
 		});
+		// Force-load full chunks that now own modules whose previously loaded chunk
+		// was removed from this runtime, so the client keeps receiving their updates.
+		if (forceLoadChunks && $ensureChunkHandlers$) {
+			forceLoadChunks.forEach(function (chunkId) {
+				if (
+					!(
+						$hasOwnProperty$($installedChunks$, chunkId) &&
+						$installedChunks$[chunkId] !== undefined
+					)
+				) {
+					Object.keys($ensureChunkHandlers$).forEach(function (key) {
+						$ensureChunkHandlers$[key](chunkId, promises);
+					});
+				}
+			});
+		}
 		if ($ensureChunkHandlers$) {
 			$ensureChunkHandlers$.$key$Hmr = function (chunkId, promises) {
 				if (

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -328,121 +328,112 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 	});
 
-	// Reproduces the TODO at lib/HotModuleReplacementPlugin.js (search "force load
-	// one of the chunks which contains the module").
-	//
 	// Two runtimes (entries `a` and `b`) initially share `shared`+`x` in one split
 	// chunk. On the second build `b` switches to `import("./shared")`, so for runtime
 	// `b` those modules leave the (loaded) `shared` chunk and move into a new async
-	// chunk `lazyShared` that the client has not loaded. The emitted `b` update therefore
-	// removes the `shared` chunk (`r`) but disposes nothing (`m` empty): `shared`/`x`
-	// stay loaded on the client with no installed chunk owning them, so later updates
-	// to them are never delivered to runtime `b`.
-	//
-	// `it.failing`: the assertion below states the desired behavior (the orphaned
-	// modules must be accounted for in `m`). It fails today, so the test is green.
-	// When the TODO is fixed (force-load the new chunk, or dispose the modules) this
-	// turns red — drop `.failing` and adjust the expectation to lock in the fix.
-	it.failing(
-		"should not orphan modules whose only loaded chunk is removed from a runtime",
-		async () => {
-			const dir = path.join(
-				__dirname,
-				"js",
-				"HotModuleReplacementPlugin",
-				"orphan-on-chunk-migration"
-			);
-			const src = path.join(dir, "src");
-			const out = path.join(dir, "dist");
-			const recordsFile = path.join(dir, "records.json");
-			fs.mkdirSync(src, { recursive: true });
-			try {
-				fs.unlinkSync(recordsFile);
-			} catch (_err) {
-				// empty
-			}
+	// chunk `lazyShared` that the client has not loaded. Without the force-load fix the
+	// `b` update would remove the `shared` chunk (`r`) yet dispose nothing (`m` empty),
+	// leaving `shared`/`x` loaded with no installed chunk owning them and cutting off
+	// their future HMR updates. The fix lists the new owning chunk in `f` so the client
+	// force-loads it.
+	it("should force-load the new owning chunk when a module's only loaded chunk is removed from a runtime", async () => {
+		const dir = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"orphan-on-chunk-migration"
+		);
+		const src = path.join(dir, "src");
+		const out = path.join(dir, "dist");
+		const recordsFile = path.join(dir, "records.json");
+		fs.mkdirSync(src, { recursive: true });
+		try {
+			fs.unlinkSync(recordsFile);
+		} catch (_err) {
+			// empty
+		}
 
-			fs.writeFileSync(path.join(src, "x.js"), "export default 1;\n");
-			fs.writeFileSync(
-				path.join(src, "shared.js"),
-				'import v from "./x";\nexport const g = () => v;\n'
-			);
-			fs.writeFileSync(
-				path.join(src, "a.js"),
-				'import { g } from "./shared";\nconsole.log("a", g());\nif (module.hot) module.hot.accept();\n'
-			);
-			// build 1: `b` statically imports `shared` -> shared chunk is {a, b}
-			fs.writeFileSync(
-				path.join(src, "b.js"),
-				'import { g } from "./shared";\nconsole.log("b", g());\nif (module.hot) module.hot.accept();\n'
-			);
+		fs.writeFileSync(path.join(src, "x.js"), "export default 1;\n");
+		fs.writeFileSync(
+			path.join(src, "shared.js"),
+			'import v from "./x";\nexport const g = () => v;\n'
+		);
+		fs.writeFileSync(
+			path.join(src, "a.js"),
+			'import { g } from "./shared";\nconsole.log("a", g());\nif (module.hot) module.hot.accept();\n'
+		);
+		// build 1: `b` statically imports `shared` -> shared chunk is {a, b}
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'import { g } from "./shared";\nconsole.log("b", g());\nif (module.hot) module.hot.accept();\n'
+		);
 
-			const compiler = webpack({
-				mode: "development",
-				devtool: false,
-				cache: false,
-				context: dir,
-				entry: { a: "./src/a.js", b: "./src/b.js" },
-				output: { path: out, filename: "[name].js" },
-				recordsPath: recordsFile,
-				optimization: {
-					chunkIds: "named",
-					runtimeChunk: false,
-					splitChunks: {
-						chunks: "initial",
-						minSize: 0,
-						cacheGroups: {
-							shared: {
-								test: /shared|x\.js/,
-								name: "shared",
-								enforce: true
-							}
+		const compiler = webpack({
+			mode: "development",
+			devtool: false,
+			cache: false,
+			context: dir,
+			entry: { a: "./src/a.js", b: "./src/b.js" },
+			output: { path: out, filename: "[name].js" },
+			recordsPath: recordsFile,
+			optimization: {
+				chunkIds: "named",
+				runtimeChunk: false,
+				splitChunks: {
+					chunks: "initial",
+					minSize: 0,
+					cacheGroups: {
+						shared: {
+							test: /shared|x\.js/,
+							name: "shared",
+							enforce: true
 						}
 					}
-				},
-				plugins: [new webpack.HotModuleReplacementPlugin()]
-			});
-			const run = () =>
-				new Promise((resolve, reject) => {
-					compiler.run((err, stats) => {
-						if (err) return reject(err);
-						if (stats.hasErrors()) {
-							return reject(
-								new Error(stats.toString({ all: false, errors: true }))
-							);
-						}
-						resolve(stats);
-					});
+				}
+			},
+			plugins: [new webpack.HotModuleReplacementPlugin()]
+		});
+		const run = () =>
+			new Promise((resolve, reject) => {
+				compiler.run((err, stats) => {
+					if (err) return reject(err);
+					if (stats.hasErrors()) {
+						return reject(
+							new Error(stats.toString({ all: false, errors: true }))
+						);
+					}
+					resolve(stats);
 				});
-
-			await run();
-			const before = new Set(fs.readdirSync(out));
-
-			// build 2: `b` switches to a dynamic import -> shared/x migrate out of the
-			// loaded `shared` chunk into a b-only async chunk `lazyShared`.
-			fs.writeFileSync(
-				path.join(src, "b.js"),
-				'const p = import(/* webpackChunkName: "lazyShared" */ "./shared");\np.then(({ g }) => console.log("b", g()));\nif (module.hot) module.hot.accept();\n'
-			);
-			await run();
-
-			const bUpdate = fs
-				.readdirSync(out)
-				.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
-			expect(bUpdate).toBeDefined();
-			const manifest = JSON.parse(
-				fs.readFileSync(path.join(out, bUpdate), "utf8")
-			);
-
-			// The `shared` chunk is removed from runtime `b`...
-			expect(manifest.r).toContain("shared");
-			// ...so the modules it carried (no longer in any installed chunk for `b`)
-			// must be accounted for. Today `m` is empty -> they are orphaned (the bug).
-			await new Promise((resolve) => {
-				compiler.close(resolve);
 			});
-			expect(manifest.m.length).toBeGreaterThan(0);
-		},
-		120000
-	);
+
+		await run();
+		const before = new Set(fs.readdirSync(out));
+
+		// build 2: `b` switches to a dynamic import -> shared/x migrate out of the
+		// loaded `shared` chunk into a b-only async chunk `lazyShared`.
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'const p = import(/* webpackChunkName: "lazyShared" */ "./shared");\np.then(({ g }) => console.log("b", g()));\nif (module.hot) module.hot.accept();\n'
+		);
+		await run();
+
+		const bUpdate = fs
+			.readdirSync(out)
+			.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
+		expect(bUpdate).toBeDefined();
+		const manifest = JSON.parse(
+			fs.readFileSync(path.join(out, bUpdate), "utf8")
+		);
+
+		await new Promise((resolve) => {
+			compiler.close(resolve);
+		});
+
+		// The `shared` chunk is removed from runtime `b`...
+		expect(manifest.r).toContain("shared");
+		// ...the migrated modules are not disposed (they still live in `b`)...
+		expect(manifest.m).toEqual([]);
+		// ...and the new owning chunk is force-loaded so they keep an installed owner.
+		expect(manifest.f).toContain("lazyShared");
+	}, 120000);
 });

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -436,4 +436,191 @@ describe("HotModuleReplacementPlugin", () => {
 		// ...and the new owning chunk is force-loaded so they keep an installed owner.
 		expect(manifest.f).toContain("lazyShared");
 	}, 120000);
+
+	// Counterpart to the force-load case: when the module no longer lives in the
+	// runtime at all, it is disposed (added to `m`), not force-loaded.
+	it("should dispose a module that no longer lives in a runtime its chunk left", async () => {
+		const dir = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"dispose-on-runtime-removal"
+		);
+		const src = path.join(dir, "src");
+		const out = path.join(dir, "dist");
+		const recordsFile = path.join(dir, "records.json");
+		fs.mkdirSync(src, { recursive: true });
+		try {
+			fs.unlinkSync(recordsFile);
+		} catch (_err) {
+			// empty
+		}
+
+		fs.writeFileSync(
+			path.join(src, "shared.js"),
+			"export const g = () => 1;\n"
+		);
+		fs.writeFileSync(
+			path.join(src, "a.js"),
+			'import { g } from "./shared";\nconsole.log("a", g());\nif (module.hot) module.hot.accept();\n'
+		);
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'import { g } from "./shared";\nconsole.log("b", g());\nif (module.hot) module.hot.accept();\n'
+		);
+
+		const compiler = webpack({
+			mode: "development",
+			devtool: false,
+			cache: false,
+			context: dir,
+			entry: { a: "./src/a.js", b: "./src/b.js" },
+			output: { path: out, filename: "[name].js" },
+			recordsPath: recordsFile,
+			optimization: {
+				moduleIds: "named",
+				chunkIds: "named",
+				runtimeChunk: false,
+				splitChunks: {
+					chunks: "initial",
+					minSize: 0,
+					cacheGroups: {
+						shared: { test: /shared/, name: "shared", enforce: true }
+					}
+				}
+			},
+			plugins: [new webpack.HotModuleReplacementPlugin()]
+		});
+		const run = () =>
+			new Promise((resolve, reject) => {
+				compiler.run((err, stats) => {
+					if (err) return reject(err);
+					if (stats.hasErrors()) {
+						return reject(
+							new Error(stats.toString({ all: false, errors: true }))
+						);
+					}
+					resolve(stats);
+				});
+			});
+
+		await run();
+		const before = new Set(fs.readdirSync(out));
+
+		// build 2: `b` stops importing `shared`, so the shared chunk leaves runtime
+		// `b` entirely and the module no longer lives there.
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'console.log("b");\nif (module.hot) module.hot.accept();\n'
+		);
+		await run();
+
+		const bUpdate = fs
+			.readdirSync(out)
+			.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
+		expect(bUpdate).toBeDefined();
+		const manifest = JSON.parse(
+			fs.readFileSync(path.join(out, bUpdate), "utf8")
+		);
+		await new Promise((resolve) => {
+			compiler.close(resolve);
+		});
+
+		expect(manifest.r).toContain("shared");
+		expect(manifest.m).toContain("./src/shared.js");
+		expect(manifest.f).toBeUndefined();
+	}, 120000);
+
+	// With a non-unique hotUpdateMainFilename the per-runtime updates collide and
+	// are merged (with a warning); the merge must carry force-load chunks too.
+	it("should merge force-load chunks across runtimes on hotUpdateMainFilename collision", async () => {
+		const dir = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"force-load-filename-collision"
+		);
+		const src = path.join(dir, "src");
+		const out = path.join(dir, "dist");
+		const recordsFile = path.join(dir, "records.json");
+		fs.mkdirSync(src, { recursive: true });
+		try {
+			fs.unlinkSync(recordsFile);
+		} catch (_err) {
+			// empty
+		}
+
+		fs.writeFileSync(path.join(src, "x.js"), "export default 1;\n");
+		fs.writeFileSync(
+			path.join(src, "shared.js"),
+			'import v from "./x";\nexport const g = () => v;\n'
+		);
+		fs.writeFileSync(
+			path.join(src, "a.js"),
+			'import { g } from "./shared";\nconsole.log("a", g());\nif (module.hot) module.hot.accept();\n'
+		);
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'import { g } from "./shared";\nconsole.log("b", g());\nif (module.hot) module.hot.accept();\n'
+		);
+
+		const compiler = webpack({
+			mode: "development",
+			devtool: false,
+			cache: false,
+			context: dir,
+			entry: { a: "./src/a.js", b: "./src/b.js" },
+			output: {
+				path: out,
+				filename: "[name].js",
+				// no [runtime] -> both runtimes write the same update manifest filename
+				hotUpdateMainFilename: "[fullhash].hot-update.json"
+			},
+			recordsPath: recordsFile,
+			optimization: {
+				chunkIds: "named",
+				runtimeChunk: false,
+				splitChunks: {
+					chunks: "initial",
+					minSize: 0,
+					cacheGroups: {
+						shared: { test: /shared|x\.js/, name: "shared", enforce: true }
+					}
+				}
+			},
+			plugins: [new webpack.HotModuleReplacementPlugin()]
+		});
+		const run = () =>
+			new Promise((resolve, reject) => {
+				compiler.run((err, stats) => {
+					if (err) return reject(err);
+					if (stats.hasErrors()) {
+						return reject(
+							new Error(stats.toString({ all: false, errors: true }))
+						);
+					}
+					resolve(stats);
+				});
+			});
+
+		await run();
+		// build 2: `b` migrates `shared` into a b-only async chunk (force-load case)
+		fs.writeFileSync(
+			path.join(src, "b.js"),
+			'const p = import(/* webpackChunkName: "lazyShared" */ "./shared");\np.then(({ g }) => console.log("b", g()));\nif (module.hot) module.hot.accept();\n'
+		);
+		const stats = await run();
+		const { warnings } = stats.toJson({ all: false, warnings: true });
+		await new Promise((resolve) => {
+			compiler.close(resolve);
+		});
+
+		expect(
+			warnings.some((w) =>
+				(w.message || String(w)).includes(
+					"doesn't lead to unique filenames per runtime"
+				)
+			)
+		).toBe(true);
+	}, 120000);
 });

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -327,4 +327,122 @@ describe("HotModuleReplacementPlugin", () => {
 			});
 		});
 	});
+
+	// Reproduces the TODO at lib/HotModuleReplacementPlugin.js (search "force load
+	// one of the chunks which contains the module").
+	//
+	// Two runtimes (entries `a` and `b`) initially share `shared`+`x` in one split
+	// chunk. On the second build `b` switches to `import("./shared")`, so for runtime
+	// `b` those modules leave the (loaded) `shared` chunk and move into a new async
+	// chunk `lazyShared` that the client has not loaded. The emitted `b` update therefore
+	// removes the `shared` chunk (`r`) but disposes nothing (`m` empty): `shared`/`x`
+	// stay loaded on the client with no installed chunk owning them, so later updates
+	// to them are never delivered to runtime `b`.
+	//
+	// `it.failing`: the assertion below states the desired behavior (the orphaned
+	// modules must be accounted for in `m`). It fails today, so the test is green.
+	// When the TODO is fixed (force-load the new chunk, or dispose the modules) this
+	// turns red — drop `.failing` and adjust the expectation to lock in the fix.
+	it.failing(
+		"should not orphan modules whose only loaded chunk is removed from a runtime",
+		async () => {
+			const dir = path.join(
+				__dirname,
+				"js",
+				"HotModuleReplacementPlugin",
+				"orphan-on-chunk-migration"
+			);
+			const src = path.join(dir, "src");
+			const out = path.join(dir, "dist");
+			const recordsFile = path.join(dir, "records.json");
+			fs.mkdirSync(src, { recursive: true });
+			try {
+				fs.unlinkSync(recordsFile);
+			} catch (_err) {
+				// empty
+			}
+
+			fs.writeFileSync(path.join(src, "x.js"), "export default 1;\n");
+			fs.writeFileSync(
+				path.join(src, "shared.js"),
+				'import v from "./x";\nexport const g = () => v;\n'
+			);
+			fs.writeFileSync(
+				path.join(src, "a.js"),
+				'import { g } from "./shared";\nconsole.log("a", g());\nif (module.hot) module.hot.accept();\n'
+			);
+			// build 1: `b` statically imports `shared` -> shared chunk is {a, b}
+			fs.writeFileSync(
+				path.join(src, "b.js"),
+				'import { g } from "./shared";\nconsole.log("b", g());\nif (module.hot) module.hot.accept();\n'
+			);
+
+			const compiler = webpack({
+				mode: "development",
+				devtool: false,
+				cache: false,
+				context: dir,
+				entry: { a: "./src/a.js", b: "./src/b.js" },
+				output: { path: out, filename: "[name].js" },
+				recordsPath: recordsFile,
+				optimization: {
+					chunkIds: "named",
+					runtimeChunk: false,
+					splitChunks: {
+						chunks: "initial",
+						minSize: 0,
+						cacheGroups: {
+							shared: {
+								test: /shared|x\.js/,
+								name: "shared",
+								enforce: true
+							}
+						}
+					}
+				},
+				plugins: [new webpack.HotModuleReplacementPlugin()]
+			});
+			const run = () =>
+				new Promise((resolve, reject) => {
+					compiler.run((err, stats) => {
+						if (err) return reject(err);
+						if (stats.hasErrors()) {
+							return reject(
+								new Error(stats.toString({ all: false, errors: true }))
+							);
+						}
+						resolve(stats);
+					});
+				});
+
+			await run();
+			const before = new Set(fs.readdirSync(out));
+
+			// build 2: `b` switches to a dynamic import -> shared/x migrate out of the
+			// loaded `shared` chunk into a b-only async chunk `lazyShared`.
+			fs.writeFileSync(
+				path.join(src, "b.js"),
+				'const p = import(/* webpackChunkName: "lazyShared" */ "./shared");\np.then(({ g }) => console.log("b", g()));\nif (module.hot) module.hot.accept();\n'
+			);
+			await run();
+
+			const bUpdate = fs
+				.readdirSync(out)
+				.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
+			expect(bUpdate).toBeDefined();
+			const manifest = JSON.parse(
+				fs.readFileSync(path.join(out, bUpdate), "utf8")
+			);
+
+			// The `shared` chunk is removed from runtime `b`...
+			expect(manifest.r).toContain("shared");
+			// ...so the modules it carried (no longer in any installed chunk for `b`)
+			// must be accounted for. Today `m` is empty -> they are orphaned (the bug).
+			await new Promise((resolve) => {
+				compiler.close(resolve);
+			});
+			expect(manifest.m.length).toBeGreaterThan(0);
+		},
+		120000
+	);
 });

--- a/test/hotCases/chunks/force-load-migrated-chunk/index.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/index.js
@@ -1,0 +1,17 @@
+import { getV } from "./mod";
+
+if (module.hot) module.hot.accept("./mod");
+
+it("should force-load a migrated chunk so the module keeps working", (done) => {
+	expect(getV()).toBe(1);
+	NEXT(
+		require("../../update")(done, true, () => {
+			// build 2 applied: `mod` now imports `shared` dynamically, so `shared`
+			// left main's shared chunk for the "lazy" async chunk and was force-loaded.
+			Promise.resolve(getV()).then((v) => {
+				expect(v).toBe(1);
+				done();
+			}, done);
+		})
+	);
+});

--- a/test/hotCases/chunks/force-load-migrated-chunk/mod.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/mod.js
@@ -1,0 +1,11 @@
+import { value } from "./shared";
+
+export function getV() {
+	return value;
+}
+---
+const p = import(/* webpackChunkName: "lazy" */ "./shared");
+
+export function getV() {
+	return p.then((m) => m.value);
+}

--- a/test/hotCases/chunks/force-load-migrated-chunk/other.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/other.js
@@ -1,0 +1,3 @@
+import { value } from "./shared";
+
+export default value;

--- a/test/hotCases/chunks/force-load-migrated-chunk/shared.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/shared.js
@@ -1,0 +1,5 @@
+export const value = 1;
+---
+export const value = 1;
+---
+export const value = 2;

--- a/test/hotCases/chunks/force-load-migrated-chunk/test.filter.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// Force-loading a not-yet-loaded async chunk during an HMR update needs the
+// web target's runtime; the node/webworker harness can't resolve the async
+// chunk file mid-update.
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/chunks/force-load-migrated-chunk/webpack.config.js
+++ b/test/hotCases/chunks/force-load-migrated-chunk/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: { main: "./index.js", other: "./other.js" },
+	output: { filename: "[name].js" },
+	optimization: {
+		splitChunks: {
+			chunks: "initial",
+			minSize: 0,
+			cacheGroups: {
+				shared: { test: /shared/, name: "shared", enforce: true }
+			}
+		}
+	}
+};

--- a/test/hotCases/chunks/force-load-runtime-collision/index.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/index.js
@@ -1,0 +1,13 @@
+import * as shared from "./shared";
+
+if (module.hot) module.hot.accept("./shared");
+
+it("should merge force-load chunks across colliding runtime updates", (done) => {
+	expect(shared.value).toBe(1);
+	NEXT(
+		require("../../update")(done, true, () => {
+			expect(shared.value).toBe(2);
+			done();
+		})
+	);
+});

--- a/test/hotCases/chunks/force-load-runtime-collision/other.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/other.js
@@ -1,0 +1,7 @@
+import { value } from "./shared";
+
+export default value;
+---
+const p = import(/* webpackChunkName: "lazy" */ "./shared");
+
+export default p;

--- a/test/hotCases/chunks/force-load-runtime-collision/shared.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/shared.js
@@ -1,0 +1,3 @@
+export const value = 1;
+---
+export const value = 2;

--- a/test/hotCases/chunks/force-load-runtime-collision/test.filter.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Force-loading the merged async chunk during an update needs the web target's
+// runtime (node/webworker harness can't resolve the async chunk file mid-update).
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/chunks/force-load-runtime-collision/warnings1.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/warnings1.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [[/doesn't lead to unique filenames per runtime/]];

--- a/test/hotCases/chunks/force-load-runtime-collision/webpack.config.js
+++ b/test/hotCases/chunks/force-load-runtime-collision/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: { main: "./index.js", other: "./other.js" },
+	output: {
+		filename: "[name].js",
+		// No [runtime]: both runtimes write the same update manifest filename, so
+		// their differing updates collide and are merged (with a warning).
+		hotUpdateMainFilename: "[fullhash].hot-update.json"
+	},
+	optimization: {
+		splitChunks: {
+			chunks: "initial",
+			minSize: 0,
+			cacheGroups: {
+				shared: { test: /shared/, name: "shared", enforce: true }
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Resolves the long-standing TODO in `lib/HotModuleReplacementPlugin.js` ("force load one of the chunks which contains the module"). In a multi-runtime build, when a module's only loaded chunk is removed from a runtime but the module survives there via a not-yet-loaded async chunk, the update removed the chunk (`r`) without disposing the module (`m` stayed empty) — leaving it loaded on the client with no installed chunk owning it, so later HMR updates to it were never delivered. The update manifest now carries a new `f` (force-load) field listing such chunks, and the runtime ensures them so the client keeps an installed owner. If the module no longer lives in the runtime at all, it is still disposed as before.

Supersedes #21127 (same commits; branch renamed to the `fix/` prefix to match the change kind).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — unit tests in `test/HotModuleReplacementPlugin.test.js` (force-load, dispose-when-gone, and cross-runtime merge on filename collision) plus `hotCases` integration tests under `test/hotCases/chunks/force-load-migrated-chunk` and `.../force-load-runtime-collision`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to investigate the TODO, build the reproduction, implement the fix, and author the tests. All output was reviewed and verified by running the suite locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsZ6ygk9q6BKQuBy1uo24b)_