### PR TITLE
fix: merge inner modules' top level declarations in concatenated modules

### DIFF
--- a/.changeset/concat-top-level-declarations.md
+++ b/.changeset/concat-top-level-declarations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix merging of inner modules' top-level declarations in concatenated modules.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1044,10 +1044,10 @@ class ConcatenatedModule extends Module {
 
 			// populate topLevelDeclarations
 			if (topLevelDeclarations) {
-				const topLevelDeclarations = buildInfo.topLevelDeclarations;
-				if (topLevelDeclarations !== undefined) {
+				const mergedTopLevelDeclarations = buildInfo.topLevelDeclarations;
+				if (mergedTopLevelDeclarations !== undefined) {
 					for (const decl of topLevelDeclarations) {
-						topLevelDeclarations.add(decl);
+						mergedTopLevelDeclarations.add(decl);
 					}
 				}
 			} else {

--- a/test/configCases/concatenate-modules/top-level-declarations-library-conflict/index.js
+++ b/test/configCases/concatenate-modules/top-level-declarations-library-conflict/index.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+import { getValue } from "./module";
+
+it("should isolate the entry when a concatenated declaration conflicts with the library name", () => {
+	// the library assignment must not clobber the inner MyLib function
+	expect(getValue()).toBe(42);
+	const source = fs.readFileSync(__filename, "utf-8");
+	// string split to not match this test's own source
+	expect(source).toContain(
+		"declares 'MyLib' on top-level, " + "which conflicts with the current library output"
+	);
+});

--- a/test/configCases/concatenate-modules/top-level-declarations-library-conflict/module.js
+++ b/test/configCases/concatenate-modules/top-level-declarations-library-conflict/module.js
@@ -1,0 +1,10 @@
+let innerDecl = 40;
+innerDecl++;
+
+function MyLib(x) {
+	return x + 1;
+}
+
+export function getValue() {
+	return innerDecl + MyLib(0);
+}

--- a/test/configCases/concatenate-modules/top-level-declarations-library-conflict/webpack.config.js
+++ b/test/configCases/concatenate-modules/top-level-declarations-library-conflict/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	output: {
+		library: { name: "MyLib", type: "var" }
+	},
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	}
+};

--- a/test/configCases/concatenate-modules/top-level-declarations/index.js
+++ b/test/configCases/concatenate-modules/top-level-declarations/index.js
@@ -1,0 +1,7 @@
+import { getValue } from "./module";
+
+const localDecl = 1;
+
+it("should compile and run", () => {
+	expect(getValue() + localDecl).toBe(43);
+});

--- a/test/configCases/concatenate-modules/top-level-declarations/module.js
+++ b/test/configCases/concatenate-modules/top-level-declarations/module.js
@@ -1,0 +1,6 @@
+let innerDecl = 41;
+innerDecl++;
+
+export function getValue() {
+	return innerDecl;
+}

--- a/test/configCases/concatenate-modules/top-level-declarations/webpack.config.js
+++ b/test/configCases/concatenate-modules/top-level-declarations/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	plugins: [
+		function testPlugin(compiler) {
+			compiler.hooks.compilation.tap("test", (compilation) => {
+				compilation.hooks.afterSeal.tap("test", () => {
+					let found = false;
+					for (const module of compilation.modules) {
+						if (module.constructor.name !== "ConcatenatedModule") continue;
+						found = true;
+						const topLevelDeclarations =
+							module.buildInfo && module.buildInfo.topLevelDeclarations;
+						expect(topLevelDeclarations).toBeDefined();
+						// declarations of all inner modules must be merged
+						expect(topLevelDeclarations).toContain("localDecl");
+						expect(topLevelDeclarations).toContain("innerDecl");
+						expect(topLevelDeclarations).toContain("getValue");
+					}
+					expect(found).toBe(true);
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A self-shadowed variable in `ConcatenatedModule._build` made the merge loop add `buildInfo.topLevelDeclarations` into itself, so concatenated modules always exposed an empty set instead of the merged inner modules' declarations; this fixes the merge so the public `buildInfo` contract is correct for plugins.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/concatenate-modules/top-level-declarations/` (regression test for the merge) and `test/configCases/concatenate-modules/top-level-declarations-library-conflict/` (end-to-end coverage of the library name conflict bailout, previously untested).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code (AI) was used to investigate the bug, implement the fix, and write the tests, directed and reviewed by the requester.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FM4kEXcEzgChtBzmuoRA1C)_