### PR TITLE
refactor(ConcatenatedModule): replace stale codegen-cache TODO with rationale

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2246,7 +2246,8 @@ ${defineGetters}`
 					usedNames
 				);
 
-				// TODO cache codeGeneration results
+				// Not cached: Compilation memoizes the outer codeGeneration per
+				// (module, runtime), so inner generation never recomputes usefully.
 				const codeGenResult = m.codeGeneration({
 					dependencyTemplates,
 					runtimeTemplate,


### PR DESCRIPTION
**Summary**

Replaces a stale `// TODO cache codeGeneration results` in `ConcatenatedModule` with a comment explaining why that cache would be useless: `Compilation` groups a module's runtimes by hash and already memoizes the outer `codeGeneration` per `(module, runtime)`, so the inner per-module `codeGeneration` call never usefully recomputes. Comment-only — no behavior, output, or performance change.

**What kind of change does this PR introduce?**

refactor (comment-only).

**Did you add tests for your changes?**

No — comment-only change with no behavior to test.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — Claude Code was used to investigate whether the TODO was worth implementing (it instrumented the inner codegen cache and confirmed 0 hits / 0 gain across builds) and to draft the explanatory comment; I reviewed the measurements and wording. Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN2Wn9gngEBnuWTYbs8hZD)_