### PR TITLE
chore: remove resolved TODO comments

### DIFF
--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -481,8 +481,6 @@ const META = new Map([
 			"msapplication-wide310x150logo",
 			"msapplication-square310x310logo",
 			"msapplication-config",
-			// TODO Do we need to parser it?
-			// "msapplication-task",
 			"twitter:image"
 		])
 	],

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5071,7 +5071,6 @@ class JavascriptParser extends Parser {
 			.for(expr.type)
 			.call(expr, commentsStartPos);
 		if (typeof result === "boolean") return result;
-		// TODO handle more cases
 		switch (expr.type) {
 			case "ClassDeclaration":
 			case "ClassExpression": {

--- a/lib/util/createHash.js
+++ b/lib/util/createHash.js
@@ -35,7 +35,6 @@ module.exports = (algorithm) => {
 		return new BulkUpdateHash(() => new algorithm());
 	}
 	switch (algorithm) {
-		// TODO add non-cryptographic algorithm here
 		case "debug":
 			if (DebugHash === undefined) {
 				DebugHash = require("./hash/DebugHash");

--- a/lib/wasm-sync/WebAssemblyParser.js
+++ b/lib/wasm-sync/WebAssemblyParser.js
@@ -39,7 +39,8 @@ const getJsIncompatibleType = (signature) => {
 };
 
 /**
- * TODO why are there two different Signature types?
+ * Same check for the other `@webassemblyjs` signature shape: imports carry the
+ * AST `Signature` node (above), the module context uses plain `FuncSignature`.
  * @param {t.FuncSignature} signature the func signature
  * @returns {null | string} the type incompatible with js types
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Remove TODO comments that are already resolved (`createHash` non-cryptographic algorithm — covered by `xxhash64`; `isPure` "handle more cases" — all expression kinds are covered with an evaluator fallback; the obsolete IE-only `msapplication-task` meta entry) and answer the wasm-sync "two Signature types" question with a short comment instead of a TODO.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

chore

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — comment-only changes, no behavior change.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was prepared with Claude Code under my direction: it verified each non-webpack-6 TODO against the current code and dependency versions, removed only the resolved ones, and I reviewed the result.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NN7TxnrberLMKBvFpUUkb)_