### PR TITLE
test: deterministic findGraphRoots across edge orderings

### DIFF
--- a/test/findGraphRoots.unittest.js
+++ b/test/findGraphRoots.unittest.js
@@ -8,6 +8,46 @@ const args = (/** @type {Record<string, string[]>} */ g) =>
 		(/** @type {string} */ m) => g[m]
 	]);
 
+// seeded PRNG keeps the permutation fuzzing deterministic across runs
+const mulberry32 = (/** @type {number} */ seed) => () => {
+	seed = (seed + 0x6d2b79f5) | 0;
+	let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+	t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+	return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+/**
+ * @param {string[]} arr array to copy and shuffle
+ * @param {() => number} rnd random source in [0, 1)
+ * @returns {string[]} shuffled copy
+ */
+const shuffle = (arr, rnd) => {
+	const a = [...arr];
+	for (let i = a.length - 1; i > 0; i--) {
+		const j = Math.floor(rnd() * (i + 1));
+		[a[i], a[j]] = [a[j], a[i]];
+	}
+	return a;
+};
+
+/**
+ * Permutes node order and each node's edge order without changing the graph.
+ * @param {Record<string, string[]>} graph adjacency list
+ * @param {() => number} rnd random source in [0, 1)
+ * @returns {Record<string, string[]>} permuted adjacency list
+ */
+const permute = (graph, rnd) => {
+	/** @type {Record<string, string[]>} */
+	const g = {};
+	for (const k of shuffle(Object.keys(graph), rnd)) {
+		g[k] = shuffle(graph[k], rnd);
+	}
+	return g;
+};
+
+const rootsOf = (/** @type {Record<string, string[]>} */ g) =>
+	new Set(findGraphRoots(...args(g)));
+
 describe("findGraphRoots", () => {
 	it("simple case", () => {
 		const g = { A: ["B"], B: ["C"], C: ["D"], D: ["B"] };
@@ -70,5 +110,41 @@ describe("findGraphRoots", () => {
 			C: ["A"]
 		};
 		expect(findGraphRoots(...args(g1))).toEqual(findGraphRoots(...args(g2)));
+	});
+
+	// Regression for #17757: chunk root selection feeds build-order-dependent
+	// edges (e.g. via thread-loader) into findGraphRoots, so the selected roots
+	// must not depend on node/edge ordering — fixed in #20452.
+	it("is deterministic across node and edge orderings in a complex multi-cycle graph", () => {
+		const g = {
+			// root SCC {A,B,C}: dense 3-cycle with chords
+			A: ["B", "C", "D"],
+			B: ["C", "A"],
+			C: ["A", "B", "E"],
+			// downstream SCC {D,E}: reachable from {A,B,C}, not a root
+			D: ["E"],
+			E: ["D"],
+			// root SCC {F,G,H}: cycle with an overlapping inner cycle {G,H}
+			F: ["G", "H"],
+			G: ["H", "F"],
+			H: ["F", "G", "I"],
+			// downstream SCC {I,J,K}: reachable from {F,G,H}, not a root
+			I: ["J"],
+			J: ["I", "K"],
+			K: ["J"],
+			// root SCC {L,M,N}: the overlapping-cycle motif from #20445
+			L: ["N", "M"],
+			M: ["N"],
+			N: ["L"]
+		};
+
+		// one representative node per root SCC, by highest internal incoming count
+		const expected = new Set(["A", "B", "C", "F", "G", "H", "N"]);
+		expect(rootsOf(g)).toEqual(expected);
+
+		const rnd = mulberry32(0x1f2e3d4c);
+		for (let i = 0; i < 1000; i++) {
+			expect(rootsOf(permute(g, rnd))).toEqual(expected);
+		}
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Adds a regression test for the nondeterministic `[contenthash]` reported in #17757. The root cause was `findGraphRoots` selecting different root sets for the same graph depending on edge insertion order — and module/chunk edge order is build-completion-order dependent (e.g. parallelism from `thread-loader`), which is what made the hashes flip between identical builds. That ordering bug was fixed in #20452; this test locks in the behavior by fuzzing a complex multi-cycle graph over 1000 seeded permutations of node and edge order and asserting a stable root set. Closes #17757.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — this PR is the test: a new case in `test/findGraphRoots.unittest.js` (`is deterministic across node and edge orderings in a complex multi-cycle graph`).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code was used to read the #17757 thread, trace the root cause to `findGraphRoots`/#20452, design the multi-cycle graph and seeded permutation fuzzing, and verify the test (jest, eslint, prettier, tsc) against the current implementation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFpJcVQHoUhyKhNrA66px8)_