### PR TITLE
perf: shrink the persistent cache

### DIFF
--- a/.changeset/serialize-shrink-cache.md
+++ b/.changeset/serialize-shrink-cache.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Shrink the persistent cache: add a NULL_AND_I16 binary tier and inline tiny strings instead of larger far back-references.

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -84,6 +84,7 @@ const NULL3_HEADER = 0x12;
 const NULLS8_HEADER = 0x13;
 const NULLS32_HEADER = 0x14;
 const NULL_AND_I8_HEADER = 0x15;
+const NULL_AND_I16_HEADER = 0x19;
 const NULL_AND_I32_HEADER = 0x16;
 const NULL_AND_TRUE_HEADER = 0x17;
 const NULL_AND_FALSE_HEADER = 0x18;
@@ -104,6 +105,7 @@ const SHORT_STRING_LENGTH_MASK = 0x7f; // 0b0111_1111
 
 const HEADER_SIZE = 1;
 const I8_SIZE = 1;
+const I16_SIZE = 2;
 const I32_SIZE = 4;
 const F64_SIZE = 8;
 
@@ -375,6 +377,21 @@ const dispatchTable = Array.from({ length: 256 }, (_, header) => {
 					s.checkOverflow();
 				} else {
 					s.result.push(null, s.read(I8_SIZE).readInt8(0));
+				}
+			};
+		case NULL_AND_I16_HEADER:
+			return (s) => {
+				s.result.push(null);
+				if (s.isInCurrentBuffer(I16_SIZE)) {
+					s.result.push(
+						/** @type {Buffer} */ (s.currentBuffer).readInt16LE(
+							s.currentPosition
+						)
+					);
+					s.currentPosition += I16_SIZE;
+					s.checkOverflow();
+				} else {
+					s.result.push(s.read(I16_SIZE).readInt16LE(0));
 				}
 			};
 		case NULL_AND_I32_HEADER:
@@ -1076,10 +1093,19 @@ class BinaryMiddleware extends SerializerMiddleware {
 										currentPosition += I8_SIZE;
 										i++;
 									} else if (type === 1) {
-										allocate(HEADER_SIZE + I32_SIZE);
-										writeU8(NULL_AND_I32_HEADER);
-										currentBuffer.writeInt32LE(next, currentPosition);
-										currentPosition += I32_SIZE;
+										// `null` + i32 is 5 bytes; if the value also fits an
+										// i16, fuse it as 3 bytes instead (helps back-references)
+										if (next >= -32768 && next <= 32767) {
+											allocate(HEADER_SIZE + I16_SIZE);
+											writeU8(NULL_AND_I16_HEADER);
+											currentBuffer.writeInt16LE(next, currentPosition);
+											currentPosition += I16_SIZE;
+										} else {
+											allocate(HEADER_SIZE + I32_SIZE);
+											writeU8(NULL_AND_I32_HEADER);
+											currentBuffer.writeInt32LE(next, currentPosition);
+											currentPosition += I32_SIZE;
+										}
 										i++;
 									} else {
 										allocate(HEADER_SIZE);

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -625,8 +625,19 @@ class ObjectMiddleware extends SerializerMiddleware {
 					// check if we can emit a reference
 					const ref = referenceable.get(item);
 					if (ref !== undefined) {
-						result.push(ESCAPE, ref - currentPos);
-						return;
+						const offset = ref - currentPos;
+						if (
+							// One far ref → 5 bytes (`null` + offset), one near ref -> 2/3 bytes
+							offset >= -32768 ||
+							// long enough that the ref wins, keep it
+							item.length >= 4 ||
+							// multibyte → inline would be even bigger, keep it
+							Buffer.byteLength(item) !== item.length
+						) {
+							// A back-reference is `null` + the offset.
+							result.push(ESCAPE, offset);
+							return;
+						}
 					}
 					addReferenceable(item);
 				}

--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -212,7 +212,7 @@ describe("BinaryMiddleware", () => {
 
 	describe("invalid streams", () => {
 		it("should throw on an unexpected header byte", () => {
-			expect(() => mw.deserialize([Buffer.from([0x19])], {})).toThrow(
+			expect(() => mw.deserialize([Buffer.from([0x1d])], {})).toThrow(
 				/Unexpected header byte/
 			);
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Two serializer changes that shrink the persistent cache, so cache files read and deserialize faster:

- `BinaryMiddleware`: add a fused `NULL_AND_I16` header (free byte `0x19`). Back-references are written as null + a relative offset; offsets that overflow an i8` `previously fell straight to `i32` (5 bytes) even though most fit an `i16`. They now pack into 3 bytes. The `i8`/`i32`/`f64` number-run prefixes are exhausted, so this targets the dominant null-prefixed reference path rather than a general `i16` run.

- `ObjectMiddleware`: when a string back-reference would be a 5-byte `i32`, inline the string instead if it's a tiny single-byte 2–3 char string (1 + length bytes is smaller). The `-32768` threshold accounts for the new `i16` tier so references in the 3-byte band are kept. The string is re-registered at the closer position, and since the deserializer already re-registers every inline length > 1 string, reference positions stay in sync and the on-disk format is unchanged.


<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->