### PR TITLE
perf: reduce retained memory in module dependencies

### DIFF
--- a/.changeset/reduce-dependency-memory.md
+++ b/.changeset/reduce-dependency-memory.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce memory by not retaining the source location object on every dependency.

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -191,7 +191,10 @@ class Dependency {
 		}
 		this._locI = "index" in loc ? loc.index : undefined;
 		this._locN = "name" in loc ? loc.name : undefined;
-		this._loc = loc;
+		// Don't retain the passed object; `get loc` rebuilds it from the numbers
+		// above on demand, so dependencies whose loc is never read hold 4 numbers
+		// instead of a SourceLocation + two Position objects.
+		this._loc = undefined;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`Dependency` already stores its source location as four numbers, but the `loc` setter also cached the original `SourceLocation` (and its two `Position` objects), so every dependency retained them even when `loc` is never read. The setter now drops that cache and `get loc` rebuilds it lazily from the numbers — the same thing `setLoc` and `serialize`/`deserialize` already do (filesystem-cached dependencies already run this way). Measured −5.9 MB retained heap (−1.4%) on a 6,000-module build; peak heap unchanged, output byte-identical.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

No new tests — it is a byte-identical refactor covered by existing suites; verified full StatsTestCases (131/131), ConfigCacheTestCases error/warning cases (cold + warm-from-cache), and byte-identical bundles + source maps.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to profile heap usage, identify the redundant `loc` retention, implement the change, and verify byte-identical output across the test suites.