### PR TITLE
test: assert inlined side-effect-only imports ship no dead import var binding

### DIFF
--- a/test/configCases/inline-exports/minified-no-dead-binding/constants.js
+++ b/test/configCases/inline-exports/minified-no-dead-binding/constants.js
@@ -1,0 +1,4 @@
+globalThis.__sideEffectRan = "constants.js";
+
+export const PI = 3.14;
+export const NAME = "lib";

--- a/test/configCases/inline-exports/minified-no-dead-binding/index.js
+++ b/test/configCases/inline-exports/minified-no-dead-binding/index.js
@@ -1,0 +1,21 @@
+import { PI, NAME } from "./constants.js";
+
+const fs = __non_webpack_require__("fs");
+const source = /** @type {string} */ (fs.readFileSync(__filename, "utf-8"));
+
+it("should inline the constants as literals", () => {
+	expect(PI).toBe(3.14);
+	expect(NAME).toBe("lib");
+});
+
+it("should keep the side-effectful module", () => {
+	expect(globalThis.__sideEffectRan).toBe("constants.js");
+	// still required for its side effect
+	expect(source).toMatch(/\(\s*"\.\/constants\.js"\s*\)/);
+});
+
+it("should not ship a dead import var binding after minification", () => {
+	// the require result for the inlined module is never assigned to a variable:
+	// every read became a literal, so the import var is dead and the minifier drops it.
+	expect(source).not.toMatch(/=\s*[\w$.]*\(\s*"\.\/constants\.js"\s*\)/);
+});

--- a/test/configCases/inline-exports/minified-no-dead-binding/test.config.js
+++ b/test/configCases/inline-exports/minified-no-dead-binding/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "bundle.js";
+	}
+};

--- a/test/configCases/inline-exports/minified-no-dead-binding/test.filter.js
+++ b/test/configCases/inline-exports/minified-no-dead-binding/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/inline-exports/minified-no-dead-binding/webpack.config.js
+++ b/test/configCases/inline-exports/minified-no-dead-binding/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	output: {
+		filename: "bundle.js",
+		pathinfo: false
+	},
+	optimization: {
+		// keep the module separate so the side-effect `require` call stays visible
+		concatenateModules: false,
+		moduleIds: "named",
+		inlineExports: true,
+		// rely on the default minifier to strip the now-dead import var binding
+		minimize: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

When `optimization.inlineExports` turns every named import of a side-effect-only module into a literal, the module's import var becomes dead. webpack still emits `var X = __webpack_require__(id)`, but the production minifier strips the unused binding while keeping the side-effect `__webpack_require__(id)` call. This adds a regression test that locks in that end-to-end behavior (production + `minimize: true`), so a future codegen or minifier change can't silently start shipping the dead binding.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — this PR is test-only: `test/configCases/inline-exports/minified-no-dead-binding/`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — used Claude Code to investigate the codegen, verify via builds that the default minifier already strips the dead import var binding, and write this test case. All output was reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9NxXDXvbu3F5Y71Wj7RGe)_