### PR TITLE
refactor(css): clean up CssGenerator

### DIFF
--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -38,9 +38,7 @@ const {
 	walkFullHashPlaceholders
 } = require("../util/publicPathPlaceholder");
 
-// `<module-type>` always has a `<basic>/<sub>` shape, so testing this prefix is
-// equivalent to `type.split("/")[0] === CSS_TYPE` without the per-connection
-// array + substring allocation on the `getTypes` hot path.
+// Avoids `type.split("/")[0]` allocation on the `getTypes` hot path.
 const CSS_TYPE_PREFIX = `${CSS_TYPE}/`;
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -77,10 +75,7 @@ const getCssModulesPlugin = memoize(() => require("./CssModulesPlugin"));
 /** @typedef {import("webpack-sources").RawSourceMap} RawSourceMap */
 
 /**
- * Build a v3 source map that maps each line in `generatedJs` containing a
- * known CSS-class export entry back to the corresponding selector position
- * in the original CSS. Lines without an associated export are left
- * unmapped — devtools simply shows them as part of the bundled JS.
+ * Build a v3 source map mapping CSS-class export lines back to their selector positions.
  * @param {string} generatedJs the generated JS string
  * @param {ExportLocsMap} exportLocs map of export names to CSS source location
  * @param {string} cssContent original CSS source content
@@ -95,10 +90,7 @@ const buildExportsSourceMap = (
 ) => {
 	const lines = generatedJs.split("\n");
 
-	// Resolve each export's generated line in a single O(L) pass instead of
-	// scanning every line per export (O(E·L), pathological for export-heavy CSS
-	// modules). Export entries are emitted as `\t"<name>": <value>`, so a line's
-	// leading JSON-string key is matched against the requested names.
+	// O(L) pass: match `\t"<name>": <value>` lines against export names.
 	const keyToName = new Map();
 	for (const [exportName] of exportLocs) {
 		keyToName.set(JSON.stringify(exportName), exportName);
@@ -128,9 +120,7 @@ const buildExportsSourceMap = (
 	const perLine = lines.map(() => null);
 	for (const [exportName, genLine] of lineByExport) {
 		const pos = /** @type {SourcePosition} */ (exportLocs.get(exportName));
-		// Source-map V3 uses 0-based lines and 0-based columns. webpack's
-		// dependency `loc` uses 1-based lines and 0-based columns, so subtract
-		// one from the line.
+		// V3 source maps are 0-based; webpack `loc` lines are 1-based.
 		perLine[genLine] = {
 			generatedColumn: 0,
 			sourceIndex: 0,
@@ -164,8 +154,6 @@ class CssGenerator extends Generator {
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
 		const localIdentName = options.localIdentName;
-		// Pre-resolve whether the local-ident template needs (content)hashing so
-		// getLocalIdent skips re-running these template regexes per export.
 		this._localIdentNeedsHash =
 			typeof localIdentName === "function" ||
 			/\[(?:fullhash|hash)\]/.test(/** @type {string} */ (localIdentName));
@@ -186,229 +174,6 @@ class CssGenerator extends Generator {
 		}
 
 		return undefined;
-	}
-
-	/**
-	 * Returns the `@charset` that will appear at the start of this module's
-	 * default export, walking through text imports when the module has no
-	 * local `@charset` of its own.
-	 * @param {NormalModule} module the module
-	 * @param {ModuleGraph} moduleGraph module graph
-	 * @param {WeakSet<NormalModule>=} visited cycle guard
-	 * @returns {string | undefined} the effective charset
-	 */
-	_getEffectiveCharset(module, moduleGraph, visited = new WeakSet()) {
-		if (!module || visited.has(module)) return undefined;
-		const exportType = /** @type {CssModule} */ (module).exportType;
-		if (exportType !== "text" && exportType !== "css-style-sheet") {
-			return undefined;
-		}
-		visited.add(module);
-		const own =
-			module.buildInfo &&
-			/** @type {CssModuleBuildInfo} */ (module.buildInfo).charset;
-		if (own !== undefined) return own;
-		if (exportType !== "text") return undefined;
-		for (const dep of module.dependencies) {
-			if (dep instanceof CssImportDependency) {
-				const depModule = /** @type {NormalModule} */ (
-					moduleGraph.getModule(dep)
-				);
-				const inherited = this._getEffectiveCharset(
-					depModule,
-					moduleGraph,
-					visited
-				);
-				if (inherited !== undefined) return inherited;
-			}
-		}
-		return undefined;
-	}
-
-	/**
-	 * Generate JavaScript expressions that evaluate each `@import`'d module
-	 * for side effects. Only used by `style` exportType, where each imported
-	 * style module injects its own `<style>` element independently — no
-	 * content merging happens at the parent. `text` and `css-style-sheet`
-	 * instead inline their imports at build time via
-	 * {@link CssGenerator#_generateMergedContentSource}.
-	 * @param {NormalModule} module the module to generate CSS text for
-	 * @param {GenerateContext} generateContext the generate context
-	 * @returns {string[]} JS expressions, one per `@import` dependency
-	 */
-	_generateImportSideEffects(module, generateContext) {
-		const { moduleGraph, concatenationScope } = generateContext;
-		const parts = [];
-
-		for (const dep of module.dependencies) {
-			if (!(dep instanceof CssImportDependency)) continue;
-			const depModule = /** @type {CssModule} */ (moduleGraph.getModule(dep));
-			// Concat-scoped deps are inlined into the same module; their side
-			// effect (own `<style>` injection) is emitted at the dep's own
-			// site, so no explicit reference is needed here.
-			if (concatenationScope && concatenationScope.isModuleInScope(depModule)) {
-				continue;
-			}
-			parts.push(
-				generateContext.runtimeTemplate.moduleExports({
-					module: depModule,
-					chunkGraph: generateContext.chunkGraph,
-					request: depModule.userRequest,
-					weak: false,
-					runtimeRequirements: generateContext.runtimeRequirements
-				})
-			);
-		}
-
-		return parts;
-	}
-
-	/**
-	 * Build a single CSS `Source` that contains, in source order, the rendered
-	 * CSS text of every transitively `@import`'d module followed by the
-	 * current module's own CSS text. Imports are inlined at build time so
-	 * the resulting `Source` carries a single, accurate source map covering
-	 * every contributing file — no runtime merge helper required.
-	 *
-	 * Only `text` / `css-style-sheet` imports contribute CSS text; `link` and
-	 * `style` imports are emitted separately (own `.css` file or own
-	 * `<style>` injection) and are skipped here.
-	 *
-	 * `ancestors` tracks the path from the top-level caller down to the
-	 * current module — not every module ever visited. A module reappearing
-	 * along a sibling branch (a "diamond import" like two different files
-	 * each `@import`'ing the same shared module) must be inlined every time,
-	 * matching the prior runtime behavior where each `default` getter was
-	 * invoked at every import site.
-	 * @param {NormalModule} module the module to render
-	 * @param {GenerateContext} generateContext the generate context
-	 * @param {Set<NormalModule>} ancestors modules on the current path
-	 * @returns {Source | null} merged CSS source, or null when the module has no content
-	 */
-	_generateMergedContentSource(module, generateContext, ancestors) {
-		if (ancestors.has(module)) return null;
-		ancestors.add(module);
-		try {
-			const { moduleGraph } = generateContext;
-			/** @type {Source[]} */
-			const parts = [];
-
-			for (const dep of module.dependencies) {
-				if (!(dep instanceof CssImportDependency)) continue;
-				const depModule = /** @type {CssModule} */ (moduleGraph.getModule(dep));
-				if (!depModule) continue;
-				const depExportType = depModule.exportType;
-				if (depExportType !== "text" && depExportType !== "css-style-sheet") {
-					continue;
-				}
-				const depMerged = this._generateMergedContentSource(
-					depModule,
-					generateContext,
-					ancestors
-				);
-				if (depMerged) parts.push(depMerged);
-			}
-
-			const own = this._generateContentSource(module, generateContext);
-			if (own) parts.push(own);
-
-			if (parts.length === 0) return null;
-			if (parts.length === 1) return parts[0];
-			return new ConcatSource(...parts);
-		} finally {
-			ancestors.delete(module);
-		}
-	}
-
-	/**
-	 * Generate CSS source for the current module
-	 * @param {NormalModule} module the module to generate CSS source for
-	 * @param {GenerateContext} generateContext the generate context
-	 * @returns {Source | null} the CSS source
-	 */
-	_generateContentSource(module, generateContext) {
-		const moduleSourceContent = /** @type {Source} */ (
-			this.generate(module, {
-				...generateContext,
-				type: CSS_TYPE
-			})
-		);
-
-		if (!moduleSourceContent) {
-			return null;
-		}
-
-		const compilation = generateContext.runtimeTemplate.compilation;
-		// For non-link exportTypes (style, text, css-style-sheet), url() in the CSS
-		// is resolved relative to the document URL (for <style> tags and CSSStyleSheet),
-		// not relative to any output file. Use empty undoPath so urls are relative to
-		// the output root.
-		const undoPath = "";
-
-		const CssModulesPlugin = getCssModulesPlugin();
-		const hooks = CssModulesPlugin.getCompilationHooks(compilation);
-		return CssModulesPlugin.renderModule(
-			/** @type {CssModule} */ (module),
-			{
-				undoPath,
-				moduleSourceContent,
-				moduleFactoryCache: this._moduleFactoryCache,
-				runtimeTemplate: generateContext.runtimeTemplate
-			},
-			hooks
-		);
-	}
-
-	/**
-	 * Serialize a CSS Source into a JS string literal with an optional
-	 * inline `sourceMappingURL` data URI so DevTools can resolve the
-	 * original sources at runtime.
-	 *
-	 * Inlined CSS (`style`/`text`/`css-style-sheet`) is emitted at code
-	 * generation time, before the compilation hash exists, so a `[fullhash]`
-	 * in a `url()` public path is left as the `PUBLIC_PATH_FULL_HASH`
-	 * placeholder by `renderModule`. Splice `__webpack_require__.h()` into the
-	 * literal so the hash is resolved at runtime (mirrors `renderModule`'s
-	 * build-time substitution for the `link` path).
-	 * @param {Source} cssSource the CSS source
-	 * @param {import("../../declarations/WebpackOptions").DevTool | undefined} devtool the devtool option
-	 * @param {GenerateContext} generateContext the generate context
-	 * @returns {Source} a Source representing a JS string literal
-	 */
-	_cssToJsLiteral(cssSource, devtool, generateContext) {
-		const { source, map } = cssSource.sourceAndMap();
-		let content = /** @type {string} */ (source);
-		if (map) {
-			const inlineMap =
-				typeof devtool === "string" && devtool.includes("nosources")
-					? { ...map, sourcesContent: undefined }
-					: map;
-			const base64Map = Buffer.from(JSON.stringify(inlineMap), "utf8").toString(
-				"base64"
-			);
-			const trailingNewline = content.endsWith("\n") ? "" : "\n";
-			content += `${trailingNewline}/*# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Map}*/`;
-		}
-
-		if (!content.includes(PUBLIC_PATH_FULL_HASH)) {
-			return new RawSource(JSON.stringify(content));
-		}
-
-		const result = new ConcatSource();
-		let last = 0;
-		walkFullHashPlaceholders(content, (start, end, length) => {
-			result.add(JSON.stringify(content.slice(last, start)));
-			result.add(
-				length === 0
-					? ` + ${RuntimeGlobals.getFullHash}() + `
-					: ` + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + `
-			);
-			last = end;
-		});
-
-		result.add(JSON.stringify(content.slice(last)));
-		generateContext.runtimeRequirements.add(RuntimeGlobals.getFullHash);
-		return result;
 	}
 
 	/**
@@ -537,10 +302,7 @@ class CssGenerator extends Generator {
 				const generateContentCode = () => {
 					switch (exportType) {
 						case "style": {
-							const cssSource = this._generateContentSource(
-								module,
-								generateContext
-							);
+							const cssSource = this._renderCss(module, generateContext);
 							if (!cssSource) return "";
 
 							generateContext.runtimeRequirements.add(
@@ -573,7 +335,7 @@ class CssGenerator extends Generator {
 				const generateImportCode = () => {
 					switch (exportType) {
 						case "style": {
-							return this._generateImportSideEffects(module, generateContext)
+							return this._generateImportExpressions(module, generateContext)
 								.map((expr) => `${expr};`)
 								.join("\n");
 						}
@@ -582,31 +344,6 @@ class CssGenerator extends Generator {
 					}
 				};
 				const generateExportCode = () => {
-					/** @returns {Source} generated CSS text as JS expression */
-					const generateCssText = () => {
-						const cssSource = this._generateMergedContentSource(
-							module,
-							generateContext,
-							new Set()
-						);
-
-						let jsLiteral = cssSource
-							? this._cssToJsLiteral(cssSource, devtool, generateContext)
-							: new RawSource('""');
-
-						const effectiveCharset =
-							exportType === "css-style-sheet" || exportType === "text"
-								? this._getEffectiveCharset(module, generateContext.moduleGraph)
-								: undefined;
-						if (effectiveCharset !== undefined) {
-							jsLiteral = new ConcatSource(
-								`'@charset "${effectiveCharset}";\\n' + `,
-								jsLiteral
-							);
-						}
-
-						return jsLiteral;
-					};
 					/**
 					 * Generates js default export.
 					 * @returns {Source | null} the default export
@@ -614,40 +351,33 @@ class CssGenerator extends Generator {
 					const generateJSDefaultExport = () => {
 						switch (exportType) {
 							case "text": {
-								return generateCssText();
+								return this._generateCssText(module, generateContext, true);
 							}
 							case "css-style-sheet": {
-								// Build a constructable stylesheet from the statically
-								// merged CSS text. The merged literal carries a single
-								// inline source map covering every contributing module.
 								const rt = generateContext.runtimeTemplate;
 								const fnPrefix = rt.supportsArrowFunction()
 									? "() => {\n"
 									: "function() {\n";
 								const constOrVar = rt.renderConst();
-								// non-arrow so `this` binds to the fallback object on `.replaceSync()`
 								const fallback =
 									"{ cssText: css, replaceSync: function(value) { this.cssText = value; } }";
-								// node has no `CSSStyleSheet`: expose the css text for SSR
 								if (rt.compilation.compiler.platform.node === true) {
 									return new ConcatSource(
 										`(${fnPrefix}${constOrVar} css = `,
-										generateCssText(),
+										this._generateCssText(module, generateContext, true),
 										`;\nreturn ${fallback};\n})()`
 									);
 								}
-								// universal: choose a real stylesheet or the text object at runtime
 								if (rt.isUniversalTarget()) {
 									return new ConcatSource(
 										`(${fnPrefix}${constOrVar} css = `,
-										generateCssText(),
+										this._generateCssText(module, generateContext, true),
 										`;\nif (typeof CSSStyleSheet === 'undefined') return ${fallback};\n${constOrVar} sheet = new CSSStyleSheet();\nsheet.replaceSync(css);\nreturn sheet;\n})()`
 									);
 								}
-								// web: a real constructable stylesheet
 								return new ConcatSource(
 									`(${fnPrefix}${constOrVar} sheet = new CSSStyleSheet();\nsheet.replaceSync(`,
-									generateCssText(),
+									this._generateCssText(module, generateContext, true),
 									");\nreturn sheet;\n})()"
 								);
 							}
@@ -676,12 +406,10 @@ class CssGenerator extends Generator {
 						/** @type {Set<string>} */
 						const usedIdentifiers = new Set();
 						const { RESERVED_IDENTIFIER } = getPropertyName();
-						// Resolve the module's ExportsInfo once for all exports below.
 						const exportsInfo =
 							generateContext.moduleGraph.getExportsInfo(module);
 
 						if (defaultExport) {
-							// CSS module exports are never inlined to primitives
 							const usedName = /** @type {string | false} */ (
 								exportsInfo
 									.getExportInfo("default")
@@ -706,7 +434,6 @@ class CssGenerator extends Generator {
 						}
 
 						for (const [name, v] of cssData.exports) {
-							// CSS module exports are never inlined to primitives
 							const usedName = /** @type {string | false} */ (
 								exportsInfo
 									.getExportInfo(name)
@@ -803,7 +530,6 @@ class CssGenerator extends Generator {
 						source.add("\n");
 					}
 				}
-				// For link-type modules without any JS emit, skip source wrapping
 				if (
 					exportType === "link" &&
 					!isCssModule &&
@@ -817,9 +543,6 @@ class CssGenerator extends Generator {
 					compilation.requestShortener
 				);
 
-				// When per-export source positions are available, emit a
-				// SourceMapSource mapping each export line back to its CSS
-				// selector; otherwise fall back to OriginalSource.
 				if (
 					/** @type {ExportLocsMap} */
 					(cssData.exportLocs).size > 0
@@ -839,42 +562,14 @@ class CssGenerator extends Generator {
 				return new OriginalSource(generatedJs, sourceName);
 			}
 			case CSS_TYPE: {
-				if (!(this._exportsOnly || (exportType && exportType !== "link"))) {
+				if (!(this._exportsOnly || exportType !== "link")) {
 					generateContext.runtimeRequirements.add(RuntimeGlobals.hasCssModules);
 				}
 
 				return InitFragment.addToSource(source, initFragments, generateContext);
 			}
-			case CSS_TEXT_TYPE: {
-				// The merged CSS text — what consumers like
-				// `HtmlInlineStyleDependency.Template` need when they want to
-				// drop the processed CSS straight into an inline `<style>`
-				// tag. Mirrors the JS-side `generateCssText()` (charset
-				// prefix included), without the JS string-literal wrapper.
-				const cssSource = this._generateMergedContentSource(
-					module,
-					generateContext,
-					new Set()
-				);
-
-				const effectiveCharset = this._getEffectiveCharset(
-					module,
-					generateContext.moduleGraph
-				);
-				const charsetPrefix =
-					effectiveCharset !== undefined
-						? `@charset "${effectiveCharset}";\n`
-						: "";
-
-				if (!cssSource) {
-					return charsetPrefix
-						? new RawSource(charsetPrefix)
-						: new RawSource("");
-				}
-				return charsetPrefix
-					? new ConcatSource(charsetPrefix, cssSource)
-					: cssSource;
-			}
+			case CSS_TEXT_TYPE:
+				return this._generateCssText(module, generateContext, false);
 			default:
 				return null;
 		}
@@ -913,9 +608,6 @@ class CssGenerator extends Generator {
 			return JAVASCRIPT_TYPES;
 		}
 
-		// Recomputed per call on a hot path (see Module#getReferencedSourceTypes),
-		// so track the two reachable types as flags and return interned sets
-		// instead of allocating a Set every time.
 		let hasJs = false;
 		let hasCssText = false;
 		const connections = this._moduleGraph.getIncomingConnections(module);
@@ -929,17 +621,11 @@ class CssGenerator extends Generator {
 				continue;
 			}
 
-			// when no hmr required, css module js output contains no sideEffects at all
-			// js sideeffect connection doesn't require js type output
 			if (connection.dependency instanceof HarmonyImportSideEffectDependency) {
 				continue;
 			}
 
-			// Inline `<style>` blocks and `style="..."` attributes in HTML
-			// modules read the merged CSS text directly via the `css-text`
-			// source type — they don't go through the JS-string wrapper that
-			// other consumers use. Matched by dependency category so the CSS
-			// package doesn't have to import HtmlInlineStyleDependency.
+			// HTML inline styles consume CSS_TEXT_TYPE directly.
 			if (
 				connection.dependency &&
 				(connection.dependency.category === "html-style" ||
@@ -957,21 +643,14 @@ class CssGenerator extends Generator {
 				hasJs = true;
 			} else {
 				const originModule = /** @type {CssModule} */ connection.originModule;
-				const originExportType = /** @type {CssModule} */ (originModule)
-					.exportType;
-				if (
-					/** @type {boolean} */ (
-						originExportType && originExportType !== "link"
-					)
-				) {
+				const originExportType =
+					/** @type {CssModule} */ (originModule).exportType || "link";
+				if (originExportType !== "link") {
 					hasJs = true;
 				}
 			}
 		}
-		if (
-			this._exportsOnly ||
-			/** @type {boolean} */ (exportType && exportType !== "link")
-		) {
+		if (this._exportsOnly || exportType !== "link") {
 			if (hasJs && hasCssText) return JAVASCRIPT_AND_CSS_TEXT_TYPES;
 			if (hasJs) return JAVASCRIPT_TYPES;
 			if (hasCssText) return CSS_TEXT_TYPES;
@@ -1022,6 +701,7 @@ class CssGenerator extends Generator {
 
 				return stringifiedExports.length + 42;
 			}
+			case CSS_TEXT_TYPE:
 			case CSS_TYPE: {
 				const originalSource = module.originalSource();
 
@@ -1044,6 +724,226 @@ class CssGenerator extends Generator {
 	updateHash(hash, { module }) {
 		hash.update(/** @type {boolean} */ (this._esModule).toString());
 		hash.update(/** @type {boolean} */ (this._exportsOnly).toString());
+	}
+
+	/**
+	 * Resolve the effective `@charset` by walking text imports.
+	 * @param {NormalModule} module the module
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @param {WeakSet<NormalModule>=} visited cycle guard
+	 * @returns {string | undefined} the effective charset
+	 */
+	_getEffectiveCharset(module, moduleGraph, visited = new WeakSet()) {
+		if (!module || visited.has(module)) return undefined;
+		const exportType = /** @type {CssModule} */ (module).exportType;
+		if (exportType !== "text" && exportType !== "css-style-sheet") {
+			return undefined;
+		}
+		visited.add(module);
+		const own =
+			module.buildInfo &&
+			/** @type {CssModuleBuildInfo} */ (module.buildInfo).charset;
+		if (own !== undefined) return own;
+		if (exportType !== "text") return undefined;
+		for (const dep of module.dependencies) {
+			if (dep instanceof CssImportDependency) {
+				const depModule = /** @type {NormalModule} */ (
+					moduleGraph.getModule(dep)
+				);
+				const inherited = this._getEffectiveCharset(
+					depModule,
+					moduleGraph,
+					visited
+				);
+				if (inherited !== undefined) return inherited;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Generate JS expressions for `@import` side effects (`style` exportType only).
+	 * @param {NormalModule} module the module to generate CSS text for
+	 * @param {GenerateContext} generateContext the generate context
+	 * @returns {string[]} JS expressions, one per `@import` dependency
+	 */
+	_generateImportExpressions(module, generateContext) {
+		const { moduleGraph, concatenationScope } = generateContext;
+		const parts = [];
+
+		for (const dep of module.dependencies) {
+			if (!(dep instanceof CssImportDependency)) continue;
+			const depModule = /** @type {CssModule} */ (moduleGraph.getModule(dep));
+			if (concatenationScope && concatenationScope.isModuleInScope(depModule)) {
+				continue;
+			}
+			parts.push(
+				generateContext.runtimeTemplate.moduleExports({
+					module: depModule,
+					chunkGraph: generateContext.chunkGraph,
+					request: depModule.userRequest,
+					weak: false,
+					runtimeRequirements: generateContext.runtimeRequirements
+				})
+			);
+		}
+
+		return parts;
+	}
+
+	/**
+	 * Recursively merge `@import`'d CSS into a single Source (text/css-style-sheet only).
+	 * @param {NormalModule} module the module to render
+	 * @param {GenerateContext} generateContext the generate context
+	 * @param {Set<NormalModule>} ancestors modules on the current path (cycle guard)
+	 * @returns {Source | null} merged CSS source, or null when the module has no content
+	 */
+	_renderMergedCss(module, generateContext, ancestors) {
+		if (ancestors.has(module)) return null;
+		ancestors.add(module);
+		try {
+			const { moduleGraph } = generateContext;
+			/** @type {Source[]} */
+			const parts = [];
+
+			for (const dep of module.dependencies) {
+				if (!(dep instanceof CssImportDependency)) continue;
+				const depModule = /** @type {CssModule} */ (moduleGraph.getModule(dep));
+				if (!depModule) continue;
+				const depExportType = depModule.exportType;
+				if (depExportType !== "text" && depExportType !== "css-style-sheet") {
+					continue;
+				}
+				const depMerged = this._renderMergedCss(
+					depModule,
+					generateContext,
+					ancestors
+				);
+				if (depMerged) parts.push(depMerged);
+			}
+
+			const own = this._renderCss(module, generateContext);
+			if (own) parts.push(own);
+
+			if (parts.length === 0) return null;
+			if (parts.length === 1) return parts[0];
+			return new ConcatSource(...parts);
+		} finally {
+			ancestors.delete(module);
+		}
+	}
+
+	/**
+	 * Generate CSS source for the current module
+	 * @param {NormalModule} module the module to generate CSS source for
+	 * @param {GenerateContext} generateContext the generate context
+	 * @returns {Source | null} the CSS source
+	 */
+	_renderCss(module, generateContext) {
+		const moduleSourceContent = /** @type {Source} */ (
+			this.generate(module, {
+				...generateContext,
+				type: CSS_TYPE
+			})
+		);
+
+		if (!moduleSourceContent) {
+			return null;
+		}
+
+		const compilation = generateContext.runtimeTemplate.compilation;
+		const undoPath = "";
+
+		const CssModulesPlugin = getCssModulesPlugin();
+		const hooks = CssModulesPlugin.getCompilationHooks(compilation);
+		return CssModulesPlugin.renderModule(
+			/** @type {CssModule} */ (module),
+			{
+				undoPath,
+				moduleSourceContent,
+				moduleFactoryCache: this._moduleFactoryCache,
+				runtimeTemplate: generateContext.runtimeTemplate
+			},
+			hooks
+		);
+	}
+
+	/**
+	 * Convert a CSS Source into a JS string literal, splicing `__webpack_require__.h()` for `[fullhash]` placeholders.
+	 * @param {Source} cssSource the CSS source
+	 * @param {import("../../declarations/WebpackOptions").DevTool | undefined} devtool the devtool option
+	 * @param {GenerateContext} generateContext the generate context
+	 * @returns {Source} a Source representing a JS string literal
+	 */
+	_cssToJsLiteral(cssSource, devtool, generateContext) {
+		const { source, map } = cssSource.sourceAndMap();
+		let content = /** @type {string} */ (source);
+		if (map) {
+			const inlineMap =
+				typeof devtool === "string" && devtool.includes("nosources")
+					? { ...map, sourcesContent: undefined }
+					: map;
+			const base64Map = Buffer.from(JSON.stringify(inlineMap), "utf8").toString(
+				"base64"
+			);
+			const trailingNewline = content.endsWith("\n") ? "" : "\n";
+			content += `${trailingNewline}/*# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Map}*/`;
+		}
+
+		if (!content.includes(PUBLIC_PATH_FULL_HASH)) {
+			return new RawSource(JSON.stringify(content));
+		}
+
+		const result = new ConcatSource();
+		let last = 0;
+		walkFullHashPlaceholders(content, (start, end, length) => {
+			result.add(JSON.stringify(content.slice(last, start)));
+			result.add(
+				length === 0
+					? ` + ${RuntimeGlobals.getFullHash}() + `
+					: ` + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + `
+			);
+			last = end;
+		});
+
+		result.add(JSON.stringify(content.slice(last)));
+		generateContext.runtimeRequirements.add(RuntimeGlobals.getFullHash);
+		return result;
+	}
+
+	/**
+	 * Generate the merged CSS text for a module, optionally wrapped as a
+	 * JS string literal for embedding in JavaScript output.
+	 * @param {NormalModule} module the module
+	 * @param {GenerateContext} generateContext the generate context
+	 * @param {boolean} asJsLiteral wrap the result as a JS string literal
+	 * @returns {Source} the CSS text source
+	 */
+	_generateCssText(module, generateContext, asJsLiteral) {
+		const cssSource = this._renderMergedCss(module, generateContext, new Set());
+		const effectiveCharset = this._getEffectiveCharset(
+			module,
+			generateContext.moduleGraph
+		);
+
+		let result;
+		if (effectiveCharset !== undefined) {
+			const prefix = `@charset "${effectiveCharset}";\n`;
+			result = cssSource
+				? new ConcatSource(prefix, cssSource)
+				: new RawSource(prefix);
+		} else {
+			result = cssSource;
+		}
+
+		if (asJsLiteral) {
+			const devtool =
+				generateContext.runtimeTemplate.compilation.options.devtool;
+			return result
+				? this._cssToJsLiteral(result, devtool, generateContext)
+				: new RawSource('""');
+		}
+		return result || new RawSource("");
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Clean up `CssGenerator` for readability: extract shared `_generateCssText` method, reorder methods (public before private), add missing `CSS_TEXT_TYPE` to `getSize`, rename internal methods to match webpack conventions, and trim verbose comments.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No, this is a pure refactor with no behavioral changes.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to implement the refactoring changes under human direction and review.