### PR TITLE
refactor: reduce EXPECTED_ANY in stats hook and printer types

### DIFF
--- a/.changeset/warm-pots-cheer.md
+++ b/.changeset/warm-pots-cheer.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Avoid building warning stats objects when counting warnings without a filter.

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -418,9 +418,8 @@ const mapObject = (obj, fn) => {
 
 /**
  * Count with children.
- * @template T
  * @param {Compilation} compilation the compilation
- * @param {(compilation: Compilation, name: string) => T[]} getItems get items
+ * @param {(compilation: Compilation, name: string) => { length: number }} getItems get items
  * @returns {number} total number
  */
 const countWithChildren = (compilation, getItems) => {
@@ -1014,8 +1013,7 @@ const SIMPLE_EXTRACTORS = {
 					/** @type {KnownNormalizedStatsOptions["warningsFilter"]} */
 					(warningsFilter).length === 0
 				) {
-					// Type is wrong, because we don't need the real value for counting
-					return /** @type {EXPECTED_ANY[]} */ (cachedGetWarnings(c));
+					return cachedGetWarnings(c);
 				}
 				return factory
 					.create(`${type}${childType}.warnings`, cachedGetWarnings(c), context)

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -1009,7 +1009,6 @@ const SIMPLE_EXTRACTORS = {
 			const { type, cachedGetWarnings } = context;
 			object.warningsCount = countWithChildren(compilation, (c, childType) => {
 				if (
-					!warningsFilter &&
 					/** @type {KnownNormalizedStatsOptions["warningsFilter"]} */
 					(warningsFilter).length === 0
 				) {

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -1689,8 +1689,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(COMPILATION_SIMPLE_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(COMPILATION_SIMPLE_PRINTERS)[key](
+						/** @type {NonNullable<CompilationSimplePrinters[keyof CompilationSimplePrinters]>} */
+						(COMPILATION_SIMPLE_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"compilation">} */
 							(ctx),

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -1717,8 +1717,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(MODULE_SIMPLE_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(MODULE_SIMPLE_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "module">} */
+						(MODULE_SIMPLE_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"module">} */
 							(ctx),
@@ -1745,8 +1745,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(MODULE_REASON_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(MODULE_REASON_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "moduleReason">} */
+						(MODULE_REASON_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"moduleReason">} */
 							(ctx),
@@ -1773,8 +1773,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(CHUNK_GROUP_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(CHUNK_GROUP_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "chunkGroupKind" | "chunkGroup">} */
+						(CHUNK_GROUP_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"chunkGroupKind" | "chunkGroup">} */
 							(ctx),
@@ -1787,8 +1787,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(CHUNK_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(CHUNK_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "chunk">} */
+						(CHUNK_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"chunk">} */
 							(ctx),
@@ -1801,8 +1801,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(ERROR_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(ERROR_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "error">} */
+						(ERROR_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"error">} */
 							(ctx),
@@ -1815,8 +1815,8 @@ class DefaultStatsPrinterPlugin {
 					Object.keys(LOG_ENTRY_PRINTERS)
 				)) {
 					stats.hooks.print.for(key).tap(PLUGIN_NAME, (obj, ctx) =>
-						/** @type {EXPECTED_ANY} */
-						(LOG_ENTRY_PRINTERS)[key](
+						/** @type {SimplePrinter<EXPECTED_ANY, "logging">} */
+						(LOG_ENTRY_PRINTERS[key])(
 							obj,
 							/** @type {DefineStatsPrinterContext<"logging">} */
 							(ctx),

--- a/lib/stats/StatsFactory.js
+++ b/lib/stats/StatsFactory.js
@@ -131,7 +131,7 @@ class StatsFactory {
 		});
 		const hooks = this.hooks;
 		this._caches =
-			/** @type {{ [Key in keyof StatsFactoryHooks]: Map<string, SyncBailHook<EXPECTED_ANY, EXPECTED_ANY>[]> }} */ ({});
+			/** @type {{ [Key in keyof StatsFactoryHooks]: StatsFactoryHooks[Key] extends HookMap<infer H> ? Map<string, H[]> : never }} */ ({});
 		for (const key of Object.keys(hooks)) {
 			this._caches[/** @type {keyof StatsFactoryHooks} */ (key)] = new Map();
 		}
@@ -169,7 +169,7 @@ class StatsFactory {
 	 * Returns hook.
 	 * @template {StatsFactoryHooks[keyof StatsFactoryHooks]} HM
 	 * @template {HM extends HookMap<infer H> ? H : never} H
-	 * @template {H extends import("tapable").Hook<EXPECTED_ANY, infer R> ? R : never} R
+	 * @template {H extends import("tapable").Hook<infer A, infer R> ? R : never} R
 	 * @param {HM} hookMap hook map
 	 * @param {Caches<H>} cache cache
 	 * @param {string} type type
@@ -207,7 +207,7 @@ class StatsFactory {
 	 * For each level filter.
 	 * @template {StatsFactoryHooks[keyof StatsFactoryHooks]} T
 	 * @template {T extends HookMap<infer H> ? H : never} H
-	 * @template {H extends import("tapable").Hook<EXPECTED_ANY, infer R> ? R : never} R
+	 * @template {H extends import("tapable").Hook<infer A, infer R> ? R : never} R
 	 * @param {T} hookMap hook map
 	 * @param {Caches<H>} cache cache
 	 * @param {string} type type

--- a/lib/stats/StatsFactory.js
+++ b/lib/stats/StatsFactory.js
@@ -188,12 +188,13 @@ class StatsFactory {
 	 * For each level waterfall.
 	 * @template {StatsFactoryHooks[keyof StatsFactoryHooks]} HM
 	 * @template {HM extends HookMap<infer H> ? H : never} H
+	 * @template [D=EXPECTED_ANY]
 	 * @param {HM} hookMap hook map
 	 * @param {Caches<H>} cache cache
 	 * @param {string} type type
-	 * @param {FactoryData} data data
-	 * @param {(hook: H, factoryData: FactoryData) => FactoryData} fn fn
-	 * @returns {FactoryData} data
+	 * @param {D} data data
+	 * @param {(hook: H, data: D) => D} fn fn
+	 * @returns {D} data
 	 * @private
 	 */
 	_forEachLevelWaterfall(hookMap, cache, type, data, fn) {
@@ -207,14 +208,14 @@ class StatsFactory {
 	 * For each level filter.
 	 * @template {StatsFactoryHooks[keyof StatsFactoryHooks]} T
 	 * @template {T extends HookMap<infer H> ? H : never} H
-	 * @template {H extends import("tapable").Hook<infer A, infer R> ? R : never} R
+	 * @template [D=EXPECTED_ANY]
 	 * @param {T} hookMap hook map
 	 * @param {Caches<H>} cache cache
 	 * @param {string} type type
-	 * @param {FactoryData[]} items items
-	 * @param {(hook: H, item: R, idx: number, i: number) => R | undefined} fn fn
+	 * @param {D[]} items items
+	 * @param {(hook: H, item: D, idx: number, i: number) => boolean | void} fn fn
 	 * @param {boolean} forceClone force clone
-	 * @returns {R[]} result for each level
+	 * @returns {D[]} result for each level
 	 * @private
 	 */
 	_forEachLevelFilter(hookMap, cache, type, items, fn, forceClone) {

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -73,6 +73,12 @@ const { HookMap, SyncBailHook, SyncWaterfallHook } = require("tapable");
  * @property {(message: string) => string=} formatError
  */
 
+/**
+ * Extracts the inner hook type held by a `HookMap`.
+ * @template T
+ * @typedef {T extends HookMap<infer H> ? H : never} HookMapHook
+ */
+
 /** @typedef {KnownStatsPrinterColorFunctions & KnownStatsPrinterFormatters & KnownStatsPrinterContext & Record<string, EXPECTED_ANY>} StatsPrinterContext */
 /** @typedef {StatsPrinterContext & Required<KnownStatsPrinterColorFunctions> & Required<KnownStatsPrinterFormatters> & { type: string }} StatsPrinterContextWithExtra */
 /** @typedef {EXPECTED_ANY} PrintObject */
@@ -107,7 +113,7 @@ class StatsPrinter {
 			print: new HookMap(() => new SyncBailHook(["object", "context"])),
 			result: new HookMap(() => new SyncWaterfallHook(["result", "context"]))
 		});
-		/** @type {Map<StatsPrintHooks[keyof StatsPrintHooks], Map<string, import("tapable").Hook<EXPECTED_ANY, EXPECTED_ANY>[]>>} */
+		/** @type {Map<StatsPrintHooks[keyof StatsPrintHooks], Map<string, HookMapHook<StatsPrintHooks[keyof StatsPrintHooks]>[]>>} */
 		this._levelHookCache = new Map();
 		this._inPrint = false;
 	}
@@ -149,7 +155,7 @@ class StatsPrinter {
 	 * @private
 	 * @template {StatsPrintHooks[keyof StatsPrintHooks]} HM
 	 * @template {HM extends HookMap<infer H> ? H : never} H
-	 * @template {H extends import("tapable").Hook<EXPECTED_ANY, infer R> ? R : never} R
+	 * @template {H extends import("tapable").Hook<infer A, infer R> ? R : never} R
 	 * @param {HM} hookMap hook map
 	 * @param {string} type type
 	 * @param {(hooK: H) => R | undefined | void} fn fn

--- a/test/statsCases/warnings-count/__snapshots__/StatsTest.snap
+++ b/test/statsCases/warnings-count/__snapshots__/StatsTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsTestCases warnings-count should print correct stats for warnings-count 1`] = `"webpack compiled with 3 warnings"`;

--- a/test/statsCases/warnings-count/index.js
+++ b/test/statsCases/warnings-count/index.js
@@ -1,0 +1,1 @@
+console.log("warnings-count");

--- a/test/statsCases/warnings-count/webpack.config.js
+++ b/test/statsCases/warnings-count/webpack.config.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const webpack = require("../../../");
+
+const PLUGIN_NAME = "AddWarningsPlugin";
+
+// Emits warnings without an `ignoreWarnings`/`warningsFilter`, so `warningsCount`
+// is computed from the raw warnings; details are hidden to assert the count alone.
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	stats: {
+		all: false,
+		warnings: false,
+		warningsCount: true
+	},
+	plugins: [
+		{
+			/**
+			 * @param {import("../../../").Compiler} compiler the compiler
+			 * @returns {void}
+			 */
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.afterSeal.tap(PLUGIN_NAME, () => {
+						for (let i = 0; i < 3; i++) {
+							compilation.warnings.push(
+								new webpack.WebpackError(`Warning ${i}`)
+							);
+						}
+					});
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`lib/stats/` used `EXPECTED_ANY` (alias for `any`) in many spots where a real type is recoverable. This PR tightens the recoverable ones while keeping `EXPECTED_ANY` only where it is genuinely existential:

- `StatsFactory`/`StatsPrinter` hook plumbing: infer the real inner-hook and result types for the level-hook caches and `_forEachLevel*` generics (also fixes the `result` cache being typed as `SyncBailHook` instead of `SyncWaterfallHook`).
- `StatsFactory` level helpers: thread a `@template [D=EXPECTED_ANY]` item type through `_forEachLevelWaterfall`/`_forEachLevelFilter` (this also fixes `_forEachLevelFilter` declaring its return as the hook result `boolean | void` instead of the item type).
- `DefaultStatsPrinterPlugin` dispatch loops: type the compilation loop with its real signature and the remaining loops as `SimplePrinter<EXPECTED_ANY, …>` so the printer context and return value are checked (only the printed value stays `EXPECTED_ANY`).
- `countWithChildren`: it only reads `.length`, so it now takes `() => { length: number }` instead of a generic `T[]`, dropping the `EXPECTED_ANY[]` cast that bridged `Error[]`/`StatsError[]`.

While dropping that cast, the `warningsCount` no-filter branch was found to be dead: it was guarded by `!warningsFilter && warningsFilter.length === 0`, which is never true because `warningsFilter` is always normalized to an array. The guard is corrected to `warningsFilter.length === 0`, so the empty-filter case returns the raw warnings for counting instead of running `factory.create(...).filter(...)` — a small perf win with an unchanged `warningsCount` (stats snapshots pass).

The remaining `EXPECTED_ANY` usages are intentional: plugin-extensible stats records (`Known* & Record<string, EXPECTED_ANY>`), existential generics (`Comparator`, `GroupConfig`), dynamic factory/printer data, and runtime-string hook dispatch. No public type surface (`types.d.ts` unchanged).

**What kind of change does this PR introduce?**

refactor (primarily a type cleanup; includes one small `perf` fix to the dead warnings-count branch surfaced by the refactor)

**Did you add tests for your changes?**

Yes — added `test/statsCases/warnings-count` asserting `warningsCount` is reported without a `warningsFilter` (covering the fixed branch). The type changes are also exercised by the existing `test/StatsTestCases` (now 132 cases, all passing).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to inventory the `EXPECTED_ANY` usages, implement the type changes and the warnings-count fix, add the test, and verify each step with `yarn tsc` and the stats tests; all changes were reviewed.