### PR TITLE
perf(html): cut allocations in special end-tag checks and entity decode

### DIFF
--- a/.changeset/html-parser-end-tag-allocations.md
+++ b/.changeset/html-parser-end-tag-allocations.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reduce allocations in the experimental HTML parser's tokenizer and entity decoder.
+Reduce allocations in the experimental HTML parser's tokenizer, tree builder, and entity decoder.

--- a/.changeset/html-parser-end-tag-allocations.md
+++ b/.changeset/html-parser-end-tag-allocations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce allocations in the experimental HTML parser's tokenizer and entity decoder.

--- a/.changeset/html-parser-end-tag-allocations.md
+++ b/.changeset/html-parser-end-tag-allocations.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reduce allocations in the experimental HTML parser's tokenizer, tree builder, and entity decoder.
+Speed up and reduce allocations in the experimental HTML parser's tokenizer, tree builder, and entity decoder.

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -433,6 +433,27 @@ const TBODY_GROUP = new Set(["tbody", "tfoot", "thead"]);
 const TD_TH = new Set(["td", "th"]);
 const TD_TH_TR = new Set(["td", "th", "tr"]);
 const STYLE_SCRIPT_TEMPLATE = new Set(["style", "script", "template"]);
+const HEAD_BODY_HTML_BR = new Set(["head", "body", "html", "br"]);
+const BODY_HTML_BR = new Set(["body", "html", "br"]);
+// <base>/<basefont>/<bgsound>/<link>/<meta>: void elements inserted then
+// immediately popped in the "in head" mode.
+const HEAD_VOID_ELEMENTS = new Set([
+	"base",
+	"basefont",
+	"bgsound",
+	"link",
+	"meta"
+]);
+const NOFRAMES_STYLE_NOSCRIPT = new Set(["noframes", "style", "noscript"]);
+// "in head noscript" start tags that are handled by reprocessing in "in head".
+const IN_HEAD_NOSCRIPT_PASSTHROUGH = new Set([
+	"basefont",
+	"bgsound",
+	"link",
+	"meta",
+	"noframes",
+	"style"
+]);
 const HEAD_ELEMENTS = new Set([
 	"base",
 	"basefont",
@@ -670,6 +691,11 @@ const FONT_BREAKOUT_ATTRS = new Set(["color", "face", "size"]);
 const EMPTY_ATTRS = /** @type {HtmlAttribute[]} */ (
 	/** @type {unknown} */ (Object.freeze([]))
 );
+
+// Hoisted so the many `open.some(...)` "is there an open HTML <template>?"
+// checks reuse one predicate instead of allocating an arrow per call.
+const isHtmlTemplateEl = (/** @type {HtmlElement} */ e) =>
+	e.tagName === "template" && e.namespace === NS_HTML;
 
 /**
  * @param {string} source HTML source
@@ -1528,9 +1554,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		/** @type {HtmlElement} */ commonAncestor
 	) => {
 		if (
-			["table", "tbody", "tfoot", "thead", "tr"].includes(
-				commonAncestor.tagName
-			) &&
+			TABLE_CONTEXT.has(commonAncestor.tagName) &&
 			commonAncestor.namespace === NS_HTML
 		) {
 			// foster
@@ -1770,10 +1794,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "beforeHead";
 			return;
 		}
-		if (
-			t.type === "endTag" &&
-			!["head", "body", "html", "br"].includes(t.name)
-		) {
+		if (t.type === "endTag" && !HEAD_BODY_HTML_BR.has(t.name)) {
 			return;
 		}
 		const el = mkEl("html", NS_HTML, [], null);
@@ -1800,10 +1821,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "inHead";
 			return;
 		}
-		if (
-			t.type === "endTag" &&
-			!["head", "body", "html", "br"].includes(t.name)
-		) {
+		if (t.type === "endTag" && !HEAD_BODY_HTML_BR.has(t.name)) {
 			return;
 		}
 		head = insertHtmlElement("head", EMPTY_ATTRS, null);
@@ -1827,7 +1845,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === "doctype") return;
 		if (t.type === "startTag") {
 			if (t.name === "html") return modes.inBody(t);
-			if (["base", "basefont", "bgsound", "link", "meta"].includes(t.name)) {
+			if (HEAD_VOID_ELEMENTS.has(t.name)) {
 				insertHtmlElement(t.name, t.attrs, t.pos);
 				open.pop();
 				return;
@@ -1836,7 +1854,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				genericRcdata(t);
 				return;
 			}
-			if (["noframes", "style", "noscript"].includes(t.name)) {
+			if (NOFRAMES_STYLE_NOSCRIPT.has(t.name)) {
 				if (t.name === "noscript") {
 					insertHtmlElement("noscript", t.attrs, t.pos);
 					mode = "inHeadNoscript";
@@ -1867,12 +1885,10 @@ const buildHtmlAst = (source, fragmentContext) => {
 				mode = "afterHead";
 				return;
 			}
-			if (["body", "html", "br"].includes(t.name)) {
+			if (BODY_HTML_BR.has(t.name)) {
 				/* fallthrough */
 			} else if (t.name === "template") {
-				if (
-					!open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-				) {
+				if (!open.some(isHtmlTemplateEl)) {
 					return;
 				}
 				generateImpliedEndTagsThorough();
@@ -1901,19 +1917,16 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		if (t.type === "char" && isAllWs(t.data)) return modes.inHead(t);
 		if (t.type === "comment") return modes.inHead(t);
-		if (
-			t.type === "startTag" &&
-			["basefont", "bgsound", "link", "meta", "noframes", "style"].includes(
-				t.name
-			)
-		) {
+		if (t.type === "startTag" && IN_HEAD_NOSCRIPT_PASSTHROUGH.has(t.name)) {
 			return modes.inHead(t);
 		}
 		// A stray end tag other than </br>/</noscript> is ignored (the comment
 		// or content stays inside <noscript>); only </br> and other content fall
 		// back to popping <noscript>.
 		if (t.type === "endTag" && t.name !== "br") return;
-		if (t.type === "startTag" && ["head", "noscript"].includes(t.name)) return;
+		if (t.type === "startTag" && (t.name === "head" || t.name === "noscript")) {
+			return;
+		}
 		open.pop();
 		mode = "inHead";
 		process(t);
@@ -1946,20 +1959,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				mode = "inFrameset";
 				return;
 			}
-			if (
-				[
-					"base",
-					"basefont",
-					"bgsound",
-					"link",
-					"meta",
-					"noframes",
-					"script",
-					"style",
-					"template",
-					"title"
-				].includes(t.name)
-			) {
+			if (HEAD_ELEMENTS.has(t.name)) {
 				const headEl = /** @type {HtmlElement} */ (head);
 				open.push(headEl);
 				modes.inHead(t);
@@ -1971,7 +1971,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		if (t.type === "endTag") {
 			if (t.name === "template") return modes.inHead(t);
-			if (!["body", "html", "br"].includes(t.name)) return;
+			if (!BODY_HTML_BR.has(t.name)) return;
 		}
 		insertHtmlElement("body", [], null);
 		mode = "inBody";
@@ -2004,9 +2004,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		const name = t.name;
 		if (name === "html") {
-			if (
-				open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (open.some(isHtmlTemplateEl)) {
 				return;
 			}
 			const htmlEl = open[0];
@@ -2022,11 +2020,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		if (name === "body") {
 			const second = open[1];
-			if (
-				!second ||
-				second.tagName !== "body" ||
-				open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (!second || second.tagName !== "body" || open.some(isHtmlTemplateEl)) {
 				return;
 			}
 			framesetOk = false;
@@ -2066,17 +2060,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		if (name === "form") {
-			if (
-				form &&
-				!open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (form && !open.some(isHtmlTemplateEl)) {
 				return;
 			}
 			closeIfPInButtonScope();
 			const el = insertHtmlElement("form", t.attrs, t.pos);
-			if (
-				!open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (!open.some(isHtmlTemplateEl)) {
 				form = el;
 			}
 			return;
@@ -2357,9 +2346,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		if (name === "form") {
-			if (
-				!open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (!open.some(isHtmlTemplateEl)) {
 				const node = form;
 				form = null;
 				if (!node || !inScopeEl(node)) return;
@@ -2553,10 +2540,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				}
 			}
 			if (name === "form") {
-				if (
-					form ||
-					open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-				) {
+				if (form || open.some(isHtmlTemplateEl)) {
 					return;
 				}
 				form = insertHtmlElement("form", t.attrs, t.pos);
@@ -2842,9 +2826,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		if (t.type === "eof") {
-			if (
-				!open.some((e) => e.tagName === "template" && e.namespace === NS_HTML)
-			) {
+			if (!open.some(isHtmlTemplateEl)) {
 				return;
 			}
 			popUntil("template");

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -417,7 +417,6 @@ const IMPLIED_THOROUGH = new Set([
 	"thead",
 	"tr"
 ]);
-const WS_CHARS = new Set([" ", "\t", "\n", "\f", "\r"]);
 const CLEAR_TABLE = new Set(["table", "template", "html"]);
 const CLEAR_TABLE_BODY = new Set([
 	"tbody",
@@ -1239,7 +1238,14 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	const isAllWs = (/** @type {string} */ s) => {
-		for (const c of s) if (!WS_CHARS.has(c)) return false;
+		for (let i = 0; i < s.length; i++) {
+			const c = s.charCodeAt(i);
+			// HTML whitespace: tab / LF / FF / CR / space. A charCodeAt loop avoids
+			// the `for…of` code-point iterator + per-char string + Set lookup.
+			if (c !== 0x09 && c !== 0x0a && c !== 0x0c && c !== 0x0d && c !== 0x20) {
+				return false;
+			}
+		}
 		return true;
 	};
 
@@ -2009,7 +2015,10 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (t.data === "") return;
 			reconstructAfe();
 			insertCharacters(t.data, t.start, t.end);
-			if (!isAllWs(t.data)) framesetOk = false;
+			// `framesetOk` only ever goes true→false, so once it's false skip the
+			// per-text-token whitespace scan entirely (it flips false very early in
+			// real documents).
+			if (framesetOk && !isAllWs(t.data)) framesetOk = false;
 			return;
 		}
 		if (t.type === "comment") {

--- a/lib/html/buildHtmlAst.js
+++ b/lib/html/buildHtmlAst.js
@@ -697,6 +697,18 @@ const EMPTY_ATTRS = /** @type {HtmlAttribute[]} */ (
 const isHtmlTemplateEl = (/** @type {HtmlElement} */ e) =>
 	e.tagName === "template" && e.namespace === NS_HTML;
 
+// Linear attribute lookup by name — avoids the per-call arrow `Array#find`
+// would allocate (attribute lists are short, so a plain loop is faster too).
+const findAttr = (
+	/** @type {HtmlAttribute[]} */ attrs,
+	/** @type {string} */ name
+) => {
+	for (let i = 0; i < attrs.length; i++) {
+		if (attrs[i].name === name) return attrs[i];
+	}
+	return undefined;
+};
+
 /**
  * @param {string} source HTML source
  * @param {string=} fragmentContext context element name for fragment parsing (e.g. `td`, `svg path`); omit for a full document
@@ -964,50 +976,63 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		return false;
 	};
-	const hasElementInScopeMatching = (
-		/** @type {(el: HtmlElement) => boolean} */ test,
-		/** @type {(el: HtmlElement) => boolean} */ extra
+	// Scope "kind" selects which extra elements act as boundaries. Passed as a
+	// small int so the scope checks below allocate no per-call predicate closure
+	// (these run several times per body tag).
+	const SCOPE_DEFAULT = 0;
+	const SCOPE_BUTTON = 1;
+	const SCOPE_LIST_ITEM = 2;
+	const isBoundaryForKind = (
+		/** @type {HtmlElement} */ el,
+		/** @type {number} */ kind
+	) => {
+		if (isScopeBoundary(el)) return true;
+		if (el.namespace !== NS_HTML) return false;
+		if (kind === SCOPE_BUTTON) return el.tagName === "button";
+		if (kind === SCOPE_LIST_ITEM) {
+			return el.tagName === "ol" || el.tagName === "ul";
+		}
+		return false;
+	};
+	// "have an element in scope": walk the open stack from the top until the
+	// named HTML element is found (true) or a scope boundary is hit (false).
+	const hasNameInScope = (
+		/** @type {string} */ tagName,
+		/** @type {number} */ kind
 	) => {
 		for (let i = open.length - 1; i >= 0; i--) {
 			const el = open[i];
-			if (test(el)) return true;
-			if (extra(el)) return false;
+			if (el.namespace === NS_HTML && el.tagName === tagName) return true;
+			if (isBoundaryForKind(el, kind)) return false;
 		}
 		return false;
 	};
 	const inScope = (/** @type {string} */ tagName) =>
-		hasElementInScopeMatching(
-			(el) => el.namespace === NS_HTML && el.tagName === tagName,
-			(el) => isScopeBoundary(el)
-		);
-	const inScopeEl = (/** @type {HtmlElement} */ target) =>
-		hasElementInScopeMatching(
-			(el) => el === target,
-			(el) => isScopeBoundary(el)
-		);
+		hasNameInScope(tagName, SCOPE_DEFAULT);
 	const inButtonScope = (/** @type {string} */ tagName) =>
-		hasElementInScopeMatching(
-			(el) => el.namespace === NS_HTML && el.tagName === tagName,
-			(el) =>
-				isScopeBoundary(el) ||
-				(el.namespace === NS_HTML && el.tagName === "button")
-		);
+		hasNameInScope(tagName, SCOPE_BUTTON);
 	const inListItemScope = (/** @type {string} */ tagName) =>
-		hasElementInScopeMatching(
-			(el) => el.namespace === NS_HTML && el.tagName === tagName,
-			(el) =>
-				isScopeBoundary(el) ||
-				(el.namespace === NS_HTML &&
-					(el.tagName === "ol" || el.tagName === "ul"))
-		);
+		hasNameInScope(tagName, SCOPE_LIST_ITEM);
+	const inScopeEl = (/** @type {HtmlElement} */ target) => {
+		for (let i = open.length - 1; i >= 0; i--) {
+			const el = open[i];
+			if (el === target) return true;
+			if (isScopeBoundary(el)) return false;
+		}
+		return false;
+	};
 	// `target` is a single tag name (the common case) or a Set of names.
-	const inTableScope = (/** @type {string | Set<string>} */ target) =>
-		hasElementInScopeMatching(
-			typeof target === "string"
-				? (el) => el.namespace === NS_HTML && el.tagName === target
-				: (el) => el.namespace === NS_HTML && target.has(el.tagName),
-			(el) => el.namespace === NS_HTML && TABLE_SCOPE_STOP.has(el.tagName)
-		);
+	const inTableScope = (/** @type {string | Set<string>} */ target) => {
+		const set = typeof target === "string" ? null : target;
+		for (let i = open.length - 1; i >= 0; i--) {
+			const el = open[i];
+			if (el.namespace === NS_HTML) {
+				if (set ? set.has(el.tagName) : el.tagName === target) return true;
+				if (TABLE_SCOPE_STOP.has(el.tagName)) return false;
+			}
+		}
+		return false;
+	};
 	const generateImpliedEndTags = (except = "") => {
 		while (open.length) {
 			const el = cur();
@@ -1277,7 +1302,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		el.namespace === NS_MATHML && MATHML_TEXT_INTEGRATION.has(el.tagName);
 	const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
 		if (el.namespace === NS_MATHML && el.tagName === "annotation-xml") {
-			const enc = el.attributes.find((a) => a.name === "encoding");
+			const enc = findAttr(el.attributes, "encoding");
 			if (
 				enc &&
 				(enc.value.toLowerCase() === "text/html" ||
@@ -2204,7 +2229,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			reconstructAfe();
 			insertHtmlElement("input", t.attrs, t.pos);
 			open.pop();
-			const ty = t.attrs.find((a) => a.name === "type");
+			const ty = findAttr(t.attrs, "type");
 			if (!ty || ty.value.toLowerCase() !== "hidden") framesetOk = false;
 			return;
 		}
@@ -2532,7 +2557,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				return modes.inHead(t);
 			}
 			if (name === "input") {
-				const ty = t.attrs.find((a) => a.name === "type");
+				const ty = findAttr(t.attrs, "type");
 				if (ty && ty.value.toLowerCase() === "hidden") {
 					insertHtmlElement("input", t.attrs, t.pos);
 					open.pop();

--- a/lib/html/walkHtmlTokens.js
+++ b/lib/html/walkHtmlTokens.js
@@ -2347,8 +2347,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2364,8 +2363,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2381,8 +2379,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2482,8 +2479,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2498,8 +2494,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2514,8 +2509,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2620,8 +2614,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2636,8 +2629,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2652,8 +2644,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2851,8 +2842,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2867,8 +2857,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2883,8 +2872,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						input.slice(tagNameStart, tagNameEnd).toLowerCase() ===
-						lastOpenTagName
+						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -3651,12 +3639,24 @@ walkHtmlTokens.decodeHtmlEntities = (str, isAttribute) => {
 				if (after === 0x3d /* = */) return match;
 			}
 
+			// Fast path: the regex usually captures exactly one entity (`&amp;`,
+			// `&lt;`, `&nbsp;`, …), so the whole `name` is the match — avoid the
+			// full-length `name.slice(0, name.length)` the loop's first iteration
+			// would allocate. No leftover, so the attribute guard never applies.
+			if (name.length <= MAX_ENTITY_NAME_LEN) {
+				const full = HTML_ENTITIES[name];
+				if (full !== undefined) return full;
+			}
+
 			// Cap the longest-prefix search at MAX_ENTITY_NAME_LEN so pathological
 			// inputs like `&` + thousands of alphanumerics stay linear-time.
 			// Anything past that cap can't possibly match and is appended
-			// verbatim as part of `name.slice(i)`.
+			// verbatim as part of `name.slice(i)`. The full-length case was just
+			// handled above, so start one shorter when it's the cap.
 			const searchLen =
-				name.length > MAX_ENTITY_NAME_LEN ? MAX_ENTITY_NAME_LEN : name.length;
+				name.length > MAX_ENTITY_NAME_LEN
+					? MAX_ENTITY_NAME_LEN
+					: name.length - 1;
 			for (let i = searchLen; i > 0; i--) {
 				const prefix = name.slice(0, i);
 				if (HTML_ENTITIES[prefix] !== undefined) {

--- a/lib/html/walkHtmlTokens.js
+++ b/lib/html/walkHtmlTokens.js
@@ -759,7 +759,20 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					if (cc === CC_NULL) {
 						reportError("unexpected-null-character", pos, pos + 1, "warning");
 					}
+					// Fast-forward over the ordinary run of the tag name.
 					pos++;
+					while (pos < len) {
+						const c2 = input.charCodeAt(pos);
+						if (
+							c2 === CC_SOLIDUS ||
+							c2 === CC_GREATER_THAN ||
+							c2 === CC_NULL ||
+							isSpace(c2)
+						) {
+							break;
+						}
+						pos++;
+					}
 				}
 				break;
 
@@ -839,7 +852,27 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 							"warning"
 						);
 					}
+					// Fast-forward over the ordinary run of the attribute name; stop on
+					// any terminator (space / `/` / `>` / `=`) or a char that needs a
+					// per-occurrence parse error (NULL / `"` / `'` / `<`), which the
+					// outer switch then re-handles.
 					pos++;
+					while (pos < len) {
+						const c2 = input.charCodeAt(pos);
+						if (
+							c2 === CC_SOLIDUS ||
+							c2 === CC_GREATER_THAN ||
+							c2 === CC_EQUALS ||
+							c2 === CC_NULL ||
+							c2 === CC_QUOTATION_MARK ||
+							c2 === CC_APOSTROPHE ||
+							c2 === CC_LESS_THAN ||
+							isSpace(c2)
+						) {
+							break;
+						}
+						pos++;
+					}
 				}
 				break;
 


### PR DESCRIPTION
Replace the per-check input.slice(...).toLowerCase() in the RCDATA /
RAWTEXT / SCRIPT_DATA / SCRIPT_DATA_ESCAPED end-tag-name states with the
existing allocation-free rangeEqualsLower helper, and add an exact-match
fast path to decodeHtmlEntities so the common single-entity case skips a
full-length prefix slice.

https://claude.ai/code/session_01RbPceANkJXa5R9WQWCfH6q