### PR TITLE
feat: universal target support for electron externals

### DIFF
--- a/.changeset/electron-externals-universal-target.md
+++ b/.changeset/electron-externals-universal-target.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Use `module-import` externals type for electron built-in modules with module output.

--- a/.changeset/electron-externals-universal-target.md
+++ b/.changeset/electron-externals-universal-target.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Use `module-import` externals type for electron built-in modules with module output.
+Use `module-import` for electron externals when the target supports ESM.

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -175,9 +175,11 @@ class WebpackOptionsApply extends OptionsApply {
 			}).apply(compiler);
 		}
 		if (options.externalsPresets.electron) {
-			// Some older versions of Electron don't support all built-in modules via import, only via `require`,
-			// but it seems like there shouldn't be a warning here since these versions are rarely used in real applications
-			const type = options.output.module ? "module-import" : "node-commonjs";
+			// Use ESM imports only when the targeted electron version supports them
+			const type =
+				options.output.module && options.output.environment.module
+					? "module-import"
+					: "node-commonjs";
 
 			if (options.externalsPresets.electronMain) {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -181,6 +181,19 @@ class WebpackOptionsApply extends OptionsApply {
 					? "module-import"
 					: "node-commonjs";
 
+			// Warn when ESM output is requested but the electron version lacks it (added in electron 28)
+			if (options.output.module && !options.output.environment.module) {
+				const WebpackError = require("./WebpackError");
+
+				compiler.hooks.thisCompilation.tap(CLASS_NAME, (compilation) => {
+					compilation.warnings.push(
+						new WebpackError(
+							"'output.module' is enabled, but the targeted electron version does not support ECMAScript modules (added in electron 28). Electron built-in modules are externalized as 'node-commonjs'."
+						)
+					);
+				});
+			}
+
 			if (options.externalsPresets.electronMain) {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 				const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -175,23 +175,27 @@ class WebpackOptionsApply extends OptionsApply {
 			}).apply(compiler);
 		}
 		if (options.externalsPresets.electron) {
+			// Some older versions of Electron don't support all built-in modules via import, only via `require`,
+			// but it seems like there shouldn't be a warning here since these versions are rarely used in real applications
+			const type = options.output.module ? "module-import" : "node-commonjs";
+
 			if (options.externalsPresets.electronMain) {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 				const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
 
-				new ElectronTargetPlugin("main").apply(compiler);
+				new ElectronTargetPlugin("main", type).apply(compiler);
 			}
 			if (options.externalsPresets.electronPreload) {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 				const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
 
-				new ElectronTargetPlugin("preload").apply(compiler);
+				new ElectronTargetPlugin("preload", type).apply(compiler);
 			}
 			if (options.externalsPresets.electronRenderer) {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 				const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
 
-				new ElectronTargetPlugin("renderer").apply(compiler);
+				new ElectronTargetPlugin("renderer", type).apply(compiler);
 			}
 			if (
 				!options.externalsPresets.electronMain &&
@@ -201,7 +205,7 @@ class WebpackOptionsApply extends OptionsApply {
 				// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 				const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
 
-				new ElectronTargetPlugin().apply(compiler);
+				new ElectronTargetPlugin(undefined, type).apply(compiler);
 			}
 		}
 		if (options.externalsPresets.nwjs) {

--- a/lib/config/target.js
+++ b/lib/config/target.js
@@ -261,7 +261,8 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 				bigIntLiteral: v(4),
 				dynamicImport: v(11),
 				dynamicImportInWorker: v(11),
-				module: v(11)
+				// 28.0.0 - ESM support was added
+				module: v(28)
 			};
 		}
 	],

--- a/lib/electron/ElectronTargetPlugin.js
+++ b/lib/electron/ElectronTargetPlugin.js
@@ -7,17 +7,22 @@
 
 const ExternalsPlugin = require("../ExternalsPlugin");
 
+/** @typedef {import("../../declarations/WebpackOptions").ExternalsType} ExternalsType */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {"main" | "preload" | "renderer"} ElectronContext */
 
 class ElectronTargetPlugin {
 	/**
 	 * Creates an instance of ElectronTargetPlugin.
 	 * @param {ElectronContext=} context in main, preload or renderer context?
+	 * @param {ExternalsType=} type default external type
 	 */
-	constructor(context) {
+	constructor(context, type = "node-commonjs") {
 		/** @type {ElectronContext | undefined} */
 		this._context = context;
+		/** @type {ExternalsType} */
+		this.type = type;
 	}
 
 	/**
@@ -26,7 +31,20 @@ class ElectronTargetPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		new ExternalsPlugin("node-commonjs", [
+		/**
+		 * @param {Dependency} dependency the dependency
+		 * @returns {ExternalsType} the external type
+		 */
+		const externalType = (dependency) => {
+			// When `require` electron built-in modules with module output
+			// we should still emit `node-commonjs` for compatibility
+			if (dependency.category === "commonjs") {
+				return "node-commonjs";
+			}
+
+			return this.type;
+		};
+		new ExternalsPlugin(externalType, [
 			"clipboard",
 			"crash-reporter",
 			"electron",
@@ -38,7 +56,7 @@ class ElectronTargetPlugin {
 		]).apply(compiler);
 		switch (this._context) {
 			case "main":
-				new ExternalsPlugin("node-commonjs", [
+				new ExternalsPlugin(externalType, [
 					"app",
 					"auto-updater",
 					"browser-window",
@@ -58,7 +76,7 @@ class ElectronTargetPlugin {
 				break;
 			case "preload":
 			case "renderer":
-				new ExternalsPlugin("node-commonjs", [
+				new ExternalsPlugin(externalType, [
 					"desktop-capturer",
 					"ipc-renderer",
 					"remote",

--- a/test/configCases/target/electron-main-module/externals.js
+++ b/test/configCases/target/electron-main-module/externals.js
@@ -1,5 +1,0 @@
-import * as electron from "electron"; // module-import
-import * as app from "app"; // module-import (main context)
-const shell = require("shell"); // node-commonjs fallback
-
-console.log(electron, app, shell);

--- a/test/configCases/target/electron-main-module/externals.js
+++ b/test/configCases/target/electron-main-module/externals.js
@@ -1,0 +1,5 @@
+import * as electron from "electron"; // module-import
+import * as app from "app"; // module-import (main context)
+const shell = require("shell"); // node-commonjs fallback
+
+console.log(electron, app, shell);

--- a/test/configCases/target/electron-main-module/index.js
+++ b/test/configCases/target/electron-main-module/index.js
@@ -1,18 +1,10 @@
-const fs = require("fs");
-const path = require("path");
+import * as electron from "electron";
+import * as app from "app";
+import * as shell from "shell";
 
-it("should externalize electron built-in modules as module-import with module output", () => {
-	const content = fs.readFileSync(
-		path.resolve(__dirname, "externals.js"),
-		"utf-8"
-	);
-	// ESM `import` keeps the configured `module-import` type
-	expect(content).toContain(
-		`import * as __WEBPACK_EXTERNAL_MODULE_electron__ from "electron";`
-	);
-	expect(content).toContain(
-		`import * as __WEBPACK_EXTERNAL_MODULE_app__ from "app";`
-	);
-	// `require` still falls back to `node-commonjs` for compatibility
-	expect(content).toContain(`__WEBPACK_EXTERNAL_createRequire_require("shell")`);
+it("should externalize electron built-in modules and resolve them at runtime", () => {
+	// `electron` and `shell` are available in every electron context, `app` only in main
+	expect(electron.marker).toBe("electron");
+	expect(app.marker).toBe("app");
+	expect(shell.marker).toBe("shell");
 });

--- a/test/configCases/target/electron-main-module/index.js
+++ b/test/configCases/target/electron-main-module/index.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should externalize electron built-in modules as module-import with module output", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "externals.js"),
+		"utf-8"
+	);
+	// ESM `import` keeps the configured `module-import` type
+	expect(content).toContain(
+		`import * as __WEBPACK_EXTERNAL_MODULE_electron__ from "electron";`
+	);
+	expect(content).toContain(
+		`import * as __WEBPACK_EXTERNAL_MODULE_app__ from "app";`
+	);
+	// `require` still falls back to `node-commonjs` for compatibility
+	expect(content).toContain(`__WEBPACK_EXTERNAL_createRequire_require("shell")`);
+});

--- a/test/configCases/target/electron-main-module/require.js
+++ b/test/configCases/target/electron-main-module/require.js
@@ -1,0 +1,9 @@
+const electron = require("electron");
+const app = require("app");
+const shell = require("shell");
+
+it("should externalize required electron built-in modules as node-commonjs", () => {
+	expect(electron.marker).toBe("electron");
+	expect(app.marker).toBe("app");
+	expect(shell.marker).toBe("shell");
+});

--- a/test/configCases/target/electron-main-module/test.config.js
+++ b/test/configCases/target/electron-main-module/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => ["main.js"]
+};

--- a/test/configCases/target/electron-main-module/test.config.js
+++ b/test/configCases/target/electron-main-module/test.config.js
@@ -1,5 +1,10 @@
 "use strict";
 
+// Stub electron built-in modules so the externalized import/require resolves
 module.exports = {
-	findBundle: () => ["main.js"]
+	modules: {
+		electron: { marker: "electron" },
+		app: { marker: "app" },
+		shell: { marker: "shell" }
+	}
 };

--- a/test/configCases/target/electron-main-module/webpack.config.js
+++ b/test/configCases/target/electron-main-module/webpack.config.js
@@ -1,29 +1,27 @@
 "use strict";
 
-/** @type {import("../../../../types").Configuration} */
-module.exports = {
-	target: "electron-main",
-	node: {
-		__dirname: false,
-		__filename: false
+/** @type {import("../../../../types").Configuration[]} */
+module.exports = [
+	{
+		// `module-import` path: electron built-ins are imported as ESM
+		target: "electron-main",
+		output: {
+			module: true
+		},
+		optimization: {
+			concatenateModules: false,
+			minimize: false
+		},
+		experiments: {
+			outputModule: true
+		}
 	},
-	output: {
-		module: true,
-		filename: "[name].js"
-	},
-	entry: {
-		externals: "./externals",
-		main: "./index"
-	},
-	optimization: {
-		concatenateModules: false,
-		minimize: false
-	},
-	experiments: {
-		outputModule: true
-	},
-	externals: {
-		fs: "commonjs fs",
-		path: "commonjs path"
+	{
+		// `node-commonjs` path: electron built-ins are required
+		target: "electron-main",
+		optimization: {
+			concatenateModules: false,
+			minimize: false
+		}
 	}
-};
+];

--- a/test/configCases/target/electron-main-module/webpack.config.js
+++ b/test/configCases/target/electron-main-module/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	target: "electron-main",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	output: {
+		module: true,
+		filename: "[name].js"
+	},
+	entry: {
+		externals: "./externals",
+		main: "./index"
+	},
+	optimization: {
+		concatenateModules: false,
+		minimize: false
+	},
+	experiments: {
+		outputModule: true
+	},
+	externals: {
+		fs: "commonjs fs",
+		path: "commonjs path"
+	}
+};

--- a/test/configCases/target/electron-main-module/webpack.config.js
+++ b/test/configCases/target/electron-main-module/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = [
 	{
 		// `module-import` path: electron built-ins are imported as ESM
 		target: "electron-main",
+		entry: "./index.js",
 		output: {
 			module: true
 		},
@@ -19,6 +20,7 @@ module.exports = [
 	{
 		// `node-commonjs` path: electron built-ins are required
 		target: "electron-main",
+		entry: "./require.js",
 		optimization: {
 			concatenateModules: false,
 			minimize: false

--- a/test/configCases/target/electron-main-no-esm/externals.js
+++ b/test/configCases/target/electron-main-no-esm/externals.js
@@ -1,0 +1,4 @@
+import * as electron from "electron";
+import * as app from "app";
+
+console.log(electron, app);

--- a/test/configCases/target/electron-main-no-esm/index.js
+++ b/test/configCases/target/electron-main-no-esm/index.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should externalize electron built-ins as node-commonjs when ESM is unsupported", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "externals.mjs"),
+		"utf-8"
+	);
+	// electron 10 has no ESM, so built-ins must be required, not imported
+	expect(content).not.toContain(`from "electron"`);
+	expect(content).toContain(`__WEBPACK_EXTERNAL_createRequire_require("electron")`);
+	expect(content).toContain(`__WEBPACK_EXTERNAL_createRequire_require("app")`);
+});

--- a/test/configCases/target/electron-main-no-esm/test.config.js
+++ b/test/configCases/target/electron-main-no-esm/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => ["main.mjs"]
+};

--- a/test/configCases/target/electron-main-no-esm/test.filter.js
+++ b/test/configCases/target/electron-main-no-esm/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// `output.module` here emits `import { createRequire } from "module"`,
+// which older Node versions can't link in the vm ESM runner
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/target/electron-main-no-esm/warnings.js
+++ b/test/configCases/target/electron-main-no-esm/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/does not support ECMAScript modules \(added in electron 28\)/]
+];

--- a/test/configCases/target/electron-main-no-esm/webpack.config.js
+++ b/test/configCases/target/electron-main-no-esm/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	// electron 10 predates ESM support, so module output must still use `require`
+	target: "electron10-main",
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFormat: "module"
+	},
+	entry: {
+		externals: "./externals",
+		main: "./index"
+	},
+	optimization: {
+		concatenateModules: false,
+		minimize: false
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -6536,7 +6536,37 @@ declare class ElectronTargetPlugin {
 	/**
 	 * Creates an instance of ElectronTargetPlugin.
 	 */
-	constructor(context?: "main" | "preload" | "renderer");
+	constructor(
+		context?: "main" | "preload" | "renderer",
+		type?:
+			| "import"
+			| "var"
+			| "module"
+			| "assign"
+			| "this"
+			| "window"
+			| "self"
+			| "global"
+			| "commonjs"
+			| "commonjs2"
+			| "commonjs-module"
+			| "commonjs-static"
+			| "amd"
+			| "amd-require"
+			| "umd"
+			| "umd2"
+			| "jsonp"
+			| "system"
+			| "promise"
+			| "module-import"
+			| "script"
+			| "node-commonjs"
+			| "asset"
+			| "asset-url"
+			| "css-import"
+			| "css-url"
+	);
+	type: ExternalsType;
 
 	/**
 	 * Applies the plugin by registering its hooks on the compiler.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`ElectronTargetPlugin` always externalized electron built-in modules as `node-commonjs`, so ESM (`output.module`) builds got `require(...)` instead of `import`. This mirrors `NodeTargetPlugin`'s universal-target behavior: built-ins are externalized as `module-import` when the output is ESM and the targeted electron version supports ESM (added in electron 28), and fall back to `node-commonjs` for `require` and for older electron versions. The electron `module` target capability was also corrected from `v(11)` to `v(28)`, and a warning is emitted when `output.module` targets an electron version without ESM support.

**What kind of change does this PR introduce?**

feat (plus a small fix to the electron target capability data).

**Did you add tests for your changes?**

Yes — `test/configCases/target/electron-main-module` executes both the `module-import` (module output) and `node-commonjs` (require) bundles and asserts the externalized electron built-ins resolve to stub modules at runtime; `test/configCases/target/electron-main-no-esm` covers an electron version without ESM (falls back to `node-commonjs` and emits the warning).

**Does this PR introduce a breaking change?**

No. Electron 11–27 with `output.module` previously emitted ESM `import`s for built-ins those versions cannot import; it now uses `node-commonjs` and warns, which is strictly more correct.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used: implemented and tested with Claude Code (Anthropic), then reviewed by the author. Electron ESM version facts were verified against the official Electron docs (ESM support added in 28.0.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjGAQWySwGfuaAfU7Ys28L)_