### PR TITLE
fix: node-side CSS HMR and node-target workers for universal builds

### DIFF
--- a/.changeset/node-global-worker.md
+++ b/.changeset/node-global-worker.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve the global `new Worker(new URL(...))` to `worker_threads` on the `node` target.

--- a/.changeset/universal-css-hmr-node.md
+++ b/.changeset/universal-css-hmr-node.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Apply CSS hot updates on the Node side of a universal target.

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -383,6 +383,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 						}) {`,
 						Template.indent([
 							"installedChunks[chunkId] = null;",
+							// prefetch is a browser-only resource hint; no-op without a DOM (e.g. node side of a universal build)
 							isNeutralPlatform
 								? "if (typeof document === 'undefined') return;"
 								: "",
@@ -423,6 +424,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 						}) {`,
 						Template.indent([
 							"installedChunks[chunkId] = null;",
+							// preload is a browser-only resource hint; no-op without a DOM (e.g. node side of a universal build)
 							isNeutralPlatform
 								? "if (typeof document === 'undefined') return;"
 								: "",
@@ -493,7 +495,49 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 							"chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList, css",
 							[
 								isNeutralPlatform
-									? "if (typeof document === 'undefined') return;"
+									? Template.asString([
+											"if (typeof document === 'undefined') {",
+											Template.indent([
+												// node SSR: refresh the server style registry from the re-emitted CSS instead of touching the DOM
+												`${cst} cssRemovedChunks = css && css.r;`,
+												`${cst} registry = ${runtimeTemplate.cssServerStyleRegistry()};`,
+												`chunkIds.forEach(${runtimeTemplate.basicFunction(
+													"chunkId",
+													[
+														`${cst} key = "chunk-" + chunkId;`,
+														`if(${runtimeTemplate.optionalChaining(
+															"cssRemovedChunks",
+															"indexOf(chunkId)"
+														)} >= 0) { delete registry[key]; return; }`,
+														`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
+														`promises.push(Promise.all([import('fs'), import('url')]).then(${runtimeTemplate.basicFunction(
+															"[{ readFile }, { URL }]",
+															[
+																`return new Promise(${runtimeTemplate.basicFunction(
+																	"resolve",
+																	[
+																		// best-effort: a non-file publicPath (e.g. a CDN) can't be read from disk, so skip
+																		"try {",
+																		Template.indent([
+																			`readFile(new URL(url, ${importMetaName}.url), 'utf8', ${runtimeTemplate.basicFunction(
+																				"err, content",
+																				[
+																					"if (!err) registry[key] = content;",
+																					"resolve();"
+																				]
+																			)});`
+																		]),
+																		"} catch (e) { resolve(); }"
+																	]
+																)});`
+															]
+														)}));`
+													]
+												)});`,
+												"return;"
+											]),
+											"}"
+										])
 									: "",
 								"applyHandlers.push(applyHandler);",
 								"// Read CSS removed chunks from update manifest",

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -28,7 +28,7 @@ const ModuleDependency = require("./ModuleDependency");
  * @typedef {object} WorkerDependencyOptions
  * @property {string=} publicPath public path for the worker
  * @property {boolean=} needNewUrl true when need generate `new URL(...)`, otherwise false
- * @property {Range=} workerConstructorRange range of the global `Worker` constructor, set only for the `new Worker()` global syntax that needs a universal-target rewrite
+ * @property {Range=} workerConstructorRange range of the global `Worker` constructor, set only for the `new Worker()` global syntax that needs a node-target rewrite
  */
 
 class WorkerDependency extends ModuleDependency {
@@ -139,9 +139,13 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 			dep.options.needNewUrl ? `new URL(${workerImportStr})` : workerImportStr
 		);
 
-		// universal target: `Worker` is global only on the web, so route node through `worker_threads`
+		// `Worker` is global only on the web, so route node (universal or node-only) through `worker_threads`
+		const { platform } = runtimeTemplate.compilation.compiler;
 		const ctorRange = dep.options.workerConstructorRange;
-		if (ctorRange && runtimeTemplate.isUniversalTarget()) {
+		if (
+			ctorRange &&
+			(runtimeTemplate.isUniversalTarget() || (platform.node && !platform.web))
+		) {
 			runtimeRequirements.add(RuntimeGlobals.worker);
 			source.replace(ctorRange[0], ctorRange[1] - 1, RuntimeGlobals.worker);
 		}

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -265,6 +265,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 				? `${
 						RuntimeGlobals.prefetchChunkHandlers
 					}.j = ${runtimeTemplate.basicFunction("chunkId", [
+						// prefetch is a browser-only resource hint; no-op without a DOM (e.g. node side of a universal build)
 						isNeutralPlatform
 							? "if (typeof document === 'undefined') return;"
 							: "",
@@ -305,6 +306,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 				? `${
 						RuntimeGlobals.preloadChunkHandlers
 					}.j = ${runtimeTemplate.basicFunction("chunkId", [
+						// preload is a browser-only resource hint; no-op without a DOM (e.g. node side of a universal build)
 						isNeutralPlatform
 							? "if (typeof document === 'undefined') return;"
 							: "",

--- a/lib/runtime/WorkerRuntimeModule.js
+++ b/lib/runtime/WorkerRuntimeModule.js
@@ -21,7 +21,7 @@ class WorkerRuntimeModule extends HelperRuntimeModule {
 	generate() {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
-		// node has no global `Worker`; fall back to `worker_threads.Worker`
+		// prefer a global `Worker` when present (web, Bun, polyfills), else `worker_threads.Worker`
 		const nodeWorker = runtimeTemplate.getBuiltinModule(
 			runtimeTemplate.renderNodePrefixForCoreModule("worker_threads"),
 			".Worker"

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -312,7 +312,13 @@ const describeCases = (config) => {
 										if (isWeb) {
 											return bundles;
 										}
-										return [bundles[bundles.length - 1]];
+										// node runs the JS entry only; skip CSS/other assets that may sort last
+										const jsBundles = bundles.filter(
+											(/** @type {string} */ n) => /\.[cm]?js$/.test(n)
+										);
+										const nodeBundles =
+											jsBundles.length > 0 ? jsBundles : bundles;
+										return [nodeBundles[nodeBundles.length - 1]];
 									}
 								});
 								Promise.all(results).then(

--- a/test/configCases/worker/node-global-worker/index.js
+++ b/test/configCases/worker/node-global-worker/index.js
@@ -1,0 +1,13 @@
+it("should resolve a global `new Worker` to worker_threads on node", async () => {
+	const worker = new Worker(new URL("./worker.js", import.meta.url), {
+		type: "module"
+	});
+	const result = await new Promise((resolve, reject) => {
+		// node `worker_threads` exposes `.on`
+		worker.on("message", resolve);
+		worker.on("error", reject);
+		worker.postMessage("ok");
+	});
+	expect(result).toBe("data: OK, thanks");
+	await worker.terminate();
+});

--- a/test/configCases/worker/node-global-worker/module.js
+++ b/test/configCases/worker/node-global-worker/module.js
@@ -1,0 +1,3 @@
+export function upper(str) {
+	return str.toUpperCase();
+}

--- a/test/configCases/worker/node-global-worker/test.config.js
+++ b/test/configCases/worker/node-global-worker/test.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "./bundle0.mjs";
+	},
+	moduleScope(scope) {
+		scope.URL = URL;
+	}
+};

--- a/test/configCases/worker/node-global-worker/test.filter.js
+++ b/test/configCases/worker/node-global-worker/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+// the node Worker resolver uses `process.getBuiltinModule` (Node >= 22.3)
+module.exports = () =>
+	supportsWorker() && typeof process.getBuiltinModule === "function";

--- a/test/configCases/worker/node-global-worker/webpack.config.js
+++ b/test/configCases/worker/node-global-worker/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true
+	}
+};

--- a/test/configCases/worker/node-global-worker/worker.js
+++ b/test/configCases/worker/node-global-worker/worker.js
@@ -1,0 +1,7 @@
+import { parentPort } from "worker_threads";
+
+const { upper } = await import("./module.js");
+
+parentPort.on("message", (data) => {
+	parentPort.postMessage(`data: ${upper(data)}, thanks`);
+});

--- a/test/hotCases/universal/css-ssr-update/index.js
+++ b/test/hotCases/universal/css-ssr-update/index.js
@@ -1,0 +1,37 @@
+import * as styles from "./style.css";
+import update from "../../update.esm.js";
+
+import.meta.webpackHot.accept(["./style.css"]);
+
+// SSR registry lives on globalThis, namespaced by uniqueName
+function collectedCss() {
+	const key = Object.keys(globalThis).find((k) =>
+		k.startsWith("__webpack_css__")
+	);
+	return key ? globalThis[key] : undefined;
+}
+
+it("should refresh the node SSR style registry on CSS hot update", (done) => {
+	const initial = styles.foo;
+	expect(typeof initial).toBe("string");
+
+	NEXT(
+		update(done, true, () => {
+			import("./style.css")
+				.then((updated) => {
+					// CSS module locals stay stable across the update on both platforms
+					expect(updated.foo).toBe(initial);
+					if (typeof document === "undefined") {
+						// node: the re-emitted CSS file is read back into the SSR registry
+						const registry = collectedCss();
+						expect(registry).toBeTruthy();
+						expect(Object.values(registry).join("\n")).toContain(
+							"color: green"
+						);
+					}
+					done();
+				})
+				.catch(done);
+		})
+	);
+});

--- a/test/hotCases/universal/css-ssr-update/style.css
+++ b/test/hotCases/universal/css-ssr-update/style.css
@@ -1,0 +1,3 @@
+.foo { color: red; }
+---
+.foo { color: green; }

--- a/test/hotCases/universal/css-ssr-update/test.filter.js
+++ b/test/hotCases/universal/css-ssr-update/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+// node SSR style collection uses globalThis (node 12+); universal target assumes it
+module.exports = () => supportsGlobalThis();

--- a/test/hotCases/universal/css-ssr-update/webpack.config.js
+++ b/test/hotCases/universal/css-ssr-update/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	module: {
+		rules: [{ test: /\.css$/, type: "css/module" }]
+	},
+	experiments: { css: true },
+	// "auto" publicPath resolves to a file:// dir on node so SSR can read the CSS
+	output: { publicPath: "auto" }
+};

--- a/test/hotCases/universal/css/test.filter.js
+++ b/test/hotCases/universal/css/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+// node SSR style collection uses globalThis (node 12+); universal target assumes it
+module.exports = () => supportsGlobalThis();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes several remaining `target: "universal"` gaps. (1) CSS hot updates were skipped on the Node side of a universal build — the `.css` HMR handler bailed when there was no DOM, so the SSR style registry kept the stale CSS. It now refreshes the registry from the re-emitted CSS via `fs` (mirroring the existing initial-SSR collection), and falls back to a no-op when `publicPath` is not a readable `file:` URL. (2) The global `new Worker(new URL(...))` syntax was only rewritten to the `worker_threads` resolver for universal, so plain `target: "node"` emitted a bare `new Worker` and threw `ReferenceError` (no global `Worker` on Node) — the rewrite now also covers node-only targets. (3) The web-only prefetch/preload no-op on Node is now documented in code as intentional.

A small test-harness fix is included: the universal hot runner picked the trailing entry asset for the Node run, which is the `.css` file for CSS entries, so the Node side of universal CSS cases never executed; it now selects the JS entry.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/hotCases/universal/css-ssr-update/` (asserts the Node SSR registry is refreshed on CSS hot update) and `test/configCases/worker/node-global-worker/` (global `new Worker(new URL(...))` on `target: "node"`). Verified the full universal hot suite, all hot suites, and the worker/CSS/universal config cases stay green.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The universal-target docs (webpack.js.org) should note that CSS hot updates now apply on the Node side, that `new Worker(new URL(...))` works on `target: "node"`, and that prefetch/preload are intentional no-ops on Node. No in-repo docs exist for this.

**Use of AI**

Yes. Implemented and verified with Claude Code (Claude Opus) — it wrote the runtime/dependency changes and tests, ran the affected Jest suites, and empirically confirmed the gating (no universal-only code is generated for known `web`/`node` targets) and that Node's `fetch` cannot read `file:` URLs (so `fs` is required on the Node side). All changes were reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01StKhzBy14bRqSW85Kjh4Ym)_