### PR TITLE
fix: write emitted assets with an absolute path as-is

### DIFF
--- a/.changeset/emit-absolute-asset-path.md
+++ b/.changeset/emit-absolute-asset-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Emit assets with absolute target paths as-is to avoid invalid Windows paths.

--- a/.changeset/output-path-root-eisdir.md
+++ b/.changeset/output-path-root-eisdir.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Allow output.path to be the filesystem root by treating EISDIR like EEXIST in mkdirp.

--- a/.changeset/windows-absolute-path-forward-slash.md
+++ b/.changeset/windows-absolute-path-forward-slash.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Recognize forward-slash Windows absolute paths (e.g. C:/dir) consistently.

--- a/lib/CleanPlugin.js
+++ b/lib/CleanPlugin.js
@@ -10,6 +10,7 @@ const asyncLib = require("neo-async");
 const { SyncBailHook } = require("tapable");
 const Compilation = require("./Compilation");
 const { join } = require("./util/fs");
+const { ABSOLUTE_PATH_REGEXP } = require("./util/identifier");
 const processAsyncTree = require("./util/processAsyncTree");
 
 /** @typedef {import("../declarations/WebpackOptions").CleanOptions} CleanOptions */
@@ -433,7 +434,7 @@ class CleanPlugin {
 				const currentAssets = new Map();
 				const now = Date.now();
 				for (const asset of Object.keys(compilation.assets)) {
-					if (/^[a-z]:\\|^\/|^\\\\/i.test(asset)) continue;
+					if (ABSOLUTE_PATH_REGEXP.test(asset)) continue;
 					/** @type {string} */
 					let normalizedAsset;
 					let newNormalizedAsset = asset.replace(/\\/g, "/");

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -28,7 +28,10 @@ const ConcurrentCompilationError = require("./errors/ConcurrentCompilationError"
 const WebpackError = require("./errors/WebpackError");
 const { Logger } = require("./logging/Logger");
 const { dirname, join, mkdirp } = require("./util/fs");
-const { makePathsRelative } = require("./util/identifier");
+const {
+	WINDOWS_ABS_PATH_REGEXP,
+	makePathsRelative
+} = require("./util/identifier");
 const memoize = require("./util/memoize");
 const parseJson = require("./util/parseJson");
 const { isSourceEqual } = require("./util/source");
@@ -778,6 +781,14 @@ class Compiler {
 								includesHash(targetFile, info.fullhash));
 					}
 
+					const fs = /** @type {OutputFileSystem} */ (this.outputFileSystem);
+					// A Windows drive-absolute targetFile is written as-is; joining it onto
+					// outputPath would produce an invalid path (e.g. C:\out\D:\file). A
+					// leading "/" stays relative to outputPath (e.g. entry name "/dir/x").
+					const targetPath = WINDOWS_ABS_PATH_REGEXP.test(targetFile)
+						? targetFile
+						: join(fs, outputPath, targetFile);
+
 					/**
 					 * Processes the provided err.
 					 * @param {Error=} err error
@@ -785,12 +796,6 @@ class Compiler {
 					 */
 					const writeOut = (err) => {
 						if (err) return callback(err);
-						const targetPath = join(
-							/** @type {OutputFileSystem} */
-							(this.outputFileSystem),
-							outputPath,
-							targetFile
-						);
 						allTargetPaths.add(targetPath);
 
 						// check if the target file has already been written by this Compiler
@@ -1056,8 +1061,7 @@ ${other}`);
 					};
 
 					if (/\/|\\/.test(targetFile)) {
-						const fs = /** @type {OutputFileSystem} */ (this.outputFileSystem);
-						const dir = dirname(fs, join(fs, outputPath, targetFile));
+						const dir = dirname(fs, targetPath);
 						mkdirp(fs, dir, writeOut);
 					} else {
 						writeOut();

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -46,6 +46,7 @@ const { createFakeHook } = require("./util/deprecation");
 const formatLocation = require("./util/formatLocation");
 const { join } = require("./util/fs");
 const {
+	ABSOLUTE_PATH_REGEXP,
 	absolutify,
 	contextify,
 	makePathsRelative
@@ -621,8 +622,6 @@ const walkSideEffectsRecursive = (
 	}
 	return propagateLinearResult(linearAncestors, current, moduleGraph, ctx);
 };
-
-const ABSOLUTE_PATH_REGEX = /^(?:[a-z]:\\|\\\\|\/)/i;
 
 /**
  * @typedef {object} LoaderItem
@@ -1882,7 +1881,7 @@ class NormalModule extends Module {
 				 */
 				const checkDependencies = (deps) => {
 					for (const dep of deps) {
-						if (!ABSOLUTE_PATH_REGEX.test(dep)) {
+						if (!ABSOLUTE_PATH_REGEXP.test(dep)) {
 							if (nonAbsoluteDependencies === undefined) {
 								nonAbsoluteDependencies = new Set();
 							}
@@ -1896,7 +1895,7 @@ class NormalModule extends Module {
 									(this.context),
 									depWithoutGlob
 								);
-								if (absolute !== dep && ABSOLUTE_PATH_REGEX.test(absolute)) {
+								if (absolute !== dep && ABSOLUTE_PATH_REGEXP.test(absolute)) {
 									(depWithoutGlob !== dep
 										? /** @type {NonNullable<KnownNormalModuleBuildInfo["contextDependencies"]>} */
 											(

--- a/lib/sharing/ProvideSharedPlugin.js
+++ b/lib/sharing/ProvideSharedPlugin.js
@@ -7,6 +7,7 @@
 
 const { parseOptions } = require("../container/options");
 const WebpackError = require("../errors/WebpackError");
+const { ABSOLUTE_PATH_REGEXP } = require("../util/identifier");
 const ProvideForSharedDependency = require("./ProvideForSharedDependency");
 const ProvideSharedDependency = require("./ProvideSharedDependency");
 const ProvideSharedModuleFactory = require("./ProvideSharedModuleFactory");
@@ -100,13 +101,13 @@ class ProvideSharedPlugin {
 				/** @type {Map<string, ProvideOptions>} */
 				const prefixMatchProvides = new Map();
 				for (const [request, config] of provides) {
-					if (/^(?:\/|[A-Z]:\\|\\\\|\.\.?(?:\/|$))/i.test(request)) {
+					if (/^\.\.?(?:\/|$)/.test(request)) {
 						// relative request
 						resolvedProvideMap.set(request, {
 							config,
 							version: config.version
 						});
-					} else if (/^(?:\/|[A-Z]:\\|\\\\)/i.test(request)) {
+					} else if (ABSOLUTE_PATH_REGEXP.test(request)) {
 						// absolute path
 						resolvedProvideMap.set(request, {
 							config,

--- a/lib/sharing/resolveMatchedConfigs.js
+++ b/lib/sharing/resolveMatchedConfigs.js
@@ -7,6 +7,7 @@
 
 const ModuleNotFoundError = require("../errors/ModuleNotFoundError");
 const LazySet = require("../util/LazySet");
+const { ABSOLUTE_PATH_REGEXP } = require("../util/identifier");
 
 /** @typedef {import("enhanced-resolve").ResolveContext} ResolveContext */
 /** @typedef {import("../Compilation")} Compilation */
@@ -80,7 +81,7 @@ module.exports.resolveMatchedConfigs = (compilation, configs) => {
 						}
 					);
 				});
-			} else if (/^(?:\/|[a-z]:\\|\\\\)/i.test(request)) {
+			} else if (ABSOLUTE_PATH_REGEXP.test(request)) {
 				// absolute path
 				resolved.set(request, config);
 			} else if (request.endsWith("/")) {

--- a/lib/util/extractSourceMap.js
+++ b/lib/util/extractSourceMap.js
@@ -92,7 +92,7 @@ function getAbsolutePath(context, request, sourceRoot) {
  * @returns {boolean} true if value is a URL
  */
 function isURL(value) {
-	return validProtocolPattern.test(value) && !path.win32.isAbsolute(value);
+	return validProtocolPattern.test(value) && !isAbsolute(value);
 }
 
 /**

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const path = require("path");
+const { ABSOLUTE_PATH_REGEXP } = require("./identifier");
 
 /** @typedef {import("../../declarations/WebpackOptions").WatchOptions} WatchOptions */
 /** @typedef {import("watchpack").Entry} Entry */
@@ -730,8 +731,7 @@ const lstatReadlinkAbsolute = (fs, p, callback) => {
  * @param {string} pathname a path
  * @returns {boolean} is absolute
  */
-const isAbsolute = (pathname) =>
-	path.posix.isAbsolute(pathname) || path.win32.isAbsolute(pathname);
+const isAbsolute = (pathname) => ABSOLUTE_PATH_REGEXP.test(pathname);
 
 module.exports.dirname = dirname;
 module.exports.isAbsolute = isAbsolute;

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -611,7 +611,9 @@ const mkdirp = (fs, p, callback) => {
 					}
 					fs.mkdir(p, (err) => {
 						if (err) {
-							if (err.code === "EEXIST") {
+							// EEXIST: parent already created it; EISDIR: memfs/BSD for an
+							// existing dir such as the root "/" (#10544)
+							if (err.code === "EEXIST" || err.code === "EISDIR") {
 								callback();
 								return;
 							}
@@ -622,7 +624,7 @@ const mkdirp = (fs, p, callback) => {
 					});
 				});
 				return;
-			} else if (err.code === "EEXIST") {
+			} else if (err.code === "EEXIST" || err.code === "EISDIR") {
 				callback();
 				return;
 			}
@@ -652,7 +654,10 @@ const mkdirpSync = (fs, p) => {
 				mkdirpSync(fs, dir);
 				fs.mkdirSync(p);
 				return;
-			} else if (/** @type {NodeJS.ErrnoException} */ (err).code === "EEXIST") {
+			} else if (
+				/** @type {NodeJS.ErrnoException} */ (err).code === "EEXIST" ||
+				/** @type {NodeJS.ErrnoException} */ (err).code === "EISDIR"
+			) {
 				return;
 			}
 			throw err;

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -6,6 +6,11 @@
 
 const path = require("path");
 
+// Any absolute path: POSIX (/foo) and every Windows form — drive-letter (C:\,
+// C:/), UNC (\\, //), rooted (\, /); equals posix||win32 isAbsolute.
+const ABSOLUTE_PATH_REGEXP = /^(?:[a-z]:)?[\\/]/i;
+// Windows drive-letter absolute path only (C:\ or C:/), where a leading "/" is
+// NOT absolute — used where POSIX paths must stay relative to a base.
 const WINDOWS_ABS_PATH_REGEXP = /^[a-z]:[\\/]/i;
 const SEGMENTS_SPLIT_REGEXP = /([|!])/;
 const WINDOWS_PATH_SEPARATOR_REGEXP = /\\/g;
@@ -525,6 +530,8 @@ const escapeHashInPathRequest = (request) => {
 	return pathPart.replace(HASH_REGEXP, "\0#") + request.slice(lastSep);
 };
 
+module.exports.ABSOLUTE_PATH_REGEXP = ABSOLUTE_PATH_REGEXP;
+module.exports.WINDOWS_ABS_PATH_REGEXP = WINDOWS_ABS_PATH_REGEXP;
 module.exports.absolutify = absolutify;
 module.exports.contextify = contextify;
 module.exports.escapeHashInPathRequest = escapeHashInPathRequest;

--- a/test/configCases/emit-asset/absolute-path/index.js
+++ b/test/configCases/emit-asset/absolute-path/index.js
@@ -1,0 +1,5 @@
+it("should emit an asset with an absolute path without crashing (#12759)", () => {
+	// Verification happens in the plugin's afterEmit hook; reaching here without
+	// a compilation error means the absolute asset was written successfully.
+	expect(true).toBe(true);
+});

--- a/test/configCases/emit-asset/absolute-path/test.filter.js
+++ b/test/configCases/emit-asset/absolute-path/test.filter.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// Only Windows joins paths in a way that makes an absolute targetFile invalid.
+module.exports = () => process.platform === "win32";

--- a/test/configCases/emit-asset/absolute-path/webpack.config.js
+++ b/test/configCases/emit-asset/absolute-path/webpack.config.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { RawSource } = require("webpack-sources");
+const webpack = require("../../../../");
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+
+const CONTENT = "emitted to an absolute path\n";
+
+class EmitAbsolutePlugin {
+	/**
+	 * @param {string} target absolute target file
+	 */
+	constructor(target) {
+		this.target = target;
+	}
+
+	/**
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const target = this.target;
+		compiler.hooks.thisCompilation.tap("EmitAbsolutePlugin", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "EmitAbsolutePlugin",
+					stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(target, new RawSource(CONTENT));
+				}
+			);
+		});
+		compiler.hooks.afterEmit.tap("EmitAbsolutePlugin", (compilation) => {
+			// Without the fix, joining this drive-absolute path onto output.path
+			// throws EINVAL on Windows; with it the file lands at `target`.
+			if (
+				!fs.existsSync(target) ||
+				fs.readFileSync(target, "utf8") !== CONTENT
+			) {
+				compilation.errors.push(
+					new webpack.WebpackError(`Asset not written to ${target}`)
+				);
+			}
+		});
+	}
+}
+
+// `testPath` is absolute (a drive path on Windows), so the emitted asset name is
+// itself absolute and lands inside the output dir, which the test harness cleans.
+/** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration} */
+module.exports = (env, { testPath }) => ({
+	entry: "./index.js",
+	plugins: [
+		new EmitAbsolutePlugin(path.join(testPath, "emitted-absolute", "asset.txt"))
+	]
+});

--- a/test/configCases/emit-asset/mkdir-eisdir/index.js
+++ b/test/configCases/emit-asset/mkdir-eisdir/index.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+it("should emit assets when mkdir reports EISDIR for existing dirs", () => {
+	// reaching here means emit did not fail; the nested asset confirms both the
+	// top-level and recursive mkdirp EISDIR branches were exercised (#10544)
+	expect(
+		fs.readFileSync(path.resolve(__dirname, "nested/deep/asset.txt"), "utf8")
+	).toBe("emitted while mkdir reported EISDIR\n");
+});

--- a/test/configCases/emit-asset/mkdir-eisdir/webpack.config.js
+++ b/test/configCases/emit-asset/mkdir-eisdir/webpack.config.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const webpack = require("../../../../");
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+
+const ASSET = "nested/deep/asset.txt";
+const CONTENT = "emitted while mkdir reported EISDIR\n";
+
+/**
+ * @returns {NodeJS.ErrnoException} an EISDIR error
+ */
+const makeEisdir = () => {
+	const err = /** @type {NodeJS.ErrnoException} */ (
+		new Error("EISDIR: illegal operation on a directory")
+	);
+	err.code = "EISDIR";
+	return err;
+};
+
+// Wrap the output file system so mkdir reports EISDIR (not EEXIST) for an
+// already-existing directory, like memfs/BSD do for the output root (#10544).
+class EisdirMkdirPlugin {
+	/**
+	 * @param {Compiler} compiler the compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const real = /** @type {EXPECTED_ANY} */ (compiler.outputFileSystem);
+		const fs = /** @type {EXPECTED_ANY} */ (Object.create(real));
+		/**
+		 * @param {string} dir directory
+		 * @param {EXPECTED_ANY} optionsOrCallback options or callback
+		 * @param {(err?: Error) => void=} maybeCallback callback
+		 * @returns {void}
+		 */
+		fs.mkdir = (dir, optionsOrCallback, maybeCallback) => {
+			const callback =
+				typeof optionsOrCallback === "function"
+					? optionsOrCallback
+					: maybeCallback;
+			real.mkdir(dir, (/** @type {NodeJS.ErrnoException | null} */ err) => {
+				// real ENOENT drives mkdirp's recursion; otherwise pretend the dir
+				// already exists by reporting EISDIR
+				callback(err && err.code === "ENOENT" ? err : makeEisdir());
+			});
+		};
+		compiler.outputFileSystem = fs;
+
+		compiler.hooks.thisCompilation.tap("EisdirMkdirPlugin", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "EisdirMkdirPlugin",
+					stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(ASSET, new RawSource(CONTENT));
+				}
+			);
+		});
+	}
+}
+
+module.exports = {
+	entry: "./index.js",
+	plugins: [new EisdirMkdirPlugin()]
+};

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -1,8 +1,82 @@
 "use strict";
 
+const path = require("path");
 const identifierUtil = require("../lib/util/identifier");
 
 describe("util/identifier", () => {
+	describe("ABSOLUTE_PATH_REGEXP", () => {
+		const { ABSOLUTE_PATH_REGEXP } = identifierUtil;
+
+		it("matches POSIX and every Windows absolute path type", () => {
+			for (const absolute of [
+				"/dir/file",
+				"/",
+				"C:\\dir\\file",
+				"c:/dir/file",
+				"C:\\",
+				"\\\\server\\share\\file",
+				"//server/share",
+				"\\dir\\file",
+				"\\\\?\\C:\\dir",
+				"\\\\.\\C:\\dir"
+			]) {
+				expect(ABSOLUTE_PATH_REGEXP.test(absolute)).toBe(true);
+			}
+		});
+
+		it("does not match relative or drive-relative paths", () => {
+			for (const relative of [
+				"dir\\file",
+				"./dir",
+				"../dir",
+				"C:dir",
+				"C:",
+				""
+			]) {
+				expect(ABSOLUTE_PATH_REGEXP.test(relative)).toBe(false);
+			}
+		});
+
+		it("agrees with path.win32.isAbsolute and path.posix.isAbsolute", () => {
+			for (const p of [
+				"C:\\dir",
+				"c:/dir",
+				"C:dir",
+				"\\\\server\\share",
+				"\\dir",
+				"/dir",
+				"dir/file",
+				"./dir",
+				"..",
+				""
+			]) {
+				expect(ABSOLUTE_PATH_REGEXP.test(p)).toBe(
+					path.win32.isAbsolute(p) || path.posix.isAbsolute(p)
+				);
+			}
+		});
+	});
+
+	describe("WINDOWS_ABS_PATH_REGEXP", () => {
+		const { WINDOWS_ABS_PATH_REGEXP } = identifierUtil;
+
+		it("matches only Windows drive-letter absolute paths", () => {
+			for (const drive of ["C:\\dir\\file", "c:/dir/file", "C:\\"]) {
+				expect(WINDOWS_ABS_PATH_REGEXP.test(drive)).toBe(true);
+			}
+			// a leading "/" is NOT a drive path: it stays relative to a base (#12759)
+			for (const other of [
+				"/dir/file",
+				"/",
+				"\\dir",
+				"\\\\server\\share",
+				"x"
+			]) {
+				expect(WINDOWS_ABS_PATH_REGEXP.test(other)).toBe(false);
+			}
+		});
+	});
+
 	describe("makePathsRelative", () => {
 		describe("given a context and a pathConstruct", () => {
 			it("computes the correct relative results for the path construct", () => {


### PR DESCRIPTION


**Summary**

Emitting an asset whose name is an absolute path threw `EINVAL` on Windows: the absolute `targetFile` was joined onto `output.path`, producing an invalid path such as `C:\out\D:\file`. Absolute target files are now written to their absolute location as-is.

While here, the scattered "is this path absolute" checks — each a slightly different regex, several of which missed forward-slash Windows paths like `C:/dir` — are consolidated onto a single cross-platform `ABSOLUTE_PATH_REGEXP` (equal to `path.posix.isAbsolute || path.win32.isAbsolute`), reused in `Compiler`, `util/fs` `isAbsolute`, `extractSourceMap`, `NormalModule`, `CleanPlugin` and the sharing plugins.

Also fixes `output.path` set to the filesystem root: `memfs` and some platforms throw `EISDIR` (not `EEXIST`) when `mkdir` targets an existing directory such as `/`, which `mkdirp`/`mkdirpSync` now treat as already-existing.

Closes #12759
Closes #20403
Closes #12906
Closes #10544

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — a Windows-only configCase `test/configCases/emit-asset/absolute-path` that emits an asset to an absolute path, a configCase `test/configCases/emit-asset/mkdir-eisdir` that wraps the output file system so `mkdir` reports `EISDIR` for existing dirs, and unit tests for `ABSOLUTE_PATH_REGEXP` in `test/identifier.unittest.js`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to investigate the issues, implement the fixes, consolidate the absolute-path checks, and write the tests. All changes were reviewed by a human before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeZmqqQhk5THgBrwWUS8PP)_