### PR TITLE
docs(claude): add path-scoped rules for lib, tests, and schemas

### DIFF
--- a/.claude/rules/lib.md
+++ b/.claude/rules/lib.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "lib/**"
+---
+[REQUIRED] If you add, rename, or remove any directory directly under `lib/`,
+update the matching bullet in the **Project Overview** section of `CLAUDE.md` in the same commit.
+CI does not check this — drift is caught only by human reviewers.
+
+Source files are **CommonJS only**. Types are declared via JSDoc `@typedef` — do not introduce `.ts` source files.
+Use `/** @type {import("./Foo").Foo} */` annotations rather than `import type`.

--- a/.claude/rules/schemas.md
+++ b/.claude/rules/schemas.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "lib/**"
+  - "schemas/**"
+---
+When adding or modifying config options in a plugin or module, update the matching JSON schema
+in `schemas/` in the same PR. Auto-generate updated types by running `yarn fix` after schema changes.
+
+[REQUIRED] If you add or remove a directory under `schemas/`, update the matching bullet
+in the **Project Overview** section of `CLAUDE.md` in the same commit.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "lib/**"
+  - "test/**"
+---
+Test files mirror the `lib/` directory structure. A new module at `lib/foo/Bar.js`
+requires a corresponding test at `test/foo/Bar.test.js`.
+
+[REQUIRED] If you add or remove a directory under `test/`, update the matching bullet
+in the **Project Overview** section of `CLAUDE.md` in the same commit.
+
+Running tests:
+- All: `yarn test` (slow) or `yarn test --no-cov` (faster)
+- Single file: `jest test/<path>.js`
+
+New features require a changeset: run `yarn changeset` and describe the change before committing.


### PR DESCRIPTION
## What

Adds three focused rule files to `.claude/rules/` with `paths:` frontmatter that restricts each rule to load only when Claude Code is working in relevant directories.

| File | Paths | Content |
|------|-------|---------|
| `lib.md` | `lib/**` | CommonJS-only enforcement, JSDoc typedef, dir-map update reminder |
| `tests.md` | `lib/**`, `test/**` | lib↔test mirror structure, test commands, changeset reminder |
| `schemas.md` | `lib/**`, `schemas/**` | Schema sync requirement, `yarn fix` reminder, dir-map update |

## Why

The existing `CLAUDE.md` documents all of these conventions, but they load into every task regardless of what files the agent touches. The `paths:` frontmatter (a Claude Code feature) makes each rule load only when relevant — e.g. the schema-update reminder fires when editing `lib/**` or `schemas/**`, but not when editing `test/**`.

The rules contain no new information beyond what is already in `CLAUDE.md` — they just make it available contextually rather than globally.

## Test plan

- [ ] Verify `tests.md` loads when editing a file in `lib/` but not when editing `schemas/`
- [ ] Verify `schemas.md` loads when editing a file in `lib/` but not when editing `test/`
- [ ] Verify rule content matches the conventions already documented in `CLAUDE.md`