### PR TITLE
refactor: strict types for the test suite

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -3,6 +3,7 @@ type EXPECTED_FUNCTION = Function;
 type EXPECTED_OBJECT = object;
 
 declare module "*.json";
+declare module "rimraf";
 
 // Deprecated NodeJS API usages in webpack
 declare namespace NodeJS {

--- a/declarations.test.d.ts
+++ b/declarations.test.d.ts
@@ -1,5 +1,8 @@
 declare module "*.json";
 
+// optional peer of webpack-cli, not installed
+declare module "webpack-dev-server";
+
 type Env = Record<string, any>;
 type TestOptions = { testPath: string; srcPath: string };
 

--- a/declarations.test.d.ts
+++ b/declarations.test.d.ts
@@ -3,6 +3,10 @@ declare module "*.json";
 type Env = Record<string, any>;
 type TestOptions = { testPath: string; srcPath: string };
 
+// jest-circus internal state, exposed on `global` by test/patch-node-env.js
+// eslint-disable-next-line no-var
+declare var JEST_STATE_SYMBOL: import("@jest/types").Circus.State;
+
 declare namespace jest {
 	interface Matchers<R> {
 		toBeTypeOf: (

--- a/test/BannerPlugin.test.js
+++ b/test/BannerPlugin.test.js
@@ -39,11 +39,12 @@ describe("BannerPlugin", () => {
 			expect(footerFileResults[0]).toBe("/*! banner is a string */");
 			fs.writeFileSync(entry2File, "2", "utf8");
 			compiler.run((err, stats) => {
-				const { assets } = stats.toJson();
-				expect(assets.find((as) => as.name === "entry1.js").emitted).toBe(
+				const { assets } = /** @type {import("../").Stats} */ (stats).toJson();
+				const assetsList = /** @type {import("../").StatsAsset[]} */ (assets);
+				expect(/** @type {import("../").StatsAsset} */ (assetsList.find((as) => as.name === "entry1.js")).emitted).toBe(
 					false
 				);
-				expect(assets.find((as) => as.name === "entry2.js").emitted).toBe(true);
+				expect(/** @type {import("../").StatsAsset} */ (assetsList.find((as) => as.name === "entry2.js")).emitted).toBe(true);
 				done(err);
 			});
 		});

--- a/test/BannerPlugin.test.js
+++ b/test/BannerPlugin.test.js
@@ -41,10 +41,16 @@ describe("BannerPlugin", () => {
 			compiler.run((err, stats) => {
 				const { assets } = /** @type {import("../").Stats} */ (stats).toJson();
 				const assetsList = /** @type {import("../").StatsAsset[]} */ (assets);
-				expect(/** @type {import("../").StatsAsset} */ (assetsList.find((as) => as.name === "entry1.js")).emitted).toBe(
-					false
-				);
-				expect(/** @type {import("../").StatsAsset} */ (assetsList.find((as) => as.name === "entry2.js")).emitted).toBe(true);
+				expect(
+					/** @type {import("../").StatsAsset} */ (
+						assetsList.find((as) => as.name === "entry1.js")
+					).emitted
+				).toBe(false);
+				expect(
+					/** @type {import("../").StatsAsset} */ (
+						assetsList.find((as) => as.name === "entry2.js")
+					).emitted
+				).toBe(true);
 				done(err);
 			});
 		});

--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -3,6 +3,11 @@
 const BinaryMiddleware = require("../lib/serialization/BinaryMiddleware");
 const SerializerMiddleware = require("../lib/serialization/SerializerMiddleware");
 
+/**
+ * @param {import("../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} base base
+ * @param {number} count count
+ * @returns {import("../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} result
+ */
 const cont = (base, count) => {
 	const result = [];
 	for (let i = 0; i < count; i++) {
@@ -12,8 +17,13 @@ const cont = (base, count) => {
 };
 
 const mw = new BinaryMiddleware();
-const other = { other: true };
+/** @type {import("../lib/serialization/SerializerMiddleware").LazyTarget} */
+const other = /** @type {EXPECTED_ANY} */ ({ other: true });
 
+/**
+ * @param {import("../lib/serialization/types").PrimitiveSerializableType} item item
+ * @returns {unknown} resolved item
+ */
 const resolveLazy = (item) => {
 	if (SerializerMiddleware.isLazy(item)) {
 		const data = item();
@@ -44,7 +54,8 @@ describe("BinaryMiddleware", () => {
 		SerializerMiddleware.createLazy([5], other)
 	];
 
-	const itemsWithLazy = [
+	/** @type {import("../lib/serialization/types").PrimitiveSerializableType[]} */
+	const itemsWithLazy = /** @type {EXPECTED_ANY} */ ([
 		...items,
 		SerializerMiddleware.createLazy(
 			[SerializerMiddleware.createLazy([5], other)],
@@ -59,13 +70,13 @@ describe("BinaryMiddleware", () => {
 			],
 			mw
 		)
-	];
+	]);
 	itemsWithLazy.push(SerializerMiddleware.createLazy([...itemsWithLazy], mw));
 	itemsWithLazy.push(
 		SerializerMiddleware.createLazy([...itemsWithLazy], other)
 	);
 
-	items.push(undefined);
+	items.push(/** @type {EXPECTED_ANY} */ (undefined));
 
 	const cases = [
 		...itemsWithLazy.map((item) => [item]),
@@ -123,8 +134,14 @@ describe("BinaryMiddleware", () => {
 						// 	`${c} x ${key.slice(0, 20)} (${data.length})\n`
 						// );
 						const realData = cont(data, data.length * c);
-						const serialized = mw.serialize(realData, {});
-						const newData = mw.deserialize(serialized, {});
+						const serialized =
+							/** @type {import("../lib/serialization/BinaryMiddleware").SerializedType} */ (
+								mw.serialize(realData, {})
+							);
+						const newData =
+							/** @type {import("../lib/serialization/BinaryMiddleware").DeserializedType} */ (
+								mw.deserialize(serialized, {})
+							);
 						expect(newData.map(resolveLazy)).toEqual(realData.map(resolveLazy));
 					});
 				}

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -3,15 +3,19 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
-// @ts-ignore
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 const cacheDirectory = path.resolve(__dirname, "js/buildDepsCache");
 const outputDirectory = path.resolve(__dirname, "js/buildDeps");
 const inputDirectory = path.resolve(__dirname, "js/buildDepsInput");
 
-/** @typedef {{ warnings?: RegExp[] | false | undefined, ignoreErrors?: boolean, invalidBuildDependencies?: boolean, definedValue?: string }} ExecOptions */
-const exec = (/** @type {string} */ n, /** @type {ExecOptions} */ options = {}) =>
+/** @typedef {{ warnings?: RegExp[] | false | undefined, ignoreErrors?: boolean, invalidBuildDependencies?: boolean, definedValue?: string, buildTwice?: boolean }} ExecOptions */
+
+const exec = (
+	/** @type {string} */ n,
+	/** @type {ExecOptions} */ options = {}
+) =>
 	new Promise((resolve, reject) => {
 		const webpack = require("../");
 
@@ -32,17 +36,25 @@ const exec = (/** @type {string} */ n, /** @type {ExecOptions} */ options = {}) 
 			n,
 			JSON.stringify(options)
 		]);
-		const p = childProcess.execFile(
-			process.execPath,
-			execArgs,
-			{
-				stdio: ["ignore", "pipe", "pipe"]
-			}
+		const p = /** @type {import("child_process").ChildProcess} */ (
+			/** @type {EXPECTED_ANY} */ (childProcess.execFile)(
+				process.execPath,
+				execArgs,
+				/** @type {import("child_process").ExecFileOptions} */ ({
+					stdio: ["ignore", "pipe", "pipe"]
+				})
+			)
 		);
 		/** @type {string[]} */
 		const chunks = [];
-		/** @type {import("stream").Readable} */ (p.stderr).on("data", (/** @type {string} */ chunk) => chunks.push(chunk));
-		/** @type {import("stream").Readable} */ (p.stdout).on("data", (/** @type {string} */ chunk) => chunks.push(chunk));
+		/** @type {import("stream").Readable} */ (p.stderr).on(
+			"data",
+			(/** @type {string} */ chunk) => chunks.push(chunk)
+		);
+		/** @type {import("stream").Readable} */ (p.stdout).on(
+			"data",
+			(/** @type {string} */ chunk) => chunks.push(chunk)
+		);
 		p.once("exit", (code) => {
 			/** @type {string[]} */
 			const errors = [];

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -3,13 +3,15 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
+// @ts-ignore
 const rimraf = require("rimraf");
 
 const cacheDirectory = path.resolve(__dirname, "js/buildDepsCache");
 const outputDirectory = path.resolve(__dirname, "js/buildDeps");
 const inputDirectory = path.resolve(__dirname, "js/buildDepsInput");
 
-const exec = (n, options = {}) =>
+/** @typedef {{ warnings?: RegExp[], ignoreErrors?: boolean }} ExecOptions */
+const exec = (/** @type {number} */ n, /** @type {ExecOptions} */ options = {}) =>
 	new Promise((resolve, reject) => {
 		const webpack = require("../");
 
@@ -17,7 +19,7 @@ const exec = (n, options = {}) =>
 
 		const p = childProcess.execFile(
 			process.execPath,
-			[
+			/** @type {string[]} */ ([
 				...(coverageEnabled
 					? [
 							require.resolve("nyc/bin/nyc.js"),
@@ -29,18 +31,21 @@ const exec = (n, options = {}) =>
 						]
 					: []),
 				path.resolve(__dirname, "fixtures/buildDependencies/run.js"),
-				n,
+				`${n}`,
 				JSON.stringify(options)
-			],
+			]),
 			{
 				stdio: ["ignore", "pipe", "pipe"]
 			}
 		);
+		/** @type {string[]} */
 		const chunks = [];
-		p.stderr.on("data", (chunk) => chunks.push(chunk));
-		p.stdout.on("data", (chunk) => chunks.push(chunk));
+		/** @type {import("stream").Readable} */ (p.stderr).on("data", (/** @type {string} */ chunk) => chunks.push(chunk));
+		/** @type {import("stream").Readable} */ (p.stdout).on("data", (/** @type {string} */ chunk) => chunks.push(chunk));
 		p.once("exit", (code) => {
+			/** @type {string[]} */
 			const errors = [];
+			/** @type {string[]} */
 			const warnings = [];
 			const rawStdout = chunks.join("");
 			const stdout = rawStdout.replace(
@@ -216,7 +221,9 @@ export default 0;`
 		await exec("7", {
 			definedValue: "other"
 		});
+		/** @type {number} */
 		let now4;
+		/** @type {number} */
 		let now5;
 		if (supportsEsm) {
 			fs.writeFileSync(

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -3,7 +3,6 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 const cacheDirectory = path.resolve(__dirname, "js/buildDepsCache");

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -10,30 +10,31 @@ const cacheDirectory = path.resolve(__dirname, "js/buildDepsCache");
 const outputDirectory = path.resolve(__dirname, "js/buildDeps");
 const inputDirectory = path.resolve(__dirname, "js/buildDepsInput");
 
-/** @typedef {{ warnings?: RegExp[], ignoreErrors?: boolean }} ExecOptions */
-const exec = (/** @type {number} */ n, /** @type {ExecOptions} */ options = {}) =>
+/** @typedef {{ warnings?: RegExp[] | false | undefined, ignoreErrors?: boolean, invalidBuildDependencies?: boolean, definedValue?: string }} ExecOptions */
+const exec = (/** @type {string} */ n, /** @type {ExecOptions} */ options = {}) =>
 	new Promise((resolve, reject) => {
 		const webpack = require("../");
 
 		const coverageEnabled = webpack.toString().includes("++");
 
+		const execArgs = /** @type {string[]} */ ([
+			...(coverageEnabled
+				? [
+						require.resolve("nyc/bin/nyc.js"),
+						"--silent",
+						"--no-clean",
+						"--cache-dir",
+						".jest-cache/nyc",
+						process.execPath
+					]
+				: []),
+			path.resolve(__dirname, "fixtures/buildDependencies/run.js"),
+			n,
+			JSON.stringify(options)
+		]);
 		const p = childProcess.execFile(
 			process.execPath,
-			/** @type {string[]} */ ([
-				...(coverageEnabled
-					? [
-							require.resolve("nyc/bin/nyc.js"),
-							"--silent",
-							"--no-clean",
-							"--cache-dir",
-							".jest-cache/nyc",
-							process.execPath
-						]
-					: []),
-				path.resolve(__dirname, "fixtures/buildDependencies/run.js"),
-				`${n}`,
-				JSON.stringify(options)
-			]),
+			execArgs,
 			{
 				stdio: ["ignore", "pipe", "pipe"]
 			}
@@ -221,10 +222,8 @@ export default 0;`
 		await exec("7", {
 			definedValue: "other"
 		});
-		/** @type {number} */
-		let now4;
-		/** @type {number} */
-		let now5;
+		let now4 = 0;
+		let now5 = 0;
 		if (supportsEsm) {
 			fs.writeFileSync(
 				path.resolve(inputDirectory, "esm-dependency.js"),

--- a/test/ChangesAndRemovals.test.js
+++ b/test/ChangesAndRemovals.test.js
@@ -5,13 +5,21 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 const { Volume, createFsFromVolume } = require("memfs");
+/** @type {(path: string, callback: (err?: unknown) => void) => void} */
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
+/**
+ * @param {import("../").Configuration} config config
+ * @returns {import("../").Compiler} compiler
+ */
 const createCompiler = (config) => {
 	const webpack = require("..");
 
-	const compiler = webpack(config);
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
+	const compiler = /** @type {import("../").Compiler} */ (webpack(config));
+	compiler.outputFileSystem = /** @type {EXPECTED_ANY} */ (
+		createFsFromVolume(new Volume())
+	);
 	return compiler;
 };
 
@@ -28,6 +36,10 @@ const createSingleCompiler = () =>
 		}
 	});
 
+/**
+ * @param {import("../").Compiler} compiler compiler
+ * @param {() => void} action action
+ */
 const onceDone = (compiler, action) => {
 	let initial = true;
 	compiler.hooks.done.tap("ChangesAndRemovalsTest", () => {
@@ -37,6 +49,10 @@ const onceDone = (compiler, action) => {
 	});
 };
 
+/**
+ * @param {import("../").Compiler} compiler compiler
+ * @returns {{ removed: string[] | undefined, modified: string[] | undefined }} changes
+ */
 const getChanges = (compiler) => {
 	const modifiedFiles = compiler.modifiedFiles;
 	const removedFiles = compiler.removedFiles;
@@ -94,18 +110,22 @@ describe("ChangesAndRemovals", () => {
 
 	it("should not track modified/removed files during initial watchRun", (done) => {
 		const compiler = createSingleCompiler();
-		const watchRunFinished = new Promise((resolve) => {
-			compiler.hooks.watchRun.tap("ChangesAndRemovalsTest", (compiler) => {
-				expect(getChanges(compiler)).toEqual({
-					removed: undefined,
-					modified: undefined
+		const watchRunFinished = /** @type {Promise<void>} */ (
+			new Promise((resolve) => {
+				compiler.hooks.watchRun.tap("ChangesAndRemovalsTest", (compiler) => {
+					expect(getChanges(compiler)).toEqual({
+						removed: undefined,
+						modified: undefined
+					});
+					resolve();
 				});
-				resolve();
-			});
-		});
-		const watcher = compiler.watch({ aggregateTimeout: 200 }, (err) => {
-			if (err) done(err);
-		});
+			})
+		);
+		const watcher = /** @type {import("../").Watching} */ (
+			compiler.watch({ aggregateTimeout: 200 }, (err) => {
+				if (err) done(err);
+			})
+		);
 
 		watchRunFinished.then(() => {
 			watcher.close(done);
@@ -114,7 +134,8 @@ describe("ChangesAndRemovals", () => {
 
 	it("should track modified files when they've been modified", (done) => {
 		const compiler = createSingleCompiler();
-		let watcher;
+		/** @type {import("../").Watching | null} */
+		let watcher = null;
 
 		compiler.hooks.watchRun.tap("ChangesAndRemovalsTest", (compiler) => {
 			if (!watcher) return;
@@ -127,9 +148,11 @@ describe("ChangesAndRemovals", () => {
 			watcher = null;
 		});
 
-		watcher = compiler.watch({ aggregateTimeout: 200 }, (err) => {
-			if (err) done(err);
-		});
+		watcher = /** @type {import("../").Watching} */ (
+			compiler.watch({ aggregateTimeout: 200 }, (err) => {
+				if (err) done(err);
+			})
+		);
 
 		onceDone(compiler, () => {
 			fs.appendFileSync(tempFilePath, "\nlet x = 'file modified';");
@@ -138,7 +161,8 @@ describe("ChangesAndRemovals", () => {
 
 	it("should track removed file when removing file", (done) => {
 		const compiler = createSingleCompiler();
-		let watcher;
+		/** @type {import("../").Watching | null} */
+		let watcher = null;
 
 		compiler.hooks.watchRun.tap("ChangesAndRemovalsTest", (compiler) => {
 			if (!watcher) return;
@@ -151,9 +175,11 @@ describe("ChangesAndRemovals", () => {
 			watcher = null;
 		});
 
-		watcher = compiler.watch({ aggregateTimeout: 200 }, (err) => {
-			if (err) done(err);
-		});
+		watcher = /** @type {import("../").Watching} */ (
+			compiler.watch({ aggregateTimeout: 200 }, (err) => {
+				if (err) done(err);
+			})
+		);
 
 		onceDone(compiler, () => {
 			fs.unlinkSync(tempFilePath);

--- a/test/ChangesAndRemovals.test.js
+++ b/test/ChangesAndRemovals.test.js
@@ -6,7 +6,6 @@ const path = require("path");
 const fs = require("graceful-fs");
 const { Volume, createFsFromVolume } = require("memfs");
 /** @type {(path: string, callback: (err?: unknown) => void) => void} */
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 /**

--- a/test/Chunk.unittest.js
+++ b/test/Chunk.unittest.js
@@ -3,10 +3,15 @@
 const Chunk = require("../lib/Chunk");
 
 describe("Chunk", () => {
+	/** @type {InstanceType<typeof Chunk>} */
 	let ChunkInstance;
 
 	beforeEach(() => {
-		ChunkInstance = new Chunk("chunk-test", "module-test", "loc-test");
+		const ChunkAny =
+			/** @type {new (...args: unknown[]) => InstanceType<typeof Chunk>} */ (
+				/** @type {unknown} */ (Chunk)
+			);
+		ChunkInstance = new ChunkAny("chunk-test", "module-test", "loc-test");
 	});
 
 	it("should have debugId more than 999", () => {

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -117,7 +117,7 @@ describe("Cli", () => {
 	});
 
 	describe("processArguments", () => {
-		const test = (/** @type {string} */ name, /** @type {Record<string, unknown>} */ values, /** @type {Record<string, unknown>} */ config, /** @type {(e: EXPECTED_ANY) => void} */ fn) => {
+		const test = (/** @type {string} */ name, /** @type {import("../lib/cli").Values} */ values, /** @type {import("../").Configuration} */ config, /** @type {(e: EXPECTED_ANY) => void} */ fn) => {
 			it(`should correctly process arguments for ${name}`, () => {
 				const args = getArguments();
 				const problems = processArguments(args, config, values);
@@ -618,6 +618,7 @@ describe("Cli", () => {
 				/** @type {import("../lib/cli").Flags} */
 				const args = {
 					"evil-flag": {
+						description: undefined,
 						configs: [
 							{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: `${key}.polluted` }
 						],
@@ -626,9 +627,7 @@ describe("Cli", () => {
 					}
 				};
 				const config = {};
-				const problems = processArguments(args, config, {
-					"evil-flag": "PWNED"
-				});
+				const problems = processArguments(args, config, /** @type {import("../lib/cli").Values} */ (/** @type {unknown} */ ({"evil-flag": "PWNED"})));
 
 				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
 				expect(problems).toEqual([
@@ -640,15 +639,14 @@ describe("Cli", () => {
 				/** @type {import("../lib/cli").Flags} */
 				const args = {
 					"evil-flag": {
+						description: undefined,
 						configs: [{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: key }],
 						simpleType: /** @type {import("../lib/cli").SimpleType} */ ("string"),
 						multiple: false
 					}
 				};
 				const config = {};
-				const problems = processArguments(args, config, {
-					"evil-flag": "PWNED"
-				});
+				const problems = processArguments(args, config, /** @type {import("../lib/cli").Values} */ (/** @type {unknown} */ ({"evil-flag": "PWNED"})));
 
 				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
 				expect(problems).toEqual([

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -50,7 +50,13 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
+			expect(
+				getArguments(
+					/** @type {Parameters<typeof getArguments>[0]} */ (
+						/** @type {unknown} */ (schema)
+					)
+				)
+			).toMatchSnapshot();
 		});
 
 		it("should generate flags for a schema using `const`", () => {
@@ -66,7 +72,13 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
+			expect(
+				getArguments(
+					/** @type {Parameters<typeof getArguments>[0]} */ (
+						/** @type {unknown} */ (schema)
+					)
+				)
+			).toMatchSnapshot();
 		});
 
 		it("should generate flags for both branches of an `if/then/else` schema", () => {
@@ -93,7 +105,13 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
+			expect(
+				getArguments(
+					/** @type {Parameters<typeof getArguments>[0]} */ (
+						/** @type {unknown} */ (schema)
+					)
+				)
+			).toMatchSnapshot();
 		});
 
 		it("reports the schema origin path in conflicting-schema errors", () => {
@@ -110,17 +128,32 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(() => getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toThrow(
+			expect(() =>
+				getArguments(
+					/** @type {Parameters<typeof getArguments>[0]} */ (
+						/** @type {unknown} */ (schema)
+					)
+				)
+			).toThrow(
 				"Conflicting schema for foo[] (#/properties/foo/oneOf/1/items) with string type"
 			);
 		});
 	});
 
 	describe("processArguments", () => {
-		const test = (/** @type {string} */ name, /** @type {import("../lib/cli").Values} */ values, /** @type {import("../").Configuration} */ config, /** @type {(e: EXPECTED_ANY) => void} */ fn) => {
+		const test = (
+			/** @type {string} */ name,
+			/** @type {Record<string, EXPECTED_ANY>} */ values,
+			/** @type {import("../").Configuration} */ config,
+			/** @type {(e: EXPECTED_ANY) => void} */ fn
+		) => {
 			it(`should correctly process arguments for ${name}`, () => {
 				const args = getArguments();
-				const problems = processArguments(args, config, values);
+				const problems = processArguments(
+					args,
+					config,
+					/** @type {import("../lib/cli").Values} */ (values)
+				);
 				fn(expect(problems || config));
 			});
 		};
@@ -620,16 +653,30 @@ describe("Cli", () => {
 					"evil-flag": {
 						description: undefined,
 						configs: [
-							{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: `${key}.polluted` }
+							{
+								type: /** @type {import("../lib/cli").SimpleType} */ ("string"),
+								multiple: false,
+								path: `${key}.polluted`
+							}
 						],
-						simpleType: /** @type {import("../lib/cli").SimpleType} */ ("string"),
+						simpleType: /** @type {import("../lib/cli").SimpleType} */ (
+							"string"
+						),
 						multiple: false
 					}
 				};
 				const config = {};
-				const problems = processArguments(args, config, /** @type {import("../lib/cli").Values} */ (/** @type {unknown} */ ({"evil-flag": "PWNED"})));
+				const problems = processArguments(
+					args,
+					config,
+					/** @type {import("../lib/cli").Values} */ (
+						/** @type {unknown} */ ({ "evil-flag": "PWNED" })
+					)
+				);
 
-				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
+				expect(
+					/** @type {Record<string, unknown>} */ ({}).polluted
+				).toBeUndefined();
 				expect(problems).toEqual([
 					expect.objectContaining({ type: "prototype-pollution-in-path" })
 				]);
@@ -640,15 +687,31 @@ describe("Cli", () => {
 				const args = {
 					"evil-flag": {
 						description: undefined,
-						configs: [{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: key }],
-						simpleType: /** @type {import("../lib/cli").SimpleType} */ ("string"),
+						configs: [
+							{
+								type: /** @type {import("../lib/cli").SimpleType} */ ("string"),
+								multiple: false,
+								path: key
+							}
+						],
+						simpleType: /** @type {import("../lib/cli").SimpleType} */ (
+							"string"
+						),
 						multiple: false
 					}
 				};
 				const config = {};
-				const problems = processArguments(args, config, /** @type {import("../lib/cli").Values} */ (/** @type {unknown} */ ({"evil-flag": "PWNED"})));
+				const problems = processArguments(
+					args,
+					config,
+					/** @type {import("../lib/cli").Values} */ (
+						/** @type {unknown} */ ({ "evil-flag": "PWNED" })
+					)
+				);
 
-				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
+				expect(
+					/** @type {Record<string, unknown>} */ ({}).polluted
+				).toBeUndefined();
 				expect(problems).toEqual([
 					expect.objectContaining({ type: "prototype-pollution-in-path" })
 				]);
@@ -772,7 +835,11 @@ describe("Cli", () => {
 
 		it("simple", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (colors))[name](name)).toBe(open + name + close);
+				expect(
+					/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (
+						/** @type {unknown} */ (colors)
+					)[name](name)
+				).toBe(open + name + close);
 			}
 		});
 
@@ -824,7 +891,11 @@ describe("Cli", () => {
 
 		it("simple (no colors)", () => {
 			for (const [name] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (noColors))[name](name)).toBe(name);
+				expect(
+					/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (
+						/** @type {unknown} */ (noColors)
+					)[name](name)
+				).toBe(name);
 			}
 		});
 
@@ -832,7 +903,11 @@ describe("Cli", () => {
 
 		it("simple (colors by default)", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (defaultColors))[name](name)).toBe(open + name + close);
+				expect(
+					/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (
+						/** @type {unknown} */ (defaultColors)
+					)[name](name)
+				).toBe(open + name + close);
 			}
 		});
 	});

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -772,7 +772,7 @@ describe("Cli", () => {
 
 		it("simple", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (colors)[name](name)).toBe(open + name + close);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (colors))[name](name)).toBe(open + name + close);
 			}
 		});
 
@@ -824,7 +824,7 @@ describe("Cli", () => {
 
 		it("simple (no colors)", () => {
 			for (const [name] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (noColors)[name](name)).toBe(name);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (noColors))[name](name)).toBe(name);
 			}
 		});
 
@@ -832,7 +832,7 @@ describe("Cli", () => {
 
 		it("simple (colors by default)", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (defaultColors)[name](name)).toBe(open + name + close);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (/** @type {unknown} */ (defaultColors))[name](name)).toBe(open + name + close);
 			}
 		});
 	});

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -50,7 +50,7 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(schema)).toMatchSnapshot();
+			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
 		});
 
 		it("should generate flags for a schema using `const`", () => {
@@ -66,7 +66,7 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(schema)).toMatchSnapshot();
+			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
 		});
 
 		it("should generate flags for both branches of an `if/then/else` schema", () => {
@@ -93,7 +93,7 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(getArguments(schema)).toMatchSnapshot();
+			expect(getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toMatchSnapshot();
 		});
 
 		it("reports the schema origin path in conflicting-schema errors", () => {
@@ -110,14 +110,14 @@ describe("Cli", () => {
 				}
 			};
 
-			expect(() => getArguments(schema)).toThrow(
+			expect(() => getArguments(/** @type {Parameters<typeof getArguments>[0]} */ (/** @type {unknown} */ (schema)))).toThrow(
 				"Conflicting schema for foo[] (#/properties/foo/oneOf/1/items) with string type"
 			);
 		});
 	});
 
 	describe("processArguments", () => {
-		const test = (name, values, config, fn) => {
+		const test = (/** @type {string} */ name, /** @type {Record<string, unknown>} */ values, /** @type {Record<string, unknown>} */ config, /** @type {(e: EXPECTED_ANY) => void} */ fn) => {
 			it(`should correctly process arguments for ${name}`, () => {
 				const args = getArguments();
 				const problems = processArguments(args, config, values);
@@ -615,12 +615,13 @@ describe("Cli", () => {
 
 		for (const key of ["__proto__", "constructor", "prototype"]) {
 			it(`should not pollute the prototype through a "${key}" path segment`, () => {
+				/** @type {import("../lib/cli").Flags} */
 				const args = {
 					"evil-flag": {
 						configs: [
-							{ type: "string", multiple: false, path: `${key}.polluted` }
+							{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: `${key}.polluted` }
 						],
-						simpleType: "string",
+						simpleType: /** @type {import("../lib/cli").SimpleType} */ ("string"),
 						multiple: false
 					}
 				};
@@ -629,17 +630,18 @@ describe("Cli", () => {
 					"evil-flag": "PWNED"
 				});
 
-				expect({}.polluted).toBeUndefined();
+				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
 				expect(problems).toEqual([
 					expect.objectContaining({ type: "prototype-pollution-in-path" })
 				]);
 			});
 
 			it(`should not pollute the prototype through a trailing "${key}" path segment`, () => {
+				/** @type {import("../lib/cli").Flags} */
 				const args = {
 					"evil-flag": {
-						configs: [{ type: "string", multiple: false, path: key }],
-						simpleType: "string",
+						configs: [{ type: /** @type {import("../lib/cli").SimpleType} */ ("string"), multiple: false, path: key }],
+						simpleType: /** @type {import("../lib/cli").SimpleType} */ ("string"),
 						multiple: false
 					}
 				};
@@ -648,7 +650,7 @@ describe("Cli", () => {
 					"evil-flag": "PWNED"
 				});
 
-				expect({}.polluted).toBeUndefined();
+				expect(/** @type {Record<string, unknown>} */ ({}).polluted).toBeUndefined();
 				expect(problems).toEqual([
 					expect.objectContaining({ type: "prototype-pollution-in-path" })
 				]);
@@ -772,7 +774,7 @@ describe("Cli", () => {
 
 		it("simple", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(colors[name](name)).toBe(open + name + close);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (colors)[name](name)).toBe(open + name + close);
 			}
 		});
 
@@ -824,7 +826,7 @@ describe("Cli", () => {
 
 		it("simple (no colors)", () => {
 			for (const [name] of colorsMap) {
-				expect(noColors[name](name)).toBe(name);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (noColors)[name](name)).toBe(name);
 			}
 		});
 
@@ -832,7 +834,7 @@ describe("Cli", () => {
 
 		it("simple (colors by default)", () => {
 			for (const [name, open, close] of colorsMap) {
-				expect(defaultColors[name](name)).toBe(open + name + close);
+				expect(/** @type {Record<string, import("../lib/cli").PrintFunction>} */ (defaultColors)[name](name)).toBe(open + name + close);
 			}
 		});
 	});

--- a/test/Compiler-caching.test.js
+++ b/test/Compiler-caching.test.js
@@ -4,47 +4,87 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (pattern: string) => void }} */
 const rimraf = require("rimraf");
 
 let fixtureCount = 0;
 
+/**
+ * @typedef {{ mkdir: string[], writeFile: unknown[] }} CachingLogs
+ * @typedef {import("../").StatsCompilation & { logs?: CachingLogs, assets: import("../").StatsAsset[], modules: import("../").StatsModule[] }} CachingStats
+ */
+
 describe("Compiler (caching)", () => {
+	/**
+	 * @param {string} entry entry file
+	 * @param {import("../").Configuration} options webpack options
+	 * @param {(stats: CachingStats, files: Record<string, string>, iteration: number) => void} callback done callback
+	 * @returns {{ compilerInstance: import("../").Compiler, runAgain: (options: Record<string, unknown> | ((stats: CachingStats, files: Record<string, string>, iteration: number) => void), callback?: (stats: CachingStats, files: Record<string, string>, iteration: number) => void) => void }} helpers
+	 */
 	function compile(entry, options, callback) {
 		const webpack = require("..");
 
-		options = webpack.config.getNormalizedWebpackOptions(options);
-		options.mode = "none";
-		options.cache = true;
-		options.entry = entry;
-		options.optimization.moduleIds = "natural";
-		options.optimization.minimize = false;
-		options.context = path.join(__dirname, "fixtures");
-		options.output.path = "/";
-		options.output.filename = "bundle.js";
-		options.output.pathinfo = true;
+		/** @type {import("../").WebpackOptionsNormalized} */
+		const normalizedOptions =
+			webpack.config.getNormalizedWebpackOptions(options);
+		normalizedOptions.mode = "none";
+		normalizedOptions.cache =
+			/** @type {import("../").WebpackOptionsNormalized["cache"]} */ (
+				/** @type {unknown} */ (true)
+			);
+		normalizedOptions.entry = /** @type {import("../").EntryNormalized} */ (
+			/** @type {unknown} */ (entry)
+		);
+		normalizedOptions.optimization.moduleIds = "natural";
+		normalizedOptions.optimization.minimize = false;
+		normalizedOptions.context = path.join(__dirname, "fixtures");
+		normalizedOptions.output.path = "/";
+		normalizedOptions.output.filename = "bundle.js";
+		normalizedOptions.output.pathinfo = true;
+		/** @type {CachingLogs} */
 		const logs = {
 			mkdir: [],
 			writeFile: []
 		};
 
-		const c = webpack(options);
+		const c = webpack(
+			/** @type {import("../").Configuration} */ (
+				/** @type {unknown} */ (normalizedOptions)
+			)
+		);
+		/** @type {Record<string, string>} */
 		const files = {};
-		c.outputFileSystem = {
-			mkdir(path, callback) {
-				logs.mkdir.push(path);
-				const err = new Error("error");
-				err.code = "EEXIST";
-				callback(err);
-			},
-			writeFile(name, content, callback) {
-				logs.writeFile.push(name, content);
-				files[name] = content.toString("utf8");
-				callback();
-			},
-			stat(path, callback) {
-				callback(new Error("ENOENT"));
-			}
-		};
+		c.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ ({
+				/**
+				 * @param {string} dirPath directory path
+				 * @param {(err: NodeJS.ErrnoException) => void} cb callback
+				 */
+				mkdir(dirPath, cb) {
+					logs.mkdir.push(dirPath);
+					const err = /** @type {NodeJS.ErrnoException} */ (new Error("error"));
+					err.code = "EEXIST";
+					cb(err);
+				},
+				/**
+				 * @param {string} name file name
+				 * @param {Buffer} content file content
+				 * @param {() => void} cb callback
+				 */
+				writeFile(name, content, cb) {
+					logs.writeFile.push(name, content);
+					files[name] = content.toString("utf8");
+					cb();
+				},
+				/**
+				 * @param {string} _filePath file path
+				 * @param {(err: Error) => void} cb callback
+				 */
+				stat(_filePath, cb) {
+					cb(new Error("ENOENT"));
+				}
+			})
+		);
 		c.hooks.compilation.tap(
 			"CompilerCachingTest",
 			(compilation) => (compilation.bail = true)
@@ -52,29 +92,43 @@ describe("Compiler (caching)", () => {
 
 		let compilerIteration = 1;
 
+		/**
+		 * @param {Record<string, unknown> | ((stats: CachingStats, files: Record<string, string>, iteration: number) => void)} options run options or callback
+		 * @param {((stats: CachingStats, files: Record<string, string>, iteration: number) => void)=} callback done callback
+		 */
 		function runCompiler(options, callback) {
 			if (typeof options === "function") {
 				callback = options;
 				options = {};
 			}
-			c.run((err, stats) => {
+			c.run((err, rawStats) => {
 				if (err) throw err;
-				expect(typeof stats).toBe("object");
-				stats = stats.toJson({
-					modules: true,
-					reasons: true
-				});
+				expect(typeof rawStats).toBe("object");
+				const stats = /** @type {CachingStats} */ (
+					/** @type {import("../").Stats} */ (rawStats).toJson({
+						modules: true,
+						reasons: true
+					})
+				);
 				expect(typeof stats).toBe("object");
 				expect(stats).toHaveProperty("errors");
 				expect(Array.isArray(stats.errors)).toBe(true);
-				if (options.expectErrors) {
-					expect(stats.errors).toHaveLength(options.expectErrors);
-				} else if (stats.errors.length > 0) {
+				if (/** @type {Record<string, unknown>} */ (options).expectErrors) {
+					expect(stats.errors).toHaveLength(
+						/** @type {number} */ (
+							/** @type {Record<string, unknown>} */ (options).expectErrors
+						)
+					);
+				} else if (stats.errors && stats.errors.length > 0) {
 					expect(typeof stats.errors[0]).toBe("string");
-					throw new Error(stats.errors[0]);
+					throw new Error(
+						/** @type {string} */ (/** @type {unknown} */ (stats.errors[0]))
+					);
 				}
 				stats.logs = logs;
-				callback(stats, files, compilerIteration++);
+				/** @type {(stats: CachingStats, files: Record<string, string>, iteration: number) => void} */ (
+					callback
+				)(stats, files, compilerIteration++);
 			});
 		}
 

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -4,8 +4,10 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-/** @type {{ sync: (path: string) => void }} */
-const rimraf = require("rimraf");
+const rimraf = /** @type {{ sync: (path: string) => void }} */ (
+	// @ts-expect-error - no type declarations for rimraf
+	require("rimraf")
+);
 
 let fixtureCount = 0;
 
@@ -16,7 +18,11 @@ describe("Compiler (filesystem caching)", () => {
 		"temp-filesystem-cache-fixture"
 	);
 
-	function compile(/** @type {string} */ entry, /** @type {(stats: import("../types").StatsCompilation) => void} */ onSuccess, /** @type {(err: Error) => void} */ onError) {
+	function compile(
+		/** @type {string} */ entry,
+		/** @type {(stats: import("../types").StatsCompilation) => void} */ onSuccess,
+		/** @type {(err: Error) => void} */ onError
+	) {
 		const webpack = require("..");
 
 		const options = webpack.config.getNormalizedWebpackOptions({});
@@ -24,22 +30,27 @@ describe("Compiler (filesystem caching)", () => {
 			type: "filesystem",
 			cacheDirectory: path.join(tempFixturePath, "cache")
 		};
-		options.entry = entry;
+		options.entry = /** @type {import("../types").EntryNormalized} */ (
+			/** @type {unknown} */ (entry)
+		);
 		options.context = path.join(__dirname, "fixtures");
 		options.output.path = path.join(tempFixturePath, "dist");
 		options.output.filename = "bundle.js";
 		options.output.pathinfo = true;
-		options.module = /** @type {import("../types").ModuleOptionsNormalized} */ (/** @type {unknown} */ ({
-			rules: [
-				{
-					test: /\.svg$/,
-					type: "asset/resource",
-					use: {
-						loader: require.resolve("./fixtures/empty-svg-loader")
-					}
-				}
-			]
-		}));
+		options.module =
+			/** @type {import("../types").WebpackOptionsNormalized["module"]} */ (
+				/** @type {unknown} */ ({
+					rules: [
+						{
+							test: /\.svg$/,
+							type: "asset/resource",
+							use: {
+								loader: require.resolve("./fixtures/empty-svg-loader")
+							}
+						}
+					]
+				})
+			);
 
 		const isBigIntSupported = typeof BigInt !== "undefined";
 		const isErrorCaseSupported =
@@ -64,9 +75,16 @@ describe("Compiler (filesystem caching)", () => {
 								const cache = compilation.getCache(name);
 								const ident = "test.ext";
 								const cacheItem_ = cache.getItemCache(ident, null);
-								const cacheItem = /** @type {{ getPromise(id: string): Promise<Record<string, unknown>>, storePromise(v: unknown): Promise<void> }} */ (/** @type {unknown} */ (cacheItem_));
+								const cacheItem =
+									/** @type {{ getPromise(id: string): Promise<unknown>, storePromise(v: unknown): Promise<void> }} */ (
+										/** @type {unknown} */ (cacheItem_)
+									);
 
-								const result = await cacheItem.getPromise(ident);
+								const result_ = await cacheItem.getPromise(ident);
+								const result =
+									/** @type {Record<string, Record<string, Record<string, unknown>> & Iterable<unknown>>} */ (
+										result_
+									);
 
 								if (result) {
 									expect(result.number).toBe(42);
@@ -92,17 +110,21 @@ describe("Compiler (filesystem caching)", () => {
 									}
 
 									if (isBigIntSupported) {
-										expect(result.bigint).toBe(5n);
-										expect(result.bigint1).toBe(124n);
-										expect(result.bigint2).toBe(125n);
-										expect(result.bigint3).toBe(12345678901234567890n);
-										expect(result.bigint4).toBe(5n);
-										expect(result.bigint5).toBe(1000000n);
-										expect(result.bigint6).toBe(128n);
-										expect(result.bigint7).toBe(2147483647n);
+										expect(result.bigint).toBe(BigInt(5));
+										expect(result.bigint1).toBe(BigInt(124));
+										expect(result.bigint2).toBe(BigInt(125));
+										expect(result.bigint3).toBe(BigInt("12345678901234567890"));
+										expect(result.bigint4).toBe(BigInt(5));
+										expect(result.bigint5).toBe(BigInt(1000000));
+										expect(result.bigint6).toBe(BigInt(128));
+										expect(result.bigint7).toBe(BigInt(2147483647));
 										expect(result.obj.foo).toBe(BigInt(-10));
 										expect([...result.set]).toEqual([BigInt(1), BigInt(2)]);
-										expect(result.arr).toEqual([256n, 257n, 258n]);
+										expect(result.arr).toEqual([
+											BigInt(256),
+											BigInt(257),
+											BigInt(258)
+										]);
 									}
 
 									return;
@@ -136,14 +158,14 @@ describe("Compiler (filesystem caching)", () => {
 									storeValue.bigint = BigInt(5);
 									storeValue.bigint1 = BigInt(124);
 									storeValue.bigint2 = BigInt(125);
-									storeValue.bigint3 = 12345678901234567890n;
-									storeValue.bigint4 = 5n;
-									storeValue.bigint5 = 1000000n;
-									storeValue.bigint6 = 128n;
-									storeValue.bigint7 = 2147483647n;
+									storeValue.bigint3 = BigInt("12345678901234567890");
+									storeValue.bigint4 = BigInt(5);
+									storeValue.bigint5 = BigInt(1000000);
+									storeValue.bigint6 = BigInt(128);
+									storeValue.bigint7 = BigInt(2147483647);
 									storeValue.obj = { foo: BigInt(-10) };
 									storeValue.set = new Set([BigInt(1), BigInt(2)]);
-									storeValue.arr = [256n, 257n, 258n];
+									storeValue.arr = [BigInt(256), BigInt(257), BigInt(258)];
 								}
 
 								await cacheItem.storePromise(storeValue);
@@ -154,23 +176,30 @@ describe("Compiler (filesystem caching)", () => {
 			}
 		];
 
-		function runCompiler(onSuccess, onError) {
-			const c = webpack(options);
+		function runCompiler(
+			/** @type {(stats: import("../types").StatsCompilation) => void} */ onSuccess,
+			/** @type {(err: Error) => void} */ onError
+		) {
+			const c = webpack(
+				/** @type {import("../types").Configuration} */ (
+					/** @type {unknown} */ (options)
+				)
+			);
 			c.hooks.compilation.tap(
 				"CompilerCachingTest",
 				(compilation) => (compilation.bail = true)
 			);
-			c.run((err, stats) => {
+			c.run((err, stats_) => {
 				if (err) throw err;
-				expect(typeof stats).toBe("object");
-				stats = stats.toJson({
+				expect(typeof stats_).toBe("object");
+				const stats = /** @type {import("../types").Stats} */ (stats_).toJson({
 					modules: true,
 					reasons: true
 				});
 				expect(typeof stats).toBe("object");
 				expect(stats).toHaveProperty("errors");
 				expect(Array.isArray(stats.errors)).toBe(true);
-				if (stats.errors.length > 0) {
+				if (/** @type {unknown[]} */ (stats.errors).length > 0) {
 					onError(new Error(JSON.stringify(stats.errors, null, 4)));
 				}
 				c.close(() => {
@@ -227,25 +256,31 @@ describe("Compiler (filesystem caching)", () => {
 	it("should compile again when cached asset has changed but loader output remains the same", (done) => {
 		const tempFixture = createTempFixture();
 
-		const onError = (error) => done(error);
+		const onError = (/** @type {Error} */ error) => done(error);
 
 		const helper = compile(
 			tempFixture.usesAssetFilepath,
 			(stats) => {
+				const assets = /** @type {import("../types").StatsAsset[]} */ (
+					stats.assets
+				);
 				// Not cached the first time
-				expect(stats.assets[0].name).toBe("bundle.js");
-				expect(stats.assets[0].emitted).toBe(true);
+				expect(assets[0].name).toBe("bundle.js");
+				expect(assets[0].emitted).toBe(true);
 
-				expect(stats.assets[1].name).toMatch(/\w+\.svg$/);
-				expect(stats.assets[0].emitted).toBe(true);
+				expect(assets[1].name).toMatch(/\w+\.svg$/);
+				expect(assets[0].emitted).toBe(true);
 
 				helper.runAgain((stats) => {
+					const assets = /** @type {import("../types").StatsAsset[]} */ (
+						stats.assets
+					);
 					// Cached the second run
-					expect(stats.assets[0].name).toBe("bundle.js");
-					expect(stats.assets[0].emitted).toBe(false);
+					expect(assets[0].name).toBe("bundle.js");
+					expect(assets[0].emitted).toBe(false);
 
-					expect(stats.assets[1].name).toMatch(/\w+\.svg$/);
-					expect(stats.assets[0].emitted).toBe(false);
+					expect(assets[1].name).toMatch(/\w+\.svg$/);
+					expect(assets[0].emitted).toBe(false);
 
 					const svgContent = fs
 						.readFileSync(tempFixture.svgFilepath)
@@ -255,12 +290,15 @@ describe("Compiler (filesystem caching)", () => {
 					fs.writeFileSync(tempFixture.svgFilepath, svgContent);
 
 					helper.runAgain((stats) => {
+						const assets = /** @type {import("../types").StatsAsset[]} */ (
+							stats.assets
+						);
 						// Still cached after file modification because loader always returns empty
-						expect(stats.assets[0].name).toBe("bundle.js");
-						expect(stats.assets[0].emitted).toBe(false);
+						expect(assets[0].name).toBe("bundle.js");
+						expect(assets[0].emitted).toBe(false);
 
-						expect(stats.assets[1].name).toMatch(/\w+\.svg$/);
-						expect(stats.assets[0].emitted).toBe(false);
+						expect(assets[1].name).toMatch(/\w+\.svg$/);
+						expect(assets[0].emitted).toBe(false);
 
 						done();
 					}, onError);

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -5,7 +5,6 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 const rimraf = /** @type {{ sync: (path: string) => void }} */ (
-	// @ts-expect-error - no type declarations for rimraf
 	require("rimraf")
 );
 

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -4,6 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (path: string) => void }} */
 const rimraf = require("rimraf");
 
 let fixtureCount = 0;
@@ -15,7 +16,7 @@ describe("Compiler (filesystem caching)", () => {
 		"temp-filesystem-cache-fixture"
 	);
 
-	function compile(entry, onSuccess, onError) {
+	function compile(/** @type {string} */ entry, /** @type {(stats: import("../types").StatsCompilation) => void} */ onSuccess, /** @type {(err: Error) => void} */ onError) {
 		const webpack = require("..");
 
 		const options = webpack.config.getNormalizedWebpackOptions({});
@@ -28,7 +29,7 @@ describe("Compiler (filesystem caching)", () => {
 		options.output.path = path.join(tempFixturePath, "dist");
 		options.output.filename = "bundle.js";
 		options.output.pathinfo = true;
-		options.module = {
+		options.module = /** @type {import("../types").ModuleOptionsNormalized} */ (/** @type {unknown} */ ({
 			rules: [
 				{
 					test: /\.svg$/,
@@ -38,7 +39,7 @@ describe("Compiler (filesystem caching)", () => {
 					}
 				}
 			]
-		};
+		}));
 
 		const isBigIntSupported = typeof BigInt !== "undefined";
 		const isErrorCaseSupported =
@@ -62,7 +63,8 @@ describe("Compiler (filesystem caching)", () => {
 							async () => {
 								const cache = compilation.getCache(name);
 								const ident = "test.ext";
-								const cacheItem = cache.getItemCache(ident, null);
+								const cacheItem_ = cache.getItemCache(ident, null);
+								const cacheItem = /** @type {{ getPromise(id: string): Promise<Record<string, unknown>>, storePromise(v: unknown): Promise<void> }} */ (/** @type {unknown} */ (cacheItem_));
 
 								const result = await cacheItem.getPromise(ident);
 

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -9,18 +9,31 @@ const captureStdio = require("./helpers/captureStdio");
 const deprecationTracking = require("./helpers/deprecationTracking");
 
 describe("Compiler", () => {
+	/**
+	 * @typedef {{ mkdir: string[], writeFile: unknown[] }} CompileLogs
+	 * @typedef {import("../").StatsCompilation & {logs?: CompileLogs}} CompileStats
+	 */
+	/**
+	 * @param {string} entry
+	 * @param {import("../").Configuration} options
+	 * @param {(stats: CompileStats, files: Record<string, string>, compilation: import("../").Compilation) => void} callback
+	 */
 	function compile(entry, options, callback) {
 		const noOutputPath = !options.output || !options.output.path;
 
 		const webpack = require("..");
 
-		options = webpack.config.getNormalizedWebpackOptions(options);
-		if (!options.mode) options.mode = "production";
-		options.entry = entry;
-		options.context = path.join(__dirname, "fixtures");
-		if (noOutputPath) options.output.path = "/";
-		options.output.pathinfo = true;
-		options.optimization = {
+		/** @type {import("../").WebpackOptionsNormalized} */
+		const normalizedOptions = webpack.config.getNormalizedWebpackOptions(options);
+		if (!normalizedOptions.mode) normalizedOptions.mode = "production";
+		normalizedOptions.entry =
+			/** @type {import("../").EntryNormalized} */ (
+				/** @type {unknown} */ (entry)
+			);
+		normalizedOptions.context = path.join(__dirname, "fixtures");
+		if (noOutputPath) normalizedOptions.output.path = "/";
+		normalizedOptions.output.pathinfo = true;
+		normalizedOptions.optimization = {
 			minimize: false
 		};
 		const logs = {
@@ -28,51 +41,80 @@ describe("Compiler", () => {
 			writeFile: []
 		};
 
-		const c = webpack(options);
+		const c = webpack(
+			/** @type {import("../").Configuration} */ (
+				/** @type {unknown} */ (normalizedOptions)
+			)
+		);
+		/** @type {Record<string, string>} */
 		const files = {};
-		c.outputFileSystem = {
-			mkdir(path, callback) {
-				logs.mkdir.push(path);
-				const err = new Error("error");
-				err.code = "EEXIST";
-				callback(err);
-			},
-			writeFile(name, content, callback) {
-				logs.writeFile.push(name, content);
-				files[name] = content.toString("utf8");
-				callback();
-			},
-			stat(path, callback) {
-				callback(new Error("ENOENT"));
-			}
-		};
+		c.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ ({
+					mkdir(/** @type {string} */ path, /** @type {(err: null | NodeJS.ErrnoException) => void} */ callback) {
+						logs.mkdir.push(path);
+						const err = /** @type {NodeJS.ErrnoException} */ (
+							new Error("error")
+						);
+						err.code = "EEXIST";
+						callback(err);
+					},
+					writeFile(/** @type {string} */ name, /** @type {Buffer} */ content, /** @type {() => void} */ callback) {
+						logs.writeFile.push(name, content);
+						files[name] = content.toString("utf8");
+						callback();
+					},
+					stat(/** @type {string} */ _path, /** @type {(err: Error) => void} */ callback) {
+						callback(new Error("ENOENT"));
+					}
+				})
+			);
 		c.hooks.compilation.tap(
 			"CompilerTest",
 			(compilation) => (compilation.bail = true)
 		);
-		c.run((err, stats) => {
-			if (err) throw err;
-			expect(typeof stats).toBe("object");
-			const compilation = stats.compilation;
-			stats = stats.toJson({
-				modules: true,
-				reasons: true
-			});
-			expect(typeof stats).toBe("object");
-			expect(stats).toHaveProperty("errors");
-			expect(Array.isArray(stats.errors)).toBe(true);
-			if (stats.errors.length > 0) {
-				expect(stats.errors[0]).toBeInstanceOf(Error);
-				throw stats.errors[0];
+		c.run(
+			(
+				err,
+				/** @type {import("../").Stats & import("../").StatsCompilation & {logs?: CompileLogs} | undefined} */
+				stats
+			) => {
+				if (err) throw err;
+				expect(typeof stats).toBe("object");
+				const compilation =
+					/** @type {import("../").Stats} */ (stats).compilation;
+				stats = /** @type {import("../").Stats & import("../").StatsCompilation & {logs?: CompileLogs}} */ (
+					/** @type {import("../").Stats} */ (stats).toJson({
+						modules: true,
+						reasons: true
+					})
+				);
+				expect(typeof stats).toBe("object");
+				expect(stats).toHaveProperty("errors");
+				expect(Array.isArray(stats.errors)).toBe(true);
+				if (/** @type {import("../").StatsError[]} */ (stats.errors).length > 0) {
+					const errors =
+						/** @type {import("../").StatsError[]} */ (stats.errors);
+					expect(errors[0]).toBeInstanceOf(Error);
+					throw errors[0];
+				}
+				stats.logs = logs;
+				c.close((err) => {
+					if (err)
+						return /** @type {(e: Error) => void} */ (
+							/** @type {unknown} */ (callback)
+						)(err);
+					callback(
+						/** @type {CompileStats} */ (stats),
+						files,
+						/** @type {import("../").Compilation} */ (compilation)
+					);
+				});
 			}
-			stats.logs = logs;
-			c.close((err) => {
-				if (err) return callback(err);
-				callback(stats, files, compilation);
-			});
-		});
+		);
 	}
 
+	/** @type {import("../").Compiler | undefined} */
 	let compiler;
 
 	afterEach((callback) => {
@@ -94,7 +136,10 @@ describe("Compiler", () => {
 				}
 			},
 			(stats, _files) => {
-				expect(stats.logs.mkdir).toEqual(["/what", "/what/the"]);
+				expect(/** @type {CompileLogs} */ (stats.logs).mkdir).toEqual([
+					"/what",
+					"/what/the"
+				]);
 				done();
 			}
 		);
@@ -208,6 +253,7 @@ describe("Compiler", () => {
 	});
 
 	describe("methods", () => {
+		/** @type {import("../").Compiler} */
 		let compiler;
 
 		beforeEach(() => {
@@ -226,7 +272,10 @@ describe("Compiler", () => {
 		afterEach((callback) => {
 			if (compiler) {
 				compiler.close(callback);
-				compiler = undefined;
+				compiler =
+					/** @type {import("../").Compiler} */ (
+						/** @type {unknown} */ (undefined)
+					);
 			} else {
 				callback();
 			}
@@ -242,9 +291,10 @@ describe("Compiler", () => {
 		describe("purgeInputFileSystem", () => {
 			it("invokes purge() if inputFileSystem.purge", (done) => {
 				const mockPurge = jest.fn();
-				compiler.inputFileSystem = {
-					purge: mockPurge
-				};
+				compiler.inputFileSystem =
+					/** @type {import("../").InputFileSystem} */ (
+						/** @type {unknown} */ ({ purge: mockPurge })
+					);
 				compiler.purgeInputFileSystem();
 				expect(mockPurge).toHaveBeenCalledTimes(1);
 				done();
@@ -261,41 +311,45 @@ describe("Compiler", () => {
 
 		describe("isChild", () => {
 			it("returns booleanized this.parentCompilation", (done) => {
-				compiler.parentCompilation = "stringyStringString";
+				const c =
+					/** @type {import("../").Compiler & {parentCompilation: unknown}} */ (
+						compiler
+					);
+				c.parentCompilation = "stringyStringString";
 				const response1 = compiler.isChild();
 				expect(response1).toBe(true);
 
-				compiler.parentCompilation = 123456789;
+				c.parentCompilation = 123456789;
 				const response2 = compiler.isChild();
 				expect(response2).toBe(true);
 
-				compiler.parentCompilation = {
+				c.parentCompilation = {
 					what: "I belong to an object"
 				};
 				const response3 = compiler.isChild();
 				expect(response3).toBe(true);
 
-				compiler.parentCompilation = ["Array", 123, true, null, [], () => {}];
+				c.parentCompilation = ["Array", 123, true, null, [], () => {}];
 				const response4 = compiler.isChild();
 				expect(response4).toBe(true);
 
-				compiler.parentCompilation = false;
+				c.parentCompilation = false;
 				const response5 = compiler.isChild();
 				expect(response5).toBe(false);
 
-				compiler.parentCompilation = 0;
+				c.parentCompilation = 0;
 				const response6 = compiler.isChild();
 				expect(response6).toBe(false);
 
-				compiler.parentCompilation = null;
+				c.parentCompilation = null;
 				const response7 = compiler.isChild();
 				expect(response7).toBe(false);
 
-				compiler.parentCompilation = "";
+				c.parentCompilation = "";
 				const response8 = compiler.isChild();
 				expect(response8).toBe(false);
 
-				compiler.parentCompilation = Number.NaN;
+				c.parentCompilation = Number.NaN;
 				const response9 = compiler.isChild();
 				expect(response9).toBe(false);
 				done();
@@ -338,7 +392,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		let sizeSeenByAfterDone;
 		compiler.hooks.afterDone.tap("Test", (stats) => {
 			sizeSeenByAfterDone = stats.compilation.codeGenerationResults.map.size;
@@ -374,7 +431,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 			if (compiler.outputFileSystem.existsSync("/bundle.js")) {
@@ -432,7 +492,10 @@ describe("Compiler", () => {
 				const webpack = require("..");
 
 				const c = webpack(options);
-				c.outputFileSystem = createFsFromVolume(new Volume());
+				c.outputFileSystem =
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 				const watching = c.watch({}, (err, stats) => {
 					watching.close(() => {
 						if (err) return reject(err);
@@ -464,7 +527,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const watching = compiler.watch({}, (err, _stats) => {
 			watching.close();
 			if (err) return done(err);
@@ -487,7 +553,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 		});
@@ -508,7 +577,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -529,7 +601,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 		});
@@ -550,7 +625,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -574,7 +652,10 @@ describe("Compiler", () => {
 			},
 			() => {}
 		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			if (err) return done();
 		});
@@ -592,7 +673,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, stats1) => {
 			if (err) return done(err);
 
@@ -616,7 +700,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		let idle = compiler.idle;
 		let idleWriteCount = 0;
 		Object.defineProperty(compiler, "idle", {
@@ -649,7 +736,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 
@@ -672,7 +762,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const watching = compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -696,7 +789,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const watching = compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 			watching.close(done);
@@ -716,7 +812,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const watching = compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -740,7 +839,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		let once = true;
 		compiler.hooks.afterDone.tap("RunAgainTest", () => {
 			if (!once) return;
@@ -767,7 +869,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const runCb = jest.fn();
 		const doneHookCb = jest.fn();
 		compiler.hooks.done.tap("afterDoneRunTest", doneHookCb);
@@ -802,7 +907,10 @@ describe("Compiler", () => {
 				instanceCb();
 			}
 		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const doneHookCb = jest.fn();
 		compiler.hooks.done.tap("afterDoneRunTest", doneHookCb);
 		compiler.hooks.afterDone.tap("afterDoneRunTest", () => {
@@ -824,7 +932,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const invalidHookCb = jest.fn();
 		const doneHookCb = jest.fn();
 		const watchCb = jest.fn();
@@ -859,7 +970,10 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		const invalidHookCb = jest.fn();
 		const watchCloseCb = jest.fn();
 		const watchCloseHookCb = jest.fn();
@@ -895,7 +1009,10 @@ describe("Compiler", () => {
 			}
 		});
 
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 
 		const watch = compiler.watch({}, (err) => {
 			if (err) return done(err);
@@ -919,7 +1036,10 @@ describe("Compiler", () => {
 				path: "/directory"
 			}
 		});
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run(() => {
 			compiler.run(() => {
 				const result = compiler.outputFileSystem.readFileSync(
@@ -948,7 +1068,10 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.hooks.failed.tap("CompilerTest", failedSpy);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		compiler.run((err, _stats) => {
 			expect(err).toBeTruthy();
 			expect(failedSpy).toHaveBeenCalledTimes(1);
@@ -1023,7 +1146,10 @@ describe("Compiler", () => {
 				},
 				plugins: [new MyPlugin()]
 			});
-			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString().replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1057,7 +1183,10 @@ describe("Compiler", () => {
 				},
 				plugins: [new MyPlugin()]
 			});
-			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString().replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1091,7 +1220,10 @@ describe("Compiler", () => {
 				},
 				plugins: [new MyPlugin()]
 			});
-			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString()).toMatchInlineSnapshot('""');
 				done();
@@ -1114,7 +1246,10 @@ describe("Compiler", () => {
 				},
 				plugins: [new MyPlugin()]
 			});
-			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 			compiler.run((_err, _stats) => {
 				expect(escapeAnsi(capture.toStringRaw()).replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1149,7 +1284,10 @@ describe("Compiler", () => {
 				},
 				plugins: [new MyPlugin()]
 			});
-			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 			compiler.run((_err, _stats) => {
 				expect(escapeAnsi(capture.toStringRaw()).replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -361,23 +361,25 @@ describe("Compiler", () => {
 	it("platformPlugin", (done) => {
 		const webpack = require("..");
 
-		const compiler = webpack({
-			entry: "./c",
-			context: path.join(__dirname, "fixtures"),
-			output: {
-				path: "/directory"
-			},
-			plugins: [
-				new (require("../lib/PlatformPlugin"))({ node: true }),
-				(compiler) => {
-					compiler.hooks.afterEnvironment.tap("test", () => {
-						const platform = compiler.platform;
-						expect(platform.node).toBe(true);
-						expect(platform.web).toBe(true);
-					});
-				}
-			]
-		});
+		const compiler = webpack(
+			/** @type {import("../").Configuration} */ ({
+				entry: "./c",
+				context: path.join(__dirname, "fixtures"),
+				output: {
+					path: "/directory"
+				},
+				plugins: [
+					new (require("../lib/PlatformPlugin"))({ node: true }),
+					(compiler) => {
+						compiler.hooks.afterEnvironment.tap("test", () => {
+							const platform = compiler.platform;
+							expect(platform.node).toBe(true);
+							expect(platform.web).toBe(true);
+						});
+					}
+				]
+			})
+		);
 		compiler.close(done);
 	});
 
@@ -397,14 +399,23 @@ describe("Compiler", () => {
 			/** @type {import("../").OutputFileSystem} */ (
 				/** @type {unknown} */ (createFsFromVolume(new Volume()))
 			);
+		/** @type {number} */
 		let sizeSeenByAfterDone;
 		compiler.hooks.afterDone.tap("Test", (stats) => {
-			sizeSeenByAfterDone = stats.compilation.codeGenerationResults.map.size;
+			sizeSeenByAfterDone =
+				/** @type {import("../").CodeGenerationResults} */ (
+					stats.compilation.codeGenerationResults
+				).map.size;
 		});
 		compiler.run((err, stats) => {
 			if (err) return done(err);
-			const { compilation } = stats;
-			expect(compilation.codeGenerationResults.map.size).toBeGreaterThan(0);
+			const { compilation } =
+				/** @type {import("../").Stats} */ (stats);
+			expect(
+				/** @type {import("../").CodeGenerationResults} */ (
+					compilation.codeGenerationResults
+				).map.size
+			).toBeGreaterThan(0);
 			// close() runs inside the run callback, i.e. before Compiler.run fires
 			// afterDone. The release is deferred a microtask, so afterDone still
 			// observes the results; assert via setTimeout once the defer ran.
@@ -412,8 +423,14 @@ describe("Compiler", () => {
 				if (closeErr) return done(closeErr);
 				setTimeout(() => {
 					expect(sizeSeenByAfterDone).toBeGreaterThan(0);
-					expect(compilation.codeGenerationResults.map.size).toBe(0);
-					expect(typeof stats.toJson().hash).toBe("string");
+					expect(
+						/** @type {import("../").CodeGenerationResults} */ (
+							compilation.codeGenerationResults
+						).map.size
+					).toBe(0);
+					expect(
+						typeof /** @type {import("../").Stats} */ (stats).toJson().hash
+					).toBe("string");
 					done();
 				}, 0);
 			});
@@ -436,9 +453,13 @@ describe("Compiler", () => {
 			/** @type {import("../").OutputFileSystem} */ (
 				/** @type {unknown} */ (createFsFromVolume(new Volume()))
 			);
-		compiler.run((err, _stats) => {
+		/** @type {import("../").Compiler} */ (compiler).run((err, _stats) => {
 			if (err) return done(err);
-			if (compiler.outputFileSystem.existsSync("/bundle.js")) {
+			if (
+				/** @type {import("memfs").IFs} */ (
+					/** @type {import("../").Compiler} */ (compiler).outputFileSystem
+				).existsSync("/bundle.js")
+			) {
 				return done(new Error("Bundle should not be created on error"));
 			}
 			done();

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -11,12 +11,12 @@ const deprecationTracking = require("./helpers/deprecationTracking");
 describe("Compiler", () => {
 	/**
 	 * @typedef {{ mkdir: string[], writeFile: unknown[] }} CompileLogs
-	 * @typedef {import("../").StatsCompilation & {logs?: CompileLogs}} CompileStats
+	 * @typedef {import("../").StatsCompilation & { logs?: CompileLogs }} CompileStats
 	 */
 	/**
-	 * @param {string} entry
-	 * @param {import("../").Configuration} options
-	 * @param {(stats: CompileStats, files: Record<string, string>, compilation: import("../").Compilation) => void} callback
+	 * @param {string} entry entry file
+	 * @param {import("../").Configuration} options webpack options
+	 * @param {(stats: CompileStats, files: Record<string, string>, compilation: import("../").Compilation) => void} callback done callback
 	 */
 	function compile(entry, options, callback) {
 		const noOutputPath = !options.output || !options.output.path;
@@ -24,12 +24,12 @@ describe("Compiler", () => {
 		const webpack = require("..");
 
 		/** @type {import("../").WebpackOptionsNormalized} */
-		const normalizedOptions = webpack.config.getNormalizedWebpackOptions(options);
+		const normalizedOptions =
+			webpack.config.getNormalizedWebpackOptions(options);
 		if (!normalizedOptions.mode) normalizedOptions.mode = "production";
-		normalizedOptions.entry =
-			/** @type {import("../").EntryNormalized} */ (
-				/** @type {unknown} */ (entry)
-			);
+		normalizedOptions.entry = /** @type {import("../").EntryNormalized} */ (
+			/** @type {unknown} */ (entry)
+		);
 		normalizedOptions.context = path.join(__dirname, "fixtures");
 		if (noOutputPath) normalizedOptions.output.path = "/";
 		normalizedOptions.output.pathinfo = true;
@@ -49,27 +49,34 @@ describe("Compiler", () => {
 		);
 		/** @type {Record<string, string>} */
 		const files = {};
-		c.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ ({
-					mkdir(/** @type {string} */ path, /** @type {(err: null | NodeJS.ErrnoException) => void} */ callback) {
-						logs.mkdir.push(path);
-						const err = /** @type {NodeJS.ErrnoException} */ (
-							new Error("error")
-						);
-						err.code = "EEXIST";
-						callback(err);
-					},
-					writeFile(/** @type {string} */ name, /** @type {Buffer} */ content, /** @type {() => void} */ callback) {
-						logs.writeFile.push(name, content);
-						files[name] = content.toString("utf8");
-						callback();
-					},
-					stat(/** @type {string} */ _path, /** @type {(err: Error) => void} */ callback) {
-						callback(new Error("ENOENT"));
-					}
-				})
-			);
+		c.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ ({
+				mkdir(
+					/** @type {string} */ path,
+					/** @type {(err: null | NodeJS.ErrnoException) => void} */ callback
+				) {
+					logs.mkdir.push(path);
+					const err = /** @type {NodeJS.ErrnoException} */ (new Error("error"));
+					err.code = "EEXIST";
+					callback(err);
+				},
+				writeFile(
+					/** @type {string} */ name,
+					/** @type {Buffer} */ content,
+					/** @type {() => void} */ callback
+				) {
+					logs.writeFile.push(name, content);
+					files[name] = content.toString("utf8");
+					callback();
+				},
+				stat(
+					/** @type {string} */ _path,
+					/** @type {(err: Error) => void} */ callback
+				) {
+					callback(new Error("ENOENT"));
+				}
+			})
+		);
 		c.hooks.compilation.tap(
 			"CompilerTest",
 			(compilation) => (compilation.bail = true)
@@ -77,34 +84,39 @@ describe("Compiler", () => {
 		c.run(
 			(
 				err,
-				/** @type {import("../").Stats & import("../").StatsCompilation & {logs?: CompileLogs} | undefined} */
+				/** @type {import("../").Stats & import("../").StatsCompilation & { logs?: CompileLogs } | undefined} */
 				stats
 			) => {
 				if (err) throw err;
 				expect(typeof stats).toBe("object");
-				const compilation =
-					/** @type {import("../").Stats} */ (stats).compilation;
-				stats = /** @type {import("../").Stats & import("../").StatsCompilation & {logs?: CompileLogs}} */ (
-					/** @type {import("../").Stats} */ (stats).toJson({
-						modules: true,
-						reasons: true
-					})
-				);
+				const compilation = /** @type {import("../").Stats} */ (stats)
+					.compilation;
+				stats =
+					/** @type {import("../").Stats & import("../").StatsCompilation & { logs?: CompileLogs }} */ (
+						/** @type {import("../").Stats} */ (stats).toJson({
+							modules: true,
+							reasons: true
+						})
+					);
 				expect(typeof stats).toBe("object");
 				expect(stats).toHaveProperty("errors");
 				expect(Array.isArray(stats.errors)).toBe(true);
-				if (/** @type {import("../").StatsError[]} */ (stats.errors).length > 0) {
-					const errors =
-						/** @type {import("../").StatsError[]} */ (stats.errors);
+				if (
+					/** @type {import("../").StatsError[]} */ (stats.errors).length > 0
+				) {
+					const errors = /** @type {import("../").StatsError[]} */ (
+						stats.errors
+					);
 					expect(errors[0]).toBeInstanceOf(Error);
 					throw errors[0];
 				}
 				stats.logs = logs;
 				c.close((err) => {
-					if (err)
+					if (err) {
 						return /** @type {(e: Error) => void} */ (
 							/** @type {unknown} */ (callback)
 						)(err);
+					}
 					callback(
 						/** @type {CompileStats} */ (stats),
 						files,
@@ -115,13 +127,15 @@ describe("Compiler", () => {
 		);
 	}
 
-	/** @type {import("../").Compiler | undefined} */
+	/** @type {import("../").Compiler} */
 	let compiler;
 
 	afterEach((callback) => {
 		if (compiler) {
 			compiler.close(callback);
-			compiler = undefined;
+			compiler = /** @type {import("../").Compiler} */ (
+				/** @type {unknown} */ (undefined)
+			);
 		} else {
 			callback();
 		}
@@ -273,10 +287,9 @@ describe("Compiler", () => {
 		afterEach((callback) => {
 			if (compiler) {
 				compiler.close(callback);
-				compiler =
-					/** @type {import("../").Compiler} */ (
-						/** @type {unknown} */ (undefined)
-					);
+				compiler = /** @type {import("../").Compiler} */ (
+					/** @type {unknown} */ (undefined)
+				);
 			} else {
 				callback();
 			}
@@ -313,7 +326,7 @@ describe("Compiler", () => {
 		describe("isChild", () => {
 			it("returns booleanized this.parentCompilation", (done) => {
 				const c =
-					/** @type {Omit<import("../").Compiler, "parentCompilation"> & {parentCompilation: unknown}} */ (
+					/** @type {Omit<import("../").Compiler, "parentCompilation"> & { parentCompilation: unknown }} */ (
 						/** @type {unknown} */ (compiler)
 					);
 				c.parentCompilation = "stringyStringString";
@@ -395,22 +408,19 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		/** @type {number} */
 		let sizeSeenByAfterDone;
 		compiler.hooks.afterDone.tap("Test", (stats) => {
-			sizeSeenByAfterDone =
-				/** @type {import("../").CodeGenerationResults} */ (
-					stats.compilation.codeGenerationResults
-				).map.size;
+			sizeSeenByAfterDone = /** @type {import("../").CodeGenerationResults} */ (
+				stats.compilation.codeGenerationResults
+			).map.size;
 		});
 		compiler.run((err, stats) => {
 			if (err) return done(err);
-			const { compilation } =
-				/** @type {import("../").Stats} */ (stats);
+			const { compilation } = /** @type {import("../").Stats} */ (stats);
 			expect(
 				/** @type {import("../").CodeGenerationResults} */ (
 					compilation.codeGenerationResults
@@ -429,7 +439,7 @@ describe("Compiler", () => {
 						).map.size
 					).toBe(0);
 					expect(
-						typeof /** @type {import("../").Stats} */ (stats).toJson().hash
+						typeof (/** @type {import("../").Stats} */ (stats).toJson().hash)
 					).toBe("string");
 					done();
 				}, 0);
@@ -449,10 +459,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		/** @type {import("../").Compiler} */ (compiler).run((err, _stats) => {
 			if (err) return done(err);
 			if (
@@ -469,7 +478,9 @@ describe("Compiler", () => {
 	it("should bubble up errors when wrapped in a promise and bail is true", async () => {
 		let errored;
 		try {
-			const createCompiler = (options) =>
+			const createCompiler = (
+				/** @type {import("../").Configuration} */ options
+			) =>
 				new Promise((resolve, reject) => {
 					const webpack = require("..");
 
@@ -509,21 +520,22 @@ describe("Compiler", () => {
 	});
 
 	it("should not emit compilation errors in async (watch)", async () => {
-		const createStats = (options) =>
+		const createStats = (/** @type {import("../").Configuration} */ options) =>
 			new Promise((resolve, reject) => {
 				const webpack = require("..");
 
 				const c = webpack(options);
-				c.outputFileSystem =
-				/** @type {import("../").OutputFileSystem} */ (
+				c.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
 					/** @type {unknown} */ (createFsFromVolume(new Volume()))
 				);
-				const watching = c.watch({}, (err, stats) => {
-					watching.close(() => {
-						if (err) return reject(err);
-						resolve(stats);
-					});
-				});
+				const watching = /** @type {import("../").Watching} */ (
+					c.watch({}, (err, stats) => {
+						/** @type {import("../").Watching} */ (watching).close(() => {
+							if (err) return reject(err);
+							resolve(stats);
+						});
+					})
+				);
 			});
 		const stats = await createStats({
 			context: __dirname,
@@ -549,18 +561,25 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
-		const watching = compiler.watch({}, (err, _stats) => {
-			watching.close();
-			if (err) return done(err);
-			if (compiler.outputFileSystem.existsSync("/bundle.js")) {
-				return done(new Error("Bundle should not be created on error"));
-			}
-			done();
-		});
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		const watching = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				/** @type {{ close: () => void }} */ (
+					/** @type {unknown} */ (watching)
+				).close();
+				if (err) return done(err);
+				if (
+					/** @type {import("memfs").IFs} */ (
+						/** @type {import("../").Compiler} */ (compiler).outputFileSystem
+					).existsSync("/bundle.js")
+				) {
+					return done(new Error("Bundle should not be created on error"));
+				}
+				done();
+			})
+		);
 	});
 
 	it("should not be running twice at a time (run)", (done) => {
@@ -575,10 +594,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 		});
@@ -599,10 +617,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -623,10 +640,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 		});
@@ -647,10 +663,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 		});
@@ -662,22 +677,23 @@ describe("Compiler", () => {
 	it("should not be running twice at a time (instance cb)", (done) => {
 		const webpack = require("..");
 
-		compiler = webpack(
-			{
-				context: __dirname,
-				mode: "production",
-				entry: "./c",
-				output: {
-					path: "/directory",
-					filename: "bundle.js"
-				}
-			},
-			() => {}
+		compiler = /** @type {import("../").Compiler} */ (
+			webpack(
+				{
+					context: __dirname,
+					mode: "production",
+					entry: "./c",
+					output: {
+						path: "/directory",
+						filename: "bundle.js"
+					}
+				},
+				() => {}
+			)
 		);
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			if (err) return done();
 		});
@@ -695,16 +711,17 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, stats1) => {
 			if (err) return done(err);
 
 			compiler.run((err, _stats2) => {
 				if (err) return done(err);
-				expect(stats1.toString({ all: true })).toBeTypeOf("string");
+				expect(
+					/** @type {import("../").Stats} */ (stats1).toString({ all: true })
+				).toBeTypeOf("string");
 				done();
 			});
 		});
@@ -722,10 +739,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		let idle = compiler.idle;
 		let idleWriteCount = 0;
 		Object.defineProperty(compiler, "idle", {
@@ -758,17 +774,18 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			if (err) return done(err);
 
-			const watching = compiler.watch({}, (err, _stats) => {
-				if (err) return done(err);
-				watching.close(done);
-			});
+			const watching = /** @type {import("../").Watching} */ (
+				compiler.watch({}, (err, _stats) => {
+					if (err) return done(err);
+					watching.close(done);
+				})
+			);
 		});
 	});
 
@@ -784,13 +801,14 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
-		const watching = compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-		});
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		const watching = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				if (err) return done(err);
+			})
+		);
 		watching.close(() => {
 			compiler.run((err, _stats) => {
 				if (err) return done(err);
@@ -811,14 +829,15 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
-		const watching = compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-			watching.close(done);
-		});
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		const watching = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				if (err) return done(err);
+				watching.close(done);
+			})
+		);
 		expect(compiler.watching).toBe(watching);
 	});
 
@@ -834,13 +853,14 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
-		const watching = compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-		});
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		const watching = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				if (err) return done(err);
+			})
+		);
 		watching.close(() => {
 			compiler.watch({}, (err, _stats) => {
 				if (err) return done(err);
@@ -861,10 +881,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		let once = true;
 		compiler.hooks.afterDone.tap("RunAgainTest", () => {
 			if (!once) return;
@@ -891,10 +910,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		const runCb = jest.fn();
 		const doneHookCb = jest.fn();
 		compiler.hooks.done.tap("afterDoneRunTest", doneHookCb);
@@ -914,25 +932,26 @@ describe("Compiler", () => {
 
 		const webpack = require("..");
 
-		compiler = webpack(
-			{
-				context: __dirname,
-				mode: "production",
-				entry: "./c",
-				output: {
-					path: "/directory",
-					filename: "bundle.js"
+		compiler = /** @type {import("../").Compiler} */ (
+			webpack(
+				{
+					context: __dirname,
+					mode: "production",
+					entry: "./c",
+					output: {
+						path: "/directory",
+						filename: "bundle.js"
+					}
+				},
+				(err, _stats) => {
+					if (err) return done(err);
+					instanceCb();
 				}
-			},
-			(err, _stats) => {
-				if (err) return done(err);
-				instanceCb();
-			}
+			)
 		);
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		const doneHookCb = jest.fn();
 		compiler.hooks.done.tap("afterDoneRunTest", doneHookCb);
 		compiler.hooks.afterDone.tap("afterDoneRunTest", () => {
@@ -954,10 +973,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		const invalidHookCb = jest.fn();
 		const doneHookCb = jest.fn();
 		const watchCb = jest.fn();
@@ -971,10 +989,12 @@ describe("Compiler", () => {
 			expect(invalidateCb).toHaveBeenCalled();
 			watching.close(done);
 		});
-		const watching = compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-			watchCb();
-		});
+		const watching = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				if (err) return done(err);
+				watchCb();
+			})
+		);
 		process.nextTick(() => {
 			watching.invalidate(invalidateCb);
 		});
@@ -992,10 +1012,9 @@ describe("Compiler", () => {
 				filename: "bundle.js"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		const invalidHookCb = jest.fn();
 		const watchCloseCb = jest.fn();
 		const watchCloseHookCb = jest.fn();
@@ -1009,10 +1028,12 @@ describe("Compiler", () => {
 			expect(invalidateCb).toHaveBeenCalled();
 			done();
 		});
-		const watch = compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-			watch.close(watchCloseCb);
-		});
+		const watch = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err, _stats) => {
+				if (err) return done(err);
+				watch.close(watchCloseCb);
+			})
+		);
 		process.nextTick(() => {
 			watch.invalidate(invalidateCb);
 		});
@@ -1031,19 +1052,20 @@ describe("Compiler", () => {
 			}
 		});
 
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 
-		const watch = compiler.watch({}, (err) => {
-			if (err) return done(err);
-			expect(compiler.watchMode).toBeTruthy();
-			watch.close(() => {
-				expect(compiler.watchMode).toBeFalsy();
-				done();
-			});
-		});
+		const watch = /** @type {import("../").Watching} */ (
+			compiler.watch({}, (err) => {
+				if (err) return done(err);
+				expect(compiler.watchMode).toBeTruthy();
+				watch.close(() => {
+					expect(compiler.watchMode).toBeFalsy();
+					done();
+				});
+			})
+		);
 	});
 
 	it("should use cache on second run call", (done) => {
@@ -1058,16 +1080,14 @@ describe("Compiler", () => {
 				path: "/directory"
 			}
 		});
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run(() => {
 			compiler.run(() => {
-				const result = compiler.outputFileSystem.readFileSync(
-					"/directory/main.js",
-					"utf8"
-				);
+				const result = /** @type {import("memfs").IFs} */ (
+					compiler.outputFileSystem
+				).readFileSync("/directory/main.js", "utf8");
 				expect(result).toContain("module.exports = 0;");
 				done();
 			});
@@ -1090,10 +1110,9 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.hooks.failed.tap("CompilerTest", failedSpy);
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			expect(err).toBeTruthy();
 			expect(failedSpy).toHaveBeenCalledTimes(1);
@@ -1119,23 +1138,25 @@ describe("Compiler", () => {
 	});
 
 	describe("infrastructure logging", () => {
+		/** @type {ReturnType<typeof captureStdio>} */
 		let capture;
 
 		beforeEach(() => {
-			capture = captureStdio(process.stderr);
+			capture = captureStdio(process.stderr, undefined);
 		});
 
 		afterEach(() => {
 			capture.restore();
 		});
 
-		const escapeAnsi = (stringRaw) =>
+		const escapeAnsi = (/** @type {string} */ stringRaw) =>
 			stringRaw
 				.replace(/\u001B\[1m\u001B\[([0-9;]*)m/g, "<CLR=$1,BOLD>")
 				.replace(/\u001B\[1m/g, "<CLR=BOLD>")
 				.replace(/\u001B\[39m\u001B\[22m/g, "</CLR>")
 				.replace(/\u001B\[([0-9;]*)m/g, "<CLR=$1>");
 		class MyPlugin {
+			/** @param {import("../").Compiler} compiler webpack compiler */
 			apply(compiler) {
 				const logger = compiler.getInfrastructureLogger("MyPlugin");
 				logger.time("Time");
@@ -1169,9 +1190,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 			compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString().replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1206,9 +1227,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 			compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString().replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1243,9 +1264,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 			compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 			compiler.run((_err, _stats) => {
 				expect(capture.toString()).toMatchInlineSnapshot('""');
 				done();
@@ -1269,9 +1290,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 			compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 			compiler.run((_err, _stats) => {
 				expect(escapeAnsi(capture.toStringRaw()).replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`
@@ -1307,9 +1328,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 			compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+				/** @type {import("../").OutputFileSystem} */ (
+					/** @type {unknown} */ (createFsFromVolume(new Volume()))
+				);
 			compiler.run((_err, _stats) => {
 				expect(escapeAnsi(capture.toStringRaw()).replace(/[\d.]+ ms/, "X ms"))
 					.toMatchInlineSnapshot(`

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -36,6 +36,7 @@ describe("Compiler", () => {
 		normalizedOptions.optimization = {
 			minimize: false
 		};
+		/** @type {{ mkdir: string[], writeFile: unknown[] }} */
 		const logs = {
 			mkdir: [],
 			writeFile: []
@@ -312,8 +313,8 @@ describe("Compiler", () => {
 		describe("isChild", () => {
 			it("returns booleanized this.parentCompilation", (done) => {
 				const c =
-					/** @type {import("../").Compiler & {parentCompilation: unknown}} */ (
-						compiler
+					/** @type {Omit<import("../").Compiler, "parentCompilation"> & {parentCompilation: unknown}} */ (
+						/** @type {unknown} */ (compiler)
 					);
 				c.parentCompilation = "stringyStringString";
 				const response1 = compiler.isChild();

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -22,7 +22,6 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 /** @type {{ sync: (p: string) => void }} */
-// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -114,10 +113,12 @@ const describeCases = (config) => {
 						registerPerCaseSnapshotHooks(testDirectory, config.name);
 
 						beforeAll(() => {
-							options = /** @type {import("../").Configuration} */ (prepareOptions(
-								require(path.join(testDirectory, "webpack.config.js")),
-								{ testPath: outputDirectory }
-							));
+							options = /** @type {import("../").Configuration} */ (
+								prepareOptions(
+									require(path.join(testDirectory, "webpack.config.js")),
+									{ testPath: outputDirectory }
+								)
+							);
 							optionsArr = [...(Array.isArray(options) ? options : [options])];
 							for (const [idx, options] of optionsArr.entries()) {
 								if (!options.context) options.context = testDirectory;
@@ -157,7 +158,9 @@ const describeCases = (config) => {
 										cacheDirectory,
 										name:
 											options.cache && options.cache !== true
-												? /** @type {import("../").FileCacheOptions} */ (options.cache).name
+												? /** @type {import("../").FileCacheOptions} */ (
+														options.cache
+													).name
 												: `config-${idx}`,
 										...config.cache
 									};
@@ -183,7 +186,10 @@ const describeCases = (config) => {
 									);
 									if (
 										fs.existsSync(
-											path.join(/** @type {string} */ (output.path), `bundle${i}${ext}`)
+											path.join(
+												/** @type {string} */ (output.path),
+												`bundle${i}${ext}`
+											)
 										)
 									) {
 										return `./bundle${i}${ext}`;
@@ -259,9 +265,7 @@ const describeCases = (config) => {
 									if (infrastructureLogging) {
 										return done(
 											new Error(
-												`Errors/Warnings during build:\n${
-													infrastructureLogging
-												}`
+												`Errors/Warnings during build:\n${infrastructureLogging}`
 											)
 										);
 									}
@@ -303,20 +307,21 @@ const describeCases = (config) => {
 
 								compiler.run((err, stats) => {
 									deprecationTracker();
-									if (err) return handleFatalError(/** @type {Error} */ (err), done);
-									const { modules, children, errorsCount } = /** @type {import("../").Stats} */ (stats).toJson({
-										all: false,
-										modules: true,
-										errorsCount: true
-									});
+									if (err) {
+										return handleFatalError(/** @type {Error} */ (err), done);
+									}
+									const { modules, children, errorsCount } =
+										/** @type {import("../").Stats} */ (stats).toJson({
+											all: false,
+											modules: true,
+											errorsCount: true
+										});
 									if (errorsCount === 0) {
 										const infrastructureLogging = stderr.toString();
 										if (infrastructureLogging) {
 											return done(
 												new Error(
-													`Errors/Warnings during build:\n${
-														infrastructureLogging
-													}`
+													`Errors/Warnings during build:\n${infrastructureLogging}`
 												)
 											);
 										}
@@ -324,23 +329,31 @@ const describeCases = (config) => {
 											? children.reduce(
 													(all, { modules }) => [
 														...all,
-														...(/** @type {import("../").StatsModule[]} */ (modules || []))
+														.../** @type {import("../").StatsModule[]} */ (
+															modules || []
+														)
 													],
-													/** @type {import("../").StatsModule[]} */ (modules || [])
+													/** @type {import("../").StatsModule[]} */ (
+														modules || []
+													)
 												)
 											: modules;
 										if (
-											/** @type {import("../").StatsModule[]} */ (allModules).some(
-												(m) => m.type !== "cached modules" && !m.cached
-											)
+											/** @type {import("../").StatsModule[]} */ (
+												allModules
+											).some((m) => m.type !== "cached modules" && !m.cached)
 										) {
 											return done(
 												new Error(
-													`Some modules were not cached:\n${/** @type {import("../").Stats} */ (stats).toString({
-														all: false,
-														modules: true,
-														modulesSpace: 100
-													})}`
+													`Some modules were not cached:\n${
+														/** @type {import("../").Stats} */ (stats).toString(
+															{
+																all: false,
+																modules: true,
+																modulesSpace: 100
+															}
+														)
+													}`
 												)
 											);
 										}
@@ -379,7 +392,10 @@ const describeCases = (config) => {
 							fs.mkdirSync(outputDirectory, { recursive: true });
 							infraStructureLog.length = 0;
 							const deprecationTracker = deprecationTracking.start();
-							const onCompiled = (/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
+							const onCompiled = (
+								/** @type {Error | null} */ err,
+								/** @type {import("../").Stats} */ stats
+							) => {
 								const deprecations = deprecationTracker();
 								if (err) return handleFatalError(err, done);
 								const statOptions = {
@@ -491,11 +507,13 @@ const describeCases = (config) => {
 										}
 									},
 									getBundlePaths: (i, options) =>
-										/** @type {NonNullable<TestConfig["findBundle"]>} */ (testConfig.findBundle)(i, options)
+										/** @type {NonNullable<TestConfig["findBundle"]>} */ (
+											testConfig.findBundle
+										)(i, options)
 								});
 								// give a free pass to compilation that generated an error
 								if (
-									!/** @type {EXPECTED_ANY[]} */ (jsonStats.errors).length &&
+									!(/** @type {EXPECTED_ANY[]} */ (jsonStats.errors).length) &&
 									filesCount !== optionsArr.length
 								) {
 									return done(
@@ -510,8 +528,11 @@ const describeCases = (config) => {
 											testConfig.afterExecute(options);
 										}
 										for (const key of Object.keys(global)) {
-											if (key.includes("webpack"))
-												delete (/** @type {Record<string, unknown>} */ (global))[key];
+											if (key.includes("webpack")) {
+												delete (
+													/** @type {Record<string, unknown>} */ (global)[key]
+												);
+											}
 										}
 										if (getNumberOfTests() < filesCount) {
 											return done(new Error("No tests exported by test case"));
@@ -525,11 +546,21 @@ const describeCases = (config) => {
 									const compiler = require("..")(options);
 
 									compiler.run((err) => {
-										if (err) return handleFatalError(/** @type {Error} */ (err), done);
+										if (err) {
+											return handleFatalError(/** @type {Error} */ (err), done);
+										}
 										compiler.run((error, stats) => {
 											compiler.close((err) => {
-												if (err) return handleFatalError(/** @type {Error} */ (err), done);
-												onCompiled(/** @type {Error | null} */ (error), /** @type {import("../").Stats} */ (stats));
+												if (err) {
+													return handleFatalError(
+														/** @type {Error} */ (err),
+														done
+													);
+												}
+												onCompiled(
+													/** @type {Error | null} */ (error),
+													/** @type {import("../").Stats} */ (stats)
+												);
 											});
 										});
 									});
@@ -537,7 +568,10 @@ const describeCases = (config) => {
 									handleFatalError(/** @type {Error} */ (err), done);
 								}
 							} else {
-								require("..")(options, /** @type {EXPECTED_ANY} */ (onCompiled));
+								require("..")(
+									options,
+									/** @type {EXPECTED_ANY} */ (onCompiled)
+								);
 							}
 						}, 30000);
 

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -4,9 +4,25 @@ require("./helpers/warmup-webpack");
 
 /** @typedef {Record<string, EXPECTED_ANY>} Env */
 /** @typedef {{ testPath: string }} TestOptions */
+/**
+ * @typedef {object} SuiteConfig
+ * @property {string} name suite name
+ * @property {import("../").FileCacheOptions=} cache filesystem cache options
+ */
+/**
+ * @typedef {object} TestConfig
+ * @property {((i: number, options: import("../").Configuration) => string | undefined)=} findBundle
+ * @property {number=} timeout
+ * @property {boolean=} noTests
+ * @property {(() => void)=} beforeExecute
+ * @property {((options: import("../").Configuration) => void)=} afterExecute
+ * @property {((scope: EXPECTED_ANY, options: import("../").Configuration, target: EXPECTED_ANY) => void)=} moduleScope
+ */
 
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (p: string) => void }} */
+// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -27,11 +43,15 @@ const categories = fs.readdirSync(casesPath).map((cat) => ({
 		.sort()
 }));
 
+/**
+ * @param {string[]} appendTarget log collector
+ * @returns {EXPECTED_ANY} logger object
+ */
 const createLogger = (appendTarget) => ({
-	log: (l) => appendTarget.push(l),
-	debug: (l) => appendTarget.push(l),
-	trace: (l) => appendTarget.push(l),
-	info: (l) => appendTarget.push(l),
+	log: (/** @type {string} */ l) => appendTarget.push(l),
+	debug: (/** @type {string} */ l) => appendTarget.push(l),
+	trace: (/** @type {string} */ l) => appendTarget.push(l),
+	info: (/** @type {string} */ l) => appendTarget.push(l),
 	warn: console.warn.bind(console),
 	error: console.error.bind(console),
 	logTime: () => {},
@@ -44,8 +64,12 @@ const createLogger = (appendTarget) => ({
 	status: () => {}
 });
 
+/**
+ * @param {SuiteConfig} config suite config
+ */
 const describeCases = (config) => {
 	describe(config.name, () => {
+		/** @type {ReturnType<typeof captureStdio>} */
 		let stderr;
 
 		beforeEach(() => {
@@ -74,22 +98,26 @@ const describeCases = (config) => {
 
 							return;
 						}
+						/** @type {string[]} */
 						const infraStructureLog = [];
 						const outBaseDir = path.join(__dirname, "js");
 						const testSubPath = path.join(config.name, category.name, testName);
 						const outputDirectory = path.join(outBaseDir, testSubPath);
 						const cacheDirectory = path.join(outBaseDir, ".cache", testSubPath);
+						/** @type {import("../").Configuration} */
 						let options;
+						/** @type {import("../").Configuration[]} */
 						let optionsArr;
+						/** @type {TestConfig} */
 						let testConfig;
 
 						registerPerCaseSnapshotHooks(testDirectory, config.name);
 
 						beforeAll(() => {
-							options = prepareOptions(
+							options = /** @type {import("../").Configuration} */ (prepareOptions(
 								require(path.join(testDirectory, "webpack.config.js")),
 								{ testPath: outputDirectory }
-							);
+							));
 							optionsArr = [...(Array.isArray(options) ? options : [options])];
 							for (const [idx, options] of optionsArr.entries()) {
 								if (!options.context) options.context = testDirectory;
@@ -129,7 +157,7 @@ const describeCases = (config) => {
 										cacheDirectory,
 										name:
 											options.cache && options.cache !== true
-												? options.cache.name
+												? /** @type {import("../").FileCacheOptions} */ (options.cache).name
 												: `config-${idx}`,
 										...config.cache
 									};
@@ -149,12 +177,13 @@ const describeCases = (config) => {
 							}
 							testConfig = {
 								findBundle(i, options) {
+									const output = /** @type {EXPECTED_ANY} */ (options.output);
 									const ext = path.extname(
-										parseResource(options.output.filename).path
+										parseResource(/** @type {string} */ (output.filename)).path
 									);
 									if (
 										fs.existsSync(
-											path.join(options.output.path, `bundle${i}${ext}`)
+											path.join(/** @type {string} */ (output.path), `bundle${i}${ext}`)
 										)
 									) {
 										return `./bundle${i}${ext}`;
@@ -181,11 +210,15 @@ const describeCases = (config) => {
 
 						afterAll(() => {
 							// cleanup
-							options = undefined;
-							optionsArr = undefined;
-							testConfig = undefined;
+							options = /** @type {EXPECTED_ANY} */ (undefined);
+							optionsArr = /** @type {EXPECTED_ANY} */ (undefined);
+							testConfig = /** @type {EXPECTED_ANY} */ (undefined);
 						});
 
+						/**
+						 * @param {Error} err error
+						 * @param {(err?: Error) => void} done done callback
+						 */
 						const handleFatalError = (err, done) => {
 							const fakeStats = {
 								errors: [
@@ -270,8 +303,8 @@ const describeCases = (config) => {
 
 								compiler.run((err, stats) => {
 									deprecationTracker();
-									if (err) return handleFatalError(err, done);
-									const { modules, children, errorsCount } = stats.toJson({
+									if (err) return handleFatalError(/** @type {Error} */ (err), done);
+									const { modules, children, errorsCount } = /** @type {import("../").Stats} */ (stats).toJson({
 										all: false,
 										modules: true,
 										errorsCount: true
@@ -289,18 +322,21 @@ const describeCases = (config) => {
 										}
 										const allModules = children
 											? children.reduce(
-													(all, { modules }) => [...all, ...modules],
-													modules || []
+													(all, { modules }) => [
+														...all,
+														...(/** @type {import("../").StatsModule[]} */ (modules || []))
+													],
+													/** @type {import("../").StatsModule[]} */ (modules || [])
 												)
 											: modules;
 										if (
-											allModules.some(
+											/** @type {import("../").StatsModule[]} */ (allModules).some(
 												(m) => m.type !== "cached modules" && !m.cached
 											)
 										) {
 											return done(
 												new Error(
-													`Some modules were not cached:\n${stats.toString({
+													`Some modules were not cached:\n${/** @type {import("../").Stats} */ (stats).toString({
 														all: false,
 														modules: true,
 														modulesSpace: 100
@@ -343,7 +379,7 @@ const describeCases = (config) => {
 							fs.mkdirSync(outputDirectory, { recursive: true });
 							infraStructureLog.length = 0;
 							const deprecationTracker = deprecationTracking.start();
-							const onCompiled = (err, stats) => {
+							const onCompiled = (/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
 								const deprecations = deprecationTracker();
 								if (err) return handleFatalError(err, done);
 								const statOptions = {
@@ -455,11 +491,11 @@ const describeCases = (config) => {
 										}
 									},
 									getBundlePaths: (i, options) =>
-										testConfig.findBundle(i, options)
+										/** @type {NonNullable<TestConfig["findBundle"]>} */ (testConfig.findBundle)(i, options)
 								});
 								// give a free pass to compilation that generated an error
 								if (
-									!jsonStats.errors.length &&
+									!/** @type {EXPECTED_ANY[]} */ (jsonStats.errors).length &&
 									filesCount !== optionsArr.length
 								) {
 									return done(
@@ -474,7 +510,8 @@ const describeCases = (config) => {
 											testConfig.afterExecute(options);
 										}
 										for (const key of Object.keys(global)) {
-											if (key.includes("webpack")) delete global[key];
+											if (key.includes("webpack"))
+												delete (/** @type {Record<string, unknown>} */ (global))[key];
 										}
 										if (getNumberOfTests() < filesCount) {
 											return done(new Error("No tests exported by test case"));
@@ -488,19 +525,19 @@ const describeCases = (config) => {
 									const compiler = require("..")(options);
 
 									compiler.run((err) => {
-										if (err) return handleFatalError(err, done);
+										if (err) return handleFatalError(/** @type {Error} */ (err), done);
 										compiler.run((error, stats) => {
 											compiler.close((err) => {
-												if (err) return handleFatalError(err, done);
-												onCompiled(error, stats);
+												if (err) return handleFatalError(/** @type {Error} */ (err), done);
+												onCompiled(/** @type {Error | null} */ (error), /** @type {import("../").Stats} */ (stats));
 											});
 										});
 									});
 								} catch (err) {
-									handleFatalError(err, done);
+									handleFatalError(/** @type {Error} */ (err), done);
 								}
 							} else {
-								require("..")(options, onCompiled);
+								require("..")(options, /** @type {EXPECTED_ANY} */ (onCompiled));
 							}
 						}, 30000);
 

--- a/test/ContextModule.unittest.js
+++ b/test/ContextModule.unittest.js
@@ -13,13 +13,18 @@ describe("contextModule", () => {
 
 	describe("#identifier", () => {
 		it("returns an safe identifier for this module", () => {
-			contextModule = new ContextModule(() => {}, {
-				type: "javascript/auto",
-				request,
-				resource: "a",
-				mode: "lazy",
-				regExp: /a|b/
-			});
+			contextModule = new ContextModule(
+				() => {},
+				/** @type {import("../lib/ContextModule").ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						type: "javascript/auto",
+						request,
+						resource: "a",
+						mode: "lazy",
+						regExp: /a|b/
+					})
+				)
+			);
 			expect(contextModule.identifier()).toEqual(
 				expect.stringContaining("/a%7Cb/")
 			);

--- a/test/ContextModuleFactory.unittest.js
+++ b/test/ContextModuleFactory.unittest.js
@@ -23,8 +23,8 @@ describe("ContextModuleFactory", () => {
 			memfs.readdir = /** @type {IFs["readdir"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _dir
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _dir directory path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_dir, callback) => {
@@ -35,8 +35,8 @@ describe("ContextModuleFactory", () => {
 			memfs.stat = /** @type {IFs["stat"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _file
-					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback
+					 * @param {string} _file file path
+					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_file, callback) => {
@@ -70,8 +70,8 @@ describe("ContextModuleFactory", () => {
 			memfs.readdir = /** @type {IFs["readdir"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _dir
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _dir directory path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_dir, callback) => {
@@ -82,8 +82,8 @@ describe("ContextModuleFactory", () => {
 			memfs.stat = /** @type {IFs["stat"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _file
-					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback
+					 * @param {string} _file file path
+					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_file, callback) => {
@@ -117,8 +117,8 @@ describe("ContextModuleFactory", () => {
 			memfs.readdir = /** @type {IFs["readdir"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _dir
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _dir directory path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_dir, callback) => {
@@ -130,8 +130,8 @@ describe("ContextModuleFactory", () => {
 			memfs.stat = /** @type {IFs["stat"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _file
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _file file path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_file, callback) => {
@@ -147,8 +147,8 @@ describe("ContextModuleFactory", () => {
 				/** @type {unknown} */ (
 					Object.assign(
 						/**
-						 * @param {string} dir
-						 * @param {(err: Error | null, result?: unknown) => void} callback
+						 * @param {string} dir directory path
+						 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 						 * @returns {void}
 						 */
 						(dir, callback) => {
@@ -180,8 +180,8 @@ describe("ContextModuleFactory", () => {
 			memfs.readdir = /** @type {IFs["readdir"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _dir
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _dir directory path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_dir, callback) => {
@@ -193,8 +193,8 @@ describe("ContextModuleFactory", () => {
 			memfs.stat = /** @type {IFs["stat"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} _file
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} _file file path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(_file, callback) => {
@@ -210,8 +210,8 @@ describe("ContextModuleFactory", () => {
 				/** @type {unknown} */ (
 					Object.assign(
 						/**
-						 * @param {string} dir
-						 * @param {(err: Error | null, result?: unknown) => void} callback
+						 * @param {string} dir directory path
+						 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 						 * @returns {void}
 						 */
 						(dir, callback) => {
@@ -244,8 +244,8 @@ describe("ContextModuleFactory", () => {
 			memfs.readdir = /** @type {IFs["readdir"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} dir
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} dir directory path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(dir, callback) => {
@@ -259,8 +259,8 @@ describe("ContextModuleFactory", () => {
 			memfs.stat = /** @type {IFs["stat"]} */ (
 				/** @type {unknown} */ (
 					/**
-					 * @param {string} file
-					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @param {string} file file path
+					 * @param {(err: Error | null, result?: unknown) => void} callback node callback
 					 * @returns {void}
 					 */
 					(file, callback) => {

--- a/test/ContextModuleFactory.unittest.js
+++ b/test/ContextModuleFactory.unittest.js
@@ -4,6 +4,8 @@ const { Volume, createFsFromVolume } = require("memfs");
 const ContextModuleFactory = require("../lib/ContextModuleFactory");
 
 /** @typedef {import("memfs").IFs} IFs */
+/** @typedef {import("../lib/util/fs").InputFileSystem} InputFileSystem */
+/** @typedef {import("../lib/ContextModule").ContextModuleOptions} ContextModuleOptions */
 
 describe("ContextModuleFactory", () => {
 	describe("resolveDependencies", () => {
@@ -13,26 +15,48 @@ describe("ContextModuleFactory", () => {
 		let memfs;
 
 		beforeEach(() => {
-			factory = new ContextModuleFactory([]);
+			factory = new ContextModuleFactory(/** @type {EXPECTED_ANY} */ ([]));
 			memfs = createFsFromVolume(new Volume());
 		});
 
 		it("should not report an error when ENOENT errors happen", (done) => {
-			memfs.readdir = (dir, callback) => {
-				setTimeout(() => callback(null, ["/file"]));
-			};
-			memfs.stat = (file, callback) => {
-				const err = new Error("fake ENOENT error");
-				err.code = "ENOENT";
-				setTimeout(() => callback(err, null));
-			};
+			memfs.readdir = /** @type {IFs["readdir"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _dir
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_dir, callback) => {
+						setTimeout(() => callback(null, ["/file"]));
+					}
+				)
+			);
+			memfs.stat = /** @type {IFs["stat"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _file
+					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_file, callback) => {
+						const err = /** @type {NodeJS.ErrnoException} */ (
+							new Error("fake ENOENT error")
+						);
+						err.code = "ENOENT";
+						setTimeout(() => callback(err, null));
+					}
+				)
+			);
 			factory.resolveDependencies(
-				memfs,
-				{
-					resource: "/",
-					recursive: true,
-					regExp: /.*/
-				},
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/",
+						recursive: true,
+						regExp: /.*/
+					})
+				),
 				(err, res) => {
 					expect(err).toBeFalsy();
 					expect(Array.isArray(res)).toBe(true);
@@ -43,21 +67,43 @@ describe("ContextModuleFactory", () => {
 		});
 
 		it("should report an error when non-ENOENT errors happen", (done) => {
-			memfs.readdir = (dir, callback) => {
-				setTimeout(() => callback(null, ["/file"]));
-			};
-			memfs.stat = (file, callback) => {
-				const err = new Error("fake EACCES error");
-				err.code = "EACCES";
-				setTimeout(() => callback(err, null));
-			};
+			memfs.readdir = /** @type {IFs["readdir"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _dir
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_dir, callback) => {
+						setTimeout(() => callback(null, ["/file"]));
+					}
+				)
+			);
+			memfs.stat = /** @type {IFs["stat"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _file
+					 * @param {(err: NodeJS.ErrnoException | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_file, callback) => {
+						const err = /** @type {NodeJS.ErrnoException} */ (
+							new Error("fake EACCES error")
+						);
+						err.code = "EACCES";
+						setTimeout(() => callback(err, null));
+					}
+				)
+			);
 			factory.resolveDependencies(
-				memfs,
-				{
-					resource: "/",
-					recursive: true,
-					regExp: /.*/
-				},
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/",
+						recursive: true,
+						regExp: /.*/
+					})
+				),
 				(err, res) => {
 					expect(err).toBeInstanceOf(Error);
 					expect(res).toBeFalsy();
@@ -68,28 +114,60 @@ describe("ContextModuleFactory", () => {
 
 		it("should return callback with [] if circular symlinks exist", (done) => {
 			let statDirStatus = 0;
-			memfs.readdir = (dir, callback) => {
-				statDirStatus++;
-				setTimeout(() => callback(null, ["/A"]));
-			};
-			memfs.stat = (file, callback) => {
-				const resolvedValue = {
-					isDirectory: () => statDirStatus === 1,
-					isFile: () => statDirStatus !== 1
-				};
-				setTimeout(() => callback(null, resolvedValue));
-			};
-			memfs.realpath = (dir, callback) => {
-				const realPath = dir.split("/");
-				setTimeout(() => callback(null, realPath[realPath.length - 1]));
-			};
+			memfs.readdir = /** @type {IFs["readdir"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _dir
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_dir, callback) => {
+						statDirStatus++;
+						setTimeout(() => callback(null, ["/A"]));
+					}
+				)
+			);
+			memfs.stat = /** @type {IFs["stat"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _file
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_file, callback) => {
+						const resolvedValue = {
+							isDirectory: () => statDirStatus === 1,
+							isFile: () => statDirStatus !== 1
+						};
+						setTimeout(() => callback(null, resolvedValue));
+					}
+				)
+			);
+			memfs.realpath = /** @type {IFs["realpath"]} */ (
+				/** @type {unknown} */ (
+					Object.assign(
+						/**
+						 * @param {string} dir
+						 * @param {(err: Error | null, result?: unknown) => void} callback
+						 * @returns {void}
+						 */
+						(dir, callback) => {
+							const realPath = dir.split("/");
+							setTimeout(() => callback(null, realPath[realPath.length - 1]));
+						},
+						{ native: undefined }
+					)
+				)
+			);
 			factory.resolveDependencies(
-				memfs,
-				{
-					resource: "/A",
-					recursive: true,
-					regExp: /.*/
-				},
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/A",
+						recursive: true,
+						regExp: /.*/
+					})
+				),
 				(err, res) => {
 					expect(res).toStrictEqual([]);
 					done();
@@ -99,28 +177,60 @@ describe("ContextModuleFactory", () => {
 
 		it("should not return callback with [] if there are no circular symlinks", (done) => {
 			let statDirStatus = 0;
-			memfs.readdir = (dir, callback) => {
-				statDirStatus++;
-				setTimeout(() => callback(null, ["/B"]));
-			};
-			memfs.stat = (file, callback) => {
-				const resolvedValue = {
-					isDirectory: () => statDirStatus === 1,
-					isFile: () => statDirStatus !== 1
-				};
-				setTimeout(() => callback(null, resolvedValue));
-			};
-			memfs.realpath = (dir, callback) => {
-				const realPath = dir.split("/");
-				setTimeout(() => callback(null, realPath[realPath.length - 1]));
-			};
+			memfs.readdir = /** @type {IFs["readdir"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _dir
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_dir, callback) => {
+						statDirStatus++;
+						setTimeout(() => callback(null, ["/B"]));
+					}
+				)
+			);
+			memfs.stat = /** @type {IFs["stat"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} _file
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(_file, callback) => {
+						const resolvedValue = {
+							isDirectory: () => statDirStatus === 1,
+							isFile: () => statDirStatus !== 1
+						};
+						setTimeout(() => callback(null, resolvedValue));
+					}
+				)
+			);
+			memfs.realpath = /** @type {IFs["realpath"]} */ (
+				/** @type {unknown} */ (
+					Object.assign(
+						/**
+						 * @param {string} dir
+						 * @param {(err: Error | null, result?: unknown) => void} callback
+						 * @returns {void}
+						 */
+						(dir, callback) => {
+							const realPath = dir.split("/");
+							setTimeout(() => callback(null, realPath[realPath.length - 1]));
+						},
+						{ native: undefined }
+					)
+				)
+			);
 			factory.resolveDependencies(
-				memfs,
-				{
-					resource: "/A",
-					recursive: true,
-					regExp: /.*/
-				},
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/A",
+						recursive: true,
+						regExp: /.*/
+					})
+				),
 				(err, res) => {
 					expect(res).not.toStrictEqual([]);
 					expect(Array.isArray(res)).toBe(true);
@@ -131,38 +241,67 @@ describe("ContextModuleFactory", () => {
 		});
 
 		it("should resolve correctly several resources", (done) => {
-			memfs.readdir = (dir, callback) => {
-				if (dir === "/a") setTimeout(() => callback(null, ["/B"]));
-				if (dir === "/b") setTimeout(() => callback(null, ["/A"]));
-				if (dir === "/a/B") setTimeout(() => callback(null, ["a"]));
-				if (dir === "/b/A") setTimeout(() => callback(null, ["b"]));
-			};
-			memfs.stat = (file, callback) => {
-				const resolvedValue = {
-					isDirectory: () => file !== "/a/B/a" && file !== "/b/A/b",
-					isFile: () => file === "/a/B/a" || file === "/b/A/b"
-				};
-				setTimeout(() => callback(null, resolvedValue));
-			};
-			memfs.realpath = undefined;
+			memfs.readdir = /** @type {IFs["readdir"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} dir
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(dir, callback) => {
+						if (dir === "/a") setTimeout(() => callback(null, ["/B"]));
+						if (dir === "/b") setTimeout(() => callback(null, ["/A"]));
+						if (dir === "/a/B") setTimeout(() => callback(null, ["a"]));
+						if (dir === "/b/A") setTimeout(() => callback(null, ["b"]));
+					}
+				)
+			);
+			memfs.stat = /** @type {IFs["stat"]} */ (
+				/** @type {unknown} */ (
+					/**
+					 * @param {string} file
+					 * @param {(err: Error | null, result?: unknown) => void} callback
+					 * @returns {void}
+					 */
+					(file, callback) => {
+						const resolvedValue = {
+							isDirectory: () => file !== "/a/B/a" && file !== "/b/A/b",
+							isFile: () => file === "/a/B/a" || file === "/b/A/b"
+						};
+						setTimeout(() => callback(null, resolvedValue));
+					}
+				)
+			);
+			memfs.realpath = /** @type {IFs["realpath"]} */ (
+				/** @type {unknown} */ (undefined)
+			);
 			factory.resolveDependencies(
-				memfs,
-				{
-					resource: ["/a", "/b"],
-					resourceFragment: "#hash",
-					resourceQuery: "?query",
-					recursive: true,
-					regExp: /.*/
-				},
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: ["/a", "/b"],
+						resourceFragment: "#hash",
+						resourceQuery: "?query",
+						recursive: true,
+						regExp: /.*/
+					})
+				),
 				(err, res) => {
 					expect(res).not.toStrictEqual([]);
 					expect(Array.isArray(res)).toBe(true);
-					expect(res.map((r) => r.request)).toEqual([
-						"./B/a?query#hash",
-						"./A/b?query#hash"
-					]);
-					expect(res.map((r) => r.getContext())).toEqual(["/a", "/b"]);
-					expect(res.map((r) => r.userRequest)).toEqual(["./B/a", "./A/b"]);
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res).map((r) => r.request)
+					).toEqual(["./B/a?query#hash", "./A/b?query#hash"]);
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res).map((r) =>
+							r.getContext()
+						)
+					).toEqual(["/a", "/b"]);
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res).map(
+							(r) => r.userRequest
+						)
+					).toEqual(["./B/a", "./A/b"]);
 					done();
 				}
 			);

--- a/test/CssIcssExportDependency.unittest.js
+++ b/test/CssIcssExportDependency.unittest.js
@@ -13,12 +13,16 @@ const makeModuleGraph = (
 	/** @type {unknown} */ module,
 	/** @type {unknown} */ exportsInfo = undefined
 ) =>
-	/** @type {import("../lib/ModuleGraph")} */ (/** @type {unknown} */ ({
-		getParentModule: () => module,
-		getExportsInfo: () => exportsInfo
-	}));
+	/** @type {import("../lib/ModuleGraph")} */ (
+		/** @type {unknown} */ ({
+			getParentModule: () => module,
+			getExportsInfo: () => exportsInfo
+		})
+	);
 
-const entry = (/** @type {Partial<import("../lib/dependencies/CssIcssExportDependency").CssExportEntry>} */ over) => ({
+const entry = (
+	/** @type {Partial<import("../lib/dependencies/CssIcssExportDependency").CssExportEntry>} */ over
+) => ({
 	name: "a",
 	value: "a",
 	range: undefined,
@@ -102,11 +106,12 @@ describe("CssIcssExportDependency", () => {
 					loc: { start: { line: 1, column: 0 } }
 				})
 			]);
-			const warnings = /** @type {NonNullable<ReturnType<typeof dep.getWarnings>>} */ (
-				dep.getWarnings(
-					makeModuleGraph(makeModule(), { isExportProvided: () => false })
-				)
-			);
+			const warnings =
+				/** @type {NonNullable<ReturnType<typeof dep.getWarnings>>} */ (
+					dep.getWarnings(
+						makeModuleGraph(makeModule(), { isExportProvided: () => false })
+					)
+				);
 			expect(warnings).toHaveLength(1);
 			expect(warnings[0].message).toContain(
 				'Self-referencing name "missing" not found'
@@ -143,15 +148,19 @@ describe("CssIcssExportDependency", () => {
 				chunkGraph: { moduleGraph: makeModuleGraph(makeModule()) }
 			});
 		dep.updateHash(
-			/** @type {import("../lib/util/Hash")} */ (/** @type {unknown} */ ({
-				update: (/** @type {string} */ s) => updates.push(s)
-			})),
+			/** @type {import("../lib/util/Hash")} */ (
+				/** @type {unknown} */ ({
+					update: (/** @type {string} */ s) => updates.push(s)
+				})
+			),
 			context
 		);
 		dep.updateHash(
-			/** @type {import("../lib/util/Hash")} */ (/** @type {unknown} */ ({
-				update: (/** @type {string} */ s) => updates.push(s)
-			})),
+			/** @type {import("../lib/util/Hash")} */ (
+				/** @type {unknown} */ ({
+					update: (/** @type {string} */ s) => updates.push(s)
+				})
+			),
 			context
 		);
 		expect(updates).toHaveLength(2);

--- a/test/CssIcssExportDependency.unittest.js
+++ b/test/CssIcssExportDependency.unittest.js
@@ -9,12 +9,16 @@ const makeModule = (convention = "as-is", localIdentName = "[local]") => ({
 	generator: { options: { exportsConvention: convention, localIdentName } }
 });
 
-const makeModuleGraph = (module, exportsInfo) => ({
-	getParentModule: () => module,
-	getExportsInfo: () => exportsInfo
-});
+const makeModuleGraph = (
+	/** @type {unknown} */ module,
+	/** @type {unknown} */ exportsInfo = undefined
+) =>
+	/** @type {import("../lib/ModuleGraph")} */ (/** @type {unknown} */ ({
+		getParentModule: () => module,
+		getExportsInfo: () => exportsInfo
+	}));
 
-const entry = (over) => ({
+const entry = (/** @type {Partial<import("../lib/dependencies/CssIcssExportDependency").CssExportEntry>} */ over) => ({
 	name: "a",
 	value: "a",
 	range: undefined,
@@ -98,8 +102,10 @@ describe("CssIcssExportDependency", () => {
 					loc: { start: { line: 1, column: 0 } }
 				})
 			]);
-			const warnings = dep.getWarnings(
-				makeModuleGraph(makeModule(), { isExportProvided: () => false })
+			const warnings = /** @type {NonNullable<ReturnType<typeof dep.getWarnings>>} */ (
+				dep.getWarnings(
+					makeModuleGraph(makeModule(), { isExportProvided: () => false })
+				)
 			);
 			expect(warnings).toHaveLength(1);
 			expect(warnings[0].message).toContain(
@@ -130,12 +136,24 @@ describe("CssIcssExportDependency", () => {
 
 	it("memoizes its hash contribution", () => {
 		const dep = new CssIcssExportDependency([entry({ range: [0, 1] })]);
+		/** @type {string[]} */
 		const updates = [];
-		const context = {
-			chunkGraph: { moduleGraph: makeModuleGraph(makeModule()) }
-		};
-		dep.updateHash({ update: (s) => updates.push(s) }, context);
-		dep.updateHash({ update: (s) => updates.push(s) }, context);
+		const context =
+			/** @type {import("../lib/Dependency").UpdateHashContext} */ ({
+				chunkGraph: { moduleGraph: makeModuleGraph(makeModule()) }
+			});
+		dep.updateHash(
+			/** @type {import("../lib/util/Hash")} */ (/** @type {unknown} */ ({
+				update: (/** @type {string} */ s) => updates.push(s)
+			})),
+			context
+		);
+		dep.updateHash(
+			/** @type {import("../lib/util/Hash")} */ (/** @type {unknown} */ ({
+				update: (/** @type {string} */ s) => updates.push(s)
+			})),
+			context
+		);
 		expect(updates).toHaveLength(2);
 		expect(updates[0]).toContain("exportsConvention");
 		expect(updates[1]).toBe(updates[0]);
@@ -159,11 +177,22 @@ describe("CssIcssExportDependency", () => {
 				exportType: EXPORT_TYPE.COMPOSES
 			})
 		]);
+		/** @type {unknown[]} */
 		const buffer = [];
-		dep.serialize({ write: (v) => buffer.push(v) });
+		dep.serialize(
+			/** @type {import("../lib/serialization/ObjectMiddleware").ObjectSerializerContext} */ (
+				/** @type {unknown} */ ({
+					write: (/** @type {unknown} */ v) => buffer.push(v)
+				})
+			)
+		);
 		let i = 0;
 		const restored = new CssIcssExportDependency([]);
-		restored.deserialize({ read: () => buffer[i++] });
+		restored.deserialize(
+			/** @type {import("../lib/serialization/ObjectMiddleware").ObjectDeserializerContext} */ (
+				/** @type {unknown} */ ({ read: () => buffer[i++] })
+			)
+		);
 		expect(restored.entries).toHaveLength(2);
 		expect(restored.entries[0].name).toBe("a");
 		expect(restored.entries[0].range).toEqual([0, 5]);

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -89,10 +89,12 @@ const getDefaultConfig = (config) => {
 	const { applyWebpackOptionsDefaults, getNormalizedWebpackOptions } =
 		require("..").config;
 
-	config = getNormalizedWebpackOptions(config);
-	applyWebpackOptionsDefaults(config);
+	const normalized = getNormalizedWebpackOptions(
+		/** @type {EXPECTED_ANY} */ (config)
+	);
+	applyWebpackOptionsDefaults(/** @type {EXPECTED_ANY} */ (normalized));
 	process.chdir(cwd);
-	return config;
+	return /** @type {WebpackOptionsNormalized} */ (normalized);
 };
 
 describe("snapshots", () => {
@@ -2080,8 +2082,10 @@ describe("snapshots", () => {
 	`)
 	);
 
-	test("ecmaVersion", { output: { ecmaVersion: 2020 } }, (e) =>
-		e.toMatchInlineSnapshot("Compared values have no visual difference.")
+	test(
+		"ecmaVersion",
+		{ output: /** @type {EXPECTED_ANY} */ ({ ecmaVersion: 2020 }) },
+		(e) => e.toMatchInlineSnapshot("Compared values have no visual difference.")
 	);
 
 	test(

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -15,17 +15,19 @@ const ERROR_STACK_PATTERN = /(?:\n\s+at\s.*)+/g;
  * @returns {Record<string, EXPECTED_ANY>} a cleaned error
  */
 function cleanError(err) {
+	/** @type {Record<string, EXPECTED_ANY>} */
 	const result = {};
-	for (const key of Object.getOwnPropertyNames(err)) {
-		result[key] = err[key];
+	const errObj = /** @type {Record<string, EXPECTED_ANY>} */ (err);
+	for (const key of Object.getOwnPropertyNames(errObj)) {
+		result[key] = errObj[key];
 	}
 
 	if (result.message) {
-		result.message = err.message.replace(ERROR_STACK_PATTERN, "");
+		result.message = errObj.message.replace(ERROR_STACK_PATTERN, "");
 	}
 
 	if (result.stack) {
-		result.stack = result.stack.replace(ERROR_STACK_PATTERN, "");
+		result.stack = /** @type {string} */ (result.stack).replace(ERROR_STACK_PATTERN, "");
 	}
 
 	return result;
@@ -36,7 +38,7 @@ function cleanError(err) {
  * @returns {string} serialized value
  */
 function serialize(received) {
-	return prettyFormat(received, prettyFormatOptions)
+	return prettyFormat(received, /** @type {import("pretty-format").Options} */ (/** @type {unknown} */ (prettyFormatOptions)))
 		.replace(CWD_PATTERN, "<cwd>")
 		.trim();
 }
@@ -46,10 +48,10 @@ const prettyFormatOptions = {
 	printFunctionName: false,
 	plugins: [
 		{
-			test(val) {
+			test(/** @type {unknown} */ val) {
 				return typeof val === "string";
 			},
-			print(val) {
+			print(/** @type {string} */ val) {
 				return `"${val
 					.replace(/\\/g, "/")
 					.replace(/"/g, '\\"')
@@ -60,10 +62,10 @@ const prettyFormatOptions = {
 };
 
 expect.addSnapshotSerializer({
-	test(received) {
+	test(/** @type {EXPECTED_ANY} */ received) {
 		return received.errors || received.warnings;
 	},
-	print(received) {
+	print(/** @type {EXPECTED_ANY} */ received) {
 		return serialize({
 			errors: received.errors.map(cleanError),
 			warnings: received.warnings.map(cleanError)
@@ -72,10 +74,10 @@ expect.addSnapshotSerializer({
 });
 
 expect.addSnapshotSerializer({
-	test(received) {
+	test(/** @type {EXPECTED_ANY} */ received) {
 		return received.message;
 	},
-	print(received) {
+	print(/** @type {EXPECTED_ANY} */ received) {
 		return serialize(cleanError(received));
 	}
 });
@@ -89,26 +91,26 @@ const defaults = {
 			minimize: false
 		}
 	},
-	outputFileSystem: {
-		mkdir(dir, callback) {
+	outputFileSystem: /** @type {import("../").OutputFileSystem} */ ({
+		mkdir(/** @type {string} */ dir, /** @type {Function} */ callback) {
 			callback();
 		},
-		writeFile(file, content, callback) {
+		writeFile(/** @type {string} */ file, /** @type {string | Buffer} */ content, /** @type {Function} */ callback) {
 			callback();
 		},
-		stat(file, callback) {
+		stat(/** @type {string} */ file, /** @type {Function} */ callback) {
 			callback(new Error("ENOENT"));
 		}
-	}
+	})
 };
 
 /**
  * @param {import("../").Configuration} options options
- * @returns {Promise<{ errors: TODO[], warnings: TODO[] }>} errors and warnings
+ * @returns {Promise<{ errors: import("../").StatsError[], warnings: import("../").StatsError[] }>} errors and warnings
  */
 async function compile(options) {
 	const stats = await new Promise((resolve, reject) => {
-		const compiler = webpack({ ...defaults.options, ...options });
+		const compiler = webpack(/** @type {import("../").Configuration} */ ({ ...defaults.options, ...options }));
 		if (options.mode === "production") {
 			if (options.optimization) options.optimization.minimize = true;
 			else options.optimization = { minimize: true };

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -27,7 +27,10 @@ function cleanError(err) {
 	}
 
 	if (result.stack) {
-		result.stack = /** @type {string} */ (result.stack).replace(ERROR_STACK_PATTERN, "");
+		result.stack = /** @type {string} */ (result.stack).replace(
+			ERROR_STACK_PATTERN,
+			""
+		);
 	}
 
 	return result;
@@ -38,7 +41,12 @@ function cleanError(err) {
  * @returns {string} serialized value
  */
 function serialize(received) {
-	return prettyFormat(received, /** @type {import("pretty-format").Options} */ (/** @type {unknown} */ (prettyFormatOptions)))
+	return prettyFormat(
+		received,
+		/** @type {import("pretty-format").Options} */ (
+			/** @type {unknown} */ (prettyFormatOptions)
+		)
+	)
 		.replace(CWD_PATTERN, "<cwd>")
 		.trim();
 }
@@ -92,13 +100,23 @@ const defaults = {
 		}
 	},
 	outputFileSystem: /** @type {import("../").OutputFileSystem} */ ({
-		mkdir(/** @type {string} */ dir, /** @type {Function} */ callback) {
+		mkdir(
+			/** @type {string} */ dir,
+			/** @type {(err?: Error | null) => void} */ callback
+		) {
 			callback();
 		},
-		writeFile(/** @type {string} */ file, /** @type {string | Buffer} */ content, /** @type {Function} */ callback) {
+		writeFile(
+			/** @type {string} */ file,
+			/** @type {string | Buffer} */ content,
+			/** @type {(err?: Error | null) => void} */ callback
+		) {
 			callback();
 		},
-		stat(/** @type {string} */ file, /** @type {Function} */ callback) {
+		stat(
+			/** @type {string} */ file,
+			/** @type {(err: Error | null, stats?: import("fs").Stats) => void} */ callback
+		) {
 			callback(new Error("ENOENT"));
 		}
 	})
@@ -110,7 +128,12 @@ const defaults = {
  */
 async function compile(options) {
 	const stats = await new Promise((resolve, reject) => {
-		const compiler = webpack(/** @type {import("../").Configuration} */ ({ ...defaults.options, ...options }));
+		const compiler = webpack(
+			/** @type {import("../").Configuration} */ ({
+				...defaults.options,
+				...options
+			})
+		);
 		if (options.mode === "production") {
 			if (options.optimization) options.optimization.minimize = true;
 			else options.optimization = { minimize: true };

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -13,7 +13,7 @@ const dynamicImport = new Function("specifier", "return import(specifier)");
 
 /**
  * @param {string} projectDir a project directory
- * @returns {EXPECTED_ANY | undefined} webpack options
+ * @returns {Promise<EXPECTED_ANY | undefined>} webpack options
  */
 async function loadConfiguration(projectDir) {
 	const paths = [
@@ -107,29 +107,33 @@ describe("Examples", () => {
 
 			const webpack = require("..");
 
-			await new Promise((resolve, reject) => {
-				webpack(options, (err, stats) => {
-					if (err) {
-						reject(err);
-						return;
-					}
-					if (stats.hasErrors()) {
-						reject(
-							new Error(
-								stats.toString({
-									all: false,
-									errors: true,
-									errorDetails: true,
-									errorStacks: true
-								})
-							)
-						);
-						return;
-					}
+			await /** @type {Promise<void>} */ (
+				new Promise((resolve, reject) => {
+					webpack(options, (err, stats) => {
+						if (err) {
+							reject(err);
+							return;
+						}
+						if (/** @type {import("../").Stats} */ (stats).hasErrors()) {
+							reject(
+								new Error(
+									/** @type {import("../").Stats} */ (stats).toString(
+										/** @type {import("../").StatsOptions} */ ({
+											all: false,
+											errors: true,
+											errorDetails: true,
+											errorStacks: true
+										})
+									)
+								)
+							);
+							return;
+						}
 
-					resolve();
-				});
-			});
+						resolve();
+					});
+				})
+			);
 		}, 90000);
 	}
 });

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -138,20 +138,31 @@ describe("FileSystemInfo", () => {
 	};
 
 	const createFsInfo = (/** @type {IFs} */ fs) => {
-		/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
-		const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
-			error: (/** @type {unknown[]} */ ...args) => {
-				throw new Error(util.format(...args));
-			}
-		}));
+		/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */
+		const logger =
+			/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */ (
+				/** @type {unknown} */ ({
+					error: (/** @type {unknown[]} */ ...args) => {
+						throw new Error(util.format(...args));
+					}
+				})
+			);
 		/** @type {import("../lib/FileSystemInfo") & Record<string, unknown>} */
-		const fsInfo = /** @type {import("../lib/FileSystemInfo") & Record<string, unknown>} */ (new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), {
-			logger,
-			unmanagedPaths,
-			managedPaths,
-			immutablePaths,
-			hashFunction: "sha256"
-		}));
+		const fsInfo =
+			/** @type {import("../lib/FileSystemInfo") & Record<string, unknown>} */ (
+				new FileSystemInfo(
+					/** @type {import("../lib/util/fs").InputFileSystem} */ (
+						/** @type {unknown} */ (fs)
+					),
+					{
+						logger,
+						unmanagedPaths,
+						managedPaths,
+						immutablePaths,
+						hashFunction: "sha256"
+					}
+				)
+			);
 		for (const method of ["warn", "info", "log", "debug"]) {
 			fsInfo.logs = [];
 			fsInfo[method] = [];
@@ -165,7 +176,11 @@ describe("FileSystemInfo", () => {
 		return fsInfo;
 	};
 
-	const createSnapshot = (/** @type {IFs} */ fs, /** @type {SnapshotOptions} */ options, /** @type {(err?: Error | null, snapshot?: Snapshot | null, snapshot2?: Snapshot | null) => void} */ callback) => {
+	const createSnapshot = (
+		/** @type {IFs} */ fs,
+		/** @type {SnapshotOptions} */ options,
+		/** @type {(err?: Error | null, snapshot?: Snapshot | null, snapshot2?: Snapshot | null) => void} */ callback
+	) => {
 		const fsInfo = createFsInfo(fs);
 		fsInfo.createSnapshot(
 			Date.now() + 10000,
@@ -175,7 +190,8 @@ describe("FileSystemInfo", () => {
 			options,
 			(err, snapshot) => {
 				if (err) return callback(err);
-				/** @type {Snapshot & Record<string, unknown>} */ (snapshot).name = "initial snapshot";
+				/** @type {Snapshot & Record<string, unknown>} */ (snapshot).name =
+					"initial snapshot";
 				// create another one to test the caching
 				fsInfo.createSnapshot(
 					Date.now() + 10000,
@@ -185,7 +201,8 @@ describe("FileSystemInfo", () => {
 					options,
 					(err, snapshot2) => {
 						if (err) return callback(err);
-						/** @type {Snapshot & Record<string, unknown>} */ (snapshot2).name = "cached snapshot";
+						/** @type {Snapshot & Record<string, unknown>} */ (snapshot2).name =
+							"cached snapshot";
 						callback(null, snapshot, snapshot2);
 					}
 				);
@@ -193,7 +210,7 @@ describe("FileSystemInfo", () => {
 		);
 	};
 
-	const clone = (/** @type {object} */ object) => {
+	const clone = (/** @type {Record<string, unknown>} */ object) => {
 		const serialized = buffersSerializer.serialize(object, {});
 		return buffersSerializer.deserialize(serialized, {});
 	};
@@ -212,46 +229,75 @@ describe("FileSystemInfo", () => {
 		});
 	};
 
-	const expectSnapshotState = (/** @type {IFs} */ fs, /** @type {Snapshot | null | undefined} */ snapshot, /** @type {boolean} */ expected, /** @type {(err?: Error | null) => void} */ callback) => {
+	const expectSnapshotState = (
+		/** @type {IFs} */ fs,
+		/** @type {Snapshot | null | undefined} */ snapshot,
+		/** @type {boolean} */ expected,
+		/** @type {(err?: Error | null) => void} */ callback
+	) => {
 		const fsInfo = createFsInfo(fs);
-		const details = (/** @type {unknown} */ snapshot) => `${/** @type {string[]} */ (/** @type {Record<string, unknown>} */ (fsInfo).logs).join("\n")}
+		const details = (
+			/** @type {unknown} */ snapshot
+		) => `${/** @type {string[]} */ (/** @type {Record<string, unknown>} */ (fsInfo).logs).join("\n")}
 ${util.inspect(snapshot, false, Infinity, true)}`;
-		fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-			if (err) return callback(err);
-			if (valid !== expected) {
-				return callback(
-					new Error(`Expected snapshot to be ${
-						expected ? "valid" : "invalid"
-					} but it is ${valid ? "valid" : "invalid"}:
-${details(snapshot)}`)
-				);
-			}
-			// Another try to check if direct caching works
-			fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
+		fsInfo.checkSnapshotValid(
+			/** @type {Snapshot} */ (snapshot),
+			(err, valid) => {
 				if (err) return callback(err);
 				if (valid !== expected) {
 					return callback(
-						new Error(`Expected snapshot lead to the same result when directly cached:
+						new Error(`Expected snapshot to be ${
+							expected ? "valid" : "invalid"
+						} but it is ${valid ? "valid" : "invalid"}:
 ${details(snapshot)}`)
 					);
 				}
-				// Another try to check if indirect caching works
-				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (/** @type {unknown} */ (clone(/** @type {object} */ (snapshot)))), (err, valid) => {
-					if (err) return callback(err);
-					if (valid !== expected) {
-						return callback(
-							new Error(`Expected snapshot lead to the same result when indirectly cached:
+				// Another try to check if direct caching works
+				fsInfo.checkSnapshotValid(
+					/** @type {Snapshot} */ (snapshot),
+					(err, valid) => {
+						if (err) return callback(err);
+						if (valid !== expected) {
+							return callback(
+								new Error(`Expected snapshot lead to the same result when directly cached:
 ${details(snapshot)}`)
+							);
+						}
+						// Another try to check if indirect caching works
+						fsInfo.checkSnapshotValid(
+							/** @type {Snapshot} */ (
+								/** @type {unknown} */ (
+									clone(
+										/** @type {Record<string, unknown>} */ (
+											/** @type {unknown} */ (snapshot)
+										)
+									)
+								)
+							),
+							(err, valid) => {
+								if (err) return callback(err);
+								if (valid !== expected) {
+									return callback(
+										new Error(`Expected snapshot lead to the same result when indirectly cached:
+${details(snapshot)}`)
+									);
+								}
+								callback();
+							}
 						);
 					}
-					callback();
-				});
-			});
-		});
+				);
+			}
+		);
 	};
 
-	const updateFile = (/** @type {IFs} */ fs, /** @type {string} */ filename) => {
-		const oldContent = /** @type {string} */ (/** @type {unknown} */ (fs.readFileSync(filename, "utf8")));
+	const updateFile = (
+		/** @type {IFs} */ fs,
+		/** @type {string} */ filename
+	) => {
+		const oldContent = /** @type {string} */ (
+			/** @type {unknown} */ (fs.readFileSync(filename, "utf8"))
+		);
 		if (filename.endsWith(".json")) {
 			const data = JSON.parse(oldContent);
 			fs.writeFileSync(
@@ -422,7 +468,9 @@ ${details(snapshot)}`)
 		it("should return same iterable for getFileIterable()", (done) => {
 			getSnapshot((err, snapshot) => {
 				if (err) done(err);
-				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(/** @type {Snapshot} */ (snapshot).getFileIterable());
+				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(
+					/** @type {Snapshot} */ (snapshot).getFileIterable()
+				);
 				done();
 			});
 		});
@@ -440,7 +488,9 @@ ${details(snapshot)}`)
 		it("should return same iterable for getMissingIterable()", (done) => {
 			getSnapshot((err, snapshot) => {
 				if (err) done(err);
-				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(/** @type {Snapshot} */ (snapshot).getFileIterable());
+				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(
+					/** @type {Snapshot} */ (snapshot).getFileIterable()
+				);
 				done();
 			});
 		});
@@ -463,16 +513,21 @@ ${details(snapshot)}`)
 			jest.spyOn(fs, "readlink").mockImplementation((path, callback) => {
 				if (path === "/path/context/sub/symlink-error" && i < 2) {
 					i += 1;
-					/** @type {Function} */ (callback)(new Error("test"));
+					/** @type {(err: Error) => void} */ (callback)(new Error("test"));
 					return;
 				}
 
-				(/** @type {Function} */ (originalReadlink))(path, callback);
+				/** @type {(path: string, cb: unknown) => void} */ (originalReadlink)(
+					/** @type {string} */ (path),
+					callback
+				);
 			});
 
 			createSnapshot(
 				fs,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot, snapshot2) => {
 					if (err) return done(err);
 					expectSnapshotsState(fs, snapshot, snapshot2, true, done);
@@ -490,7 +545,7 @@ ${details(snapshot)}`)
 			);
 
 			jest.spyOn(fs, "readlink").mockImplementation((path, callback) => {
-				/** @type {Function} */ (callback)(new Error("test"));
+				/** @type {(err: Error) => void} */ (callback)(new Error("test"));
 			});
 
 			const fsInfo = createFsInfo(fs);
@@ -499,7 +554,9 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					expect(snapshot).toBeNull();
 					done();
@@ -537,7 +594,9 @@ ${details(snapshot)}`)
 	// `timestampHash`. Cache lookups now treat existence-only entries as a
 	// cache miss and re-read from disk so snapshots stay valid.
 	describe("existence-only watchpack entries", () => {
-		const buildFsInfoWithSnapshot = (/** @type {(err?: Error | null, fs?: IFs, snapshot?: Snapshot | null) => void} */ callback) => {
+		const buildFsInfoWithSnapshot = (
+			/** @type {(err?: Error | null, fs?: IFs, snapshot?: Snapshot | null) => void} */ callback
+		) => {
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			fsInfo.createSnapshot(
@@ -545,7 +604,9 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					if (err) return callback(err);
 					callback(null, fs, snapshot);
@@ -553,7 +614,8 @@ ${details(snapshot)}`)
 			);
 		};
 
-		const onlyNonIgnored = (/** @type {string[]} */ paths) => paths.filter((/** @type {string} */ p) => !ignored.includes(p));
+		const onlyNonIgnored = (/** @type {string[]} */ paths) =>
+			paths.filter((/** @type {string} */ p) => !ignored.includes(p));
 
 		it("keeps the snapshot valid when watchpack reports `{}` for context dirs", (done) => {
 			buildFsInfoWithSnapshot((err, fs, snapshot) => {
@@ -561,11 +623,14 @@ ${details(snapshot)}`)
 				const fsInfo = createFsInfo(/** @type {IFs} */ (fs));
 				const map = new Map(directories.map((d) => [d, {}]));
 				fsInfo.addContextTimestamps(map, true);
-				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-					if (err) return done(err);
-					expect(valid).toBe(true);
-					done();
-				});
+				fsInfo.checkSnapshotValid(
+					/** @type {Snapshot} */ (snapshot),
+					(err, valid) => {
+						if (err) return done(err);
+						expect(valid).toBe(true);
+						done();
+					}
+				);
 			});
 		});
 
@@ -575,11 +640,14 @@ ${details(snapshot)}`)
 				const fsInfo = createFsInfo(/** @type {IFs} */ (fs));
 				const map = new Map(onlyNonIgnored(files).map((f) => [f, {}]));
 				fsInfo.addFileTimestamps(map, true);
-				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-					if (err) return done(err);
-					expect(valid).toBe(true);
-					done();
-				});
+				fsInfo.checkSnapshotValid(
+					/** @type {Snapshot} */ (snapshot),
+					(err, valid) => {
+						if (err) return done(err);
+						expect(valid).toBe(true);
+						done();
+					}
+				);
 			});
 		});
 
@@ -593,11 +661,14 @@ ${details(snapshot)}`)
 					new Map([["/path/context+files", { safeTime: 1 }]]),
 					true
 				);
-				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-					if (err) return done(err);
-					expect(valid).toBe(true);
-					done();
-				});
+				fsInfo.checkSnapshotValid(
+					/** @type {Snapshot} */ (snapshot),
+					(err, valid) => {
+						if (err) return done(err);
+						expect(valid).toBe(true);
+						done();
+					}
+				);
 			});
 		});
 
@@ -610,7 +681,9 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const fsInfo2 = createFsInfo(fs);
@@ -618,11 +691,14 @@ ${details(snapshot)}`)
 						new Map([["/path/context+files", { safeTime: startTime + 5000 }]]),
 						true
 					);
-					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-						if (err) return done(err);
-						expect(valid).toBe(false);
-						done();
-					});
+					fsInfo2.checkSnapshotValid(
+						/** @type {Snapshot} */ (snapshot),
+						(err, valid) => {
+							if (err) return done(err);
+							expect(valid).toBe(false);
+							done();
+						}
+					);
 				}
 			);
 		});
@@ -663,7 +739,9 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const fsInfo2 = createFsInfo(fs);
@@ -674,11 +752,14 @@ ${details(snapshot)}`)
 						new Map([["/path/package.json", {}]]),
 						true
 					);
-					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-						if (err) return done(err);
-						expect(valid).toBe(true);
-						done();
-					});
+					fsInfo2.checkSnapshotValid(
+						/** @type {Snapshot} */ (snapshot),
+						(err, valid) => {
+							if (err) return done(err);
+							expect(valid).toBe(true);
+							done();
+						}
+					);
 				}
 			);
 		});
@@ -691,17 +772,22 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					if (err) return done(err);
 					// Create the missing file and re-check.
 					fs.writeFileSync("/path/package.json", "{}");
 					const fsInfo2 = createFsInfo(fs);
-					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-						if (err) return done(err);
-						expect(valid).toBe(false);
-						done();
-					});
+					fsInfo2.checkSnapshotValid(
+						/** @type {Snapshot} */ (snapshot),
+						(err, valid) => {
+							if (err) return done(err);
+							expect(valid).toBe(false);
+							done();
+						}
+					);
 				}
 			);
 		});
@@ -735,7 +821,9 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const stored = /** @type {Map<string, EXPECTED_ANY>} */ (
@@ -778,21 +866,27 @@ ${details(snapshot)}`)
 						updateFile(fs, changedFile);
 						// Sanity: without ignoring, the change invalidates the snapshot.
 						const control = createFsInfo(fs);
-						control.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
-							if (err) return done(err);
-							expect(valid).toBe(false);
-							// Mark the directory ignored: the snapshot stays valid.
-							const fsInfo2 = createFsInfo(fs);
-							fsInfo2.addContextTimestamps(
-								new Map([[ignoredDir, "ignore"]]),
-								true
-							);
-							fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
+						control.checkSnapshotValid(
+							/** @type {Snapshot} */ (snapshot),
+							(err, valid) => {
 								if (err) return done(err);
-								expect(valid).toBe(true);
-								done();
-							});
-						});
+								expect(valid).toBe(false);
+								// Mark the directory ignored: the snapshot stays valid.
+								const fsInfo2 = createFsInfo(fs);
+								fsInfo2.addContextTimestamps(
+									new Map([[ignoredDir, "ignore"]]),
+									true
+								);
+								fsInfo2.checkSnapshotValid(
+									/** @type {Snapshot} */ (snapshot),
+									(err, valid) => {
+										if (err) return done(err);
+										expect(valid).toBe(true);
+										done();
+									}
+								);
+							}
+						);
 					}
 				);
 			});
@@ -821,8 +915,13 @@ ${details(snapshot)}`)
 	});
 
 	describe("cache maintenance", () => {
-		/** @typedef {import("../lib/FileSystemInfo") & Record<string, unknown>} FsInfoExt */
-		const buildWithStats = (/** @type {(err: Error | null | undefined, fsInfo?: FsInfoExt) => void} */ callback) => {
+		/**
+		 * @typedef {import("../lib/FileSystemInfo") & Record<string, unknown>} FsInfoExt
+		 * @param {(err: Error | null | undefined, fsInfo?: FsInfoExt) => void} callback result callback
+		 */
+		const buildWithStats = (
+			/** @type {(err: Error | null | undefined, fsInfo?: FsInfoExt) => void} */ callback
+		) => {
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			// Two overlapping snapshots populate the optimization statistics so
@@ -855,9 +954,11 @@ ${details(snapshot)}`)
 				if (err) return done(err);
 				const fsInfo = /** @type {FsInfoExt} */ (fsInfo_);
 				expect(() => fsInfo.logStatistics()).not.toThrow();
-				expect(/** @type {string[]} */ (fsInfo.log).some((/** @type {string} */ m) => /new snapshots created/.test(m))).toBe(
-					true
-				);
+				expect(
+					/** @type {string[]} */ (fsInfo.log).some((/** @type {string} */ m) =>
+						/new snapshots created/.test(m)
+					)
+				).toBe(true);
 				done();
 			});
 		});
@@ -934,9 +1035,17 @@ ${details(snapshot)}`)
 						options,
 						(err, s2) => {
 							if (err) return done(err);
-							const merged = fsInfo.mergeSnapshots(/** @type {Snapshot} */ (s1), /** @type {Snapshot} */ (s2));
+							const merged = fsInfo.mergeSnapshots(
+								/** @type {Snapshot} */ (s1),
+								/** @type {Snapshot} */ (s2)
+							);
 							expect(merged.startTime).toBe(
-								Math.min(/** @type {number} */ (/** @type {Snapshot} */ (s1).startTime), /** @type {number} */ (/** @type {Snapshot} */ (s2).startTime))
+								Math.min(
+									/** @type {number} */ (
+										/** @type {Snapshot} */ (s1).startTime
+									),
+									/** @type {number} */ (/** @type {Snapshot} */ (s2).startTime)
+								)
 							);
 							// both inputs are cached as valid → so is the merge
 							expect(fsInfo._snapshotCache.get(merged)).toBe(true);
@@ -970,15 +1079,28 @@ ${details(snapshot)}`)
 						{ timestamp: true },
 						(err, withStart) => {
 							if (err) return done(err);
-							expect(/** @type {Snapshot} */ (noStart).hasStartTime()).toBe(false);
-							expect(fsInfo.mergeSnapshots(/** @type {Snapshot} */ (noStart), /** @type {Snapshot} */ (withStart)).startTime).toBe(
-								/** @type {Snapshot} */ (withStart).startTime
-							);
-							expect(fsInfo.mergeSnapshots(/** @type {Snapshot} */ (withStart), /** @type {Snapshot} */ (noStart)).startTime).toBe(
-								/** @type {Snapshot} */ (withStart).startTime
+							expect(/** @type {Snapshot} */ (noStart).hasStartTime()).toBe(
+								false
 							);
 							expect(
-								fsInfo.mergeSnapshots(/** @type {Snapshot} */ (noStart), /** @type {Snapshot} */ (noStart)).hasStartTime()
+								fsInfo.mergeSnapshots(
+									/** @type {Snapshot} */ (noStart),
+									/** @type {Snapshot} */ (withStart)
+								).startTime
+							).toBe(/** @type {Snapshot} */ (withStart).startTime);
+							expect(
+								fsInfo.mergeSnapshots(
+									/** @type {Snapshot} */ (withStart),
+									/** @type {Snapshot} */ (noStart)
+								).startTime
+							).toBe(/** @type {Snapshot} */ (withStart).startTime);
+							expect(
+								fsInfo
+									.mergeSnapshots(
+										/** @type {Snapshot} */ (noStart),
+										/** @type {Snapshot} */ (noStart)
+									)
+									.hasStartTime()
 							).toBe(false);
 							done();
 						}
@@ -994,7 +1116,10 @@ ${details(snapshot)}`)
 			const fsInfo = createFsInfo(fs);
 			// Fixed start time so the shared-snapshot start-time guard always passes.
 			const startTime = Date.now() + 10000;
-			const make = (/** @type {string[]} */ fileList, /** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ cb) =>
+			const make = (
+				/** @type {string[]} */ fileList,
+				/** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ cb
+			) =>
 				fsInfo.createSnapshot(
 					startTime,
 					fileList,
@@ -1057,16 +1182,24 @@ ${details(snapshot)}`)
 		};
 
 		const createProjectFsInfo = (/** @type {IFs} */ fs) => {
-			/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
-			const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
-				error: (/** @type {unknown[]} */ ...args) => {
-					throw new Error(util.format(...args));
-				}
-			}));
+			/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */
+			const logger =
+				/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */ (
+					/** @type {unknown} */ ({
+						error: (/** @type {unknown[]} */ ...args) => {
+							throw new Error(util.format(...args));
+						}
+					})
+				);
 			for (const method of ["warn", "info", "log", "debug"]) {
 				logger[method] = () => {};
 			}
-			return new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), { logger, hashFunction: "sha256" });
+			return new FileSystemInfo(
+				/** @type {import("../lib/util/fs").InputFileSystem} */ (
+					/** @type {unknown} */ (fs)
+				),
+				{ logger, hashFunction: "sha256" }
+			);
 		};
 
 		it("collects files, directories and resolve results across cjs/esm", (done) => {
@@ -1077,7 +1210,10 @@ ${details(snapshot)}`)
 				["/proj/entry.js", "/proj/", "/proj/empty-dir/"],
 				(err, result_) => {
 					if (err) return done(err);
-					const result = /** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (result_);
+					const result =
+						/** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (
+							result_
+						);
 					expect(result.files).toContain("/proj/entry.js");
 					expect(result.files).toContain("/proj/lib.mjs");
 					expect(result.files).toContain("/proj/node_modules/dep/index.js");
@@ -1106,7 +1242,10 @@ ${details(snapshot)}`)
 			const fsInfo = createProjectFsInfo(fs);
 			fsInfo.resolveBuildDependencies("/proj", ["/proj/"], (err, result_) => {
 				if (err) return done(err);
-				const result = /** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (result_);
+				const result =
+					/** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (
+						result_
+					);
 				// Create the previously-missing optional dependency.
 				fs.mkdirSync("/proj/node_modules/missing-dep", { recursive: true });
 				fs.writeFileSync(
@@ -1147,12 +1286,15 @@ ${details(snapshot)}`)
 				JSON.stringify({ name: "normal", version: "1.0.0" })
 			);
 			extra(/** @type {IFs} */ (/** @type {unknown} */ (fs)));
-			/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
-			const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
-				error: (/** @type {unknown[]} */ ...args) => {
-					throw new Error(util.format(...args));
-				}
-			}));
+			/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */
+			const logger =
+				/** @type {import("../lib/logging/Logger").Logger & Record<string, (...args: unknown[]) => unknown>} */ (
+					/** @type {unknown} */ ({
+						error: (/** @type {unknown[]} */ ...args) => {
+							throw new Error(util.format(...args));
+						}
+					})
+				);
 			/** @type {string[]} */
 			const warnings = [];
 			for (const method of ["warn", "info", "log", "debug"]) {
@@ -1160,15 +1302,24 @@ ${details(snapshot)}`)
 					if (method === "warn") warnings.push(util.format(...args));
 				};
 			}
-			const fsInfo = new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), {
-				logger,
-				managedPaths: ["/root/node_modules"],
-				hashFunction: "sha256"
-			});
+			const fsInfo = new FileSystemInfo(
+				/** @type {import("../lib/util/fs").InputFileSystem} */ (
+					/** @type {unknown} */ (fs)
+				),
+				{
+					logger,
+					managedPaths: ["/root/node_modules"],
+					hashFunction: "sha256"
+				}
+			);
 			return { fs, fsInfo, warnings };
 		};
 
-		const snapshotFiles = (/** @type {import("../lib/FileSystemInfo")} */ fsInfo, /** @type {string[]} */ fileList, /** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ callback) => {
+		const snapshotFiles = (
+			/** @type {import("../lib/FileSystemInfo")} */ fsInfo,
+			/** @type {string[]} */ fileList,
+			/** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ callback
+		) => {
 			fsInfo.createSnapshot(
 				Date.now() + 10000,
 				fileList,
@@ -1194,7 +1345,9 @@ ${details(snapshot)}`)
 				],
 				(err, snapshot) => {
 					if (err) return done(err);
-					const info = /** @type {Map<string, string>} */ (/** @type {Snapshot} */ (snapshot).managedItemInfo);
+					const info = /** @type {Map<string, string>} */ (
+						/** @type {Snapshot} */ (snapshot).managedItemInfo
+					);
 					expect(info.get("/root/node_modules/normal")).toBe("normal@1.0.0");
 					expect(info.get("/root/node_modules/group")).toBe("*nested");
 					done();
@@ -1214,7 +1367,9 @@ ${details(snapshot)}`)
 				(err, snapshot) => {
 					if (err) return done(err);
 					expect(
-						/** @type {Map<string, string>} */ (/** @type {Snapshot} */ (snapshot).managedItemInfo).get("/root/node_modules/sub/node_modules")
+						/** @type {Map<string, string>} */ (
+							/** @type {Snapshot} */ (snapshot).managedItemInfo
+						).get("/root/node_modules/sub/node_modules")
 					).toBe("*node_modules");
 					done();
 				}
@@ -1381,7 +1536,16 @@ ${details(snapshot)}`)
 									base.setManagedMissing(new Set(["/mm"]));
 									// Two children → the iterator's multi-child queue path.
 									base.setChildren(new Set([cA, cB]));
-									const restored = /** @type {Snapshot & Record<string, Function>} */ (/** @type {unknown} */ (clone(base)));
+									const restored =
+										/** @type {Snapshot & Record<string, (...args: unknown[]) => unknown>} */ (
+											/** @type {unknown} */ (
+												clone(
+													/** @type {Record<string, unknown>} */ (
+														/** @type {unknown} */ (base)
+													)
+												)
+											)
+										);
 									for (const has of [
 										"hasStartTime",
 										"hasFileTimestamps",
@@ -1432,9 +1596,11 @@ ${details(snapshot)}`)
 				if (err) return done(err);
 				expect(hash).toBe("directory");
 				jest.spyOn(fs, "readFile").mockImplementation((p, cb) => {
-					const err = /** @type {Error & { code: string }} */ (new Error("denied"));
+					const err = /** @type {Error & { code: string }} */ (
+						new Error("denied")
+					);
 					err.code = "EACCES";
-					/** @type {Function} */ (cb)(err);
+					/** @type {(err: Error & { code: string }) => void} */ (cb)(err);
 				});
 				fsInfo.createSnapshot(
 					Date.now() + 10000,
@@ -1454,9 +1620,11 @@ ${details(snapshot)}`)
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			jest.spyOn(fs, "stat").mockImplementation((p, cb) => {
-				const err = /** @type {Error & { code: string }} */ (new Error("denied"));
+				const err = /** @type {Error & { code: string }} */ (
+					new Error("denied")
+				);
 				err.code = "EACCES";
-				/** @type {Function} */ (cb)(err);
+				/** @type {(err: Error & { code: string }) => void} */ (cb)(err);
 			});
 			fsInfo.createSnapshot(
 				Date.now() + 10000,

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -1,5 +1,10 @@
 "use strict";
 
+/** @typedef {import("../lib/FileSystemInfo").Snapshot} Snapshot */
+/** @typedef {import("../lib/FileSystemInfo").SnapshotOptions} SnapshotOptions */
+/** @typedef {import("../lib/errors/WebpackError")} WebpackError */
+/** @typedef {import("memfs").IFs} IFs */
+
 const util = require("util");
 const { Volume, createFsFromVolume } = require("memfs");
 const FileSystemInfo = require("../lib/FileSystemInfo");
@@ -132,33 +137,35 @@ describe("FileSystemInfo", () => {
 		return fs;
 	};
 
-	const createFsInfo = (fs) => {
-		const logger = {
-			error: (...args) => {
+	const createFsInfo = (/** @type {IFs} */ fs) => {
+		/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
+		const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
+			error: (/** @type {unknown[]} */ ...args) => {
 				throw new Error(util.format(...args));
 			}
-		};
-		const fsInfo = new FileSystemInfo(fs, {
+		}));
+		/** @type {import("../lib/FileSystemInfo") & Record<string, unknown>} */
+		const fsInfo = /** @type {import("../lib/FileSystemInfo") & Record<string, unknown>} */ (new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), {
 			logger,
 			unmanagedPaths,
 			managedPaths,
 			immutablePaths,
 			hashFunction: "sha256"
-		});
+		}));
 		for (const method of ["warn", "info", "log", "debug"]) {
 			fsInfo.logs = [];
 			fsInfo[method] = [];
-			logger[method] = (...args) => {
+			logger[method] = (/** @type {unknown[]} */ ...args) => {
 				const msg = util.format(...args);
-				fsInfo[method].push(msg);
-				fsInfo.logs.push(`[${method}] ${msg}`);
+				/** @type {string[]} */ (fsInfo[method]).push(msg);
+				/** @type {string[]} */ (fsInfo.logs).push(`[${method}] ${msg}`);
 			};
 		}
 		fsInfo.addFileTimestamps(new Map(ignored.map((i) => [i, "ignore"])));
 		return fsInfo;
 	};
 
-	const createSnapshot = (fs, options, callback) => {
+	const createSnapshot = (/** @type {IFs} */ fs, /** @type {SnapshotOptions} */ options, /** @type {(err?: Error | null, snapshot?: Snapshot | null, snapshot2?: Snapshot | null) => void} */ callback) => {
 		const fsInfo = createFsInfo(fs);
 		fsInfo.createSnapshot(
 			Date.now() + 10000,
@@ -168,7 +175,7 @@ describe("FileSystemInfo", () => {
 			options,
 			(err, snapshot) => {
 				if (err) return callback(err);
-				snapshot.name = "initial snapshot";
+				/** @type {Snapshot & Record<string, unknown>} */ (snapshot).name = "initial snapshot";
 				// create another one to test the caching
 				fsInfo.createSnapshot(
 					Date.now() + 10000,
@@ -178,7 +185,7 @@ describe("FileSystemInfo", () => {
 					options,
 					(err, snapshot2) => {
 						if (err) return callback(err);
-						snapshot2.name = "cached snapshot";
+						/** @type {Snapshot & Record<string, unknown>} */ (snapshot2).name = "cached snapshot";
 						callback(null, snapshot, snapshot2);
 					}
 				);
@@ -186,17 +193,17 @@ describe("FileSystemInfo", () => {
 		);
 	};
 
-	const clone = (object) => {
+	const clone = (/** @type {object} */ object) => {
 		const serialized = buffersSerializer.serialize(object, {});
 		return buffersSerializer.deserialize(serialized, {});
 	};
 
 	const expectSnapshotsState = (
-		fs,
-		snapshot,
-		snapshot2,
-		expected,
-		callback
+		/** @type {IFs} */ fs,
+		/** @type {Snapshot | null | undefined} */ snapshot,
+		/** @type {Snapshot | null | undefined} */ snapshot2,
+		/** @type {boolean} */ expected,
+		/** @type {(err?: Error | null) => void} */ callback
 	) => {
 		expectSnapshotState(fs, snapshot, expected, (err) => {
 			if (err) return callback(err);
@@ -205,11 +212,11 @@ describe("FileSystemInfo", () => {
 		});
 	};
 
-	const expectSnapshotState = (fs, snapshot, expected, callback) => {
+	const expectSnapshotState = (/** @type {IFs} */ fs, /** @type {Snapshot | null | undefined} */ snapshot, /** @type {boolean} */ expected, /** @type {(err?: Error | null) => void} */ callback) => {
 		const fsInfo = createFsInfo(fs);
-		const details = (snapshot) => `${fsInfo.logs.join("\n")}
+		const details = (/** @type {unknown} */ snapshot) => `${/** @type {string[]} */ (/** @type {Record<string, unknown>} */ (fsInfo).logs).join("\n")}
 ${util.inspect(snapshot, false, Infinity, true)}`;
-		fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
+		fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 			if (err) return callback(err);
 			if (valid !== expected) {
 				return callback(
@@ -220,7 +227,7 @@ ${details(snapshot)}`)
 				);
 			}
 			// Another try to check if direct caching works
-			fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
+			fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 				if (err) return callback(err);
 				if (valid !== expected) {
 					return callback(
@@ -229,7 +236,7 @@ ${details(snapshot)}`)
 					);
 				}
 				// Another try to check if indirect caching works
-				fsInfo.checkSnapshotValid(clone(snapshot), (err, valid) => {
+				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (/** @type {unknown} */ (clone(/** @type {object} */ (snapshot)))), (err, valid) => {
 					if (err) return callback(err);
 					if (valid !== expected) {
 						return callback(
@@ -243,8 +250,8 @@ ${details(snapshot)}`)
 		});
 	};
 
-	const updateFile = (fs, filename) => {
-		const oldContent = fs.readFileSync(filename, "utf8");
+	const updateFile = (/** @type {IFs} */ fs, /** @type {string} */ filename) => {
+		const oldContent = /** @type {string} */ (/** @type {unknown} */ (fs.readFileSync(filename, "utf8")));
 		if (filename.endsWith(".json")) {
 			const data = JSON.parse(oldContent);
 			fs.writeFileSync(
@@ -259,11 +266,11 @@ ${details(snapshot)}`)
 		}
 	};
 
-	for (const [name, options] of [
+	for (const [name, options] of /** @type {[string, SnapshotOptions][]} */ ([
 		["timestamp", { timestamp: true }],
 		["hash", { hash: true }],
 		["tsh", { timestamp: true, hash: true }]
-	]) {
+	])) {
 		describe(`${name} mode`, () => {
 			it("should always accept an empty snapshot", (done) => {
 				const fs = createFs();
@@ -415,7 +422,7 @@ ${details(snapshot)}`)
 		it("should return same iterable for getFileIterable()", (done) => {
 			getSnapshot((err, snapshot) => {
 				if (err) done(err);
-				expect(snapshot.getFileIterable()).toEqual(snapshot.getFileIterable());
+				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(/** @type {Snapshot} */ (snapshot).getFileIterable());
 				done();
 			});
 		});
@@ -423,8 +430,8 @@ ${details(snapshot)}`)
 		it("should return same iterable for getContextIterable()", (done) => {
 			getSnapshot((err, snapshot) => {
 				if (err) done(err);
-				expect(snapshot.getContextIterable()).toEqual(
-					snapshot.getContextIterable()
+				expect(/** @type {Snapshot} */ (snapshot).getContextIterable()).toEqual(
+					/** @type {Snapshot} */ (snapshot).getContextIterable()
 				);
 				done();
 			});
@@ -433,7 +440,7 @@ ${details(snapshot)}`)
 		it("should return same iterable for getMissingIterable()", (done) => {
 			getSnapshot((err, snapshot) => {
 				if (err) done(err);
-				expect(snapshot.getFileIterable()).toEqual(snapshot.getFileIterable());
+				expect(/** @type {Snapshot} */ (snapshot).getFileIterable()).toEqual(/** @type {Snapshot} */ (snapshot).getFileIterable());
 				done();
 			});
 		});
@@ -456,16 +463,16 @@ ${details(snapshot)}`)
 			jest.spyOn(fs, "readlink").mockImplementation((path, callback) => {
 				if (path === "/path/context/sub/symlink-error" && i < 2) {
 					i += 1;
-					callback(new Error("test"));
+					/** @type {Function} */ (callback)(new Error("test"));
 					return;
 				}
 
-				originalReadlink(path, callback);
+				(/** @type {Function} */ (originalReadlink))(path, callback);
 			});
 
 			createSnapshot(
 				fs,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot, snapshot2) => {
 					if (err) return done(err);
 					expectSnapshotsState(fs, snapshot, snapshot2, true, done);
@@ -483,7 +490,7 @@ ${details(snapshot)}`)
 			);
 
 			jest.spyOn(fs, "readlink").mockImplementation((path, callback) => {
-				callback(new Error("test"));
+				/** @type {Function} */ (callback)(new Error("test"));
 			});
 
 			const fsInfo = createFsInfo(fs);
@@ -492,7 +499,7 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					expect(snapshot).toBeNull();
 					done();
@@ -530,7 +537,7 @@ ${details(snapshot)}`)
 	// `timestampHash`. Cache lookups now treat existence-only entries as a
 	// cache miss and re-read from disk so snapshots stay valid.
 	describe("existence-only watchpack entries", () => {
-		const buildFsInfoWithSnapshot = (callback) => {
+		const buildFsInfoWithSnapshot = (/** @type {(err?: Error | null, fs?: IFs, snapshot?: Snapshot | null) => void} */ callback) => {
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			fsInfo.createSnapshot(
@@ -538,7 +545,7 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					if (err) return callback(err);
 					callback(null, fs, snapshot);
@@ -546,15 +553,15 @@ ${details(snapshot)}`)
 			);
 		};
 
-		const onlyNonIgnored = (paths) => paths.filter((p) => !ignored.includes(p));
+		const onlyNonIgnored = (/** @type {string[]} */ paths) => paths.filter((/** @type {string} */ p) => !ignored.includes(p));
 
 		it("keeps the snapshot valid when watchpack reports `{}` for context dirs", (done) => {
 			buildFsInfoWithSnapshot((err, fs, snapshot) => {
 				if (err) return done(err);
-				const fsInfo = createFsInfo(fs);
+				const fsInfo = createFsInfo(/** @type {IFs} */ (fs));
 				const map = new Map(directories.map((d) => [d, {}]));
 				fsInfo.addContextTimestamps(map, true);
-				fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
+				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 					if (err) return done(err);
 					expect(valid).toBe(true);
 					done();
@@ -565,10 +572,10 @@ ${details(snapshot)}`)
 		it("keeps the snapshot valid when watchpack reports `{}` for files", (done) => {
 			buildFsInfoWithSnapshot((err, fs, snapshot) => {
 				if (err) return done(err);
-				const fsInfo = createFsInfo(fs);
+				const fsInfo = createFsInfo(/** @type {IFs} */ (fs));
 				const map = new Map(onlyNonIgnored(files).map((f) => [f, {}]));
 				fsInfo.addFileTimestamps(map, true);
-				fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
+				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 					if (err) return done(err);
 					expect(valid).toBe(true);
 					done();
@@ -579,14 +586,14 @@ ${details(snapshot)}`)
 		it("keeps the snapshot valid when watchpack reports `{ safeTime }` (no timestampHash) for an existing context dir", (done) => {
 			buildFsInfoWithSnapshot((err, fs, snapshot) => {
 				if (err) return done(err);
-				const fsInfo = createFsInfo(fs);
+				const fsInfo = createFsInfo(/** @type {IFs} */ (fs));
 				// Only target existing directories — for missing ones the cache
 				// would claim the dir exists while the snapshot says it doesn't.
 				fsInfo.addContextTimestamps(
 					new Map([["/path/context+files", { safeTime: 1 }]]),
 					true
 				);
-				fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
+				fsInfo.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 					if (err) return done(err);
 					expect(valid).toBe(true);
 					done();
@@ -603,7 +610,7 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const fsInfo2 = createFsInfo(fs);
@@ -611,7 +618,7 @@ ${details(snapshot)}`)
 						new Map([["/path/context+files", { safeTime: startTime + 5000 }]]),
 						true
 					);
-					fsInfo2.checkSnapshotValid(snapshot, (err, valid) => {
+					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 						if (err) return done(err);
 						expect(valid).toBe(false);
 						done();
@@ -656,7 +663,7 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const fsInfo2 = createFsInfo(fs);
@@ -667,7 +674,7 @@ ${details(snapshot)}`)
 						new Map([["/path/package.json", {}]]),
 						true
 					);
-					fsInfo2.checkSnapshotValid(snapshot, (err, valid) => {
+					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 						if (err) return done(err);
 						expect(valid).toBe(true);
 						done();
@@ -684,13 +691,13 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					if (err) return done(err);
 					// Create the missing file and re-check.
 					fs.writeFileSync("/path/package.json", "{}");
 					const fsInfo2 = createFsInfo(fs);
-					fsInfo2.checkSnapshotValid(snapshot, (err, valid) => {
+					fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 						if (err) return done(err);
 						expect(valid).toBe(false);
 						done();
@@ -728,11 +735,11 @@ ${details(snapshot)}`)
 				files,
 				directories,
 				missing,
-				["timestamp", { timestamp: true }],
+				/** @type {SnapshotOptions} */ (/** @type {unknown} */ (["timestamp", { timestamp: true }])),
 				(err, snapshot) => {
 					if (err) return done(err);
 					const stored = /** @type {Map<string, EXPECTED_ANY>} */ (
-						snapshot.contextTimestamps
+						/** @type {Snapshot} */ (snapshot).contextTimestamps
 					).get("/path/context+files");
 					expect(stored).toBeTruthy();
 					expect(stored).toHaveProperty("timestampHash");
@@ -753,10 +760,10 @@ ${details(snapshot)}`)
 		// isolates the context check from the per-file checks.
 		const changedFile = "/path/context+files/sub/file3.txt";
 
-		for (const [name, options] of [
+		for (const [name, options] of /** @type {[string, SnapshotOptions][]} */ ([
 			["timestamp", { timestamp: true }],
 			["tsh", { timestamp: true, hash: true }]
-		]) {
+		])) {
 			it(`keeps the snapshot valid when a tracked context dir becomes ignored (${name})`, (done) => {
 				const fs = createFs();
 				const fsInfo = createFsInfo(fs);
@@ -771,7 +778,7 @@ ${details(snapshot)}`)
 						updateFile(fs, changedFile);
 						// Sanity: without ignoring, the change invalidates the snapshot.
 						const control = createFsInfo(fs);
-						control.checkSnapshotValid(snapshot, (err, valid) => {
+						control.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 							if (err) return done(err);
 							expect(valid).toBe(false);
 							// Mark the directory ignored: the snapshot stays valid.
@@ -780,7 +787,7 @@ ${details(snapshot)}`)
 								new Map([[ignoredDir, "ignore"]]),
 								true
 							);
-							fsInfo2.checkSnapshotValid(snapshot, (err, valid) => {
+							fsInfo2.checkSnapshotValid(/** @type {Snapshot} */ (snapshot), (err, valid) => {
 								if (err) return done(err);
 								expect(valid).toBe(true);
 								done();
@@ -804,7 +811,7 @@ ${details(snapshot)}`)
 				(err, snapshot) => {
 					if (err) return done(err);
 					const ts = /** @type {Map<string, EXPECTED_ANY> | undefined} */ (
-						snapshot.contextTimestamps
+						/** @type {Snapshot} */ (snapshot).contextTimestamps
 					);
 					expect(ts === undefined || !ts.has(ignoredDir)).toBe(true);
 					done();
@@ -814,7 +821,8 @@ ${details(snapshot)}`)
 	});
 
 	describe("cache maintenance", () => {
-		const buildWithStats = (callback) => {
+		/** @typedef {import("../lib/FileSystemInfo") & Record<string, unknown>} FsInfoExt */
+		const buildWithStats = (/** @type {(err: Error | null | undefined, fsInfo?: FsInfoExt) => void} */ callback) => {
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			// Two overlapping snapshots populate the optimization statistics so
@@ -843,10 +851,11 @@ ${details(snapshot)}`)
 		};
 
 		it("logStatistics() logs cache and optimization stats", (done) => {
-			buildWithStats((err, fsInfo) => {
+			buildWithStats((err, fsInfo_) => {
 				if (err) return done(err);
+				const fsInfo = /** @type {FsInfoExt} */ (fsInfo_);
 				expect(() => fsInfo.logStatistics()).not.toThrow();
-				expect(fsInfo.log.some((m) => /new snapshots created/.test(m))).toBe(
+				expect(/** @type {string[]} */ (fsInfo.log).some((/** @type {string} */ m) => /new snapshots created/.test(m))).toBe(
 					true
 				);
 				done();
@@ -854,8 +863,9 @@ ${details(snapshot)}`)
 		});
 
 		it("clear() empties caches and resets stats", (done) => {
-			buildWithStats((err, fsInfo) => {
+			buildWithStats((err, fsInfo_) => {
 				if (err) return done(err);
+				const fsInfo = /** @type {FsInfoExt} */ (fsInfo_);
 				expect(fsInfo._fileTimestamps.size).toBeGreaterThan(0);
 				expect(fsInfo._statCreatedSnapshots).toBeGreaterThan(0);
 				fsInfo.clear();
@@ -924,9 +934,9 @@ ${details(snapshot)}`)
 						options,
 						(err, s2) => {
 							if (err) return done(err);
-							const merged = fsInfo.mergeSnapshots(s1, s2);
+							const merged = fsInfo.mergeSnapshots(/** @type {Snapshot} */ (s1), /** @type {Snapshot} */ (s2));
 							expect(merged.startTime).toBe(
-								Math.min(s1.startTime, s2.startTime)
+								Math.min(/** @type {number} */ (/** @type {Snapshot} */ (s1).startTime), /** @type {number} */ (/** @type {Snapshot} */ (s2).startTime))
 							);
 							// both inputs are cached as valid → so is the merge
 							expect(fsInfo._snapshotCache.get(merged)).toBe(true);
@@ -960,15 +970,15 @@ ${details(snapshot)}`)
 						{ timestamp: true },
 						(err, withStart) => {
 							if (err) return done(err);
-							expect(noStart.hasStartTime()).toBe(false);
-							expect(fsInfo.mergeSnapshots(noStart, withStart).startTime).toBe(
-								withStart.startTime
+							expect(/** @type {Snapshot} */ (noStart).hasStartTime()).toBe(false);
+							expect(fsInfo.mergeSnapshots(/** @type {Snapshot} */ (noStart), /** @type {Snapshot} */ (withStart)).startTime).toBe(
+								/** @type {Snapshot} */ (withStart).startTime
 							);
-							expect(fsInfo.mergeSnapshots(withStart, noStart).startTime).toBe(
-								withStart.startTime
+							expect(fsInfo.mergeSnapshots(/** @type {Snapshot} */ (withStart), /** @type {Snapshot} */ (noStart)).startTime).toBe(
+								/** @type {Snapshot} */ (withStart).startTime
 							);
 							expect(
-								fsInfo.mergeSnapshots(noStart, noStart).hasStartTime()
+								fsInfo.mergeSnapshots(/** @type {Snapshot} */ (noStart), /** @type {Snapshot} */ (noStart)).hasStartTime()
 							).toBe(false);
 							done();
 						}
@@ -984,7 +994,7 @@ ${details(snapshot)}`)
 			const fsInfo = createFsInfo(fs);
 			// Fixed start time so the shared-snapshot start-time guard always passes.
 			const startTime = Date.now() + 10000;
-			const make = (fileList, cb) =>
+			const make = (/** @type {string[]} */ fileList, /** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ cb) =>
 				fsInfo.createSnapshot(
 					startTime,
 					fileList,
@@ -994,12 +1004,12 @@ ${details(snapshot)}`)
 					cb
 				);
 			// 1st + 2nd identical snapshots create a shared common snapshot.
-			make(files, (err) => {
+			make(files, (/** @type {Error | null | undefined} */ err) => {
 				if (err) return done(err);
-				make(files, (err) => {
+				make(files, (/** @type {Error | null | undefined} */ err) => {
 					if (err) return done(err);
 					// 3rd identical snapshot reuses the shared snapshot as a whole.
-					make(files, (err) => {
+					make(files, (/** @type {Error | null | undefined} */ err) => {
 						if (err) return done(err);
 						const opt = fsInfo._fileTimestampsOptimization;
 						expect(opt._statReusedSharedSnapshots).toBeGreaterThan(0);
@@ -1046,16 +1056,17 @@ ${details(snapshot)}`)
 			return fs;
 		};
 
-		const createProjectFsInfo = (fs) => {
-			const logger = {
-				error: (...args) => {
+		const createProjectFsInfo = (/** @type {IFs} */ fs) => {
+			/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
+			const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
+				error: (/** @type {unknown[]} */ ...args) => {
 					throw new Error(util.format(...args));
 				}
-			};
+			}));
 			for (const method of ["warn", "info", "log", "debug"]) {
 				logger[method] = () => {};
 			}
-			return new FileSystemInfo(fs, { logger, hashFunction: "sha256" });
+			return new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), { logger, hashFunction: "sha256" });
 		};
 
 		it("collects files, directories and resolve results across cjs/esm", (done) => {
@@ -1064,8 +1075,9 @@ ${details(snapshot)}`)
 			fsInfo.resolveBuildDependencies(
 				"/proj",
 				["/proj/entry.js", "/proj/", "/proj/empty-dir/"],
-				(err, result) => {
+				(err, result_) => {
 					if (err) return done(err);
+					const result = /** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (result_);
 					expect(result.files).toContain("/proj/entry.js");
 					expect(result.files).toContain("/proj/lib.mjs");
 					expect(result.files).toContain("/proj/node_modules/dep/index.js");
@@ -1092,8 +1104,9 @@ ${details(snapshot)}`)
 		it("checkResolveResultsValid reports invalid when an expected-missing dep appears", (done) => {
 			const fs = createProjectFs();
 			const fsInfo = createProjectFsInfo(fs);
-			fsInfo.resolveBuildDependencies("/proj", ["/proj/"], (err, result) => {
+			fsInfo.resolveBuildDependencies("/proj", ["/proj/"], (err, result_) => {
 				if (err) return done(err);
+				const result = /** @type {import("../lib/FileSystemInfo").ResolveBuildDependenciesResult} */ (result_);
 				// Create the previously-missing optional dependency.
 				fs.mkdirSync("/proj/node_modules/missing-dep", { recursive: true });
 				fs.writeFileSync(
@@ -1126,26 +1139,28 @@ ${details(snapshot)}`)
 	});
 
 	describe("managed item info", () => {
-		const setupManaged = (extra) => {
+		const setupManaged = (/** @type {(fs: IFs) => void} */ extra) => {
 			const fs = createFsFromVolume(new Volume());
 			fs.mkdirSync("/root/node_modules/normal", { recursive: true });
 			fs.writeFileSync(
 				"/root/node_modules/normal/package.json",
 				JSON.stringify({ name: "normal", version: "1.0.0" })
 			);
-			extra(fs);
-			const logger = {
-				error: (...args) => {
+			extra(/** @type {IFs} */ (/** @type {unknown} */ (fs)));
+			/** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */
+			const logger = /** @type {import("../lib/logging/Logger").Logger & Record<string, Function>} */ (/** @type {unknown} */ ({
+				error: (/** @type {unknown[]} */ ...args) => {
 					throw new Error(util.format(...args));
 				}
-			};
+			}));
+			/** @type {string[]} */
 			const warnings = [];
 			for (const method of ["warn", "info", "log", "debug"]) {
-				logger[method] = (...args) => {
+				logger[method] = (/** @type {unknown[]} */ ...args) => {
 					if (method === "warn") warnings.push(util.format(...args));
 				};
 			}
-			const fsInfo = new FileSystemInfo(fs, {
+			const fsInfo = new FileSystemInfo(/** @type {import("../lib/util/fs").InputFileSystem} */ (/** @type {unknown} */ (fs)), {
 				logger,
 				managedPaths: ["/root/node_modules"],
 				hashFunction: "sha256"
@@ -1153,7 +1168,7 @@ ${details(snapshot)}`)
 			return { fs, fsInfo, warnings };
 		};
 
-		const snapshotFiles = (fsInfo, fileList, callback) => {
+		const snapshotFiles = (/** @type {import("../lib/FileSystemInfo")} */ fsInfo, /** @type {string[]} */ fileList, /** @type {(err?: Error | null, snapshot?: Snapshot | null) => void} */ callback) => {
 			fsInfo.createSnapshot(
 				Date.now() + 10000,
 				fileList,
@@ -1179,7 +1194,7 @@ ${details(snapshot)}`)
 				],
 				(err, snapshot) => {
 					if (err) return done(err);
-					const info = snapshot.managedItemInfo;
+					const info = /** @type {Map<string, string>} */ (/** @type {Snapshot} */ (snapshot).managedItemInfo);
 					expect(info.get("/root/node_modules/normal")).toBe("normal@1.0.0");
 					expect(info.get("/root/node_modules/group")).toBe("*nested");
 					done();
@@ -1199,7 +1214,7 @@ ${details(snapshot)}`)
 				(err, snapshot) => {
 					if (err) return done(err);
 					expect(
-						snapshot.managedItemInfo.get("/root/node_modules/sub/node_modules")
+						/** @type {Map<string, string>} */ (/** @type {Snapshot} */ (snapshot).managedItemInfo).get("/root/node_modules/sub/node_modules")
 					).toBe("*node_modules");
 					done();
 				}
@@ -1349,8 +1364,11 @@ ${details(snapshot)}`)
 								directories,
 								missing,
 								{ timestamp: true, hash: true },
-								(err, base) => {
+								(err, base_) => {
 									if (err) return done(err);
+									const base = /** @type {Snapshot} */ (base_);
+									const cA = /** @type {Snapshot} */ (childA);
+									const cB = /** @type {Snapshot} */ (childB);
 									// Populate every remaining map/set so all serialization
 									// flags and `has*` getters are exercised.
 									base.setFileTimestamps(new Map([["/f", null]]));
@@ -1362,8 +1380,8 @@ ${details(snapshot)}`)
 									base.setManagedContexts(new Set(["/mc"]));
 									base.setManagedMissing(new Set(["/mm"]));
 									// Two children → the iterator's multi-child queue path.
-									base.setChildren(new Set([childA, childB]));
-									const restored = clone(base);
+									base.setChildren(new Set([cA, cB]));
+									const restored = /** @type {Snapshot & Record<string, Function>} */ (/** @type {unknown} */ (clone(base)));
 									for (const has of [
 										"hasStartTime",
 										"hasFileTimestamps",
@@ -1391,8 +1409,8 @@ ${details(snapshot)}`)
 										[...restored.getMissingIterable()].length
 									).toBeGreaterThan(0);
 									// A single-child snapshot exercises the iterator shortcut.
-									childA.setChildren(new Set([childB]));
-									expect([...childA.getFileIterable()]).toContain(
+									cA.setChildren(new Set([cB]));
+									expect([...cA.getFileIterable()]).toContain(
 										"/path/file2.txt"
 									);
 									done();
@@ -1414,9 +1432,9 @@ ${details(snapshot)}`)
 				if (err) return done(err);
 				expect(hash).toBe("directory");
 				jest.spyOn(fs, "readFile").mockImplementation((p, cb) => {
-					const err = new Error("denied");
+					const err = /** @type {Error & { code: string }} */ (new Error("denied"));
 					err.code = "EACCES";
-					cb(err);
+					/** @type {Function} */ (cb)(err);
 				});
 				fsInfo.createSnapshot(
 					Date.now() + 10000,
@@ -1436,9 +1454,9 @@ ${details(snapshot)}`)
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
 			jest.spyOn(fs, "stat").mockImplementation((p, cb) => {
-				const err = new Error("denied");
+				const err = /** @type {Error & { code: string }} */ (new Error("denied"));
 				err.code = "EACCES";
-				cb(err);
+				/** @type {Function} */ (cb)(err);
 			});
 			fsInfo.createSnapshot(
 				Date.now() + 10000,

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -57,34 +57,40 @@ describe("HotModuleReplacementPlugin", () => {
 			}
 		});
 		fs.writeFileSync(entryFile, "1", "utf8");
-		compiler.run((err, stats) => {
+		compiler.run((err, _stats) => {
 			if (err) throw err;
+			const stats = /** @type {import("../").Stats} */ (_stats);
 			const oldHash1 = stats.toJson().hash;
 			fs.writeFileSync(statsFile1, stats.toString());
-			compiler.run((err, stats) => {
+			compiler.run((err, _stats) => {
 				if (err) throw err;
+				const stats = /** @type {import("../").Stats} */ (_stats);
 				const lastHash1 = stats.toJson().hash;
 				fs.writeFileSync(statsFile2, stats.toString());
 				expect(lastHash1).toBe(oldHash1); // hash shouldn't change when bundle stay equal
 				fs.writeFileSync(entryFile, "2", "utf8");
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) throw err;
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					const lastHash2 = stats.toJson().hash;
 					fs.writeFileSync(statsFile1, stats.toString());
 					expect(lastHash2).not.toBe(lastHash1); // hash should change when bundle changes
 					fs.writeFileSync(entryFile, "1", "utf8");
-					compiler.run((err, stats) => {
+					compiler.run((err, _stats) => {
 						if (err) throw err;
+						const stats = /** @type {import("../").Stats} */ (_stats);
 						const currentHash1 = stats.toJson().hash;
 						fs.writeFileSync(statsFile2, stats.toString());
 						expect(currentHash1).not.toBe(lastHash1); // hash shouldn't change to the first hash if bundle changed back to first bundle
 						fs.writeFileSync(entryFile, "2", "utf8");
-						compiler.run((err, stats) => {
+						compiler.run((err, _stats) => {
 							if (err) throw err;
+							const stats = /** @type {import("../").Stats} */ (_stats);
 							const currentHash2 = stats.toJson().hash;
 							fs.writeFileSync(statsFile1, stats.toString());
-							compiler.run((err, stats) => {
+							compiler.run((err, _stats) => {
 								if (err) throw err;
+								const stats = /** @type {import("../").Stats} */ (_stats);
 								expect(stats.toJson().hash).toBe(currentHash2);
 								expect(currentHash2).not.toBe(lastHash2);
 								expect(currentHash1).not.toBe(currentHash2);
@@ -103,6 +109,7 @@ describe("HotModuleReplacementPlugin", () => {
 		const entryFile = path.join(outputPath, "entry.js");
 		const recordsFile = path.join(outputPath, "records.json");
 		let step = 0;
+		/** @type {string} */
 		let firstUpdate;
 		try {
 			fs.mkdirSync(outputPath, { recursive: true });
@@ -111,7 +118,7 @@ describe("HotModuleReplacementPlugin", () => {
 		}
 		fs.writeFileSync(entryFile, `${++step}`, "utf8");
 		const updates = new Set();
-		const hasFile = (file) => {
+		const hasFile = (/** @type {string} */ file) => {
 			try {
 				fs.statSync(path.join(outputPath, file));
 				return true;
@@ -132,8 +139,9 @@ describe("HotModuleReplacementPlugin", () => {
 			},
 			plugins: [new webpack.HotModuleReplacementPlugin()]
 		});
-		const callback = (err, stats) => {
+		const callback = (/** @type {Error | null} */ err, /** @type {import("../").Stats | undefined} */ _stats) => {
 			if (err) return done(err);
+			const stats = /** @type {import("../").Stats} */ (_stats);
 			const jsonStats = stats.toJson();
 			const hash = jsonStats.hash;
 			const hmrUpdateMainFileName = `0.${hash}.hot-update.json`;
@@ -211,18 +219,21 @@ describe("HotModuleReplacementPlugin", () => {
 			}
 		});
 		fs.writeFileSync(entryFile, "1", "utf8");
-		compiler.run((err, stats) => {
+		compiler.run((err, _stats) => {
 			if (err) throw err;
+			const stats = /** @type {import("../").Stats} */ (_stats);
 			const jsonStats = stats.toJson();
 			const hash = jsonStats.hash;
-			const chunkName = Object.keys(jsonStats.assetsByChunkName)[0];
+			const chunkName = Object.keys(/** @type {Record<string, string[]>} */ (jsonStats.assetsByChunkName))[0];
 			fs.writeFileSync(statsFile3, stats.toString());
-			compiler.run((err, stats) => {
+			compiler.run((err, _stats) => {
 				if (err) throw err;
+				const stats = /** @type {import("../").Stats} */ (_stats);
 				fs.writeFileSync(statsFile4, stats.toString());
 				fs.writeFileSync(entryFile, "2", "utf8");
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) throw err;
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					fs.writeFileSync(statsFile3, stats.toString());
 					const result = JSON.parse(
 						fs.readFileSync(
@@ -298,15 +309,18 @@ describe("HotModuleReplacementPlugin", () => {
 			}
 		});
 		fs.writeFileSync(entryFile, "1", "utf8");
-		compiler.run((err, stats) => {
+		compiler.run((err, _stats) => {
 			if (err) return done(err);
+			const stats = /** @type {import("../").Stats} */ (_stats);
 			fs.writeFileSync(statsFile3, stats.toString());
-			compiler.run((err, stats) => {
+			compiler.run((err, _stats) => {
 				if (err) return done(err);
+				const stats = /** @type {import("../").Stats} */ (_stats);
 				fs.writeFileSync(statsFile4, stats.toString());
 				fs.writeFileSync(entryFile, "2", "utf8");
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) return done(err);
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					fs.writeFileSync(statsFile3, stats.toString());
 
 					let foundUpdates = false;
@@ -395,8 +409,9 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 		const run = () =>
 			new Promise((resolve, reject) => {
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) return reject(err);
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					if (stats.hasErrors()) {
 						return reject(
 							new Error(stats.toString({ all: false, errors: true }))
@@ -422,7 +437,7 @@ describe("HotModuleReplacementPlugin", () => {
 			.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
 		expect(bUpdate).toBeDefined();
 		const manifest = JSON.parse(
-			fs.readFileSync(path.join(out, bUpdate), "utf8")
+			fs.readFileSync(path.join(out, /** @type {string} */ (bUpdate)), "utf8")
 		);
 
 		await new Promise((resolve) => {
@@ -493,8 +508,9 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 		const run = () =>
 			new Promise((resolve, reject) => {
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) return reject(err);
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					if (stats.hasErrors()) {
 						return reject(
 							new Error(stats.toString({ all: false, errors: true }))
@@ -520,7 +536,7 @@ describe("HotModuleReplacementPlugin", () => {
 			.find((f) => !before.has(f) && /^b\..*\.hot-update\.json$/.test(f));
 		expect(bUpdate).toBeDefined();
 		const manifest = JSON.parse(
-			fs.readFileSync(path.join(out, bUpdate), "utf8")
+			fs.readFileSync(path.join(out, /** @type {string} */ (bUpdate)), "utf8")
 		);
 		await new Promise((resolve) => {
 			compiler.close(resolve);
@@ -592,8 +608,9 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 		const run = () =>
 			new Promise((resolve, reject) => {
-				compiler.run((err, stats) => {
+				compiler.run((err, _stats) => {
 					if (err) return reject(err);
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					if (stats.hasErrors()) {
 						return reject(
 							new Error(stats.toString({ all: false, errors: true }))
@@ -609,14 +626,14 @@ describe("HotModuleReplacementPlugin", () => {
 			path.join(src, "b.js"),
 			'const p = import(/* webpackChunkName: "lazyShared" */ "./shared");\np.then(({ g }) => console.log("b", g()));\nif (module.hot) module.hot.accept();\n'
 		);
-		const stats = await run();
+		const stats = /** @type {import("../").Stats} */ (await run());
 		const { warnings } = stats.toJson({ all: false, warnings: true });
 		await new Promise((resolve) => {
 			compiler.close(resolve);
 		});
 
 		expect(
-			warnings.some((w) =>
+			/** @type {import("../").StatsError[]} */ (warnings).some((/** @type {import("../").StatsError} */ w) =>
 				(w.message || String(w)).includes(
 					"doesn't lead to unique filenames per runtime"
 				)

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -139,7 +139,10 @@ describe("HotModuleReplacementPlugin", () => {
 			},
 			plugins: [new webpack.HotModuleReplacementPlugin()]
 		});
-		const callback = (/** @type {Error | null} */ err, /** @type {import("../").Stats | undefined} */ _stats) => {
+		const callback = (
+			/** @type {Error | null} */ err,
+			/** @type {import("../").Stats | undefined} */ _stats
+		) => {
 			if (err) return done(err);
 			const stats = /** @type {import("../").Stats} */ (_stats);
 			const jsonStats = stats.toJson();
@@ -224,7 +227,9 @@ describe("HotModuleReplacementPlugin", () => {
 			const stats = /** @type {import("../").Stats} */ (_stats);
 			const jsonStats = stats.toJson();
 			const hash = jsonStats.hash;
-			const chunkName = Object.keys(/** @type {Record<string, string[]>} */ (jsonStats.assetsByChunkName))[0];
+			const chunkName = Object.keys(
+				/** @type {Record<string, string[]>} */ (jsonStats.assetsByChunkName)
+			)[0];
 			fs.writeFileSync(statsFile3, stats.toString());
 			compiler.run((err, _stats) => {
 				if (err) throw err;
@@ -633,10 +638,11 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 
 		expect(
-			/** @type {import("../").StatsError[]} */ (warnings).some((/** @type {import("../").StatsError} */ w) =>
-				(w.message || String(w)).includes(
-					"doesn't lead to unique filenames per runtime"
-				)
+			/** @type {import("../").StatsError[]} */ (warnings).some(
+				(/** @type {import("../").StatsError} */ w) =>
+					(w.message || String(w)).includes(
+						"doesn't lead to unique filenames per runtime"
+					)
 			)
 		).toBe(true);
 	}, 120000);

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -2,7 +2,7 @@
 
 require("./helpers/warmup-webpack");
 
-/** @typedef {{ name: string; tests: string[] }} Category */
+/** @typedef {{ name: string, tests: string[] }} Category */
 /**
  * @typedef {object} SuiteConfig
  * @property {string} name suite name
@@ -16,7 +16,6 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 /** @type {{ sync: (p: string) => void }} */
-// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const { TestRunner } = require("./harness/runner");
@@ -81,7 +80,9 @@ const describeCases = (config) => {
 							/** @type {import("../").Configuration} */
 							let options = /** @type {import("../").Configuration} */ ({});
 							if (fs.existsSync(configPath)) options = require(configPath);
-							if (typeof (/** @type {EXPECTED_ANY} */ (options)) === "function") {
+							if (
+								typeof (/** @type {EXPECTED_ANY} */ (options)) === "function"
+							) {
 								options = /** @type {EXPECTED_ANY} */ (options)({ config });
 							}
 							if (!options.mode) options.mode = "development";
@@ -142,7 +143,10 @@ const describeCases = (config) => {
 								// ignored
 							}
 
-							const onCompiled = (/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
+							const onCompiled = (
+								/** @type {Error | null} */ err,
+								/** @type {import("../").Stats} */ stats
+							) => {
 								if (err) return done(err);
 								const jsonStats = stats.toJson({
 									errorDetails: true
@@ -172,7 +176,9 @@ const describeCases = (config) => {
 									return;
 								}
 
-								function runCompiler(/** @type {(err: EXPECTED_ANY, stats?: EXPECTED_ANY) => void} */ callback) {
+								function runCompiler(
+									/** @type {(err: EXPECTED_ANY, stats?: EXPECTED_ANY) => void} */ callback
+								) {
 									fakeUpdateLoaderOptions.updateIndex++;
 									compiler.run((err, _stats) => {
 										const stats = /** @type {import("../").Stats} */ (_stats);
@@ -244,9 +250,10 @@ const describeCases = (config) => {
 										});
 									},
 									getBundlePaths: (_i, _options, runner) => {
-										const bundles = /** @type {EXPECTED_ANY[]} */ (/** @type {EXPECTED_ANY} */ (_stats.entrypoints).main.assets).map(
-											(/** @type {EXPECTED_ANY} */ i) => i.name
-										);
+										const bundles = /** @type {EXPECTED_ANY[]} */ (
+											/** @type {EXPECTED_ANY} */ (_stats.entrypoints).main
+												.assets
+										).map((/** @type {EXPECTED_ANY} */ i) => i.name);
 										if (config.target === "web") {
 											return bundles;
 										}

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -130,6 +130,7 @@ const describeCases = (config) => {
 								new webpack.LoaderOptionsPlugin(fakeUpdateLoaderOptions)
 							);
 							if (!options.recordsPath) options.recordsPath = recordsPath;
+							/** @type {HotTestConfig} */
 							let testConfig = {};
 							try {
 								// try to load a test file
@@ -141,7 +142,7 @@ const describeCases = (config) => {
 								// ignored
 							}
 
-							const onCompiled = (err, stats) => {
+							const onCompiled = (/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
 								if (err) return done(err);
 								const jsonStats = stats.toJson({
 									errorDetails: true
@@ -171,9 +172,10 @@ const describeCases = (config) => {
 									return;
 								}
 
-								function runCompiler(callback) {
+								function runCompiler(/** @type {(err: EXPECTED_ANY, stats?: EXPECTED_ANY) => void} */ callback) {
 									fakeUpdateLoaderOptions.updateIndex++;
-									compiler.run((err, stats) => {
+									compiler.run((err, _stats) => {
+										const stats = /** @type {import("../").Stats} */ (_stats);
 										if (err) return callback(err);
 										const jsonStats = stats.toJson({
 											errorDetails: true
@@ -228,7 +230,7 @@ const describeCases = (config) => {
 											afterEach: _afterEach,
 											STATE: jsonStats,
 											NEXT: runCompiler,
-											NEXT_DEFERRED: (cb) => {
+											NEXT_DEFERRED: (/** @type {EXPECTED_ANY} */ cb) => {
 												// https://github.com/webpack/webpack/actions/runs/22039709807/job/63678606467?pr=20412
 												// When lazyCompilation is enabled, delay the first compilation re-run by 1000ms during HMR
 												// to ensure that HTTP requests from dynamic imports (e.g., const promiseA = import("./moduleA"))
@@ -242,8 +244,8 @@ const describeCases = (config) => {
 										});
 									},
 									getBundlePaths: (_i, _options, runner) => {
-										const bundles = _stats.entrypoints.main.assets.map(
-											(i) => i.name
+										const bundles = /** @type {EXPECTED_ANY[]} */ (/** @type {EXPECTED_ANY} */ (_stats.entrypoints).main.assets).map(
+											(/** @type {EXPECTED_ANY} */ i) => i.name
 										);
 										if (config.target === "web") {
 											return bundles;
@@ -266,7 +268,7 @@ const describeCases = (config) => {
 								);
 							};
 							compiler = webpack(options);
-							compiler.run(onCompiled);
+							compiler.run(/** @type {EXPECTED_ANY} */ (onCompiled));
 						}, 20000);
 
 						const {

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -2,24 +2,41 @@
 
 require("./helpers/warmup-webpack");
 
+/** @typedef {{ name: string; tests: string[] }} Category */
+/**
+ * @typedef {object} SuiteConfig
+ * @property {string} name suite name
+ * @property {string=} target target
+ */
+/**
+ * @typedef {object} HotTestConfig
+ * @property {((scope: EXPECTED_ANY, options: import("../").Configuration) => void)=} moduleScope
+ */
+
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (p: string) => void }} */
+// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const { TestRunner } = require("./harness/runner");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 
 const casesPath = path.join(__dirname, "hotCases");
-let categories = fs
+/** @type {Category[]} */
+const categories = fs
 	.readdirSync(casesPath)
-	.filter((dir) => fs.statSync(path.join(casesPath, dir)).isDirectory());
-categories = categories.map((cat) => ({
-	name: cat,
-	tests: fs
-		.readdirSync(path.join(casesPath, cat))
-		.filter((folder) => !folder.includes("_"))
-}));
+	.filter((dir) => fs.statSync(path.join(casesPath, dir)).isDirectory())
+	.map((cat) => ({
+		name: cat,
+		tests: fs
+			.readdirSync(path.join(casesPath, cat))
+			.filter((folder) => !folder.includes("_"))
+	}));
 
+/**
+ * @param {SuiteConfig} config suite config
+ */
 const describeCases = (config) => {
 	describe(config.name, () => {
 		for (const category of categories) {
@@ -37,11 +54,12 @@ const describeCases = (config) => {
 					}
 
 					describe(testName, () => {
+						/** @type {import("../").Compiler} */
 						let compiler;
 
-						afterAll((callback) => {
+						afterAll((/** @type {EXPECTED_ANY} */ callback) => {
 							compiler.close(callback);
-							compiler = undefined;
+							compiler = /** @type {EXPECTED_ANY} */ (undefined);
 						});
 
 						it(`${testName} should compile`, (done) => {
@@ -60,10 +78,11 @@ const describeCases = (config) => {
 								updateIndex: 0
 							};
 							const configPath = path.join(testDirectory, "webpack.config.js");
-							let options = {};
+							/** @type {import("../").Configuration} */
+							let options = /** @type {import("../").Configuration} */ ({});
 							if (fs.existsSync(configPath)) options = require(configPath);
-							if (typeof options === "function") {
-								options = options({ config });
+							if (typeof (/** @type {EXPECTED_ANY} */ (options)) === "function") {
+								options = /** @type {EXPECTED_ANY} */ (options)({ config });
 							}
 							if (!options.mode) options.mode = "development";
 							if (!options.devtool) options.devtool = false;

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -4,39 +4,45 @@ const path = require("path");
 
 jest.mock("../lib/html/buildHtmlAst", () => jest.fn());
 
+/** @typedef {import("../lib/html/buildHtmlAst") & { mockReturnValue: (val: EXPECTED_ANY) => void }} MockedBuildHtmlAst */
+
 const HtmlInlineScriptDependency = require("../lib/dependencies/HtmlInlineScriptDependency");
 const HtmlInlineStyleDependency = require("../lib/dependencies/HtmlInlineStyleDependency");
 const CommentCompilationWarning = require("../lib/errors/CommentCompilationWarning");
 const UnsupportedFeatureWarning = require("../lib/errors/UnsupportedFeatureWarning");
 const HtmlParser = require("../lib/html/HtmlParser");
-const buildHtmlAst = require("../lib/html/buildHtmlAst");
+const buildHtmlAst = /** @type {MockedBuildHtmlAst} */ (require("../lib/html/buildHtmlAst"));
 
 /**
- * @returns {{ module: EXPECTED_ANY, presentationalDependencies: EXPECTED_ANY[], dependencies: EXPECTED_ANY[], warnings: EXPECTED_ANY[], errors: EXPECTED_ANY[] }} test doubles
+ * @returns {{ module: EXPECTED_ANY, presentationalDependencies: object[], dependencies: object[], warnings: object[], errors: object[] }} test doubles
  */
 const makeModule = () => {
+	/** @type {object[]} */
 	const presentationalDependencies = [];
+	/** @type {object[]} */
 	const dependencies = [];
+	/** @type {object[]} */
 	const warnings = [];
+	/** @type {object[]} */
 	const errors = [];
 	const module = {
 		resource: path.resolve(__dirname, "index.html"),
-		buildInfo: {},
+		buildInfo: /** @type {Record<string, EXPECTED_ANY>} */ ({}),
 		buildMeta: {},
 		identifier() {
 			return this.resource;
 		},
-		addPresentationalDependency(dependency) {
+		addPresentationalDependency(/** @type {object} */ dependency) {
 			presentationalDependencies.push(dependency);
 		},
-		addDependency(dependency) {
+		addDependency(/** @type {object} */ dependency) {
 			dependencies.push(dependency);
 		},
 		addCodeGenerationDependency() {},
-		addWarning(warning) {
+		addWarning(/** @type {object} */ warning) {
 			warnings.push(warning);
 		},
-		addError(error) {
+		addError(/** @type {object} */ error) {
 			errors.push(error);
 		}
 	};
@@ -46,16 +52,16 @@ const makeModule = () => {
 /**
  * @param {EXPECTED_ANY} module module double
  * @param {{ outputModule?: boolean, css?: boolean }=} options options
- * @returns {EXPECTED_ANY} parser state
+ * @returns {import("../lib/Parser").ParserState} parser state
  */
-const makeState = (module, { outputModule = false, css = false } = {}) => ({
+const makeState = (module, { outputModule = false, css = false } = {}) => /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
 	module,
 	compilation: {
 		outputOptions: { hashFunction: "md4", module: outputModule },
 		compiler: { context: path.resolve(__dirname, "..") },
 		options: { experiments: { css } }
 	}
-});
+}));
 
 describe("HtmlParser", () => {
 	it("should aggregate inline script content across all text children", () => {
@@ -67,22 +73,24 @@ describe("HtmlParser", () => {
 			secondText,
 			firstStart + firstText.length
 		);
+		/** @type {object[]} */
 		const presentationalDependencies = [];
+		/** @type {object[]} */
 		const dependencies = [];
-		const module = {
+		const module = /** @type {EXPECTED_ANY} */ ({
 			resource: path.resolve(__dirname, "index.html"),
-			buildInfo: {},
+			buildInfo: /** @type {Record<string, EXPECTED_ANY>} */ ({}),
 			buildMeta: {},
 			identifier() {
 				return this.resource;
 			},
-			addPresentationalDependency(dependency) {
+			addPresentationalDependency(/** @type {object} */ dependency) {
 				presentationalDependencies.push(dependency);
 			},
-			addDependency(dependency) {
+			addDependency(/** @type {object} */ dependency) {
 				dependencies.push(dependency);
 			}
-		};
+		});
 
 		buildHtmlAst.mockReturnValue({
 			type: "document",
@@ -116,7 +124,7 @@ describe("HtmlParser", () => {
 		});
 
 		const parser = new HtmlParser({});
-		parser.parse(source, {
+		parser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
 			module,
 			compilation: {
 				outputOptions: {
@@ -132,13 +140,13 @@ describe("HtmlParser", () => {
 					}
 				}
 			}
-		});
+		})));
 
 		expect(buildHtmlAst).toHaveBeenCalledWith(source);
 		expect(dependencies).toHaveLength(1);
 		expect(presentationalDependencies).toHaveLength(1);
 
-		const dependency = presentationalDependencies[0];
+		const dependency = /** @type {EXPECTED_ANY} */ (presentationalDependencies[0]);
 		expect(dependency).toBeInstanceOf(HtmlInlineScriptDependency);
 		expect(dependency.contentRange).toEqual([
 			firstStart,
@@ -174,8 +182,9 @@ describe("HtmlParser", () => {
 			secondText,
 			firstStart + firstText.length
 		); // 20
+		/** @type {object[]} */
 		const dependencies = [];
-		const module = {
+		const module = /** @type {EXPECTED_ANY} */ ({
 			resource: path.resolve(__dirname, "index.html"),
 			buildInfo: {},
 			buildMeta: {},
@@ -183,11 +192,11 @@ describe("HtmlParser", () => {
 				return this.resource;
 			},
 			addPresentationalDependency() {},
-			addDependency(dependency) {
+			addDependency(/** @type {object} */ dependency) {
 				dependencies.push(dependency);
 			},
 			addCodeGenerationDependency() {}
-		};
+		});
 
 		buildHtmlAst.mockReturnValue({
 			type: "document",
@@ -227,7 +236,7 @@ describe("HtmlParser", () => {
 		});
 
 		const parser = new HtmlParser({});
-		parser.parse(source, {
+		parser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
 			module,
 			compilation: {
 				outputOptions: {
@@ -243,7 +252,7 @@ describe("HtmlParser", () => {
 					}
 				}
 			}
-		});
+		})));
 
 		const styleDeps = dependencies.filter(
 			(d) => d instanceof HtmlInlineStyleDependency
@@ -263,19 +272,21 @@ describe("HtmlParser", () => {
 		 * @returns {EXPECTED_ANY} module double with dependency sets + diagnostics
 		 */
 		const templateModule = () => {
+			/** @type {object[]} */
 			const warnings = [];
+			/** @type {object[]} */
 			const errors = [];
 			return {
 				resource: path.resolve(__dirname, "index.html"),
-				buildInfo: {
+				buildInfo: /** @type {Record<string, EXPECTED_ANY>} */ ({
 					fileDependencies: new Set(),
 					contextDependencies: new Set(),
 					missingDependencies: new Set()
-				},
-				addWarning(warning) {
+				}),
+				addWarning(/** @type {object} */ warning) {
 					warnings.push(warning);
 				},
-				addError(error) {
+				addError(/** @type {object} */ error) {
 					errors.push(error);
 				},
 				warnings,
@@ -473,7 +484,7 @@ describe("HtmlParser", () => {
 
 	// Build a `<script type=… src=…>` AST element with offsets derived from the
 	// source so reconcileScriptTypeAttr sees the real attribute spans.
-	const scriptWithType = (source) => {
+	const scriptWithType = (/** @type {string} */ source) => {
 		/**
 		 * @param {string} name attribute name
 		 * @returns {EXPECTED_ANY} attribute

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -11,19 +11,21 @@ const HtmlInlineStyleDependency = require("../lib/dependencies/HtmlInlineStyleDe
 const CommentCompilationWarning = require("../lib/errors/CommentCompilationWarning");
 const UnsupportedFeatureWarning = require("../lib/errors/UnsupportedFeatureWarning");
 const HtmlParser = require("../lib/html/HtmlParser");
-const buildHtmlAst = /** @type {MockedBuildHtmlAst} */ (require("../lib/html/buildHtmlAst"));
+const buildHtmlAst = /** @type {MockedBuildHtmlAst} */ (
+	require("../lib/html/buildHtmlAst")
+);
 
 /**
- * @returns {{ module: EXPECTED_ANY, presentationalDependencies: object[], dependencies: object[], warnings: object[], errors: object[] }} test doubles
+ * @returns {{ module: EXPECTED_ANY, presentationalDependencies: EXPECTED_OBJECT[], dependencies: EXPECTED_OBJECT[], warnings: EXPECTED_OBJECT[], errors: EXPECTED_OBJECT[] }} test doubles
  */
 const makeModule = () => {
-	/** @type {object[]} */
+	/** @type {EXPECTED_OBJECT[]} */
 	const presentationalDependencies = [];
-	/** @type {object[]} */
+	/** @type {EXPECTED_OBJECT[]} */
 	const dependencies = [];
-	/** @type {object[]} */
+	/** @type {EXPECTED_OBJECT[]} */
 	const warnings = [];
-	/** @type {object[]} */
+	/** @type {EXPECTED_OBJECT[]} */
 	const errors = [];
 	const module = {
 		resource: path.resolve(__dirname, "index.html"),
@@ -32,17 +34,17 @@ const makeModule = () => {
 		identifier() {
 			return this.resource;
 		},
-		addPresentationalDependency(/** @type {object} */ dependency) {
+		addPresentationalDependency(/** @type {EXPECTED_OBJECT} */ dependency) {
 			presentationalDependencies.push(dependency);
 		},
-		addDependency(/** @type {object} */ dependency) {
+		addDependency(/** @type {EXPECTED_OBJECT} */ dependency) {
 			dependencies.push(dependency);
 		},
 		addCodeGenerationDependency() {},
-		addWarning(/** @type {object} */ warning) {
+		addWarning(/** @type {EXPECTED_OBJECT} */ warning) {
 			warnings.push(warning);
 		},
-		addError(/** @type {object} */ error) {
+		addError(/** @type {EXPECTED_OBJECT} */ error) {
 			errors.push(error);
 		}
 	};
@@ -54,14 +56,17 @@ const makeModule = () => {
  * @param {{ outputModule?: boolean, css?: boolean }=} options options
  * @returns {import("../lib/Parser").ParserState} parser state
  */
-const makeState = (module, { outputModule = false, css = false } = {}) => /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
-	module,
-	compilation: {
-		outputOptions: { hashFunction: "md4", module: outputModule },
-		compiler: { context: path.resolve(__dirname, "..") },
-		options: { experiments: { css } }
-	}
-}));
+const makeState = (module, { outputModule = false, css = false } = {}) =>
+	/** @type {import("../lib/Parser").ParserState} */ (
+		/** @type {unknown} */ ({
+			module,
+			compilation: {
+				outputOptions: { hashFunction: "md4", module: outputModule },
+				compiler: { context: path.resolve(__dirname, "..") },
+				options: { experiments: { css } }
+			}
+		})
+	);
 
 describe("HtmlParser", () => {
 	it("should aggregate inline script content across all text children", () => {
@@ -73,9 +78,9 @@ describe("HtmlParser", () => {
 			secondText,
 			firstStart + firstText.length
 		);
-		/** @type {object[]} */
+		/** @type {EXPECTED_OBJECT[]} */
 		const presentationalDependencies = [];
-		/** @type {object[]} */
+		/** @type {EXPECTED_OBJECT[]} */
 		const dependencies = [];
 		const module = /** @type {EXPECTED_ANY} */ ({
 			resource: path.resolve(__dirname, "index.html"),
@@ -84,10 +89,10 @@ describe("HtmlParser", () => {
 			identifier() {
 				return this.resource;
 			},
-			addPresentationalDependency(/** @type {object} */ dependency) {
+			addPresentationalDependency(/** @type {EXPECTED_OBJECT} */ dependency) {
 				presentationalDependencies.push(dependency);
 			},
-			addDependency(/** @type {object} */ dependency) {
+			addDependency(/** @type {EXPECTED_OBJECT} */ dependency) {
 				dependencies.push(dependency);
 			}
 		});
@@ -124,29 +129,36 @@ describe("HtmlParser", () => {
 		});
 
 		const parser = new HtmlParser({});
-		parser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
-			module,
-			compilation: {
-				outputOptions: {
-					hashFunction: "md4",
-					module: false
-				},
-				compiler: {
-					context: path.resolve(__dirname, "..")
-				},
-				options: {
-					experiments: {
-						css: false
+		parser.parse(
+			source,
+			/** @type {import("../lib/Parser").ParserState} */ (
+				/** @type {unknown} */ ({
+					module,
+					compilation: {
+						outputOptions: {
+							hashFunction: "md4",
+							module: false
+						},
+						compiler: {
+							context: path.resolve(__dirname, "..")
+						},
+						options: {
+							experiments: {
+								css: false
+							}
+						}
 					}
-				}
-			}
-		})));
+				})
+			)
+		);
 
 		expect(buildHtmlAst).toHaveBeenCalledWith(source);
 		expect(dependencies).toHaveLength(1);
 		expect(presentationalDependencies).toHaveLength(1);
 
-		const dependency = /** @type {EXPECTED_ANY} */ (presentationalDependencies[0]);
+		const dependency = /** @type {EXPECTED_ANY} */ (
+			presentationalDependencies[0]
+		);
 		expect(dependency).toBeInstanceOf(HtmlInlineScriptDependency);
 		expect(dependency.contentRange).toEqual([
 			firstStart,
@@ -182,7 +194,7 @@ describe("HtmlParser", () => {
 			secondText,
 			firstStart + firstText.length
 		); // 20
-		/** @type {object[]} */
+		/** @type {EXPECTED_OBJECT[]} */
 		const dependencies = [];
 		const module = /** @type {EXPECTED_ANY} */ ({
 			resource: path.resolve(__dirname, "index.html"),
@@ -192,7 +204,7 @@ describe("HtmlParser", () => {
 				return this.resource;
 			},
 			addPresentationalDependency() {},
-			addDependency(/** @type {object} */ dependency) {
+			addDependency(/** @type {EXPECTED_OBJECT} */ dependency) {
 				dependencies.push(dependency);
 			},
 			addCodeGenerationDependency() {}
@@ -236,23 +248,28 @@ describe("HtmlParser", () => {
 		});
 
 		const parser = new HtmlParser({});
-		parser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({
-			module,
-			compilation: {
-				outputOptions: {
-					hashFunction: "md4",
-					module: false
-				},
-				compiler: {
-					context: path.resolve(__dirname, "..")
-				},
-				options: {
-					experiments: {
-						css: true
+		parser.parse(
+			source,
+			/** @type {import("../lib/Parser").ParserState} */ (
+				/** @type {unknown} */ ({
+					module,
+					compilation: {
+						outputOptions: {
+							hashFunction: "md4",
+							module: false
+						},
+						compiler: {
+							context: path.resolve(__dirname, "..")
+						},
+						options: {
+							experiments: {
+								css: true
+							}
+						}
 					}
-				}
-			}
-		})));
+				})
+			)
+		);
 
 		const styleDeps = dependencies.filter(
 			(d) => d instanceof HtmlInlineStyleDependency
@@ -272,9 +289,9 @@ describe("HtmlParser", () => {
 		 * @returns {EXPECTED_ANY} module double with dependency sets + diagnostics
 		 */
 		const templateModule = () => {
-			/** @type {object[]} */
+			/** @type {EXPECTED_OBJECT[]} */
 			const warnings = [];
-			/** @type {object[]} */
+			/** @type {EXPECTED_OBJECT[]} */
 			const errors = [];
 			return {
 				resource: path.resolve(__dirname, "index.html"),
@@ -283,10 +300,10 @@ describe("HtmlParser", () => {
 					contextDependencies: new Set(),
 					missingDependencies: new Set()
 				}),
-				addWarning(/** @type {object} */ warning) {
+				addWarning(/** @type {EXPECTED_OBJECT} */ warning) {
 					warnings.push(warning);
 				},
-				addError(/** @type {object} */ error) {
+				addError(/** @type {EXPECTED_OBJECT} */ error) {
 					errors.push(error);
 				},
 				warnings,

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -7,14 +7,13 @@ const BasicEvaluatedExpression = require("../lib/javascript/BasicEvaluatedExpres
 const JavascriptParser = require("../lib/javascript/JavascriptParser");
 
 describe("JavascriptParser", () => {
-	/* eslint-disable no-undef */
 	/* eslint-disable no-unused-vars */
-	/** @type {EXPECTED_ANY} */ var abc;
-	/** @type {EXPECTED_ANY} */ var cde;
-	/** @type {EXPECTED_ANY} */ var fgh;
-	/** @type {EXPECTED_ANY} */ var memberExpr;
-	/** @type {EXPECTED_ANY} */ var ijk;
-	/** @type {EXPECTED_ANY} */ var xyz;
+	/** @type {EXPECTED_ANY} */ let abc;
+	/** @type {EXPECTED_ANY} */ let cde;
+	/** @type {EXPECTED_ANY} */ let fgh;
+	/** @type {EXPECTED_ANY} */ let memberExpr;
+	/** @type {EXPECTED_ANY} */ let ijk;
+	/** @type {EXPECTED_ANY} */ let xyz;
 	const testCases = /** @type {EXPECTED_ANY} */ ({
 		"call ident": [
 			function () {
@@ -79,9 +78,8 @@ describe("JavascriptParser", () => {
 				// @ts-expect-error
 				test[memberExpr];
 
-				// eslint-disable-next-line no-implicit-coercion
 				// @ts-expect-error
-				test[+memberExpr];
+				test[+memberExpr]; // eslint-disable-line no-implicit-coercion
 			},
 			{
 				expressions: ["memberExpr", "memberExpr"]
@@ -263,7 +261,7 @@ describe("JavascriptParser", () => {
 					!function () {
 						// @ts-expect-error
 						this.sub;
-					// @ts-expect-error
+						// @ts-expect-error
 					}.call(this);
 				}.call(ijk);
 			},
@@ -291,16 +289,22 @@ describe("JavascriptParser", () => {
 			}
 		]
 	});
-	/* eslint-enable no-undef */
+
 	/* eslint-enable no-unused-vars */
 
 	for (const name of Object.keys(testCases)) {
 		it(`should parse ${name}`, () => {
-			let source = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[name][0].toString();
+			let source = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[
+				name
+			][0].toString();
 			source = source.slice(13, -1).trim();
-			const state = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[name][1];
+			const state = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[
+				name
+			][1];
 
-			const testParser = new JavascriptParser(/** @type {"auto"} */ (/** @type {unknown} */ ({})));
+			const testParser = new JavascriptParser(
+				/** @type {"auto"} */ (/** @type {unknown} */ ({}))
+			);
 			testParser.hooks.canRename
 				.for("abc")
 				.tap("JavascriptParserTest", (_expr) => true);
@@ -309,7 +313,11 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (_expr) => true);
 			testParser.hooks.call.for("abc").tap("JavascriptParserTest", (expr) => {
 				if (!testParser.state.abc) testParser.state.abc = [];
-				testParser.state.abc.push(testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0])));
+				testParser.state.abc.push(
+					testParser.parseString(
+						/** @type {import("estree").Expression} */ (expr.arguments[0])
+					)
+				);
 				return true;
 			});
 			testParser.hooks.call
@@ -317,7 +325,9 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.cdeabc) testParser.state.cdeabc = [];
 					testParser.state.cdeabc.push(
-						testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0]))
+						testParser.parseString(
+							/** @type {import("estree").Expression} */ (expr.arguments[0])
+						)
 					);
 					return true;
 				});
@@ -326,7 +336,9 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.cdedddabc) testParser.state.cdedddabc = [];
 					testParser.state.cdedddabc.push(
-						testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0]))
+						testParser.parseString(
+							/** @type {import("estree").Expression} */ (expr.arguments[0])
+						)
 					);
 					return true;
 				});
@@ -359,15 +371,26 @@ describe("JavascriptParser", () => {
 				.for("memberExpr")
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.expressions) testParser.state.expressions = [];
-					testParser.state.expressions.push(/** @type {import("estree").Identifier} */ (expr).name);
+					testParser.state.expressions.push(
+						/** @type {import("estree").Identifier} */ (expr).name
+					);
 					return true;
 				});
 			testParser.hooks.new.for("xyz").tap("JavascriptParserTest", (expr) => {
 				if (!testParser.state.xyz) testParser.state.xyz = [];
-				testParser.state.xyz.push(testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0])));
+				testParser.state.xyz.push(
+					testParser.parseString(
+						/** @type {import("estree").Expression} */ (expr.arguments[0])
+					)
+				);
 				return true;
 			});
-			const actual = testParser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
+			const actual = testParser.parse(
+				source,
+				/** @type {import("../lib/Parser").ParserState} */ (
+					/** @type {unknown} */ ({})
+				)
+			);
 			expect(typeof actual).toBe("object");
 			expect(actual).toEqual(state);
 		});
@@ -386,14 +409,21 @@ describe("JavascriptParser", () => {
 			}
 		];
 
-		const testParser = new JavascriptParser(/** @type {"auto"} */ (/** @type {unknown} */ ({})));
+		const testParser = new JavascriptParser(
+			/** @type {"auto"} */ (/** @type {unknown} */ ({}))
+		);
 
 		testParser.hooks.program.tap("JavascriptParserTest", (ast, comments) => {
 			if (!testParser.state.comments) testParser.state.comments = comments;
 			return true;
 		});
 
-		const actual = testParser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
+		const actual = testParser.parse(
+			source,
+			/** @type {import("../lib/Parser").ParserState} */ (
+				/** @type {unknown} */ ({})
+			)
+		);
 		expect(typeof actual).toBe("object");
 		expect(typeof actual.comments).toBe("object");
 		for (const [index, element] of actual.comments.entries()) {
@@ -419,14 +449,29 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) =>
 					new BasicEvaluatedExpression()
 						.setString("aString")
-						.setRange(/** @type {import("../lib/javascript/JavascriptParser").Range} */ (expr.range))
+						.setRange(
+							/** @type {import("../lib/javascript/JavascriptParser").Range} */ (
+								expr.range
+							)
+						)
 				);
 			parser.hooks.evaluateIdentifier
 				.for("b.Number")
 				.tap("JavascriptParserTest", (expr) =>
-					new BasicEvaluatedExpression().setNumber(123).setRange(/** @type {import("../lib/javascript/JavascriptParser").Range} */ (expr.range))
+					new BasicEvaluatedExpression()
+						.setNumber(123)
+						.setRange(
+							/** @type {import("../lib/javascript/JavascriptParser").Range} */ (
+								expr.range
+							)
+						)
 				);
-			return parser.parse(`test(${source});`, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({}))).result;
+			return parser.parse(
+				`test(${source});`,
+				/** @type {import("../lib/Parser").ParserState} */ (
+					/** @type {unknown} */ ({})
+				)
+			).result;
 		}
 
 		const testCases = {
@@ -638,7 +683,9 @@ describe("JavascriptParser", () => {
 					);
 				}
 				if (evalExpr.isConstArray()) {
-					result.push(`array=[${/** @type {(string | number | boolean | null | RegExp | bigint)[]} */ (evalExpr.array).join("],[")}]`);
+					result.push(
+						`array=[${/** @type {(string | number | boolean | null | RegExp | bigint)[]} */ (evalExpr.array).join("],[")}]`
+					);
 				}
 				if (evalExpr.isTemplateString()) {
 					result.push(
@@ -648,7 +695,9 @@ describe("JavascriptParser", () => {
 				if (evalExpr.isWrapped()) {
 					result.push(
 						`wrapped=[${evalExprToString(/** @type {import("../lib/javascript/BasicEvaluatedExpression")} */ (evalExpr.prefix))}]+[${evalExprToString(
-							/** @type {import("../lib/javascript/BasicEvaluatedExpression")} */ (evalExpr.postfix)
+							/** @type {import("../lib/javascript/BasicEvaluatedExpression")} */ (
+								evalExpr.postfix
+							)
 						)}]`
 					);
 				}
@@ -666,7 +715,9 @@ describe("JavascriptParser", () => {
 			it(`should eval ${key}`, () => {
 				const evalExpr = evaluateInParser(key);
 				expect(evalExprToString(evalExpr)).toBe(
-					/** @type {Record<string, string>} */ (testCases)[key] ? `${key} ${/** @type {Record<string, string>} */ (testCases)[key]}` : key
+					/** @type {Record<string, string>} */ (testCases)[key]
+						? `${key} ${/** @type {Record<string, string>} */ (testCases)[key]}`
+						: key
 				);
 			});
 		}
@@ -685,7 +736,12 @@ describe("JavascriptParser", () => {
 				const expr = /** @type {Record<string, string>} */ (cases)[name];
 
 				it(name, () => {
-					const actual = parser.parse(expr, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
+					const actual = parser.parse(
+						expr,
+						/** @type {import("../lib/Parser").ParserState} */ (
+							/** @type {unknown} */ ({})
+						)
+					);
 					expect(typeof actual).toBe("object");
 				});
 			}
@@ -719,8 +775,15 @@ describe("JavascriptParser", () => {
 
 			for (const name of Object.keys(cases)) {
 				it(name, () => {
-					const actual = parser.parse(/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][0], /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
-					expect(actual).toEqual(/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][1]);
+					const actual = parser.parse(
+						/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][0],
+						/** @type {import("../lib/Parser").ParserState} */ (
+							/** @type {unknown} */ ({})
+						)
+					);
+					expect(actual).toEqual(
+						/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][1]
+					);
 				});
 			}
 		});
@@ -736,7 +799,12 @@ describe("JavascriptParser", () => {
 				const expr = /** @type {Record<string, string>} */ (cases)[name];
 
 				it(name, () => {
-					const actual = JavascriptParser._parse(expr, /** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ (/** @type {unknown} */ ({})));
+					const actual = JavascriptParser._parse(
+						expr,
+						/** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ (
+							/** @type {unknown} */ ({})
+						)
+					);
 					expect(typeof actual).toBe("object");
 				});
 			}
@@ -753,7 +821,12 @@ describe("JavascriptParser", () => {
 				return true;
 			});
 
-			parser.parse("const { a, ...rest } = { a: 1, b: 2 };", /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
+			parser.parse(
+				"const { a, ...rest } = { a: 1, b: 2 };",
+				/** @type {import("../lib/Parser").ParserState} */ (
+					/** @type {unknown} */ ({})
+				)
+			);
 
 			expect(definitions.has("a")).toBe(true);
 			expect(definitions.has("rest")).toBe(true);
@@ -870,11 +943,20 @@ describe("JavascriptParser", () => {
 
 				it(name, () => {
 					const parser = new JavascriptParser();
-					const { ast } = JavascriptParser._parse(expr.code, /** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ ({ ranges: true }));
-					expect(typeof ast).toBe("object");
-					expect(parser.parseCalculatedString(/** @type {import("estree").Expression} */ (/** @type {EXPECTED_ANY} */ (ast.body[0]).expression))).toEqual(
-						expr.result
+					const { ast } = JavascriptParser._parse(
+						expr.code,
+						/** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ ({
+							ranges: true
+						})
 					);
+					expect(typeof ast).toBe("object");
+					expect(
+						parser.parseCalculatedString(
+							/** @type {import("estree").Expression} */ (
+								/** @type {EXPECTED_ANY} */ (ast.body[0]).expression
+							)
+						)
+					).toEqual(expr.result);
 				});
 			}
 		});

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -267,7 +267,7 @@ describe("JavascriptParser", () => {
 			source = source.slice(13, -1).trim();
 			const state = testCases[name][1];
 
-			const testParser = new JavascriptParser({});
+			const testParser = new JavascriptParser(/** @type {"auto"} */ (/** @type {unknown} */ ({})));
 			testParser.hooks.canRename
 				.for("abc")
 				.tap("JavascriptParserTest", (_expr) => true);

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -9,7 +9,13 @@ const JavascriptParser = require("../lib/javascript/JavascriptParser");
 describe("JavascriptParser", () => {
 	/* eslint-disable no-undef */
 	/* eslint-disable no-unused-vars */
-	const testCases = {
+	/** @type {EXPECTED_ANY} */ var abc;
+	/** @type {EXPECTED_ANY} */ var cde;
+	/** @type {EXPECTED_ANY} */ var fgh;
+	/** @type {EXPECTED_ANY} */ var memberExpr;
+	/** @type {EXPECTED_ANY} */ var ijk;
+	/** @type {EXPECTED_ANY} */ var xyz;
+	const testCases = /** @type {EXPECTED_ANY} */ ({
 		"call ident": [
 			function () {
 				abc("test");
@@ -70,9 +76,11 @@ describe("JavascriptParser", () => {
 		],
 		"member expression": [
 			function () {
+				// @ts-expect-error
 				test[memberExpr];
 
 				// eslint-disable-next-line no-implicit-coercion
+				// @ts-expect-error
 				test[+memberExpr];
 			},
 			{
@@ -82,10 +90,14 @@ describe("JavascriptParser", () => {
 		"in function definition": [
 			function () {
 				(function (abc, cde, fgh) {
+					// @ts-expect-error
 					abc("test");
+					// @ts-expect-error
 					cde.abc("test");
+					// @ts-expect-error
 					cde.ddd.abc("test");
 					fgh;
+					// @ts-expect-error
 					fgh.sub;
 				})();
 			},
@@ -95,10 +107,14 @@ describe("JavascriptParser", () => {
 			function () {
 				// eslint-disable-next-line one-var
 				let abc, cde, fgh;
+				// @ts-expect-error
 				abc("test");
+				// @ts-expect-error
 				cde.abc("test");
+				// @ts-expect-error
 				cde.ddd.abc("test");
 				fgh;
+				// @ts-expect-error
 				fgh.sub;
 			},
 			{}
@@ -107,10 +123,14 @@ describe("JavascriptParser", () => {
 			function () {
 				// eslint-disable-next-line one-var
 				let abc, cde, fgh;
+				// @ts-expect-error
 				abc("test");
+				// @ts-expect-error
 				cde.abc("test");
+				// @ts-expect-error
 				cde.ddd.abc("test");
 				fgh;
+				// @ts-expect-error
 				fgh.sub;
 			},
 			{}
@@ -122,10 +142,14 @@ describe("JavascriptParser", () => {
 				function cde() {}
 
 				function fgh() {}
+				// @ts-expect-error
 				abc("test");
+				// @ts-expect-error
 				cde.abc("test");
+				// @ts-expect-error
 				cde.ddd.abc("test");
 				fgh;
+				// @ts-expect-error
 				fgh.sub;
 			},
 			{}
@@ -154,6 +178,7 @@ describe("JavascriptParser", () => {
 					fgh.sub;
 					fgh;
 
+					// @ts-expect-error
 					function test(ttt) {
 						fgh.sub;
 						fgh;
@@ -197,6 +222,7 @@ describe("JavascriptParser", () => {
 		],
 		"renaming with IIFE": [
 			function () {
+				// @ts-expect-error
 				!(function (xyz) {
 					xyz("test");
 				})(abc);
@@ -207,6 +233,7 @@ describe("JavascriptParser", () => {
 		],
 		"renaming arguments with IIFE (called)": [
 			function () {
+				// @ts-expect-error
 				!function (xyz) {
 					xyz("test");
 				}.call(fgh, abc);
@@ -218,7 +245,9 @@ describe("JavascriptParser", () => {
 		],
 		"renaming this's properties with IIFE (called)": [
 			function () {
+				// @ts-expect-error
 				!function () {
+					// @ts-expect-error
 					this.sub;
 				}.call(ijk);
 			},
@@ -228,9 +257,13 @@ describe("JavascriptParser", () => {
 		],
 		"renaming this's properties with nested IIFE (called)": [
 			function () {
+				// @ts-expect-error
 				!function () {
+					// @ts-expect-error
 					!function () {
+						// @ts-expect-error
 						this.sub;
+					// @ts-expect-error
 					}.call(this);
 				}.call(ijk);
 			},
@@ -257,15 +290,15 @@ describe("JavascriptParser", () => {
 				fgh: ["xyz"]
 			}
 		]
-	};
+	});
 	/* eslint-enable no-undef */
 	/* eslint-enable no-unused-vars */
 
 	for (const name of Object.keys(testCases)) {
 		it(`should parse ${name}`, () => {
-			let source = testCases[name][0].toString();
+			let source = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[name][0].toString();
 			source = source.slice(13, -1).trim();
-			const state = testCases[name][1];
+			const state = /** @type {Record<string, EXPECTED_ANY[]>} */ (testCases)[name][1];
 
 			const testParser = new JavascriptParser(/** @type {"auto"} */ (/** @type {unknown} */ ({})));
 			testParser.hooks.canRename
@@ -276,7 +309,7 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (_expr) => true);
 			testParser.hooks.call.for("abc").tap("JavascriptParserTest", (expr) => {
 				if (!testParser.state.abc) testParser.state.abc = [];
-				testParser.state.abc.push(testParser.parseString(expr.arguments[0]));
+				testParser.state.abc.push(testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0])));
 				return true;
 			});
 			testParser.hooks.call
@@ -284,7 +317,7 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.cdeabc) testParser.state.cdeabc = [];
 					testParser.state.cdeabc.push(
-						testParser.parseString(expr.arguments[0])
+						testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0]))
 					);
 					return true;
 				});
@@ -293,7 +326,7 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.cdedddabc) testParser.state.cdedddabc = [];
 					testParser.state.cdedddabc.push(
-						testParser.parseString(expr.arguments[0])
+						testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0]))
 					);
 					return true;
 				});
@@ -326,15 +359,15 @@ describe("JavascriptParser", () => {
 				.for("memberExpr")
 				.tap("JavascriptParserTest", (expr) => {
 					if (!testParser.state.expressions) testParser.state.expressions = [];
-					testParser.state.expressions.push(expr.name);
+					testParser.state.expressions.push(/** @type {import("estree").Identifier} */ (expr).name);
 					return true;
 				});
 			testParser.hooks.new.for("xyz").tap("JavascriptParserTest", (expr) => {
 				if (!testParser.state.xyz) testParser.state.xyz = [];
-				testParser.state.xyz.push(testParser.parseString(expr.arguments[0]));
+				testParser.state.xyz.push(testParser.parseString(/** @type {import("estree").Expression} */ (expr.arguments[0])));
 				return true;
 			});
-			const actual = testParser.parse(source, {});
+			const actual = testParser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
 			expect(typeof actual).toBe("object");
 			expect(actual).toEqual(state);
 		});
@@ -353,14 +386,14 @@ describe("JavascriptParser", () => {
 			}
 		];
 
-		const testParser = new JavascriptParser({});
+		const testParser = new JavascriptParser(/** @type {"auto"} */ (/** @type {unknown} */ ({})));
 
 		testParser.hooks.program.tap("JavascriptParserTest", (ast, comments) => {
 			if (!testParser.state.comments) testParser.state.comments = comments;
 			return true;
 		});
 
-		const actual = testParser.parse(source, {});
+		const actual = testParser.parse(source, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
 		expect(typeof actual).toBe("object");
 		expect(typeof actual.comments).toBe("object");
 		for (const [index, element] of actual.comments.entries()) {
@@ -374,7 +407,7 @@ describe("JavascriptParser", () => {
 	describe("expression evaluation", () => {
 		/**
 		 * @param {string} source source
-		 * @returns {import("../lib/javascript/JavascriptParser").ParserState} the parser state
+		 * @returns {import("../lib/javascript/BasicEvaluatedExpression")} the evaluated expression
 		 */
 		function evaluateInParser(source) {
 			const parser = new JavascriptParser();
@@ -386,14 +419,14 @@ describe("JavascriptParser", () => {
 				.tap("JavascriptParserTest", (expr) =>
 					new BasicEvaluatedExpression()
 						.setString("aString")
-						.setRange(expr.range)
+						.setRange(/** @type {import("../lib/javascript/JavascriptParser").Range} */ (expr.range))
 				);
 			parser.hooks.evaluateIdentifier
 				.for("b.Number")
 				.tap("JavascriptParserTest", (expr) =>
-					new BasicEvaluatedExpression().setNumber(123).setRange(expr.range)
+					new BasicEvaluatedExpression().setNumber(123).setRange(/** @type {import("../lib/javascript/JavascriptParser").Range} */ (expr.range))
 				);
-			return parser.parse(`test(${source});`, {}).result;
+			return parser.parse(`test(${source});`, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({}))).result;
 		}
 
 		const testCases = {
@@ -596,26 +629,26 @@ describe("JavascriptParser", () => {
 				if (evalExpr.isRegExp()) result.push(`regExp=${evalExpr.regExp}`);
 				if (evalExpr.isConditional()) {
 					result.push(
-						`options=[${evalExpr.options.map(evalExprToString).join("],[")}]`
+						`options=[${/** @type {import("../lib/javascript/BasicEvaluatedExpression")[]} */ (evalExpr.options).map(evalExprToString).join("],[")}]`
 					);
 				}
 				if (evalExpr.isArray()) {
 					result.push(
-						`items=[${evalExpr.items.map(evalExprToString).join("],[")}]`
+						`items=[${/** @type {import("../lib/javascript/BasicEvaluatedExpression")[]} */ (evalExpr.items).map(evalExprToString).join("],[")}]`
 					);
 				}
 				if (evalExpr.isConstArray()) {
-					result.push(`array=[${evalExpr.array.join("],[")}]`);
+					result.push(`array=[${/** @type {(string | number | boolean | null | RegExp | bigint)[]} */ (evalExpr.array).join("],[")}]`);
 				}
 				if (evalExpr.isTemplateString()) {
 					result.push(
-						`template=[${evalExpr.quasis.map(evalExprToString).join("],[")}]`
+						`template=[${/** @type {import("../lib/javascript/BasicEvaluatedExpression")[]} */ (evalExpr.quasis).map(evalExprToString).join("],[")}]`
 					);
 				}
 				if (evalExpr.isWrapped()) {
 					result.push(
-						`wrapped=[${evalExprToString(evalExpr.prefix)}]+[${evalExprToString(
-							evalExpr.postfix
+						`wrapped=[${evalExprToString(/** @type {import("../lib/javascript/BasicEvaluatedExpression")} */ (evalExpr.prefix))}]+[${evalExprToString(
+							/** @type {import("../lib/javascript/BasicEvaluatedExpression")} */ (evalExpr.postfix)
 						)}]`
 					);
 				}
@@ -633,7 +666,7 @@ describe("JavascriptParser", () => {
 			it(`should eval ${key}`, () => {
 				const evalExpr = evaluateInParser(key);
 				expect(evalExprToString(evalExpr)).toBe(
-					testCases[key] ? `${key} ${testCases[key]}` : key
+					/** @type {Record<string, string>} */ (testCases)[key] ? `${key} ${/** @type {Record<string, string>} */ (testCases)[key]}` : key
 				);
 			});
 		}
@@ -649,10 +682,10 @@ describe("JavascriptParser", () => {
 			};
 			const parser = new JavascriptParser();
 			for (const name of Object.keys(cases)) {
-				const expr = cases[name];
+				const expr = /** @type {Record<string, string>} */ (cases)[name];
 
 				it(name, () => {
-					const actual = parser.parse(expr, {});
+					const actual = parser.parse(expr, /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
 					expect(typeof actual).toBe("object");
 				});
 			}
@@ -686,8 +719,8 @@ describe("JavascriptParser", () => {
 
 			for (const name of Object.keys(cases)) {
 				it(name, () => {
-					const actual = parser.parse(cases[name][0], {});
-					expect(actual).toEqual(cases[name][1]);
+					const actual = parser.parse(/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][0], /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
+					expect(actual).toEqual(/** @type {Record<string, EXPECTED_ANY[]>} */ (cases)[name][1]);
 				});
 			}
 		});
@@ -700,16 +733,17 @@ describe("JavascriptParser", () => {
 				"object rest": "({...obj} = foo)"
 			};
 			for (const name of Object.keys(cases)) {
-				const expr = cases[name];
+				const expr = /** @type {Record<string, string>} */ (cases)[name];
 
 				it(name, () => {
-					const actual = JavascriptParser._parse(expr, {});
+					const actual = JavascriptParser._parse(expr, /** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ (/** @type {unknown} */ ({})));
 					expect(typeof actual).toBe("object");
 				});
 			}
 		});
 
 		it("should collect definitions from identifiers introduced in object patterns", () => {
+			/** @type {EXPECTED_ANY} */
 			let definitions;
 
 			const parser = new JavascriptParser();
@@ -719,7 +753,7 @@ describe("JavascriptParser", () => {
 				return true;
 			});
 
-			parser.parse("const { a, ...rest } = { a: 1, b: 2 };", {});
+			parser.parse("const { a, ...rest } = { a: 1, b: 2 };", /** @type {import("../lib/Parser").ParserState} */ (/** @type {unknown} */ ({})));
 
 			expect(definitions.has("a")).toBe(true);
 			expect(definitions.has("rest")).toBe(true);
@@ -832,13 +866,13 @@ describe("JavascriptParser", () => {
 				}
 			};
 			for (const name of Object.keys(cases)) {
-				const expr = cases[name];
+				const expr = /** @type {Record<string, EXPECTED_ANY>} */ (cases)[name];
 
 				it(name, () => {
 					const parser = new JavascriptParser();
-					const { ast } = JavascriptParser._parse(expr.code, { ranges: true });
+					const { ast } = JavascriptParser._parse(expr.code, /** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ ({ ranges: true }));
 					expect(typeof ast).toBe("object");
-					expect(parser.parseCalculatedString(ast.body[0].expression)).toEqual(
+					expect(parser.parseCalculatedString(/** @type {import("estree").Expression} */ (/** @type {EXPECTED_ANY} */ (ast.body[0]).expression))).toEqual(
 						expr.result
 					);
 				});
@@ -853,7 +887,7 @@ describe("JavascriptParser", () => {
 				acc.push([flag, true]);
 				acc.push([flag + flag, false]);
 				return acc;
-			}, []),
+			}, /** @type {[string, boolean][]} */ ([])),
 			["", true],
 			["igm", true],
 			["igmy", true],

--- a/test/LocalModulesHelpers.unittest.js
+++ b/test/LocalModulesHelpers.unittest.js
@@ -8,9 +8,12 @@ const {
 describe("LocalModulesHelpers", () => {
 	describe("addLocalModule", () => {
 		it("returns a module var without special characters", () => {
-			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
-				localModules: ["first", "second"]
-			}));
+			const state =
+				/** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (
+					/** @type {unknown} */ ({
+						localModules: ["first", "second"]
+					})
+				);
 			const localModule = addLocalModule(state, "local_module_sample");
 			expect(localModule).toBeInstanceOf(Object);
 			expect(localModule).toMatchObject({
@@ -24,32 +27,38 @@ describe("LocalModulesHelpers", () => {
 
 	describe("getLocalModule", () => {
 		it("returns `null` if names information doesn't match", () => {
-			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
-				module: "module_sample",
-				localModules: [
-					{
-						name: "first"
-					},
-					{
-						name: "second"
-					}
-				]
-			}));
+			const state =
+				/** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (
+					/** @type {unknown} */ ({
+						module: "module_sample",
+						localModules: [
+							{
+								name: "first"
+							},
+							{
+								name: "second"
+							}
+						]
+					})
+				);
 			expect(getLocalModule(state, "local_module_sample")).toBeNull();
 		});
 
 		it("returns local module information", () => {
-			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
-				module: "module_sample",
-				localModules: [
-					{
-						name: "first"
-					},
-					{
-						name: "second"
-					}
-				]
-			}));
+			const state =
+				/** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (
+					/** @type {unknown} */ ({
+						module: "module_sample",
+						localModules: [
+							{
+								name: "first"
+							},
+							{
+								name: "second"
+							}
+						]
+					})
+				);
 			expect(getLocalModule(state, "first")).toEqual({
 				name: "first"
 			});

--- a/test/LocalModulesHelpers.unittest.js
+++ b/test/LocalModulesHelpers.unittest.js
@@ -8,9 +8,9 @@ const {
 describe("LocalModulesHelpers", () => {
 	describe("addLocalModule", () => {
 		it("returns a module var without special characters", () => {
-			const state = {
+			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
 				localModules: ["first", "second"]
-			};
+			}));
 			const localModule = addLocalModule(state, "local_module_sample");
 			expect(localModule).toBeInstanceOf(Object);
 			expect(localModule).toMatchObject({
@@ -24,7 +24,7 @@ describe("LocalModulesHelpers", () => {
 
 	describe("getLocalModule", () => {
 		it("returns `null` if names information doesn't match", () => {
-			const state = {
+			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
 				module: "module_sample",
 				localModules: [
 					{
@@ -34,12 +34,12 @@ describe("LocalModulesHelpers", () => {
 						name: "second"
 					}
 				]
-			};
+			}));
 			expect(getLocalModule(state, "local_module_sample")).toBeNull();
 		});
 
 		it("returns local module information", () => {
-			const state = {
+			const state = /** @type {import("../lib/javascript/JavascriptParser").JavascriptParserState} */ (/** @type {unknown} */ ({
 				module: "module_sample",
 				localModules: [
 					{
@@ -49,7 +49,7 @@ describe("LocalModulesHelpers", () => {
 						name: "second"
 					}
 				]
-			};
+			}));
 			expect(getLocalModule(state, "first")).toEqual({
 				name: "first"
 			});

--- a/test/MemoryLimitTestCases.test.js
+++ b/test/MemoryLimitTestCases.test.js
@@ -4,7 +4,6 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");

--- a/test/MemoryLimitTestCases.test.js
+++ b/test/MemoryLimitTestCases.test.js
@@ -96,7 +96,8 @@ describe("MemoryLimitTestCases", () => {
 			}
 			const heapSizeStart = process.memoryUsage().heapUsed;
 			const c = webpack(options);
-			const compilers = c.compilers ? c.compilers : [c];
+			const cAny = /** @type {EXPECTED_ANY} */ (c);
+			const compilers = /** @type {import("../").Compiler[]} */ (cAny.compilers ? cAny.compilers : [c]);
 			for (const c of compilers) {
 				const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem);
 				c.inputFileSystem = Object.create(ifs);

--- a/test/MemoryLimitTestCases.test.js
+++ b/test/MemoryLimitTestCases.test.js
@@ -4,12 +4,13 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-ignore
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
 
-const toMiB = (/** @type {number} */ bytes) => `${Math.round(bytes / 1024 / 1024)}MiB`;
+const toMiB = (/** @type {number} */ bytes) =>
+	`${Math.round(bytes / 1024 / 1024)}MiB`;
 const base = path.join(__dirname, "memoryLimitCases");
 const outputBase = path.join(__dirname, "js", "memoryLimit");
 const tests = fs
@@ -83,7 +84,9 @@ describe("MemoryLimitTestCases", () => {
 				options = require(path.join(base, testName, "webpack.config.js"));
 			}
 
-			const resolvedOptions = /** @type {import("../").Configuration[]} */ (Array.isArray(options) ? options : [options]);
+			const resolvedOptions = /** @type {import("../").Configuration[]} */ (
+				Array.isArray(options) ? options : [options]
+			);
 			for (const options of resolvedOptions) {
 				if (!options.context) options.context = path.join(base, testName);
 				if (!options.output) options.output = options.output || {};
@@ -97,23 +100,39 @@ describe("MemoryLimitTestCases", () => {
 			const heapSizeStart = process.memoryUsage().heapUsed;
 			const c = webpack(options);
 			const cAny = /** @type {EXPECTED_ANY} */ (c);
-			const compilers = /** @type {import("../").Compiler[]} */ (cAny.compilers ? cAny.compilers : [c]);
+			const compilers = /** @type {import("../").Compiler[]} */ (
+				cAny.compilers ? cAny.compilers : [c]
+			);
 			for (const c of compilers) {
-				const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem);
+				const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (
+					c.inputFileSystem
+				);
 				c.inputFileSystem = Object.create(ifs);
-				/** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem).readFile = function readFile() {
+				/** @type {NonNullable<typeof c.inputFileSystem>} */ (
+					c.inputFileSystem
+				).readFile = function readFile() {
 					// eslint-disable-next-line prefer-rest-params
 					const args = Array.prototype.slice.call(arguments);
 					const callback = args.pop();
 					// eslint-disable-next-line no-useless-call
-					/** @type {NonNullable<typeof ifs>} */ (ifs).readFile.apply(ifs, [
+					/** @type {EXPECTED_ANY} */ (
+						/** @type {NonNullable<typeof ifs>} */ (ifs).readFile
+					).apply(ifs, [
 						...args,
-						(/** @type {Error | null} */ err, /** @type {Buffer | undefined} */ result) => {
+						(
+							/** @type {Error | null} */ err,
+							/** @type {Buffer | undefined} */ result
+						) => {
 							if (err) return callback(err);
 							if (!/\.(?:js|json|txt)$/.test(args[0])) {
 								return callback(null, result);
 							}
-							callback(null, /** @type {Buffer} */ (result).toString("utf8").replace(/\r/g, ""));
+							callback(
+								null,
+								/** @type {Buffer} */ (result)
+									.toString("utf8")
+									.replace(/\r/g, "")
+							);
 						}
 					]);
 				};

--- a/test/MemoryLimitTestCases.test.js
+++ b/test/MemoryLimitTestCases.test.js
@@ -4,11 +4,12 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+// @ts-ignore
 const rimraf = require("rimraf");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
 
-const toMiB = (bytes) => `${Math.round(bytes / 1024 / 1024)}MiB`;
+const toMiB = (/** @type {number} */ bytes) => `${Math.round(bytes / 1024 / 1024)}MiB`;
 const base = path.join(__dirname, "memoryLimitCases");
 const outputBase = path.join(__dirname, "js", "memoryLimit");
 const tests = fs
@@ -30,8 +31,11 @@ const tests = fs
 		return true;
 	});
 
+/** @typedef {{ toString(): string, toStringRaw(): string, restore(): void, data: string[], reset(): void }} CapturedStdio */
+
 describe("MemoryLimitTestCases", () => {
 	jest.setTimeout(40000);
+	/** @type {CapturedStdio} */
 	let stderr;
 
 	beforeEach(() => {
@@ -47,6 +51,7 @@ describe("MemoryLimitTestCases", () => {
 	});
 
 	for (const testName of tests) {
+		/** @type {{ heapSizeLimitBytes: number, validate?: (stats: import("../").Stats, stderr: string) => void }} */
 		let testConfig = {
 			heapSizeLimitBytes: 250 * 1024 * 1024
 		};
@@ -66,6 +71,7 @@ describe("MemoryLimitTestCases", () => {
 			const outputDirectory = path.join(outputBase, testName);
 			rimraf.sync(outputDirectory);
 			fs.mkdirSync(outputDirectory, { recursive: true });
+			/** @type {import("../").Configuration} */
 			let options = {
 				mode: "development",
 				entry: "./index",
@@ -77,7 +83,7 @@ describe("MemoryLimitTestCases", () => {
 				options = require(path.join(base, testName, "webpack.config.js"));
 			}
 
-			const resolvedOptions = Array.isArray(options) ? options : [options];
+			const resolvedOptions = /** @type {import("../").Configuration[]} */ (Array.isArray(options) ? options : [options]);
 			for (const options of resolvedOptions) {
 				if (!options.context) options.context = path.join(base, testName);
 				if (!options.output) options.output = options.output || {};
@@ -92,27 +98,28 @@ describe("MemoryLimitTestCases", () => {
 			const c = webpack(options);
 			const compilers = c.compilers ? c.compilers : [c];
 			for (const c of compilers) {
-				const ifs = c.inputFileSystem;
+				const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem);
 				c.inputFileSystem = Object.create(ifs);
-				c.inputFileSystem.readFile = function readFile() {
+				/** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem).readFile = function readFile() {
 					// eslint-disable-next-line prefer-rest-params
 					const args = Array.prototype.slice.call(arguments);
 					const callback = args.pop();
 					// eslint-disable-next-line no-useless-call
-					ifs.readFile.apply(ifs, [
+					/** @type {NonNullable<typeof ifs>} */ (ifs).readFile.apply(ifs, [
 						...args,
-						(err, result) => {
+						(/** @type {Error | null} */ err, /** @type {Buffer | undefined} */ result) => {
 							if (err) return callback(err);
 							if (!/\.(?:js|json|txt)$/.test(args[0])) {
 								return callback(null, result);
 							}
-							callback(null, result.toString("utf8").replace(/\r/g, ""));
+							callback(null, /** @type {Buffer} */ (result).toString("utf8").replace(/\r/g, ""));
 						}
 					]);
 				};
 			}
-			c.run((err, stats) => {
+			c.run((err, _stats) => {
 				if (err) return done(err);
+				const stats = /** @type {import("../").Stats} */ (_stats);
 				expect(stats.hasErrors()).toBe(testName.endsWith("error"));
 				if (!testName.endsWith("error") && stats.hasErrors()) {
 					return done(

--- a/test/ModuleDependencyError.unittest.js
+++ b/test/ModuleDependencyError.unittest.js
@@ -4,6 +4,7 @@ const path = require("path");
 const ModuleDependencyError = require("../lib/errors/ModuleDependencyError");
 
 describe("ModuleDependencyError", () => {
+	/** @type {{ error?: Error, moduleDependencyError?: InstanceType<typeof ModuleDependencyError> }} */
 	let env;
 
 	beforeEach(() => {
@@ -14,9 +15,13 @@ describe("ModuleDependencyError", () => {
 		beforeEach(() => {
 			env.error = new Error("Error Message");
 			env.moduleDependencyError = new ModuleDependencyError(
-				"myModule",
+				/** @type {import("../lib/Module")} */ (
+					/** @type {unknown} */ ("myModule")
+				),
 				env.error,
-				"Location"
+				/** @type {import("../lib/Dependency").DependencyLocation} */ (
+					/** @type {unknown} */ ("Location")
+				)
 			);
 		});
 
@@ -25,29 +30,52 @@ describe("ModuleDependencyError", () => {
 		});
 
 		it("has a name property", () => {
-			expect(env.moduleDependencyError.name).toBe("ModuleDependencyError");
+			expect(env.moduleDependencyError).toBeDefined();
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).name
+			).toBe("ModuleDependencyError");
 		});
 
 		it("has a message property", () => {
-			expect(env.moduleDependencyError.message).toBe("Error Message");
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).message
+			).toBe("Error Message");
 		});
 
 		it("has a loc property", () => {
-			expect(env.moduleDependencyError.loc).toBe("Location");
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).loc
+			).toBe("Location");
 		});
 
 		it("has a details property", () => {
-			expect(env.moduleDependencyError.details).toMatch(
-				path.join("test", "ModuleDependencyError.unittest.js:")
-			);
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).details
+			).toMatch(path.join("test", "ModuleDependencyError.unittest.js:"));
 		});
 
 		it("has an module property", () => {
-			expect(env.moduleDependencyError.module).toBe("myModule");
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).module
+			).toBe("myModule");
 		});
 
 		it("has an error property", () => {
-			expect(env.moduleDependencyError.error).toBe(env.error);
+			expect(
+				/** @type {NonNullable<typeof env.moduleDependencyError>} */ (
+					env.moduleDependencyError
+				).error
+			).toBe(env.error);
 		});
 	});
 });

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -6,9 +6,13 @@ const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 
+/**
+ * @param {import("../").MultiCompilerOptions=} options options
+ * @returns {import("../").MultiCompiler} compiler
+ */
 const createMultiCompiler = (options) => {
-	const compiler = webpack(
-		Object.assign(
+	const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
+		/** @type {import("../").MultiConfiguration} */ (Object.assign(
 			[
 				{
 					name: "a",
@@ -22,12 +26,12 @@ const createMultiCompiler = (options) => {
 				}
 			],
 			options
-		)
-	);
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
-	compiler.watchFileSystem = {
-		watch(_a, _b, _c, _d, _e, _f, _g) {}
-	};
+		))
+	));
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+	compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+		watch: (_a, _b, _c, _d, _e, _f, _g) => /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined))
+	});
 	return compiler;
 };
 
@@ -51,7 +55,7 @@ describe("MultiCompiler", () => {
 		let called = 0;
 
 		compiler.hooks.watchRun.tap("MultiCompiler test", () => called++);
-		compiler.watch(1000, (err) => {
+		compiler.watch(/** @type {import("../declarations/WebpackOptions").WatchOptions} */ (/** @type {unknown} */ (1000)), (err) => {
 			if (err) {
 				throw err;
 			}
@@ -109,7 +113,7 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should not be running twice at a time (instance cb)", (done) => {
-		const compiler = webpack(
+		const compiler = /** @type {import("../").Compiler} */ (webpack(
 			{
 				context: __dirname,
 				mode: "production",
@@ -120,8 +124,8 @@ describe("MultiCompiler", () => {
 				}
 			},
 			() => {}
-		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		));
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 		compiler.run((err, _stats) => {
 			if (err) {
 				compiler.close(done);
@@ -145,10 +149,10 @@ describe("MultiCompiler", () => {
 		const compiler = createMultiCompiler();
 		compiler.run((err, stats) => {
 			if (err) return done(err);
-			for (const childStats of stats.stats) {
+			for (const childStats of /** @type {import("../").MultiStats} */ (stats).stats) {
 				const compilation = childStats.compilation;
 				// codeGenerationResults: only used during seal/emit, dropped.
-				expect(compilation.codeGenerationResults.map.size).toBe(0);
+				expect(/** @type {import("../").CodeGenerationResults} */ (compilation.codeGenerationResults).map.size).toBe(0);
 				// Stats must still be usable on the slimmed compilation.
 				expect(typeof childStats.toJson().hash).toBe("string");
 			}
@@ -157,8 +161,8 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should release a finished child's codeGenerationResults before a dependent sibling runs (#15521)", (done) => {
-		const compiler = webpack(
-			Object.assign(
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
+			/** @type {import("../").MultiConfiguration} */ (Object.assign(
 				[
 					{
 						name: "a",
@@ -173,11 +177,14 @@ describe("MultiCompiler", () => {
 					}
 				],
 				{ parallelism: 1 }
-			)
-		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
-		compiler.watchFileSystem = { watch(_a, _b, _c, _d, _e, _f, _g) {} };
+			))
+		));
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+			watch: (_a, _b, _c, _d, _e, _f, _g) => /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined))
+		});
 		const [a, b] = compiler.compilers;
+		/** @type {import("../").Compilation | undefined} */
 		let aCompilation;
 		a.hooks.done.tap("test", (stats) => {
 			aCompilation = stats.compilation;
@@ -185,9 +192,10 @@ describe("MultiCompiler", () => {
 		// With dependencies + parallelism 1, b only starts after a is fully
 		// done (including a's afterDone release tap). Capture a's map size at
 		// that point: it must already be cleared while b is about to build.
+		/** @type {number | undefined} */
 		let aMapSizeWhenBStarts;
 		b.hooks.run.tap("test", () => {
-			aMapSizeWhenBStarts = aCompilation.codeGenerationResults.map.size;
+			aMapSizeWhenBStarts = /** @type {import("../").CodeGenerationResults} */ (/** @type {import("../").Compilation} */ (aCompilation).codeGenerationResults).map.size;
 		});
 		compiler.run((err) => {
 			if (err) return done(err);
@@ -210,9 +218,9 @@ describe("MultiCompiler", () => {
 
 	it("should run again correctly after first closed watch", (done) => {
 		const compiler = createMultiCompiler();
-		const watching = compiler.watch({}, (err, _stats) => {
+		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
-		});
+		})));
 		watching.close(() => {
 			compiler.run((err, _stats) => {
 				if (err) return done(err);
@@ -223,9 +231,9 @@ describe("MultiCompiler", () => {
 
 	it("should watch again correctly after first closed watch", (done) => {
 		const compiler = createMultiCompiler();
-		const watching = compiler.watch({}, (err, _stats) => {
+		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
-		});
+		})));
 		watching.close(() => {
 			compiler.watch({}, (err, _stats) => {
 				if (err) return done(err);
@@ -235,7 +243,7 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism and dependencies for running", (done) => {
-		const compiler = createMultiCompiler({
+		const compiler = createMultiCompiler(/** @type {import("../").MultiCompilerOptions} */ ({
 			parallelism: 1,
 			2: {
 				name: "c",
@@ -253,7 +261,8 @@ describe("MultiCompiler", () => {
 				context: path.join(__dirname, "fixtures"),
 				entry: "./a.js"
 			}
-		});
+		}));
+		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
 			c.hooks.run.tap("test", () => {
@@ -272,8 +281,8 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism and dependencies for watching", (done) => {
-		const compiler = webpack(
-			Object.assign(
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
+			/** @type {import("../").MultiConfiguration} */ (Object.assign(
 				[
 					{
 						name: "a",
@@ -296,12 +305,14 @@ describe("MultiCompiler", () => {
 					}
 				],
 				{ parallelism: 1 }
-			)
-		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+			))
+		));
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		/** @type {Function[]} */
 		const watchCallbacks = [];
+		/** @type {Function[]} */
 		const watchCallbacksUndelayed = [];
-		compiler.watchFileSystem = {
+		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
 			watch(
 				files,
 				directories,
@@ -313,8 +324,10 @@ describe("MultiCompiler", () => {
 			) {
 				watchCallbacks.push(callback);
 				watchCallbacksUndelayed.push(callbackUndelayed);
+				return /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined));
 			}
-		};
+		});
+		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
 			c.hooks.invalid.tap("test", () => {
@@ -331,7 +344,7 @@ describe("MultiCompiler", () => {
 		let update = 0;
 		compiler.watch({}, (err, stats) => {
 			if (err) return done(err);
-			const info = () => stats.toString({ preset: "summary", version: false });
+			const info = () => /** @type {import("../").MultiStats} */ (stats).toString({ preset: "summary", version: false });
 			switch (update++) {
 				case 0:
 					expect(info()).toMatchInlineSnapshot(`
@@ -444,23 +457,27 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism when using invalidate", (done) => {
-		const configs = [
-			{
-				name: "a",
-				mode: "development",
-				entry: { a: "./a.js" },
-				context: path.join(__dirname, "fixtures")
-			},
-			{
-				name: "b",
-				mode: "development",
-				entry: { b: "./b.js" },
-				context: path.join(__dirname, "fixtures")
-			}
-		];
-		configs.parallelism = 1;
-		const compiler = webpack(configs);
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
+			/** @type {import("../").MultiConfiguration} */ (/** @type {unknown} */ (Object.assign(
+				[
+					{
+						name: "a",
+						mode: "development",
+						entry: { a: "./a.js" },
+						context: path.join(__dirname, "fixtures")
+					},
+					{
+						name: "b",
+						mode: "development",
+						entry: { b: "./b.js" },
+						context: path.join(__dirname, "fixtures")
+					}
+				],
+				{ parallelism: 1 }
+			)))
+		));
 
+		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
 			c.hooks.invalid.tap("test", () => {
@@ -474,11 +491,11 @@ describe("MultiCompiler", () => {
 			});
 		}
 
-		compiler.watchFileSystem = { watch() {} };
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 
 		let state = 0;
-		const watching = compiler.watch({}, (error) => {
+		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
 			if (error) {
 				done(error);
 				return;
@@ -520,11 +537,11 @@ describe("MultiCompiler", () => {
 					done(err);
 				}
 			});
-		});
+		})));
 	}, 2000);
 
 	it("should respect dependencies when using invalidate", (done) => {
-		const compiler = webpack([
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack([
 			{
 				name: "a",
 				mode: "development",
@@ -538,8 +555,9 @@ describe("MultiCompiler", () => {
 				entry: { b: "./b.js" },
 				context: path.join(__dirname, "fixtures")
 			}
-		]);
+		]));
 
+		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
 			c.hooks.invalid.tap("test", () => {
@@ -553,11 +571,11 @@ describe("MultiCompiler", () => {
 			});
 		}
 
-		compiler.watchFileSystem = { watch() {} };
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 
 		let state = 0;
-		const watching = compiler.watch({}, (error) => {
+		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
 			if (error) {
 				done(error);
 				return;
@@ -599,13 +617,13 @@ describe("MultiCompiler", () => {
 					done(err);
 				}
 			});
-		});
+		})));
 	}, 2000);
 
 	it("shouldn't hang when invalidating watchers", (done) => {
-		const entriesA = { a: "./a.js" };
-		const entriesB = { b: "./b.js" };
-		const compiler = webpack([
+		const entriesA = /** @type {Record<string, string>} */ ({ a: "./a.js" });
+		const entriesB = /** @type {Record<string, string>} */ ({ b: "./b.js" });
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack([
 			{
 				name: "a",
 				mode: "development",
@@ -618,12 +636,12 @@ describe("MultiCompiler", () => {
 				entry: () => entriesB,
 				context: path.join(__dirname, "fixtures")
 			}
-		]);
+		]));
 
-		compiler.watchFileSystem = { watch() {} };
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 
-		const watching = compiler.watch({}, (error) => {
+		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
 			if (error) {
 				done(error);
 				return;
@@ -636,12 +654,12 @@ describe("MultiCompiler", () => {
 				if (err) return done(err);
 				compiler.close(done);
 			});
-		});
+		})));
 	}, 2000);
 
 	it("shouldn't hang when invalidating during build", (done) => {
-		const compiler = webpack(
-			Object.assign([
+		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
+			/** @type {import("../").MultiConfiguration} */ (Object.assign([
 				{
 					name: "a",
 					mode: "development",
@@ -655,13 +673,15 @@ describe("MultiCompiler", () => {
 					entry: "./b.js",
 					dependencies: ["a"]
 				}
-			])
-		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+			]))
+		));
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		/** @type {Function[]} */
 		const watchCallbacks = [];
+		/** @type {Function[]} */
 		const watchCallbacksUndelayed = [];
 		let firstRun = true;
-		compiler.watchFileSystem = {
+		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
 			watch(
 				files,
 				directories,
@@ -673,14 +693,15 @@ describe("MultiCompiler", () => {
 			) {
 				watchCallbacks.push(callback);
 				watchCallbacksUndelayed.push(callbackUndelayed);
-				if (firstRun && files.has(path.join(__dirname, "fixtures", "a.js"))) {
+				if (firstRun && /** @type {Set<string>} */ (files).has(path.join(__dirname, "fixtures", "a.js"))) {
 					process.nextTick(() => {
 						callback(null, new Map(), new Map(), new Set(), new Set());
 					});
 					firstRun = false;
 				}
+				return /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined));
 			}
-		};
+		});
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 			compiler.close(done);

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -11,27 +11,37 @@ const webpack = require("..");
  * @returns {import("../").MultiCompiler} compiler
  */
 const createMultiCompiler = (options) => {
-	const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
-		/** @type {import("../").MultiConfiguration} */ (Object.assign(
-			[
-				{
-					name: "a",
-					context: path.join(__dirname, "fixtures"),
-					entry: "./a.js"
-				},
-				{
-					name: "b",
-					context: path.join(__dirname, "fixtures"),
-					entry: "./b.js"
-				}
-			],
-			options
-		))
-	));
-	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
-	compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
-		watch: (_a, _b, _c, _d, _e, _f, _g) => /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined))
-	});
+	const compiler = /** @type {import("../").MultiCompiler} */ (
+		webpack(
+			/** @type {import("../").MultiConfiguration} */ (
+				Object.assign(
+					[
+						{
+							name: "a",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./a.js"
+						},
+						{
+							name: "b",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./b.js"
+						}
+					],
+					options
+				)
+			)
+		)
+	);
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+		/** @type {unknown} */ (createFsFromVolume(new Volume()))
+	);
+	compiler.watchFileSystem =
+		/** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+			watch: (_a, _b, _c, _d, _e, _f, _g) =>
+				/** @type {import("../lib/util/fs").Watcher} */ (
+					/** @type {unknown} */ (undefined)
+				)
+		});
 	return compiler;
 };
 
@@ -55,13 +65,18 @@ describe("MultiCompiler", () => {
 		let called = 0;
 
 		compiler.hooks.watchRun.tap("MultiCompiler test", () => called++);
-		compiler.watch(/** @type {import("../declarations/WebpackOptions").WatchOptions} */ (/** @type {unknown} */ (1000)), (err) => {
-			if (err) {
-				throw err;
+		compiler.watch(
+			/** @type {import("../declarations/WebpackOptions").WatchOptions} */ (
+				/** @type {unknown} */ (1000)
+			),
+			(err) => {
+				if (err) {
+					throw err;
+				}
+				expect(called).toBe(2);
+				compiler.close(done);
 			}
-			expect(called).toBe(2);
-			compiler.close(done);
-		});
+		);
 	});
 
 	it("should not be running twice at a time (run)", (done) => {
@@ -113,19 +128,23 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should not be running twice at a time (instance cb)", (done) => {
-		const compiler = /** @type {import("../").Compiler} */ (webpack(
-			{
-				context: __dirname,
-				mode: "production",
-				entry: "./c",
-				output: {
-					path: "/",
-					filename: "bundle.js"
-				}
-			},
-			() => {}
-		));
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		const compiler = /** @type {import("../").Compiler} */ (
+			webpack(
+				{
+					context: __dirname,
+					mode: "production",
+					entry: "./c",
+					output: {
+						path: "/",
+						filename: "bundle.js"
+					}
+				},
+				() => {}
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		compiler.run((err, _stats) => {
 			if (err) {
 				compiler.close(done);
@@ -149,10 +168,15 @@ describe("MultiCompiler", () => {
 		const compiler = createMultiCompiler();
 		compiler.run((err, stats) => {
 			if (err) return done(err);
-			for (const childStats of /** @type {import("../").MultiStats} */ (stats).stats) {
+			for (const childStats of /** @type {import("../").MultiStats} */ (stats)
+				.stats) {
 				const compilation = childStats.compilation;
 				// codeGenerationResults: only used during seal/emit, dropped.
-				expect(/** @type {import("../").CodeGenerationResults} */ (compilation.codeGenerationResults).map.size).toBe(0);
+				expect(
+					/** @type {import("../").CodeGenerationResults} */ (
+						compilation.codeGenerationResults
+					).map.size
+				).toBe(0);
 				// Stats must still be usable on the slimmed compilation.
 				expect(typeof childStats.toJson().hash).toBe("string");
 			}
@@ -161,28 +185,38 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should release a finished child's codeGenerationResults before a dependent sibling runs (#15521)", (done) => {
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
-			/** @type {import("../").MultiConfiguration} */ (Object.assign(
-				[
-					{
-						name: "a",
-						context: path.join(__dirname, "fixtures"),
-						entry: "./a.js"
-					},
-					{
-						name: "b",
-						context: path.join(__dirname, "fixtures"),
-						entry: "./b.js",
-						dependencies: ["a"]
-					}
-				],
-				{ parallelism: 1 }
-			))
-		));
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
-		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
-			watch: (_a, _b, _c, _d, _e, _f, _g) => /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined))
-		});
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ (
+					Object.assign(
+						[
+							{
+								name: "a",
+								context: path.join(__dirname, "fixtures"),
+								entry: "./a.js"
+							},
+							{
+								name: "b",
+								context: path.join(__dirname, "fixtures"),
+								entry: "./b.js",
+								dependencies: ["a"]
+							}
+						],
+						{ parallelism: 1 }
+					)
+				)
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		compiler.watchFileSystem =
+			/** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+				watch: (_a, _b, _c, _d, _e, _f, _g) =>
+					/** @type {import("../lib/util/fs").Watcher} */ (
+						/** @type {unknown} */ (undefined)
+					)
+			});
 		const [a, b] = compiler.compilers;
 		/** @type {import("../").Compilation | undefined} */
 		let aCompilation;
@@ -195,7 +229,10 @@ describe("MultiCompiler", () => {
 		/** @type {number | undefined} */
 		let aMapSizeWhenBStarts;
 		b.hooks.run.tap("test", () => {
-			aMapSizeWhenBStarts = /** @type {import("../").CodeGenerationResults} */ (/** @type {import("../").Compilation} */ (aCompilation).codeGenerationResults).map.size;
+			aMapSizeWhenBStarts = /** @type {import("../").CodeGenerationResults} */ (
+				/** @type {import("../").Compilation} */ (aCompilation)
+					.codeGenerationResults
+			).map.size;
 		});
 		compiler.run((err) => {
 			if (err) return done(err);
@@ -218,9 +255,13 @@ describe("MultiCompiler", () => {
 
 	it("should run again correctly after first closed watch", (done) => {
 		const compiler = createMultiCompiler();
-		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-		})));
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (err, _stats) => {
+					if (err) return done(err);
+				})
+			)
+		);
 		watching.close(() => {
 			compiler.run((err, _stats) => {
 				if (err) return done(err);
@@ -231,9 +272,13 @@ describe("MultiCompiler", () => {
 
 	it("should watch again correctly after first closed watch", (done) => {
 		const compiler = createMultiCompiler();
-		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (err, _stats) => {
-			if (err) return done(err);
-		})));
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (err, _stats) => {
+					if (err) return done(err);
+				})
+			)
+		);
 		watching.close(() => {
 			compiler.watch({}, (err, _stats) => {
 				if (err) return done(err);
@@ -243,25 +288,27 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism and dependencies for running", (done) => {
-		const compiler = createMultiCompiler(/** @type {import("../").MultiCompilerOptions} */ ({
-			parallelism: 1,
-			2: {
-				name: "c",
-				context: path.join(__dirname, "fixtures"),
-				entry: "./a.js",
-				dependencies: ["d", "e"]
-			},
-			3: {
-				name: "d",
-				context: path.join(__dirname, "fixtures"),
-				entry: "./a.js"
-			},
-			4: {
-				name: "e",
-				context: path.join(__dirname, "fixtures"),
-				entry: "./a.js"
-			}
-		}));
+		const compiler = createMultiCompiler(
+			/** @type {import("../").MultiCompilerOptions} */ ({
+				parallelism: 1,
+				2: {
+					name: "c",
+					context: path.join(__dirname, "fixtures"),
+					entry: "./a.js",
+					dependencies: ["d", "e"]
+				},
+				3: {
+					name: "d",
+					context: path.join(__dirname, "fixtures"),
+					entry: "./a.js"
+				},
+				4: {
+					name: "e",
+					context: path.join(__dirname, "fixtures"),
+					entry: "./a.js"
+				}
+			})
+		);
 		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
@@ -281,52 +328,61 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism and dependencies for watching", (done) => {
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
-			/** @type {import("../").MultiConfiguration} */ (Object.assign(
-				[
-					{
-						name: "a",
-						mode: "development",
-						context: path.join(__dirname, "fixtures"),
-						entry: "./a.js",
-						dependencies: ["b", "c"]
-					},
-					{
-						name: "b",
-						mode: "development",
-						context: path.join(__dirname, "fixtures"),
-						entry: "./b.js"
-					},
-					{
-						name: "c",
-						mode: "development",
-						context: path.join(__dirname, "fixtures"),
-						entry: "./a.js"
-					}
-				],
-				{ parallelism: 1 }
-			))
-		));
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
-		/** @type {Function[]} */
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ (
+					Object.assign(
+						[
+							{
+								name: "a",
+								mode: "development",
+								context: path.join(__dirname, "fixtures"),
+								entry: "./a.js",
+								dependencies: ["b", "c"]
+							},
+							{
+								name: "b",
+								mode: "development",
+								context: path.join(__dirname, "fixtures"),
+								entry: "./b.js"
+							},
+							{
+								name: "c",
+								mode: "development",
+								context: path.join(__dirname, "fixtures"),
+								entry: "./a.js"
+							}
+						],
+						{ parallelism: 1 }
+					)
+				)
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		/** @type {((...args: EXPECTED_ANY[]) => void)[]} */
 		const watchCallbacks = [];
-		/** @type {Function[]} */
+		/** @type {((...args: EXPECTED_ANY[]) => void)[]} */
 		const watchCallbacksUndelayed = [];
-		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
-			watch(
-				files,
-				directories,
-				missing,
-				startTime,
-				options,
-				callback,
-				callbackUndelayed
-			) {
-				watchCallbacks.push(callback);
-				watchCallbacksUndelayed.push(callbackUndelayed);
-				return /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined));
-			}
-		});
+		compiler.watchFileSystem =
+			/** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+				watch(
+					files,
+					directories,
+					missing,
+					startTime,
+					options,
+					callback,
+					callbackUndelayed
+				) {
+					watchCallbacks.push(callback);
+					watchCallbacksUndelayed.push(callbackUndelayed);
+					return /** @type {import("../lib/util/fs").Watcher} */ (
+						/** @type {unknown} */ (undefined)
+					);
+				}
+			});
 		/** @type {string[]} */
 		const events = [];
 		for (const c of compiler.compilers) {
@@ -344,7 +400,11 @@ describe("MultiCompiler", () => {
 		let update = 0;
 		compiler.watch({}, (err, stats) => {
 			if (err) return done(err);
-			const info = () => /** @type {import("../").MultiStats} */ (stats).toString({ preset: "summary", version: false });
+			const info = () =>
+				/** @type {import("../").MultiStats} */ (stats).toString({
+					preset: "summary",
+					version: false
+				});
 			switch (update++) {
 				case 0:
 					expect(info()).toMatchInlineSnapshot(`
@@ -457,25 +517,31 @@ describe("MultiCompiler", () => {
 	});
 
 	it("should respect parallelism when using invalidate", (done) => {
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
-			/** @type {import("../").MultiConfiguration} */ (/** @type {unknown} */ (Object.assign(
-				[
-					{
-						name: "a",
-						mode: "development",
-						entry: { a: "./a.js" },
-						context: path.join(__dirname, "fixtures")
-					},
-					{
-						name: "b",
-						mode: "development",
-						entry: { b: "./b.js" },
-						context: path.join(__dirname, "fixtures")
-					}
-				],
-				{ parallelism: 1 }
-			)))
-		));
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ (
+					/** @type {unknown} */ (
+						Object.assign(
+							[
+								{
+									name: "a",
+									mode: "development",
+									entry: { a: "./a.js" },
+									context: path.join(__dirname, "fixtures")
+								},
+								{
+									name: "b",
+									mode: "development",
+									entry: { b: "./b.js" },
+									context: path.join(__dirname, "fixtures")
+								}
+							],
+							{ parallelism: 1 }
+						)
+					)
+				)
+			)
+		);
 
 		/** @type {string[]} */
 		const events = [];
@@ -491,19 +557,27 @@ describe("MultiCompiler", () => {
 			});
 		}
 
-		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		compiler.watchFileSystem = {
+			watch: /** @type {import("../lib/util/fs").WatchMethod} */ (
+				/** @type {unknown} */ (/** @type {() => void} */ (() => {}))
+			)
+		};
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 
 		let state = 0;
-		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
-			if (error) {
-				done(error);
-				return;
-			}
-			if (state !== 0) return;
-			state++;
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (error) => {
+					if (error) {
+						done(error);
+						return;
+					}
+					if (state !== 0) return;
+					state++;
 
-			expect(events).toMatchInlineSnapshot(`
+					expect(events).toMatchInlineSnapshot(`
 			Array [
 			  "a run",
 			  "a done",
@@ -511,13 +585,13 @@ describe("MultiCompiler", () => {
 			  "b done",
 			]
 		`);
-			events.length = 0;
+					events.length = 0;
 
-			watching.invalidate((err) => {
-				try {
-					if (err) return done(err);
+					watching.invalidate((err) => {
+						try {
+							if (err) return done(err);
 
-					expect(events).toMatchInlineSnapshot(`
+							expect(events).toMatchInlineSnapshot(`
 				Array [
 				  "a invalid",
 				  "b invalid",
@@ -527,35 +601,39 @@ describe("MultiCompiler", () => {
 				  "b done",
 				]
 			`);
-					events.length = 0;
-					expect(state).toBe(1);
-					setTimeout(() => {
-						compiler.close(done);
-					}, 1000);
-				} catch (err) {
-					console.error(err);
-					done(err);
-				}
-			});
-		})));
+							events.length = 0;
+							expect(state).toBe(1);
+							setTimeout(() => {
+								compiler.close(done);
+							}, 1000);
+						} catch (err) {
+							console.error(err);
+							done(err);
+						}
+					});
+				})
+			)
+		);
 	}, 2000);
 
 	it("should respect dependencies when using invalidate", (done) => {
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack([
-			{
-				name: "a",
-				mode: "development",
-				entry: { a: "./a.js" },
-				context: path.join(__dirname, "fixtures"),
-				dependencies: ["b"]
-			},
-			{
-				name: "b",
-				mode: "development",
-				entry: { b: "./b.js" },
-				context: path.join(__dirname, "fixtures")
-			}
-		]));
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack([
+				{
+					name: "a",
+					mode: "development",
+					entry: { a: "./a.js" },
+					context: path.join(__dirname, "fixtures"),
+					dependencies: ["b"]
+				},
+				{
+					name: "b",
+					mode: "development",
+					entry: { b: "./b.js" },
+					context: path.join(__dirname, "fixtures")
+				}
+			])
+		);
 
 		/** @type {string[]} */
 		const events = [];
@@ -571,19 +649,27 @@ describe("MultiCompiler", () => {
 			});
 		}
 
-		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+		compiler.watchFileSystem = {
+			watch: /** @type {import("../lib/util/fs").WatchMethod} */ (
+				/** @type {unknown} */ (/** @type {() => void} */ (() => {}))
+			)
+		};
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 
 		let state = 0;
-		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
-			if (error) {
-				done(error);
-				return;
-			}
-			if (state !== 0) return;
-			state++;
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (error) => {
+					if (error) {
+						done(error);
+						return;
+					}
+					if (state !== 0) return;
+					state++;
 
-			expect(events).toMatchInlineSnapshot(`
+					expect(events).toMatchInlineSnapshot(`
 			Array [
 			  "b run",
 			  "b done",
@@ -591,13 +677,13 @@ describe("MultiCompiler", () => {
 			  "a done",
 			]
 		`);
-			events.length = 0;
+					events.length = 0;
 
-			watching.invalidate((err) => {
-				try {
-					if (err) return done(err);
+					watching.invalidate((err) => {
+						try {
+							if (err) return done(err);
 
-					expect(events).toMatchInlineSnapshot(`
+							expect(events).toMatchInlineSnapshot(`
 				Array [
 				  "a invalid",
 				  "b invalid",
@@ -607,101 +693,129 @@ describe("MultiCompiler", () => {
 				  "a done",
 				]
 			`);
-					events.length = 0;
-					expect(state).toBe(1);
-					setTimeout(() => {
-						compiler.close(done);
-					}, 1000);
-				} catch (err) {
-					console.error(err);
-					done(err);
-				}
-			});
-		})));
+							events.length = 0;
+							expect(state).toBe(1);
+							setTimeout(() => {
+								compiler.close(done);
+							}, 1000);
+						} catch (err) {
+							console.error(err);
+							done(err);
+						}
+					});
+				})
+			)
+		);
 	}, 2000);
 
 	it("shouldn't hang when invalidating watchers", (done) => {
 		const entriesA = /** @type {Record<string, string>} */ ({ a: "./a.js" });
 		const entriesB = /** @type {Record<string, string>} */ ({ b: "./b.js" });
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack([
-			{
-				name: "a",
-				mode: "development",
-				entry: () => entriesA,
-				context: path.join(__dirname, "fixtures")
-			},
-			{
-				name: "b",
-				mode: "development",
-				entry: () => entriesB,
-				context: path.join(__dirname, "fixtures")
-			}
-		]));
-
-		compiler.watchFileSystem = { watch: /** @type {import("../lib/util/fs").WatchMethod} */ (/** @type {unknown} */ (/** @type {() => void} */ (() => {}))) };
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
-
-		const watching = /** @type {import("../lib/MultiWatching")} */ (/** @type {unknown} */ (compiler.watch({}, (error) => {
-			if (error) {
-				done(error);
-				return;
-			}
-
-			entriesA.b = "./b.js";
-			entriesB.a = "./a.js";
-
-			watching.invalidate((err) => {
-				if (err) return done(err);
-				compiler.close(done);
-			});
-		})));
-	}, 2000);
-
-	it("shouldn't hang when invalidating during build", (done) => {
-		const compiler = /** @type {import("../").MultiCompiler} */ (webpack(
-			/** @type {import("../").MultiConfiguration} */ (Object.assign([
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack([
 				{
 					name: "a",
 					mode: "development",
-					context: path.join(__dirname, "fixtures"),
-					entry: "./a.js"
+					entry: () => entriesA,
+					context: path.join(__dirname, "fixtures")
 				},
 				{
 					name: "b",
 					mode: "development",
-					context: path.join(__dirname, "fixtures"),
-					entry: "./b.js",
-					dependencies: ["a"]
+					entry: () => entriesB,
+					context: path.join(__dirname, "fixtures")
 				}
-			]))
-		));
-		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
-		/** @type {Function[]} */
+			])
+		);
+
+		compiler.watchFileSystem = {
+			watch: /** @type {import("../lib/util/fs").WatchMethod} */ (
+				/** @type {unknown} */ (/** @type {() => void} */ (() => {}))
+			)
+		};
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (error) => {
+					if (error) {
+						done(error);
+						return;
+					}
+
+					entriesA.b = "./b.js";
+					entriesB.a = "./a.js";
+
+					watching.invalidate((err) => {
+						if (err) return done(err);
+						compiler.close(done);
+					});
+				})
+			)
+		);
+	}, 2000);
+
+	it("shouldn't hang when invalidating during build", (done) => {
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ (
+					Object.assign([
+						{
+							name: "a",
+							mode: "development",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./a.js"
+						},
+						{
+							name: "b",
+							mode: "development",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./b.js",
+							dependencies: ["a"]
+						}
+					])
+				)
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		/** @type {((...args: EXPECTED_ANY[]) => void)[]} */
 		const watchCallbacks = [];
-		/** @type {Function[]} */
+		/** @type {((...args: EXPECTED_ANY[]) => void)[]} */
 		const watchCallbacksUndelayed = [];
 		let firstRun = true;
-		compiler.watchFileSystem = /** @type {import("../lib/util/fs").WatchFileSystem} */ ({
-			watch(
-				files,
-				directories,
-				missing,
-				startTime,
-				options,
-				callback,
-				callbackUndelayed
-			) {
-				watchCallbacks.push(callback);
-				watchCallbacksUndelayed.push(callbackUndelayed);
-				if (firstRun && /** @type {Set<string>} */ (files).has(path.join(__dirname, "fixtures", "a.js"))) {
-					process.nextTick(() => {
-						callback(null, new Map(), new Map(), new Set(), new Set());
-					});
-					firstRun = false;
+		compiler.watchFileSystem =
+			/** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+				watch(
+					files,
+					directories,
+					missing,
+					startTime,
+					options,
+					callback,
+					callbackUndelayed
+				) {
+					watchCallbacks.push(callback);
+					watchCallbacksUndelayed.push(callbackUndelayed);
+					if (
+						firstRun &&
+						/** @type {Set<string>} */ (files).has(
+							path.join(__dirname, "fixtures", "a.js")
+						)
+					) {
+						process.nextTick(() => {
+							callback(null, new Map(), new Map(), new Set(), new Set());
+						});
+						firstRun = false;
+					}
+					return /** @type {import("../lib/util/fs").Watcher} */ (
+						/** @type {unknown} */ (undefined)
+					);
 				}
-				return /** @type {import("../lib/util/fs").Watcher} */ (/** @type {unknown} */ (undefined));
-			}
-		});
+			});
 		compiler.watch({}, (err, _stats) => {
 			if (err) return done(err);
 			compiler.close(done);

--- a/test/MultiItemCache.unittest.js
+++ b/test/MultiItemCache.unittest.js
@@ -6,7 +6,13 @@ const { ItemCacheFacade, MultiItemCache } = require("../lib/CacheFacade");
 describe("MultiItemCache", () => {
 	it("throws when getting items from an empty Cache", () => {
 		const multiItemCache = new MultiItemCache(generateItemCaches(0));
-		expect(() => multiItemCache.get(/** @type {EXPECTED_ANY} */ ((/** @type {unknown} */ _) => /** @type {Function} */ (_)()))).toThrow(/_ is not a function/);
+		expect(() =>
+			multiItemCache.get(
+				/** @type {EXPECTED_ANY} */ (
+					(/** @type {unknown} */ _) => /** @type {() => unknown} */ (_)()
+				)
+			)
+		).toThrow(/_ is not a function/);
 	});
 
 	it("returns the single ItemCacheFacade when passed an array of length 1", () => {
@@ -18,7 +24,10 @@ describe("MultiItemCache", () => {
 	it("retrieves items from the underlying Cache when get is called", () => {
 		const itemCaches = generateItemCaches(10);
 		const multiItemCache = new MultiItemCache(itemCaches);
-		const callback = (/** @type {Error | null | undefined} */ err, /** @type {unknown} */ res) => {
+		const callback = (
+			/** @type {Error | null | undefined} */ err,
+			/** @type {unknown} */ res
+		) => {
 			expect(err).toBeNull();
 			expect(res).toBeInstanceOf(Object);
 		};
@@ -31,7 +40,10 @@ describe("MultiItemCache", () => {
 		const itemCaches = generateItemCaches(10000, () => undefined);
 		const multiItemCache = new MultiItemCache(itemCaches);
 		let callbacks = 0;
-		const callback = (/** @type {Error | null | undefined} */ err, /** @type {unknown} */ res) => {
+		const callback = (
+			/** @type {Error | null | undefined} */ err,
+			/** @type {unknown} */ res
+		) => {
 			expect(err).toBeNull();
 			expect(res).toBeUndefined();
 			++callbacks;

--- a/test/MultiItemCache.unittest.js
+++ b/test/MultiItemCache.unittest.js
@@ -6,7 +6,7 @@ const { ItemCacheFacade, MultiItemCache } = require("../lib/CacheFacade");
 describe("MultiItemCache", () => {
 	it("throws when getting items from an empty Cache", () => {
 		const multiItemCache = new MultiItemCache(generateItemCaches(0));
-		expect(() => multiItemCache.get((/** @type {Function} */ _) => /** @type {Function} */ (_)())).toThrow(/_ is not a function/);
+		expect(() => multiItemCache.get(/** @type {EXPECTED_ANY} */ ((/** @type {unknown} */ _) => /** @type {Function} */ (_)()))).toThrow(/_ is not a function/);
 	});
 
 	it("returns the single ItemCacheFacade when passed an array of length 1", () => {

--- a/test/MultiItemCache.unittest.js
+++ b/test/MultiItemCache.unittest.js
@@ -6,7 +6,7 @@ const { ItemCacheFacade, MultiItemCache } = require("../lib/CacheFacade");
 describe("MultiItemCache", () => {
 	it("throws when getting items from an empty Cache", () => {
 		const multiItemCache = new MultiItemCache(generateItemCaches(0));
-		expect(() => multiItemCache.get((_) => _())).toThrow(/_ is not a function/);
+		expect(() => multiItemCache.get((/** @type {Function} */ _) => /** @type {Function} */ (_)())).toThrow(/_ is not a function/);
 	});
 
 	it("returns the single ItemCacheFacade when passed an array of length 1", () => {
@@ -18,7 +18,7 @@ describe("MultiItemCache", () => {
 	it("retrieves items from the underlying Cache when get is called", () => {
 		const itemCaches = generateItemCaches(10);
 		const multiItemCache = new MultiItemCache(itemCaches);
-		const callback = (err, res) => {
+		const callback = (/** @type {Error | null | undefined} */ err, /** @type {unknown} */ res) => {
 			expect(err).toBeNull();
 			expect(res).toBeInstanceOf(Object);
 		};
@@ -31,7 +31,7 @@ describe("MultiItemCache", () => {
 		const itemCaches = generateItemCaches(10000, () => undefined);
 		const multiItemCache = new MultiItemCache(itemCaches);
 		let callbacks = 0;
-		const callback = (err, res) => {
+		const callback = (/** @type {Error | null | undefined} */ err, /** @type {unknown} */ res) => {
 			expect(err).toBeNull();
 			expect(res).toBeUndefined();
 			++callbacks;

--- a/test/MultiStats.test.js
+++ b/test/MultiStats.test.js
@@ -4,20 +4,30 @@ require("./helpers/warmup-webpack");
 
 const { Volume, createFsFromVolume } = require("memfs");
 
+/**
+ * @param {import("../").Configuration | import("../").MultiConfiguration} options options
+ * @returns {Promise<import("../").MultiStats>} stats
+ */
 const compile = (options) =>
-	new Promise((resolve, reject) => {
-		const webpack = require("..");
+	/** @type {Promise<import("../").MultiStats>} */ (
+		new Promise((resolve, reject) => {
+			const webpack = require("..");
 
-		const compiler = webpack(options);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
-		compiler.run((err, stats) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(stats);
-			}
-		});
-	});
+			const compiler = /** @type {import("../").MultiCompiler} */ (
+				/** @type {unknown} */ (webpack(/** @type {EXPECTED_ANY} */ (options)))
+			);
+			compiler.outputFileSystem = /** @type {EXPECTED_ANY} */ (
+				createFsFromVolume(new Volume())
+			);
+			compiler.run((err, stats) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(/** @type {import("../").MultiStats} */ (stats));
+				}
+			});
+		})
+	);
 
 describe("MultiStats", () => {
 	it("should create JSON of children stats", async () => {
@@ -187,9 +197,11 @@ describe("MultiStats", () => {
 			}
 		]);
 
-		const statsOptions = {
-			children: ["none", "none"]
-		};
+		const statsOptions = /** @type {import("../").StatsOptions} */ (
+			/** @type {unknown} */ ({
+				children: ["none", "none"]
+			})
+		);
 
 		expect(stats.toJson(statsOptions)).toMatchInlineSnapshot(`
 		Object {

--- a/test/MultiWatching.unittest.js
+++ b/test/MultiWatching.unittest.js
@@ -10,12 +10,14 @@ const MultiWatching = require("../lib/MultiWatching");
  * @returns {Watching} watching
  */
 const createWatching = () =>
-	/** @type {Watching} */ (/** @type {unknown} */ ({
-		invalidate: jest.fn(),
-		suspend: jest.fn(),
-		resume: jest.fn(),
-		close: jest.fn()
-	}));
+	/** @type {Watching} */ (
+		/** @type {unknown} */ ({
+			invalidate: jest.fn(),
+			suspend: jest.fn(),
+			resume: jest.fn(),
+			close: jest.fn()
+		})
+	);
 
 /**
  * @returns {MultiCompiler} compiler

--- a/test/MultiWatching.unittest.js
+++ b/test/MultiWatching.unittest.js
@@ -10,12 +10,12 @@ const MultiWatching = require("../lib/MultiWatching");
  * @returns {Watching} watching
  */
 const createWatching = () =>
-	/** @type {Watching} */ ({
+	/** @type {Watching} */ (/** @type {unknown} */ ({
 		invalidate: jest.fn(),
 		suspend: jest.fn(),
 		resume: jest.fn(),
 		close: jest.fn()
-	});
+	}));
 
 /**
  * @returns {MultiCompiler} compiler
@@ -69,9 +69,10 @@ describe("MultiWatching", () => {
 	});
 
 	describe("close", () => {
+		/** @type {jest.Mock} */
 		let callback;
-		const callClosedFinishedCallback = (watching) => {
-			watching.close.mock.calls[0][0]();
+		const callClosedFinishedCallback = (/** @type {Watching} */ watching) => {
+			/** @type {jest.Mock} */ (watching.close).mock.calls[0][0]();
 		};
 
 		beforeEach(() => {

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -25,16 +25,17 @@ describe("NodeTemplatePlugin", () => {
 			},
 			(err, stats) => {
 				if (err) return err;
-				expect(stats.hasErrors()).toBe(false);
-				expect(stats.hasWarnings()).toBe(false);
+				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(false);
+				expect(/** @type {import("../").Stats} */ (stats).hasWarnings()).toBe(false);
 
+				// @ts-ignore
 				const result = require("./js/NodeTemplatePlugin/result").abc;
 
 				expect(result.nextTick).toBe(process.nextTick);
 				expect(result.fs).toBe(require("fs"));
-				result.loadChunk(456, (chunk) => {
+				result.loadChunk(456, /** @param {unknown} chunk */ (chunk) => {
 					expect(chunk).toBe(123);
-					result.loadChunk(567, (chunk) => {
+					result.loadChunk(567, /** @param {unknown} chunk */ (chunk) => {
 						expect(chunk).toEqual({
 							a: 1
 						});
@@ -70,17 +71,18 @@ describe("NodeTemplatePlugin", () => {
 			},
 			(err, stats) => {
 				if (err) return err;
-				expect(stats.hasErrors()).toBe(false);
+				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(false);
 
+				// @ts-ignore
 				const result = require("./js/NodeTemplatePluginSingle/result2");
 
 				expect(result.nextTick).toBe(process.nextTick);
 				expect(result.fs).toBe(require("fs"));
 				const sameTick = true;
-				result.loadChunk(456, (chunk) => {
+				result.loadChunk(456, /** @param {unknown} chunk */ (chunk) => {
 					expect(chunk).toBe(123);
 					expect(sameTick).toBe(true);
-					result.loadChunk(567, (chunk) => {
+					result.loadChunk(567, /** @param {unknown} chunk */ (chunk) => {
 						expect(chunk).toEqual({
 							a: 1
 						});

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -25,23 +25,33 @@ describe("NodeTemplatePlugin", () => {
 			},
 			(err, stats) => {
 				if (err) return err;
-				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(false);
-				expect(/** @type {import("../").Stats} */ (stats).hasWarnings()).toBe(false);
+				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(
+					false
+				);
+				expect(/** @type {import("../").Stats} */ (stats).hasWarnings()).toBe(
+					false
+				);
 
-				// @ts-ignore
+				// @ts-expect-error generated file does not exist at type-check time
 				const result = require("./js/NodeTemplatePlugin/result").abc;
 
 				expect(result.nextTick).toBe(process.nextTick);
 				expect(result.fs).toBe(require("fs"));
-				result.loadChunk(456, /** @param {unknown} chunk */ (chunk) => {
-					expect(chunk).toBe(123);
-					result.loadChunk(567, /** @param {unknown} chunk */ (chunk) => {
-						expect(chunk).toEqual({
-							a: 1
-						});
-						done();
-					});
-				});
+				result.loadChunk(
+					456,
+					/** @param {unknown} chunk loaded chunk */ (chunk) => {
+						expect(chunk).toBe(123);
+						result.loadChunk(
+							567,
+							/** @param {unknown} chunk loaded chunk */ (chunk) => {
+								expect(chunk).toEqual({
+									a: 1
+								});
+								done();
+							}
+						);
+					}
+				);
 			}
 		);
 	});
@@ -71,24 +81,32 @@ describe("NodeTemplatePlugin", () => {
 			},
 			(err, stats) => {
 				if (err) return err;
-				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(false);
+				expect(/** @type {import("../").Stats} */ (stats).hasErrors()).toBe(
+					false
+				);
 
-				// @ts-ignore
+				// @ts-expect-error generated file does not exist at type-check time
 				const result = require("./js/NodeTemplatePluginSingle/result2");
 
 				expect(result.nextTick).toBe(process.nextTick);
 				expect(result.fs).toBe(require("fs"));
 				const sameTick = true;
-				result.loadChunk(456, /** @param {unknown} chunk */ (chunk) => {
-					expect(chunk).toBe(123);
-					expect(sameTick).toBe(true);
-					result.loadChunk(567, /** @param {unknown} chunk */ (chunk) => {
-						expect(chunk).toEqual({
-							a: 1
-						});
-						done();
-					});
-				});
+				result.loadChunk(
+					456,
+					/** @param {unknown} chunk loaded chunk */ (chunk) => {
+						expect(chunk).toBe(123);
+						expect(sameTick).toBe(true);
+						result.loadChunk(
+							567,
+							/** @param {unknown} chunk loaded chunk */ (chunk) => {
+								expect(chunk).toEqual({
+									a: 1
+								});
+								done();
+							}
+						);
+					}
+				);
 			}
 		);
 	});

--- a/test/NormalModule.unittest.js
+++ b/test/NormalModule.unittest.js
@@ -6,7 +6,14 @@ const RawSource = require("webpack-sources").RawSource;
 const NormalModule = require("../lib/NormalModule");
 const HarmonyImportSideEffectDependency = require("../lib/dependencies/HarmonyImportSideEffectDependency");
 
+/** @typedef {import("../lib/NormalModule").LoaderItem} LoaderItem */
+/** @typedef {import("../lib/Parser")} Parser */
+/** @typedef {import("../lib/Generator")} Generator */
+/** @typedef {import("../lib/ModuleGraph")} ModuleGraph */
+/** @typedef {import("../lib/dependencies/ImportPhase").ImportPhaseType} ImportPhaseType */
+
 describe("NormalModule", () => {
+	/** @type {InstanceType<typeof NormalModule>} */
 	let normalModule;
 	/** @type {string} */
 	let request;
@@ -14,33 +21,40 @@ describe("NormalModule", () => {
 	let userRequest;
 	/** @type {string} */
 	let rawRequest;
-	/** @type {string[]} */
+	/** @type {LoaderItem[]} */
 	let loaders;
 	/** @type {string} */
 	let resource;
+	/** @type {Parser} */
 	let parser;
 
 	beforeEach(() => {
 		request = "/some/request";
 		userRequest = "/some/userRequest";
 		rawRequest = "some/rawRequest";
-		/** @type {string[]} */
+		/** @type {LoaderItem[]} */
 		loaders = [];
 		resource = "/some/resource";
-		parser = {
-			parse() {}
-		};
-		normalModule = new NormalModule({
-			type: "javascript/auto",
-			request,
-			userRequest,
-			rawRequest,
-			loaders,
-			resource,
-			parser,
-			generator: null,
-			resolveOptions: {}
-		});
+		parser = /** @type {Parser} */ (
+			/** @type {unknown} */ ({
+				parse() {}
+			})
+		);
+		normalModule = new NormalModule(
+			/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+				/** @type {unknown} */ ({
+					type: "javascript/auto",
+					request,
+					userRequest,
+					rawRequest,
+					loaders,
+					resource,
+					parser,
+					generator: null,
+					resolveOptions: {}
+				})
+			)
+		);
 		normalModule.buildInfo = {
 			cacheable: true
 		};
@@ -61,9 +75,13 @@ describe("NormalModule", () => {
 	describe("#readableIdentifier", () => {
 		it("calls the given requestShortener with the user request", () => {
 			const spy = jest.fn();
-			normalModule.readableIdentifier({
-				shorten: spy
-			});
+			normalModule.readableIdentifier(
+				/** @type {import("../lib/RequestShortener")} */ (
+					/** @type {unknown} */ ({
+						shorten: spy
+					})
+				)
+			);
 			expect(spy).toHaveBeenCalledTimes(1);
 			expect(spy.mock.calls[0][0]).toBe(userRequest);
 		});
@@ -82,15 +100,19 @@ describe("NormalModule", () => {
 			beforeEach(() => {
 				userRequest =
 					"/some/userRequest!/some/other/userRequest!/some/thing/is/off/here";
-				normalModule = new NormalModule({
-					type: "javascript/auto",
-					request,
-					userRequest,
-					rawRequest,
-					loaders,
-					resource,
-					parser
-				});
+				normalModule = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request,
+							userRequest,
+							rawRequest,
+							loaders,
+							resource,
+							parser
+						})
+					)
+				);
 			});
 
 			it("contextifies every path in the userRequest", () => {
@@ -107,15 +129,19 @@ describe("NormalModule", () => {
 				// cspell:word testpath
 				userRequest =
 					"F:\\some\\context\\loader?query=foo\\bar&otherPath=testpath/other";
-				normalModule = new NormalModule({
-					type: "javascript/auto",
-					request,
-					userRequest,
-					rawRequest,
-					loaders,
-					resource,
-					parser
-				});
+				normalModule = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request,
+							userRequest,
+							rawRequest,
+							loaders,
+							resource,
+							parser
+						})
+					)
+				);
 				expect(
 					normalModule.libIdent({
 						context: "F:\\some\\context"
@@ -135,15 +161,19 @@ describe("NormalModule", () => {
 
 			beforeEach(() => {
 				resource = `${baseResource}?some=query`;
-				normalModule = new NormalModule({
-					type: "javascript/auto",
-					request,
-					userRequest,
-					rawRequest,
-					loaders,
-					resource,
-					parser
-				});
+				normalModule = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request,
+							userRequest,
+							rawRequest,
+							loaders,
+							resource,
+							parser
+						})
+					)
+				);
 			});
 
 			it("return only the part before the ?-sign", () => {
@@ -153,8 +183,11 @@ describe("NormalModule", () => {
 	});
 
 	describe("#createSourceForAsset", () => {
+		/** @type {string} */
 		let name;
+		/** @type {string} */
 		let content;
+		/** @type {string | (() => void)} */
 		let sourceMap;
 
 		beforeEach(() => {
@@ -174,7 +207,12 @@ describe("NormalModule", () => {
 		describe("given a string as the sourcemap", () => {
 			it("returns a OriginalSource", () => {
 				expect(
-					normalModule.createSourceForAsset("/", name, content, sourceMap)
+					normalModule.createSourceForAsset(
+						"/",
+						name,
+						content,
+						/** @type {string} */ (sourceMap)
+					)
 				).toBeInstanceOf(OriginalSource);
 			});
 		});
@@ -187,7 +225,12 @@ describe("NormalModule", () => {
 
 			it("returns a SourceMapSource", () => {
 				expect(
-					normalModule.createSourceForAsset("/", name, content, sourceMap)
+					normalModule.createSourceForAsset(
+						"/",
+						name,
+						content,
+						/** @type {string} */ (/** @type {unknown} */ (sourceMap))
+					)
 				).toBeInstanceOf(RawSource);
 			});
 		});
@@ -199,7 +242,12 @@ describe("NormalModule", () => {
 
 			it("returns a SourceMapSource", () => {
 				expect(
-					normalModule.createSourceForAsset("/", name, content, sourceMap)
+					normalModule.createSourceForAsset(
+						"/",
+						name,
+						content,
+						/** @type {string} */ (/** @type {unknown} */ (sourceMap))
+					)
 				).toBeInstanceOf(RawSource);
 			});
 		});
@@ -212,7 +260,12 @@ describe("NormalModule", () => {
 
 			it("returns a SourceMapSource", () => {
 				expect(
-					normalModule.createSourceForAsset("/", name, content, sourceMap)
+					normalModule.createSourceForAsset(
+						"/",
+						name,
+						content,
+						/** @type {string} */ (/** @type {unknown} */ (sourceMap))
+					)
 				).toBeInstanceOf(SourceMapSource);
 			});
 		});
@@ -222,16 +275,22 @@ describe("NormalModule", () => {
 		const expectedSource = "some source";
 
 		beforeEach(() => {
-			normalModule._source = new RawSource(expectedSource);
+			/** @type {EXPECTED_ANY} */ (normalModule)._source = new RawSource(
+				expectedSource
+			);
 		});
 
 		it("returns an original Source", () => {
-			expect(normalModule.originalSource()).toBe(normalModule._source);
+			expect(normalModule.originalSource()).toBe(
+				/** @type {EXPECTED_ANY} */ (normalModule)._source
+			);
 		});
 	});
 
 	describe("#applyNoParseRule", () => {
+		/** @type {string | RegExp} */
 		let rule;
+		/** @type {string} */
 		let content;
 
 		describe("given a string as rule", () => {
@@ -245,7 +304,12 @@ describe("NormalModule", () => {
 				});
 
 				it("returns true", () => {
-					expect(normalModule.shouldPreventParsing(rule, content)).toBe(true);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							rule,
+							content
+						)
+					).toBe(true);
 				});
 			});
 
@@ -255,7 +319,12 @@ describe("NormalModule", () => {
 				});
 
 				it("returns false", () => {
-					expect(normalModule.shouldPreventParsing(rule, content)).toBe(false);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							rule,
+							content
+						)
+					).toBe(false);
 				});
 			});
 		});
@@ -271,7 +340,12 @@ describe("NormalModule", () => {
 				});
 
 				it("returns true", () => {
-					expect(normalModule.shouldPreventParsing(rule, content)).toBe(true);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							rule,
+							content
+						)
+					).toBe(true);
 				});
 			});
 
@@ -281,13 +355,19 @@ describe("NormalModule", () => {
 				});
 
 				it("returns false", () => {
-					expect(normalModule.shouldPreventParsing(rule, content)).toBe(false);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							rule,
+							content
+						)
+					).toBe(false);
 				});
 			});
 		});
 	});
 
 	describe("#shouldPreventParsing", () => {
+		/** @type {jest.Mock} */
 		let applyNoParseRuleSpy;
 
 		beforeEach(() => {
@@ -297,12 +377,15 @@ describe("NormalModule", () => {
 
 		describe("given no noParseRule", () => {
 			it("returns false", () => {
-				expect(normalModule.shouldPreventParsing()).toBe(false);
+				expect(
+					/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing()
+				).toBe(false);
 				expect(applyNoParseRuleSpy).not.toHaveBeenCalled();
 			});
 		});
 
 		describe("given a noParseRule", () => {
+			/** @type {boolean} */
 			let returnValOfSpy;
 
 			beforeEach(() => {
@@ -312,24 +395,29 @@ describe("NormalModule", () => {
 
 			describe("that is a string", () => {
 				it("calls and returns whatever applyNoParseRule returns", () => {
-					expect(normalModule.shouldPreventParsing("some rule")).toBe(
-						returnValOfSpy
-					);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							"some rule"
+						)
+					).toBe(returnValOfSpy);
 					expect(applyNoParseRuleSpy).toHaveBeenCalledTimes(1);
 				});
 			});
 
 			describe("that is a regex", () => {
 				it("calls and returns whatever applyNoParseRule returns", () => {
-					expect(normalModule.shouldPreventParsing("some rule")).toBe(
-						returnValOfSpy
-					);
+					expect(
+						/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+							"some rule"
+						)
+					).toBe(returnValOfSpy);
 					expect(applyNoParseRuleSpy).toHaveBeenCalledTimes(1);
 				});
 			});
 
 			describe("that is an array", () => {
 				describe("of strings and or regexps", () => {
+					/** @type {(string | RegExp)[]} */
 					let someRules;
 
 					beforeEach(() => {
@@ -343,9 +431,11 @@ describe("NormalModule", () => {
 						});
 
 						it("returns false", () => {
-							expect(normalModule.shouldPreventParsing(someRules)).toBe(
-								returnValOfSpy
-							);
+							expect(
+								/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+									someRules
+								)
+							).toBe(returnValOfSpy);
 							expect(applyNoParseRuleSpy).toHaveBeenCalledTimes(3);
 						});
 					});
@@ -357,9 +447,11 @@ describe("NormalModule", () => {
 						});
 
 						it("returns true", () => {
-							expect(normalModule.shouldPreventParsing(someRules)).toBe(
-								returnValOfSpy
-							);
+							expect(
+								/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+									someRules
+								)
+							).toBe(returnValOfSpy);
 							expect(applyNoParseRuleSpy).toHaveBeenCalledTimes(1);
 						});
 					});
@@ -373,9 +465,11 @@ describe("NormalModule", () => {
 						});
 
 						it("returns true", () => {
-							expect(normalModule.shouldPreventParsing(someRules)).toBe(
-								returnValOfSpy
-							);
+							expect(
+								/** @type {EXPECTED_ANY} */ (normalModule).shouldPreventParsing(
+									someRules
+								)
+							).toBe(returnValOfSpy);
 							expect(applyNoParseRuleSpy).toHaveBeenCalledTimes(3);
 						});
 					});
@@ -389,20 +483,28 @@ describe("NormalModule", () => {
 		// linked by HarmonyImportSideEffectDependency. Walking the chain via
 		// the recursive form used 2 stack frames per module and overflowed on
 		// long chains (issue #20986).
+		/**
+		 * @param {number} count chain length
+		 * @returns {{ modules: InstanceType<typeof NormalModule>[], moduleGraph: ModuleGraph }} chain
+		 */
 		const buildChain = (count) => {
 			const modules = [];
 			for (let i = 0; i < count; i++) {
-				const mod = new NormalModule({
-					type: "javascript/auto",
-					request: `/m${i}`,
-					userRequest: `/m${i}`,
-					rawRequest: `m${i}`,
-					loaders: [],
-					resource: `/m${i}`,
-					parser: { parse() {} },
-					generator: null,
-					resolveOptions: {}
-				});
+				const mod = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request: `/m${i}`,
+							userRequest: `/m${i}`,
+							rawRequest: `m${i}`,
+							loaders: [],
+							resource: `/m${i}`,
+							parser: { parse() {} },
+							generator: null,
+							resolveOptions: {}
+						})
+					)
+				);
 				mod.buildMeta = { sideEffectFree: true };
 				modules.push(mod);
 			}
@@ -411,16 +513,19 @@ describe("NormalModule", () => {
 				const dep = new HarmonyImportSideEffectDependency(
 					`m${i + 1}`,
 					0,
-					"evaluation"
+					/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
 				);
 				modules[i].dependencies = [dep];
 				depToModule.set(dep, modules[i + 1]);
 			}
 			modules[count - 1].dependencies = [];
-			const moduleGraph = {
-				getModule: (dep) => depToModule.get(dep),
-				getOptimizationBailout: () => []
-			};
+			const moduleGraph = /** @type {ModuleGraph} */ (
+				/** @type {unknown} */ ({
+					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					getModule: (dep) => depToModule.get(dep),
+					getOptimizationBailout: () => []
+				})
+			);
 			return { modules, moduleGraph };
 		};
 
@@ -446,12 +551,14 @@ describe("NormalModule", () => {
 			const lastDep = new HarmonyImportSideEffectDependency(
 				"m0",
 				0,
-				"evaluation"
+				/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
 			);
 			modules[49].dependencies = [lastDep];
 			const originalGetModule = moduleGraph.getModule;
-			moduleGraph.getModule = (dep) =>
-				dep === lastDep ? modules[0] : originalGetModule(dep);
+			moduleGraph.getModule = /** @type {ModuleGraph["getModule"]} */ (
+				/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+				(dep) => (dep === lastDep ? modules[0] : originalGetModule(dep))
+			);
 			// Cycles fold to `false` (the accumulator's identity) when all
 			// participating modules are side-effect free — same as the original
 			// recursive behavior.
@@ -464,10 +571,15 @@ describe("NormalModule", () => {
 			// Make module 5 have side effects.
 			modules[5].buildMeta = { sideEffectFree: false };
 			const bailouts = new Map();
-			moduleGraph.getOptimizationBailout = (mod) => {
-				if (!bailouts.has(mod)) bailouts.set(mod, []);
-				return bailouts.get(mod);
-			};
+			/** @type {EXPECTED_ANY} */ (moduleGraph).getOptimizationBailout =
+				/**
+				 * @param {import("../lib/NormalModule")} mod module
+				 * @returns {unknown[]} bailout list
+				 */
+				(mod) => {
+					if (!bailouts.has(mod)) bailouts.set(mod, []);
+					return bailouts.get(mod);
+				};
 			expect(modules[0].getSideEffectsConnectionState(moduleGraph)).toBe(true);
 			// Each ancestor in the chain (modules 0..4) records the bailout once
 			// for the dep that triggered descent, matching the recursive baseline.
@@ -482,18 +594,25 @@ describe("NormalModule", () => {
 
 		it("aggregates state across branching deps", () => {
 			// Diamond: root depends on two side-effect-free leaves.
+			/**
+			 * @param {string} id module id
+			 */
 			const make = (id) => {
-				const mod = new NormalModule({
-					type: "javascript/auto",
-					request: `/${id}`,
-					userRequest: `/${id}`,
-					rawRequest: id,
-					loaders: [],
-					resource: `/${id}`,
-					parser: { parse() {} },
-					generator: null,
-					resolveOptions: {}
-				});
+				const mod = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request: `/${id}`,
+							userRequest: `/${id}`,
+							rawRequest: id,
+							loaders: [],
+							resource: `/${id}`,
+							parser: { parse() {} },
+							generator: null,
+							resolveOptions: {}
+						})
+					)
+				);
 				mod.buildMeta = { sideEffectFree: true };
 				mod.dependencies = [];
 				return mod;
@@ -501,13 +620,24 @@ describe("NormalModule", () => {
 			const root = make("root");
 			const a = make("a");
 			const b = make("b");
-			const depA = new HarmonyImportSideEffectDependency("a", 0, "evaluation");
-			const depB = new HarmonyImportSideEffectDependency("b", 1, "evaluation");
+			const depA = new HarmonyImportSideEffectDependency(
+				"a",
+				0,
+				/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
+			);
+			const depB = new HarmonyImportSideEffectDependency(
+				"b",
+				1,
+				/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
+			);
 			root.dependencies = [depA, depB];
-			const moduleGraph = {
-				getModule: (dep) => (dep === depA ? a : dep === depB ? b : undefined),
-				getOptimizationBailout: () => []
-			};
+			const moduleGraph = /** @type {ModuleGraph} */ (
+				/** @type {unknown} */ ({
+					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					getModule: (dep) => (dep === depA ? a : dep === depB ? b : undefined),
+					getOptimizationBailout: () => []
+				})
+			);
 			expect(root.getSideEffectsConnectionState(moduleGraph)).toBe(false);
 			expect(root._isEvaluatingSideEffects).toBe(false);
 			expect(a._isEvaluatingSideEffects).toBe(false);
@@ -527,17 +657,21 @@ describe("NormalModule", () => {
 			const N = 5000;
 			const modules = [];
 			for (let i = 0; i < N; i++) {
-				const mod = new NormalModule({
-					type: "javascript/auto",
-					request: `/m${i}`,
-					userRequest: `/m${i}`,
-					rawRequest: `m${i}`,
-					loaders: [],
-					resource: `/m${i}`,
-					parser: { parse() {} },
-					generator: null,
-					resolveOptions: {}
-				});
+				const mod = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request: `/m${i}`,
+							userRequest: `/m${i}`,
+							rawRequest: `m${i}`,
+							loaders: [],
+							resource: `/m${i}`,
+							parser: { parse() {} },
+							generator: null,
+							resolveOptions: {}
+						})
+					)
+				);
 				mod.buildMeta = { sideEffectFree: true };
 				modules.push(mod);
 			}
@@ -546,7 +680,7 @@ describe("NormalModule", () => {
 				const sideDep = new HarmonyImportSideEffectDependency(
 					`m${(i + 1) % N}`,
 					0,
-					"evaluation"
+					/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
 				);
 				modules[i].dependencies = [
 					sideDep,
@@ -555,10 +689,13 @@ describe("NormalModule", () => {
 				];
 				depToModule.set(sideDep, modules[(i + 1) % N]);
 			}
-			const moduleGraph = {
-				getModule: (dep) => depToModule.get(dep),
-				getOptimizationBailout: () => []
-			};
+			const moduleGraph = /** @type {ModuleGraph} */ (
+				/** @type {unknown} */ ({
+					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					getModule: (dep) => depToModule.get(dep),
+					getOptimizationBailout: () => []
+				})
+			);
 			expect(modules[0].getSideEffectsConnectionState(moduleGraph)).toBe(false);
 		});
 
@@ -573,18 +710,25 @@ describe("NormalModule", () => {
 			// enough past that boundary that any regression in the
 			// iterative fallback path will overflow V8's stack.
 			const N = 2500;
+			/**
+			 * @param {string} id module id
+			 */
 			const make = (id) => {
-				const mod = new NormalModule({
-					type: "javascript/auto",
-					request: `/${id}`,
-					userRequest: `/${id}`,
-					rawRequest: id,
-					loaders: [],
-					resource: `/${id}`,
-					parser: { parse() {} },
-					generator: null,
-					resolveOptions: {}
-				});
+				const mod = new NormalModule(
+					/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+						/** @type {unknown} */ ({
+							type: "javascript/auto",
+							request: `/${id}`,
+							userRequest: `/${id}`,
+							rawRequest: id,
+							loaders: [],
+							resource: `/${id}`,
+							parser: { parse() {} },
+							generator: null,
+							resolveOptions: {}
+						})
+					)
+				);
 				mod.buildMeta = { sideEffectFree: true };
 				return mod;
 			};
@@ -597,22 +741,25 @@ describe("NormalModule", () => {
 				const next = new HarmonyImportSideEffectDependency(
 					`m${i + 1}`,
 					0,
-					"evaluation"
+					/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
 				);
 				const aside = new HarmonyImportSideEffectDependency(
 					"leaf",
 					1,
-					"evaluation"
+					/** @type {ImportPhaseType} */ (/** @type {unknown} */ ("evaluation"))
 				);
 				modules[i].dependencies = [next, aside];
 				depToModule.set(next, modules[i + 1]);
 				depToModule.set(aside, leaf);
 			}
 			modules[N - 1].dependencies = [];
-			const moduleGraph = {
-				getModule: (dep) => depToModule.get(dep),
-				getOptimizationBailout: () => []
-			};
+			const moduleGraph = /** @type {ModuleGraph} */ (
+				/** @type {unknown} */ ({
+					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					getModule: (dep) => depToModule.get(dep),
+					getOptimizationBailout: () => []
+				})
+			);
 			expect(modules[0].getSideEffectsConnectionState(moduleGraph)).toBe(false);
 			for (let i = 0; i < N; i++) {
 				expect(modules[i]._isEvaluatingSideEffects).toBe(false);

--- a/test/NormalModule.unittest.js
+++ b/test/NormalModule.unittest.js
@@ -521,7 +521,10 @@ describe("NormalModule", () => {
 			modules[count - 1].dependencies = [];
 			const moduleGraph = /** @type {ModuleGraph} */ (
 				/** @type {unknown} */ ({
-					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					/**
+					 * @param {import("../lib/Dependency")} dep dependency
+					 * @returns {import("../lib/Module") | null} module
+					 */
 					getModule: (dep) => depToModule.get(dep),
 					getOptimizationBailout: () => []
 				})
@@ -556,7 +559,10 @@ describe("NormalModule", () => {
 			modules[49].dependencies = [lastDep];
 			const originalGetModule = moduleGraph.getModule;
 			moduleGraph.getModule = /** @type {ModuleGraph["getModule"]} */ (
-				/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+				/**
+				 * @param {import("../lib/Dependency")} dep dependency
+				 * @returns {import("../lib/Module") | null} module
+				 */
 				(dep) => (dep === lastDep ? modules[0] : originalGetModule(dep))
 			);
 			// Cycles fold to `false` (the accumulator's identity) when all
@@ -596,6 +602,7 @@ describe("NormalModule", () => {
 			// Diamond: root depends on two side-effect-free leaves.
 			/**
 			 * @param {string} id module id
+			 * @returns {InstanceType<typeof NormalModule>} module
 			 */
 			const make = (id) => {
 				const mod = new NormalModule(
@@ -633,8 +640,11 @@ describe("NormalModule", () => {
 			root.dependencies = [depA, depB];
 			const moduleGraph = /** @type {ModuleGraph} */ (
 				/** @type {unknown} */ ({
-					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
-					getModule: (dep) => (dep === depA ? a : dep === depB ? b : undefined),
+					/**
+					 * @param {import("../lib/Dependency")} dep dependency
+					 * @returns {import("../lib/Module") | null} module
+					 */
+					getModule: (dep) => (dep === depA ? a : dep === depB ? b : null),
 					getOptimizationBailout: () => []
 				})
 			);
@@ -691,7 +701,10 @@ describe("NormalModule", () => {
 			}
 			const moduleGraph = /** @type {ModuleGraph} */ (
 				/** @type {unknown} */ ({
-					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					/**
+					 * @param {import("../lib/Dependency")} dep dependency
+					 * @returns {import("../lib/Module") | null} module
+					 */
 					getModule: (dep) => depToModule.get(dep),
 					getOptimizationBailout: () => []
 				})
@@ -712,6 +725,7 @@ describe("NormalModule", () => {
 			const N = 2500;
 			/**
 			 * @param {string} id module id
+			 * @returns {InstanceType<typeof NormalModule>} module
 			 */
 			const make = (id) => {
 				const mod = new NormalModule(
@@ -755,7 +769,10 @@ describe("NormalModule", () => {
 			modules[N - 1].dependencies = [];
 			const moduleGraph = /** @type {ModuleGraph} */ (
 				/** @type {unknown} */ ({
-					/** @param {import("../lib/Dependency")} dep dependency @returns {InstanceType<typeof import("../lib/NormalModule")> | undefined} module */
+					/**
+					 * @param {import("../lib/Dependency")} dep dependency
+					 * @returns {import("../lib/Module") | null} module
+					 */
 					getModule: (dep) => depToModule.get(dep),
 					getOptimizationBailout: () => []
 				})

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const path = require("path");
 const util = require("util");
 const vm = require("vm");
+// @ts-ignore
 const rimraf = require("rimraf");
 
 const readdir = util.promisify(fs.readdir);
@@ -52,7 +53,7 @@ describe("Persistent Caching", () => {
 		rimraf(tempPath, done);
 	});
 
-	const updateSrc = async (data) => {
+	const updateSrc = async (/** @type {Record<string, string>} */ data) => {
 		const ts = new Date(Date.now() - 10000);
 		await mkdir(srcPath, { recursive: true });
 		for (const key of Object.keys(data)) {
@@ -62,17 +63,17 @@ describe("Persistent Caching", () => {
 		}
 	};
 
-	const compile = async (configAdditions = {}) =>
+	const compile = async (/** @type {Partial<import("../").Configuration>} */ configAdditions = {}) =>
 		new Promise((resolve, reject) => {
 			const webpack = require("../");
 
 			webpack(
-				{
+				/** @type {import("../").Configuration} */ (/** @type {unknown} */ ({
 					...config,
 					...configAdditions,
-					cache: { ...config.cache, ...configAdditions.cache }
-				},
-				(err, stats) => {
+					cache: { ...config.cache, .../** @type {EXPECTED_ANY} */ (configAdditions).cache }
+				})),
+				(/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
 					if (err) return reject(err);
 					if (stats.hasErrors()) {
 						return reject(stats.toString({ preset: "errors-only" }));
@@ -93,21 +94,22 @@ describe("Persistent Caching", () => {
 	};
 
 	const execute = () => {
+		/** @type {Record<string, { exports: unknown }>} */
 		const cache = {};
-		const require = (name) => {
+		const require = (/** @type {string} */ name) => {
 			if (cache[name]) return cache[name].exports;
 			if (!name.endsWith(".js")) name += ".js";
 			const p = path.resolve(outputPath, name);
 			const source = fs.readFileSync(p, "utf8");
 			const context = {};
-			const fn = vm.runInThisContext(
+			const fn = /** @type {Function} */ (/** @type {EXPECTED_ANY} */ (vm.runInThisContext)(
 				`(function(require, module, exports) { ${source} })`,
 				context,
 				{
 					filename: p
 				}
-			);
-			const m = { exports: {} };
+			));
+			const m = { exports: /** @type {unknown} */ ({}) };
 			cache[name] = m;
 			fn(require, m, m.exports);
 			return m.exports;
@@ -144,7 +146,7 @@ export { style };
 }`
 		};
 		for (const file of files) {
-			data[file] = "export default 1;";
+			/** @type {Record<string, string>} */ (data)[file] = "export default 1;";
 		}
 		await updateSrc(data);
 		await compile({ cache: { compression: false } });
@@ -171,7 +173,8 @@ export { style };
 			"e.js": 'import "lodash";'
 		};
 		await updateSrc(data);
-		const c = (items) => {
+		const c = (/** @type {string} */ items) => {
+			/** @type {Record<string, string>} */
 			const entry = {};
 			for (const item of items) entry[item] = `./src/${item}.js`;
 			return compile({ entry, cache: { compression: false } });

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -6,7 +6,6 @@ const fs = require("fs");
 const path = require("path");
 const util = require("util");
 const vm = require("vm");
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 const readdir = util.promisify(fs.readdir);

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const path = require("path");
 const util = require("util");
 const vm = require("vm");
-// @ts-ignore
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 const readdir = util.promisify(fs.readdir);
@@ -68,12 +68,20 @@ describe("Persistent Caching", () => {
 			const webpack = require("../");
 
 			webpack(
-				/** @type {import("../").Configuration} */ (/** @type {unknown} */ ({
-					...config,
-					...configAdditions,
-					cache: { ...config.cache, .../** @type {EXPECTED_ANY} */ (configAdditions).cache }
-				})),
-				(/** @type {Error | null} */ err, /** @type {import("../").Stats | undefined} */ _stats) => {
+				/** @type {import("../").Configuration} */ (
+					/** @type {unknown} */ ({
+						...config,
+						...configAdditions,
+						cache: {
+							...config.cache,
+							.../** @type {EXPECTED_ANY} */ (configAdditions).cache
+						}
+					})
+				),
+				(
+					/** @type {Error | null} */ err,
+					/** @type {import("../").Stats | undefined} */ _stats
+				) => {
 					if (err) return reject(err);
 					const stats = /** @type {import("../").Stats} */ (_stats);
 					if (stats.hasErrors()) {
@@ -103,13 +111,16 @@ describe("Persistent Caching", () => {
 			const p = path.resolve(outputPath, name);
 			const source = fs.readFileSync(p, "utf8");
 			const context = {};
-			const fn = /** @type {Function} */ (/** @type {EXPECTED_ANY} */ (vm.runInThisContext)(
-				`(function(require, module, exports) { ${source} })`,
-				context,
-				{
-					filename: p
-				}
-			));
+			const fn =
+				/** @type {(require: (name: string) => EXPECTED_ANY, module: { exports: unknown }, exports: unknown) => void} */ (
+					/** @type {EXPECTED_ANY} */ (vm.runInThisContext)(
+						`(function(require, module, exports) { ${source} })`,
+						context,
+						{
+							filename: p
+						}
+					)
+				);
 			const m = { exports: /** @type {unknown} */ ({}) };
 			cache[name] = m;
 			fn(require, m, m.exports);

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -63,7 +63,7 @@ describe("Persistent Caching", () => {
 		}
 	};
 
-	const compile = async (/** @type {Partial<import("../").Configuration>} */ configAdditions = {}) =>
+	const compile = async (/** @type {EXPECTED_ANY} */ configAdditions = {}) =>
 		new Promise((resolve, reject) => {
 			const webpack = require("../");
 
@@ -73,8 +73,9 @@ describe("Persistent Caching", () => {
 					...configAdditions,
 					cache: { ...config.cache, .../** @type {EXPECTED_ANY} */ (configAdditions).cache }
 				})),
-				(/** @type {Error | null} */ err, /** @type {import("../").Stats} */ stats) => {
+				(/** @type {Error | null} */ err, /** @type {import("../").Stats | undefined} */ _stats) => {
 					if (err) return reject(err);
+					const stats = /** @type {import("../").Stats} */ (_stats);
 					if (stats.hasErrors()) {
 						return reject(stats.toString({ preset: "errors-only" }));
 					}

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -4,7 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-ignore
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 describe("Profiling Plugin", () => {
@@ -63,13 +63,19 @@ describe("Profiling Plugin", () => {
 
 				const data = require(finalPath);
 
-				const maxTs = data.reduce((/** @type {number} */ max, /** @type {EXPECTED_ANY} */ entry) => Math.max(max, entry.ts), 0);
+				const maxTs = data.reduce(
+					(/** @type {number} */ max, /** @type {EXPECTED_ANY} */ entry) =>
+						Math.max(max, entry.ts),
+					0
+				);
 				const minTs = data[0].ts;
 				const duration = maxTs - minTs;
 				expect(duration).toBeLessThan(
 					testDuration[0] * 1000000 + testDuration[1] / 1000
 				);
-				const cpuProfile = data.find((/** @type {EXPECTED_ANY} */ entry) => entry.name === "CpuProfile");
+				const cpuProfile = data.find(
+					(/** @type {EXPECTED_ANY} */ entry) => entry.name === "CpuProfile"
+				);
 				expect(cpuProfile).toBeTypeOf("object");
 				const profile = cpuProfile.args.data.cpuProfile;
 				expect(profile.startTime).toBeGreaterThanOrEqual(minTs);

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -4,6 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+// @ts-ignore
 const rimraf = require("rimraf");
 
 describe("Profiling Plugin", () => {
@@ -62,13 +63,13 @@ describe("Profiling Plugin", () => {
 
 				const data = require(finalPath);
 
-				const maxTs = data.reduce((max, entry) => Math.max(max, entry.ts), 0);
+				const maxTs = data.reduce((/** @type {number} */ max, /** @type {EXPECTED_ANY} */ entry) => Math.max(max, entry.ts), 0);
 				const minTs = data[0].ts;
 				const duration = maxTs - minTs;
 				expect(duration).toBeLessThan(
 					testDuration[0] * 1000000 + testDuration[1] / 1000
 				);
-				const cpuProfile = data.find((entry) => entry.name === "CpuProfile");
+				const cpuProfile = data.find((/** @type {EXPECTED_ANY} */ entry) => entry.name === "CpuProfile");
 				expect(cpuProfile).toBeTypeOf("object");
 				const profile = cpuProfile.args.data.cpuProfile;
 				expect(profile.startTime).toBeGreaterThanOrEqual(minTs);

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -4,7 +4,6 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 
 describe("Profiling Plugin", () => {

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -26,11 +26,13 @@ describe("Profiling Plugin", () => {
 	});
 
 	it("should handle when unable to start a profiling session", () => {
-		const profiler = new ProfilingPlugin.Profiler(/** @type {EXPECTED_ANY} */ ({
-			Session() {
-				throw new Error("Sean Larkin was here.");
-			}
-		}));
+		const profiler = new ProfilingPlugin.Profiler(
+			/** @type {EXPECTED_ANY} */ ({
+				Session() {
+					throw new Error("Sean Larkin was here.");
+				}
+			})
+		);
 
 		return profiler.startProfiling();
 	});
@@ -38,7 +40,10 @@ describe("Profiling Plugin", () => {
 	it("handles sending a profiling message when no session", () => {
 		// @ts-expect-error intentionally calling without required argument
 		const profiler = new ProfilingPlugin.Profiler();
-		return profiler.sendCommand("randy", /** @type {object} */ (/** @type {unknown} */ ("is awesome")));
+		return profiler.sendCommand(
+			"randy",
+			/** @type {EXPECTED_OBJECT} */ (/** @type {unknown} */ ("is awesome"))
+		);
 	});
 
 	it("handles destroying when no session", () => {

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -20,26 +20,29 @@ describe("Profiling Plugin", () => {
 	});
 
 	it("should handle when unable to require the inspector", () => {
+		// @ts-expect-error intentionally calling without required argument
 		const profiler = new ProfilingPlugin.Profiler();
 		return profiler.startProfiling();
 	});
 
 	it("should handle when unable to start a profiling session", () => {
-		const profiler = new ProfilingPlugin.Profiler({
+		const profiler = new ProfilingPlugin.Profiler(/** @type {EXPECTED_ANY} */ ({
 			Session() {
 				throw new Error("Sean Larkin was here.");
 			}
-		});
+		}));
 
 		return profiler.startProfiling();
 	});
 
 	it("handles sending a profiling message when no session", () => {
+		// @ts-expect-error intentionally calling without required argument
 		const profiler = new ProfilingPlugin.Profiler();
-		return profiler.sendCommand("randy", "is awesome");
+		return profiler.sendCommand("randy", /** @type {object} */ (/** @type {unknown} */ ("is awesome")));
 	});
 
 	it("handles destroying when no session", () => {
+		// @ts-expect-error intentionally calling without required argument
 		const profiler = new ProfilingPlugin.Profiler();
 		return profiler.destroy();
 	});

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -8,7 +8,10 @@ const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
 
-const createMultiCompiler = (/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined, /** @type {Record<string, unknown> | undefined} */ configOptions = undefined) => {
+const createMultiCompiler = (
+	/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined,
+	/** @type {Record<string, unknown> | undefined} */ configOptions = undefined
+) => {
 	const compiler = webpack(
 		Object.assign(
 			[
@@ -24,14 +27,18 @@ const createMultiCompiler = (/** @type {Record<string, unknown> | undefined} */ 
 			configOptions
 		)
 	);
-	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+		/** @type {unknown} */ (createFsFromVolume(new Volume()))
+	);
 
 	new webpack.ProgressPlugin(progressOptions).apply(compiler);
 
 	return compiler;
 };
 
-const createSimpleCompiler = (/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined) => {
+const createSimpleCompiler = (
+	/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined
+) => {
 	const compiler = webpack({
 		context: path.join(__dirname, "fixtures"),
 		entry: "./a.js",
@@ -46,18 +53,24 @@ const createSimpleCompiler = (/** @type {Record<string, unknown> | undefined} */
 		]
 	});
 
-	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+		/** @type {unknown} */ (createFsFromVolume(new Volume()))
+	);
 
 	return compiler;
 };
 
-const createSimpleCompilerWithCustomHandler = (/** @type {Record<string, unknown> | undefined} */ options = undefined) => {
+const createSimpleCompilerWithCustomHandler = (
+	/** @type {Record<string, unknown> | undefined} */ options = undefined
+) => {
 	const compiler = webpack({
 		context: path.join(__dirname, "fixtures"),
 		entry: "./a.js"
 	});
 
-	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+		/** @type {unknown} */ (createFsFromVolume(new Volume()))
+	);
 	const logger = compiler.getInfrastructureLogger("custom test logger");
 	new webpack.ProgressPlugin({
 		activeModules: true,
@@ -68,9 +81,12 @@ const createSimpleCompilerWithCustomHandler = (/** @type {Record<string, unknown
 	return compiler;
 };
 
-const getLogs = (/** @type {string} */ logsStr) => logsStr.split(/\r/).filter((/** @type {string} */ v) => v !== " ");
+const getLogs = (/** @type {string} */ logsStr) =>
+	logsStr.split(/\r/).filter((/** @type {string} */ v) => v !== " ");
 
-const runCompilerAsync = (/** @type {import("../").Compiler | import("../").MultiCompiler} */ compiler) =>
+const runCompilerAsync = (
+	/** @type {import("../").Compiler | import("../").MultiCompiler} */ compiler
+) =>
 	new Promise((resolve, reject) => {
 		compiler.run((/** @type {Error | null} */ err) => {
 			if (err) {
@@ -101,14 +117,16 @@ describe("ProgressPlugin", () => {
 		stdout && stdout.restore();
 	});
 
-	const nanTest = (/** @type {Function} */ createCompiler) => () => {
-		const compiler = createCompiler();
+	const nanTest =
+		(/** @type {(...args: EXPECTED_ANY[]) => EXPECTED_ANY} */ createCompiler) =>
+		() => {
+			const compiler = createCompiler();
 
-		return runCompilerAsync(compiler).then(() => {
-			expect(stderr.toString()).toContain("%");
-			expect(stderr.toString()).not.toContain("NaN");
-		});
-	};
+			return runCompilerAsync(compiler).then(() => {
+				expect(stderr.toString()).toContain("%");
+				expect(stderr.toString()).not.toContain("NaN");
+			});
+		};
 
 	it(
 		"should not contain NaN as a percentage when it is applied to Compiler",
@@ -166,27 +184,29 @@ describe("ProgressPlugin", () => {
 		});
 	});
 
-	const monotonicTest = (/** @type {Function} */ createCompiler) => () => {
-		/** @type {{ value: number, text: string }[]} */
-		const handlerCalls = [];
-		const compiler = createCompiler({
-			handler: (/** @type {number} */ p, /** @type {string[]} */ ...args) => {
-				handlerCalls.push({ value: p, text: `${p}% ${args.join(" ")}` });
-			}
-		});
-
-		return runCompilerAsync(compiler).then(() => {
-			let lastLine = handlerCalls[0];
-			for (const line of handlerCalls) {
-				if (line.value < lastLine.value) {
-					throw new Error(
-						`Progress value is not monotonic increasing:\n${lastLine.text}\n${line.text}`
-					);
+	const monotonicTest =
+		(/** @type {(...args: EXPECTED_ANY[]) => EXPECTED_ANY} */ createCompiler) =>
+		() => {
+			/** @type {{ value: number, text: string }[]} */
+			const handlerCalls = [];
+			const compiler = createCompiler({
+				handler: (/** @type {number} */ p, /** @type {string[]} */ ...args) => {
+					handlerCalls.push({ value: p, text: `${p}% ${args.join(" ")}` });
 				}
-				lastLine = line;
-			}
-		});
-	};
+			});
+
+			return runCompilerAsync(compiler).then(() => {
+				let lastLine = handlerCalls[0];
+				for (const line of handlerCalls) {
+					if (line.value < lastLine.value) {
+						throw new Error(
+							`Progress value is not monotonic increasing:\n${lastLine.text}\n${line.text}`
+						);
+					}
+					lastLine = line;
+				}
+			});
+		};
 
 	it(
 		"should have monotonic increasing progress",
@@ -200,7 +220,9 @@ describe("ProgressPlugin", () => {
 
 	it(
 		"should have monotonic increasing progress (multi compiler, parallelism)",
-		monotonicTest((/** @type {Record<string, unknown>} */ o) => createMultiCompiler(o, { parallelism: 1 }))
+		monotonicTest((/** @type {Record<string, unknown>} */ o) =>
+			createMultiCompiler(o, { parallelism: 1 })
+		)
 	);
 
 	it("should not print lines longer than stderr.columns", () => {
@@ -232,7 +254,9 @@ describe("ProgressPlugin", () => {
 			const logs = getLogs(stderr.toString());
 
 			expect(logs.length).toBeGreaterThan(20);
-			expect(/** @type {string} */ (_.maxBy(logs, "length")).length).not.toBeGreaterThan(40);
+			expect(
+				/** @type {string} */ (_.maxBy(logs, "length")).length
+			).not.toBeGreaterThan(40);
 		});
 	});
 

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -8,7 +8,7 @@ const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
 
-const createMultiCompiler = (progressOptions, configOptions) => {
+const createMultiCompiler = (/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined, /** @type {Record<string, unknown> | undefined} */ configOptions = undefined) => {
 	const compiler = webpack(
 		Object.assign(
 			[
@@ -24,14 +24,14 @@ const createMultiCompiler = (progressOptions, configOptions) => {
 			configOptions
 		)
 	);
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 
 	new webpack.ProgressPlugin(progressOptions).apply(compiler);
 
 	return compiler;
 };
 
-const createSimpleCompiler = (progressOptions) => {
+const createSimpleCompiler = (/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined) => {
 	const compiler = webpack({
 		context: path.join(__dirname, "fixtures"),
 		entry: "./a.js",
@@ -46,18 +46,18 @@ const createSimpleCompiler = (progressOptions) => {
 		]
 	});
 
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 
 	return compiler;
 };
 
-const createSimpleCompilerWithCustomHandler = (options) => {
+const createSimpleCompilerWithCustomHandler = (/** @type {Record<string, unknown> | undefined} */ options = undefined) => {
 	const compiler = webpack({
 		context: path.join(__dirname, "fixtures"),
 		entry: "./a.js"
 	});
 
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
+	compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (/** @type {unknown} */ (createFsFromVolume(new Volume())));
 	const logger = compiler.getInfrastructureLogger("custom test logger");
 	new webpack.ProgressPlugin({
 		activeModules: true,
@@ -68,21 +68,25 @@ const createSimpleCompilerWithCustomHandler = (options) => {
 	return compiler;
 };
 
-const getLogs = (logsStr) => logsStr.split(/\r/).filter((v) => v !== " ");
+const getLogs = (/** @type {string} */ logsStr) => logsStr.split(/\r/).filter((/** @type {string} */ v) => v !== " ");
 
-const runCompilerAsync = (compiler) =>
+const runCompilerAsync = (/** @type {import("../").Compiler | import("../").MultiCompiler} */ compiler) =>
 	new Promise((resolve, reject) => {
-		compiler.run((err) => {
+		compiler.run((/** @type {Error | null} */ err) => {
 			if (err) {
 				reject(err);
 			} else {
-				resolve();
+				resolve(undefined);
 			}
 		});
 	});
 
+/** @typedef {{ toString(): string, toStringRaw(): string, restore(): void, data: string[], reset(): void }} CapturedStdio */
+
 describe("ProgressPlugin", () => {
+	/** @type {CapturedStdio} */
 	let stderr;
+	/** @type {CapturedStdio} */
 	let stdout;
 
 	beforeEach(() => {
@@ -97,7 +101,7 @@ describe("ProgressPlugin", () => {
 		stdout && stdout.restore();
 	});
 
-	const nanTest = (createCompiler) => () => {
+	const nanTest = (/** @type {Function} */ createCompiler) => () => {
 		const compiler = createCompiler();
 
 		return runCompilerAsync(compiler).then(() => {
@@ -162,10 +166,11 @@ describe("ProgressPlugin", () => {
 		});
 	});
 
-	const monotonicTest = (createCompiler) => () => {
+	const monotonicTest = (/** @type {Function} */ createCompiler) => () => {
+		/** @type {{ value: number, text: string }[]} */
 		const handlerCalls = [];
 		const compiler = createCompiler({
-			handler: (p, ...args) => {
+			handler: (/** @type {number} */ p, /** @type {string[]} */ ...args) => {
 				handlerCalls.push({ value: p, text: `${p}% ${args.join(" ")}` });
 			}
 		});
@@ -195,7 +200,7 @@ describe("ProgressPlugin", () => {
 
 	it(
 		"should have monotonic increasing progress (multi compiler, parallelism)",
-		monotonicTest((o) => createMultiCompiler(o, { parallelism: 1 }))
+		monotonicTest((/** @type {Record<string, unknown>} */ o) => createMultiCompiler(o, { parallelism: 1 }))
 	);
 
 	it("should not print lines longer than stderr.columns", () => {
@@ -210,7 +215,7 @@ describe("ProgressPlugin", () => {
 				expect(log.length).toBeLessThanOrEqual(35);
 			}
 			// cspell:ignore mization nsPlugin
-			expect(logs).toContain(
+			/** @type {EXPECTED_ANY} */ (expect(logs)).toContain(
 				"75% sealing ...mization ...nsPlugin",
 				"trims each detail string equally"
 			);
@@ -222,19 +227,19 @@ describe("ProgressPlugin", () => {
 	it("should handle when stderr.columns is undefined", () => {
 		const compiler = createSimpleCompiler();
 
-		process.stderr.columns = undefined;
+		/** @type {EXPECTED_ANY} */ (process.stderr).columns = undefined;
 		return runCompilerAsync(compiler).then(() => {
 			const logs = getLogs(stderr.toString());
 
 			expect(logs.length).toBeGreaterThan(20);
-			expect(_.maxBy(logs, "length").length).not.toBeGreaterThan(40);
+			expect(/** @type {string} */ (_.maxBy(logs, "length")).length).not.toBeGreaterThan(40);
 		});
 	});
 
 	it("should contain the new compiler hooks", () => {
 		const compiler = createSimpleCompiler();
 
-		process.stderr.columns = undefined;
+		/** @type {EXPECTED_ANY} */ (process.stderr).columns = undefined;
 		return runCompilerAsync(compiler).then(() => {
 			const logs = getLogs(stderr.toString());
 

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -3,11 +3,17 @@
 const RequestShortener = require("../lib/RequestShortener");
 const RuntimeTemplate = require("../lib/RuntimeTemplate");
 
+/** @typedef {import("../lib/config/defaults").OutputNormalizedWithDefaults} OutputOptions */
+
 describe("RuntimeTemplate.concatenation", () => {
 	it("no args", () => {
 		const runtimeTemplate = new RuntimeTemplate(
-			undefined,
-			{ environment: { templateLiteral: false } },
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ (undefined)
+			),
+			/** @type {OutputOptions} */ (
+				/** @type {unknown} */ ({ environment: { templateLiteral: false } })
+			),
 			new RequestShortener(__dirname)
 		);
 		expect(runtimeTemplate.concatenation()).toBe('""');
@@ -15,18 +21,30 @@ describe("RuntimeTemplate.concatenation", () => {
 
 	it("1 arg", () => {
 		const runtimeTemplate = new RuntimeTemplate(
-			undefined,
-			{ environment: { templateLiteral: false } },
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ (undefined)
+			),
+			/** @type {OutputOptions} */ (
+				/** @type {unknown} */ ({ environment: { templateLiteral: false } })
+			),
 			new RequestShortener(__dirname)
 		);
-		expect(runtimeTemplate.concatenation({ expr: 1 })).toBe('"" + 1');
+		expect(
+			runtimeTemplate.concatenation({
+				expr: /** @type {string} */ (/** @type {unknown} */ (1))
+			})
+		).toBe('"" + 1');
 		expect(runtimeTemplate.concatenation("str")).toBe('"str"');
 	});
 
 	it("es5", () => {
 		const runtimeTemplate = new RuntimeTemplate(
-			undefined,
-			{ environment: { templateLiteral: false } },
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ (undefined)
+			),
+			/** @type {OutputOptions} */ (
+				/** @type {unknown} */ ({ environment: { templateLiteral: false } })
+			),
 			new RequestShortener(__dirname)
 		);
 
@@ -40,38 +58,61 @@ describe("RuntimeTemplate.concatenation", () => {
 				"str"
 			)
 		).toBe('"" + __webpack__.p + str.a + "str"');
-		expect(runtimeTemplate.concatenation("a", "b", { expr: 1 })).toBe(
-			'"a" + "b" + 1'
-		);
-		expect(runtimeTemplate.concatenation("a", { expr: 1 }, "b")).toBe(
-			'"a" + 1 + "b"'
-		);
+		expect(
+			runtimeTemplate.concatenation("a", "b", {
+				expr: /** @type {string} */ (/** @type {unknown} */ (1))
+			})
+		).toBe('"a" + "b" + 1');
+		expect(
+			runtimeTemplate.concatenation(
+				"a",
+				{ expr: /** @type {string} */ (/** @type {unknown} */ (1)) },
+				"b"
+			)
+		).toBe('"a" + 1 + "b"');
 	});
 
 	describe("es6", () => {
 		const runtimeTemplate = new RuntimeTemplate(
-			undefined,
-			{ environment: { templateLiteral: true } },
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ (undefined)
+			),
+			/** @type {OutputOptions} */ (
+				/** @type {unknown} */ ({ environment: { templateLiteral: true } })
+			),
 			new RequestShortener(__dirname)
 		);
 
 		it("should prefer shorten variant #1", () => {
-			expect(runtimeTemplate.concatenation({ expr: 1 }, "a", { expr: 2 })).toBe(
-				'1 + "a" + 2'
-			);
+			expect(
+				runtimeTemplate.concatenation(
+					{ expr: /** @type {string} */ (/** @type {unknown} */ (1)) },
+					"a",
+					{ expr: /** @type {string} */ (/** @type {unknown} */ (2)) }
+				)
+			).toBe('1 + "a" + 2');
 		});
 
 		it("should prefer shorten variant #2", () => {
 			expect(
-				runtimeTemplate.concatenation({ expr: 1 }, "a", { expr: 2 }, "b")
+				runtimeTemplate.concatenation(
+					{ expr: /** @type {string} */ (/** @type {unknown} */ (1)) },
+					"a",
+					{ expr: /** @type {string} */ (/** @type {unknown} */ (2)) },
+					"b"
+				)
 			).toBe('1 + "a" + 2 + "b"');
 		});
 
 		it("should prefer shorten variant #3", () => {
 			/* eslint-disable no-template-curly-in-string */
-			expect(runtimeTemplate.concatenation("a", { expr: 1 }, "b")).toBe(
-				"`a${1}b`"
-			);
+			expect(
+				runtimeTemplate.concatenation(
+					"a",
+					{ expr: /** @type {string} */ (/** @type {unknown} */ (1)) },
+					"b"
+				)
+			).toBe("`a${1}b`");
 			/* eslint-enable */
 		});
 	});

--- a/test/SemVer.unittest.js
+++ b/test/SemVer.unittest.js
@@ -13,12 +13,12 @@ const {
 } = require("../lib/util/semver");
 
 describe("SemVer", () => {
-	const createRuntimeFunction = (/** @type {(helpers: object) => string} */ runtimeCodeFunction) => {
+	const createRuntimeFunction = (/** @type {(helpers: unknown) => string} */ runtimeCodeFunction) => {
 		const runtimeFunction = runtimeCodeFunction({
 			basicFunction: (/** @type {string} */ args, /** @type {string[]} */ body) => `(${args}) => {\n${body.join("\n")}\n}`,
 			supportsArrowFunction: () => true
 		});
-		const functionName = runtimeFunction.match(/^var (\w+)/)[1];
+		const functionName = /** @type {RegExpMatchArray} */ (runtimeFunction.match(/^var (\w+)/))[1];
 		return eval(
 			`(function (...args) { ${runtimeFunction}; return ${functionName}(...args); })`
 		);

--- a/test/SemVer.unittest.js
+++ b/test/SemVer.unittest.js
@@ -13,9 +13,9 @@ const {
 } = require("../lib/util/semver");
 
 describe("SemVer", () => {
-	const createRuntimeFunction = (runtimeCodeFunction) => {
+	const createRuntimeFunction = (/** @type {(helpers: object) => string} */ runtimeCodeFunction) => {
 		const runtimeFunction = runtimeCodeFunction({
-			basicFunction: (args, body) => `(${args}) => {\n${body.join("\n")}\n}`,
+			basicFunction: (/** @type {string} */ args, /** @type {string[]} */ body) => `(${args}) => {\n${body.join("\n")}\n}`,
 			supportsArrowFunction: () => true
 		});
 		const functionName = runtimeFunction.match(/^var (\w+)/)[1];

--- a/test/SemVer.unittest.js
+++ b/test/SemVer.unittest.js
@@ -13,12 +13,19 @@ const {
 } = require("../lib/util/semver");
 
 describe("SemVer", () => {
-	const createRuntimeFunction = (/** @type {(helpers: unknown) => string} */ runtimeCodeFunction) => {
+	const createRuntimeFunction = (
+		/** @type {(helpers: unknown) => string} */ runtimeCodeFunction
+	) => {
 		const runtimeFunction = runtimeCodeFunction({
-			basicFunction: (/** @type {string} */ args, /** @type {string[]} */ body) => `(${args}) => {\n${body.join("\n")}\n}`,
+			basicFunction: (
+				/** @type {string} */ args,
+				/** @type {string[]} */ body
+			) => `(${args}) => {\n${body.join("\n")}\n}`,
 			supportsArrowFunction: () => true
 		});
-		const functionName = /** @type {RegExpMatchArray} */ (runtimeFunction.match(/^var (\w+)/))[1];
+		const functionName = /** @type {RegExpMatchArray} */ (
+			runtimeFunction.match(/^var (\w+)/)
+		)[1];
 		return eval(
 			`(function (...args) { ${runtimeFunction}; return ${functionName}(...args); })`
 		);
@@ -26,7 +33,14 @@ describe("SemVer", () => {
 
 	for (const [name, fn] of [
 		["normal", parseVersion],
-		["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (parseVersionRuntimeCode)))]
+		[
+			"runtime",
+			createRuntimeFunction(
+				/** @type {(helpers: unknown) => string} */ (
+					/** @type {unknown} */ (parseVersionRuntimeCode)
+				)
+			)
+		]
 	]) {
 		it(`should parseVersion correctly (${name})`, () => {
 			expect(fn("1")).toEqual([1]);
@@ -115,7 +129,14 @@ describe("SemVer", () => {
 
 			for (const [name, fn] of [
 				["normal", versionLt],
-				["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (versionLtRuntimeCode)))]
+				[
+					"runtime",
+					createRuntimeFunction(
+						/** @type {(helpers: unknown) => string} */ (
+							/** @type {unknown} */ (versionLtRuntimeCode)
+						)
+					)
+				]
 			]) {
 				it(`${c} (${name})`, () => {
 					expect(fn(a, a)).toBe(false);
@@ -199,7 +220,14 @@ describe("SemVer", () => {
 
 			for (const [name, fn] of [
 				["normal", rangeToString],
-				["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (rangeToStringRuntimeCode)))]
+				[
+					"runtime",
+					createRuntimeFunction(
+						/** @type {(helpers: unknown) => string} */ (
+							/** @type {unknown} */ (rangeToStringRuntimeCode)
+						)
+					)
+				]
 			]) {
 				it(`should ${key} stringify to ${expected} (${name})`, () => {
 					expect(fn(parseRange(key))).toEqual(expected);
@@ -575,7 +603,14 @@ describe("SemVer", () => {
 				for (const item of cases[range]) {
 					for (const [name, fn] of [
 						["normal", satisfy],
-						["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (satisfyRuntimeCode)))]
+						[
+							"runtime",
+							createRuntimeFunction(
+								/** @type {(helpers: unknown) => string} */ (
+									/** @type {unknown} */ (satisfyRuntimeCode)
+								)
+							)
+						]
 					]) {
 						if (item.startsWith("!")) {
 							it(`should not be satisfied by ${item.slice(

--- a/test/SemVer.unittest.js
+++ b/test/SemVer.unittest.js
@@ -26,7 +26,7 @@ describe("SemVer", () => {
 
 	for (const [name, fn] of [
 		["normal", parseVersion],
-		["runtime", createRuntimeFunction(parseVersionRuntimeCode)]
+		["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (parseVersionRuntimeCode)))]
 	]) {
 		it(`should parseVersion correctly (${name})`, () => {
 			expect(fn("1")).toEqual([1]);
@@ -115,7 +115,7 @@ describe("SemVer", () => {
 
 			for (const [name, fn] of [
 				["normal", versionLt],
-				["runtime", createRuntimeFunction(versionLtRuntimeCode)]
+				["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (versionLtRuntimeCode)))]
 			]) {
 				it(`${c} (${name})`, () => {
 					expect(fn(a, a)).toBe(false);
@@ -199,7 +199,7 @@ describe("SemVer", () => {
 
 			for (const [name, fn] of [
 				["normal", rangeToString],
-				["runtime", createRuntimeFunction(rangeToStringRuntimeCode)]
+				["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (rangeToStringRuntimeCode)))]
 			]) {
 				it(`should ${key} stringify to ${expected} (${name})`, () => {
 					expect(fn(parseRange(key))).toEqual(expected);
@@ -575,7 +575,7 @@ describe("SemVer", () => {
 				for (const item of cases[range]) {
 					for (const [name, fn] of [
 						["normal", satisfy],
-						["runtime", createRuntimeFunction(satisfyRuntimeCode)]
+						["runtime", createRuntimeFunction(/** @type {(helpers: unknown) => string} */ (/** @type {unknown} */ (satisfyRuntimeCode)))]
 					]) {
 						if (item.startsWith("!")) {
 							it(`should not be satisfied by ${item.slice(

--- a/test/SharingUtil.unittest.js
+++ b/test/SharingUtil.unittest.js
@@ -925,13 +925,14 @@ describe("normalize dep version", () => {
 
 	it("should return empty string for some invalid URL deps", () => {
 		for (const url of commonInvalid) {
-			expect(normalizeVersion(url)).toBe("");
+			expect(normalizeVersion(/** @type {string} */ (url))).toBe("");
 		}
 	});
 
 	it("should get correct version for some valid URL deps", () => {
+		const commonValidMap = /** @type {Record<string, string>} */ (commonValid);
 		for (const url of Object.keys(commonValid)) {
-			expect(normalizeVersion(url)).toBe(commonValid[url]);
+			expect(normalizeVersion(url)).toBe(commonValidMap[url]);
 		}
 	});
 
@@ -942,8 +943,9 @@ describe("normalize dep version", () => {
 	});
 
 	it("should get correct version for github URL deps", () => {
+		const githubValidMap = /** @type {Record<string, string>} */ (githubValid);
 		for (const url of Object.keys(githubValid)) {
-			expect(normalizeVersion(url)).toBe(githubValid[url]);
+			expect(normalizeVersion(url)).toBe(githubValidMap[url]);
 		}
 	});
 
@@ -954,8 +956,9 @@ describe("normalize dep version", () => {
 	});
 
 	it("should get correct version for gitlab URL deps", () => {
+		const gitlabValidMap = /** @type {Record<string, string>} */ (gitlabValid);
 		for (const url of Object.keys(gitlabValid)) {
-			expect(normalizeVersion(url)).toBe(gitlabValid[url]);
+			expect(normalizeVersion(url)).toBe(gitlabValidMap[url]);
 		}
 	});
 
@@ -966,8 +969,11 @@ describe("normalize dep version", () => {
 	});
 
 	it("should get correct version for bitbucket URL deps", () => {
+		const bitbucketValidMap = /** @type {Record<string, string>} */ (
+			bitbucketValid
+		);
 		for (const url of Object.keys(bitbucketValid)) {
-			expect(normalizeVersion(url)).toBe(bitbucketValid[url]);
+			expect(normalizeVersion(url)).toBe(bitbucketValidMap[url]);
 		}
 	});
 
@@ -978,8 +984,9 @@ describe("normalize dep version", () => {
 	});
 
 	it("should get correct version for gist URL deps", () => {
+		const gistValidMap = /** @type {Record<string, string>} */ (gistValid);
 		for (const url of Object.keys(gistValid)) {
-			expect(normalizeVersion(url)).toBe(gistValid[url]);
+			expect(normalizeVersion(url)).toBe(gistValidMap[url]);
 		}
 	});
 
@@ -990,8 +997,11 @@ describe("normalize dep version", () => {
 	});
 
 	it("should return correct version for other domain URL deps", () => {
+		const otherDomainValidMap = /** @type {Record<string, string>} */ (
+			otherDomainValid
+		);
 		for (const url of Object.keys(otherDomainValid)) {
-			expect(normalizeVersion(url)).toBe(otherDomainValid[url]);
+			expect(normalizeVersion(url)).toBe(otherDomainValidMap[url]);
 		}
 	});
 });

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -4,20 +4,28 @@ require("./helpers/warmup-webpack");
 
 const { Volume, createFsFromVolume } = require("memfs");
 
+/**
+ * @param {import("../").Configuration} options options
+ * @returns {Promise<import("../").Stats>} stats
+ */
 const compile = (options) =>
-	new Promise((resolve, reject) => {
-		const webpack = require("..");
+	/** @type {Promise<import("../").Stats>} */ (
+		new Promise((resolve, reject) => {
+			const webpack = require("..");
 
-		const compiler = webpack(options);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
-		compiler.run((err, stats) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(stats);
-			}
-		});
-	});
+			const compiler = /** @type {import("../").Compiler} */ (webpack(options));
+			compiler.outputFileSystem = /** @type {EXPECTED_ANY} */ (
+				createFsFromVolume(new Volume())
+			);
+			compiler.run((err, stats) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(/** @type {import("../").Stats} */ (stats));
+				}
+			});
+		})
+	);
 
 describe("Stats", () => {
 	it("should work with a boolean value", async () => {
@@ -72,21 +80,29 @@ describe("Stats", () => {
 			entry: "./fixtures/a"
 		});
 		expect(
-			stats.toString({
-				all: false,
-				env: true,
-				_env: "production"
-			})
+			stats.toString(
+				/** @type {import("../").StatsOptions} */ (
+					/** @type {unknown} */ ({
+						all: false,
+						env: true,
+						_env: "production"
+					})
+				)
+			)
 		).toBe('Environment (--env): "production"');
 		expect(
-			stats.toString({
-				all: false,
-				env: true,
-				_env: {
-					prod: ["foo", "bar"],
-					baz: true
-				}
-			})
+			stats.toString(
+				/** @type {import("../").StatsOptions} */ (
+					/** @type {unknown} */ ({
+						all: false,
+						env: true,
+						_env: {
+							prod: ["foo", "bar"],
+							baz: true
+						}
+					})
+				)
+			)
 		).toBe(
 			"Environment (--env): {\n" +
 				'  "prod": [\n' +

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -75,6 +75,7 @@ describe("StatsTestCases", () => {
 				if (fs.existsSync(path.join(testDirectory, "webpack.config.js"))) {
 					options = require(path.join(testDirectory, "webpack.config.js"));
 				}
+				/** @type {{ validate?: (stats: import("../").Stats, stderr: string) => void }} */
 				let testConfig = {};
 				try {
 					// try to load a test file
@@ -177,13 +178,15 @@ describe("StatsTestCases", () => {
 						"utf8"
 					);
 
+					/** @type {EXPECTED_ANY} */
 					let toStringOptions = {
 						context: testDirectory,
 						colors: false
 					};
 					let hasColorSetting = false;
-					if (typeof c.options.stats !== "undefined") {
-						toStringOptions = c.options.stats;
+					const cOptions = /** @type {EXPECTED_ANY} */ (c.options);
+					if (typeof cOptions.stats !== "undefined") {
+						toStringOptions = cOptions.stats;
 						if (
 							toStringOptions === null ||
 							typeof toStringOptions !== "object"
@@ -195,17 +198,17 @@ describe("StatsTestCases", () => {
 						}
 						hasColorSetting = typeof toStringOptions.colors !== "undefined";
 					}
-					if (Array.isArray(c.options) && !toStringOptions.children) {
-						toStringOptions.children = c.options.map((o) => o.stats);
+					if (Array.isArray(cOptions) && !toStringOptions.children) {
+						toStringOptions.children = cOptions.map((/** @type {EXPECTED_ANY} */ o) => o.stats);
 					}
 					// mock timestamps
-					for (const { compilation: s } of stats.stats
-						? stats.stats
+					for (const { compilation: s } of statsAny.stats
+						? statsAny.stats
 						: [stats]) {
-						expect(s.startTime).toBeGreaterThan(0);
-						expect(s.endTime).toBeGreaterThan(0);
-						s.endTime = new Date("04/20/1970, 12:42:42 PM").getTime();
-						s.startTime = s.endTime - 1234;
+						expect(/** @type {EXPECTED_ANY} */ (s).startTime).toBeGreaterThan(0);
+						expect(/** @type {EXPECTED_ANY} */ (s).endTime).toBeGreaterThan(0);
+						/** @type {EXPECTED_ANY} */ (s).endTime = new Date("04/20/1970, 12:42:42 PM").getTime();
+						/** @type {EXPECTED_ANY} */ (s).startTime = /** @type {EXPECTED_ANY} */ (s).endTime - 1234;
 					}
 					let actual = stats.toString(toStringOptions);
 					expect(typeof actual).toBe("string");

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -4,7 +4,6 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 const webpack = require("..");
 const { registerPerCaseSnapshotHooks } = require("./harness/snapshot");

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -4,6 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+// @ts-ignore
 const rimraf = require("rimraf");
 const webpack = require("..");
 const { registerPerCaseSnapshotHooks } = require("./harness/snapshot");
@@ -37,8 +38,11 @@ const tests = fs
 		return true;
 	});
 
+/** @typedef {{ toString(): string, toStringRaw(): string, restore(): void, data: string[], reset(): void }} CapturedStdio */
+
 describe("StatsTestCases", () => {
 	jest.setTimeout(30000);
+	/** @type {CapturedStdio} */
 	let stderr;
 
 	beforeEach(() => {
@@ -60,6 +64,7 @@ describe("StatsTestCases", () => {
 				const outputDirectory = path.join(outputBase, testName);
 				rimraf.sync(outputDirectory);
 				fs.mkdirSync(outputDirectory, { recursive: true });
+				/** @type {import("../").Configuration} */
 				let options = {
 					mode: "development",
 					entry: "./index",
@@ -104,27 +109,28 @@ describe("StatsTestCases", () => {
 					}
 				}
 				const c = webpack(options);
-				const compilers = c.compilers ? c.compilers : [c];
+				const cAny = /** @type {EXPECTED_ANY} */ (c);
+				const compilers = /** @type {import("../").Compiler[]} */ (cAny.compilers ? cAny.compilers : [c]);
 				for (const c of compilers) {
-					const ifs = c.inputFileSystem;
+					const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem);
 					c.inputFileSystem = Object.create(ifs);
-					c.inputFileSystem.readFile = function readFile() {
+					/** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem).readFile = function readFile() {
 						// eslint-disable-next-line prefer-rest-params
 						const args = Array.prototype.slice.call(arguments);
 						const callback = args.pop();
 						// eslint-disable-next-line no-useless-call
-						ifs.readFile.apply(ifs, [
+						/** @type {NonNullable<typeof ifs>} */ (ifs).readFile.apply(ifs, [
 							...args,
-							(err, result) => {
+							(/** @type {Error | null} */ err, /** @type {Buffer | undefined} */ result) => {
 								if (err) return callback(err);
 								if (!/\.(?:js|json|txt)$/.test(args[0])) {
 									return callback(null, result);
 								}
-								callback(null, result.toString("utf8").replace(/\r/g, ""));
+								callback(null, /** @type {Buffer} */ (result).toString("utf8").replace(/\r/g, ""));
 							}
 						]);
 					};
-					c.hooks.compilation.tap("StatsTestCasesTest", (compilation) => {
+					c.hooks.compilation.tap("StatsTestCasesTest", (/** @type {import("../").Compilation} */ compilation) => {
 						for (const hook of [
 							"optimize",
 							"optimizeModules",
@@ -133,17 +139,19 @@ describe("StatsTestCases", () => {
 							"afterOptimizeAssets",
 							"beforeHash"
 						]) {
-							compilation.hooks[hook].tap("TestCasesTest", () =>
+							/** @type {Record<string, EXPECTED_ANY>} */ (compilation.hooks)[hook].tap("TestCasesTest", () =>
 								compilation.checkConstraints()
 							);
 						}
 					});
 				}
-				c.run((err, stats) => {
+				c.run((err, _stats) => {
 					if (err) return done(err);
-					for (const compilation of [
-						...(stats.stats ? stats.stats : [stats])
-					].map((s) => s.compilation)) {
+					const stats = /** @type {import("../").Stats} */ (_stats);
+					const statsAny = /** @type {EXPECTED_ANY} */ (stats);
+					for (const compilation of /** @type {import("../").Compilation[]} */ ([
+						...(statsAny.stats ? statsAny.stats : [stats])
+					].map((/** @type {EXPECTED_ANY} */ s) => s.compilation))) {
 						compilation.logging.delete("webpack.Compilation.ModuleProfile");
 					}
 					expect(stats.hasErrors()).toBe(testName.endsWith("error"));

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -4,7 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-// @ts-ignore
+// @ts-expect-error no types for rimraf
 const rimraf = require("rimraf");
 const webpack = require("..");
 const { registerPerCaseSnapshotHooks } = require("./harness/snapshot");
@@ -111,48 +111,69 @@ describe("StatsTestCases", () => {
 				}
 				const c = webpack(options);
 				const cAny = /** @type {EXPECTED_ANY} */ (c);
-				const compilers = /** @type {import("../").Compiler[]} */ (cAny.compilers ? cAny.compilers : [c]);
+				const compilers = /** @type {import("../").Compiler[]} */ (
+					cAny.compilers ? cAny.compilers : [c]
+				);
 				for (const c of compilers) {
-					const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem);
+					const ifs = /** @type {NonNullable<typeof c.inputFileSystem>} */ (
+						c.inputFileSystem
+					);
 					c.inputFileSystem = Object.create(ifs);
-					/** @type {NonNullable<typeof c.inputFileSystem>} */ (c.inputFileSystem).readFile = function readFile() {
+					/** @type {NonNullable<typeof c.inputFileSystem>} */ (
+						c.inputFileSystem
+					).readFile = function readFile() {
 						// eslint-disable-next-line prefer-rest-params
 						const args = Array.prototype.slice.call(arguments);
 						const callback = args.pop();
 						// eslint-disable-next-line no-useless-call
-						/** @type {NonNullable<typeof ifs>} */ (ifs).readFile.apply(ifs, [
+						/** @type {EXPECTED_ANY} */ (
+							/** @type {NonNullable<typeof ifs>} */ (ifs).readFile
+						).apply(ifs, [
 							...args,
-							(/** @type {Error | null} */ err, /** @type {Buffer | undefined} */ result) => {
+							(
+								/** @type {Error | null} */ err,
+								/** @type {Buffer | undefined} */ result
+							) => {
 								if (err) return callback(err);
 								if (!/\.(?:js|json|txt)$/.test(args[0])) {
 									return callback(null, result);
 								}
-								callback(null, /** @type {Buffer} */ (result).toString("utf8").replace(/\r/g, ""));
+								callback(
+									null,
+									/** @type {Buffer} */ (result)
+										.toString("utf8")
+										.replace(/\r/g, "")
+								);
 							}
 						]);
 					};
-					c.hooks.compilation.tap("StatsTestCasesTest", (/** @type {import("../").Compilation} */ compilation) => {
-						for (const hook of [
-							"optimize",
-							"optimizeModules",
-							"optimizeChunks",
-							"afterOptimizeTree",
-							"afterOptimizeAssets",
-							"beforeHash"
-						]) {
-							/** @type {Record<string, EXPECTED_ANY>} */ (compilation.hooks)[hook].tap("TestCasesTest", () =>
-								compilation.checkConstraints()
-							);
+					c.hooks.compilation.tap(
+						"StatsTestCasesTest",
+						(/** @type {import("../").Compilation} */ compilation) => {
+							for (const hook of [
+								"optimize",
+								"optimizeModules",
+								"optimizeChunks",
+								"afterOptimizeTree",
+								"afterOptimizeAssets",
+								"beforeHash"
+							]) {
+								/** @type {Record<string, EXPECTED_ANY>} */ (compilation.hooks)[
+									hook
+								].tap("TestCasesTest", () => compilation.checkConstraints());
+							}
 						}
-					});
+					);
 				}
 				c.run((err, _stats) => {
 					if (err) return done(err);
 					const stats = /** @type {import("../").Stats} */ (_stats);
 					const statsAny = /** @type {EXPECTED_ANY} */ (stats);
-					for (const compilation of /** @type {import("../").Compilation[]} */ ([
-						...(statsAny.stats ? statsAny.stats : [stats])
-					].map((/** @type {EXPECTED_ANY} */ s) => s.compilation))) {
+					for (const compilation of /** @type {import("../").Compilation[]} */ (
+						[...(statsAny.stats ? statsAny.stats : [stats])].map(
+							(/** @type {EXPECTED_ANY} */ s) => s.compilation
+						)
+					)) {
 						compilation.logging.delete("webpack.Compilation.ModuleProfile");
 					}
 					expect(stats.hasErrors()).toBe(testName.endsWith("error"));
@@ -199,16 +220,23 @@ describe("StatsTestCases", () => {
 						hasColorSetting = typeof toStringOptions.colors !== "undefined";
 					}
 					if (Array.isArray(cOptions) && !toStringOptions.children) {
-						toStringOptions.children = cOptions.map((/** @type {EXPECTED_ANY} */ o) => o.stats);
+						toStringOptions.children = cOptions.map(
+							(/** @type {EXPECTED_ANY} */ o) => o.stats
+						);
 					}
 					// mock timestamps
 					for (const { compilation: s } of statsAny.stats
 						? statsAny.stats
 						: [stats]) {
-						expect(/** @type {EXPECTED_ANY} */ (s).startTime).toBeGreaterThan(0);
+						expect(/** @type {EXPECTED_ANY} */ (s).startTime).toBeGreaterThan(
+							0
+						);
 						expect(/** @type {EXPECTED_ANY} */ (s).endTime).toBeGreaterThan(0);
-						/** @type {EXPECTED_ANY} */ (s).endTime = new Date("04/20/1970, 12:42:42 PM").getTime();
-						/** @type {EXPECTED_ANY} */ (s).startTime = /** @type {EXPECTED_ANY} */ (s).endTime - 1234;
+						/** @type {EXPECTED_ANY} */ (s).endTime = new Date(
+							"04/20/1970, 12:42:42 PM"
+						).getTime();
+						/** @type {EXPECTED_ANY} */ (s).startTime =
+							/** @type {EXPECTED_ANY} */ (s).endTime - 1234;
 					}
 					let actual = stats.toString(toStringOptions);
 					expect(typeof actual).toBe("string");

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -59,7 +59,12 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		expect(interpolate("[chunkhash]", data)).toBe("1122334455");
 		expect(interpolate("[contenthash:4]", data)).toBe("9988");
 		// chunk name falls back to id when unnamed
-		expect(interpolate("[name]", { chunk: { id: "9" } })).toBe("9");
+		expect(
+			interpolate(
+				"[name]",
+				/** @type {EXPECTED_ANY} */ ({ chunk: { id: "9" } })
+			)
+		).toBe("9");
 	});
 
 	it("interpolates module placeholders incl. legacy aliases", () => {
@@ -81,7 +86,12 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		expect(interpolate("[url]", { url: "u" })).toBe("u");
 		expect(interpolate("[runtime]", { runtime: "main" })).toBe("main");
 		// non-string runtime collapses to "_"
-		expect(interpolate("[runtime]", { runtime: ["a", "b"] })).toBe("_");
+		expect(
+			interpolate(
+				"[runtime]",
+				/** @type {EXPECTED_ANY} */ ({ runtime: ["a", "b"] })
+			)
+		).toBe("_");
 	});
 
 	it("unescapes bracket-escaped placeholders", () => {

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -2,8 +2,32 @@
 
 require("./helpers/warmup-webpack");
 
+/** @typedef {{ name: string; tests: string[] }} Category */
+/**
+ * @typedef {object} SuiteConfig
+ * @property {string} name suite name
+ * @property {string=} target target
+ * @property {string=} mode mode
+ * @property {boolean=} module module
+ * @property {string | false=} devtool devtool
+ * @property {EXPECTED_ANY=} cache cache
+ * @property {EXPECTED_ANY=} optimization optimization
+ * @property {string[]=} deprecations expected deprecations
+ * @property {EXPECTED_ANY[]=} plugins plugins
+ */
+/**
+ * @typedef {object} TestConfig
+ * @property {((i: EXPECTED_ANY, options: EXPECTED_ANY) => string)=} findBundle
+ * @property {number=} timeout
+ * @property {number=} cachedTimeout
+ * @property {boolean=} noTests
+ * @property {((scope: EXPECTED_ANY, options: EXPECTED_ANY) => void)=} moduleScope
+ */
+
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (p: string) => void, (p: string, cb: (err: EXPECTED_ANY) => void): void }} */
+// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -14,19 +38,23 @@ const deprecationTracking = require("./helpers/deprecationTracking");
 const filterInfraStructureErrors = require("./helpers/infrastructureLogErrors");
 
 const casesPath = path.join(__dirname, "cases");
-let categories = fs.readdirSync(casesPath);
-categories = categories.map((cat) => ({
+/** @type {Category[]} */
+const categories = fs.readdirSync(casesPath).map((cat) => ({
 	name: cat,
 	tests: fs
 		.readdirSync(path.join(casesPath, cat))
 		.filter((folder) => !folder.includes("_"))
 }));
 
+/**
+ * @param {string[]} appendTarget log collector
+ * @returns {EXPECTED_ANY} logger object
+ */
 const createLogger = (appendTarget) => ({
-	log: (l) => appendTarget.push(l),
-	debug: (l) => appendTarget.push(l),
-	trace: (l) => appendTarget.push(l),
-	info: (l) => appendTarget.push(l),
+	log: (/** @type {string} */ l) => appendTarget.push(l),
+	debug: (/** @type {string} */ l) => appendTarget.push(l),
+	trace: (/** @type {string} */ l) => appendTarget.push(l),
+	info: (/** @type {string} */ l) => appendTarget.push(l),
 	warn: console.warn.bind(console),
 	error: console.error.bind(console),
 	logTime: () => {},
@@ -39,8 +67,12 @@ const createLogger = (appendTarget) => ({
 	status: () => {}
 });
 
+/**
+ * @param {SuiteConfig} config suite config
+ */
 const describeCases = (config) => {
 	describe(config.name, () => {
+		/** @type {ReturnType<typeof captureStdio>} */
 		let stderr;
 
 		beforeEach(() => {
@@ -69,6 +101,7 @@ const describeCases = (config) => {
 					}
 					return true;
 				})) {
+					/** @type {string[]} */
 					const infraStructureLog = [];
 
 					// eslint-disable-next-line no-loop-func
@@ -88,6 +121,7 @@ const describeCases = (config) => {
 							category.name,
 							testName
 						);
+						/** @type {TestConfig} */
 						let testConfig = {
 							findBundle(_, options) {
 								const ext = path.extname(
@@ -106,7 +140,8 @@ const describeCases = (config) => {
 						const terserForTesting = new TerserPlugin({
 							parallel: false
 						});
-						let options = {
+						/** @type {import("../").Configuration} */
+						let options = /** @type {import("../").Configuration} */ ({
 							context: casesPath,
 							entry: `./${category.name}/${testName}/`,
 							target: config.target || "async-node",
@@ -197,8 +232,8 @@ const describeCases = (config) => {
 							},
 							plugins: [
 								...(config.plugins || []),
-								function testCasesTest() {
-									this.hooks.compilation.tap("TestCasesTest", (compilation) => {
+								function testCasesTest(/** @type {import("../").Compiler} */ this) {
+									this.hooks.compilation.tap("TestCasesTest", (/** @type {EXPECTED_ANY} */ compilation) => {
 										for (const hook of [
 											"optimize",
 											"optimizeModules",
@@ -223,17 +258,18 @@ const describeCases = (config) => {
 								debug: true,
 								console: createLogger(infraStructureLog)
 							}
-						};
+						});
 
 						beforeAll((done) => {
 							rimraf(cacheDirectory, done);
 						});
 
+						/** @type {(() => void)[]} */
 						const cleanups = [];
 
 						afterAll(() => {
-							options = undefined;
-							testConfig = undefined;
+							options = /** @type {EXPECTED_ANY} */ (undefined);
+							testConfig = /** @type {EXPECTED_ANY} */ (undefined);
 							for (const fn of cleanups) fn();
 						});
 
@@ -241,9 +277,10 @@ const describeCases = (config) => {
 							it(
 								`${testName} should pre-compile to fill disk cache (1st)`,
 								(done) => {
-									const oldPath = options.output.path;
-									options.output.path = path.join(
-										options.output.path,
+									const output = /** @type {EXPECTED_ANY} */ (options.output);
+									const oldPath = output.path;
+									output.path = path.join(
+										/** @type {string} */ (output.path),
 										"cache1"
 									);
 									infraStructureLog.length = 0;
@@ -253,7 +290,7 @@ const describeCases = (config) => {
 
 									webpack(options, (err) => {
 										deprecationTracker();
-										options.output.path = oldPath;
+										output.path = oldPath;
 										if (err) return done(err);
 										const infrastructureLogErrors = filterInfraStructureErrors(
 											infraStructureLog,
@@ -285,9 +322,10 @@ const describeCases = (config) => {
 							it(
 								`${testName} should pre-compile to fill disk cache (2nd)`,
 								(done) => {
-									const oldPath = options.output.path;
-									options.output.path = path.join(
-										options.output.path,
+									const output2 = /** @type {EXPECTED_ANY} */ (options.output);
+									const oldPath = output2.path;
+									output2.path = path.join(
+										/** @type {string} */ (output2.path),
 										"cache2"
 									);
 									infraStructureLog.length = 0;
@@ -297,7 +335,7 @@ const describeCases = (config) => {
 
 									webpack(options, (err) => {
 										deprecationTracker();
-										options.output.path = oldPath;
+										output2.path = oldPath;
 										if (err) return done(err);
 										const infrastructureLogErrors = filterInfraStructureErrors(
 											infraStructureLog,
@@ -337,7 +375,8 @@ const describeCases = (config) => {
 								const compiler = webpack(options);
 								const run = () => {
 									const deprecationTracker = deprecationTracking.start();
-									compiler.run((err, stats) => {
+									compiler.run((err, _stats) => {
+										const stats = /** @type {import("../").Stats} */ (_stats);
 										const deprecations = deprecationTracker();
 										if (err) return done(err);
 										const infrastructureLogErrors = filterInfraStructureErrors(
@@ -453,10 +492,10 @@ const describeCases = (config) => {
 									if (testConfig.moduleScope) {
 										testConfig.moduleScope(runner._moduleScope, options);
 									}
-									runner.require.webpackTestSuiteRequire = true;
+									(/** @type {EXPECTED_ANY} */ (runner.require)).webpackTestSuiteRequire = true;
 								},
 								getBundlePaths: (i, options) =>
-									testConfig.findBundle(i, options)
+									/** @type {NonNullable<TestConfig["findBundle"]>} */ (testConfig.findBundle)(i, options)
 							});
 							Promise.all(results).then(() => {
 								if (getNumberOfTests() === 0) {

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -9,8 +9,10 @@ require("./helpers/warmup-webpack");
  * @property {string=} target target
  * @property {string=} mode mode
  * @property {boolean=} module module
+ * @property {boolean=} minimize minimize
  * @property {string | false=} devtool devtool
  * @property {EXPECTED_ANY=} cache cache
+ * @property {EXPECTED_ANY=} snapshot snapshot
  * @property {EXPECTED_ANY=} optimization optimization
  * @property {string[]=} deprecations expected deprecations
  * @property {EXPECTED_ANY[]=} plugins plugins
@@ -493,9 +495,10 @@ const describeCases = (config) => {
 									if (testConfig.moduleScope) {
 										testConfig.moduleScope(runner._moduleScope, options);
 									}
-									/** @type {EXPECTED_ANY} */ (
+									const runnerRequire = /** @type {EXPECTED_ANY} */ (
 										runner.require
-									).webpackTestSuiteRequire = true;
+									);
+									runnerRequire.webpackTestSuiteRequire = true;
 								},
 								getBundlePaths: (i, options) =>
 									/** @type {NonNullable<TestConfig["findBundle"]>} */ (

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -2,7 +2,7 @@
 
 require("./helpers/warmup-webpack");
 
-/** @typedef {{ name: string; tests: string[] }} Category */
+/** @typedef {{ name: string, tests: string[] }} Category */
 /**
  * @typedef {object} SuiteConfig
  * @property {string} name suite name
@@ -27,7 +27,6 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 /** @type {{ sync: (p: string) => void, (p: string, cb: (err: EXPECTED_ANY) => void): void }} */
-// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -232,20 +231,24 @@ const describeCases = (config) => {
 							},
 							plugins: [
 								...(config.plugins || []),
-								function testCasesTest(/** @type {import("../").Compiler} */ this) {
-									this.hooks.compilation.tap("TestCasesTest", (/** @type {EXPECTED_ANY} */ compilation) => {
-										for (const hook of [
-											"optimize",
-											"optimizeModules",
-											"optimizeChunks",
-											"afterOptimizeTree",
-											"afterOptimizeAssets"
-										]) {
-											compilation.hooks[hook].tap("TestCasesTest", () =>
-												compilation.checkConstraints()
-											);
+								/** @this {import("../").Compiler} */
+								function testCasesTest() {
+									this.hooks.compilation.tap(
+										"TestCasesTest",
+										(/** @type {EXPECTED_ANY} */ compilation) => {
+											for (const hook of [
+												"optimize",
+												"optimizeModules",
+												"optimizeChunks",
+												"afterOptimizeTree",
+												"afterOptimizeAssets"
+											]) {
+												compilation.hooks[hook].tap("TestCasesTest", () =>
+													compilation.checkConstraints()
+												);
+											}
 										}
-									});
+									);
 								}
 							],
 							experiments: {
@@ -448,9 +451,7 @@ const describeCases = (config) => {
 											if (infrastructureLogging) {
 												done(
 													new Error(
-														`Errors/Warnings during build:\n${
-															infrastructureLogging
-														}`
+														`Errors/Warnings during build:\n${infrastructureLogging}`
 													)
 												);
 											}
@@ -492,10 +493,14 @@ const describeCases = (config) => {
 									if (testConfig.moduleScope) {
 										testConfig.moduleScope(runner._moduleScope, options);
 									}
-									(/** @type {EXPECTED_ANY} */ (runner.require)).webpackTestSuiteRequire = true;
+									/** @type {EXPECTED_ANY} */ (
+										runner.require
+									).webpackTestSuiteRequire = true;
 								},
 								getBundlePaths: (i, options) =>
-									/** @type {NonNullable<TestConfig["findBundle"]>} */ (testConfig.findBundle)(i, options)
+									/** @type {NonNullable<TestConfig["findBundle"]>} */ (
+										testConfig.findBundle
+									)(i, options)
 							});
 							Promise.all(results).then(() => {
 								if (getNumberOfTests() === 0) {

--- a/test/TestCasesAllCombined.longtest.js
+++ b/test/TestCasesAllCombined.longtest.js
@@ -3,21 +3,24 @@
 const { describeCases } = require("./TestCases.template");
 
 describe("TestCases", () => {
-	describeCases({
-		name: "all-combined",
-		mode: "production",
-		devtool: "source-map",
-		minimize: true,
-		optimization: {
-			moduleIds: "named",
-			chunkIds: "named"
-		},
-		plugins: [
-			(c) => {
-				const webpack = require("..");
+	describeCases(
+		/** @type {EXPECTED_ANY} */ ({
+			name: "all-combined",
+			mode: "production",
+			devtool: "source-map",
+			minimize: true,
+			optimization: {
+				moduleIds: "named",
+				chunkIds: "named"
+			},
+			plugins: [
+				/** @param {import("../").Compiler} c compiler */
+				(c) => {
+					const webpack = require("..");
 
-				new webpack.HotModuleReplacementPlugin().apply(c);
-			}
-		]
-	});
+					new webpack.HotModuleReplacementPlugin().apply(c);
+				}
+			]
+		})
+	);
 });

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -3,8 +3,9 @@
 require("./helpers/warmup-webpack");
 
 describe("Validation", () => {
-	const createTestCase = (name, config, fn, only) => {
+	const createTestCase = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config, /** @type {(msg: string) => void} */ fn, /** @type {unknown} */ only = undefined) => {
 		it(`should fail validation for ${name}`, () => {
+			/** @type {Error | undefined} */
 			let errored;
 
 			try {
@@ -12,9 +13,9 @@ describe("Validation", () => {
 
 				webpack(config);
 			} catch (err) {
-				if (err.name !== "ValidationError") throw err;
-				errored = err;
-				fn(err.message);
+				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") throw err;
+				errored = /** @type {Error} */ (err);
+				fn(/** @type {Error} */ (err).message);
 
 				return;
 			}
@@ -27,8 +28,9 @@ describe("Validation", () => {
 		});
 	};
 
-	const createTestCaseOnlyValidate = (name, config, fn) => {
+	const createTestCaseOnlyValidate = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config, /** @type {(msg: string) => void} */ fn) => {
 		it(`should fail validation for ${name}`, () => {
+			/** @type {Error | undefined} */
 			let errored;
 
 			try {
@@ -36,9 +38,9 @@ describe("Validation", () => {
 
 				webpack.validate(config);
 			} catch (err) {
-				if (err.name !== "ValidationError") throw err;
-				errored = err;
-				fn(err.message);
+				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") throw err;
+				errored = /** @type {Error} */ (err);
+				fn(/** @type {Error} */ (err).message);
 
 				return;
 			}
@@ -51,7 +53,7 @@ describe("Validation", () => {
 		});
 	};
 
-	const createTestCaseWithoutError = (name, config) => {
+	const createTestCaseWithoutError = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config) => {
 		it(`should success validation for ${name}`, () => {
 			let errored;
 
@@ -60,8 +62,8 @@ describe("Validation", () => {
 
 				webpack(config);
 			} catch (err) {
-				if (err.name === "ValidationError") {
-					throw new Error("Validation didn't success", { cause: err });
+				if (/** @type {EXPECTED_ANY} */ (err).name === "ValidationError") {
+					throw new Error("Validation didn't success", { cause: /** @type {Error} */ (err) });
 				}
 
 				errored = err;

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -3,57 +3,57 @@
 require("./helpers/warmup-webpack");
 
 describe("Validation", () => {
-	const createTestCase = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config, /** @type {(msg: string) => void} */ fn, /** @type {unknown} */ only = undefined) => {
+	const createTestCase = (
+		/** @type {string} */ name,
+		/** @type {EXPECTED_ANY} */ config,
+		/** @type {(msg: string) => void} */ fn,
+		/** @type {unknown} */ only = undefined
+	) => {
 		it(`should fail validation for ${name}`, () => {
-			/** @type {Error | undefined} */
-			let errored;
-
 			try {
 				const webpack = require("..");
 
 				webpack(config);
 			} catch (err) {
-				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") throw err;
-				errored = /** @type {Error} */ (err);
+				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") {
+					throw err;
+				}
 				fn(/** @type {Error} */ (err).message);
 
 				return;
 			}
 
-			if (!errored) {
-				throw new Error("Validation didn't fail");
-			}
-
-			expect(errored.message).toMatch(/^Invalid configuration object./);
+			throw new Error("Validation didn't fail");
 		});
 	};
 
-	const createTestCaseOnlyValidate = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config, /** @type {(msg: string) => void} */ fn) => {
+	const createTestCaseOnlyValidate = (
+		/** @type {string} */ name,
+		/** @type {EXPECTED_ANY} */ config,
+		/** @type {(msg: string) => void} */ fn
+	) => {
 		it(`should fail validation for ${name}`, () => {
-			/** @type {Error | undefined} */
-			let errored;
-
 			try {
 				const webpack = require("..");
 
 				webpack.validate(config);
 			} catch (err) {
-				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") throw err;
-				errored = /** @type {Error} */ (err);
+				if (/** @type {EXPECTED_ANY} */ (err).name !== "ValidationError") {
+					throw err;
+				}
 				fn(/** @type {Error} */ (err).message);
 
 				return;
 			}
 
-			if (!errored) {
-				throw new Error("Validation didn't fail");
-			}
-
-			expect(errored.message).toMatch(/^Invalid configuration object./);
+			throw new Error("Validation didn't fail");
 		});
 	};
 
-	const createTestCaseWithoutError = (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ config) => {
+	const createTestCaseWithoutError = (
+		/** @type {string} */ name,
+		/** @type {EXPECTED_ANY} */ config
+	) => {
 		it(`should success validation for ${name}`, () => {
 			let errored;
 
@@ -63,7 +63,9 @@ describe("Validation", () => {
 				webpack(config);
 			} catch (err) {
 				if (/** @type {EXPECTED_ANY} */ (err).name === "ValidationError") {
-					throw new Error("Validation didn't success", { cause: /** @type {Error} */ (err) });
+					throw new Error("Validation didn't success", {
+						cause: /** @type {Error} */ (err)
+					});
 				}
 
 				errored = err;

--- a/test/WasmHashes.unittest.js
+++ b/test/WasmHashes.unittest.js
@@ -50,7 +50,10 @@ const wasmHashes = {
 };
 
 for (const name of Object.keys(wasmHashes)) {
-	const { createHash, createReferenceHash, regExp } = wasmHashes[name]();
+	const { createHash, createReferenceHash, regExp } =
+		/** @type {Record<string, () => { createHash: EXPECTED_ANY, createReferenceHash: EXPECTED_ANY, regExp: RegExp }>} */ (
+			wasmHashes
+		)[name]();
 
 	describe(name, () => {
 		const sizes = [

--- a/test/Watch.test.js
+++ b/test/Watch.test.js
@@ -11,44 +11,52 @@ describe("Watch", () => {
 		let counterBeforeCompile = 0;
 		let counterDone = 0;
 		let counterHandler = 0;
-		const compiler = webpack(
-			{
-				context: path.resolve(__dirname, "fixtures/watch"),
-				watch: true,
-				mode: "development",
-				snapshot: {
-					managedPaths: [/^(.+?[\\/]node_modules[\\/])/]
-				},
-				experiments: {
-					futureDefaults: true
-				},
-				module: {
-					// unsafeCache: false,
-					rules: [
-						{
-							test: /\.js$/,
-							use: "some-loader"
+		const compiler = /** @type {import("../").Compiler} */ (
+			webpack(
+				{
+					context: path.resolve(__dirname, "fixtures/watch"),
+					watch: true,
+					mode: "development",
+					snapshot: {
+						managedPaths: [/^(.+?[\\/]node_modules[\\/])/]
+					},
+					experiments: {
+						futureDefaults: true
+					},
+					module: {
+						// unsafeCache: false,
+						rules: [
+							{
+								test: /\.js$/,
+								use: "some-loader"
+							}
+						]
+					},
+					plugins: [
+						(c) => {
+							c.hooks.beforeCompile.tap("test", () => {
+								counterBeforeCompile++;
+							});
+							c.hooks.done.tap("test", () => {
+								counterDone++;
+							});
 						}
 					]
 				},
-				plugins: [
-					(c) => {
-						c.hooks.beforeCompile.tap("test", () => {
-							counterBeforeCompile++;
-						});
-						c.hooks.done.tap("test", () => {
-							counterDone++;
-						});
-					}
-				]
-			},
-			(err, stats) => {
-				if (err) return done(err);
-				if (stats.hasErrors()) return done(new Error(stats.toString()));
-				counterHandler++;
-			}
+				(err, stats) => {
+					if (err) return done(err);
+					if (/** @type {import("../").Stats} */ (stats).hasErrors())
+						return done(
+							new Error(/** @type {import("../").Stats} */ (stats).toString())
+						);
+					counterHandler++;
+				}
+			)
 		);
-		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */ (
+				/** @type {unknown} */ (createFsFromVolume(new Volume()))
+			);
 		setTimeout(() => {
 			expect(counterBeforeCompile).toBe(1);
 			expect(counterDone).toBe(1);
@@ -58,8 +66,11 @@ describe("Watch", () => {
 	});
 
 	it("should correctly emit asset when invalidation occurs again", (done) => {
+		/**
+		 * @param {unknown} err
+		 */
 		function handleError(err) {
-			if (err) done(err);
+			if (err) done(/** @type {Error} */ (err));
 		}
 		let calls = 0;
 		const compiler = webpack({
@@ -93,10 +104,10 @@ describe("Watch", () => {
 		});
 
 		// First invalidation
-		compiler.watching.invalidate();
+		/** @type {import("../").Watching} */ (compiler.watching).invalidate();
 		// Second invalidation while compiler is still running
 		setTimeout(() => {
-			compiler.watching.invalidate();
+			/** @type {import("../").Watching} */ (compiler.watching).invalidate();
 		}, 50);
 	});
 });

--- a/test/Watch.test.js
+++ b/test/Watch.test.js
@@ -45,18 +45,18 @@ describe("Watch", () => {
 				},
 				(err, stats) => {
 					if (err) return done(err);
-					if (/** @type {import("../").Stats} */ (stats).hasErrors())
+					if (/** @type {import("../").Stats} */ (stats).hasErrors()) {
 						return done(
 							new Error(/** @type {import("../").Stats} */ (stats).toString())
 						);
+					}
 					counterHandler++;
 				}
 			)
 		);
-		compiler.outputFileSystem =
-			/** @type {import("../").OutputFileSystem} */ (
-				/** @type {unknown} */ (createFsFromVolume(new Volume()))
-			);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 		setTimeout(() => {
 			expect(counterBeforeCompile).toBe(1);
 			expect(counterDone).toBe(1);
@@ -67,7 +67,7 @@ describe("Watch", () => {
 
 	it("should correctly emit asset when invalidation occurs again", (done) => {
 		/**
-		 * @param {unknown} err
+		 * @param {unknown} err error
 		 */
 		function handleError(err) {
 			if (err) done(/** @type {Error} */ (err));

--- a/test/WatchClose.test.js
+++ b/test/WatchClose.test.js
@@ -26,14 +26,17 @@ describe("WatchClose", () => {
 					filename: "bundle.js"
 				}
 			});
-			watcher = /** @type {import("../").Compiler} */ (compiler).watch(
-				{ poll: 300 },
-				() => {}
-			);
+			watcher =
+				/** @type {import("../").Watching} */ (
+					/** @type {import("../").Compiler} */ (compiler).watch(
+						{ poll: 300 },
+						() => {}
+					)
+				);
 		});
 
 		afterEach(() => {
-			/** @type {{ close: () => void }} */ (watcher).close();
+			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
 			compiler = null;
 		});
 

--- a/test/WatchClose.test.js
+++ b/test/WatchClose.test.js
@@ -26,17 +26,18 @@ describe("WatchClose", () => {
 					filename: "bundle.js"
 				}
 			});
-			watcher =
-				/** @type {import("../").Watching} */ (
-					/** @type {import("../").Compiler} */ (compiler).watch(
-						{ poll: 300 },
-						() => {}
-					)
-				);
+			watcher = /** @type {import("../").Watching} */ (
+				/** @type {import("../").Compiler} */ (compiler).watch(
+					{ poll: 300 },
+					() => {}
+				)
+			);
 		});
 
 		afterEach(() => {
-			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
+			/** @type {{ close: () => void }} */ (
+				/** @type {unknown} */ (watcher)
+			).close();
 			compiler = null;
 		});
 

--- a/test/WatchClose.test.js
+++ b/test/WatchClose.test.js
@@ -10,7 +10,9 @@ describe("WatchClose", () => {
 		const outputPath = path.join(__dirname, "js/WatchClose");
 		const filePath = path.join(fixturePath, "a.js");
 
+		/** @type {import("../").Compiler | null} */
 		let compiler;
+		/** @type {import("../").Watching} */
 		let watcher;
 
 		beforeEach(() => {
@@ -24,17 +26,20 @@ describe("WatchClose", () => {
 					filename: "bundle.js"
 				}
 			});
-			watcher = compiler.watch({ poll: 300 }, () => {});
+			watcher = /** @type {import("../").Compiler} */ (compiler).watch(
+				{ poll: 300 },
+				() => {}
+			);
 		});
 
 		afterEach(() => {
-			watcher.close();
+			/** @type {{ close: () => void }} */ (watcher).close();
 			compiler = null;
 		});
 
 		/**
 		 * @param {import("../").Watching} watcher watcher
-		 * @param {(err?: null | Error) -> void} callback callback
+		 * @param {(err?: null | Error) => void} callback callback
 		 * @returns {Promise<void>}
 		 */
 		function close(watcher, callback) {

--- a/test/WatchDetection.test.js
+++ b/test/WatchDetection.test.js
@@ -81,14 +81,17 @@ describe("WatchDetection", () => {
 						filename: "bundle.js"
 					}
 				});
-				const memfs = (compiler.outputFileSystem = createFsFromVolume(
-					new Volume()
-				));
+				const memfs = (compiler.outputFileSystem =
+					/** @type {import("../").OutputFileSystem & import("memfs").IFs} */ (
+						/** @type {unknown} */ (createFsFromVolume(new Volume()))
+					));
+				/** @type {(() => void) | null | undefined} */
 				let onChange;
 				compiler.hooks.done.tap("WatchDetectionTest", () => {
 					if (onChange) onChange();
 				});
 
+				/** @type {import("../").Watching} */
 				let watcher;
 
 				step1();
@@ -109,12 +112,15 @@ describe("WatchDetection", () => {
 						}
 					};
 
-					watcher = compiler.watch(
-						{
-							aggregateTimeout: 50
-						},
-						() => {}
-					);
+					watcher =
+						/** @type {import("../").Watching} */ (
+							compiler.watch(
+								{
+									aggregateTimeout: 50
+								},
+								() => {}
+							)
+						);
 				}
 
 				/**

--- a/test/WatchDetection.test.js
+++ b/test/WatchDetection.test.js
@@ -112,15 +112,14 @@ describe("WatchDetection", () => {
 						}
 					};
 
-					watcher =
-						/** @type {import("../").Watching} */ (
-							compiler.watch(
-								{
-									aggregateTimeout: 50
-								},
-								() => {}
-							)
-						);
+					watcher = /** @type {import("../").Watching} */ (
+						compiler.watch(
+							{
+								aggregateTimeout: 50
+							},
+							() => {}
+						)
+					);
 				}
 
 				/**

--- a/test/WatchSuspend.test.js
+++ b/test/WatchSuspend.test.js
@@ -25,11 +25,13 @@ describe("WatchSuspend", () => {
 		const outputPath = path.join(__dirname, "js/WatchSuspend");
 		const outputFile = path.join(outputPath, "bundle.js");
 		/** @type {import("../").Compiler} */
-		let compiler =
-			/** @type {import("../").Compiler} */ (/** @type {unknown} */ (null));
+		let compiler = /** @type {import("../").Compiler} */ (
+			/** @type {unknown} */ (null)
+		);
 		/** @type {import("../").Watching} */
-		let watching =
-			/** @type {import("../").Watching} */ (/** @type {unknown} */ (null));
+		let watching = /** @type {import("../").Watching} */ (
+			/** @type {unknown} */ (null)
+		);
 		/** @type {(() => void) | null} */
 		let onChange = null;
 
@@ -57,10 +59,9 @@ describe("WatchSuspend", () => {
 					filename: "bundle.js"
 				}
 			});
-			watching =
-				/** @type {import("../").Watching} */ (
-					compiler.watch({ aggregateTimeout: 50 }, () => {})
-				);
+			watching = /** @type {import("../").Watching} */ (
+				compiler.watch({ aggregateTimeout: 50 }, () => {})
+			);
 
 			compiler.hooks.done.tap("WatchSuspendTest", () => {
 				if (onChange) onChange();
@@ -68,8 +69,12 @@ describe("WatchSuspend", () => {
 		});
 
 		afterAll(() => {
-			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watching)).close();
-			compiler = /** @type {import("../").Compiler} */ (/** @type {unknown} */ (null));
+			/** @type {{ close: () => void }} */ (
+				/** @type {unknown} */ (watching)
+			).close();
+			compiler = /** @type {import("../").Compiler} */ (
+				/** @type {unknown} */ (null)
+			);
 			try {
 				fs.unlinkSync(filePath);
 			} catch (_err) {
@@ -118,12 +123,11 @@ describe("WatchSuspend", () => {
 					//  So set-up new watcher and wait when initial compilation is done
 					await new Promise((resolve) => {
 						watching.close(() => {
-							watching =
-								/** @type {import("../").Watching} */ (
-									compiler.watch({ aggregateTimeout: 1000 }, () => {
-										resolve(undefined);
-									})
-								);
+							watching = /** @type {import("../").Watching} */ (
+								compiler.watch({ aggregateTimeout: 1000 }, () => {
+									resolve(undefined);
+								})
+							);
 						});
 					});
 					return /** @type {Promise<void>} */ (
@@ -133,8 +137,9 @@ describe("WatchSuspend", () => {
 								watching.suspend();
 								fs.writeFileSync(filePath, "'baz'", "utf8");
 
-								onChange =
-									/** @type {null} */ (/** @type {unknown} */ ("throw"));
+								onChange = /** @type {null} */ (
+									/** @type {unknown} */ ("throw")
+								);
 								setTimeout(() => {
 									onChange = () => {
 										expect(fs.readFileSync(outputFile, "utf8")).toContain(

--- a/test/WatchSuspend.test.js
+++ b/test/WatchSuspend.test.js
@@ -24,8 +24,13 @@ describe("WatchSuspend", () => {
 		const file3Path = path.join(fixturePath, "file3.js");
 		const outputPath = path.join(__dirname, "js/WatchSuspend");
 		const outputFile = path.join(outputPath, "bundle.js");
-		let compiler = null;
-		let watching = null;
+		/** @type {import("../").Compiler} */
+		let compiler =
+			/** @type {import("../").Compiler} */ (/** @type {unknown} */ (null));
+		/** @type {import("../").Watching} */
+		let watching =
+			/** @type {import("../").Watching} */ (/** @type {unknown} */ (null));
+		/** @type {(() => void) | null} */
 		let onChange = null;
 
 		beforeAll(() => {
@@ -52,7 +57,10 @@ describe("WatchSuspend", () => {
 					filename: "bundle.js"
 				}
 			});
-			watching = compiler.watch({ aggregateTimeout: 50 }, () => {});
+			watching =
+				/** @type {import("../").Watching} */ (
+					compiler.watch({ aggregateTimeout: 50 }, () => {})
+				);
 
 			compiler.hooks.done.tap("WatchSuspendTest", () => {
 				if (onChange) onChange();
@@ -60,8 +68,8 @@ describe("WatchSuspend", () => {
 		});
 
 		afterAll(() => {
-			watching.close();
-			compiler = null;
+			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watching)).close();
+			compiler = /** @type {import("../").Compiler} */ (/** @type {unknown} */ (null));
 			try {
 				fs.unlinkSync(filePath);
 			} catch (_err) {
@@ -110,37 +118,43 @@ describe("WatchSuspend", () => {
 					//  So set-up new watcher and wait when initial compilation is done
 					await new Promise((resolve) => {
 						watching.close(() => {
-							watching = compiler.watch({ aggregateTimeout: 1000 }, () => {
-								resolve();
-							});
+							watching =
+								/** @type {import("../").Watching} */ (
+									compiler.watch({ aggregateTimeout: 1000 }, () => {
+										resolve(undefined);
+									})
+								);
 						});
 					});
-					return new Promise((resolve) => {
-						if (changeBefore) fs.writeFileSync(filePath, "'bar'", "utf8");
-						setTimeout(() => {
-							watching.suspend();
-							fs.writeFileSync(filePath, "'baz'", "utf8");
-
-							onChange = "throw";
+					return /** @type {Promise<void>} */ (
+						new Promise((resolve) => {
+							if (changeBefore) fs.writeFileSync(filePath, "'bar'", "utf8");
 							setTimeout(() => {
-								onChange = () => {
-									expect(fs.readFileSync(outputFile, "utf8")).toContain(
-										"'baz'"
-									);
-									expect(
-										compiler.modifiedFiles && [...compiler.modifiedFiles].sort()
-									).toEqual([filePath]);
-									expect(
-										compiler.removedFiles && [...compiler.removedFiles]
-									).toEqual([]);
-									onChange = null;
-									resolve();
-								};
-								watching.resume();
-							}, delay);
-						}, 200);
-					});
-				});
+								watching.suspend();
+								fs.writeFileSync(filePath, "'baz'", "utf8");
+
+								onChange =
+									/** @type {null} */ (/** @type {unknown} */ ("throw"));
+								setTimeout(() => {
+									onChange = () => {
+										expect(fs.readFileSync(outputFile, "utf8")).toContain(
+											"'baz'"
+										);
+										expect(
+											compiler.modifiedFiles &&
+												[...compiler.modifiedFiles].sort()
+										).toEqual([filePath]);
+										expect(
+											compiler.removedFiles && [...compiler.removedFiles]
+										).toEqual([]);
+										onChange = null;
+										resolve();
+									};
+									watching.resume();
+								}, delay);
+							}, 200);
+						})
+					);
 			}
 		}
 

--- a/test/WatchSuspend.test.js
+++ b/test/WatchSuspend.test.js
@@ -155,6 +155,7 @@ describe("WatchSuspend", () => {
 							}, 200);
 						})
 					);
+				});
 			}
 		}
 

--- a/test/WatchTestCases.template.js
+++ b/test/WatchTestCases.template.js
@@ -19,7 +19,6 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 /** @type {{ sync: (p: string) => void, (p: string, cb: (err: EXPECTED_ANY) => void): void }} */
-// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -126,7 +125,7 @@ const describeCases = (config) => {
 							testName
 						);
 						const testDirectory = path.join(casesPath, category.name, testName);
-						/** @type {Array<{ name: string, done?: boolean, stats?: import("../").Stats, it?: EXPECTED_ANY, getNumberOfTests?: () => number }>} */
+						/** @type {{ name: string, done?: boolean, stats?: import("../").Stats, it?: EXPECTED_ANY, getNumberOfTests?: () => number }[]} */
 						const runs = fs
 							.readdirSync(testDirectory)
 							.sort()
@@ -158,7 +157,10 @@ const describeCases = (config) => {
 									srcPath: tempDirectory
 								});
 							}
-							const applyConfig = (/** @type {import("../").Configuration} */ options, /** @type {number} */ idx) => {
+							const applyConfig = (
+								/** @type {import("../").Configuration} */ options,
+								/** @type {number} */ idx
+							) => {
 								if (!options.mode) options.mode = "development";
 								if (!options.context) options.context = tempDirectory;
 								if (!options.entry) options.entry = "./index.js";
@@ -178,24 +180,41 @@ const describeCases = (config) => {
 											: ".js"
 									}`;
 								}
-								if (options.cache && /** @type {import("../").FileCacheOptions} */ (options.cache).type === "filesystem") {
+								if (
+									options.cache &&
+									/** @type {import("../").FileCacheOptions} */ (options.cache)
+										.type === "filesystem"
+								) {
 									const cacheDirectory = path.join(tempDirectory, ".cache");
-									/** @type {import("../").FileCacheOptions} */ (options.cache).cacheDirectory = cacheDirectory;
-									/** @type {import("../").FileCacheOptions} */ (options.cache).name = `config-${idx}`;
+									/** @type {import("../").FileCacheOptions} */ (
+										options.cache
+									).cacheDirectory = cacheDirectory;
+									/** @type {import("../").FileCacheOptions} */ (
+										options.cache
+									).name = `config-${idx}`;
 								}
 								if (config.experiments) {
 									if (!options.experiments) options.experiments = {};
 									for (const key of Object.keys(config.experiments)) {
-										if ((/** @type {EXPECTED_ANY} */ (options.experiments))[key] === undefined) {
-											(/** @type {EXPECTED_ANY} */ (options.experiments))[key] = config.experiments[key];
+										if (
+											/** @type {EXPECTED_ANY} */ (options.experiments)[key] ===
+											undefined
+										) {
+											/** @type {EXPECTED_ANY} */ (options.experiments)[key] =
+												config.experiments[key];
 										}
 									}
 								}
 								if (config.optimization) {
 									if (!options.optimization) options.optimization = {};
 									for (const key of Object.keys(config.optimization)) {
-										if ((/** @type {EXPECTED_ANY} */ (options.optimization))[key] === undefined) {
-											(/** @type {EXPECTED_ANY} */ (options.optimization))[key] = config.optimization[key];
+										if (
+											/** @type {EXPECTED_ANY} */ (options.optimization)[
+												key
+											] === undefined
+										) {
+											/** @type {EXPECTED_ANY} */ (options.optimization)[key] =
+												config.optimization[key];
 										}
 									}
 								}
@@ -220,7 +239,9 @@ const describeCases = (config) => {
 
 							/** @type {(err?: Error | null) => void} */
 							let compilationFinished = /** @type {EXPECTED_ANY} */ (done);
-							(/** @type {{ step: string | undefined }} */ (currentWatchStepModule)).step = run.name;
+							/** @type {{ step: string | undefined }} */ (
+								currentWatchStepModule
+							).step = run.name;
 							copyDiff(path.join(testDirectory, run.name), tempDirectory, true);
 
 							setTimeout(() => {
@@ -251,9 +272,7 @@ const describeCases = (config) => {
 										if (run.done && lastHash !== stats.hash) {
 											return compilationFinished(
 												new Error(
-													`Compilation changed but no change was issued ${
-														lastHash
-													} != ${stats.hash} (run ${runIdx})\n` +
+													`Compilation changed but no change was issued ${lastHash} != ${stats.hash} (run ${runIdx})\n` +
 														`Triggering change: ${triggeringFilename}`
 												)
 											);
@@ -348,11 +367,15 @@ const describeCases = (config) => {
 												});
 											},
 											getBundlePaths: (i, options) =>
-												testConfig.findBundle(i, options)
+												/** @type {NonNullable<WatchTestConfig["findBundle"]>} */ (
+													testConfig.findBundle
+												)(i, options)
 										});
 										await Promise.all(results);
 
-										if (/** @type {() => number} */ (run.getNumberOfTests)() < 1) {
+										if (
+											/** @type {() => number} */ (run.getNumberOfTests)() < 1
+										) {
 											return compilationFinished(
 												new Error("No tests exported by test case")
 											);
@@ -368,7 +391,9 @@ const describeCases = (config) => {
 													setTimeout(() => {
 														waitMode = false;
 														compilationFinished = done;
-														(/** @type {{ step: string | undefined }} */ (currentWatchStepModule)).step = run.name;
+														/** @type {{ step: string | undefined }} */ (
+															currentWatchStepModule
+														).step = run.name;
 														copyDiff(
 															path.join(testDirectory, run.name),
 															tempDirectory,

--- a/test/WatchTestCases.template.js
+++ b/test/WatchTestCases.template.js
@@ -4,9 +4,22 @@ require("./helpers/warmup-webpack");
 
 /** @typedef {Record<string, EXPECTED_ANY>} Env */
 /** @typedef {{ testPath: string, srcPath: string }} TestOptions */
+/**
+ * @typedef {object} SuiteConfig
+ * @property {string} name suite name
+ * @property {EXPECTED_ANY=} experiments experiments overrides
+ * @property {EXPECTED_ANY=} optimization optimization overrides
+ */
+/**
+ * @typedef {object} WatchTestConfig
+ * @property {((i: EXPECTED_ANY, options: EXPECTED_ANY) => string)=} findBundle
+ * @property {boolean=} noTests
+ */
 
 const path = require("path");
 const fs = require("graceful-fs");
+/** @type {{ sync: (p: string) => void, (p: string, cb: (err: EXPECTED_ANY) => void): void }} */
+// @ts-ignore no declaration file for rimraf
 const rimraf = require("rimraf");
 const { parseResource } = require("../lib/util/identifier");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -51,6 +64,9 @@ function copyDiff(src, dest, initial) {
 	}
 }
 
+/**
+ * @param {SuiteConfig} config suite config
+ */
 const describeCases = (config) => {
 	describe(config.name, () => {
 		beforeAll(() => {
@@ -110,7 +126,7 @@ const describeCases = (config) => {
 							testName
 						);
 						const testDirectory = path.join(casesPath, category.name, testName);
-						/** @type {TODO} */
+						/** @type {Array<{ name: string, done?: boolean, stats?: import("../").Stats, it?: EXPECTED_ANY, getNumberOfTests?: () => number }>} */
 						const runs = fs
 							.readdirSync(testDirectory)
 							.sort()
@@ -142,7 +158,7 @@ const describeCases = (config) => {
 									srcPath: tempDirectory
 								});
 							}
-							const applyConfig = (options, idx) => {
+							const applyConfig = (/** @type {import("../").Configuration} */ options, /** @type {number} */ idx) => {
 								if (!options.mode) options.mode = "development";
 								if (!options.context) options.context = tempDirectory;
 								if (!options.entry) options.entry = "./index.js";
@@ -162,24 +178,24 @@ const describeCases = (config) => {
 											: ".js"
 									}`;
 								}
-								if (options.cache && options.cache.type === "filesystem") {
+								if (options.cache && /** @type {import("../").FileCacheOptions} */ (options.cache).type === "filesystem") {
 									const cacheDirectory = path.join(tempDirectory, ".cache");
-									options.cache.cacheDirectory = cacheDirectory;
-									options.cache.name = `config-${idx}`;
+									/** @type {import("../").FileCacheOptions} */ (options.cache).cacheDirectory = cacheDirectory;
+									/** @type {import("../").FileCacheOptions} */ (options.cache).name = `config-${idx}`;
 								}
 								if (config.experiments) {
 									if (!options.experiments) options.experiments = {};
 									for (const key of Object.keys(config.experiments)) {
-										if (options.experiments[key] === undefined) {
-											options.experiments[key] = config.experiments[key];
+										if ((/** @type {EXPECTED_ANY} */ (options.experiments))[key] === undefined) {
+											(/** @type {EXPECTED_ANY} */ (options.experiments))[key] = config.experiments[key];
 										}
 									}
 								}
 								if (config.optimization) {
 									if (!options.optimization) options.optimization = {};
 									for (const key of Object.keys(config.optimization)) {
-										if (options.optimization[key] === undefined) {
-											options.optimization[key] = config.optimization[key];
+										if ((/** @type {EXPECTED_ANY} */ (options.optimization))[key] === undefined) {
+											(/** @type {EXPECTED_ANY} */ (options.optimization))[key] = config.optimization[key];
 										}
 									}
 								}
@@ -196,13 +212,14 @@ const describeCases = (config) => {
 							let runIdx = 0;
 							let waitMode = false;
 							let run = runs[runIdx];
+							/** @type {string | null | undefined} */
 							let triggeringFilename;
 							let lastHash = "";
 
 							const currentWatchStepModule = require("./helpers/currentWatchStep");
 
 							let compilationFinished = done;
-							currentWatchStepModule.step = run.name;
+							(/** @type {{ step: string | undefined }} */ (currentWatchStepModule)).step = run.name;
 							copyDiff(path.join(testDirectory, run.name), tempDirectory, true);
 
 							setTimeout(() => {
@@ -288,6 +305,7 @@ const describeCases = (config) => {
 											return;
 										}
 
+										/** @type {WatchTestConfig} */
 										let testConfig = {
 											findBundle(_, options) {
 												const ext = path.extname(
@@ -341,7 +359,7 @@ const describeCases = (config) => {
 
 										run.it(
 											"should compile the next step",
-											(done) => {
+											(/** @type {(err?: Error) => void} */ done) => {
 												runIdx++;
 												if (runIdx < runs.length) {
 													run = runs[runIdx];

--- a/test/WatchTestCases.template.js
+++ b/test/WatchTestCases.template.js
@@ -218,7 +218,8 @@ const describeCases = (config) => {
 
 							const currentWatchStepModule = require("./helpers/currentWatchStep");
 
-							let compilationFinished = done;
+							/** @type {(err?: Error | null) => void} */
+							let compilationFinished = /** @type {EXPECTED_ANY} */ (done);
 							(/** @type {{ step: string | undefined }} */ (currentWatchStepModule)).step = run.name;
 							copyDiff(path.join(testDirectory, run.name), tempDirectory, true);
 
@@ -351,15 +352,15 @@ const describeCases = (config) => {
 										});
 										await Promise.all(results);
 
-										if (run.getNumberOfTests() < 1) {
+										if (/** @type {() => number} */ (run.getNumberOfTests)() < 1) {
 											return compilationFinished(
 												new Error("No tests exported by test case")
 											);
 										}
 
-										run.it(
+										/** @type {EXPECTED_ANY} */ (run.it)(
 											"should compile the next step",
-											(/** @type {(err?: Error) => void} */ done) => {
+											(/** @type {(err?: Error | null) => void} */ done) => {
 												runIdx++;
 												if (runIdx < runs.length) {
 													run = runs[runIdx];
@@ -367,7 +368,7 @@ const describeCases = (config) => {
 													setTimeout(() => {
 														waitMode = false;
 														compilationFinished = done;
-														currentWatchStepModule.step = run.name;
+														(/** @type {{ step: string | undefined }} */ (currentWatchStepModule)).step = run.name;
 														copyDiff(
 															path.join(testDirectory, run.name),
 															tempDirectory,

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -5,8 +5,8 @@ const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 
 /**
- * @param {import("../").Configuration | import("../").MultiConfiguration} config
- * @returns {import("../").Compiler | import("../").MultiCompiler}
+ * @param {import("../").Configuration | import("../").MultiConfiguration} config webpack config
+ * @returns {import("../").Compiler | import("../").MultiCompiler} compiler instance
  */
 const createCompiler = (config) => {
 	const compiler =
@@ -63,7 +63,9 @@ describe("WatcherEvents", () => {
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
+			/** @type {{ close: () => void }} */ (
+				/** @type {unknown} */ (watcher)
+			).close();
 		});
 	});
 
@@ -84,7 +86,9 @@ describe("WatcherEvents", () => {
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
+			/** @type {{ close: () => void }} */ (
+				/** @type {unknown} */ (watcher)
+			).close();
 		});
 	});
 });

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -4,9 +4,16 @@ const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 
+/**
+ * @param {import("../").Configuration | import("../").Configuration[]} config
+ * @returns {import("../").Compiler | import("../").MultiCompiler}
+ */
 const createCompiler = (config) => {
 	const compiler = webpack(config);
-	compiler.outputFileSystem = createFsFromVolume(new Volume());
+	compiler.outputFileSystem =
+		/** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
 	return compiler;
 };
 
@@ -36,17 +43,20 @@ describe("WatcherEvents", () => {
 		let called = false;
 
 		const compiler = createSingleCompiler();
-		const watcher = compiler.watch({}, (err, _stats) => {
-			expect(called).toBe(true);
-			done(err);
-		});
+		const watcher = /** @type {import("../").Compiler} */ (compiler).watch(
+			{},
+			(err, _stats) => {
+				expect(called).toBe(true);
+				done(err);
+			}
+		);
 
 		compiler.hooks.watchClose.tap("WatcherEventsTest", () => {
 			called = true;
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			watcher.close();
+			/** @type {{ close: () => void }} */ (watcher).close();
 		});
 	});
 
@@ -54,17 +64,20 @@ describe("WatcherEvents", () => {
 		let called = false;
 
 		const compiler = createMultiCompiler();
-		const watcher = compiler.watch({}, (err, _stats) => {
-			expect(called).toBe(true);
-			done(err);
-		});
+		const watcher = /** @type {import("../").MultiCompiler} */ (compiler).watch(
+			{},
+			(err, _stats) => {
+				expect(called).toBe(true);
+				done(err);
+			}
+		);
 
 		compiler.hooks.watchClose.tap("WatcherEventsTest", () => {
 			called = true;
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			watcher.close();
+			/** @type {{ close: () => void }} */ (watcher).close();
 		});
 	});
 });

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -5,12 +5,19 @@ const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 
 /**
- * @param {import("../").Configuration | import("../").Configuration[]} config
+ * @param {import("../").Configuration | import("../").MultiConfiguration} config
  * @returns {import("../").Compiler | import("../").MultiCompiler}
  */
 const createCompiler = (config) => {
-	const compiler = webpack(config);
-	compiler.outputFileSystem =
+	const compiler =
+		/** @type {import("../").Compiler | import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").Configuration} */ (
+					/** @type {unknown} */ (config)
+				)
+			)
+		);
+	/** @type {import("../").Compiler} */ (compiler).outputFileSystem =
 		/** @type {import("../").OutputFileSystem} */ (
 			/** @type {unknown} */ (createFsFromVolume(new Volume()))
 		);
@@ -56,7 +63,7 @@ describe("WatcherEvents", () => {
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			/** @type {{ close: () => void }} */ (watcher).close();
+			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
 		});
 	});
 
@@ -77,7 +84,7 @@ describe("WatcherEvents", () => {
 		});
 
 		compiler.hooks.done.tap("WatcherEventsTest", () => {
-			/** @type {{ close: () => void }} */ (watcher).close();
+			/** @type {{ close: () => void }} */ (/** @type {unknown} */ (watcher)).close();
 		});
 	});
 });

--- a/test/WebpackCli.longtest.js
+++ b/test/WebpackCli.longtest.js
@@ -11,11 +11,11 @@ const MOCK_WEBPACK = path.resolve(
 
 // webpack-cli requires a newer Node than webpack itself, so skip on Node versions
 // it does not support (derived from webpack-cli's own `engines` field).
-const [reqMajor, reqMinor = 0, reqPatch = 0] =
-	require("webpack-cli/package.json")
-		.engines.node.match(/\d+(?:\.\d+)*/)[0]
-		.split(".")
-		.map(Number);
+const [reqMajor, reqMinor = 0, reqPatch = 0] = /** @type {RegExpMatchArray} */ (
+	require("webpack-cli/package.json").engines.node.match(/\d+(?:\.\d+)*/)
+)[0]
+	.split(".")
+	.map(Number);
 
 const [major, minor, patch] = process.versions.node.split(".").map(Number);
 const supportsWebpackCli =
@@ -29,6 +29,10 @@ const supportsWebpackCli =
 // documented WEBPACK_PACKAGE env var (webpack-cli loads webpack through a native
 // import jest.mock cannot intercept). process.exit/console.error are spied so a
 // validation failure surfaces as an exit code plus the captured messages.
+/**
+ * @param {string[]} args args
+ * @returns {Promise<{ config: Record<string, EXPECTED_ANY>, exitCode: number, errors: string }>} result
+ */
 const run = async (args) => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wp-cli-"));
 	const capture = path.join(dir, "config.json");
@@ -36,11 +40,13 @@ const run = async (args) => {
 	process.env.WEBPACK_CLI_TEST_CAPTURE = capture;
 	jest.resetModules();
 
+	/** @type {EXPECTED_ANY} */
 	const WebpackCLI = require("webpack-cli").default;
 
 	const exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
 		throw new Error(`__exit__ ${code}`);
 	});
+	/** @type {string[]} */
 	const errors = [];
 	const errorSpy = jest
 		.spyOn(console, "error")
@@ -49,7 +55,7 @@ const run = async (args) => {
 	try {
 		await new WebpackCLI().run(["node", "webpack", "build", ...args]);
 	} catch (error) {
-		const match = /__exit__ (\d+)/.exec(error.message);
+		const match = /__exit__ (\d+)/.exec(/** @type {Error} */ (error).message);
 		if (!match) throw error;
 		exitCode = Number(match[1]);
 	} finally {

--- a/test/WebpackError.unittest.js
+++ b/test/WebpackError.unittest.js
@@ -16,7 +16,7 @@ describe("WebpackError", () => {
 	}
 
 	it("should provide inspect method for use by for util.inspect", () => {
-		const error = new CustomError("Message");
+		const error = new /** @type {EXPECTED_ANY} */ (CustomError)("Message");
 		expect(error.toString()).toContain("CustomError: CustomMessage");
 		expect(error.stack).toContain(__filename);
 	});

--- a/test/WebpackError.unittest.js
+++ b/test/WebpackError.unittest.js
@@ -16,7 +16,7 @@ describe("WebpackError", () => {
 	}
 
 	it("should provide inspect method for use by for util.inspect", () => {
-		const error = new /** @type {EXPECTED_ANY} */ (CustomError)("Message");
+		const error = new CustomError();
 		expect(error.toString()).toContain("CustomError: CustomMessage");
 		expect(error.stack).toContain(__filename);
 	});

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -18,14 +18,23 @@ const child = (children, tagName) =>
 
 // The tree builder always produces a full document (html > head, body); these
 // helpers reach the interesting subtrees.
-/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement} */
+/**
+ * @param {string} src source
+ * @returns {import("../lib/html/buildHtmlAst").HtmlElement} html element
+ */
 const html = (src) => child(buildHtmlAst(src).children, "html");
-/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} */
+/**
+ * @param {string} src source
+ * @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} body children
+ */
 const body = (src) =>
 	/** @type {import("../lib/html/buildHtmlAst").HtmlElement[]} */ (
 		child(html(src).children, "body").children
 	);
-/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} */
+/**
+ * @param {string} src source
+ * @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} head children
+ */
 const head = (src) =>
 	/** @type {import("../lib/html/buildHtmlAst").HtmlElement[]} */ (
 		child(html(src).children, "head").children
@@ -39,7 +48,7 @@ const head = (src) =>
 const find = (src, tagName) => {
 	/** @type {import("../lib/html/buildHtmlAst").HtmlElement | undefined} */
 	let found;
-	/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node */
+	/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node node to search */
 	const walk = (node) => {
 		if (found || node.type !== "element") return;
 		if (node.tagName === tagName) {
@@ -72,10 +81,9 @@ describe("buildHtmlAst", () => {
 
 	it("should parse nested elements", () => {
 		const div = body("<div><span>hello</span></div>")[0];
-		const span =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				div.children[0]
-			);
+		const span = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			div.children[0]
+		);
 		expect(span.tagName).toBe("span");
 		expect(span.children[0].type).toBe("text");
 		expect(
@@ -242,10 +250,9 @@ describe("buildHtmlAst", () => {
 				table.children[0]
 			);
 		expect(tbody.tagName).toBe("tbody");
-		const tr =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				tbody.children[0]
-			);
+		const tr = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			tbody.children[0]
+		);
 		expect(
 			tr.children.map(
 				(c) =>
@@ -259,20 +266,18 @@ describe("buildHtmlAst", () => {
 		const svg = body(
 			"<svg><foreignObject><div>html</div></foreignObject></svg>"
 		)[0];
-		const fo =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				svg.children[0]
-			);
+		const fo = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			svg.children[0]
+		);
 		expect(fo.namespace).toBe(NS_SVG);
 		expect(
 			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
 				fo.children[0]
 			).namespace
 		).toBe(NS_HTML);
-		const desc =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				body("<svg><desc><div>x</div></desc></svg>")[0].children[0]
-			);
+		const desc = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			body("<svg><desc><div>x</div></desc></svg>")[0].children[0]
+		);
 		expect(
 			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
 				desc.children[0]
@@ -322,10 +327,9 @@ describe("buildHtmlAst", () => {
 	it("should update end offsets when an element is closed", () => {
 		const src = "<div><span>text</div>";
 		const div = body(src)[0];
-		const span =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				div.children[0]
-			);
+		const span = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			div.children[0]
+		);
 		expect(div.end).toBe(src.length);
 		expect(span.end).toBe(src.length);
 	});
@@ -403,7 +407,7 @@ describe("buildHtmlAst", () => {
 			const nodes = body("<a href=x.png><div>y</a>");
 			/** @type {string[]} */
 			const spans = [];
-			/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node */
+			/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node node to collect from */
 			const collect = (node) => {
 				if (node.type !== "element") return;
 				for (const attr of node.attributes) {
@@ -467,10 +471,9 @@ describe("buildHtmlAst", () => {
 			child(select.children, "button").children,
 			"selectedcontent"
 		);
-		const span =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				selectedcontent.children[0]
-			);
+		const span = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			selectedcontent.children[0]
+		);
 		expect(span.tagName).toBe("span");
 		expect(
 			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
@@ -502,15 +505,13 @@ describe("buildHtmlAst", () => {
 	it("foster-parents stray text in a table fragment context", () => {
 		// Context is a `table`, so there is no `<table>` on the open stack: stray
 		// character data is fostered to the fragment root, beside the table rows.
-		const root =
-			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
-				buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0]
-			);
+		const root = /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+			buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0]
+		);
 		const texts = root.children
 			.filter((c) => c.type === "text")
 			.map(
-				(/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ c) =>
-					c.data
+				(/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ c) => c.data
 			);
 		expect(texts).toContain("x");
 		expect(child(root.children, "tbody")).toBeDefined();

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -18,9 +18,18 @@ const child = (children, tagName) =>
 
 // The tree builder always produces a full document (html > head, body); these
 // helpers reach the interesting subtrees.
+/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement} */
 const html = (src) => child(buildHtmlAst(src).children, "html");
-const body = (src) => child(html(src).children, "body").children;
-const head = (src) => child(html(src).children, "head").children;
+/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} */
+const body = (src) =>
+	/** @type {import("../lib/html/buildHtmlAst").HtmlElement[]} */ (
+		child(html(src).children, "body").children
+	);
+/** @param {string} src @returns {import("../lib/html/buildHtmlAst").HtmlElement[]} */
+const head = (src) =>
+	/** @type {import("../lib/html/buildHtmlAst").HtmlElement[]} */ (
+		child(html(src).children, "head").children
+	);
 
 /**
  * @param {string} src source
@@ -28,7 +37,9 @@ const head = (src) => child(html(src).children, "head").children;
  * @returns {import("../lib/html/buildHtmlAst").HtmlElement} first matching element anywhere
  */
 const find = (src, tagName) => {
+	/** @type {import("../lib/html/buildHtmlAst").HtmlElement | undefined} */
 	let found;
+	/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node */
 	const walk = (node) => {
 		if (found || node.type !== "element") return;
 		if (node.tagName === tagName) {
@@ -38,7 +49,7 @@ const find = (src, tagName) => {
 		for (const c of node.children) walk(c);
 	};
 	for (const c of buildHtmlAst(src).children) walk(c);
-	return found;
+	return /** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (found);
 };
 
 describe("buildHtmlAst", () => {
@@ -61,10 +72,17 @@ describe("buildHtmlAst", () => {
 
 	it("should parse nested elements", () => {
 		const div = body("<div><span>hello</span></div>")[0];
-		const span = div.children[0];
+		const span =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				div.children[0]
+			);
 		expect(span.tagName).toBe("span");
 		expect(span.children[0].type).toBe("text");
-		expect(span.children[0].data).toBe("hello");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				span.children[0]
+			).data
+		).toBe("hello");
 	});
 
 	it("should parse void elements", () => {
@@ -94,13 +112,21 @@ describe("buildHtmlAst", () => {
 	it("should parse comments", () => {
 		const ast = buildHtmlAst("<!-- hello -->");
 		expect(ast.children[0].type).toBe("comment");
-		expect(ast.children[0].data).toBe(" hello ");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlComment} */ (
+				ast.children[0]
+			).data
+		).toBe(" hello ");
 	});
 
 	it("should parse doctype", () => {
 		const ast = buildHtmlAst("<!DOCTYPE html><html></html>");
 		expect(ast.children[0].type).toBe("doctype");
-		expect(ast.children[0].name).toBe("html");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlDoctype} */ (
+				ast.children[0]
+			).name
+		).toBe("html");
 	});
 
 	it("should handle self-closing tags", () => {
@@ -113,15 +139,31 @@ describe("buildHtmlAst", () => {
 		const nodes = body("<p>one<div>two</div>");
 		expect(nodes).toHaveLength(2);
 		expect(nodes[0].tagName).toBe("p");
-		expect(nodes[0].children[0].data).toBe("one");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				nodes[0].children[0]
+			).data
+		).toBe("one");
 		expect(nodes[1].tagName).toBe("div");
 	});
 
 	it("should auto-close same-name elements like <li>", () => {
 		const ul = body("<ul><li>one<li>two</ul>")[0];
 		expect(ul.children).toHaveLength(2);
-		expect(ul.children[0].children[0].data).toBe("one");
-		expect(ul.children[1].children[0].data).toBe("two");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					ul.children[0]
+				).children[0]
+			).data
+		).toBe("one");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					ul.children[1]
+				).children[0]
+			).data
+		).toBe("two");
 	});
 
 	it("should merge adjacent text nodes", () => {
@@ -129,7 +171,11 @@ describe("buildHtmlAst", () => {
 		// the adjacent-text-node merge.
 		const nodes = body("Text<table>Misplaced</table>");
 		expect(nodes[0].type).toBe("text");
-		expect(nodes[0].data).toBe("TextMisplaced");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				/** @type {unknown} */ (nodes[0])
+			).data
+		).toBe("TextMisplaced");
 		expect(child(nodes, "table").tagName).toBe("table");
 	});
 
@@ -137,14 +183,26 @@ describe("buildHtmlAst", () => {
 		const svg = body("<svg><lineargradient></lineargradient></svg>")[0];
 		expect(svg.namespace).toBe(NS_SVG);
 		// SVG tag-name case is corrected per the foreign adjustment table.
-		expect(svg.children[0].tagName).toBe("linearGradient");
-		expect(svg.children[0].namespace).toBe(NS_SVG);
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				svg.children[0]
+			).tagName
+		).toBe("linearGradient");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				svg.children[0]
+			).namespace
+		).toBe(NS_SVG);
 	});
 
 	it("should detect MathML namespace", () => {
 		const math = body("<math><mi>x</mi></math>")[0];
 		expect(math.namespace).toBe(NS_MATHML);
-		expect(math.children[0].namespace).toBe(NS_MATHML);
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				math.children[0]
+			).namespace
+		).toBe(NS_MATHML);
 	});
 
 	it("should route head and body content to the right place", () => {
@@ -179,40 +237,78 @@ describe("buildHtmlAst", () => {
 
 	it("should construct the table structure with implied tbody/tr", () => {
 		const table = body("<table><tr><td>a<td>b</tr></table>")[0];
-		const tbody = table.children[0];
+		const tbody =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				table.children[0]
+			);
 		expect(tbody.tagName).toBe("tbody");
-		const tr = tbody.children[0];
-		expect(tr.children.map((c) => c.tagName)).toEqual(["td", "td"]);
+		const tr =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				tbody.children[0]
+			);
+		expect(
+			tr.children.map(
+				(c) =>
+					/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (c)
+						.tagName
+			)
+		).toEqual(["td", "td"]);
 	});
 
 	it("should treat SVG foreignObject/desc as HTML integration points", () => {
 		const svg = body(
 			"<svg><foreignObject><div>html</div></foreignObject></svg>"
 		)[0];
-		const fo = svg.children[0];
+		const fo =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				svg.children[0]
+			);
 		expect(fo.namespace).toBe(NS_SVG);
-		expect(fo.children[0].namespace).toBe(NS_HTML);
-		const desc = body("<svg><desc><div>x</div></desc></svg>")[0].children[0];
-		expect(desc.children[0].namespace).toBe(NS_HTML);
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				fo.children[0]
+			).namespace
+		).toBe(NS_HTML);
+		const desc =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				body("<svg><desc><div>x</div></desc></svg>")[0].children[0]
+			);
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				desc.children[0]
+			).namespace
+		).toBe(NS_HTML);
 	});
 
 	it("should keep CDATA text in foreign content", () => {
 		const svg = body("<svg><![CDATA[foo]]></svg>")[0];
 		expect(svg.children[0].type).toBe("text");
-		expect(svg.children[0].data).toBe("foo");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				svg.children[0]
+			).data
+		).toBe("foo");
 	});
 
 	it("should treat bogus comments as comments", () => {
 		// A leading bogus comment is inserted into the document before <html>.
 		const ast = buildHtmlAst("<?bogus comment>");
 		expect(ast.children[0].type).toBe("comment");
-		expect(ast.children[0].data).toBe("?bogus comment");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlComment} */ (
+				ast.children[0]
+			).data
+		).toBe("?bogus comment");
 	});
 
 	it("should parse raw-text elements without decoding entities", () => {
 		const script = find("<script>var a = 1 < 2 &amp; 3;</script>", "script");
 		expect(script.children[0].type).toBe("text");
-		expect(script.children[0].data).toBe("var a = 1 < 2 &amp; 3;");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				script.children[0]
+			).data
+		).toBe("var a = 1 < 2 &amp; 3;");
 	});
 
 	it("should set tagEnd, nameEnd and start used by the consumer", () => {
@@ -226,7 +322,10 @@ describe("buildHtmlAst", () => {
 	it("should update end offsets when an element is closed", () => {
 		const src = "<div><span>text</div>";
 		const div = body(src)[0];
-		const span = div.children[0];
+		const span =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				div.children[0]
+			);
 		expect(div.end).toBe(src.length);
 		expect(span.end).toBe(src.length);
 	});
@@ -236,7 +335,11 @@ describe("buildHtmlAst", () => {
 			"<table><div>Misplaced</div><tr><td>OK</td></tr></table>"
 		);
 		expect(nodes[0].tagName).toBe("div");
-		expect(nodes[0].children[0].data).toBe("Misplaced");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				nodes[0].children[0]
+			).data
+		).toBe("Misplaced");
 		expect(nodes[1].tagName).toBe("table");
 	});
 
@@ -247,19 +350,46 @@ describe("buildHtmlAst", () => {
 			// <b> clone wraps the content that stayed inside <p>.
 			const nodes = body("<b>1<p>2</b>3</p>");
 			expect(nodes.map((n) => n.tagName)).toEqual(["b", "p"]);
-			expect(nodes[0].children.map((n) => n.data)).toEqual(["1"]);
+			expect(
+				nodes[0].children.map(
+					(n) =>
+						/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (n).data
+				)
+			).toEqual(["1"]);
 			const p = nodes[1];
-			expect(p.children[0].tagName).toBe("b");
-			expect(p.children[0].children[0].data).toBe("2");
-			expect(p.children[1].data).toBe("3");
+			expect(
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					p.children[0]
+				).tagName
+			).toBe("b");
+			expect(
+				/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+					/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+						p.children[0]
+					).children[0]
+				).data
+			).toBe("2");
+			expect(
+				/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+					p.children[1]
+				).data
+			).toBe("3");
 		});
 
 		it("should reconstruct active formatting elements", () => {
 			const nodes = body("<p>1<b>2</p>3</b>");
 			expect(nodes[0].tagName).toBe("p");
-			expect(nodes[0].children[1].tagName).toBe("b");
+			expect(
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					nodes[0].children[1]
+				).tagName
+			).toBe("b");
 			expect(nodes[1].tagName).toBe("b");
-			expect(nodes[1].children[0].data).toBe("3");
+			expect(
+				/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+					nodes[1].children[0]
+				).data
+			).toBe("3");
 		});
 
 		it("should apply Noah's Ark limit of three formatting elements", () => {
@@ -271,7 +401,9 @@ describe("buildHtmlAst", () => {
 			// The <a> is reopened around <div> by the algorithm; the clone must not
 			// reuse the original's href span, or the parser emits two dependencies.
 			const nodes = body("<a href=x.png><div>y</a>");
+			/** @type {string[]} */
 			const spans = [];
+			/** @param {import("../lib/html/buildHtmlAst").HtmlNode} node */
 			const collect = (node) => {
 				if (node.type !== "element") return;
 				for (const attr of node.attributes) {
@@ -289,9 +421,27 @@ describe("buildHtmlAst", () => {
 	it("should auto-close and close <dd>/<dt>", () => {
 		const dl = body("<dl><dd>a</dd><dt>b</dt></dl>")[0];
 		expect(dl.tagName).toBe("dl");
-		expect(dl.children.map((c) => c.tagName)).toEqual(["dd", "dt"]);
-		expect(dl.children[0].children[0].data).toBe("a");
-		expect(dl.children[1].children[0].data).toBe("b");
+		expect(
+			dl.children.map(
+				(c) =>
+					/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (c)
+						.tagName
+			)
+		).toEqual(["dd", "dt"]);
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					dl.children[0]
+				).children[0]
+			).data
+		).toBe("a");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+					dl.children[1]
+				).children[0]
+			).data
+		).toBe("b");
 	});
 
 	it("should keep <table> inside <p> in quirks mode (transitional doctype)", () => {
@@ -317,9 +467,16 @@ describe("buildHtmlAst", () => {
 			child(select.children, "button").children,
 			"selectedcontent"
 		);
-		const span = selectedcontent.children[0];
+		const span =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				selectedcontent.children[0]
+			);
 		expect(span.tagName).toBe("span");
-		expect(span.children[0].data).toBe("Y");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				span.children[0]
+			).data
+		).toBe("Y");
 		// The clone carries the attribute name/value but no source offsets, so
 		// the consumer never re-emits a dependency for it.
 		expect(span.attributes[0].name).toBe("id");
@@ -335,16 +492,26 @@ describe("buildHtmlAst", () => {
 			child(select.children, "button").children,
 			"selectedcontent"
 		);
-		expect(selectedcontent.children[0].data).toBe("B");
+		expect(
+			/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ (
+				selectedcontent.children[0]
+			).data
+		).toBe("B");
 	});
 
 	it("foster-parents stray text in a table fragment context", () => {
 		// Context is a `table`, so there is no `<table>` on the open stack: stray
 		// character data is fostered to the fragment root, beside the table rows.
-		const root = buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0];
+		const root =
+			/** @type {import("../lib/html/buildHtmlAst").HtmlElement} */ (
+				buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0]
+			);
 		const texts = root.children
 			.filter((c) => c.type === "text")
-			.map((c) => c.data);
+			.map(
+				(/** @type {import("../lib/html/buildHtmlAst").HtmlText} */ c) =>
+					c.data
+			);
 		expect(texts).toContain("x");
 		expect(child(root.children, "tbody")).toBeDefined();
 	});

--- a/test/checkArrayExpectation.js
+++ b/test/checkArrayExpectation.js
@@ -74,6 +74,11 @@ const normalizeString = (str, testDirectory) => {
 const normalizeForSnapshot = (items, testDirectory) =>
 	items.map((item) => normalizeString(item.message, testDirectory) || "");
 
+/**
+ * @param {EXPECTED_ANY} expected expected value or RegExp or array
+ * @param {EXPECTED_ANY} actual actual value
+ * @returns {boolean} whether actual matches expected
+ */
 const check = (expected, actual) => {
 	if (expected instanceof RegExp) {
 		expected = { message: expected };
@@ -90,6 +95,10 @@ const check = (expected, actual) => {
 	});
 };
 
+/**
+ * @param {EXPECTED_ANY} object stats item or RegExp
+ * @returns {string} explanation string
+ */
 const explain = (object) => {
 	if (object instanceof RegExp) {
 		object = { message: object };
@@ -109,6 +118,12 @@ const explain = (object) => {
 		.join("; ");
 };
 
+/**
+ * @param {EXPECTED_ANY[]} actual actual items
+ * @param {EXPECTED_ANY[]} expected expected items
+ * @param {string} kind error/warning/etc
+ * @returns {string} diff string
+ */
 const diffItems = (actual, expected, kind) => {
 	const tooMuch = [...actual];
 	const missing = [...expected];
@@ -135,6 +150,16 @@ ${tooMuch.map((item) => `${explain(item)}`).join("\n\n")}`);
 	return diff.join("\n\n");
 };
 
+/**
+ * @param {string} testDirectory test directory
+ * @param {EXPECTED_ANY} object stats object
+ * @param {string} kind error/warning/etc
+ * @param {string} filename filename or upperCaseKind when 6-arg form
+ * @param {string | EXPECTED_ANY} upperCaseKind upperCaseKind or options when 6-arg form
+ * @param {EXPECTED_ANY} options options or done when 6-arg form
+ * @param {EXPECTED_ANY=} done done callback
+ * @returns {boolean | undefined} true if expectation failed
+ */
 module.exports = function checkArrayExpectation(
 	testDirectory,
 	object,

--- a/test/cleverMerge.unittest.js
+++ b/test/cleverMerge.unittest.js
@@ -8,6 +8,8 @@ const {
 	resolveByProperty
 } = require("../lib/util/cleverMerge");
 
+/** @typedef {Record<string, unknown[]>} CasesMap */
+
 describe("cleverMerge", () => {
 	const base = {
 		a1: [1],
@@ -529,7 +531,7 @@ describe("cleverMerge", () => {
 			{
 				b: 50,
 				y: 20,
-				byArguments: (x, y, z) => ({
+				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
 					c: 60,
 					x,
 					y,
@@ -550,7 +552,7 @@ describe("cleverMerge", () => {
 				a: 4, // keep
 				b: 5, // static override
 				c: 6, // dynamic override
-				byArguments: (x, y, z) => ({
+				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
 					x, // keep
 					y, // static override
 					z // dynamic override
@@ -559,7 +561,7 @@ describe("cleverMerge", () => {
 			{
 				b: 50,
 				y: 20,
-				byArguments: (x, y, z) => ({
+				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
 					c: 60,
 					z: z * 10
 				})
@@ -581,7 +583,7 @@ describe("cleverMerge", () => {
 					c: 8, // dynamic override
 					d: 9, // static override (3rd)
 					e: 10, // dynamic override (3rd)
-					byArguments: (x, y, z, v, w) => ({
+					byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z, /** @type {number} */ v, /** @type {number} */ w) => ({
 						x, // keep
 						y, // static override
 						z, // dynamic override
@@ -592,7 +594,7 @@ describe("cleverMerge", () => {
 				{
 					b: 70,
 					y: 20,
-					byArguments: (x, y, z) => ({
+					byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
 						c: 80,
 						z: z * 10
 					})
@@ -601,7 +603,7 @@ describe("cleverMerge", () => {
 			{
 				d: 90,
 				v: 40,
-				byArguments: (x, y, z, v, w) => ({
+				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z, /** @type {number} */ v, /** @type {number} */ w) => ({
 					e: 100,
 					w: w * 10
 				})
@@ -657,7 +659,7 @@ describe("cleverMerge", () => {
 		nonObject5: [undefined, { a: 1 }, { a: 1 }]
 	};
 	for (const key of Object.keys(cases)) {
-		const testCase = cases[key];
+		const testCase = /** @type {CasesMap} */ (cases)[key];
 
 		it(`should merge ${key} correctly`, () => {
 			let merged = cleverMerge(testCase[0], testCase[1]);

--- a/test/cleverMerge.unittest.js
+++ b/test/cleverMerge.unittest.js
@@ -8,7 +8,7 @@ const {
 	resolveByProperty
 } = require("../lib/util/cleverMerge");
 
-/** @typedef {Record<string, unknown[]>} CasesMap */
+/** @typedef {Record<string, EXPECTED_ANY[]>} CasesMap */
 
 describe("cleverMerge", () => {
 	const base = {
@@ -531,7 +531,11 @@ describe("cleverMerge", () => {
 			{
 				b: 50,
 				y: 20,
-				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
+				byArguments: (
+					/** @type {number} */ x,
+					/** @type {number} */ y,
+					/** @type {number} */ z
+				) => ({
 					c: 60,
 					x,
 					y,
@@ -552,7 +556,11 @@ describe("cleverMerge", () => {
 				a: 4, // keep
 				b: 5, // static override
 				c: 6, // dynamic override
-				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
+				byArguments: (
+					/** @type {number} */ x,
+					/** @type {number} */ y,
+					/** @type {number} */ z
+				) => ({
 					x, // keep
 					y, // static override
 					z // dynamic override
@@ -561,7 +569,11 @@ describe("cleverMerge", () => {
 			{
 				b: 50,
 				y: 20,
-				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
+				byArguments: (
+					/** @type {number} */ x,
+					/** @type {number} */ y,
+					/** @type {number} */ z
+				) => ({
 					c: 60,
 					z: z * 10
 				})
@@ -583,7 +595,13 @@ describe("cleverMerge", () => {
 					c: 8, // dynamic override
 					d: 9, // static override (3rd)
 					e: 10, // dynamic override (3rd)
-					byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z, /** @type {number} */ v, /** @type {number} */ w) => ({
+					byArguments: (
+						/** @type {number} */ x,
+						/** @type {number} */ y,
+						/** @type {number} */ z,
+						/** @type {number} */ v,
+						/** @type {number} */ w
+					) => ({
 						x, // keep
 						y, // static override
 						z, // dynamic override
@@ -594,7 +612,11 @@ describe("cleverMerge", () => {
 				{
 					b: 70,
 					y: 20,
-					byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z) => ({
+					byArguments: (
+						/** @type {number} */ x,
+						/** @type {number} */ y,
+						/** @type {number} */ z
+					) => ({
 						c: 80,
 						z: z * 10
 					})
@@ -603,7 +625,13 @@ describe("cleverMerge", () => {
 			{
 				d: 90,
 				v: 40,
-				byArguments: (/** @type {number} */ x, /** @type {number} */ y, /** @type {number} */ z, /** @type {number} */ v, /** @type {number} */ w) => ({
+				byArguments: (
+					/** @type {number} */ x,
+					/** @type {number} */ y,
+					/** @type {number} */ z,
+					/** @type {number} */ v,
+					/** @type {number} */ w
+				) => ({
 					e: 100,
 					w: w * 10
 				})

--- a/test/compareLocations.unittest.js
+++ b/test/compareLocations.unittest.js
@@ -2,21 +2,37 @@
 
 const { compareLocations } = require("../lib/util/comparators");
 
+/** @typedef {import("../lib/Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("../lib/Dependency").SourcePosition} SourcePosition */
+/** @typedef {import("../lib/Dependency").RealDependencyLocation} RealDependencyLocation */
+
+/**
+ * @param {Partial<SourcePosition>=} overrides position overrides
+ * @returns {SourcePosition} source position
+ */
 const createPosition = (overrides) => ({
 	line: 10,
 	column: 5,
 	...overrides
 });
 
+/**
+ * @param {Partial<SourcePosition> | null=} start start position overrides
+ * @param {Partial<SourcePosition> | null=} end end position overrides
+ * @param {number=} index location index
+ * @returns {RealDependencyLocation} real dependency location
+ */
 const createLocation = (start, end, index) => ({
-	start: createPosition(start),
-	end: createPosition(end),
+	start: createPosition(start || undefined),
+	end: createPosition(end || undefined),
 	index: index || 3
 });
 
 describe("compareLocations", () => {
 	describe("object location comparison", () => {
+		/** @type {DependencyLocation} */
 		let a;
+		/** @type {DependencyLocation} */
 		let b;
 
 		describe("location line number", () => {
@@ -86,17 +102,42 @@ describe("compareLocations", () => {
 
 	describe("unknown location type comparison", () => {
 		it("returns 1 when the first parameter is an object and the second parameter is not", () => {
-			expect(compareLocations(createLocation(), 123)).toBe(1);
-			expect(compareLocations(createLocation(), "alpha")).toBe(1);
+			expect(
+				compareLocations(
+					createLocation(),
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ (123))
+				)
+			).toBe(1);
+			expect(
+				compareLocations(
+					createLocation(),
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ ("alpha"))
+				)
+			).toBe(1);
 		});
 
 		it("returns -1 when the first parameter is not an object and the second parameter is", () => {
-			expect(compareLocations(123, createLocation())).toBe(-1);
-			expect(compareLocations("alpha", createLocation())).toBe(-1);
+			expect(
+				compareLocations(
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ (123)),
+					createLocation()
+				)
+			).toBe(-1);
+			expect(
+				compareLocations(
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ ("alpha")),
+					createLocation()
+				)
+			).toBe(-1);
 		});
 
 		it("returns 0 when both the first parameter and the second parameter are not objects", () => {
-			expect(compareLocations(123, 456)).toBe(0);
+			expect(
+				compareLocations(
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ (123)),
+					/** @type {DependencyLocation} */ (/** @type {unknown} */ (456))
+				)
+			).toBe(0);
 		});
 	});
 });

--- a/test/compareSourceOrder.unittest.js
+++ b/test/compareSourceOrder.unittest.js
@@ -2,7 +2,11 @@
 
 const { sortWithSourceOrder } = require("../lib/util/comparators");
 
+/** @typedef {import("../lib/Dependency")} Dependency */
+/** @typedef {import("../lib/util/comparators").DependencySourceOrder} DependencySourceOrder */
+
 describe("sortWithSourceOrder", () => {
+	/** @type {WeakMap<Dependency, DependencySourceOrder>} */
 	let dependencySourceOrderMap;
 
 	beforeEach(() => {
@@ -10,28 +14,37 @@ describe("sortWithSourceOrder", () => {
 	});
 
 	it("dependency without the sourceOrder attribute must keep their original index in the array", () => {
-		const deps = [
-			// HarmonyImportSpecifierDependency
-			{ name: "b", sourceOrder: 10 },
-			// CommonJSRequireDependency
-			{ name: "a" },
-			// CommonJSRequireDependency
-			{ name: "d" },
-			// HarmonyImportSpecifierDependency
-			{ name: "c", sourceOrder: 5 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				// HarmonyImportSpecifierDependency
+				{ name: "b", sourceOrder: 10 },
+				// CommonJSRequireDependency
+				{ name: "a" },
+				// CommonJSRequireDependency
+				{ name: "d" },
+				// HarmonyImportSpecifierDependency
+				{ name: "c", sourceOrder: 5 }
+			])
+		);
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["c", "a", "d", "b"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"c",
+			"a",
+			"d",
+			"b"
+		]);
 	});
 
 	it("should sort dependencies by main order when both in map", () => {
-		const deps = [
-			{ name: "b", sourceOrder: 5 },
-			{ name: "a", sourceOrder: 10 },
-			{ name: "c", sourceOrder: 3 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "b", sourceOrder: 5 },
+				{ name: "a", sourceOrder: 10 },
+				{ name: "c", sourceOrder: 3 }
+			])
+		);
 
 		// Add to map with main and sub orders
 		dependencySourceOrderMap.set(deps[0], { main: 5, sub: 0 });
@@ -40,15 +53,21 @@ describe("sortWithSourceOrder", () => {
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["c", "b", "a"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"c",
+			"b",
+			"a"
+		]);
 	});
 
 	it("should sort by sub order when main order is same", () => {
-		const deps = [
-			{ name: "b", sourceOrder: 5 },
-			{ name: "a", sourceOrder: 5 },
-			{ name: "c", sourceOrder: 5 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "b", sourceOrder: 5 },
+				{ name: "a", sourceOrder: 5 },
+				{ name: "c", sourceOrder: 5 }
+			])
+		);
 
 		// Add to map with same main but different sub orders
 		dependencySourceOrderMap.set(deps[0], { main: 5, sub: 3 });
@@ -57,45 +76,63 @@ describe("sortWithSourceOrder", () => {
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["a", "c", "b"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"a",
+			"c",
+			"b"
+		]);
 	});
 
 	it("should sort mixed dependencies - some in map, some not", () => {
-		const deps = [
-			{ name: "b", sourceOrder: 10 },
-			{ name: "a", sourceOrder: 5 },
-			{ name: "c", sourceOrder: 15 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "b", sourceOrder: 10 },
+				{ name: "a", sourceOrder: 5 },
+				{ name: "c", sourceOrder: 15 }
+			])
+		);
 
 		// Only add one to map
 		dependencySourceOrderMap.set(deps[0], { main: 10, sub: 0 });
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["a", "b", "c"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"a",
+			"b",
+			"c"
+		]);
 	});
 
 	it("should sort by sourceOrder when none in map", () => {
-		const deps = [
-			{ name: "b", sourceOrder: 10 },
-			{ name: "a", sourceOrder: 5 },
-			{ name: "c", sourceOrder: 15 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "b", sourceOrder: 10 },
+				{ name: "a", sourceOrder: 5 },
+				{ name: "c", sourceOrder: 15 }
+			])
+		);
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["a", "b", "c"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"a",
+			"b",
+			"c"
+		]);
 	});
 
 	it("should sort complex scenario with negative and decimal values", () => {
-		const deps = [
-			{ name: "f", sourceOrder: 10 },
-			{ name: "e", sourceOrder: 5 },
-			{ name: "d", sourceOrder: 20 },
-			{ name: "c", sourceOrder: 10 },
-			{ name: "b", sourceOrder: 5 },
-			{ name: "a", sourceOrder: 3 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "f", sourceOrder: 10 },
+				{ name: "e", sourceOrder: 5 },
+				{ name: "d", sourceOrder: 20 },
+				{ name: "c", sourceOrder: 10 },
+				{ name: "b", sourceOrder: 5 },
+				{ name: "a", sourceOrder: 3 }
+			])
+		);
 
 		dependencySourceOrderMap.set(deps[0], { main: 10, sub: 0.5 });
 		dependencySourceOrderMap.set(deps[1], { main: 5, sub: 0.5 });
@@ -106,18 +143,31 @@ describe("sortWithSourceOrder", () => {
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["a", "b", "e", "c", "f", "d"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"a",
+			"b",
+			"e",
+			"c",
+			"f",
+			"d"
+		]);
 	});
 
 	it("should maintain stable sort for equal values", () => {
-		const deps = [
-			{ name: "b", sourceOrder: 5 },
-			{ name: "a", sourceOrder: 5 },
-			{ name: "c", sourceOrder: 5 }
-		];
+		const deps = /** @type {Dependency[]} */ (
+			/** @type {unknown[]} */ ([
+				{ name: "b", sourceOrder: 5 },
+				{ name: "a", sourceOrder: 5 },
+				{ name: "c", sourceOrder: 5 }
+			])
+		);
 
 		sortWithSourceOrder(deps, dependencySourceOrderMap);
 
-		expect(deps.map((d) => d.name)).toEqual(["b", "a", "c"]);
+		expect(deps.map((d) => /** @type {EXPECTED_ANY} */ (d).name)).toEqual([
+			"b",
+			"a",
+			"c"
+		]);
 	});
 });

--- a/test/createMappings.unittest.js
+++ b/test/createMappings.unittest.js
@@ -16,7 +16,7 @@ describe("encodeVLQ", () => {
 
 	for (const [input, expected] of cases) {
 		it(`encodes ${input} -> ${expected}`, () => {
-			expect(encodeVLQ(input)).toBe(expected);
+			expect(encodeVLQ(/** @type {number} */ (input))).toBe(expected);
 		});
 	}
 });

--- a/test/cssIdentifier.unittest.js
+++ b/test/cssIdentifier.unittest.js
@@ -167,8 +167,8 @@ describe("css identifier utils", () => {
 					equalsLowerCase(s, "button");
 				} catch (err) {
 					failures.push(
-					`throw on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
-				);
+						`throw on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
+					);
 				}
 			}
 			expect(failures).toEqual([]);
@@ -193,8 +193,8 @@ describe("css identifier utils", () => {
 						cssExportConvention(s, c);
 					} catch (err) {
 						failures.push(
-						`${c} on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
-					);
+							`${c} on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
+						);
 					}
 				}
 			}

--- a/test/cssIdentifier.unittest.js
+++ b/test/cssIdentifier.unittest.js
@@ -123,7 +123,7 @@ describe("css identifier utils", () => {
 		const { escapeIdentifier, unescapeIdentifier, equalsLowerCase } =
 			walkCssTokens;
 		// mulberry32
-		const makeRng = (seed) => {
+		const makeRng = (/** @type {number} */ seed) => {
 			let s = seed >>> 0;
 			return () => {
 				s = (s + 0x6d2b79f5) >>> 0;
@@ -137,7 +137,7 @@ describe("css identifier utils", () => {
 			"\\\\\\41\\3 \\{}\\@.#:;()[]<>\"' \t\n\r\f",
 			"-_0123456789"
 		];
-		const randStr = (rng) => {
+		const randStr = (/** @type {() => number} */ rng) => {
 			const len = (rng() * 40) | 0;
 			const surrogateMode = rng() < 0.2;
 			let out = "";
@@ -166,7 +166,9 @@ describe("css identifier utils", () => {
 					unescapeIdentifier(s);
 					equalsLowerCase(s, "button");
 				} catch (err) {
-					failures.push(`throw on ${JSON.stringify(s)}: ${err.message}`);
+					failures.push(
+					`throw on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
+				);
 				}
 			}
 			expect(failures).toEqual([]);
@@ -190,7 +192,9 @@ describe("css identifier utils", () => {
 					try {
 						cssExportConvention(s, c);
 					} catch (err) {
-						failures.push(`${c} on ${JSON.stringify(s)}: ${err.message}`);
+						failures.push(
+						`${c} on ${JSON.stringify(s)}: ${/** @type {Error} */ (err).message}`
+					);
 					}
 				}
 			}

--- a/test/deterministicGrouping.unittest.js
+++ b/test/deterministicGrouping.unittest.js
@@ -3,15 +3,15 @@
 const deterministicGrouping = require("../lib/util/deterministicGrouping");
 
 describe("deterministicGrouping", () => {
-	const group = (/** @type {object[]} */ items, /** @type {object} */ minSize, /** @type {object} */ maxSize) =>
+	const group = (/** @type {Record<string, number>[]} */ items, /** @type {Record<string, number>} */ minSize, /** @type {Record<string, number>} */ maxSize) =>
 		deterministicGrouping({
-			items: items.map((/** @type {object} */ item, /** @type {number} */ i) => [i, item]),
+			items: items.map((/** @type {Record<string, number>} */ item, /** @type {number} */ i) => /** @type {[number, Record<string, number>]} */ ([i, item])),
 			minSize,
 			maxSize,
-			getKey: ([key]) => `${100000 + key}`,
-			getSize: ([, size]) => size
+			getKey: (/** @type {[number, Record<string, number>]} */ [key]) => `${100000 + key}`,
+			getSize: (/** @type {[number, Record<string, number>]} */ [, size]) => size
 		}).map((group) => ({
-			items: group.items.map(([i]) => i),
+			items: group.items.map((/** @type {[number, Record<string, number>]} */ [i]) => i),
 			size: group.size
 		}));
 

--- a/test/deterministicGrouping.unittest.js
+++ b/test/deterministicGrouping.unittest.js
@@ -3,9 +3,9 @@
 const deterministicGrouping = require("../lib/util/deterministicGrouping");
 
 describe("deterministicGrouping", () => {
-	const group = (items, minSize, maxSize) =>
+	const group = (/** @type {object[]} */ items, /** @type {object} */ minSize, /** @type {object} */ maxSize) =>
 		deterministicGrouping({
-			items: items.map((item, i) => [i, item]),
+			items: items.map((/** @type {object} */ item, /** @type {number} */ i) => [i, item]),
 			minSize,
 			maxSize,
 			getKey: ([key]) => `${100000 + key}`,

--- a/test/deterministicGrouping.unittest.js
+++ b/test/deterministicGrouping.unittest.js
@@ -3,15 +3,26 @@
 const deterministicGrouping = require("../lib/util/deterministicGrouping");
 
 describe("deterministicGrouping", () => {
-	const group = (/** @type {Record<string, number>[]} */ items, /** @type {Record<string, number>} */ minSize, /** @type {Record<string, number>} */ maxSize) =>
+	const group = (
+		/** @type {Record<string, number>[]} */ items,
+		/** @type {Record<string, number>} */ minSize,
+		/** @type {Record<string, number>} */ maxSize
+	) =>
 		deterministicGrouping({
-			items: items.map((/** @type {Record<string, number>} */ item, /** @type {number} */ i) => /** @type {[number, Record<string, number>]} */ ([i, item])),
+			items: items.map(
+				(/** @type {Record<string, number>} */ item, /** @type {number} */ i) =>
+					/** @type {[number, Record<string, number>]} */ ([i, item])
+			),
 			minSize,
 			maxSize,
-			getKey: (/** @type {[number, Record<string, number>]} */ [key]) => `${100000 + key}`,
-			getSize: (/** @type {[number, Record<string, number>]} */ [, size]) => size
+			getKey: (/** @type {[number, Record<string, number>]} */ [key]) =>
+				`${100000 + key}`,
+			getSize: (/** @type {[number, Record<string, number>]} */ [, size]) =>
+				size
 		}).map((group) => ({
-			items: group.items.map((/** @type {[number, Record<string, number>]} */ [i]) => i),
+			items: group.items.map(
+				(/** @type {[number, Record<string, number>]} */ [i]) => i
+			),
 			size: group.size
 		}));
 

--- a/test/findGraphRoots.unittest.js
+++ b/test/findGraphRoots.unittest.js
@@ -2,7 +2,11 @@
 
 const findGraphRoots = require("../lib/util/findGraphRoots");
 
-const args = (/** @type {Record<string, string[]>} */ g) => /** @type {[string[], (m: string) => string[]]} */ ([Object.keys(g), (/** @type {string} */ m) => g[m]]);
+const args = (/** @type {Record<string, string[]>} */ g) =>
+	/** @type {[string[], (m: string) => string[]]} */ ([
+		Object.keys(g),
+		(/** @type {string} */ m) => g[m]
+	]);
 
 describe("findGraphRoots", () => {
 	it("simple case", () => {

--- a/test/findGraphRoots.unittest.js
+++ b/test/findGraphRoots.unittest.js
@@ -2,7 +2,7 @@
 
 const findGraphRoots = require("../lib/util/findGraphRoots");
 
-const args = (g) => [Object.keys(g), (m) => g[m]];
+const args = (/** @type {Record<string, string[]>} */ g) => /** @type {[string[], (m: string) => string[]]} */ ([Object.keys(g), (/** @type {string} */ m) => g[m]]);
 
 describe("findGraphRoots", () => {
 	it("simple case", () => {

--- a/test/fixtures/errors/throw-error-plugin.js
+++ b/test/fixtures/errors/throw-error-plugin.js
@@ -1,6 +1,9 @@
 module.exports = {
+	/**
+	 * @param {import("../../../").Compiler} compiler compiler
+	 */
 	apply(compiler) {
-		compiler.hooks.compilation.tap("Errors.test-unhandled-throws", compilation => {
+		compiler.hooks.compilation.tap("Errors.test-unhandled-throws", (compilation) => {
 			throw new Error('foo');
 		});
 	}

--- a/test/formatLocation.unittest.js
+++ b/test/formatLocation.unittest.js
@@ -85,7 +85,13 @@ describe("formatLocation", () => {
 	];
 	for (const testCase of testCases) {
 		it(`should format location correctly for ${testCase.name}`, () => {
-			expect(formatLocation(testCase.loc)).toEqual(testCase.result);
+			expect(
+				formatLocation(
+					/** @type {import("../lib/Dependency").DependencyLocation} */ (
+						testCase.loc
+					)
+				)
+			).toEqual(testCase.result);
 		});
 	}
 });

--- a/test/harness/runner/asModule.js
+++ b/test/harness/runner/asModule.js
@@ -11,9 +11,9 @@ const LINKER = () => {};
 /**
  * @param {vm.SourceTextModule | vm.Module | EXPECTED_ANY} something module or object
  * @param {EXPECTED_ANY} context context
- * @param {{ esmReturnStatus?: boolean }=} options options
+ * @param {{ esmReturnStatus?: string }=} options options
  * @param {Record<string, string>=} importAttributes import attributes
- * @returns {Promise<vm.SourceTextModule> | Promise<vm.SyntheticModule>} module
+ * @returns {Promise<vm.SourceTextModule | vm.SyntheticModule>} module
  */
 module.exports = async (
 	something,
@@ -24,7 +24,7 @@ module.exports = async (
 	if (
 		something instanceof (vm.Module || /* node.js 10 */ vm.SourceTextModule)
 	) {
-		return something;
+		return /** @type {vm.SourceTextModule} */ (something);
 	}
 
 	if (importAttributes && importAttributes.type === "bytes") {
@@ -36,7 +36,7 @@ module.exports = async (
 			{ context }
 		);
 
-		await byteModule.link(() => {});
+		await byteModule.link(/** @type {EXPECTED_ANY} */ (() => {}));
 		await byteModule.evaluate();
 
 		return byteModule;
@@ -60,14 +60,19 @@ module.exports = async (
 	if (options.esmReturnStatus === ESModuleStatus.Unlinked) return esm;
 
 	if (major === 10) {
-		if (esm.linkingStatus === ESModuleStatus.Unlinked) {
-			await esm.link(LINKER);
+		if (
+			/** @type {EXPECTED_ANY} */ (esm).linkingStatus ===
+			ESModuleStatus.Unlinked
+		) {
+			await esm.link(/** @type {EXPECTED_ANY} */ (() => {}));
 		}
-		if (esm.linkingStatus === ESModuleStatus.Linked) {
+		if (
+			/** @type {EXPECTED_ANY} */ (esm).linkingStatus === ESModuleStatus.Linked
+		) {
 			esm.instantiate();
 		}
 	} else if (esm.status === ESModuleStatus.Unlinked) {
-		await esm.link(LINKER);
+		await esm.link(/** @type {EXPECTED_ANY} */ (() => {}));
 	}
 
 	await esm.evaluate();

--- a/test/harness/runner/index.js
+++ b/test/harness/runner/index.js
@@ -120,14 +120,14 @@ class TestRunner {
 			target === false
 				? /** @type {false} */ (false)
 				: typeof target === "string"
-				? getTargetProperties(
-						target,
-						/** @type {string} */ (webpackOptions.context)
-				  )
-				: getTargetsProperties(
-						/** @type {string[]} */ (target),
-						/** @type {string} */ (webpackOptions.context)
-				  );
+					? getTargetProperties(
+							target,
+							/** @type {string} */ (webpackOptions.context)
+						)
+					: getTargetsProperties(
+							/** @type {string[]} */ (target),
+							/** @type {string} */ (webpackOptions.context)
+						);
 		const props =
 			/** @type {import("../../../lib/config/target").TargetProperties} */ (
 				targetProperties
@@ -191,8 +191,8 @@ class TestRunner {
 						const normalized = path.isAbsolute(p)
 							? p
 							: p.startsWith("./")
-							? p
-							: `./${p}`;
+								? p
+								: `./${p}`;
 						results.push(runner.require(outputDirectory, normalized));
 					}
 
@@ -594,11 +594,11 @@ class TestRunner {
 								? `./${path.relative(
 										path.dirname(identifier),
 										fileURLToPath(specifier)
-								  )}`
+									)}`
 								: specifier.replace(
 										/https:\/\/example.com\/public\/path\//,
 										"./"
-								  );
+									);
 
 							const res = await this.require(
 								path.dirname(identifier),
@@ -801,12 +801,12 @@ class TestRunner {
 					typeof TextEncoder !== "undefined"
 						? TextEncoder
 						: // eslint-disable-next-line n/prefer-global/text-encoder
-						  require("util").TextEncoder,
+							require("util").TextEncoder,
 				TextDecoder:
 					typeof TextDecoder !== "undefined"
 						? TextDecoder
 						: // eslint-disable-next-line n/prefer-global/text-decoder
-						  require("util").TextDecoder,
+							require("util").TextDecoder,
 				EventSource,
 				clearTimeout,
 				fetch

--- a/test/harness/runner/index.js
+++ b/test/harness/runner/index.js
@@ -120,19 +120,19 @@ class TestRunner {
 			target === false
 				? /** @type {false} */ (false)
 				: typeof target === "string"
-					? getTargetProperties(
-							target,
-							/** @type {Context} */ (webpackOptions.context)
-						)
-					: getTargetsProperties(
-							/** @type {string[]} */ (target),
-							/** @type {Context} */ (webpackOptions.context)
-						);
-		return (
-			outputModule &&
-			targetProperties.node === null &&
-			targetProperties.web === null
-		);
+				? getTargetProperties(
+						target,
+						/** @type {string} */ (webpackOptions.context)
+				  )
+				: getTargetsProperties(
+						/** @type {string[]} */ (target),
+						/** @type {string} */ (webpackOptions.context)
+				  );
+		const props =
+			/** @type {import("../../../lib/config/target").TargetProperties} */ (
+				targetProperties
+			);
+		return outputModule && props.node === null && props.web === null;
 	}
 
 	/**
@@ -191,8 +191,8 @@ class TestRunner {
 						const normalized = path.isAbsolute(p)
 							? p
 							: p.startsWith("./")
-								? p
-								: `./${p}`;
+							? p
+							: `./${p}`;
 						results.push(runner.require(outputDirectory, normalized));
 					}
 
@@ -251,7 +251,7 @@ class TestRunner {
 		const target = this.target;
 		const context = /** @type {string} */ (this.webpackOptions.context);
 
-		if (target === false) return false;
+		if (/** @type {EXPECTED_ANY} */ (target) === false) return false;
 
 		return typeof target === "string"
 			? getTargetProperties(target, context)
@@ -293,7 +293,7 @@ class TestRunner {
 			console,
 			expect,
 			jest,
-			nsObj: (m) => {
+			nsObj: (/** @type {EXPECTED_ANY} */ m) => {
 				Object.defineProperty(m, Symbol.toStringTag, {
 					value: "Module"
 				});
@@ -302,8 +302,8 @@ class TestRunner {
 		};
 		Object.assign(base, this._globalContext);
 		if (this.jsDom()) {
-			base.window = this._globalContext;
-			base.self = this._globalContext;
+			/** @type {EXPECTED_ANY} */ (base).window = this._globalContext;
+			/** @type {EXPECTED_ANY} */ (base).self = this._globalContext;
 		}
 		return base;
 	}
@@ -345,12 +345,12 @@ class TestRunner {
 	/**
 	 * @param {string} currentDirectory current directory
 	 * @param {string | string[]} module module
-	 * @returns {ModuleInfo} module info
+	 * @returns {ModuleInfo | undefined} module info
 	 */
 	_resolveModule(currentDirectory, module) {
 		if (Array.isArray(module)) {
 			return {
-				origin: module,
+				origin: /** @type {string} */ (/** @type {EXPECTED_ANY} */ (module)),
 				subPath: "",
 				modulePath: path.join(currentDirectory, ".array-require.js"),
 				content: `module.exports = (${module
@@ -392,9 +392,20 @@ class TestRunner {
 	 * @param {Record<string, string>=} importAttributes import attributes
 	 * @returns {EXPECTED_ANY} require result
 	 */
-	require(currentDirectory, module, context = {}, importAttributes = {}) {
-		if (this.testConfig.modules && module in this.testConfig.modules) {
-			return this.testConfig.modules[module];
+	require(
+		currentDirectory,
+		module,
+		context = /** @type {RequireContext} */ ({}),
+		importAttributes = {}
+	) {
+		if (
+			/** @type {EXPECTED_ANY} */ (this.testConfig).modules &&
+			/** @type {string} */ (module) in
+				/** @type {EXPECTED_ANY} */ (this.testConfig).modules
+		) {
+			return /** @type {EXPECTED_ANY} */ (this.testConfig).modules[
+				/** @type {string} */ (module)
+			];
 		}
 		if (this.testConfig.resolveModule) {
 			module = this.testConfig.resolveModule(
@@ -409,7 +420,8 @@ class TestRunner {
 			const rawRequire = Module.createRequire
 				? Module.createRequire(currentDirectory)
 				: require;
-			return rawRequire(module.startsWith("node:") ? module.slice(5) : module);
+			const mod = /** @type {string} */ (module);
+			return rawRequire(mod.startsWith("node:") ? mod.slice(5) : mod);
 		}
 		const { modulePath } = moduleInfo;
 		if (importAttributes && importAttributes.type === "bytes") {
@@ -453,7 +465,7 @@ class TestRunner {
 					this.require.bind(this, path.dirname(modulePath)),
 					this.require
 				),
-				importScripts: (url) => {
+				importScripts: (/** @type {string} */ url) => {
 					expect(url).toMatch(/^https:\/\/test\.cases\/path\//);
 					this.require(this.outputDirectory, urlToRelativePath(url));
 				},
@@ -537,6 +549,7 @@ class TestRunner {
 				}
 			);
 
+		/** @type {vm.Context | null} */
 		let esmContext = null;
 
 		/** @type {Map<string, vm.SourceTextModule>} */
@@ -544,7 +557,8 @@ class TestRunner {
 		const { category, name, round } = this.testMeta;
 
 		const testMetaStr = `${category}-${name}-${round || 0}`;
-		const appendTestMeta = (identifier) => `${identifier}?${testMetaStr}`;
+		const appendTestMeta = (/** @type {string} */ identifier) =>
+			`${identifier}?${testMetaStr}`;
 
 		/**
 		 * @param {string} identifier identifier
@@ -554,50 +568,60 @@ class TestRunner {
 		const getModuleInstance = (identifier, content) => {
 			let instance = esmCache.get(identifier);
 			if (!instance) {
-				instance = new vm.SourceTextModule(content, {
-					identifier: appendTestMeta(identifier),
-					url: appendTestMeta(pathToFileURL(identifier).href),
-					context: esmContext,
-					initializeImportMeta: (meta, _module) => {
-						meta.url = pathToFileURL(identifier).href;
+				instance = new vm.SourceTextModule(
+					content,
+					/** @type {EXPECTED_ANY} */ ({
+						identifier: appendTestMeta(identifier),
+						url: appendTestMeta(pathToFileURL(identifier).href),
+						context: esmContext,
+						initializeImportMeta: (
+							/** @type {EXPECTED_ANY} */ meta,
+							/** @type {EXPECTED_ANY} */ _module
+						) => {
+							meta.url = pathToFileURL(identifier).href;
 
-						if (this.hasNodeTarget()) {
-							meta.filename = identifier;
-							meta.dirname = path.dirname(identifier);
+							if (this.hasNodeTarget()) {
+								meta.filename = identifier;
+								meta.dirname = path.dirname(identifier);
+							}
+						},
+						importModuleDynamically: async (
+							/** @type {string} */ specifier,
+							/** @type {vm.Module} */ module,
+							/** @type {EXPECTED_ANY} */ importAttributes
+						) => {
+							const normalizedSpecifier = specifier.startsWith("file:")
+								? `./${path.relative(
+										path.dirname(identifier),
+										fileURLToPath(specifier)
+								  )}`
+								: specifier.replace(
+										/https:\/\/example.com\/public\/path\//,
+										"./"
+								  );
+
+							const res = await this.require(
+								path.dirname(identifier),
+								normalizedSpecifier,
+								{
+									esmReturnStatus: ESModuleStatus.Evaluated
+								},
+								/** @type {Record<string, string>} */ (
+									/** @type {EXPECTED_ANY} */ (importAttributes)
+								)
+							);
+
+							return await asModule(
+								res,
+								module.context,
+								undefined,
+								/** @type {Record<string, string>} */ (
+									/** @type {EXPECTED_ANY} */ (importAttributes)
+								)
+							);
 						}
-					},
-					importModuleDynamically: async (
-						specifier,
-						module,
-						importAttributes
-					) => {
-						const normalizedSpecifier = specifier.startsWith("file:")
-							? `./${path.relative(
-									path.dirname(identifier),
-									fileURLToPath(specifier)
-								)}`
-							: specifier.replace(
-									/https:\/\/example.com\/public\/path\//,
-									"./"
-								);
-
-						const res = await this.require(
-							path.dirname(identifier),
-							normalizedSpecifier,
-							{
-								esmReturnStatus: ESModuleStatus.Evaluated
-							},
-							importAttributes
-						);
-
-						return await asModule(
-							res,
-							module.context,
-							undefined,
-							importAttributes
-						);
-					}
-				});
+					})
+				);
 				esmCache.set(identifier, instance);
 			}
 
@@ -620,7 +644,8 @@ class TestRunner {
 
 			const esm = getModuleInstance(modulePath, content);
 
-			if (esmReturnStatus === ESModuleStatus.Unlinked) return esm;
+			if (esmReturnStatus === ESModuleStatus.Unlinked)
+				return Promise.resolve(esm);
 
 			const link = async () => {
 				await esm.link(
@@ -630,7 +655,11 @@ class TestRunner {
 							await this.require(
 								path.dirname(
 									referencingModule.identifier ||
-										fileURLToPath(referencingModule.url)
+										fileURLToPath(
+											/** @type {string} */ (
+												/** @type {EXPECTED_ANY} */ (referencingModule).url
+											)
+										)
 								),
 								specifier,
 								{ esmReturnStatus: ESModuleStatus.Unlinked }
@@ -646,11 +675,17 @@ class TestRunner {
 			const run = async () => {
 				// Link module dependencies
 				if (major === 10) {
-					if (esm.linkingStatus === ESModuleStatus.Unlinked) {
+					if (
+						/** @type {EXPECTED_ANY} */ (esm).linkingStatus ===
+						ESModuleStatus.Unlinked
+					) {
 						await link();
 					}
-					if (esm.linkingStatus === ESModuleStatus.Linked) {
-						esm.instantiate();
+					if (
+						/** @type {EXPECTED_ANY} */ (esm).linkingStatus ===
+						ESModuleStatus.Linked
+					) {
+						/** @type {EXPECTED_ANY} */ (esm).instantiate();
 					}
 				} else if (esm.status === ESModuleStatus.Unlinked) {
 					await link();
@@ -660,7 +695,7 @@ class TestRunner {
 				await esm.evaluate();
 				if (esmReturnStatus === ESModuleStatus.Evaluated) return esm;
 
-				const ns = esm.namespace;
+				const ns = /** @type {EXPECTED_ANY} */ (esm.namespace);
 				return ns.default && ns.default instanceof Promise ? ns.default : ns;
 			};
 
@@ -717,11 +752,14 @@ class TestRunner {
 
 			const document = new FakeDocument(outputDirectory);
 			if (this.testConfig.evaluateScriptOnAttached) {
-				document.onScript = (src) => {
-					this.require(outputDirectory, urlToRelativePath(src));
+				document.onScript = (/** @type {string | undefined} */ src) => {
+					this.require(
+						outputDirectory,
+						urlToRelativePath(/** @type {string} */ (src))
+					);
 				};
 			}
-			const fetch = async (url) => {
+			const fetch = async (/** @type {string} */ url) => {
 				try {
 					const buffer = await new Promise((resolve, reject) => {
 						fs.readFile(urlToPath(url, this.outputDirectory), (err, b) =>
@@ -733,7 +771,7 @@ class TestRunner {
 						ok: true,
 						json: async () => JSON.parse(buffer.toString("utf8"))
 					};
-				} catch (err) {
+				} catch (/** @type {EXPECTED_ANY} */ err) {
 					if (err.code === "ENOENT") {
 						return {
 							status: 404,
@@ -763,19 +801,19 @@ class TestRunner {
 					typeof TextEncoder !== "undefined"
 						? TextEncoder
 						: // eslint-disable-next-line n/prefer-global/text-encoder
-							require("util").TextEncoder,
+						  require("util").TextEncoder,
 				TextDecoder:
 					typeof TextDecoder !== "undefined"
 						? TextDecoder
 						: // eslint-disable-next-line n/prefer-global/text-decoder
-							require("util").TextDecoder,
+						  require("util").TextDecoder,
 				EventSource,
 				clearTimeout,
 				fetch
 			};
 			if (typeof Blob !== "undefined") {
 				// node.js >= 18
-				env.Blob = Blob;
+				/** @type {EXPECTED_ANY} */ (env).Blob = Blob;
 			}
 			return env;
 		}

--- a/test/harness/snapshot/index.js
+++ b/test/harness/snapshot/index.js
@@ -15,6 +15,7 @@ const getSnapshotPath = function (caseDir, suiteName) {
 	return path.join(caseDir, "__snapshots__", `${suiteName}.snap`);
 };
 
+/** @type {Array<{ caseDir: string, suiteName: string, originalState: SnapshotState, perCaseState: SnapshotState, snapshotPath: string }>} */
 const activeSnapshotContexts = [];
 
 /**
@@ -29,15 +30,21 @@ const createPerCaseSnapshotState = function (
 	suiteName,
 	originalState = expect.getState().snapshotState
 ) {
+	const s = /** @type {EXPECTED_ANY} */ (originalState);
 	return new SnapshotState(getSnapshotPath(caseDir, suiteName), {
-		updateSnapshot: originalState._updateSnapshot,
+		updateSnapshot: s._updateSnapshot,
 		snapshotFormat: originalState.snapshotFormat,
 		expand: originalState.expand,
-		prettierPath: originalState._prettierPath,
-		rootDir: originalState._rootDir || process.cwd()
+		prettierPath: s._prettierPath,
+		rootDir: s._rootDir || process.cwd()
 	});
 };
 
+/**
+ * @param {string} caseDir Absolute path to the test case directory
+ * @param {string} suiteName Name of the test suite
+ * @returns {{ caseDir: string, suiteName: string, originalState: SnapshotState, perCaseState: SnapshotState, snapshotPath: string }} snapshot context
+ */
 const activateSnapshotState = function (caseDir, suiteName) {
 	const originalState = expect.getState().snapshotState;
 	const snapshotContext = {
@@ -52,6 +59,9 @@ const activateSnapshotState = function (caseDir, suiteName) {
 	return snapshotContext;
 };
 
+/**
+ * @param {{ caseDir: string, suiteName: string, originalState: SnapshotState, perCaseState: SnapshotState, snapshotPath: string }} snapshotContext snapshot context
+ */
 const deactivateSnapshotState = function (snapshotContext) {
 	const index = activeSnapshotContexts.lastIndexOf(snapshotContext);
 	if (index >= 0) {
@@ -59,6 +69,9 @@ const deactivateSnapshotState = function (snapshotContext) {
 	}
 };
 
+/**
+ * @param {{ caseDir: string, suiteName: string, originalState: SnapshotState, perCaseState: SnapshotState, snapshotPath: string }} snapshotContext snapshot context
+ */
 const finalizePerCaseSnapshotState = function (snapshotContext) {
 	const { originalState, perCaseState } = snapshotContext;
 
@@ -86,6 +99,7 @@ const getActiveSnapshotState = function () {
  * @param {string} suiteName Name of the test suite
  */
 const registerPerCaseSnapshotHooks = function (caseDir, suiteName) {
+	/** @type {{ caseDir: string, suiteName: string, originalState: SnapshotState, perCaseState: SnapshotState, snapshotPath: string } | undefined} */
 	let snapshotContext;
 
 	beforeAll(() => {
@@ -100,7 +114,7 @@ const registerPerCaseSnapshotHooks = function (caseDir, suiteName) {
 		try {
 			finalizePerCaseSnapshotState(snapshotContext);
 		} finally {
-			deactivateSnapshotState(snapshotContext);
+			deactivateSnapshotState(/** @type {EXPECTED_ANY} */ (snapshotContext));
 			snapshotContext = undefined;
 		}
 	});
@@ -119,30 +133,33 @@ const matchKindSnapshot = function (caseDir, kind, received) {
 	const snapshotPath = path.join(caseDir, "__snapshots__", `${kind}.snap`);
 	const parentState =
 		getActiveSnapshotState() || expect.getState().snapshotState;
+	const ps = /** @type {EXPECTED_ANY} */ (parentState);
 
 	const kindState = new SnapshotState(snapshotPath, {
-		updateSnapshot: parentState._updateSnapshot === "all" ? "all" : "none",
+		updateSnapshot: ps._updateSnapshot === "all" ? "all" : "none",
 		snapshotFormat: parentState.snapshotFormat,
 		expand: parentState.expand,
-		prettierPath: parentState._prettierPath,
-		rootDir: parentState._rootDir || process.cwd()
+		prettierPath: ps._prettierPath,
+		rootDir: ps._rootDir || process.cwd()
 	});
 
 	// Call jest-snapshot's toMatchSnapshot directly with a controlled
 	// matcher context. Using `kind` as currentTestName produces the
 	// stable key "<kind> 1" (e.g. "errors 1"), independent of suite.
 	const { toMatchSnapshot } = require("jest-snapshot");
-	const context = {
+	const context = /** @type {EXPECTED_ANY} */ ({
 		snapshotState: kindState,
 		currentTestName: kind,
 		isNot: false,
 		promise: "",
 		utils: require("jest-matcher-utils"),
 		expand: false
-	};
+	});
 
 	try {
-		const result = toMatchSnapshot.call(context, received);
+		const result = /** @type {import("expect").SyncExpectationResult} */ (
+			toMatchSnapshot.call(context, received)
+		);
 		if (!result.pass) {
 			throw new Error(result.message());
 		}

--- a/test/helpers/EventSourceForNode.js
+++ b/test/helpers/EventSourceForNode.js
@@ -12,7 +12,7 @@ module.exports = class EventSource {
 	constructor(url) {
 		/** @type {import("http").IncomingMessage | undefined} */
 		this.response = undefined;
-		/** @type {undefined | ((err: EXPECTED_ANY) => void)} */
+		/** @type {undefined | ((err: Error | { message: Error }) => void)} */
 		this.onerror = undefined;
 		const request = (
 			url.startsWith("https:") ? require("https") : require("http")
@@ -41,12 +41,12 @@ module.exports = class EventSource {
 	}
 
 	// eslint-disable-next-line accessor-pairs
-	set onopen(/** @type {EXPECTED_ANY} */ value) {
+	set onopen(/** @type {unknown} */ value) {
 		throw new Error("not implemented");
 	}
 
 	// eslint-disable-next-line accessor-pairs
-	set onmessage(/** @type {EXPECTED_ANY} */ value) {
+	set onmessage(/** @type {unknown} */ value) {
 		throw new Error("not implemented");
 	}
 };

--- a/test/helpers/EventSourceForNode.js
+++ b/test/helpers/EventSourceForNode.js
@@ -6,8 +6,14 @@
 "use strict";
 
 module.exports = class EventSource {
+	/**
+	 * @param {string} url url
+	 */
 	constructor(url) {
+		/** @type {import("http").IncomingMessage | undefined} */
 		this.response = undefined;
+		/** @type {undefined | ((err: EXPECTED_ANY) => void)} */
+		this.onerror = undefined;
 		const request = (
 			url.startsWith("https:") ? require("https") : require("http")
 		).request(
@@ -31,16 +37,16 @@ module.exports = class EventSource {
 	}
 
 	close() {
-		this.response.destroy();
+		if (this.response) this.response.destroy();
 	}
 
 	// eslint-disable-next-line accessor-pairs
-	set onopen(value) {
+	set onopen(/** @type {EXPECTED_ANY} */ value) {
 		throw new Error("not implemented");
 	}
 
 	// eslint-disable-next-line accessor-pairs
-	set onmessage(value) {
+	set onmessage(/** @type {EXPECTED_ANY} */ value) {
 		throw new Error("not implemented");
 	}
 };

--- a/test/helpers/FakeDocument.js
+++ b/test/helpers/FakeDocument.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 /**
- * @this {FakeDocument}
+ * @this {Record<string, EXPECTED_ANY>}
  * @param {string} property property
  * @returns {EXPECTED_ANY} value
  */
@@ -13,22 +13,36 @@ function getPropertyValue(property) {
 }
 
 class FakeDocument {
+	/**
+	 * @param {string} basePath base path
+	 */
 	constructor(basePath) {
 		this.head = this.createElement("head");
 		this.body = this.createElement("body");
 		this.baseURI = "https://test.cases/path/index.html";
 		this.title = "";
+		/** @type {Map<string, FakeElement[]>} */
 		this._elementsByTagName = new Map([
 			["head", [this.head]],
 			["body", [this.body]]
 		]);
 		this._basePath = basePath;
+		/** @type {undefined | ((src: string | undefined) => void)} */
+		this.onScript = undefined;
 	}
 
+	/**
+	 * @param {string} type element type
+	 * @returns {FakeElement} element
+	 */
 	createElement(type) {
 		return new FakeElement(this, type, this._basePath);
 	}
 
+	/**
+	 * @param {FakeElement} element element
+	 * @returns {void}
+	 */
 	_onElementAttached(element) {
 		const type = element._type;
 		let list = this._elementsByTagName.get(type);
@@ -39,17 +53,30 @@ class FakeDocument {
 		list.push(element);
 	}
 
+	/**
+	 * @param {FakeElement} element element
+	 * @returns {void}
+	 */
 	_onElementRemoved(element) {
 		const type = element._type;
 		const list = this._elementsByTagName.get(type);
+		if (list === undefined) return;
 		const idx = list.indexOf(element);
 		list.splice(idx, 1);
 	}
 
+	/**
+	 * @param {string} name tag name
+	 * @returns {FakeElement[]} elements
+	 */
 	getElementsByTagName(name) {
 		return this._elementsByTagName.get(name) || [];
 	}
 
+	/**
+	 * @param {string} selector selector
+	 * @returns {FakeElement[]} matching elements
+	 */
 	querySelectorAll(selector) {
 		// Simple selector support for common cases
 		// Tag selector: "link", "script", etc.
@@ -59,6 +86,7 @@ class FakeDocument {
 		// Class selector: ".class"
 		if (selector.startsWith(".")) {
 			const className = selector.slice(1);
+			/** @type {FakeElement[]} */
 			const allElements = [];
 			for (const elements of this._elementsByTagName.values()) {
 				for (const element of elements) {
@@ -84,6 +112,7 @@ class FakeDocument {
 		// Attribute selector: "[attr]", "[attr=value]"
 		if (selector.startsWith("[") && selector.endsWith("]")) {
 			const attrSelector = selector.slice(1, -1);
+			/** @type {FakeElement[]} */
 			const allElements = [];
 			if (attrSelector.includes("=")) {
 				const [attr, value] = attrSelector
@@ -111,10 +140,15 @@ class FakeDocument {
 		return [];
 	}
 
+	/**
+	 * @param {FakeElement} element element
+	 * @returns {EXPECTED_ANY} computed style
+	 */
 	getComputedStyle(element) {
 		const style = { getPropertyValue };
 		const links = this.getElementsByTagName("link");
 		for (const link of links) {
+			if (!link.sheet) continue;
 			for (const rule of link.sheet.cssRules) {
 				if (rule.selectorText === element._type) {
 					Object.assign(style, rule.style);
@@ -126,17 +160,31 @@ class FakeDocument {
 }
 
 class FakeElement {
+	/**
+	 * @param {FakeDocument} document owning document
+	 * @param {string} type element type
+	 * @param {string} basePath base path
+	 */
 	constructor(document, type, basePath) {
 		this._document = document;
 		this._type = type;
+		/** @type {FakeElement[]} */
 		this._children = [];
+		/** @type {Record<string, EXPECTED_ANY>} */
 		this._attributes = Object.create(null);
+		/** @type {string | undefined} */
 		this._src = undefined;
+		/** @type {string | undefined} */
 		this._href = undefined;
+		/** @type {FakeElement | undefined} */
 		this.parentNode = undefined;
 		this.sheet = type === "link" ? new FakeSheet(this, basePath) : undefined;
 		this._textContent = "";
 		this._innerHTML = "";
+		/** @type {Map<string, EXPECTED_FUNCTION[]> | undefined} */
+		this._eventListeners = undefined;
+		/** @type {undefined | ((event: EXPECTED_ANY) => void)} */
+		this.onload = undefined;
 	}
 
 	get nodeName() {
@@ -163,12 +211,20 @@ class FakeElement {
 			value === undefined || value === null ? "" : String(value);
 	}
 
+	/**
+	 * @param {FakeElement} node node to attach
+	 * @returns {void}
+	 */
 	_attach(node) {
 		this._document._onElementAttached(node);
 		this._children.push(node);
 		node.parentNode = this;
 	}
 
+	/**
+	 * @param {FakeElement} node node to load
+	 * @returns {void}
+	 */
 	_load(node) {
 		if (node._type === "link") {
 			const timer = setTimeout(() => {
@@ -179,21 +235,34 @@ class FakeElement {
 			}, 100);
 		} else if (node._type === "script" && this._document.onScript) {
 			Promise.resolve().then(() => {
-				this._document.onScript(node.src);
+				/** @type {(src: string | undefined) => void} */
+				(this._document.onScript)(node.src);
 			});
 		}
 	}
 
+	/**
+	 * @param {FakeElement} node node to insert
+	 * @returns {void}
+	 */
 	insertBefore(node) {
 		this._attach(node);
 		this._load(node);
 	}
 
+	/**
+	 * @param {FakeElement} node node to append
+	 * @returns {void}
+	 */
 	appendChild(node) {
 		this._attach(node);
 		this._load(node);
 	}
 
+	/**
+	 * @param {FakeElement} node node to remove
+	 * @returns {void}
+	 */
 	removeChild(node) {
 		const idx = this._children.indexOf(node);
 		if (idx >= 0) {
@@ -203,18 +272,31 @@ class FakeElement {
 		}
 	}
 
+	/**
+	 * @param {string} name attribute name
+	 * @param {EXPECTED_ANY} value attribute value
+	 * @returns {void}
+	 */
 	setAttribute(name, value) {
 		if (this._type === "link" && name === "href") {
-			this.href(value);
+			this.href = value;
 		} else {
 			this._attributes[name] = value;
 		}
 	}
 
+	/**
+	 * @param {string} name attribute name
+	 * @returns {void}
+	 */
 	removeAttribute(name) {
 		delete this._attributes[name];
 	}
 
+	/**
+	 * @param {string} name attribute name
+	 * @returns {EXPECTED_ANY} attribute value
+	 */
 	getAttribute(name) {
 		if (this._type === "link" && name === "href") {
 			return this.href;
@@ -223,6 +305,10 @@ class FakeElement {
 		return this._attributes[name];
 	}
 
+	/**
+	 * @param {string} value raw url value
+	 * @returns {string} resolved url
+	 */
 	_toRealUrl(value) {
 		if (/^\//.test(value)) {
 			return `https://test.cases${value}`;
@@ -241,7 +327,7 @@ class FakeElement {
 
 	set src(value) {
 		if (this._type === "script") {
-			this._src = this._toRealUrl(value);
+			this._src = this._toRealUrl(/** @type {string} */ (value));
 		}
 	}
 
@@ -251,10 +337,12 @@ class FakeElement {
 
 	set href(value) {
 		if (this._type === "link") {
-			this._href = this._toRealUrl(value);
+			this._href = this._toRealUrl(/** @type {string} */ (value));
 			try {
-				this.sheet._css = this.sheet.css;
-				this.sheet._cssRules = this.sheet.cssRules;
+				if (this.sheet) {
+					this.sheet._css = this.sheet.css;
+					this.sheet._cssRules = this.sheet.cssRules;
+				}
 			} catch (_error) {
 				// Ignore error
 			}
@@ -276,16 +364,28 @@ class FakeElement {
 		this._attributes.rel = value;
 	}
 
+	/**
+	 * @param {string} event event name
+	 * @param {EXPECTED_FUNCTION} handler handler
+	 * @returns {void}
+	 */
 	addEventListener(event, handler) {
 		if (!this._eventListeners) {
 			this._eventListeners = new Map();
 		}
-		if (!this._eventListeners.has(event)) {
-			this._eventListeners.set(event, []);
+		let handlers = this._eventListeners.get(event);
+		if (handlers === undefined) {
+			handlers = [];
+			this._eventListeners.set(event, handlers);
 		}
-		this._eventListeners.get(event).push(handler);
+		handlers.push(handler);
 	}
 
+	/**
+	 * @param {string} event event name
+	 * @param {EXPECTED_FUNCTION} handler handler
+	 * @returns {void}
+	 */
 	removeEventListener(event, handler) {
 		if (!this._eventListeners) return;
 		const handlers = this._eventListeners.get(event);
@@ -296,6 +396,10 @@ class FakeElement {
 		}
 	}
 
+	/**
+	 * @param {{ type: string }} event event
+	 * @returns {void}
+	 */
 	_dispatchEvent(event) {
 		if (!this._eventListeners) return;
 		const handlers = this._eventListeners.get(event.type);
@@ -306,6 +410,10 @@ class FakeElement {
 		}
 	}
 
+	/**
+	 * @param {boolean=} deep whether to deep-clone children
+	 * @returns {FakeElement} cloned element
+	 */
 	cloneNode(deep = false) {
 		const cloned = new FakeElement(
 			this._document,
@@ -353,6 +461,10 @@ class FakeElement {
 }
 
 class FakeSheet {
+	/**
+	 * @param {FakeElement} element owning element
+	 * @param {string} basePath base path
+	 */
 	constructor(element, basePath) {
 		this._element = element;
 		this._basePath = basePath;
@@ -360,7 +472,9 @@ class FakeSheet {
 		// We cannot lazily load file content in getter because in HMR scenarios,
 		// the file path will have ?hmr=timestamp appended. If we load lazily,
 		// we can only get the latest file content, and the previous content will be lost.
+		/** @type {string | undefined} */
 		this._css = undefined;
+		/** @type {EXPECTED_ANY[] | undefined} */
 		this._cssRules = undefined;
 	}
 
@@ -369,7 +483,7 @@ class FakeSheet {
 		let css = fs.readFileSync(
 			path.resolve(
 				this._basePath,
-				this._element.href
+				/** @type {string} */ (this._element.href)
 					.replace(/^https:\/\/test\.cases\/path\//, "")
 					.replace(/^https:\/\/example\.com\//, "")
 					.split("?")[0] // Remove query parameters (e.g., ?hmr=timestamp)
@@ -408,12 +522,15 @@ class FakeSheet {
 			readToken
 		} = require("../../lib/css/walkCssTokens");
 
+		/** @type {EXPECTED_ANY[]} */
 		const rules = [];
+		/** @type {Record<string, EXPECTED_ANY>} */
 		let currentRule = { getPropertyValue };
+		/** @type {string | undefined} */
 		let selector;
 		let last = 0;
 		let ruleStart = 0; // Track the start of the current rule
-		const processDeclaration = (str) => {
+		const processDeclaration = (/** @type {string} */ str) => {
 			const colon = str.indexOf(":");
 			if (colon > 0) {
 				const property = str.slice(0, colon).trim();
@@ -421,7 +538,7 @@ class FakeSheet {
 				currentRule[property] = value;
 			}
 		};
-		const href = this._element.href.split("?")[0]; // Remove query parameters (e.g., ?hmr=timestamp)
+		const href = /** @type {string} */ (this._element.href).split("?")[0]; // Remove query parameters (e.g., ?hmr=timestamp)
 		const filepath = /file:\/\//.test(href)
 			? new URL(href)
 			: path.resolve(
@@ -454,7 +571,7 @@ class FakeSheet {
 				);
 			});
 		for (let pos = 0; ; ) {
-			const t = readToken(css, pos, {});
+			const t = readToken(css, pos, /** @type {EXPECTED_ANY} */ ({}));
 			if (t === undefined) break;
 			pos = t.end;
 			if (t.type === TT_LEFT_CURLY_BRACKET) {
@@ -489,6 +606,7 @@ class FakeSheet {
 class CSSStyleSheet {
 	constructor() {
 		this._cssText = "";
+		/** @type {EXPECTED_ANY[]} */
 		this._cssRules = [];
 	}
 
@@ -515,7 +633,7 @@ class CSSStyleSheet {
 
 	/**
 	 * Get the parsed CSS rules
-	 * @returns {Array} Array of CSS rules
+	 * @returns {EXPECTED_ANY[]} Array of CSS rules
 	 */
 	get cssRules() {
 		return this._cssRules;
@@ -533,12 +651,15 @@ class CSSStyleSheet {
 			readToken
 		} = require("../../lib/css/walkCssTokens");
 
+		/** @type {EXPECTED_ANY[]} */
 		const rules = [];
+		/** @type {Record<string, EXPECTED_ANY>} */
 		let currentRule = { getPropertyValue };
+		/** @type {string | undefined} */
 		let selector;
 		let last = 0;
 
-		const processDeclaration = (str) => {
+		const processDeclaration = (/** @type {string} */ str) => {
 			const colon = str.indexOf(":");
 			if (colon > 0) {
 				const property = str.slice(0, colon).trim();
@@ -555,7 +676,7 @@ class CSSStyleSheet {
 		let ruleStart = 0;
 
 		for (let pos = 0; ; ) {
-			const t = readToken(cleanCss, pos, {});
+			const t = readToken(cleanCss, pos, /** @type {EXPECTED_ANY} */ ({}));
 			if (t === undefined) break;
 			pos = t.end;
 			if (t.type === TT_LEFT_CURLY_BRACKET) {

--- a/test/helpers/FakeDocument.js
+++ b/test/helpers/FakeDocument.js
@@ -3,10 +3,16 @@
 const fs = require("fs");
 const path = require("path");
 
+/** @typedef {import("../../lib/css/walkCssTokens").MutableToken} MutableToken */
+/** @typedef {Record<string, unknown> & { getPropertyValue: (property: string) => unknown }} StyleDeclaration */
+/** @typedef {{ selectorText: string | undefined, style: StyleDeclaration, cssText: string }} CssRule */
+/** @typedef {{ type: string, target?: FakeElement }} FakeEvent */
+/** @typedef {(event: FakeEvent) => void} EventHandler */
+
 /**
- * @this {Record<string, EXPECTED_ANY>}
+ * @this {StyleDeclaration}
  * @param {string} property property
- * @returns {EXPECTED_ANY} value
+ * @returns {unknown} value
  */
 function getPropertyValue(property) {
 	return this[property];
@@ -142,9 +148,10 @@ class FakeDocument {
 
 	/**
 	 * @param {FakeElement} element element
-	 * @returns {EXPECTED_ANY} computed style
+	 * @returns {StyleDeclaration} computed style
 	 */
 	getComputedStyle(element) {
+		/** @type {StyleDeclaration} */
 		const style = { getPropertyValue };
 		const links = this.getElementsByTagName("link");
 		for (const link of links) {
@@ -170,7 +177,7 @@ class FakeElement {
 		this._type = type;
 		/** @type {FakeElement[]} */
 		this._children = [];
-		/** @type {Record<string, EXPECTED_ANY>} */
+		/** @type {Record<string, unknown>} */
 		this._attributes = Object.create(null);
 		/** @type {string | undefined} */
 		this._src = undefined;
@@ -181,9 +188,9 @@ class FakeElement {
 		this.sheet = type === "link" ? new FakeSheet(this, basePath) : undefined;
 		this._textContent = "";
 		this._innerHTML = "";
-		/** @type {Map<string, EXPECTED_FUNCTION[]> | undefined} */
+		/** @type {Map<string, EventHandler[]> | undefined} */
 		this._eventListeners = undefined;
-		/** @type {undefined | ((event: EXPECTED_ANY) => void)} */
+		/** @type {EventHandler | undefined} */
 		this.onload = undefined;
 	}
 
@@ -274,7 +281,7 @@ class FakeElement {
 
 	/**
 	 * @param {string} name attribute name
-	 * @param {EXPECTED_ANY} value attribute value
+	 * @param {string} value attribute value
 	 * @returns {void}
 	 */
 	setAttribute(name, value) {
@@ -295,7 +302,7 @@ class FakeElement {
 
 	/**
 	 * @param {string} name attribute name
-	 * @returns {EXPECTED_ANY} attribute value
+	 * @returns {unknown} attribute value
 	 */
 	getAttribute(name) {
 		if (this._type === "link" && name === "href") {
@@ -366,7 +373,7 @@ class FakeElement {
 
 	/**
 	 * @param {string} event event name
-	 * @param {EXPECTED_FUNCTION} handler handler
+	 * @param {EventHandler} handler handler
 	 * @returns {void}
 	 */
 	addEventListener(event, handler) {
@@ -383,7 +390,7 @@ class FakeElement {
 
 	/**
 	 * @param {string} event event name
-	 * @param {EXPECTED_FUNCTION} handler handler
+	 * @param {EventHandler} handler handler
 	 * @returns {void}
 	 */
 	removeEventListener(event, handler) {
@@ -397,7 +404,7 @@ class FakeElement {
 	}
 
 	/**
-	 * @param {{ type: string }} event event
+	 * @param {FakeEvent} event event
 	 * @returns {void}
 	 */
 	_dispatchEvent(event) {
@@ -474,7 +481,7 @@ class FakeSheet {
 		// we can only get the latest file content, and the previous content will be lost.
 		/** @type {string | undefined} */
 		this._css = undefined;
-		/** @type {EXPECTED_ANY[] | undefined} */
+		/** @type {CssRule[] | undefined} */
 		this._cssRules = undefined;
 	}
 
@@ -522,9 +529,9 @@ class FakeSheet {
 			readToken
 		} = require("../../lib/css/walkCssTokens");
 
-		/** @type {EXPECTED_ANY[]} */
+		/** @type {CssRule[]} */
 		const rules = [];
-		/** @type {Record<string, EXPECTED_ANY>} */
+		/** @type {StyleDeclaration} */
 		let currentRule = { getPropertyValue };
 		/** @type {string | undefined} */
 		let selector;
@@ -571,7 +578,7 @@ class FakeSheet {
 				);
 			});
 		for (let pos = 0; ; ) {
-			const t = readToken(css, pos, /** @type {EXPECTED_ANY} */ ({}));
+			const t = readToken(css, pos, /** @type {MutableToken} */ ({}));
 			if (t === undefined) break;
 			pos = t.end;
 			if (t.type === TT_LEFT_CURLY_BRACKET) {
@@ -606,7 +613,7 @@ class FakeSheet {
 class CSSStyleSheet {
 	constructor() {
 		this._cssText = "";
-		/** @type {EXPECTED_ANY[]} */
+		/** @type {CssRule[]} */
 		this._cssRules = [];
 	}
 
@@ -633,7 +640,7 @@ class CSSStyleSheet {
 
 	/**
 	 * Get the parsed CSS rules
-	 * @returns {EXPECTED_ANY[]} Array of CSS rules
+	 * @returns {CssRule[]} Array of CSS rules
 	 */
 	get cssRules() {
 		return this._cssRules;
@@ -651,9 +658,9 @@ class CSSStyleSheet {
 			readToken
 		} = require("../../lib/css/walkCssTokens");
 
-		/** @type {EXPECTED_ANY[]} */
+		/** @type {CssRule[]} */
 		const rules = [];
-		/** @type {Record<string, EXPECTED_ANY>} */
+		/** @type {StyleDeclaration} */
 		let currentRule = { getPropertyValue };
 		/** @type {string | undefined} */
 		let selector;
@@ -676,7 +683,7 @@ class CSSStyleSheet {
 		let ruleStart = 0;
 
 		for (let pos = 0; ; ) {
-			const t = readToken(cleanCss, pos, /** @type {EXPECTED_ANY} */ ({}));
+			const t = readToken(cleanCss, pos, /** @type {MutableToken} */ ({}));
 			if (t === undefined) break;
 			pos = t.end;
 			if (t.type === TT_LEFT_CURLY_BRACKET) {

--- a/test/helpers/PluginEnvironment.js
+++ b/test/helpers/PluginEnvironment.js
@@ -28,6 +28,7 @@ module.exports = function PluginEnvironment() {
 	}
 
 	this.getEnvironmentStub = function getEnvironmentStub() {
+		/** @type {Map<string | symbol, EXPECTED_ANY>} */
 		const hooks = new Map();
 		return {
 			plugin: addEvent,
@@ -41,15 +42,24 @@ module.exports = function PluginEnvironment() {
 					get(target, hookName) {
 						let hook = hooks.get(hookName);
 						if (hook === undefined) {
-							const eventName = getEventName(hookName);
+							const eventName = getEventName(/** @type {string} */ (hookName));
 							hook = {
-								tap(_, handler) {
+								tap(
+									/** @type {EXPECTED_ANY} */ _,
+									/** @type {EXPECTED_FUNCTION} */ handler
+								) {
 									addEvent(eventName, handler);
 								},
-								tapAsync(_, handler) {
+								tapAsync(
+									/** @type {EXPECTED_ANY} */ _,
+									/** @type {EXPECTED_FUNCTION} */ handler
+								) {
 									addEvent(eventName, handler);
 								},
-								tapPromise(_, handler) {
+								tapPromise(
+									/** @type {EXPECTED_ANY} */ _,
+									/** @type {EXPECTED_FUNCTION} */ handler
+								) {
 									addEvent(eventName, handler);
 								}
 							};

--- a/test/helpers/PluginEnvironment.js
+++ b/test/helpers/PluginEnvironment.js
@@ -1,14 +1,17 @@
 "use strict";
 
+/** @typedef {(...args: unknown[]) => unknown} Handler */
+/** @typedef {{ tap: (options: unknown, handler: Handler) => void, tapAsync: (options: unknown, handler: Handler) => void, tapPromise: (options: unknown, handler: Handler) => void }} FakeHook */
+
 module.exports = function PluginEnvironment() {
 	/**
-	 * @type {{ name: string, handler: EXPECTED_FUNCTION }[]}
+	 * @type {{ name: string, handler: Handler }[]}
 	 */
 	const events = [];
 
 	/**
 	 * @param {string} name the name
-	 * @param {EXPECTED_FUNCTION} handler the handler
+	 * @param {Handler} handler the handler
 	 */
 	function addEvent(name, handler) {
 		events.push({
@@ -28,7 +31,7 @@ module.exports = function PluginEnvironment() {
 	}
 
 	this.getEnvironmentStub = function getEnvironmentStub() {
-		/** @type {Map<string | symbol, EXPECTED_ANY>} */
+		/** @type {Map<string | symbol, FakeHook>} */
 		const hooks = new Map();
 		return {
 			plugin: addEvent,
@@ -44,22 +47,13 @@ module.exports = function PluginEnvironment() {
 						if (hook === undefined) {
 							const eventName = getEventName(/** @type {string} */ (hookName));
 							hook = {
-								tap(
-									/** @type {EXPECTED_ANY} */ _,
-									/** @type {EXPECTED_FUNCTION} */ handler
-								) {
+								tap(options, handler) {
 									addEvent(eventName, handler);
 								},
-								tapAsync(
-									/** @type {EXPECTED_ANY} */ _,
-									/** @type {EXPECTED_FUNCTION} */ handler
-								) {
+								tapAsync(options, handler) {
 									addEvent(eventName, handler);
 								},
-								tapPromise(
-									/** @type {EXPECTED_ANY} */ _,
-									/** @type {EXPECTED_FUNCTION} */ handler
-								) {
+								tapPromise(options, handler) {
 									addEvent(eventName, handler);
 								}
 							};

--- a/test/helpers/applyPluginWithOptions.js
+++ b/test/helpers/applyPluginWithOptions.js
@@ -2,9 +2,17 @@
 
 const PluginEnvironment = require("./PluginEnvironment");
 
+/**
+ * @this {EXPECTED_ANY}
+ * @param {EXPECTED_ANY} Plugin plugin constructor
+ * @returns {EXPECTED_ANY} recorded event bindings
+ */
 module.exports = function applyPluginWithOptions(Plugin) {
-	// eslint-disable-next-line prefer-rest-params
-	const plugin = new (Function.prototype.bind.apply(Plugin, arguments))();
+	const plugin = new (Function.prototype.bind.apply(
+		Plugin,
+		// eslint-disable-next-line prefer-rest-params
+		/** @type {EXPECTED_ANY} */ (arguments)
+	))();
 	const pluginEnvironment = new PluginEnvironment();
 	plugin.apply(pluginEnvironment.getEnvironmentStub());
 

--- a/test/helpers/applyPluginWithOptions.js
+++ b/test/helpers/applyPluginWithOptions.js
@@ -2,21 +2,22 @@
 
 const PluginEnvironment = require("./PluginEnvironment");
 
+/** @typedef {{ apply: (env: unknown) => void }} PluginInstance */
+
 /**
- * @this {EXPECTED_ANY}
- * @param {EXPECTED_ANY} Plugin plugin constructor
- * @returns {EXPECTED_ANY} recorded event bindings
+ * @this {Record<string, unknown> | typeof globalThis}
+ * @param {new (...args: unknown[]) => PluginInstance} Plugin plugin constructor
+ * @param {...unknown} args constructor arguments
+ * @returns {{ name: string, handler: (...args: unknown[]) => unknown }[]} recorded event bindings
  */
-module.exports = function applyPluginWithOptions(Plugin) {
-	const plugin = new (Function.prototype.bind.apply(
-		Plugin,
-		// eslint-disable-next-line prefer-rest-params
-		/** @type {EXPECTED_ANY} */ (arguments)
-	))();
+module.exports = function applyPluginWithOptions(Plugin, ...args) {
+	const plugin = new Plugin(...args);
 	const pluginEnvironment = new PluginEnvironment();
 	plugin.apply(pluginEnvironment.getEnvironmentStub());
 
-	const env = this === global ? {} : this;
+	const env = /** @type {Record<string, unknown>} */ (
+		this === global ? {} : this
+	);
 	env.plugin = plugin;
 	env.pluginEnvironment = pluginEnvironment;
 

--- a/test/helpers/captureStdio.js
+++ b/test/helpers/captureStdio.js
@@ -2,12 +2,10 @@
 
 const stripVTControlCharacters = require("./stripVTControlCharacters");
 
-/**
- * @param {NodeJS.WriteStream} stdio writable stream to capture
- * @param {boolean=} tty whether to force a TTY value
- * @returns {EXPECTED_ANY} capture handle
- */
-module.exports = (stdio, tty) => {
+module.exports = (
+	/** @type {NodeJS.WriteStream} */ stdio,
+	/** @type {boolean=} */ tty
+) => {
 	/** @type {string[]} */
 	let logs = [];
 

--- a/test/helpers/captureStdio.js
+++ b/test/helpers/captureStdio.js
@@ -2,15 +2,24 @@
 
 const stripVTControlCharacters = require("./stripVTControlCharacters");
 
+/**
+ * @param {NodeJS.WriteStream} stdio writable stream to capture
+ * @param {boolean=} tty whether to force a TTY value
+ * @returns {EXPECTED_ANY} capture handle
+ */
 module.exports = (stdio, tty) => {
+	/** @type {string[]} */
 	let logs = [];
 
 	const write = stdio.write;
 	const isTTY = stdio.isTTY;
 
-	stdio.write = function write(str) {
-		logs.push(str);
-	};
+	stdio.write = /** @type {NodeJS.WriteStream["write"]} */ (
+		function write(/** @type {string} */ str) {
+			logs.push(str);
+			return true;
+		}
+	);
 	if (tty !== undefined) stdio.isTTY = tty;
 
 	return {

--- a/test/helpers/createFakeWorker.js
+++ b/test/helpers/createFakeWorker.js
@@ -2,8 +2,16 @@
 
 const path = require("path");
 
+/**
+ * @param {{ outputDirectory: string }} options factory options
+ * @returns {EXPECTED_ANY} fake Worker class
+ */
 module.exports = ({ outputDirectory }) =>
 	class Worker {
+		/**
+		 * @param {EXPECTED_ANY} resource worker resource (URL or string)
+		 * @param {EXPECTED_ANY} options worker options
+		 */
 		constructor(resource, options = {}) {
 			const isFileURL = /^file:/i.test(resource);
 			const isBlobURL = /^blob:/i.test(resource);
@@ -96,15 +104,16 @@ if (${options.type === "module"}) {
 				eval: true
 			});
 
+			/** @type {((data: EXPECTED_ANY) => void) | undefined} */
 			this._onmessage = undefined;
 		}
 
 		// eslint-disable-next-line accessor-pairs
-		set onmessage(value) {
+		set onmessage(/** @type {EXPECTED_FUNCTION} */ value) {
 			if (this._onmessage) this.worker.off("message", this._onmessage);
 			this.worker.on(
 				"message",
-				(this._onmessage = (data) => {
+				(this._onmessage = (/** @type {EXPECTED_ANY} */ data) => {
 					value({
 						data
 					});
@@ -112,7 +121,7 @@ if (${options.type === "module"}) {
 			);
 		}
 
-		postMessage(data) {
+		postMessage(/** @type {EXPECTED_ANY} */ data) {
 			this.worker.postMessage(data);
 		}
 

--- a/test/helpers/createFakeWorker.js
+++ b/test/helpers/createFakeWorker.js
@@ -2,23 +2,23 @@
 
 const path = require("path");
 
-/**
- * @param {{ outputDirectory: string }} options factory options
- * @returns {EXPECTED_ANY} fake Worker class
- */
-module.exports = ({ outputDirectory }) =>
+module.exports = (
+	/** @type {{ outputDirectory: string }} */ { outputDirectory }
+) =>
 	class Worker {
 		/**
-		 * @param {EXPECTED_ANY} resource worker resource (URL or string)
-		 * @param {EXPECTED_ANY} options worker options
+		 * @param {string | URL} resource worker resource
+		 * @param {{ type?: string, originalURL?: URL }} options worker options
 		 */
 		constructor(resource, options = {}) {
-			const isFileURL = /^file:/i.test(resource);
-			const isBlobURL = /^blob:/i.test(resource);
+			const isFileURL = /^file:/i.test(/** @type {string} */ (resource));
+			const isBlobURL = /^blob:/i.test(/** @type {string} */ (resource));
 
 			if (!isFileURL && !isBlobURL) {
-				expect(resource.origin).toBe("https://test.cases");
-				expect(resource.pathname.startsWith("/path/")).toBe(true);
+				expect(/** @type {URL} */ (resource).origin).toBe("https://test.cases");
+				expect(
+					/** @type {URL} */ (resource).pathname.startsWith("/path/")
+				).toBe(true);
 			}
 
 			this.url = resource;
@@ -27,8 +27,8 @@ module.exports = ({ outputDirectory }) =>
 				: path.resolve(
 						outputDirectory,
 						isBlobURL
-							? options.originalURL.pathname.slice(6)
-							: resource.pathname.slice(6)
+							? /** @type {URL} */ (options.originalURL).pathname.slice(6)
+							: /** @type {URL} */ (resource).pathname.slice(6)
 					);
 
 			const workerBootstrap = `
@@ -104,16 +104,16 @@ if (${options.type === "module"}) {
 				eval: true
 			});
 
-			/** @type {((data: EXPECTED_ANY) => void) | undefined} */
+			/** @type {((data: unknown) => void) | undefined} */
 			this._onmessage = undefined;
 		}
 
 		// eslint-disable-next-line accessor-pairs
-		set onmessage(/** @type {EXPECTED_FUNCTION} */ value) {
+		set onmessage(/** @type {(event: { data: unknown }) => void} */ value) {
 			if (this._onmessage) this.worker.off("message", this._onmessage);
 			this.worker.on(
 				"message",
-				(this._onmessage = (/** @type {EXPECTED_ANY} */ data) => {
+				(this._onmessage = (data) => {
 					value({
 						data
 					});
@@ -121,7 +121,7 @@ if (${options.type === "module"}) {
 			);
 		}
 
-		postMessage(/** @type {EXPECTED_ANY} */ data) {
+		postMessage(/** @type {unknown} */ data) {
 			this.worker.postMessage(data);
 		}
 

--- a/test/helpers/createLazyTestEnv.js
+++ b/test/helpers/createLazyTestEnv.js
@@ -2,19 +2,27 @@
 
 module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 	const state = global.JEST_STATE_SYMBOL;
+	/** @type {import("@jest/types").Circus.DescribeBlock} */
 	let currentDescribeBlock;
+	/** @type {import("@jest/types").Circus.TestEntry | null | undefined} */
 	let currentlyRunningTest;
 	let runTests = -1;
+	/** @type {(() => void)[]} */
 	const disposables = [];
 
 	// this function allows to release memory in fn context
 	// manually, usually after the suite has been run.
+	/**
+	 * @param {EXPECTED_FUNCTION} fn test or hook function
+	 * @param {boolean=} isTest whether this wraps a test (vs a hook)
+	 * @returns {EXPECTED_ANY} wrapped function
+	 */
 	const createDisposableFn = (fn, isTest) => {
 		if (!fn) return null;
 		const rfn =
 			fn.length >= 1
-				? (done) => {
-						fn((...args) => {
+				? (/** @type {EXPECTED_FUNCTION} */ done) => {
+						fn((/** @type {EXPECTED_ANY[]} */ ...args) => {
 							if (isTest) runTests++;
 							done(...args);
 						});
@@ -25,7 +33,7 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 						return r;
 					};
 		disposables.push(() => {
-			fn = null;
+			fn = /** @type {EXPECTED_ANY} */ (null);
 		});
 		return rfn;
 	};
@@ -48,6 +56,10 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 		}
 	);
 	let numberOfTests = 0;
+	/**
+	 * @param {() => void} fn function to run inside the exported suite scope
+	 * @returns {void}
+	 */
 	const inSuite = (fn) => {
 		const {
 			currentDescribeBlock: oldCurrentDescribeBlock,
@@ -71,6 +83,10 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 		state.currentlyRunningTest = oldCurrentlyRunningTest;
 		state.hasStarted = oldHasStarted;
 	};
+	/**
+	 * @param {import("@jest/types").Circus.TestEntry | import("@jest/types").Circus.Hook} block test or hook entry
+	 * @returns {void}
+	 */
 	const fixAsyncError = (block) => {
 		// By default jest leaks memory as it stores asyncError
 		// for each "it" call to track the origin test suite
@@ -89,7 +105,7 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 		getNumberOfTests() {
 			return numberOfTests;
 		},
-		it(...args) {
+		it(/** @type {EXPECTED_ANY[]} */ ...args) {
 			numberOfTests++;
 			if (runTests >= numberOfTests) throw new Error("it called too late");
 			args[1] = createDisposableFn(args[1], true);
@@ -102,7 +118,7 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 				);
 			});
 		},
-		beforeEach(...args) {
+		beforeEach(/** @type {EXPECTED_ANY[]} */ ...args) {
 			if (runTests >= numberOfTests) {
 				throw new Error("beforeEach called too late");
 			}
@@ -115,7 +131,7 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 				);
 			});
 		},
-		afterEach(...args) {
+		afterEach(/** @type {EXPECTED_ANY[]} */ ...args) {
 			if (runTests >= numberOfTests) {
 				throw new Error("afterEach called too late");
 			}

--- a/test/helpers/createLazyTestEnv.js
+++ b/test/helpers/createLazyTestEnv.js
@@ -1,5 +1,7 @@
 "use strict";
 
+/** @typedef {(...args: unknown[]) => unknown} AnyFn */
+
 module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 	const state = global.JEST_STATE_SYMBOL;
 	/** @type {import("@jest/types").Circus.DescribeBlock} */
@@ -13,27 +15,30 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 	// this function allows to release memory in fn context
 	// manually, usually after the suite has been run.
 	/**
-	 * @param {EXPECTED_FUNCTION} fn test or hook function
+	 * @param {AnyFn | undefined} fn test or hook function
 	 * @param {boolean=} isTest whether this wraps a test (vs a hook)
-	 * @returns {EXPECTED_ANY} wrapped function
+	 * @returns {((done: AnyFn) => void) | (() => unknown) | null} wrapped function
 	 */
 	const createDisposableFn = (fn, isTest) => {
 		if (!fn) return null;
+		/** @type {AnyFn | null} */
+		let f = fn;
 		const rfn =
-			fn.length >= 1
-				? (/** @type {EXPECTED_FUNCTION} */ done) => {
-						fn((/** @type {EXPECTED_ANY[]} */ ...args) => {
+			f.length >= 1
+				? (/** @type {AnyFn} */ done) => {
+						/** @type {AnyFn} */
+						(f)((/** @type {unknown[]} */ ...args) => {
 							if (isTest) runTests++;
 							done(...args);
 						});
 					}
 				: () => {
-						const r = fn();
+						const r = /** @type {AnyFn} */ (f)();
 						if (isTest) runTests++;
 						return r;
 					};
 		disposables.push(() => {
-			fn = /** @type {EXPECTED_ANY} */ (null);
+			f = null;
 		});
 		return rfn;
 	};
@@ -74,7 +79,7 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 		} catch (err) {
 			/* eslint-disable no-unused-expressions */
 			// avoid leaking memory
-			/** @type {EXPECTED_ANY} */
+			/** @type {Error} */
 			(err).stack;
 			/* eslint-enable no-unused-expressions */
 			throw err;
@@ -105,10 +110,13 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 		getNumberOfTests() {
 			return numberOfTests;
 		},
-		it(/** @type {EXPECTED_ANY[]} */ ...args) {
+		it(/** @type {unknown[]} */ ...args) {
 			numberOfTests++;
 			if (runTests >= numberOfTests) throw new Error("it called too late");
-			args[1] = createDisposableFn(args[1], true);
+			args[1] = createDisposableFn(
+				/** @type {AnyFn | undefined} */ (args[1]),
+				true
+			);
 			args[2] = args[2] || globalTimeout;
 			inSuite(() => {
 				// @ts-expect-error expected
@@ -118,11 +126,11 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 				);
 			});
 		},
-		beforeEach(/** @type {EXPECTED_ANY[]} */ ...args) {
+		beforeEach(/** @type {unknown[]} */ ...args) {
 			if (runTests >= numberOfTests) {
 				throw new Error("beforeEach called too late");
 			}
-			args[0] = createDisposableFn(args[0]);
+			args[0] = createDisposableFn(/** @type {AnyFn | undefined} */ (args[0]));
 			inSuite(() => {
 				// @ts-expect-error expected
 				beforeEach(...args);
@@ -131,11 +139,11 @@ module.exports = (globalTimeout = 2000, nameSuffix = "") => {
 				);
 			});
 		},
-		afterEach(/** @type {EXPECTED_ANY[]} */ ...args) {
+		afterEach(/** @type {unknown[]} */ ...args) {
 			if (runTests >= numberOfTests) {
 				throw new Error("afterEach called too late");
 			}
-			args[0] = createDisposableFn(args[0]);
+			args[0] = createDisposableFn(/** @type {AnyFn | undefined} */ (args[0]));
 			inSuite(() => {
 				// @ts-expect-error expected
 				afterEach(...args);

--- a/test/helpers/deprecationTracking.js
+++ b/test/helpers/deprecationTracking.js
@@ -40,7 +40,7 @@ util.deprecate = (fn, message, _code) => {
 };
 
 /**
- * @returns {() => EXPECTED_ANY} result
+ * @returns {() => { code: string, message: string, stack: string }[]} result
  */
 module.exports.start = () => {
 	interception = new Map();

--- a/test/helpers/expectWarningFactory.js
+++ b/test/helpers/expectWarningFactory.js
@@ -1,7 +1,9 @@
 "use strict";
 
 module.exports = () => {
+	/** @type {EXPECTED_ANY[]} */
 	const warnings = [];
+	/** @type {typeof console.warn} */
 	let oldWarn;
 
 	beforeEach((done) => {
@@ -16,6 +18,10 @@ module.exports = () => {
 		done();
 	});
 
+	/**
+	 * @param {...(string | RegExp)} regexp expected warning patterns
+	 * @returns {void}
+	 */
 	const expectWarning = (...regexp) => {
 		expect(warnings).toEqual(regexp.map((r) => expect.stringMatching(r)));
 		warnings.length = 0;

--- a/test/helpers/expectWarningFactory.js
+++ b/test/helpers/expectWarningFactory.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = () => {
-	/** @type {EXPECTED_ANY[]} */
+	/** @type {string[]} */
 	const warnings = [];
 	/** @type {typeof console.warn} */
 	let oldWarn;

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -1,16 +1,33 @@
 "use strict";
 
+/** @typedef {(value: unknown) => void} Setter */
+/** @typedef {{ setters: Setter[], execute: () => void }} ModuleInstance */
+/** @typedef {{ meta: { url: string }, import: () => Promise<void> }} SystemContext */
+/** @typedef {(dynamicExport: (result: unknown) => void, context: SystemContext) => ModuleInstance} RegisterFn */
+
+/**
+ * @typedef {object} ModuleEntry
+ * @property {string=} name module name
+ * @property {string[]=} deps dependency names
+ * @property {RegisterFn=} fn register function
+ * @property {ModuleInstance=} mod module instance returned by `fn`
+ * @property {boolean} executed whether the module body has run
+ * @property {unknown=} exports module exports
+ */
+
 const System = {
-	register: (
-		/** @type {EXPECTED_ANY} */ name,
-		/** @type {EXPECTED_ANY} */ deps,
-		/** @type {EXPECTED_ANY} */ fn
-	) => {
+	/**
+	 * @param {string | string[]} name module name (or deps for anonymous modules)
+	 * @param {string[] | RegisterFn} deps dependency names (or register fn)
+	 * @param {RegisterFn=} fn register function
+	 * @returns {void}
+	 */
+	register: (name, deps, fn) => {
 		if (!System.registry) {
 			throw new Error("System is no initialized");
 		}
 		if (typeof name !== "string") {
-			fn = deps;
+			fn = /** @type {RegisterFn} */ (deps);
 			deps = name;
 			name = System._nextName;
 		}
@@ -18,9 +35,10 @@ const System = {
 			fn = deps;
 			deps = [];
 		}
-		const dynamicExport = (/** @type {EXPECTED_ANY} */ result) => {
-			if (System.registry[name] !== entry) {
-				throw new Error(`Module ${name} calls dynamicExport too late`);
+		const moduleName = name;
+		const dynamicExport = (/** @type {unknown} */ result) => {
+			if (System.registry[moduleName] !== entry) {
+				throw new Error(`Module ${moduleName} calls dynamicExport too late`);
 			}
 			entry.exports = result;
 			for (const mod of Object.keys(System.registry)) {
@@ -28,8 +46,8 @@ const System = {
 				if (!m.deps) continue;
 				for (let i = 0; i < m.deps.length; i++) {
 					const dep = m.deps[i];
-					if (dep !== name) continue;
-					const setters = m.mod.setters[i];
+					if (dep !== moduleName) continue;
+					const setters = /** @type {ModuleInstance} */ (m.mod).setters[i];
 					setters(result);
 				}
 			}
@@ -45,7 +63,7 @@ const System = {
 		if (name in System.registry) {
 			throw new Error(`Module ${name} is already registered`);
 		}
-		const mod = fn(dynamicExport, systemContext);
+		const mod = /** @type {RegisterFn} */ (fn)(dynamicExport, systemContext);
 		if (deps.length > 0) {
 			if (!Array.isArray(mod.setters)) {
 				throw new Error(
@@ -58,6 +76,7 @@ const System = {
 				);
 			}
 		}
+		/** @type {ModuleEntry} */
 		const entry = {
 			name,
 			deps,
@@ -68,22 +87,37 @@ const System = {
 		};
 		System.registry[name] = entry;
 	},
-	set: (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ exports) => {
+	/**
+	 * @param {string} name module name
+	 * @param {unknown} exports module exports
+	 * @returns {void}
+	 */
+	set: (name, exports) => {
 		System.registry[name] = {
 			name,
 			executed: true,
 			exports
 		};
 	},
-	/** @type {Record<string, EXPECTED_ANY>} */
-	registry: /** @type {EXPECTED_ANY} */ (undefined),
+	// Starts uninitialized; `register` guards on `!System.registry` until `init`.
+	registry:
+		/** @type {Record<string, ModuleEntry>} */
+		(/** @type {unknown} */ (undefined)),
 	/** @type {((name: string) => void) | undefined} */
 	_require: undefined,
 	_nextName: "(anonym)",
-	setRequire: (/** @type {(name: string) => void} */ req) => {
+	/**
+	 * @param {(name: string) => void} req require implementation
+	 * @returns {void}
+	 */
+	setRequire: (req) => {
 		System._require = req;
 	},
-	init: (/** @type {Record<string, EXPECTED_ANY>=} */ modules) => {
+	/**
+	 * @param {Record<string, unknown>=} modules preset modules
+	 * @returns {void}
+	 */
+	init: (modules) => {
 		System.registry = {};
 		if (modules) {
 			for (const name of Object.keys(modules)) {
@@ -94,13 +128,21 @@ const System = {
 			}
 		}
 	},
-	execute: (/** @type {string} */ name) => {
+	/**
+	 * @param {string} name module name
+	 * @returns {unknown} module exports
+	 */
+	execute: (name) => {
 		const m = System.registry[name];
 		if (!m) throw new Error(`Module ${name} not registered`);
 		if (m.executed) throw new Error(`Module ${name} was already executed`);
 		return System.ensureExecuted(name);
 	},
-	ensureExecuted: (/** @type {string} */ name) => {
+	/**
+	 * @param {string} name module name
+	 * @returns {unknown} module exports
+	 */
+	ensureExecuted: (name) => {
 		let m = System.registry[name];
 		if (!m && System._require) {
 			const oldName = System._nextName;
@@ -114,14 +156,16 @@ const System = {
 		}
 		if (!m.executed) {
 			m.executed = true;
-			for (let i = 0; i < m.deps.length; i++) {
-				const dep = m.deps[i];
-				const setters = m.mod.setters[i];
+			const deps = /** @type {string[]} */ (m.deps);
+			const mod = /** @type {ModuleInstance} */ (m.mod);
+			for (let i = 0; i < deps.length; i++) {
+				const dep = deps[i];
+				const setters = mod.setters[i];
 				System.ensureExecuted(dep);
 				const { exports } = System.registry[dep];
 				if (exports !== undefined) setters(exports);
 			}
-			m.mod.execute();
+			mod.execute();
 		}
 		return m.exports;
 	}

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -1,7 +1,11 @@
 "use strict";
 
 const System = {
-	register: (name, deps, fn) => {
+	register: (
+		/** @type {EXPECTED_ANY} */ name,
+		/** @type {EXPECTED_ANY} */ deps,
+		/** @type {EXPECTED_ANY} */ fn
+	) => {
 		if (!System.registry) {
 			throw new Error("System is no initialized");
 		}
@@ -14,7 +18,7 @@ const System = {
 			fn = deps;
 			deps = [];
 		}
-		const dynamicExport = (result) => {
+		const dynamicExport = (/** @type {EXPECTED_ANY} */ result) => {
 			if (System.registry[name] !== entry) {
 				throw new Error(`Module ${name} calls dynamicExport too late`);
 			}
@@ -64,20 +68,22 @@ const System = {
 		};
 		System.registry[name] = entry;
 	},
-	set: (name, exports) => {
+	set: (/** @type {string} */ name, /** @type {EXPECTED_ANY} */ exports) => {
 		System.registry[name] = {
 			name,
 			executed: true,
 			exports
 		};
 	},
-	registry: undefined,
+	/** @type {Record<string, EXPECTED_ANY>} */
+	registry: /** @type {EXPECTED_ANY} */ (undefined),
+	/** @type {((name: string) => void) | undefined} */
 	_require: undefined,
 	_nextName: "(anonym)",
-	setRequire: (req) => {
+	setRequire: (/** @type {(name: string) => void} */ req) => {
 		System._require = req;
 	},
-	init: (modules) => {
+	init: (/** @type {Record<string, EXPECTED_ANY>=} */ modules) => {
 		System.registry = {};
 		if (modules) {
 			for (const name of Object.keys(modules)) {
@@ -88,13 +94,13 @@ const System = {
 			}
 		}
 	},
-	execute: (name) => {
+	execute: (/** @type {string} */ name) => {
 		const m = System.registry[name];
 		if (!m) throw new Error(`Module ${name} not registered`);
 		if (m.executed) throw new Error(`Module ${name} was already executed`);
 		return System.ensureExecuted(name);
 	},
-	ensureExecuted: (name) => {
+	ensureExecuted: (/** @type {string} */ name) => {
 		let m = System.registry[name];
 		if (!m && System._require) {
 			const oldName = System._nextName;

--- a/test/helpers/infrastructureLogErrors.js
+++ b/test/helpers/infrastructureLogErrors.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/** @typedef {{ run: number, options?: EXPECTED_ANY }} Config */
+/** @typedef {{ run: number, options?: unknown }} Config */
 
 /**
  * @param {string} log log line

--- a/test/helpers/infrastructureLogErrors.js
+++ b/test/helpers/infrastructureLogErrors.js
@@ -1,5 +1,12 @@
 "use strict";
 
+/** @typedef {{ run: number, options?: EXPECTED_ANY }} Config */
+
+/**
+ * @param {string} log log line
+ * @param {Config} config config
+ * @returns {string | undefined} error message
+ */
 const PERSISTENCE_CACHE_INVALIDATE_ERROR = (log, config) => {
 	if (config.run < 2) return;
 	const match =
@@ -14,10 +21,11 @@ const errorsFilter = [PERSISTENCE_CACHE_INVALIDATE_ERROR];
 
 /**
  * @param {string[]} logs logs
- * @param {TODO} config config
- * @returns {string[]} errors
+ * @param {Config} config config
+ * @returns {{ message: string }[]} errors
  */
 module.exports = function filterInfraStructureErrors(logs, config) {
+	/** @type {{ message: string }[]} */
 	const results = [];
 	for (const log of logs) {
 		for (const filter of errorsFilter) {

--- a/test/helpers/prepareOptions.js
+++ b/test/helpers/prepareOptions.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @param {EXPECTED_ANY} options options
+ * @returns {EXPECTED_ANY} options
+ */
 const handleExport = (options) => {
 	const isES6DefaultExported =
 		typeof options === "object" &&
@@ -9,6 +13,11 @@ const handleExport = (options) => {
 	return options;
 };
 
+/**
+ * @param {EXPECTED_ANY} options options
+ * @param {EXPECTED_ANY} argv argv
+ * @returns {EXPECTED_ANY} options
+ */
 const handleFunction = (options, argv) => {
 	if (typeof options === "function") {
 		options = options(argv.env, argv);
@@ -16,6 +25,11 @@ const handleFunction = (options, argv) => {
 	return options;
 };
 
+/**
+ * @param {EXPECTED_ANY} options options
+ * @param {EXPECTED_ANY=} argv argv
+ * @returns {EXPECTED_ANY} options
+ */
 module.exports = (options, argv) => {
 	argv = argv || {};
 

--- a/test/helpers/prepareOptions.js
+++ b/test/helpers/prepareOptions.js
@@ -1,42 +1,49 @@
 "use strict";
 
+/** @typedef {import("../../").Configuration} Configuration */
+/** @typedef {Configuration | Configuration[]} Config */
+/** @typedef {{ testPath?: string, srcPath?: string, env?: Record<string, unknown> }} Argv */
+/** @typedef {(env: Record<string, unknown> | undefined, argv: Argv) => Config} ConfigFn */
+/** @typedef {Config | ConfigFn} ConfigOrFn */
+/** @typedef {ConfigOrFn | { default: ConfigOrFn }} ConfigModule */
+
 /**
- * @param {EXPECTED_ANY} options options
- * @returns {EXPECTED_ANY} options
+ * @param {ConfigModule} options exported config value
+ * @returns {ConfigOrFn} unwrapped config value
  */
 const handleExport = (options) => {
-	const isES6DefaultExported =
+	if (
 		typeof options === "object" &&
 		options !== null &&
-		typeof options.default !== "undefined";
-	options = isES6DefaultExported ? options.default : options;
-	return options;
-};
-
-/**
- * @param {EXPECTED_ANY} options options
- * @param {EXPECTED_ANY} argv argv
- * @returns {EXPECTED_ANY} options
- */
-const handleFunction = (options, argv) => {
-	if (typeof options === "function") {
-		options = options(argv.env, argv);
+		"default" in options &&
+		options.default !== undefined
+	) {
+		return options.default;
 	}
-	return options;
+	return /** @type {ConfigOrFn} */ (options);
 };
 
 /**
- * @param {EXPECTED_ANY} options options
- * @param {EXPECTED_ANY=} argv argv
- * @returns {EXPECTED_ANY} options
+ * @param {ConfigOrFn} options config or config factory
+ * @param {Argv} argv argv
+ * @returns {Config} config
  */
-module.exports = (options, argv) => {
-	argv = argv || {};
+const handleFunction = (options, argv) =>
+	typeof options === "function" ? options(argv.env, argv) : options;
 
-	options = handleExport(options);
+/**
+ * @param {ConfigModule} options exported config value
+ * @param {Argv=} argv argv
+ * @returns {Config} config
+ */
+module.exports = (options, argv = {}) => {
+	const unwrapped = handleExport(options);
 
-	options = Array.isArray(options)
-		? options.map((_options) => handleFunction(_options, argv))
-		: handleFunction(options, argv);
-	return options;
+	if (Array.isArray(unwrapped)) {
+		return /** @type {Configuration[]} */ (
+			unwrapped.map((_options) => handleFunction(_options, argv))
+		);
+	}
+
+	return handleFunction(unwrapped, argv);
 };

--- a/test/helpers/regexEscape.js
+++ b/test/helpers/regexEscape.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @param {string} string string to escape
+ * @returns {string} escaped string
+ */
 module.exports = function regexEscape(string) {
 	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 };

--- a/test/helpers/supportsSpread.js
+++ b/test/helpers/supportsSpread.js
@@ -3,6 +3,8 @@
 module.exports = function supportsSpread() {
 	try {
 		const x = { a: true };
+
+		/** @type {EXPECTED_ANY} */
 		// eslint-disable-next-line no-unassigned-vars
 		let y;
 		eval("y = { ...x }");

--- a/test/helpers/supportsSpread.js
+++ b/test/helpers/supportsSpread.js
@@ -3,11 +3,7 @@
 module.exports = function supportsSpread() {
 	try {
 		const x = { a: true };
-
-		/** @type {EXPECTED_ANY} */
-		// eslint-disable-next-line no-unassigned-vars
-		let y;
-		eval("y = { ...x }");
+		const y = eval("({ ...x })");
 		return y !== x && y.a;
 	} catch (_err) {
 		return false;

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -53,6 +53,7 @@ describe("util/identifier", () => {
 	});
 
 	describe("getUndoPath", () => {
+		/** @type {[string, string, boolean?][]} */
 		const cases = [
 			["file.js", ""],
 			["file.js", "./", true],
@@ -83,7 +84,11 @@ describe("util/identifier", () => {
 					"C:\\a\\b\\c\\d\\"
 				]) {
 					expect(
-						identifierUtil.getUndoPath(filename, outputPath, enforceRelative)
+						identifierUtil.getUndoPath(
+							filename,
+							outputPath,
+							/** @type {boolean} */ (enforceRelative)
+						)
 					).toBe(expected);
 				}
 			});

--- a/test/mimeTypes.unittest.js
+++ b/test/mimeTypes.unittest.js
@@ -19,10 +19,10 @@ describe("mimeTypes", () => {
 		});
 
 		it("should return undefined for non-strings", () => {
-			expect(mimeTypes.extension(null)).toBeUndefined();
-			expect(mimeTypes.extension(undefined)).toBeUndefined();
-			expect(mimeTypes.extension(42)).toBeUndefined();
-			expect(mimeTypes.extension({})).toBeUndefined();
+			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (null)))).toBeUndefined();
+			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (undefined)))).toBeUndefined();
+			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (42)))).toBeUndefined();
+			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ ({})))).toBeUndefined();
 			expect(mimeTypes.extension("")).toBeUndefined();
 		});
 
@@ -80,10 +80,10 @@ describe("mimeTypes", () => {
 		});
 
 		it("should return undefined for non-strings", () => {
-			expect(mimeTypes.lookup(null)).toBeUndefined();
-			expect(mimeTypes.lookup(undefined)).toBeUndefined();
-			expect(mimeTypes.lookup(42)).toBeUndefined();
-			expect(mimeTypes.lookup({})).toBeUndefined();
+			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (null)))).toBeUndefined();
+			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (undefined)))).toBeUndefined();
+			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (42)))).toBeUndefined();
+			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ ({})))).toBeUndefined();
 			expect(mimeTypes.lookup("")).toBeUndefined();
 		});
 

--- a/test/mimeTypes.unittest.js
+++ b/test/mimeTypes.unittest.js
@@ -19,10 +19,22 @@ describe("mimeTypes", () => {
 		});
 
 		it("should return undefined for non-strings", () => {
-			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (null)))).toBeUndefined();
-			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (undefined)))).toBeUndefined();
-			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (42)))).toBeUndefined();
-			expect(mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ ({})))).toBeUndefined();
+			expect(
+				mimeTypes.extension(
+					/** @type {string} */ (/** @type {unknown} */ (null))
+				)
+			).toBeUndefined();
+			expect(
+				mimeTypes.extension(
+					/** @type {string} */ (/** @type {unknown} */ (undefined))
+				)
+			).toBeUndefined();
+			expect(
+				mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ (42)))
+			).toBeUndefined();
+			expect(
+				mimeTypes.extension(/** @type {string} */ (/** @type {unknown} */ ({})))
+			).toBeUndefined();
 			expect(mimeTypes.extension("")).toBeUndefined();
 		});
 
@@ -80,10 +92,20 @@ describe("mimeTypes", () => {
 		});
 
 		it("should return undefined for non-strings", () => {
-			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (null)))).toBeUndefined();
-			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (undefined)))).toBeUndefined();
-			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (42)))).toBeUndefined();
-			expect(mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ ({})))).toBeUndefined();
+			expect(
+				mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (null)))
+			).toBeUndefined();
+			expect(
+				mimeTypes.lookup(
+					/** @type {string} */ (/** @type {unknown} */ (undefined))
+				)
+			).toBeUndefined();
+			expect(
+				mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ (42)))
+			).toBeUndefined();
+			expect(
+				mimeTypes.lookup(/** @type {string} */ (/** @type {unknown} */ ({})))
+			).toBeUndefined();
 			expect(mimeTypes.lookup("")).toBeUndefined();
 		});
 

--- a/test/parseJson.unittest.js
+++ b/test/parseJson.unittest.js
@@ -11,9 +11,20 @@ const currentNodeMajor = Number.parseInt(
 // value where the current major version is >= the latest key. eg: in node 24,
 // for the input {20:1, 22:2}, this will return 2 if not match is found it will
 // return the value of the `default` key.
-const getLatestMatchingNode = (/** @type {Record<string, unknown> & { default?: unknown }} */ { default: defaultNode, ...majors }) => {
-	for (const major of Object.keys(majors).sort((a, b) => /** @type {number} */ (/** @type {unknown} */ (b)) - /** @type {number} */ (/** @type {unknown} */ (a)))) {
-		if (currentNodeMajor >= /** @type {number} */ (/** @type {unknown} */ (major))) {
+const getLatestMatchingNode = (
+	/** @type {Record<string, unknown> & { default?: unknown }} */ {
+		default: defaultNode,
+		...majors
+	}
+) => {
+	for (const major of Object.keys(majors).sort(
+		(a, b) =>
+			/** @type {number} */ (/** @type {unknown} */ (b)) -
+			/** @type {number} */ (/** @type {unknown} */ (a))
+	)) {
+		if (
+			currentNodeMajor >= /** @type {number} */ (/** @type {unknown} */ (major))
+		) {
 			return majors[major];
 		}
 	}
@@ -21,20 +32,29 @@ const getLatestMatchingNode = (/** @type {Record<string, unknown> & { default?: 
 	return defaultNode;
 };
 
-const expectMessage = (/** @type {Array<string | RegExp | Record<string, unknown>>} */ ...args) =>
+const expectMessage = (
+	/** @type {(string | RegExp | Record<string, unknown>)[]} */ ...args
+) =>
 	new RegExp(
 		args
 			.map((rawValue) => {
 				const value =
 					rawValue.constructor === Object
-						? getLatestMatchingNode(/** @type {Record<string, unknown> & { default?: unknown }} */ (rawValue))
+						? getLatestMatchingNode(
+								/** @type {Record<string, unknown> & { default?: unknown }} */ (
+									rawValue
+								)
+							)
 						: rawValue;
 				return value instanceof RegExp ? value.source : value;
 			})
 			.join("")
 	);
 
-const jsonThrows = (/** @type {unknown} */ data, /** @type {Array<unknown>} */ ...args) => {
+const jsonThrows = (
+	/** @type {unknown} */ data,
+	/** @type {unknown[]} */ ...args
+) => {
 	/** @type {number | undefined} */
 	let context;
 
@@ -46,7 +66,11 @@ const jsonThrows = (/** @type {unknown} */ data, /** @type {Array<unknown>} */ .
 
 	// If expected is an Error constructor or instance, use it directly
 	if (typeof expected === "function" || expected instanceof Error) {
-		expect(() => /** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context)).toThrow(/** @type {Error} */ (/** @type {unknown} */ (expected)));
+		expect(() =>
+			/** @type {(data: unknown, reviver: null, context: number | undefined) => unknown} */ (
+				/** @type {unknown} */ (parseJson)
+			)(data, null, context)
+		).toThrow(/** @type {Error} */ (/** @type {unknown} */ (expected)));
 		return;
 	}
 
@@ -54,7 +78,9 @@ const jsonThrows = (/** @type {unknown} */ data, /** @type {Array<unknown>} */ .
 	let err = {};
 
 	try {
-		/** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context);
+		/** @type {(data: unknown, reviver: null, context: number | undefined) => unknown} */ (
+			/** @type {unknown} */ (parseJson)
+		)(data, null, context);
 	} catch (err_) {
 		err = /** @type {Record<string, unknown>} */ (err_);
 	}
@@ -120,8 +146,16 @@ describe("parseJson", () => {
 		const data = Buffer.from(str);
 		const bom = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), data]);
 
-		expect(JSON.stringify(parseJson(/** @type {string} */ (/** @type {unknown} */ (data))))).toBe(str);
-		expect(JSON.stringify(parseJson(/** @type {string} */ (/** @type {unknown} */ (bom))))).toBe(str);
+		expect(
+			JSON.stringify(
+				parseJson(/** @type {string} */ (/** @type {unknown} */ (data)))
+			)
+		).toBe(str);
+		expect(
+			JSON.stringify(
+				parseJson(/** @type {string} */ (/** @type {unknown} */ (bom)))
+			)
+		).toBe(str);
 	});
 
 	it("better errors when faced with repeated BOM bytes and trailing \\b characters", () => {

--- a/test/parseJson.unittest.js
+++ b/test/parseJson.unittest.js
@@ -46,12 +46,12 @@ const jsonThrows = (/** @type {unknown} */ data, /** @type {Array<unknown>} */ .
 
 	// If expected is an Error constructor or instance, use it directly
 	if (typeof expected === "function" || expected instanceof Error) {
-		expect(() => /** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context)).toThrow(expected);
+		expect(() => /** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context)).toThrow(/** @type {Error} */ (/** @type {unknown} */ (expected)));
 		return;
 	}
 
 	/** @type {Record<string, unknown>} */
-	let err;
+	let err = {};
 
 	try {
 		/** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context);

--- a/test/parseJson.unittest.js
+++ b/test/parseJson.unittest.js
@@ -11,9 +11,9 @@ const currentNodeMajor = Number.parseInt(
 // value where the current major version is >= the latest key. eg: in node 24,
 // for the input {20:1, 22:2}, this will return 2 if not match is found it will
 // return the value of the `default` key.
-const getLatestMatchingNode = ({ default: defaultNode, ...majors }) => {
-	for (const major of Object.keys(majors).sort((a, b) => b - a)) {
-		if (currentNodeMajor >= major) {
+const getLatestMatchingNode = (/** @type {Record<string, unknown> & { default?: unknown }} */ { default: defaultNode, ...majors }) => {
+	for (const major of Object.keys(majors).sort((a, b) => /** @type {number} */ (/** @type {unknown} */ (b)) - /** @type {number} */ (/** @type {unknown} */ (a)))) {
+		if (currentNodeMajor >= /** @type {number} */ (/** @type {unknown} */ (major))) {
 			return majors[major];
 		}
 	}
@@ -21,64 +21,68 @@ const getLatestMatchingNode = ({ default: defaultNode, ...majors }) => {
 	return defaultNode;
 };
 
-const expectMessage = (...args) =>
+const expectMessage = (/** @type {Array<string | RegExp | Record<string, unknown>>} */ ...args) =>
 	new RegExp(
 		args
 			.map((rawValue) => {
 				const value =
 					rawValue.constructor === Object
-						? getLatestMatchingNode(rawValue)
+						? getLatestMatchingNode(/** @type {Record<string, unknown> & { default?: unknown }} */ (rawValue))
 						: rawValue;
 				return value instanceof RegExp ? value.source : value;
 			})
 			.join("")
 	);
 
-const jsonThrows = (data, ...args) => {
+const jsonThrows = (/** @type {unknown} */ data, /** @type {Array<unknown>} */ ...args) => {
+	/** @type {number | undefined} */
 	let context;
 
 	if (typeof args[0] === "number") {
-		context = args.shift();
+		context = /** @type {number} */ (args.shift());
 	}
 
 	const expected = args[0];
 
 	// If expected is an Error constructor or instance, use it directly
 	if (typeof expected === "function" || expected instanceof Error) {
-		expect(() => parseJson(data, null, context)).toThrow(expected);
+		expect(() => /** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context)).toThrow(expected);
 		return;
 	}
 
+	/** @type {Record<string, unknown>} */
 	let err;
 
 	try {
-		parseJson(data, null, context);
+		/** @type {Function} */ (/** @type {unknown} */ (parseJson))(data, null, context);
 	} catch (err_) {
-		err = err_;
+		err = /** @type {Record<string, unknown>} */ (err_);
 	}
 
-	if (expected.message) {
-		if (expected.message instanceof RegExp) {
-			expect(err.message).toMatch(expected.message);
+	const expectedObj = /** @type {Record<string, unknown>} */ (expected);
+
+	if (expectedObj.message) {
+		if (expectedObj.message instanceof RegExp) {
+			expect(/** @type {string} */ (err.message)).toMatch(expectedObj.message);
 		} else {
-			expect(err.message).toBe(expected.message);
+			expect(err.message).toBe(expectedObj.message);
 		}
 	}
 
-	if (expected.code) {
-		expect(err.code).toBe(expected.code);
+	if (expectedObj.code) {
+		expect(err.code).toBe(expectedObj.code);
 	}
 
-	if (expected.name) {
-		expect(err.name).toBe(expected.name);
+	if (expectedObj.name) {
+		expect(err.name).toBe(expectedObj.name);
 	}
 
-	if (expected.position !== undefined) {
-		expect(err.position).toBe(expected.position);
+	if (expectedObj.position !== undefined) {
+		expect(err.position).toBe(expectedObj.position);
 	}
 
-	if (expected.systemError) {
-		expect(err.systemError).toBeInstanceOf(expected.systemError);
+	if (expectedObj.systemError) {
+		expect(err.systemError).toBeInstanceOf(expectedObj.systemError);
 	}
 };
 
@@ -116,8 +120,8 @@ describe("parseJson", () => {
 		const data = Buffer.from(str);
 		const bom = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), data]);
 
-		expect(JSON.stringify(parseJson(data))).toBe(str);
-		expect(JSON.stringify(parseJson(bom))).toBe(str);
+		expect(JSON.stringify(parseJson(/** @type {string} */ (/** @type {unknown} */ (data))))).toBe(str);
+		expect(JSON.stringify(parseJson(/** @type {string} */ (/** @type {unknown} */ (bom))))).toBe(str);
 	});
 
 	it("better errors when faced with repeated BOM bytes and trailing \\b characters", () => {

--- a/test/smartGrouping.unittest.js
+++ b/test/smartGrouping.unittest.js
@@ -8,8 +8,8 @@ describe("util/smartGrouping", () => {
 			/** @type {import("../lib/util/smartGrouping").GroupConfig<string, { name: string, items: string[] }>[]} */ ([
 				{
 					/**
-					 * @param {string} item
-					 * @returns {string[] | undefined}
+					 * @param {string} item group item
+					 * @returns {string[] | undefined} keys
 					 */
 					getKeys(item) {
 						return /** @type {string[] | undefined} */ (
@@ -17,8 +17,9 @@ describe("util/smartGrouping", () => {
 						);
 					},
 					/**
-					 * @param {string} key
-					 * @param {string[]} items
+					 * @param {string} key group key
+					 * @param {string[]} items group items
+					 * @returns {{ name: string, items: string[] }} group object
 					 */
 					createGroup(key, items) {
 						return {
@@ -29,8 +30,8 @@ describe("util/smartGrouping", () => {
 				},
 				{
 					/**
-					 * @param {string} item
-					 * @returns {string[] | undefined}
+					 * @param {string} item group item
+					 * @returns {string[] | undefined} keys
 					 */
 					getKeys(item) {
 						return /** @type {string[] | undefined} */ (
@@ -38,8 +39,9 @@ describe("util/smartGrouping", () => {
 						);
 					},
 					/**
-					 * @param {string} key
-					 * @param {string[]} items
+					 * @param {string} key group key
+					 * @param {string[]} items group items
+					 * @returns {{ name: string, items: string[] }} group object
 					 */
 					createGroup(key, items) {
 						return {

--- a/test/smartGrouping.unittest.js
+++ b/test/smartGrouping.unittest.js
@@ -4,30 +4,51 @@ const smartGrouping = require("../lib/util/smartGrouping");
 
 describe("util/smartGrouping", () => {
 	it("should group correctly", () => {
-		const groupConfigs = [
-			{
-				getKeys(item) {
-					return item.match(/\d+/g);
+		const groupConfigs =
+			/** @type {import("../lib/util/smartGrouping").GroupConfig<string, { name: string, items: string[] }>[]} */ ([
+				{
+					/**
+					 * @param {string} item
+					 * @returns {string[] | undefined}
+					 */
+					getKeys(item) {
+						return /** @type {string[] | undefined} */ (
+							/** @type {unknown} */ (item.match(/\d+/g))
+						);
+					},
+					/**
+					 * @param {string} key
+					 * @param {string[]} items
+					 */
+					createGroup(key, items) {
+						return {
+							name: `has number ${key}`,
+							items
+						};
+					}
 				},
-				createGroup(key, items) {
-					return {
-						name: `has number ${key}`,
-						items
-					};
+				{
+					/**
+					 * @param {string} item
+					 * @returns {string[] | undefined}
+					 */
+					getKeys(item) {
+						return /** @type {string[] | undefined} */ (
+							/** @type {unknown} */ (item.match(/\w+/g))
+						);
+					},
+					/**
+					 * @param {string} key
+					 * @param {string[]} items
+					 */
+					createGroup(key, items) {
+						return {
+							name: `has word ${key}`,
+							items
+						};
+					}
 				}
-			},
-			{
-				getKeys(item) {
-					return item.match(/\w+/g);
-				},
-				createGroup(key, items) {
-					return {
-						name: `has word ${key}`,
-						items
-					};
-				}
-			}
-		];
+			]);
 		expect(
 			smartGrouping(
 				[

--- a/test/walkCssTokens.unittest.js
+++ b/test/walkCssTokens.unittest.js
@@ -35,6 +35,7 @@ const {
 // Snapshot uses the spec-style kebab-case names for multi-word token types;
 // the tokenizer emits numeric `TT_*` values. Map between them so the existing
 // snapshot files stay valid.
+/** @type {Record<number, string>} */
 const TYPE_TO_PRINTED = {
 	[TT_WHITESPACE]: "whitespace",
 	[TT_COMMENT]: "comment",
@@ -79,7 +80,7 @@ describe("readToken", () => {
 			// Drive the lexer core directly: a fresh `out` per call collects the
 			// raw token list (comments included); `readToken` returns undefined at EOF.
 			for (let pos = 0; ; ) {
-				const t = readToken(code, pos, {});
+				const t = readToken(code, pos, /** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({}));
 				if (t === undefined) break;
 				pos = t.end;
 				const printed = TYPE_TO_PRINTED[t.type] || t.type;
@@ -111,7 +112,7 @@ describe("readToken", () => {
 const tokenRoundtrip = (input) => {
 	let out = "";
 	for (let pos = 0; ; ) {
-		const t = readToken(input, pos, {});
+		const t = readToken(input, pos, /** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({}));
 		if (t === undefined) break;
 		pos = t.end;
 		out += input.slice(t.start, t.end);

--- a/test/walkCssTokens.unittest.js
+++ b/test/walkCssTokens.unittest.js
@@ -80,7 +80,11 @@ describe("readToken", () => {
 			// Drive the lexer core directly: a fresh `out` per call collects the
 			// raw token list (comments included); `readToken` returns undefined at EOF.
 			for (let pos = 0; ; ) {
-				const t = readToken(code, pos, /** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({}));
+				const t = readToken(
+					code,
+					pos,
+					/** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({})
+				);
 				if (t === undefined) break;
 				pos = t.end;
 				const printed = TYPE_TO_PRINTED[t.type] || t.type;
@@ -112,7 +116,11 @@ describe("readToken", () => {
 const tokenRoundtrip = (input) => {
 	let out = "";
 	for (let pos = 0; ; ) {
-		const t = readToken(input, pos, /** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({}));
+		const t = readToken(
+			input,
+			pos,
+			/** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({})
+		);
 		if (t === undefined) break;
 		pos = t.end;
 		out += input.slice(t.start, t.end);

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -31,70 +31,117 @@ const cvTypes = (src) => parseAListOfComponentValues(src).map((n) => n.type);
  * @param {string} src css source
  * @returns {number} the first token's type
  */
-const firstTokenType = (src) => readToken(src, 0, {}).type;
+const firstTokenType = (src) =>
+	/** @type {import("../lib/css/walkCssTokens").MutableToken} */ (
+		readToken(
+			src,
+			0,
+			/** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({})
+		)
+	).type;
 
 describe("walkCssTokens — component values (tokenToNode)", () => {
 	it("classifies each leaf token type", () => {
-		expect(parseAComponentValue("123").type).toBe(NodeType.Number);
-		expect(parseAComponentValue("50%").type).toBe(NodeType.Percentage);
-		expect(parseAComponentValue("10px").type).toBe(NodeType.Dimension);
-		expect(parseAComponentValue("#id").type).toBe(NodeType.Hash);
-		expect(parseAComponentValue('"ab"').type).toBe(NodeType.String);
-		expect(parseAComponentValue("url(a.png)").type).toBe(NodeType.Url);
-		expect(parseAComponentValue("foo(1)").type).toBe(NodeType.Function);
-		expect(parseAComponentValue("[a]").type).toBe(NodeType.SimpleBlock);
-		expect(parseAComponentValue("(a)").type).toBe(NodeType.SimpleBlock);
-		expect(parseAComponentValue("{a}").type).toBe(NodeType.SimpleBlock);
-		expect(parseAComponentValue("+").type).toBe(NodeType.Delim);
-		expect(parseAComponentValue(":").type).toBe(NodeType.Colon);
-		expect(parseAComponentValue(",").type).toBe(NodeType.Comma);
-		expect(parseAComponentValue(";").type).toBe(NodeType.Semicolon);
-		expect(parseAComponentValue("foo").type).toBe(NodeType.Ident);
-		expect(parseAComponentValue(".5").type).toBe(NodeType.Number);
-		expect(parseAComponentValue("@media").type).toBe(NodeType.AtKeyword);
+		/** @param {string} s @returns {import("../lib/css/walkCssTokens").ComponentValue} */
+		const cv = (s) =>
+			/** @type {import("../lib/css/walkCssTokens").ComponentValue} */ (
+				parseAComponentValue(s)
+			);
+		expect(cv("123").type).toBe(NodeType.Number);
+		expect(cv("50%").type).toBe(NodeType.Percentage);
+		expect(cv("10px").type).toBe(NodeType.Dimension);
+		expect(cv("#id").type).toBe(NodeType.Hash);
+		expect(cv('"ab"').type).toBe(NodeType.String);
+		expect(cv("url(a.png)").type).toBe(NodeType.Url);
+		expect(cv("foo(1)").type).toBe(NodeType.Function);
+		expect(cv("[a]").type).toBe(NodeType.SimpleBlock);
+		expect(cv("(a)").type).toBe(NodeType.SimpleBlock);
+		expect(cv("{a}").type).toBe(NodeType.SimpleBlock);
+		expect(cv("+").type).toBe(NodeType.Delim);
+		expect(cv(":").type).toBe(NodeType.Colon);
+		expect(cv(",").type).toBe(NodeType.Comma);
+		expect(cv(";").type).toBe(NodeType.Semicolon);
+		expect(cv("foo").type).toBe(NodeType.Ident);
+		expect(cv(".5").type).toBe(NodeType.Number);
+		expect(cv("@media").type).toBe(NodeType.AtKeyword);
 	});
 
 	it("decodes numeric token metadata", () => {
-		const int = parseAComponentValue("123");
+		/** @param {string} s @returns {import("../lib/css/walkCssTokens").NumberToken} */
+		const num = (s) =>
+			/** @type {import("../lib/css/walkCssTokens").NumberToken} */ (
+				parseAComponentValue(s)
+			);
+		const int = num("123");
 		expect([int.numericValue, int.typeFlag, int.sign]).toEqual([
 			123,
 			"integer",
 			""
 		]);
-		const signed = parseAComponentValue("+1.5");
+		const signed = num("+1.5");
 		expect([signed.numericValue, signed.typeFlag, signed.sign]).toEqual([
 			1.5,
 			"number",
 			"+"
 		]);
-		expect(parseAComponentValue("-2").sign).toBe("-");
-		expect(parseAComponentValue("1e3").typeFlag).toBe("number");
+		expect(num("-2").sign).toBe("-");
+		expect(num("1e3").typeFlag).toBe("number");
 	});
 
 	it("decodes percentage and dimension metadata", () => {
-		const pct = parseAComponentValue("-50%");
+		const pct =
+			/** @type {import("../lib/css/walkCssTokens").PercentageToken} */ (
+				parseAComponentValue("-50%")
+			);
 		expect([pct.numericValue, pct.sign]).toEqual([-50, "-"]);
-		const dim = parseAComponentValue("10px");
+		const dim =
+			/** @type {import("../lib/css/walkCssTokens").DimensionToken} */ (
+				parseAComponentValue("10px")
+			);
 		expect([dim.numericValue, dim.unit, dim.typeFlag]).toEqual([
 			10,
 			"px",
 			"integer"
 		]);
-		expect(parseAComponentValue("1.5EM").unit).toBe("em");
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").DimensionToken} */ (
+				parseAComponentValue("1.5EM")
+			).unit
+		).toBe("em");
 	});
 
 	it("decodes hash id vs unrestricted and url content", () => {
-		expect(parseAComponentValue("#id").typeFlag).toBe("id");
-		expect(parseAComponentValue("#123").typeFlag).toBe("unrestricted");
-		const url = parseAComponentValue("url(a.png)");
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").HashToken} */ (
+				parseAComponentValue("#id")
+			).typeFlag
+		).toBe("id");
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").HashToken} */ (
+				parseAComponentValue("#123")
+			).typeFlag
+		).toBe("unrestricted");
+		const url =
+			/** @type {import("../lib/css/walkCssTokens").UrlToken} */ (
+				parseAComponentValue("url(a.png)")
+			);
 		expect(url.value).toBe("a.png");
 		expect("a.png").toHaveLength(url.contentEnd - url.contentStart);
 	});
 
 	it("exposes function name and nested values", () => {
-		const fn = parseAComponentValue("calc(1 + 2)");
+		const fn =
+			/** @type {import("../lib/css/walkCssTokens").FunctionNode} */ (
+				parseAComponentValue("calc(1 + 2)")
+			);
 		expect(fn.name).toBe("calc");
-		expect(fn.value.some((c) => c.type === NodeType.Number)).toBe(true);
+		expect(
+			fn.value.some(
+				/** @param {import("../lib/css/walkCssTokens").ComponentValue} c */ (
+					c
+				) => c.type === NodeType.Number
+			)
+		).toBe(true);
 	});
 
 	it("preserves stray closers, CDO and CDC as component values", () => {
@@ -118,11 +165,18 @@ describe("walkCssTokens — component values (tokenToNode)", () => {
 
 describe("walkCssTokens — parser entry points", () => {
 	it("parseADeclaration parses name, value and !important", () => {
-		const d = parseADeclaration("color: red");
+		const d =
+			/** @type {import("../lib/css/walkCssTokens").Declaration} */ (
+				parseADeclaration("color: red")
+			);
 		expect(d.name).toBe("color");
 		expect(d.important).toBe(false);
 		expect(d.value.length).toBeGreaterThan(0);
-		expect(parseADeclaration("color: red !important").important).toBe(true);
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").Declaration} */ (
+				parseADeclaration("color: red !important")
+			).important
+		).toBe(true);
 		expect(parseADeclaration("123")).toBeUndefined();
 		expect(parseADeclaration("color red")).toBeUndefined();
 		expect(parseADeclaration("color")).toBeUndefined();
@@ -131,10 +185,16 @@ describe("walkCssTokens — parser entry points", () => {
 	});
 
 	it("parseARule parses qualified rules and at-rules", () => {
-		const qr = parseARule("a { color: red }");
+		const qr =
+			/** @type {import("../lib/css/walkCssTokens").QualifiedRule} */ (
+				parseARule("a { color: red }")
+			);
 		expect(qr.type).toBe(NodeType.QualifiedRule);
 		expect(qr.declarations).toHaveLength(1);
-		const at = parseARule('@import "x";');
+		const at =
+			/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
+				parseARule('@import "x";')
+			);
 		expect(at.type).toBe(NodeType.AtRule);
 		expect(at.name).toBe("import");
 		expect(at.declarations).toBeNull();
@@ -151,7 +211,11 @@ describe("walkCssTokens — parser entry points", () => {
 		expect(parseAComponentValue("")).toBeUndefined();
 		expect(parseAComponentValue("   ")).toBeUndefined();
 		expect(parseAComponentValue("a b")).toBeUndefined();
-		expect(parseAComponentValue("  a  ").type).toBe(NodeType.Ident);
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").ComponentValue} */ (
+				parseAComponentValue("  a  ")
+			).type
+		).toBe(NodeType.Ident);
 	});
 
 	it("parseAListOfComponentValues keeps whitespace and all values", () => {
@@ -184,10 +248,18 @@ describe("walkCssTokens — parser entry points", () => {
 			NodeType.AtRule,
 			NodeType.QualifiedRule
 		]);
-		expect(ss.rules[0].name).toBe("media");
-		expect(ss.rules[0].childRules.map((r) => r.type)).toEqual([
-			NodeType.QualifiedRule
-		]);
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
+				ss.rules[0]
+			).name
+		).toBe("media");
+		expect(
+			/** @type {import("../lib/css/walkCssTokens").Rule[]} */ (
+				/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
+					ss.rules[0]
+				).childRules
+			).map((r) => r.type)
+		).toEqual([NodeType.QualifiedRule]);
 		expect([ss.start, ss.end]).toEqual([0, src.length]);
 	});
 
@@ -206,23 +278,39 @@ describe("walkCssTokens — parser entry points", () => {
 
 describe("walkCssTokens — Node / Token", () => {
 	it("exposes range, loc and toString over the source", () => {
-		const decl = parseADeclaration("color: red");
+		const decl =
+			/** @type {import("../lib/css/walkCssTokens").Declaration} */ (
+				parseADeclaration("color: red")
+			);
 		expect(decl).toBeInstanceOf(Node);
 		expect(decl.range).toEqual([decl.start, decl.end]);
 		expect(decl.toString()).toBe("color: red");
 	});
 
 	it("computes 1-based line / 0-based column via loc", () => {
+		/** @type {{ start: { line: number, column: number }, end: { line: number, column: number } } | undefined} */
 		let loc;
 		new SourceProcessor()
-			.use({ [NodeType.Declaration]: (n) => (loc = n.loc) })
+			.use({
+				[NodeType.Declaration]: (/** @type {import("../lib/css/walkCssTokens").Node} */ n) =>
+					(loc = n.loc)
+			})
 			.process("a{\n  color: red\n}");
-		expect(loc.start).toEqual({ line: 2, column: 2 });
-		expect(loc.end).toEqual({ line: 3, column: 0 });
+		expect(/** @type {NonNullable<typeof loc>} */ (loc).start).toEqual({
+			line: 2,
+			column: 2
+		});
+		expect(/** @type {NonNullable<typeof loc>} */ (loc).end).toEqual({
+			line: 3,
+			column: 0
+		});
 	});
 
 	it("lazily computes a token's value once", () => {
-		const ident = parseAComponentValue("foo");
+		const ident =
+			/** @type {import("../lib/css/walkCssTokens").Token} */ (
+				parseAComponentValue("foo")
+			);
 		expect(ident).toBeInstanceOf(Token);
 		expect(ident.value).toBe("foo");
 		expect(ident.value).toBe("foo");
@@ -231,24 +319,34 @@ describe("walkCssTokens — Node / Token", () => {
 
 describe("walkCssTokens — SourceProcessor", () => {
 	it("fires enter / exit visitors in source order", () => {
+		/** @type {string[]} */
 		const log = [];
 		new SourceProcessor()
-			.use({
-				[NodeType.QualifiedRule]: {
-					enter: () => log.push("enter"),
-					exit: () => log.push("exit")
-				},
-				[NodeType.Declaration]: (n) => log.push(`decl:${n.name}`)
-			})
+			.use(
+				/** @type {import("../lib/css/walkCssTokens").VisitorMap} */ ({
+					[NodeType.QualifiedRule]: {
+						enter: () => log.push("enter"),
+						exit: () => log.push("exit")
+					},
+					[NodeType.Declaration]: (
+						/** @type {import("../lib/css/walkCssTokens").Declaration} */ n
+					) => log.push(`decl:${n.name}`)
+				})
+			)
 			.process("a{color:red;width:1px}");
 		expect(log).toEqual(["enter", "decl:color", "decl:width", "exit"]);
 	});
 
 	it("ctx.skipChildren() stops descent into a node", () => {
+		/** @type {string[]} */
 		const log = [];
 		new SourceProcessor()
 			.use({
-				[NodeType.QualifiedRule]: (n, p, ctx) => {
+				[NodeType.QualifiedRule]: (
+					/** @type {import("../lib/css/walkCssTokens").Node} */ n,
+					/** @type {import("../lib/css/walkCssTokens").Node | null} */ p,
+					/** @type {import("../lib/css/walkCssTokens").VisitorContext} */ ctx
+				) => {
 					log.push("qr");
 					ctx.skipChildren();
 				},
@@ -259,7 +357,7 @@ describe("walkCssTokens — SourceProcessor", () => {
 	});
 
 	it("recurseBlocks: false stops at top-level rules", () => {
-		const count = (recurseBlocks) => {
+		const count = (/** @type {boolean} */ recurseBlocks) => {
 			let n = 0;
 			new SourceProcessor()
 				.use({ [NodeType.QualifiedRule]: () => n++ })
@@ -271,9 +369,16 @@ describe("walkCssTokens — SourceProcessor", () => {
 	});
 
 	it("walks declarations inside at-rule blocks", () => {
+		/** @type {string[]} */
 		const names = [];
 		new SourceProcessor()
-			.use({ [NodeType.Declaration]: (n) => names.push(n.name) })
+			.use(
+				/** @type {import("../lib/css/walkCssTokens").VisitorMap} */ ({
+					[NodeType.Declaration]: (
+						/** @type {import("../lib/css/walkCssTokens").Declaration} */ n
+					) => names.push(n.name)
+				})
+			)
 			.process("@font-face{font-family:x;src:url(y)}");
 		expect(names).toEqual(["font-family", "src"]);
 	});
@@ -290,6 +395,7 @@ describe("walkCssTokens — SourceProcessor", () => {
 	});
 
 	it("forwards the comment callback", () => {
+		/** @type {string[]} */
 		const seen = [];
 		new SourceProcessor()
 			.use({ [NodeType.Declaration]: () => {} })
@@ -398,8 +504,20 @@ describe("walkCssTokens — tokenizer edge cases", () => {
 
 	it("readToken returns undefined once the input is fully consumed", () => {
 		// "a" is a single 1-char ident token; reading past it (offset 1) is EOF.
-		expect(readToken("a", 0, {})).toBeDefined();
-		expect(readToken("a", 1, {})).toBeUndefined();
+		expect(
+			readToken(
+				"a",
+				0,
+				/** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({})
+			)
+		).toBeDefined();
+		expect(
+			readToken(
+				"a",
+				1,
+				/** @type {import("../lib/css/walkCssTokens").MutableToken} */ ({})
+			)
+		).toBeUndefined();
 	});
 
 	it("turns a newline inside a string into a bad-string token", () => {

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -42,7 +42,10 @@ const firstTokenType = (src) =>
 
 describe("walkCssTokens — component values (tokenToNode)", () => {
 	it("classifies each leaf token type", () => {
-		/** @param {string} s @returns {import("../lib/css/walkCssTokens").ComponentValue} */
+		/**
+		 * @param {string} s source
+		 * @returns {import("../lib/css/walkCssTokens").ComponentValue} parsed component value
+		 */
 		const cv = (s) =>
 			/** @type {import("../lib/css/walkCssTokens").ComponentValue} */ (
 				parseAComponentValue(s)
@@ -67,7 +70,10 @@ describe("walkCssTokens — component values (tokenToNode)", () => {
 	});
 
 	it("decodes numeric token metadata", () => {
-		/** @param {string} s @returns {import("../lib/css/walkCssTokens").NumberToken} */
+		/**
+		 * @param {string} s source
+		 * @returns {import("../lib/css/walkCssTokens").NumberToken} parsed number token
+		 */
 		const num = (s) =>
 			/** @type {import("../lib/css/walkCssTokens").NumberToken} */ (
 				parseAComponentValue(s)
@@ -121,25 +127,24 @@ describe("walkCssTokens — component values (tokenToNode)", () => {
 				parseAComponentValue("#123")
 			).typeFlag
 		).toBe("unrestricted");
-		const url =
-			/** @type {import("../lib/css/walkCssTokens").UrlToken} */ (
-				parseAComponentValue("url(a.png)")
-			);
+		const url = /** @type {import("../lib/css/walkCssTokens").UrlToken} */ (
+			parseAComponentValue("url(a.png)")
+		);
 		expect(url.value).toBe("a.png");
 		expect("a.png").toHaveLength(url.contentEnd - url.contentStart);
 	});
 
 	it("exposes function name and nested values", () => {
-		const fn =
-			/** @type {import("../lib/css/walkCssTokens").FunctionNode} */ (
-				parseAComponentValue("calc(1 + 2)")
-			);
+		const fn = /** @type {import("../lib/css/walkCssTokens").FunctionNode} */ (
+			parseAComponentValue("calc(1 + 2)")
+		);
 		expect(fn.name).toBe("calc");
 		expect(
 			fn.value.some(
-				/** @param {import("../lib/css/walkCssTokens").ComponentValue} c */ (
-					c
-				) => c.type === NodeType.Number
+				/**
+				 * @param {import("../lib/css/walkCssTokens").ComponentValue} c component value
+				 * @returns {boolean} true if the value is a Number node
+				 */ (c) => c.type === NodeType.Number
 			)
 		).toBe(true);
 	});
@@ -165,10 +170,9 @@ describe("walkCssTokens — component values (tokenToNode)", () => {
 
 describe("walkCssTokens — parser entry points", () => {
 	it("parseADeclaration parses name, value and !important", () => {
-		const d =
-			/** @type {import("../lib/css/walkCssTokens").Declaration} */ (
-				parseADeclaration("color: red")
-			);
+		const d = /** @type {import("../lib/css/walkCssTokens").Declaration} */ (
+			parseADeclaration("color: red")
+		);
 		expect(d.name).toBe("color");
 		expect(d.important).toBe(false);
 		expect(d.value.length).toBeGreaterThan(0);
@@ -185,16 +189,14 @@ describe("walkCssTokens — parser entry points", () => {
 	});
 
 	it("parseARule parses qualified rules and at-rules", () => {
-		const qr =
-			/** @type {import("../lib/css/walkCssTokens").QualifiedRule} */ (
-				parseARule("a { color: red }")
-			);
+		const qr = /** @type {import("../lib/css/walkCssTokens").QualifiedRule} */ (
+			parseARule("a { color: red }")
+		);
 		expect(qr.type).toBe(NodeType.QualifiedRule);
 		expect(qr.declarations).toHaveLength(1);
-		const at =
-			/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
-				parseARule('@import "x";')
-			);
+		const at = /** @type {import("../lib/css/walkCssTokens").AtRule} */ (
+			parseARule('@import "x";')
+		);
 		expect(at.type).toBe(NodeType.AtRule);
 		expect(at.name).toBe("import");
 		expect(at.declarations).toBeNull();
@@ -249,15 +251,13 @@ describe("walkCssTokens — parser entry points", () => {
 			NodeType.QualifiedRule
 		]);
 		expect(
-			/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
-				ss.rules[0]
-			).name
+			/** @type {import("../lib/css/walkCssTokens").AtRule} */ (ss.rules[0])
+				.name
 		).toBe("media");
 		expect(
 			/** @type {import("../lib/css/walkCssTokens").Rule[]} */ (
-				/** @type {import("../lib/css/walkCssTokens").AtRule} */ (
-					ss.rules[0]
-				).childRules
+				/** @type {import("../lib/css/walkCssTokens").AtRule} */ (ss.rules[0])
+					.childRules
 			).map((r) => r.type)
 		).toEqual([NodeType.QualifiedRule]);
 		expect([ss.start, ss.end]).toEqual([0, src.length]);
@@ -278,10 +278,9 @@ describe("walkCssTokens — parser entry points", () => {
 
 describe("walkCssTokens — Node / Token", () => {
 	it("exposes range, loc and toString over the source", () => {
-		const decl =
-			/** @type {import("../lib/css/walkCssTokens").Declaration} */ (
-				parseADeclaration("color: red")
-			);
+		const decl = /** @type {import("../lib/css/walkCssTokens").Declaration} */ (
+			parseADeclaration("color: red")
+		);
 		expect(decl).toBeInstanceOf(Node);
 		expect(decl.range).toEqual([decl.start, decl.end]);
 		expect(decl.toString()).toBe("color: red");
@@ -292,8 +291,9 @@ describe("walkCssTokens — Node / Token", () => {
 		let loc;
 		new SourceProcessor()
 			.use({
-				[NodeType.Declaration]: (/** @type {import("../lib/css/walkCssTokens").Node} */ n) =>
-					(loc = n.loc)
+				[NodeType.Declaration]: (
+					/** @type {import("../lib/css/walkCssTokens").Node} */ n
+				) => (loc = n.loc)
 			})
 			.process("a{\n  color: red\n}");
 		expect(/** @type {NonNullable<typeof loc>} */ (loc).start).toEqual({
@@ -307,10 +307,9 @@ describe("walkCssTokens — Node / Token", () => {
 	});
 
 	it("lazily computes a token's value once", () => {
-		const ident =
-			/** @type {import("../lib/css/walkCssTokens").Token} */ (
-				parseAComponentValue("foo")
-			);
+		const ident = /** @type {import("../lib/css/walkCssTokens").Token} */ (
+			parseAComponentValue("foo")
+		);
 		expect(ident).toBeInstanceOf(Token);
 		expect(ident.value).toBe("foo");
 		expect(ident.value).toBe("foo");

--- a/test/walkHtmlTokens.unittest.js
+++ b/test/walkHtmlTokens.unittest.js
@@ -823,7 +823,7 @@ describe("walkHtmlTokens", () => {
 		 * @returns {[string, ...EXPECTED_ANY[]][]} token stream
 		 */
 		const walk = (html) => {
-			/** @type {unknown[]} */
+			/** @type {[string, ...EXPECTED_ANY[]][]} */
 			const out = [];
 			walkHtmlTokens(html, 0, {
 				openTag: (input, start, end, ns, ne, selfClosing) => {
@@ -1998,11 +1998,11 @@ describe("walkHtmlTokens", () => {
 			/** @type {[string, ...EXPECTED_ANY[]][]} */
 			const out = [];
 			const skipFn =
-				(label) =>
+				(/** @type {string} */ label) =>
 				(
-					input,
-					start,
-					end,
+					/** @type {string} */ input,
+					/** @type {number} */ start,
+					/** @type {number} */ end,
 					/** @type {number} */ ns,
 					/** @type {number} */ ne
 				) => {

--- a/test/walkHtmlTokens.unittest.js
+++ b/test/walkHtmlTokens.unittest.js
@@ -18,6 +18,7 @@ describe("walkHtmlTokens", () => {
 
 	for (const [name, code] of tests) {
 		it(`should tokenize and roundtrip "${name}"`, () => {
+			/** @type {unknown[]} */
 			const results = [];
 
 			walkHtmlTokens(code, 0, {
@@ -78,6 +79,7 @@ describe("walkHtmlTokens", () => {
 			expect(results).toMatchSnapshot();
 
 			// Roundtrip: concatenating all token values must reconstruct the original
+			/** @type {unknown[]} */
 			const reconstructed = [];
 			walkHtmlTokens(code, 0, {
 				openTag: (input, start, end) => {
@@ -107,6 +109,7 @@ describe("walkHtmlTokens", () => {
 	}
 
 	it("should handle empty input", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("", 0, {
 			text: (input, start, end) => {
@@ -118,6 +121,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle plain text with no tags", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("hello world", 0, {
 			text: (input, start, end) => {
@@ -129,6 +133,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should detect self-closing tags", () => {
+		/** @type {unknown[]} */
 		const tags = [];
 		walkHtmlTokens("<br/><img src='x'/>", 0, {
 			openTag: (input, start, end, nameStart, nameEnd, selfClosing) => {
@@ -143,6 +148,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should parse boolean attributes", () => {
+		/** @type {unknown[]} */
 		const attrs = [];
 		walkHtmlTokens('<input disabled required type="text">', 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
@@ -163,6 +169,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle all quote types", () => {
+		/** @type {unknown[]} */
 		const attrs = [];
 		walkHtmlTokens("<div a=\"1\" b='2' c=3>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
@@ -179,6 +186,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should parse comments", () => {
+		/** @type {unknown[]} */
 		const comments = [];
 		walkHtmlTokens("before<!-- hi -->after", 0, {
 			comment: (input, start, end) => {
@@ -190,6 +198,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle lone < at EOF", () => {
+		/** @type {unknown[]} */
 		const texts = [];
 		walkHtmlTokens("hello<", 0, {
 			text: (input, start, end) => {
@@ -201,6 +210,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should parse DOCTYPE as doctype", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<!DOCTYPE html><div>hi</div>", 0, {
 			doctype: (input, start, end) => {
@@ -229,6 +239,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should parse DOCTYPE case-insensitively", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<!doctype html><!DoCtYpE html>", 0, {
 			doctype: (input, start, end) => {
@@ -240,6 +251,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle CDATA sections", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<div><![CDATA[<img src='x'>]]></div>", 0, {
 			comment: (input, start, end) => {
@@ -264,6 +276,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle nested brackets in CDATA", () => {
+		/** @type {unknown[]} */
 		const comments = [];
 		walkHtmlTokens("<![CDATA[a]b]]c]]>", 0, {
 			comment: (input, start, end) => {
@@ -275,6 +288,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle nested <!-- inside comments", () => {
+		/** @type {unknown[]} */
 		const comments = [];
 		walkHtmlTokens("<!-- outer <!-- inner -->", 0, {
 			comment: (input, start, end) => {
@@ -286,6 +300,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle EOF in DOCTYPE", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<!DOCTYPE html", 0, {
 			doctype: (input, start, end) => {
@@ -297,6 +312,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle EOF in CDATA", () => {
+		/** @type {unknown[]} */
 		const comments = [];
 		walkHtmlTokens("<![CDATA[unclosed", 0, {
 			comment: (input, start, end) => {
@@ -309,6 +325,7 @@ describe("walkHtmlTokens", () => {
 
 	it("should roundtrip DOCTYPE + tags + CDATA", () => {
 		const html = "<!DOCTYPE html><html><body><![CDATA[data]]></body></html>";
+		/** @type {unknown[]} */
 		const parts = [];
 		walkHtmlTokens(html, 0, {
 			openTag: (input, start, end) => {
@@ -336,6 +353,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle RCDATA for title element", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<title>Hello <b>World</b></title>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -359,6 +377,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle RCDATA for textarea element", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<textarea><p>not a tag</p></textarea>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -382,6 +401,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle RAWTEXT for style element", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<style>.a { color: red; }</style>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -405,6 +425,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle script data state", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<script>var x = 1 < 2;</script>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -428,6 +449,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle script data escaped state (<!-- inside script)", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<script><!--- comment --></script>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -451,6 +473,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle script data double escaped state transitions (<script and </script)", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens(
 			"<script><!-- <script> var x = 1; </script> --></script>",
@@ -483,6 +506,7 @@ describe("walkHtmlTokens", () => {
 		// `</scripts>` (or any longer prefix) would falsely match `"script"`
 		// and prematurely exit the double-escaped state.
 		const html = "<script><!--<script>x</scripts>y</script>--></script>";
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens(html, 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -511,6 +535,7 @@ describe("walkHtmlTokens", () => {
 		// `tagStart` must point to the `<` of the actual close tag — otherwise
 		// `flushText(tagStart)` emits an empty range and the script body is lost.
 		const html = "<script><!--<script></script></script>";
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens(html, 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -534,6 +559,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should not match wrong end tag in RCDATA", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<title>text</div></title>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -557,6 +583,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle case-insensitive end tags in content modes", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<style>.a{}</STYLE>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -582,6 +609,7 @@ describe("walkHtmlTokens", () => {
 	it("should roundtrip HTML with script and style", () => {
 		const html =
 			"<html><head><style>.a{}</style></head><body><script>var x=1;</script></body></html>";
+		/** @type {unknown[]} */
 		const parts = [];
 		walkHtmlTokens(html, 0, {
 			openTag: (input, start, end) => {
@@ -601,6 +629,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle PLAINTEXT state", () => {
+		/** @type {unknown[]} */
 		const results = [];
 		walkHtmlTokens("<div><plaintext><p>ignored</p></div>", 0, {
 			openTag: (input, start, end, ns, ne) => {
@@ -624,6 +653,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle named character references in text", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>Tom &amp; Jerry</p>";
 		walkHtmlTokens(html, 0, {
@@ -644,6 +674,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle named character references in double-quoted attributes", () => {
+		/** @type {unknown[]} */
 		const attrs = [];
 		walkHtmlTokens('<a href="?a=1&amp;b=2">', 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
@@ -656,6 +687,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle named character references in single-quoted attributes", () => {
+		/** @type {unknown[]} */
 		const attrs = [];
 		walkHtmlTokens("<a href='?x=1&lt;2'>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
@@ -668,6 +700,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle character references in unquoted attributes", () => {
+		/** @type {unknown[]} */
 		const attrs = [];
 		walkHtmlTokens("<a href=foo&amp;bar>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
@@ -680,6 +713,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle decimal numeric character references", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#65;&#66;&#67;</p>";
 		walkHtmlTokens(html, 0, {
@@ -700,6 +734,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle hexadecimal character references", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#x41;&#X42;</p>";
 		walkHtmlTokens(html, 0, {
@@ -720,6 +755,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle bare ampersand (not a character reference)", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>bare & alone</p>";
 		walkHtmlTokens(html, 0, {
@@ -740,6 +776,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle unknown named character references", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&unknown;</p>";
 		walkHtmlTokens(html, 0, {
@@ -760,6 +797,7 @@ describe("walkHtmlTokens", () => {
 	});
 
 	it("should handle empty numeric character references (&#; and &#x;)", () => {
+		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#;&#x;</p>";
 		walkHtmlTokens(html, 0, {
@@ -785,6 +823,7 @@ describe("walkHtmlTokens", () => {
 		 * @returns {[string, ...EXPECTED_ANY[]][]} token stream
 		 */
 		const walk = (html) => {
+			/** @type {unknown[]} */
 			const out = [];
 			walkHtmlTokens(html, 0, {
 				openTag: (input, start, end, ns, ne, selfClosing) => {
@@ -827,6 +866,7 @@ describe("walkHtmlTokens", () => {
 		 * @returns {string} reconstructed html
 		 */
 		const roundtrip = (html) => {
+			/** @type {unknown[]} */
 			const parts = [];
 			walkHtmlTokens(html, 0, {
 				openTag: (input, start, end) => {
@@ -1867,6 +1907,7 @@ describe("walkHtmlTokens", () => {
 			// Each branch checks `callbacks.X !== undefined`; exercise the false
 			// side by walking a document that would produce those tokens but
 			// passing only `openTag` / `text`.
+			/** @type {unknown[]} */
 			const opens = [];
 			expect(() =>
 				walkHtmlTokens("<!DOCTYPE html><!-- c --><a>x</a><![CDATA[ y ]]>", 0, {

--- a/tsconfig.types.test.json
+++ b/tsconfig.types.test.json
@@ -6,6 +6,7 @@
   "include": [
     "declarations.d.ts",
     "declarations/*.d.ts",
+    "test/helpers/**/*.js",
     "test/**/webpack.config.js",
     "test/cases/**/*loader*.js",
     "test/watchCases/**/*loader*.js",

--- a/tsconfig.types.test.json
+++ b/tsconfig.types.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "strict": true,
     "types": ["node", "jest"]
   },
   "include": [

--- a/tsconfig.types.test.json
+++ b/tsconfig.types.test.json
@@ -13,10 +13,10 @@
     "test/watchCases/**/*loader*.js",
     "test/configCases/**/*loader*.js",
     "test/hotCases/**/*loader*.js",
-    // "test/*.unittest.js",
-    // "test/*.basictest.js",
-    // "test/*.test.js",
-    // "test/*.longtest.js",
+    "test/*.unittest.js",
+    "test/*.basictest.js",
+    "test/*.test.js",
+    "test/*.longtest.js",
     "declarations.test.d.ts"
   ],
   "exclude": ["test/js/**/*"]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Enables strict type-checking for the test files (`test/*.{unittest,basictest,test,longtest}.js` and `test/helpers/**`) and annotates them so `tsc -p tsconfig.types.test.json` passes. Builds on #21145: completes the remaining type errors, makes the lint suite green, and addresses the GitHub code-quality review (misleading multi-line cast, dead `errored` locals, superfluous `CustomError` argument).

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No — this only adds JSDoc types and lint/formatting fixes to existing test files; no behavior changes, so no new test cases. Existing suites still pass.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to finish the test type annotations, resolve the remaining `tsc` errors, fix ESLint/Prettier issues, and address the code-quality review comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMykeYVrv433xPgUDccgRs)_