### PR TITLE
perf: extend avoidEntryIife no-parse fast path to multi-entry chunks

### DIFF
--- a/.changeset/avoid-entry-iife-multi-entry-fast-path.md
+++ b/.changeset/avoid-entry-iife-multi-entry-fast-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Extend the avoidEntryIife no-parse fast path to multi-entry chunks.

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -118,6 +118,7 @@ const makeSerializable = require("./util/makeSerializable");
  * Defines the all code generation schemas type used by this module.
  * @typedef {object} AllCodeGenerationSchemas
  * @property {Set<string>} topLevelDeclarations top level declarations for javascript modules
+ * @property {Set<string>} freeNames free identifier names in the rendered source for javascript modules
  * @property {InitFragment<EXPECTED_ANY>[]} chunkInitFragments chunk init fragments for javascript modules
  * @property {{ javascript?: string, ["asset-url"]?: string }} url url for asset modules
  * @property {string} filename a filename for asset modules

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -2048,14 +2048,15 @@ class JavascriptModulesPlugin {
 			for (const m of inlinedModuleSources.keys()) {
 				if (!codeGenerationResults.has(m, chunk.runtime)) break fastPath;
 				const result = codeGenerationResults.get(m, chunk.runtime);
-				const declarations =
-					result.data && result.data.get("topLevelDeclarations");
+				const data = result.data;
+				if (!data) break fastPath;
+				const declarations = data.get("topLevelDeclarations");
 				if (!declarations) break fastPath;
 				declarationsList.push(declarations);
 				if (!isMultipleEntries) continue;
 				// Entries share the startup scope: an entry's free names and runtime
 				// globals must not be shadowed by another entry's declarations.
-				const freeNames = result.data.get("freeNames");
+				const freeNames = data.get("freeNames");
 				if (!freeNames) break fastPath;
 				for (const name of freeNames) usedNames.add(name);
 				if (result.runtimeRequirements) {

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -2033,36 +2033,50 @@ class JavascriptModulesPlugin {
 			}
 		}
 
-		// Fast path for a single inlined entry: codegen reports the rendered
-		// source's top-level declarations (post-concatenation names), so when none
-		// of them collides with a free name of the non-inlined modules or a
-		// reserved name, no renaming is needed and the entry doesn't have to be
-		// parsed at all.
-		if (!isMultipleEntries && inlinedModuleSources.size === 1) {
-			const [[m, moduleSource]] = inlinedModuleSources;
+		// Fast path: codegen reports each inlined entry's rendered top-level
+		// declarations and free names (post-concatenation), so when no declaration
+		// collides with a free name of any other module, another entry's
+		// declarations, or a reserved name, no renaming is needed and the entries
+		// don't have to be parsed at all.
+		fastPath: {
 			const { codeGenerationResults, chunk } = renderContext;
-			/** @type {Set<string> | undefined} */
-			let declarations;
-			if (codeGenerationResults.has(m, chunk.runtime)) {
-				const data = codeGenerationResults.get(m, chunk.runtime).data;
-				if (data) declarations = data.get("topLevelDeclarations");
-			}
-			if (declarations) {
-				let needsRename = false;
-				for (const name of declarations) {
-					if (
-						nonInlinedModuleThroughIdentifiers.has(name) ||
-						RESERVED_NAMES.has(name)
-					) {
-						needsRename = true;
-						break;
+			/** @type {Set<string>} */
+			const usedNames = new Set(nonInlinedModuleThroughIdentifiers);
+			for (const name of RESERVED_NAMES) usedNames.add(name);
+			/** @type {Set<string>[]} */
+			const declarationsList = [];
+			for (const m of inlinedModuleSources.keys()) {
+				if (!codeGenerationResults.has(m, chunk.runtime)) break fastPath;
+				const result = codeGenerationResults.get(m, chunk.runtime);
+				const declarations =
+					result.data && result.data.get("topLevelDeclarations");
+				if (!declarations) break fastPath;
+				declarationsList.push(declarations);
+				if (!isMultipleEntries) continue;
+				// Entries share the startup scope: an entry's free names and runtime
+				// globals must not be shadowed by another entry's declarations.
+				const freeNames = result.data.get("freeNames");
+				if (!freeNames) break fastPath;
+				for (const name of freeNames) usedNames.add(name);
+				if (result.runtimeRequirements) {
+					for (const req of result.runtimeRequirements) {
+						const dot = req.indexOf(".");
+						usedNames.add(dot === -1 ? req : req.slice(0, dot));
 					}
 				}
-				if (!needsRename) {
-					renamedInlinedModules.set(m, moduleSource);
-					return renamedInlinedModules;
-				}
 			}
+			for (const declarations of declarationsList) {
+				for (const name of declarations) {
+					if (usedNames.has(name)) break fastPath;
+				}
+				// earlier entries' declarations join the used set so later entries
+				// are checked against them
+				for (const name of declarations) usedNames.add(name);
+			}
+			for (const [m, moduleSource] of inlinedModuleSources) {
+				renamedInlinedModules.set(m, moduleSource);
+			}
+			return renamedInlinedModules;
 		}
 
 		for (const [m, moduleSource] of inlinedModuleSources) {

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1452,6 +1452,11 @@ class ConcatenatedModule extends Module {
 		/** @type {TopLevelDeclarations} */
 		const topLevelDeclarations = new Set();
 
+		// Free names remaining in the rendered source (runtime globals are
+		// tracked by runtimeRequirements instead)
+		/** @type {Set<string>} */
+		const freeNames = new Set();
+
 		// List of additional names in scope for module references
 		/** @type {UsedNamesInScopeInfo} */
 		const usedNamesInScopeInfo = new Map();
@@ -1554,6 +1559,7 @@ class ConcatenatedModule extends Module {
 							);
 						} else {
 							allUsedNames.add(name);
+							freeNames.add(name);
 						}
 					}
 				}
@@ -2201,6 +2207,7 @@ ${defineGetters}`
 			data.set("chunkInitFragments", chunkInitFragments);
 		}
 		data.set("topLevelDeclarations", topLevelDeclarations);
+		data.set("freeNames", freeNames);
 
 		/** @type {CodeGenerationResult} */
 		const resultEntry = {

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/first-dep.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/first-dep.js
@@ -1,0 +1,3 @@
+export function getFirst() {
+	return "first";
+}

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/first.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/first.js
@@ -1,0 +1,7 @@
+import { getFirst } from "./first-dep.js";
+
+it("isolates second's top-level `value` from first without an IIFE", () => {
+	expect(getFirst()).toBe("first");
+	// second declares `value`; renaming keeps it from leaking into this scope
+	expect(typeof value).toBe("undefined");
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/second-dep.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/second-dep.js
@@ -1,0 +1,3 @@
+export function getSecond() {
+	return "second";
+}

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/second.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/second.js
@@ -1,0 +1,11 @@
+import { getSecond } from "./second-dep.js";
+
+var value = 42;
+const shorthand = { value };
+
+// `value` collides with first's global read, so it is renamed; the object
+// shorthand must be rewritten to `{ value: <renamed> }`.
+it("renames second's `value`, including the object shorthand, without an IIFE", () => {
+	expect(shorthand.value).toBe(42);
+	expect(getSecond()).toBe("second");
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/test.config.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["collide-true.mjs", "test.js"];
+	}
+};

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/test.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, file), "utf-8");
+const MARKER = "isolated against other entry modules";
+
+it("resolves the colliding declaration by renaming instead of an IIFE", () => {
+	// `value` collides (first reads it as a global, second declares it); the
+	// codegen-data fast path must bail out so the collision is renamed away
+	expect(read("collide-true.mjs")).not.toContain(MARKER);
+	// ...while disabling the optimization keeps the per-entry IIFE
+	expect(read("collide-false.mjs")).toContain(MARKER);
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries-collision/webpack.config.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries-collision/webpack.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+const base = {
+	entry: ["./first.js", "./second.js"],
+	output: {
+		module: true
+	},
+	optimization: {
+		concatenateModules: true
+	},
+	experiments: {
+		outputModule: true
+	},
+	target: "es2020"
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		...base,
+		name: "collide-true",
+		output: { ...base.output, filename: "collide-true.mjs" },
+		optimization: { ...base.optimization, avoidEntryIife: true }
+	},
+	{
+		...base,
+		name: "collide-false",
+		output: { ...base.output, filename: "collide-false.mjs" },
+		optimization: { ...base.optimization, avoidEntryIife: false }
+	},
+	{
+		name: "test-output",
+		entry: "./test.js",
+		output: {
+			filename: "test.js"
+		}
+	}
+];

--- a/test/configCases/module/iife-multiple-concatenated-entries/first-dep.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/first-dep.js
@@ -1,0 +1,3 @@
+export function getFirst() {
+	return "first";
+}

--- a/test/configCases/module/iife-multiple-concatenated-entries/first.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/first.js
@@ -1,0 +1,7 @@
+import { getFirst } from "./first-dep.js";
+
+const firstValue = getFirst();
+
+it("the first concatenated entry runs in the shared startup scope", () => {
+	expect(firstValue).toBe("first");
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries/second-dep.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/second-dep.js
@@ -1,0 +1,3 @@
+export function getSecond() {
+	return "second";
+}

--- a/test/configCases/module/iife-multiple-concatenated-entries/second.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/second.js
@@ -1,0 +1,7 @@
+import { getSecond } from "./second-dep.js";
+
+const secondValue = getSecond();
+
+it("the second concatenated entry shares scope without collisions", () => {
+	expect(secondValue).toBe("second");
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries/test.config.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["concat-true.mjs", "test.js"];
+	}
+};

--- a/test/configCases/module/iife-multiple-concatenated-entries/test.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, file), "utf-8");
+const MARKER = "isolated against other entry modules";
+
+it("avoids the per-entry IIFE for multiple concatenated entries without collisions", () => {
+	// concatenated entries report declarations/free names via codegen data, so
+	// the no-collision check runs without re-parsing the entries
+	expect(read("concat-true.mjs")).not.toContain(MARKER);
+	// ...and the per-entry IIFE is kept when the optimization is disabled
+	expect(read("concat-false.mjs")).toContain(MARKER);
+});

--- a/test/configCases/module/iife-multiple-concatenated-entries/webpack.config.js
+++ b/test/configCases/module/iife-multiple-concatenated-entries/webpack.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+const base = {
+	entry: ["./first.js", "./second.js"],
+	output: {
+		module: true
+	},
+	optimization: {
+		concatenateModules: true
+	},
+	experiments: {
+		outputModule: true
+	},
+	target: "es2020"
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		...base,
+		name: "concat-true",
+		output: { ...base.output, filename: "concat-true.mjs" },
+		optimization: { ...base.optimization, avoidEntryIife: true }
+	},
+	{
+		...base,
+		name: "concat-false",
+		output: { ...base.output, filename: "concat-false.mjs" },
+		optimization: { ...base.optimization, avoidEntryIife: false }
+	},
+	{
+		name: "test-output",
+		entry: "./test.js",
+		output: {
+			filename: "test.js"
+		}
+	}
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -326,6 +326,11 @@ declare interface AllCodeGenerationSchemas {
 	topLevelDeclarations: Set<string>;
 
 	/**
+	 * free identifier names in the rendered source for javascript modules
+	 */
+	freeNames: Set<string>;
+
+	/**
 	 * chunk init fragments for javascript modules
 	 */
 	chunkInitFragments: InitFragment<any>[];
@@ -2929,6 +2934,7 @@ type CodeGenValue<K extends string> = K extends
 	| "assetInfo"
 	| "share-init"
 	| "topLevelDeclarations"
+	| "freeNames"
 	| "chunkInitFragments"
 	| "url"
 	| "fullContentHash"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

With `optimization.avoidEntryIife`, multi-entry chunks re-parsed every inlined concatenated entry (acorn + eslint-scope over the whole rendered app) on every build to check for name collisions. `ConcatenatedModule` codegen now also reports its free names, extending the single-entry no-parse fast path from #21167 to multi-entry chunks (rename step ~480ms → ~6ms on a 3k-module two-entry build, byte-identical output).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/module/iife-multiple-concatenated-entries` (fast path taken) and `test/configCases/module/iife-multiple-concatenated-entries-collision` (fast path bails, renaming still applies).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to implement the change, write the tests, and run the verification/benchmarks under maintainer direction; the result was reviewed before submission.

https://claude.ai/code/session_01AbYA9s4rUycBWPNyZbzP1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbYA9s4rUycBWPNyZbzP1Y)_