### PR TITLE
fix(html): decode HTML entities in extracted attribute URLs

### DIFF
--- a/test/configCases/html/entity-decode/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/entity-decode/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html entity-decode exported tests decodes HTML entities in an extracted attribute URL 1`] = `
+"<!DOCTYPE html>
+<html>
+	<body>
+		<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"entity in url\\">
+	</body>
+</html>
+"
+`;

--- a/test/configCases/html/entity-decode/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/entity-decode/__snapshots__/ConfigTest.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html entity-decode exported tests decodes HTML entities in an extracted attribute URL 1`] = `
+"<!DOCTYPE html>
+<html>
+	<body>
+		<img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"entity in url\\">
+	</body>
+</html>
+"
+`;

--- a/test/configCases/html/entity-decode/index.js
+++ b/test/configCases/html/entity-decode/index.js
@@ -1,0 +1,5 @@
+import page from "./page.html";
+
+it("decodes HTML entities in an extracted attribute URL", () => {
+	expect(page).toMatchSnapshot();
+});

--- a/test/configCases/html/entity-decode/page.html
+++ b/test/configCases/html/entity-decode/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+	<body>
+		<img src="./img&amp;x.png" alt="entity in url">
+	</body>
+</html>

--- a/test/configCases/html/entity-decode/webpack.config.js
+++ b/test/configCases/html/entity-decode/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	experiments: {
+		html: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Attribute values like `<img src="a&amp;b.png">` were resolved with the entity left raw (`a&amp;b.png`), so the file failed to resolve. This decodes the extracted URL via the existing `walkHtmlTokens.decodeHtmlEntities`, matching html-loader. `srcset` is intentionally left raw — its parser runs first and decoding before it would change how candidates are tokenized (see the existing `TODO(html-entities)` note in `test/configCases/html/srcset/errors.js`).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/html/entity-decode` (an `&amp;` in a `src` resolves to the real file).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

YES Paritally