### PR TITLE
perf: skip dependency error/warning reporting for unchanged modules on rebuilds

### DIFF
--- a/.changeset/skip-dependency-report-unchanged-modules.md
+++ b/.changeset/skip-dependency-report-unchanged-modules.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip dependency error/warning reporting for unchanged modules on rebuilds.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -546,6 +546,37 @@ const unsafeCacheDependencies = new WeakMap();
 /** @type {WeakMap<ModuleWithRestoreFromUnsafeCache, UnsafeCacheData>} */
 const unsafeCacheData = new WeakMap();
 
+/** @typedef {EXPECTED_OBJECT} DependencyReportCacheToken */
+
+/**
+ * Renewed when the module or a transitively referenced module is rebuilt.
+ * @type {WeakMap<Module, DependencyReportCacheToken>}
+ */
+const dependencyReportCacheTokens = new WeakMap();
+
+/**
+ * Modules known to have no dependency errors/warnings, per cache token.
+ * @type {WeakMap<DependencyReportCacheToken, WeakSet<Module>>}
+ */
+const modulesWithoutProblems = new WeakMap();
+
+/**
+ * Reduce affect type.
+ * @param {Readonly<ModuleGraphConnection[]>} connections connections
+ * @returns {symbol | boolean} result
+ */
+const reduceAffectType = (connections) => {
+	let affected = false;
+	for (const { dependency } of connections) {
+		if (!dependency) continue;
+		const type = dependency.couldAffectReferencingModule();
+		if (type === Dependency.TRANSITIVE) return Dependency.TRANSITIVE;
+		if (type === false) continue;
+		affected = true;
+	}
+	return affected;
+};
+
 /** @typedef {{ id: ModuleId, modules?: Map<Module, ModuleId>, blocks?: (ChunkId | null)[], sourceTypes?: SourceTypes }} References */
 /** @typedef {Map<Module, WeakTupleMap<EXPECTED_ANY[], EXPECTED_ANY>>} ModuleMemCaches */
 
@@ -2814,22 +2845,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			}
 		}
 
-		/**
-		 * Reduce affect type.
-		 * @param {Readonly<ModuleGraphConnection[]>} connections connections
-		 * @returns {symbol | boolean} result
-		 */
-		const reduceAffectType = (connections) => {
-			let affected = false;
-			for (const { dependency } of connections) {
-				if (!dependency) continue;
-				const type = dependency.couldAffectReferencingModule();
-				if (type === Dependency.TRANSITIVE) return Dependency.TRANSITIVE;
-				if (type === false) continue;
-				affected = true;
-			}
-			return affected;
-		};
 		/** @type {Set<Module>} */
 		const directOnlyInfectedModules = new Set();
 		for (const module of infectedModules) {
@@ -3016,6 +3031,57 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				(100 * statChanged) / (statNew + statChanged + statUnchanged)
 			)}% modules flagged as affected by chunk graph (${statNew} new modules, ${statChanged} changed, ${statUnchanged} unchanged)`
 		);
+	}
+
+	/**
+	 * Assigns a fresh dependency report cache token to every module whose
+	 * dependency errors/warnings could have changed since the previous
+	 * compilation: built modules and their (transitive) parents.
+	 * @private
+	 * @param {Set<Module>} modules modules
+	 * @returns {void}
+	 */
+	_flagModulesForDependencyReporting(modules) {
+		/** @type {DependencyReportCacheToken} */
+		const token = {};
+		const { moduleGraph, builtModules } = this;
+		/** @type {Set<Module>} */
+		const updatedModules = new Set();
+		for (const module of modules) {
+			if (
+				builtModules.has(module) ||
+				!dependencyReportCacheTokens.has(module)
+			) {
+				updatedModules.add(module);
+			}
+		}
+		// skip the parent walk when everything is updated anyway (initial build)
+		if (updatedModules.size !== modules.size) {
+			/** @type {Set<Module>} */
+			const directOnlyUpdatedModules = new Set();
+			for (const module of updatedModules) {
+				for (const [
+					referencingModule,
+					connections
+				] of moduleGraph.getIncomingConnectionsByOriginModule(module)) {
+					if (!referencingModule) continue;
+					if (updatedModules.has(referencingModule)) continue;
+					const type = reduceAffectType(connections);
+					if (!type) continue;
+					if (type === true) {
+						directOnlyUpdatedModules.add(referencingModule);
+					} else {
+						updatedModules.add(referencingModule);
+					}
+				}
+			}
+			for (const module of directOnlyUpdatedModules) {
+				updatedModules.add(module);
+			}
+		}
+		for (const module of updatedModules) {
+			dependencyReportCacheTokens.set(module, token);
+		}
 	}
 
 	/**
@@ -3238,15 +3304,24 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 			// extract warnings and errors from modules
 			this.moduleGraph.freeze("dependency errors");
-			// TODO keep a cacheToken (= {}) for each module in the graph
-			// create a new one per compilation and flag all updated files
-			// and parents with it
 			this.logger.time("report dependency errors and warnings");
+			// moduleMemCaches has its own invalidation (incl. reference changes),
+			// so cache tokens are only used without it
+			const useReportCacheTokens = moduleMemCaches === undefined;
+			if (useReportCacheTokens) {
+				this._flagModulesForDependencyReporting(modules);
+			}
 			for (const module of modules) {
-				// TODO only run for modules with changed cacheToken
-				// global WeakMap<CacheToken, WeakSet<Module>> to keep modules without errors/warnings
 				const memCache = moduleMemCaches && moduleMemCaches.get(module);
 				if (memCache && memCache.get("noWarningsOrErrors")) continue;
+				let token;
+				if (useReportCacheTokens) {
+					token = dependencyReportCacheTokens.get(module);
+					const cleanModules = modulesWithoutProblems.get(
+						/** @type {DependencyReportCacheToken} */ (token)
+					);
+					if (cleanModules !== undefined && cleanModules.has(module)) continue;
+				}
 				let hasProblems = this.reportDependencyErrorsAndWarnings(module, [
 					module
 				]);
@@ -3270,7 +3345,21 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						hasProblems = true;
 					}
 				}
-				if (!hasProblems && memCache) memCache.set("noWarningsOrErrors", true);
+				if (!hasProblems) {
+					if (memCache) memCache.set("noWarningsOrErrors", true);
+					if (useReportCacheTokens) {
+						let cleanModules = modulesWithoutProblems.get(
+							/** @type {DependencyReportCacheToken} */ (token)
+						);
+						if (cleanModules === undefined) {
+							modulesWithoutProblems.set(
+								/** @type {DependencyReportCacheToken} */ (token),
+								(cleanModules = new WeakSet())
+							);
+						}
+						cleanModules.add(module);
+					}
+				}
 			}
 			this.moduleGraph.unfreeze();
 			this.logger.timeEnd("report dependency errors and warnings");

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/dyn.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/dyn.js
@@ -1,0 +1,3 @@
+export function load(name) {
+	return require(name);
+}

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/index.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/index.js
@@ -1,0 +1,8 @@
+import "./dyn";
+import { y } from "./module";
+import { other } from "./other";
+
+it("should report dependency warnings of unchanged modules on rebuilds", () => {
+	expect(y).toBe(WATCH_STEP === "2" ? undefined : 2);
+	expect(other).toBe(WATCH_STEP === "0" ? "a" : "b");
+});

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/module.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/module.js
@@ -1,0 +1,2 @@
+export const x = 1;
+export const y = 2;

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/other.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/other.js
@@ -1,0 +1,1 @@
+export const other = "a";

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/warnings.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/0/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/Critical dependency: the request of a dependency is an expression/]
+];

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/1/other.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/1/other.js
@@ -1,0 +1,1 @@
+export const other = "b";

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/1/warnings.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/1/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/Critical dependency: the request of a dependency is an expression/]
+];

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/2/module.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/2/module.js
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/2/warnings.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/2/warnings.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/Critical dependency: the request of a dependency is an expression/],
+	[/export 'y' \(imported as 'y'\) was not found in '\.\/module'/]
+];

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/3/module.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/3/module.js
@@ -1,0 +1,2 @@
+export const x = 1;
+export const y = 2;

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/3/warnings.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/3/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/Critical dependency: the request of a dependency is an expression/]
+];

--- a/test/watchCases/warnings/dependency-warnings-unchanged-modules/webpack.config.js
+++ b/test/watchCases/warnings/dependency-warnings-unchanged-modules/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		parser: {
+			javascript: {
+				exportsPresence: "warn"
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Resolves the long-standing `cacheToken` TODO in `Compilation.finish`: the "report dependency errors and warnings" pass walked every module's dependency tree on every rebuild, even for unchanged modules, unless `experiments.cacheUnaffected` was enabled. Each compilation now renews a cache token for built modules and their (transitive) parents (using the same `couldAffectReferencingModule()` rules as `_computeAffectedModules`), and modules known to be clean under their current token are skipped — on a 4100-module benchmark this cuts the phase from ~8.6 ms to ~1.1 ms per rebuild with default development cache, while `experiments.cacheUnaffected` keeps its existing, more precise invalidation untouched.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/watchCases/warnings/dependency-warnings-unchanged-modules` covers warning persistence for unchanged modules across rebuilds and a new export warning appearing on an unchanged importer when its dependency changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This change was implemented with Claude (Claude Code) under my direction: it wrote the implementation, the watch test case, and ran before/after CPU/memory benchmarks; I reviewed the approach and results.

https://claude.ai/code/session_015WjGhYn6DRDRoUWmWG32NL

---
_Generated by [Claude Code](https://claude.ai/code/session_015WjGhYn6DRDRoUWmWG32NL)_