### PR TITLE
perf: reduce always-on overhead of the lazy barrel optimization

### DIFF
--- a/.changeset/lazy-barrel-overhead.md
+++ b/.changeset/lazy-barrel-overhead.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce CPU and memory overhead of the lazy barrel optimization.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3482,6 +3482,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			this.rebuildQueue.clear();
 			this.processDependenciesQueue.clear();
 			this.addModuleQueue.clear();
+			// lazy barrel only acts during make; release its bookkeeping now
+			this._lazyBarrelController.clear();
 			return callback(err);
 		};
 

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -101,13 +101,15 @@ const memoize = require("./util/memoize");
 
 /**
  * Lazy barrel classification of a dependency within a side-effect-free module.
- * `{ id }`: named re-export deferred until the export name is requested.
- * `{ local }`: locally provided export name, requesting it requires no dependency.
+ * `LAZY_UNTIL_LOCAL`: locally provided export name (`getLazyName`), requesting it requires no dependency.
+ * `LAZY_UNTIL_ID`: named re-export (`getLazyName`) deferred until the export name is requested.
  * `LAZY_UNTIL_FALLBACK`: star re-export, deferred until an unknown name or all names are requested.
  * `LAZY_UNTIL_REQUEST`: deferred together with other dependencies of the same request.
- * @typedef {{ id: string } | { local: string } | "*" | "@"} LazyUntil
+ * @typedef {"local" | "id" | "*" | "@"} LazyUntil
  */
 
+const LAZY_UNTIL_LOCAL = /** @type {"local"} */ ("local");
+const LAZY_UNTIL_ID = /** @type {"id"} */ ("id");
 const LAZY_UNTIL_FALLBACK = /** @type {"*"} */ ("*");
 const LAZY_UNTIL_REQUEST = /** @type {"@"} */ ("@");
 
@@ -264,6 +266,14 @@ class Dependency {
 	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
 	 */
 	getLazyUntil() {
+		return null;
+	}
+
+	/**
+	 * Returns the export name for a `LAZY_UNTIL_LOCAL`/`LAZY_UNTIL_ID` classification (lazy barrel optimization).
+	 * @returns {string | null} export name, null when not applicable
+	 */
+	getLazyName() {
 		return null;
 	}
 
@@ -476,6 +486,8 @@ Object.defineProperty(Dependency.prototype, "disconnect", {
 });
 
 Dependency.TRANSITIVE = TRANSITIVE;
+Dependency.LAZY_UNTIL_LOCAL = LAZY_UNTIL_LOCAL;
+Dependency.LAZY_UNTIL_ID = LAZY_UNTIL_ID;
 Dependency.LAZY_UNTIL_FALLBACK = LAZY_UNTIL_FALLBACK;
 Dependency.LAZY_UNTIL_REQUEST = LAZY_UNTIL_REQUEST;
 

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -127,6 +127,16 @@ class LazyBarrelInfo {
 	}
 
 	/**
+	 * Drops the export-name lookups once no group stays deferred; they only serve
+	 * to find still-deferred groups, so keeping them per module wastes memory.
+	 */
+	_release() {
+		this._forwardIdToRequest.clear();
+		this._terminalIds = undefined;
+		this._fallbackRequests = undefined;
+	}
+
+	/**
 	 * Removes and returns the groups needed to provide the requested export names.
 	 * @param {Set<string> | true} forwardedIds requested export names, true for all
 	 * @returns {DependencyGroup[]} groups that must be processed now
@@ -146,6 +156,7 @@ class LazyBarrelInfo {
 		if (forwardedIds === true) {
 			for (const group of this._requestToDepGroup.values()) unlazy(group);
 			this._requestToDepGroup.clear();
+			this._release();
 			return result;
 		}
 		/**
@@ -169,6 +180,7 @@ class LazyBarrelInfo {
 				for (const fallbackKey of this._fallbackRequests) take(fallbackKey);
 			}
 		}
+		if (this._requestToDepGroup.size === 0) this._release();
 		return result;
 	}
 }
@@ -243,10 +255,11 @@ class LazyBarrelController {
 		if (state !== undefined) {
 			// barrel classified after its targets were already requested: replay the
 			// recorded ids so processDependency un-lazies and builds those targets now
-			state.lazyBarrelInfo = info;
 			info.request(state.forwardedIds);
 			// stay lazy only while some targets remain deferred
-			return !info.isEmpty();
+			if (info.isEmpty()) return false;
+			state.lazyBarrelInfo = info;
+			return true;
 		}
 
 		modules.set(module, {
@@ -291,6 +304,8 @@ class LazyBarrelController {
 		// Pending requests will be replayed during `classify` later
 		if (info === undefined) return;
 		const groups = info.request(forwardedIds);
+		// drop the per-module state once every deferred target has been built
+		if (info.isEmpty()) state.lazyBarrelInfo = undefined;
 		if (groups.length === 0) return;
 		return groups.map((group) => ({
 			factory: group.factory,

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -221,12 +221,14 @@ class LazyBarrelController {
 		for (const dep of dependencies) {
 			// TODO remove in webpack 6
 			// It may be missing on custom dependency types not extending the base Dependency
-			if (!("getLazyUntil" in dep && "setLazy" in dep)) continue;
+			if (!("getLazyUntil" in dep)) continue;
 
 			const until = dep.getLazyUntil();
 			// null (eager) and LAZY_UNTIL_LOCAL (terminal) defer nothing; terminals are
 			// only consulted alongside a star re-export, so they are recorded below
 			if (until === null || until === Dependency.LAZY_UNTIL_LOCAL) continue;
+			// deferrable: setLazy is needed to toggle its deferred state
+			if (!("setLazy" in dep)) continue;
 			const resourceIdent = dep.getResourceIdentifier();
 			if (resourceIdent === null) continue;
 			const factory = dependencyFactories.get(
@@ -296,12 +298,14 @@ class LazyBarrelController {
 	 * @returns {UnlazyDependencyInfo[] | undefined} items to process, if any
 	 */
 	request(module, dependencies) {
+		// state only exists for side-effect-free modules, so a non-side-effect-free
+		// module never has state — skip the WeakMap lookup entirely for it
+		const factoryMeta = module.factoryMeta;
+		if (factoryMeta === undefined || !factoryMeta.sideEffectFree) return;
 		const modules = this._modules;
 		const state = modules.get(module);
 
 		if (state === undefined) {
-			const factoryMeta = module.factoryMeta;
-			if (factoryMeta === undefined || !factoryMeta.sideEffectFree) return;
 			const forwardedIds = getForwardedIds(dependencies);
 			if (forwardedIds !== true && forwardedIds.size === 0) return;
 			modules.set(module, {

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -202,6 +202,14 @@ class LazyBarrelController {
 	}
 
 	/**
+	 * Releases all per-module deferral state. Lazy barrel only acts while the
+	 * module graph is built, so the bookkeeping is dead weight once make is done.
+	 */
+	clear() {
+		this._modules = new WeakMap();
+	}
+
+	/**
 	 * Classifies the re-export dependencies of a side-effect-free module (lazy barrel)
 	 * into deferrable groups and marks the deferred ones.
 	 * @param {Module} module the module whose dependencies are processed

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -213,21 +213,20 @@ class LazyBarrelController {
 		if (factoryMeta === undefined || !factoryMeta.sideEffectFree) {
 			return false;
 		}
+		const dependencies = module.dependencies;
 		const dependencyFactories = this._compilation.dependencyFactories;
 		/** @type {LazyBarrelInfo | undefined} */
 		let info;
-		for (const dep of module.dependencies) {
+		let hasFallback = false;
+		for (const dep of dependencies) {
 			// TODO remove in webpack 6
 			// It may be missing on custom dependency types not extending the base Dependency
 			if (!("getLazyUntil" in dep && "setLazy" in dep)) continue;
 
 			const until = dep.getLazyUntil();
-			if (until === null) continue;
-			if (info === undefined) info = new LazyBarrelInfo();
-			if (typeof until === "object" && "local" in until) {
-				info.addTerminal(until.local);
-				continue;
-			}
+			// null (eager) and LAZY_UNTIL_LOCAL (terminal) defer nothing; terminals are
+			// only consulted alongside a star re-export, so they are recorded below
+			if (until === null || until === Dependency.LAZY_UNTIL_LOCAL) continue;
 			const resourceIdent = dep.getResourceIdentifier();
 			if (resourceIdent === null) continue;
 			const factory = dependencyFactories.get(
@@ -240,17 +239,35 @@ class LazyBarrelController {
 				category === esmDependencyCategory
 					? resourceIdent
 					: `${category}${resourceIdent}`;
+			if (info === undefined) info = new LazyBarrelInfo();
 			info.addLazy(requestKey, dep, factory, dep.getContext());
-			if (typeof until === "object") {
-				info.addForwardId(until.id, requestKey);
+			if (until === Dependency.LAZY_UNTIL_ID) {
+				info.addForwardId(
+					/** @type {string} */ (dep.getLazyName()),
+					requestKey
+				);
 			} else if (until === Dependency.LAZY_UNTIL_FALLBACK) {
 				info.addFallback(requestKey);
+				hasFallback = true;
 			}
 		}
 		const state = modules.get(module);
-		if (info === undefined || info.isEmpty()) {
+		// info is only created once a deferrable target exists, so it is never empty here
+		if (info === undefined) {
 			if (state !== undefined) modules.delete(module);
 			return false;
+		}
+		// terminals only matter together with a star re-export (to avoid building it
+		// for a locally-provided name); skip the extra pass otherwise
+		if (hasFallback) {
+			for (const dep of dependencies) {
+				if (
+					"getLazyUntil" in dep &&
+					dep.getLazyUntil() === Dependency.LAZY_UNTIL_LOCAL
+				) {
+					info.addTerminal(/** @type {string} */ (dep.getLazyName()));
+				}
+			}
 		}
 		if (state !== undefined) {
 			// barrel classified after its targets were already requested: replay the

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const ConcatenationScope = require("../ConcatenationScope");
+const Dependency = require("../Dependency");
 const InitFragment = require("../InitFragment");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
@@ -17,7 +18,6 @@ const NullDependency = require("./NullDependency");
 const DEFAULT_EXPORT_NAME = "default";
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
-/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
 /** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
@@ -55,7 +55,15 @@ class HarmonyExportExpressionDependency extends NullDependency {
 	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
 	 */
 	getLazyUntil() {
-		return { local: DEFAULT_EXPORT_NAME };
+		return Dependency.LAZY_UNTIL_LOCAL;
+	}
+
+	/**
+	 * Returns the export name for a `LAZY_UNTIL_LOCAL`/`LAZY_UNTIL_ID` classification (lazy barrel optimization).
+	 * @returns {string | null} export name, null when not applicable
+	 */
+	getLazyName() {
+		return DEFAULT_EXPORT_NAME;
 	}
 
 	/**

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -554,8 +554,16 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	 */
 	getLazyUntil() {
 		return this.name !== null
-			? { id: this.name }
+			? Dependency.LAZY_UNTIL_ID
 			: Dependency.LAZY_UNTIL_FALLBACK;
+	}
+
+	/**
+	 * Returns the export name for a `LAZY_UNTIL_LOCAL`/`LAZY_UNTIL_ID` classification (lazy barrel optimization).
+	 * @returns {string | null} export name, null when not applicable
+	 */
+	getLazyName() {
+		return this.name;
 	}
 
 	/**

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const Dependency = require("../Dependency");
 const { InlinedUsedName } = require("../optimize/InlineExports");
 const makeSerializable = require("../util/makeSerializable");
 const ExportBindingInitFragment = require("./ExportBindingInitFragment");
@@ -12,7 +13,6 @@ const HarmonyExportInitFragment = require("./HarmonyExportInitFragment");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
-/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
 /** @typedef {import("../Dependency").LazyUntil} LazyUntil */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
@@ -48,7 +48,15 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 	 * @returns {LazyUntil | null} lazy classification, null when it must be processed eagerly
 	 */
 	getLazyUntil() {
-		return { local: this.name };
+		return Dependency.LAZY_UNTIL_LOCAL;
+	}
+
+	/**
+	 * Returns the export name for a `LAZY_UNTIL_LOCAL`/`LAZY_UNTIL_ID` classification (lazy barrel optimization).
+	 * @returns {string | null} export name, null when not applicable
+	 */
+	getLazyName() {
+		return this.name;
 	}
 
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -4795,6 +4795,8 @@ declare class ConstDependency extends NullDependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_LOCAL: "local";
+	static LAZY_UNTIL_ID: "id";
 	static LAZY_UNTIL_FALLBACK: "*";
 	static LAZY_UNTIL_REQUEST: "@";
 }
@@ -5600,7 +5602,7 @@ declare class CssModulesPlugin {
 	static chunkHasCss(chunk: Chunk, chunkGraph: ChunkGraph): boolean;
 }
 declare abstract class CssParser extends ParserClass {
-	defaultMode: "global" | "auto" | "pure" | "local";
+	defaultMode: "global" | "auto" | "local" | "pure";
 	options: {
 		/**
 		 * Enable/disable renaming of `@keyframes`.
@@ -5653,7 +5655,7 @@ declare abstract class CssParser extends ParserClass {
 		/**
 		 * default mode
 		 */
-		defaultMode?: "global" | "auto" | "pure" | "local";
+		defaultMode?: "global" | "auto" | "local" | "pure";
 	};
 	magicCommentContext: ContextImport;
 }
@@ -5845,7 +5847,12 @@ declare class Dependency {
 	/**
 	 * Returns how this dependency may be deferred when its parent module is side-effect-free (lazy barrel optimization).
 	 */
-	getLazyUntil(): null | "*" | "@" | { id: string } | { local: string };
+	getLazyUntil(): null | "local" | "id" | "*" | "@";
+
+	/**
+	 * Returns the export name for a `LAZY_UNTIL_LOCAL`/`LAZY_UNTIL_ID` classification (lazy barrel optimization).
+	 */
+	getLazyName(): null | string;
 
 	/**
 	 * Whether the lazy barrel currently defers creating this dependency's target module (lazy barrel optimization).
@@ -5950,6 +5957,8 @@ declare class Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_LOCAL: "local";
+	static LAZY_UNTIL_ID: "id";
 	static LAZY_UNTIL_FALLBACK: "*";
 	static LAZY_UNTIL_REQUEST: "@";
 }
@@ -9168,6 +9177,8 @@ declare class HarmonyImportDependency extends ModuleDependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_LOCAL: "local";
+	static LAZY_UNTIL_ID: "id";
 	static LAZY_UNTIL_FALLBACK: "*";
 	static LAZY_UNTIL_REQUEST: "@";
 }
@@ -15093,6 +15104,8 @@ declare class ModuleDependency extends Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_LOCAL: "local";
+	static LAZY_UNTIL_ID: "id";
 	static LAZY_UNTIL_FALLBACK: "*";
 	static LAZY_UNTIL_REQUEST: "@";
 }
@@ -17416,6 +17429,8 @@ declare class NullDependency extends Dependency {
 	 */
 	static canConcatenate(dependency: Dependency): boolean;
 	static TRANSITIVE: symbol;
+	static LAZY_UNTIL_LOCAL: "local";
+	static LAZY_UNTIL_ID: "id";
 	static LAZY_UNTIL_FALLBACK: "*";
 	static LAZY_UNTIL_REQUEST: "@";
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up perf/memory work on the lazy barrel optimization merged in #21165, which runs for every side-effect-free ESM module. This trims that always-on path: dependency classification is now allocation-free (a string tag + `getLazyName()` instead of a fresh `{ id }` / `{ local }` object per dependency), `LazyBarrelInfo` is allocated only when a module actually defers something, terminal export names are recorded only when a star re-export is present, the per-module lookups are released once targets are built, and the controller's per-module state is cleared after the make phase.

Net: barrel-heavy builds keep the large win from #21165 (e.g. importing 3 of 600 exports: ~8x faster, ~45% lower peak RSS), while builds that don't benefit (side-effect-free heavy, no barrels) stay flat on CPU and flat-or-lower on retained memory. Refs #21165.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new tests — behavior is unchanged and is covered by the existing `test/configCases/lazy-barrel`, `test/watchCases/lazy-barrel`, side-effects and stats suites (all passing).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to analyze #21165 for allocation/retention hotspots on the always-on path, implement these optimizations, and benchmark before/after; every change was measured and verified against the existing test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeX9EKwYM6yg5omUDEAyrw)_