### PR TITLE
fix: reject new import.defer()/import.source() member access as SyntaxError

### DIFF
--- a/.changeset/new-import-call-member-access.md
+++ b/.changeset/new-import-call-member-access.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reject `new import.defer(...)`/`new import.source(...)` with member access as a SyntaxError.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -3946,16 +3946,9 @@ class JavascriptParser extends Parser {
 	 * @param {NewExpression} expression new expression
 	 */
 	walkNewExpression(expression) {
-		// TODO: not a webpack bug — `acorn-import-phases` accepts
-		// `new import.defer(...)` / `new import.source(...)`, including member
-		// access on them (`new import.defer(...).x`), even though `ImportCall`
-		// is a `CallExpression` per spec and is therefore not a valid `new`
-		// operand. Acorn rejects bare `new import(...)` correctly. Drop this
-		// block once the upstream plugin (or acorn itself) reports the
-		// SyntaxError. We descend the leftmost callee chain to the base
-		// `ImportExpression`; parenthesized forms (`new (import.defer(...)).x`)
-		// share the AST shape, so we look at the source between `new` and that
-		// base (with comments stripped) to keep them valid.
+		// TODO acorn bug: `import.defer(...)`/`import.source(...)` (unlike bare
+		// `import(...)`) are wrongly accepted as `new` operands; drop once fixed.
+		// Parenthesized forms stay valid, so check for `(` before the import.
 		if (typeof this.state.source === "string") {
 			let base = expression.callee;
 			while (

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -3947,34 +3947,42 @@ class JavascriptParser extends Parser {
 	 */
 	walkNewExpression(expression) {
 		// TODO: not a webpack bug — `acorn-import-phases` accepts
-		// `new import.defer(...)` / `new import.source(...)` even though
-		// `ImportCall` is a `CallExpression` per spec and is therefore not a
-		// valid `new` operand. Acorn rejects bare `new import(...)` correctly.
-		// Drop this block once the upstream plugin (or acorn itself) reports
-		// the SyntaxError. Parenthesized forms (`new (import.defer(...))`)
-		// produce the same AST shape, so we look at the source between `new`
-		// and the callee (with comments stripped) to keep them valid.
-		if (
-			expression.callee.type === "ImportExpression" &&
-			typeof this.state.source === "string"
-		) {
-			const newStart = /** @type {Range} */ (expression.range)[0];
-			const calleeStart = /** @type {Range} */ (expression.callee.range)[0];
-			const between = this.state.source
-				.slice(newStart, calleeStart)
-				.replace(/\/\*[\s\S]*?\*\//g, "")
-				.replace(/\/\/[^\n]*/g, "");
-			if (!between.includes("(")) {
-				const err =
-					/** @type {SyntaxError & { loc?: { line: number, column: number } }} */
-					(new SyntaxError("import call cannot be the target of `new`"));
-				if (expression.loc) {
-					err.loc = {
-						line: expression.loc.start.line,
-						column: expression.loc.start.column
-					};
+		// `new import.defer(...)` / `new import.source(...)`, including member
+		// access on them (`new import.defer(...).x`), even though `ImportCall`
+		// is a `CallExpression` per spec and is therefore not a valid `new`
+		// operand. Acorn rejects bare `new import(...)` correctly. Drop this
+		// block once the upstream plugin (or acorn itself) reports the
+		// SyntaxError. We descend the leftmost callee chain to the base
+		// `ImportExpression`; parenthesized forms (`new (import.defer(...)).x`)
+		// share the AST shape, so we look at the source between `new` and that
+		// base (with comments stripped) to keep them valid.
+		if (typeof this.state.source === "string") {
+			let base = expression.callee;
+			while (
+				base.type === "MemberExpression" ||
+				base.type === "CallExpression"
+			) {
+				base = base.type === "MemberExpression" ? base.object : base.callee;
+			}
+			if (base.type === "ImportExpression") {
+				const newStart = /** @type {Range} */ (expression.range)[0];
+				const importStart = /** @type {Range} */ (base.range)[0];
+				const between = this.state.source
+					.slice(newStart, importStart)
+					.replace(/\/\*[\s\S]*?\*\//g, "")
+					.replace(/\/\/[^\n]*/g, "");
+				if (!between.includes("(")) {
+					const err =
+						/** @type {SyntaxError & { loc?: { line: number, column: number } }} */
+						(new SyntaxError("import call cannot be the target of `new`"));
+					if (expression.loc) {
+						err.loc = {
+							line: expression.loc.start.line,
+							column: expression.loc.start.column
+						};
+					}
+					throw err;
 				}
-				throw err;
 			}
 		}
 		const result = this.callHooksForExpression(

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -3946,9 +3946,9 @@ class JavascriptParser extends Parser {
 	 * @param {NewExpression} expression new expression
 	 */
 	walkNewExpression(expression) {
-		// TODO acorn bug: `import.defer(...)`/`import.source(...)` (unlike bare
-		// `import(...)`) are wrongly accepted as `new` operands; drop once fixed.
-		// Parenthesized forms stay valid, so check for `(` before the import.
+		// TODO acorn-import-phases bug: it omits acorn's `!forNew` guard, so
+		// `import.defer(...)`/`import.source(...)` are wrongly accepted as `new`
+		// operands; drop once fixed. Parenthesized forms stay valid (check `(`).
 		if (typeof this.state.source === "string") {
 			let base = expression.callee;
 			while (

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -989,4 +989,63 @@ describe("JavascriptParser", () => {
 			});
 		}
 	});
+
+	describe("new import call (acorn-import-phases)", () => {
+		beforeAll(() => {
+			const parser =
+				/** @type {typeof JavascriptParser & { __importPhasesExtended?: true }} */
+				(JavascriptParser);
+			if (!parser.__importPhasesExtended) {
+				JavascriptParser.extend(
+					require("acorn-import-phases")({ source: true, defer: true })
+				);
+				parser.__importPhasesExtended = true;
+			}
+		});
+
+		/**
+		 * @param {string} source source
+		 * @returns {Error | null} thrown error, if any
+		 */
+		function parse(source) {
+			try {
+				new JavascriptParser().parse(
+					source,
+					/** @type {import("../lib/Parser").ParserState} */ (
+						/** @type {unknown} */ ({ source })
+					)
+				);
+				return null;
+			} catch (err) {
+				return /** @type {Error} */ (err);
+			}
+		}
+
+		// `import.defer(...)`/`import.source(...)` are CallExpressions, so they
+		// cannot be the operand of `new`, including with member access (#21212).
+		for (const source of [
+			'new import.defer("x");',
+			'new import.defer("x").prop;',
+			'new import.defer("x").a.b;',
+			'new import.source("x").prop;'
+		]) {
+			it(`rejects ${JSON.stringify(source)}`, () => {
+				const err = parse(source);
+				expect(err).toBeInstanceOf(SyntaxError);
+				expect(/** @type {Error} */ (err).message).toBe(
+					"import call cannot be the target of `new`"
+				);
+			});
+		}
+
+		// Parenthesized forms and non-`new` member access stay valid.
+		for (const source of [
+			'new (import.defer("x")).prop;',
+			'import.defer("x").then(() => {});'
+		]) {
+			it(`accepts ${JSON.stringify(source)}`, () => {
+				expect(parse(source)).toBeNull();
+			});
+		}
+	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`new import.defer('').prop` and `new import.source('').prop` are accepted by webpack's parser but are `SyntaxError`s per spec — `ImportCall` is a `CallExpression`, so it cannot be a `new` operand. The root cause is an `acorn-import-phases` bug: its `parseExprImport` override omits acorn core's `!forNew` guard, so phased dynamic imports are wrongly parsed as `new` operands (acorn core rejects bare `new import(...)` correctly). webpack already rejected the bare `new import.defer('')` form; this extends the `walkNewExpression` guard to descend the leftmost callee chain to the base `ImportExpression`, so property-access forms are rejected too, while parenthesized forms (`new (import.defer('')).prop`) stay valid. Also bumps `test/test262-cases` to `de8e621`, which adds the new conformance tests and was failing the `test262 (2/2)` job. Supersedes #21161 and tracked by the follow-up issue for removing the workaround once upstream is fixed.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — covered by the bumped test262 suite (`expressions/dynamic-import/syntax/invalid/*-no-new-call-expression-prop-access.js`).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to investigate the failing test262 job, pinpoint the root cause in `acorn-import-phases`, implement the parser guard, and draft this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJebDPwpEY9GNLRNpPjjCV)_