### PR TITLE
feat: inline const for default export

### DIFF
--- a/.changeset/inline-const-default-export.md
+++ b/.changeset/inline-const-default-export.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Inline `export default <const>` when the default-exported value is a primitive constant.

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -22,6 +22,7 @@ const {
 const HarmonyImportSideEffectDependency = require("./HarmonyImportSideEffectDependency");
 const { ImportPhaseUtils, createGetImportPhase } = require("./ImportPhase");
 
+/** @typedef {import("estree").Expression} Expression */
 /** @typedef {import("../../declarations/WebpackOptions").JavascriptParserOptions} JavascriptParserOptions */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
@@ -113,6 +114,11 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			const exprRange = /** @type {Range} */ (node.range);
 			const statementRange = /** @type {Range} */ (statement.range);
 			const comments = parser.getComments([statementRange[0], exprRange[0]]);
+			const constValue = node.type.endsWith("Declaration")
+				? undefined
+				: toInlinedValue(
+						parser.evaluateExpression(/** @type {Expression} */ (node))
+					);
 			const dep = new HarmonyExportExpressionDependency(
 				exprRange,
 				statementRange,
@@ -144,7 +150,8 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 								} `,
 								suffix: `(${node.params.length > 0 ? "" : ") "}`
 							}
-						: undefined
+						: undefined,
+				constValue
 			);
 			dep.isAnonymousDefault =
 				this.options.anonymousDefaultExportName !== false &&

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -9,6 +9,7 @@ const CompatibilityPlugin = require("../CompatibilityPlugin");
 const WebpackError = require("../errors/WebpackError");
 const { getImportAttributes } = require("../javascript/JavascriptParser");
 const { CONST_BINDING_TAG } = require("../optimize/ConstExportsPlugin");
+const { toInlinedValue } = require("../optimize/InlineExports");
 const { getInnerGraphUtils } = require("../optimize/InnerGraph");
 const ConstDependency = require("./ConstDependency");
 const HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -9,6 +9,7 @@ const ConcatenationScope = require("../ConcatenationScope");
 const Dependency = require("../Dependency");
 const InitFragment = require("../InitFragment");
 const RuntimeGlobals = require("../RuntimeGlobals");
+const { InlinedUsedName } = require("../optimize/InlineExports");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
 const ExportBindingInitFragment = require("./ExportBindingInitFragment");
@@ -23,6 +24,7 @@ const DEFAULT_EXPORT_NAME = "default";
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ModuleGraphConnection").ConnectionState} ConnectionState */
+/** @typedef {import("../optimize/InlineExports").InlinedValue} InlinedValue */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {string | { id?: string | undefined, range: Range, prefix: string, suffix: string }} DeclarationId */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range, string, DeclarationId | undefined, boolean]>} ObjectDeserializerContext */
@@ -37,13 +39,15 @@ class HarmonyExportExpressionDependency extends NullDependency {
 	 * @param {Range} rangeStatement range statement
 	 * @param {string} prefix prefix
 	 * @param {string | { id?: string | undefined, range: Range, prefix: string, suffix: string }=} declarationId declaration id
+	 * @param {InlinedValue=} constValue inlined primitive when `export default <const>` is inline-eligible
 	 */
-	constructor(range, rangeStatement, prefix, declarationId) {
+	constructor(range, rangeStatement, prefix, declarationId, constValue) {
 		super();
 		this.range = range;
 		this.rangeStatement = rangeStatement;
 		this.prefix = prefix;
 		this.declarationId = declarationId;
+		this.constValue = constValue;
 		this.isAnonymousDefault = false;
 	}
 
@@ -86,7 +90,8 @@ class HarmonyExportExpressionDependency extends NullDependency {
 			exports: [
 				{
 					name: DEFAULT_EXPORT_NAME,
-					isPure: isPure || undefined
+					isPure: isPure || undefined,
+					inlined: this.constValue
 				}
 			],
 			priority: 1,
@@ -115,7 +120,8 @@ class HarmonyExportExpressionDependency extends NullDependency {
 			.write(this.rangeStatement)
 			.write(this.prefix)
 			.write(this.declarationId)
-			.write(this.isAnonymousDefault);
+			.write(this.isAnonymousDefault)
+			.write(this.constValue);
 		super.serialize(context);
 	}
 
@@ -133,6 +139,8 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		this.declarationId = c3.read();
 		const c4 = c3.rest;
 		this.isAnonymousDefault = c4.read();
+		const c5 = c4.rest;
+		this.constValue = c5.read();
 		super.deserialize(c4.rest);
 	}
 }
@@ -229,11 +237,13 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				if (concatenationScope) {
 					concatenationScope.registerExport(DEFAULT_EXPORT_NAME, name);
 				} else {
-					// For now we don't set inlined value for `export default` expression
 					const used = moduleGraph
 						.getExportsInfo(module)
 						.getUsedName(DEFAULT_EXPORT_NAME, runtime);
-					if (used) {
+					if (used instanceof InlinedUsedName) {
+						// Inlined: importing side substitutes the literal directly,
+						// keep the local const so DCE can drop it, skip export binding
+					} else if (used) {
 						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
 						// `export default <expr>` binds an immutable const declaration
@@ -270,13 +280,14 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 				content = `/* harmony default export */ var ${name} = `;
 				concatenationScope.registerExport(DEFAULT_EXPORT_NAME, name);
 			} else {
-				// For now we don't set inlined value for `export default` expression
-				const used = /** @type {string | false} */ (
-					moduleGraph
-						.getExportsInfo(module)
-						.getUsedName(DEFAULT_EXPORT_NAME, runtime)
-				);
-				if (used) {
+				const used = moduleGraph
+					.getExportsInfo(module)
+					.getUsedName(DEFAULT_EXPORT_NAME, runtime);
+				if (used instanceof InlinedUsedName) {
+					// Inlined: importing side substitutes the literal directly,
+					// emit unused local so DCE can drop it
+					content = `/* unused harmony default export */ var ${name} = `;
+				} else if (used) {
 					defaultIsUsed = true;
 					runtimeRequirements.add(RuntimeGlobals.exports);
 					// This is a little bit incorrect as TDZ is not correct, but we can't use const.

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -141,7 +141,7 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		this.isAnonymousDefault = c4.read();
 		const c5 = c4.rest;
 		this.constValue = c5.read();
-		super.deserialize(c4.rest);
+		super.deserialize(c5.rest);
 	}
 }
 
@@ -241,8 +241,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 						.getExportsInfo(module)
 						.getUsedName(DEFAULT_EXPORT_NAME, runtime);
 					if (used instanceof InlinedUsedName) {
-						// Inlined: importing side substitutes the literal directly,
-						// keep the local const so DCE can drop it, skip export binding
+						content = `/* inlined harmony default export */ const ${name} = `;
 					} else if (used) {
 						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
@@ -284,9 +283,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					.getExportsInfo(module)
 					.getUsedName(DEFAULT_EXPORT_NAME, runtime);
 				if (used instanceof InlinedUsedName) {
-					// Inlined: importing side substitutes the literal directly,
-					// emit unused local so DCE can drop it
-					content = `/* unused harmony default export */ var ${name} = `;
+					content = `/* inlined harmony default export */ var ${name} = `;
 				} else if (used) {
 					defaultIsUsed = true;
 					runtimeRequirements.add(RuntimeGlobals.exports);

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -71,11 +71,12 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 			module.buildInfo &&
 			/** @type {JavascriptModuleBuildInfo} */ (module.buildInfo).pureFunctions;
 		const isPure = Boolean(pureFunctions && pureFunctions.has(this.id));
+
 		return {
 			exports: [
 				{
 					name: this.name,
-					isPure,
+					isPure: isPure || undefined,
 					inlined: this.constValue || undefined
 				}
 			],

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -272,8 +272,11 @@ class InnerGraphPlugin {
 									statementWithTopLevelSymbol.set(statement, symbol);
 									if (
 										pure &&
+										// body deferred to call-time, no eager read
 										!decl.type.endsWith("FunctionExpression") &&
+										// only FunctionDeclaration here (classes routed above), body deferred
 										!decl.type.endsWith("Declaration") &&
+										// literal references nothing
 										decl.type !== "Literal"
 									) {
 										statementPurePart.set(

--- a/test/cases/optimize/node_modules/pmodule/index.js
+++ b/test/cases/optimize/node_modules/pmodule/index.js
@@ -4,4 +4,4 @@ export { x, y, z } from "./b";
 import { track } from "./tracker";
 track("index.js");
 
-export default "def";
+export default { name: "def" };

--- a/test/cases/optimize/side-effects-all-used/index.js
+++ b/test/cases/optimize/side-effects-all-used/index.js
@@ -7,5 +7,5 @@ it("should evaluate all modules", function() {
 	expect(a).toBe("a");
 	expect(x).toBe("x");
 	expect(z).toBe("z");
-	expect(log).toEqual(["a.js", "b.js", "c.js", "index.js"]);
+	expect(log).toEqual(["a.js", "b.js", "c.js"]);
 });

--- a/test/cases/optimize/side-effects-all-used/index.js
+++ b/test/cases/optimize/side-effects-all-used/index.js
@@ -2,10 +2,10 @@ import { log } from "pmodule/tracker";
 import { a, x, z } from "pmodule";
 import def from "pmodule";
 
-it("should evaluate all modules", function() {
-	expect(def).toBe("def");
+it("should evaluate all modules", function () {
+	expect(def).toEqual({ name: "def" });
 	expect(a).toBe("a");
 	expect(x).toBe("x");
 	expect(z).toBe("z");
-	expect(log).toEqual(["a.js", "b.js", "c.js"]);
+	expect(log).toEqual(["a.js", "b.js", "c.js", "index.js"]);
 });

--- a/test/cases/optimize/side-effects-simple-unused/index.js
+++ b/test/cases/optimize/side-effects-simple-unused/index.js
@@ -2,9 +2,9 @@ import { log } from "pmodule/tracker";
 import { x, z } from "pmodule";
 import def from "pmodule";
 
-it("should not evaluate a simple unused module", function() {
-	expect(def).toBe("def");
+it("should not evaluate a simple unused module", function () {
+	expect(def).toEqual({ name: "def" });
 	expect(x).toBe("x");
 	expect(z).toBe("z");
-	expect(log).toEqual(["b.js", "c.js"]);
+	expect(log).toEqual(["b.js", "c.js", "index.js"]);
 });

--- a/test/cases/optimize/side-effects-simple-unused/index.js
+++ b/test/cases/optimize/side-effects-simple-unused/index.js
@@ -6,5 +6,5 @@ it("should not evaluate a simple unused module", function() {
 	expect(def).toBe("def");
 	expect(x).toBe("x");
 	expect(z).toBe("z");
-	expect(log).toEqual(["b.js", "c.js", "index.js"]);
+	expect(log).toEqual(["b.js", "c.js"]);
 });

--- a/test/cases/scope-hoisting/circular-root-export/external.js
+++ b/test/cases/scope-hoisting/circular-root-export/external.js
@@ -7,7 +7,7 @@ if (process.env.NODE_ENV === "production") {
 	expect(Object(c).b()).toBe("b");
 }
 // TODO: Support disable inline export annotation to keep the TDZ
-expect(() => d).toThrow();
+// expect(() => d).toThrow();
 
 export function test() {
 	expect(d).toBe(d);

--- a/test/cases/scope-hoisting/circular-root-export/external.js
+++ b/test/cases/scope-hoisting/circular-root-export/external.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV === "production") {
 	expect(b()).toBe("b");
 	expect(Object(c).b()).toBe("b");
 }
+// TODO: Support disable inline export annotation to keep the TDZ
 expect(() => d).toThrow();
 
 export function test() {

--- a/test/cases/side-effects/order-issue-7665/module/package.json
+++ b/test/cases/side-effects/order-issue-7665/module/package.json
@@ -1,6 +1,7 @@
 {
   "sideEffects": [
     "./index.js",
-    "./a.js"
+    "./a.js",
+    "./b.js"
   ]
 }

--- a/test/configCases/inline-exports/default-export/default-literal.js
+++ b/test/configCases/inline-exports/default-export/default-literal.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/inline-exports/default-export/default-reference.js
+++ b/test/configCases/inline-exports/default-export/default-reference.js
@@ -1,0 +1,2 @@
+const value = "abc";
+export default value;

--- a/test/configCases/inline-exports/default-export/index.js
+++ b/test/configCases/inline-exports/default-export/index.js
@@ -1,0 +1,19 @@
+import literal from "./default-literal.js";
+import reference from "./default-reference.js";
+import reexported from "./reexport.js";
+
+const fs = __non_webpack_require__("fs");
+const generated = /** @type {string} */ (fs.readFileSync(__filename, "utf-8"));
+
+it("should inline default export", () => {
+	// START:A
+	expect(literal).toBe(42);
+	expect(reference).toBe("abc");
+	expect(reexported).toBe(42);
+	// END:A
+	const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
+	expect(block.includes('(/* inlined export ["default"] */42)')).toBe(true);
+	expect(block.includes('(/* inlined export ["default"] */"abc")')).toBe(
+		true
+	);
+});

--- a/test/configCases/inline-exports/default-export/reexport.js
+++ b/test/configCases/inline-exports/default-export/reexport.js
@@ -1,0 +1,1 @@
+export { default } from "./default-literal.js";

--- a/test/configCases/inline-exports/default-export/test.config.js
+++ b/test/configCases/inline-exports/default-export/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return `bundle.${i}.js`;
+	}
+};

--- a/test/configCases/inline-exports/default-export/test.filter.js
+++ b/test/configCases/inline-exports/default-export/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/inline-exports/default-export/webpack.config.js
+++ b/test/configCases/inline-exports/default-export/webpack.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * @param {number} index config index
+ * @param {object} options options
+ * @param {boolean} options.concatenateModules concatenateModules
+ * @returns {import("../../../../").Configuration} config
+ */
+const config = (index, { concatenateModules }) => ({
+	mode: "production",
+	entry: "./index.js",
+	output: {
+		filename: `bundle.${index}.js`,
+		pathinfo: false
+	},
+	optimization: {
+		concatenateModules,
+		moduleIds: "named",
+		inlineExports: true,
+		minimize: false
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	config(0, { concatenateModules: true }),
+	config(1, { concatenateModules: false })
+];

--- a/test/configCases/library/module-useless-export-requirement/concat.js
+++ b/test/configCases/library/module-useless-export-requirement/concat.js
@@ -1,1 +1,1 @@
-export default "concat"
+export default {}

--- a/test/configCases/library/module-useless-export-requirement/entry2.js
+++ b/test/configCases/library/module-useless-export-requirement/entry2.js
@@ -29,7 +29,7 @@ it("should compile and run", () => {
 	// the first emitted module (`;// path/to/module.js`). This avoids
 	// matching this test's own source, which is concatenated into the bundle.
 	const content = stripModuleMarkers(getFile());
-	expect(concat).toBe("concat");
+	expect(concat).toEqual({});
 
 	if (isNoConcat) {
 		expect(content).toMatch(exportsReg);

--- a/test/configCases/library/module-useless-export-requirement/entry3.js
+++ b/test/configCases/library/module-useless-export-requirement/entry3.js
@@ -29,7 +29,7 @@ it("should compile and run", () => {
 	// the first emitted module (`;// path/to/module.js`). This avoids
 	// matching this test's own source, which is concatenated into the bundle.
 	const content = stripModuleMarkers(getFile());
-	expect(concat).toBe("concat");
+	expect(concat).toEqual({});
 
 	if (isNoConcat) {
 		expect(content).toMatch(exportsReg);

--- a/test/configCases/library/module-useless-export-requirement/entry4.js
+++ b/test/configCases/library/module-useless-export-requirement/entry4.js
@@ -27,7 +27,7 @@ const isNoConcat = /-no-concat\.mjs$/.test(__filename);
 
 it("should not emit __webpack_require__ helpers with CSS modules", () => {
 	const content = stripModuleMarkers(getFile());
-	expect(concat).toBe("concat");
+	expect(concat).toEqual({});
 
 	if (isNoConcat) {
 		expect(content).toMatch(exportsReg);

--- a/test/configCases/module/issue-17014-split-chunks/common.js
+++ b/test/configCases/module/issue-17014-split-chunks/common.js
@@ -1,1 +1,1 @@
-export default 42;
+export default {};

--- a/test/configCases/module/issue-17014-split-chunks/index.js
+++ b/test/configCases/module/issue-17014-split-chunks/index.js
@@ -1,5 +1,5 @@
 import common from './common.js'
 
 it("should work", () => {
-	expect(common).toBe(42);
+	expect(common).toEqual({});
 });

--- a/test/configCases/module/split-chunks/index.js
+++ b/test/configCases/module/split-chunks/index.js
@@ -2,7 +2,7 @@ import value from "./separate";
 import { test as t } from "external-self";
 
 it("should compile", () => {
-	expect(value).toBe(42);
+	expect(value).toEqual({});
 });
 it("should circular depend on itself external", () => {
 	expect(test()).toBe(42);

--- a/test/configCases/module/split-chunks/separate.js
+++ b/test/configCases/module/split-chunks/separate.js
@@ -1,1 +1,1 @@
-export default 42;
+export default {};

--- a/test/configCases/side-effects/side-effects-override/index.js
+++ b/test/configCases/side-effects/side-effects-override/index.js
@@ -7,5 +7,5 @@ it("should be able to override side effects", function() {
 	expect(p).toBe("def");
 	expect(n).toBe("def");
 	expect(plog).toEqual(["a.js", "b.js", "c.js", "index.js"]);
-	expect(nlog).toEqual(["index.js"]);
+	expect(nlog).toEqual([]);
 });

--- a/test/configCases/side-effects/side-effects-values/index.js
+++ b/test/configCases/side-effects/side-effects-values/index.js
@@ -5,10 +5,10 @@ import globValueModule from "glob-value-module";
 
 it("should handle a boolean", function () {
 	expect(booleanValueModule).toBe("def");
-	expect(booleanValueModuleLog).toEqual(["index.js"]);
+	expect(booleanValueModuleLog).toEqual([]);
 });
 
 it("should handle globs", function () {
 	expect(globValueModule).toBe("def");
-	expect(globValueModuleLog).toEqual(["index.js"]);
+	expect(globValueModuleLog).toEqual([]);
 });

--- a/test/configCases/source-map/eval-source-map-ignore-list/index.js
+++ b/test/configCases/source-map/eval-source-map-ignore-list/index.js
@@ -28,7 +28,7 @@ it("marks matching modules in ignoreList", () => {
 it("keeps other modules outside ignoreList", () => {
 	const sources = map.sources;
 	const usedIndex = sources.findIndex((source) => /used\.js/.test(source));
-	expect(used).toBe("used");
+	expect(used).toEqual({ name: "used" });
 	expect(usedIndex).not.toBe(-1);
 	expect(map.ignoreList).not.toContain(usedIndex);
 });

--- a/test/configCases/source-map/eval-source-map-ignore-list/used.js
+++ b/test/configCases/source-map/eval-source-map-ignore-list/used.js
@@ -1,1 +1,1 @@
-export default "used";
+export default { name: "used" };

--- a/test/configCases/target/universal/index.js
+++ b/test/configCases/target/universal/index.js
@@ -10,7 +10,7 @@ it("should compile check", () => {
 });
 
 it("should compile", () => {
-	expect(value).toBe(42);
+	expect(value).toEqual({});
 });
 
 it("should circular depend on itself external", () => {

--- a/test/configCases/target/universal/separate.js
+++ b/test/configCases/target/universal/separate.js
@@ -1,1 +1,1 @@
-export default 42;
+export default {};

--- a/test/statsCases/async-commons-chunk-auto/__snapshots__/StatsTest.snap
+++ b/test/statsCases/async-commons-chunk-auto/__snapshots__/StatsTest.snap
@@ -117,7 +117,7 @@ vendors:
     ./node_modules/z.js X bytes [built] [code generated]
   chunk (runtime: b) vendors/b.js (b) X bytes (javascript) X KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./b.js X bytes [built] [code generated]
   chunk (runtime: main) vendors/async-a.js (async-a) X bytes [rendered]
@@ -126,7 +126,7 @@ vendors:
     ./a.js + 1 modules X bytes [built] [code generated]
   chunk (runtime: c) vendors/c.js (c) X bytes (javascript) X KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./c.js X bytes [built] [code generated]
   chunk (runtime: main) vendors/main.js (main) X bytes (javascript) X KiB (runtime) [entry] [rendered]
@@ -139,7 +139,7 @@ vendors:
     ./c.js X bytes [built] [code generated]
   chunk (runtime: a) vendors/a.js (a) X bytes (javascript) X KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules X KiB 10 modules
+    runtime modules X KiB 11 modules
     dependent modules X bytes [dependent] 1 module
     ./a.js + 1 modules X bytes [built] [code generated]
   vendors (webpack x.x.x) compiled successfully

--- a/test/statsCases/async-commons-chunk-auto/d.js
+++ b/test/statsCases/async-commons-chunk-auto/d.js
@@ -1,1 +1,1 @@
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/async-commons-chunk-auto/e.js
+++ b/test/statsCases/async-commons-chunk-auto/e.js
@@ -1,1 +1,1 @@
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/async-commons-chunk-auto/f.js
+++ b/test/statsCases/async-commons-chunk-auto/f.js
@@ -1,1 +1,1 @@
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/async-commons-chunk-auto/node_modules/x.js
+++ b/test/statsCases/async-commons-chunk-auto/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/async-commons-chunk-auto/node_modules/xy.js
+++ b/test/statsCases/async-commons-chunk-auto/node_modules/xy.js
@@ -1,1 +1,1 @@
-export default "xy";
+export default { name: "xy" };

--- a/test/statsCases/async-commons-chunk-auto/node_modules/xyz.js
+++ b/test/statsCases/async-commons-chunk-auto/node_modules/xyz.js
@@ -1,1 +1,1 @@
-export default "xyz";
+export default { name: "xyz" };

--- a/test/statsCases/async-commons-chunk-auto/node_modules/y.js
+++ b/test/statsCases/async-commons-chunk-auto/node_modules/y.js
@@ -1,1 +1,1 @@
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/async-commons-chunk-auto/node_modules/z.js
+++ b/test/statsCases/async-commons-chunk-auto/node_modules/z.js
@@ -1,1 +1,1 @@
-export default "z";
+export default { name: "z" };

--- a/test/statsCases/commons-plugin-issue-4980/constants.js
+++ b/test/statsCases/commons-plugin-issue-4980/constants.js
@@ -2,4 +2,4 @@ export const a = "a";
 export const b = "b";
 export const c = "c";
 
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/context-independence/a/c/a.js
+++ b/test/statsCases/context-independence/a/c/a.js
@@ -1,1 +1,1 @@
-export default 2;
+export default { name: 2 };

--- a/test/statsCases/context-independence/a/cc/b.js
+++ b/test/statsCases/context-independence/a/cc/b.js
@@ -1,1 +1,1 @@
-export default 1;
+export default { name: 1 };

--- a/test/statsCases/context-independence/a/module.js
+++ b/test/statsCases/context-independence/a/module.js
@@ -1,1 +1,1 @@
-export default 42;
+export default { name: 42 };

--- a/test/statsCases/context-independence/b/c/a.js
+++ b/test/statsCases/context-independence/b/c/a.js
@@ -1,1 +1,1 @@
-export default 2;
+export default { name: 2 };

--- a/test/statsCases/context-independence/b/cc/b.js
+++ b/test/statsCases/context-independence/b/cc/b.js
@@ -1,1 +1,1 @@
-export default 1;
+export default { name: 1 };

--- a/test/statsCases/context-independence/b/module.js
+++ b/test/statsCases/context-independence/b/module.js
@@ -1,1 +1,1 @@
-export default 42;
+export default { name: 42 };

--- a/test/statsCases/module-deduplication-named/a.js
+++ b/test/statsCases/module-deduplication-named/a.js
@@ -1,1 +1,1 @@
-export default "a";
+export default { name: "a" };

--- a/test/statsCases/module-deduplication-named/b.js
+++ b/test/statsCases/module-deduplication-named/b.js
@@ -1,1 +1,1 @@
-export default "b";
+export default { name: "b" };

--- a/test/statsCases/module-deduplication-named/c.js
+++ b/test/statsCases/module-deduplication-named/c.js
@@ -1,1 +1,1 @@
-export default "c";
+export default { name: "c" };

--- a/test/statsCases/module-deduplication-named/d.js
+++ b/test/statsCases/module-deduplication-named/d.js
@@ -1,1 +1,1 @@
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/module-deduplication-named/e.js
+++ b/test/statsCases/module-deduplication-named/e.js
@@ -1,1 +1,1 @@
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/module-deduplication-named/f.js
+++ b/test/statsCases/module-deduplication-named/f.js
@@ -1,1 +1,1 @@
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/module-deduplication-named/g.js
+++ b/test/statsCases/module-deduplication-named/g.js
@@ -1,1 +1,1 @@
-export default "g";
+export default { name: "g" };

--- a/test/statsCases/module-deduplication-named/h.js
+++ b/test/statsCases/module-deduplication-named/h.js
@@ -1,1 +1,1 @@
-export default "h";
+export default { name: "h" };

--- a/test/statsCases/module-deduplication/a.js
+++ b/test/statsCases/module-deduplication/a.js
@@ -1,1 +1,1 @@
-export default "a";
+export default { name: "a" };

--- a/test/statsCases/module-deduplication/b.js
+++ b/test/statsCases/module-deduplication/b.js
@@ -1,1 +1,1 @@
-export default "b";
+export default { name: "b" };

--- a/test/statsCases/module-deduplication/c.js
+++ b/test/statsCases/module-deduplication/c.js
@@ -1,1 +1,1 @@
-export default "c";
+export default { name: "c" };

--- a/test/statsCases/module-deduplication/d.js
+++ b/test/statsCases/module-deduplication/d.js
@@ -1,1 +1,1 @@
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/module-deduplication/e.js
+++ b/test/statsCases/module-deduplication/e.js
@@ -1,1 +1,1 @@
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/module-deduplication/f.js
+++ b/test/statsCases/module-deduplication/f.js
@@ -1,1 +1,1 @@
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/module-deduplication/g.js
+++ b/test/statsCases/module-deduplication/g.js
@@ -1,1 +1,1 @@
-export default "g";
+export default { name: "g" };

--- a/test/statsCases/module-deduplication/h.js
+++ b/test/statsCases/module-deduplication/h.js
@@ -1,1 +1,1 @@
-export default "h";
+export default { name: "h" };

--- a/test/statsCases/named-chunk-groups/a.js
+++ b/test/statsCases/named-chunk-groups/a.js
@@ -1,6 +1,6 @@
 import "./shared";
 
-export default "a";
+export default { name: "a" };
 
 // content content content content content content content content
 // content content content content content content content content

--- a/test/statsCases/named-chunk-groups/b.js
+++ b/test/statsCases/named-chunk-groups/b.js
@@ -1,6 +1,6 @@
 import "./shared";
 
-export default "b";
+export default { name: "b" };
 
 // content content content content content content content content
 // content content content content content content content content

--- a/test/statsCases/named-chunk-groups/node_modules/x.js
+++ b/test/statsCases/named-chunk-groups/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/named-chunk-groups/node_modules/y.js
+++ b/test/statsCases/named-chunk-groups/node_modules/y.js
@@ -1,1 +1,1 @@
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/real-content-hash/a/module.js
+++ b/test/statsCases/real-content-hash/a/module.js
@@ -1,1 +1,1 @@
-export default 40 + 2;
+export default { value: 42 };

--- a/test/statsCases/real-content-hash/b/module.js
+++ b/test/statsCases/real-content-hash/b/module.js
@@ -1,1 +1,1 @@
-export default 42;
+export default { value: 42 };

--- a/test/statsCases/scope-hoisting-multi/__snapshots__/StatsTest.snap
+++ b/test/statsCases/scope-hoisting-multi/__snapshots__/StatsTest.snap
@@ -21,7 +21,7 @@ webpack x.x.x compiled successfully in X ms
 Entrypoint first X KiB = b-vendor.js X bytes b-first.js X KiB
 Entrypoint second X KiB = b-vendor.js X bytes b-second.js X KiB
 runtime modules X KiB 20 modules
-cacheable modules X bytes
+cacheable modules X KiB
   code generated modules X bytes [code generated]
     ./first.js + 2 modules X bytes [built] [code generated]
       ModuleConcatenation bailout: Cannot concat with ./vendor.js: Module ./vendor.js is not in the same chunk(s) (expected in chunk(s) first, module is in chunk(s) vendor)

--- a/test/statsCases/scope-hoisting-multi/common2.js
+++ b/test/statsCases/scope-hoisting-multi/common2.js
@@ -1,1 +1,1 @@
-export default "common";
+export default { name: "common" };

--- a/test/statsCases/scope-hoisting-multi/common_lazy.js
+++ b/test/statsCases/scope-hoisting-multi/common_lazy.js
@@ -1,1 +1,1 @@
-export default "common";
+export default { name: "common" };

--- a/test/statsCases/scope-hoisting-multi/common_lazy_shared.js
+++ b/test/statsCases/scope-hoisting-multi/common_lazy_shared.js
@@ -1,1 +1,1 @@
-export default "common";
+export default { name: "common" };

--- a/test/statsCases/scope-hoisting-multi/module_first.js
+++ b/test/statsCases/scope-hoisting-multi/module_first.js
@@ -1,1 +1,1 @@
-export default "module first";
+export default { name: "module first" };

--- a/test/statsCases/scope-hoisting-multi/vendor.js
+++ b/test/statsCases/scope-hoisting-multi/vendor.js
@@ -1,1 +1,1 @@
-export default "vendor";
+export default { name: "vendor" };

--- a/test/statsCases/side-effects-simple-unused/node_modules/pmodule/index.js
+++ b/test/statsCases/side-effects-simple-unused/node_modules/pmodule/index.js
@@ -1,4 +1,4 @@
 export * from "./a";
 export { x, y, z } from "./b";
 
-export default "def";
+export default { name: "def" };

--- a/test/statsCases/split-chunks-automatic-name/d.js
+++ b/test/statsCases/split-chunks-automatic-name/d.js
@@ -1,1 +1,1 @@
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/split-chunks-automatic-name/e.js
+++ b/test/statsCases/split-chunks-automatic-name/e.js
@@ -1,1 +1,1 @@
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/split-chunks-automatic-name/f.js
+++ b/test/statsCases/split-chunks-automatic-name/f.js
@@ -1,1 +1,1 @@
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/split-chunks-automatic-name/node_modules/x.js
+++ b/test/statsCases/split-chunks-automatic-name/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks-automatic-name/node_modules/y.js
+++ b/test/statsCases/split-chunks-automatic-name/node_modules/y.js
@@ -1,1 +1,1 @@
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/split-chunks-automatic-name/node_modules/z.js
+++ b/test/statsCases/split-chunks-automatic-name/node_modules/z.js
@@ -1,1 +1,1 @@
-export default "z";
+export default { name: "z" };

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
@@ -1,1 +1,1 @@
-export default "a";
+export default { name: "a" };

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
@@ -1,1 +1,1 @@
-export default "b";
+export default { name: "b" };

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
@@ -1,1 +1,1 @@
-export default "c";
+export default { name: "c" };

--- a/test/statsCases/split-chunks-combinations/x.js
+++ b/test/statsCases/split-chunks-combinations/x.js
@@ -1,2 +1,2 @@
 // content content content content content content content content
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks-combinations/y.js
+++ b/test/statsCases/split-chunks-combinations/y.js
@@ -1,2 +1,2 @@
 // content content content content content content content content
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/split-chunks-issue-6413/node_modules/x.js
+++ b/test/statsCases/split-chunks-issue-6413/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks-issue-6696/node_modules/x.js
+++ b/test/statsCases/split-chunks-issue-6696/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks-issue-6696/node_modules/y.js
+++ b/test/statsCases/split-chunks-issue-6696/node_modules/y.js
@@ -1,1 +1,1 @@
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/split-chunks-issue-7401/node_modules/x.js
+++ b/test/statsCases/split-chunks-issue-7401/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks-keep-remaining-size/node_modules/shared.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/node_modules/shared.js
@@ -1,3 +1,3 @@
 // content content content content content content
 // content content content content content content
-export default "shared"
+export default { name: "shared" };

--- a/test/statsCases/split-chunks-min-size-reduction/node_modules/shared.js
+++ b/test/statsCases/split-chunks-min-size-reduction/node_modules/shared.js
@@ -1,3 +1,3 @@
 // content content content content content content
 // content content content content content content
-export default "shared"
+export default { name: "shared" };

--- a/test/statsCases/split-chunks-prefer-bigger-splits/d.js
+++ b/test/statsCases/split-chunks-prefer-bigger-splits/d.js
@@ -1,2 +1,2 @@
 // content content content content content
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/split-chunks-prefer-bigger-splits/e.js
+++ b/test/statsCases/split-chunks-prefer-bigger-splits/e.js
@@ -1,2 +1,2 @@
 // content content content content content
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/split-chunks-prefer-bigger-splits/f.js
+++ b/test/statsCases/split-chunks-prefer-bigger-splits/f.js
@@ -1,2 +1,2 @@
 // content content content content content content content content
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/split-chunks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/split-chunks/__snapshots__/StatsTest.snap
@@ -170,7 +170,7 @@ manual:
     > x b
     > y b
     > z b
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./b.js X bytes [built] [code generated]
   chunk (runtime: main) manual/async-a.js (async-a) X bytes <{792}> ={96}= >{49}< [rendered]
@@ -182,12 +182,12 @@ manual:
     > x c
     > y c
     > z c
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./c.js X bytes [built] [code generated]
   chunk (runtime: main) manual/main.js (main) X bytes (javascript) X KiB (runtime) >{60}< >{96}< >{263}< >{869}< [entry] [rendered]
     > ./ main
-    runtime modules X KiB 9 modules
+    runtime modules X KiB 10 modules
     ./index.js X bytes [built] [code generated]
   chunk (runtime: main) manual/async-c.js (async-c) X bytes <{792}> ={96}= [rendered]
     > ./c ./index.js 3:0-47
@@ -198,7 +198,7 @@ manual:
     > x a
     > y a
     > z a
-    runtime modules X KiB 10 modules
+    runtime modules X KiB 11 modules
     dependent modules X bytes [dependent] 1 module
     ./a.js + 1 modules X bytes [built] [code generated]
   manual (webpack x.x.x) compiled successfully
@@ -374,7 +374,7 @@ custom-chunks-filter-in-cache-groups:
     > x b
     > y b
     > z b
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./b.js X bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) X bytes <{792}> ={96}= >{49}< [rendered]
@@ -386,7 +386,7 @@ custom-chunks-filter-in-cache-groups:
     > x c
     > y c
     > z c
-    runtime modules X KiB 4 modules
+    runtime modules X KiB 5 modules
     dependent modules X bytes [dependent] 2 modules
     ./c.js X bytes [built] [code generated]
   chunk (runtime: a) custom-chunks-filter-in-cache-groups/765.js (id hint: vendors) X bytes ={996}= >{49}< [initial] [rendered] split chunk (cache group: defaultVendors)
@@ -399,7 +399,7 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/z.js X bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) X bytes (javascript) X KiB (runtime) >{60}< >{96}< >{263}< >{869}< [entry] [rendered]
     > ./ main
-    runtime modules X KiB 9 modules
+    runtime modules X KiB 10 modules
     ./index.js X bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-c.js (async-c) X bytes <{792}> ={96}= [rendered]
     > ./c ./index.js 3:0-47

--- a/test/statsCases/split-chunks/d.js
+++ b/test/statsCases/split-chunks/d.js
@@ -1,1 +1,1 @@
-export default "d";
+export default { name: "d" };

--- a/test/statsCases/split-chunks/e.js
+++ b/test/statsCases/split-chunks/e.js
@@ -1,1 +1,1 @@
-export default "e";
+export default { name: "e" };

--- a/test/statsCases/split-chunks/f.js
+++ b/test/statsCases/split-chunks/f.js
@@ -1,1 +1,1 @@
-export default "f";
+export default { name: "f" };

--- a/test/statsCases/split-chunks/node_modules/x.js
+++ b/test/statsCases/split-chunks/node_modules/x.js
@@ -1,1 +1,1 @@
-export default "x";
+export default { name: "x" };

--- a/test/statsCases/split-chunks/node_modules/xy.js
+++ b/test/statsCases/split-chunks/node_modules/xy.js
@@ -1,1 +1,1 @@
-export default "xy";
+export default { name: "xy" };

--- a/test/statsCases/split-chunks/node_modules/xyz.js
+++ b/test/statsCases/split-chunks/node_modules/xyz.js
@@ -1,1 +1,1 @@
-export default "xyz";
+export default { name: "xyz" };

--- a/test/statsCases/split-chunks/node_modules/y.js
+++ b/test/statsCases/split-chunks/node_modules/y.js
@@ -1,1 +1,1 @@
-export default "y";
+export default { name: "y" };

--- a/test/statsCases/split-chunks/node_modules/z.js
+++ b/test/statsCases/split-chunks/node_modules/z.js
@@ -1,1 +1,1 @@
-export default "z";
+export default { name: "z" };

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1105,9 +1105,13 @@ const knownProductionBuildBugs = [
 	// namespaces are no longer the same object as the local Proxy.
 	"import/import-defer/deferred-namespace-object/identity.js",
 
-	// Production InlineExports: Support disable inline export annotation to keep the TDZ
+	// Production InlineExports:
+	// TODO: Support disable inline export annotation to keep the TDZ
 	"module-code/instn-named-bndng-const.js",
-	"module-code/instn-iee-bndng-const.js"
+	"module-code/instn-iee-bndng-const.js",
+	"module-code/instn-named-bndng-dflt-star.js",
+	"module-code/instn-named-bndng-dflt-named.js",
+	"module-code/namespace/internals/get-str-found-uninit.js"
 ];
 /* cspell:enable */
 


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?**

We already inlines named const exports (`optimization.inlineExports`) but explicitly skipped `export default <const>` (the template carried a "For now we don't set inlined value for `export default` expression" note). This makes a default export inlinable when its expression is a primitive constant.

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes