### PR TITLE
feat: keep export mangling for modules whose namespace object escapes

### DIFF
--- a/.changeset/mangle-escaping-namespaces.md
+++ b/.changeset/mangle-escaping-namespaces.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Keep export mangling enabled for modules whose namespace object is used as a whole value, by materializing a decoupled namespace object that keeps the original export names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ Make sure to read our AI policy (https://github.com/webpack/governance/blob/main
 
 Required answer per section — **one sentence each is the target, two or three the absolute maximum**:
 
-- **Summary** — motivation and what problem is solved; link the related issue (`Closes #…` / `Fixes #…`).
+- **Summary** — motivation and what problem is solved; link the related issue. When the PR actually fixes the bug or implements the feature the issue asks for, use the auto-closing form `Closes #…` / `Fixes #…` (not `Refs #…`); reserve `Refs #…` for issues the PR only relates to but does not resolve.
 - **What kind of change does this PR introduce?** — one of: fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs.
 - **Did you add tests for your changes?** — yes/no + which test files.
 - **Does this PR introduce a breaking change?** — yes/no + migration path if yes.

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -17,7 +17,7 @@ const {
 /** @typedef {import("./optimize/ConcatenatedModule").ExportName} Ids */
 
 const MODULE_REFERENCE_REGEXP =
-	/^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?(_directImport)?(_deferredImport)?(?:_asiSafe(\d))?__$/;
+	/^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?(_directImport)?(_deferredImport)?(_mangleableNs)?(?:_asiSafe(\d))?__$/;
 
 /**
  * Encodes how a concatenated module reference should be interpreted when it is
@@ -27,6 +27,7 @@ const MODULE_REFERENCE_REGEXP =
  * @property {boolean} call true, when this referenced export is called
  * @property {boolean} directImport true, when this referenced export is directly imported (not via property access)
  * @property {boolean} deferredImport true, when this referenced export is deferred
+ * @property {boolean} mangleableNamespace true, when a whole-namespace reference may use a decoupled namespace object that keeps the original export names
  * @property {boolean | undefined} asiSafe if the position is ASI safe or unknown
  */
 
@@ -147,6 +148,7 @@ class ConcatenationScope {
 			call = false,
 			directImport = false,
 			deferredImport = false,
+			mangleableNamespace = false,
 			asiSafe = false
 		}
 	) {
@@ -154,6 +156,7 @@ class ConcatenationScope {
 		const callFlag = call ? "_call" : "";
 		const directImportFlag = directImport ? "_directImport" : "";
 		const deferredImportFlag = deferredImport ? "_deferredImport" : "";
+		const mangleableNamespaceFlag = mangleableNamespace ? "_mangleableNs" : "";
 		const asiSafeFlag = asiSafe
 			? "_asiSafe1"
 			: asiSafe === false
@@ -163,7 +166,7 @@ class ConcatenationScope {
 			? Buffer.from(JSON.stringify(ids), "utf8").toString("hex")
 			: "ns";
 		// a "._" is appended to allow "delete ...", which would cause a SyntaxError in strict mode
-		return `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${callFlag}${directImportFlag}${deferredImportFlag}${asiSafeFlag}__._`;
+		return `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${callFlag}${directImportFlag}${deferredImportFlag}${mangleableNamespaceFlag}${asiSafeFlag}__._`;
 	}
 
 	/**
@@ -186,7 +189,7 @@ class ConcatenationScope {
 		const match = MODULE_REFERENCE_REGEXP.exec(name);
 		if (!match) return null;
 		const index = Number(match[1]);
-		const asiSafe = match[6];
+		const asiSafe = match[7];
 		return {
 			index,
 			ids:
@@ -196,6 +199,7 @@ class ConcatenationScope {
 			call: Boolean(match[3]),
 			directImport: Boolean(match[4]),
 			deferredImport: Boolean(match[5]),
+			mangleableNamespace: Boolean(match[6]),
 			asiSafe: asiSafe ? asiSafe === "1" : undefined
 		};
 	}

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -463,6 +463,11 @@ class Dependency {
 Dependency.NO_EXPORTS_REFERENCED = [];
 /** @type {RawReferencedExports} */
 Dependency.EXPORTS_OBJECT_REFERENCED = [[]];
+// Like EXPORTS_OBJECT_REFERENCED, but the reference can be rendered as a
+// decoupled namespace object, so the module's exports stay mangleable.
+// Same shape as EXPORTS_OBJECT_REFERENCED; only distinguished by identity.
+/** @type {RawReferencedExports} */
+Dependency.EXPORTS_OBJECT_REFERENCED_MANGLEABLE = [[]];
 
 // TODO remove in webpack 6
 Object.defineProperty(Dependency.prototype, "module", {

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -21,7 +21,11 @@ const { getEntryRuntime, mergeRuntimeOwned } = require("./util/runtime");
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
 
-const { NO_EXPORTS_REFERENCED, EXPORTS_OBJECT_REFERENCED } = Dependency;
+const {
+	NO_EXPORTS_REFERENCED,
+	EXPORTS_OBJECT_REFERENCED,
+	EXPORTS_OBJECT_REFERENCED_MANGLEABLE
+} = Dependency;
 
 const PLUGIN_NAME = "FlagDependencyUsagePlugin";
 const PLUGIN_LOGGER_NAME = `webpack.${PLUGIN_NAME}`;
@@ -30,10 +34,13 @@ class FlagDependencyUsagePlugin {
 	/**
 	 * Creates an instance of FlagDependencyUsagePlugin.
 	 * @param {boolean} global do a global analysis instead of per runtime
+	 * @param {boolean=} mangleEscapingNamespaces keep exports mangleable when a module's namespace object escapes
 	 */
-	constructor(global) {
+	constructor(global, mangleEscapingNamespaces = false) {
 		/** @type {boolean} */
 		this.global = global;
+		/** @type {boolean} */
+		this.mangleEscapingNamespaces = mangleEscapingNamespaces;
 	}
 
 	/**
@@ -75,6 +82,42 @@ class FlagDependencyUsagePlugin {
 						forceSideEffects
 					) => {
 						const exportsInfo = moduleGraph.getExportsInfo(module);
+						if (usedExports === EXPORTS_OBJECT_REFERENCED_MANGLEABLE) {
+							// The whole namespace object escapes via a reference that codegen
+							// can materialize as a decoupled namespace object. When all exports
+							// are statically known we keep them mangleable instead of marking
+							// them used-in-unknown-way.
+							if (
+								this.mangleEscapingNamespaces &&
+								module.buildMeta &&
+								module.buildMeta.exportsType === "namespace" &&
+								exportsInfo.otherExportsInfo.provided === false
+							) {
+								let changed = exportsInfo.setAllKnownExportsUsed(runtime);
+								// The whole namespace object is observed as a value, so the
+								// module must stay a real ES module namespace at runtime
+								// (keep __esModule / the namespace object, i.e. `r()`).
+								if (
+									exportsInfo
+										.getExportInfo("__esModule")
+										.setUsed(UsageState.Used, runtime)
+								) {
+									changed = true;
+								}
+								// Exports must keep a real binding (not be inlined) so member
+								// access on the namespace has ES namespace semantics, e.g.
+								// `delete ns.x` hits a non-configurable property and throws.
+								for (const exportInfo of exportsInfo.ownedExports) {
+									exportInfo.canInlineUse = false;
+								}
+								if (changed) {
+									queue.enqueue(module, runtime);
+								}
+							} else if (exportsInfo.setUsedInUnknownWay(runtime)) {
+								queue.enqueue(module, runtime);
+							}
+							return;
+						}
 						if (usedExports.length > 0) {
 							if (!module.buildMeta || !module.buildMeta.exportsType) {
 								if (exportsInfo.setUsedWithoutInfo(runtime)) {
@@ -183,6 +226,11 @@ class FlagDependencyUsagePlugin {
 						/** @typedef {Map<string, string[] | ReferencedExport>} ExportMaps */
 						/** @type {Map<Module, ReferencedExports | ExportMaps>} */
 						const map = new Map();
+						// Modules whose whole namespace object escapes in a mangleable way.
+						// Tracked separately so specific member references are still merged
+						// (and marked used) instead of being dropped by the escape marker.
+						/** @type {Set<Module>} */
+						const mangleableEscapeModules = new Set();
 
 						/** @type {ArrayQueue<DependenciesBlock>} */
 						const queue = new ArrayQueue();
@@ -221,10 +269,27 @@ class FlagDependencyUsagePlugin {
 								}
 								const referencedExports =
 									compilation.getDependencyReferencedExports(dep, runtime);
+								// The non-mangleable whole-object reference is the most
+								// conservative result and always wins.
+								if (referencedExports === EXPORTS_OBJECT_REFERENCED) {
+									map.set(module, EXPORTS_OBJECT_REFERENCED);
+									mangleableEscapeModules.delete(module);
+									continue;
+								}
+								// A mangleable whole-object escape keeps the module's exports
+								// mangleable (applied after the merge). Unlike the conservative
+								// marker it must not drop specific member references: those still
+								// need their own (possibly non-existent) export marked used so
+								// they render as a qualified access, not a bare `undefined`.
+								if (
+									referencedExports === EXPORTS_OBJECT_REFERENCED_MANGLEABLE
+								) {
+									mangleableEscapeModules.add(module);
+									continue;
+								}
 								if (
 									oldReferencedExports === undefined ||
-									oldReferencedExports === NO_EXPORTS_REFERENCED ||
-									referencedExports === EXPORTS_OBJECT_REFERENCED
+									oldReferencedExports === NO_EXPORTS_REFERENCED
 								) {
 									map.set(module, referencedExports);
 								} else if (
@@ -292,6 +357,14 @@ class FlagDependencyUsagePlugin {
 									forceSideEffects
 								);
 							}
+						}
+						for (const module of mangleableEscapeModules) {
+							processReferencedModule(
+								module,
+								EXPORTS_OBJECT_REFERENCED_MANGLEABLE,
+								runtime,
+								forceSideEffects
+							);
 						}
 					};
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -20,7 +20,7 @@ const {
 const { equals } = require("./util/ArrayHelpers");
 const compileBooleanMatcher = require("./util/compileBooleanMatcher");
 const memoize = require("./util/memoize");
-const { propertyAccess } = require("./util/property");
+const { propertyAccess, propertyName } = require("./util/property");
 const { forEachRuntime, subtractRuntime } = require("./util/runtime");
 
 const getHarmonyImportDependency = memoize(() =>
@@ -1159,6 +1159,7 @@ class RuntimeTemplate {
 	 * @param {RuntimeSpec} options.runtime runtime for which this code will be generated
 	 * @param {RuntimeRequirements} options.runtimeRequirements if set, will be filled with runtime requirements
 	 * @param {ModuleDependency} options.dependency module dependency
+	 * @param {boolean=} options.mangleableNamespace true, when a whole-namespace value may use a decoupled namespace object that keeps the original export names
 	 * @returns {string} expression
 	 */
 	exportFromImport({
@@ -1176,7 +1177,8 @@ class RuntimeTemplate {
 		initFragments,
 		runtime,
 		runtimeRequirements,
-		dependency
+		dependency,
+		mangleableNamespace = false
 	}) {
 		if (!module) {
 			return this.missingModule({
@@ -1342,10 +1344,99 @@ class RuntimeTemplate {
 				asiSafe ? "" : asiSafe === false ? ";" : "Object"
 			}(${importVar}_deferred_namespace_cache || (${importVar}_deferred_namespace_cache = ${init}))`;
 		}
+		// The whole namespace object is used as a value. If the module's exports
+		// were mangled, importVar's keys are the mangled names, so we materialize
+		// a decoupled namespace object that exposes the original names.
+		if (
+			exportsType === "namespace" &&
+			mangleableNamespace &&
+			this.compilation &&
+			this.compilation.options.optimization.mangleExports
+		) {
+			const materialized = this._materializedNamespaceObject({
+				moduleGraph,
+				module,
+				importVar,
+				initFragments,
+				runtime,
+				runtimeRequirements
+			});
+			if (materialized !== undefined) return materialized;
+		}
 		// if we hit here, the importVar is either
 		// - already a ES module namespace object
 		// - or imported by a way that does not need interop.
 		return importVar;
+	}
+
+	/**
+	 * Materializes a namespace object that keeps the original export names while
+	 * the module's own exports are mangled. Returns undefined when no export was
+	 * mangled (then the raw namespace object can be used as-is).
+	 * @template GenerateContext
+	 * @param {object} options options
+	 * @param {ModuleGraph} options.moduleGraph the module graph
+	 * @param {Module} options.module the imported module
+	 * @param {string} options.importVar the import variable referencing the module
+	 * @param {InitFragment<GenerateContext>[]} options.initFragments target array for init fragments
+	 * @param {RuntimeSpec} options.runtime the runtime
+	 * @param {RuntimeRequirements} options.runtimeRequirements runtime requirements
+	 * @returns {string | undefined} expression of the materialized namespace object, or undefined
+	 */
+	_materializedNamespaceObject({
+		moduleGraph,
+		module,
+		importVar,
+		initFragments,
+		runtime,
+		runtimeRequirements
+	}) {
+		const exportsInfo = moduleGraph.getExportsInfo(module);
+		/** @type {string[]} */
+		const definitions = [];
+		let mangled = false;
+		for (const exportInfo of exportsInfo.orderedExports) {
+			if (exportInfo.provided === false) continue;
+			const used = exportsInfo.getUsedName([exportInfo.name], runtime);
+			if (!used) continue;
+			if (used instanceof InlinedUsedName) {
+				// An inlined export isn't reachable by name on the raw exports object,
+				// so the decoupled object must expose the inlined value directly.
+				mangled = true;
+				definitions.push(
+					`${propertyName(exportInfo.name)}: ${this.returningFunction(
+						used.render(
+							Template.toNormalComment(
+								`inlined export ${propertyAccess([exportInfo.name])}`
+							)
+						)
+					)}`
+				);
+				continue;
+			}
+			if (used[used.length - 1] !== exportInfo.name) mangled = true;
+			definitions.push(
+				`${propertyName(exportInfo.name)}: ${this.returningFunction(
+					`${importVar}${propertyAccess(used)}`
+				)}`
+			);
+		}
+		if (!mangled) return;
+		const name = `${importVar}_namespace_object`;
+		runtimeRequirements.add(RuntimeGlobals.exports);
+		runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
+		runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+		initFragments.push(
+			new InitFragment(
+				`var ${name} = {};\n${RuntimeGlobals.makeNamespaceObject}(${name});\n${
+					RuntimeGlobals.definePropertyGetters
+				}(${name}, {\n\t${definitions.join(",\n\t")}\n});\n`,
+				InitFragment.STAGE_PROVIDES,
+				0,
+				name
+			)
+		);
+		return name;
 	}
 
 	/**

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -640,7 +640,9 @@ class WebpackOptionsApply extends OptionsApply {
 			const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");
 
 			new FlagDependencyUsagePlugin(
-				options.optimization.usedExports === "global"
+				options.optimization.usedExports === "global",
+				// Keep an escaping module's exports mangleable when mangling is on.
+				Boolean(options.optimization.mangleExports)
 			).apply(compiler);
 		}
 		if (options.optimization.innerGraph) {

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -229,7 +229,16 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 */
 	getReferencedExports(moduleGraph, runtime) {
 		let ids = this.getIds(moduleGraph);
-		if (ids.length === 0) return this._getReferencedExportsInDestructuring();
+		if (ids.length === 0) {
+			const refs = this._getReferencedExportsInDestructuring();
+			// The whole namespace object is used as a value (no destructuring): it
+			// can be rendered as a decoupled namespace object, keeping the module's
+			// exports mangleable. Deferred imports keep their special namespace.
+			return refs === Dependency.EXPORTS_OBJECT_REFERENCED &&
+				!ImportPhaseUtils.isDefer(this.phase)
+				? Dependency.EXPORTS_OBJECT_REFERENCED_MANGLEABLE
+				: refs;
+		}
 		let namespaceObjectAsContext = this.namespaceObjectAsContext;
 		if (ids[0] === "default") {
 			const selfModule =
@@ -569,7 +578,13 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 					connection.module,
 					{
 						asiSafe: dep.asiSafe,
-						deferredImport: ImportPhaseUtils.isDefer(dep.phase)
+						deferredImport: ImportPhaseUtils.isDefer(dep.phase),
+						// A bare namespace value that isn't destructured may escape, so
+						// allow a decoupled namespace object that keeps the original names.
+						// Deferred imports keep their special namespace object.
+						mangleableNamespace:
+							!dep.referencedPropertiesInDestructuring &&
+							!ImportPhaseUtils.isDefer(dep.phase)
 					}
 				);
 			} else if (dep.namespaceObjectAsContext && ids.length === 1) {
@@ -611,7 +626,14 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 				initFragments,
 				runtime,
 				runtimeRequirements,
-				dependency: dep
+				dependency: dep,
+				// A bare namespace value that isn't destructured may escape, so allow a
+				// decoupled namespace object that keeps the original export names.
+				// Deferred imports keep their special namespace object.
+				mangleableNamespace:
+					ids.length === 0 &&
+					!dep.referencedPropertiesInDestructuring &&
+					!ImportPhaseUtils.isDefer(dep.phase)
 			});
 		}
 		return exportExpr;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -164,6 +164,7 @@ if (!ReferencerClass.prototype.PropertyDefinition) {
  * @property {ExportMap | undefined} rawExportMap
  * @property {string=} namespaceExportSymbol
  * @property {string | undefined} namespaceObjectName
+ * @property {string | undefined} escapeNamespaceObjectName decoupled namespace object that keeps original export names when the exports are mangled
  * @property {ConcatenationScope | undefined} concatenationScope
  * @property {boolean} interopNamespaceObjectUsed "default-with-named" namespace
  * @property {string | undefined} interopNamespaceObjectName "default-with-named" namespace
@@ -183,6 +184,7 @@ if (!ReferencerClass.prototype.PropertyDefinition) {
  * @property {NonDeferAccess} nonDeferAccess
  * @property {number} index
  * @property {string | undefined} name module.exports / harmony namespace object
+ * @property {string | undefined} escapeNamespaceObjectName decoupled namespace object that keeps original export names when the exports are mangled
  * @property {string | undefined} deferredName deferred module.exports / harmony namespace object
  * @property {boolean} deferred the module is deferred at least once
  * @property {boolean} deferredNamespaceObjectUsed deferred namespace object that being used in a not-analyzable way so it must be materialized
@@ -1449,6 +1451,11 @@ class ConcatenatedModule extends Module {
 		/** @type {NeededNamespaceObjects} */
 		const neededNamespaceObjects = new Set();
 
+		// Set with modules whose mangled namespace escapes as a whole value and
+		// therefore needs a decoupled namespace object keyed by the original names
+		/** @type {Set<ConcatenatedModuleInfo | ExternalModuleInfo>} */
+		const neededEscapeNamespaceObjects = new Set();
+
 		// List of all used names to avoid conflicts
 		const allUsedNames = new Set(RESERVED_NAMES);
 
@@ -1486,6 +1493,53 @@ class ConcatenatedModule extends Module {
 		// Set of already checked scopes
 		/** @type {Set<Scope>} */
 		const ignoredScopes = new Set();
+
+		/**
+		 * Lazily allocates a decoupled namespace object for a concatenated module
+		 * whose exports are mangled, so an escaping whole-namespace value still
+		 * exposes the original export names. Returns undefined when no export is
+		 * mangled (the regular namespace object can be used as-is).
+		 * @param {ConcatenatedModuleInfo | ExternalModuleInfo} info module info
+		 * @returns {string | undefined} the escape namespace object name
+		 */
+		const getEscapeNamespaceObjectName = (info) => {
+			if (info.type === "concatenated" && info.namespaceExportSymbol) {
+				return undefined;
+			}
+			// Deferred external modules keep their special deferred namespace object
+			// and are rendered through a different path that wouldn't emit ours.
+			if (info.type === "external" && info.deferred) return undefined;
+			// Only real ES module namespaces are decoupled; non-harmony modules use
+			// their interop/fake namespace object as before.
+			const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
+			if (!buildMeta || buildMeta.exportsType !== "namespace") return undefined;
+			if (info.escapeNamespaceObjectName !== undefined) {
+				return info.escapeNamespaceObjectName;
+			}
+			const exportsInfo = moduleGraph.getExportsInfo(info.module);
+			let mangled = false;
+			for (const exportInfo of exportsInfo.orderedExports) {
+				if (exportInfo.provided === false) continue;
+				const usedName = exportInfo.getUsedName(undefined, runtime);
+				if (!usedName || usedName instanceof InlinedUsedName) continue;
+				if (usedName[usedName.length - 1] !== exportInfo.name) {
+					mangled = true;
+					break;
+				}
+			}
+			if (!mangled) return undefined;
+			const name = findNewName(
+				"namespaceObject",
+				allUsedNames,
+				/** @type {UsedNames} */ (new Set()),
+				info.module.readableIdentifier(requestShortener)
+			);
+			allUsedNames.add(name);
+			topLevelDeclarations.add(name);
+			info.escapeNamespaceObjectName = name;
+			neededEscapeNamespaceObjects.add(info);
+			return name;
+		};
 
 		// get all global names
 		for (const info of modulesWithInfo) {
@@ -1538,6 +1592,18 @@ class ConcatenatedModule extends Module {
 							const referencedInfo = modulesWithInfo[match.index];
 							if (referencedInfo.type === "reference") {
 								throw new Error("Module reference can't point to a reference");
+							}
+							// An escaping mangled namespace resolves to its own decoupled
+							// namespace object (a unique top-level name), so it neither needs
+							// the regular namespace object nor super-class scope handling.
+							if (
+								match.mangleableNamespace &&
+								match.ids.length === 0 &&
+								(referencedInfo.type === "concatenated" ||
+									referencedInfo.type === "external") &&
+								getEscapeNamespaceObjectName(referencedInfo) !== undefined
+							) {
+								continue;
 							}
 							const binding = getFinalBinding(
 								moduleGraph,
@@ -1849,22 +1915,35 @@ class ConcatenatedModule extends Module {
 								concatenationScope.setRawExportMap(exportId, newName);
 							}
 						}
-						const finalName = getFinalName(
-							moduleGraph,
-							referencedInfo,
-							match.ids,
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							match.call,
-							match.deferredImport,
-							!match.directImport,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							match.asiSafe
-						);
+						// A whole-namespace value that escapes: when the module's exports
+						// are mangled, point it at a decoupled namespace object that keeps
+						// the original names so untracked access keeps working.
+						const escapeName =
+							match.mangleableNamespace &&
+							match.ids.length === 0 &&
+							(referencedInfo.type === "concatenated" ||
+								referencedInfo.type === "external")
+								? getEscapeNamespaceObjectName(referencedInfo)
+								: undefined;
+						const finalName =
+							escapeName !== undefined
+								? escapeName
+								: getFinalName(
+										moduleGraph,
+										referencedInfo,
+										match.ids,
+										moduleToInfoMap,
+										runtime,
+										requestShortener,
+										runtimeTemplate,
+										neededNamespaceObjects,
+										match.call,
+										match.deferredImport,
+										!match.directImport,
+										/** @type {BuildMeta} */
+										(info.module.buildMeta).strictHarmonyModule,
+										match.asiSafe
+									);
 
 						for (const reference of references) {
 							const r = /** @type {Range} */ (reference.identifier.range);
@@ -2012,6 +2091,80 @@ class ConcatenatedModule extends Module {
 			);
 		}
 
+		// generate decoupled namespace objects for escaping mangled namespaces:
+		// same getters as the regular namespace object, but keyed by the original
+		// export names so untracked access by name keeps working. Done before the
+		// regular namespace objects so any nested namespace they pull in is built.
+		/** @type {Map<ConcatenatedModuleInfo | ExternalModuleInfo, string>} */
+		const escapeNamespaceObjectSources = new Map();
+		for (const info of neededEscapeNamespaceObjects) {
+			/** @type {string[]} */
+			const nsObj = [];
+			const exportsInfo = moduleGraph.getExportsInfo(info.module);
+			for (const exportInfo of exportsInfo.orderedExports) {
+				if (exportInfo.provided === false) continue;
+				const usedName = exportInfo.getUsedName(undefined, runtime);
+				if (!usedName) continue;
+				if (usedName instanceof InlinedUsedName) {
+					nsObj.push(
+						`\n  ${propertyName(exportInfo.name)}: ${runtimeTemplate.returningFunction(
+							usedName.render(
+								Template.toNormalComment(
+									`inlined export ${propertyAccess(exportInfo.name)}`
+								)
+							)
+						)}`
+					);
+				} else {
+					// External (non-concatenated) modules are accessed through their
+					// import variable; concatenated ones resolve to an internal binding.
+					const finalName =
+						info.type === "external"
+							? `${/** @type {string} */ (info.name)}${propertyAccess(usedName)}`
+							: getFinalName(
+									moduleGraph,
+									info,
+									[exportInfo.name],
+									moduleToInfoMap,
+									runtime,
+									requestShortener,
+									runtimeTemplate,
+									neededNamespaceObjects,
+									false,
+									false,
+									undefined,
+									/** @type {BuildMeta} */
+									(info.module.buildMeta).strictHarmonyModule,
+									true
+								);
+					nsObj.push(
+						`\n  ${propertyName(exportInfo.name)}: ${runtimeTemplate.returningFunction(
+							finalName
+						)}`
+					);
+				}
+			}
+			const name = /** @type {string} */ (info.escapeNamespaceObjectName);
+			const defineGetters =
+				nsObj.length > 0
+					? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
+							","
+						)}\n});\n`
+					: "";
+			if (nsObj.length > 0) {
+				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+			}
+			escapeNamespaceObjectSources.set(
+				info,
+				`
+// NAMESPACE OBJECT (decoupled): ${info.module.readableIdentifier(requestShortener)}
+var ${name} = {};
+${RuntimeGlobals.makeNamespaceObject}(${name});
+${defineGetters}`
+			);
+			runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
+		}
+
 		// generate namespace objects
 		/** @type {Map<ConcatenatedModuleInfo, string>} */
 		const namespaceObjectSources = new Map();
@@ -2085,8 +2238,12 @@ ${defineGetters}`
 		for (const info of modulesWithInfo) {
 			if (info.type === "concatenated") {
 				const source = namespaceObjectSources.get(info);
-				if (!source) continue;
-				result.add(source);
+				if (source) result.add(source);
+				const escapeSource = escapeNamespaceObjectSources.get(
+					/** @type {ConcatenatedModuleInfo} */ (info)
+				);
+				if (escapeSource) result.add(escapeSource);
+				if (!source && !escapeSource) continue;
 			}
 
 			if (info.type === "external" && info.deferred) {
@@ -2180,6 +2337,10 @@ ${defineGetters}`
 						// so they must remain function-scoped (`var`).
 						result.add(`var ${info.name} = __webpack_require__(${moduleId});`);
 						name = info.name;
+						// Decoupled namespace object for an escaping mangled external
+						// module must come after its import variable is defined.
+						const escapeSource = escapeNamespaceObjectSources.get(info);
+						if (escapeSource) result.add(escapeSource);
 					}
 					// If a module is deferred in other places, but used as non-deferred here,
 					// the module itself will be emitted as mod_deferred (in the case "external"),
@@ -2388,6 +2549,7 @@ ${defineGetters}`
 							rawExportMap: undefined,
 							namespaceExportSymbol: undefined,
 							namespaceObjectName: undefined,
+							escapeNamespaceObjectName: undefined,
 							interopNamespaceObjectUsed: false,
 							interopNamespaceObjectName: undefined,
 							interopNamespaceObject2Used: false,
@@ -2407,6 +2569,7 @@ ${defineGetters}`
 							nonDeferAccess: info.nonDeferAccess,
 							index,
 							name: undefined,
+							escapeNamespaceObjectName: undefined,
 							deferredName: undefined,
 							interopNamespaceObjectUsed: false,
 							interopNamespaceObjectName: undefined,

--- a/test/configCases/code-generation/re-export-namespace-concat/index.js
+++ b/test/configCases/code-generation/re-export-namespace-concat/index.js
@@ -4,7 +4,16 @@ import * as m_2 from './module2';
 import * as m_3 from './module3';
 import data from "./data";
 
-const { expectSourceToContain } = require("../../../helpers/expectSource");
+const regexEscape = require("../../../helpers/regexEscape");
+const {
+	expectSourceToContain,
+	expectSourceToMatch
+} = require("../../../helpers/expectSource");
+
+// "@" marks a mangled export accessor name. Its exact value depends on the
+// mangleExports "size" ranking (and can differ between cached and non-cached
+// builds), so match it as `\w+` while still pinning the accessor *form*.
+const re = (tpl) => tpl.split("@").map(regexEscape).join("\\w+");
 
 // It's important to preserve the same accessor syntax (quotes vs. dot notatation) after the actual export variable.
 // Else, minifiers such as Closure Compiler will not be able to minify correctly in ADVANCED mode.
@@ -51,33 +60,36 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 	// Imported objects and import namespaces should use dot notation.  Any references to the properties of exports
 	// should be preserved as either quotes or dot notation, depending on the original source.
+	// `obj1` is mangled here (its namespace escapes via `const x1 = m_1`, which is rendered as a decoupled
+	// namespace object that keeps the original names); the mangled accessor name is matched as `\w+` below, but
+	// the accessor *form* (dot vs. quotes) is still pinned.
 
-	expectSourceToContain(source, 'const x1 = module1;');
-	expectSourceToContain(source, 'const x2 = module1.obj1;');
+	expectSourceToContain(source, 'const x1 = module1_namespaceObject;');
+	expectSourceToMatch(source, re('const x2 = module1/* obj1 */.@;'));
 
-	expectSourceToContain(source, 'const z1 = module1.obj1["plants"];');
-	expectSourceToContain(source, 'const z2 = module1.obj1["funcs"]();');
-	expectSourceToContain(source, 'const z3 = module1.obj1["pots"];');
-	expectSourceToContain(source, 'const z4 = module1.obj1["subs"]();');
+	expectSourceToMatch(source, re('const z1 = module1/* obj1 */.@["plants"];'));
+	expectSourceToMatch(source, re('const z2 = module1/* obj1 */.@["funcs"]();'));
+	expectSourceToMatch(source, re('const z3 = module1/* obj1 */.@["pots"];'));
+	expectSourceToMatch(source, re('const z4 = module1/* obj1 */.@["subs"]();'));
 
-	expectSourceToContain(source, 'const a = module1.obj1["flip"].flap;');
-	expectSourceToContain(source, 'const b = module1.obj1.zip["zap"];');
-	expectSourceToContain(source, 'const c = module1.obj1["ding"].dong();');
-	expectSourceToContain(source, 'const d = module1.obj1.sing["song"]();');
+	expectSourceToMatch(source, re('const a = module1/* obj1 */.@["flip"].flap;'));
+	expectSourceToMatch(source, re('const b = module1/* obj1 */.@.zip["zap"];'));
+	expectSourceToMatch(source, re('const c = module1/* obj1 */.@["ding"].dong();'));
+	expectSourceToMatch(source, re('const d = module1/* obj1 */.@.sing["song"]();'));
 
-	expectSourceToContain(source, 'const aa = module1.obj1["zoom"];');
+	expectSourceToMatch(source, re('const aa = module1/* obj1 */.@["zoom"];'));
 
-	expectSourceToContain(source, 'const bb = module1.obj1.up.down?.left.right;');
+	expectSourceToMatch(source, re('const bb = module1/* obj1 */.@.up.down?.left.right;'));
 
-	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 602).obj1)["bing"]?.bang;');
-	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 602).obj1)["pip"].pop();');
-	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 818)/* .m_2.m_1.obj1 */ .a.a.obj1)["tip"].top();');
+	expectSourceToMatch(source, re('const ww = (__webpack_require__(/*! ./module1 */ 602)/* .obj1 */ .@)["bing"]?.bang;'));
+	expectSourceToMatch(source, re('const xx = (__webpack_require__(/*! ./module1 */ 602)/* .obj1 */ .@)["pip"].pop();'));
+	expectSourceToMatch(source, re('const yy = (__webpack_require__(/*! ./module3 */ 818)/* .m_2.m_1.obj1 */ .@.@.@)["tip"].top();'));
 
 	expectSourceToContain(source, 'data_namespaceObject.a.a["unknownProperty"].depth = "deep";');
 
-	expectSourceToContain(source, '(module1.obj1)["aaa"].bbb;');
-	expectSourceToContain(source, '(module1.obj1)["ccc"].ddd;');
-	expectSourceToContain(source, '(module1.obj1["eee"]).fff;');
-	expectSourceToContain(source, '(module1.obj1["ggg"]).hhh;');
-	expectSourceToContain(source, '((module1.obj1)["iii"]).jjj;');
+	expectSourceToMatch(source, re('(module1/* obj1 */.@)["aaa"].bbb;'));
+	expectSourceToMatch(source, re('(module1/* obj1 */.@)["ccc"].ddd;'));
+	expectSourceToMatch(source, re('(module1/* obj1 */.@["eee"]).fff;'));
+	expectSourceToMatch(source, re('(module1/* obj1 */.@["ggg"]).hhh;'));
+	expectSourceToMatch(source, re('((module1/* obj1 */.@)["iii"]).jjj;'));
 });

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/cjs-provider.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/cjs-provider.js
@@ -1,0 +1,3 @@
+import * as ns from "./cjs";
+// Whole CommonJS namespace escapes; interop must keep working (no mangling).
+export const getCjs = () => ns;

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/cjs.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/cjs.js
@@ -1,0 +1,2 @@
+exports.CJS_A = "cjs-a";
+exports.CJS_B = "cjs-b";

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/consumer.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/consumer.js
@@ -1,0 +1,6 @@
+import { ENUM_A, NUM } from "./enums";
+
+// Static, trackable access -> should use the mangled name.
+export const direct = ENUM_A;
+// Inlinable const used in an inlinable position.
+export const sum = NUM + 1;

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/destr.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/destr.js
@@ -1,0 +1,7 @@
+import * as ns from "./enums";
+
+// Tracked destructuring of the same module whose namespace also escapes.
+export function read() {
+	const { ENUM_B } = ns;
+	return ENUM_B;
+}

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/dynamic.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/dynamic.js
@@ -1,0 +1,2 @@
+export const DYN_A = "dyn-a";
+export const DYN_B = "dyn-b";

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/enums.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/enums.js
@@ -1,0 +1,5 @@
+export const ENUM_A = "a-value";
+export const ENUM_B = "b-value";
+export const ENUM_C = "c-value";
+export const NUM = 42; // inlinable const, also accessed via the escaped namespace
+export default "default-value";

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/index.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/index.js
@@ -1,0 +1,60 @@
+import { getEnums } from "./provider";
+import { enumsNs } from "./reexport";
+import { getCjs } from "./cjs-provider";
+import { direct } from "./consumer";
+import { read } from "./destr";
+import fs from "fs";
+
+it("should keep escaped namespace access working while mangling the exports", () => {
+	const ns = getEnums();
+	expect(ns.ENUM_A).toBe("a-value");
+	expect(ns.ENUM_B).toBe("b-value");
+	expect(ns.ENUM_C).toBe("c-value");
+	expect(ns.default).toBe("default-value");
+	// inlinable const must still be reachable by its original name on the escape
+	expect(ns.NUM).toBe(42);
+	expect(direct).toBe("a-value");
+});
+
+it("should keep an escaped re-exported (export * as) namespace working", () => {
+	const get = () => enumsNs;
+	const ns = get();
+	expect(ns.ENUM_A).toBe("a-value");
+	expect(ns.default).toBe("default-value");
+});
+
+it("should keep destructuring working for a module that also escapes", () => {
+	expect(read()).toBe("b-value");
+});
+
+it("should keep a dynamically imported escaping namespace correct", async () => {
+	const ns = await import("./dynamic");
+	const whole = ns;
+	expect(whole.DYN_A).toBe("dyn-a");
+	expect(whole.DYN_B).toBe("dyn-b");
+});
+
+it("should keep an escaped CommonJS namespace interop correct", () => {
+	const ns = getCjs();
+	expect(ns.CJS_A).toBe("cjs-a");
+	expect(ns.CJS_B).toBe("cjs-b");
+});
+
+it("should expose the original names when enumerating an escaped namespace", () => {
+	const ns = getEnums();
+	const keys = Object.keys(ns);
+	expect(keys).toContain("ENUM_A");
+	expect(keys).toContain("ENUM_B");
+	expect(keys).toContain("ENUM_C");
+});
+
+it("should mangle the escaping module's exports", () => {
+	const bundle = fs.readFileSync(__filename, "utf-8");
+	// Build needles dynamically so this test's own source doesn't appear
+	// verbatim in the inspected bundle.
+	const a = `ENUM${"_"}A`;
+	// The raw export of enums.js must not be defined under its original name.
+	expect(bundle.includes(`"${a}", 0`)).toBe(false);
+	// The materialized namespace object must expose the original name.
+	expect(bundle.includes(`${a}: () =>`)).toBe(true);
+});

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/provider.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/provider.js
@@ -1,0 +1,5 @@
+import * as ns from "./enums";
+
+// The whole namespace object escapes via a function return, so it can't be
+// statically tracked by the consumer.
+export const getEnums = () => ns;

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/reexport.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/reexport.js
@@ -1,0 +1,2 @@
+// re-exported namespace object (export * as) that later escapes
+export * as enumsNs from "./enums";

--- a/test/configCases/mangle/mangle-escaping-namespace-concat/webpack.config.js
+++ b/test/configCases/mangle/mangle-escaping-namespace-concat/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	optimization: {
+		usedExports: true,
+		providedExports: true,
+		mangleExports: true,
+		inlineExports: true,
+		concatenateModules: true,
+		minimize: false
+	}
+};

--- a/test/configCases/mangle/mangle-escaping-namespace/cjs-provider.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/cjs-provider.js
@@ -1,0 +1,3 @@
+import * as ns from "./cjs";
+// Whole CommonJS namespace escapes; interop must keep working (no mangling).
+export const getCjs = () => ns;

--- a/test/configCases/mangle/mangle-escaping-namespace/cjs.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/cjs.js
@@ -1,0 +1,2 @@
+exports.CJS_A = "cjs-a";
+exports.CJS_B = "cjs-b";

--- a/test/configCases/mangle/mangle-escaping-namespace/consumer.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/consumer.js
@@ -1,0 +1,6 @@
+import { ENUM_A, NUM } from "./enums";
+
+// Static, trackable access -> should use the mangled name.
+export const direct = ENUM_A;
+// Inlinable const used in an inlinable position.
+export const sum = NUM + 1;

--- a/test/configCases/mangle/mangle-escaping-namespace/del-enums.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/del-enums.js
@@ -1,0 +1,2 @@
+export const DEL_A = "del-a";
+export const DEL_B = "del-b";

--- a/test/configCases/mangle/mangle-escaping-namespace/del.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/del.js
@@ -1,0 +1,11 @@
+import * as ns from "./del-enums";
+
+// The whole namespace object escapes (kept mangleable + materialized)...
+export const getDelNs = () => ns;
+
+// ...while non-existent members are deleted on it. With mangling on, the access
+// must stay a qualified property access, never a bare `delete undefined` (which
+// is a SyntaxError in strict/ESM mode).
+export function delMissing() {
+	return [delete ns.MISSING, delete ns.alsoMissing];
+}

--- a/test/configCases/mangle/mangle-escaping-namespace/destr.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/destr.js
@@ -1,0 +1,7 @@
+import * as ns from "./enums";
+
+// Tracked destructuring of the same module whose namespace also escapes.
+export function read() {
+	const { ENUM_B } = ns;
+	return ENUM_B;
+}

--- a/test/configCases/mangle/mangle-escaping-namespace/dynamic.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/dynamic.js
@@ -1,0 +1,2 @@
+export const DYN_A = "dyn-a";
+export const DYN_B = "dyn-b";

--- a/test/configCases/mangle/mangle-escaping-namespace/enums.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/enums.js
@@ -1,0 +1,5 @@
+export const ENUM_A = "a-value";
+export const ENUM_B = "b-value";
+export const ENUM_C = "c-value";
+export const NUM = 42; // inlinable const, also accessed via the escaped namespace
+export default "default-value";

--- a/test/configCases/mangle/mangle-escaping-namespace/index.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/index.js
@@ -1,0 +1,70 @@
+import { getEnums } from "./provider";
+import { enumsNs } from "./reexport";
+import { getCjs } from "./cjs-provider";
+import { direct } from "./consumer";
+import { read } from "./destr";
+import { getDelNs, delMissing } from "./del";
+import fs from "fs";
+
+it("should keep escaped namespace access working while mangling the exports", () => {
+	const ns = getEnums();
+	expect(ns.ENUM_A).toBe("a-value");
+	expect(ns.ENUM_B).toBe("b-value");
+	expect(ns.ENUM_C).toBe("c-value");
+	expect(ns.default).toBe("default-value");
+	// inlinable const must still be reachable by its original name on the escape
+	expect(ns.NUM).toBe(42);
+	expect(direct).toBe("a-value");
+});
+
+it("should keep an escaped re-exported (export * as) namespace working", () => {
+	const get = () => enumsNs;
+	const ns = get();
+	expect(ns.ENUM_A).toBe("a-value");
+	expect(ns.default).toBe("default-value");
+});
+
+it("should keep destructuring working for a module that also escapes", () => {
+	expect(read()).toBe("b-value");
+});
+
+it("should keep `delete ns.member` valid when the namespace escapes", () => {
+	// Deleting non-existent members of a namespace returns true (per spec) and
+	// must not be emitted as a bare `delete undefined`.
+	expect(delMissing()).toEqual([true, true]);
+	const ns = getDelNs();
+	expect(ns.DEL_A).toBe("del-a");
+	expect(ns.DEL_B).toBe("del-b");
+});
+
+it("should keep a dynamically imported escaping namespace correct", async () => {
+	const ns = await import("./dynamic");
+	const whole = ns;
+	expect(whole.DYN_A).toBe("dyn-a");
+	expect(whole.DYN_B).toBe("dyn-b");
+});
+
+it("should keep an escaped CommonJS namespace interop correct", () => {
+	const ns = getCjs();
+	expect(ns.CJS_A).toBe("cjs-a");
+	expect(ns.CJS_B).toBe("cjs-b");
+});
+
+it("should expose the original names when enumerating an escaped namespace", () => {
+	const ns = getEnums();
+	const keys = Object.keys(ns);
+	expect(keys).toContain("ENUM_A");
+	expect(keys).toContain("ENUM_B");
+	expect(keys).toContain("ENUM_C");
+});
+
+it("should mangle the escaping module's exports", () => {
+	const bundle = fs.readFileSync(__filename, "utf-8");
+	// Build needles dynamically so this test's own source doesn't appear
+	// verbatim in the inspected bundle.
+	const a = `ENUM${"_"}A`;
+	// The raw export of enums.js must not be defined under its original name.
+	expect(bundle.includes(`"${a}", 0`)).toBe(false);
+	// The materialized namespace object must expose the original name.
+	expect(bundle.includes(`${a}: () =>`)).toBe(true);
+});

--- a/test/configCases/mangle/mangle-escaping-namespace/provider.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/provider.js
@@ -1,0 +1,5 @@
+import * as ns from "./enums";
+
+// The whole namespace object escapes via a function return, so it can't be
+// statically tracked by the consumer.
+export const getEnums = () => ns;

--- a/test/configCases/mangle/mangle-escaping-namespace/reexport.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/reexport.js
@@ -1,0 +1,2 @@
+// re-exported namespace object (export * as) that later escapes
+export * as enumsNs from "./enums";

--- a/test/configCases/mangle/mangle-escaping-namespace/webpack.config.js
+++ b/test/configCases/mangle/mangle-escaping-namespace/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	// `del.js` intentionally deletes non-existent namespace members.
+	module: { parser: { javascript: { exportsPresence: false } } },
+	optimization: {
+		usedExports: true,
+		providedExports: true,
+		mangleExports: true,
+		inlineExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/index.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/index.js
@@ -31,12 +31,14 @@ it("should mangle export when destructuring module's property is a module", () =
 	expect(obj3CanMangle).toBe(true)
 });
 
-it("should not mangle export when destructuring module's nested property is a module (used in unknown way)", () => {
+it("should mangle export when destructuring module's nested property is a module (escaping namespace)", () => {
 	const { nested: { obj5, obj5CanMangle } } = obj4;
 	expect(obj5.aaa).toBe("a");
 	expect(obj5.bbb).toBe("b");
 	expect(obj4CanMangle).toBe(true);
-	expect(obj5CanMangle).toBe(false); // obj5 is used in unknown way
+	// The namespace escapes as a whole value but is rendered as a decoupled
+	// namespace object that keeps the original names, so it stays mangleable.
+	expect(obj5CanMangle).toBe(true);
 });
 
 it("should mangle default in namespace import", async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -4346,6 +4346,11 @@ declare interface ConcatenatedModuleInfo {
 	rawExportMap?: Map<string, string>;
 	namespaceExportSymbol?: string;
 	namespaceObjectName?: string;
+
+	/**
+	 * decoupled namespace object that keeps original export names when the exports are mangled
+	 */
+	escapeNamespaceObjectName?: string;
 	concatenationScope?: ConcatenationScope;
 
 	/**
@@ -4791,6 +4796,7 @@ declare class ConstDependency extends NullDependency {
 	static compareLocations(a: Dependency, b: Dependency): 0 | 1 | -1;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED_MANGLEABLE: string[][];
 
 	/**
 	 * Returns true if the dependency is a low priority dependency.
@@ -5995,6 +6001,7 @@ declare class Dependency {
 	static compareLocations(a: Dependency, b: Dependency): 0 | 1 | -1;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED_MANGLEABLE: string[][];
 
 	/**
 	 * Returns true if the dependency is a low priority dependency.
@@ -8151,6 +8158,11 @@ declare interface ExternalModuleInfo {
 	name?: string;
 
 	/**
+	 * decoupled namespace object that keeps original export names when the exports are mangled
+	 */
+	escapeNamespaceObjectName?: string;
+
+	/**
 	 * deferred module.exports / harmony namespace object
 	 */
 	deferredName?: string;
@@ -9250,6 +9262,7 @@ declare class HarmonyImportDependency extends ModuleDependency {
 	static compareLocations(a: Dependency, b: Dependency): 0 | 1 | -1;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED_MANGLEABLE: string[][];
 
 	/**
 	 * Returns true if the dependency is a low priority dependency.
@@ -15204,6 +15217,7 @@ declare class ModuleDependency extends Dependency {
 	static compareLocations(a: Dependency, b: Dependency): 0 | 1 | -1;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED_MANGLEABLE: string[][];
 
 	/**
 	 * Returns true if the dependency is a low priority dependency.
@@ -16155,6 +16169,11 @@ declare interface ModuleReferenceOptions {
 	 * true, when this referenced export is deferred
 	 */
 	deferredImport: boolean;
+
+	/**
+	 * true, when a whole-namespace reference may use a decoupled namespace object that keeps the original export names
+	 */
+	mangleableNamespace: boolean;
 
 	/**
 	 * if the position is ASI safe or unknown
@@ -17543,6 +17562,7 @@ declare class NullDependency extends Dependency {
 	static compareLocations(a: Dependency, b: Dependency): 0 | 1 | -1;
 	static NO_EXPORTS_REFERENCED: string[][];
 	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED_MANGLEABLE: string[][];
 
 	/**
 	 * Returns true if the dependency is a low priority dependency.
@@ -22902,6 +22922,10 @@ declare abstract class RuntimeTemplate {
 		 * module dependency
 		 */
 		dependency: ModuleDependency;
+		/**
+		 * true, when a whole-namespace value may use a decoupled namespace object that keeps the original export names
+		 */
+		mangleableNamespace?: boolean;
 	}): string;
 
 	/**


### PR DESCRIPTION


**Summary**

When a module's namespace object is used as a whole value (for example re-exported and returned, spread, or passed around), export mangling was disabled for the entire module, so every reference in all other consumers kept full export names — bloating the output.

This PR keeps such modules mangleable: the escaping reference is rendered as a decoupled namespace object whose getters expose the original export names onto the mangled bindings, so access by the original name (including dynamic/`Object.keys`) keeps working. It is driven by `optimization.mangleExports` and works for both non-concatenated and concatenated builds (inner, external/standalone, and code-split shared modules). CommonJS interop, dynamic imports and deferred imports are left conservative (unchanged). Closes #19153.

On a barrel-with-escape build (1 escaping module, 300 exports, 150 static consumers, minified) the output drops from 38.4 KB → 17.2 KB raw (−55%) / 5.3 KB → 4.3 KB gzip (−19%), with no build-time or peak-memory regression.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — new `test/configCases/mangle/mangle-escaping-namespace` and `…-concat` cases covering ESM named/default exports, `export * as` re-exports, CommonJS interop, destructuring of an escaping module, dynamically imported namespaces, inlined-const exports, namespace enumeration, and `delete ns.member` on an escaping namespace; plus updated `mangle-with-destructuring-assignment` and `code-generation/re-export-namespace-concat` to the new (runtime-identical) output. Verified against the `test262` module-namespace `[[Delete]]` cases.

**Does this PR introduce a breaking change?**

No. Runtime semantics are unchanged (verified across all the contexts above); only the generated output is smaller because more exports get mangled.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — no new option; `optimization.mangleExports` now also applies to modules whose namespace object escapes.

**Use of AI**

AI (Claude Code) was used to implement the change, write the tests, run the test suite, measure output size / build time / memory, and investigate edge cases across rendering contexts. All output was reviewed and validated against the webpack test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_015njPuz57Eq3Pj3cjxWcVJT)_