### PR TITLE
Add types to HMR runtime templates and drop @ts-nocheck

### DIFF
--- a/lib/Template.js
+++ b/lib/Template.js
@@ -34,6 +34,10 @@ const NUMBER_OF_IDENTIFIER_START_CHARS = DELTA_A_TO_Z * 2 + 2; // a-z A-Z _ $
 const NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS =
 	NUMBER_OF_IDENTIFIER_START_CHARS + 10; // a-z A-Z _ $ 0-9
 const FUNCTION_CONTENT_REGEX = /^function\s?\(\)\s?\{\r?\n?|\r?\n?\}$/g;
+// JSDoc type annotations exist only to type the runtime template; strip them so
+// they are never emitted into the bundle. Whole-line blocks drop the line too.
+const JSDOC_LINE_REGEX = /^[ \t]*\/\*\*(?:[^*]|\*(?!\/))*\*\/[ \t]*\r?\n/gm;
+const JSDOC_INLINE_REGEX = /\/\*\*(?:[^*]|\*(?!\/))*\*\/[ \t]*/g;
 const INDENT_MULTILINE_REGEX = /^\t/gm;
 const LINE_SEPARATOR_REGEX = /\r?\n/g;
 const IDENTIFIER_NAME_REPLACE_REGEX = /^([^a-z$_])/i;
@@ -102,6 +106,8 @@ class Template {
 	static getFunctionContent(fn) {
 		return fn
 			.toString()
+			.replace(JSDOC_LINE_REGEX, "")
+			.replace(JSDOC_INLINE_REGEX, "")
 			.replace(FUNCTION_CONTENT_REGEX, "")
 			.replace(INDENT_MULTILINE_REGEX, "")
 			.replace(LINE_SEPARATOR_REGEX, "\n");

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
@@ -6,33 +5,111 @@
 
 "use strict";
 
-var $interceptModuleExecution$ = undefined;
-var $moduleCache$ = undefined;
-var $hmrModuleData$ = undefined;
-/** @type {() => Promise}  */
-var $hmrDownloadManifest$ = undefined;
-var $hmrDownloadUpdateHandlers$ = undefined;
-var $hmrInvalidateModuleHandlers$ = undefined;
-var __webpack_require__ = undefined;
+/** @typedef {string | number} ModuleId */
+/** @typedef {Record<string, EXPECTED_ANY>} HotData */
+/** @typedef {(data: HotData) => void} DisposeHandler */
+/** @typedef {(outdatedDependencies: ModuleId[]) => void} AcceptCallback */
+/** @typedef {(err: Error, context: { moduleId: ModuleId, dependencyId?: ModuleId, module?: HotModule }) => void} AcceptErrorHandler */
+/** @typedef {(status: string) => (Promise<void> | void)} StatusHandler */
+/** @typedef {Record<string, EXPECTED_ANY>} ApplyOptions */
+/** @typedef {(reportError: (err: Error) => void) => Promise<ModuleId[]>} ApplyFn */
+
+/**
+ * @typedef {object} ApplyResult
+ * @property {Error=} error fatal error that aborts the update
+ * @property {(() => void)=} dispose dispose phase of the update
+ * @property {ApplyFn=} apply apply phase of the update
+ */
+
+/** @typedef {(options: ApplyOptions) => ApplyResult} ApplyHandler */
+/** @typedef {(moduleId: ModuleId, applyHandlers: ApplyHandler[]) => void} InvalidateModuleHandler */
+/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<EXPECTED_ANY>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
+
+/**
+ * @typedef {object} HMRManifest
+ * @property {ModuleId[]} c updated chunk ids
+ * @property {ModuleId[]} r removed chunk ids
+ * @property {ModuleId[]} m removed module ids
+ * @property {ModuleId[]=} css updated css chunk ids
+ * @property {ModuleId[]=} f chunk ids to force-load
+ */
+
+/**
+ * @typedef {object} HotModule
+ * @property {ModuleId} id module id
+ * @property {Hot} hot hot API of the module
+ * @property {ModuleId[]} parents ids of modules requiring this module
+ * @property {ModuleId[]} children ids of modules required by this module
+ */
+
+/**
+ * @typedef {object} Hot
+ * @property {Record<ModuleId, AcceptCallback>} _acceptedDependencies accept callbacks by dependency id
+ * @property {Record<ModuleId, AcceptErrorHandler | undefined>} _acceptedErrorHandlers error handlers by dependency id
+ * @property {Record<ModuleId, boolean>} _declinedDependencies declined dependency ids
+ * @property {boolean | EXPECTED_FUNCTION} _selfAccepted true or the self-accept error handler
+ * @property {boolean} _selfDeclined module declined itself
+ * @property {boolean} _selfInvalidated module invalidated itself
+ * @property {DisposeHandler[]} _disposeHandlers registered dispose handlers
+ * @property {boolean} _main module is the entry of the update
+ * @property {() => void} _requireSelf re-require the module on apply
+ * @property {boolean} active module is not disposed
+ * @property {(dep?: ModuleId | ModuleId[] | AcceptCallback, callback?: AcceptCallback, errorHandler?: AcceptErrorHandler) => void} accept accept updates
+ * @property {(dep?: ModuleId | ModuleId[]) => void} decline decline updates
+ * @property {(callback: DisposeHandler) => void} dispose add a dispose handler
+ * @property {(callback: DisposeHandler) => void} addDisposeHandler add a dispose handler
+ * @property {(callback: DisposeHandler) => void} removeDisposeHandler remove a dispose handler
+ * @property {() => void} invalidate invalidate the module
+ * @property {(applyOnUpdate?: boolean | ApplyOptions) => Promise<ModuleId[] | null>} check check for an update
+ * @property {(options?: ApplyOptions) => Promise<ModuleId[]>} apply apply a checked update
+ * @property {(l?: StatusHandler) => string | void} status get status or add a status handler
+ * @property {(l: StatusHandler) => void} addStatusHandler add a status handler
+ * @property {(l: StatusHandler) => void} removeStatusHandler remove a status handler
+ * @property {HotData} data data left from the previous dispose
+ */
+
+/** @typedef {{ module: HotModule, require: EXPECTED_ANY, id: ModuleId }} InterceptOptions */
+
+/** @type {((options: InterceptOptions) => void)[]} */
+var $interceptModuleExecution$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<ModuleId, HotModule>} */
+var $moduleCache$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<ModuleId, HotData>} */
+var $hmrModuleData$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {() => Promise<HMRManifest | void>} */
+var $hmrDownloadManifest$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<string, DownloadUpdateHandler>} */
+var $hmrDownloadUpdateHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<string, InvalidateModuleHandler>} */
+var $hmrInvalidateModuleHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {(id: ModuleId) => unknown} */
+var __webpack_require__ = /** @type {EXPECTED_ANY} */ (undefined);
 
 module.exports = function () {
+	/** @type {Record<ModuleId, HotData>} */
 	var currentModuleData = {};
 	var installedModules = $moduleCache$;
 
 	// module and require creation
+	/** @type {ModuleId | undefined} */
 	var currentChildModule;
+	/** @type {ModuleId[]} */
 	var currentParents = [];
 
 	// status
+	/** @type {StatusHandler[]} */
 	var registeredStatusHandlers = [];
 	var currentStatus = "idle";
 
 	// while downloading
 	var blockingPromises = 0;
+	/** @type {(() => void)[]} */
 	var blockingPromisesWaiting = [];
 
 	// The update info
+	/** @type {ApplyHandler[] | undefined} */
 	var currentUpdateApplyHandlers;
+	/** @type {ModuleId[] | undefined} */
 	var queuedInvalidatedModules;
 
 	$hmrModuleData$ = currentModuleData;
@@ -50,9 +127,18 @@ module.exports = function () {
 	$hmrDownloadUpdateHandlers$ = {};
 	$hmrInvalidateModuleHandlers$ = {};
 
+	/**
+	 * @param {EXPECTED_ANY} require the original require function
+	 * @param {ModuleId} moduleId module id
+	 * @returns {EXPECTED_ANY} hot-aware require function
+	 */
 	function createRequire(require, moduleId) {
 		var me = installedModules[moduleId];
 		if (!me) return require;
+		/**
+		 * @param {ModuleId} request requested module id
+		 * @returns {unknown} module exports
+		 */
 		var fn = function (request) {
 			if (me.hot.active) {
 				if (installedModules[request]) {
@@ -78,6 +164,10 @@ module.exports = function () {
 			}
 			return require(request);
 		};
+		/**
+		 * @param {string} name property name
+		 * @returns {PropertyDescriptor} descriptor forwarding to require
+		 */
 		var createPropertyDescriptor = function (name) {
 			return {
 				configurable: true,
@@ -95,14 +185,23 @@ module.exports = function () {
 				Object.defineProperty(fn, name, createPropertyDescriptor(name));
 			}
 		}
-		fn.e = function (chunkId, fetchPriority) {
+		/** @type {EXPECTED_ANY} */ (fn).e = function (
+			/** @type {ModuleId} */ chunkId,
+			/** @type {EXPECTED_ANY} */ fetchPriority
+		) {
 			return trackBlockingPromise(require.e(chunkId, fetchPriority));
 		};
 		return fn;
 	}
 
+	/**
+	 * @param {ModuleId} moduleId module id
+	 * @param {HotModule} me the module
+	 * @returns {Hot} hot API
+	 */
 	function createModuleHotObject(moduleId, me) {
 		var _main = currentChildModule !== moduleId;
+		/** @type {Hot} */
 		var hot = {
 			// private stuff
 			_acceptedDependencies: {},
@@ -159,7 +258,7 @@ module.exports = function () {
 						Object.keys($hmrInvalidateModuleHandlers$).forEach(function (key) {
 							$hmrInvalidateModuleHandlers$[key](
 								moduleId,
-								currentUpdateApplyHandlers
+								/** @type {ApplyHandler[]} */ (currentUpdateApplyHandlers)
 							);
 						});
 						setStatus("ready");
@@ -168,7 +267,7 @@ module.exports = function () {
 						Object.keys($hmrInvalidateModuleHandlers$).forEach(function (key) {
 							$hmrInvalidateModuleHandlers$[key](
 								moduleId,
-								currentUpdateApplyHandlers
+								/** @type {ApplyHandler[]} */ (currentUpdateApplyHandlers)
 							);
 						});
 						break;
@@ -208,8 +307,13 @@ module.exports = function () {
 		return hot;
 	}
 
+	/**
+	 * @param {string} newStatus new status
+	 * @returns {Promise<void>} promise resolving when all handlers ran
+	 */
 	function setStatus(newStatus) {
 		currentStatus = newStatus;
+		/** @type {(Promise<void> | void)[]} */
 		var results = [];
 
 		for (var i = 0; i < registeredStatusHandlers.length; i++)
@@ -232,6 +336,10 @@ module.exports = function () {
 		}
 	}
 
+	/**
+	 * @param {Promise<EXPECTED_ANY>} promise blocking promise
+	 * @returns {Promise<EXPECTED_ANY>} the same promise
+	 */
 	function trackBlockingPromise(promise) {
 		switch (currentStatus) {
 			case "ready":
@@ -246,6 +354,10 @@ module.exports = function () {
 		}
 	}
 
+	/**
+	 * @param {() => EXPECTED_ANY} fn function to run once unblocked
+	 * @returns {EXPECTED_ANY} result of fn
+	 */
 	function waitForBlockingPromises(fn) {
 		if (blockingPromises === 0) return fn();
 		return new Promise(function (resolve) {
@@ -255,6 +367,10 @@ module.exports = function () {
 		});
 	}
 
+	/**
+	 * @param {boolean | ApplyOptions=} applyOnUpdate apply the update right away
+	 * @returns {Promise<ModuleId[] | null>} updated module ids or null
+	 */
 	function hotCheck(applyOnUpdate) {
 		if (currentStatus !== "idle") {
 			throw new Error("check() is only allowed in idle status");
@@ -271,6 +387,7 @@ module.exports = function () {
 				}
 
 				return setStatus("prepare").then(function () {
+					/** @type {ModuleId[]} */
 					var updatedModules = [];
 					currentUpdateApplyHandlers = [];
 
@@ -284,13 +401,13 @@ module.exports = function () {
 								update.r,
 								update.m,
 								promises,
-								currentUpdateApplyHandlers,
+								/** @type {ApplyHandler[]} */ (currentUpdateApplyHandlers),
 								updatedModules,
 								update.css,
 								update.f
 							);
 							return promises;
-						}, [])
+						}, /** @type {Promise<EXPECTED_ANY>[]} */ ([]))
 					).then(function () {
 						return waitForBlockingPromises(function () {
 							if (applyOnUpdate) {
@@ -305,6 +422,10 @@ module.exports = function () {
 			});
 	}
 
+	/**
+	 * @param {ApplyOptions=} options apply options
+	 * @returns {Promise<ModuleId[]>} updated module ids
+	 */
 	function hotApply(options) {
 		if (currentStatus !== "ready") {
 			return Promise.resolve().then(function () {
@@ -318,13 +439,19 @@ module.exports = function () {
 		return internalApply(options);
 	}
 
+	/**
+	 * @param {boolean | ApplyOptions=} options apply options
+	 * @returns {Promise<ModuleId[]>} updated module ids
+	 */
 	function internalApply(options) {
 		options = options || {};
 
 		applyInvalidatedModules();
 
-		var results = currentUpdateApplyHandlers.map(function (handler) {
-			return handler(options);
+		var results = /** @type {ApplyHandler[]} */ (
+			currentUpdateApplyHandlers
+		).map(function (handler) {
+			return handler(/** @type {ApplyOptions} */ (options));
 		});
 		currentUpdateApplyHandlers = undefined;
 
@@ -350,13 +477,22 @@ module.exports = function () {
 		// Now in "apply" phase
 		var applyPromise = setStatus("apply");
 
+		/** @type {Error | undefined} */
 		var error;
+		/**
+		 * @param {Error} err error thrown while applying
+		 * @returns {void}
+		 */
 		var reportError = function (err) {
 			if (!error) error = err;
 		};
 
+		/** @type {ModuleId[]} */
 		var outdatedModules = [];
 
+		/**
+		 * @returns {Promise<ModuleId[]>} updated module ids
+		 */
 		var onAccepted = function () {
 			return Promise.all([disposePromise, applyPromise]).then(function () {
 				// handle errors in accept handlers and self accepted module load
@@ -387,7 +523,7 @@ module.exports = function () {
 					return result.apply;
 				})
 				.map(function (result) {
-					return result.apply(reportError);
+					return /** @type {ApplyFn} */ (result.apply)(reportError);
 				})
 		)
 			.then(function (applyResults) {
@@ -402,16 +538,21 @@ module.exports = function () {
 			.then(onAccepted);
 	}
 
+	/**
+	 * @returns {boolean | undefined} true when invalidated modules were applied
+	 */
 	function applyInvalidatedModules() {
 		if (queuedInvalidatedModules) {
 			if (!currentUpdateApplyHandlers) currentUpdateApplyHandlers = [];
 			Object.keys($hmrInvalidateModuleHandlers$).forEach(function (key) {
-				queuedInvalidatedModules.forEach(function (moduleId) {
-					$hmrInvalidateModuleHandlers$[key](
-						moduleId,
-						currentUpdateApplyHandlers
-					);
-				});
+				/** @type {ModuleId[]} */ (queuedInvalidatedModules).forEach(
+					function (moduleId) {
+						$hmrInvalidateModuleHandlers$[key](
+							moduleId,
+							/** @type {ApplyHandler[]} */ (currentUpdateApplyHandlers)
+						);
+					}
+				);
 			});
 			queuedInvalidatedModules = undefined;
 			return true;

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -6,13 +6,14 @@
 "use strict";
 
 /** @typedef {string | number} ModuleId */
-/** @typedef {Record<string, EXPECTED_ANY>} HotData */
+/** @typedef {Record<string, unknown>} HotData */
 /** @typedef {(data: HotData) => void} DisposeHandler */
 /** @typedef {(outdatedDependencies: ModuleId[]) => void} AcceptCallback */
 /** @typedef {(err: Error, context: { moduleId: ModuleId, dependencyId?: ModuleId, module?: HotModule }) => void} AcceptErrorHandler */
 /** @typedef {(status: string) => (Promise<void> | void)} StatusHandler */
-/** @typedef {Record<string, EXPECTED_ANY>} ApplyOptions */
+/** @typedef {Record<string, unknown>} ApplyOptions */
 /** @typedef {(reportError: (err: Error) => void) => Promise<ModuleId[]>} ApplyFn */
+/** @typedef {{ (id: ModuleId): unknown, e: (chunkId: ModuleId, fetchPriority?: string) => Promise<unknown>, [name: string]: unknown }} WebpackRequire */
 
 /**
  * @typedef {object} ApplyResult
@@ -23,7 +24,7 @@
 
 /** @typedef {(options: ApplyOptions) => ApplyResult} ApplyHandler */
 /** @typedef {(moduleId: ModuleId, applyHandlers: ApplyHandler[]) => void} InvalidateModuleHandler */
-/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<EXPECTED_ANY>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
+/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<unknown>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
 
 /**
  * @typedef {object} HMRManifest
@@ -68,22 +69,25 @@
  * @property {HotData} data data left from the previous dispose
  */
 
-/** @typedef {{ module: HotModule, require: EXPECTED_ANY, id: ModuleId }} InterceptOptions */
+/** @typedef {{ module: HotModule, require: WebpackRequire, id: ModuleId }} InterceptOptions */
 
+// Globals injected by code generation; declared here only to type the template.
+/* eslint-disable no-unassigned-vars */
 /** @type {((options: InterceptOptions) => void)[]} */
-var $interceptModuleExecution$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $interceptModuleExecution$;
 /** @type {Record<ModuleId, HotModule>} */
-var $moduleCache$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $moduleCache$;
 /** @type {Record<ModuleId, HotData>} */
-var $hmrModuleData$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrModuleData$;
 /** @type {() => Promise<HMRManifest | void>} */
-var $hmrDownloadManifest$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrDownloadManifest$;
 /** @type {Record<string, DownloadUpdateHandler>} */
-var $hmrDownloadUpdateHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrDownloadUpdateHandlers$;
 /** @type {Record<string, InvalidateModuleHandler>} */
-var $hmrInvalidateModuleHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrInvalidateModuleHandlers$;
 /** @type {(id: ModuleId) => unknown} */
-var __webpack_require__ = /** @type {EXPECTED_ANY} */ (undefined);
+var __webpack_require__;
+/* eslint-enable no-unassigned-vars */
 
 module.exports = function () {
 	/** @type {Record<ModuleId, HotData>} */
@@ -128,9 +132,9 @@ module.exports = function () {
 	$hmrInvalidateModuleHandlers$ = {};
 
 	/**
-	 * @param {EXPECTED_ANY} require the original require function
+	 * @param {WebpackRequire} require the original require function
 	 * @param {ModuleId} moduleId module id
-	 * @returns {EXPECTED_ANY} hot-aware require function
+	 * @returns {WebpackRequire} hot-aware require function
 	 */
 	function createRequire(require, moduleId) {
 		var me = installedModules[moduleId];
@@ -185,13 +189,10 @@ module.exports = function () {
 				Object.defineProperty(fn, name, createPropertyDescriptor(name));
 			}
 		}
-		/** @type {EXPECTED_ANY} */ (fn).e = function (
-			/** @type {ModuleId} */ chunkId,
-			/** @type {EXPECTED_ANY} */ fetchPriority
-		) {
+		/** @type {WebpackRequire} */ (fn).e = function (chunkId, fetchPriority) {
 			return trackBlockingPromise(require.e(chunkId, fetchPriority));
 		};
-		return fn;
+		return /** @type {WebpackRequire} */ (fn);
 	}
 
 	/**
@@ -337,8 +338,8 @@ module.exports = function () {
 	}
 
 	/**
-	 * @param {Promise<EXPECTED_ANY>} promise blocking promise
-	 * @returns {Promise<EXPECTED_ANY>} the same promise
+	 * @param {Promise<unknown>} promise blocking promise
+	 * @returns {Promise<unknown>} the same promise
 	 */
 	function trackBlockingPromise(promise) {
 		switch (currentStatus) {
@@ -355,16 +356,18 @@ module.exports = function () {
 	}
 
 	/**
-	 * @param {() => EXPECTED_ANY} fn function to run once unblocked
-	 * @returns {EXPECTED_ANY} result of fn
+	 * @param {() => Promise<ModuleId[]>} fn function to run once unblocked
+	 * @returns {Promise<ModuleId[]>} result of fn
 	 */
 	function waitForBlockingPromises(fn) {
 		if (blockingPromises === 0) return fn();
-		return new Promise(function (resolve) {
-			blockingPromisesWaiting.push(function () {
-				resolve(fn());
-			});
-		});
+		return /** @type {Promise<ModuleId[]>} */ (
+			new Promise(function (resolve) {
+				blockingPromisesWaiting.push(function () {
+					resolve(fn());
+				});
+			})
+		);
 	}
 
 	/**
@@ -407,7 +410,7 @@ module.exports = function () {
 								update.f
 							);
 							return promises;
-						}, /** @type {Promise<EXPECTED_ANY>[]} */ ([]))
+						}, /** @type {Promise<unknown>[]} */ ([]))
 					).then(function () {
 						return waitForBlockingPromises(function () {
 							if (applyOnUpdate) {

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
@@ -6,29 +5,110 @@
 
 "use strict";
 
-var $installedChunks$ = undefined;
-var $loadUpdateChunk$ = undefined;
-var $moduleCache$ = undefined;
-var $moduleFactories$ = undefined;
-var $ensureChunkHandlers$ = undefined;
-var $hasOwnProperty$ = undefined;
-var $hmrModuleData$ = undefined;
-var $hmrDownloadUpdateHandlers$ = undefined;
-var $hmrInvalidateModuleHandlers$ = undefined;
-var __webpack_require__ = undefined;
+/** @typedef {string | number} ModuleId */
+/** @typedef {Record<string, EXPECTED_ANY>} HotData */
+/** @typedef {(data: HotData) => void} DisposeHandler */
+/** @typedef {(outdatedDependencies: ModuleId[]) => void} AcceptCallback */
+/** @typedef {(err: EXPECTED_ANY, context: { moduleId: ModuleId, dependencyId: ModuleId }) => void} AcceptErrorHandler */
+/** @typedef {Record<string, EXPECTED_ANY>} ApplyOptions */
+/** @typedef {(reportError: (err: EXPECTED_ANY) => void) => Promise<ModuleId[]>} ApplyFn */
+
+/**
+ * @typedef {object} ApplyResult
+ * @property {Error=} error fatal error that aborts the update
+ * @property {(() => void)=} dispose dispose phase of the update
+ * @property {ApplyFn=} apply apply phase of the update
+ */
+
+/** @typedef {(options: ApplyOptions) => ApplyResult} ApplyHandler */
+/** @typedef {(moduleId: ModuleId, applyHandlers: ApplyHandler[]) => void} InvalidateModuleHandler */
+/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<EXPECTED_ANY>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
+/** @typedef {(chunkId: ModuleId, promises: Promise<EXPECTED_ANY>[]) => void} EnsureChunkHandler */
+/** @typedef {(webpackRequire: EXPECTED_ANY) => void} RuntimeModuleFn */
+
+/**
+ * @typedef {object} Hot
+ * @property {Record<ModuleId, AcceptCallback>} _acceptedDependencies accept callbacks by dependency id
+ * @property {Record<ModuleId, AcceptErrorHandler | undefined>} _acceptedErrorHandlers error handlers by dependency id
+ * @property {Record<ModuleId, boolean>} _declinedDependencies declined dependency ids
+ * @property {boolean | EXPECTED_FUNCTION} _selfAccepted true or the self-accept error handler
+ * @property {boolean} _selfDeclined module declined itself
+ * @property {boolean} _selfInvalidated module invalidated itself
+ * @property {DisposeHandler[]} _disposeHandlers registered dispose handlers
+ * @property {boolean} _main module is the entry of the update
+ * @property {EXPECTED_FUNCTION} _requireSelf re-require the module on apply
+ * @property {boolean} active module is not disposed
+ */
+
+/**
+ * @typedef {object} HotModule
+ * @property {ModuleId} id module id
+ * @property {Hot} hot hot API of the module
+ * @property {ModuleId[]} parents ids of modules requiring this module
+ * @property {ModuleId[]} children ids of modules required by this module
+ */
+
+/**
+ * @typedef {object} ModuleEffect
+ * @property {string} type effect type
+ * @property {ModuleId} moduleId affected module id
+ * @property {ModuleId[]=} chain update propagation chain
+ * @property {ModuleId=} parentId declining parent id
+ * @property {ModuleId[]=} outdatedModules outdated module ids
+ * @property {Record<ModuleId, ModuleId[]>=} outdatedDependencies outdated dependencies by module id
+ */
+
+/** @typedef {{ chain: ModuleId[], id: ModuleId }} QueueItem */
+/** @typedef {{ module: ModuleId, require: EXPECTED_FUNCTION, errorHandler: boolean | EXPECTED_FUNCTION }} SelfAcceptedModule */
+
+/** @type {Record<ModuleId, EXPECTED_ANY>} */
+var $installedChunks$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {(chunkId: ModuleId, updatedModulesList?: ModuleId[]) => Promise<EXPECTED_ANY>} */
+var $loadUpdateChunk$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<ModuleId, HotModule>} */
+var $moduleCache$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<ModuleId, EXPECTED_FUNCTION>} */
+var $moduleFactories$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<string, EnsureChunkHandler>} */
+var $ensureChunkHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {(obj: object, key: ModuleId) => boolean} */
+var $hasOwnProperty$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<ModuleId, HotData>} */
+var $hmrModuleData$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<string, DownloadUpdateHandler>} */
+var $hmrDownloadUpdateHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {Record<string, InvalidateModuleHandler>} */
+var $hmrInvalidateModuleHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+/** @type {(id: ModuleId) => unknown} */
+var __webpack_require__ = /** @type {EXPECTED_ANY} */ (undefined);
 
 module.exports = function () {
+	/** @type {Record<ModuleId, boolean>} */
 	var currentUpdateChunks;
+	/** @type {Record<ModuleId, EXPECTED_FUNCTION | false>} */
 	var currentUpdate;
+	/** @type {ModuleId[]} */
 	var currentUpdateRemovedChunks;
+	/** @type {RuntimeModuleFn[]} */
 	var currentUpdateRuntime;
+	/**
+	 * @param {ApplyOptions} options apply options
+	 * @returns {ApplyResult} dispose/apply handlers or a fatal error
+	 */
 	function applyHandler(options) {
 		if ($ensureChunkHandlers$) delete $ensureChunkHandlers$.$key$Hmr;
-		currentUpdateChunks = undefined;
+		currentUpdateChunks = /** @type {EXPECTED_ANY} */ (undefined);
+		/**
+		 * @param {ModuleId} updateModuleId updated module id
+		 * @returns {ModuleEffect} effect of updating the module
+		 */
 		function getAffectedModuleEffects(updateModuleId) {
+			/** @type {ModuleId[]} */
 			var outdatedModules = [updateModuleId];
+			/** @type {Record<ModuleId, ModuleId[]>} */
 			var outdatedDependencies = {};
 
+			/** @type {QueueItem[]} */
 			var queue = outdatedModules.map(function (id) {
 				return {
 					chain: [id],
@@ -36,7 +116,7 @@ module.exports = function () {
 				};
 			});
 			while (queue.length > 0) {
-				var queueItem = queue.pop();
+				var queueItem = /** @type {QueueItem} */ (queue.pop());
 				var moduleId = queueItem.id;
 				var chain = queueItem.chain;
 				var module = $moduleCache$[moduleId];
@@ -95,6 +175,11 @@ module.exports = function () {
 			};
 		}
 
+		/**
+		 * @param {ModuleId[]} a target set
+		 * @param {ModuleId[]} b items to add
+		 * @returns {void}
+		 */
 		function addAllToSet(a, b) {
 			for (var i = 0; i < b.length; i++) {
 				var item = b[i];
@@ -104,10 +189,17 @@ module.exports = function () {
 
 		// at begin all updates modules are outdated
 		// the "outdated" status can propagate to parents if they don't accept the children
+		/** @type {Record<ModuleId, ModuleId[]>} */
 		var outdatedDependencies = {};
+		/** @type {ModuleId[]} */
 		var outdatedModules = [];
+		/** @type {Record<ModuleId, EXPECTED_FUNCTION>} */
 		var appliedUpdate = {};
 
+		/**
+		 * @param {HotModule} module disposed module
+		 * @returns {void}
+		 */
 		var warnUnexpectedRequire = function warnUnexpectedRequire(module) {
 			console.warn(
 				"[HMR] unexpected require(" + module.id + ") to disposed module"
@@ -117,6 +209,7 @@ module.exports = function () {
 		for (var moduleId in currentUpdate) {
 			if ($hasOwnProperty$(currentUpdate, moduleId)) {
 				var newModuleFactory = currentUpdate[moduleId];
+				/** @type {ModuleEffect} */
 				var result = newModuleFactory
 					? getAffectedModuleEffects(moduleId)
 					: {
@@ -176,15 +269,24 @@ module.exports = function () {
 					};
 				}
 				if (doApply) {
-					appliedUpdate[moduleId] = newModuleFactory;
-					addAllToSet(outdatedModules, result.outdatedModules);
-					for (moduleId in result.outdatedDependencies) {
-						if ($hasOwnProperty$(result.outdatedDependencies, moduleId)) {
+					appliedUpdate[moduleId] = /** @type {EXPECTED_FUNCTION} */ (
+						newModuleFactory
+					);
+					addAllToSet(
+						outdatedModules,
+						/** @type {ModuleId[]} */ (result.outdatedModules)
+					);
+					var resultOutdatedDependencies =
+						/** @type {Record<ModuleId, ModuleId[]>} */ (
+							result.outdatedDependencies
+						);
+					for (moduleId in resultOutdatedDependencies) {
+						if ($hasOwnProperty$(resultOutdatedDependencies, moduleId)) {
 							if (!outdatedDependencies[moduleId])
 								outdatedDependencies[moduleId] = [];
 							addAllToSet(
 								outdatedDependencies[moduleId],
-								result.outdatedDependencies[moduleId]
+								resultOutdatedDependencies[moduleId]
 							);
 						}
 					}
@@ -195,9 +297,10 @@ module.exports = function () {
 				}
 			}
 		}
-		currentUpdate = undefined;
+		currentUpdate = /** @type {EXPECTED_ANY} */ (undefined);
 
 		// Store self accepted outdated modules to require them later by the module system
+		/** @type {SelfAcceptedModule[]} */
 		var outdatedSelfAcceptedModules = [];
 		for (var j = 0; j < outdatedModules.length; j++) {
 			var outdatedModuleId = outdatedModules[j];
@@ -218,6 +321,7 @@ module.exports = function () {
 			}
 		}
 
+		/** @type {ModuleId[]} */
 		var moduleOutdatedDependencies;
 
 		return {
@@ -225,15 +329,16 @@ module.exports = function () {
 				currentUpdateRemovedChunks.forEach(function (chunkId) {
 					delete $installedChunks$[chunkId];
 				});
-				currentUpdateRemovedChunks = undefined;
+				currentUpdateRemovedChunks = /** @type {EXPECTED_ANY} */ (undefined);
 
 				var idx;
 				var queue = outdatedModules.slice();
 				while (queue.length > 0) {
-					var moduleId = queue.pop();
+					var moduleId = /** @type {ModuleId} */ (queue.pop());
 					var module = $moduleCache$[moduleId];
 					if (!module) continue;
 
+					/** @type {HotData} */
 					var data = {};
 
 					// Call dispose handlers
@@ -281,6 +386,7 @@ module.exports = function () {
 				}
 			},
 			apply: function (reportError) {
+				/** @type {Promise<EXPECTED_ANY>[]} */
 				var acceptPromises = [];
 				// insert new code
 				for (var updateModuleId in appliedUpdate) {
@@ -301,8 +407,11 @@ module.exports = function () {
 						if (module) {
 							moduleOutdatedDependencies =
 								outdatedDependencies[outdatedModuleId];
+							/** @type {AcceptCallback[]} */
 							var callbacks = [];
+							/** @type {(AcceptErrorHandler | undefined)[]} */
 							var errorHandlers = [];
+							/** @type {ModuleId[]} */
 							var dependenciesForCallbacks = [];
 							for (var j = 0; j < moduleOutdatedDependencies.length; j++) {
 								var dependency = moduleOutdatedDependencies[j];
@@ -318,13 +427,15 @@ module.exports = function () {
 								}
 							}
 							for (var k = 0; k < callbacks.length; k++) {
+								/** @type {EXPECTED_ANY} */
 								var result;
 								try {
 									result = callbacks[k].call(null, moduleOutdatedDependencies);
 								} catch (err) {
 									if (typeof errorHandlers[k] === "function") {
 										try {
-											errorHandlers[k](err, {
+											/** @type {AcceptErrorHandler} */
+											(errorHandlers[k])(err, {
 												moduleId: outdatedModuleId,
 												dependencyId: dependenciesForCallbacks[k]
 											});
@@ -444,7 +555,7 @@ module.exports = function () {
 		currentUpdate = removedModules.reduce(function (obj, key) {
 			obj[key] = false;
 			return obj;
-		}, {});
+		}, /** @type {Record<ModuleId, EXPECTED_FUNCTION | false>} */ ({}));
 		currentUpdateRuntime = [];
 		chunkIds.forEach(function (chunkId) {
 			if (

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -6,12 +6,24 @@
 "use strict";
 
 /** @typedef {string | number} ModuleId */
-/** @typedef {Record<string, EXPECTED_ANY>} HotData */
+/** @typedef {Record<string, unknown>} HotData */
 /** @typedef {(data: HotData) => void} DisposeHandler */
 /** @typedef {(outdatedDependencies: ModuleId[]) => void} AcceptCallback */
-/** @typedef {(err: EXPECTED_ANY, context: { moduleId: ModuleId, dependencyId: ModuleId }) => void} AcceptErrorHandler */
-/** @typedef {Record<string, EXPECTED_ANY>} ApplyOptions */
-/** @typedef {(reportError: (err: EXPECTED_ANY) => void) => Promise<ModuleId[]>} ApplyFn */
+/** @typedef {(err: unknown, context: { moduleId: ModuleId, dependencyId: ModuleId }) => void} AcceptErrorHandler */
+/** @typedef {{ type: string, moduleId: ModuleId, dependencyId?: ModuleId, error: unknown, originalError?: unknown }} HotErrorEvent */
+/** @typedef {(reportError: (err: unknown) => void) => Promise<ModuleId[]>} ApplyFn */
+
+/**
+ * @typedef {object} ApplyOptions
+ * @property {boolean=} ignoreUnaccepted ignore unaccepted modules
+ * @property {boolean=} ignoreDeclined ignore declined modules
+ * @property {boolean=} ignoreErrored ignore errors thrown while applying
+ * @property {((event: ModuleEffect) => void)=} onDeclined called for declined modules
+ * @property {((event: ModuleEffect) => void)=} onUnaccepted called for unaccepted modules
+ * @property {((event: ModuleEffect) => void)=} onAccepted called for accepted modules
+ * @property {((event: ModuleEffect) => void)=} onDisposed called for disposed modules
+ * @property {((event: HotErrorEvent) => void)=} onErrored called on apply errors
+ */
 
 /**
  * @typedef {object} ApplyResult
@@ -22,9 +34,9 @@
 
 /** @typedef {(options: ApplyOptions) => ApplyResult} ApplyHandler */
 /** @typedef {(moduleId: ModuleId, applyHandlers: ApplyHandler[]) => void} InvalidateModuleHandler */
-/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<EXPECTED_ANY>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
-/** @typedef {(chunkId: ModuleId, promises: Promise<EXPECTED_ANY>[]) => void} EnsureChunkHandler */
-/** @typedef {(webpackRequire: EXPECTED_ANY) => void} RuntimeModuleFn */
+/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<unknown>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
+/** @typedef {(chunkId: ModuleId, promises: Promise<unknown>[]) => void} EnsureChunkHandler */
+/** @typedef {(webpackRequire: (id: ModuleId) => unknown) => void} RuntimeModuleFn */
 
 /**
  * @typedef {object} Hot
@@ -36,7 +48,7 @@
  * @property {boolean} _selfInvalidated module invalidated itself
  * @property {DisposeHandler[]} _disposeHandlers registered dispose handlers
  * @property {boolean} _main module is the entry of the update
- * @property {EXPECTED_FUNCTION} _requireSelf re-require the module on apply
+ * @property {() => void} _requireSelf re-require the module on apply
  * @property {boolean} active module is not disposed
  */
 
@@ -59,28 +71,31 @@
  */
 
 /** @typedef {{ chain: ModuleId[], id: ModuleId }} QueueItem */
-/** @typedef {{ module: ModuleId, require: EXPECTED_FUNCTION, errorHandler: boolean | EXPECTED_FUNCTION }} SelfAcceptedModule */
+/** @typedef {{ module: ModuleId, require: (id?: ModuleId) => void, errorHandler: boolean | EXPECTED_FUNCTION }} SelfAcceptedModule */
 
-/** @type {Record<ModuleId, EXPECTED_ANY>} */
-var $installedChunks$ = /** @type {EXPECTED_ANY} */ (undefined);
-/** @type {(chunkId: ModuleId, updatedModulesList?: ModuleId[]) => Promise<EXPECTED_ANY>} */
-var $loadUpdateChunk$ = /** @type {EXPECTED_ANY} */ (undefined);
+// Globals injected by code generation; declared here only to type the template.
+/* eslint-disable no-unassigned-vars */
+/** @type {Record<ModuleId, unknown>} */
+var $installedChunks$;
+/** @type {(chunkId: ModuleId, updatedModulesList?: ModuleId[]) => Promise<unknown>} */
+var $loadUpdateChunk$;
 /** @type {Record<ModuleId, HotModule>} */
-var $moduleCache$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $moduleCache$;
 /** @type {Record<ModuleId, EXPECTED_FUNCTION>} */
-var $moduleFactories$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $moduleFactories$;
 /** @type {Record<string, EnsureChunkHandler>} */
-var $ensureChunkHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $ensureChunkHandlers$;
 /** @type {(obj: object, key: ModuleId) => boolean} */
-var $hasOwnProperty$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hasOwnProperty$;
 /** @type {Record<ModuleId, HotData>} */
-var $hmrModuleData$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrModuleData$;
 /** @type {Record<string, DownloadUpdateHandler>} */
-var $hmrDownloadUpdateHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrDownloadUpdateHandlers$;
 /** @type {Record<string, InvalidateModuleHandler>} */
-var $hmrInvalidateModuleHandlers$ = /** @type {EXPECTED_ANY} */ (undefined);
+var $hmrInvalidateModuleHandlers$;
 /** @type {(id: ModuleId) => unknown} */
-var __webpack_require__ = /** @type {EXPECTED_ANY} */ (undefined);
+var __webpack_require__;
+/* eslint-enable no-unassigned-vars */
 
 module.exports = function () {
 	/** @type {Record<ModuleId, boolean>} */
@@ -97,7 +112,9 @@ module.exports = function () {
 	 */
 	function applyHandler(options) {
 		if ($ensureChunkHandlers$) delete $ensureChunkHandlers$.$key$Hmr;
-		currentUpdateChunks = /** @type {EXPECTED_ANY} */ (undefined);
+		currentUpdateChunks = /** @type {Record<ModuleId, boolean>} */ (
+			/** @type {unknown} */ (undefined)
+		);
 		/**
 		 * @param {ModuleId} updateModuleId updated module id
 		 * @returns {ModuleEffect} effect of updating the module
@@ -297,7 +314,9 @@ module.exports = function () {
 				}
 			}
 		}
-		currentUpdate = /** @type {EXPECTED_ANY} */ (undefined);
+		currentUpdate = /** @type {Record<ModuleId, EXPECTED_FUNCTION | false>} */ (
+			/** @type {unknown} */ (undefined)
+		);
 
 		// Store self accepted outdated modules to require them later by the module system
 		/** @type {SelfAcceptedModule[]} */
@@ -329,7 +348,9 @@ module.exports = function () {
 				currentUpdateRemovedChunks.forEach(function (chunkId) {
 					delete $installedChunks$[chunkId];
 				});
-				currentUpdateRemovedChunks = /** @type {EXPECTED_ANY} */ (undefined);
+				currentUpdateRemovedChunks = /** @type {ModuleId[]} */ (
+					/** @type {unknown} */ (undefined)
+				);
 
 				var idx;
 				var queue = outdatedModules.slice();
@@ -386,7 +407,7 @@ module.exports = function () {
 				}
 			},
 			apply: function (reportError) {
-				/** @type {Promise<EXPECTED_ANY>[]} */
+				/** @type {Promise<unknown>[]} */
 				var acceptPromises = [];
 				// insert new code
 				for (var updateModuleId in appliedUpdate) {
@@ -427,7 +448,7 @@ module.exports = function () {
 								}
 							}
 							for (var k = 0; k < callbacks.length; k++) {
-								/** @type {EXPECTED_ANY} */
+								/** @type {unknown} */
 								var result;
 								try {
 									result = callbacks[k].call(null, moduleOutdatedDependencies);
@@ -468,8 +489,12 @@ module.exports = function () {
 										}
 									}
 								}
-								if (result && typeof result.then === "function") {
-									acceptPromises.push(result);
+								if (
+									result &&
+									typeof (/** @type {{ then?: unknown }} */ (result).then) ===
+										"function"
+								) {
+									acceptPromises.push(/** @type {Promise<unknown>} */ (result));
 								}
 							}
 						}

--- a/test/Template.unittest.js
+++ b/test/Template.unittest.js
@@ -24,4 +24,22 @@ describe("Template", () => {
 			"path-to-sdfas-sadfome$$-js"
 		);
 	});
+
+	it("should strip JSDoc types from runtime function content but keep other comments", () => {
+		const content = Template.getFunctionContent({
+			toString: () =>
+				[
+					"function () {",
+					"\t/** @type {number} */",
+					"\tvar a = /** @type {EXPECTED_ANY} */ (1);",
+					"\t// keep this line comment",
+					"\treturn a /* keep */;",
+					"}"
+				].join("\n")
+		});
+		expect(content).not.toContain("@type");
+		expect(content).toContain("var a = (1);");
+		expect(content).toContain("// keep this line comment");
+		expect(content).toContain("/* keep */");
+	});
 });


### PR DESCRIPTION
Type the two HMR runtime template functions with JSDoc and remove their
// @ts-nocheck pragmas. Strip JSDoc comments in Template.getFunctionContent
so the type annotations are never emitted into the bundled runtime.