### PR TITLE
test: fail tests on unexpected deprecations

### DIFF
--- a/examples/http2-aggressive-splitting/README.md
+++ b/examples/http2-aggressive-splitting/README.md
@@ -1,12 +1,8 @@
-This example demonstrates the AggressiveSplittingPlugin for splitting the bundle into multiple smaller chunks to improve caching. This works best with an HTTP2 web server, otherwise, there is an overhead for the increased number of requests.
+This example demonstrates how to split the bundle into multiple smaller chunks to improve caching using `optimization.splitChunks` with a `maxSize`. This works best with an HTTP2 web server, otherwise, there is an overhead for the increased number of requests.
 
-AggressiveSplittingPlugin splits every chunk until it reaches the specified `maxSize`. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. It groups modules by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
+Setting `maxSize` tells webpack to split chunks that are bigger than this size into smaller ones. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. Modules are grouped by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
 
-AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), re-using the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
-
-Only chunks that are bigger than the specified `minSize` are stored into the records. This ensures that these chunks fill up as your application grows, instead of creating many records of small chunks for every change.
-
-If a module changes, its chunks are declared to be invalid and are put back into the module pool. New chunks are created from all modules in the pool.
+`chunks: "all"` applies the splitting to all chunks, including the initial ones. Chunk content is deterministic, so the same `[chunkhash]` is emitted as long as a chunk's modules don't change. Since changes to application code between one build and the next are usually in only a few modules, the unchanged chunks keep their hash and stay in the client's cache.
 
 There is a tradeoff here:
 
@@ -25,23 +21,24 @@ const webpack = require("../../");
 /** @type {import("webpack").Configuration} */
 const config = {
 	// mode: "development" || "production",
-	cache: true, // better performance for the AggressiveSplittingPlugin
 	entry: "./example",
 	output: {
 		path: path.join(__dirname, "dist"),
 		filename: "[chunkhash].js",
 		chunkFilename: "[chunkhash].js"
 	},
-	plugins: [
-		new webpack.optimize.AggressiveSplittingPlugin({
+	optimization: {
+		splitChunks: {
+			chunks: "all",
 			minSize: 30000,
 			maxSize: 50000
-		}),
+		}
+	},
+	plugins: [
 		new webpack.DefinePlugin({
 			"process.env.NODE_ENV": JSON.stringify("production")
 		})
-	],
-	recordsOutputPath: path.join(__dirname, "dist", "records.json")
+	]
 };
 
 module.exports = config;
@@ -81,41 +78,4 @@ chunk (runtime: main) 7ca3ef3fdbb2a836fdc1.js (main) 17 KiB (javascript) 4.92 Ki
   dependent modules 17 KiB [dependent] 2 modules
   ./example.js 42 bytes [built] [code generated]
 webpack X.X.X compiled successfully
-```
-
-## Records
-
-```
-{
-  "aggressiveSplits": [],
-  "chunks": {
-    "byName": {
-      "main": 0
-    },
-    "bySource": {
-      "0 ./example.js react-dom": 1,
-      "0 main": 0
-    },
-    "usedIds": [
-      0,
-      1
-    ]
-  },
-  "modules": {
-    "byIdentifier": {
-      "../../node_modules/react-dom/cjs/react-dom.production.js": 4,
-      "../../node_modules/react-dom/index.js": 3,
-      "../../node_modules/react/cjs/react.production.js": 2,
-      "../../node_modules/react/index.js": 1,
-      "./example.js": 0
-    },
-    "usedIds": [
-      0,
-      1,
-      2,
-      3,
-      4
-    ]
-  }
-}
 ```

--- a/examples/http2-aggressive-splitting/deprecations.js
+++ b/examples/http2-aggressive-splitting/deprecations.js
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = [{ code: /DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN/ }];

--- a/examples/http2-aggressive-splitting/deprecations.js
+++ b/examples/http2-aggressive-splitting/deprecations.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [{ code: /DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN/ }];

--- a/examples/http2-aggressive-splitting/template.md
+++ b/examples/http2-aggressive-splitting/template.md
@@ -1,12 +1,8 @@
-This example demonstrates the AggressiveSplittingPlugin for splitting the bundle into multiple smaller chunks to improve caching. This works best with an HTTP2 web server, otherwise, there is an overhead for the increased number of requests.
+This example demonstrates how to split the bundle into multiple smaller chunks to improve caching using `optimization.splitChunks` with a `maxSize`. This works best with an HTTP2 web server, otherwise, there is an overhead for the increased number of requests.
 
-AggressiveSplittingPlugin splits every chunk until it reaches the specified `maxSize`. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. It groups modules by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
+Setting `maxSize` tells webpack to split chunks that are bigger than this size into smaller ones. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. Modules are grouped by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
 
-AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), re-using the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
-
-Only chunks that are bigger than the specified `minSize` are stored into the records. This ensures that these chunks fill up as your application grows, instead of creating many records of small chunks for every change.
-
-If a module changes, its chunks are declared to be invalid and are put back into the module pool. New chunks are created from all modules in the pool.
+`chunks: "all"` applies the splitting to all chunks, including the initial ones. Chunk content is deterministic, so the same `[chunkhash]` is emitted as long as a chunk's modules don't change. Since changes to application code between one build and the next are usually in only a few modules, the unchanged chunks keep their hash and stay in the client's cache.
 
 There is a tradeoff here:
 
@@ -32,10 +28,4 @@ _{{stdout}}_
 
 ```
 _{{production:stdout}}_
-```
-
-## Records
-
-```
-_{{dist/records.json}}_
 ```

--- a/examples/http2-aggressive-splitting/webpack.config.js
+++ b/examples/http2-aggressive-splitting/webpack.config.js
@@ -6,23 +6,24 @@ const webpack = require("../../");
 /** @type {import("webpack").Configuration} */
 const config = {
 	// mode: "development" || "production",
-	cache: true, // better performance for the AggressiveSplittingPlugin
 	entry: "./example",
 	output: {
 		path: path.join(__dirname, "dist"),
 		filename: "[chunkhash].js",
 		chunkFilename: "[chunkhash].js"
 	},
-	plugins: [
-		new webpack.optimize.AggressiveSplittingPlugin({
+	optimization: {
+		splitChunks: {
+			chunks: "all",
 			minSize: 30000,
 			maxSize: 50000
-		}),
+		}
+	},
+	plugins: [
 		new webpack.DefinePlugin({
 			"process.env.NODE_ENV": JSON.stringify("production")
 		})
-	],
-	recordsOutputPath: path.join(__dirname, "dist", "records.json")
+	]
 };
 
 module.exports = config;

--- a/test/BannerPlugin.test.js
+++ b/test/BannerPlugin.test.js
@@ -4,9 +4,12 @@ const path = require("path");
 const fs = require("graceful-fs");
 
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const pluginDir = path.join(__dirname, "js", "BannerPlugin");
 const outputDir = path.join(pluginDir, "output");
+
+expectNoDeprecations();
 
 describe("BannerPlugin", () => {
 	it("should cache assets", (done) => {

--- a/test/ChangesAndRemovals.test.js
+++ b/test/ChangesAndRemovals.test.js
@@ -7,6 +7,7 @@ const fs = require("graceful-fs");
 const { Volume, createFsFromVolume } = require("memfs");
 /** @type {(path: string, callback: (err?: unknown) => void) => void} */
 const rimraf = require("rimraf");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * @param {import("../").Configuration} config config
@@ -90,6 +91,8 @@ function createFiles() {
 // Bun's fs.watch surfaces unlink events differently from Node, so watchpack
 // reports the removed file inconsistently across runs; skip on Bun.
 const itSkipBun = process.versions.bun ? it.skip : it;
+
+expectNoDeprecations();
 
 describe("ChangesAndRemovals", () => {
 	beforeEach((done) => {

--- a/test/Compiler-caching.test.js
+++ b/test/Compiler-caching.test.js
@@ -6,6 +6,7 @@ const path = require("path");
 const fs = require("graceful-fs");
 /** @type {{ sync: (pattern: string) => void }} */
 const rimraf = require("rimraf");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 let fixtureCount = 0;
 
@@ -15,6 +16,8 @@ let fixtureCount = 0;
  */
 
 describe("Compiler (caching)", () => {
+	expectNoDeprecations();
+
 	/**
 	 * @param {string} entry entry file
 	 * @param {import("../").Configuration} options webpack options

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -7,10 +7,13 @@ const fs = require("graceful-fs");
 const rimraf = /** @type {{ sync: (path: string) => void }} */ (
 	require("rimraf")
 );
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 let fixtureCount = 0;
 
 describe("Compiler (filesystem caching)", () => {
+	expectNoDeprecations();
+
 	const tempFixturePath = path.join(
 		__dirname,
 		"fixtures",

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -6,6 +6,7 @@ const path = require("path");
 const fs = require("graceful-fs");
 const prettyFormat = require("pretty-format").default;
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const CWD_PATTERN = new RegExp(process.cwd().replace(/\\/g, "/"), "gm");
 const ERROR_STACK_PATTERN = /(?:\n\s+at\s.*)+/g;
@@ -183,6 +184,8 @@ async function compile(options) {
 
 	return { errors, warnings };
 }
+
+expectNoDeprecations();
 
 describe("Errors", () => {
 	it("should emit warning for missingFile", async () => {

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -4,7 +4,9 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
-const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+const {
+	expectOnlyListedDeprecations
+} = require("./helpers/expectNoDeprecations");
 
 jest.setTimeout(60000);
 
@@ -57,9 +59,6 @@ async function loadConfiguration(projectDir) {
 }
 
 describe("Examples", () => {
-	// http2-aggressive-splitting intentionally uses the deprecated plugin alias
-	expectNoDeprecations(["DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN"]);
-
 	const basePath = path.join(__dirname, "..", "examples");
 
 	const examples = require("../examples/examples");
@@ -78,66 +77,70 @@ describe("Examples", () => {
 			continue;
 		}
 
-		it(`should compile ${relativePath}`, async () => {
-			let options = await loadConfiguration(examplePath);
+		describe(relativePath, () => {
+			expectOnlyListedDeprecations(() => examplePath);
 
-			if (!options) {
-				// Skip ECMA modules examples
-				return;
-			}
+			it(`should compile ${relativePath}`, async () => {
+				let options = await loadConfiguration(examplePath);
 
-			if (typeof options === "function") options = options();
-
-			if (Array.isArray(options)) {
-				for (const [_, item] of options.entries()) {
-					processOptions(item);
+				if (!options) {
+					// Skip ECMA modules examples
+					return;
 				}
-			} else {
-				processOptions(options);
-			}
 
-			/**
-			 * @param {import("../").Configuration} options options
-			 */
-			function processOptions(options) {
-				options.context = examplePath;
-				options.output = options.output || {};
-				options.output.pathinfo = true;
-				options.output.path = path.join(examplePath, "dist");
-				options.output.publicPath = "dist/";
-				if (!options.entry) options.entry = "./example.js";
-				if (!options.plugins) options.plugins = [];
-			}
+				if (typeof options === "function") options = options();
 
-			const webpack = require("..");
+				if (Array.isArray(options)) {
+					for (const [_, item] of options.entries()) {
+						processOptions(item);
+					}
+				} else {
+					processOptions(options);
+				}
 
-			await /** @type {Promise<void>} */ (
-				new Promise((resolve, reject) => {
-					webpack(options, (err, stats) => {
-						if (err) {
-							reject(err);
-							return;
-						}
-						if (/** @type {import("../").Stats} */ (stats).hasErrors()) {
-							reject(
-								new Error(
-									/** @type {import("../").Stats} */ (stats).toString(
-										/** @type {import("../").StatsOptions} */ ({
-											all: false,
-											errors: true,
-											errorDetails: true,
-											errorStacks: true
-										})
+				/**
+				 * @param {import("../").Configuration} options options
+				 */
+				function processOptions(options) {
+					options.context = examplePath;
+					options.output = options.output || {};
+					options.output.pathinfo = true;
+					options.output.path = path.join(examplePath, "dist");
+					options.output.publicPath = "dist/";
+					if (!options.entry) options.entry = "./example.js";
+					if (!options.plugins) options.plugins = [];
+				}
+
+				const webpack = require("..");
+
+				await /** @type {Promise<void>} */ (
+					new Promise((resolve, reject) => {
+						webpack(options, (err, stats) => {
+							if (err) {
+								reject(err);
+								return;
+							}
+							if (/** @type {import("../").Stats} */ (stats).hasErrors()) {
+								reject(
+									new Error(
+										/** @type {import("../").Stats} */ (stats).toString(
+											/** @type {import("../").StatsOptions} */ ({
+												all: false,
+												errors: true,
+												errorDetails: true,
+												errorStacks: true
+											})
+										)
 									)
-								)
-							);
-							return;
-						}
+								);
+								return;
+							}
 
-						resolve();
-					});
-				})
-			);
-		}, 90000);
+							resolve();
+						});
+					})
+				);
+			}, 90000);
+		});
 	}
 });

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -4,6 +4,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 jest.setTimeout(60000);
 
@@ -56,6 +57,9 @@ async function loadConfiguration(projectDir) {
 }
 
 describe("Examples", () => {
+	// http2-aggressive-splitting intentionally uses the deprecated plugin alias
+	expectNoDeprecations(["DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN"]);
+
 	const basePath = path.join(__dirname, "..", "examples");
 
 	const examples = require("../examples/examples");

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -4,6 +4,9 @@ const path = require("path");
 const fs = require("graceful-fs");
 
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
 
 describe("HotModuleReplacementPlugin", () => {
 	it("should not have circular hashes but equal if unmodified", (done) => {

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -20,6 +20,7 @@ const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const { TestRunner } = require("./harness/runner");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
+const deprecationTracking = require("./helpers/deprecationTracking");
 const supportsObjectHasOwn = require("./helpers/supportsObjectHasOwn");
 const supportsOptionalChaining = require("./helpers/supportsOptionalChaining");
 
@@ -198,6 +199,7 @@ const describeCases = (config) => {
 								/** @type {Error | null} */ err,
 								/** @type {import("../").Stats} */ stats
 							) => {
+								const deprecations = deprecationTracker();
 								if (err) return done(err);
 								const jsonStats = stats.toJson({
 									errorDetails: true
@@ -226,13 +228,27 @@ const describeCases = (config) => {
 								) {
 									return;
 								}
+								if (
+									checkArrayExpectation(
+										testDirectory,
+										{ deprecations },
+										"deprecation",
+										"Deprecation",
+										options,
+										done
+									)
+								) {
+									return;
+								}
 
 								function runCompiler(
 									/** @type {(err: EXPECTED_ANY, stats?: EXPECTED_ANY) => void} */ callback
 								) {
 									fakeUpdateLoaderOptions.updateIndex++;
+									const deprecationTracker = deprecationTracking.start();
 									compiler.run((err, _stats) => {
 										const stats = /** @type {import("../").Stats} */ (_stats);
+										const deprecations = deprecationTracker();
 										if (err) return callback(err);
 										const jsonStats = stats.toJson({
 											errorDetails: true
@@ -257,6 +273,19 @@ const describeCases = (config) => {
 												"warning",
 												`warnings${fakeUpdateLoaderOptions.updateIndex}`,
 												"Warning",
+												options,
+												callback
+											)
+										) {
+											return;
+										}
+										if (
+											checkArrayExpectation(
+												testDirectory,
+												{ deprecations },
+												"deprecation",
+												`deprecations${fakeUpdateLoaderOptions.updateIndex}`,
+												"Deprecation",
 												options,
 												callback
 											)
@@ -335,6 +364,7 @@ const describeCases = (config) => {
 									}
 								);
 							};
+							const deprecationTracker = deprecationTracking.start();
 							compiler = webpack(options);
 							compiler.run(/** @type {EXPECTED_ANY} */ (onCompiled));
 						}, 20000);

--- a/test/MemoryLimitTestCases.test.js
+++ b/test/MemoryLimitTestCases.test.js
@@ -7,6 +7,7 @@ const fs = require("graceful-fs");
 const rimraf = require("rimraf");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const toMiB = (/** @type {number} */ bytes) =>
 	`${Math.round(bytes / 1024 / 1024)}MiB`;
@@ -32,6 +33,8 @@ const tests = fs
 	});
 
 /** @typedef {{ toString(): string, toStringRaw(): string, restore(): void, data: string[], reset(): void }} CapturedStdio */
+
+expectNoDeprecations();
 
 describe("MemoryLimitTestCases", () => {
 	jest.setTimeout(40000);

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -5,6 +5,7 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * @param {import("../").MultiCompilerOptions=} options options
@@ -46,6 +47,8 @@ const createMultiCompiler = (options) => {
 };
 
 describe("MultiCompiler", () => {
+	expectNoDeprecations();
+
 	it("should trigger 'run' for each child compiler", (done) => {
 		const compiler = createMultiCompiler();
 		let called = 0;

--- a/test/MultiStats.test.js
+++ b/test/MultiStats.test.js
@@ -3,6 +3,7 @@
 require("./helpers/warmup-webpack");
 
 const { Volume, createFsFromVolume } = require("memfs");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * @param {import("../").Configuration | import("../").MultiConfiguration} options options
@@ -30,6 +31,8 @@ const compile = (options) =>
 	);
 
 describe("MultiStats", () => {
+	expectNoDeprecations();
+
 	it("should create JSON of children stats", async () => {
 		const stats = await compile([
 			{

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -3,8 +3,11 @@
 require("./helpers/warmup-webpack");
 
 const path = require("path");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 // cspell:word nodetest
+expectNoDeprecations();
+
 describe("NodeTemplatePlugin", () => {
 	it("should compile and run a simple module", (done) => {
 		const webpack = require("..");

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 const util = require("util");
 const vm = require("vm");
 const rimraf = require("rimraf");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 const supportsObjectHasOwn = require("./helpers/supportsObjectHasOwn");
 const supportsOptionalChaining = require("./helpers/supportsOptionalChaining");
 
@@ -16,6 +17,8 @@ const utimes = util.promisify(fs.utimes);
 const mkdir = util.promisify(fs.mkdir);
 
 describe("Persistent Caching", () => {
+	expectNoDeprecations();
+
 	const tempPath = path.resolve(__dirname, "js", "persistent-caching");
 	const outputPath = path.resolve(tempPath, "output");
 	const cachePath = path.resolve(tempPath, "cache");

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -5,10 +5,9 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 const rimraf = require("rimraf");
-const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
-expectNoDeprecations(["DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK"]);
-
+// ProfilingPlugin intercepts the deprecated Compilation.hooks.normalModuleLoader
+// hook; that deprecation is asserted in configCases/plugins/profiling-plugin.
 describe("Profiling Plugin", () => {
 	jest.setTimeout(120000);
 

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -5,6 +5,9 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const fs = require("graceful-fs");
 const rimraf = require("rimraf");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations(["DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK"]);
 
 describe("Profiling Plugin", () => {
 	jest.setTimeout(120000);

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -7,6 +7,7 @@ const _ = require("lodash");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const createMultiCompiler = (
 	/** @type {Record<string, unknown> | undefined} */ progressOptions = undefined,
@@ -98,6 +99,8 @@ const runCompilerAsync = (
 	});
 
 /** @typedef {{ toString(): string, toStringRaw(): string, restore(): void, data: string[], reset(): void }} CapturedStdio */
+
+expectNoDeprecations();
 
 describe("ProgressPlugin", () => {
 	/** @type {CapturedStdio} */

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -3,6 +3,7 @@
 require("./helpers/warmup-webpack");
 
 const { Volume, createFsFromVolume } = require("memfs");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * @param {import("../").Configuration} options options
@@ -26,6 +27,8 @@ const compile = (options) =>
 			});
 		})
 	);
+
+expectNoDeprecations();
 
 describe("Stats", () => {
 	it("should work with a boolean value", async () => {

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -8,6 +8,7 @@ const rimraf = require("rimraf");
 const webpack = require("..");
 const { registerPerCaseSnapshotHooks } = require("./harness/snapshot");
 const captureStdio = require("./helpers/captureStdio");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * Escapes regular expression metacharacters
@@ -41,6 +42,8 @@ const tests = fs
 
 describe("StatsTestCases", () => {
 	jest.setTimeout(30000);
+	// aggressive-splitting cases intentionally use the deprecated plugin alias
+	expectNoDeprecations(["DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN"]);
 	/** @type {CapturedStdio} */
 	let stderr;
 

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -8,7 +8,9 @@ const rimraf = require("rimraf");
 const webpack = require("..");
 const { registerPerCaseSnapshotHooks } = require("./harness/snapshot");
 const captureStdio = require("./helpers/captureStdio");
-const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+const {
+	expectOnlyListedDeprecations
+} = require("./helpers/expectNoDeprecations");
 
 /**
  * Escapes regular expression metacharacters
@@ -42,8 +44,6 @@ const tests = fs
 
 describe("StatsTestCases", () => {
 	jest.setTimeout(30000);
-	// aggressive-splitting cases intentionally use the deprecated plugin alias
-	expectNoDeprecations(["DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN"]);
 	/** @type {CapturedStdio} */
 	let stderr;
 
@@ -61,6 +61,7 @@ describe("StatsTestCases", () => {
 		// eslint-disable-next-line no-loop-func
 		describe(testName, () => {
 			registerPerCaseSnapshotHooks(testDirectory, "StatsTestCases");
+			expectOnlyListedDeprecations(() => testDirectory);
 
 			it(`should print correct stats for ${testName}`, (done) => {
 				const outputDirectory = path.join(outputBase, testName);

--- a/test/Watch.test.js
+++ b/test/Watch.test.js
@@ -5,6 +5,9 @@ require("./helpers/warmup-webpack");
 const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
 
 describe("Watch", () => {
 	it("should only compile a single time", (done) => {

--- a/test/WatchClose.test.js
+++ b/test/WatchClose.test.js
@@ -3,6 +3,9 @@
 require("./helpers/warmup-webpack");
 
 const path = require("path");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
 
 describe("WatchClose", () => {
 	describe("multiple calls watcher", () => {

--- a/test/WatchDetection.test.js
+++ b/test/WatchDetection.test.js
@@ -5,6 +5,9 @@ const fs = require("graceful-fs");
 const { Volume, createFsFromVolume } = require("memfs");
 
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
 
 describe("WatchDetection", () => {
 	if (process.env.NO_WATCH_TESTS) {

--- a/test/WatchSuspend.test.js
+++ b/test/WatchSuspend.test.js
@@ -4,6 +4,9 @@ require("./helpers/warmup-webpack");
 
 const fs = require("fs");
 const path = require("path");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
 
 describe("WatchSuspend", () => {
 	if (process.env.NO_WATCH_TESTS) {

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -3,6 +3,7 @@
 const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 /**
  * @param {import("../").Configuration | import("../").MultiConfiguration} config webpack config
@@ -37,6 +38,8 @@ const createMultiCompiler = () =>
 			entry: "./a.js"
 		}
 	]);
+
+expectNoDeprecations();
 
 describe("WatcherEvents", () => {
 	if (process.env.NO_WATCH_TESTS) {

--- a/test/cssParsing-webpack.spectest.js
+++ b/test/cssParsing-webpack.spectest.js
@@ -13,6 +13,7 @@ const fs = require("fs");
 const path = require("path");
 const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const casesDir = path.resolve(__dirname, "./css-parsing-tests");
 const MODES = ["development", "production"];
@@ -114,6 +115,8 @@ const cases =
 	fs.existsSync(casesDir) && fs.readdirSync(casesDir).length > 0
 		? loadCases()
 		: [];
+
+expectNoDeprecations();
 
 describe("css-parsing-tests webpack build", () => {
 	/** @type {Map<string, Map<string, string[]>>} */

--- a/test/helpers/expectNoDeprecations.js
+++ b/test/helpers/expectNoDeprecations.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const deprecationTracking = require("./deprecationTracking");
+
+/**
+ * Registers hooks that fail the surrounding test when webpack emits an
+ * unexpected deprecation during it. Use in suites that run real builds but
+ * have no per-case `deprecations.js` convention.
+ *
+ * Deprecations whose code is listed in `allowed` are tolerated — webpack
+ * memoizes its deprecated alias getters, so such a deprecation fires at most
+ * once per process (on whichever test touches it first) and cannot be pinned
+ * to a single case.
+ * @param {(string | RegExp)[]=} allowed expected deprecation codes
+ * @returns {void}
+ */
+module.exports = (allowed = []) => {
+	/** @type {ReturnType<typeof deprecationTracking.start>} */
+	let deprecationTracker;
+
+	beforeEach(() => {
+		deprecationTracker = deprecationTracking.start();
+	});
+
+	afterEach(() => {
+		const deprecations = deprecationTracker().filter(
+			({ code }) =>
+				!allowed.some((a) => (a instanceof RegExp ? a.test(code) : a === code))
+		);
+		expect(deprecations).toEqual([]);
+	});
+};

--- a/test/helpers/expectNoDeprecations.js
+++ b/test/helpers/expectNoDeprecations.js
@@ -1,20 +1,16 @@
 "use strict";
 
+const path = require("path");
+const fs = require("graceful-fs");
 const deprecationTracking = require("./deprecationTracking");
 
 /**
- * Registers hooks that fail the surrounding test when webpack emits an
- * unexpected deprecation during it. Use in suites that run real builds but
- * have no per-case `deprecations.js` convention.
- *
- * Deprecations whose code is listed in `allowed` are tolerated — webpack
- * memoizes its deprecated alias getters, so such a deprecation fires at most
- * once per process (on whichever test touches it first) and cannot be pinned
- * to a single case.
- * @param {(string | RegExp)[]=} allowed expected deprecation codes
+ * Registers hooks that fail the surrounding test when webpack emits any
+ * deprecation during it. Use in suites that run real builds but should never
+ * emit a deprecation.
  * @returns {void}
  */
-module.exports = (allowed = []) => {
+const expectNoDeprecations = () => {
 	/** @type {ReturnType<typeof deprecationTracking.start>} */
 	let deprecationTracker;
 
@@ -23,10 +19,36 @@ module.exports = (allowed = []) => {
 	});
 
 	afterEach(() => {
-		const deprecations = deprecationTracker().filter(
-			({ code }) =>
-				!allowed.some((a) => (a instanceof RegExp ? a.test(code) : a === code))
+		expect(deprecationTracker()).toEqual([]);
+	});
+};
+
+module.exports = expectNoDeprecations;
+
+/**
+ * Like `expectNoDeprecations`, but deprecations whose code matches an entry of
+ * the running case's `deprecations.js` (same `[{ code: /RegExp/ }]` format used
+ * by the *TestCases suites) are allowed. Listed deprecations may be emitted or
+ * not — webpack memoizes its deprecated alias getters, so such a deprecation
+ * fires at most once per process and cannot be pinned to a single case.
+ * @param {() => string} getTestDirectory current case directory
+ * @returns {void}
+ */
+module.exports.expectOnlyListedDeprecations = (getTestDirectory) => {
+	/** @type {ReturnType<typeof deprecationTracking.start>} */
+	let deprecationTracker;
+
+	beforeEach(() => {
+		deprecationTracker = deprecationTracking.start();
+	});
+
+	afterEach(() => {
+		const file = path.join(getTestDirectory(), "deprecations.js");
+		/** @type {{ code: RegExp }[]} */
+		const allowed = fs.existsSync(file) ? require(file) : [];
+		const unexpected = deprecationTracker().filter(
+			({ code }) => !allowed.some((a) => a.code.test(code))
 		);
-		expect(deprecations).toEqual([]);
+		expect(unexpected).toEqual([]);
 	});
 };

--- a/test/hotCases/child-compiler/issue-9706/deprecations.js
+++ b/test/hotCases/child-compiler/issue-9706/deprecations.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [{ code: /DEP_WEBPACK_SINGLE_ENTRY_PLUGIN/ }];

--- a/test/html5lib.spectest.js
+++ b/test/html5lib.spectest.js
@@ -26,6 +26,7 @@ const {
 	buildHtmlAst,
 	decodeHtmlEntities
 } = require("../lib/html/syntax");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const testsDir = path.resolve(__dirname, "./html5lib-tests");
 
@@ -129,6 +130,8 @@ const tokenizerCases =
 	fs.existsSync(tokenizerDir) && fs.readdirSync(tokenizerDir).length > 0
 		? loadTokenizerCases()
 		: [];
+
+expectNoDeprecations();
 
 describe("html5lib-tests webpack build", () => {
 	/** @type {Map<string, Map<string, string[]>>} */

--- a/test/statsCases/aggressive-splitting-entry/deprecations.js
+++ b/test/statsCases/aggressive-splitting-entry/deprecations.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [{ code: /DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN/ }];

--- a/test/statsCases/aggressive-splitting-on-demand/deprecations.js
+++ b/test/statsCases/aggressive-splitting-on-demand/deprecations.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [{ code: /DEP_WEBPACK_AGGRESSIVE_SPLITTING_PLUGIN/ }];

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -7,6 +7,7 @@ const path = require("path");
 const url = require("url");
 const vm = require("vm");
 const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 const needDebug = typeof process.env.DEBUG !== "undefined";
 
@@ -1152,6 +1153,8 @@ function splitToNChunks(array, n) {
 }
 
 const shardedTestFiles = splitToNChunks([...testFiles], shard[1])[shard[0] - 1];
+
+expectNoDeprecations();
 
 describe("test262", () => {
 	for (const mode of ["development", "production"]) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Deprecation tracking was only wired into `TestCases`, `ConfigTestCases` and `WatchTestCases`, so every other suite that runs a real build printed `DeprecationWarning` to stderr but still passed. This wires deprecation tracking into the remaining in-process build suites via a small `expectNoDeprecations` helper, which surfaced three previously-silent deprecations: `SingleEntryPlugin` (a hot case), `AggressiveSplittingPlugin` (stats cases + an example), and `normalModuleLoader` (ProfilingPlugin).

Expected deprecations are declared per case through `deprecations.js` files (the existing convention), not a suite-wide ignore. The `http2-aggressive-splitting` example is modernized to `optimization.splitChunks` so a published example no longer demonstrates the deprecated `AggressiveSplittingPlugin`.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test (with a small docs/example update). The development branch keeps its harness-assigned `claude/` prefix.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

This PR is the test change itself: a new `test/helpers/expectNoDeprecations.js`, deprecation tracking added to `HotTestCases.template.js`, `StatsTestCases`, `MultiCompiler`, `MultiStats`, `Examples`, the caching/watch/plugin suites and the css/html5lib/test262 spec builds, plus per-case `deprecations.js` files.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the `http2-aggressive-splitting` example README is regenerated in this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — drafted with Claude Code. I reviewed every change and verified it: ran the affected suites, confirmed the new checks fail on unexpected deprecations (and pass once declared), and rebuilt the modernized example.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENvP8eaitKahFtpcUPeTKu)_