### PR TITLE
test(SideEffectsFlagPlugin): cover multi-star and mixed barrel passthrough

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -533,7 +533,9 @@ class SideEffectsFlagPlugin {
 										if (connection.originModule !== null) {
 											optimizeIncomingConnections(connection.originModule);
 										}
-										// TODO improve for export *
+										// Named re-exports resolve their single target here; bare `export *`
+										// collapses in the next branch. Multi-star / mixed barrels are merge
+										// points (no single source), so only their sub-chains collapse.
 										if (isReexport && dep.name) {
 											const exportInfo = moduleGraph.getExportInfo(
 												/** @type {Module} */ (connection.originModule),

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/index.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/index.js
@@ -1,0 +1,28 @@
+import * as ns from "lib";
+import { foo } from "lib";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+it("should resolve named and namespace imports through a star + named barrel", () => {
+	expect(foo()).toBe(1);
+	expect(ns.foo()).toBe(1);
+	expect(ns.c()).toBe(3);
+	expect(Object.keys(ns).sort()).toEqual(["c", "foo"]);
+});
+
+it("should skip the single-star sub-chains and land consumers on the real modules", () => {
+	const mods = __STATS__.modules;
+	const reasons = (suffix) => {
+		const m = mods.find((m) => m.name.endsWith(suffix));
+		return new Set(m.reasons.filter((r) => r.explanation === SKIP).map((r) => r.moduleName));
+	};
+	expect(reasons("lib/real-a.js").has("./node_modules/lib/index.js")).toBe(true);
+	expect(reasons("lib/real-c.js").has("./node_modules/lib/index.js")).toBe(true);
+});
+
+it("should leave the intermediate single-star passthroughs unused", () => {
+	const mods = __STATS__.modules;
+	for (const s of ["lib/a.js", "lib/c.js"]) {
+		expect(mods.find((m) => m.name.endsWith(s)).usedExports).toBe(false);
+	}
+});

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/a.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./real-a.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/c.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/c.js
@@ -1,0 +1,1 @@
+export * from "./real-c.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/index.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/index.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export { c } from "./c.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/package.json
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-a.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-a.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 1;
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-c.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-c.js
@@ -1,0 +1,3 @@
+export function c() {
+	return 3;
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/webpack.config.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-mixed/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/index.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/index.js
@@ -1,0 +1,32 @@
+import * as ns from "lib";
+import { foo, bar } from "lib";
+import { foo as rfoo } from "./reexport.js";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+it("should resolve named, namespace and re-exported imports through a multi-star barrel", () => {
+	expect(foo()).toBe(1);
+	expect(bar()).toBe(2);
+	expect(rfoo()).toBe(1);
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(Object.keys(ns).sort()).toEqual(["bar", "foo"]);
+});
+
+it("should skip the single-star sub-chains and land consumers on the real modules", () => {
+	const mods = __STATS__.modules;
+	const reasons = (suffix) => {
+		const m = mods.find((m) => m.name.endsWith(suffix));
+		return new Set(m.reasons.filter((r) => r.explanation === SKIP).map((r) => r.moduleName));
+	};
+	// real modules are reached directly, past the side-effect-free a.js/b.js
+	expect(reasons("lib/real-a.js").has("./node_modules/lib/index.js")).toBe(true);
+	expect(reasons("lib/real-b.js").has("./node_modules/lib/index.js")).toBe(true);
+});
+
+it("should leave the intermediate single-star passthroughs unused", () => {
+	const mods = __STATS__.modules;
+	for (const s of ["lib/a.js", "lib/b.js"]) {
+		expect(mods.find((m) => m.name.endsWith(s)).usedExports).toBe(false);
+	}
+});

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/a.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./real-a.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/b.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./real-b.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/index.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/index.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export * from "./b.js";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/package.json
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-a.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-a.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 1;
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-b.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-b.js
@@ -1,0 +1,3 @@
+export function bar() {
+	return 2;
+}

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/reexport.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/reexport.js
@@ -1,0 +1,1 @@
+export * from "lib";

--- a/test/configCases/side-effects/star-reexport-passthrough-skip-multi/webpack.config.js
+++ b/test/configCases/side-effects/star-reexport-passthrough-skip-multi/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};


### PR DESCRIPTION
Multi-star (`export * from a; export * from b`) and mixed (`export *` +
named) barrels are merge points: named imports already resolve per-name onto
the real modules and single-star sub-chains collapse, while the barrel itself
is retained for namespace imports. Add regression tests for both cases and
replace the stale `TODO improve for export *` with an accurate note.

https://claude.ai/code/session_01XN2Wn9gngEBnuWTYbs8hZD