### PR TITLE
refactor: extract Compilation.createHooksRegistry

### DIFF
--- a/lib/CleanPlugin.js
+++ b/lib/CleanPlugin.js
@@ -8,7 +8,7 @@
 const path = require("path");
 const asyncLib = require("neo-async");
 const { SyncBailHook } = require("tapable");
-const Compilation = require("./Compilation");
+const createHooksRegistry = require("./util/createHooksRegistry");
 const { join } = require("./util/fs");
 const { ABSOLUTE_PATH_REGEXP } = require("./util/identifier");
 const processAsyncTree = require("./util/processAsyncTree");
@@ -335,33 +335,9 @@ const applyDiff = (fs, outputPath, dry, logger, diff, isKept, callback) => {
 	);
 };
 
-/** @type {WeakMap<Compilation, CleanPluginCompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 const PLUGIN_NAME = "CleanPlugin";
 
 class CleanPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CleanPluginCompilationHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				keep: new SyncBailHook(["ignore"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/** @param {CleanOptions} options options */
 	constructor(options = {}) {
 		/** @type {CleanOptions} */
@@ -507,6 +483,13 @@ class CleanPlugin {
 		);
 	}
 }
+
+CleanPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CleanPluginCompilationHooks} */ ({
+			keep: new SyncBailHook(["ignore"])
+		})
+);
 
 module.exports = CleanPlugin;
 module.exports._getDirectories = getDirectories;

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -21,6 +21,7 @@ const {
 	toConstantDependency
 } = require("./javascript/JavascriptParserHelpers");
 const createHash = require("./util/createHash");
+const createHooksRegistry = require("./util/createHooksRegistry");
 
 /** @typedef {import("estree").Expression} Expression */
 /** @typedef {import("./Compiler")} Compiler */
@@ -362,26 +363,7 @@ const WEBPACK_REQUIRE_IDENTIFIER_REGEXP = new RegExp(RuntimeGlobals.require);
 
 /** @typedef {Record<string, CodeValue>} Definitions */
 
-/** @type {WeakMap<Compilation, DefinePluginHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class DefinePlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {DefinePluginHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				definitions: new SyncWaterfallHook(["definitions"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * Create a new define plugin
 	 * @param {Definitions} definitions A map of global object definitions
@@ -961,5 +943,12 @@ class DefinePlugin {
 		);
 	}
 }
+
+DefinePlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {DefinePluginHooks} */ ({
+			definitions: new SyncWaterfallHook(["definitions"])
+		})
+);
 
 module.exports = DefinePlugin;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -26,6 +26,7 @@ const { ImportPhaseUtils } = require("./dependencies/ImportPhase");
 const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
 const EnvironmentNotSupportAsyncWarning = require("./errors/EnvironmentNotSupportAsyncWarning");
 const createHash = require("./util/createHash");
+const createHooksRegistry = require("./util/createHooksRegistry");
 const extractUrlAndGlobal = require("./util/extractUrlAndGlobal");
 const makeSerializable = require("./util/makeSerializable");
 const { propertyAccess } = require("./util/property");
@@ -716,9 +717,6 @@ const getSourceForDefaultCase = (optional, request, runtimeTemplate) => {
  * @property {SyncBailHook<[Chunk, Compilation], boolean>} chunkCondition
  */
 
-/** @type {WeakMap<Compilation, ExternalModuleHooks>} */
-const compilationHooksMap = new WeakMap();
-
 /**
  * Defines the build info properties specific to external modules.
  * @typedef {object} KnownExternalModuleBuildInfo
@@ -751,22 +749,6 @@ class ExternalModule extends Module {
 		this.userRequest = userRequest;
 		/** @type {DependencyMeta=} */
 		this.dependencyMeta = dependencyMeta;
-	}
-
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {ExternalModuleHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				chunkCondition: new SyncBailHook(["chunk", "compilation"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
 	}
 
 	/**
@@ -1344,6 +1326,13 @@ class ExternalModule extends Module {
 		super.deserialize(c3.rest);
 	}
 }
+
+ExternalModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {ExternalModuleHooks} */ ({
+			chunkCondition: new SyncBailHook(["chunk", "compilation"])
+		})
+);
 
 makeSerializable(ExternalModule, "webpack/lib/ExternalModule");
 

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -19,7 +19,6 @@ const {
 	RawSource,
 	SourceMapSource
 } = require("webpack-sources");
-const Compilation = require("./Compilation");
 const Dependency = require("./Dependency");
 const Module = require("./Module");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
@@ -41,6 +40,7 @@ const {
 	sortWithSourceOrder
 } = require("./util/comparators");
 const createHash = require("./util/createHash");
+const createHooksRegistry = require("./util/createHooksRegistry");
 const { createFakeHook } = require("./util/deprecation");
 const formatLocation = require("./util/formatLocation");
 const { join } = require("./util/fs");
@@ -60,6 +60,7 @@ const parseJson = require("./util/parseJson");
 /** @typedef {import("webpack-sources").RawSourceMap} RawSourceMap */
 /** @typedef {import("../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("../declarations/WebpackOptions").NoParse} NoParse */
+/** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./config/defaults").WebpackOptionsNormalizedWithDefaults} WebpackOptions */
 /** @typedef {import("./Dependency").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("./Generator")} Generator */
@@ -762,8 +763,52 @@ const asBuffer = (input) => {
 
 /** @typedef {BuildInfo & KnownNormalModuleBuildInfo} NormalModuleBuildInfo */
 
-/** @type {WeakMap<Compilation, NormalModuleCompilationHooks>} */
-const compilationHooksMap = new WeakMap();
+const normalModuleHooksRegistry = createHooksRegistry(() => {
+	// TODO webpack 6 deprecate
+	/** @type {Partial<NormalModuleCompilationHooks>} */
+	const hooks = {};
+	hooks.readResourceForScheme = new HookMap((scheme) => {
+		const hook =
+			/** @type {NormalModuleCompilationHooks} */
+			(hooks).readResource.for(scheme);
+		return createFakeHook(
+			/** @type {AsyncSeriesBailHook<[string, NormalModule], string | Buffer | null>} */ ({
+				tap: (options, fn) =>
+					hook.tap(options, (loaderContext) =>
+						fn(
+							loaderContext.resource,
+							/** @type {NormalModule} */ (loaderContext._module)
+						)
+					),
+				tapAsync: (options, fn) =>
+					hook.tapAsync(options, (loaderContext, callback) =>
+						fn(
+							loaderContext.resource,
+							/** @type {NormalModule} */ (loaderContext._module),
+							callback
+						)
+					),
+				tapPromise: (options, fn) =>
+					hook.tapPromise(options, (loaderContext) =>
+						fn(
+							loaderContext.resource,
+							/** @type {NormalModule} */ (loaderContext._module)
+						)
+					)
+			})
+		);
+	});
+	hooks.readResource = new HookMap(
+		() => new AsyncSeriesBailHook(["loaderContext"])
+	);
+	hooks.loader = new SyncHook(["loaderContext", "module"]);
+	hooks.beforeLoaders = new SyncHook(["loaders", "module", "loaderContext"]);
+	hooks.beforeParse = new SyncHook(["module"]);
+	hooks.beforeSnapshot = new SyncHook(["module"]);
+	hooks.processResult = new SyncWaterfallHook(["result", "module"]);
+	hooks.needBuild = new AsyncSeriesBailHook(["module", "context"]);
+	return /** @type {NormalModuleCompilationHooks} */ (hooks);
+});
 
 class NormalModule extends Module {
 	/**
@@ -771,62 +816,7 @@ class NormalModule extends Module {
 	 * @returns {NormalModuleCompilationHooks} the attached hooks
 	 */
 	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				loader: new SyncHook(["loaderContext", "module"]),
-				beforeLoaders: new SyncHook(["loaders", "module", "loaderContext"]),
-				beforeParse: new SyncHook(["module"]),
-				beforeSnapshot: new SyncHook(["module"]),
-				// TODO webpack 6 deprecate
-				readResourceForScheme: new HookMap((scheme) => {
-					const hook =
-						/** @type {NormalModuleCompilationHooks} */
-						(hooks).readResource.for(scheme);
-					return createFakeHook(
-						/** @type {AsyncSeriesBailHook<[string, NormalModule], string | Buffer | null>} */ ({
-							tap: (options, fn) =>
-								hook.tap(options, (loaderContext) =>
-									fn(
-										loaderContext.resource,
-										/** @type {NormalModule} */ (loaderContext._module)
-									)
-								),
-							tapAsync: (options, fn) =>
-								hook.tapAsync(options, (loaderContext, callback) =>
-									fn(
-										loaderContext.resource,
-										/** @type {NormalModule} */ (loaderContext._module),
-										callback
-									)
-								),
-							tapPromise: (options, fn) =>
-								hook.tapPromise(options, (loaderContext) =>
-									fn(
-										loaderContext.resource,
-										/** @type {NormalModule} */ (loaderContext._module)
-									)
-								)
-						})
-					);
-				}),
-				readResource: new HookMap(
-					() => new AsyncSeriesBailHook(["loaderContext"])
-				),
-				processResult: new SyncWaterfallHook(["result", "module"]),
-				needBuild: new AsyncSeriesBailHook(["module", "context"])
-			};
-			compilationHooksMap.set(
-				compilation,
-				/** @type {NormalModuleCompilationHooks} */ (hooks)
-			);
-		}
-		return /** @type {NormalModuleCompilationHooks} */ (hooks);
+		return normalModuleHooksRegistry(compilation);
 	}
 
 	/**

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -7,8 +7,8 @@
 
 const { SyncHook } = require("tapable");
 const isValidExternalsType = require("../../schemas/plugins/container/ExternalsType.check");
-const Compilation = require("../Compilation");
 const SharePlugin = require("../sharing/SharePlugin");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const ContainerPlugin = require("./ContainerPlugin");
 const ContainerReferencePlugin = require("./ContainerReferencePlugin");
 const HoistContainerReferences = require("./HoistContainerReferencesPlugin");
@@ -25,8 +25,6 @@ const HoistContainerReferences = require("./HoistContainerReferencesPlugin");
  * @property {SyncHook<Dependency>} addFederationRuntimeDependency
  */
 
-/** @type {WeakMap<Compilation, CompilationHooks>} */
-const compilationHooksMap = new WeakMap();
 const PLUGIN_NAME = "ModuleFederationPlugin";
 
 class ModuleFederationPlugin {
@@ -37,28 +35,6 @@ class ModuleFederationPlugin {
 	constructor(options) {
 		/** @type {ModuleFederationPluginOptions} */
 		this.options = options;
-	}
-
-	/**
-	 * Get the compilation hooks associated with this plugin.
-	 * @param {Compilation} compilation The compilation instance.
-	 * @returns {CompilationHooks} The hooks for the compilation.
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (!hooks) {
-			hooks = {
-				addContainerEntryDependency: new SyncHook(["dependency"]),
-				addFederationRuntimeDependency: new SyncHook(["dependency"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
 	}
 
 	/**
@@ -133,5 +109,13 @@ class ModuleFederationPlugin {
 		});
 	}
 }
+
+ModuleFederationPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CompilationHooks} */ ({
+			addContainerEntryDependency: new SyncHook(["dependency"]),
+			addFederationRuntimeDependency: new SyncHook(["dependency"])
+		})
+);
 
 module.exports = ModuleFederationPlugin;

--- a/lib/css/CssInjectStyleRuntimeModule.js
+++ b/lib/css/CssInjectStyleRuntimeModule.js
@@ -6,10 +6,11 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
+const createHooksRegistry = require("../util/createHooksRegistry");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
@@ -19,30 +20,7 @@ const Template = require("../Template");
  * @property {SyncWaterfallHook<[string, Chunk]>} createStyle
  */
 
-/** @type {WeakMap<Compilation, CssInjectCompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class CssInjectStyleRuntimeModule extends RuntimeModule {
-	/**
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CssInjectCompilationHooks} hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				createStyle: new SyncWaterfallHook(["source", "chunk"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements runtime requirements
 	 */
@@ -206,5 +184,12 @@ class CssInjectStyleRuntimeModule extends RuntimeModule {
 		]);
 	}
 }
+
+CssInjectStyleRuntimeModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CssInjectCompilationHooks} */ ({
+			createStyle: new SyncWaterfallHook(["source", "chunk"])
+		})
+);
 
 module.exports = CssInjectStyleRuntimeModule;

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -6,12 +6,13 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const { CSS_TYPE } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { chunkHasCss } = require("./CssModulesPlugin");
 
 /** @typedef {import("../Chunk")} Chunk */
@@ -27,33 +28,7 @@ const { chunkHasCss } = require("./CssModulesPlugin");
  * @property {SyncWaterfallHook<[string, Chunk]>} linkInsert
  */
 
-/** @type {WeakMap<Compilation, CssLoadingRuntimeModulePluginHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class CssLoadingRuntimeModule extends RuntimeModule {
-	/**
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CssLoadingRuntimeModulePluginHooks} hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				createStylesheet: new SyncWaterfallHook(["source", "chunk"]),
-				linkPreload: new SyncWaterfallHook(["source", "chunk"]),
-				linkPrefetch: new SyncWaterfallHook(["source", "chunk"]),
-				linkInsert: new SyncWaterfallHook(["source", "chunk"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements runtime requirements
 	 */
@@ -596,5 +571,15 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		]);
 	}
 }
+
+CssLoadingRuntimeModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CssLoadingRuntimeModulePluginHooks} */ ({
+			createStylesheet: new SyncWaterfallHook(["source", "chunk"]),
+			linkPreload: new SyncWaterfallHook(["source", "chunk"]),
+			linkPrefetch: new SyncWaterfallHook(["source", "chunk"]),
+			linkInsert: new SyncWaterfallHook(["source", "chunk"])
+		})
+);
 
 module.exports = CssLoadingRuntimeModule;

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -13,7 +13,7 @@ const {
 	RawSource,
 	ReplaceSource
 } = require("webpack-sources");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const HotUpdateChunk = require("../HotUpdateChunk");
 const { CSS_IMPORT_TYPE, CSS_TYPE } = require("../ModuleSourceTypeConstants");
 const {
@@ -37,6 +37,7 @@ const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin")
 const ConcatenatedModule = require("../optimize/ConcatenatedModule");
 const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { getUndoPath } = require("../util/identifier");
 const memoize = require("../util/memoize");
 const { digestNonNumericOnlyWithFull } = require("../util/nonNumericOnlyHash");
@@ -180,39 +181,9 @@ const generatorValidationOptions = {
 	baseDataPath: "generator"
 };
 
-/** @type {WeakMap<Compilation, CompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 const PLUGIN_NAME = "CssModulesPlugin";
 
 class CssModulesPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CompilationHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				renderModulePackage: new SyncWaterfallHook([
-					"source",
-					"module",
-					"renderContext"
-				]),
-				chunkHash: new SyncHook(["chunk", "hash", "context"]),
-				orderModules: new SyncBailHook(["chunk", "modules", "compilation"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	constructor() {
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
@@ -1163,5 +1134,18 @@ class CssModulesPlugin {
 		);
 	}
 }
+
+CssModulesPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CompilationHooks} */ ({
+			renderModulePackage: new SyncWaterfallHook([
+				"source",
+				"module",
+				"renderContext"
+			]),
+			chunkHash: new SyncHook(["chunk", "hash", "context"]),
+			orderModules: new SyncBailHook(["chunk", "modules", "compilation"])
+		})
+);
 
 module.exports = CssModulesPlugin;

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -7,7 +7,7 @@
 
 const { pathToFileURL } = require("url");
 const { SyncBailHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const DefinePlugin = require("../DefinePlugin");
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
@@ -22,6 +22,7 @@ const {
 	evaluateToString,
 	toConstantDependency
 } = require("../javascript/JavascriptParserHelpers");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { propertyAccess } = require("../util/property");
 const ConstDependency = require("./ConstDependency");
 const ModuleInitFragmentDependency = require("./ModuleInitFragmentDependency");
@@ -109,31 +110,7 @@ const collectImportMetaEnvDefinitions = (compilation) => {
  * @property {SyncBailHook<[DestructuringAssignmentProperty], string | void>} propertyInDestructuring
  */
 
-/** @type {WeakMap<Compilation, ImportMetaPluginHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class ImportMetaPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {ImportMetaPluginHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				propertyInDestructuring: new SyncBailHook(["property"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * Applies the plugin by registering its hooks on the compiler.
 	 * @param {Compiler} compiler compiler
@@ -500,6 +477,13 @@ class ImportMetaPlugin {
 		);
 	}
 }
+
+ImportMetaPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {ImportMetaPluginHooks} */ ({
+			propertyInDestructuring: new SyncBailHook(["property"])
+		})
+);
 
 module.exports = ImportMetaPlugin;
 module.exports.IMPORT_META_DIRNAME = IMPORT_META_DIRNAME;

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
@@ -18,6 +18,7 @@ const {
 } = require("../javascript/JavascriptModulesPlugin");
 const { getInitialChunkIds } = require("../javascript/StartupHelpers");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { getUndoPath } = require("../util/identifier");
 
 /** @typedef {import("../Chunk")} Chunk */
@@ -31,32 +32,7 @@ const { getUndoPath } = require("../util/identifier");
  * @property {SyncWaterfallHook<[string, Chunk]>} linkPrefetch
  */
 
-/** @type {WeakMap<Compilation, JsonpCompilationPluginHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
-	/**
-	 * Returns hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {JsonpCompilationPluginHooks} hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				linkPreload: new SyncWaterfallHook(["source", "chunk"]),
-				linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * Creates an instance of ModuleChunkLoadingRuntimeModule.
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements runtime requirements
@@ -432,5 +408,13 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 		]);
 	}
 }
+
+ModuleChunkLoadingRuntimeModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {JsonpCompilationPluginHooks} */ ({
+			linkPreload: new SyncWaterfallHook(["source", "chunk"]),
+			linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
+		})
+);
 
 module.exports = ModuleChunkLoadingRuntimeModule;

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -16,7 +16,7 @@ const {
 	RawSource,
 	ReplaceSource
 } = require("webpack-sources");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const HotUpdateChunk = require("../HotUpdateChunk");
 const InitFragment = require("../InitFragment");
 const { JAVASCRIPT_TYPE } = require("../ModuleSourceTypeConstants");
@@ -42,6 +42,7 @@ const {
 	getUsedNamesInScopeInfo
 } = require("../util/concatenate");
 const createHash = require("../util/createHash");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { digestNonNumericOnlyWithFull } = require("../util/nonNumericOnlyHash");
 const removeBOM = require("../util/removeBOM");
 const { intersectRuntime } = require("../util/runtime");
@@ -345,9 +346,6 @@ const printGeneratedCodeForStack = (module, code) => {
  * @property {SyncBailHook<[Chunk, RenderContext], boolean | void>} useSourceMap
  */
 
-/** @type {WeakMap<Compilation, CompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 /**
  * Renames an inlined module's top-level declaration (and all its references) when
  * its name is already taken in the shared startup scope, recording the chosen name
@@ -422,56 +420,6 @@ const PLUGIN_NAME = "JavascriptModulesPlugin";
 /** @typedef {{ header: string[], beforeStartup: string[], startup: string[], afterStartup: string[], allowInlineStartup: boolean }} Bootstrap */
 
 class JavascriptModulesPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CompilationHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				renderModuleContent: new SyncWaterfallHook([
-					"source",
-					"module",
-					"moduleRenderContext"
-				]),
-				renderModuleContainer: new SyncWaterfallHook([
-					"source",
-					"module",
-					"moduleRenderContext"
-				]),
-				renderModulePackage: new SyncWaterfallHook([
-					"source",
-					"module",
-					"moduleRenderContext"
-				]),
-				render: new SyncWaterfallHook(["source", "renderContext"]),
-				renderContent: new SyncWaterfallHook(["source", "renderContext"]),
-				renderStartup: new SyncWaterfallHook([
-					"source",
-					"module",
-					"startupRenderContext"
-				]),
-				renderChunk: new SyncWaterfallHook(["source", "renderContext"]),
-				renderMain: new SyncWaterfallHook(["source", "renderContext"]),
-				renderRequire: new SyncWaterfallHook(["code", "renderContext"]),
-				inlineInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
-				embedInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
-				strictRuntimeBailout: new SyncBailHook(["renderContext"]),
-				chunkHash: new SyncHook(["chunk", "hash", "context"]),
-				useSourceMap: new SyncBailHook(["chunk", "renderContext"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	constructor(options = {}) {
 		this.options = options;
 		/** @type {WeakMap<Source, { source: Source, needModule: boolean, needExports: boolean, needRequire: boolean, needThisAsExports: boolean, needStrict: boolean | undefined, renderShorthand: boolean }>} */
@@ -2184,6 +2132,42 @@ class JavascriptModulesPlugin {
 		return renamedInlinedModules;
 	}
 }
+
+JavascriptModulesPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CompilationHooks} */ ({
+			renderModuleContent: new SyncWaterfallHook([
+				"source",
+				"module",
+				"moduleRenderContext"
+			]),
+			renderModuleContainer: new SyncWaterfallHook([
+				"source",
+				"module",
+				"moduleRenderContext"
+			]),
+			renderModulePackage: new SyncWaterfallHook([
+				"source",
+				"module",
+				"moduleRenderContext"
+			]),
+			render: new SyncWaterfallHook(["source", "renderContext"]),
+			renderContent: new SyncWaterfallHook(["source", "renderContext"]),
+			renderStartup: new SyncWaterfallHook([
+				"source",
+				"module",
+				"startupRenderContext"
+			]),
+			renderChunk: new SyncWaterfallHook(["source", "renderContext"]),
+			renderMain: new SyncWaterfallHook(["source", "renderContext"]),
+			renderRequire: new SyncWaterfallHook(["code", "renderContext"]),
+			inlineInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
+			embedInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
+			strictRuntimeBailout: new SyncBailHook(["renderContext"]),
+			chunkHash: new SyncHook(["chunk", "hash", "context"]),
+			useSourceMap: new SyncBailHook(["chunk", "renderContext"])
+		})
+);
 
 module.exports = JavascriptModulesPlugin;
 module.exports.chunkHasJs = chunkHasJs;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -43,6 +43,7 @@ const {
 	getUsedNamesInScopeInfo
 } = require("../util/concatenate");
 const createHash = require("../util/createHash");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const { makePathsRelative } = require("../util/identifier");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess, propertyName } = require("../util/property");
@@ -817,9 +818,6 @@ const getFinalName = (
 
 /** @typedef {BuildInfo & KnownConcatenatedModuleBuildInfo} ConcatenatedModuleBuildInfo */
 
-/** @type {WeakMap<Compilation, ConcatenateModuleHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class ConcatenatedModule extends Module {
 	/**
 	 * @param {Module} rootModule the root module of the concatenation
@@ -851,30 +849,6 @@ class ConcatenatedModule extends Module {
 			runtime,
 			compilation
 		});
-	}
-
-	/**
-	 * @param {Compilation} compilation the compilation
-	 * @returns {ConcatenateModuleHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				onDemandExportsGeneration: new SyncBailHook([
-					"module",
-					"runtimes",
-					"exportsFinalName",
-					"exportsSource"
-				]),
-				concatenatedModuleInfo: new SyncBailHook([
-					"updatedInfo",
-					"concatenatedModuleInfo"
-				])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
 	}
 
 	/**
@@ -2660,6 +2634,22 @@ ${defineGetters}`
 		return obj;
 	}
 }
+
+ConcatenatedModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {ConcatenateModuleHooks} */ ({
+			onDemandExportsGeneration: new SyncBailHook([
+				"module",
+				"runtimes",
+				"exportsFinalName",
+				"exportsSource"
+			]),
+			concatenatedModuleInfo: new SyncBailHook([
+				"updatedInfo",
+				"concatenatedModuleInfo"
+			])
+		})
+);
 
 makeSerializable(ConcatenatedModule, "webpack/lib/optimize/ConcatenatedModule");
 

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -11,6 +11,7 @@ const Compilation = require("../Compilation");
 const WebpackError = require("../errors/WebpackError");
 const { compareSelect, compareStrings } = require("../util/comparators");
 const createHash = require("../util/createHash");
+const createHooksRegistry = require("../util/createHooksRegistry");
 
 /** @typedef {import("../../declarations/WebpackOptions").HashFunction} HashFunction */
 /** @typedef {import("../../declarations/WebpackOptions").HashDigest} HashDigest */
@@ -171,9 +172,6 @@ const toCachedSource = (source) => {
  * @property {SyncBailHook<[Buffer[], string], string | void>} updateHash
  */
 
-/** @type {WeakMap<Compilation, CompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 /**
  * Defines the real content hash plugin options type used by this module.
  * @typedef {object} RealContentHashPluginOptions
@@ -184,27 +182,6 @@ const compilationHooksMap = new WeakMap();
 const PLUGIN_NAME = "RealContentHashPlugin";
 
 class RealContentHashPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CompilationHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				updateHash: new SyncBailHook(["content", "oldHash"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * Creates an instance of RealContentHashPlugin.
 	 * @param {RealContentHashPluginOptions} options options
@@ -575,5 +552,12 @@ ${referencingAssets
 		});
 	}
 }
+
+RealContentHashPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CompilationHooks} */ ({
+			updateHash: new SyncBailHook(["content", "oldHash"])
+		})
+);
 
 module.exports = RealContentHashPlugin;

--- a/lib/runtime/LoadScriptRuntimeModule.js
+++ b/lib/runtime/LoadScriptRuntimeModule.js
@@ -5,9 +5,10 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const HelperRuntimeModule = require("./HelperRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
@@ -17,30 +18,7 @@ const HelperRuntimeModule = require("./HelperRuntimeModule");
  * @property {SyncWaterfallHook<[string, Chunk]>} createScript
  */
 
-/** @type {WeakMap<Compilation, LoadScriptCompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class LoadScriptRuntimeModule extends HelperRuntimeModule {
-	/**
-	 * @param {Compilation} compilation the compilation
-	 * @returns {LoadScriptCompilationHooks} hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				createScript: new SyncWaterfallHook(["source", "chunk"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * @param {boolean=} withCreateScriptUrl use create script url for trusted types
 	 * @param {boolean=} withFetchPriority use `fetchPriority` attribute
@@ -176,5 +154,12 @@ class LoadScriptRuntimeModule extends HelperRuntimeModule {
 		]);
 	}
 }
+
+LoadScriptRuntimeModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {LoadScriptCompilationHooks} */ ({
+			createScript: new SyncWaterfallHook(["source", "chunk"])
+		})
+);
 
 module.exports = LoadScriptRuntimeModule;

--- a/lib/util/createHooksRegistry.js
+++ b/lib/util/createHooksRegistry.js
@@ -1,0 +1,35 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const memoize = require("./memoize");
+
+const getCompilation = memoize(() => require("../Compilation"));
+
+/**
+ * @template T
+ * @param {() => T} createHooks factory that returns a fresh hooks object
+ * @returns {(compilation: import("../Compilation")) => T} getter that returns (or creates) hooks for the compilation
+ */
+const createHooksRegistry = (createHooks) => {
+	/** @type {WeakMap<import("../Compilation"), T>} */
+	const map = new WeakMap();
+	return (compilation) => {
+		const Compilation = getCompilation();
+		if (!(compilation instanceof Compilation)) {
+			throw new TypeError(
+				"The 'compilation' argument must be an instance of Compilation"
+			);
+		}
+		let hooks = map.get(compilation);
+		if (hooks === undefined) {
+			hooks = createHooks();
+			map.set(compilation, hooks);
+		}
+		return hooks;
+	};
+};
+
+module.exports = createHooksRegistry;

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -6,12 +6,12 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
 const Generator = require("../Generator");
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
 const { tryRunOrWebpackError } = require("../errors/HookWebpackError");
 const { compareModulesByFullName } = require("../util/comparators");
+const createHooksRegistry = require("../util/createHooksRegistry");
 const memoize = require("../util/memoize");
 const AsyncWasmModule = require("./AsyncWasmModule");
 
@@ -59,37 +59,9 @@ const getAsyncWebAssemblyParser = memoize(() =>
  * @property {boolean=} mangleImports mangle imports
  */
 
-/** @type {WeakMap<Compilation, CompilationHooks>} */
-const compilationHooksMap = new WeakMap();
-
 const PLUGIN_NAME = "AsyncWebAssemblyModulesPlugin";
 
 class AsyncWebAssemblyModulesPlugin {
-	/**
-	 * Returns the attached hooks.
-	 * @param {Compilation} compilation the compilation
-	 * @returns {CompilationHooks} the attached hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				renderModuleContent: new SyncWaterfallHook([
-					"source",
-					"module",
-					"renderContext"
-				])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * Creates an instance of AsyncWebAssemblyModulesPlugin.
 	 * @param {AsyncWebAssemblyModulesPluginOptions} options options
@@ -223,5 +195,16 @@ class AsyncWebAssemblyModulesPlugin {
 		}
 	}
 }
+
+AsyncWebAssemblyModulesPlugin.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {CompilationHooks} */ ({
+			renderModuleContent: new SyncWaterfallHook([
+				"source",
+				"module",
+				"renderContext"
+			])
+		})
+);
 
 module.exports = AsyncWebAssemblyModulesPlugin;

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
-const Compilation = require("../Compilation");
+/** @typedef {import("../Compilation")} Compilation */
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
@@ -15,6 +15,7 @@ const {
 const chunkHasJs = require("../javascript/JavascriptModulesPlugin").chunkHasJs;
 const { getInitialChunkIds } = require("../javascript/StartupHelpers");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
+const createHooksRegistry = require("../util/createHooksRegistry");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
@@ -26,31 +27,7 @@ const compileBooleanMatcher = require("../util/compileBooleanMatcher");
  * @property {SyncWaterfallHook<[string, Chunk]>} linkPrefetch
  */
 
-/** @type {WeakMap<Compilation, JsonpCompilationPluginHooks>} */
-const compilationHooksMap = new WeakMap();
-
 class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
-	/**
-	 * @param {Compilation} compilation the compilation
-	 * @returns {JsonpCompilationPluginHooks} hooks
-	 */
-	static getCompilationHooks(compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				linkPreload: new SyncWaterfallHook(["source", "chunk"]),
-				linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-
 	/**
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements runtime requirements
 	 */
@@ -458,5 +435,13 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 		]);
 	}
 }
+
+JsonpChunkLoadingRuntimeModule.getCompilationHooks = createHooksRegistry(
+	() =>
+		/** @type {JsonpCompilationPluginHooks} */ ({
+			linkPreload: new SyncWaterfallHook(["source", "chunk"]),
+			linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
+		})
+);
 
 module.exports = JsonpChunkLoadingRuntimeModule;

--- a/types.d.ts
+++ b/types.d.ts
@@ -679,13 +679,9 @@ declare class AsyncWebAssemblyModulesPlugin {
 		renderContext: WebAssemblyRenderContext,
 		hooks: CompilationHooksAsyncWebAssemblyModulesPlugin
 	): Source;
-
-	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): CompilationHooksAsyncWebAssemblyModulesPlugin;
+	) => CompilationHooksAsyncWebAssemblyModulesPlugin;
 }
 declare interface AsyncWebAssemblyModulesPluginOptions {
 	/**
@@ -2757,6 +2753,13 @@ declare interface ChunkRenderContextCssModulesPlugin {
 	 */
 	moduleSourceContent: Source;
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface ChunkRenderContextJavascriptModulesPlugin {
 	/**
 	 * the chunk
@@ -2904,13 +2907,9 @@ declare class CleanPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-
-	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): CleanPluginCompilationHooks;
+	) => CleanPluginCompilationHooks;
 }
 declare interface CleanPluginCompilationHooks {
 	/**
@@ -3974,6 +3973,13 @@ declare interface CompilationHooksCssModulesPlugin {
 		undefined | void | Module[]
 	>;
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface CompilationHooksJavascriptModulesPlugin {
 	renderModuleContent: SyncWaterfallHook<
 		[Source, Module, ModuleRenderContext],
@@ -4172,18 +4178,18 @@ declare class Compiler {
 	fileTimestamps?: Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 	contextTimestamps?: Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 	fsStartTime?: number;
 	resolverFactory: ResolverFactory;
@@ -5154,8 +5160,8 @@ declare interface ContextResolveData {
 }
 type ContextTimestamp =
 	| null
-	| ContextFileSystemInfoEntry
 	| "ignore"
+	| ContextFileSystemInfoEntry
 	| ExistenceOnlyTimeEntryFileSystemInfo;
 declare interface ContextTimestampAndHash {
 	safeTime: number;
@@ -5399,9 +5405,9 @@ declare interface CssImportDependencyMeta {
 type CssLayer = undefined | string;
 declare class CssLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements: ReadonlySet<string>);
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): CssLoadingRuntimeModulePluginHooks;
+	) => CssLoadingRuntimeModulePluginHooks;
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -5600,13 +5606,6 @@ declare class CssModulesPlugin {
 	): Source;
 
 	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(
-		compilation: Compilation
-	): CompilationHooksCssModulesPlugin;
-
-	/**
 	 * Renders css module source.
 	 */
 	static renderModule(
@@ -5627,6 +5626,9 @@ declare class CssModulesPlugin {
 	 * Returns true, when the chunk has css.
 	 */
 	static chunkHasCss(chunk: Chunk, chunkGraph: ChunkGraph): boolean;
+	static getCompilationHooks: (
+		compilation: Compilation
+	) => CompilationHooksCssModulesPlugin;
 }
 declare abstract class CssParser extends ParserClass {
 	defaultMode: "global" | "auto" | "local" | "pure";
@@ -5753,11 +5755,6 @@ declare class DefinePlugin {
 	apply(compiler: Compiler): void;
 
 	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(compilation: Compilation): DefinePluginHooks;
-
-	/**
 	 * Returns runtime value.
 	 */
 	static runtimeValue(
@@ -5768,6 +5765,7 @@ declare class DefinePlugin {
 		}) => CodeValuePrimitive,
 		options?: true | string[] | RuntimeValueOptions
 	): RuntimeValue;
+	static getCompilationHooks: (compilation: Compilation) => DefinePluginHooks;
 }
 declare interface DefinePluginHooks {
 	definitions: SyncWaterfallHook<
@@ -8136,11 +8134,7 @@ declare class ExternalModule extends Module {
 		unsafeCacheData: UnsafeCacheData,
 		normalModuleFactory: NormalModuleFactory
 	): void;
-
-	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(compilation: Compilation): ExternalModuleHooks;
+	static getCompilationHooks: (compilation: Compilation) => ExternalModuleHooks;
 	static ModuleExternalInitFragment: typeof ModuleExternalInitFragment;
 	static getExternalModuleNodeCommonjsInitFragment: (
 		runtimeTemplate: RuntimeTemplate,
@@ -8693,7 +8687,7 @@ declare abstract class FileSystemInfo {
 		path: string,
 		callback: (
 			err?: null | WebpackError,
-			fileTimestamp?: null | FileSystemInfoEntry | "ignore"
+			fileTimestamp?: null | "ignore" | FileSystemInfoEntry
 		) => void
 	): void;
 
@@ -8791,8 +8785,8 @@ declare interface FileSystemInfoEntry {
 }
 type FileTimestamp =
 	| null
-	| FileSystemInfoEntry
 	| "ignore"
+	| FileSystemInfoEntry
 	| ExistenceOnlyTimeEntryFileSystemInfo;
 type FilterItemTypes = string | RegExp | ((value: string) => boolean);
 declare interface Flags {
@@ -10467,19 +10461,15 @@ declare class JavascriptModulesPlugin {
 	): string;
 
 	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(
-		compilation: Compilation
-	): CompilationHooksJavascriptModulesPlugin;
-
-	/**
 	 * Gets chunk filename template.
 	 */
 	static getChunkFilenameTemplate(
 		chunk: Chunk,
 		outputOptions: OutputNormalizedWithDefaults
 	): ChunkFilenameTemplate;
+	static getCompilationHooks: (
+		compilation: Compilation
+	) => CompilationHooksJavascriptModulesPlugin;
 	static chunkHasJs: (chunk: Chunk, chunkGraph: ChunkGraph) => boolean;
 }
 declare class JavascriptParser extends ParserClass {
@@ -12881,9 +12871,9 @@ type JsonValueTypes =
 	| JsonValueTypes[];
 declare class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements: ReadonlySet<string>);
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): JsonpCompilationPluginHooks;
+	) => JsonpCompilationPluginHooks;
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -14015,9 +14005,9 @@ declare interface LoadScriptCompilationHooks {
 }
 declare class LoadScriptRuntimeModule extends HelperRuntimeModule {
 	constructor(withCreateScriptUrl?: boolean, withFetchPriority?: boolean);
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): LoadScriptCompilationHooks;
+	) => LoadScriptCompilationHooks;
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -14369,6 +14359,13 @@ type LogTypeEnum =
 	| "status";
 declare const MEASURE_END_OPERATION: unique symbol;
 declare const MEASURE_START_OPERATION: unique symbol;
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface MainRenderContext {
 	/**
 	 * the chunk
@@ -15171,13 +15168,9 @@ declare class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 	 * Creates an instance of ModuleChunkLoadingRuntimeModule.
 	 */
 	constructor(runtimeRequirements: ReadonlySet<string>);
-
-	/**
-	 * Returns hooks.
-	 */
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): JsonpCompilationPluginHooks;
+	) => JsonpCompilationPluginHooks;
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -15375,13 +15368,9 @@ declare class ModuleFederationPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-
-	/**
-	 * Get the compilation hooks associated with this plugin.
-	 */
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): CompilationHooksModuleFederationPlugin;
+	) => CompilationHooksModuleFederationPlugin;
 }
 declare interface ModuleFederationPluginOptions {
 	/**
@@ -16200,6 +16189,13 @@ declare interface ModuleReferenceOptions {
 	 */
 	asiSafe?: boolean;
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface ModuleRenderContext {
 	/**
 	 * the chunk
@@ -20597,13 +20593,9 @@ declare class RealContentHashPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-
-	/**
-	 * Returns the attached hooks.
-	 */
-	static getCompilationHooks(
+	static getCompilationHooks: (
 		compilation: Compilation
-	): CompilationHooksRealContentHashPlugin;
+	) => CompilationHooksRealContentHashPlugin;
 }
 declare interface RealContentHashPluginOptions {
 	/**
@@ -20818,6 +20810,13 @@ declare interface RemotesConfig {
 declare interface RemotesObject {
 	[index: string]: string | RemotesConfig | string[];
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface RenderBootstrapContext {
 	/**
 	 * the chunk
@@ -20890,6 +20889,13 @@ declare interface RenderContextCssModulesPlugin {
 	 */
 	modules: CssModule[];
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface RenderContextJavascriptModulesPlugin {
 	/**
 	 * the chunk
@@ -24037,6 +24043,13 @@ declare interface StarListSerializerContext {
 		obj?: LazyOptions
 	) => LazyFunction<any, any, any, LazyOptions>;
 }
+
+/**
+ * Renames an inlined module's top-level declaration (and all its references) when
+ * its name is already taken in the shared startup scope, recording the chosen name
+ * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
+ * IIFE by resolving name collisions instead of isolating each module.
+ */
 declare interface StartupRenderContext {
 	/**
 	 * the chunk
@@ -25406,18 +25419,18 @@ declare interface WatchFileSystem {
 			timeInfoEntries1?: Map<
 				string,
 				| null
+				| "ignore"
 				| EntryTypesIndex
 				| OnlySafeTimeEntry
 				| ExistenceOnlyTimeEntryTypesIndex
-				| "ignore"
 			>,
 			timeInfoEntries2?: Map<
 				string,
 				| null
+				| "ignore"
 				| EntryTypesIndex
 				| OnlySafeTimeEntry
 				| ExistenceOnlyTimeEntryTypesIndex
-				| "ignore"
 			>,
 			changes?: Set<string>,
 			removals?: Set<string>
@@ -25504,10 +25517,10 @@ declare interface Watcher {
 	getFileTimeInfoEntries: () => Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 
 	/**
@@ -25516,10 +25529,10 @@ declare interface Watcher {
 	getContextTimeInfoEntries: () => Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 
 	/**
@@ -25548,10 +25561,10 @@ declare interface WatcherInfo {
 	fileTimeInfoEntries: Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 
 	/**
@@ -25560,10 +25573,10 @@ declare interface WatcherInfo {
 	contextTimeInfoEntries: Map<
 		string,
 		| null
+		| "ignore"
 		| EntryTypesIndex
 		| OnlySafeTimeEntry
 		| ExistenceOnlyTimeEntryTypesIndex
-		| "ignore"
 	>;
 }
 declare abstract class Watching {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Extract the repeated `getCompilationHooks` WeakMap + instanceof + lazy-init pattern (duplicated across 16 files) into a single `Compilation.createHooksRegistry` static method, reducing ~240 lines of boilerplate.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No, this is a pure refactor with no behavioral changes.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to implement the refactoring changes under human direction and review.