### PR TITLE
perf(ChunkGraph): track ownership of module runtime requirements instead of cloning

### DIFF
--- a/.changeset/chunk-graph-runtime-requirements-ownership.md
+++ b/.changeset/chunk-graph-runtime-requirements-ownership.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Avoid copying module runtime requirements when ownership is not transferred.

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -304,6 +304,13 @@ class ChunkGraph {
 		 * @type {Map<string, RuntimeId>}
 		 */
 		this._runtimeIds = new Map();
+		/**
+		 * Module runtime requirement Sets stored without copying (ownership not
+		 * transferred). They must be copied before being mutated.
+		 * @private
+		 * @type {WeakSet<RuntimeRequirements>}
+		 */
+		this._sharedModuleRuntimeRequirements = new WeakSet();
 		/** @type {ModuleGraph} */
 		this.moduleGraph = moduleGraph;
 
@@ -1661,24 +1668,33 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 	) {
 		const cgm = this._getChunkGraphModule(module);
 		const runtimeRequirementsMap = cgm.runtimeRequirements;
+		if (!transferOwnership) this._sharedModuleRuntimeRequirements.add(items);
 		if (runtimeRequirementsMap === undefined) {
 			/** @type {ChunkGraphRuntimeRequirements} */
 			const map = new RuntimeSpecMap();
-			// TODO avoid cloning item and track ownership instead
-			map.set(runtime, transferOwnership ? items : new Set(items));
+			map.set(runtime, items);
 			cgm.runtimeRequirements = map;
 			return;
 		}
 		runtimeRequirementsMap.update(runtime, (runtimeRequirements) => {
-			if (runtimeRequirements === undefined) {
-				return transferOwnership ? items : new Set(items);
-			} else if (!transferOwnership || runtimeRequirements.size >= items.size) {
+			if (runtimeRequirements === undefined) return items;
+			const owned =
+				!this._sharedModuleRuntimeRequirements.has(runtimeRequirements);
+			// Merge into whichever owned Set is larger; otherwise copy-on-write.
+			if (owned && runtimeRequirements.size >= items.size) {
+				for (const item of items) runtimeRequirements.add(item);
+				return runtimeRequirements;
+			} else if (transferOwnership) {
+				for (const item of runtimeRequirements) items.add(item);
+				this._sharedModuleRuntimeRequirements.delete(items);
+				return items;
+			} else if (owned) {
 				for (const item of items) runtimeRequirements.add(item);
 				return runtimeRequirements;
 			}
-
-			for (const item of runtimeRequirements) items.add(item);
-			return items;
+			const merged = new Set(runtimeRequirements);
+			for (const item of items) merged.add(item);
+			return merged;
 		});
 	}
 


### PR DESCRIPTION
Store the runtime requirements Set by reference when ownership is not
transferred and copy lazily (copy-on-write) only if a later merge needs
to mutate a shared Set, avoiding an eager clone on the cached rebuild path.