### PR TITLE
feat: defer building unused reexport targets of barrel modules

### DIFF
--- a/.changeset/lazy-barrel.md
+++ b/.changeset/lazy-barrel.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Defer building unused re-export targets of side-effect-free barrel modules.

--- a/cspell.json
+++ b/cspell.json
@@ -326,6 +326,7 @@
     "undelayed",
     "unexception",
     "uniquename",
+    "unlazy",
     "unoptimized",
     "unreviewed",
     "unshifted",

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -104,21 +104,6 @@ const { isSourceEqual } = require("./util/source");
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("./Dependency").ReferencedExports} ReferencedExports */
-/** @typedef {import("./LazyBarrel").DependencyGroup} LazyBarrelGroup */
-/**
- * Defines the lazy barrel state type used by this module.
- * @typedef {object} LazyBarrelState
- * @property {Set<string> | true} forwardedIds export names requested so far, true for all
- * @property {LazyBarrel | undefined} lazyBarrelInfo deferred dependencies, undefined until classified
- */
-/**
- * Defines the lazy barrel unlazy item type used by this module.
- * @typedef {object} LazyBarrelItem
- * @property {ModuleFactory} factory factory for the request
- * @property {Dependency[]} dependencies deferred dependencies of the request
- * @property {string | undefined} context request context
- * @property {Module} originModule the lazy barrel module
- */
 /** @typedef {import("./Entrypoint").EntryOptions} EntryOptions */
 /** @typedef {import("./Module").NameForCondition} NameForCondition */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
@@ -1385,12 +1370,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		/** @type {UnsafeCachePredicate} */
 		this._unsafeCachePredicate =
 			typeof unsafeCache === "function" ? unsafeCache : () => true;
+
 		/**
-		 * Per side-effect-free module lazy barrel state.
 		 * @private
-		 * @type {WeakMap<Module, LazyBarrelState>}
+		 * @type {LazyBarrel}
 		 */
-		this._lazyBarrelModules = new WeakMap();
+		this._lazyBarrel = new LazyBarrel(this);
 	}
 
 	getStats() {
@@ -1801,7 +1786,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 
 		// lazy barrel: defer re-export targets of side-effect-free modules
-		const hasLazyBarrel = this._classifyLazyBarrelDependencies(module);
+		const hasLazyBarrel = this._lazyBarrel.classify(module);
 
 		/** @type {DependenciesBlock} */
 		let currentBlock;
@@ -1884,10 +1869,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			this.moduleGraph.setParents(dep, currentBlock, module, index);
 			if (
 				hasLazyBarrel &&
-				/** @type {{ _lazyMake?: boolean }} */ (dep)._lazyMake === true
+				// `isLazy` may be missing on custom dependency types not extending the base Dependency
+				typeof dep.isLazy === "function" &&
+				dep.isLazy()
 			) {
 				return;
 			}
+
 			if (this._unsafeCache) {
 				try {
 					const unsafeCachedModule = unsafeCacheDependencies.get(dep);
@@ -1901,7 +1889,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								dep,
 								unsafeCachedModule
 							);
-							this._unlazyBarrelForDependency(
+							this._lazyBarrel.unlazyForDependency(
 								unsafeCachedModule,
 								dep,
 								sortedDependencies
@@ -1919,7 +1907,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								dep,
 								cachedModule
 							);
-							this._unlazyBarrelForDependency(
+							this._lazyBarrel.unlazyForDependency(
 								cachedModule,
 								dep,
 								sortedDependencies
@@ -1984,7 +1972,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 									dep,
 									cachedModule
 								); // a3
-								this._unlazyBarrelForDependency(
+								this._lazyBarrel.unlazyForDependency(
 									cachedModule,
 									dep,
 									sortedDependencies
@@ -2124,127 +2112,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		}
 
 		if (--inProgressSorting === 0) onDependenciesSorted();
-	}
-
-	/**
-	 * Classifies the re-export dependencies of a side-effect-free module (lazy barrel)
-	 * into deferrable groups and marks the deferred ones.
-	 * @private
-	 * @param {Module} module the module whose dependencies are processed
-	 * @returns {boolean} true, when some dependencies were deferred
-	 */
-	_classifyLazyBarrelDependencies(module) {
-		const lazyBarrelModules = this._lazyBarrelModules;
-		const factoryMeta = module.factoryMeta;
-		if (factoryMeta === undefined || !factoryMeta.sideEffectFree) {
-			return false;
-		}
-		/** @type {LazyBarrel | undefined} */
-		let info;
-		for (const dep of module.dependencies) {
-			const until = dep.getLazyUntil();
-			if (until === null) continue;
-			if (info === undefined) info = new LazyBarrel();
-			if (typeof until === "object" && "local" in until) {
-				info.addTerminal(until.local);
-				continue;
-			}
-			const resourceIdent = dep.getResourceIdentifier();
-			if (resourceIdent === null) continue;
-			const factory = this.dependencyFactories.get(
-				/** @type {DependencyConstructor} */ (dep.constructor)
-			);
-			if (factory === undefined) continue;
-			const category = dep.category;
-			// Match the request grouping key of `processDependencyForResolving`
-			const requestKey =
-				category === esmDependencyCategory
-					? resourceIdent
-					: `${category}${resourceIdent}`;
-			info.addLazy(requestKey, dep, factory, dep.getContext());
-			if (typeof until === "object") {
-				info.addForwardId(until.id, requestKey);
-			} else if (until === Dependency.LAZY_UNTIL_FALLBACK) {
-				info.addFallback(requestKey);
-			}
-		}
-		const state = lazyBarrelModules.get(module);
-		if (info === undefined || info.isEmpty()) {
-			if (state !== undefined) lazyBarrelModules.delete(module);
-			return false;
-		}
-		if (state !== undefined) {
-			// barrel classified after its targets were already requested: replay the
-			// recorded ids so processDependency un-lazies and builds those targets now
-			state.lazyBarrelInfo = info;
-			info.request(state.forwardedIds);
-			// stay lazy only while some targets remain deferred
-			return !info.isEmpty();
-		}
-
-		lazyBarrelModules.set(module, {
-			forwardedIds: new Set(),
-			lazyBarrelInfo: info
-		});
-
-		return true;
-	}
-
-	/**
-	 * Requests the export names that `dependencies` need from a lazy barrel and
-	 * returns the deferred re-export targets that must be built now. Records the
-	 * request when the barrel's dependencies were not classified yet.
-	 * @private
-	 * @param {Module} module the resolved module
-	 * @param {Dependency[]} dependencies the dependencies that resolved to the module
-	 * @returns {LazyBarrelItem[] | undefined} items to process, if any
-	 */
-	_requestLazyBarrelItems(module, dependencies) {
-		const lazyBarrelModules = this._lazyBarrelModules;
-		const state = lazyBarrelModules.get(module);
-
-		if (state === undefined) {
-			const factoryMeta = module.factoryMeta;
-			if (factoryMeta === undefined || !factoryMeta.sideEffectFree) return;
-			const forwardedIds = LazyBarrel.getForwardedIds(dependencies);
-			if (forwardedIds !== true && forwardedIds.size === 0) return;
-			lazyBarrelModules.set(module, {
-				forwardedIds,
-				lazyBarrelInfo: undefined
-			});
-			return;
-		}
-
-		const forwardedIds = LazyBarrel.getForwardedIds(dependencies);
-		if (forwardedIds !== true && forwardedIds.size === 0) return;
-		if (state.forwardedIds !== true) {
-			if (forwardedIds === true) state.forwardedIds = true;
-			else for (const id of forwardedIds) state.forwardedIds.add(id);
-		}
-		const info = state.lazyBarrelInfo;
-		// Pending requests will be replayed during `_classifyLazyBarrelDependencies` later
-		if (info === undefined) return;
-		const groups = info.request(forwardedIds);
-		if (groups.length === 0) return;
-		return groups.map((group) => ({
-			factory: group.factory,
-			dependencies: group.dependencies,
-			context: group.context,
-			originModule: module
-		}));
-	}
-
-	/**
-	 * Queues the deferred dependency groups of a lazy barrel requested by a single dependency.
-	 * @private
-	 * @param {Module} module the resolved module of the dependency
-	 * @param {Dependency} dependency the requesting dependency
-	 * @param {{ factory: ModuleFactory, dependencies: Dependency[], context: string | undefined, originModule: Module | null }[]} sortedDependencies item list to append to
-	 */
-	_unlazyBarrelForDependency(module, dependency, sortedDependencies) {
-		const items = this._requestLazyBarrelItems(module, [dependency]);
-		if (items === undefined) return;
-		for (const item of items) sortedDependencies.push(item);
 	}
 
 	/**
@@ -2651,13 +2518,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			// lazy barrel:
 			// 1. first call: barrel module is not classified yet, so this records the requested
 			//    ids and returns undefined; the targets get built below when
-			//    `processModuleDependencies` runs `_classifyLazyBarrelDependencies` and replays them.
+			//    `processModuleDependencies` runs `_lazyBarrel.classify` and replays them.
 			// 2. later call: barrel module is already built, so `processModuleDependencies` won't
 			//    re-walk it; the newly requested targets must be built here.
-			const lazyItems = this._requestLazyBarrelItems(module, dependencies);
+			const unlazyItems = this._lazyBarrel.request(module, dependencies);
 
-			if (lazyItems !== undefined) {
-				let inProgress = lazyItems.length + 1; // +1 = the module's own dep processing
+			if (unlazyItems !== undefined) {
+				let inProgress = unlazyItems.length + 1; // +1 = the module's own dep processing
 				let errored = false;
 				/**
 				 * @param {(WebpackError | null)=} err error
@@ -2671,7 +2538,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					}
 					if (--inProgress === 0) callback(null, module);
 				};
-				for (const item of lazyItems) {
+				for (const item of unlazyItems) {
 					this.handleModuleCreation(item, (err) => {
 						onJobDone(err && this.bail ? err : null);
 					});

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1869,8 +1869,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			this.moduleGraph.setParents(dep, currentBlock, module, index);
 			if (
 				hasLazyBarrel &&
-				// `isLazy` may be missing on custom dependency types not extending the base Dependency
-				typeof dep.isLazy === "function" &&
+				// TODO remove in webpack 6
+				// It may be missing on custom dependency types not extending the base Dependency
+				"isLazy" in dep &&
 				dep.isLazy()
 			) {
 				return;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -28,6 +28,7 @@ const DependencyTemplates = require("./DependencyTemplates");
 const Entrypoint = require("./Entrypoint");
 const ErrorHelpers = require("./ErrorHelpers");
 const FileSystemInfo = require("./FileSystemInfo");
+const LazyBarrel = require("./LazyBarrel");
 const MainTemplate = require("./MainTemplate");
 const Module = require("./Module");
 const ModuleGraph = require("./ModuleGraph");
@@ -103,6 +104,21 @@ const { isSourceEqual } = require("./util/source");
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("./Dependency").ReferencedExports} ReferencedExports */
+/** @typedef {import("./LazyBarrel").DependencyGroup} LazyBarrelGroup */
+/**
+ * Defines the lazy barrel state type used by this module.
+ * @typedef {object} LazyBarrelState
+ * @property {Set<string> | true} forwardedIds export names requested so far, true for all
+ * @property {LazyBarrel | undefined} lazyBarrelInfo deferred dependencies, undefined until classified
+ */
+/**
+ * Defines the lazy barrel unlazy item type used by this module.
+ * @typedef {object} LazyBarrelItem
+ * @property {ModuleFactory} factory factory for the request
+ * @property {Dependency[]} dependencies deferred dependencies of the request
+ * @property {string | undefined} context request context
+ * @property {Module} originModule the lazy barrel module
+ */
 /** @typedef {import("./Entrypoint").EntryOptions} EntryOptions */
 /** @typedef {import("./Module").NameForCondition} NameForCondition */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
@@ -1369,6 +1385,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		/** @type {UnsafeCachePredicate} */
 		this._unsafeCachePredicate =
 			typeof unsafeCache === "function" ? unsafeCache : () => true;
+		/**
+		 * Per side-effect-free module lazy barrel state.
+		 * @private
+		 * @type {WeakMap<Module, LazyBarrelState>}
+		 */
+		this._lazyBarrelModules = new WeakMap();
 	}
 
 	getStats() {
@@ -1488,7 +1510,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						typeof console.profileEnd === "function"
 					) {
 						console.profileEnd(
-							`[${name}] ${/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]}`
+							`[${name}] ${
+								/** @type {NonNullable<LogEntry["args"]>} */ (logEntry.args)[0]
+							}`
 						);
 					}
 					if (logEntries === undefined) {
@@ -1776,6 +1800,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			Dependency.isLowPriorityDependency
 		);
 
+		// lazy barrel: defer re-export targets of side-effect-free modules
+		const hasLazyBarrel = this._classifyLazyBarrelDependencies(module);
+
 		/** @type {DependenciesBlock} */
 		let currentBlock;
 
@@ -1855,6 +1882,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		 */
 		const processDependency = (dep, index) => {
 			this.moduleGraph.setParents(dep, currentBlock, module, index);
+			if (
+				hasLazyBarrel &&
+				/** @type {{ _lazyMake?: boolean }} */ (dep)._lazyMake === true
+			) {
+				return;
+			}
 			if (this._unsafeCache) {
 				try {
 					const unsafeCachedModule = unsafeCacheDependencies.get(dep);
@@ -1868,6 +1901,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								dep,
 								unsafeCachedModule
 							);
+							this._unlazyBarrelForDependency(
+								unsafeCachedModule,
+								dep,
+								sortedDependencies
+							);
 							return;
 						}
 						const identifier = unsafeCachedModule.identifier();
@@ -1880,6 +1918,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								module,
 								dep,
 								cachedModule
+							);
+							this._unlazyBarrelForDependency(
+								cachedModule,
+								dep,
+								sortedDependencies
 							);
 							return;
 						}
@@ -1941,6 +1984,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 									dep,
 									cachedModule
 								); // a3
+								this._unlazyBarrelForDependency(
+									cachedModule,
+									dep,
+									sortedDependencies
+								);
 							} catch (err) {
 								if (inProgressSorting <= 0) return;
 								inProgressSorting = -1;
@@ -2079,6 +2127,127 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	}
 
 	/**
+	 * Classifies the re-export dependencies of a side-effect-free module (lazy barrel)
+	 * into deferrable groups and marks the deferred ones.
+	 * @private
+	 * @param {Module} module the module whose dependencies are processed
+	 * @returns {boolean} true, when some dependencies were deferred
+	 */
+	_classifyLazyBarrelDependencies(module) {
+		const lazyBarrelModules = this._lazyBarrelModules;
+		const factoryMeta = module.factoryMeta;
+		if (factoryMeta === undefined || !factoryMeta.sideEffectFree) {
+			return false;
+		}
+		/** @type {LazyBarrel | undefined} */
+		let info;
+		for (const dep of module.dependencies) {
+			const until = dep.getLazyUntil();
+			if (until === null) continue;
+			if (info === undefined) info = new LazyBarrel();
+			if (typeof until === "object" && "local" in until) {
+				info.addTerminal(until.local);
+				continue;
+			}
+			const resourceIdent = dep.getResourceIdentifier();
+			if (resourceIdent === null) continue;
+			const factory = this.dependencyFactories.get(
+				/** @type {DependencyConstructor} */ (dep.constructor)
+			);
+			if (factory === undefined) continue;
+			const category = dep.category;
+			// Match the request grouping key of `processDependencyForResolving`
+			const requestKey =
+				category === esmDependencyCategory
+					? resourceIdent
+					: `${category}${resourceIdent}`;
+			info.addLazy(requestKey, dep, factory, dep.getContext());
+			if (typeof until === "object") {
+				info.addForwardId(until.id, requestKey);
+			} else if (until === Dependency.LAZY_UNTIL_FALLBACK) {
+				info.addFallback(requestKey);
+			}
+		}
+		const state = lazyBarrelModules.get(module);
+		if (info === undefined || info.isEmpty()) {
+			if (state !== undefined) lazyBarrelModules.delete(module);
+			return false;
+		}
+		if (state !== undefined) {
+			// barrel classified after its targets were already requested: replay the
+			// recorded ids so processDependency un-lazies and builds those targets now
+			state.lazyBarrelInfo = info;
+			info.request(state.forwardedIds);
+			// stay lazy only while some targets remain deferred
+			return !info.isEmpty();
+		}
+
+		lazyBarrelModules.set(module, {
+			forwardedIds: new Set(),
+			lazyBarrelInfo: info
+		});
+
+		return true;
+	}
+
+	/**
+	 * Requests the export names that `dependencies` need from a lazy barrel and
+	 * returns the deferred re-export targets that must be built now. Records the
+	 * request when the barrel's dependencies were not classified yet.
+	 * @private
+	 * @param {Module} module the resolved module
+	 * @param {Dependency[]} dependencies the dependencies that resolved to the module
+	 * @returns {LazyBarrelItem[] | undefined} items to process, if any
+	 */
+	_requestLazyBarrelItems(module, dependencies) {
+		const lazyBarrelModules = this._lazyBarrelModules;
+		const state = lazyBarrelModules.get(module);
+
+		if (state === undefined) {
+			const factoryMeta = module.factoryMeta;
+			if (factoryMeta === undefined || !factoryMeta.sideEffectFree) return;
+			const forwardedIds = LazyBarrel.getForwardedIds(dependencies);
+			if (forwardedIds !== true && forwardedIds.size === 0) return;
+			lazyBarrelModules.set(module, {
+				forwardedIds,
+				lazyBarrelInfo: undefined
+			});
+			return;
+		}
+
+		const forwardedIds = LazyBarrel.getForwardedIds(dependencies);
+		if (forwardedIds !== true && forwardedIds.size === 0) return;
+		if (state.forwardedIds !== true) {
+			if (forwardedIds === true) state.forwardedIds = true;
+			else for (const id of forwardedIds) state.forwardedIds.add(id);
+		}
+		const info = state.lazyBarrelInfo;
+		// Pending requests will be replayed during `_classifyLazyBarrelDependencies` later
+		if (info === undefined) return;
+		const groups = info.request(forwardedIds);
+		if (groups.length === 0) return;
+		return groups.map((group) => ({
+			factory: group.factory,
+			dependencies: group.dependencies,
+			context: group.context,
+			originModule: module
+		}));
+	}
+
+	/**
+	 * Queues the deferred dependency groups of a lazy barrel requested by a single dependency.
+	 * @private
+	 * @param {Module} module the resolved module of the dependency
+	 * @param {Dependency} dependency the requesting dependency
+	 * @param {{ factory: ModuleFactory, dependencies: Dependency[], context: string | undefined, originModule: Module | null }[]} sortedDependencies item list to append to
+	 */
+	_unlazyBarrelForDependency(module, dependency, sortedDependencies) {
+		const items = this._requestLazyBarrelItems(module, [dependency]);
+		if (items === undefined) return;
+		for (const item of items) sortedDependencies.push(item);
+	}
+
+	/**
 	 * Handle new module from unsafe cache.
 	 * @private
 	 * @param {Module} originModule original module
@@ -2107,6 +2276,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			module,
 			true,
 			false,
+			[dependency],
 			callback
 		);
 	}
@@ -2389,6 +2559,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						module,
 						recursive,
 						checkCycle,
+						dependencies,
 						callback
 					);
 				});
@@ -2403,6 +2574,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 * @param {Module} module module
 	 * @param {boolean} recursive true if make it recursive, otherwise false
 	 * @param {boolean} checkCycle true if need to check cycle, otherwise false
+	 * @param {Dependency[]} dependencies the dependencies that resolved to the module (lazy barrel)
 	 * @param {ModuleCallback} callback callback
 	 * @returns {void}
 	 */
@@ -2411,6 +2583,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		module,
 		recursive,
 		checkCycle,
+		dependencies,
 		callback
 	) {
 		// Check for cycles when build is trigger inside another build
@@ -2475,17 +2648,52 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				return;
 			}
 
-			// This avoids deadlocks for circular dependencies
-			if (this.processDependenciesQueue.isProcessing(module)) {
-				return callback(null, module);
-			}
+			// lazy barrel:
+			// 1. first call: barrel module is not classified yet, so this records the requested
+			//    ids and returns undefined; the targets get built below when
+			//    `processModuleDependencies` runs `_classifyLazyBarrelDependencies` and replays them.
+			// 2. later call: barrel module is already built, so `processModuleDependencies` won't
+			//    re-walk it; the newly requested targets must be built here.
+			const lazyItems = this._requestLazyBarrelItems(module, dependencies);
 
-			this.processModuleDependencies(module, (err) => {
-				if (err) {
-					return callback(err);
+			if (lazyItems !== undefined) {
+				let inProgress = lazyItems.length + 1; // +1 = the module's own dep processing
+				let errored = false;
+				/**
+				 * @param {(WebpackError | null)=} err error
+				 * @returns {void}
+				 */
+				const onJobDone = (err) => {
+					if (errored) return;
+					if (err) {
+						errored = true;
+						return callback(err);
+					}
+					if (--inProgress === 0) callback(null, module);
+				};
+				for (const item of lazyItems) {
+					this.handleModuleCreation(item, (err) => {
+						onJobDone(err && this.bail ? err : null);
+					});
 				}
-				callback(null, module);
-			});
+				if (this.processDependenciesQueue.isProcessing(module)) {
+					onJobDone();
+				} else {
+					this.processModuleDependencies(module, onJobDone);
+				}
+			} else {
+				// This avoids deadlocks for circular dependencies
+				if (this.processDependenciesQueue.isProcessing(module)) {
+					return callback(null, module);
+				}
+
+				this.processModuleDependencies(module, (err) => {
+					if (err) {
+						return callback(err);
+					}
+					callback(null, module);
+				});
+			}
 		});
 	}
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -28,7 +28,7 @@ const DependencyTemplates = require("./DependencyTemplates");
 const Entrypoint = require("./Entrypoint");
 const ErrorHelpers = require("./ErrorHelpers");
 const FileSystemInfo = require("./FileSystemInfo");
-const LazyBarrel = require("./LazyBarrel");
+const LazyBarrelController = require("./LazyBarrel");
 const MainTemplate = require("./MainTemplate");
 const Module = require("./Module");
 const ModuleGraph = require("./ModuleGraph");
@@ -1373,9 +1373,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 		/**
 		 * @private
-		 * @type {LazyBarrel}
+		 * @type {LazyBarrelController}
 		 */
-		this._lazyBarrel = new LazyBarrel(this);
+		this._lazyBarrelController = new LazyBarrelController(this);
 	}
 
 	getStats() {
@@ -1786,7 +1786,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 
 		// lazy barrel: defer re-export targets of side-effect-free modules
-		const hasLazyBarrel = this._lazyBarrel.classify(module);
+		const hasLazyBarrel = this._lazyBarrelController.classify(module);
 
 		/** @type {DependenciesBlock} */
 		let currentBlock;
@@ -1889,7 +1889,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								dep,
 								unsafeCachedModule
 							);
-							this._lazyBarrel.unlazyForDependency(
+							this._lazyBarrelController.unlazyForDependency(
 								unsafeCachedModule,
 								dep,
 								sortedDependencies
@@ -1907,7 +1907,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								dep,
 								cachedModule
 							);
-							this._lazyBarrel.unlazyForDependency(
+							this._lazyBarrelController.unlazyForDependency(
 								cachedModule,
 								dep,
 								sortedDependencies
@@ -1972,7 +1972,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 									dep,
 									cachedModule
 								); // a3
-								this._lazyBarrel.unlazyForDependency(
+								this._lazyBarrelController.unlazyForDependency(
 									cachedModule,
 									dep,
 									sortedDependencies
@@ -2518,10 +2518,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			// lazy barrel:
 			// 1. first call: barrel module is not classified yet, so this records the requested
 			//    ids and returns undefined; the targets get built below when
-			//    `processModuleDependencies` runs `_lazyBarrel.classify` and replays them.
+			//    `processModuleDependencies` runs `_lazyBarrelController.classify` and replays them.
 			// 2. later call: barrel module is already built, so `processModuleDependencies` won't
 			//    re-walk it; the newly requested targets must be built here.
-			const unlazyItems = this._lazyBarrel.request(module, dependencies);
+			const unlazyItems = this._lazyBarrelController.request(
+				module,
+				dependencies
+			);
 
 			if (unlazyItems !== undefined) {
 				let inProgress = unlazyItems.length + 1; // +1 = the module's own dep processing

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -99,6 +99,18 @@ const memoize = require("./util/memoize");
 
 /** @typedef {(moduleGraphConnection: ModuleGraphConnection, runtime: RuntimeSpec) => ConnectionState} GetConditionFn */
 
+/**
+ * Lazy barrel classification of a dependency within a side-effect-free module.
+ * `{ id }`: named re-export deferred until the export name is requested.
+ * `{ local }`: locally provided export name, requesting it requires no dependency.
+ * `LAZY_UNTIL_FALLBACK`: star re-export, deferred until an unknown name or all names are requested.
+ * `LAZY_UNTIL_REQUEST`: deferred together with other dependencies of the same request.
+ * @typedef {{ id: string } | { local: string } | "*" | "@"} LazyUntil
+ */
+
+const LAZY_UNTIL_FALLBACK = /** @type {"*"} */ ("*");
+const LAZY_UNTIL_REQUEST = /** @type {"@"} */ ("@");
+
 const TRANSITIVE = /** @type {symbol} */ (Symbol("transitive"));
 
 const getIgnoredModule = memoize(() => {
@@ -236,6 +248,23 @@ class Dependency {
 	 */
 	couldAffectReferencingModule() {
 		return TRANSITIVE;
+	}
+
+	/**
+	 * Returns the export name this dependency requests from its target module (lazy barrel optimization).
+	 * @returns {string | true | null} export name, true for all exports, null for none
+	 */
+	getForwardId() {
+		// unknown dependency types conservatively request all exports
+		return true;
+	}
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
+	 */
+	getLazyUntil() {
+		return null;
 	}
 
 	/**
@@ -433,5 +462,7 @@ Object.defineProperty(Dependency.prototype, "disconnect", {
 });
 
 Dependency.TRANSITIVE = TRANSITIVE;
+Dependency.LAZY_UNTIL_FALLBACK = LAZY_UNTIL_FALLBACK;
+Dependency.LAZY_UNTIL_REQUEST = LAZY_UNTIL_REQUEST;
 
 module.exports = Dependency;

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -268,6 +268,20 @@ class Dependency {
 	}
 
 	/**
+	 * Whether the lazy barrel currently defers creating this dependency's target module (lazy barrel optimization).
+	 * @returns {boolean} true while deferred, so it must not be processed or rendered
+	 */
+	isLazy() {
+		return false;
+	}
+
+	/**
+	 * Sets whether the lazy barrel defers creating this dependency's target module (lazy barrel optimization).
+	 * @param {boolean} value true to defer, false to create it now
+	 */
+	setLazy(value) {}
+
+	/**
 	 * Returns the referenced module and export
 	 * @deprecated
 	 * @param {ModuleGraph} moduleGraph module graph

--- a/lib/FlagAllModulesAsUsedPlugin.js
+++ b/lib/FlagAllModulesAsUsedPlugin.js
@@ -42,11 +42,6 @@ class FlagAllModulesAsUsedPlugin {
 					const exportsInfo = moduleGraph.getExportsInfo(module);
 					exportsInfo.setUsedInUnknownWay(runtime);
 					moduleGraph.addExtraReason(module, this.explanation);
-					if (module.factoryMeta === undefined) {
-						module.factoryMeta = {};
-					}
-					/** @type {FactoryMeta} */
-					(module.factoryMeta).sideEffectFree = false;
 				}
 			});
 		});

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -45,6 +45,10 @@ function getForwardedIds(dependencies) {
 	/** @type {Set<string>} */
 	const ids = new Set();
 	for (const dependency of dependencies) {
+		// TODO remove in webpack 6
+		// It may be missing on custom dependency types not extending the base Dependency
+		if (!("getForwardId" in dependency)) continue;
+
 		const id = dependency.getForwardId();
 		if (id === true) return true;
 		if (id !== null) ids.add(id);
@@ -201,6 +205,10 @@ class LazyBarrelController {
 		/** @type {LazyBarrelInfo | undefined} */
 		let info;
 		for (const dep of module.dependencies) {
+			// TODO remove in webpack 6
+			// It may be missing on custom dependency types not extending the base Dependency
+			if (!("getLazyUntil" in dep && "setLazy" in dep)) continue;
+
 			const until = dep.getLazyUntil();
 			if (until === null) continue;
 			if (info === undefined) info = new LazyBarrelInfo();

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -5,10 +5,12 @@
 
 "use strict";
 
-/** @typedef {import("./Dependency")} Dependency */
-/** @typedef {import("./ModuleFactory")} ModuleFactory */
+const Dependency = require("./Dependency");
 
-/** @typedef {Dependency & { _lazyMake: boolean }} LazyMakeDependency */
+/** @typedef {import("./Compilation")} Compilation */
+/** @typedef {import("./Compilation").DependencyConstructor} DependencyConstructor */
+/** @typedef {import("./Module")} Module */
+/** @typedef {import("./ModuleFactory")} ModuleFactory */
 
 /**
  * Defines the deferred request group type used by this module.
@@ -19,10 +21,42 @@
  */
 
 /**
+ * Defines the lazy barrel state type used by this module.
+ * @typedef {object} LazyBarrelState
+ * @property {Set<string> | true} forwardedIds export names requested so far, true for all
+ * @property {LazyBarrelInfo | undefined} lazyBarrelInfo deferred dependencies, undefined until classified
+ */
+
+/**
+ * Defines the lazy barrel unlazy item type used by this module.
+ * @typedef {object} UnlazyDependencyInfo
+ * @property {ModuleFactory} factory factory for the request
+ * @property {Dependency[]} dependencies deferred dependencies of the request
+ * @property {string | undefined} context request context
+ * @property {Module} originModule the lazy barrel module
+ */
+
+/**
+ * Collects the export names a dependency group requests from its target.
+ * @param {Dependency[]} dependencies dependency group resolving to one module
+ * @returns {Set<string> | true} requested export names, true for all
+ */
+function getForwardedIds(dependencies) {
+	/** @type {Set<string>} */
+	const ids = new Set();
+	for (const dependency of dependencies) {
+		const id = dependency.getForwardId();
+		if (id === true) return true;
+		if (id !== null) ids.add(id);
+	}
+	return ids;
+}
+
+/**
  * Tracks the deferred (not yet factorized/built) dependencies of a
  * side-effect-free barrel module and which export names resolve to them.
  */
-class LazyBarrel {
+class LazyBarrelInfo {
 	constructor() {
 		/** @type {Map<string, string>} forward id -> request key */
 		this._forwardIdToRequest = new Map();
@@ -48,7 +82,7 @@ class LazyBarrel {
 			this._requestToDepGroup.set(requestKey, group);
 		}
 		group.dependencies.push(dependency);
-		/** @type {LazyMakeDependency} */ (dependency)._lazyMake = true;
+		dependency.setLazy(true);
 	}
 
 	/**
@@ -101,7 +135,7 @@ class LazyBarrel {
 		 */
 		const unlazy = (group) => {
 			for (const dependency of group.dependencies) {
-				/** @type {LazyMakeDependency} */ (dependency)._lazyMake = false;
+				dependency.setLazy(false);
 			}
 			result.push(group);
 		};
@@ -133,21 +167,141 @@ class LazyBarrel {
 		}
 		return result;
 	}
+}
+
+const esmDependencyCategory = "esm";
+
+/**
+ * Owns the per side-effect-free module lazy barrel state for a `Compilation`,
+ * keeping the deferral bookkeeping out of `Compilation` itself.
+ */
+class LazyBarrel {
+	/**
+	 * @param {Compilation} compilation the owning compilation
+	 */
+	constructor(compilation) {
+		this._compilation = compilation;
+		/** @type {WeakMap<Module, LazyBarrelState>} */
+		this._modules = new WeakMap();
+	}
 
 	/**
-	 * Collects the export names a dependency group requests from its target.
-	 * @param {Dependency[]} dependencies dependency group resolving to one module
-	 * @returns {Set<string> | true} requested export names, true for all
+	 * Classifies the re-export dependencies of a side-effect-free module (lazy barrel)
+	 * into deferrable groups and marks the deferred ones.
+	 * @param {Module} module the module whose dependencies are processed
+	 * @returns {boolean} true, when some dependencies were deferred
 	 */
-	static getForwardedIds(dependencies) {
-		/** @type {Set<string>} */
-		const ids = new Set();
-		for (const dependency of dependencies) {
-			const id = dependency.getForwardId();
-			if (id === true) return true;
-			if (id !== null) ids.add(id);
+	classify(module) {
+		const modules = this._modules;
+		const factoryMeta = module.factoryMeta;
+		if (factoryMeta === undefined || !factoryMeta.sideEffectFree) {
+			return false;
 		}
-		return ids;
+		const dependencyFactories = this._compilation.dependencyFactories;
+		/** @type {LazyBarrelInfo | undefined} */
+		let info;
+		for (const dep of module.dependencies) {
+			const until = dep.getLazyUntil();
+			if (until === null) continue;
+			if (info === undefined) info = new LazyBarrelInfo();
+			if (typeof until === "object" && "local" in until) {
+				info.addTerminal(until.local);
+				continue;
+			}
+			const resourceIdent = dep.getResourceIdentifier();
+			if (resourceIdent === null) continue;
+			const factory = dependencyFactories.get(
+				/** @type {DependencyConstructor} */ (dep.constructor)
+			);
+			if (factory === undefined) continue;
+			const category = dep.category;
+			// Match the request grouping key of `processDependencyForResolving`
+			const requestKey =
+				category === esmDependencyCategory
+					? resourceIdent
+					: `${category}${resourceIdent}`;
+			info.addLazy(requestKey, dep, factory, dep.getContext());
+			if (typeof until === "object") {
+				info.addForwardId(until.id, requestKey);
+			} else if (until === Dependency.LAZY_UNTIL_FALLBACK) {
+				info.addFallback(requestKey);
+			}
+		}
+		const state = modules.get(module);
+		if (info === undefined || info.isEmpty()) {
+			if (state !== undefined) modules.delete(module);
+			return false;
+		}
+		if (state !== undefined) {
+			// barrel classified after its targets were already requested: replay the
+			// recorded ids so processDependency un-lazies and builds those targets now
+			state.lazyBarrelInfo = info;
+			info.request(state.forwardedIds);
+			// stay lazy only while some targets remain deferred
+			return !info.isEmpty();
+		}
+
+		modules.set(module, {
+			forwardedIds: new Set(),
+			lazyBarrelInfo: info
+		});
+
+		return true;
+	}
+
+	/**
+	 * Requests the export names that `dependencies` need from a lazy barrel and
+	 * returns the deferred re-export targets that must be built now. Records the
+	 * request when the barrel's dependencies were not classified yet.
+	 * @param {Module} module the resolved module
+	 * @param {Dependency[]} dependencies the dependencies that resolved to the module
+	 * @returns {UnlazyDependencyInfo[] | undefined} items to process, if any
+	 */
+	request(module, dependencies) {
+		const modules = this._modules;
+		const state = modules.get(module);
+
+		if (state === undefined) {
+			const factoryMeta = module.factoryMeta;
+			if (factoryMeta === undefined || !factoryMeta.sideEffectFree) return;
+			const forwardedIds = getForwardedIds(dependencies);
+			if (forwardedIds !== true && forwardedIds.size === 0) return;
+			modules.set(module, {
+				forwardedIds,
+				lazyBarrelInfo: undefined
+			});
+			return;
+		}
+
+		const forwardedIds = getForwardedIds(dependencies);
+		if (forwardedIds !== true && forwardedIds.size === 0) return;
+		if (state.forwardedIds !== true) {
+			if (forwardedIds === true) state.forwardedIds = true;
+			else for (const id of forwardedIds) state.forwardedIds.add(id);
+		}
+		const info = state.lazyBarrelInfo;
+		// Pending requests will be replayed during `classify` later
+		if (info === undefined) return;
+		const groups = info.request(forwardedIds);
+		if (groups.length === 0) return;
+		return groups.map((group) => ({
+			factory: group.factory,
+			dependencies: group.dependencies,
+			context: group.context,
+			originModule: module
+		}));
+	}
+
+	/**
+	 * Queues the deferred dependency groups of a lazy barrel requested by a single dependency.
+	 * @param {Module} module the resolved module of the dependency
+	 * @param {Dependency} dependency the requesting dependency
+	 * @param {{ factory: ModuleFactory, dependencies: Dependency[], context: string | undefined, originModule: Module | null }[]} sortedDependencies item list to append to
+	 */
+	unlazyForDependency(module, dependency, sortedDependencies) {
+		const unlazyItems = this.request(module, [dependency]);
+		if (unlazyItems === undefined) return;
+		for (const item of unlazyItems) sortedDependencies.push(item);
 	}
 }
 

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -1,0 +1,154 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Haijie Xie @hai-x
+*/
+
+"use strict";
+
+/** @typedef {import("./Dependency")} Dependency */
+/** @typedef {import("./ModuleFactory")} ModuleFactory */
+
+/** @typedef {Dependency & { _lazyMake: boolean }} LazyMakeDependency */
+
+/**
+ * Defines the deferred request group type used by this module.
+ * @typedef {object} DependencyGroup
+ * @property {ModuleFactory} factory factory for the request
+ * @property {Dependency[]} dependencies deferred dependencies of the request
+ * @property {string | undefined} context request context
+ */
+
+/**
+ * Tracks the deferred (not yet factorized/built) dependencies of a
+ * side-effect-free barrel module and which export names resolve to them.
+ */
+class LazyBarrel {
+	constructor() {
+		/** @type {Map<string, string>} forward id -> request key */
+		this._forwardIdToRequest = new Map();
+		/** @type {Map<string, DependencyGroup>} request key -> still-deferred group */
+		this._requestToDepGroup = new Map();
+		/** @type {Set<string> | undefined} locally provided export names */
+		this._terminalIds = undefined;
+		/** @type {Set<string> | undefined} request keys of star re-exports */
+		this._fallbackRequests = undefined;
+	}
+
+	/**
+	 * Defers a dependency under its request key.
+	 * @param {string} requestKey request key
+	 * @param {Dependency} dependency dependency to defer
+	 * @param {ModuleFactory} factory factory for the request
+	 * @param {string | undefined} context request context
+	 */
+	addLazy(requestKey, dependency, factory, context) {
+		let group = this._requestToDepGroup.get(requestKey);
+		if (group === undefined) {
+			group = { factory, dependencies: [], context };
+			this._requestToDepGroup.set(requestKey, group);
+		}
+		group.dependencies.push(dependency);
+		/** @type {LazyMakeDependency} */ (dependency)._lazyMake = true;
+	}
+
+	/**
+	 * Maps an export name to the request providing it.
+	 * @param {string} id export name
+	 * @param {string} requestKey request key
+	 */
+	addForwardId(id, requestKey) {
+		this._forwardIdToRequest.set(id, requestKey);
+	}
+
+	/**
+	 * Registers a locally provided export name.
+	 * @param {string} id export name
+	 */
+	addTerminal(id) {
+		if (this._terminalIds === undefined) this._terminalIds = new Set();
+		this._terminalIds.add(id);
+	}
+
+	/**
+	 * Registers a star re-export request key.
+	 * @param {string} requestKey request key
+	 */
+	addFallback(requestKey) {
+		if (this._fallbackRequests === undefined) {
+			this._fallbackRequests = new Set();
+		}
+		this._fallbackRequests.add(requestKey);
+	}
+
+	/**
+	 * Returns whether nothing is deferred.
+	 * @returns {boolean} true, when no dependency is deferred
+	 */
+	isEmpty() {
+		return this._requestToDepGroup.size === 0;
+	}
+
+	/**
+	 * Removes and returns the groups needed to provide the requested export names.
+	 * @param {Set<string> | true} forwardedIds requested export names, true for all
+	 * @returns {DependencyGroup[]} groups that must be processed now
+	 */
+	request(forwardedIds) {
+		/** @type {DependencyGroup[]} */
+		const result = [];
+		/**
+		 * @param {DependencyGroup} group taken group
+		 */
+		const unlazy = (group) => {
+			for (const dependency of group.dependencies) {
+				/** @type {LazyMakeDependency} */ (dependency)._lazyMake = false;
+			}
+			result.push(group);
+		};
+		if (forwardedIds === true) {
+			for (const group of this._requestToDepGroup.values()) unlazy(group);
+			this._requestToDepGroup.clear();
+			return result;
+		}
+		/**
+		 * @param {string} requestKey request key to take
+		 */
+		const take = (requestKey) => {
+			const group = this._requestToDepGroup.get(requestKey);
+			if (group === undefined) return;
+			this._requestToDepGroup.delete(requestKey);
+			unlazy(group);
+		};
+		for (const id of forwardedIds) {
+			if (this._terminalIds !== undefined && this._terminalIds.has(id)) {
+				continue;
+			}
+			const requestKey = this._forwardIdToRequest.get(id);
+			if (requestKey !== undefined) {
+				take(requestKey);
+			} else if (this._fallbackRequests !== undefined) {
+				// unknown name: any star re-export may provide it
+				for (const fallbackKey of this._fallbackRequests) take(fallbackKey);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Collects the export names a dependency group requests from its target.
+	 * @param {Dependency[]} dependencies dependency group resolving to one module
+	 * @returns {Set<string> | true} requested export names, true for all
+	 */
+	static getForwardedIds(dependencies) {
+		/** @type {Set<string>} */
+		const ids = new Set();
+		for (const dependency of dependencies) {
+			const id = dependency.getForwardId();
+			if (id === true) return true;
+			if (id !== null) ids.add(id);
+		}
+		return ids;
+	}
+}
+
+module.exports = LazyBarrel;

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -175,7 +175,7 @@ const esmDependencyCategory = "esm";
  * Owns the per side-effect-free module lazy barrel state for a `Compilation`,
  * keeping the deferral bookkeeping out of `Compilation` itself.
  */
-class LazyBarrel {
+class LazyBarrelController {
 	/**
 	 * @param {Compilation} compilation the owning compilation
 	 */
@@ -305,4 +305,4 @@ class LazyBarrel {
 	}
 }
 
-module.exports = LazyBarrel;
+module.exports = LazyBarrelController;

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -19,6 +19,7 @@ const DEFAULT_EXPORT_NAME = "default";
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
+/** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ModuleGraphConnection").ConnectionState} ConnectionState */
@@ -47,6 +48,14 @@ class HarmonyExportExpressionDependency extends NullDependency {
 
 	get type() {
 		return "harmony export expression";
+	}
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
+	 */
+	getLazyUntil() {
+		return { local: DEFAULT_EXPORT_NAME };
 	}
 
 	/**

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -38,6 +38,7 @@ const processExportInfo = require("./processExportInfo");
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
 /** @typedef {import("../Dependency").GetConditionFn} GetConditionFn */
+/** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../Dependency").RawReferencedExports} RawReferencedExports */
 /** @typedef {import("../Dependency").ReferencedExports} ReferencedExports */
 /** @typedef {import("../Dependency").TRANSITIVE} TRANSITIVE */
@@ -537,6 +538,24 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 
 	get type() {
 		return "harmony export imported specifier";
+	}
+
+	/**
+	 * Returns the export name this dependency requests from its target module (lazy barrel optimization).
+	 * @returns {string | true | null} export name, true for all exports, null for none
+	 */
+	getForwardId() {
+		return this.ids.length > 0 ? this.ids[0] : true;
+	}
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
+	 */
+	getLazyUntil() {
+		return this.name !== null
+			? { id: this.name }
+			: Dependency.LAZY_UNTIL_FALLBACK;
 	}
 
 	/**

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -14,6 +14,7 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
+/** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ModuleGraphConnection").ConnectionState} ConnectionState */
@@ -40,6 +41,14 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 
 	get type() {
 		return "harmony export specifier";
+	}
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
+	 */
+	getLazyUntil() {
+		return { local: this.name };
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -114,6 +114,22 @@ class HarmonyImportDependency extends ModuleDependency {
 	}
 
 	/**
+	 * Whether the lazy barrel currently defers creating this dependency's target module (lazy barrel optimization).
+	 * @returns {boolean} true while deferred, so it must not be processed or rendered
+	 */
+	isLazy() {
+		return this._lazyMake;
+	}
+
+	/**
+	 * Sets whether the lazy barrel defers creating this dependency's target module (lazy barrel optimization).
+	 * @param {boolean} value true to defer, false to create it now
+	 */
+	setLazy(value) {
+		this._lazyMake = value;
+	}
+
+	/**
 	 * Returns true if this dependency can be concatenated
 	 * @returns {boolean} true if this dependency can be concatenated
 	 */
@@ -383,7 +399,7 @@ HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate extends
 
 		const connection = moduleGraph.getConnection(dep);
 		// deferred by lazy barrel: never resolved, must not render a missing module
-		if (connection === undefined && dep._lazyMake) {
+		if (connection === undefined && dep.isLazy()) {
 			return;
 		}
 		if (connection && !connection.isTargetActive(runtime)) return;

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -106,6 +106,7 @@ class HarmonyImportDependency extends ModuleDependency {
 		super(request, sourceOrder);
 		this.phase = phase;
 		this.attributes = attributes;
+		this._lazyMake = false;
 	}
 
 	get category() {
@@ -381,6 +382,10 @@ HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate extends
 		const { module, chunkGraph, moduleGraph, runtime } = templateContext;
 
 		const connection = moduleGraph.getConnection(dep);
+		// deferred by lazy barrel: never resolved, must not render a missing module
+		if (connection === undefined && dep._lazyMake) {
+			return;
+		}
 		if (connection && !connection.isTargetActive(runtime)) return;
 
 		const referencedModule = connection && connection.module;

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -5,14 +5,15 @@
 
 "use strict";
 
+const Dependency = require("../Dependency");
 const Module = require("../Module");
 const { JAVASCRIPT_TYPE } = require("../ModuleSourceTypeConstants");
 const makeSerializable = require("../util/makeSerializable");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
-/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").GetConditionFn} GetConditionFn */
+/** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ModuleGraphConnection").ConnectionState} ConnectionState */
@@ -33,6 +34,22 @@ class HarmonyImportSideEffectDependency extends HarmonyImportDependency {
 
 	get type() {
 		return "harmony side effect evaluation";
+	}
+
+	/**
+	 * Returns the export name this dependency requests from its target module (lazy barrel optimization).
+	 * @returns {string | true | null} export name, true for all exports, null for none
+	 */
+	getForwardId() {
+		return null;
+	}
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
+	 */
+	getLazyUntil() {
+		return Dependency.LAZY_UNTIL_REQUEST;
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -136,6 +136,14 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	}
 
 	/**
+	 * Returns the export name this dependency requests from its target module (lazy barrel optimization).
+	 * @returns {string | true | null} export name, true for all exports, null for none
+	 */
+	getForwardId() {
+		return this.ids.length > 0 ? this.ids[0] : true;
+	}
+
+	/**
 	 * Returns the imported ids.
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @returns {Ids} the imported ids

--- a/lib/dll/DllPlugin.js
+++ b/lib/dll/DllPlugin.js
@@ -11,6 +11,7 @@ const LibManifestPlugin = require("./LibManifestPlugin");
 
 /** @typedef {import("../../declarations/plugins/dll/DllPlugin").DllPluginOptions} DllPluginOptions */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Module").FactoryMeta} FactoryMeta */
 /** @typedef {import("./DllEntryPlugin").Entries} Entries */
 /** @typedef {import("./DllEntryPlugin").Options} Options */
 
@@ -68,6 +69,21 @@ class DllPlugin {
 		new LibManifestPlugin({ ...this.options, entryOnly }).apply(compiler);
 		if (!entryOnly) {
 			new FlagAllModulesAsUsedPlugin(PLUGIN_NAME).apply(compiler);
+			compiler.hooks.compilation.tap(
+				PLUGIN_NAME,
+				(_compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.module.tap(
+						{ name: PLUGIN_NAME, stage: 10 },
+						(module) => {
+							if (module.factoryMeta === undefined) {
+								module.factoryMeta = {};
+							}
+							module.factoryMeta.sideEffectFree = false;
+							return module;
+						}
+					);
+				}
+			);
 		}
 	}
 }

--- a/test/configCases/lazy-barrel/basic/index.js
+++ b/test/configCases/lazy-barrel/basic/index.js
@@ -1,0 +1,25 @@
+import { b as a, cc } from "./named-barrel";
+import { b as c, d } from "./mixed-barrel";
+import { b } from "./star-barrel";
+import * as nested from "./nested-barrel";
+import { inner } from "./ns-barrel";
+// two consumers of one barrel: `one` requests `a` (builds the barrel),
+// `two` requests `b` after the barrel is already built (lazyItems path)
+import { one } from "./shared-barrel/one";
+import { two } from "./shared-barrel/two";
+
+it("should provide the requested re-exports across barrel shapes", () => {
+	expect(a).toBe("a");
+	expect(cc).toBe("c");
+	expect(b).toBe("b");
+	expect(c).toBe("c");
+	expect(d).toBe("d");
+	expect(nested.a).toBe("b");
+	expect(inner.p).toBe("p");
+	expect(inner.q).toBe("q");
+});
+
+it("should build a re-export target requested after the barrel was built", () => {
+	expect(one).toBe("abc");
+	expect(two).toBe("b");
+});

--- a/test/configCases/lazy-barrel/basic/mixed-barrel/a.js
+++ b/test/configCases/lazy-barrel/basic/mixed-barrel/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/configCases/lazy-barrel/basic/mixed-barrel/b.js
+++ b/test/configCases/lazy-barrel/basic/mixed-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/lazy-barrel/basic/mixed-barrel/c.js
+++ b/test/configCases/lazy-barrel/basic/mixed-barrel/c.js
@@ -1,0 +1,1 @@
+export const value = "c";

--- a/test/configCases/lazy-barrel/basic/mixed-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/mixed-barrel/index.js
@@ -1,0 +1,4 @@
+export { default as a } from "./a";
+export * from "./b";
+export { value as b } from "./c";
+export const d = "d";

--- a/test/configCases/lazy-barrel/basic/named-barrel/a.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/configCases/lazy-barrel/basic/named-barrel/b.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/lazy-barrel/basic/named-barrel/c.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/configCases/lazy-barrel/basic/named-barrel/d.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/d.js
@@ -1,0 +1,1 @@
+export const d = "d";

--- a/test/configCases/lazy-barrel/basic/named-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/index.js
@@ -1,0 +1,7 @@
+export { a as b } from "./a";
+export { b as c } from "./b";
+
+import { c as cc } from "./c";
+import { d as dd } from "./d";
+
+export { cc, dd };

--- a/test/configCases/lazy-barrel/basic/nested-barrel/a.js
+++ b/test/configCases/lazy-barrel/basic/nested-barrel/a.js
@@ -1,0 +1,4 @@
+import { b as a } from "./b";
+
+export { a };
+export { c } from "./c";

--- a/test/configCases/lazy-barrel/basic/nested-barrel/b.js
+++ b/test/configCases/lazy-barrel/basic/nested-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/lazy-barrel/basic/nested-barrel/c.js
+++ b/test/configCases/lazy-barrel/basic/nested-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/configCases/lazy-barrel/basic/nested-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/nested-barrel/index.js
@@ -1,0 +1,2 @@
+export { a } from "./a";
+export { c } from "./c";

--- a/test/configCases/lazy-barrel/basic/ns-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/ns-barrel/index.js
@@ -1,0 +1,2 @@
+export * as inner from "./inner";
+export { x } from "./other";

--- a/test/configCases/lazy-barrel/basic/ns-barrel/inner-p.js
+++ b/test/configCases/lazy-barrel/basic/ns-barrel/inner-p.js
@@ -1,0 +1,1 @@
+export const p = "p";

--- a/test/configCases/lazy-barrel/basic/ns-barrel/inner-q.js
+++ b/test/configCases/lazy-barrel/basic/ns-barrel/inner-q.js
@@ -1,0 +1,1 @@
+export const q = "q";

--- a/test/configCases/lazy-barrel/basic/ns-barrel/inner.js
+++ b/test/configCases/lazy-barrel/basic/ns-barrel/inner.js
@@ -1,0 +1,2 @@
+export { p } from "./inner-p";
+export { q } from "./inner-q";

--- a/test/configCases/lazy-barrel/basic/ns-barrel/other.js
+++ b/test/configCases/lazy-barrel/basic/ns-barrel/other.js
@@ -1,0 +1,1 @@
+export const x = "x";

--- a/test/configCases/lazy-barrel/basic/package.json
+++ b/test/configCases/lazy-barrel/basic/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "basic",
+	"version": "1.0.0",
+	"sideEffects": false
+}

--- a/test/configCases/lazy-barrel/basic/shared-barrel/a.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/configCases/lazy-barrel/basic/shared-barrel/b.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/lazy-barrel/basic/shared-barrel/barrel.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/barrel.js
@@ -1,0 +1,4 @@
+export { a } from "./a";
+export { b } from "./b";
+export { c } from "./c";
+export { d } from "./d";

--- a/test/configCases/lazy-barrel/basic/shared-barrel/bc.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/bc.js
@@ -1,0 +1,2 @@
+import { b, c } from "./barrel";
+export const bc = b + c;

--- a/test/configCases/lazy-barrel/basic/shared-barrel/c.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/configCases/lazy-barrel/basic/shared-barrel/d.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/d.js
@@ -1,0 +1,1 @@
+export const d = "d";

--- a/test/configCases/lazy-barrel/basic/shared-barrel/one.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/one.js
@@ -1,0 +1,3 @@
+import { a } from "./barrel";
+import { bc } from "./bc";
+export const one = a + bc;

--- a/test/configCases/lazy-barrel/basic/shared-barrel/two.js
+++ b/test/configCases/lazy-barrel/basic/shared-barrel/two.js
@@ -1,0 +1,3 @@
+import { b } from "./barrel";
+
+export const two = b;

--- a/test/configCases/lazy-barrel/basic/star-barrel/a.js
+++ b/test/configCases/lazy-barrel/basic/star-barrel/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/configCases/lazy-barrel/basic/star-barrel/b.js
+++ b/test/configCases/lazy-barrel/basic/star-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/configCases/lazy-barrel/basic/star-barrel/c.js
+++ b/test/configCases/lazy-barrel/basic/star-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/configCases/lazy-barrel/basic/star-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/star-barrel/index.js
@@ -1,0 +1,4 @@
+export { c } from "./c";
+export * from "./a";
+export * from "./b";
+export const d = "d";

--- a/test/configCases/lazy-barrel/basic/test.config.js
+++ b/test/configCases/lazy-barrel/basic/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return `bundle${i}.js`;
+	}
+};

--- a/test/configCases/lazy-barrel/basic/test.filter.js
+++ b/test/configCases/lazy-barrel/basic/test.filter.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// Node v16 doesn't support recursive readdir
+module.exports = () => !process.version.startsWith("v16");

--- a/test/configCases/lazy-barrel/basic/webpack.config.js
+++ b/test/configCases/lazy-barrel/basic/webpack.config.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+/** @type {string[]} */
+const allModules = fs
+	.readdirSync(__dirname, { recursive: true })
+	.filter((rel) => typeof rel === "string")
+	.map((rel) => path.resolve(__dirname, rel))
+	.filter((file) => {
+		const name = path.basename(file);
+		return (
+			fs.statSync(file).isFile() &&
+			name !== "package.json" &&
+			name !== "webpack.config.js" &&
+			name !== "test.filter.js" &&
+			name !== "test.config.js"
+		);
+	});
+
+// re-export targets that must stay deferred; `named-barrel/d.js` is a locally
+// imported binding re-exported unused, which webpack keeps lazy too
+const lazyModules = new Set(
+	[
+		"named-barrel/b.js",
+		"named-barrel/d.js",
+		"mixed-barrel/a.js",
+		"mixed-barrel/b.js",
+		"star-barrel/c.js",
+		"nested-barrel/c.js",
+		"ns-barrel/other.js",
+		"shared-barrel/d.js"
+	].map((file) => path.resolve(__dirname, file))
+);
+
+/** @type {(variant: boolean) => import("../../../../").Configuration} */
+const config = (variant) => ({
+	optimization: {
+		inlineExports: variant,
+		providedExports: variant,
+		concatenateModules: variant
+	},
+	plugins: [
+		(compiler) => {
+			const created = new Set();
+			compiler.hooks.thisCompilation.tap(
+				"Test",
+				(compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.createModule.tap("Test", (createData) => {
+						created.add(createData.resource);
+					});
+				}
+			);
+			compiler.hooks.done.tap("Test", () => {
+				for (const module of lazyModules) {
+					expect(created.has(module)).toBe(false);
+				}
+				expect(
+					allModules.filter(
+						(module) => !created.has(module) && !lazyModules.has(module)
+					)
+				).toEqual([]);
+			});
+		}
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [config(false), config(true)];

--- a/test/configCases/side-effects/side-effects-values/index.js
+++ b/test/configCases/side-effects/side-effects-values/index.js
@@ -3,16 +3,12 @@ import booleanValueModule from "boolean-value-module";
 import { log as globValueModuleLog } from "glob-value-module/tracker";
 import globValueModule from "glob-value-module";
 
-it("should handle a boolean", function() {
+it("should handle a boolean", function () {
 	expect(booleanValueModule).toBe("def");
 	expect(booleanValueModuleLog).toEqual(["index.js"]);
 });
 
-it("should handle globs", function() {
+it("should handle globs", function () {
 	expect(globValueModule).toBe("def");
-	expect(globValueModuleLog).toEqual([
-		"./src/a.js",
-		"a.js",
-		"index.js",
-	]);
+	expect(globValueModuleLog).toEqual(["index.js"]);
 });

--- a/test/statsCases/side-effects-issue-7428/__snapshots__/StatsTest.snap
+++ b/test/statsCases/side-effects-issue-7428/__snapshots__/StatsTest.snap
@@ -7,8 +7,13 @@ runtime modules X KiB 9 modules
 cacheable modules X bytes
   modules by path ./components/src/ X bytes
     orphan modules X bytes [orphan]
-      modules by path ./components/src/CompAB/*.js X bytes 2 modules
-      modules by path ./components/src/CompC/*.js X bytes 2 modules
+      ./components/src/CompAB/CompB.js X bytes [orphan] [built]
+        [only some exports used: default]
+        [inactive] from origin ./components/src/CompAB/index.js
+          [inactive] harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
+          [inactive] harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
+        [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
+        harmony import specifier ./components ./main.js 4:15-20 (skipped side-effect-free modules)
       ./components/src/index.js X bytes [orphan] [built]
         [module unused]
         [inactive] from origin ./main.js + 1 modules
@@ -18,6 +23,11 @@ cacheable modules X bytes
         [inactive] from origin ./foo.js
           [inactive] harmony side effect evaluation ./components ./foo.js 1:0-37
           [inactive] harmony import specifier ./components ./foo.js 3:20-25
+      ./components/src/CompAB/index.js X bytes [orphan] [built]
+        [module unused]
+        [inactive] harmony side effect evaluation ./CompAB ./components/src/index.js 1:0-40
+        [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40
+        [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40
     code generated modules X bytes [code generated]
       ./components/src/CompAB/CompA.js X bytes [built] [code generated]
         [only some exports used: default]
@@ -28,15 +38,9 @@ cacheable modules X bytes
         harmony import specifier ./components ./foo.js 3:20-25 (skipped side-effect-free modules)
         harmony import specifier ./components ./main.js + 1 modules ./main.js 3:15-20 (skipped side-effect-free modules)
       ./components/src/CompAB/utils.js X bytes [built] [code generated]
-        from origin ./components/src/CompAB/CompA.js
-          [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompA.js 1:0-35
-          harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
-        from origin ./components/src/CompAB/CompB.js
-          [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompB.js 1:0-30
-          harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
-        from origin ./main.js + 1 modules
-          [inactive] harmony side effect evaluation ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 1:0-30
-          harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
+        harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
+        harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
+        harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
   modules by path ./*.js X bytes
     ./main.js + 1 modules X bytes [built] [code generated]
       [no exports used]

--- a/test/statsCases/side-effects-simple-unused/__snapshots__/StatsTest.snap
+++ b/test/statsCases/side-effects-simple-unused/__snapshots__/StatsTest.snap
@@ -31,14 +31,6 @@ exports[`StatsTestCases side-effects-simple-unused should print correct stats fo
     [inactive] harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
   harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
   [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30 (skipped side-effect-free modules)
-./node_modules/pmodule/a.js X bytes [orphan] [built]
-  [module unused]
-  [inactive] from origin ./index.js + 2 modules
-    [inactive] harmony side effect evaluation ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
-    [inactive] harmony export imported specifier ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
-  [inactive] from origin ./node_modules/pmodule/index.js
-    [inactive] harmony side effect evaluation ./a ./node_modules/pmodule/index.js 1:0-20
-    [inactive] harmony export imported specifier ./a ./node_modules/pmodule/index.js 1:0-20
 ./node_modules/pmodule/b.js X bytes [orphan] [built]
   [module unused]
   [inactive] from origin ./index.js + 2 modules

--- a/test/watchCases/lazy-barrel/build-on-new-import/0/index.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/0/index.js
@@ -1,0 +1,8 @@
+import { a } from "./pkg";
+
+it("should not build the unused re-export target initially", () => {
+	expect(a).toBe("a");
+	expect(STATS_JSON.modules.some((m) => m.name.endsWith("pkg/b.js"))).toBe(
+		false
+	);
+});

--- a/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/a.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/b.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/index.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/0/pkg/index.js
@@ -1,0 +1,2 @@
+export { a } from "./a";
+export { b } from "./b";

--- a/test/watchCases/lazy-barrel/build-on-new-import/1/index.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/1/index.js
@@ -1,0 +1,9 @@
+import { a, b } from "./pkg";
+
+it("should build the newly imported re-export target on rebuild", () => {
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(STATS_JSON.modules.some((m) => m.name.endsWith("pkg/b.js"))).toBe(
+		true
+	);
+});

--- a/test/watchCases/lazy-barrel/build-on-new-import/webpack.config.js
+++ b/test/watchCases/lazy-barrel/build-on-new-import/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /pkg/,
+				sideEffects: false
+			}
+		]
+	}
+};

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/index.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/index.js
@@ -1,0 +1,15 @@
+import { a } from "./pkg";
+
+const built = (file) =>
+	STATS_JSON.modules.some((m) => m.name.endsWith(file));
+
+it("should provide the requested re-export with unsafe cache", () => {
+	expect(a).toBe("a");
+});
+
+it("should not build the nested barrel or its targets initially", () => {
+	expect(built("pkg/a.js")).toBe(true);
+	expect(built("pkg/sub/index.js")).toBe(false);
+	expect(built("pkg/sub/b.js")).toBe(false);
+	expect(built("pkg/sub/c.js")).toBe(false);
+});

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/a.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/index.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/index.js
@@ -1,0 +1,2 @@
+export { a } from "./a";
+export { b, c } from "./sub";

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/b.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/c.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/c.js
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/index.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/0/pkg/sub/index.js
@@ -1,0 +1,2 @@
+export { b } from "./b";
+export { c } from "./c";

--- a/test/watchCases/lazy-barrel/unsafe-cache/1/index.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/1/index.js
@@ -1,0 +1,13 @@
+import { a, b } from "./pkg";
+
+const built = (file) =>
+	STATS_JSON.modules.some((m) => m.name.endsWith(file));
+
+// requesting `b` resolves the nested barrel from the unsafe cache and must
+// un-defer its targets (the _unlazyBarrelForDependency path)
+it("should build a newly requested re-export through the unsafe-cached nested barrel", () => {
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(built("pkg/sub/index.js")).toBe(true);
+	expect(built("pkg/sub/b.js")).toBe(true);
+});

--- a/test/watchCases/lazy-barrel/unsafe-cache/2/index.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/2/index.js
@@ -1,0 +1,11 @@
+import { a, b, c } from "./pkg";
+
+const built = (file) =>
+	STATS_JSON.modules.some((m) => m.name.endsWith(file));
+
+it("should keep the nested re-exports intact on a later rebuild", () => {
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(c).toBe("c");
+	expect(built("pkg/sub/c.js")).toBe(true);
+});

--- a/test/watchCases/lazy-barrel/unsafe-cache/webpack.config.js
+++ b/test/watchCases/lazy-barrel/unsafe-cache/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	cache: {
+		type: "memory"
+	},
+	module: {
+		unsafeCache: true,
+		rules: [
+			{
+				test: /pkg/,
+				sideEffects: false
+			}
+		]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -4799,6 +4799,8 @@ declare class ConstDependency extends NullDependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_FALLBACK: "*";
+	static LAZY_UNTIL_REQUEST: "@";
 }
 declare class ConstDependencyTemplate extends NullDependencyTemplate {
 	constructor();
@@ -5854,6 +5856,16 @@ declare class Dependency {
 	couldAffectReferencingModule(): boolean | symbol;
 
 	/**
+	 * Returns the export name this dependency requests from its target module (lazy barrel optimization).
+	 */
+	getForwardId(): null | string | true;
+
+	/**
+	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
+	 */
+	getLazyUntil(): null | "*" | "@" | { id: string } | { local: string };
+
+	/**
 	 * Returns the referenced module and export
 	 * @deprecated
 	 */
@@ -5946,6 +5958,8 @@ declare class Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_FALLBACK: "*";
+	static LAZY_UNTIL_REQUEST: "@";
 }
 declare interface DependencyConstructor {
 	new (...args: any[]): Dependency;
@@ -9142,6 +9156,8 @@ declare class HarmonyImportDependency extends ModuleDependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_FALLBACK: "*";
+	static LAZY_UNTIL_REQUEST: "@";
 }
 declare class HarmonyImportDependencyTemplate extends DependencyTemplate {
 	constructor();
@@ -15065,6 +15081,8 @@ declare class ModuleDependency extends Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_FALLBACK: "*";
+	static LAZY_UNTIL_REQUEST: "@";
 }
 
 /**
@@ -17386,6 +17404,8 @@ declare class NullDependency extends Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_FALLBACK: "*";
+	static LAZY_UNTIL_REQUEST: "@";
 }
 declare class NullDependencyTemplate extends DependencyTemplate {
 	constructor();

--- a/types.d.ts
+++ b/types.d.ts
@@ -5866,6 +5866,16 @@ declare class Dependency {
 	getLazyUntil(): null | "*" | "@" | { id: string } | { local: string };
 
 	/**
+	 * Whether the lazy barrel currently defers creating this dependency's target module (lazy barrel optimization).
+	 */
+	isLazy(): boolean;
+
+	/**
+	 * Sets whether the lazy barrel defers creating this dependency's target module (lazy barrel optimization).
+	 */
+	setLazy(value: boolean): void;
+
+	/**
 	 * Returns the referenced module and export
 	 * @deprecated
 	 */


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

**What kind of change does this PR introduce?**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

This is a port of rspack's lazy barrel optimization ([RFC discussion](https://github.com/web-infra-dev/rspack/discussions/11273), [docs](https://rspack.rs/guide/optimization/lazy-barrel)).

When importing from a `side-effect-free` barrel file, we defers `factorizing/resolving/building` the re-export target modules until an importer actually requests those export names, so unused re-export targets are never built, it can significantly speeding up builds that import a few names from large barrels (e.g. component libraries). 

The local benchmark on a M4 MacBook Pro:

```
package             import     module counts without lazybarrel  module counts with lazybarrel  modules  time without lazybarrel  time with lazybarrel  speedup
------------------  ---------  --------------------------------  -----------------------------  -------  -----------------------  --------------------  -------
antd                Button                                 1449                            310     -79%                    541ms                 126ms    4.29x
lucide-react        Camera                                 1730                             15     -99%                    205ms                  23ms    8.91x
material-ui-core    Button                                  489                            137     -72%                    135ms                  47ms    2.87x
material-ui-icons   Menu                                   5712                            124     -98%                    655ms                  63ms   10.40x
react-use           useToggle                               146                              6     -96%                     31ms                   6ms    5.17x
recharts            LineChart                               565                            320     -43%                    155ms                  89ms    1.74x
rxjs                map                                     226                             19     -92%                     36ms                   8ms    4.50x
tabler-icons-react  IconHome                               6155                              8    -100%                    671ms                  34ms   19.74x
```

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a pplications. -->

No

**If relevant, what needs to be documented once your changes are merged or what**

<!-- List all the information that needs to be added to the documentation afterdocumented in this PR. -->

Document `experiments.lazyBarrel` on the Experiments page: requires `sideEffectodule.rules[].sideEffects`), ESM only, and skipped modules never resolve/build so their resolve/loader errors and "export not found" warnings may not surface.

**Use of AI**

Partial