### PR TITLE
refactor: unify const binding tracking via tag system

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -212,7 +212,6 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {Set<string>=} topLevelDeclarations top level declaration names
  * @property {Set<string>=} pureFunctions names of locally declared functions known to be free of side effects
  * @property {boolean=} inlineExports whether this module was parsed with `optimization.inlineExports` enabled (gates inlining of its exports)
- * @property {Set<string>=} constBindings names of top-level variables declared with const
  * @property {boolean=} isCircular true when the module is part of a circular dependency chain
  */
 

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -8,7 +8,7 @@
 const CompatibilityPlugin = require("../CompatibilityPlugin");
 const WebpackError = require("../errors/WebpackError");
 const { getImportAttributes } = require("../javascript/JavascriptParser");
-const { INLINED_CONST_TAG } = require("../optimize/InlineExports");
+const { CONST_BINDING_TAG } = require("../optimize/InlineExports");
 const { getInnerGraphUtils } = require("../optimize/InnerGraph");
 const ConstDependency = require("./ConstDependency");
 const HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");
@@ -193,10 +193,10 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 					id,
 					name
 				);
-				const inlined = settings
+				const tagData = settings
 					? undefined
-					: /** @type {{ value: import("../optimize/InlineExports").InlinedValue } | undefined} */
-						(parser.getTagData(id, INLINED_CONST_TAG));
+					: /** @type {{ value?: import("../optimize/InlineExports").InlinedValue } | undefined} */
+						(parser.getTagData(id, CONST_BINDING_TAG));
 				const dep = settings
 					? new HarmonyExportImportedSpecifierDependency(
 							settings.source,
@@ -213,7 +213,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 					: new HarmonyExportSpecifierDependency(
 							id,
 							name,
-							inlined && inlined.value
+							tagData ? tagData.value || null : undefined
 						);
 				dep.loc = Object.create(
 					/** @type {DependencyLocation} */ (statement.loc)

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -28,13 +28,13 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 	 * Creates an instance of HarmonyExportSpecifierDependency.
 	 * @param {string} id the id
 	 * @param {string} name the name
-	 * @param {InlinedValue=} inlined inlined primitive value bound to this export
+	 * @param {InlinedValue | null=} constValue undefined = not const, null = const but not inline-eligible, InlinedValue = const and inline-eligible
 	 */
-	constructor(id, name, inlined) {
+	constructor(id, name, constValue) {
 		super();
 		this.id = id;
 		this.name = name;
-		this.inlined = inlined;
+		this.constValue = constValue;
 	}
 
 	get type() {
@@ -51,18 +51,13 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 		const pureFunctions =
 			module && module.buildInfo && module.buildInfo.pureFunctions;
 		const isPure = Boolean(pureFunctions && pureFunctions.has(this.id));
-		const isConst =
-			module &&
-			module.buildInfo &&
-			module.buildInfo.constBindings &&
-			module.buildInfo.constBindings.has(this.id);
 		return {
 			exports: [
 				{
 					name: this.name,
 					isPure,
-					inlined: this.inlined,
-					immutableBinding: isConst
+					inlined: this.constValue || undefined,
+					immutableBinding: this.constValue !== undefined
 				}
 			],
 			priority: 1,
@@ -88,7 +83,7 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 		const { write } = context;
 		write(this.id);
 		write(this.name);
-		write(this.inlined);
+		write(this.constValue);
 		super.serialize(context);
 	}
 
@@ -100,7 +95,7 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 		const { read } = context;
 		this.id = read();
 		this.name = read();
-		this.inlined = read();
+		this.constValue = read();
 		super.deserialize(context);
 	}
 }

--- a/lib/optimize/ConstValueParserPlugin.js
+++ b/lib/optimize/ConstValueParserPlugin.js
@@ -7,7 +7,7 @@
 
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { VariableInfoFlags } = require("../javascript/JavascriptParser");
-const { INLINED_CONST_TAG, toInlinedValue } = require("./InlineExports");
+const { CONST_BINDING_TAG, toInlinedValue } = require("./InlineExports");
 
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("./InlineExports").InlinedValue} InlinedValue */
@@ -24,11 +24,8 @@ class ConstValueParserPlugin {
 		// Only const is tracked; function/class names can be reassigned in sloppy mode.
 		// Re-exports always use getters: cross-module bindings may be mutable,
 		// and SideEffectsFlagPlugin can rewire connections skipping the template.
-		/** @type {Set<string> | undefined} */
-		let constBindings;
 
 		parser.hooks.program.tap(PLUGIN_NAME, () => {
-			constBindings = undefined;
 			const buildInfo =
 				/** @type {BuildInfo | undefined} */
 				(parser.state.module.buildInfo);
@@ -36,48 +33,45 @@ class ConstValueParserPlugin {
 		});
 
 		// Detect top-level `const` declarations:
-		// - Record ALL const names in constBindings (for value binding optimization)
-		// - Tag inline-eligible primitives with INLINED_CONST_TAG (for inline optimization)
+		// - Tag ALL const bindings with CONST_BINDING_TAG (for const detection via tag system)
+		// - Carry inlined primitive value in tag data when eligible (for inline optimization)
 		parser.hooks.preDeclarator.tap(PLUGIN_NAME, (declarator, statement) => {
 			if (statement.kind !== "const") return;
 			if (parser.scope.topLevelScope !== true) return;
 
-			// Record all const bindings for value binding optimization
-			if (constBindings === undefined) constBindings = new Set();
 			if (declarator.id.type === "Identifier") {
-				constBindings.add(declarator.id.name);
+				let inlinedValue;
+				if (declarator.init) {
+					const evaluated = parser.evaluateExpression(declarator.init);
+					inlinedValue = toInlinedValue(evaluated);
+				}
+				parser.tagVariable(
+					declarator.id.name,
+					CONST_BINDING_TAG,
+					inlinedValue ? { value: inlinedValue } : {},
+					VariableInfoFlags.Normal
+				);
 			} else {
 				// Handle destructuring patterns (ObjectPattern, ArrayPattern, etc.)
 				parser.enterPattern(declarator.id, (name) => {
-					/** @type {Set<string>} */
-					(constBindings).add(name);
+					parser.tagVariable(
+						name,
+						CONST_BINDING_TAG,
+						{},
+						VariableInfoFlags.Normal
+					);
 				});
 			}
-
-			// Tag only simple identifier inline-eligible primitives for inline optimization
-			if (declarator.id.type !== "Identifier") return;
-			if (!declarator.init) return;
-			const evaluated = parser.evaluateExpression(declarator.init);
-			const inlinedValue = toInlinedValue(evaluated);
-			if (!inlinedValue) return;
-			parser.tagVariable(
-				declarator.id.name,
-				INLINED_CONST_TAG,
-				{
-					value: inlinedValue
-				},
-				VariableInfoFlags.Normal
-			);
 		});
 
 		// Propagate inlined constant through evaluator so chained constants and uses see the literal
 		parser.hooks.evaluateIdentifier
-			.for(INLINED_CONST_TAG)
+			.for(CONST_BINDING_TAG)
 			.tap(PLUGIN_NAME, (expr) => {
 				const tagData =
-					/** @type {{ value: InlinedValue } | undefined} */
+					/** @type {{ value?: InlinedValue } | undefined} */
 					(parser.currentTagData);
-				if (!tagData) return;
+				if (!tagData || !tagData.value) return;
 				const { value } = tagData;
 				const eval_ = new BasicEvaluatedExpression().setRange(
 					/** @type {[number, number]} */ (expr.range)
@@ -95,12 +89,6 @@ class ConstValueParserPlugin {
 						return eval_.setString(/** @type {string} */ (value.value));
 				}
 			});
-
-		parser.hooks.finish.tap(PLUGIN_NAME, () => {
-			if (constBindings === undefined) return;
-			/** @type {BuildInfo} */
-			(parser.state.module.buildInfo).constBindings = constBindings;
-		});
 	}
 }
 

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -17,7 +17,7 @@ const { propertyAccess } = require("../util/property");
 const MAX_INLINE_BYTES = 6;
 
 // Parser tag for top-level `const X = <primitive>` bindings
-const INLINED_CONST_TAG = Symbol("inlined const");
+const CONST_BINDING_TAG = Symbol("const binding");
 
 /** @typedef {"null" | "undefined" | "boolean" | "number" | "string"} InlinedValueKind */
 
@@ -151,7 +151,7 @@ const isExportInlined = (moduleGraph, module, ids, runtime) => {
 	);
 };
 
-module.exports.INLINED_CONST_TAG = INLINED_CONST_TAG;
+module.exports.CONST_BINDING_TAG = CONST_BINDING_TAG;
 module.exports.InlinedUsedName = InlinedUsedName;
 module.exports.InlinedValue = InlinedValue;
 module.exports.MAX_INLINE_BYTES = MAX_INLINE_BYTES;

--- a/types.d.ts
+++ b/types.d.ts
@@ -12822,11 +12822,6 @@ declare interface KnownBuildInfo {
 	inlineExports?: boolean;
 
 	/**
-	 * names of top-level variables declared with const
-	 */
-	constBindings?: Set<string>;
-
-	/**
 	 * true when the module is part of a circular dependency chain
 	 */
 	isCircular?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Tag all top-level const bindings with `CONST_BINDING_TAG` (renamed from `INLINED_CONST_TAG`) instead of collecting names into a separate `constBindings` Set on `buildInfo`. This removes one intermediate data structure, one `finish` hook, and one `buildInfo` field by letting the existing parser tag system carry const-binding information that was previously duplicated.

- `ConstValueParserPlugin`: tag all const bindings (including non-inlinable and destructured), remove `constBindings` Set and `finish` hook.
- `HarmonyExportSpecifierDependency`: merge `inlined` + `immutableBinding` into a single `constValue` field (`undefined`/`null`/`InlinedValue` three-state).
- `HarmonyExportDependencyParserPlugin`: derive `constValue` from tag data at parse time.
- Remove `buildInfo.constBindings` from `Module` typedef.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No, this is a refactor with no behavior change. Existing tests cover the affected code paths.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used to analyze the existing implementation, compare it with the rspack equivalent (`ConstValuePlugin`), identify the redundant `constBindings` Set, and implement the refactor.