### PR TITLE
docs: add Hot Module Replacement examples for web, node and universal

### DIFF
--- a/examples/hot-module-replacement/README.md
+++ b/examples/hot-module-replacement/README.md
@@ -87,6 +87,7 @@ const { HotModuleReplacementPlugin } = require("../../");
 
 // `webpack` resolves to this repo only because the example lives inside it;
 // real projects can drop this alias and import `webpack/hot/*` directly.
+/** @type {import("../../").Configuration} */
 const base = {
 	mode: "development",
 	context: __dirname,

--- a/examples/hot-module-replacement/README.md
+++ b/examples/hot-module-replacement/README.md
@@ -1,0 +1,133 @@
+This example shows Hot Module Replacement (HMR) for the three platform setups, all sharing one module that gets hot-swapped at runtime.
+
+The download/apply runtime is the same everywhere; only the **trigger** (what tells the app to check for an update) differs:
+
+- **Web** — `webpack/hot/dev-server` reacts to the update signal pushed by `webpack-dev-server` over EventSource. Run it with `webpack serve`.
+- **Node** — there is no EventSource, so a Node trigger drives the check: `webpack/hot/poll` re-checks on a timer (`webpack/hot/signal` waits for a process signal). Run it with `webpack --watch` and `node dist/node/main.js`, then edit `message.js`.
+- **Universal** — one ESM bundle for web *and* Node. `webpack/hot/dev-server` is universal: it consumes the same update signal on either platform (a browser dev-server, or a Node dev-server/middleware feeding the emitter), so no per-target client is needed.
+
+Edit `message.js` while the app runs to see the module reload in place — no full restart, no page reload.
+
+# message.js
+
+```javascript
+module.exports =
+	"Hello! Edit this message, save, and watch HMR swap it in without a reload.";
+```
+
+# web.js
+
+```javascript
+// Browser HMR: webpack-dev-server pushes update signals over EventSource and
+// the dev-server client runs the check. Start it with `webpack serve`.
+import "webpack/hot/dev-server";
+
+const render = () => {
+	document.body.textContent = require("./message");
+};
+
+render();
+
+if (module.hot) {
+	module.hot.accept("./message", render);
+}
+```
+
+# node.js
+
+```javascript
+// Node HMR: there is no EventSource, so a Node trigger drives the check.
+// `webpack/hot/poll` re-checks on a timer; `webpack/hot/signal` waits for
+// SIGUSR2. Run with `webpack --watch` and `node dist/node/main.js`.
+import "webpack/hot/poll?1000";
+
+const render = () => {
+	console.log("message:", require("./message"));
+};
+
+render();
+
+if (module.hot) {
+	module.hot.accept("./message", render);
+}
+```
+
+# universal.js
+
+```javascript
+// One ESM bundle for web and Node. The dev-server client is universal: it
+// listens for the same update signal on either platform (browser dev-server,
+// or a Node dev-server/middleware feeding the emitter), so no per-target client
+// is needed.
+import message from "./message";
+import "webpack/hot/dev-server";
+
+const render = () => {
+	if (typeof document !== "undefined") {
+		document.body.textContent = message;
+	} else {
+		console.log("message:", message);
+	}
+};
+
+render();
+
+if (import.meta.webpackHot) {
+	import.meta.webpackHot.accept("./message", render);
+}
+```
+
+# webpack.config.js
+
+```javascript
+"use strict";
+
+const path = require("path");
+const { HotModuleReplacementPlugin } = require("../../");
+
+// `webpack` resolves to this repo only because the example lives inside it;
+// real projects can drop this alias and import `webpack/hot/*` directly.
+const base = {
+	mode: "development",
+	context: __dirname,
+	devtool: false,
+	resolve: { alias: { webpack: path.resolve(__dirname, "../../") } },
+	plugins: [new HotModuleReplacementPlugin()]
+};
+
+/** @type {import("../../").Configuration[]} */
+const config = [
+	// Web — driven by webpack-dev-server (`webpack serve`).
+	{
+		...base,
+		name: "web",
+		target: "web",
+		entry: "./web.js",
+		output: { path: path.resolve(__dirname, "dist/web"), filename: "main.js" }
+	},
+	// Node — driven by webpack/hot/poll (`webpack --watch` + `node dist/node/main.js`).
+	{
+		...base,
+		name: "node",
+		target: "node",
+		entry: "./node.js",
+		output: { path: path.resolve(__dirname, "dist/node"), filename: "main.js" }
+	},
+	// Universal — single ESM bundle for web + Node, one dev-server client.
+	{
+		...base,
+		name: "universal",
+		target: ["web", "node"],
+		entry: "./universal.js",
+		experiments: { outputModule: true },
+		output: {
+			path: path.resolve(__dirname, "dist/universal"),
+			filename: "main.mjs",
+			module: true,
+			chunkFormat: "module"
+		}
+	}
+];
+
+module.exports = config;
+```

--- a/examples/hot-module-replacement/build.js
+++ b/examples/hot-module-replacement/build.js
@@ -1,0 +1,2 @@
+global.NO_TARGET_ARGS = true;
+require("../build-common");

--- a/examples/hot-module-replacement/message.js
+++ b/examples/hot-module-replacement/message.js
@@ -1,0 +1,2 @@
+module.exports =
+	"Hello! Edit this message, save, and watch HMR swap it in without a reload.";

--- a/examples/hot-module-replacement/node.js
+++ b/examples/hot-module-replacement/node.js
@@ -1,0 +1,14 @@
+// Node HMR: there is no EventSource, so a Node trigger drives the check.
+// `webpack/hot/poll` re-checks on a timer; `webpack/hot/signal` waits for
+// SIGUSR2. Run with `webpack --watch` and `node dist/node/main.js`.
+import "webpack/hot/poll?1000";
+
+const render = () => {
+	console.log("message:", require("./message"));
+};
+
+render();
+
+if (module.hot) {
+	module.hot.accept("./message", render);
+}

--- a/examples/hot-module-replacement/template.md
+++ b/examples/hot-module-replacement/template.md
@@ -1,0 +1,39 @@
+This example shows Hot Module Replacement (HMR) for the three platform setups, all sharing one module that gets hot-swapped at runtime.
+
+The download/apply runtime is the same everywhere; only the **trigger** (what tells the app to check for an update) differs:
+
+- **Web** — `webpack/hot/dev-server` reacts to the update signal pushed by `webpack-dev-server` over EventSource. Run it with `webpack serve`.
+- **Node** — there is no EventSource, so a Node trigger drives the check: `webpack/hot/poll` re-checks on a timer (`webpack/hot/signal` waits for a process signal). Run it with `webpack --watch` and `node dist/node/main.js`, then edit `message.js`.
+- **Universal** — one ESM bundle for web *and* Node. `webpack/hot/dev-server` is universal: it consumes the same update signal on either platform (a browser dev-server, or a Node dev-server/middleware feeding the emitter), so no per-target client is needed.
+
+Edit `message.js` while the app runs to see the module reload in place — no full restart, no page reload.
+
+# message.js
+
+```javascript
+_{{message.js}}_
+```
+
+# web.js
+
+```javascript
+_{{web.js}}_
+```
+
+# node.js
+
+```javascript
+_{{node.js}}_
+```
+
+# universal.js
+
+```javascript
+_{{universal.js}}_
+```
+
+# webpack.config.js
+
+```javascript
+_{{webpack.config.js}}_
+```

--- a/examples/hot-module-replacement/universal.js
+++ b/examples/hot-module-replacement/universal.js
@@ -1,0 +1,20 @@
+// One ESM bundle for web and Node. The dev-server client is universal: it
+// listens for the same update signal on either platform (browser dev-server,
+// or a Node dev-server/middleware feeding the emitter), so no per-target client
+// is needed.
+import message from "./message";
+import "webpack/hot/dev-server";
+
+const render = () => {
+	if (typeof document !== "undefined") {
+		document.body.textContent = message;
+	} else {
+		console.log("message:", message);
+	}
+};
+
+render();
+
+if (import.meta.webpackHot) {
+	import.meta.webpackHot.accept("./message", render);
+}

--- a/examples/hot-module-replacement/web.js
+++ b/examples/hot-module-replacement/web.js
@@ -1,0 +1,13 @@
+// Browser HMR: webpack-dev-server pushes update signals over EventSource and
+// the dev-server client runs the check. Start it with `webpack serve`.
+import "webpack/hot/dev-server";
+
+const render = () => {
+	document.body.textContent = require("./message");
+};
+
+render();
+
+if (module.hot) {
+	module.hot.accept("./message", render);
+}

--- a/examples/hot-module-replacement/webpack.config.js
+++ b/examples/hot-module-replacement/webpack.config.js
@@ -5,6 +5,7 @@ const { HotModuleReplacementPlugin } = require("../../");
 
 // `webpack` resolves to this repo only because the example lives inside it;
 // real projects can drop this alias and import `webpack/hot/*` directly.
+/** @type {import("../../").Configuration} */
 const base = {
 	mode: "development",
 	context: __dirname,

--- a/examples/hot-module-replacement/webpack.config.js
+++ b/examples/hot-module-replacement/webpack.config.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const path = require("path");
+const { HotModuleReplacementPlugin } = require("../../");
+
+// `webpack` resolves to this repo only because the example lives inside it;
+// real projects can drop this alias and import `webpack/hot/*` directly.
+const base = {
+	mode: "development",
+	context: __dirname,
+	devtool: false,
+	resolve: { alias: { webpack: path.resolve(__dirname, "../../") } },
+	plugins: [new HotModuleReplacementPlugin()]
+};
+
+/** @type {import("../../").Configuration[]} */
+const config = [
+	// Web — driven by webpack-dev-server (`webpack serve`).
+	{
+		...base,
+		name: "web",
+		target: "web",
+		entry: "./web.js",
+		output: { path: path.resolve(__dirname, "dist/web"), filename: "main.js" }
+	},
+	// Node — driven by webpack/hot/poll (`webpack --watch` + `node dist/node/main.js`).
+	{
+		...base,
+		name: "node",
+		target: "node",
+		entry: "./node.js",
+		output: { path: path.resolve(__dirname, "dist/node"), filename: "main.js" }
+	},
+	// Universal — single ESM bundle for web + Node, one dev-server client.
+	{
+		...base,
+		name: "universal",
+		target: ["web", "node"],
+		entry: "./universal.js",
+		experiments: { outputModule: true },
+		output: {
+			path: path.resolve(__dirname, "dist/universal"),
+			filename: "main.mjs",
+			module: true,
+			chunkFormat: "module"
+		}
+	}
+];
+
+module.exports = config;

--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 /* globals __webpack_hash__ */
+// Universal regular-HMR client (web + Node): runs `module.hot.check` whenever a
+// `webpackHotUpdate` signal arrives on ./emitter (pushed by the dev-server).
 if (module.hot) {
 	/** @type {undefined|string} */
 	var lastHash;

--- a/test/hotCases/universal/dev-server-client/index.js
+++ b/test/hotCases/universal/dev-server-client/index.js
@@ -1,0 +1,26 @@
+import value from "./module";
+// universal regular-HMR client: works on web (dev-server EventSource signal)
+// and Node (same emitter signal) without a platform-specific client
+import emitter from "../../../../hot/emitter";
+import "../../../../hot/dev-server";
+
+import.meta.webpackHot.accept("./module");
+
+it("should trigger HMR via the dev-server signal on web and node", (done) => {
+	expect(value).toBe("value-1");
+
+	import.meta.webpackHot.accept("./module", () => {
+		import("./module")
+			.then((updated) => {
+				expect(updated.default).toBe("value-2");
+				done();
+			})
+			.catch(done);
+	});
+
+	NEXT((err, stats) => {
+		if (err) return done(err);
+		// emulate the dev-server pushing an update signal through the emitter
+		emitter.emit("webpackHotUpdate", stats.hash);
+	});
+});

--- a/test/hotCases/universal/dev-server-client/module.js
+++ b/test/hotCases/universal/dev-server-client/module.js
@@ -1,0 +1,3 @@
+export default "value-1";
+---
+export default "value-2";

--- a/test/hotCases/universal/dev-server-client/webpack.config.js
+++ b/test/hotCases/universal/dev-server-client/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// hot/dev-server pulls in hot/emitter (node `events`); bundle it instead of
+	// externalizing via createRequire, which the ESM test runner can't resolve
+	externalsPresets: { node: false }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Adds a `hot-module-replacement` example with web, node and universal setups in one directory, sharing a module that is hot-swapped at runtime. It documents that the download/apply runtime is identical across platforms and only the trigger differs (`hot/dev-server` on web, `hot/poll` on node, and the already-universal `hot/dev-server` for a single ESM bundle). Also adds a universal hotCase proving `hot/dev-server` triggers HMR on both web and Node, plus a one-line usage comment on `hot/dev-server.js` — no separate universal client is needed.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs (also adds a test; no functional code change).

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/hotCases/universal/dev-server-client/` runs in both the web and Node universal runners.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the example documents itself; nothing extra needed in this repo.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to draft the example files, the hotCase test and the comment, and to verify HMR reloading on real Node; all changes were reviewed before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0194GwMzJETyHy5kWBLUpmT5)_