### PR TITLE
refactor: decompose CSS-Modules parser and move escape handling into the tokenizer

### DIFF
--- a/.changeset/css-parser-decomposition.md
+++ b/.changeset/css-parser-decomposition.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve full CSS escapes (including hex) in CSS-Modules names, so e.g. `\75 rl()` matches `url()`.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -178,15 +178,6 @@ const isDashedIdentifier = (identifier) =>
 	identifier.startsWith("--") && identifier.length >= 3;
 
 /**
- * Strip CSS escape backslashes from an ident / function name. Most names have no
- * escape, so the `indexOf` gate skips the regex engine + the new-string
- * allocation for that common case.
- * @param {string} s ident / function name
- * @returns {string} `s` with backslashes removed
- */
-const stripBackslashes = (s) => (s.includes("\\") ? s.replace(/\\/g, "") : s);
-
-/**
  * `binarySearchBounds` comparator for `getComments` — hoisted so the lookup
  * doesn't allocate a fresh closure per call.
  * @param {Comment} comment comment
@@ -339,7 +330,7 @@ const GRID = {
  * @param {{ animation?: boolean, container?: boolean, customIdents?: boolean, grid?: boolean }=} options options
  * @returns {Map<string, Record<string, number>>} list of known properties
  */
-const getKnownProperties = (options = {}) => {
+const buildKnownProperties = (options = {}) => {
 	/** @type {Map<string, Record<string, number>>} */
 	const knownProperties = new Map();
 
@@ -453,6 +444,31 @@ const getKnownProperties = (options = {}) => {
 	}
 
 	return knownProperties;
+};
+
+/** @type {Map<number, Map<string, Record<string, number>>>} */
+const KNOWN_PROPERTIES_CACHE = new Map();
+
+/**
+ * Memoized {@link buildKnownProperties}: the table depends only on the four
+ * boolean options (≤16 combinations) and is read-only, while the same parser is
+ * reused across modules — so build each combination once and share it instead
+ * of rebuilding the Map (and its value objects) per parsed module.
+ * @param {{ animation?: boolean, container?: boolean, customIdents?: boolean, grid?: boolean }=} options options
+ * @returns {Map<string, Record<string, number>>} known properties table
+ */
+const getKnownProperties = (options = {}) => {
+	const key =
+		(options.animation ? 1 : 0) |
+		(options.container ? 2 : 0) |
+		(options.customIdents ? 4 : 0) |
+		(options.grid ? 8 : 0);
+	let table = KNOWN_PROPERTIES_CACHE.get(key);
+	if (table === undefined) {
+		table = buildKnownProperties(options);
+		KNOWN_PROPERTIES_CACHE.set(key, table);
+	}
+	return table;
 };
 
 const EMPTY_COMMENT_OPTIONS = {
@@ -671,10 +687,7 @@ const parseImportPrelude = (prelude) => {
 			}
 			if (
 				cv.type === NodeType.Function &&
-				equalsLowerCase(
-					stripBackslashes(/** @type {FunctionNode} */ (cv).name),
-					"url"
-				)
+				equalsLowerCase(/** @type {FunctionNode} */ (cv).unescapedName, "url")
 			) {
 				urlNode = cv;
 				continue;
@@ -689,21 +702,13 @@ const parseImportPrelude = (prelude) => {
 
 		if (!layerNode && !supportsNode) {
 			if (cv.type === NodeType.Ident) {
-				if (
-					equalsLowerCase(
-						stripBackslashes(/** @type {Token} */ (cv).value),
-						"layer"
-					)
-				) {
+				if (equalsLowerCase(/** @type {Token} */ (cv).unescaped, "layer")) {
 					layerNode = cv;
 					continue;
 				}
 			} else if (
 				cv.type === NodeType.Function &&
-				equalsLowerCase(
-					stripBackslashes(/** @type {FunctionNode} */ (cv).name),
-					"layer"
-				)
+				equalsLowerCase(/** @type {FunctionNode} */ (cv).unescapedName, "layer")
 			) {
 				layerNode = cv;
 				continue;
@@ -714,7 +719,7 @@ const parseImportPrelude = (prelude) => {
 			!supportsNode &&
 			cv.type === NodeType.Function &&
 			equalsLowerCase(
-				stripBackslashes(/** @type {FunctionNode} */ (cv).name),
+				/** @type {FunctionNode} */ (cv).unescapedName,
 				"supports"
 			)
 		) {
@@ -792,11 +797,6 @@ class CssParser extends Parser {
 		/** @type {Comment[] | undefined} */
 		this.comments = undefined;
 		this.magicCommentContext = createMagicCommentContext();
-		// Built once on first parse — depends only on the (fixed) option flags
-		// below, and the parser instance is reused across modules. Read-only
-		// during parse, so it's safe to share.
-		/** @type {Map<string, Record<string, number>> | undefined} */
-		this._knownProperties = undefined;
 	}
 
 	/**
@@ -856,10 +856,6 @@ class CssParser extends Parser {
 			source = source.slice(1);
 		}
 
-		const unescapeIdentifierCached = unescapeIdentifier.bindCache(
-			state.compilation.compiler.root
-		);
-
 		// Reset per-parse — parser instances are reused across modules.
 		this.comments = [];
 
@@ -906,9 +902,6 @@ class CssParser extends Parser {
 			});
 		};
 
-		// `parseResource` is uncached without a cache object, so resolve the
-		// module resource once and reuse it for both the auto-mode check and
-		// self-reference resolution.
 		const parsedModuleResource = parseResource(
 			/** @type {string} */ (module.getResource())
 		);
@@ -945,14 +938,12 @@ class CssParser extends Parser {
 			}
 		};
 
-		const knownProperties =
-			this._knownProperties ||
-			(this._knownProperties = getKnownProperties({
-				animation: this.options.animation,
-				container: this.options.container,
-				customIdents: this.options.customIdents,
-				grid: this.options.grid
-			}));
+		const knownProperties = getKnownProperties({
+			animation: this.options.animation,
+			container: this.options.container,
+			customIdents: this.options.customIdents,
+			grid: this.options.grid
+		});
 
 		/** @type {CssModuleBuildMeta} */
 		(module.buildMeta).isCssModule = isModules;
@@ -1032,6 +1023,17 @@ class CssParser extends Parser {
 
 		// Closure-scope alias for `source` used by AST-walking helpers for substring extraction.
 		const input = source;
+
+		/**
+		 * Unescape a CSS identifier from a source byte range — for value spans not
+		 * backed by a single token (string contents, `--` dashed-ident bodies,
+		 * composed names). Token-backed names use `node.unescaped` instead.
+		 * @param {number} start start offset
+		 * @param {number} end end offset
+		 * @returns {string} the unescaped identifier
+		 */
+		const unescapeRange = (start, end) =>
+			unescapeIdentifier(input.slice(start, end));
 
 		let lastTokenEndForComments = 0;
 		/** Generates unique `__ICSS_IMPORT_${n}__` placeholders per ICSS import. */
@@ -1196,9 +1198,9 @@ class CssParser extends Parser {
 			/** Previous `composes: … from "…"` file in this rule (for the load-order graph edges). */
 			/** @type {string | undefined} */
 			composesPrevFile: undefined,
-			/** All files this rule has composed from (so an edge is added only once per file pair). */
-			/** @type {Set<string>} */
-			composesFiles: new Set()
+			/** All files this rule has composed from (so an edge is added only once per file pair); lazily created — null until the rule's first `composes: … from`. */
+			/** @type {Set<string> | null} */
+			composesFiles: null
 		};
 
 		/**
@@ -1405,7 +1407,7 @@ class CssParser extends Parser {
 			if (type === 1) {
 				for (const cv of fn.value) {
 					if (cv.type !== NodeType.Ident) continue;
-					let identifier = unescapeIdentifier(/** @type {Token} */ (cv).value);
+					let identifier = /** @type {Token} */ (cv).unescaped;
 					const {
 						start: { line: sl, column: sc },
 						end: { line: el, column: ec }
@@ -1448,9 +1450,7 @@ class CssParser extends Parser {
 
 				if (cv.type === NodeType.String) {
 					if (!found && options.string) {
-						const value = unescapeIdentifier(
-							input.slice(cv.start + 1, cv.end - 1)
-						);
+						const value = /** @type {Token} */ (cv).unescaped;
 						const {
 							start: { line: sl, column: sc },
 							end: { line: el, column: ec }
@@ -1474,8 +1474,7 @@ class CssParser extends Parser {
 
 				if (cv.type === NodeType.Ident) {
 					if (!found && options.identifier) {
-						const value = /** @type {Token} */ (cv).value;
-						const identifier = unescapeIdentifier(value);
+						const identifier = /** @type {Token} */ (cv).unescaped;
 						if (
 							options.identifier instanceof RegExp &&
 							options.identifier.test(identifier)
@@ -1506,7 +1505,7 @@ class CssParser extends Parser {
 
 				if (cv.type === NodeType.Function) {
 					const fn = /** @type {FunctionNode} */ (cv);
-					const fname = stripBackslashes(fn.name).toLowerCase();
+					const fname = fn.unescapedName.toLowerCase();
 					const type =
 						fname === "local" ? 1 : fname === "global" ? 2 : undefined;
 					if (!found && type) {
@@ -1532,9 +1531,7 @@ class CssParser extends Parser {
 		 * @param {number} identEnd end of the ident (exclusive)
 		 */
 		const emitDashedIdentExport = (identStart, identEnd) => {
-			const identifier = unescapeIdentifier(
-				input.slice(identStart + 2, identEnd)
-			);
+			const identifier = unescapeRange(identStart + 2, identEnd);
 			const { line: sl, column: sc } = locConverter.get(identStart);
 			const { line: el, column: ec } = locConverter.get(identEnd);
 			addCssExport(
@@ -1566,9 +1563,7 @@ class CssParser extends Parser {
 			sourceEnd,
 			pathContent
 		) => {
-			const identifier = unescapeIdentifier(
-				input.slice(identStart + 2, identEnd)
-			);
+			const identifier = unescapeRange(identStart + 2, identEnd);
 			const { line: sl, column: sc } = locConverter.get(identStart);
 			const { line: el, column: ec } = locConverter.get(sourceEnd - 1);
 			const localName = nextIcssImportName();
@@ -1711,37 +1706,169 @@ class CssParser extends Parser {
 			active: false,
 			/** Should top-level dashed-ident exports be emitted at this nesting level? */
 			emit: false,
-			/** Save/restore stack for `active` / `emit` across function nesting. */
-			/** @type {{ active: boolean, emit: boolean }[]} */
+			/** LIFO save/restore of `active` + `emit` across function nesting, bit-packed (bit 0 = active, bit 1 = emit) to avoid a per-function-token object allocation. */
+			/** @type {number[]} */
 			stack: [],
 			/** Push the current scope; call before descending into a `Function` body. */
 			push() {
-				this.stack.push({ active: this.active, emit: this.emit });
+				this.stack.push((this.active ? 1 : 0) | (this.emit ? 2 : 0));
 			},
 			/** Pop the saved scope; call when leaving a `Function` body. */
 			pop() {
-				const s = /** @type {{ active: boolean, emit: boolean }} */ (
-					this.stack.pop()
-				);
-				this.active = s.active;
-				this.emit = s.emit;
+				const s = /** @type {number} */ (this.stack.pop());
+				this.active = (s & 1) !== 0;
+				this.emit = (s & 2) !== 0;
 			}
 		};
 		// Nearest enclosing declaration / at-rule / qualified-rule, set by each structural enter; the Url / Function / Ident / Comma visitors read it (via `urlActive` / `localGlobalActive` / `icssActive`) to decide value handling from the node hierarchy instead of carrying precomputed flags.
 		/** @type {AstNode | undefined} */
 		let currentStructural;
-		// Normalized name of `currentStructural`, set alongside it: the `@`-prefixed
-		// lower-cased at-rule name for an AtRule, the vendor-stripped lower-cased
-		// property name for a Declaration. Lets the per-value-token `localGlobalActive`
-		// / `icssActive` / `composesAnchorSkip` checks read it instead of recomputing
-		// the regex `.replace` + `.toLowerCase` once per value token.
-		let currentStructuralName = "";
+		// Cached on each structural enter and read per value token, so the hot Function / Ident / Url visitors don't re-derive the property / at-rule name on every visit.
+		let currentAtRuleName = "";
+		/** Whether the current Declaration's property is a localizable known property. */
+		let currentDeclIsKnownProperty = false;
+		/** Whether the current `composes:` declaration owns the whole value (suppresses value rewrites). */
+		let currentDeclComposesSkip = false;
 
 		/**
 		 * Per-at-rule scope frames; `exit` reads `hasBlock` to pick the block-cleanup vs `suppressNextRulePrelude` branch.
 		 * @type {{ savedAnchor: boolean, savedLocalIdentifiers: string[], name: string, hasBlock: boolean, endsWithSemicolon: boolean }[]}
 		 */
 		const atRuleStateStack = [];
+
+		/**
+		 * Strip a bare `:local` / `:global` marker (modules only): the marker plus one adjacent whitespace (a comment between ends the run, since comments aren't AST nodes).
+		 * @param {AstNode} colon the `:` node
+		 * @param {AstNode} ident the `local` / `global` ident node
+		 * @param {AstNode} after the node following the ident (may be `undefined` at runtime)
+		 * @returns {boolean} whether whitespace follows the marker
+		 */
+		const stripBareMarker = (colon, ident, after) => {
+			const afterIsWhitespace = Boolean(
+				after && after.type === NodeType.Whitespace
+			);
+			const stripEnd =
+				afterIsWhitespace && after.start === ident.end ? after.end : ident.end;
+			if (isModules) {
+				module.addPresentationalDependency(
+					new ConstDependency("", [colon.start, stripEnd])
+				);
+			}
+			return afterIsWhitespace;
+		};
+
+		/**
+		 * Strip a `:local(…)` / `:global(…)` wrapper (modules only) with two source-level deps: the leading `:name(` up to the first arg, and the trailing `)` (`:local` also eats whitespace before it).
+		 * @param {AstNode} colon the `:` node
+		 * @param {FunctionNode} fn the `local(…)` / `global(…)` function node
+		 * @param {boolean} isLocal whether the marker is `:local(`
+		 * @returns {void}
+		 */
+		const stripFunctionMarker = (colon, fn, isLocal) => {
+			if (!isModules) return;
+			let stripLeadEnd = fn.end - 1;
+			for (const arg of fn.value) {
+				if (arg.type !== NodeType.Whitespace) {
+					stripLeadEnd = arg.start;
+					break;
+				}
+			}
+			module.addPresentationalDependency(
+				new ConstDependency("", [colon.start, stripLeadEnd])
+			);
+			let trailStart = fn.end - 1; // position of `)`
+			if (isLocal) {
+				while (
+					trailStart > 0 &&
+					isCssWhitespace(source.charCodeAt(trailStart - 1))
+				) {
+					trailStart--;
+				}
+			}
+			module.addPresentationalDependency(
+				new ConstDependency("", [trailStart, fn.end])
+			);
+		};
+
+		/**
+		 * Emit the ICSS export for an attribute selector `[class="foo"]` / `[class~="foo"]` (not a composes anchor) by walking the `[…]` block's parsed children. No-op for any other attribute shape.
+		 * @param {SimpleBlock} block the `[…]` block
+		 * @returns {void}
+		 */
+		const handleAttributeSelector = (block) => {
+			const attrParts = block.value;
+			let ai = 0;
+			while (
+				ai < attrParts.length &&
+				attrParts[ai].type === NodeType.Whitespace
+			) {
+				ai++;
+			}
+			const attrNameNode = attrParts[ai];
+			if (!attrNameNode || attrNameNode.type !== NodeType.Ident) return;
+			const attrName = /** @type {Token} */ (attrNameNode).unescaped;
+			if (!equalsLowerCase(attrName, "class")) return;
+			ai++;
+			while (
+				ai < attrParts.length &&
+				attrParts[ai].type === NodeType.Whitespace
+			) {
+				ai++;
+			}
+			// `=` or `~=` (two `Delim` tokens for the latter).
+			const op1 = attrParts[ai];
+			if (!op1 || op1.type !== NodeType.Delim) return;
+			const op1v = /** @type {Token} */ (op1).value;
+			if (op1v === "~") {
+				ai++;
+				const op2 = attrParts[ai];
+				if (
+					!op2 ||
+					op2.type !== NodeType.Delim ||
+					/** @type {Token} */ (op2).value !== "="
+				) {
+					return;
+				}
+			} else if (op1v !== "=") {
+				return;
+			}
+			ai++;
+			while (
+				ai < attrParts.length &&
+				attrParts[ai].type === NodeType.Whitespace
+			) {
+				ai++;
+			}
+			const attrValueNode = attrParts[ai];
+			if (!attrValueNode) return;
+			/** @type {number} */
+			let classNameStart;
+			/** @type {number} */
+			let classNameEnd;
+			if (attrValueNode.type === NodeType.String) {
+				classNameStart = attrValueNode.start + 1;
+				classNameEnd = attrValueNode.end - 1;
+			} else if (attrValueNode.type === NodeType.Ident) {
+				classNameStart = attrValueNode.start;
+				classNameEnd = attrValueNode.end;
+			} else {
+				return;
+			}
+			const className = unescapeRange(classNameStart, classNameEnd);
+			const { line: sl, column: sc } = locConverter.get(classNameStart);
+			const { line: el, column: ec } = locConverter.get(classNameEnd);
+			addCssExport(
+				sl,
+				sc,
+				el,
+				ec,
+				className,
+				getReexport(className),
+				[classNameStart, classNameEnd],
+				true,
+				CssIcssExportDependency.EXPORT_MODE.NONE
+			);
+		};
 
 		/**
 		 * Walk component values as a selector list, emitting ID / attribute deps and recursing into `:not()`/`:is()`/`:local()`/`:global()` wrappers; `localMode` is the sub-tree mode and `topLevel` controls whether commas reset it (only outside parentheses).
@@ -1763,302 +1890,163 @@ class CssParser extends Parser {
 			}
 			for (let i = 0; i < values.length; i++) {
 				const v = values[i];
-				if (v.type === NodeType.Comma) {
-					if (topLevel) {
-						// Top-level comma resets the segment + persistent mode and, in pure mode, finalizes the segment's purity.
-						segmentMode = localMode;
-						modeData = undefined;
-						pure.finalizeSelector();
-					}
-					continue;
-				}
-				if (v.type === NodeType.Whitespace) continue;
-				// Pure-mode: a nesting `&` inherits a pure ancestor's purity.
-				if (
-					topLevel &&
-					v.type === NodeType.Delim &&
-					/** @type {Token} */ (v).value === "&" &&
-					pure.ancestorHadLocal()
-				) {
-					pure.markLocal();
-				}
-				if (v.type === NodeType.Colon) {
-					// Look ahead for `:local` / `:global` markers.
-					const next = values[i + 1];
-					if (!next) continue;
-					if (next.type === NodeType.Ident) {
-						const raw = /** @type {Token} */ (next).value;
-						const isLocal = equalsLowerCase(raw, "local");
-						if (isLocal || equalsLowerCase(raw, "global")) {
-							const id = isLocal ? "local" : "global";
-							// Bare `:local` / `:global`: switch the segment (and top-level persistent) mode and strip the marker. The next sibling token is whitespace when any whitespace separates the marker from the next selector (comments aren't AST nodes); strip the marker plus that whitespace, but only when it's adjacent (a comment between would end the run).
-							const afterMarker = values[i + 2];
-							const afterIsWhitespace = Boolean(
-								afterMarker && afterMarker.type === NodeType.Whitespace
-							);
-							const stripEnd =
-								afterIsWhitespace && afterMarker.start === next.end
-									? afterMarker.end
-									: next.end;
-							if (isModules) {
-								module.addPresentationalDependency(
-									new ConstDependency("", [v.start, stripEnd])
+				switch (v.type) {
+					case NodeType.Whitespace:
+						break;
+					case NodeType.Comma:
+						if (topLevel) {
+							// Top-level comma resets the segment + persistent mode and, in pure mode, finalizes the segment's purity.
+							segmentMode = localMode;
+							modeData = undefined;
+							pure.finalizeSelector();
+						}
+						break;
+					case NodeType.Colon: {
+						// Look ahead for `:local` / `:global` markers; other pseudos fall through.
+						const next = values[i + 1];
+						if (!next) break;
+						if (next.type === NodeType.Ident) {
+							const raw = /** @type {Token} */ (next).value;
+							const isLocal = equalsLowerCase(raw, "local");
+							if (isLocal || equalsLowerCase(raw, "global")) {
+								const id = isLocal ? "local" : "global";
+								// Bare `:local` / `:global`: switch the segment (and top-level persistent) mode and strip the marker.
+								const afterIsWhitespace = stripBareMarker(
+									v,
+									next,
+									values[i + 2]
 								);
-							}
-							// Bare `:local` / `:global` needs whitespace before the next selector (else `:local.b` is ambiguous) — warn when none follows.
-							if (!afterIsWhitespace) {
-								this._emitWarning(
-									state,
-									`Missing whitespace after ':${id}' in '${source.slice(
+								// Bare `:local` / `:global` needs whitespace before the next selector (else `:local.b` is ambiguous) — warn when none follows.
+								if (!afterIsWhitespace) {
+									this._emitWarning(
+										state,
+										`Missing whitespace after ':${id}' in '${source.slice(
+											v.start,
+											findLeftCurly(source, next.end) + 1
+										)}'`,
+										locConverter,
 										v.start,
-										findLeftCurly(source, next.end) + 1
-									)}'`,
-									locConverter,
-									v.start,
-									next.end
-								);
+										next.end
+									);
+								}
+								segmentMode = id;
+								if (topLevel) modeData = id;
+								// Skip past the colon + ident.
+								i += 1;
 							}
-							segmentMode = id;
-							if (topLevel) modeData = id;
-							// Skip past the colon + ident.
-							i += 1;
-							continue;
-						}
-					} else if (next.type === NodeType.Function) {
-						const rawName = /** @type {FunctionNode} */ (next).name.replace(
-							/\\/g,
-							""
-						);
-						const isLocal = equalsLowerCase(rawName, "local");
-						if (isLocal || equalsLowerCase(rawName, "global")) {
-							const fname = isLocal ? "local" : "global";
-							// `:local(…)` / `:global(…)`: scope mode to the args and strip the wrapper with two source-level strip deps (leading `:name(` + whitespace, then trailing `)` — `:local` also eats whitespace before `)`).
+						} else if (next.type === NodeType.Function) {
 							const fn = /** @type {FunctionNode} */ (next);
-							if (isModules) {
-								// Strip `:name(` up to the first arg (leading whitespace / comments inside the parens aren't AST nodes).
-								let stripLeadEnd = fn.end - 1;
-								for (const arg of fn.value) {
-									if (arg.type !== NodeType.Whitespace) {
-										stripLeadEnd = arg.start;
-										break;
-									}
-								}
-								module.addPresentationalDependency(
-									new ConstDependency("", [v.start, stripLeadEnd])
-								);
-								let trailStart = fn.end - 1; // position of `)`
-								if (fname === "local") {
-									while (
-										trailStart > 0 &&
-										isCssWhitespace(source.charCodeAt(trailStart - 1))
-									) {
-										trailStart--;
-									}
-								}
-								module.addPresentationalDependency(
-									new ConstDependency("", [trailStart, fn.end])
-								);
+							const rawName = fn.unescapedName;
+							const isLocal = equalsLowerCase(rawName, "local");
+							if (isLocal || equalsLowerCase(rawName, "global")) {
+								// `:local(…)` / `:global(…)`: scope mode to the args and strip the `:name(` … `)` wrapper.
+								stripFunctionMarker(v, fn, isLocal);
+								walkSelectorList(fn.value, isLocal ? "local" : "global", false);
+								// Skip past the colon + function.
+								i += 1;
 							}
-							walkSelectorList(
-								/** @type {FunctionNode} */ (next).value,
-								/** @type {"local" | "global"} */ (fname),
-								false
-							);
-							i += 1;
-							continue;
 						}
+						break;
 					}
-					continue;
-				}
-				if (v.type === NodeType.Function) {
-					// Any other function (`:not(…)`, `:is(…)`, …): recurse with the segment mode preserved (only `:local(…)` / `:global(…)`, handled above, switch mode).
-					walkSelectorList(
-						/** @type {FunctionNode} */ (v).value,
-						segmentMode,
-						false
-					);
-					continue;
-				}
-				if (
-					v.type === NodeType.Hash &&
-					/** @type {HashToken} */ (v).typeFlag === "id" &&
-					segmentMode === "local"
-				) {
-					// ID selectors emit the ICSS export but aren't a `composes:` anchor.
-					const idValueStart = v.start + 1;
-					const idName = unescapeIdentifierCached(
-						source.slice(idValueStart, v.end)
-					);
-					const {
-						start: { line: idSl, column: idSc },
-						end: { line: idEl, column: idEc }
-					} = v.loc;
-					addCssExport(
-						idSl,
-						idSc,
-						idEl,
-						idEc,
-						idName,
-						getReexport(idName),
-						[idValueStart, v.end],
-						true,
-						CssIcssExportDependency.EXPORT_MODE.ONCE
-					);
-					pure.markLocal();
-					continue;
-				}
-				if (
-					v.type === NodeType.SimpleBlock &&
-					/** @type {SimpleBlock} */ (v).token === "[" &&
-					segmentMode === "local"
-				) {
-					// Attribute selectors `[class="foo"]` / `[class~="foo"]` emit the ICSS export (not a composes anchor) by walking the `[…]` block's parsed children.
-					const attrParts = /** @type {SimpleBlock} */ (v).value;
-					let ai = 0;
-					while (
-						ai < attrParts.length &&
-						attrParts[ai].type === NodeType.Whitespace
-					) {
-						ai++;
-					}
-					const attrNameNode = attrParts[ai];
-					if (!attrNameNode || attrNameNode.type !== NodeType.Ident) continue;
-					const attrName = unescapeIdentifier(
-						source.slice(attrNameNode.start, attrNameNode.end)
-					);
-					if (!equalsLowerCase(attrName, "class")) continue;
-					ai++;
-					while (
-						ai < attrParts.length &&
-						attrParts[ai].type === NodeType.Whitespace
-					) {
-						ai++;
-					}
-					// `=` or `~=` (two `Delim` tokens for the latter).
-					const op1 = attrParts[ai];
-					if (!op1 || op1.type !== NodeType.Delim) continue;
-					const op1v = /** @type {Token} */ (op1).value;
-					if (op1v === "~") {
-						ai++;
-						const op2 = attrParts[ai];
+					case NodeType.Function:
+						// Any other function (`:not(…)`, `:is(…)`, …): recurse with the segment mode preserved (only `:local(…)` / `:global(…)`, handled above, switch mode).
+						walkSelectorList(
+							/** @type {FunctionNode} */ (v).value,
+							segmentMode,
+							false
+						);
+						break;
+					case NodeType.Hash: {
 						if (
-							!op2 ||
-							op2.type !== NodeType.Delim ||
-							/** @type {Token} */ (op2).value !== "="
+							/** @type {HashToken} */ (v).typeFlag !== "id" ||
+							segmentMode !== "local"
 						) {
-							continue;
+							break;
 						}
-					} else if (op1v !== "=") {
-						continue;
-					}
-					ai++;
-					while (
-						ai < attrParts.length &&
-						attrParts[ai].type === NodeType.Whitespace
-					) {
-						ai++;
-					}
-					const attrValueNode = attrParts[ai];
-					if (!attrValueNode) continue;
-					/** @type {number} */
-					let classNameStart;
-					/** @type {number} */
-					let classNameEnd;
-					if (attrValueNode.type === NodeType.String) {
-						classNameStart = attrValueNode.start + 1;
-						classNameEnd = attrValueNode.end - 1;
-					} else if (attrValueNode.type === NodeType.Ident) {
-						classNameStart = attrValueNode.start;
-						classNameEnd = attrValueNode.end;
-					} else {
-						continue;
-					}
-					const className = unescapeIdentifier(
-						source.slice(classNameStart, classNameEnd)
-					);
-					const { line: sl, column: sc } = locConverter.get(classNameStart);
-					const { line: el, column: ec } = locConverter.get(classNameEnd);
-					addCssExport(
-						sl,
-						sc,
-						el,
-						ec,
-						className,
-						getReexport(className),
-						[classNameStart, classNameEnd],
-						true,
-						CssIcssExportDependency.EXPORT_MODE.NONE
-					);
-					continue;
-				}
-				// `@scope (.foo)` and other parenthesised selector wrappers — recurse into the `(…)` block.
-				if (
-					v.type === NodeType.SimpleBlock &&
-					/** @type {SimpleBlock} */ (v).token === "("
-				) {
-					walkSelectorList(
-						/** @type {SimpleBlock} */ (v).value,
-						segmentMode,
-						false
-					);
-					continue;
-				}
-				// `.<ident>` in local mode is a class selector (dep covers the ident bytes only).
-				if (
-					v.type === NodeType.Delim &&
-					/** @type {Token} */ (v).value === "." &&
-					segmentMode === "local"
-				) {
-					const next = values[i + 1];
-					if (next && next.type === NodeType.Ident) {
-						const name = unescapeIdentifier(source.slice(next.start, next.end));
+						// ID selectors emit the ICSS export but aren't a `composes:` anchor.
+						const idValueStart = v.start + 1;
+						const idName = /** @type {Token} */ (v).unescaped;
 						const {
-							start: { line: sl, column: sc },
-							end: { line: el, column: ec }
-						} = next.loc;
+							start: { line: idSl, column: idSc },
+							end: { line: idEl, column: idEc }
+						} = v.loc;
 						addCssExport(
-							sl,
-							sc,
-							el,
-							ec,
-							name,
-							getReexport(name),
-							[next.start, next.end],
+							idSl,
+							idSc,
+							idEl,
+							idEc,
+							idName,
+							getReexport(idName),
+							[idValueStart, v.end],
 							true,
 							CssIcssExportDependency.EXPORT_MODE.ONCE
 						);
-						currentRule.hasLocalAnchor = true;
-						currentRule.localIdentifiers.push(name);
 						pure.markLocal();
-						i += 1;
+						break;
 					}
-					continue;
-				}
-				// `.<ident>` in global mode: not localized, but the ident may be `@value`-defined and need ICSS rewrite.
-				if (
-					v.type === NodeType.Delim &&
-					/** @type {Token} */ (v).value === "." &&
-					segmentMode === "global"
-				) {
-					const next = values[i + 1];
-					if (next && next.type === NodeType.Ident) {
-						const ident = /** @type {Token} */ (next).value;
-						if (!isDashedIdentifier(ident) && icssDefinitions.has(ident)) {
-							emitICSSSymbol(ident, next.start, next.end);
+					case NodeType.SimpleBlock: {
+						const block = /** @type {SimpleBlock} */ (v);
+						if (block.token === "[") {
+							// Attribute selectors `[class="foo"]` localize only in local mode.
+							if (segmentMode === "local") handleAttributeSelector(block);
+						} else if (block.token === "(") {
+							// `@scope (.foo)` and other parenthesised selector wrappers — recurse into the `(…)` block.
+							walkSelectorList(block.value, segmentMode, false);
 						}
-						// Skip the ident so the bare-ident branch below doesn't re-emit it.
-						i += 1;
+						break;
 					}
-					continue;
-				}
-				// ICSS rewrite for a bare `@value`-defined ident used as a type-style selector.
-				if (
-					v.type === NodeType.Ident &&
-					!isDashedIdentifier(/** @type {Token} */ (v).value) &&
-					icssDefinitions.has(/** @type {Token} */ (v).value)
-				) {
-					emitICSSSymbol(/** @type {Token} */ (v).value, v.start, v.end);
-					continue;
+					case NodeType.Delim: {
+						const delim = /** @type {Token} */ (v).value;
+						if (delim === "&") {
+							// Pure-mode: a nesting `&` inherits a pure ancestor's purity.
+							if (topLevel && pure.ancestorHadLocal()) pure.markLocal();
+							break;
+						}
+						if (delim !== ".") break;
+						const next = values[i + 1];
+						if (!next || next.type !== NodeType.Ident) break;
+						if (segmentMode === "local") {
+							// `.<ident>` in local mode is a class selector (dep covers the ident bytes only).
+							const name = /** @type {Token} */ (next).unescaped;
+							const {
+								start: { line: sl, column: sc },
+								end: { line: el, column: ec }
+							} = next.loc;
+							addCssExport(
+								sl,
+								sc,
+								el,
+								ec,
+								name,
+								getReexport(name),
+								[next.start, next.end],
+								true,
+								CssIcssExportDependency.EXPORT_MODE.ONCE
+							);
+							currentRule.hasLocalAnchor = true;
+							currentRule.localIdentifiers.push(name);
+							pure.markLocal();
+						} else {
+							// `.<ident>` in global mode: not localized, but the ident may be `@value`-defined and need ICSS rewrite.
+							const ident = /** @type {Token} */ (next).value;
+							if (!isDashedIdentifier(ident) && icssDefinitions.has(ident)) {
+								emitICSSSymbol(ident, next.start, next.end);
+							}
+						}
+						// Skip the consumed ident.
+						i += 1;
+						break;
+					}
+					case NodeType.Ident: {
+						// ICSS rewrite for a bare `@value`-defined ident used as a type-style selector.
+						const ident = /** @type {Token} */ (v).value;
+						if (!isDashedIdentifier(ident) && icssDefinitions.has(ident)) {
+							emitICSSSymbol(ident, v.start, v.end);
+						}
+						break;
+					}
+					default:
+						break;
 				}
 			}
 			// Pure-mode: finalize the trailing comma-separated segment.
@@ -2066,7 +2054,7 @@ class CssParser extends Parser {
 		};
 		/**
 		 * Per-qualified-rule scope frames; `{ bailed: true }` for inline-handled `:import` / `:export` pseudo-rules.
-		 * @type {({ bailed: true } | { bailed: false, savedAnchor: boolean, savedLocalIdentifiers: string[], savedPrevComposesFile: string | undefined, savedComposesFiles: Set<string> })[]}
+		 * @type {({ bailed: true } | { bailed: false, savedAnchor: boolean, savedLocalIdentifiers: string[], savedPrevComposesFile: string | undefined, savedComposesFiles: Set<string> | null })[]}
 		 */
 		const qualifiedRuleStateStack = [];
 
@@ -2103,24 +2091,16 @@ class CssParser extends Parser {
 					(this.options.container && name === "@container")));
 
 		/**
-		 * Whether the current `composes:` declaration with a local anchor owns the whole declaration (its strip-dep covers the value), suppressing the generic value rewrites. Reads `currentStructuralName` (the active declaration's normalized property name).
-		 * @returns {boolean} true when the value rewrites should be skipped
-		 */
-		const composesAnchorSkip = () =>
-			currentRule.hasLocalAnchor &&
-			COMPOSES_PROPERTY.test(currentStructuralName);
-
-		/**
 		 * Whether `local()` / `global()` value functions are rewritten to ICSS here (from `currentStructural`).
 		 * @returns {boolean} true when the rewrite is active
 		 */
 		const localGlobalActive = () => {
 			if (!isModules || !currentStructural) return false;
 			if (currentStructural.type === NodeType.AtRule) {
-				return !isLocalHandledAtRule(currentStructuralName);
+				return !isLocalHandledAtRule(currentAtRuleName);
 			}
 			if (currentStructural.type === NodeType.Declaration) {
-				return !composesAnchorSkip();
+				return !currentDeclComposesSkip;
 			}
 			return false;
 		};
@@ -2132,13 +2112,12 @@ class CssParser extends Parser {
 		const icssActive = () => {
 			if (!isModules || !currentStructural) return false;
 			if (currentStructural.type === NodeType.AtRule) {
-				const name = currentStructuralName;
-				return name !== "@value" && name !== "@import";
+				return (
+					currentAtRuleName !== "@value" && currentAtRuleName !== "@import"
+				);
 			}
 			if (currentStructural.type === NodeType.Declaration) {
-				return (
-					!composesAnchorSkip() && !knownProperties.has(currentStructuralName)
-				);
+				return !currentDeclComposesSkip && !currentDeclIsKnownProperty;
 			}
 			return false;
 		};
@@ -2156,6 +2135,132 @@ class CssParser extends Parser {
 			}
 			pure.markSeenTopLevelRule();
 			modeData = undefined;
+		};
+
+		/**
+		 * Emit the ICSS export/import deps for one parsed `composes:` group onto `lastLocalIdentifier`: `from "<file>"` imports each name (tracking file load order), `from global` and bare names re-export locally. The caller has already validated and scanned the group.
+		 * @param {{ start: number, end: number, isGlobal: boolean }[]} classNames composed names with source ranges
+		 * @param {{ kind: "string", path: string } | { kind: "global" } | undefined} fromSource the `from …` clause, if any
+		 * @param {string} lastLocalIdentifier the rule's single local-class anchor
+		 * @returns {void}
+		 */
+		const emitComposesGroup = (classNames, fromSource, lastLocalIdentifier) => {
+			if (fromSource && fromSource.kind === "string") {
+				const request = fromSource.path;
+				const selfReference = isSelfReferenceRequest(request);
+
+				if (!selfReference) {
+					let files = currentRule.composesFiles;
+					if (!files) {
+						files = new Set();
+						currentRule.composesFiles = files;
+					}
+					if (!files.has(request)) {
+						files.add(request);
+						if (
+							currentRule.composesPrevFile !== undefined &&
+							currentRule.composesPrevFile !== request
+						) {
+							let successors = composesGraph.get(currentRule.composesPrevFile);
+							if (!successors) {
+								successors = new Set();
+								composesGraph.set(currentRule.composesPrevFile, successors);
+							}
+							successors.add(request);
+						}
+						currentRule.composesPrevFile = request;
+					}
+				}
+
+				for (const { start, end } of classNames) {
+					const identifier = unescapeRange(start, end);
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+
+					if (selfReference) {
+						if (identifier === lastLocalIdentifier) continue;
+						addCssExport(
+							sl,
+							sc,
+							el,
+							ec,
+							lastLocalIdentifier,
+							getReexport(identifier),
+							[start, end],
+							true,
+							CssIcssExportDependency.EXPORT_MODE.SELF_REFERENCE,
+							CssIcssExportDependency.EXPORT_TYPE.COMPOSES
+						);
+						continue;
+					}
+
+					const localName = nextIcssImportName();
+
+					const importDep = new CssIcssImportDependency(
+						request,
+						[start, end],
+						/** @type {"local" | "global"} */ (mode),
+						identifier,
+						localName
+					);
+					importDep.setLoc(sl, sc, el, ec);
+					module.addDependency(importDep);
+					if (!composesFirstFileImport.has(request)) {
+						composesFirstFileImport.set(request, importDep);
+					}
+
+					addCssExport(
+						sl,
+						sc,
+						el,
+						ec,
+						lastLocalIdentifier,
+						getReexport(identifier, localName),
+						[start, end],
+						true,
+						CssIcssExportDependency.EXPORT_MODE.APPEND,
+						CssIcssExportDependency.EXPORT_TYPE.COMPOSES
+					);
+				}
+			} else if (fromSource && fromSource.kind === "global") {
+				for (const { start, end } of classNames) {
+					const identifier = unescapeRange(start, end);
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					addCssExport(
+						sl,
+						sc,
+						el,
+						ec,
+						lastLocalIdentifier,
+						getReexport(identifier),
+						[start, end],
+						false,
+						CssIcssExportDependency.EXPORT_MODE.APPEND,
+						CssIcssExportDependency.EXPORT_TYPE.COMPOSES
+					);
+				}
+			} else {
+				for (const { start, end, isGlobal } of classNames) {
+					const identifier = unescapeRange(start, end);
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					addCssExport(
+						sl,
+						sc,
+						el,
+						ec,
+						lastLocalIdentifier,
+						getReexport(identifier),
+						[start, end],
+						!isGlobal,
+						isGlobal
+							? CssIcssExportDependency.EXPORT_MODE.APPEND
+							: CssIcssExportDependency.EXPORT_MODE.SELF_REFERENCE,
+						CssIcssExportDependency.EXPORT_TYPE.COMPOSES
+					);
+				}
+			}
 		};
 
 		/**
@@ -2255,10 +2360,7 @@ class CssParser extends Parser {
 
 					if (cv.type === NodeType.Function) {
 						const fn = /** @type {FunctionNode} */ (cv);
-						const isGlobal = equalsLowerCase(
-							stripBackslashes(fn.name),
-							"global"
-						);
+						const isGlobal = equalsLowerCase(fn.unescapedName, "global");
 						for (const inner of fn.value) {
 							if (inner.type === NodeType.Ident) {
 								classNames.push({
@@ -2298,115 +2400,7 @@ class CssParser extends Parser {
 
 				if (classNames.length === 0) continue;
 
-				if (fromSource && fromSource.kind === "string") {
-					const request = fromSource.path;
-					const selfReference = isSelfReferenceRequest(request);
-
-					if (!selfReference && !currentRule.composesFiles.has(request)) {
-						currentRule.composesFiles.add(request);
-						if (
-							currentRule.composesPrevFile !== undefined &&
-							currentRule.composesPrevFile !== request
-						) {
-							let successors = composesGraph.get(currentRule.composesPrevFile);
-							if (!successors) {
-								successors = new Set();
-								composesGraph.set(currentRule.composesPrevFile, successors);
-							}
-							successors.add(request);
-						}
-						currentRule.composesPrevFile = request;
-					}
-
-					for (const { start, end } of classNames) {
-						const identifier = unescapeIdentifier(source.slice(start, end));
-						const { line: sl, column: sc } = locConverter.get(start);
-						const { line: el, column: ec } = locConverter.get(end);
-
-						if (selfReference) {
-							if (identifier === lastLocalIdentifier) continue;
-							addCssExport(
-								sl,
-								sc,
-								el,
-								ec,
-								lastLocalIdentifier,
-								getReexport(identifier),
-								[start, end],
-								true,
-								CssIcssExportDependency.EXPORT_MODE.SELF_REFERENCE,
-								CssIcssExportDependency.EXPORT_TYPE.COMPOSES
-							);
-							continue;
-						}
-
-						const localName = nextIcssImportName();
-
-						const importDep = new CssIcssImportDependency(
-							request,
-							[start, end],
-							/** @type {"local" | "global"} */ (mode),
-							identifier,
-							localName
-						);
-						importDep.setLoc(sl, sc, el, ec);
-						module.addDependency(importDep);
-						if (!composesFirstFileImport.has(request)) {
-							composesFirstFileImport.set(request, importDep);
-						}
-
-						addCssExport(
-							sl,
-							sc,
-							el,
-							ec,
-							lastLocalIdentifier,
-							getReexport(identifier, localName),
-							[start, end],
-							true,
-							CssIcssExportDependency.EXPORT_MODE.APPEND,
-							CssIcssExportDependency.EXPORT_TYPE.COMPOSES
-						);
-					}
-				} else if (fromSource && fromSource.kind === "global") {
-					for (const { start, end } of classNames) {
-						const identifier = unescapeIdentifier(source.slice(start, end));
-						const { line: sl, column: sc } = locConverter.get(start);
-						const { line: el, column: ec } = locConverter.get(end);
-						addCssExport(
-							sl,
-							sc,
-							el,
-							ec,
-							lastLocalIdentifier,
-							getReexport(identifier),
-							[start, end],
-							false,
-							CssIcssExportDependency.EXPORT_MODE.APPEND,
-							CssIcssExportDependency.EXPORT_TYPE.COMPOSES
-						);
-					}
-				} else {
-					for (const { start, end, isGlobal } of classNames) {
-						const identifier = unescapeIdentifier(source.slice(start, end));
-						const { line: sl, column: sc } = locConverter.get(start);
-						const { line: el, column: ec } = locConverter.get(end);
-						addCssExport(
-							sl,
-							sc,
-							el,
-							ec,
-							lastLocalIdentifier,
-							getReexport(identifier),
-							[start, end],
-							!isGlobal,
-							isGlobal
-								? CssIcssExportDependency.EXPORT_MODE.APPEND
-								: CssIcssExportDependency.EXPORT_MODE.SELF_REFERENCE,
-							CssIcssExportDependency.EXPORT_TYPE.COMPOSES
-						);
-					}
-				}
+				emitComposesGroup(classNames, fromSource, lastLocalIdentifier);
 			}
 
 			// Strip the whole `composes: …;` (property name included) plus trailing same-line whitespace. The `;` and that whitespace aren't AST nodes (a block's contents drop them), so scan the source here.
@@ -2799,6 +2793,181 @@ class CssParser extends Parser {
 			module.addPresentationalDependency(dep);
 		};
 
+		/**
+		 * Export the localizable idents / strings in a known property's value (`animation-name: foo`, grid line-names / template-areas, …). Top-level only, except `grid-template` recurses into `repeat(…)` and `[line-name]` blocks.
+		 * @param {Declaration} decl the declaration
+		 * @param {string} declPropertyName the vendor-stripped, lower-cased property name
+		 * @returns {void}
+		 */
+		const emitKnownPropertyExports = (decl, declPropertyName) => {
+			/** @type {Record<string, number>} */
+			let parsedKeywords = Object.create(null);
+			const isGridProperty = Boolean(declPropertyName.startsWith("grid"));
+			const isGridTemplate = isGridProperty
+				? Boolean(
+						declPropertyName === "grid" ||
+						declPropertyName === "grid-template" ||
+						declPropertyName === "grid-template-columns" ||
+						declPropertyName === "grid-template-rows"
+					)
+				: false;
+			const keywords =
+				/** @type {Record<string, number>} */
+				(knownProperties.get(declPropertyName));
+			let afterExclamation = false;
+			/**
+			 * Emit the ICSS export for one collected name span (a quoted string drops its delimiters). Called inline during the walk so no intermediate `values` array / per-name tuples are allocated.
+			 * @param {number} start name start offset
+			 * @param {number} end name end offset
+			 * @param {boolean=} isString whether the span is a quoted string
+			 * @returns {void}
+			 */
+			const emit = (start, end, isString) => {
+				const { line: sl, column: sc } = locConverter.get(start);
+				const { line: el, column: ec } = locConverter.get(end);
+				const name = unescapeRange(
+					isString ? start + 1 : start,
+					isString ? end - 1 : end
+				);
+				addCssExport(
+					sl,
+					sc,
+					el,
+					ec,
+					name,
+					getReexport(name),
+					[start, end],
+					true,
+					CssIcssExportDependency.EXPORT_MODE.ONCE,
+					isGridProperty
+						? CssIcssExportDependency.EXPORT_TYPE.GRID_CUSTOM_IDENTIFIER
+						: CssIcssExportDependency.EXPORT_TYPE.NORMAL
+				);
+			};
+			// Collect idents/strings to export — top-level only, except grid-template recurses (`[line-name]` blocks live in `repeat(…)`).
+			/** @type {(cvs: AstNode[]) => void} */
+			const walkExports = (cvs) => {
+				for (const cv of cvs) {
+					switch (cv.type) {
+						case NodeType.Comma:
+							parsedKeywords = Object.create(null);
+							break;
+						case NodeType.Delim:
+							afterExclamation = /** @type {Token} */ (cv).value === "!";
+							break;
+						case NodeType.Ident: {
+							if (isGridTemplate) break;
+							if (afterExclamation) {
+								afterExclamation = false;
+								break;
+							}
+							const identifier = /** @type {Token} */ (cv).value;
+							const keyword = identifier.toLowerCase();
+							parsedKeywords[keyword] =
+								typeof parsedKeywords[keyword] !== "undefined"
+									? parsedKeywords[keyword] + 1
+									: 0;
+							if (
+								keywords[keyword] &&
+								parsedKeywords[keyword] < keywords[keyword]
+							) {
+								break;
+							}
+							emit(cv.start, cv.end);
+							break;
+						}
+						case NodeType.String: {
+							if (
+								declPropertyName === "animation" ||
+								declPropertyName === "animation-name"
+							) {
+								emit(cv.start, cv.end, true);
+							}
+							if (
+								declPropertyName === "grid" ||
+								declPropertyName === "grid-template" ||
+								declPropertyName === "grid-template-areas"
+							) {
+								const areas = /** @type {Token} */ (cv).unescaped;
+								const matches = matchAll(/\b\w+\b/g, areas);
+								for (const match of matches) {
+									const areaStart = cv.start + 1 + match.index;
+									emit(areaStart, areaStart + match[0].length, false);
+								}
+							}
+							break;
+						}
+						case NodeType.SimpleBlock: {
+							const block = /** @type {SimpleBlock} */ (cv);
+							if (block.token === "[") {
+								// Collect identifiers until the first non-ident token (`<line-names> = '[' <custom-ident>* ']'`).
+								for (const inner of block.value) {
+									if (inner.type === NodeType.Whitespace) continue;
+									if (inner.type !== NodeType.Ident) break;
+									emit(inner.start, inner.end);
+								}
+							} else if (isGridTemplate) {
+								walkExports(block.value);
+							}
+							break;
+						}
+						case NodeType.Function:
+							if (isGridTemplate) {
+								walkExports(/** @type {FunctionNode} */ (cv).value);
+							}
+							break;
+						// Other types carry no ICSS-export information.
+					}
+				}
+			};
+			walkExports(decl.value);
+		};
+
+		/**
+		 * Pure-mode: mark the at-rule local when its prelude names a local `@keyframes` / `@counter-style` / `@container` identifier (or a `:local(…)` function), so the rule isn't flagged impure. `@container` ignores the `none`/`and`/`or`/`not` keywords.
+		 * @param {AtRule} at the at-rule
+		 * @param {boolean} isKeyframes whether it's `@keyframes`
+		 * @param {boolean} isCounterStyle whether it's `@counter-style`
+		 * @param {boolean} isContainer whether it's `@container`
+		 * @returns {void}
+		 */
+		const markPureFromAtRulePrelude = (
+			at,
+			isKeyframes,
+			isCounterStyle,
+			isContainer
+		) => {
+			/** @type {RegExp | null} */
+			const identSkip = isContainer ? /^(none|and|or|not)$/ : null;
+			const acceptIdent = isKeyframes || isCounterStyle || isContainer;
+			const acceptString = isKeyframes;
+			for (const cv of at.prelude) {
+				if (cv.type === NodeType.Whitespace) continue;
+				if (cv.type === NodeType.String) {
+					if (acceptString) pure.markLocal();
+					break;
+				}
+				if (cv.type === NodeType.Ident) {
+					if (!acceptIdent) break;
+					const text = source.slice(cv.start, cv.end);
+					if (identSkip && identSkip.test(text)) continue;
+					pure.markLocal();
+					break;
+				}
+				if (cv.type === NodeType.Function) {
+					if (
+						equalsLowerCase(
+							/** @type {FunctionNode} */ (cv).unescapedName,
+							"local"
+						)
+					) {
+						pure.markLocal();
+					}
+					break;
+				}
+			}
+		};
+
 		// Drive the walk through SourceProcessor: structural enter / exit map to the `walkAst…Enter` / `…Exit` halves; value visitors handle url / ICSS / local-global.
 		/** @type {VisitorMap} */
 		const visitors = {
@@ -2897,7 +3066,7 @@ class CssParser extends Parser {
 					const effectiveLocalMode = isEffectivelyLocal();
 					const isProcessedByLocalAtRule = isLocalHandledAtRule(name);
 					currentStructural = at;
-					currentStructuralName = name;
+					currentAtRuleName = name;
 					dashed.active = false;
 					// `@import` url() is the import target — only walk its prelude for url deps on malformed-import recovery (flagged on the node).
 					const atWithRecovery =
@@ -2934,35 +3103,12 @@ class CssParser extends Parser {
 							atSkipChildren = true;
 							atTreatAsLeaf = true;
 						}
-						/** @type {RegExp | null} */
-						const identSkip = isContainer ? /^(none|and|or|not)$/ : null;
-						const acceptIdent = isKeyframes || isCounterStyle || isContainer;
-						const acceptString = isKeyframes;
-						for (const cv of at.prelude) {
-							if (cv.type === NodeType.Whitespace) continue;
-							if (cv.type === NodeType.String) {
-								if (acceptString) pure.markLocal();
-								break;
-							}
-							if (cv.type === NodeType.Ident) {
-								if (!acceptIdent) break;
-								const text = source.slice(cv.start, cv.end);
-								if (identSkip && identSkip.test(text)) continue;
-								pure.markLocal();
-								break;
-							}
-							if (cv.type === NodeType.Function) {
-								if (
-									equalsLowerCase(
-										stripBackslashes(/** @type {FunctionNode} */ (cv).name),
-										"local"
-									)
-								) {
-									pure.markLocal();
-								}
-								break;
-							}
-						}
+						markPureFromAtRulePrelude(
+							at,
+							isKeyframes,
+							isCounterStyle,
+							isContainer
+						);
 					}
 
 					// pure.stack push for block-bearing at-rules.
@@ -3057,19 +3203,15 @@ class CssParser extends Parser {
 					const savedAnchor = currentRule.hasLocalAnchor;
 					const savedLocalIdentifiers = currentRule.localIdentifiers;
 					currentRule.hasLocalAnchor = false;
-					// Only modules-mode walks mutate `localIdentifiers` / `composesFiles`;
-					// otherwise share the (empty) parent containers instead of copying
-					// them per rule.
+					// Only modules-mode walks mutate `localIdentifiers`; otherwise share the (empty) parent list instead of copying it per rule.
 					currentRule.localIdentifiers = isModules
 						? [...savedLocalIdentifiers]
 						: savedLocalIdentifiers;
-					// Composes-state reset between rules (saved / restored around this rule).
+					// Composes-state reset between rules (saved / restored around this rule); composesFiles is swapped out and re-created lazily only if this rule composes.
 					const savedPrevComposesFile = currentRule.composesPrevFile;
-					const savedComposesFiles = isModules
-						? new Set(currentRule.composesFiles)
-						: currentRule.composesFiles;
+					const savedComposesFiles = currentRule.composesFiles;
 					currentRule.composesPrevFile = undefined;
-					currentRule.composesFiles.clear();
+					currentRule.composesFiles = null;
 					qualifiedRuleStateStack.push({
 						bailed: false,
 						savedAnchor,
@@ -3131,10 +3273,7 @@ class CssParser extends Parser {
 					currentRule.hasLocalAnchor = state.savedAnchor;
 					currentRule.localIdentifiers = state.savedLocalIdentifiers;
 					currentRule.composesPrevFile = state.savedPrevComposesFile;
-					currentRule.composesFiles.clear();
-					for (const f of state.savedComposesFiles) {
-						currentRule.composesFiles.add(f);
-					}
+					currentRule.composesFiles = state.savedComposesFiles;
 					if (parent === null) finishTopLevelRule(node, false);
 				}
 			},
@@ -3148,7 +3287,8 @@ class CssParser extends Parser {
 				const declPropertyName = decl.name
 					.replace(/^(-\w+-)/, "")
 					.toLowerCase();
-				currentStructuralName = declPropertyName;
+				// Cache the known-property flag so the per-token value visitors don't recompute it.
+				currentDeclIsKnownProperty = knownProperties.has(declPropertyName);
 				// Position `lastTokenEndForComments` just past the `:` so a magic comment before the url() is found.
 				let colonPos = decl.nameEnd;
 				while (
@@ -3160,141 +3300,14 @@ class CssParser extends Parser {
 				lastTokenEndForComments = colonPos + 1;
 				const effectiveLocalMode = isEffectivelyLocal();
 				// `composes:` with a local anchor: its strip-dep covers the whole declaration, so suppress the value's local/global/dashed/ICSS rewrites.
-				const isComposesWithAnchor =
-					COMPOSES_PROPERTY.test(declPropertyName) &&
-					currentRule.hasLocalAnchor;
-				if (isComposesWithAnchor) emitComposesWithAnchor(decl);
-				const skipForComposes = isComposesWithAnchor;
+				currentDeclComposesSkip =
+					currentRule.hasLocalAnchor &&
+					COMPOSES_PROPERTY.test(declPropertyName);
+				if (currentDeclComposesSkip) emitComposesWithAnchor(decl);
+				const skipForComposes = currentDeclComposesSkip;
 				// Known-property value localization (`animation-name: foo` exports `foo`).
-				if (
-					isModules &&
-					effectiveLocalMode &&
-					knownProperties.has(declPropertyName)
-				) {
-					/** @type {[number, number, boolean?][]} */
-					const values = [];
-					/** @type {Record<string, number>} */
-					let parsedKeywords = Object.create(null);
-					const isGridProperty = Boolean(declPropertyName.startsWith("grid"));
-					const isGridTemplate = isGridProperty
-						? Boolean(
-								declPropertyName === "grid" ||
-								declPropertyName === "grid-template" ||
-								declPropertyName === "grid-template-columns" ||
-								declPropertyName === "grid-template-rows"
-							)
-						: false;
-					const keywords =
-						/** @type {Record<string, number>} */
-						(knownProperties.get(declPropertyName));
-					let afterExclamation = false;
-					// Collect idents/strings to export — top-level only, except grid-template recurses (`[line-name]` blocks live in `repeat(…)`).
-					/** @type {(cvs: AstNode[]) => void} */
-					const walkExports = (cvs) => {
-						for (const cv of cvs) {
-							switch (cv.type) {
-								case NodeType.Comma:
-									parsedKeywords = Object.create(null);
-									break;
-								case NodeType.Delim:
-									afterExclamation = /** @type {Token} */ (cv).value === "!";
-									break;
-								case NodeType.Ident: {
-									if (isGridTemplate) break;
-									if (afterExclamation) {
-										afterExclamation = false;
-										break;
-									}
-									const identifier = /** @type {Token} */ (cv).value;
-									const keyword = identifier.toLowerCase();
-									parsedKeywords[keyword] =
-										typeof parsedKeywords[keyword] !== "undefined"
-											? parsedKeywords[keyword] + 1
-											: 0;
-									if (
-										keywords[keyword] &&
-										parsedKeywords[keyword] < keywords[keyword]
-									) {
-										break;
-									}
-									values.push([cv.start, cv.end]);
-									break;
-								}
-								case NodeType.String: {
-									if (
-										declPropertyName === "animation" ||
-										declPropertyName === "animation-name"
-									) {
-										values.push([cv.start, cv.end, true]);
-									}
-									if (
-										declPropertyName === "grid" ||
-										declPropertyName === "grid-template" ||
-										declPropertyName === "grid-template-areas"
-									) {
-										const areas = unescapeIdentifier(
-											source.slice(cv.start + 1, cv.end - 1)
-										);
-										const matches = matchAll(/\b\w+\b/g, areas);
-										for (const match of matches) {
-											const areaStart = cv.start + 1 + match.index;
-											values.push([
-												areaStart,
-												areaStart + match[0].length,
-												false
-											]);
-										}
-									}
-									break;
-								}
-								case NodeType.SimpleBlock: {
-									const block = /** @type {SimpleBlock} */ (cv);
-									if (block.token === "[") {
-										// Collect identifiers until the first non-ident token (`<line-names> = '[' <custom-ident>* ']'`).
-										for (const inner of block.value) {
-											if (inner.type === NodeType.Whitespace) continue;
-											if (inner.type !== NodeType.Ident) break;
-											values.push([inner.start, inner.end]);
-										}
-									} else if (isGridTemplate) {
-										walkExports(block.value);
-									}
-									break;
-								}
-								case NodeType.Function:
-									if (isGridTemplate) {
-										walkExports(/** @type {FunctionNode} */ (cv).value);
-									}
-									break;
-								// Other types carry no ICSS-export information.
-							}
-						}
-					};
-					walkExports(decl.value);
-					for (const value of values) {
-						const { line: sl, column: sc } = locConverter.get(value[0]);
-						const { line: el, column: ec } = locConverter.get(value[1]);
-						const [start, end, isString] = value;
-						const name = unescapeIdentifier(
-							isString
-								? source.slice(start + 1, end - 1)
-								: source.slice(start, end)
-						);
-						addCssExport(
-							sl,
-							sc,
-							el,
-							ec,
-							name,
-							getReexport(name),
-							[start, end],
-							true,
-							CssIcssExportDependency.EXPORT_MODE.ONCE,
-							isGridProperty
-								? CssIcssExportDependency.EXPORT_TYPE.GRID_CUSTOM_IDENTIFIER
-								: CssIcssExportDependency.EXPORT_TYPE.NORMAL
-						);
-					}
+				if (isModules && effectiveLocalMode && currentDeclIsKnownProperty) {
+					emitKnownPropertyExports(decl, declPropertyName);
 				}
 				// Dashed-ident (custom-property) export of the property name; the value's dashed idents are scoped by the Ident / Function visitors (top-level only for unknown properties).
 				if (
@@ -3307,13 +3320,13 @@ class CssParser extends Parser {
 						emitDashedIdentExport(decl.nameStart, decl.nameEnd);
 					}
 					dashed.active = true;
-					dashed.emit = !knownProperties.has(declPropertyName);
+					dashed.emit = !currentDeclIsKnownProperty;
 				}
 				// ICSS-symbol rewrite (`color: foo` when `foo` is `@value`-defined), skipping known properties, the composes anchor, and dashed idents (handled above).
 				if (
 					isModules &&
 					!skipForComposes &&
-					!knownProperties.has(declPropertyName) &&
+					!currentDeclIsKnownProperty &&
 					!(dashed.active && isDashedIdentifier(decl.name)) &&
 					icssDefinitions.has(decl.name)
 				) {
@@ -3325,14 +3338,12 @@ class CssParser extends Parser {
 				const url = /** @type {UrlToken} */ (node);
 				if (!urlActive()) return;
 				// Skip bare url-tokens for a known property in CSS-Modules local mode.
-				// `currentStructuralName` already holds the declaration's normalized
-				// property name (set on Declaration enter).
 				if (
 					currentStructural &&
 					currentStructural.type === NodeType.Declaration &&
 					isModules &&
-					isEffectivelyLocal() &&
-					knownProperties.has(currentStructuralName)
+					currentDeclIsKnownProperty &&
+					isEffectivelyLocal()
 				) {
 					return;
 				}
@@ -3385,7 +3396,7 @@ class CssParser extends Parser {
 			[NodeType.Function]: {
 				enter: (node) => {
 					const fn = /** @type {FunctionNode} */ (node);
-					const fnameRaw = stripBackslashes(fn.name);
+					const fnameRaw = fn.unescapedName;
 					const fname = fnameRaw.toLowerCase();
 					if (urlActive()) emitUrlFunction(fn, fname);
 					if (

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1186,6 +1186,19 @@ class Node {
 	toString() {
 		return this._locConverter._input.slice(this.start, this.end);
 	}
+
+	/**
+	 * For name-bearing nodes (function / at-rule): the `name` with CSS escapes
+	 * resolved, for case-insensitive keyword matching (`\75 rl` → `url`). Computed
+	 * on read via `unescapeIdentifier`'s no-escape fast path. Callers without a
+	 * `name` must not read this.
+	 * @returns {string} the unescaped name
+	 */
+	get unescapedName() {
+		return unescapeIdentifier(
+			/** @type {{ name: string }} */ (/** @type {unknown} */ (this)).name
+		);
+	}
 }
 
 /**
@@ -1243,6 +1256,23 @@ class Token extends Node {
 			this.start,
 			this.end
 		));
+	}
+
+	/**
+	 * The token's value with CSS escapes resolved (`\2d` → `-`, `\75 rl` → `url`),
+	 * per https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point — the
+	 * form to match keywords / export as a CSS-Modules name against. For a string
+	 * token it is the content between the quotes (the spec string value). Computed
+	 * on read; `unescapeIdentifier` fast-returns the value unchanged when it has no
+	 * escapes (the common case), so nothing is stored per token.
+	 * @returns {string} the unescaped value
+	 */
+	get unescaped() {
+		const v = this.value;
+		// A string token's `value` carries its delimiting quotes; its value is the content between them.
+		return this.type === T_STRING
+			? unescapeIdentifier(v.slice(1, -1))
+			: unescapeIdentifier(v);
 	}
 
 	/**

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -484,20 +484,25 @@ class CssIcssExportDependency extends NullDependency {
 }
 
 /**
- * Finds the export entry with `name` in `module`'s consolidated dependency.
- * @param {CssModule} module module to search
- * @param {string} name export name
- * @returns {CssExportEntry | undefined} matching entry, if any
+ * Get (or lazily build into `indexCache`) a name -> entries index for `dep`,
+ * so composes resolution does a Map lookup instead of scanning all entries per
+ * reference. The cache is owned by one `apply` call and GC'd with it.
+ * @param {Map<CssIcssExportDependency, Map<string, CssExportEntry[]>>} indexCache transient cache
+ * @param {CssIcssExportDependency} dep export dependency
+ * @returns {Map<string, CssExportEntry[]>} entries grouped by name
  */
-const findExportEntry = (module, name) => {
-	for (const dep of module.dependencies) {
-		if (dep instanceof CssIcssExportDependency) {
-			for (const entry of dep.entries) {
-				if (entry.name === name) return entry;
-			}
+const indexEntries = (indexCache, dep) => {
+	let map = indexCache.get(dep);
+	if (map === undefined) {
+		map = new Map();
+		for (const e of dep.entries) {
+			const list = map.get(e.name);
+			if (list) list.push(e);
+			else map.set(e.name, [e]);
 		}
+		indexCache.set(dep, map);
 	}
-	return undefined;
+	return map;
 };
 
 /**
@@ -535,6 +540,7 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @param {string | undefined} request user request of the `@value` import
 	 * @param {Set<CssExportEntry>=} seen cycle guard
+	 * @param {Map<CssIcssExportDependency, Map<string, CssExportEntry[]>>=} indexCache transient per-codegen name index (shared with `resolveReferences` within one `apply`)
 	 * @returns {string | undefined} found reference
 	 */
 	static resolve(
@@ -542,7 +548,8 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 		importName,
 		templateContext,
 		request,
-		seen = new Set()
+		seen = new Set(),
+		indexCache = new Map()
 	) {
 		const { moduleGraph } = templateContext;
 		const importDep = findImportDep(
@@ -555,7 +562,16 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 		const module = /** @type {CssModule} */ (moduleGraph.getModule(importDep));
 		if (!module) return undefined;
 
-		const exportEntry = findExportEntry(module, importName);
+		/** @type {CssExportEntry | undefined} */
+		let exportEntry;
+		for (const dep of module.dependencies) {
+			if (!(dep instanceof CssIcssExportDependency)) continue;
+			const matches = indexEntries(indexCache, dep).get(importName);
+			if (matches) {
+				exportEntry = matches[0];
+				break;
+			}
+		}
 		if (!exportEntry) return undefined;
 		if (seen.has(exportEntry)) return undefined;
 		seen.add(exportEntry);
@@ -568,7 +584,8 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 				value[1],
 				{ ...templateContext, module },
 				value[2],
-				seen
+				seen,
+				indexCache
 			);
 		}
 
@@ -587,9 +604,10 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 	 * @param {CssExportEntry} entry composes entry
 	 * @param {DependencyTemplateContext} templateContext template context
 	 * @param {Set<CssExportEntry>} seen cycle guard
+	 * @param {Map<CssIcssExportDependency, Map<string, CssExportEntry[]>>} indexCache transient per-codegen name index, discarded after the module's `apply` (so it isn't retained on the dependency)
 	 * @returns {string[]} final names
 	 */
-	static resolveReferences(entry, templateContext, seen) {
+	static resolveReferences(entry, templateContext, seen, indexCache) {
 		/** @type {string[]} */
 		const references = [];
 
@@ -609,24 +627,30 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 				(templateContext.moduleGraph.getModule(importDep));
 			if (!module) return references;
 
+			// Same overridden context and target name for every matched entry — build once, not per entry.
+			const subContext = { ...templateContext, module };
+			const name = /** @type {string[]} */ (entry.value)[1];
 			for (const dep of module.dependencies) {
 				if (!(dep instanceof CssIcssExportDependency)) continue;
-				for (const d of dep.entries) {
-					if (d.name !== /** @type {string[]} */ (entry.value)[1]) continue;
+				const matches = indexEntries(indexCache, dep).get(name);
+				if (!matches) continue;
+				for (const d of matches) {
 					if (Array.isArray(d.value)) {
 						references.push(
 							...CssIcssExportDependencyTemplate.resolveReferences(
 								d,
-								{ ...templateContext, module },
-								seen
+								subContext,
+								seen,
+								indexCache
 							)
 						);
 					} else {
 						references.push(
-							CssIcssExportDependencyTemplate.getIdentifier(d.value, d, {
-								...templateContext,
-								module
-							})
+							CssIcssExportDependencyTemplate.getIdentifier(
+								d.value,
+								d,
+								subContext
+							)
 						);
 					}
 				}
@@ -642,31 +666,35 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 
 			for (const dep of templateContext.module.dependencies) {
 				if (!(dep instanceof CssIcssExportDependency)) continue;
-				for (const d of dep.entries) {
-					if (d.exportType === EXPORT_TYPE.COMPOSES && d.name === entry.value) {
-						if (Array.isArray(d.value)) {
-							references.push(
-								...CssIcssExportDependencyTemplate.resolveReferences(
-									d,
-									templateContext,
-									seen
-								)
-							);
-						} else {
-							references.push(
-								CssIcssExportDependencyTemplate.getIdentifier(
-									d.value,
-									d,
-									templateContext
-								)
-							);
-						}
+				const matches = indexEntries(indexCache, dep).get(
+					/** @type {string} */ (entry.value)
+				);
+				if (!matches) continue;
+				for (const d of matches) {
+					if (d.exportType !== EXPORT_TYPE.COMPOSES) continue;
+					if (Array.isArray(d.value)) {
+						references.push(
+							...CssIcssExportDependencyTemplate.resolveReferences(
+								d,
+								templateContext,
+								seen,
+								indexCache
+							)
+						);
+					} else {
+						references.push(
+							CssIcssExportDependencyTemplate.getIdentifier(
+								d.value,
+								d,
+								templateContext
+							)
+						);
 					}
 				}
 			}
 		}
 
-		return [...new Set(references)];
+		return references.length > 1 ? [...new Set(references)] : references;
 	}
 
 	/**
@@ -706,6 +734,9 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 		// All entries belong to this one module, so resolve its ExportsInfo once
 		// instead of re-resolving `module -> exportsInfo` per export name.
 		const exportsInfo = isJs ? moduleGraph.getExportsInfo(module) : undefined;
+		// Transient name index for composes resolution within this module's codegen; GC'd when apply returns (never retained on the dependency).
+		/** @type {Map<CssIcssExportDependency, Map<string, CssExportEntry[]>>} */
+		const indexCache = new Map();
 
 		for (const entry of dep.entries) {
 			if (!entry.range && !isJs) continue;
@@ -717,7 +748,8 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 				value = CssIcssExportDependencyTemplate.resolveReferences(
 					entry,
 					templateContext,
-					new Set()
+					new Set(),
+					indexCache
 				).join(" ");
 			} else if (isReference) {
 				const resolved = CssIcssExportDependencyTemplate.resolve(
@@ -725,7 +757,8 @@ CssIcssExportDependency.Template = class CssIcssExportDependencyTemplate extends
 					/** @type {string[]} */ (entry.value)[1],
 					templateContext,
 					/** @type {string[]} */ (entry.value)[2],
-					new Set()
+					new Set(),
+					indexCache
 				);
 				value = resolved || /** @type {string[]} */ (entry.value)[0];
 			} else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Decomposes the CSS-Modules logic in `lib/css/CssParser.js` into focused helpers and a node-type `switch` (`walkSelectorList`, `emitComposesWithAnchor`, the `Declaration` visitor), and moves CSS escape resolution into the tokenizer as lazy accessors (`Token#unescaped`, `Node#unescapedName`) so the parser reads clean names instead of scattered escape-strip / `unescapeIdentifier(source.slice(...))` calls.

Also adds profiling-guided perf that does **not** overlap #21181: in `CssIcssExportDependency` codegen, a context-allocation hoist in `resolveReferences` plus an O(entries²)→O(entries) composes-resolution index (transient, so retained heap is unchanged); and assorted parser allocation cuts (dashed-ident scope stack, known-property export tuples, lazy per-rule `composesFiles`).

Behavior is unchanged (the CSS suites are byte-identical to baseline) **except one correctness fix**: function/pseudo names are now fully unescaped, so e.g. `\75 rl()` resolves to `url()` (previously only backslashes were stripped).

**Rebased onto `main` after #21181 merged.** #21181 independently added some of the same micro-optimizations (a `stripBackslashes` helper, property-name caching); this PR keeps #21181's orthogonal wins (normalizeUrl/getComments/getReexport fast-paths, lazy `webpackIgnored` loc, non-modules `localIdentifiers` sharing) and **supersedes** its backslash-only stripping with the fuller tokenizer-level unescaping here. Note: the local benchmark (~5–6% on a CSS-Modules fixture) was measured against the *pre-#21181* base, so part of that gap is now already upstream — the decomposition, the `CssIcss` codegen perf, and the correctness fix are the parts unique to this PR.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor (with `perf` work in `CssIcssExportDependency` and a small `fix` for hex-escaped names).

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new test cases — behavior is covered by the existing CSS suites (`ConfigTestCases`/`ConfigCacheTestCases` `css`, `cssParsing-webpack.spectest`, `walkCssTokens*`/`cssIdentifier` unit tests, `cases/css`, `configCases/css/postcss-modules-plugins`), which stay green and byte-identical to baseline. Happy to add a focused case for hex-escaped function/selector names to lock in the correctness fix if preferred.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — internal refactor of CSS-Modules parsing/codegen; no public API or configuration change. A changeset (`patch`) is included for the escape-resolution fix.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. -->

Yes. Developed with AI assistance (Claude Code): used to profile hot paths, propose and apply the decomposition and performance changes, reconcile the rebase onto #21181, and validate each step against the existing CSS test suites and a compile-time/heap benchmark. Every change was reviewed and verified before pushing.