### PR TITLE
refactor: add per-walk cycle state through side-effects walker

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -174,9 +174,10 @@ const SIDE_EFFECTS_RECURSION_LIMIT = 2000;
  * behavior.
  * @param {NormalModule} rootMod the module to walk
  * @param {ModuleGraph} moduleGraph the module graph
+ * @param {SideEffectsWalkContext} ctx per-walk cycle-tracking context
  * @returns {ConnectionState} the side-effects connection state
  */
-const walkSideEffectsIterative = (rootMod, moduleGraph) => {
+const walkSideEffectsIterative = (rootMod, moduleGraph, ctx) => {
 	const SideEffectDep = getHarmonyImportSideEffectDependency();
 
 	/** @type {NormalModule[]} */
@@ -259,7 +260,7 @@ const walkSideEffectsIterative = (rootMod, moduleGraph) => {
 						) {
 							state = true;
 						} else if (refModule._isEvaluatingSideEffects) {
-							_sideEffectsCircularSeen = true;
+							ctx.circular = true;
 							state = ModuleGraphConnection.CIRCULAR_CONNECTION;
 						} else {
 							// Descend
@@ -281,7 +282,7 @@ const walkSideEffectsIterative = (rootMod, moduleGraph) => {
 					) {
 						state = true;
 					} else if (refModule._isEvaluatingSideEffects) {
-						_sideEffectsCircularSeen = true;
+						ctx.circular = true;
 						state = ModuleGraphConnection.CIRCULAR_CONNECTION;
 					} else {
 						// Descend
@@ -296,7 +297,7 @@ const walkSideEffectsIterative = (rootMod, moduleGraph) => {
 						break;
 					}
 				} else {
-					_sideEffectsCircularSeen = true;
+					ctx.circular = true;
 					state = refModule.getSideEffectsConnectionState(moduleGraph);
 				}
 			} else {
@@ -325,7 +326,7 @@ const walkSideEffectsIterative = (rootMod, moduleGraph) => {
 		if (descended) continue;
 
 		topMod._isEvaluatingSideEffects = false;
-		if (!_sideEffectsCircularSeen) {
+		if (!ctx.circular) {
 			topMod._sideEffectsStateGraph = moduleGraph;
 			topMod._sideEffectsStateValue = current;
 		}
@@ -340,15 +341,9 @@ const walkSideEffectsIterative = (rootMod, moduleGraph) => {
 };
 
 /**
- * Tracks whether a cycle (CIRCULAR_CONNECTION) was encountered anywhere
- * in the currently-executing walk. The walker uses this to decide whether
- * an intermediate result is safe to memoize on the module: a result
- * computed in the presence of a cycle can differ from the result computed
- * fresh, because cycle short-circuiting hides the contribution of the
- * back-edge target. Reset to `false` at the top-level entry; read and
- * propagated by each recursive frame.
+ * @typedef {object} SideEffectsWalkContext
+ * @property {boolean} circular whether a cycle was seen anywhere in this walk
  */
-let _sideEffectsCircularSeen = false;
 
 /**
  * Walks back up a stack of linear-chain ancestors, applying the result
@@ -359,9 +354,10 @@ let _sideEffectsCircularSeen = false;
  * @param {(NormalModule | Dependency)[] | null} ancestors interleaved stack of `[mod, sideEffectDep, mod, sideEffectDep, …]` in descent order; `null` if there were none
  * @param {ConnectionState} state result from the chain's tail
  * @param {ModuleGraph} moduleGraph the module graph
+ * @param {SideEffectsWalkContext} ctx per-walk cycle-tracking context
  * @returns {ConnectionState} the root ancestor's result
  */
-const propagateLinearResult = (ancestors, state, moduleGraph) => {
+const propagateLinearResult = (ancestors, state, moduleGraph, ctx) => {
 	if (ancestors === null) return state;
 	while (ancestors.length > 0) {
 		const dep = /** @type {Dependency} */ (ancestors.pop());
@@ -378,9 +374,9 @@ const propagateLinearResult = (ancestors, state, moduleGraph) => {
 			// so the ancestor's `current` stays at its initial `false`. From
 			// this point upward the propagated state is `false`, and the
 			// cycle taint prevents memoization further up (handled by
-			// `_sideEffectsCircularSeen`).
+			// `ctx.circular`).
 			state = false;
-		} else if (!_sideEffectsCircularSeen) {
+		} else if (!ctx.circular) {
 			ancestor._sideEffectsStateGraph = moduleGraph;
 			ancestor._sideEffectsStateValue = state;
 		}
@@ -415,9 +411,16 @@ const propagateLinearResult = (ancestors, state, moduleGraph) => {
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {number} depth current recursion depth (only counts true V8 frames)
  * @param {EXPECTED_ANY} SideEffectDep `HarmonyImportSideEffectDependency` constructor, resolved once at the public entry to avoid repeated `require` lookups in the recursive call
+ * @param {SideEffectsWalkContext} ctx per-walk cycle-tracking context
  * @returns {ConnectionState} the side-effects connection state
  */
-const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
+const walkSideEffectsRecursive = (
+	mod,
+	moduleGraph,
+	depth,
+	SideEffectDep,
+	ctx
+) => {
 	// Interleaved `[mod, linearDep, mod, linearDep, …]` for the linear
 	// chain head; `null` until the first descent.
 	/** @type {(NormalModule | Dependency)[] | null} */
@@ -430,27 +433,29 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 			return propagateLinearResult(
 				linearAncestors,
 				/** @type {ConnectionState} */ (mod._sideEffectsStateValue),
-				moduleGraph
+				moduleGraph,
+				ctx
 			);
 		}
 
 		if (mod.factoryMeta !== undefined) {
 			if (mod.factoryMeta.sideEffectFree) {
-				return propagateLinearResult(linearAncestors, false, moduleGraph);
+				return propagateLinearResult(linearAncestors, false, moduleGraph, ctx);
 			}
 			if (mod.factoryMeta.sideEffectFree === false) {
-				return propagateLinearResult(linearAncestors, true, moduleGraph);
+				return propagateLinearResult(linearAncestors, true, moduleGraph, ctx);
 			}
 		}
 		if (!(mod.buildMeta !== undefined && mod.buildMeta.sideEffectFree)) {
-			return propagateLinearResult(linearAncestors, true, moduleGraph);
+			return propagateLinearResult(linearAncestors, true, moduleGraph, ctx);
 		}
 		if (mod._isEvaluatingSideEffects) {
-			_sideEffectsCircularSeen = true;
+			ctx.circular = true;
 			return propagateLinearResult(
 				linearAncestors,
 				ModuleGraphConnection.CIRCULAR_CONNECTION,
-				moduleGraph
+				moduleGraph,
+				ctx
 			);
 		}
 
@@ -487,7 +492,7 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 					recordSideEffectsBailout(mod, moduleGraph, dep);
 					mod._sideEffectsStateGraph = moduleGraph;
 					mod._sideEffectsStateValue = true;
-					return propagateLinearResult(linearAncestors, true, moduleGraph);
+					return propagateLinearResult(linearAncestors, true, moduleGraph, ctx);
 				}
 				if (state !== ModuleGraphConnection.CIRCULAR_CONNECTION) {
 					nonRecursiveCurrent = ModuleGraphConnection.addConnectionStates(
@@ -509,11 +514,11 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 		if (linearDep === null) {
 			// No `SideEffectDep` — the module is a leaf as far as the
 			// side-effects graph is concerned. Cache and propagate `false`.
-			if (!_sideEffectsCircularSeen) {
+			if (!ctx.circular) {
 				mod._sideEffectsStateGraph = moduleGraph;
 				mod._sideEffectsStateValue = false;
 			}
-			return propagateLinearResult(linearAncestors, false, moduleGraph);
+			return propagateLinearResult(linearAncestors, false, moduleGraph, ctx);
 		}
 
 		const refModule = moduleGraph.getModule(linearDep);
@@ -521,7 +526,7 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 			recordSideEffectsBailout(mod, moduleGraph, linearDep);
 			mod._sideEffectsStateGraph = moduleGraph;
 			mod._sideEffectsStateValue = true;
-			return propagateLinearResult(linearAncestors, true, moduleGraph);
+			return propagateLinearResult(linearAncestors, true, moduleGraph, ctx);
 		}
 		if (!(refModule instanceof NormalModule)) {
 			// Non-NormalModule's `getSideEffectsConnectionState` re-enters
@@ -545,8 +550,9 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 	if (depth >= SIDE_EFFECTS_RECURSION_LIMIT) {
 		return propagateLinearResult(
 			linearAncestors,
-			walkSideEffectsIterative(mod, moduleGraph),
-			moduleGraph
+			walkSideEffectsIterative(mod, moduleGraph, ctx),
+			moduleGraph,
+			ctx
 		);
 	}
 
@@ -566,7 +572,8 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 					refModule,
 					moduleGraph,
 					depth + 1,
-					SideEffectDep
+					SideEffectDep,
+					ctx
 				);
 			} else {
 				// Non-NormalModule's `getSideEffectsConnectionState` (notably
@@ -576,7 +583,7 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 				// the inner walk hit a cycle that reflected the outer's
 				// state, so treat the walk as cycle-tainted and skip the
 				// cache for safety.
-				_sideEffectsCircularSeen = true;
+				ctx.circular = true;
 				state = refModule.getSideEffectsConnectionState(moduleGraph);
 			}
 		} else {
@@ -591,7 +598,7 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 			// always safe to memoize.
 			mod._sideEffectsStateGraph = moduleGraph;
 			mod._sideEffectsStateValue = true;
-			return propagateLinearResult(linearAncestors, true, moduleGraph);
+			return propagateLinearResult(linearAncestors, true, moduleGraph, ctx);
 		}
 		if (state !== ModuleGraphConnection.CIRCULAR_CONNECTION) {
 			current = ModuleGraphConnection.addConnectionStates(current, state);
@@ -606,11 +613,11 @@ const walkSideEffectsRecursive = (mod, moduleGraph, depth, SideEffectDep) => {
 	// CIRCULAR_CONNECTION short-circuiting), so this single flag is the
 	// conservative-but-cheap approximation of "this subtree's result is
 	// independent of cycle context". The public entry resets the flag.
-	if (!_sideEffectsCircularSeen) {
+	if (!ctx.circular) {
 		mod._sideEffectsStateGraph = moduleGraph;
 		mod._sideEffectsStateValue = current;
 	}
-	return propagateLinearResult(linearAncestors, current, moduleGraph);
+	return propagateLinearResult(linearAncestors, current, moduleGraph, ctx);
 };
 
 const ABSOLUTE_PATH_REGEX = /^(?:[a-z]:\\|\\\\|\/)/i;
@@ -1981,19 +1988,16 @@ class NormalModule extends Module {
 	 * @returns {ConnectionState} how this module should be connected to referencing modules when consumed for side-effects only
 	 */
 	getSideEffectsConnectionState(moduleGraph) {
-		// Save and restore the cycle-tracking flag so that re-entrant calls
-		// (e.g. `ConcatenatedModule.getSideEffectsConnectionState` delegating
-		// back through here) don't clobber the outer walk's state.
-		const savedCircular = _sideEffectsCircularSeen;
-		_sideEffectsCircularSeen = false;
-		const result = walkSideEffectsRecursive(
+		// Fresh per-walk context; re-entrant calls (e.g.
+		// `ConcatenatedModule.getSideEffectsConnectionState` delegating back
+		// through here) get their own and can't clobber the outer walk.
+		return walkSideEffectsRecursive(
 			this,
 			moduleGraph,
 			0,
-			getHarmonyImportSideEffectDependency()
+			getHarmonyImportSideEffectDependency(),
+			{ circular: false }
 		);
-		_sideEffectsCircularSeen = savedCircular;
-		return result;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

**What kind of change does this PR introduce?**

The side-effects walker remembers whether it has seen a cycle so it knows when a result is safe to cache. Now the flag lives in a module-level variable shared by every walk. but the single shared flag will carrie a few risks:

- **Re-entrancy clobbering** — a nested walk (e.g. `ConcatenatedModule` calling back into `getSideEffectsConnectionState`) overwrites the outer walk's flag, so today the code has to manually save the flag before the nested walk and restore it after.
- **Leaks on a throw** — if a walk throws partway through, the flag is left dirty and the *next* unrelated query can silently cache (or skip caching) a wrong result.
- **Fragile by construction** — correctness depends on every current and future re-entrant path remembering the save/restore contract; a new branch that forgets it breaks caching in a way that's hard to spot, since the state is invisible at the call site.

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your ce you already documented?**

n/a

**Use of AI**

Partial