### PR TITLE
fix: keep all CommonJS exports when an exported function accesses them via this

### DIFF
--- a/.changeset/cjs-this-in-exported-function.md
+++ b/.changeset/cjs-this-in-exported-function.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep all CommonJS exports when an exported function accesses them via `this`.

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -19,7 +19,9 @@ const ModuleDecoratorDependency = require("./ModuleDecoratorDependency");
 /** @typedef {import("estree").AssignmentExpression} AssignmentExpression */
 /** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("estree").Expression} Expression */
+/** @typedef {import("estree").Node} Node */
 /** @typedef {import("estree").Super} Super */
+/** @typedef {import("estree").ThisExpression} ThisExpression */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
@@ -178,6 +180,105 @@ const parseRequireCall = (parser, expr) => {
 	return { argument: argValue, ids: ids.reverse() };
 };
 
+/**
+ * Checks if a value is an AST node.
+ * @param {unknown} value candidate
+ * @returns {value is Node} true when the value is an AST node
+ */
+const isNode = (value) =>
+	typeof value === "object" &&
+	value !== null &&
+	typeof (/** @type {{ type?: unknown }} */ (value).type) === "string";
+
+/** Positional/metadata keys that never hold child AST nodes. */
+const NON_CHILD_KEYS = new Set([
+	"type",
+	"start",
+	"end",
+	"loc",
+	"range",
+	"leadingComments",
+	"trailingComments"
+]);
+
+/** @type {Map<string, string[]>} per node type: own keys that may hold child nodes */
+const childKeysByType = new Map();
+
+/**
+ * Returns the keys of a node that may hold child nodes, excluding positional
+ * metadata. Computed once per node type and cached: acorn initializes every
+ * field of a given type (to `null` when absent), so the key set is stable, and
+ * the cache stays allocation-free on the hot path after the first node of each
+ * type is seen.
+ * @param {Node} node node
+ * @returns {string[]} candidate child keys
+ */
+const getChildKeys = (node) => {
+	let keys = childKeysByType.get(node.type);
+	if (keys === undefined) {
+		keys = Object.keys(node).filter((key) => !NON_CHILD_KEYS.has(key));
+		childKeysByType.set(node.type, keys);
+	}
+	return keys;
+};
+
+/**
+ * Searches for a `this` belonging to the scanned function's own `this`-scope.
+ * Descends into arrow functions, but not into nested functions, static blocks
+ * and class field values, which have their own `this`. Class method bodies are
+ * function expressions and are skipped by the same rule, while computed keys
+ * and `extends` clauses evaluate in the outer scope and are searched. The
+ * `this`-scope boundary is enforced when a node is popped, so the generic
+ * branch may enumerate any child without crossing it.
+ * @param {Node[]} initialNodes nodes to search
+ * @returns {ThisExpression | undefined} first own `this` expression
+ */
+const findOwnThisExpression = (initialNodes) => {
+	const stack = [...initialNodes];
+	let node;
+	while ((node = stack.pop()) !== undefined) {
+		switch (node.type) {
+			case "ThisExpression":
+				return node;
+			case "FunctionExpression":
+			case "FunctionDeclaration":
+			case "StaticBlock":
+				break;
+			case "PropertyDefinition":
+				if (node.computed) stack.push(node.key);
+				break;
+			default: {
+				const children =
+					/** @type {Record<string, unknown>} */
+					(/** @type {unknown} */ (node));
+				const keys = getChildKeys(node);
+				for (let i = 0; i < keys.length; i++) {
+					const value = children[keys[i]];
+					if (Array.isArray(value)) {
+						for (const item of value) {
+							if (isNode(item)) stack.push(item);
+						}
+					} else if (isNode(value)) {
+						stack.push(value);
+					}
+				}
+			}
+		}
+	}
+};
+
+/**
+ * Returns the own `this` of a function-expression export value. When such a
+ * function is called as a method of the exports object, `this` is the exports
+ * object and may reach any sibling export (#21178).
+ * @param {Node} expr the exported value
+ * @returns {ThisExpression | undefined} first own `this` expression
+ */
+const getThisAccessInExportedValue = (expr) =>
+	expr.type === "FunctionExpression"
+		? findOwnThisExpression([...expr.params, expr.body])
+		: undefined;
+
 const PLUGIN_NAME = "CommonJsExportsParserPlugin";
 
 class CommonJsExportsParserPlugin {
@@ -232,6 +333,36 @@ class CommonJsExportsParserPlugin {
 			this.moduleGraph
 				.getOptimizationBailout(parser.state.module)
 				.push(`CommonJS bailout: ${reason}`);
+		};
+		/** @type {unknown} */
+		let keptAllExportsForState;
+		/**
+		 * An exported function accessing its own `this` may reach any export
+		 * through it when called as a method of the exports object, so the
+		 * whole exports object must be kept (#21178).
+		 * @param {Node} valueExpr the exported value
+		 * @param {CommonJSDependencyBaseKeywords} base commonjs base keywords
+		 * @returns {void}
+		 */
+		const keepAllExportsOnThisAccess = (valueExpr, base) => {
+			// One bailout per module is enough
+			if (keptAllExportsForState === parser.state) return;
+			const thisExpr = getThisAccessInExportedValue(valueExpr);
+			if (thisExpr === undefined) return;
+			keptAllExportsForState = parser.state;
+			bailoutHint(
+				`this in exported function may access any export, so all exports are kept, at ${formatLocation(
+					/** @type {DependencyLocation} */ (thisExpr.loc)
+				)}`
+			);
+			const dep = new CommonJsSelfReferenceDependency(
+				/** @type {Range} */ (thisExpr.range),
+				base,
+				[],
+				false
+			);
+			dep.loc = /** @type {DependencyLocation} */ (thisExpr.loc);
+			parser.state.module.addDependency(dep);
 		};
 
 		// metadata //
@@ -302,6 +433,7 @@ class CommonJsExportsParserPlugin {
 			/** @type {JavascriptModuleBuildMeta} */ (
 				parser.state.module.buildMeta
 			).treatAsCommonJs = true;
+			keepAllExportsOnThisAccess(expr.right, base);
 			parser.walkExpression(expr.right);
 			return true;
 		};
@@ -390,6 +522,18 @@ class CommonJsExportsParserPlugin {
 					parser.state.module.buildMeta
 				).treatAsCommonJs = true;
 
+				if (descArg.type === "ObjectExpression") {
+					// `value`, `get` and `set` descriptor functions are all called
+					// with the exports object as `this`
+					for (const descProperty of descArg.properties) {
+						if (descProperty.type === "SpreadElement") continue;
+						keepAllExportsOnThisAccess(
+							descProperty.value,
+							/** @type {CommonJSDependencyBaseKeywords} */
+							(exportsArg.identifier)
+						);
+					}
+				}
 				parser.walkExpression(expr.arguments[2]);
 				return true;
 			});

--- a/test/cases/cjs-tree-shaking/this-in-exported-function-modern/index.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function-modern/index.js
@@ -1,0 +1,5 @@
+it("should still tree-shake when this appears in static blocks and class fields", () => {
+	const m = require("./module-inner");
+	expect(m.a()).toBe(2);
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/this-in-exported-function-modern/module-inner.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function-modern/module-inner.js
@@ -1,0 +1,23 @@
+exports.a = function () {
+	// `this` in static blocks and class field values is not the exports object,
+	// so it must not disable tree-shaking
+	const results = [];
+	class Inner {
+		static {
+			results.push(this);
+		}
+		[`computed${1}`] = 1;
+		field = this;
+		method() {
+			results.push(this);
+		}
+	}
+	new Inner().method();
+	return results.length;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function-modern/test.filter.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function-modern/test.filter.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const [major, minor] = process.versions.node.split(".").map(Number);
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode; the output
+	// contains class static blocks, which require Node.js >= 16.11.
+	return (
+		config.mode !== "development" &&
+		(major > 16 || (major === 16 && minor >= 11))
+	);
+};

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/esm.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/esm.js
@@ -1,0 +1,4 @@
+import * as m from "./module-esm-used";
+
+// Calling a namespace method passes the exports object as `this`
+export const result = m.sign("/esm");

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/index.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/index.js
@@ -1,0 +1,65 @@
+it("should keep all exports when an exported function uses this (#21178)", () => {
+	const signUtils = require("./module");
+	expect(signUtils.buildCanonicalString("/bucket")).toBe("resource:/bucket");
+	// `this` may reach any export, so nothing may be shaken.
+	expect(signUtils.usedExports).toBe(true);
+});
+
+it("should keep all exports when a module.exports member function uses this", () => {
+	const m = require("./module-module-exports");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when a top-level this member function uses this", () => {
+	const m = require("./module-top-this");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when this is captured by a nested arrow function", () => {
+	const m = require("./module-arrow");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when a defineProperty export descriptor uses this", () => {
+	const m = require("./module-define");
+	expect(m.a()).toBe("b");
+	expect(m.c).toBe("b");
+	m.d = "!";
+	expect(m.received).toBe("b!");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should detect this in generator, async, default-param and computed accesses", async () => {
+	const m = require("./module-misc");
+	expect(m.viaGenerator().next().value).toBe("h");
+	expect(await m.viaAsync()).toBe("h");
+	expect(m.viaDefaultParam()).toBe("h");
+	expect(m.viaComputed()).toBe("h");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when the consumer is an ESM module", () => {
+	const { result } = require("./esm");
+	expect(result).toBe("resource:/esm");
+});
+
+it("should still tree-shake when this only appears in nested functions", () => {
+	const m = require("./module-inner");
+	expect(m.a()).toBe(2);
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should still tree-shake when this is used in an exported class", () => {
+	const m = require("./module-class");
+	expect(new m.Impl().x).toBe("x");
+	expect(m.usedExports).toEqual(["Impl", "usedExports"]);
+});
+
+it("should still tree-shake when the exported values contain no this", () => {
+	const m = require("./module-no-this");
+	expect(m.a()).toBe("function");
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-arrow.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-arrow.js
@@ -1,0 +1,10 @@
+exports.a = function () {
+	// Arrows inherit the enclosing function's `this`
+	return (() => this.b())();
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-class.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-class.js
@@ -1,0 +1,12 @@
+exports.Impl = class Impl {
+	constructor() {
+		// `this` in an exported class is the instance, never the exports object
+		this.x = "x";
+	}
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-define.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-define.js
@@ -1,0 +1,30 @@
+Object.defineProperty(exports, "a", {
+	value: function a() {
+		return this.b();
+	}
+});
+
+Object.defineProperty(exports, "b", {
+	value: function b() {
+		return "b";
+	}
+});
+
+Object.defineProperty(exports, "c", {
+	get() {
+		// getters are called with the exports object as `this` too
+		return this.b();
+	}
+});
+
+const enumerable = { enumerable: true };
+
+Object.defineProperty(exports, "d", {
+	...enumerable,
+	set(value) {
+		// setters are called with the exports object as `this` too
+		this.received = this.b() + value;
+	}
+});
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-esm-used.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-esm-used.js
@@ -1,0 +1,7 @@
+exports.build = function (resourcePath) {
+	return `resource:${resourcePath}`;
+};
+
+exports.sign = function (resourcePath) {
+	return this.build(resourcePath);
+};

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-inner.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-inner.js
@@ -1,0 +1,22 @@
+exports.a = function () {
+	// `this` in nested functions and class bodies is not the exports object,
+	// so it must not disable tree-shaking
+	const results = [];
+	function inner() {
+		results.push(this);
+	}
+	class Inner {
+		method() {
+			results.push(this);
+		}
+	}
+	inner.call("inner");
+	new Inner().method();
+	return results.length;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-misc.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-misc.js
@@ -1,0 +1,21 @@
+exports.helper = function () {
+	return "h";
+};
+
+exports.viaGenerator = function* () {
+	yield this.helper();
+};
+
+exports.viaAsync = async function () {
+	return this.helper();
+};
+
+exports.viaDefaultParam = function (x = this.helper()) {
+	return x;
+};
+
+exports.viaComputed = function () {
+	return this["helper"]();
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-module-exports.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-module-exports.js
@@ -1,0 +1,9 @@
+module.exports.a = function () {
+	return this.b();
+};
+
+module.exports.b = function () {
+	return "b";
+};
+
+module.exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-no-this.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-no-this.js
@@ -1,0 +1,14 @@
+function helper() {
+	// `this` outside an exported value does not disable tree-shaking
+	return this;
+}
+
+exports.a = function () {
+	return typeof helper;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module-top-this.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module-top-this.js
@@ -1,0 +1,9 @@
+this.a = function () {
+	return this.b();
+};
+
+this.b = function () {
+	return "b";
+};
+
+this.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/module.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/module.js
@@ -1,0 +1,10 @@
+exports.buildCanonicalizedResource = function (resourcePath) {
+	return `resource:${resourcePath}`;
+};
+
+exports.buildCanonicalString = function (resourcePath) {
+	// `this` is the exports object when called as `signUtils.buildCanonicalString()`
+	return this.buildCanonicalizedResource(resourcePath);
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/this-in-exported-function/test.filter.js
+++ b/test/cases/cjs-tree-shaking/this-in-exported-function/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #21178. Since #21003 (5.107.1), CommonJS tree-shaking dropped exports that are only reached via `this` from a sibling exported function (e.g. `exports.a = function () { return this.b(); }` in `ali-oss`), breaking them at runtime; exported function expressions (including `Object.defineProperty(exports, ...)` descriptor functions) are now scanned for own-`this` usage and the whole exports object is kept used (and unmangled) when found, while exported classes and `this` in nested functions still tree-shake.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, `test/cases/cjs-tree-shaking/this-in-exported-function/` with 10 scenarios (sibling call via `this`, `module.exports`/top-level `this` bases, arrow capture, defineProperty value/getter/setter, generator/async/default-param/computed access, ESM consumer, plus controls proving classes, nested-`this` functions and `this`-free modules still tree-shake).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was developed with Claude Code under human direction: the AI reproduced the issue, implemented the fix and tests, and ran the test suites; the approach and trade-offs were reviewed and chosen by the requester.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk3FjZ29dL86M2666sPHFy)_