### PR TITLE
docs(claude): add path-scoped rules for lib, tests, and schemas

### DIFF
--- a/.claude/rules/lib.md
+++ b/.claude/rules/lib.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "lib/**"
+---
+[REQUIRED] If you add, rename, or remove any directory directly under `lib/`,
+update the matching bullet in the **Project Overview** section of `CLAUDE.md` in the same commit.
+CI does not check this — drift is caught only by human reviewers.
+
+Source files are **CommonJS only**. Types are declared via JSDoc `@typedef` — do not introduce `.ts` source files.
+Use `/** @type {import("./Foo").Foo} */` annotations rather than `import type`.

--- a/.claude/rules/schemas.md
+++ b/.claude/rules/schemas.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "lib/**"
+  - "schemas/**"
+---
+When adding or modifying config options in a plugin or module, update the matching JSON schema
+in `schemas/` in the same PR. Auto-generate updated types by running `yarn fix` after schema changes.
+
+[REQUIRED] If you add or remove a directory under `schemas/`, update the matching bullet
+in the **Project Overview** section of `CLAUDE.md` in the same commit.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "lib/**"
+  - "test/**"
+---
+Test files mirror the `lib/` directory structure. A new module at `lib/foo/Bar.js`
+requires a corresponding test at `test/foo/Bar.test.js`.
+
+[REQUIRED] If you add or remove a directory under `test/`, update the matching bullet
+in the **Project Overview** section of `CLAUDE.md` in the same commit.
+
+Running tests:
+- All: `yarn test` (slow) or `yarn test --no-cov` (faster)
+- Single file: `jest test/<path>.js`
+
+New features require a changeset: run `yarn changeset` and describe the change before committing.


### PR DESCRIPTION
## What this does

Adds three path-scoped rule files under `.claude/rules/` so Claude Code only loads each rule when working on files in the relevant directory — reducing context noise for unrelated edits.

| File | Loads when editing |
|------|--------------------|
| `lib.md` | `lib/**` |
| `tests.md` | `lib/**`, `test/**` |
| `schemas.md` | `lib/**`, `schemas/**` |

The rules themselves surface guidance already in `CLAUDE.md` (CommonJS-only, JSDoc typedefs, lib↔test mirroring, schema sync, changeset requirement) — this change just makes them load contextually rather than always.

Note: no changeset needed — this adds tooling configuration files only, with no effect on the compiled output or public API.