### PR TITLE
refactor: generalize SourceProcessor and adopt it for HTML modules

### DIFF
--- a/.changeset/html-modules-source-processor.md
+++ b/.changeset/html-modules-source-processor.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Make SourceProcessor reusable across syntaxes and use it for HTML modules.

--- a/.changeset/html-modules-source-processor.md
+++ b/.changeset/html-modules-source-processor.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Make SourceProcessor reusable across syntaxes and use it for HTML modules.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const LocConverter = require("../util/LocConverter");
+const GenericSourceProcessor = require("../util/SourceProcessor");
 const { makeCacheable } = require("../util/identifier");
 
 // spec: https://drafts.csswg.org/css-syntax/
@@ -2599,16 +2600,14 @@ const _unescapeIdentifier = (str) => {
 const escapeIdentifier = makeCacheable(_escapeIdentifier);
 const unescapeIdentifier = makeCacheable(_unescapeIdentifier);
 
+// CSS-typed views over the generic visitor machinery (`util/SourceProcessor`),
+// re-exported so consumers keep importing them from this module.
 /**
- * Babel-style visitor map keyed by `Node#type`; a bucket is a function
- * (enter-only) or `{ enter?, exit? }`. `ctx.skipChildren()` (enter only)
- * stops the walker descending into the node's children.
- * @typedef {{ skipChildren(): void }} VisitorContext
- * @typedef {(node: Node, parent: Node | null, ctx: VisitorContext) => void} VisitorFn
- * @typedef {VisitorFn | { enter?: VisitorFn, exit?: VisitorFn }} VisitorBucket
- * @typedef {{ [nodeType: number]: VisitorBucket }} VisitorMap
- * @typedef {{ enter: VisitorFn[], exit: VisitorFn[] }} CompiledVisitorBucket
- * @typedef {CompiledVisitorBucket[]} CompiledVisitorMap a sparse array indexed by node type
+ * @typedef {import("../util/SourceProcessor").VisitorContext} VisitorContext
+ * @typedef {import("../util/SourceProcessor").VisitorFn<Node>} VisitorFn
+ * @typedef {import("../util/SourceProcessor").VisitorBucket<Node>} VisitorBucket
+ * @typedef {import("../util/SourceProcessor").VisitorMap<Node>} VisitorMap
+ * @typedef {import("../util/SourceProcessor").CompiledVisitorMap<Node>} CompiledVisitorMap
  */
 
 /**
@@ -2630,26 +2629,27 @@ const TOP_LEVEL_CONSUMERS = {
 };
 
 /**
- * @typedef {object} GrammarContext
- * @property {CompiledVisitorMap} visitors compiled visitor map
- * @property {LocConverter} locConverter shared loc converter
+ * @typedef {object} CssProcessOptions
+ * @property {LocConverter=} locConverter shared loc converter (default a fresh one over the input)
  * @property {((input: string, start: number, end: number) => number)=} comment comment-token callback
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
  */
 
 /**
- * The `SourceProcessor` grammar: consume top-level rules one at a time (§5.4.1)
- * and walk each immediately, firing `enter` / `exit` in source order without
- * building a whole-stylesheet array first. `recurseBlocks: false` skips walking
- * block bodies' (eagerly parsed) nested rules (caller drives nested traversal
- * itself).
+ * The CSS `SourceProcessor` grammar: consume top-level rules one at a time
+ * (§5.4.1) and walk each immediately, firing `enter` / `exit` in source order
+ * without building a whole-stylesheet array first. `recurseBlocks: false` skips
+ * walking block bodies' (eagerly parsed) nested rules (caller drives nested
+ * traversal itself).
  * @param {string} input source text
- * @param {GrammarContext} ctx grammar context
+ * @param {CompiledVisitorMap} visitors compiled visitor map
+ * @param {CssProcessOptions} options process options
  */
-const grammar = (input, ctx) => {
-	const { visitors, locConverter, comment } = ctx;
-	const recurseBlocks = ctx.recurseBlocks !== false;
+const grammar = (input, visitors, options) => {
+	const { comment } = options;
+	const locConverter = options.locConverter || new LocConverter(input);
+	const recurseBlocks = options.recurseBlocks !== false;
 
 	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.
 	let skipFlag = false;
@@ -2745,67 +2745,24 @@ const grammar = (input, ctx) => {
 	// held at once; peak heap is ~one top-level node's subtree.
 	const ts = new TokenStream(input, 0, locConverter, comment);
 	const consume =
-		TOP_LEVEL_CONSUMERS[ctx.as || "stylesheet"] || consumeAStylesheetsContents;
+		TOP_LEVEL_CONSUMERS[options.as || "stylesheet"] ||
+		consumeAStylesheetsContents;
 	consume(ts, (node) => walkRule(node, null));
 };
 
 /**
- * Visitor coordinator: owns the visitor registry and drives the CSS `grammar`
- * over the source. Babel-style usage:
+ * The generic visitor coordinator (`util/SourceProcessor`) bound to the CSS
+ * `grammar`. Babel-style usage:
  *
  * ```
- * processor.use({ AtRule: (at) => {}, Declaration: { enter, exit } });
+ * processor.use({ [NodeType.AtRule]: (at) => {}, [NodeType.Declaration]: { enter, exit } });
  * processor.process(source);
  * ```
+ * @extends {GenericSourceProcessor<Node, CssProcessOptions>}
  */
-class SourceProcessor {
+class SourceProcessor extends GenericSourceProcessor {
 	constructor() {
-		/** @type {CompiledVisitorMap} */
-		this._visitors = [];
-	}
-
-	/**
-	 * Register a Babel-style visitor map; calls accumulate per node type.
-	 * A bucket is a function (= `{ enter }`) or `{ enter?, exit? }`.
-	 * @param {VisitorMap} map visitor map keyed by node type
-	 * @returns {SourceProcessor} `this`, for chaining
-	 */
-	use(map) {
-		// `map`'s keys are `NodeType` members; `Object.keys` stringifies them, so
-		// index the compiled array by the number to match the numeric `node.type`.
-		for (const type of Object.keys(map)) {
-			const key = Number(type);
-			const v = map[key];
-			let bucket = this._visitors[key];
-			if (!bucket) {
-				bucket = { enter: [], exit: [] };
-				this._visitors[key] = bucket;
-			}
-			if (typeof v === "function") {
-				bucket.enter.push(v);
-			} else {
-				if (v.enter) bucket.enter.push(v.enter);
-				if (v.exit) bucket.exit.push(v.exit);
-			}
-		}
-		return this;
-	}
-
-	/**
-	 * Run the grammar over `input`, firing visitors in source order. No
-	 * AST retained.
-	 * @param {string} input source text
-	 * @param {{ locConverter?: LocConverter, comment?: (input: string, start: number, end: number) => number, recurseBlocks?: boolean, as?: ("stylesheet" | "block-contents") }=} ctx reuse a `locConverter`, forward a `comment` callback, set `recurseBlocks: false` to stop at top-level rules, or set `as: "block-contents"` to parse a block's contents (e.g. an HTML `style` attribute) instead of a full stylesheet
-	 */
-	process(input, ctx = {}) {
-		const locConverter = ctx.locConverter || new LocConverter(input);
-		grammar(input, {
-			visitors: this._visitors,
-			locConverter,
-			comment: ctx.comment,
-			recurseBlocks: ctx.recurseBlocks,
-			as: ctx.as
-		});
+		super(grammar);
 	}
 }
 

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1159,7 +1159,7 @@ class HtmlParser extends Parser {
 							let contentStart;
 							let contentEnd = node.tagEnd;
 							for (const child of node.children) {
-								if (child.type === "text") {
+								if (child.type === NodeType.Text) {
 									if (contentStart === undefined) {
 										contentStart = child.start;
 									}
@@ -1442,7 +1442,7 @@ class HtmlParser extends Parser {
 								let contentEnd = node.tagEnd;
 								let hasSeenTextChild = false;
 								for (const child of node.children) {
-									if (child.type === "text") {
+									if (child.type === NodeType.Text) {
 										if (!hasSeenTextChild) {
 											contentStart = child.start;
 											hasSeenTextChild = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -4,7 +4,6 @@
 
 "use strict";
 
-const vm = require("vm");
 const Parser = require("../Parser");
 const ConstDependency = require("../dependencies/ConstDependency");
 const HtmlInlineScriptDependency = require("../dependencies/HtmlInlineScriptDependency");
@@ -22,6 +21,7 @@ const createHash = require("../util/createHash");
 const { contextify } = require("../util/identifier");
 const {
 	createMagicCommentContext,
+	parseMagicComment,
 	webpackCommentRegExp
 } = require("../util/magicComment");
 const {
@@ -1027,454 +1027,464 @@ class HtmlParser extends Parser {
 			}
 		};
 
-		/** @param {import("./syntax").HtmlComment} node comment node */
-		const onComment = (node) => {
-			// Only proper `<!-- ... -->` comments carry magic comments.
-			if (
-				node.end - node.start < 7 ||
-				source.charCodeAt(node.start) !== 0x3c ||
-				source.charCodeAt(node.start + 1) !== 0x21 ||
-				source.charCodeAt(node.start + 2) !== 0x2d ||
-				source.charCodeAt(node.start + 3) !== 0x2d ||
-				source.charCodeAt(node.end - 1) !== 0x3e ||
-				source.charCodeAt(node.end - 2) !== 0x2d ||
-				source.charCodeAt(node.end - 3) !== 0x2d
-			) {
-				pendingWebpackIgnore = undefined;
-				return;
-			}
-			const value = node.data;
-			if (!webpackCommentRegExp.test(value)) {
-				pendingWebpackIgnore = undefined;
-				return;
-			}
-			/** @type {Record<string, EXPECTED_ANY>} */
-			let options;
-			try {
-				options = vm.runInContext(
-					`(function(){return {${value}};})()`,
-					magicCommentContext
-				);
-			} catch (err) {
-				const { line: sl, column: sc } = locConverter.get(node.start);
-				const { line: el, column: ec } = locConverter.get(node.end);
-				module.addWarning(
-					new CommentCompilationWarning(
-						`Compilation error while processing magic comment(-s): /*${value}*/: ${
-							/** @type {Error} */ (err).message
-						}`,
-						{
-							start: { line: sl, column: sc },
-							end: { line: el, column: ec }
-						}
-					)
-				);
-				pendingWebpackIgnore = undefined;
-				return;
-			}
-			if (options.webpackIgnore === undefined) {
-				pendingWebpackIgnore = undefined;
-				return;
-			}
-			if (typeof options.webpackIgnore !== "boolean") {
-				const { line: sl, column: sc } = locConverter.get(node.start);
-				const { line: el, column: ec } = locConverter.get(node.end);
-				module.addWarning(
-					new UnsupportedFeatureWarning(
-						`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
-						{
-							start: { line: sl, column: sc },
-							end: { line: el, column: ec }
-						}
-					)
-				);
-				pendingWebpackIgnore = undefined;
-				return;
-			}
-			pendingWebpackIgnore = options.webpackIgnore;
-		};
-
-		/**
-		 * Element `enter` visitor — children (and `<template>` content) are
-		 * descended by the walker itself after this returns.
-		 * @param {import("./syntax").HtmlElement} node element node
-		 */
-		const onElement = (node) => {
-			const ignore = pendingWebpackIgnore === true;
-			pendingWebpackIgnore = undefined;
-
-			if (ignore) {
-				return;
-			}
-
-			const elementName = node.tagName;
-			const attrs = node.attributes;
-
-			/** @type {Map<string, string> | undefined} */
-			let attributesMap;
-			const getAttributesMap = () => {
-				if (attributesMap) return attributesMap;
-				attributesMap = new Map();
-				for (const attr of attrs) {
-					// Decoded values — filters and type resolvers compare what
-					// the browser sees (e.g. `rel="&#105;con"` means `icon`)
-					attributesMap.set(attr.name, decodeHtmlEntities(attr.value, true));
-				}
-				return attributesMap;
-			};
-
-			if (elementName === "style") {
-				/** @type {string | undefined} */
-				let typeValue;
-				for (const attr of attrs) {
-					if (attr.name === "type") {
-						typeValue = attr.value;
-						break;
-					}
-				}
-
-				const trimmedType =
-					typeValue !== undefined ? typeValue.trim().toLowerCase() : "";
-				if (
-					typeValue !== undefined &&
-					trimmedType !== "" &&
-					trimmedType !== "text/css"
-				) {
-					return;
-				}
-
-				if (!css) {
-					return;
-				}
-
-				/** @type {number | undefined} */
-				let contentStart;
-				let contentEnd = node.tagEnd;
-				for (const child of node.children) {
-					if (child.type === "text") {
-						if (contentStart === undefined) {
-							contentStart = child.start;
-						}
-						contentEnd = child.end;
-					}
-				}
-
-				if (contentStart === undefined) {
-					contentStart = node.tagEnd;
-				}
-
-				const cssContent = source.slice(contentStart, contentEnd);
-				if (cssContent.trim() === "") {
-					return;
-				}
-
-				const request = `data:text/css;base64,${Buffer.from(
-					cssContent,
-					"utf8"
-				).toString("base64")}`;
-
-				const { line: sl, column: sc } = locConverter.get(contentStart);
-				const { line: el, column: ec } = locConverter.get(contentEnd);
-				const dep = new HtmlInlineStyleDependency(request, [
-					contentStart,
-					contentEnd
-				]);
-				dep.setLoc(sl, sc, el, ec);
-				module.addDependency(dep);
-				module.addCodeGenerationDependency(dep);
-				return;
-			}
-
-			// Inline `style="..."` attribute — a CSS block's contents. Route
-			// URL-bearing values through the CSS pipeline so `url()` & co.
-			// resolve relative to the HTML file (parsed via `as:
-			// "block-contents"`, see the `html-style-attribute` default rule).
-			if (css) {
-				for (const attr of attrs) {
-					if (attr.name !== "style") continue;
-					if (attr.valueStart === undefined || attr.valueStart === -1) break;
-					const value = attr.value;
-					if (!value) break;
-					// The browser sees the decoded value as the CSS text (so the
-					// url() pre-filter must run on it too); the dependency
-					// template re-escapes on write-back.
-					const cssText = decodeHtmlEntities(value, true);
-					if (!STYLE_ATTR_URL_REGEXP.test(cssText)) break;
-					const request = `data:text/css;base64,${Buffer.from(
-						cssText,
-						"utf8"
-					).toString("base64")}`;
-					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
-					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
-					const dep = new HtmlInlineStyleDependency(
-						request,
-						[attr.valueStart, attr.valueEnd],
-						true
-					);
-					dep.setLoc(sl, sc, el, ec);
-					module.addDependency(dep);
-					module.addCodeGenerationDependency(dep);
-					break;
-				}
-			}
-
-			// TODO parse `<iframe srcdoc>` (an entity-escaped HTML document)
-			// and rewrite its asset URLs in place — needs a restricted walk
-			// with offsets composed through `decodeHtmlEntitiesWithMap`
-
-			const tagSources = this.sourcesByTag[elementName] || this.anyTagSources;
-			if (!tagSources && elementName !== "script") {
-				return;
-			}
-
-			for (const attr of tagSources ? attrs : []) {
-				const sourceItem = tagSources[attr.name];
-				if (!sourceItem) continue;
-
-				// Attributes on adoption-agency clones carry no source offsets;
-				// the original element already owns the dependency span.
-				if (attr.valueStart === undefined || attr.valueStart === -1) continue;
-
-				const attributeValue = attr.value;
-				if (!attributeValue || !/\S/.test(attributeValue)) continue;
-
-				if (
-					typeof sourceItem.filter === "function" &&
-					!sourceItem.filter(getAttributesMap())
-				) {
-					continue;
-				}
-
-				const type =
-					typeof sourceItem.type === "function"
-						? sourceItem.type(getAttributesMap(), css)
-						: sourceItem.type;
-				let parse = type === "srcset" ? parseSrcset : parseSrc;
-				if (elementName === "meta") {
-					const name = getAttributesMap().get("name");
-					if (
-						name !== undefined &&
-						name.trim().toLowerCase() === "msapplication-task"
-					) {
-						parse = parseMsapplicationTask;
-					}
-				}
-
-				// Inline CSS attribute value: `stylesheet-style` parses it as a
-				// full stylesheet (like a `<style>` body), `stylesheet-style-attribute`
-				// as a block's contents (a declaration list, like a `style` attribute).
-				if (
-					type === "stylesheet-style" ||
-					type === "stylesheet-style-attribute"
-				) {
-					if (attributeValue.trim() === "") continue;
-					// The browser sees the decoded value as the CSS text
-					const cssText = decodeHtmlEntities(attributeValue, true);
-					const request = `data:text/css;base64,${Buffer.from(
-						cssText,
-						"utf8"
-					).toString("base64")}`;
-					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
-					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
-					const dep = new HtmlInlineStyleDependency(
-						request,
-						[attr.valueStart, attr.valueEnd],
-						type === "stylesheet-style-attribute",
-						// Both types read an attribute value, so write-back
-						// must re-escape regardless of the CSS parse mode
-						true
-					);
-					dep.setLoc(sl, sc, el, ec);
-					module.addDependency(dep);
-					module.addCodeGenerationDependency(dep);
-					continue;
-				}
-
-				// Browsers decode character references at tokenize time, so the
-				// parsers run on the decoded value (entity-encoded whitespace
-				// separates srcset candidates, etc.); the boundary map
-				// translates spans back to raw source offsets for rewriting.
-				let parseValue = attributeValue;
-				/** @type {number[] | undefined} */
-				let offsetMap;
-				if (attributeValue.includes("&")) {
-					({ text: parseValue, map: offsetMap } = decodeHtmlEntitiesWithMap(
-						attributeValue,
-						true
-					));
-					if (!/\S/.test(parseValue)) continue;
-				}
-
-				/** @type {ParsedSource[] | undefined} */
-				let parsedAttributeValue;
-
-				try {
-					parsedAttributeValue = parse(parseValue);
-				} catch (err) {
-					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
-					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
-
-					module.addError(
-						new ModuleDependencyError(
-							module,
-							new WebpackError(
-								`Bad value for attribute "${
-									attr.name
-								}" on element "${elementName}": ${
-									/** @type {Error} */ (err).message
-								}`
-							),
-							{
-								start: { line: sl, column: sc },
-								end: { line: el, column: ec }
-							}
-						)
-					);
-				}
-
-				if (!parsedAttributeValue) continue;
-
-				for (const parsedSource of parsedAttributeValue) {
-					const [value, innerStart, innerEnd] = parsedSource;
-					if (value.startsWith("#")) continue;
-					const rawStart =
-						offsetMap === undefined ? innerStart : offsetMap[innerStart];
-					const rawEnd =
-						offsetMap === undefined ? innerEnd : offsetMap[innerEnd];
-					const sourceStart = attr.valueStart + rawStart;
-					const sourceEnd = attr.valueStart + rawEnd;
-					const { line: sl, column: sc } = locConverter.get(sourceStart);
-					const { line: el, column: ec } = locConverter.get(sourceEnd);
-					if (type === "src" || type === "srcset") {
-						const dep = new HtmlSourceDependency(value, [
-							sourceStart,
-							sourceEnd
-						]);
-						dep.setLoc(sl, sc, el, ec);
-						module.addDependency(dep);
-						module.addCodeGenerationDependency(dep);
-						continue;
-					}
-
-					const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
-					const willBeModuleScript =
-						type === "script-module" || (outputModule && type === "script");
-					/** @type {"script" | "script-module" | "modulepreload" | "stylesheet"} */
-					const elementKind =
-						type === "modulepreload"
-							? "modulepreload"
-							: type === "stylesheet"
-								? "stylesheet"
-								: willBeModuleScript
-									? "script-module"
-									: "script";
-					const entryCategory =
-						type === "stylesheet"
-							? "css-import"
-							: type === "script-module" || type === "modulepreload"
-								? "esm"
-								: undefined;
-					const dep = new HtmlScriptSrcDependency(
-						value,
-						[sourceStart, sourceEnd],
-						entryName,
-						entryCategory,
-						elementKind,
-						node.start,
-						node.tagEnd
-					);
-					dep.setLoc(sl, sc, el, ec);
-					module.addPresentationalDependency(dep);
-					if (
-						elementName === "script" &&
-						(type === "script" || type === "script-module")
-					) {
-						const typeAttr = attrs.find((a) => a.name === "type");
-						reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
-					}
-					const collection =
-						type === "script"
-							? scriptEntries
-							: type === "script-module"
-								? scriptModuleEntries
-								: type === "stylesheet"
-									? stylesheetEntries
-									: modulePreloadEntries;
-					collection.push({ request: value, entryName, type });
-				}
-			}
-
-			if (elementName === "script") {
-				const scriptAttrs = getAttributesMap();
-				// SVG scripts reference their source via `href`/`xlink:href`;
-				// content is ignored when an external source is present.
-				const hasSrc =
-					scriptAttrs.has("src") ||
-					scriptAttrs.has("href") ||
-					scriptAttrs.has("xlink:href");
-
-				if (!hasSrc && isExecutableJsScript(scriptAttrs)) {
-					let contentStart = node.tagEnd;
-					let contentEnd = node.tagEnd;
-					let hasSeenTextChild = false;
-					for (const child of node.children) {
-						if (child.type === "text") {
-							if (!hasSeenTextChild) {
-								contentStart = child.start;
-								hasSeenTextChild = true;
-							}
-							contentEnd = child.end;
-						}
-					}
-
-					const jsContent = source.slice(contentStart, contentEnd);
-					if (jsContent.trim() !== "") {
-						const request = `data:text/javascript;base64,${Buffer.from(
-							jsContent,
-							"utf8"
-						).toString("base64")}`;
-
-						const useEsmEntry = isModuleScript(scriptAttrs);
-						const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
-						/** @type {"script" | "script-module"} */
-						const type = useEsmEntry ? "script-module" : "script";
-						const { line: sl, column: sc } = locConverter.get(contentStart);
-						const { line: el, column: ec } = locConverter.get(contentEnd);
-						const dep = new HtmlInlineScriptDependency(
-							request,
-							node.nameEnd,
-							[contentStart, contentEnd],
-							entryName,
-							useEsmEntry ? "esm" : "commonjs"
-						);
-						dep.setLoc(sl, sc, el, ec);
-						module.addPresentationalDependency(dep);
-
-						const typeAttr = attrs.find((a) => a.name === "type");
-						reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
-
-						const collection =
-							type === "script" ? scriptEntries : scriptModuleEntries;
-						collection.push({ request, entryName, type });
-					}
-				}
-			}
-		};
-
 		// TODO implement full HTML parser (WASM)
 		// The walker descends into children (and `<template>` content) itself;
 		// the Element `exit` clears a pending `webpackIgnore` once an element's
 		// children are done (the old `walkChildren` behaviour).
 		new SourceProcessor()
 			.use({
-				[NodeType.Comment]: (node) =>
-					onComment(/** @type {import("./syntax").HtmlComment} */ (node)),
+				[NodeType.Comment]: (n) => {
+					const node = /** @type {import("./syntax").HtmlComment} */ (n);
+					// Only proper `<!-- ... -->` comments carry magic comments.
+					if (
+						node.end - node.start < 7 ||
+						source.charCodeAt(node.start) !== 0x3c ||
+						source.charCodeAt(node.start + 1) !== 0x21 ||
+						source.charCodeAt(node.start + 2) !== 0x2d ||
+						source.charCodeAt(node.start + 3) !== 0x2d ||
+						source.charCodeAt(node.end - 1) !== 0x3e ||
+						source.charCodeAt(node.end - 2) !== 0x2d ||
+						source.charCodeAt(node.end - 3) !== 0x2d
+					) {
+						pendingWebpackIgnore = undefined;
+						return;
+					}
+					const value = node.data;
+					if (!webpackCommentRegExp.test(value)) {
+						pendingWebpackIgnore = undefined;
+						return;
+					}
+					/** @type {Record<string, EXPECTED_ANY>} */
+					let options;
+					try {
+						options = parseMagicComment(value, magicCommentContext);
+					} catch (err) {
+						const { line: sl, column: sc } = locConverter.get(node.start);
+						const { line: el, column: ec } = locConverter.get(node.end);
+						module.addWarning(
+							new CommentCompilationWarning(
+								`Compilation error while processing magic comment(-s): /*${value}*/: ${
+									/** @type {Error} */ (err).message
+								}`,
+								{
+									start: { line: sl, column: sc },
+									end: { line: el, column: ec }
+								}
+							)
+						);
+						pendingWebpackIgnore = undefined;
+						return;
+					}
+					if (options.webpackIgnore === undefined) {
+						pendingWebpackIgnore = undefined;
+						return;
+					}
+					if (typeof options.webpackIgnore !== "boolean") {
+						const { line: sl, column: sc } = locConverter.get(node.start);
+						const { line: el, column: ec } = locConverter.get(node.end);
+						module.addWarning(
+							new UnsupportedFeatureWarning(
+								`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
+								{
+									start: { line: sl, column: sc },
+									end: { line: el, column: ec }
+								}
+							)
+						);
+						pendingWebpackIgnore = undefined;
+						return;
+					}
+					pendingWebpackIgnore = options.webpackIgnore;
+				},
 				[NodeType.Doctype]: () => {
 					pendingWebpackIgnore = undefined;
 				},
 				[NodeType.Element]: {
-					enter: (node) =>
-						onElement(/** @type {import("./syntax").HtmlElement} */ (node)),
+					// Children (and `<template>` content) are walked by the
+					// processor after `enter`; `exit` clears a pending
+					// `webpackIgnore` once they're done.
+					enter: (n) => {
+						const node = /** @type {import("./syntax").HtmlElement} */ (n);
+						const ignore = pendingWebpackIgnore === true;
+						pendingWebpackIgnore = undefined;
+
+						if (ignore) {
+							return;
+						}
+
+						const elementName = node.tagName;
+						const attrs = node.attributes;
+
+						/** @type {Map<string, string> | undefined} */
+						let attributesMap;
+						const getAttributesMap = () => {
+							if (attributesMap) return attributesMap;
+							attributesMap = new Map();
+							for (const attr of attrs) {
+								// Decoded values — filters and type resolvers compare what
+								// the browser sees (e.g. `rel="&#105;con"` means `icon`)
+								attributesMap.set(
+									attr.name,
+									decodeHtmlEntities(attr.value, true)
+								);
+							}
+							return attributesMap;
+						};
+
+						if (elementName === "style") {
+							/** @type {string | undefined} */
+							let typeValue;
+							for (const attr of attrs) {
+								if (attr.name === "type") {
+									typeValue = attr.value;
+									break;
+								}
+							}
+
+							const trimmedType =
+								typeValue !== undefined ? typeValue.trim().toLowerCase() : "";
+							if (
+								typeValue !== undefined &&
+								trimmedType !== "" &&
+								trimmedType !== "text/css"
+							) {
+								return;
+							}
+
+							if (!css) {
+								return;
+							}
+
+							/** @type {number | undefined} */
+							let contentStart;
+							let contentEnd = node.tagEnd;
+							for (const child of node.children) {
+								if (child.type === "text") {
+									if (contentStart === undefined) {
+										contentStart = child.start;
+									}
+									contentEnd = child.end;
+								}
+							}
+
+							if (contentStart === undefined) {
+								contentStart = node.tagEnd;
+							}
+
+							const cssContent = source.slice(contentStart, contentEnd);
+							if (cssContent.trim() === "") {
+								return;
+							}
+
+							const request = `data:text/css;base64,${Buffer.from(
+								cssContent,
+								"utf8"
+							).toString("base64")}`;
+
+							const { line: sl, column: sc } = locConverter.get(contentStart);
+							const { line: el, column: ec } = locConverter.get(contentEnd);
+							const dep = new HtmlInlineStyleDependency(request, [
+								contentStart,
+								contentEnd
+							]);
+							dep.setLoc(sl, sc, el, ec);
+							module.addDependency(dep);
+							module.addCodeGenerationDependency(dep);
+							return;
+						}
+
+						// Inline `style="..."` attribute — a CSS block's contents. Route
+						// URL-bearing values through the CSS pipeline so `url()` & co.
+						// resolve relative to the HTML file (parsed via `as:
+						// "block-contents"`, see the `html-style-attribute` default rule).
+						if (css) {
+							for (const attr of attrs) {
+								if (attr.name !== "style") continue;
+								if (attr.valueStart === undefined || attr.valueStart === -1) {
+									break;
+								}
+								const value = attr.value;
+								if (!value) break;
+								// The browser sees the decoded value as the CSS text (so the
+								// url() pre-filter must run on it too); the dependency
+								// template re-escapes on write-back.
+								const cssText = decodeHtmlEntities(value, true);
+								if (!STYLE_ATTR_URL_REGEXP.test(cssText)) break;
+								const request = `data:text/css;base64,${Buffer.from(
+									cssText,
+									"utf8"
+								).toString("base64")}`;
+								const { line: sl, column: sc } = locConverter.get(
+									attr.valueStart
+								);
+								const { line: el, column: ec } = locConverter.get(
+									attr.valueEnd
+								);
+								const dep = new HtmlInlineStyleDependency(
+									request,
+									[attr.valueStart, attr.valueEnd],
+									true
+								);
+								dep.setLoc(sl, sc, el, ec);
+								module.addDependency(dep);
+								module.addCodeGenerationDependency(dep);
+								break;
+							}
+						}
+
+						// TODO parse `<iframe srcdoc>` (an entity-escaped HTML document)
+						// and rewrite its asset URLs in place — needs a restricted walk
+						// with offsets composed through `decodeHtmlEntitiesWithMap`
+
+						const tagSources =
+							this.sourcesByTag[elementName] || this.anyTagSources;
+						if (!tagSources && elementName !== "script") {
+							return;
+						}
+
+						for (const attr of tagSources ? attrs : []) {
+							const sourceItem = tagSources[attr.name];
+							if (!sourceItem) continue;
+
+							// Attributes on adoption-agency clones carry no source offsets;
+							// the original element already owns the dependency span.
+							if (attr.valueStart === undefined || attr.valueStart === -1) {
+								continue;
+							}
+
+							const attributeValue = attr.value;
+							if (!attributeValue || !/\S/.test(attributeValue)) continue;
+
+							if (
+								typeof sourceItem.filter === "function" &&
+								!sourceItem.filter(getAttributesMap())
+							) {
+								continue;
+							}
+
+							const type =
+								typeof sourceItem.type === "function"
+									? sourceItem.type(getAttributesMap(), css)
+									: sourceItem.type;
+							let parse = type === "srcset" ? parseSrcset : parseSrc;
+							if (elementName === "meta") {
+								const name = getAttributesMap().get("name");
+								if (
+									name !== undefined &&
+									name.trim().toLowerCase() === "msapplication-task"
+								) {
+									parse = parseMsapplicationTask;
+								}
+							}
+
+							// Inline CSS attribute value: `stylesheet-style` parses it as a
+							// full stylesheet (like a `<style>` body), `stylesheet-style-attribute`
+							// as a block's contents (a declaration list, like a `style` attribute).
+							if (
+								type === "stylesheet-style" ||
+								type === "stylesheet-style-attribute"
+							) {
+								if (attributeValue.trim() === "") continue;
+								// The browser sees the decoded value as the CSS text
+								const cssText = decodeHtmlEntities(attributeValue, true);
+								const request = `data:text/css;base64,${Buffer.from(
+									cssText,
+									"utf8"
+								).toString("base64")}`;
+								const { line: sl, column: sc } = locConverter.get(
+									attr.valueStart
+								);
+								const { line: el, column: ec } = locConverter.get(
+									attr.valueEnd
+								);
+								const dep = new HtmlInlineStyleDependency(
+									request,
+									[attr.valueStart, attr.valueEnd],
+									type === "stylesheet-style-attribute",
+									// Both types read an attribute value, so write-back
+									// must re-escape regardless of the CSS parse mode
+									true
+								);
+								dep.setLoc(sl, sc, el, ec);
+								module.addDependency(dep);
+								module.addCodeGenerationDependency(dep);
+								continue;
+							}
+
+							// Browsers decode character references at tokenize time, so the
+							// parsers run on the decoded value (entity-encoded whitespace
+							// separates srcset candidates, etc.); the boundary map
+							// translates spans back to raw source offsets for rewriting.
+							let parseValue = attributeValue;
+							/** @type {number[] | undefined} */
+							let offsetMap;
+							if (attributeValue.includes("&")) {
+								({ text: parseValue, map: offsetMap } =
+									decodeHtmlEntitiesWithMap(attributeValue, true));
+								if (!/\S/.test(parseValue)) continue;
+							}
+
+							/** @type {ParsedSource[] | undefined} */
+							let parsedAttributeValue;
+
+							try {
+								parsedAttributeValue = parse(parseValue);
+							} catch (err) {
+								const { line: sl, column: sc } = locConverter.get(
+									attr.valueStart
+								);
+								const { line: el, column: ec } = locConverter.get(
+									attr.valueEnd
+								);
+
+								module.addError(
+									new ModuleDependencyError(
+										module,
+										new WebpackError(
+											`Bad value for attribute "${
+												attr.name
+											}" on element "${elementName}": ${
+												/** @type {Error} */ (err).message
+											}`
+										),
+										{
+											start: { line: sl, column: sc },
+											end: { line: el, column: ec }
+										}
+									)
+								);
+							}
+
+							if (!parsedAttributeValue) continue;
+
+							for (const parsedSource of parsedAttributeValue) {
+								const [value, innerStart, innerEnd] = parsedSource;
+								if (value.startsWith("#")) continue;
+								const rawStart =
+									offsetMap === undefined ? innerStart : offsetMap[innerStart];
+								const rawEnd =
+									offsetMap === undefined ? innerEnd : offsetMap[innerEnd];
+								const sourceStart = attr.valueStart + rawStart;
+								const sourceEnd = attr.valueStart + rawEnd;
+								const { line: sl, column: sc } = locConverter.get(sourceStart);
+								const { line: el, column: ec } = locConverter.get(sourceEnd);
+								if (type === "src" || type === "srcset") {
+									const dep = new HtmlSourceDependency(value, [
+										sourceStart,
+										sourceEnd
+									]);
+									dep.setLoc(sl, sc, el, ec);
+									module.addDependency(dep);
+									module.addCodeGenerationDependency(dep);
+									continue;
+								}
+
+								const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+								const willBeModuleScript =
+									type === "script-module" ||
+									(outputModule && type === "script");
+								/** @type {"script" | "script-module" | "modulepreload" | "stylesheet"} */
+								const elementKind =
+									type === "modulepreload"
+										? "modulepreload"
+										: type === "stylesheet"
+											? "stylesheet"
+											: willBeModuleScript
+												? "script-module"
+												: "script";
+								const entryCategory =
+									type === "stylesheet"
+										? "css-import"
+										: type === "script-module" || type === "modulepreload"
+											? "esm"
+											: undefined;
+								const dep = new HtmlScriptSrcDependency(
+									value,
+									[sourceStart, sourceEnd],
+									entryName,
+									entryCategory,
+									elementKind,
+									node.start,
+									node.tagEnd
+								);
+								dep.setLoc(sl, sc, el, ec);
+								module.addPresentationalDependency(dep);
+								if (
+									elementName === "script" &&
+									(type === "script" || type === "script-module")
+								) {
+									const typeAttr = attrs.find((a) => a.name === "type");
+									reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
+								}
+								const collection =
+									type === "script"
+										? scriptEntries
+										: type === "script-module"
+											? scriptModuleEntries
+											: type === "stylesheet"
+												? stylesheetEntries
+												: modulePreloadEntries;
+								collection.push({ request: value, entryName, type });
+							}
+						}
+
+						if (elementName === "script") {
+							const scriptAttrs = getAttributesMap();
+							// SVG scripts reference their source via `href`/`xlink:href`;
+							// content is ignored when an external source is present.
+							const hasSrc =
+								scriptAttrs.has("src") ||
+								scriptAttrs.has("href") ||
+								scriptAttrs.has("xlink:href");
+
+							if (!hasSrc && isExecutableJsScript(scriptAttrs)) {
+								let contentStart = node.tagEnd;
+								let contentEnd = node.tagEnd;
+								let hasSeenTextChild = false;
+								for (const child of node.children) {
+									if (child.type === "text") {
+										if (!hasSeenTextChild) {
+											contentStart = child.start;
+											hasSeenTextChild = true;
+										}
+										contentEnd = child.end;
+									}
+								}
+
+								const jsContent = source.slice(contentStart, contentEnd);
+								if (jsContent.trim() !== "") {
+									const request = `data:text/javascript;base64,${Buffer.from(
+										jsContent,
+										"utf8"
+									).toString("base64")}`;
+
+									const useEsmEntry = isModuleScript(scriptAttrs);
+									const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+									/** @type {"script" | "script-module"} */
+									const type = useEsmEntry ? "script-module" : "script";
+									const { line: sl, column: sc } =
+										locConverter.get(contentStart);
+									const { line: el, column: ec } = locConverter.get(contentEnd);
+									const dep = new HtmlInlineScriptDependency(
+										request,
+										node.nameEnd,
+										[contentStart, contentEnd],
+										entryName,
+										useEsmEntry ? "esm" : "commonjs"
+									);
+									dep.setLoc(sl, sc, el, ec);
+									module.addPresentationalDependency(dep);
+
+									const typeAttr = attrs.find((a) => a.name === "type");
+									reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
+
+									const collection =
+										type === "script" ? scriptEntries : scriptModuleEntries;
+									collection.push({ request, entryName, type });
+								}
+							}
+						}
+					},
 					exit: () => {
 						pendingWebpackIgnore = undefined;
 					}

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -25,7 +25,9 @@ const {
 	webpackCommentRegExp
 } = require("../util/magicComment");
 const {
+	NodeType,
 	SVG_TAG_ADJUST,
+	SourceProcessor,
 	buildHtmlAst,
 	decodeHtmlEntities,
 	decodeHtmlEntitiesWithMap
@@ -977,9 +979,6 @@ class HtmlParser extends Parser {
 
 		const magicCommentContext = this.magicCommentContext;
 
-		// TODO implement full HTML parser (WASM)
-		const doc = buildHtmlAst(source);
-
 		/**
 		 * @param {import("./syntax").HtmlAttribute | undefined} typeAttr type attribute
 		 * @param {number} nameEnd end offset of the tag name
@@ -1028,113 +1027,83 @@ class HtmlParser extends Parser {
 			}
 		};
 
-		/**
-		 * @param {import("./syntax").HtmlNode[]} children children
-		 * @returns {void}
-		 */
-		const walkChildren = (children) => {
-			for (const child of children) walkNode(child);
-			pendingWebpackIgnore = undefined;
-		};
-
-		/**
-		 * `<template>` children live in a separate content fragment, not in
-		 * `children` — walk both so template content is not skipped.
-		 * @param {import("./syntax").HtmlElement} node element node
-		 * @returns {void}
-		 */
-		const walkElementChildren = (node) => {
-			if (node.templateContent !== undefined) {
-				walkChildren(node.templateContent.children);
-			}
-			walkChildren(node.children);
-		};
-
-		/** @param {import("./syntax").HtmlNode} node AST node */
-		const walkNode = (node) => {
-			if (node.type === "comment") {
-				// Only proper `<!-- ... -->` comments carry magic comments.
-				if (
-					node.end - node.start < 7 ||
-					source.charCodeAt(node.start) !== 0x3c ||
-					source.charCodeAt(node.start + 1) !== 0x21 ||
-					source.charCodeAt(node.start + 2) !== 0x2d ||
-					source.charCodeAt(node.start + 3) !== 0x2d ||
-					source.charCodeAt(node.end - 1) !== 0x3e ||
-					source.charCodeAt(node.end - 2) !== 0x2d ||
-					source.charCodeAt(node.end - 3) !== 0x2d
-				) {
-					pendingWebpackIgnore = undefined;
-					return;
-				}
-				const value = node.data;
-				if (!webpackCommentRegExp.test(value)) {
-					pendingWebpackIgnore = undefined;
-					return;
-				}
-				/** @type {Record<string, EXPECTED_ANY>} */
-				let options;
-				try {
-					options = vm.runInContext(
-						`(function(){return {${value}};})()`,
-						magicCommentContext
-					);
-				} catch (err) {
-					const { line: sl, column: sc } = locConverter.get(node.start);
-					const { line: el, column: ec } = locConverter.get(node.end);
-					module.addWarning(
-						new CommentCompilationWarning(
-							`Compilation error while processing magic comment(-s): /*${value}*/: ${
-								/** @type {Error} */ (err).message
-							}`,
-							{
-								start: { line: sl, column: sc },
-								end: { line: el, column: ec }
-							}
-						)
-					);
-					pendingWebpackIgnore = undefined;
-					return;
-				}
-				if (options.webpackIgnore === undefined) {
-					pendingWebpackIgnore = undefined;
-					return;
-				}
-				if (typeof options.webpackIgnore !== "boolean") {
-					const { line: sl, column: sc } = locConverter.get(node.start);
-					const { line: el, column: ec } = locConverter.get(node.end);
-					module.addWarning(
-						new UnsupportedFeatureWarning(
-							`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
-							{
-								start: { line: sl, column: sc },
-								end: { line: el, column: ec }
-							}
-						)
-					);
-					pendingWebpackIgnore = undefined;
-					return;
-				}
-				pendingWebpackIgnore = options.webpackIgnore;
-				return;
-			}
-
-			if (node.type === "doctype") {
+		/** @param {import("./syntax").HtmlComment} node comment node */
+		const onComment = (node) => {
+			// Only proper `<!-- ... -->` comments carry magic comments.
+			if (
+				node.end - node.start < 7 ||
+				source.charCodeAt(node.start) !== 0x3c ||
+				source.charCodeAt(node.start + 1) !== 0x21 ||
+				source.charCodeAt(node.start + 2) !== 0x2d ||
+				source.charCodeAt(node.start + 3) !== 0x2d ||
+				source.charCodeAt(node.end - 1) !== 0x3e ||
+				source.charCodeAt(node.end - 2) !== 0x2d ||
+				source.charCodeAt(node.end - 3) !== 0x2d
+			) {
 				pendingWebpackIgnore = undefined;
 				return;
 			}
-
-			if (node.type === "text") {
+			const value = node.data;
+			if (!webpackCommentRegExp.test(value)) {
+				pendingWebpackIgnore = undefined;
 				return;
 			}
+			/** @type {Record<string, EXPECTED_ANY>} */
+			let options;
+			try {
+				options = vm.runInContext(
+					`(function(){return {${value}};})()`,
+					magicCommentContext
+				);
+			} catch (err) {
+				const { line: sl, column: sc } = locConverter.get(node.start);
+				const { line: el, column: ec } = locConverter.get(node.end);
+				module.addWarning(
+					new CommentCompilationWarning(
+						`Compilation error while processing magic comment(-s): /*${value}*/: ${
+							/** @type {Error} */ (err).message
+						}`,
+						{
+							start: { line: sl, column: sc },
+							end: { line: el, column: ec }
+						}
+					)
+				);
+				pendingWebpackIgnore = undefined;
+				return;
+			}
+			if (options.webpackIgnore === undefined) {
+				pendingWebpackIgnore = undefined;
+				return;
+			}
+			if (typeof options.webpackIgnore !== "boolean") {
+				const { line: sl, column: sc } = locConverter.get(node.start);
+				const { line: el, column: ec } = locConverter.get(node.end);
+				module.addWarning(
+					new UnsupportedFeatureWarning(
+						`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
+						{
+							start: { line: sl, column: sc },
+							end: { line: el, column: ec }
+						}
+					)
+				);
+				pendingWebpackIgnore = undefined;
+				return;
+			}
+			pendingWebpackIgnore = options.webpackIgnore;
+		};
 
-			if (node.type !== "element") return;
-
+		/**
+		 * Element `enter` visitor — children (and `<template>` content) are
+		 * descended by the walker itself after this returns.
+		 * @param {import("./syntax").HtmlElement} node element node
+		 */
+		const onElement = (node) => {
 			const ignore = pendingWebpackIgnore === true;
 			pendingWebpackIgnore = undefined;
 
 			if (ignore) {
-				walkElementChildren(node);
 				return;
 			}
 
@@ -1171,12 +1140,10 @@ class HtmlParser extends Parser {
 					trimmedType !== "" &&
 					trimmedType !== "text/css"
 				) {
-					walkChildren(node.children);
 					return;
 				}
 
 				if (!css) {
-					walkChildren(node.children);
 					return;
 				}
 
@@ -1198,11 +1165,13 @@ class HtmlParser extends Parser {
 
 				const cssContent = source.slice(contentStart, contentEnd);
 				if (cssContent.trim() === "") {
-					walkChildren(node.children);
 					return;
 				}
 
-				const request = `data:text/css;base64,${Buffer.from(cssContent, "utf8").toString("base64")}`;
+				const request = `data:text/css;base64,${Buffer.from(
+					cssContent,
+					"utf8"
+				).toString("base64")}`;
 
 				const { line: sl, column: sc } = locConverter.get(contentStart);
 				const { line: el, column: ec } = locConverter.get(contentEnd);
@@ -1213,7 +1182,6 @@ class HtmlParser extends Parser {
 				dep.setLoc(sl, sc, el, ec);
 				module.addDependency(dep);
 				module.addCodeGenerationDependency(dep);
-				walkChildren(node.children);
 				return;
 			}
 
@@ -1232,7 +1200,10 @@ class HtmlParser extends Parser {
 					// template re-escapes on write-back.
 					const cssText = decodeHtmlEntities(value, true);
 					if (!STYLE_ATTR_URL_REGEXP.test(cssText)) break;
-					const request = `data:text/css;base64,${Buffer.from(cssText, "utf8").toString("base64")}`;
+					const request = `data:text/css;base64,${Buffer.from(
+						cssText,
+						"utf8"
+					).toString("base64")}`;
 					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
 					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
 					const dep = new HtmlInlineStyleDependency(
@@ -1253,7 +1224,6 @@ class HtmlParser extends Parser {
 
 			const tagSources = this.sourcesByTag[elementName] || this.anyTagSources;
 			if (!tagSources && elementName !== "script") {
-				walkElementChildren(node);
 				return;
 			}
 
@@ -1300,7 +1270,10 @@ class HtmlParser extends Parser {
 					if (attributeValue.trim() === "") continue;
 					// The browser sees the decoded value as the CSS text
 					const cssText = decodeHtmlEntities(attributeValue, true);
-					const request = `data:text/css;base64,${Buffer.from(cssText, "utf8").toString("base64")}`;
+					const request = `data:text/css;base64,${Buffer.from(
+						cssText,
+						"utf8"
+					).toString("base64")}`;
 					const { line: sl, column: sc } = locConverter.get(attr.valueStart);
 					const { line: el, column: ec } = locConverter.get(attr.valueEnd);
 					const dep = new HtmlInlineStyleDependency(
@@ -1345,7 +1318,9 @@ class HtmlParser extends Parser {
 						new ModuleDependencyError(
 							module,
 							new WebpackError(
-								`Bad value for attribute "${attr.name}" on element "${elementName}": ${
+								`Bad value for attribute "${
+									attr.name
+								}" on element "${elementName}": ${
 									/** @type {Error} */ (err).message
 								}`
 							),
@@ -1484,11 +1459,28 @@ class HtmlParser extends Parser {
 					}
 				}
 			}
-
-			walkElementChildren(node);
 		};
 
-		for (const child of doc.children) walkNode(child);
+		// TODO implement full HTML parser (WASM)
+		// The walker descends into children (and `<template>` content) itself;
+		// the Element `exit` clears a pending `webpackIgnore` once an element's
+		// children are done (the old `walkChildren` behaviour).
+		new SourceProcessor()
+			.use({
+				[NodeType.Comment]: (node) =>
+					onComment(/** @type {import("./syntax").HtmlComment} */ (node)),
+				[NodeType.Doctype]: () => {
+					pendingWebpackIgnore = undefined;
+				},
+				[NodeType.Element]: {
+					enter: (node) =>
+						onElement(/** @type {import("./syntax").HtmlElement} */ (node)),
+					exit: () => {
+						pendingWebpackIgnore = undefined;
+					}
+				}
+			})
+			.process(source, { ast: buildHtmlAst(source) });
 
 		const buildInfo = /** @type {BuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3791,7 +3791,7 @@ const NS_SVG = 2;
 
 /**
  * @typedef {object} HtmlElement
- * @property {"element"} type
+ * @property {typeof NodeType.Element} type
  * @property {string} tagName
  * @property {number} namespace
  * @property {HtmlAttribute[]} attributes
@@ -3806,7 +3806,7 @@ const NS_SVG = 2;
 
 /**
  * @typedef {object} HtmlText
- * @property {"text"} type
+ * @property {typeof NodeType.Text} type
  * @property {string} data
  * @property {number} start
  * @property {number} end
@@ -3814,7 +3814,7 @@ const NS_SVG = 2;
 
 /**
  * @typedef {object} HtmlComment
- * @property {"comment"} type
+ * @property {typeof NodeType.Comment} type
  * @property {string} data
  * @property {number} start
  * @property {number} end
@@ -3822,7 +3822,7 @@ const NS_SVG = 2;
 
 /**
  * @typedef {object} HtmlDoctype
- * @property {"doctype"} type
+ * @property {typeof NodeType.Doctype} type
  * @property {string} name
  * @property {string | null} publicId
  * @property {string | null} systemId
@@ -3832,13 +3832,13 @@ const NS_SVG = 2;
 
 /**
  * @typedef {object} HtmlDocument
- * @property {"document"} type
+ * @property {typeof NodeType.Document} type
  * @property {HtmlNode[]} children
  */
 
 /**
  * @typedef {object} HtmlDocumentFragment
- * @property {"document-fragment"} type
+ * @property {typeof NodeType.DocumentFragment} type
  * @property {HtmlNode[]} children
  */
 
@@ -3846,12 +3846,22 @@ const NS_SVG = 2;
 
 /** @typedef {{ start: number, end: number, tagEnd: number, nameEnd: number }} TagPos */
 
-/** @typedef {{ type: "char", data: string, start: number, end: number }} CharToken */
-/** @typedef {{ type: "comment", data: string, start: number, end: number }} CommentToken */
-/** @typedef {{ type: "doctype", name: string, publicId: (string | null), systemId: (string | null), start: number, end: number }} DoctypeToken */
-/** @typedef {{ type: "startTag", name: string, attrs: HtmlAttribute[], selfClosing: boolean, pos: TagPos, swallowNewline?: boolean }} StartTagToken */
-/** @typedef {{ type: "endTag", name: string, pos: TagPos }} EndTagToken */
-/** @typedef {{ type: "eof" }} EofToken */
+// Tree-construction token `type` discriminators. Numeric for the same reason
+// as `NodeType` / the CSS `TT_*` constants: the insertion modes dispatch on
+// `t.type` per token, and integer `===` beats string comparison there.
+const TOKEN_CHAR = 1;
+const TOKEN_COMMENT = 2;
+const TOKEN_DOCTYPE = 3;
+const TOKEN_START_TAG = 4;
+const TOKEN_END_TAG = 5;
+const TOKEN_EOF = 6;
+
+/** @typedef {{ type: typeof TOKEN_CHAR, data: string, start: number, end: number }} CharToken */
+/** @typedef {{ type: typeof TOKEN_COMMENT, data: string, start: number, end: number }} CommentToken */
+/** @typedef {{ type: typeof TOKEN_DOCTYPE, name: string, publicId: (string | null), systemId: (string | null), start: number, end: number }} DoctypeToken */
+/** @typedef {{ type: typeof TOKEN_START_TAG, name: string, attrs: HtmlAttribute[], selfClosing: boolean, pos: TagPos, swallowNewline?: boolean }} StartTagToken */
+/** @typedef {{ type: typeof TOKEN_END_TAG, name: string, pos: TagPos }} EndTagToken */
+/** @typedef {{ type: typeof TOKEN_EOF }} EofToken */
 
 /**
  * Internal token passed through the tree-construction insertion modes.
@@ -3866,7 +3876,7 @@ const NS_SVG = 2;
  * stale values that those handlers never read. Tokens that must outlive the
  * current callback (buffered table characters, synthesized re-dispatches) are
  * copied into fresh plain objects instead.
- * @typedef {{ type: string, name: string, data: string, attrs: HtmlAttribute[], selfClosing: boolean, start: number, end: number, publicId: (string | null), systemId: (string | null), swallowNewline: boolean, pos: TagPos }} MutableToken
+ * @typedef {{ type: number, name: string, data: string, attrs: HtmlAttribute[], selfClosing: boolean, start: number, end: number, publicId: (string | null), systemId: (string | null), swallowNewline: boolean, pos: TagPos }} MutableToken
  */
 
 /** @typedef {{ parent: HtmlElement | HtmlDocument | HtmlDocumentFragment, beforeNode: (HtmlNode | null) }} InsertionPlace */
@@ -4479,7 +4489,7 @@ const findAttr = (
  */
 const buildHtmlAst = (source, fragmentContext) => {
 	/** @type {HtmlDocument} */
-	const doc = { type: "document", children: [] };
+	const doc = { type: NodeType.Document, children: [] };
 	let mode = "initial";
 	/** @type {string | null} */
 	let originalMode = null;
@@ -4518,7 +4528,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		/** @type {TagPos | null | undefined} */ pos
 	) =>
 		/** @type {HtmlElement} */ ({
-			type: "element",
+			type: NodeType.Element,
 			tagName,
 			namespace: ns,
 			attributes: attributes || EMPTY_ATTRS,
@@ -4552,7 +4562,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	 * @returns {HtmlNode[]} children array to insert into
 	 */
 	const childrenOf = (parent) =>
-		parent.type === "element" && parent.templateContent
+		parent.type === NodeType.Element && parent.templateContent
 			? parent.templateContent.children
 			: parent.children;
 
@@ -4562,7 +4572,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
-		if (node.type === "text" && last && last.type === "text") {
+		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
 			last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
@@ -4640,7 +4650,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				);
 			for (const k of childrenOf(x)) {
 				if (k === node) return x;
-				if (k.type === "element") stack.push(k);
+				if (k.type === NodeType.Element) stack.push(k);
 			}
 		}
 		return null;
@@ -4653,7 +4663,11 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (place.beforeNode) {
 			const arr = childrenOf(place.parent);
 			const idx = arr.indexOf(place.beforeNode);
-			if (node.type === "text" && idx > 0 && arr[idx - 1].type === "text") {
+			if (
+				node.type === NodeType.Text &&
+				idx > 0 &&
+				arr[idx - 1].type === NodeType.Text
+			) {
 				/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
 				return;
 			}
@@ -4669,7 +4683,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		/** @type {number} */ end
 	) => {
 		const place = appropriatePlace();
-		if (place.parent.type === "document") return; // never insert text into document
+		if (place.parent.type === NodeType.Document) return; // never insert text into document
 		// Inlined text insert: when the run merges into the adjacent text sibling
 		// (common with inline formatting) only the string is appended — no
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
@@ -4678,19 +4692,19 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
-			if (prev && prev.type === "text") {
+			if (prev && prev.type === NodeType.Text) {
 				prev.data += data;
 				return;
 			}
-			arr.splice(idx, 0, { type: "text", data, start, end });
+			arr.splice(idx, 0, { type: NodeType.Text, data, start, end });
 		} else {
 			const last = arr[arr.length - 1];
-			if (last && last.type === "text") {
+			if (last && last.type === NodeType.Text) {
 				last.data += data;
 				last.end = end;
 				return;
 			}
-			arr.push({ type: "text", data, start, end });
+			arr.push({ type: NodeType.Text, data, start, end });
 		}
 	};
 
@@ -4702,7 +4716,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	 */
 	const insertComment = (data, start, end, place) => {
 		const p = place || appropriatePlace();
-		insertAtPlace(p, { type: "comment", data, start, end });
+		insertAtPlace(p, { type: NodeType.Comment, data, start, end });
 	};
 
 	const insertHtmlElement = (
@@ -5018,15 +5032,15 @@ const buildHtmlAst = (source, fragmentContext) => {
 		// Dispatch on `type` instead of the `in` operator, which goes megamorphic
 		// across the token union and shows up on the per-token hot path.
 		const ty = t.type;
-		if (ty === "startTag" || ty === "endTag") tokenEnd = t.pos.end;
-		else if (ty !== "eof") tokenEnd = t.end;
+		if (ty === TOKEN_START_TAG || ty === TOKEN_END_TAG) tokenEnd = t.pos.end;
+		else if (ty !== TOKEN_EOF) tokenEnd = t.end;
 		// foreign content dispatch
 		const ac = adjustedCurrent();
 		const useForeign =
 			open.length > 0 &&
 			ac &&
 			ac.namespace !== NS_HTML &&
-			ty !== "eof" &&
+			ty !== TOKEN_EOF &&
 			shouldUseForeignRules(ac, t);
 		if (useForeign) {
 			foreignContent(t);
@@ -5040,7 +5054,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		/** @type {Token} */ t
 	) => {
 		if (ac.namespace === NS_HTML) return false;
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_START_TAG) {
 			if (
 				mathmlTextIntegrationPoint(ac) &&
 				t.name !== "mglyph" &&
@@ -5058,13 +5072,13 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (htmlIntegrationPoint(ac)) return false;
 			return true;
 		}
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			if (mathmlTextIntegrationPoint(ac)) return false;
 			if (htmlIntegrationPoint(ac)) return false;
 			return true;
 		}
-		if (t.type === "endTag") return true;
-		if (t.type === "comment") return true;
+		if (t.type === TOKEN_END_TAG) return true;
+		if (t.type === TOKEN_COMMENT) return true;
 		return false;
 	};
 
@@ -5124,19 +5138,19 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	const foreignContent = (/** @type {Token} */ t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const data = t.data.replace(/\0/g, "�");
 			insertCharacters(data, t.start, t.end);
 			// eslint-disable-next-line no-control-regex
 			if (/[^\t\n\f\r \u0000]/.test(t.data)) framesetOk = false;
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG) {
 			const acn = adjustedCurrent().namespace;
 			if (
 				FOREIGN_BREAKOUT.has(t.name) ||
@@ -5174,7 +5188,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			}
 			return;
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			if (
 				t.name === "script" &&
 				cur().tagName === "script" &&
@@ -5541,7 +5555,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.initial = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, false);
 			if (!r) return;
 			quirks = true;
@@ -5549,13 +5563,13 @@ const buildHtmlAst = (source, fragmentContext) => {
 			process(r);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: null });
 			return;
 		}
-		if (t.type === "doctype") {
+		if (t.type === TOKEN_DOCTYPE) {
 			doc.children.push({
-				type: "doctype",
+				type: NodeType.Doctype,
 				name: t.name,
 				publicId: t.publicId,
 				systemId: t.systemId,
@@ -5572,24 +5586,24 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.beforeHtml = (t) => {
-		if (t.type === "doctype") return;
-		if (t.type === "comment") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: null });
 			return;
 		}
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, false);
 			if (!r) return;
 			t = r;
 		}
-		if (t.type === "startTag" && t.name === "html") {
+		if (t.type === TOKEN_START_TAG && t.name === "html") {
 			const el = mkEl("html", NS_HTML, t.attrs, t.pos);
 			doc.children.push(el);
 			open.push(el);
 			mode = "beforeHead";
 			return;
 		}
-		if (t.type === "endTag" && !HEAD_BODY_HTML_BR.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
 			return;
 		}
 		const el = mkEl("html", NS_HTML, [], null);
@@ -5600,23 +5614,23 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.beforeHead = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, false);
 			if (!r) return;
 			t = r;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "head") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "head") {
 			head = insertHtmlElement("head", t.attrs, t.pos);
 			mode = "inHead";
 			return;
 		}
-		if (t.type === "endTag" && !HEAD_BODY_HTML_BR.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
 			return;
 		}
 		head = insertHtmlElement("head", EMPTY_ATTRS, null);
@@ -5625,7 +5639,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inHead = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, true);
 			if (!r) return;
 			open.pop();
@@ -5633,12 +5647,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 			process(r);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG) {
 			if (t.name === "html") return modes.inBody(t);
 			if (HEAD_VOID_ELEMENTS.has(t.name)) {
 				insertHtmlElement(t.name, t.attrs, t.pos);
@@ -5669,12 +5683,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 				mode = "inTemplate";
 				templateModes.push("inTemplate");
 				const el = cur();
-				el.templateContent = { type: "document-fragment", children: [] };
+				el.templateContent = { type: NodeType.DocumentFragment, children: [] };
 				return;
 			}
 			if (t.name === "head") return;
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			if (t.name === "head") {
 				open.pop();
 				mode = "afterHead";
@@ -5703,23 +5717,29 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inHeadNoscript = (t) => {
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "endTag" && t.name === "noscript") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_END_TAG && t.name === "noscript") {
 			open.pop();
 			mode = "inHead";
 			return;
 		}
-		if (t.type === "char" && isAllWs(t.data)) return modes.inHead(t);
-		if (t.type === "comment") return modes.inHead(t);
-		if (t.type === "startTag" && IN_HEAD_NOSCRIPT_PASSTHROUGH.has(t.name)) {
+		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inHead(t);
+		if (t.type === TOKEN_COMMENT) return modes.inHead(t);
+		if (
+			t.type === TOKEN_START_TAG &&
+			IN_HEAD_NOSCRIPT_PASSTHROUGH.has(t.name)
+		) {
 			return modes.inHead(t);
 		}
 		// A stray end tag other than </br>/</noscript> is ignored (the comment
 		// or content stays inside <noscript>); only </br> and other content fall
 		// back to popping <noscript>.
-		if (t.type === "endTag" && t.name !== "br") return;
-		if (t.type === "startTag" && (t.name === "head" || t.name === "noscript")) {
+		if (t.type === TOKEN_END_TAG && t.name !== "br") return;
+		if (
+			t.type === TOKEN_START_TAG &&
+			(t.name === "head" || t.name === "noscript")
+		) {
 			return;
 		}
 		open.pop();
@@ -5728,7 +5748,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.afterHead = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, true);
 			if (!r) return;
 			insertHtmlElement("body", [], null);
@@ -5736,12 +5756,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 			process(r);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG) {
 			if (t.name === "html") return modes.inBody(t);
 			if (t.name === "body") {
 				insertHtmlElement("body", t.attrs, t.pos);
@@ -5764,7 +5784,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			}
 			if (t.name === "head") return;
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			if (t.name === "template") return modes.inHead(t);
 			if (!BODY_HTML_BR.has(t.name)) return;
 		}
@@ -5774,7 +5794,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inBody = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			if (t.data.includes("\0")) t = { ...t, data: t.data.replace(/\0/g, "") };
 			if (t.data === "") return;
 			reconstructAfe();
@@ -5785,14 +5805,16 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (framesetOk && !isAllWs(t.data)) framesetOk = false;
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag") return startTagInBody(t);
-		if (t.type === "endTag") return endTagInBody(t);
-		if (t.type === "eof" && templateModes.length) return modes.inTemplate(t);
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG) return startTagInBody(t);
+		if (t.type === TOKEN_END_TAG) return endTagInBody(t);
+		if (t.type === TOKEN_EOF && templateModes.length) {
+			return modes.inTemplate(t);
+		}
 	};
 
 	const closeIfPInButtonScope = () => {
@@ -6240,17 +6262,17 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.text = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			insertCharacters(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "eof") {
+		if (t.type === TOKEN_EOF) {
 			if (open.length) open.pop();
 			mode = /** @type {string} */ (originalMode);
 			process(t);
 			return;
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			// Treat as rawtext rather than an end tag when it can't close the
 			// current element: a non-matching name (e.g. a fragment context), or
 			// a name that ran straight to EOF with no delimiter (`</script` at
@@ -6273,7 +6295,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	let pendingTableChars = null;
 
 	modes.inTable = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const c = cur();
 			if (TABLE_CONTEXT.has(c.tagName) && c.namespace === NS_HTML) {
 				pendingTableChars = { list: [], hasNonWs: false };
@@ -6282,12 +6304,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 				return process(t);
 			}
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG) {
 			const name = t.name;
 			if (name === "caption") {
 				clearStackToTableContext();
@@ -6346,7 +6368,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				return;
 			}
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			if (t.name === "table") {
 				if (!inTableScope("table")) return;
 				popUntil("table");
@@ -6358,7 +6380,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			}
 			if (t.name === "template") return modes.inHead(t);
 		}
-		if (t.type === "eof") return modes.inBody(t);
+		if (t.type === TOKEN_EOF) return modes.inBody(t);
 		// anything else: foster parenting
 		fosterParenting = true;
 		modes.inBody(t);
@@ -6366,13 +6388,13 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inTableText = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const data = t.data.includes("\0") ? t.data.replace(/\0/g, "") : t.data;
 			if (data === "") return;
 			// Snapshot into a fresh token: these are buffered and replayed after
 			// later tokens arrive, so they must not alias the reused token.
 			/** @type {CharToken} */
-			const tc = { type: "char", data, start: t.start, end: t.end };
+			const tc = { type: TOKEN_CHAR, data, start: t.start, end: t.end };
 			const pending = /** @type {{ list: CharToken[], hasNonWs: boolean }} */ (
 				pendingTableChars
 			);
@@ -6428,26 +6450,28 @@ const buildHtmlAst = (source, fragmentContext) => {
 
 	modes.inCaption = (t) => {
 		if (
-			(t.type === "endTag" && t.name === "caption") ||
-			(t.type === "startTag" && CAPTION_TABLE_STARTS.has(t.name)) ||
-			(t.type === "endTag" && t.name === "table")
+			(t.type === TOKEN_END_TAG && t.name === "caption") ||
+			(t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) ||
+			(t.type === TOKEN_END_TAG && t.name === "table")
 		) {
 			if (!inTableScope("caption")) return;
 			generateImpliedEndTags();
 			popUntil("caption");
 			clearAfeToMarker();
 			mode = "inTable";
-			if (!(t.type === "endTag" && t.name === "caption")) return process(t);
+			if (!(t.type === TOKEN_END_TAG && t.name === "caption")) {
+				return process(t);
+			}
 			return;
 		}
-		if (t.type === "endTag" && CAPTION_IGNORED_ENDS.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && CAPTION_IGNORED_ENDS.has(t.name)) {
 			return;
 		}
 		return modes.inBody(t);
 	};
 
 	modes.inColumnGroup = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, true);
 			if (!r) return;
 			if (cur().tagName !== "colgroup") return;
@@ -6456,31 +6480,31 @@ const buildHtmlAst = (source, fragmentContext) => {
 			process(r);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "col") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "col") {
 			insertHtmlElement("col", t.attrs, t.pos);
 			open.pop();
 			return;
 		}
-		if (t.type === "endTag" && t.name === "colgroup") {
+		if (t.type === TOKEN_END_TAG && t.name === "colgroup") {
 			if (cur().tagName !== "colgroup") return;
 			open.pop();
 			mode = "inTable";
 			return;
 		}
-		if (t.type === "endTag" && t.name === "col") return;
+		if (t.type === TOKEN_END_TAG && t.name === "col") return;
 		if (
-			(t.type === "startTag" || t.type === "endTag") &&
+			(t.type === TOKEN_START_TAG || t.type === TOKEN_END_TAG) &&
 			t.name === "template"
 		) {
 			return modes.inHead(t);
 		}
-		if (t.type === "eof") return modes.inBody(t);
+		if (t.type === TOKEN_EOF) return modes.inBody(t);
 		if (cur().tagName !== "colgroup") return;
 		open.pop();
 		mode = "inTable";
@@ -6488,19 +6512,19 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inTableBody = (t) => {
-		if (t.type === "startTag" && t.name === "tr") {
+		if (t.type === TOKEN_START_TAG && t.name === "tr") {
 			clearStackToTableBodyContext();
 			insertHtmlElement("tr", t.attrs, t.pos);
 			mode = "inRow";
 			return;
 		}
-		if (t.type === "startTag" && (t.name === "th" || t.name === "td")) {
+		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
 			clearStackToTableBodyContext();
 			insertHtmlElement("tr", EMPTY_ATTRS, t.pos);
 			mode = "inRow";
 			return process(t);
 		}
-		if (t.type === "endTag" && TBODY_GROUP.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
 			if (!inTableScope(t.name)) return;
 			clearStackToTableBodyContext();
 			open.pop();
@@ -6508,8 +6532,8 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		if (
-			(t.type === "startTag" && TBODY_TRIGGER_STARTS.has(t.name)) ||
-			(t.type === "endTag" && t.name === "table")
+			(t.type === TOKEN_START_TAG && TBODY_TRIGGER_STARTS.has(t.name)) ||
+			(t.type === TOKEN_END_TAG && t.name === "table")
 		) {
 			if (!inTableScope(TBODY_GROUP)) return;
 			clearStackToTableBodyContext();
@@ -6517,21 +6541,21 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "inTable";
 			return process(t);
 		}
-		if (t.type === "endTag" && TBODY_IGNORED_ENDS.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && TBODY_IGNORED_ENDS.has(t.name)) {
 			return;
 		}
 		return modes.inTable(t);
 	};
 
 	modes.inRow = (t) => {
-		if (t.type === "startTag" && (t.name === "th" || t.name === "td")) {
+		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
 			clearStackToTableRowContext();
 			insertHtmlElement(t.name, t.attrs, t.pos);
 			mode = "inCell";
 			insertMarker();
 			return;
 		}
-		if (t.type === "endTag" && t.name === "tr") {
+		if (t.type === TOKEN_END_TAG && t.name === "tr") {
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
 			open.pop();
@@ -6539,8 +6563,8 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		if (
-			(t.type === "startTag" && ROW_TRIGGER_STARTS.has(t.name)) ||
-			(t.type === "endTag" && t.name === "table")
+			(t.type === TOKEN_START_TAG && ROW_TRIGGER_STARTS.has(t.name)) ||
+			(t.type === TOKEN_END_TAG && t.name === "table")
 		) {
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
@@ -6548,7 +6572,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "inTableBody";
 			return process(t);
 		}
-		if (t.type === "endTag" && TBODY_GROUP.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
 			if (!inTableScope(t.name)) return;
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
@@ -6556,14 +6580,14 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "inTableBody";
 			return process(t);
 		}
-		if (t.type === "endTag" && ROW_IGNORED_ENDS.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && ROW_IGNORED_ENDS.has(t.name)) {
 			return;
 		}
 		return modes.inTable(t);
 	};
 
 	modes.inCell = (t) => {
-		if (t.type === "endTag" && (t.name === "td" || t.name === "th")) {
+		if (t.type === TOKEN_END_TAG && (t.name === "td" || t.name === "th")) {
 			if (!inTableScope(t.name)) return;
 			generateImpliedEndTags();
 			popUntil(t.name);
@@ -6571,17 +6595,17 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = "inRow";
 			return;
 		}
-		if (t.type === "startTag" && CAPTION_TABLE_STARTS.has(t.name)) {
+		if (t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) {
 			if (!inTableScope("td") && !inTableScope("th")) return;
 			closeCell();
 			return process(t);
 		}
-		if (t.type === "endTag" && TABLE_CONTEXT.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && TABLE_CONTEXT.has(t.name)) {
 			if (!inTableScope(t.name)) return;
 			closeCell();
 			return process(t);
 		}
-		if (t.type === "endTag" && CELL_IGNORED_ENDS.has(t.name)) {
+		if (t.type === TOKEN_END_TAG && CELL_IGNORED_ENDS.has(t.name)) {
 			return;
 		}
 		return modes.inBody(t);
@@ -6594,10 +6618,14 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.inTemplate = (t) => {
-		if (t.type === "char" || t.type === "comment" || t.type === "doctype") {
+		if (
+			t.type === TOKEN_CHAR ||
+			t.type === TOKEN_COMMENT ||
+			t.type === TOKEN_DOCTYPE
+		) {
 			return modes.inBody(t);
 		}
-		if (t.type === "startTag") {
+		if (t.type === TOKEN_START_TAG) {
 			if (HEAD_ELEMENTS.has(t.name)) {
 				return modes.inHead(t);
 			}
@@ -6619,11 +6647,11 @@ const buildHtmlAst = (source, fragmentContext) => {
 			mode = target;
 			return process(t);
 		}
-		if (t.type === "endTag") {
+		if (t.type === TOKEN_END_TAG) {
 			if (t.name === "template") return modes.inHead(t);
 			return;
 		}
-		if (t.type === "eof") {
+		if (t.type === TOKEN_EOF) {
 			if (!open.some(isHtmlTemplateEl)) {
 				return;
 			}
@@ -6636,97 +6664,103 @@ const buildHtmlAst = (source, fragmentContext) => {
 	};
 
 	modes.afterBody = (t) => {
-		if (t.type === "char" && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === "comment") {
+		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end, {
 				parent: open[0],
 				beforeNode: null
 			});
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "endTag" && t.name === "html") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_END_TAG && t.name === "html") {
 			if (fragment) return;
 			mode = "afterAfterBody";
 			return;
 		}
-		if (t.type === "eof") return;
+		if (t.type === TOKEN_EOF) return;
 		mode = "inBody";
 		process(t);
 	};
 
 	modes.inFrameset = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
 			if (ws) insertCharacters(ws, t.start, t.end);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "frameset") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "frameset") {
 			insertHtmlElement("frameset", t.attrs, t.pos);
 			return;
 		}
-		if (t.type === "endTag" && t.name === "frameset") {
+		if (t.type === TOKEN_END_TAG && t.name === "frameset") {
 			if (cur().tagName === "html") return;
 			open.pop();
 			if (!fragment && cur().tagName !== "frameset") mode = "afterFrameset";
 			return;
 		}
-		if (t.type === "startTag" && t.name === "frame") {
+		if (t.type === TOKEN_START_TAG && t.name === "frame") {
 			insertHtmlElement("frame", t.attrs, t.pos);
 			open.pop();
 			return;
 		}
-		if (t.type === "startTag" && t.name === "noframes") return modes.inHead(t);
+		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+			return modes.inHead(t);
+		}
 	};
 
 	modes.afterFrameset = (t) => {
-		if (t.type === "char") {
+		if (t.type === TOKEN_CHAR) {
 			const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
 			if (ws) insertCharacters(ws, t.start, t.end);
 			return;
 		}
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end);
 			return;
 		}
-		if (t.type === "doctype") return;
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "endTag" && t.name === "html") {
+		if (t.type === TOKEN_DOCTYPE) return;
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_END_TAG && t.name === "html") {
 			mode = "afterAfterFrameset";
 			return;
 		}
-		if (t.type === "startTag" && t.name === "noframes") return modes.inHead(t);
+		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+			return modes.inHead(t);
+		}
 	};
 
 	modes.afterAfterBody = (t) => {
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: null });
 			return;
 		}
-		if (t.type === "doctype") return modes.inBody(t);
-		if (t.type === "char" && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "eof") return;
+		if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
+		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_EOF) return;
 		mode = "inBody";
 		process(t);
 	};
 
 	modes.afterAfterFrameset = (t) => {
-		if (t.type === "comment") {
+		if (t.type === TOKEN_COMMENT) {
 			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: null });
 			return;
 		}
-		if (t.type === "doctype") return modes.inBody(t);
-		if (t.type === "char" && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "html") return modes.inBody(t);
-		if (t.type === "startTag" && t.name === "noframes") return modes.inHead(t);
+		if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
+		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+			return modes.inHead(t);
+		}
 	};
 
 	// ---------- fragment setup ----------
@@ -6782,7 +6816,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	// callback only runs after the current token is fully consumed.
 	/** @type {MutableToken} */
 	const tok = {
-		type: "eof",
+		type: TOKEN_EOF,
 		name: "",
 		data: "",
 		attrs: [],
@@ -6811,7 +6845,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const { name, publicId, systemId } = parseDoctype(
 				input.slice(start, end)
 			);
-			tok.type = "doctype";
+			tok.type = TOKEN_DOCTYPE;
 			tok.name = name;
 			tok.publicId = publicId;
 			tok.systemId = systemId;
@@ -6828,7 +6862,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 					const innerEnd = input.endsWith("]]>", end) ? end - 3 : end;
 					const data = input.slice(start + 9, innerEnd).replace(/\r\n?/g, "\n");
 					if (data !== "") {
-						tok.type = "char";
+						tok.type = TOKEN_CHAR;
 						tok.data = data;
 						tok.start = start;
 						tok.end = end;
@@ -6836,7 +6870,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 					}
 					return end;
 				}
-				tok.type = "comment";
+				tok.type = TOKEN_COMMENT;
 				tok.data = input.slice(
 					start + 2,
 					input.charCodeAt(end - 1) === 0x3e ? end - 1 : end
@@ -6858,7 +6892,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			else if (input.endsWith("--", end)) e = end - 2;
 			else if (input.charCodeAt(end - 1) === 0x2d) e = end - 1;
 			if (e < s) e = s;
-			tok.type = "comment";
+			tok.type = TOKEN_COMMENT;
 			tok.data = input.slice(s, e).replace(/\0/g, "�");
 			tok.start = start;
 			tok.end = end;
@@ -6888,7 +6922,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				if (data[0] === "\n") data = data.slice(1);
 			}
 			if (data === "") return end;
-			tok.type = "char";
+			tok.type = TOKEN_CHAR;
 			tok.data = data;
 			tok.start = start;
 			tok.end = end;
@@ -6947,7 +6981,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				attrs = pendingAttrs;
 				pendingAttrs = [];
 			}
-			tok.type = "startTag";
+			tok.type = TOKEN_START_TAG;
 			tok.name = name;
 			tok.attrs = attrs;
 			tok.selfClosing = selfClosing;
@@ -6964,7 +6998,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const name = input.slice(nameStart, nameEnd).toLowerCase();
 			// End tags drop any parsed attributes; only reallocate if non-empty.
 			if (pendingAttrs.length !== 0) pendingAttrs = [];
-			tok.type = "endTag";
+			tok.type = TOKEN_END_TAG;
 			tok.name = name;
 			tok.pos.start = start;
 			tok.pos.end = end;
@@ -6974,7 +7008,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return end;
 		}
 	});
-	tok.type = "eof";
+	tok.type = TOKEN_EOF;
 	dispatch();
 
 	if (sawSelectedContent) mirrorSelectedContent(doc, null);
@@ -6989,9 +7023,9 @@ const buildHtmlAst = (source, fragmentContext) => {
  * @returns {HtmlNode} clone
  */
 const cloneSubtree = (node) => {
-	if (node.type !== "element") return { ...node };
+	if (node.type !== NodeType.Element) return { ...node };
 	return {
-		type: "element",
+		type: NodeType.Element,
 		tagName: node.tagName,
 		namespace: node.namespace,
 		attributes: node.attributes.map((a) => ({
@@ -7024,7 +7058,7 @@ const selectedOption = (select) => {
 	/** @param {HtmlElement} el element */
 	const collect = (el) => {
 		for (const c of el.children) {
-			if (c.type !== "element" || c.namespace !== NS_HTML) continue;
+			if (c.type !== NodeType.Element || c.namespace !== NS_HTML) continue;
 			if (c.tagName === "option") options.push(c);
 			else if (c.tagName === "optgroup") collect(c);
 		}
@@ -7047,11 +7081,11 @@ const selectedOption = (select) => {
  */
 const mirrorSelectedContent = (node, select) => {
 	const children =
-		node.type === "element" && node.templateContent
+		node.type === NodeType.Element && node.templateContent
 			? node.templateContent.children
 			: node.children;
 	for (const child of children) {
-		if (child.type !== "element") continue;
+		if (child.type !== NodeType.Element) continue;
 		if (child.namespace === NS_HTML && child.tagName === "select") {
 			mirrorSelectedContent(child, child);
 		} else if (
@@ -7094,11 +7128,11 @@ const parseDoctype = (/** @type {string} */ raw) => {
 };
 
 /**
- * AST node `type` discriminators for the visitor map. Numeric for the same
- * reason as the CSS `NodeType`: compact `Map`-free dispatch on the walk hot
- * path. The HTML AST itself keeps its string `type` tags (the tree builder and
- * html5lib serializer compare them); `nodeTypeOf` maps a node to its member.
- * @enum {number}
+ * AST node `type` discriminators. Numeric for the same reason as the CSS
+ * `NodeType`: compact integer `===` dispatch on the tree-construction and
+ * visitor-walk hot paths. Members are literal-typed so `node.type ===
+ * NodeType.X` still narrows the `HtmlNode` union.
+ * @type {{ Document: 1, DocumentFragment: 2, Element: 3, Text: 4, Comment: 5, Doctype: 6 }}
  */
 const NodeType = {
 	Document: 1,
@@ -7119,27 +7153,6 @@ const NodeType = {
  * @typedef {import("../util/SourceProcessor").VisitorMap<HtmlVisitableNode>} VisitorMap
  * @typedef {import("../util/SourceProcessor").CompiledVisitorMap<HtmlVisitableNode>} CompiledVisitorMap
  */
-
-/**
- * @param {HtmlVisitableNode} node AST node
- * @returns {number} the `NodeType` member for the node's string `type` tag
- */
-const nodeTypeOf = (node) => {
-	switch (node.type) {
-		case "element":
-			return NodeType.Element;
-		case "text":
-			return NodeType.Text;
-		case "comment":
-			return NodeType.Comment;
-		case "doctype":
-			return NodeType.Doctype;
-		case "document":
-			return NodeType.Document;
-		default:
-			return NodeType.DocumentFragment;
-	}
-};
 
 /**
  * @typedef {object} HtmlProcessOptions
@@ -7171,7 +7184,7 @@ const grammar = (input, visitors, options) => {
 	 * @param {HtmlVisitableNode | null} parent enclosing node
 	 */
 	const walk = (node, parent) => {
-		const b = visitors[nodeTypeOf(node)];
+		const b = visitors[node.type];
 		let skip = false;
 		if (b !== undefined && b.enter.length !== 0) {
 			skipFlag = false;
@@ -7181,7 +7194,7 @@ const grammar = (input, visitors, options) => {
 			skipFlag = false;
 		}
 		if (!skip) {
-			if (node.type === "element") {
+			if (node.type === NodeType.Element) {
 				// `<template>` children live in a separate content fragment, not in
 				// `children` — walk it first so template content is not skipped.
 				const tc = node.templateContent;
@@ -7189,8 +7202,8 @@ const grammar = (input, visitors, options) => {
 				const c = node.children;
 				for (let i = 0; i < c.length; i++) walk(c[i], node);
 			} else if (
-				node.type === "document" ||
-				node.type === "document-fragment"
+				node.type === NodeType.Document ||
+				node.type === NodeType.DocumentFragment
 			) {
 				const c = node.children;
 				for (let i = 0; i < c.length; i++) walk(c[i], node);

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const GenericSourceProcessor = require("../util/SourceProcessor");
+
 // cspell:ignore apos notpre noncharacter noncharacters DFFF FFFE CCLS ALNUM
 
 // #region html entities
@@ -7091,15 +7093,146 @@ const parseDoctype = (/** @type {string} */ raw) => {
 	return { name, publicId, systemId };
 };
 
+/**
+ * AST node `type` discriminators for the visitor map. Numeric for the same
+ * reason as the CSS `NodeType`: compact `Map`-free dispatch on the walk hot
+ * path. The HTML AST itself keeps its string `type` tags (the tree builder and
+ * html5lib serializer compare them); `nodeTypeOf` maps a node to its member.
+ * @enum {number}
+ */
+const NodeType = {
+	Document: 1,
+	DocumentFragment: 2,
+	Element: 3,
+	Text: 4,
+	Comment: 5,
+	Doctype: 6
+};
+
+/** @typedef {HtmlNode | HtmlDocument | HtmlDocumentFragment} HtmlVisitableNode */
+
+// HTML-typed views over the generic visitor machinery (`util/SourceProcessor`).
+/**
+ * @typedef {import("../util/SourceProcessor").VisitorContext} VisitorContext
+ * @typedef {import("../util/SourceProcessor").VisitorFn<HtmlVisitableNode>} VisitorFn
+ * @typedef {import("../util/SourceProcessor").VisitorBucket<HtmlVisitableNode>} VisitorBucket
+ * @typedef {import("../util/SourceProcessor").VisitorMap<HtmlVisitableNode>} VisitorMap
+ * @typedef {import("../util/SourceProcessor").CompiledVisitorMap<HtmlVisitableNode>} CompiledVisitorMap
+ */
+
+/**
+ * @param {HtmlVisitableNode} node AST node
+ * @returns {number} the `NodeType` member for the node's string `type` tag
+ */
+const nodeTypeOf = (node) => {
+	switch (node.type) {
+		case "element":
+			return NodeType.Element;
+		case "text":
+			return NodeType.Text;
+		case "comment":
+			return NodeType.Comment;
+		case "doctype":
+			return NodeType.Doctype;
+		case "document":
+			return NodeType.Document;
+		default:
+			return NodeType.DocumentFragment;
+	}
+};
+
+/**
+ * @typedef {object} HtmlProcessOptions
+ * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`)
+ * @property {(HtmlDocument | HtmlDocumentFragment)=} ast walk this pre-built AST instead of parsing the input
+ */
+
+/**
+ * The HTML `SourceProcessor` grammar: build the document AST (WHATWG tree
+ * construction) and walk it, firing `enter` / `exit` in source order. The root
+ * document / fragment node is visited too (with a `null` parent).
+ * @param {string} input source text
+ * @param {CompiledVisitorMap} visitors compiled visitor map
+ * @param {HtmlProcessOptions} options process options
+ */
+const grammar = (input, visitors, options) => {
+	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.
+	let skipFlag = false;
+	const visitorCtx = {
+		skipChildren() {
+			skipFlag = true;
+		}
+	};
+
+	/**
+	 * Fetches the node's visitor bucket once (reused for enter + exit) and uses
+	 * index loops — `for…of` would allocate an iterator per node on this hot path.
+	 * @param {HtmlVisitableNode} node subtree root
+	 * @param {HtmlVisitableNode | null} parent enclosing node
+	 */
+	const walk = (node, parent) => {
+		const b = visitors[nodeTypeOf(node)];
+		let skip = false;
+		if (b !== undefined && b.enter.length !== 0) {
+			skipFlag = false;
+			const e = b.enter;
+			for (let i = 0; i < e.length; i++) e[i](node, parent, visitorCtx);
+			skip = skipFlag;
+			skipFlag = false;
+		}
+		if (!skip) {
+			if (node.type === "element") {
+				// `<template>` children live in a separate content fragment, not in
+				// `children` — walk it first so template content is not skipped.
+				const tc = node.templateContent;
+				if (tc !== undefined) walk(tc, node);
+				const c = node.children;
+				for (let i = 0; i < c.length; i++) walk(c[i], node);
+			} else if (
+				node.type === "document" ||
+				node.type === "document-fragment"
+			) {
+				const c = node.children;
+				for (let i = 0; i < c.length; i++) walk(c[i], node);
+			}
+			// All other types are leaves.
+		}
+		if (b !== undefined) {
+			const x = b.exit;
+			for (let i = 0; i < x.length; i++) x[i](node, parent, visitorCtx);
+		}
+	};
+
+	walk(options.ast || buildHtmlAst(input, options.fragmentContext), null);
+};
+
+/**
+ * The generic visitor coordinator (`util/SourceProcessor`) bound to the HTML
+ * `grammar`. Babel-style usage:
+ *
+ * ```
+ * processor.use({ [NodeType.Element]: (el) => {}, [NodeType.Comment]: { enter, exit } });
+ * processor.process(source);
+ * ```
+ * @extends {GenericSourceProcessor<HtmlVisitableNode, HtmlProcessOptions>}
+ */
+class SourceProcessor extends GenericSourceProcessor {
+	constructor() {
+		super(grammar);
+	}
+}
+
 module.exports.NS_HTML = NS_HTML;
 module.exports.NS_MATHML = NS_MATHML;
 module.exports.NS_SVG = NS_SVG;
+module.exports.NodeType = NodeType;
 module.exports.QUOTE_DOUBLE = QUOTE_DOUBLE;
 module.exports.QUOTE_NONE = QUOTE_NONE;
 module.exports.QUOTE_SINGLE = QUOTE_SINGLE;
+module.exports.SVG_TAG_ADJUST = SVG_TAG_ADJUST;
+module.exports.SourceProcessor = SourceProcessor;
 // Exposed so HtmlParser can map user-configured (lowercased) tag names to
 // the adjusted camelCase names the AST carries for foreign content.
-module.exports.SVG_TAG_ADJUST = SVG_TAG_ADJUST;
 module.exports.buildHtmlAst = buildHtmlAst;
 module.exports.decodeHtmlEntities = decodeHtmlEntities;
 module.exports.decodeHtmlEntitiesWithMap = decodeHtmlEntitiesWithMap;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3768,7 +3768,7 @@ const decodeHtmlEntitiesWithMap = (str, isAttribute) => {
 	return { text: str, map };
 };
 
-// cspell:ignore advasoft altglyph altglyphdef altglyphitem animatecolor animatemotion animatetransform arcrole aswedit attributename attributetype basefrequency baseprofile bgsound calcmode clippathunits definitionurl diffuseconstant fedropshadow filterunits glyphref gradienttransform gradientunits hotjava hotmetal kernelmatrix kernelunitlength keypoints keysplines keytimes limitingconeangle malignmark markerheight markerwidth maskcontentunits maskunits metrius mglyph mtext numoctaves pathlength patterncontentunits patterntransform patternunits pointsatx pointsaty pointsatz preservealpha primitiveunits refx refy repeatcount repeatdur requiredextensions requiredfeatures selectedcontent silmaril softquad specularconstant specularexponent startoffset stddeviation stitchtiles surfacescale systemlanguage tablevalues targetx targety textlength viewbox viewtarget webtechs xchannelselector ychannelselector megamorphic attributeless
+// cspell:ignore advasoft altglyph altglyphdef altglyphitem animatecolor animatemotion animatetransform arcrole aswedit attributename attributetype basefrequency baseprofile bgsound calcmode clippathunits definitionurl diffuseconstant fedropshadow filterunits glyphref gradienttransform gradientunits hotjava hotmetal kernelmatrix kernelunitlength keypoints keysplines keytimes limitingconeangle malignmark markerheight markerwidth maskcontentunits maskunits metrius mglyph mtext numoctaves pathlength patterncontentunits patterntransform patternunits pointsatx pointsaty pointsatz preservealpha primitiveunits refx refy repeatcount repeatdur requiredextensions requiredfeatures selectedcontent silmaril softquad specularconstant specularexponent startoffset stddeviation stitchtiles surfacescale systemlanguage tablevalues targetx targety textlength viewbox viewtarget webtechs xchannelselector ychannelselector megamorphic attributeless rowspan imagesizes novalidate maxlength
 
 // WHATWG HTML tree construction (https://html.spec.whatwg.org/multipage/parsing.html#tree-construction)
 // on top of walkHtmlTokens. Scripting is always disabled (webpack is a build tool).
@@ -3880,6 +3880,43 @@ const TOKEN_EOF = 6;
  */
 
 /** @typedef {{ parent: HtmlElement | HtmlDocument | HtmlDocumentFragment, beforeNode: (HtmlNode | null) }} InsertionPlace */
+
+// Insertion modes (§13.2.4.1). Numeric for the same reason as the token and
+// `NodeType` enums: `runMode` dispatches on `mode` once per token.
+const MODE_INITIAL = 1;
+const MODE_BEFORE_HTML = 2;
+const MODE_BEFORE_HEAD = 3;
+const MODE_IN_HEAD = 4;
+const MODE_IN_HEAD_NOSCRIPT = 5;
+const MODE_AFTER_HEAD = 6;
+const MODE_IN_BODY = 7;
+const MODE_TEXT = 8;
+const MODE_IN_TABLE = 9;
+const MODE_IN_TABLE_TEXT = 10;
+const MODE_IN_CAPTION = 11;
+const MODE_IN_COLUMN_GROUP = 12;
+const MODE_IN_TABLE_BODY = 13;
+const MODE_IN_ROW = 14;
+const MODE_IN_CELL = 15;
+const MODE_IN_TEMPLATE = 16;
+const MODE_AFTER_BODY = 17;
+const MODE_IN_FRAMESET = 18;
+const MODE_AFTER_FRAMESET = 19;
+const MODE_AFTER_AFTER_BODY = 20;
+const MODE_AFTER_AFTER_FRAMESET = 21;
+
+// "in template" start-tag re-dispatch targets (§13.2.6.4.18).
+const TEMPLATE_START_TAG_MODES = new Map([
+	["caption", MODE_IN_TABLE],
+	["colgroup", MODE_IN_TABLE],
+	["tbody", MODE_IN_TABLE],
+	["tfoot", MODE_IN_TABLE],
+	["thead", MODE_IN_TABLE],
+	["col", MODE_IN_COLUMN_GROUP],
+	["tr", MODE_IN_TABLE_BODY],
+	["td", MODE_IN_ROW],
+	["th", MODE_IN_ROW]
+]);
 
 const VOID = new Set([
 	"area",
@@ -4465,6 +4502,105 @@ const EMPTY_ATTRS = /** @type {HtmlAttribute[]} */ (
 	/** @type {unknown} */ (Object.freeze([]))
 );
 
+/**
+ * Hash of the ASCII-lowercased `name` for the intern tables below; must stay
+ * in sync with the range hash in `internLowerName`.
+ * @param {string} name lowercase name
+ * @returns {number} hash
+ */
+const hashLowerName = (name) => {
+	let h = name.length;
+	for (let i = 0; i < name.length; i++) {
+		let c = name.charCodeAt(i);
+		if (c >= 0x41 && c <= 0x5a) c += 0x20;
+		h = ((h << 5) - h + c) | 0;
+	}
+	return h;
+};
+
+/**
+ * @param {Iterable<string>} names lowercase names to intern
+ * @returns {Map<number, string | string[]>} hash → name(s)
+ */
+const buildNameInternTable = (names) => {
+	/** @type {Map<number, string | string[]>} */
+	const table = new Map();
+	for (const name of names) {
+		const h = hashLowerName(name);
+		const cur = table.get(h);
+		if (cur === undefined) {
+			table.set(h, name);
+		} else if (typeof cur === "string") {
+			if (cur !== name) table.set(h, [cur, name]);
+		} else if (!cur.includes(name)) {
+			cur.push(name);
+		}
+	}
+	return table;
+};
+
+/**
+ * The lowercased name for `input[start..end)`, returning the shared interned
+ * string for known names — skipping the per-tag `slice().toLowerCase()`
+ * allocation, and making the tree builder's many Set/Map lookups and `===`
+ * comparisons on the name hit one string instance with a cached hash.
+ * @param {Map<number, string | string[]>} table intern table
+ * @param {string} input source text
+ * @param {number} start name start
+ * @param {number} end name end
+ * @returns {string} lowercased name
+ */
+const internLowerName = (table, input, start, end) => {
+	let h = end - start;
+	for (let i = start; i < end; i++) {
+		let c = input.charCodeAt(i);
+		if (c >= 0x41 && c <= 0x5a) c += 0x20;
+		h = ((h << 5) - h + c) | 0;
+	}
+	const hit = table.get(h);
+	if (hit !== undefined) {
+		if (typeof hit === "string") {
+			if (rangeEqualsLower(input, start, end, hit)) return hit;
+		} else {
+			for (let i = 0; i < hit.length; i++) {
+				if (rangeEqualsLower(input, start, end, hit[i])) return hit[i];
+			}
+		}
+	}
+	// Unknown name (custom element, data-* attribute, non-ASCII, …).
+	return input.slice(start, end).toLowerCase();
+};
+
+// Every tag name the tree builder compares against (the sets above already
+// cover most of the spec), plus the remaining standard/foreign names so
+// ordinary documents intern every tag.
+const TAG_NAME_INTERN = buildNameInternTable([
+	...VOID,
+	...SPECIAL,
+	...FORMATTING,
+	...HEADING,
+	...MATHML_TEXT_INTEGRATION,
+	...MATHML_SPECIAL,
+	...SVG_SPECIAL,
+	...HTML_SCOPE,
+	...TABLE_CONTEXT,
+	...VOID_FORMATTING,
+	...NO_DECODE_TEXT,
+	...FOREIGN_BREAKOUT,
+	...HEAD_ELEMENTS,
+	...Object.keys(SVG_TAG_ADJUST),
+	..."a abbr audio bdi bdo canvas cite data datalist del dfn dialog ins kbd label legend map mark math menuitem meter optgroup option output picture progress q rb rp rt rtc ruby samp selectedcontent slot span sub sup svg time u var video".split(
+		" "
+	)
+]);
+
+// Common attribute names (unknown ones — data-*, ARIA, events — fall back).
+const ATTR_NAME_INTERN = buildNameInternTable(
+	"href src srcset sizes alt title class id style name type value content charset rel media target action method placeholder disabled checked selected multiple readonly required hidden tabindex role lang dir width height loading decoding async defer integrity crossorigin referrerpolicy nonce as for colspan rowspan span label max min step pattern autocomplete autofocus autoplay controls loop muted poster preload download ping imagesrcset imagesizes slot part is property http-equiv accept enctype novalidate maxlength minlength size cols rows wrap open scope headers datetime cite usemap ismap shape coords start reversed face color encoding xmlns".split(
+		" "
+	)
+);
+
 // Hoisted so the many `open.some(...)` "is there an open HTML <template>?"
 // checks reuse one predicate instead of allocating an arrow per call.
 const isHtmlTemplateEl = (/** @type {HtmlElement} */ e) =>
@@ -4490,9 +4626,9 @@ const findAttr = (
 const buildHtmlAst = (source, fragmentContext) => {
 	/** @type {HtmlDocument} */
 	const doc = { type: NodeType.Document, children: [] };
-	let mode = "initial";
-	/** @type {string | null} */
-	let originalMode = null;
+	let mode = MODE_INITIAL;
+	// Mode to return to after MODE_TEXT / MODE_IN_TABLE_TEXT (0 = unset).
+	let originalMode = 0;
 	/** @type {HtmlElement[]} stack of open elements (bottom .. top) */
 	const open = [];
 	/** @type {{ element?: HtmlElement, marker?: boolean }[]} active formatting elements */
@@ -4507,7 +4643,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 	/** @type {HtmlAttribute[]} */
 	let pendingAttrs = [];
 	let fosterParenting = false;
-	/** @type {string[]} */
+	/** @type {number[]} */
 	const templateModes = [];
 	let quirks = false;
 	/** @type {HtmlElement | null} */
@@ -4948,27 +5084,27 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const tn = node.tagName;
 			if (node.namespace === NS_HTML) {
 				if ((tn === "td" || tn === "th") && !last) {
-					mode = "inCell";
+					mode = MODE_IN_CELL;
 					return;
 				}
 				if (tn === "tr") {
-					mode = "inRow";
+					mode = MODE_IN_ROW;
 					return;
 				}
 				if (TBODY_GROUP.has(tn)) {
-					mode = "inTableBody";
+					mode = MODE_IN_TABLE_BODY;
 					return;
 				}
 				if (tn === "caption") {
-					mode = "inCaption";
+					mode = MODE_IN_CAPTION;
 					return;
 				}
 				if (tn === "colgroup") {
-					mode = "inColumnGroup";
+					mode = MODE_IN_COLUMN_GROUP;
 					return;
 				}
 				if (tn === "table") {
-					mode = "inTable";
+					mode = MODE_IN_TABLE;
 					return;
 				}
 				if (tn === "template") {
@@ -4976,24 +5112,24 @@ const buildHtmlAst = (source, fragmentContext) => {
 					return;
 				}
 				if (tn === "head" && !last) {
-					mode = "inHead";
+					mode = MODE_IN_HEAD;
 					return;
 				}
 				if (tn === "body") {
-					mode = "inBody";
+					mode = MODE_IN_BODY;
 					return;
 				}
 				if (tn === "frameset") {
-					mode = "inFrameset";
+					mode = MODE_IN_FRAMESET;
 					return;
 				}
 				if (tn === "html") {
-					mode = head ? "afterHead" : "beforeHead";
+					mode = head ? MODE_AFTER_HEAD : MODE_BEFORE_HEAD;
 					return;
 				}
 			}
 			if (last) {
-				mode = "inBody";
+				mode = MODE_IN_BODY;
 				return;
 			}
 		}
@@ -5414,56 +5550,56 @@ const buildHtmlAst = (source, fragmentContext) => {
 	/** @type {Record<string, (t: Token) => void>} */
 	const modes = {};
 
-	// Dispatch the current insertion mode. A switch (cases ordered by frequency)
-	// keeps this monomorphic, where `modes[mode]` is a megamorphic keyed load on
-	// the per-token hot path. The `default` keeps behaviour identical for any
-	// mode not listed.
+	// Dispatch the current insertion mode. An integer switch (cases ordered by
+	// frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
+	// `modes[mode]` load + indirect call would defeat inlining on the per-token
+	// hot path.
 	const runMode = (/** @type {Token} */ t) => {
 		switch (mode) {
-			case "inBody":
+			case MODE_IN_BODY:
 				return modes.inBody(t);
-			case "text":
+			case MODE_TEXT:
 				return modes.text(t);
-			case "inCell":
+			case MODE_IN_CELL:
 				return modes.inCell(t);
-			case "inRow":
+			case MODE_IN_ROW:
 				return modes.inRow(t);
-			case "inTableBody":
+			case MODE_IN_TABLE_BODY:
 				return modes.inTableBody(t);
-			case "inTable":
+			case MODE_IN_TABLE:
 				return modes.inTable(t);
-			case "inTableText":
+			case MODE_IN_TABLE_TEXT:
 				return modes.inTableText(t);
-			case "inCaption":
+			case MODE_IN_CAPTION:
 				return modes.inCaption(t);
-			case "inColumnGroup":
+			case MODE_IN_COLUMN_GROUP:
 				return modes.inColumnGroup(t);
-			case "inTemplate":
+			case MODE_IN_TEMPLATE:
 				return modes.inTemplate(t);
-			case "inHead":
+			case MODE_IN_HEAD:
 				return modes.inHead(t);
-			case "inHeadNoscript":
+			case MODE_IN_HEAD_NOSCRIPT:
 				return modes.inHeadNoscript(t);
-			case "afterHead":
+			case MODE_AFTER_HEAD:
 				return modes.afterHead(t);
-			case "beforeHead":
+			case MODE_BEFORE_HEAD:
 				return modes.beforeHead(t);
-			case "beforeHtml":
+			case MODE_BEFORE_HTML:
 				return modes.beforeHtml(t);
-			case "initial":
+			case MODE_INITIAL:
 				return modes.initial(t);
-			case "afterBody":
+			case MODE_AFTER_BODY:
 				return modes.afterBody(t);
-			case "afterAfterBody":
+			case MODE_AFTER_AFTER_BODY:
 				return modes.afterAfterBody(t);
-			case "inFrameset":
+			case MODE_IN_FRAMESET:
 				return modes.inFrameset(t);
-			case "afterFrameset":
+			case MODE_AFTER_FRAMESET:
 				return modes.afterFrameset(t);
-			case "afterAfterFrameset":
-				return modes.afterAfterFrameset(t);
+			// MODE_AFTER_AFTER_FRAMESET — every mode is enumerated, so the last
+			// one is the `default` (also satisfies exhaustiveness linting).
 			default:
-				return modes[mode](t);
+				return modes.afterAfterFrameset(t);
 		}
 	};
 
@@ -5559,7 +5695,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const r = leadingWs(t, false);
 			if (!r) return;
 			quirks = true;
-			mode = "beforeHtml";
+			mode = MODE_BEFORE_HTML;
 			process(r);
 			return;
 		}
@@ -5577,11 +5713,11 @@ const buildHtmlAst = (source, fragmentContext) => {
 				end: t.end
 			});
 			quirks = isQuirky(t.name, t.publicId, t.systemId);
-			mode = "beforeHtml";
+			mode = MODE_BEFORE_HTML;
 			return;
 		}
 		quirks = true;
-		mode = "beforeHtml";
+		mode = MODE_BEFORE_HTML;
 		process(t);
 	};
 
@@ -5600,7 +5736,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const el = mkEl("html", NS_HTML, t.attrs, t.pos);
 			doc.children.push(el);
 			open.push(el);
-			mode = "beforeHead";
+			mode = MODE_BEFORE_HEAD;
 			return;
 		}
 		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
@@ -5609,7 +5745,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		const el = mkEl("html", NS_HTML, [], null);
 		doc.children.push(el);
 		open.push(el);
-		mode = "beforeHead";
+		mode = MODE_BEFORE_HEAD;
 		process(t);
 	};
 
@@ -5627,14 +5763,14 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
 		if (t.type === TOKEN_START_TAG && t.name === "head") {
 			head = insertHtmlElement("head", t.attrs, t.pos);
-			mode = "inHead";
+			mode = MODE_IN_HEAD;
 			return;
 		}
 		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
 			return;
 		}
 		head = insertHtmlElement("head", EMPTY_ATTRS, null);
-		mode = "inHead";
+		mode = MODE_IN_HEAD;
 		process(t);
 	};
 
@@ -5643,7 +5779,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const r = leadingWs(t, true);
 			if (!r) return;
 			open.pop();
-			mode = "afterHead";
+			mode = MODE_AFTER_HEAD;
 			process(r);
 			return;
 		}
@@ -5666,7 +5802,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (NOFRAMES_STYLE_NOSCRIPT.has(t.name)) {
 				if (t.name === "noscript") {
 					insertHtmlElement("noscript", t.attrs, t.pos);
-					mode = "inHeadNoscript";
+					mode = MODE_IN_HEAD_NOSCRIPT;
 					return;
 				}
 				genericRawtext(t);
@@ -5680,8 +5816,8 @@ const buildHtmlAst = (source, fragmentContext) => {
 				insertHtmlElement("template", t.attrs, t.pos);
 				insertMarker();
 				framesetOk = false;
-				mode = "inTemplate";
-				templateModes.push("inTemplate");
+				mode = MODE_IN_TEMPLATE;
+				templateModes.push(MODE_IN_TEMPLATE);
 				const el = cur();
 				el.templateContent = { type: NodeType.DocumentFragment, children: [] };
 				return;
@@ -5691,7 +5827,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_END_TAG) {
 			if (t.name === "head") {
 				open.pop();
-				mode = "afterHead";
+				mode = MODE_AFTER_HEAD;
 				return;
 			}
 			if (BODY_HTML_BR.has(t.name)) {
@@ -5712,7 +5848,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		// anything else
 		open.pop();
-		mode = "afterHead";
+		mode = MODE_AFTER_HEAD;
 		process(t);
 	};
 
@@ -5721,7 +5857,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
 		if (t.type === TOKEN_END_TAG && t.name === "noscript") {
 			open.pop();
-			mode = "inHead";
+			mode = MODE_IN_HEAD;
 			return;
 		}
 		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inHead(t);
@@ -5743,7 +5879,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return;
 		}
 		open.pop();
-		mode = "inHead";
+		mode = MODE_IN_HEAD;
 		process(t);
 	};
 
@@ -5752,7 +5888,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const r = leadingWs(t, true);
 			if (!r) return;
 			insertHtmlElement("body", [], null);
-			mode = "inBody";
+			mode = MODE_IN_BODY;
 			process(r);
 			return;
 		}
@@ -5766,12 +5902,12 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (t.name === "body") {
 				insertHtmlElement("body", t.attrs, t.pos);
 				framesetOk = false;
-				mode = "inBody";
+				mode = MODE_IN_BODY;
 				return;
 			}
 			if (t.name === "frameset") {
 				insertHtmlElement("frameset", t.attrs, t.pos);
-				mode = "inFrameset";
+				mode = MODE_IN_FRAMESET;
 				return;
 			}
 			if (HEAD_ELEMENTS.has(t.name)) {
@@ -5789,7 +5925,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!BODY_HTML_BR.has(t.name)) return;
 		}
 		insertHtmlElement("body", [], null);
-		mode = "inBody";
+		mode = MODE_IN_BODY;
 		process(t);
 	};
 
@@ -5858,7 +5994,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			detach(second);
 			while (open.length > 1) open.pop();
 			insertHtmlElement("frameset", t.attrs, t.pos);
-			mode = "inFrameset";
+			mode = MODE_IN_FRAMESET;
 			return;
 		}
 		if (BLOCK_START.has(name)) {
@@ -5998,7 +6134,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!quirks) closeIfPInButtonScope();
 			insertHtmlElement("table", t.attrs, t.pos);
 			framesetOk = false;
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			return;
 		}
 		if (VOID_FORMATTING.has(name)) {
@@ -6155,7 +6291,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		if (name === "body" || name === "html") {
 			if (!inScope("body")) return;
-			mode = "afterBody";
+			mode = MODE_AFTER_BODY;
 			if (name === "html") process(t);
 			return;
 		}
@@ -6252,13 +6388,13 @@ const buildHtmlAst = (source, fragmentContext) => {
 	const genericRawtext = (/** @type {StartTagToken} */ t) => {
 		insertHtmlElement(t.name, t.attrs, t.pos);
 		originalMode = mode;
-		mode = "text";
+		mode = MODE_TEXT;
 	};
 	const genericRcdata = (/** @type {StartTagToken} */ t, swallow = false) => {
 		insertHtmlElement(t.name, t.attrs, t.pos);
 		if (swallow) t.swallowNewline = true;
 		originalMode = mode;
-		mode = "text";
+		mode = MODE_TEXT;
 	};
 
 	modes.text = (t) => {
@@ -6268,7 +6404,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		}
 		if (t.type === TOKEN_EOF) {
 			if (open.length) open.pop();
-			mode = /** @type {string} */ (originalMode);
+			mode = originalMode;
 			process(t);
 			return;
 		}
@@ -6286,7 +6422,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				return;
 			}
 			open.pop();
-			mode = /** @type {string} */ (originalMode);
+			mode = originalMode;
 		}
 	};
 
@@ -6300,7 +6436,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (TABLE_CONTEXT.has(c.tagName) && c.namespace === NS_HTML) {
 				pendingTableChars = { list: [], hasNonWs: false };
 				originalMode = mode;
-				mode = "inTableText";
+				mode = MODE_IN_TABLE_TEXT;
 				return process(t);
 			}
 		}
@@ -6315,31 +6451,31 @@ const buildHtmlAst = (source, fragmentContext) => {
 				clearStackToTableContext();
 				insertMarker();
 				insertHtmlElement("caption", t.attrs, t.pos);
-				mode = "inCaption";
+				mode = MODE_IN_CAPTION;
 				return;
 			}
 			if (name === "colgroup") {
 				clearStackToTableContext();
 				insertHtmlElement("colgroup", t.attrs, t.pos);
-				mode = "inColumnGroup";
+				mode = MODE_IN_COLUMN_GROUP;
 				return;
 			}
 			if (name === "col") {
 				clearStackToTableContext();
 				insertHtmlElement("colgroup", EMPTY_ATTRS, t.pos);
-				mode = "inColumnGroup";
+				mode = MODE_IN_COLUMN_GROUP;
 				return process(t);
 			}
 			if (TBODY_GROUP.has(name)) {
 				clearStackToTableContext();
 				insertHtmlElement(name, t.attrs, t.pos);
-				mode = "inTableBody";
+				mode = MODE_IN_TABLE_BODY;
 				return;
 			}
 			if (TD_TH_TR.has(name)) {
 				clearStackToTableContext();
 				insertHtmlElement("tbody", EMPTY_ATTRS, t.pos);
-				mode = "inTableBody";
+				mode = MODE_IN_TABLE_BODY;
 				return process(t);
 			}
 			if (name === "table") {
@@ -6407,7 +6543,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			pendingTableChars
 		);
 		pendingTableChars = null;
-		mode = /** @type {string} */ (originalMode);
+		mode = originalMode;
 		for (const ct of chars.list) {
 			if (chars.hasNonWs) {
 				fosterParenting = true;
@@ -6458,7 +6594,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			generateImpliedEndTags();
 			popUntil("caption");
 			clearAfeToMarker();
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			if (!(t.type === TOKEN_END_TAG && t.name === "caption")) {
 				return process(t);
 			}
@@ -6476,7 +6612,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!r) return;
 			if (cur().tagName !== "colgroup") return;
 			open.pop();
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			process(r);
 			return;
 		}
@@ -6494,7 +6630,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_END_TAG && t.name === "colgroup") {
 			if (cur().tagName !== "colgroup") return;
 			open.pop();
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			return;
 		}
 		if (t.type === TOKEN_END_TAG && t.name === "col") return;
@@ -6507,7 +6643,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_EOF) return modes.inBody(t);
 		if (cur().tagName !== "colgroup") return;
 		open.pop();
-		mode = "inTable";
+		mode = MODE_IN_TABLE;
 		process(t);
 	};
 
@@ -6515,20 +6651,20 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_START_TAG && t.name === "tr") {
 			clearStackToTableBodyContext();
 			insertHtmlElement("tr", t.attrs, t.pos);
-			mode = "inRow";
+			mode = MODE_IN_ROW;
 			return;
 		}
 		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
 			clearStackToTableBodyContext();
 			insertHtmlElement("tr", EMPTY_ATTRS, t.pos);
-			mode = "inRow";
+			mode = MODE_IN_ROW;
 			return process(t);
 		}
 		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
 			if (!inTableScope(t.name)) return;
 			clearStackToTableBodyContext();
 			open.pop();
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			return;
 		}
 		if (
@@ -6538,7 +6674,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!inTableScope(TBODY_GROUP)) return;
 			clearStackToTableBodyContext();
 			open.pop();
-			mode = "inTable";
+			mode = MODE_IN_TABLE;
 			return process(t);
 		}
 		if (t.type === TOKEN_END_TAG && TBODY_IGNORED_ENDS.has(t.name)) {
@@ -6551,7 +6687,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
 			clearStackToTableRowContext();
 			insertHtmlElement(t.name, t.attrs, t.pos);
-			mode = "inCell";
+			mode = MODE_IN_CELL;
 			insertMarker();
 			return;
 		}
@@ -6559,7 +6695,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
 			open.pop();
-			mode = "inTableBody";
+			mode = MODE_IN_TABLE_BODY;
 			return;
 		}
 		if (
@@ -6569,7 +6705,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
 			open.pop();
-			mode = "inTableBody";
+			mode = MODE_IN_TABLE_BODY;
 			return process(t);
 		}
 		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
@@ -6577,7 +6713,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (!inTableScope("tr")) return;
 			clearStackToTableRowContext();
 			open.pop();
-			mode = "inTableBody";
+			mode = MODE_IN_TABLE_BODY;
 			return process(t);
 		}
 		if (t.type === TOKEN_END_TAG && ROW_IGNORED_ENDS.has(t.name)) {
@@ -6592,7 +6728,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			generateImpliedEndTags();
 			popUntil(t.name);
 			clearAfeToMarker();
-			mode = "inRow";
+			mode = MODE_IN_ROW;
 			return;
 		}
 		if (t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) {
@@ -6614,7 +6750,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		generateImpliedEndTags();
 		popUntilOneOf(TD_TH);
 		clearAfeToMarker();
-		mode = "inRow";
+		mode = MODE_IN_ROW;
 	};
 
 	modes.inTemplate = (t) => {
@@ -6629,20 +6765,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			if (HEAD_ELEMENTS.has(t.name)) {
 				return modes.inHead(t);
 			}
-			const map = {
-				caption: "inTable",
-				colgroup: "inTable",
-				tbody: "inTable",
-				tfoot: "inTable",
-				thead: "inTable",
-				col: "inColumnGroup",
-				tr: "inTableBody",
-				td: "inRow",
-				th: "inRow"
-			};
-			let target = "inBody";
-			const tagMode = /** @type {Record<string, string>} */ (map);
-			if (tagMode[t.name]) target = tagMode[t.name];
+			const target = TEMPLATE_START_TAG_MODES.get(t.name) || MODE_IN_BODY;
 			templateModes[templateModes.length - 1] = target;
 			mode = target;
 			return process(t);
@@ -6676,11 +6799,11 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
 		if (t.type === TOKEN_END_TAG && t.name === "html") {
 			if (fragment) return;
-			mode = "afterAfterBody";
+			mode = MODE_AFTER_AFTER_BODY;
 			return;
 		}
 		if (t.type === TOKEN_EOF) return;
-		mode = "inBody";
+		mode = MODE_IN_BODY;
 		process(t);
 	};
 
@@ -6703,7 +6826,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_END_TAG && t.name === "frameset") {
 			if (cur().tagName === "html") return;
 			open.pop();
-			if (!fragment && cur().tagName !== "frameset") mode = "afterFrameset";
+			if (!fragment && cur().tagName !== "frameset") mode = MODE_AFTER_FRAMESET;
 			return;
 		}
 		if (t.type === TOKEN_START_TAG && t.name === "frame") {
@@ -6729,7 +6852,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_DOCTYPE) return;
 		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
 		if (t.type === TOKEN_END_TAG && t.name === "html") {
-			mode = "afterAfterFrameset";
+			mode = MODE_AFTER_AFTER_FRAMESET;
 			return;
 		}
 		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
@@ -6746,7 +6869,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
 		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
 		if (t.type === TOKEN_EOF) return;
-		mode = "inBody";
+		mode = MODE_IN_BODY;
 		process(t);
 	};
 
@@ -6779,25 +6902,25 @@ const buildHtmlAst = (source, fragmentContext) => {
 		doc.children.push(htmlEl);
 		open.push(htmlEl);
 		if (ctxNs !== NS_HTML) {
-			mode = "inBody";
+			mode = MODE_IN_BODY;
 		} else if (["title", "textarea"].includes(ctxName)) {
-			originalMode = "inBody";
-			mode = "text";
+			originalMode = MODE_IN_BODY;
+			mode = MODE_TEXT;
 		} else if (
 			["style", "xmp", "iframe", "noembed", "noframes", "script"].includes(
 				ctxName
 			)
 		) {
-			originalMode = "inBody";
-			mode = "text";
+			originalMode = MODE_IN_BODY;
+			mode = MODE_TEXT;
 		} else if (ctxName === "noscript" || ctxName === "plaintext") {
-			mode = "inBody";
+			mode = MODE_IN_BODY;
 		} else {
 			resetInsertionMode();
 		}
 		if (ctxName === "template") {
-			templateModes.push("inTemplate");
-			mode = "inTemplate";
+			templateModes.push(MODE_IN_TEMPLATE);
+			mode = MODE_IN_TEMPLATE;
 		}
 	}
 
@@ -6905,13 +7028,13 @@ const buildHtmlAst = (source, fragmentContext) => {
 			const s = !raw.includes("\r") ? raw : raw.replace(/\r\n?/g, "\n");
 			const top = adjustedCurrent();
 			const rawMode =
-				mode === "text" ||
+				mode === MODE_TEXT ||
 				(top && top.namespace === NS_HTML && top.tagName === "plaintext");
 			const noDecode =
 				top &&
 				top.namespace === NS_HTML &&
 				NO_DECODE_TEXT.has(top.tagName) &&
-				(mode === "text" || mode === "inBody");
+				(mode === MODE_TEXT || mode === MODE_IN_BODY);
 			let data = noDecode ? s : decode(s, false);
 			// In RAWTEXT/RCDATA/script/PLAINTEXT, NULL becomes U+FFFD (tokenizer
 			// rule); in data state NULLs pass through to be dropped in "in body".
@@ -6930,7 +7053,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return end;
 		},
 		attribute: (input, nameStart, nameEnd, valueStart, valueEnd, quoteType) => {
-			const name = input.slice(nameStart, nameEnd).toLowerCase();
+			const name = internLowerName(ATTR_NAME_INTERN, input, nameStart, nameEnd);
 			// Raw (undecoded) value: consumers re-resolve requests from it and the
 			// offsets must stay aligned with the source. Entity decoding for the
 			// html5lib serializer happens there, not here.
@@ -6968,7 +7091,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 				if (pendingAttrs.length !== 0) pendingAttrs = [];
 				return end;
 			}
-			const name = input.slice(nameStart, nameEnd).toLowerCase();
+			const name = internLowerName(TAG_NAME_INTERN, input, nameStart, nameEnd);
 			if (name === "selectedcontent") sawSelectedContent = true;
 			// Attributeless elements share the frozen EMPTY_ATTRS (no allocation);
 			// the empty pendingAttrs buffer is reused for the next tag. `<html>`
@@ -6995,7 +7118,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			return end;
 		},
 		closeTag: (input, start, end, nameStart, nameEnd) => {
-			const name = input.slice(nameStart, nameEnd).toLowerCase();
+			const name = internLowerName(TAG_NAME_INTERN, input, nameStart, nameEnd);
 			// End tags drop any parsed attributes; only reallocate if non-empty.
 			if (pendingAttrs.length !== 0) pendingAttrs = [];
 			tok.type = TOKEN_END_TAG;

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -1,0 +1,105 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+/**
+ * Babel-style visitor map keyed by a numeric node-type discriminator; a bucket
+ * is a function (enter-only) or `{ enter?, exit? }`. `ctx.skipChildren()`
+ * (enter only) stops the walker descending into the node's children.
+ * @typedef {{ skipChildren(): void }} VisitorContext
+ */
+/**
+ * @template TNode
+ * @typedef {(node: TNode, parent: TNode | null, ctx: VisitorContext) => void} VisitorFn
+ */
+/**
+ * @template TNode
+ * @typedef {VisitorFn<TNode> | { enter?: VisitorFn<TNode>, exit?: VisitorFn<TNode> }} VisitorBucket
+ */
+/**
+ * @template TNode
+ * @typedef {{ [nodeType: number]: VisitorBucket<TNode> }} VisitorMap
+ */
+/**
+ * @template TNode
+ * @typedef {{ enter: VisitorFn<TNode>[], exit: VisitorFn<TNode>[] }} CompiledVisitorBucket
+ */
+/**
+ * @template TNode
+ * @typedef {CompiledVisitorBucket<TNode>[]} CompiledVisitorMap a sparse array indexed by node type
+ */
+/**
+ * A language grammar: parse `input` and fire the compiled visitors in source
+ * order (the grammar owns tokenizing, parsing, and walking).
+ * @template TNode
+ * @template TProcessOptions
+ * @typedef {(input: string, visitors: CompiledVisitorMap<TNode>, options: TProcessOptions) => void} Grammar
+ */
+
+/**
+ * Visitor coordinator: owns the visitor registry and drives a language
+ * `grammar` over the source. Language-agnostic — each syntax (CSS, HTML, …)
+ * binds its own grammar and node-type enum. Babel-style usage:
+ *
+ * ```
+ * processor.use({ [NodeType.X]: (node) => {}, [NodeType.Y]: { enter, exit } });
+ * processor.process(source);
+ * ```
+ * @template TNode
+ * @template [TProcessOptions=object]
+ */
+class SourceProcessor {
+	/**
+	 * @param {Grammar<TNode, TProcessOptions>} grammar the grammar to drive over the source
+	 */
+	constructor(grammar) {
+		this._grammar = grammar;
+		/** @type {CompiledVisitorMap<TNode>} */
+		this._visitors = [];
+	}
+
+	/**
+	 * Register a Babel-style visitor map; calls accumulate per node type.
+	 * A bucket is a function (= `{ enter }`) or `{ enter?, exit? }`.
+	 * @param {VisitorMap<TNode>} map visitor map keyed by node type
+	 * @returns {SourceProcessor<TNode, TProcessOptions>} `this`, for chaining
+	 */
+	use(map) {
+		// `map`'s keys are node-type enum members; `Object.keys` stringifies them,
+		// so index the compiled array by the number to match the numeric `node.type`.
+		for (const type of Object.keys(map)) {
+			const key = Number(type);
+			const v = map[key];
+			let bucket = this._visitors[key];
+			if (!bucket) {
+				bucket = { enter: [], exit: [] };
+				this._visitors[key] = bucket;
+			}
+			if (typeof v === "function") {
+				bucket.enter.push(v);
+			} else {
+				if (v.enter) bucket.enter.push(v.enter);
+				if (v.exit) bucket.exit.push(v.exit);
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * Run the grammar over `input`, firing visitors in source order. No
+	 * AST retained.
+	 * @param {string} input source text
+	 * @param {TProcessOptions=} options grammar-specific options
+	 */
+	process(input, options) {
+		this._grammar(
+			input,
+			this._visitors,
+			options || /** @type {TProcessOptions} */ ({})
+		);
+	}
+}
+
+module.exports = SourceProcessor;

--- a/lib/util/magicComment.js
+++ b/lib/util/magicComment.js
@@ -24,6 +24,48 @@ module.exports.createMagicCommentContext = () =>
 		codeGeneration: { strings: false, wasm: false }
 	});
 
+// Whole-comment `webpackXxx: <bool|number|null>` pair — parsed without `vm`.
+const MAGIC_COMMENT_FAST_PATH =
+	/^\s*(webpack[A-Z][A-Za-z]+)\s*:\s*(true|false|null|-?\d+(?:\.\d+)?)\s*$/;
+
+/**
+ * Parse one magic comment's text into its options object. Values are detached
+ * from the vm context (RegExps recreated, other objects JSON-cloned). Throws
+ * when the comment body fails to evaluate.
+ * @param {string} value comment text (should already match `webpackCommentRegExp`)
+ * @param {import("vm").Context} context context from `createMagicCommentContext`
+ * @returns {Record<string, EXPECTED_ANY>} parsed options
+ */
+module.exports.parseMagicComment = (value, context) => {
+	const fast = MAGIC_COMMENT_FAST_PATH.exec(value);
+	if (fast !== null) {
+		const raw = fast[2];
+		return {
+			[fast[1]]:
+				raw === "true"
+					? true
+					: raw === "false"
+						? false
+						: raw === "null"
+							? null
+							: Number(raw)
+		};
+	}
+	/** @type {Record<string, EXPECTED_ANY>} */
+	const options = {};
+	for (let [key, val] of Object.entries(
+		getVm().runInContext(`(function(){return {${value}};})()`, context)
+	)) {
+		if (typeof val === "object" && val !== null) {
+			val =
+				val.constructor.name === "RegExp"
+					? new RegExp(val)
+					: JSON.parse(JSON.stringify(val));
+		}
+		options[key] = val;
+	}
+	return options;
+};
 module.exports.webpackCommentRegExp = new RegExp(
 	/(^|\W)webpack[A-Z][A-Za-z]+:/
 );

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -17,6 +17,7 @@ const HtmlParser = require("../lib/html/HtmlParser");
 const buildHtmlAst = /** @type {MockedBuildHtmlAst} */ (
 	require("../lib/html/syntax").buildHtmlAst
 );
+const { NodeType } = require("../lib/html/syntax");
 
 /**
  * @returns {{ module: EXPECTED_ANY, presentationalDependencies: EXPECTED_OBJECT[], dependencies: EXPECTED_OBJECT[], warnings: EXPECTED_OBJECT[], errors: EXPECTED_OBJECT[] }} test doubles
@@ -101,22 +102,22 @@ describe("HtmlParser", () => {
 		});
 
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "element",
+					type: NodeType.Element,
 					tagName: "script",
 					namespace: 0,
 					attributes: [],
 					children: [
 						{
-							type: "text",
+							type: NodeType.Text,
 							data: firstText,
 							start: firstStart,
 							end: firstStart + firstText.length
 						},
 						{
-							type: "text",
+							type: NodeType.Text,
 							data: secondText,
 							start: secondStart,
 							end: secondStart + secondText.length
@@ -214,28 +215,28 @@ describe("HtmlParser", () => {
 		});
 
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "element",
+					type: NodeType.Element,
 					tagName: "style",
 					namespace: 0,
 					attributes: [],
 					children: [
 						{
-							type: "text",
+							type: NodeType.Text,
 							data: firstText,
 							start: firstStart,
 							end: firstStart + firstText.length
 						},
 						{
-							type: "comment",
+							type: NodeType.Comment,
 							data: " X ",
 							start: firstStart + firstText.length,
 							end: secondStart
 						},
 						{
-							type: "text",
+							type: NodeType.Text,
 							data: secondText,
 							start: secondStart,
 							end: secondStart + secondText.length
@@ -365,10 +366,10 @@ describe("HtmlParser", () => {
 		const source = "<!-- webpackIgnore: ) -->";
 		const { module, warnings } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "comment",
+					type: NodeType.Comment,
 					data: " webpackIgnore: ) ",
 					start: 0,
 					end: source.length
@@ -386,10 +387,10 @@ describe("HtmlParser", () => {
 		const source = "<!-- webpackIgnore: 5 -->";
 		const { module, warnings } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "comment",
+					type: NodeType.Comment,
 					data: " webpackIgnore: 5 ",
 					start: 0,
 					end: source.length
@@ -407,14 +408,14 @@ describe("HtmlParser", () => {
 		const source = "<style>   </style>";
 		const { module, dependencies } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "element",
+					type: NodeType.Element,
 					tagName: "style",
 					namespace: 0,
 					attributes: [],
-					children: [{ type: "text", data: "   ", start: 7, end: 10 }],
+					children: [{ type: NodeType.Text, data: "   ", start: 7, end: 10 }],
 					selfClosing: false,
 					start: 0,
 					end: source.length,
@@ -434,7 +435,7 @@ describe("HtmlParser", () => {
 	it("accepts a Buffer source and strips a leading BOM", () => {
 		const { module } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: []
 		});
 
@@ -459,10 +460,10 @@ describe("HtmlParser", () => {
 		const source = "<!-- webpackPreload: true -->";
 		const { module, warnings } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "comment",
+					type: NodeType.Comment,
 					data: " webpackPreload: true ",
 					start: 0,
 					end: source.length
@@ -478,10 +479,10 @@ describe("HtmlParser", () => {
 		const source = "<style></style>";
 		const { module, dependencies } = makeModule();
 		buildHtmlAst.mockReturnValue({
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "element",
+					type: NodeType.Element,
 					tagName: "style",
 					namespace: 0,
 					attributes: [],
@@ -527,10 +528,10 @@ describe("HtmlParser", () => {
 			};
 		};
 		return {
-			type: "document",
+			type: NodeType.Document,
 			children: [
 				{
-					type: "element",
+					type: NodeType.Element,
 					tagName: "script",
 					namespace: 0,
 					attributes: [attr("type"), attr("src")],

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -505,3 +505,142 @@ describe("buildHtmlAst", () => {
 		expect(child(root.children, "tbody")).toBeDefined();
 	});
 });
+
+describe("buildHtmlAst — SourceProcessor", () => {
+	const { NodeType, SourceProcessor } = require("../lib/html/syntax");
+
+	it("fires enter / exit visitors in source order", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/html/syntax").VisitorMap} */ ({
+					[NodeType.Element]: {
+						enter: (n) =>
+							log.push(
+								`enter:${
+									/** @type {import("../lib/html/syntax").HtmlElement} */ (n)
+										.tagName
+								}`
+							),
+						exit: (n) =>
+							log.push(
+								`exit:${
+									/** @type {import("../lib/html/syntax").HtmlElement} */ (n)
+										.tagName
+								}`
+							)
+					},
+					[NodeType.Text]: (n) =>
+						log.push(
+							`text:${
+								/** @type {import("../lib/html/syntax").HtmlText} */ (n).data
+							}`
+						)
+				})
+			)
+			.process("<div><span>a</span>b</div>");
+		expect(log).toEqual([
+			"enter:html",
+			"enter:head",
+			"exit:head",
+			"enter:body",
+			"enter:div",
+			"enter:span",
+			"text:a",
+			"exit:span",
+			"text:b",
+			"exit:div",
+			"exit:body",
+			"exit:html"
+		]);
+	});
+
+	it("visits the document root with a null parent", () => {
+		/** @type {[string, string | null][]} */
+		const seen = [];
+		new SourceProcessor()
+			.use({
+				[NodeType.Document]: (n, parent) =>
+					seen.push([n.type, parent && parent.type])
+			})
+			.process("<p>x</p>");
+		expect(seen).toEqual([["document", null]]);
+	});
+
+	it("fires comment / doctype visitors", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use({
+				[NodeType.Doctype]: () => log.push("doctype"),
+				[NodeType.Comment]: (n) =>
+					log.push(
+						`comment:${
+							/** @type {import("../lib/html/syntax").HtmlComment} */ (n).data
+						}`
+					)
+			})
+			.process("<!DOCTYPE html><!--c--><p>x</p>");
+		expect(log).toEqual(["doctype", "comment:c"]);
+	});
+
+	it("ctx.skipChildren() stops descent into a node", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use({
+				[NodeType.Element]: (n, p, ctx) => {
+					const el = /** @type {import("../lib/html/syntax").HtmlElement} */ (
+						n
+					);
+					log.push(el.tagName);
+					if (el.tagName === "div") ctx.skipChildren();
+				}
+			})
+			.process("<div><span>a</span></div><p>b</p>");
+		expect(log).toEqual(["html", "head", "body", "div", "p"]);
+	});
+
+	it("walks <template> content as a document fragment", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use({
+				[NodeType.DocumentFragment]: () => log.push("fragment"),
+				[NodeType.Element]: (n) =>
+					log.push(
+						/** @type {import("../lib/html/syntax").HtmlElement} */ (n).tagName
+					)
+			})
+			.process("<template><p>x</p></template>");
+		expect(log).toEqual(["html", "head", "template", "fragment", "p", "body"]);
+	});
+
+	it("walks a pre-built AST when options.ast is given", () => {
+		/** @type {string[]} */
+		const log = [];
+		const ast = buildHtmlAst("<p>x</p>");
+		new SourceProcessor()
+			.use({
+				[NodeType.Element]: (n) =>
+					log.push(
+						/** @type {import("../lib/html/syntax").HtmlElement} */ (n).tagName
+					)
+			})
+			.process("ignored input", { ast });
+		expect(log).toEqual(["html", "head", "body", "p"]);
+	});
+
+	it("use() chains and accumulates visitors per type", () => {
+		let a = 0;
+		let b = 0;
+		const sp = new SourceProcessor()
+			.use({ [NodeType.Element]: () => a++ })
+			.use({ [NodeType.Element]: () => b++ });
+		expect(sp).toBeInstanceOf(SourceProcessor);
+		sp.process("<p>x</p>");
+		expect(a).toBe(b);
+		expect(a).toBeGreaterThan(0);
+	});
+});

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -645,3 +645,201 @@ describe("buildHtmlAst — SourceProcessor", () => {
 		expect(a).toBeGreaterThan(0);
 	});
 });
+
+describe("buildHtmlAst — insertion-mode edge cases", () => {
+	it("merges foster-parented text runs before a table", () => {
+		const nodes = body("<table>x<tr></tr>y</table>");
+		// Both stray runs are fostered before the table and merged into one node.
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlText} */ (nodes[0]).data
+		).toBe("xy");
+		expect(nodes[1].type).toBe(NodeType.Element);
+	});
+
+	it("keeps end tags and comments under foreign rules inside <svg>", () => {
+		const svg = find("<svg><circle></circle><!--c--></svg>", "svg");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (svg.children[0])
+				.tagName
+		).toBe("circle");
+		expect(svg.children[1].type).toBe(NodeType.Comment);
+	});
+
+	it("ignores stray end tags before head", () => {
+		const nodes = body("</div><p>x</p>");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (nodes[0]).tagName
+		).toBe("p");
+	});
+
+	it("handles <noscript> in head with comments, whitespace, and stray tags", () => {
+		const noscript = find(
+			"<head><noscript><!--c--> <link></div><head></noscript></head>",
+			"noscript"
+		);
+		expect(noscript.children[0].type).toBe(NodeType.Comment);
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (
+				noscript.children.find((c) => c.type === NodeType.Element)
+			).tagName
+		).toBe("link");
+	});
+
+	it("pops <noscript> in head on non-passthrough content", () => {
+		// <span> is not allowed in head-noscript: noscript is popped and the
+		// span lands in the body.
+		const nodes = body("<head><noscript><span>x</span></noscript></head>");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (nodes[0]).tagName
+		).toBe("span");
+	});
+
+	it("keeps comments between </head> and <body>", () => {
+		const root = html("<head></head><!--c--><body>x</body>");
+		expect(root.children.some((c) => c.type === NodeType.Comment)).toBe(true);
+	});
+
+	it("re-dispatches EOF inside an unterminated <template>", () => {
+		const template = find("<template>x", "template");
+		expect(template.templateContent).toBeDefined();
+	});
+
+	it("keeps comments inside <table>", () => {
+		const table = find("<table><!--c--></table>", "table");
+		expect(table.children[0].type).toBe(NodeType.Comment);
+	});
+
+	it("closes <caption> via </caption>, </table>, and row triggers", () => {
+		const t1 = find("<table><caption>a</caption></table>", "table");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (t1.children[0])
+				.tagName
+		).toBe("caption");
+		// A <tr> start while in caption closes the caption first.
+		const t2 = find("<table><caption>a<tr><td>b</table>", "table");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (t2.children[0])
+				.tagName
+		).toBe("caption");
+		expect(child(t2.children, "tbody")).toBeDefined();
+		// Ignored stray ends inside caption.
+		const t3 = find("<table><caption>a</td></tbody>b</table>", "table");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlText} */ (
+				/** @type {import("../lib/html/syntax").HtmlElement} */ (t3.children[0])
+					.children[0]
+			).data
+		).toBe("ab");
+	});
+
+	it("parses <colgroup> with cols, comments, and implicit close", () => {
+		const table = find(
+			"<table><colgroup><!--c--><col span='2'></col></colgroup><tr><td>x</table>",
+			"table"
+		);
+		const colgroup = child(table.children, "colgroup");
+		expect(colgroup.children.some((c) => c.type === NodeType.Comment)).toBe(
+			true
+		);
+		expect(child(colgroup.children, "col")).toBeDefined();
+		// Implicit close: a row start while in colgroup pops it.
+		expect(child(table.children, "tbody")).toBeDefined();
+		// Character data pops colgroup back to table (fostered out).
+		const t2 = find("<table><colgroup>x</table>", "table");
+		expect(child(t2.children, "colgroup")).toBeDefined();
+	});
+
+	it("closes a row via </tbody> and ignores stray cell ends in a row", () => {
+		const table = find("<table><tbody><tr><td>a</td></tbody></table>", "table");
+		const tbody = child(table.children, "tbody");
+		expect(child(child(tbody.children, "tr").children, "td")).toBeDefined();
+		// ROW_IGNORED_ENDS: a stray </td> directly in row mode is dropped.
+		const t2 = find("<table><tr></td><td>b</td></tr></table>", "table");
+		expect(
+			child(child(child(t2.children, "tbody").children, "tr").children, "td")
+		).toBeDefined();
+	});
+
+	it("handles content after </html> (after-after-body)", () => {
+		const ast = buildHtmlAst("<p>a</p></html><!--c-->z");
+		// Comment after </html> attaches to the document.
+		expect(ast.children.some((c) => c.type === NodeType.Comment)).toBe(true);
+		// Non-whitespace text re-enters the body.
+		const texts = body("<p>a</p></html>z");
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlText} */ (
+				/** @type {import("../lib/html/syntax").HtmlElement} */ (texts[0])
+					.children[0]
+			).data
+		).toBe("a");
+	});
+
+	it("parses nested frameset elements, frames, and noframes", () => {
+		const src =
+			"<frameset cols='50%,50%'> <!--c--><frame src='a'><frameset><frame></frameset></frameset> <!--d--></html> <!--e--><noframes>n</noframes>";
+		const root = html(src);
+		const frameset = child(root.children, "frameset");
+		expect(frameset).toBeDefined();
+		expect(child(frameset.children, "frame")).toBeDefined();
+		expect(child(frameset.children, "frameset")).toBeDefined();
+		expect(frameset.children.some((c) => c.type === NodeType.Comment)).toBe(
+			true
+		);
+		// afterFrameset comment + </html> → afterAfterFrameset comment/noframes.
+		const ast = buildHtmlAst(src);
+		expect(ast.children.some((c) => c.type === NodeType.Comment)).toBe(true);
+		expect(find(src, "noframes")).toBeDefined();
+	});
+
+	it("ignores </frameset> at the root frameset and html start in frameset", () => {
+		const src = "<frameset></frameset></frameset><html lang='x'>";
+		expect(child(html(src).children, "frameset")).toBeDefined();
+	});
+
+	it("mirrors the selected option from an <optgroup> into <selectedcontent>", () => {
+		const select = body(
+			"<select><button><selectedcontent></selectedcontent></button><optgroup><option selected>B</optgroup></select>"
+		)[0];
+		const selectedcontent = child(
+			child(select.children, "button").children,
+			"selectedcontent"
+		);
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlText} */ (
+				selectedcontent.children[0]
+			).data
+		).toBe("B");
+	});
+});
+
+describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
+	it("ignores a mid-document doctype and merges stray <html> attributes", () => {
+		// A stray doctype is dropped and a repeated <html> merges new
+		// attributes in colgroup / table / noscript / frameset modes.
+		const t = find(
+			"<table><colgroup><!DOCTYPE html></col><template></template><col></colgroup></table>",
+			"table"
+		);
+		expect(child(child(t.children, "colgroup").children, "col")).toBeDefined();
+		expect(find("<table><colgroup>", "colgroup")).toBeDefined();
+		expect(
+			find("<head><noscript><!DOCTYPE html></noscript>", "noscript")
+		).toBeDefined();
+		const t2 = find("<table><!DOCTYPE html><tr><td>x</table>", "table");
+		expect(child(t2.children, "tbody")).toBeDefined();
+	});
+
+	it("handles stray doctype and <html> around frameset content", () => {
+		const root = html(
+			"<frameset><!DOCTYPE html><html lang='a'><frame></frameset><!DOCTYPE html><html lang='b'></html><!DOCTYPE html><html lang='c'>"
+		);
+		expect(child(root.children, "frameset")).toBeDefined();
+		// The stray <html> start tags merged their attributes into the root.
+		expect(root.attributes.some((a) => a.name === "lang")).toBe(true);
+	});
+
+	it("merges stray <html> after </html> (after-after-body)", () => {
+		const root = html("<p>x</p></html><html lang='z'>");
+		expect(root.attributes.some((a) => a.name === "lang")).toBe(true);
+	});
+});

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -558,7 +558,7 @@ describe("buildHtmlAst — SourceProcessor", () => {
 	});
 
 	it("visits the document root with a null parent", () => {
-		/** @type {[string, string | null][]} */
+		/** @type {[number, number | null][]} */
 		const seen = [];
 		new SourceProcessor()
 			.use({

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -651,7 +651,9 @@ describe("buildHtmlAst — insertion-mode edge cases", () => {
 		const nodes = body("<table>x<tr></tr>y</table>");
 		// Both stray runs are fostered before the table and merged into one node.
 		expect(
-			/** @type {import("../lib/html/syntax").HtmlText} */ (nodes[0]).data
+			/** @type {import("../lib/html/syntax").HtmlText} */ (
+				/** @type {unknown} */ (nodes[0])
+			).data
 		).toBe("xy");
 		expect(nodes[1].type).toBe(NodeType.Element);
 	});

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -6,6 +6,7 @@ const {
 	NS_HTML,
 	NS_MATHML,
 	NS_SVG,
+	NodeType,
 	buildHtmlAst
 } = require("../lib/html/syntax");
 
@@ -16,7 +17,7 @@ const {
  */
 const child = (children, tagName) =>
 	/** @type {import("../lib/html/syntax").HtmlElement} */ (
-		children.find((c) => c.type === "element" && c.tagName === tagName)
+		children.find((c) => c.type === NodeType.Element && c.tagName === tagName)
 	);
 
 // The tree builder always produces a full document (html > head, body); these
@@ -53,7 +54,7 @@ const find = (src, tagName) => {
 	let found;
 	/** @param {import("../lib/html/syntax").HtmlNode} node node to search */
 	const walk = (node) => {
-		if (found || node.type !== "element") return;
+		if (found || node.type !== NodeType.Element) return;
 		if (node.tagName === tagName) {
 			found = node;
 			return;
@@ -67,7 +68,7 @@ const find = (src, tagName) => {
 describe("buildHtmlAst", () => {
 	it("should produce an empty document with html/head/body scaffolding", () => {
 		const ast = buildHtmlAst("");
-		expect(ast.type).toBe("document");
+		expect(ast.type).toBe(NodeType.Document);
 		const root = child(ast.children, "html");
 		expect(root.tagName).toBe("html");
 		expect(child(root.children, "head").tagName).toBe("head");
@@ -77,7 +78,7 @@ describe("buildHtmlAst", () => {
 	it("should parse a simple element into the body", () => {
 		const nodes = body("<div></div>");
 		expect(nodes).toHaveLength(1);
-		expect(nodes[0].type).toBe("element");
+		expect(nodes[0].type).toBe(NodeType.Element);
 		expect(nodes[0].tagName).toBe("div");
 		expect(nodes[0].children).toEqual([]);
 	});
@@ -88,7 +89,7 @@ describe("buildHtmlAst", () => {
 			div.children[0]
 		);
 		expect(span.tagName).toBe("span");
-		expect(span.children[0].type).toBe("text");
+		expect(span.children[0].type).toBe(NodeType.Text);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlText} */ (span.children[0])
 				.data
@@ -121,7 +122,7 @@ describe("buildHtmlAst", () => {
 
 	it("should parse comments", () => {
 		const ast = buildHtmlAst("<!-- hello -->");
-		expect(ast.children[0].type).toBe("comment");
+		expect(ast.children[0].type).toBe(NodeType.Comment);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlComment} */ (ast.children[0])
 				.data
@@ -130,7 +131,7 @@ describe("buildHtmlAst", () => {
 
 	it("should parse doctype", () => {
 		const ast = buildHtmlAst("<!DOCTYPE html><html></html>");
-		expect(ast.children[0].type).toBe("doctype");
+		expect(ast.children[0].type).toBe(NodeType.Doctype);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlDoctype} */ (ast.children[0])
 				.name
@@ -176,7 +177,7 @@ describe("buildHtmlAst", () => {
 		// Foster-parenting the table's text next to the leading text exercises
 		// the adjacent-text-node merge.
 		const nodes = body("Text<table>Misplaced</table>");
-		expect(nodes[0].type).toBe("text");
+		expect(nodes[0].type).toBe(NodeType.Text);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlText} */ (
 				/** @type {unknown} */ (nodes[0])
@@ -287,7 +288,7 @@ describe("buildHtmlAst", () => {
 
 	it("should keep CDATA text in foreign content", () => {
 		const svg = body("<svg><![CDATA[foo]]></svg>")[0];
-		expect(svg.children[0].type).toBe("text");
+		expect(svg.children[0].type).toBe(NodeType.Text);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlText} */ (svg.children[0])
 				.data
@@ -297,7 +298,7 @@ describe("buildHtmlAst", () => {
 	it("should treat bogus comments as comments", () => {
 		// A leading bogus comment is inserted into the document before <html>.
 		const ast = buildHtmlAst("<?bogus comment>");
-		expect(ast.children[0].type).toBe("comment");
+		expect(ast.children[0].type).toBe(NodeType.Comment);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlComment} */ (ast.children[0])
 				.data
@@ -306,7 +307,7 @@ describe("buildHtmlAst", () => {
 
 	it("should parse raw-text elements without decoding entities", () => {
 		const script = find("<script>var a = 1 < 2 &amp; 3;</script>", "script");
-		expect(script.children[0].type).toBe("text");
+		expect(script.children[0].type).toBe(NodeType.Text);
 		expect(
 			/** @type {import("../lib/html/syntax").HtmlText} */ (script.children[0])
 				.data
@@ -403,7 +404,7 @@ describe("buildHtmlAst", () => {
 			const spans = [];
 			/** @param {import("../lib/html/syntax").HtmlNode} node node to collect from */
 			const collect = (node) => {
-				if (node.type !== "element") return;
+				if (node.type !== NodeType.Element) return;
 				for (const attr of node.attributes) {
 					if (attr.valueStart !== undefined && attr.valueStart !== -1) {
 						spans.push(`${attr.valueStart},${attr.valueEnd}`);
@@ -499,7 +500,7 @@ describe("buildHtmlAst", () => {
 			buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0]
 		);
 		const texts = root.children
-			.filter((c) => c.type === "text")
+			.filter((c) => c.type === NodeType.Text)
 			.map((/** @type {import("../lib/html/syntax").HtmlText} */ c) => c.data);
 		expect(texts).toContain("x");
 		expect(child(root.children, "tbody")).toBeDefined();
@@ -565,7 +566,7 @@ describe("buildHtmlAst — SourceProcessor", () => {
 					seen.push([n.type, parent && parent.type])
 			})
 			.process("<p>x</p>");
-		expect(seen).toEqual([["document", null]]);
+		expect(seen).toEqual([[NodeType.Document, null]]);
 	});
 
 	it("fires comment / doctype visitors", () => {

--- a/test/html5lib.spectest.js
+++ b/test/html5lib.spectest.js
@@ -22,6 +22,7 @@ const webpack = require("..");
 const {
 	NS_MATHML,
 	NS_SVG,
+	NodeType,
 	buildHtmlAst,
 	decodeHtmlEntities
 } = require("../lib/html/syntax");
@@ -200,7 +201,7 @@ const serialize = (doc) => {
 	 */
 	const walk = (node, depth) => {
 		const indent = `| ${"  ".repeat(depth)}`;
-		if (node.type === "doctype") {
+		if (node.type === NodeType.Doctype) {
 			let s = `<!DOCTYPE ${node.name || ""}`;
 			if (node.publicId !== null || node.systemId !== null) {
 				s += ` "${node.publicId || ""}" "${node.systemId || ""}"`;
@@ -208,11 +209,11 @@ const serialize = (doc) => {
 			lines.push(`${indent}${s}>`);
 			return;
 		}
-		if (node.type === "comment") {
+		if (node.type === NodeType.Comment) {
 			lines.push(`${indent}<!-- ${node.data} -->`);
 			return;
 		}
-		if (node.type === "text") {
+		if (node.type === NodeType.Text) {
 			lines.push(`${indent}"${node.data}"`);
 			return;
 		}
@@ -319,7 +320,7 @@ const runTreeCase = (c) => {
 	const root =
 		c.fragment && doc.children[0]
 			? /** @type {import("../lib/html/syntax").HtmlDocument} */ ({
-					type: "document",
+					type: NodeType.Document,
 					children: /** @type {import("../lib/html/syntax").HtmlElement} */ (
 						doc.children[0]
 					).children

--- a/test/magicComment.unittest.js
+++ b/test/magicComment.unittest.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const {
+	createMagicCommentContext,
+	parseMagicComment
+} = require("../lib/util/magicComment");
+
+describe("parseMagicComment", () => {
+	const context = createMagicCommentContext();
+
+	it("parses a single boolean pair without vm (fast path)", () => {
+		expect(parseMagicComment(" webpackIgnore: true ", context)).toEqual({
+			webpackIgnore: true
+		});
+		expect(parseMagicComment("webpackIgnore: false", context)).toEqual({
+			webpackIgnore: false
+		});
+	});
+
+	it("parses numbers and null via the fast path", () => {
+		expect(parseMagicComment("webpackPrefetch: 5", context)).toEqual({
+			webpackPrefetch: 5
+		});
+		expect(parseMagicComment("webpackPrefetch: -1.5", context)).toEqual({
+			webpackPrefetch: -1.5
+		});
+		expect(parseMagicComment("webpackMode: null", context)).toEqual({
+			webpackMode: null
+		});
+	});
+
+	it("evaluates multi-option comments via vm", () => {
+		expect(
+			parseMagicComment(
+				'webpackChunkName: "foo", webpackPrefetch: true',
+				context
+			)
+		).toEqual({ webpackChunkName: "foo", webpackPrefetch: true });
+	});
+
+	it("detaches RegExp and object values from the vm context", () => {
+		const options = parseMagicComment(
+			"webpackInclude: /\\.json$/, webpackExports: ['a', 'b']",
+			context
+		);
+		expect(options.webpackInclude).toBeInstanceOf(RegExp);
+		expect(options.webpackInclude.source).toBe("\\.json$");
+		expect(options.webpackExports).toEqual(["a", "b"]);
+	});
+
+	it("throws on a malformed comment body", () => {
+		expect(() => parseMagicComment("webpackIgnore: )", context)).toThrow(
+			/Unexpected token/
+		);
+	});
+});


### PR DESCRIPTION


**Summary**

Moves the CSS-only `SourceProcessor` visitor coordinator to `lib/util/SourceProcessor.js`, parameterized by a language grammar, adds an HTML grammar + `NodeType` to `lib/html/syntax.js`, and switches `HtmlParser` from its hand-rolled recursive walk to the same Babel-style visitor machinery `CssParser` uses; magic-comment parsing (fast path + vm evaluation, mirroring `CssParser`) is extracted into `lib/util/magicComment.js`. A follow-up perf commit interns tag/attribute names (skipping the per-tag `slice().toLowerCase()` allocation) and finishes the numeric-enum conversion for insertion modes: AST builds on tag-dense documents are ~5% faster and retained AST memory drops ~7%, with output verified byte-identical and the html5lib tree-construction corpus passing; full-build wall time and peak RSS remain flat. No changeset — internal refactor with no user-facing change.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Yes — HTML `SourceProcessor` visitor tests in `test/buildHtmlAst.unittest.js` and `parseMagicComment` tests in `test/magicComment.unittest.js`; existing CSS/HTML suites cover the rest.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with Claude Code (AI) under maintainer direction: the AI moved/wrote the code and tests, and ran the before/after benchmarks and test suites.

https://claude.ai/code/session_01B4AFajV31GitERzKMKXG8C