### PR TITLE
perf: speed up CSS and HTML parsing and code generation

### DIFF
--- a/.changeset/css-html-parsing-allocations.md
+++ b/.changeset/css-html-parsing-allocations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce allocations on CSS/HTML parsing and code-generation hot paths.

--- a/.changeset/css-html-parsing-allocations.md
+++ b/.changeset/css-html-parsing-allocations.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Reduce allocations on CSS/HTML parsing and code-generation hot paths.

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -38,6 +38,11 @@ const {
 	walkFullHashPlaceholders
 } = require("../util/publicPathPlaceholder");
 
+// `<module-type>` always has a `<basic>/<sub>` shape, so testing this prefix is
+// equivalent to `type.split("/")[0] === CSS_TYPE` without the per-connection
+// array + substring allocation on the `getTypes` hot path.
+const CSS_TYPE_PREFIX = `${CSS_TYPE}/`;
+
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").CssModuleGeneratorOptions} CssModuleGeneratorOptions */
 /** @typedef {import("../Compilation").DependencyConstructor} DependencyConstructor */
@@ -929,7 +934,7 @@ class CssGenerator extends Generator {
 				continue;
 			}
 
-			if (connection.originModule.type.split("/")[0] !== CSS_TYPE) {
+			if (!connection.originModule.type.startsWith(CSS_TYPE_PREFIX)) {
 				hasJs = true;
 			} else {
 				const originModule = /** @type {CssModule} */ connection.originModule;

--- a/lib/css/CssModule.js
+++ b/lib/css/CssModule.js
@@ -91,14 +91,13 @@ class CssModule extends NormalModule {
 		}
 
 		if (this.inheritance) {
-			const inheritance = this.inheritance.map(
-				(item, index) =>
-					`inheritance_${index}|${item[0] || ""}|${item[1] || ""}|${
-						item[2] || ""
-					}`
-			);
-
-			identifier += `|${inheritance.join("|")}`;
+			// Append directly — same bytes as `|` + items.join("|"), without the
+			// intermediate `.map()` array + per-item strings (`identifier()` is
+			// uncached and called repeatedly per module).
+			for (let i = 0; i < this.inheritance.length; i++) {
+				const item = this.inheritance[i];
+				identifier += `|inheritance_${i}|${item[0] || ""}|${item[1] || ""}|${item[2] || ""}`;
+			}
 		}
 
 		if (this.exportType) {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -781,6 +781,11 @@ class CssParser extends Parser {
 		/** @type {Comment[] | undefined} */
 		this.comments = undefined;
 		this.magicCommentContext = createMagicCommentContext();
+		// Built once on first parse — depends only on the (fixed) option flags
+		// below, and the parser instance is reused across modules. Read-only
+		// during parse, so it's safe to share.
+		/** @type {Map<string, Record<string, number>> | undefined} */
+		this._knownProperties = undefined;
 	}
 
 	/**
@@ -890,20 +895,21 @@ class CssParser extends Parser {
 			});
 		};
 
+		// `parseResource` is uncached without a cache object, so resolve the
+		// module resource once and reuse it for both the auto-mode check and
+		// self-reference resolution.
+		const parsedModuleResource = parseResource(
+			/** @type {string} */ (module.getResource())
+		);
+
 		const mode =
 			this.defaultMode === "auto" &&
 			module.type === CSS_MODULE_TYPE_AUTO &&
-			IS_MODULES.test(
-				parseResource(/** @type {string} */ (module.getResource())).path
-			)
+			IS_MODULES.test(parsedModuleResource.path)
 				? "local"
 				: this.defaultMode;
 
 		const isModules = mode === "global" || mode === "local";
-
-		const parsedModuleResource = parseResource(
-			/** @type {string} */ (module.getResource())
-		);
 
 		/**
 		 * Whether a relative `from "<request>"` resolves back to the current module (matching query/fragment too).
@@ -928,12 +934,14 @@ class CssParser extends Parser {
 			}
 		};
 
-		const knownProperties = getKnownProperties({
-			animation: this.options.animation,
-			container: this.options.container,
-			customIdents: this.options.customIdents,
-			grid: this.options.grid
-		});
+		const knownProperties =
+			this._knownProperties ||
+			(this._knownProperties = getKnownProperties({
+				animation: this.options.animation,
+				container: this.options.container,
+				customIdents: this.options.customIdents,
+				grid: this.options.grid
+			}));
 
 		/** @type {CssModuleBuildMeta} */
 		(module.buildMeta).isCssModule = isModules;
@@ -1236,9 +1244,12 @@ class CssParser extends Parser {
 		 * @returns {string | [string, string] | [string, string, string]} resolved reexport (`localName`, `importName` and optional `request` of the active `@value` import)
 		 */
 		const getReexport = (value, localName, isCustomProperty) => {
-			const reexport = icssDefinitions.get(
-				isCustomProperty ? `--${value}` : value
-			);
+			// No `@value` / `:import` / composes definitions: skip the `--` key
+			// concat + map probe (the common case for plain CSS-Modules files).
+			const reexport =
+				icssDefinitions.size === 0
+					? undefined
+					: icssDefinitions.get(isCustomProperty ? `--${value}` : value);
 
 			if (reexport) {
 				if (reexport.importName) {
@@ -3297,16 +3308,16 @@ class CssParser extends Parser {
 				const url = /** @type {UrlToken} */ (node);
 				if (!urlActive()) return;
 				// Skip bare url-tokens for a known property in CSS-Modules local mode.
+				// `currentStructuralName` already holds the declaration's normalized
+				// property name (set on Declaration enter).
 				if (
 					currentStructural &&
-					currentStructural.type === NodeType.Declaration
+					currentStructural.type === NodeType.Declaration &&
+					isModules &&
+					isEffectivelyLocal() &&
+					knownProperties.has(currentStructuralName)
 				) {
-					const prop = /** @type {Declaration} */ (currentStructural).name
-						.replace(/^(-\w+-)/, "")
-						.toLowerCase();
-					if (isModules && isEffectivelyLocal() && knownProperties.has(prop)) {
-						return;
-					}
+					return;
 				}
 				if (
 					webpackIgnored(

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -166,6 +166,25 @@ const normalizeUrl = (str, isString) => {
 const isDashedIdentifier = (identifier) =>
 	identifier.startsWith("--") && identifier.length >= 3;
 
+/**
+ * Strip CSS escape backslashes from an ident / function name. Most names have no
+ * escape, so the `indexOf` gate skips the regex engine + the new-string
+ * allocation for that common case.
+ * @param {string} s ident / function name
+ * @returns {string} `s` with backslashes removed
+ */
+const stripBackslashes = (s) => (s.includes("\\") ? s.replace(/\\/g, "") : s);
+
+/**
+ * `binarySearchBounds` comparator for `getComments` — hoisted so the lookup
+ * doesn't allocate a fresh closure per call.
+ * @param {Comment} comment comment
+ * @param {number} needle needle (byte offset)
+ * @returns {number} comparison
+ */
+const compareCommentStart = (comment, needle) =>
+	/** @type {Range} */ (comment.range)[0] - needle;
+
 /** @type {Record<string, number>} */
 const PREDEFINED_COUNTER_STYLES = {
 	decimal: 1,
@@ -642,7 +661,7 @@ const parseImportPrelude = (prelude) => {
 			if (
 				cv.type === NodeType.Function &&
 				equalsLowerCase(
-					/** @type {FunctionNode} */ (cv).name.replace(/\\/g, ""),
+					stripBackslashes(/** @type {FunctionNode} */ (cv).name),
 					"url"
 				)
 			) {
@@ -661,7 +680,7 @@ const parseImportPrelude = (prelude) => {
 			if (cv.type === NodeType.Ident) {
 				if (
 					equalsLowerCase(
-						/** @type {Token} */ (cv).value.replace(/\\/g, ""),
+						stripBackslashes(/** @type {Token} */ (cv).value),
 						"layer"
 					)
 				) {
@@ -671,7 +690,7 @@ const parseImportPrelude = (prelude) => {
 			} else if (
 				cv.type === NodeType.Function &&
 				equalsLowerCase(
-					/** @type {FunctionNode} */ (cv).name.replace(/\\/g, ""),
+					stripBackslashes(/** @type {FunctionNode} */ (cv).name),
 					"layer"
 				)
 			) {
@@ -684,7 +703,7 @@ const parseImportPrelude = (prelude) => {
 			!supportsNode &&
 			cv.type === NodeType.Function &&
 			equalsLowerCase(
-				/** @type {FunctionNode} */ (cv).name.replace(/\\/g, ""),
+				stripBackslashes(/** @type {FunctionNode} */ (cv).name),
 				"supports"
 			)
 		) {
@@ -1462,7 +1481,7 @@ class CssParser extends Parser {
 
 				if (cv.type === NodeType.Function) {
 					const fn = /** @type {FunctionNode} */ (cv);
-					const fname = fn.name.replace(/\\/g, "").toLowerCase();
+					const fname = stripBackslashes(fn.name).toLowerCase();
 					const type =
 						fname === "local" ? 1 : fname === "global" ? 2 : undefined;
 					if (!found && type) {
@@ -1686,6 +1705,12 @@ class CssParser extends Parser {
 		// Nearest enclosing declaration / at-rule / qualified-rule, set by each structural enter; the Url / Function / Ident / Comma visitors read it (via `urlActive` / `localGlobalActive` / `icssActive`) to decide value handling from the node hierarchy instead of carrying precomputed flags.
 		/** @type {AstNode | undefined} */
 		let currentStructural;
+		// Normalized name of `currentStructural`, set alongside it: the `@`-prefixed
+		// lower-cased at-rule name for an AtRule, the vendor-stripped lower-cased
+		// property name for a Declaration. Lets the per-value-token `localGlobalActive`
+		// / `icssActive` / `composesAnchorSkip` checks read it instead of recomputing
+		// the regex `.replace` + `.toLowerCase` once per value token.
+		let currentStructuralName = "";
 
 		/**
 		 * Per-at-rule scope frames; `exit` reads `hasBlock` to pick the block-cleanup vs `suppressNextRulePrelude` branch.
@@ -2053,13 +2078,12 @@ class CssParser extends Parser {
 					(this.options.container && name === "@container")));
 
 		/**
-		 * Whether a `composes:` declaration with a local anchor owns the whole declaration (its strip-dep covers the value), suppressing the generic value rewrites.
-		 * @param {Declaration} decl declaration node
+		 * Whether the current `composes:` declaration with a local anchor owns the whole declaration (its strip-dep covers the value), suppressing the generic value rewrites. Reads `currentStructuralName` (the active declaration's normalized property name).
 		 * @returns {boolean} true when the value rewrites should be skipped
 		 */
-		const composesAnchorSkip = (decl) =>
+		const composesAnchorSkip = () =>
 			currentRule.hasLocalAnchor &&
-			COMPOSES_PROPERTY.test(decl.name.replace(/^(-\w+-)/, "").toLowerCase());
+			COMPOSES_PROPERTY.test(currentStructuralName);
 
 		/**
 		 * Whether `local()` / `global()` value functions are rewritten to ICSS here (from `currentStructural`).
@@ -2068,14 +2092,10 @@ class CssParser extends Parser {
 		const localGlobalActive = () => {
 			if (!isModules || !currentStructural) return false;
 			if (currentStructural.type === NodeType.AtRule) {
-				return !isLocalHandledAtRule(
-					`@${/** @type {AtRule} */ (currentStructural).name.toLowerCase()}`
-				);
+				return !isLocalHandledAtRule(currentStructuralName);
 			}
 			if (currentStructural.type === NodeType.Declaration) {
-				return !composesAnchorSkip(
-					/** @type {Declaration} */ (currentStructural)
-				);
+				return !composesAnchorSkip();
 			}
 			return false;
 		};
@@ -2087,16 +2107,12 @@ class CssParser extends Parser {
 		const icssActive = () => {
 			if (!isModules || !currentStructural) return false;
 			if (currentStructural.type === NodeType.AtRule) {
-				const name = `@${
-					/** @type {AtRule} */ (currentStructural).name.toLowerCase()
-				}`;
+				const name = currentStructuralName;
 				return name !== "@value" && name !== "@import";
 			}
 			if (currentStructural.type === NodeType.Declaration) {
-				const decl = /** @type {Declaration} */ (currentStructural);
 				return (
-					!composesAnchorSkip(decl) &&
-					!knownProperties.has(decl.name.replace(/^(-\w+-)/, "").toLowerCase())
+					!composesAnchorSkip() && !knownProperties.has(currentStructuralName)
 				);
 			}
 			return false;
@@ -2215,7 +2231,7 @@ class CssParser extends Parser {
 					if (cv.type === NodeType.Function) {
 						const fn = /** @type {FunctionNode} */ (cv);
 						const isGlobal = equalsLowerCase(
-							fn.name.replace(/\\/g, ""),
+							stripBackslashes(fn.name),
 							"global"
 						);
 						for (const inner of fn.value) {
@@ -2766,7 +2782,11 @@ class CssParser extends Parser {
 					advanceCommentCursor(at.start);
 					const savedAnchor = currentRule.hasLocalAnchor;
 					const savedLocalIdentifiers = currentRule.localIdentifiers;
-					currentRule.localIdentifiers = [...savedLocalIdentifiers];
+					// Only modules-mode walks mutate `localIdentifiers`; otherwise share
+					// the (empty) parent list instead of copying it per rule.
+					currentRule.localIdentifiers = isModules
+						? [...savedLocalIdentifiers]
+						: savedLocalIdentifiers;
 					const name = `@${at.name.toLowerCase()}`;
 					switch (name) {
 						case "@namespace": {
@@ -2849,6 +2869,7 @@ class CssParser extends Parser {
 					const effectiveLocalMode = isEffectivelyLocal();
 					const isProcessedByLocalAtRule = isLocalHandledAtRule(name);
 					currentStructural = at;
+					currentStructuralName = name;
 					dashed.active = false;
 					// `@import` url() is the import target — only walk its prelude for url deps on malformed-import recovery (flagged on the node).
 					const atWithRecovery =
@@ -2905,7 +2926,7 @@ class CssParser extends Parser {
 							if (cv.type === NodeType.Function) {
 								if (
 									equalsLowerCase(
-										/** @type {FunctionNode} */ (cv).name.replace(/\\/g, ""),
+										stripBackslashes(/** @type {FunctionNode} */ (cv).name),
 										"local"
 									)
 								) {
@@ -3008,10 +3029,17 @@ class CssParser extends Parser {
 					const savedAnchor = currentRule.hasLocalAnchor;
 					const savedLocalIdentifiers = currentRule.localIdentifiers;
 					currentRule.hasLocalAnchor = false;
-					currentRule.localIdentifiers = [...savedLocalIdentifiers];
+					// Only modules-mode walks mutate `localIdentifiers` / `composesFiles`;
+					// otherwise share the (empty) parent containers instead of copying
+					// them per rule.
+					currentRule.localIdentifiers = isModules
+						? [...savedLocalIdentifiers]
+						: savedLocalIdentifiers;
 					// Composes-state reset between rules (saved / restored around this rule).
 					const savedPrevComposesFile = currentRule.composesPrevFile;
-					const savedComposesFiles = new Set(currentRule.composesFiles);
+					const savedComposesFiles = isModules
+						? new Set(currentRule.composesFiles)
+						: currentRule.composesFiles;
 					currentRule.composesPrevFile = undefined;
 					currentRule.composesFiles.clear();
 					qualifiedRuleStateStack.push({
@@ -3092,6 +3120,7 @@ class CssParser extends Parser {
 				const declPropertyName = decl.name
 					.replace(/^(-\w+-)/, "")
 					.toLowerCase();
+				currentStructuralName = declPropertyName;
 				// Position `lastTokenEndForComments` just past the `:` so a magic comment before the url() is found.
 				let colonPos = decl.nameEnd;
 				while (
@@ -3327,7 +3356,7 @@ class CssParser extends Parser {
 			[NodeType.Function]: {
 				enter: (node) => {
 					const fn = /** @type {FunctionNode} */ (node);
-					const fnameRaw = fn.name.replace(/\\/g, "");
+					const fnameRaw = stripBackslashes(fn.name);
 					const fname = fnameRaw.toLowerCase();
 					if (urlActive()) emitUrlFunction(fn, fname);
 					if (
@@ -3465,18 +3494,12 @@ class CssParser extends Parser {
 	 * @returns {Comment[]} comments in the range
 	 */
 	getComments(range) {
-		if (!this.comments) return [];
-		const [start, end] = range;
-		/**
-		 * Returns compared.
-		 * @param {Comment} comment comment
-		 * @param {number} needle needle
-		 * @returns {number} compared
-		 */
-		const compare = (comment, needle) =>
-			/** @type {Range} */ (comment.range)[0] - needle;
 		const comments = /** @type {Comment[]} */ (this.comments);
-		let idx = binarySearchBounds.ge(comments, start, compare);
+		// No comments: skip the binary search + result-array allocation entirely
+		// (the common case — most CSS has no magic comments).
+		if (!comments || comments.length === 0) return [];
+		const [start, end] = range;
+		let idx = binarySearchBounds.ge(comments, start, compareCommentStart);
 		/** @type {Comment[]} */
 		const commentsInRange = [];
 		while (

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -124,21 +124,32 @@ const matchAll = (regexp, str) => {
  * @returns {string} normalized url
  */
 const normalizeUrl = (str, isString) => {
+	// Fast paths: skip the regex engine for the common URL with no escape and
+	// no edge whitespace (e.g. `./img.png`). Each guard is equivalent to the
+	// regex being a no-op.
 	// Remove escaped newlines from a string-token url like `url("im\<newline>g.png")`.
-	if (isString) {
+	if (isString && str.includes("\\")) {
 		str = str.replace(STRING_MULTILINE, "");
 	}
 
-	str = str
-		// Remove unnecessary spaces from `url("   img.png	 ")`
-		.replace(TRIM_WHITE_SPACES, "")
-		// Unescape
-		.replace(UNESCAPE, (match) => {
+	// Remove unnecessary spaces from `url("   img.png	 ")`
+	if (
+		str.length !== 0 &&
+		(isCssWhitespace(str.charCodeAt(0)) ||
+			isCssWhitespace(str.charCodeAt(str.length - 1)))
+	) {
+		str = str.replace(TRIM_WHITE_SPACES, "");
+	}
+
+	// Unescape
+	if (str.includes("\\")) {
+		str = str.replace(UNESCAPE, (match) => {
 			if (match.length > 2) {
 				return String.fromCharCode(Number.parseInt(match.slice(1).trim(), 16));
 			}
 			return match[1];
 		});
+	}
 
 	if (/^data:/i.test(str)) {
 		return str;
@@ -986,10 +997,11 @@ class CssParser extends Parser {
 		/**
 		 * Apply the magic comments in `range`: warn on any compilation error, validate `webpackIgnore`, and report whether the resource is ignored (so the caller skips emitting its dependency).
 		 * @param {Range} range byte range to scan for magic comments
-		 * @param {{ start: Position, end: Position }} warnLoc loc for an invalid-`webpackIgnore` warning
+		 * @param {number} warnStart start offset of the loc for an invalid-`webpackIgnore` warning (computed lazily)
+		 * @param {number} warnEnd end offset of that loc
 		 * @returns {boolean} true when `webpackIgnore: true`
 		 */
-		const webpackIgnored = (range, warnLoc) => {
+		const webpackIgnored = (range, warnStart, warnEnd) => {
 			const { options, errors } = this.parseCommentOptions(range);
 			if (errors) {
 				for (const e of errors) {
@@ -1003,10 +1015,12 @@ class CssParser extends Parser {
 			}
 			if (options && options.webpackIgnore !== undefined) {
 				if (typeof options.webpackIgnore !== "boolean") {
+					// Loc is computed lazily here — it's only needed for this rare
+					// warning, not on every checked `url()` / `@import`.
 					state.module.addWarning(
 						new UnsupportedFeatureWarning(
 							`\`webpackIgnore\` expected a boolean, but received: ${options.webpackIgnore}.`,
-							warnLoc
+							rangeLoc(warnStart, warnEnd)
 						)
 					);
 				} else {
@@ -2417,7 +2431,13 @@ class CssParser extends Parser {
 				const first = fn.value[nextNonWhitespace(fn.value, 0)];
 				if (!first || first.type !== NodeType.String) return;
 				const string = /** @type {Token} */ (first);
-				if (webpackIgnored([lastTokenEndForComments, fn.start], string.loc)) {
+				if (
+					webpackIgnored(
+						[lastTokenEndForComments, fn.start],
+						string.start,
+						string.end
+					)
+				) {
 					return;
 				}
 				const value = normalizeUrl(
@@ -2456,7 +2476,9 @@ class CssParser extends Parser {
 						true
 					);
 					if (value.length === 0) continue;
-					if (webpackIgnored([start, string.end], string.loc)) continue;
+					if (webpackIgnored([start, string.end], string.start, string.end)) {
+						continue;
+					}
 					const dep = new CssUrlDependency(
 						value,
 						[string.start, string.end],
@@ -2585,12 +2607,7 @@ class CssParser extends Parser {
 			}
 
 			const newline = skipWhiteLine(input, semi);
-			if (
-				webpackIgnored(
-					[importNameEnd, urlNode.end],
-					rangeLoc(importStart, newline)
-				)
-			) {
+			if (webpackIgnored([importNameEnd, urlNode.end], importStart, newline)) {
 				return;
 			}
 			if (url.length === 0) {
@@ -3322,7 +3339,8 @@ class CssParser extends Parser {
 				if (
 					webpackIgnored(
 						[lastTokenEndForComments, node.end],
-						rangeLoc(lastTokenEndForComments, node.end)
+						lastTokenEndForComments,
+						node.end
 					)
 				) {
 					return;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2015,7 +2015,9 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 			if (
 				first &&
 				first.type === T_IDENT &&
-				/** @type {Token} */ (first).value.startsWith("--") &&
+				// Test the source bytes directly — avoids forcing the lazy `value`
+				// slice just to check the `--` custom-property prefix.
+				ts.input.startsWith("--", first.start) &&
 				second &&
 				second.type === T_COLON
 			) {

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -66,6 +66,30 @@ const EXPORT_TYPE = {
 	COMPOSES: 3
 };
 
+// Hoisted out of `getLocalIdent`'s `prepareId` so the patterns + the replacer
+// aren't recompiled/reallocated per interpolated id.
+const IDENT_LEADING_INVALID_REGEXP = /^([.-]|[^a-z0-9_-])+/i;
+const IDENT_INVALID_CHARS_REGEXP = /[^a-z0-9@_-]+/gi;
+const IDENT_LOCAL_PLACEHOLDER_REGEXP = /\[local\]/g;
+const IDENT_LEADING_PROTECT_REGEXP = /^((-?\d)|--)/;
+
+/**
+ * `interpolate` `prepareId` hook — sanitize an id segment into a valid CSS ident.
+ * Pure (captures nothing), so it's shared rather than allocated per call.
+ * @param {string | number} id id segment
+ * @returns {string | number} sanitized id segment
+ */
+const prepareLocalIdentId = (id) => {
+	if (typeof id !== "string") return id;
+	return (
+		id
+			.replace(IDENT_LEADING_INVALID_REGEXP, "")
+			// We keep the `@` symbol because it can be used in the package name (e.g. `@company/package`), and if we replace it with `_`, a class conflict may occur.
+			// For example - `@import "@foo/package/style.module.css"` and `@import "foo/package/style.module.css"` (`foo` is a package, `package` is just a directory) will create a class conflict.
+			.replace(IDENT_INVALID_CHARS_REGEXP, "_")
+	);
+};
+
 /**
  * Returns local ident.
  * @param {string} local css local
@@ -141,17 +165,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 	}
 
 	let localIdent = interpolate(localIdentName, {
-		prepareId: (id) => {
-			if (typeof id !== "string") return id;
-
-			return (
-				id
-					.replace(/^([.-]|[^a-z0-9_-])+/i, "")
-					// We keep the `@` symbol because it can be used in the package name (e.g. `@company/package`), and if we replace it with `_`, a class conflict may occur.
-					// For example - `@import "@foo/package/style.module.css"` and `@import "foo/package/style.module.css"` (`foo` is a package, `package` is just a directory) will create a class conflict.
-					.replace(/[^a-z0-9@_-]+/gi, "_")
-			);
-		},
+		prepareId: prepareLocalIdentId,
 		filename: relativeResourcePath,
 		hash: localIdentHash,
 		local,
@@ -162,12 +176,12 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 	});
 
 	// TODO move this into interpolate
-	if (/\[local\]/.test(localIdent)) {
-		localIdent = localIdent.replace(/\[local\]/g, local);
-	}
+	// `replace` on a non-matching global regexp returns the string unchanged, so
+	// the `.test` guard is redundant — one scan instead of two.
+	localIdent = localIdent.replace(IDENT_LOCAL_PLACEHOLDER_REGEXP, local);
 
 	// Protect the first character from unsupported values
-	return localIdent.replace(/^((-?\d)|--)/, "_$1");
+	return localIdent.replace(IDENT_LEADING_PROTECT_REGEXP, "_$1");
 };
 
 /**

--- a/lib/dependencies/CssUrlDependency.js
+++ b/lib/dependencies/CssUrlDependency.js
@@ -105,6 +105,17 @@ class CssUrlDependency extends ModuleDependency {
 	}
 }
 
+// Hoisted out of `cssEscapeString` so the patterns + replacer aren't
+// recompiled/reallocated per `url()` / `src()` reference at code-gen.
+const CSS_ESCAPE_UNQUOTED_REGEXP = /[\n\t ()'"\\]/g;
+const CSS_ESCAPE_DOUBLE_REGEXP = /[\n"\\]/g;
+const CSS_ESCAPE_SINGLE_REGEXP = /[\n'\\]/g;
+/**
+ * @param {string} m matched character
+ * @returns {string} the character backslash-escaped
+ */
+const cssEscapeReplacer = (m) => `\\${m}`;
+
 /**
  * Returns string in quotes if needed.
  * @param {string} str string
@@ -133,11 +144,11 @@ const cssEscapeString = (str) => {
 		}
 	}
 	if (countWhiteOrBracket < 2) {
-		return str.replace(/[\n\t ()'"\\]/g, (m) => `\\${m}`);
+		return str.replace(CSS_ESCAPE_UNQUOTED_REGEXP, cssEscapeReplacer);
 	} else if (countQuotation <= countApostrophe) {
-		return `"${str.replace(/[\n"\\]/g, (m) => `\\${m}`)}"`;
+		return `"${str.replace(CSS_ESCAPE_DOUBLE_REGEXP, cssEscapeReplacer)}"`;
 	}
-	return `'${str.replace(/[\n'\\]/g, (m) => `\\${m}`)}'`;
+	return `'${str.replace(CSS_ESCAPE_SINGLE_REGEXP, cssEscapeReplacer)}'`;
 };
 
 CssUrlDependency.Template = class CssUrlDependencyTemplate extends (

--- a/lib/dependencies/HtmlInlineStyleDependency.js
+++ b/lib/dependencies/HtmlInlineStyleDependency.js
@@ -21,6 +21,19 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
+const TRAILING_WHITESPACE_REGEXP = /\s+$/;
+// One pass over the source: each char is replaced once and replacements aren't
+// re-scanned, so this matches the `&`-first sequential escape chain exactly
+// while avoiding two extra full-string scans + intermediate strings.
+const ATTR_ESCAPE_REGEXP = /[&"']/g;
+/** @type {Record<string, string>} */
+const ATTR_ESCAPES = { "&": "&amp;", '"': "&quot;", "'": "&#39;" };
+/**
+ * @param {string} c matched character
+ * @returns {string} the HTML-attribute-escaped entity
+ */
+const escapeAttrChar = (c) => ATTR_ESCAPES[c];
+
 /**
  * Represents inline CSS in an HTML module — either a `<style>...</style>`
  * block (a stylesheet) or an element's `style="..."` attribute (a CSS
@@ -121,10 +134,8 @@ HtmlInlineStyleDependency.Template = class HtmlInlineStyleDependencyTemplate ext
 		// appends so the rewritten attribute stays on one line.
 		if (dep.inAttribute) {
 			cssText = cssText
-				.replace(/\s+$/, "")
-				.replace(/&/g, "&amp;")
-				.replace(/"/g, "&quot;")
-				.replace(/'/g, "&#39;");
+				.replace(TRAILING_WHITESPACE_REGEXP, "")
+				.replace(ATTR_ESCAPE_REGEXP, escapeAttrChar);
 		}
 
 		source.replace(dep.range[0], dep.range[1] - 1, cssText);

--- a/lib/dependencies/HtmlScriptSrcDependency.js
+++ b/lib/dependencies/HtmlScriptSrcDependency.js
@@ -207,27 +207,23 @@ const chunkHasCss = (chunk, chunkGraph) =>
 	);
 
 /**
- * Compare two chunks for a deterministic tie-break in CSS link ordering.
- * `chunk.name` and `chunk.id` are both stable strings (when present);
- * one of them is set for every chunk webpack emits. We can't rely on
- * `Array.prototype.sort` being stable — webpack still supports Node
- * 10.13 where V8's sort is not guaranteed stable for arrays larger
- * than ten elements — so any time `firstCssModulePostOrderIndex`
- * returns the same value for two chunks (most commonly when several
- * chunks have no reachable CSS module in the entrypoint's dependency
- * walk and all map to `Infinity`) this comparator picks the canonical
- * order.
- * @param {Chunk} a first chunk
- * @param {Chunk} b second chunk
- * @returns {-1 | 0 | 1} ordering
+ * Deterministic tie-break key for CSS link ordering. `chunk.name` and
+ * `chunk.id` are both stable strings (when present); one of them is set for
+ * every chunk webpack emits. We can't rely on `Array.prototype.sort` being
+ * stable — webpack still supports Node 10.13 where V8's sort is not guaranteed
+ * stable for arrays larger than ten elements — so any time
+ * `firstCssModulePostOrderIndex` returns the same value for two chunks (most
+ * commonly when several chunks have no reachable CSS module in the entrypoint's
+ * dependency walk and all map to `Infinity`) this key picks the canonical order.
+ * Computed once per chunk when building the sort array rather than per
+ * comparison.
+ * @param {Chunk} chunk chunk
+ * @returns {string} the tie-break key
  */
-const compareChunksForCssTieBreak = (a, b) => {
-	const an = `${a.name || ""} ${a.id === null || a.id === undefined ? "" : a.id}`;
-	const bn = `${b.name || ""} ${b.id === null || b.id === undefined ? "" : b.id}`;
-	if (an < bn) return -1;
-	if (an > bn) return 1;
-	return 0;
-};
+const cssChunkSortKey = (chunk) =>
+	`${chunk.name || ""} ${chunk.id === null || chunk.id === undefined ? "" : chunk.id}`;
+
+const CSS_SOURCE_TYPES = [CSS_TYPE, CSS_IMPORT_TYPE];
 
 /**
  * Smallest post-order index among the CSS modules of a chunk, taken
@@ -252,7 +248,7 @@ const compareChunksForCssTieBreak = (a, b) => {
  */
 const firstCssModulePostOrderIndex = (chunk, entrypoint, chunkGraph) => {
 	let min = Number.POSITIVE_INFINITY;
-	for (const sourceType of [CSS_TYPE, CSS_IMPORT_TYPE]) {
+	for (const sourceType of CSS_SOURCE_TYPES) {
 		const modules = chunkGraph.getChunkModulesIterableBySourceType(
 			chunk,
 			sourceType
@@ -266,7 +262,15 @@ const firstCssModulePostOrderIndex = (chunk, entrypoint, chunkGraph) => {
 	return min;
 };
 
-const COPYABLE_LINK_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
+// One precompiled matcher per CSP/fetch attribute copied onto synthesized
+// sibling tags (` <attr>`, ` <attr>=value`, ` <attr>="value"`, ` <attr>='value'`).
+// `buildStylesheetLink` / `buildScriptTag` previously built these via
+// `new RegExp(string)` on every call.
+const COPYABLE_ATTR_REGEXPS = [
+	/\snonce(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i,
+	/\scrossorigin(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i,
+	/\sreferrerpolicy(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i
+];
 
 /**
  * Build a fresh `<link rel="stylesheet" href="…">` for a CSS chunk that
@@ -282,20 +286,13 @@ const COPYABLE_LINK_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
  */
 const buildStylesheetLink = (originalTag, href) => {
 	let extra = "";
-	for (const attr of COPYABLE_LINK_ATTRS) {
-		// Match ` <attr>`, ` <attr>=value`, ` <attr>="value"`, ` <attr>='value'`.
-		const re = new RegExp(
-			`\\s${attr}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?(?=[\\s/>])`,
-			"i"
-		);
+	for (const re of COPYABLE_ATTR_REGEXPS) {
 		const m = originalTag.match(re);
 		if (m) extra += m[0];
 	}
 	const safeHref = href.replace(/"/g, "&quot;");
 	return `<link rel="stylesheet" href="${safeHref}"${extra}>`;
 };
-
-const COPYABLE_SCRIPT_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
 
 /**
  * Build a fresh `<script src="…">` for a JS chunk pulled in by a custom
@@ -313,11 +310,7 @@ const COPYABLE_SCRIPT_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
  */
 const buildScriptTag = (originalTag, src, isModule) => {
 	let extra = "";
-	for (const attr of COPYABLE_SCRIPT_ATTRS) {
-		const re = new RegExp(
-			`\\s${attr}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?(?=[\\s/>])`,
-			"i"
-		);
+	for (const re of COPYABLE_ATTR_REGEXPS) {
 		const m = originalTag.match(re);
 		if (m) extra += m[0];
 	}
@@ -356,11 +349,14 @@ const cloneTagWithUrl = (
 
 	// Strip dangerous-to-copy attributes from the cloned tag — currently
 	// just `integrity`. The match handles all three quoting styles
-	// (`"…"`, `'…'`, unquoted) and the bare-attribute form.
-	body = body.replace(
-		/\s+integrity(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/gi,
-		""
-	);
+	// (`"…"`, `'…'`, unquoted) and the bare-attribute form. The `includes`
+	// gate skips the regex engine for the common no-SRI tag.
+	if (body.includes("integrity")) {
+		body = body.replace(
+			/\s+integrity(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/gi,
+			""
+		);
+	}
 
 	if (elementKind === "script-module") {
 		if (/\stype\s*=/i.test(body)) {
@@ -379,6 +375,9 @@ const cloneTagWithUrl = (
 		: `${body}</script>`;
 };
 
+const NATIVE_LINK_REGEXP = /^<link(?=[\s/>])/i;
+const NATIVE_SCRIPT_REGEXP = /^<script(?=[\s/>])/i;
+
 /**
  * Whether `originalTag` is the native HTML element that loads a chunk of
  * `elementKind` — `<script>` for `script`/`script-module`, `<link>` for
@@ -390,13 +389,11 @@ const cloneTagWithUrl = (
  * @param {HtmlScriptElementKind} elementKind element kind
  * @returns {boolean} true when the tag is the native element for the kind
  */
-const isNativeTagForKind = (originalTag, elementKind) => {
-	const nativeTag =
-		elementKind === "stylesheet" || elementKind === "modulepreload"
-			? "link"
-			: "script";
-	return new RegExp(`^<${nativeTag}(?=[\\s/>])`, "i").test(originalTag);
-};
+const isNativeTagForKind = (originalTag, elementKind) =>
+	(elementKind === "stylesheet" || elementKind === "modulepreload"
+		? NATIVE_LINK_REGEXP
+		: NATIVE_SCRIPT_REGEXP
+	).test(originalTag);
 
 HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends (
 	ModuleDependency.Template
@@ -523,7 +520,7 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 			// re-derive the order from the entrypoint's module post-order
 			// index, which mirrors the dependency walk and so reflects the
 			// import order.
-			/** @type {{ chunk: Chunk, index: number }[]} */
+			/** @type {{ chunk: Chunk, index: number, key: string }[]} */
 			const cssChunkOrder = [];
 			/** @type {Chunk[]} */
 			const jsChunks = [];
@@ -534,7 +531,8 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 				if (hasCss) {
 					cssChunkOrder.push({
 						chunk,
-						index: firstCssModulePostOrderIndex(chunk, entrypoint, chunkGraph)
+						index: firstCssModulePostOrderIndex(chunk, entrypoint, chunkGraph),
+						key: cssChunkSortKey(chunk)
 					});
 				}
 				// Anything that isn't CSS-only stays on the JS lane, in the
@@ -556,7 +554,8 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 						entryChunk,
 						entrypoint,
 						chunkGraph
-					)
+					),
+					key: cssChunkSortKey(entryChunk)
 				});
 			}
 			cssChunkOrder.sort((a, b) => {
@@ -569,7 +568,9 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 				// including the `Infinity === Infinity` case.
 				if (a.index < b.index) return -1;
 				if (a.index > b.index) return 1;
-				return compareChunksForCssTieBreak(a.chunk, b.chunk);
+				if (a.key < b.key) return -1;
+				if (a.key > b.key) return 1;
+				return 0;
 			});
 			for (const { chunk } of cssChunkOrder) {
 				siblings.push(buildSibling(chunk, "css"));

--- a/lib/dependencies/HtmlScriptSrcDependency.js
+++ b/lib/dependencies/HtmlScriptSrcDependency.js
@@ -36,6 +36,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 	 * @param {number=} tagStart position of the opening `<` of the originating tag in the source; sibling tags emitted for additional entry chunks are inserted right before this
 	 * @param {number=} tagOpenEnd position of the character immediately after the opening tag's `>` in the source; combined with `tagStart` this lets the template clone the original opening tag verbatim (preserving attributes like `nonce`, `crossorigin`, `referrerpolicy`, `defer`, `async`) when generating sibling tags
 	 * @param {boolean=} tagIsNative whether the originating element is the native tag for `elementKind` (`<script>` / `<link>`); decided at parse time from the tag name so the template needn't re-parse the source text. A custom element mapped to a `script`/`stylesheet` source `type` is non-native and gets a freshly synthesized sibling tag instead of a verbatim clone
+	 * @param {string=} copyableAttrsText the originating tag's `nonce`/`crossorigin`/`referrerpolicy` attribute source spans (leading-space-prefixed, in that fixed order), captured at parse time so synthesized sibling `<link>`/`<script>` tags carry the same CSP/fetch policy without the template re-parsing the tag text; empty when none are present
 	 */
 	constructor(
 		request,
@@ -45,7 +46,8 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		elementKind,
 		tagStart,
 		tagOpenEnd,
-		tagIsNative
+		tagIsNative,
+		copyableAttrsText
 	) {
 		super(request);
 		this.range = range;
@@ -60,6 +62,8 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		this.tagOpenEnd = tagOpenEnd === undefined ? -1 : tagOpenEnd;
 		/** @type {boolean} */
 		this.tagIsNative = tagIsNative !== false;
+		/** @type {string} */
+		this.copyableAttrsText = copyableAttrsText || "";
 	}
 
 	get type() {
@@ -82,6 +86,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		write(this.tagStart);
 		write(this.tagOpenEnd);
 		write(this.tagIsNative);
+		write(this.copyableAttrsText);
 		super.serialize(context);
 	}
 
@@ -97,6 +102,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		this.tagStart = read();
 		this.tagOpenEnd = read();
 		this.tagIsNative = read();
+		this.copyableAttrsText = read();
 		super.deserialize(context);
 	}
 }
@@ -268,34 +274,19 @@ const firstCssModulePostOrderIndex = (chunk, entrypoint, chunkGraph) => {
 	return min;
 };
 
-// One precompiled matcher per CSP/fetch attribute copied onto synthesized
-// sibling tags (` <attr>`, ` <attr>=value`, ` <attr>="value"`, ` <attr>='value'`).
-// `buildStylesheetLink` / `buildScriptTag` previously built these via
-// `new RegExp(string)` on every call.
-const COPYABLE_ATTR_REGEXPS = [
-	/\snonce(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i,
-	/\scrossorigin(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i,
-	/\sreferrerpolicy(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/i
-];
-
 /**
  * Build a fresh `<link rel="stylesheet" href="…">` for a CSS chunk that
  * was pulled in by a `<script src>` entry — the originating tag was a
  * `<script>`, but the chunk is CSS so cloning the script tag verbatim
- * would produce nonsense (`<script src="…\.css">`). Copy
- * `nonce`/`crossorigin`/`referrerpolicy` from the original element so
- * the same CSP and fetch policy applies; `defer`/`async`/`type` have no
- * meaning on `<link>` and are dropped.
- * @param {string} originalTag the originating `<script>`/`<link>` tag's source text
+ * would produce nonsense (`<script src="…\.css">`). `extra` carries the
+ * `nonce`/`crossorigin`/`referrerpolicy` source spans captured from the
+ * original element at parse time so the same CSP and fetch policy applies;
+ * `defer`/`async`/`type` have no meaning on `<link>` and are dropped.
+ * @param {string} extra the copyable CSP/fetch attribute source text (leading-space-prefixed, or empty)
  * @param {string} href URL for the stylesheet
  * @returns {string} the sibling `<link>` tag's HTML
  */
-const buildStylesheetLink = (originalTag, href) => {
-	let extra = "";
-	for (const re of COPYABLE_ATTR_REGEXPS) {
-		const m = originalTag.match(re);
-		if (m) extra += m[0];
-	}
+const buildStylesheetLink = (extra, href) => {
 	const safeHref = href.replace(/"/g, "&quot;");
 	return `<link rel="stylesheet" href="${safeHref}"${extra}>`;
 };
@@ -307,19 +298,14 @@ const buildStylesheetLink = (originalTag, href) => {
  * `</script>` (as `cloneTagWithUrl` does for a real `<script>`) would emit
  * mismatched, non-executing markup such as `<my-script src="…"></script>`,
  * so synthesize a real script element instead — copying only the CSP/fetch
- * attributes, since the custom element's other attributes have no defined
- * meaning on a `<script>`.
- * @param {string} originalTag the originating element's source text
+ * attributes (`extra`, captured at parse time), since the custom element's
+ * other attributes have no defined meaning on a `<script>`.
+ * @param {string} extra the copyable CSP/fetch attribute source text (leading-space-prefixed, or empty)
  * @param {string} src URL for the script
  * @param {boolean} isModule whether to emit `type="module"`
  * @returns {string} the sibling `<script>` tag's HTML
  */
-const buildScriptTag = (originalTag, src, isModule) => {
-	let extra = "";
-	for (const re of COPYABLE_ATTR_REGEXPS) {
-		const m = originalTag.match(re);
-		if (m) extra += m[0];
-	}
+const buildScriptTag = (extra, src, isModule) => {
 	const safeSrc = src.replace(/"/g, "&quot;");
 	return `<script${isModule ? ' type="module"' : ""} src="${safeSrc}"${extra}></script>`;
 };
@@ -465,7 +451,7 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 						dep.elementKind
 					);
 				}
-				return buildStylesheetLink(originalTag, url);
+				return buildStylesheetLink(dep.copyableAttrsText, url);
 			}
 			// A JS chunk is loaded via `<script>`. Clone a native `<script>`
 			// verbatim; synthesize a real `<script>` for custom elements that
@@ -480,7 +466,7 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 				);
 			}
 			return buildScriptTag(
-				originalTag,
+				dep.copyableAttrsText,
 				url,
 				dep.elementKind === "script-module"
 			);

--- a/lib/dependencies/HtmlScriptSrcDependency.js
+++ b/lib/dependencies/HtmlScriptSrcDependency.js
@@ -35,6 +35,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 	 * @param {HtmlScriptElementKind=} elementKind shape of the originating HTML element; used when expanding sibling tags for split/runtime chunks
 	 * @param {number=} tagStart position of the opening `<` of the originating tag in the source; sibling tags emitted for additional entry chunks are inserted right before this
 	 * @param {number=} tagOpenEnd position of the character immediately after the opening tag's `>` in the source; combined with `tagStart` this lets the template clone the original opening tag verbatim (preserving attributes like `nonce`, `crossorigin`, `referrerpolicy`, `defer`, `async`) when generating sibling tags
+	 * @param {boolean=} tagIsNative whether the originating element is the native tag for `elementKind` (`<script>` / `<link>`); decided at parse time from the tag name so the template needn't re-parse the source text. A custom element mapped to a `script`/`stylesheet` source `type` is non-native and gets a freshly synthesized sibling tag instead of a verbatim clone
 	 */
 	constructor(
 		request,
@@ -43,7 +44,8 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		category,
 		elementKind,
 		tagStart,
-		tagOpenEnd
+		tagOpenEnd,
+		tagIsNative
 	) {
 		super(request);
 		this.range = range;
@@ -56,6 +58,8 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		this.tagStart = tagStart === undefined ? -1 : tagStart;
 		/** @type {number} */
 		this.tagOpenEnd = tagOpenEnd === undefined ? -1 : tagOpenEnd;
+		/** @type {boolean} */
+		this.tagIsNative = tagIsNative !== false;
 	}
 
 	get type() {
@@ -77,6 +81,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		write(this.elementKind);
 		write(this.tagStart);
 		write(this.tagOpenEnd);
+		write(this.tagIsNative);
 		super.serialize(context);
 	}
 
@@ -91,6 +96,7 @@ class HtmlScriptSrcDependency extends ModuleDependency {
 		this.elementKind = read();
 		this.tagStart = read();
 		this.tagOpenEnd = read();
+		this.tagIsNative = read();
 		super.deserialize(context);
 	}
 }
@@ -375,26 +381,6 @@ const cloneTagWithUrl = (
 		: `${body}</script>`;
 };
 
-const NATIVE_LINK_REGEXP = /^<link(?=[\s/>])/i;
-const NATIVE_SCRIPT_REGEXP = /^<script(?=[\s/>])/i;
-
-/**
- * Whether `originalTag` is the native HTML element that loads a chunk of
- * `elementKind` — `<script>` for `script`/`script-module`, `<link>` for
- * `stylesheet`/`modulepreload`. A user can map an arbitrary custom element
- * (e.g. `<my-script src>`) onto a `script`/`stylesheet` source `type`; for
- * those, the original tag must not be cloned when emitting sibling tags for
- * extra chunks, because the clone would be invalid markup.
- * @param {string} originalTag the originating tag's source text
- * @param {HtmlScriptElementKind} elementKind element kind
- * @returns {boolean} true when the tag is the native element for the kind
- */
-const isNativeTagForKind = (originalTag, elementKind) =>
-	(elementKind === "stylesheet" || elementKind === "modulepreload"
-		? NATIVE_LINK_REGEXP
-		: NATIVE_SCRIPT_REGEXP
-	).test(originalTag);
-
 HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends (
 	ModuleDependency.Template
 ) {
@@ -450,11 +436,12 @@ HtmlScriptSrcDependency.Template = class HtmlScriptSrcDependencyTemplate extends
 		const originalTag = originalContent.slice(dep.tagStart, dep.tagOpenEnd);
 		const srcStartInTag = dep.range[0] - dep.tagStart;
 		const srcEndInTag = dep.range[1] - dep.tagStart;
-		// A user-configured source `type` can sit on an arbitrary custom
-		// element; cloning that element for sibling chunks would emit
-		// invalid markup (e.g. `<my-script …></script>`), so fall back to
-		// synthesizing real native tags for non-native originating elements.
-		const tagIsNative = isNativeTagForKind(originalTag, dep.elementKind);
+		// Non-native originating elements (a custom element mapped to a
+		// `script`/`stylesheet` source `type`) can't be cloned verbatim — the
+		// clone would be invalid markup (e.g. `<my-script …></script>`), so a
+		// real native tag is synthesized instead. Decided at parse time from the
+		// tag name (`dep.tagIsNative`) rather than re-parsing the source text.
+		const tagIsNative = dep.tagIsNative;
 
 		/**
 		 * @param {Chunk} chunk chunk to emit a sibling tag for

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -47,6 +47,12 @@ const JAVASCRIPT_AND_HTML_TYPES = new Set([JAVASCRIPT_TYPE, HTML_TYPE]);
 /** @type {WeakMap<Compilation, Map<string, Chunk>>} */
 const chunksByIdCache = new WeakMap();
 
+// Hoisted so `resolveChunkUrlSentinels` (per chunk × module) doesn't allocate a
+// fresh `RegExp` each call. `String#replace` resets `lastIndex`, so sharing the
+// global-flag instance is safe under these synchronous, non-reentrant calls.
+const CHUNK_URL_SENTINEL_REGEXP =
+	/__WEBPACK_HTML_CHUNK_URL__([0-9a-f]+)__([a-z]+)__END__/g;
+
 class HtmlGenerator extends Generator {
 	/**
 	 * Emit a sentinel for a chunk URL that can't be resolved at code-gen time
@@ -81,7 +87,7 @@ class HtmlGenerator extends Generator {
 			chunksByIdCache.set(compilation, chunksById);
 		}
 		return content.replace(
-			/__WEBPACK_HTML_CHUNK_URL__([0-9a-f]+)__([a-z]+)__END__/g,
+			CHUNK_URL_SENTINEL_REGEXP,
 			(_, hexId, contentHashType) => {
 				const chunkId = Buffer.from(hexId, "hex").toString("utf8");
 				const chunk = chunksById.get(chunkId);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -17,6 +17,8 @@ const HtmlScriptSrcDependency = require("../dependencies/HtmlScriptSrcDependency
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
 const { compareModulesByFullName } = require("../util/comparators");
+const createHash = require("../util/createHash");
+const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
 const removeBOM = require("../util/removeBOM");
 const HtmlGenerator = require("./HtmlGenerator");
 const HtmlModule = require("./HtmlModule");
@@ -61,9 +63,6 @@ class HtmlModulesPlugin {
 	 * @returns {string} content hash
 	 */
 	static computeContentHash(content, outputOptions) {
-		const createHash = require("../util/createHash");
-		const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
-
 		const hash = createHash(
 			/** @type {import("../../declarations/WebpackOptions").HashFunction} */
 			(outputOptions.hashFunction)

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1400,6 +1400,14 @@ class HtmlParser extends Parser {
 										: type === "script-module" || type === "modulepreload"
 											? "esm"
 											: undefined;
+								// Native = the element loading the chunk is the tag the
+								// template would clone verbatim (`<script>` / `<link>`);
+								// a custom element mapped to a source `type` is not.
+								const tagIsNative =
+									elementKind === "stylesheet" ||
+									elementKind === "modulepreload"
+										? elementName === "link"
+										: elementName === "script";
 								const dep = new HtmlScriptSrcDependency(
 									value,
 									[sourceStart, sourceEnd],
@@ -1407,7 +1415,8 @@ class HtmlParser extends Parser {
 									entryCategory,
 									elementKind,
 									node.start,
-									node.tagEnd
+									node.tagEnd,
+									tagIsNative
 								);
 								dep.setLoc(sl, sc, el, ec);
 								module.addPresentationalDependency(dep);

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -95,6 +95,33 @@ function isASCIIWhitespace(char) {
 // `image()` / `image-set()`), otherwise the processed text equals the input.
 const STYLE_ATTR_URL_REGEXP = /url\(|src\(|image\(|image-set\(/i;
 
+// CSP/fetch attributes copied verbatim onto a synthesized sibling `<link>` /
+// `<script>` (`HtmlScriptSrcDependency`). Fixed output order, independent of
+// source order.
+const COPYABLE_SIBLING_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
+
+const CC_QUOTATION = '"'.charCodeAt(0);
+const CC_APOSTROPHE = "'".charCodeAt(0);
+
+/**
+ * Byte-exact source span of an attribute including the single leading
+ * whitespace (` name`, ` name=value`, ` name="value"`), mirroring the
+ * tokenizer's end-of-attribute rule (`valueEnd + 1` past the closing quote).
+ * @param {string} source HTML source
+ * @param {import("./syntax").HtmlAttribute} attr attribute
+ * @returns {string} the attribute's source slice
+ */
+const attrSourceSpan = (source, attr) => {
+	const end =
+		attr.valueStart === -1
+			? attr.nameEnd
+			: source.charCodeAt(attr.valueStart - 1) === CC_QUOTATION ||
+				  source.charCodeAt(attr.valueStart - 1) === CC_APOSTROPHE
+				? attr.valueEnd + 1
+				: attr.valueEnd;
+	return source.slice(attr.nameStart - 1, end);
+};
+
 // eslint-disable-next-line no-control-regex
 const IGNORE_CHARS_REGEXP = /[\u0000-\u001F\u007F-\u009F\u00A0]/g;
 
@@ -1408,6 +1435,18 @@ class HtmlParser extends Parser {
 									elementKind === "modulepreload"
 										? elementName === "link"
 										: elementName === "script";
+								// CSP/fetch attributes the template copies onto synthesized
+								// sibling tags — captured here from the parsed attributes so
+								// the template needn't re-parse the tag text with a regexp.
+								let copyableAttrsText = "";
+								if (node.start >= 0) {
+									for (const copyableName of COPYABLE_SIBLING_ATTRS) {
+										const copyableAttr = findAttr(attrs, copyableName);
+										if (copyableAttr) {
+											copyableAttrsText += attrSourceSpan(source, copyableAttr);
+										}
+									}
+								}
 								const dep = new HtmlScriptSrcDependency(
 									value,
 									[sourceStart, sourceEnd],
@@ -1416,7 +1455,8 @@ class HtmlParser extends Parser {
 									elementKind,
 									node.start,
 									node.tagEnd,
-									tagIsNative
+									tagIsNative,
+									copyableAttrsText
 								);
 								dep.setLoc(sl, sc, el, ec);
 								module.addPresentationalDependency(dep);

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -604,6 +604,20 @@ const filterLinkItemprop = (attributes) => {
 	return allowedAttributes.has(value.trim().toLowerCase());
 };
 
+// `<link rel>` values whose `href`/`imagesrcset` webpack treats as a reference.
+const ALLOWED_LINK_RELS = new Set([
+	"stylesheet",
+	"icon",
+	"mask-icon",
+	"apple-touch-icon",
+	"apple-touch-icon-precomposed",
+	"apple-touch-startup-image",
+	"manifest",
+	"prefetch",
+	"preload",
+	"modulepreload"
+]);
+
 /**
  * @param {Map<string, string>} attributes attributes
  * @returns {boolean} true when need to parse, otherwise false
@@ -612,20 +626,10 @@ const filterLinkHref = (attributes) => {
 	const rel = getAttributeValue(attributes, "rel");
 	if (!rel) return false;
 	const usedRels = rel.trim().toLowerCase().split(/\s+/);
-	const allowedRels = [
-		"stylesheet",
-		"icon",
-		"mask-icon",
-		"apple-touch-icon",
-		"apple-touch-icon-precomposed",
-		"apple-touch-startup-image",
-		"manifest",
-		"prefetch",
-		"preload",
-		"modulepreload"
-	];
-
-	return allowedRels.some((value) => usedRels.includes(value));
+	for (let i = 0; i < usedRels.length; i++) {
+		if (ALLOWED_LINK_RELS.has(usedRels[i])) return true;
+	}
+	return false;
 };
 
 /**

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -30,7 +30,8 @@ const {
 	SourceProcessor,
 	buildHtmlAst,
 	decodeHtmlEntities,
-	decodeHtmlEntitiesWithMap
+	decodeHtmlEntitiesWithMap,
+	findAttr
 } = require("./syntax");
 
 /** @typedef {import("../../declarations/WebpackOptions").HtmlParserOptions} HtmlParserOptions */
@@ -1414,7 +1415,7 @@ class HtmlParser extends Parser {
 									elementName === "script" &&
 									(type === "script" || type === "script-module")
 								) {
-									const typeAttr = attrs.find((a) => a.name === "type");
+									const typeAttr = findAttr(attrs, "type");
 									reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
 								}
 								const collection =
@@ -1476,7 +1477,7 @@ class HtmlParser extends Parser {
 									dep.setLoc(sl, sc, el, ec);
 									module.addPresentationalDependency(dep);
 
-									const typeAttr = attrs.find((a) => a.name === "type");
+									const typeAttr = findAttr(attrs, "type");
 									reconcileScriptTypeAttr(typeAttr, node.nameEnd, type, source);
 
 									const collection =

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7372,4 +7372,5 @@ module.exports.SourceProcessor = SourceProcessor;
 module.exports.buildHtmlAst = buildHtmlAst;
 module.exports.decodeHtmlEntities = decodeHtmlEntities;
 module.exports.decodeHtmlEntitiesWithMap = decodeHtmlEntitiesWithMap;
+module.exports.findAttr = findAttr;
 module.exports.walkHtmlTokens = walkHtmlTokens;

--- a/test/configCases/html/script-src-sibling-attrs/entry.js
+++ b/test/configCases/html/script-src-sibling-attrs/entry.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/test/configCases/html/script-src-sibling-attrs/page.html
+++ b/test/configCases/html/script-src-sibling-attrs/page.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>script src sibling attrs</title>
+<script src="./entry.js" nonce="tok-1" crossorigin referrerpolicy=origin defer></script>
+</head>
+<body><div class="hero">Box</div></body>
+</html>

--- a/test/configCases/html/script-src-sibling-attrs/style.css
+++ b/test/configCases/html/script-src-sibling-attrs/style.css
@@ -1,0 +1,1 @@
+.hero { color: green; }

--- a/test/configCases/html/script-src-sibling-attrs/test.config.js
+++ b/test/configCases/html/script-src-sibling-attrs/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/script-src-sibling-attrs/test.js
+++ b/test/configCases/html/script-src-sibling-attrs/test.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+const readFile = (name) =>
+	fs.readFileSync(path.resolve(__dirname, name), "utf-8");
+
+it("should copy quoted, bare and unquoted CSP/fetch attributes byte-exact onto the synthesized sibling <link>", () => {
+	const extracted = readFile("page.html");
+
+	const linkMatch = extracted.match(/<link rel="stylesheet"[^>]*>/);
+	expect(linkMatch).not.toBeNull();
+	const linkTag = linkMatch[0];
+	expect(linkTag).toMatch(/href="[^"]+\.css"/);
+
+	// Each copyable attribute is carried back in its original source form —
+	// quoted, bare (valueless), and unquoted — in the fixed nonce/crossorigin/
+	// referrerpolicy order, regardless of source order.
+	expect(linkTag).toContain(
+		' nonce="tok-1" crossorigin referrerpolicy=origin'
+	);
+	// `defer` is not a copyable attribute, so it must not leak onto the link.
+	expect(linkTag).not.toContain("defer");
+
+	// The link precedes the script so the stylesheet download starts first.
+	const scriptIdx = extracted.indexOf("<script");
+	const linkIdx = extracted.indexOf('<link rel="stylesheet"');
+	expect(linkIdx).toBeGreaterThan(-1);
+	expect(linkIdx).toBeLessThan(scriptIdx);
+});

--- a/test/configCases/html/script-src-sibling-attrs/webpack.config.js
+++ b/test/configCases/html/script-src-sibling-attrs/webpack.config.js
@@ -1,0 +1,47 @@
+"use strict";
+
+// A `<script src>` HTML entry whose JS imports CSS, carrying the three
+// copyable CSP/fetch attributes in all three source forms — quoted
+// (`nonce="…"`), bare (`crossorigin`), and unquoted (`referrerpolicy=…`).
+// The synthesized sibling `<link>` must carry each one back byte-exact,
+// exercising every branch of the parser's `attrSourceSpan`.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: {
+		page: "./page.html"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true, css: true },
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Constant-factor performance work across the CSS and HTML parsers, their code generators, and the related dependency templates — no behavior change. Highlights: memoize the CSS parser's per-module `getKnownProperties` setup and dedupe `parseResource`; drop per-token/per-export `replace`/`toLowerCase`/Map work (reuse the already-normalized declaration name, short-circuit empty ICSS lookups); hoist per-call regexes/closures in the CSS/HTML dependency templates; move HTML sibling-tag native-tag detection and CSP attribute capture to the parse step instead of re-parsing tag text with regex at code-gen; and a profiler-guided `url()` fast path (lazy `webpackIgnore` warning loc + guarded `normalizeUrl` replaces). Profiling-driven: a parse-isolated benchmark shows ~20% faster CSS parse on a `url()`-heavy stylesheet, and emitted output is byte-identical.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/html/script-src-sibling-attrs` covers the new parse-time CSP-attribute capture (quoted/bare/unquoted source forms copied byte-exact onto a synthesized sibling `<link>`). Otherwise these are behavior-preserving optimizations already covered by the existing CSS/HTML `ConfigTestCases`/`ConfigCacheTestCases`, the `cssParsing`/`html5lib` spec suites, and the `HtmlParser`/`CssIcssExportDependency` unit tests, all passing with unchanged snapshots.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — I used Claude (Anthropic) to profile the parsers, identify the hot paths, implement these optimizations, and validate them against the full CSS/HTML test suites and a parse-isolated benchmark. All changes were reviewed for correctness and behavior-identical output.