### PR TITLE
refactor: simplify star-reexport passthrough skipping

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -1609,7 +1609,7 @@ class ExportInfo {
 	 * Move the target forward as long resolveTargetFilter is fulfilled
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @param {ResolveTargetFilter} resolveTargetFilter filter function to further resolve target
-	 * @param {(target: TargetItemWithConnection) => ModuleGraphConnection=} updateOriginalConnection updates the original connection instead of using the target connection
+	 * @param {((target: TargetItemWithConnection) => ModuleGraphConnection | undefined)=} updateOriginalConnection updates the original connection instead of using the target connection
 	 * @returns {TargetItemWithConnection | undefined} the resolved target when moved
 	 */
 	moveTarget(moduleGraph, resolveTargetFilter, updateOriginalConnection) {
@@ -1633,7 +1633,7 @@ class ExportInfo {
 		/** @type {Target} */
 		(this._target).set(undefined, {
 			connection: updateOriginalConnection
-				? updateOriginalConnection(target)
+				? updateOriginalConnection(target) || target.connection
 				: target.connection,
 			export: /** @type {NonNullable<TargetItemWithConnection["export"]>} */ (
 				target.export

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -95,33 +95,31 @@ const notSideEffectsTag = Symbol("NoSideEffects");
 const RETURNS_FALSE = () => false;
 
 /**
- * Detects a "pure single-star passthrough" module: one whose entire export
+ * Detects if the module is "pure single-star passthrough": one whose entire export
  * surface is exactly one `export * from "x"` (no named/local/default-bearing
  * exports, no second star). For such a module `export * from "passthrough"` is
  * equivalent to `export * from "x"`, so the passthrough can be skipped.
- * @param {ModuleGraph} moduleGraph the module graph
  * @param {Module} module the candidate passthrough module
- * @returns {ModuleGraphConnection | undefined} the single star connection, or undefined
+ * @returns {boolean} true when the module is a pure single-star passthrough
  */
-const getSingleStarReexportConnection = (moduleGraph, module) => {
+const moduleHasSingleStarReexport = (module) => {
 	/** @type {HarmonyExportImportedSpecifierDependency | undefined} */
-	let starDep;
+	let starReexportDep;
 	for (const dep of module.dependencies) {
 		if (!(dep instanceof HarmonyExportImportedSpecifierDependency)) continue;
 		// a named re-export (`export { x } from` / `export * as ns from`) means
 		// the module owns names a star into its source wouldn't reproduce
-		if (dep.name !== null) return;
+		if (dep.name !== null) return false;
 		// any named/local export populates the shared activeExports set
-		if (dep.activeExports.size !== 0) return;
+		if (dep.activeExports.size !== 0) return false;
 		// more than one `export *` can't be collapsed to a single source
 		if (dep.allStarExports && dep.allStarExports.dependencies.length !== 1) {
-			return;
+			return false;
 		}
-		starDep = dep;
+		starReexportDep = dep;
 	}
-	if (starDep === undefined) return;
-	const connection = moduleGraph.getConnection(starDep);
-	return connection && connection.module ? connection : undefined;
+	if (starReexportDep === undefined) return false;
+	return true;
 };
 
 class SideEffectsFlagPlugin {
@@ -508,6 +506,25 @@ class SideEffectsFlagPlugin {
 						/** @type {Map<ExportInfo, TargetItemWithConnection | null>} */
 						const reexportTargetCache = new Map();
 
+						// Dependencies don't change within the pass, so the passthrough
+						// check is cached per module across all moveTarget filter calls.
+						/** @type {Map<Module, boolean>} */
+						const singleStarReexportCache = new Map();
+
+						/**
+						 * Cached variant of moduleHasSingleStarReexport.
+						 * @param {Module} module the candidate passthrough module
+						 * @returns {boolean} true when the module is a pure single-star passthrough
+						 */
+						const hasSingleStarReexport = (module) => {
+							let result = singleStarReexportCache.get(module);
+							if (result === undefined) {
+								result = moduleHasSingleStarReexport(module);
+								singleStarReexportCache.set(module, result);
+							}
+							return result;
+						};
+
 						/**
 						 * Optimize incoming connections.
 						 * @param {Module} module module
@@ -533,115 +550,78 @@ class SideEffectsFlagPlugin {
 										if (connection.originModule !== null) {
 											optimizeIncomingConnections(connection.originModule);
 										}
-										// Named re-exports resolve their single target here; bare `export *`
-										// collapses in the next branch. Multi-star / mixed barrels are merge
-										// points (no single source), so only their sub-chains collapse.
-										if (isReexport && dep.name) {
-											const exportInfo = moduleGraph.getExportInfo(
-												/** @type {Module} */ (connection.originModule),
-												dep.name
-											);
-											exportInfo.moveTarget(
-												moduleGraph,
-												({ module }) =>
-													module.getSideEffectsConnectionState(moduleGraph) ===
-													false,
-												({
-													module: newModule,
-													export: exportName,
-													connection: targetConnection
-												}) => {
-													moduleGraph.updateModule(dep, newModule);
-													moduleGraph.updateParent(
-														dep,
-														targetConnection,
-														/** @type {Module} */ (connection.originModule)
-													);
-													moduleGraph.addExplanation(
-														dep,
-														"(skipped side-effect-free modules)"
-													);
-													const ids = dep.getIds(moduleGraph);
-													dep.setIds(
-														moduleGraph,
-														exportName
-															? [...exportName, ...ids.slice(1)]
-															: ids.slice(1)
-													);
-													return /** @type {ModuleGraphConnection} */ (
-														moduleGraph.getConnection(dep)
-													);
-												}
-											);
-											continue;
-										}
+
 										if (isReexport) {
-											// plain `export *` (no `dep.name`): when this module is a
-											// pure single-star passthrough, move the re-exported names
-											// and the star itself past the side-effect-free chain.
-											const originModule = connection.originModule;
-											const firstStar = getSingleStarReexportConnection(
-												moduleGraph,
-												module
-											);
-											if (firstStar !== undefined && originModule !== null) {
-												let targetConnection = firstStar;
-												let targetModule = firstStar.module;
-												/** @type {Set<Module> | undefined} */
-												let visited;
-												while (
-													targetModule.getSideEffectsConnectionState(
-														moduleGraph
-													) === false
-												) {
-													const next = getSingleStarReexportConnection(
-														moduleGraph,
-														targetModule
-													);
-													if (next === undefined) break;
-													if (visited === undefined) {
-														visited = new Set([module]);
-													}
-													if (visited.has(targetModule)) break;
-													visited.add(targetModule);
-													targetConnection = next;
-													targetModule = next.module;
-												}
-												const originExportsInfo =
-													moduleGraph.getExportsInfo(originModule);
-												for (const exportInfo of originExportsInfo.orderedExports) {
-													// only the names this star contributes route through dep
-													const immediate = exportInfo.getTarget(
-														moduleGraph,
-														RETURNS_FALSE
-													);
-													if (
-														immediate === undefined ||
-														immediate.connection.dependency !== dep
-													) {
-														continue;
-													}
-													exportInfo.moveTarget(
-														moduleGraph,
-														({ module }) =>
-															module.getSideEffectsConnectionState(
-																moduleGraph
-															) === false
-													);
-												}
-												moduleGraph.updateModule(dep, targetModule);
-												moduleGraph.updateParent(
-													dep,
-													targetConnection,
-													originModule
+											if (!dep.name && !hasSingleStarReexport(module)) continue;
+
+											const infos = dep.name
+												? // Named re-exports resolve their single target here;
+													// e.g. `export * as foo from "mod"` / `export { dep as name } from "mod"`
+													[
+														moduleGraph.getExportInfo(
+															/** @type {Module} */ (connection.originModule),
+															dep.name
+														)
+													]
+												: moduleGraph.getExportsInfo(
+														/** @type {Module} */ (connection.originModule)
+													).exports;
+
+											for (const exportInfo of infos) {
+												const immediate = exportInfo.getTarget(
+													moduleGraph,
+													RETURNS_FALSE
 												);
-												moduleGraph.addExplanation(
-													dep,
-													"(skipped side-effect-free modules)"
+												if (
+													immediate === undefined ||
+													immediate.connection.dependency !== dep
+												) {
+													continue;
+												}
+
+												exportInfo.moveTarget(
+													moduleGraph,
+													({ module }) =>
+														module.getSideEffectsConnectionState(
+															moduleGraph
+														) === false &&
+														(Boolean(dep.name) ||
+															hasSingleStarReexport(
+																/** @type {Module} */ (module)
+															)),
+													({
+														module: newModule,
+														export: exportName,
+														connection: targetConnection
+													}) => {
+														moduleGraph.updateModule(dep, newModule);
+														moduleGraph.updateParent(
+															dep,
+															targetConnection,
+															/** @type {Module} */ (connection.originModule)
+														);
+														moduleGraph.addExplanation(
+															dep,
+															"(skipped side-effect-free modules)"
+														);
+														const ids = dep.getIds(moduleGraph);
+														if (ids.length) {
+															dep.setIds(
+																moduleGraph,
+																exportName
+																	? [...exportName, ...ids.slice(1)]
+																	: ids.slice(1)
+															);
+														}
+														return /** @type {ModuleGraphConnection} */ (
+															moduleGraph.getConnection(dep)
+														);
+													}
 												);
 											}
 											continue;
 										}
+
 										const ids = dep.getIds(moduleGraph);
 										if (ids.length > 0) {
 											const exportInfo = exportsInfo.getExportInfo(ids[0]);

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/index.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/index.js
@@ -1,0 +1,30 @@
+import * as ns from "lib";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+const stats = __STATS__.children[__STATS_I__];
+const find = (suffix) => stats.modules.find((m) => m.name.endsWith(suffix));
+const skippedFrom = (suffix) =>
+	new Set(
+		find(suffix)
+			.reasons.filter((r) => r.explanation === SKIP)
+			.map((r) => r.moduleName)
+	);
+
+it("should resolve fan-out named imports to their distinct real source modules", () => {
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(ns.baz()).toBe(3);
+
+	// No `dep.id`, but still re-target/re-connect the deep star-reexport exportInfo.
+	expect(Object.keys(ns).length).toBe(3);
+});
+
+it("should repoint each name past the passthrough and re-connect to its own real module", () => {
+	expect(skippedFrom("lib/b-source.js").has("./node_modules/lib/b.js")).toBe(
+		true
+	);
+	expect(skippedFrom("lib/b-source.js").has("./node_modules/lib/b-1.js")).toBe(
+		true
+	);
+});

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/a.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/a.js
@@ -1,0 +1,6 @@
+export function foo() {
+	return 1;
+}
+export function baz() {
+	return 3;
+}

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-1.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-1.js
@@ -1,0 +1,1 @@
+export * from "./b-2"

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-2.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-2.js
@@ -1,0 +1,1 @@
+export * from "./b-source"

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-source.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-source.js
@@ -1,0 +1,3 @@
+export function bar() {
+	return 2;
+}

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./b-1"

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/index.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/index.js
@@ -1,0 +1,1 @@
+export * from "./mid.js";

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/mid.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/mid.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export * from "./b.js";

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/package.json
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib",
+  "version": "0.0.1",
+  "sideEffects": ["./index.js", "./b.js"]
+}

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/test.config.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return [`./bundle${i}.js`];
+	}
+};

--- a/test/configCases/side-effects/star-reexport-fan-out-skip/webpack.config.js
+++ b/test/configCases/side-effects/star-reexport-fan-out-skip/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const optimization = {
+	sideEffects: true,
+	usedExports: true,
+	providedExports: true,
+	minimize: false
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		mode: "production",
+		output: { filename: "bundle0.js" },
+		optimization: { ...optimization, concatenateModules: false }
+	},
+	{
+		mode: "production",
+		output: { filename: "bundle1.js" },
+		optimization: { ...optimization, concatenateModules: true }
+	}
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -7481,7 +7481,7 @@ declare abstract class ExportInfo {
 		resolveTargetFilter: (target: TargetItemWithConnection) => boolean,
 		updateOriginalConnection?: (
 			target: TargetItemWithConnection
-		) => ModuleGraphConnection
+		) => undefined | ModuleGraphConnection
 	): undefined | TargetItemWithConnection;
 
 	/**


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

**What kind of change does this PR introduce?**

Follow-up to the `export *` passthrough skipping in `SideEffectsFlagPlugin`: replaces the special handled single-star chain walk with a unified `ExportsInfo#moveTarget` pass guarded by `hasSingleStarReexport`, so the per-name target resolution and the star connection repoint share one computation. 

Behavior is preserved — a plain `export *` only repoints when its source is a pure single-star passthrough, so fan-out sources are not over-collapsed.

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your ce you already documented?**

n/a

**Use of AI**

Yes, for better code understanding