### PR TITLE
refactor: drop immutableBinding, read constValue when rendering

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -61,7 +61,6 @@ const memoize = require("./util/memoize");
  * @property {boolean=} canMangle can the export be renamed (defaults to true)
  * @property {boolean=} terminalBinding is the export a terminal binding that should be checked for export star conflicts
  * @property {boolean=} isPure calling this export has no observable side effects
- * @property {boolean=} immutableBinding the export binding never changes (eligible for value-based export instead of getter)
  * @property {(string | ExportSpec)[]=} exports nested exports
  * @property {ModuleGraphConnection=} from when reexported: from which module
  * @property {string[] | null=} export when reexported: from which export

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -53,7 +53,6 @@ const { forEachRuntime } = require("./util/runtime");
  * @property {ExportInfo["canInlineProvide"]=} canInlineProvide
  * @property {ExportInfo["terminalBinding"]} terminalBinding
  * @property {ExportInfo["pureProvide"]=} pureProvide
- * @property {ExportInfo["immutableBinding"]=} immutableBinding
  * @property {RestoreProvidedData | undefined} exportsInfo
  */
 
@@ -74,7 +73,6 @@ const INLINE_USE_TRUE = 1;
 const INLINE_USE_FALSE = 2;
 const INLINE_USE_MASK = 3;
 const PURE_PROVIDE_FLAG = 4;
-const IMMUTABLE_BINDING_FLAG = 8;
 
 class RestoreProvidedData {
 	/**
@@ -945,13 +943,10 @@ class ExportsInfo {
 		for (const exportInfo of this.orderedExports) {
 			const canInlineProvide = exportInfo.canInlineProvide;
 			const pureProvide = exportInfo.pureProvide;
-			const immutableBinding = exportInfo.immutableBinding;
 			// inline-exports data is only stored when present, so builds without the
 			// feature don't pay for it in the persistent cache
 			const hasInlineInfo =
-				canInlineProvide !== undefined ||
-				pureProvide !== undefined ||
-				immutableBinding !== undefined;
+				canInlineProvide !== undefined || pureProvide !== undefined;
 			if (
 				exportInfo.provided !== otherProvided ||
 				exportInfo.canMangleProvide !== otherCanMangleProvide ||
@@ -972,7 +967,6 @@ class ExportsInfo {
 								canInlineProvide,
 								terminalBinding: exportInfo.terminalBinding,
 								pureProvide,
-								immutableBinding,
 								exportsInfo
 							}
 						: {
@@ -1020,7 +1014,6 @@ class ExportsInfo {
 			exportInfo.canInlineProvide = exp.canInlineProvide;
 			exportInfo.terminalBinding = exp.terminalBinding;
 			exportInfo.pureProvide = exp.pureProvide;
-			exportInfo.immutableBinding = exp.immutableBinding;
 			if (exp.exportsInfo) {
 				const exportsInfo = exportInfo.createNestedExportsInfo();
 				exportsInfo.restoreProvided(exp.exportsInfo);
@@ -1100,7 +1093,7 @@ class ExportInfo {
 		 */
 		this.canMangleUse = initFrom ? initFrom.canMangleUse : undefined;
 		/**
-		 * bitfield backing `canInlineUse`, `pureProvide` and `immutableBinding`
+		 * bitfield backing `canInlineUse` and `pureProvide`
 		 * @private
 		 * @type {number}
 		 */
@@ -1174,22 +1167,6 @@ class ExportInfo {
 	set pureProvide(value) {
 		if (value) this._inlineFlags |= PURE_PROVIDE_FLAG;
 		else this._inlineFlags &= ~PURE_PROVIDE_FLAG;
-	}
-
-	/**
-	 * true: the export binding never changes (eligible for value-based export)
-	 * undefined: not determined
-	 * @returns {boolean | undefined} immutable binding
-	 */
-	get immutableBinding() {
-		return (this._inlineFlags & IMMUTABLE_BINDING_FLAG) !== 0
-			? true
-			: undefined;
-	}
-
-	set immutableBinding(value) {
-		if (value) this._inlineFlags |= IMMUTABLE_BINDING_FLAG;
-		else this._inlineFlags &= ~IMMUTABLE_BINDING_FLAG;
 	}
 
 	get canMangle() {
@@ -1863,7 +1840,7 @@ class ExportInfo {
 		hash.update(
 			`${usedNameHash}${this.getUsed(runtime)}${this.provided}${
 				this.terminalBinding
-			}${this.pureProvide ? "P" : ""}${this.immutableBinding ? "I" : ""}`
+			}${this.pureProvide ? "P" : ""}`
 		);
 		if (this.exportsInfo && !alreadyVisitedExportsInfo.has(this.exportsInfo)) {
 			this.exportsInfo._updateHash(hash, runtime, alreadyVisitedExportsInfo);

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -200,7 +200,6 @@ class FlagDependencyExportsPlugin {
 											let canMangle = globalCanMangle;
 											let terminalBinding = globalTerminalBinding;
 											let pure = globalPure;
-											let immutableBinding = false;
 											/** @type {ExportSpec["exports"]} */
 											let exports;
 											let from = globalFrom;
@@ -241,9 +240,6 @@ class FlagDependencyExportsPlugin {
 												if (exportNameOrSpec.inlined !== undefined) {
 													inlined = exportNameOrSpec.inlined;
 												}
-												if (exportNameOrSpec.immutableBinding !== undefined) {
-													immutableBinding = exportNameOrSpec.immutableBinding;
-												}
 											}
 											const exportInfo = exportsInfo.getExportInfo(name);
 
@@ -278,14 +274,6 @@ class FlagDependencyExportsPlugin {
 
 											if (pure && exportInfo.pureProvide !== true) {
 												exportInfo.pureProvide = true;
-												changed = true;
-											}
-
-											if (
-												immutableBinding &&
-												exportInfo.immutableBinding !== true
-											) {
-												exportInfo.immutableBinding = true;
 												changed = true;
 											}
 

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -86,8 +86,7 @@ class HarmonyExportExpressionDependency extends NullDependency {
 			exports: [
 				{
 					name: DEFAULT_EXPORT_NAME,
-					isPure: isPure || undefined,
-					immutableBinding: true
+					isPure: isPure || undefined
 				}
 			],
 			priority: 1,
@@ -237,12 +236,8 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					if (used) {
 						defaultIsUsed = true;
 						runtimeRequirements.add(RuntimeGlobals.exports);
-						const exportsInfo = moduleGraph.getExportsInfo(module);
-						const exportInfo =
-							exportsInfo.getReadOnlyExportInfo(DEFAULT_EXPORT_NAME);
+						// `export default <expr>` binds an immutable const declaration
 						const canUseValueBinding =
-							exportInfo &&
-							exportInfo.immutableBinding === true &&
 							/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
 								.isCircular === false;
 						if (canUseValueBinding) {

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -76,8 +76,7 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 				{
 					name: this.name,
 					isPure,
-					inlined: this.constValue || undefined,
-					immutableBinding: this.constValue !== undefined
+					inlined: this.constValue || undefined
 				}
 			],
 			priority: 1,
@@ -161,11 +160,8 @@ HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependen
 			return;
 		}
 
-		const exportsInfo = moduleGraph.getExportsInfo(module);
-		const exportInfo = exportsInfo.getReadOnlyExportInfo(dep.name);
 		const canUseValueBinding =
-			exportInfo &&
-			exportInfo.immutableBinding === true &&
+			dep.constValue !== undefined &&
 			/** @type {import("../Module").BuildInfo} */ (module.buildInfo)
 				.isCircular === false;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -7530,12 +7530,6 @@ declare abstract class ExportInfo {
 	 * undefined: it was not determined whether the export is pure
 	 */
 	pureProvide?: boolean;
-
-	/**
-	 * true: the export binding never changes (eligible for value-based export)
-	 * undefined: not determined
-	 */
-	immutableBinding?: boolean;
 	get canMangle(): boolean;
 	canInline(): undefined | InlinedValue;
 
@@ -7704,11 +7698,6 @@ declare interface ExportSpec {
 	 * calling this export has no observable side effects
 	 */
 	isPure?: boolean;
-
-	/**
-	 * the export binding never changes (eligible for value-based export instead of getter)
-	 */
-	immutableBinding?: boolean;
 
 	/**
 	 * nested exports
@@ -21732,7 +21721,6 @@ declare interface RestoreProvidedDataExports {
 	canInlineProvide?: InlinedValue;
 	terminalBinding: boolean;
 	pureProvide?: boolean;
-	immutableBinding?: boolean;
 	exportsInfo?: RestoreProvidedData;
 }
 type Rule = string | RegExp | ((str: string) => boolean);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

The value-based export binding optimization carried an `immutableBinding` flag from each export dependency's `getExports()` through `ExportsSpec` into `ExportInfo`, only for the dependency template to read it back at codegen time. The dependency already knows its own immutability locally, so this round-trip through the exports graph is unnecessary state.

cc @xiaoxiaojx 

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Existing
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->