### PR TITLE
perf: release inner-graph state, fast-path inlined-export checks and skip inlined entry re-parse

### DIFF
--- a/.changeset/avoid-entry-iife-fast-path.md
+++ b/.changeset/avoid-entry-iife-fast-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip re-parsing the inlined entry module when no renaming is needed.

--- a/.changeset/concatenate-hash-micro-opts.md
+++ b/.changeset/concatenate-hash-micro-opts.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce allocations in export hashing and concatenation name lookups.

--- a/.changeset/inner-graph-release-and-inline-fast-paths.md
+++ b/.changeset/inner-graph-release-and-inline-fast-paths.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Release inner-graph state after use and speed up inlined-export checks.

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -842,16 +842,14 @@ class ExportsInfo {
 			// follow redirects for the fast-path flag; InlinedUsedName can only
 			// exist on a level whose (redirected) exportsInfo is marked
 			let hasInlined = false;
-			for (
-				/** @type {ExportsInfo | undefined} */
-				let e = exportsInfo;
-				e !== undefined;
-				e = e._redirectTo
-			) {
+			/** @type {ExportsInfo | undefined} */
+			let e = exportsInfo;
+			while (e !== undefined) {
 				if (e._hasInlinedExports) {
 					hasInlined = true;
 					break;
 				}
+				e = e._redirectTo;
 			}
 			if (!hasInlined && i === last) return false;
 			const info = exportsInfo.getReadOnlyExportInfo(name[i]);

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -142,6 +142,17 @@ class ExportsInfo {
 		this._exportsAreOrdered = false;
 		/** @type {ExportsInfo=} */
 		this._redirectTo = undefined;
+		// fast-path flag for hasInlinedUsedName; set by InlineExportsPlugin
+		/** @type {boolean} */
+		this._hasInlinedExports = false;
+	}
+
+	/**
+	 * Records that an owned export got an inlined used name.
+	 * @returns {void}
+	 */
+	markInlinedExports() {
+		this._hasInlinedExports = true;
 	}
 
 	/**
@@ -813,6 +824,52 @@ class ExportsInfo {
 		}
 		const info = this.getReadOnlyExportInfo(name);
 		return info.getUsedName(name, runtime);
+	}
+
+	/**
+	 * Checks whether `getUsedName(name, runtime)` would return an `InlinedUsedName`,
+	 * without allocating intermediate used-name arrays (hot path for connection conditions).
+	 * @param {ExportInfoName[]} name the export name path
+	 * @param {RuntimeSpec} runtime check usage for this runtime only
+	 * @returns {boolean} true when the used name resolves to an inlined value
+	 */
+	hasInlinedUsedName(name, runtime) {
+		if (name.length === 0) return false;
+		/** @type {ExportsInfo} */
+		let exportsInfo = this;
+		const last = name.length - 1;
+		for (let i = 0; ; i++) {
+			// follow redirects for the fast-path flag; InlinedUsedName can only
+			// exist on a level whose (redirected) exportsInfo is marked
+			let hasInlined = false;
+			for (
+				/** @type {ExportsInfo | undefined} */
+				let e = exportsInfo;
+				e !== undefined;
+				e = e._redirectTo
+			) {
+				if (e._hasInlinedExports) {
+					hasInlined = true;
+					break;
+				}
+			}
+			if (!hasInlined && i === last) return false;
+			const info = exportsInfo.getReadOnlyExportInfo(name[i]);
+			if (hasInlined) {
+				const x = info.getUsedName(name[i], runtime);
+				if (x === false) return false;
+				if (x instanceof InlinedUsedName) return true;
+				if (i === last) return false;
+			}
+			if (
+				info.exportsInfo &&
+				info.getUsed(runtime) === UsageState.OnlyPropertiesUsed
+			) {
+				exportsInfo = info.exportsInfo;
+				continue;
+			}
+			return false;
+		}
 	}
 
 	/**

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -890,18 +890,27 @@ class ExportsInfo {
 	 * @returns {void}
 	 */
 	_updateHash(hash, runtime, alreadyVisitedExportsInfo) {
-		const set = new Set(alreadyVisitedExportsInfo);
-		set.add(this);
+		// add/delete keeps path semantics without copying the set per level
+		alreadyVisitedExportsInfo.add(this);
 		for (const exportInfo of this.orderedExports) {
 			if (exportInfo.hasInfo(this._otherExportsInfo, runtime)) {
-				exportInfo._updateHash(hash, runtime, set);
+				exportInfo._updateHash(hash, runtime, alreadyVisitedExportsInfo);
 			}
 		}
-		this._sideEffectsOnlyInfo._updateHash(hash, runtime, set);
-		this._otherExportsInfo._updateHash(hash, runtime, set);
+		this._sideEffectsOnlyInfo._updateHash(
+			hash,
+			runtime,
+			alreadyVisitedExportsInfo
+		);
+		this._otherExportsInfo._updateHash(
+			hash,
+			runtime,
+			alreadyVisitedExportsInfo
+		);
 		if (this._redirectTo !== undefined) {
-			this._redirectTo._updateHash(hash, runtime, set);
+			this._redirectTo._updateHash(hash, runtime, alreadyVisitedExportsInfo);
 		}
+		alreadyVisitedExportsInfo.delete(this);
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -10,7 +10,8 @@ const InitFragment = require("../InitFragment");
 const Template = require("../Template");
 const {
 	InlinedUsedName,
-	isExportInlined
+	isExportInlined,
+	isInlineExportsEnabled
 } = require("../optimize/InlineExports");
 const {
 	getDependencyUsedByExportsCondition
@@ -166,6 +167,14 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			moduleGraph
 		);
 		if (usedByExportsCondition === false) return false;
+		// Keep the connection unconditional (fast path) when nothing can deactivate it
+		if (
+			usedByExportsCondition === null &&
+			this.branchGuards === undefined &&
+			!isInlineExportsEnabled(moduleGraph)
+		) {
+			return null;
+		}
 		const dep = this;
 		return (connection, runtime) => {
 			if (usedByExportsCondition !== null) {

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1987,6 +1987,8 @@ class JavascriptModulesPlugin {
 		const inlinedModulesToInfo = new Map();
 		/** @type {Set<string>} */
 		const nonInlinedModuleThroughIdentifiers = new Set();
+		/** @type {Map<Module, Source>} */
+		const inlinedModuleSources = new Map();
 
 		for (const m of allModules) {
 			const isInlinedModule = inlinedModules && inlinedModules.has(m);
@@ -2001,6 +2003,12 @@ class JavascriptModulesPlugin {
 			);
 
 			if (!moduleSource) continue;
+			if (isInlinedModule) {
+				// Parsing the inlined entry (often the whole concatenated app) is
+				// expensive; defer it until we know renaming is actually needed.
+				inlinedModuleSources.set(m, moduleSource);
+				continue;
+			}
 			const code = /** @type {string} */ (moduleSource.source());
 
 			const { ast } = JavascriptParser._parse(
@@ -2020,22 +2028,73 @@ class JavascriptModulesPlugin {
 			});
 
 			const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
-			if (inlinedModules && inlinedModules.has(m)) {
-				const moduleScope = globalScope.childScopes[0];
-				inlinedModulesToInfo.set(m, {
-					source: moduleSource,
-					ast,
-					module: m,
-					variables: new Set(moduleScope.variables),
-					through: new Set(moduleScope.through),
-					usedInNonInlined: new Set(),
-					moduleScope
-				});
-			} else {
-				for (const ref of globalScope.through) {
-					nonInlinedModuleThroughIdentifiers.add(ref.identifier.name);
+			for (const ref of globalScope.through) {
+				nonInlinedModuleThroughIdentifiers.add(ref.identifier.name);
+			}
+		}
+
+		// Fast path for a single inlined entry: codegen reports the rendered
+		// source's top-level declarations (post-concatenation names), so when none
+		// of them collides with a free name of the non-inlined modules or a
+		// reserved name, no renaming is needed and the entry doesn't have to be
+		// parsed at all.
+		if (!isMultipleEntries && inlinedModuleSources.size === 1) {
+			const [[m, moduleSource]] = inlinedModuleSources;
+			const { codeGenerationResults, chunk } = renderContext;
+			/** @type {Set<string> | undefined} */
+			let declarations;
+			if (codeGenerationResults.has(m, chunk.runtime)) {
+				const data = codeGenerationResults.get(m, chunk.runtime).data;
+				if (data) declarations = data.get("topLevelDeclarations");
+			}
+			if (declarations) {
+				let needsRename = false;
+				for (const name of declarations) {
+					if (
+						nonInlinedModuleThroughIdentifiers.has(name) ||
+						RESERVED_NAMES.has(name)
+					) {
+						needsRename = true;
+						break;
+					}
+				}
+				if (!needsRename) {
+					renamedInlinedModules.set(m, moduleSource);
+					return renamedInlinedModules;
 				}
 			}
+		}
+
+		for (const [m, moduleSource] of inlinedModuleSources) {
+			const code = /** @type {string} */ (moduleSource.source());
+
+			const { ast } = JavascriptParser._parse(
+				code,
+				{
+					sourceType: "auto",
+					ranges: true
+				},
+				JavascriptParser._getModuleParseFunction(compilation, m)
+			);
+
+			const scopeManager = eslintScope.analyze(ast, {
+				ecmaVersion: 6,
+				sourceType: "module",
+				optimistic: true,
+				ignoreEval: true
+			});
+
+			const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
+			const moduleScope = globalScope.childScopes[0];
+			inlinedModulesToInfo.set(m, {
+				source: moduleSource,
+				ast,
+				module: m,
+				variables: new Set(moduleScope.variables),
+				through: new Set(moduleScope.through),
+				usedInNonInlined: new Set(),
+				moduleScope
+			});
 		}
 
 		for (const [, { variables, usedInNonInlined }] of inlinedModulesToInfo) {

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -96,7 +96,7 @@ const { InlinedUsedName } = require("./InlineExports");
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../util/Hash").HashFunction} HashFunction */
 /** @typedef {import("../util/concatenate").UsedNames} UsedNames */
-/** @typedef {import("../util/concatenate").ScopeInfo} ScopeInfo */
+/** @typedef {import("../util/concatenate").UsedNamesInScopeInfo} UsedNamesInScopeInfo */
 /** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("../util/identifier").AssociatedObjectForCache} AssociatedObjectForCache */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
@@ -1453,7 +1453,7 @@ class ConcatenatedModule extends Module {
 		const topLevelDeclarations = new Set();
 
 		// List of additional names in scope for module references
-		/** @type {Map<string, ScopeInfo>} */
+		/** @type {UsedNamesInScopeInfo} */
 		const usedNamesInScopeInfo = new Map();
 
 		// Set of already checked scopes

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -123,6 +123,25 @@ const toInlinedValue = (evaluated) => {
 	}
 };
 
+/** @type {WeakSet<ModuleGraph>} */
+const inlineEnabledModuleGraphs = new WeakSet();
+
+/**
+ * Marks export inlining as active for this module graph (set by InlineExportsPlugin).
+ * @param {ModuleGraph} moduleGraph module graph
+ * @returns {void}
+ */
+const enableInlineExports = (moduleGraph) => {
+	inlineEnabledModuleGraphs.add(moduleGraph);
+};
+
+/**
+ * @param {ModuleGraph} moduleGraph module graph
+ * @returns {boolean} true when InlineExportsPlugin is active for this module graph
+ */
+const isInlineExportsEnabled = (moduleGraph) =>
+	inlineEnabledModuleGraphs.has(moduleGraph);
+
 /**
  * @param {Module} module the target module
  * @returns {boolean} true when inlining is enabled for this module
@@ -145,16 +164,15 @@ const isInlineEnabled = (module) =>
 const isExportInlined = (moduleGraph, module, ids, runtime) => {
 	if (!ids || ids.length === 0) return false;
 	if (!isInlineEnabled(module)) return false;
-	return (
-		moduleGraph.getExportsInfo(module).getUsedName(ids, runtime) instanceof
-		InlinedUsedName
-	);
+	return moduleGraph.getExportsInfo(module).hasInlinedUsedName(ids, runtime);
 };
 
 module.exports.CONST_BINDING_TAG = CONST_BINDING_TAG;
 module.exports.InlinedUsedName = InlinedUsedName;
 module.exports.InlinedValue = InlinedValue;
 module.exports.MAX_INLINE_BYTES = MAX_INLINE_BYTES;
+module.exports.enableInlineExports = enableInlineExports;
 module.exports.isExportInlined = isExportInlined;
 module.exports.isInlineEnabled = isInlineEnabled;
+module.exports.isInlineExportsEnabled = isInlineExportsEnabled;
 module.exports.toInlinedValue = toInlinedValue;

--- a/lib/optimize/InlineExportsPlugin.js
+++ b/lib/optimize/InlineExportsPlugin.js
@@ -11,7 +11,7 @@ const {
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("../ModuleTypeConstants");
 const ConstValueParserPlugin = require("./ConstValueParserPlugin");
-const { InlinedUsedName } = require("./InlineExports");
+const { InlinedUsedName, enableInlineExports } = require("./InlineExports");
 
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../ExportsInfo")} ExportsInfo */
@@ -28,6 +28,9 @@ class InlineExportsPlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				// Lets HarmonyImportSpecifierDependency.getCondition skip the inline check
+				// (and stay unconditional) when this plugin is not active
+				enableInlineExports(compilation.moduleGraph);
 				/**
 				 * @param {JavascriptParser} parser the parser
 				 * @returns {void}
@@ -72,6 +75,7 @@ class InlineExportsPlugin {
 									exportInfo.provided === true;
 								if (doInline) {
 									exportInfo.setUsedName(new InlinedUsedName(inlined));
+									exportsInfo.markInlinedExports();
 								}
 								if (exportInfo.exportsInfoOwned && exportInfo.exportsInfo) {
 									const used = exportInfo.getUsed(undefined);

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -554,6 +554,8 @@ class InnerGraphPlugin {
 					logger.time("infer dependency usage");
 					for (const module of modules) {
 						innerGraph.inferDependencyUsage(module);
+						// state is dead after inference; release it to not retain ASTs via callbacks
+						innerGraph.release(module);
 					}
 					logger.timeEnd("infer dependency usage");
 				});

--- a/lib/util/concatenate.js
+++ b/lib/util/concatenate.js
@@ -68,9 +68,28 @@ const getPathInAst = (ast, node) => {
 	};
 
 	if (Array.isArray(ast)) {
-		for (let i = 0; i < ast.length; i++) {
-			const enterResult = enterNode(ast[i]);
-			if (enterResult !== undefined) return enterResult;
+		// sibling ranges are ordered and disjoint; binary search the container
+		let lo = 0;
+		let hi = ast.length - 1;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			const item = ast[mid];
+			const r = item && item.range;
+			if (!r) {
+				// holes or range-less nodes: scan the remaining window linearly
+				for (let i = lo; i <= hi; i++) {
+					const enterResult = enterNode(ast[i]);
+					if (enterResult !== undefined) return enterResult;
+				}
+				return;
+			}
+			if (r[0] > nr[0]) {
+				hi = mid - 1;
+			} else if (nr[0] >= r[1]) {
+				lo = mid + 1;
+			} else {
+				return r[1] >= nr[1] ? enterNode(item) : undefined;
+			}
 		}
 	} else if (ast && typeof ast === "object") {
 		const keys =
@@ -204,7 +223,7 @@ const RESERVED_NAMES = new Set(
 );
 
 /** @typedef {{ usedNames: UsedNames, alreadyCheckedScopes: ScopeSet }} ScopeInfo */
-/** @typedef {Map<string, ScopeInfo>} UsedNamesInScopeInfo */
+/** @typedef {Map<string, Map<string, ScopeInfo>>} UsedNamesInScopeInfo */
 
 /**
  * Gets used names in scope info.
@@ -214,14 +233,19 @@ const RESERVED_NAMES = new Set(
  * @returns {ScopeInfo} info
  */
 const getUsedNamesInScopeInfo = (usedNamesInScopeInfo, module, id) => {
-	const key = `${module}-${id}`;
-	let info = usedNamesInScopeInfo.get(key);
+	// nested maps avoid building a `${module}-${id}` key string per lookup
+	let byId = usedNamesInScopeInfo.get(module);
+	if (byId === undefined) {
+		byId = new Map();
+		usedNamesInScopeInfo.set(module, byId);
+	}
+	let info = byId.get(id);
 	if (info === undefined) {
 		info = {
 			usedNames: new Set(),
 			alreadyCheckedScopes: new Set()
 		};
-		usedNamesInScopeInfo.set(key, info);
+		byId.set(id, info);
 	}
 	return info;
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -7572,6 +7572,11 @@ declare interface ExportSpec {
 type ExportedVariableInfo = string | VariableInfo | ScopeInfo;
 declare abstract class ExportsInfo {
 	/**
+	 * Records that an owned export got an inlined used name.
+	 */
+	markInlinedExports(): void;
+
+	/**
 	 * Gets owned exports.
 	 */
 	get ownedExports(): Iterable<ExportInfo>;
@@ -7708,6 +7713,12 @@ declare abstract class ExportsInfo {
 	 * Returns the used name.
 	 */
 	getUsedName(name: string | string[], runtime: RuntimeSpec): UsedName;
+
+	/**
+	 * Checks whether `getUsedName(name, runtime)` would return an `InlinedUsedName`,
+	 * without allocating intermediate used-name arrays (hot path for connection conditions).
+	 */
+	hasInlinedUsedName(name: string[], runtime: RuntimeSpec): boolean;
 
 	/**
 	 * Updates the hash with the data contributed by this instance.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Profiling a 7k-module three.js production build against v5.107.2 showed regressed memory (+34 MB retained heap) and large per-build costs: inner-graph state was retained for the whole compilation, every harmony import connection became conditional with an allocating inline-export check, and `avoidEntryIife` re-parsed the entire rendered entry (the whole concatenated app) on every build. This PR releases the inner-graph state after inference, adds allocation-free fast paths for the inlined-export checks, skips the entry re-parse when codegen-reported top-level declarations show no collision, and trims allocations in export hashing and concatenation lookups. On the benchmark: initial build ~14.0s → ~8.8s, watch rebuild ~8.9s → ~3.4s, retained heap 347 MB → 303 MB, with byte-identical output.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

No new tests; behavior is unchanged and covered by the existing suites (ConfigTestCases, StatsTestCases, TestCasesProduction/Development, inline-exports, inner-graph, side-effects all pass).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was developed with Claude Code (AI agent): it profiled the builds, located the regressions, wrote the patches and benchmarks, and ran the test suites; the work was directed and reviewed by the requester.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab1MSNJvUMuuesmS81226v)_