### PR TITLE
refactor: replace glob-to-regexp with watchpack globToRegExp

### DIFF
--- a/.changeset/remove-glob-to-regexp.md
+++ b/.changeset/remove-glob-to-regexp.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Replace glob-to-regexp dependency with watchpack's globToRegExp utility.

--- a/lib/node/NodeWatchFileSystem.js
+++ b/lib/node/NodeWatchFileSystem.js
@@ -8,6 +8,7 @@
 const util = require("util");
 const Watchpack = require("watchpack");
 
+/** @typedef {InstanceType<import("watchpack")>} Watchpack */
 /** @typedef {import("watchpack").TimeInfoEntries} TimeInfoEntries */
 /** @typedef {import("watchpack").WatchOptions} WatchOptions */
 /** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const glob2regexp = require("glob-to-regexp");
+const glob2regexp = require("watchpack").util.globToRegExp;
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
 	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
@@ -63,9 +63,8 @@ const globToRegexp = (glob, cache) => {
 	if (!glob.includes("/")) {
 		glob = `**/${glob}`;
 	}
-	const baseRegexp = glob2regexp(glob, { globstar: true, extended: true });
-	const regexpSource = baseRegexp.source;
-	const regexp = new RegExp(`^(\\./)?${regexpSource.slice(1)}`);
+	const regexpSource = glob2regexp(glob);
+	const regexp = new RegExp(`^(\\./)?${regexpSource}$`);
 	cache.set(glob, regexp);
 	return regexp;
 };

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "es-module-lexer": "^2.1.0",
     "eslint-scope": "5.1.1",
     "events": "^3.2.0",
-    "glob-to-regexp": "^0.4.1",
     "graceful-fs": "^4.2.11",
     "loader-runner": "^4.3.2",
     "mime-db": "^1.54.0",
@@ -113,7 +112,7 @@
     "neo-async": "^2.6.2",
     "schema-utils": "^4.3.3",
     "tapable": "^2.3.0",
-    "watchpack": "^2.5.1",
+    "watchpack": "^2.5.2",
     "webpack-sources": "^3.5.0"
   },
   "devDependencies": {
@@ -123,7 +122,6 @@
     "@changesets/get-github-info": "^0.8.0",
     "@codspeed/core": "^5.5.0",
     "@types/eslint-scope": "^3.7.7",
-    "@types/glob-to-regexp": "^0.4.4",
     "@types/graceful-fs": "^4.1.9",
     "@types/jest": "^30.0.0",
     "@types/mime-db": "^1.43.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,11 +2031,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
-"@types/glob-to-regexp@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@types/glob-to-regexp/-/glob-to-regexp-0.4.4.tgz#409e71290253203185b1ea8a3d6ea406a4bdc902"
-  integrity sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==
-
 "@types/graceful-fs@^4.1.9":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
@@ -4932,11 +4927,6 @@ glob-to-regex.js@^1.0.0, glob-to-regex.js@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz#2b323728271d133830850e32311f40766c5f6413"
   integrity sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==
-
-glob-to-regexp@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^10.5.0:
   version "10.5.0"
@@ -9477,12 +9467,11 @@ wast-loader@^1.12.1:
   dependencies:
     wabt "1.0.0-nightly.20180421"
 
-watchpack@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.5.1.tgz#dd38b601f669e0cbf567cb802e75cead82cde102"
-  integrity sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==
+watchpack@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.5.2.tgz#e12e82d84674266fc1c6dbfe38891b92ff0522ec"
+  integrity sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==
   dependencies:
-    glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
 webassembly-feature@1.3.0:


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Drops the direct `glob-to-regexp` dependency by reusing `watchpack`'s `util.globToRegExp` (exposed since watchpack 2.5.2, with the same globstar + extended semantics), shrinking webpack's dependency tree.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your ce you already documented?**

n/a

**Use of AI**

Yes