### PR TITLE
refactor: scope CJS require-binding WeakMap per-parser

### DIFF
--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -53,12 +53,9 @@ const RequireResolveHeaderDependency = require("./RequireResolveHeaderDependency
  * member-access references on `NAME` to the `CommonJsRequireDependency`
  * created for the `require()` call.
  * @typedef {object} RequireBindingData
- * @property {RawReferencedExports | null} referencedExports mutable list shared with the dependency; pushed to as `NAME.x.y` accesses are walked; null means the whole namespace is used
- * @property {InstanceType<typeof import("./CommonJsRequireDependency")> | null} dep dependency for the `require()` call (assigned during walk)
+ * @property {RawReferencedExports | null} referencedExports mutable list, pushed to as `NAME.x.y` accesses are walked; null means the whole namespace is used. Separate from `dep` so a deferred require (walked after accesses on `NAME`) still collects them; becomes the dep's shared list on creation.
+ * @property {InstanceType<typeof import("./CommonJsRequireDependency")> | null} dep dependency for the `require()` call, null until the `require()` is walked; kept so a later whole-namespace use can null its list directly
  */
-
-/** @type {WeakMap<CallExpression, RequireBindingData>} */
-const requireBindingData = new WeakMap();
 
 const REQUIRE_BINDING_TAG = Symbol(
 	"CommonJsImportsParserPlugin require binding"
@@ -157,9 +154,15 @@ const createRequireAsExpressionHandler =
  * @param {JavascriptParser} parser parser
  * @param {JavascriptParserOptions} options options
  * @param {() => undefined | string} getContext context accessor
+ * @param {WeakMap<CallExpression, RequireBindingData>=} requireBindingData per-parser `const NAME = require(LITERAL)` binding state; only the free-`require` plugin populates it
  * @returns {(callNew: boolean) => (expr: CallExpression | NewExpression) => (boolean | void)} handler factory
  */
-const createRequireCallHandler = (parser, options, getContext) => {
+const createRequireCallHandler = (
+	parser,
+	options,
+	getContext,
+	requireBindingData
+) => {
 	/**
 	 * Process require item.
 	 * @param {CallExpression | NewExpression} expr expression
@@ -172,9 +175,9 @@ const createRequireCallHandler = (parser, options, getContext) => {
 				parser,
 				expr
 			);
-			const binding = requireBindingData.get(
-				/** @type {CallExpression} */ (expr)
-			);
+			const binding =
+				requireBindingData &&
+				requireBindingData.get(/** @type {CallExpression} */ (expr));
 			if (binding && !referencedExports) {
 				// `const NAME = require(LITERAL)` — let later member-access walks
 				// on `NAME` populate the dependency's referenced exports.
@@ -577,10 +580,13 @@ class CommonJsImportsParserPlugin {
 		 * @param {boolean} callNew true, when require is called with new
 		 * @returns {(expr: CallExpression | NewExpression) => (boolean | void)} handler
 		 */
+		/** @type {WeakMap<CallExpression, RequireBindingData>} */
+		const requireBindingData = new WeakMap();
 		const createRequireHandler = createRequireCallHandler(
 			parser,
 			options,
-			getContext
+			getContext,
+			requireBindingData
 		);
 		parser.hooks.call
 			.for("require")


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?**

`requireBindingData` is keyed by AST `CallExpression` nodes and only ever written/read within a single module parse, so it's now created per-parser inside `apply()` and passes it into `createRequireCallHandler`, instead of holding WeakMap itself for the process lifetime. 

Also documents on `RequireBindingData` why `referencedExports` is kept separate from `dep` (deferred-require timing, #21123). No behavior change.

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes, for code understanding.