### PR TITLE
test: fail config cache tests when the filesystem cache fails

### DIFF
--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -53,8 +53,17 @@ const createLogger = (appendTarget) => ({
 	debug: (/** @type {string} */ l) => appendTarget.push(l),
 	trace: (/** @type {string} */ l) => appendTarget.push(l),
 	info: (/** @type {string} */ l) => appendTarget.push(l),
-	warn: console.warn.bind(console),
-	error: console.error.bind(console),
+	// Also collect warn/error so cache store/restore failures (logged via
+	// `logger.warn`, e.g. "Caching failed for pack") are recorded and fail the
+	// test instead of being swallowed by jest's console buffering.
+	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.warn(l, ...args);
+	},
+	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.error(l, ...args);
+	},
 	logTime: () => {},
 	group: () => {},
 	groupCollapsed: () => {},
@@ -291,37 +300,39 @@ const describeCases = (config) => {
 								compiler.run((err) => {
 									deprecationTracker();
 									if (err) return handleFatalError(err, done);
-									const infrastructureLogging = stderr.toString();
-									if (infrastructureLogging) {
-										return done(
-											new Error(
-												`Errors/Warnings during build:\n${infrastructureLogging}`
-											)
-										);
-									}
-									const infrastructureLogErrors = filterInfraStructureErrors(
-										infraStructureLog,
-										{
-											run: 1,
-											options
-										}
-									);
-									if (
-										infrastructureLogErrors.length &&
-										checkArrayExpectation(
-											testDirectory,
-											{ infrastructureLogs: infrastructureLogErrors },
-											"infrastructureLog",
-											"infrastructure-log",
-											"InfrastructureLog",
-											options,
-											done
-										)
-									) {
-										return;
-									}
+									// Check after close: the disk cache is stored during close,
+									// so store failures (warnings) only surface afterwards.
 									compiler.close((closeErr) => {
 										if (closeErr) return handleFatalError(closeErr, done);
+										const infrastructureLogging = stderr.toString();
+										if (infrastructureLogging) {
+											return done(
+												new Error(
+													`Errors/Warnings during build:\n${infrastructureLogging}`
+												)
+											);
+										}
+										const infrastructureLogErrors = filterInfraStructureErrors(
+											infraStructureLog,
+											{
+												run: 1,
+												options
+											}
+										);
+										if (
+											infrastructureLogErrors.length &&
+											checkArrayExpectation(
+												testDirectory,
+												{ infrastructureLogs: infrastructureLogErrors },
+												"infrastructureLog",
+												"infrastructure-log",
+												"InfrastructureLog",
+												options,
+												done
+											)
+										) {
+											return;
+										}
 										done();
 									});
 								});
@@ -347,14 +358,6 @@ const describeCases = (config) => {
 											errorsCount: true
 										});
 									if (errorsCount === 0) {
-										const infrastructureLogging = stderr.toString();
-										if (infrastructureLogging) {
-											return done(
-												new Error(
-													`Errors/Warnings during build:\n${infrastructureLogging}`
-												)
-											);
-										}
 										const allModules = children
 											? children.reduce(
 													(all, { modules }) => [
@@ -388,29 +391,41 @@ const describeCases = (config) => {
 											);
 										}
 									}
-									const infrastructureLogErrors = filterInfraStructureErrors(
-										infraStructureLog,
-										{
-											run: 2,
-											options
-										}
-									);
-									if (
-										infrastructureLogErrors.length &&
-										checkArrayExpectation(
-											testDirectory,
-											{ infrastructureLogs: infrastructureLogErrors },
-											"infrastructureLog",
-											"infrastructure-log",
-											"InfrastructureLog",
-											options,
-											done
-										)
-									) {
-										return;
-									}
+									// Check after close: the disk cache is stored during close,
+									// so store failures (warnings) only surface afterwards.
 									compiler.close((closeErr) => {
 										if (closeErr) return handleFatalError(closeErr, done);
+										if (errorsCount === 0) {
+											const infrastructureLogging = stderr.toString();
+											if (infrastructureLogging) {
+												return done(
+													new Error(
+														`Errors/Warnings during build:\n${infrastructureLogging}`
+													)
+												);
+											}
+										}
+										const infrastructureLogErrors = filterInfraStructureErrors(
+											infraStructureLog,
+											{
+												run: 2,
+												options
+											}
+										);
+										if (
+											infrastructureLogErrors.length &&
+											checkArrayExpectation(
+												testDirectory,
+												{ infrastructureLogs: infrastructureLogErrors },
+												"infrastructureLog",
+												"infrastructure-log",
+												"InfrastructureLog",
+												options,
+												done
+											)
+										) {
+											return;
+										}
 										done();
 									});
 								});

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -46,22 +46,23 @@ const categories = fs.readdirSync(casesPath).map((cat) => ({
 
 /**
  * @param {string[]} appendTarget log collector
+ * @param {string[]} appendErrors warn/error collector
  * @returns {EXPECTED_ANY} logger object
  */
-const createLogger = (appendTarget) => ({
+const createLogger = (appendTarget, appendErrors) => ({
 	log: (/** @type {string} */ l) => appendTarget.push(l),
 	debug: (/** @type {string} */ l) => appendTarget.push(l),
 	trace: (/** @type {string} */ l) => appendTarget.push(l),
 	info: (/** @type {string} */ l) => appendTarget.push(l),
-	// Also collect warn/error so cache store/restore failures (logged via
-	// `logger.warn`, e.g. "Caching failed for pack") are recorded and fail the
-	// test instead of being swallowed by jest's console buffering.
+	// Collect warn/error separately: every infrastructure warning/error must be
+	// declared in the case's infrastructure-log.js or the test fails, so a cache
+	// store/restore failure can't slip through unnoticed.
 	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.warn(l, ...args);
 	},
 	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.error(l, ...args);
 	},
 	logTime: () => {},
@@ -110,6 +111,8 @@ const describeCases = (config) => {
 						}
 						/** @type {string[]} */
 						const infraStructureLog = [];
+						/** @type {string[]} */
+						const infraStructureErrors = [];
 						const outBaseDir = path.join(__dirname, "js");
 						const testSubPath = path.join(config.name, category.name, testName);
 						const outputDirectory = path.join(outBaseDir, testSubPath);
@@ -207,7 +210,10 @@ const describeCases = (config) => {
 								if (config.cache) {
 									options.infrastructureLogging = {
 										debug: true,
-										console: createLogger(infraStructureLog)
+										console: createLogger(
+											infraStructureLog,
+											infraStructureErrors
+										)
 									};
 								}
 								if (!options.snapshot) options.snapshot = {};
@@ -293,6 +299,7 @@ const describeCases = (config) => {
 								rimraf.sync(outputDirectory);
 								fs.mkdirSync(outputDirectory, { recursive: true });
 								infraStructureLog.length = 0;
+								infraStructureErrors.length = 0;
 								const deprecationTracker = deprecationTracking.start();
 
 								const compiler = require("..")(options);
@@ -312,13 +319,13 @@ const describeCases = (config) => {
 												)
 											);
 										}
-										const infrastructureLogErrors = filterInfraStructureErrors(
-											infraStructureLog,
-											{
+										const infrastructureLogErrors = [
+											...filterInfraStructureErrors(infraStructureLog, {
 												run: 1,
 												options
-											}
-										);
+											}),
+											...infraStructureErrors.map((message) => ({ message }))
+										];
 										if (
 											infrastructureLogErrors.length &&
 											checkArrayExpectation(
@@ -342,6 +349,7 @@ const describeCases = (config) => {
 								rimraf.sync(outputDirectory);
 								fs.mkdirSync(outputDirectory, { recursive: true });
 								infraStructureLog.length = 0;
+								infraStructureErrors.length = 0;
 								const deprecationTracker = deprecationTracking.start();
 
 								const compiler = require("..")(options);
@@ -405,13 +413,13 @@ const describeCases = (config) => {
 												);
 											}
 										}
-										const infrastructureLogErrors = filterInfraStructureErrors(
-											infraStructureLog,
-											{
+										const infrastructureLogErrors = [
+											...filterInfraStructureErrors(infraStructureLog, {
 												run: 2,
 												options
-											}
-										);
+											}),
+											...infraStructureErrors.map((message) => ({ message }))
+										];
 										if (
 											infrastructureLogErrors.length &&
 											checkArrayExpectation(
@@ -505,13 +513,13 @@ const describeCases = (config) => {
 								) {
 									return;
 								}
-								const infrastructureLogErrors = filterInfraStructureErrors(
-									infraStructureLog,
-									{
+								const infrastructureLogErrors = [
+									...filterInfraStructureErrors(infraStructureLog, {
 										run: 3,
 										options
-									}
-								);
+									}),
+									...infraStructureErrors.map((message) => ({ message }))
+								];
 								if (
 									infrastructureLogErrors.length &&
 									checkArrayExpectation(

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -4,11 +4,42 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const fs = require("graceful-fs");
+const checkArrayExpectation = require("./checkArrayExpectation");
 const {
 	expectOnlyListedDeprecations
 } = require("./helpers/expectNoDeprecations");
+const filterInfraStructureErrors = require("./helpers/infrastructureLogErrors");
 
 jest.setTimeout(60000);
+
+/**
+ * @param {string[]} appendTarget log collector
+ * @returns {EXPECTED_ANY} logger object
+ */
+const createLogger = (appendTarget) => ({
+	log: (/** @type {string} */ l) => appendTarget.push(l),
+	debug: (/** @type {string} */ l) => appendTarget.push(l),
+	trace: (/** @type {string} */ l) => appendTarget.push(l),
+	info: (/** @type {string} */ l) => appendTarget.push(l),
+	// Collect warn/error so a filesystem-cache store/restore failure (logged via
+	// `logger.warn`, e.g. "Caching failed for pack") fails the example build.
+	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.warn(l, ...args);
+	},
+	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.error(l, ...args);
+	},
+	logTime: () => {},
+	group: () => {},
+	groupCollapsed: () => {},
+	groupEnd: () => {},
+	profile: () => {},
+	profileEnd: () => {},
+	clear: () => {},
+	status: () => {}
+});
 
 const nodeVersion = Number.parseInt(process.version.slice(1).split(".")[0], 10);
 // eslint-disable-next-line no-new-func
@@ -81,6 +112,8 @@ describe("Examples", () => {
 			expectOnlyListedDeprecations(() => examplePath);
 
 			it(`should compile ${relativePath}`, async () => {
+				/** @type {string[]} */
+				const infraStructureLog = [];
 				let options = await loadConfiguration(examplePath);
 
 				if (!options) {
@@ -89,6 +122,8 @@ describe("Examples", () => {
 				}
 
 				if (typeof options === "function") options = options();
+
+				let usesFilesystemCache = false;
 
 				if (Array.isArray(options)) {
 					for (const [_, item] of options.entries()) {
@@ -109,13 +144,28 @@ describe("Examples", () => {
 					options.output.publicPath = "dist/";
 					if (!options.entry) options.entry = "./example.js";
 					if (!options.plugins) options.plugins = [];
+					// Only filesystem-cache examples have a persistent store that can
+					// fail; capture infra logs so a store/restore failure (emitted
+					// during the idle store on close) fails the build.
+					if (
+						options.cache &&
+						typeof options.cache === "object" &&
+						options.cache.type === "filesystem"
+					) {
+						usesFilesystemCache = true;
+						options.infrastructureLogging = {
+							...options.infrastructureLogging,
+							debug: true,
+							console: createLogger(infraStructureLog)
+						};
+					}
 				}
 
 				const webpack = require("..");
 
 				await /** @type {Promise<void>} */ (
 					new Promise((resolve, reject) => {
-						webpack(options, (err, stats) => {
+						const compiler = webpack(options, (err, stats) => {
 							if (err) {
 								reject(err);
 								return;
@@ -136,7 +186,45 @@ describe("Examples", () => {
 								return;
 							}
 
-							resolve();
+							// Examples without a persistent cache keep the original
+							// behavior (no close — some, e.g. lazy-compilation, manage
+							// their own server lifecycle).
+							if (!usesFilesystemCache || !compiler) {
+								resolve();
+								return;
+							}
+
+							// Close to flush and await the filesystem cache store, then
+							// fail if it logged a cache store/restore failure. close() is
+							// best-effort here: cache store failures surface as logged
+							// warnings, not as a close error (some examples, e.g.
+							// lazy-compilation, error on close from their own backend).
+							compiler.close(() => {
+								const infrastructureLogErrors = filterInfraStructureErrors(
+									infraStructureLog,
+									{ run: 1, options }
+								);
+								if (infrastructureLogErrors.length) {
+									/** @type {Error | undefined} */
+									let expectationError;
+									checkArrayExpectation(
+										examplePath,
+										{ infrastructureLogs: infrastructureLogErrors },
+										"infrastructureLog",
+										"infrastructure-log",
+										"InfrastructureLog",
+										options,
+										(/** @type {Error=} */ err) => {
+											expectationError = err;
+										}
+									);
+									if (expectationError) {
+										reject(expectationError);
+										return;
+									}
+								}
+								resolve();
+							});
 						});
 					})
 				);

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -8,27 +8,27 @@ const checkArrayExpectation = require("./checkArrayExpectation");
 const {
 	expectOnlyListedDeprecations
 } = require("./helpers/expectNoDeprecations");
-const filterInfraStructureErrors = require("./helpers/infrastructureLogErrors");
 
 jest.setTimeout(60000);
 
 /**
- * @param {string[]} appendTarget log collector
+ * @param {string[]} appendErrors warn/error collector
  * @returns {EXPECTED_ANY} logger object
  */
-const createLogger = (appendTarget) => ({
-	log: (/** @type {string} */ l) => appendTarget.push(l),
-	debug: (/** @type {string} */ l) => appendTarget.push(l),
-	trace: (/** @type {string} */ l) => appendTarget.push(l),
-	info: (/** @type {string} */ l) => appendTarget.push(l),
-	// Collect warn/error so a filesystem-cache store/restore failure (logged via
-	// `logger.warn`, e.g. "Caching failed for pack") fails the example build.
+const createLogger = (appendErrors) => ({
+	log: () => {},
+	debug: () => {},
+	trace: () => {},
+	info: () => {},
+	// Every infrastructure warning/error must be declared in the example's
+	// infrastructure-log.js or the build fails, so a filesystem-cache
+	// store/restore failure can't slip through unnoticed.
 	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.warn(l, ...args);
 	},
 	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.error(l, ...args);
 	},
 	logTime: () => {},
@@ -113,7 +113,7 @@ describe("Examples", () => {
 
 			it(`should compile ${relativePath}`, async () => {
 				/** @type {string[]} */
-				const infraStructureLog = [];
+				const infraStructureErrors = [];
 				let options = await loadConfiguration(examplePath);
 
 				if (!options) {
@@ -156,7 +156,7 @@ describe("Examples", () => {
 						options.infrastructureLogging = {
 							...options.infrastructureLogging,
 							debug: true,
-							console: createLogger(infraStructureLog)
+							console: createLogger(infraStructureErrors)
 						};
 					}
 				}
@@ -200,16 +200,16 @@ describe("Examples", () => {
 							// warnings, not as a close error (some examples, e.g.
 							// lazy-compilation, error on close from their own backend).
 							compiler.close(() => {
-								const infrastructureLogErrors = filterInfraStructureErrors(
-									infraStructureLog,
-									{ run: 1, options }
-								);
-								if (infrastructureLogErrors.length) {
+								if (infraStructureErrors.length) {
 									/** @type {Error | undefined} */
 									let expectationError;
 									checkArrayExpectation(
 										examplePath,
-										{ infrastructureLogs: infrastructureLogErrors },
+										{
+											infrastructureLogs: infraStructureErrors.map(
+												(message) => ({ message })
+											)
+										},
 										"infrastructureLog",
 										"infrastructure-log",
 										"InfrastructureLog",

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -58,8 +58,17 @@ const createLogger = (appendTarget) => ({
 	debug: (/** @type {string} */ l) => appendTarget.push(l),
 	trace: (/** @type {string} */ l) => appendTarget.push(l),
 	info: (/** @type {string} */ l) => appendTarget.push(l),
-	warn: console.warn.bind(console),
-	error: console.error.bind(console),
+	// Also collect warn/error so cache store/restore failures (logged via
+	// `logger.warn`, e.g. "Caching failed for pack") are recorded and fail the
+	// test instead of being swallowed by jest's console buffering.
+	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.warn(l, ...args);
+	},
+	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
+		appendTarget.push(l);
+		console.error(l, ...args);
+	},
 	logTime: () => {},
 	group: () => {},
 	groupCollapsed: () => {},

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -51,22 +51,23 @@ const categories = fs.readdirSync(casesPath).map((cat) => ({
 
 /**
  * @param {string[]} appendTarget log collector
+ * @param {string[]} appendErrors warn/error collector
  * @returns {EXPECTED_ANY} logger object
  */
-const createLogger = (appendTarget) => ({
+const createLogger = (appendTarget, appendErrors) => ({
 	log: (/** @type {string} */ l) => appendTarget.push(l),
 	debug: (/** @type {string} */ l) => appendTarget.push(l),
 	trace: (/** @type {string} */ l) => appendTarget.push(l),
 	info: (/** @type {string} */ l) => appendTarget.push(l),
-	// Also collect warn/error so cache store/restore failures (logged via
-	// `logger.warn`, e.g. "Caching failed for pack") are recorded and fail the
-	// test instead of being swallowed by jest's console buffering.
+	// Collect warn/error separately: every infrastructure warning/error must be
+	// declared in the case's infrastructure-log.js or the test fails, so a cache
+	// store/restore failure can't slip through unnoticed.
 	warn: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.warn(l, ...args);
 	},
 	error: (/** @type {string} */ l, /** @type {EXPECTED_ANY[]} */ ...args) => {
-		appendTarget.push(l);
+		appendErrors.push(l);
 		console.error(l, ...args);
 	},
 	logTime: () => {},
@@ -115,6 +116,8 @@ const describeCases = (config) => {
 				})) {
 					/** @type {string[]} */
 					const infraStructureLog = [];
+					/** @type {string[]} */
+					const infraStructureErrors = [];
 
 					// eslint-disable-next-line no-loop-func
 					describe(testName, () => {
@@ -284,7 +287,7 @@ const describeCases = (config) => {
 							},
 							infrastructureLogging: config.cache && {
 								debug: true,
-								console: createLogger(infraStructureLog)
+								console: createLogger(infraStructureLog, infraStructureErrors)
 							}
 						});
 
@@ -312,6 +315,7 @@ const describeCases = (config) => {
 										"cache1"
 									);
 									infraStructureLog.length = 0;
+									infraStructureErrors.length = 0;
 									const deprecationTracker = deprecationTracking.start();
 
 									const webpack = require("..");
@@ -320,13 +324,13 @@ const describeCases = (config) => {
 										deprecationTracker();
 										output.path = oldPath;
 										if (err) return done(err);
-										const infrastructureLogErrors = filterInfraStructureErrors(
-											infraStructureLog,
-											{
+										const infrastructureLogErrors = [
+											...filterInfraStructureErrors(infraStructureLog, {
 												run: 1,
 												options
-											}
-										);
+											}),
+											...infraStructureErrors.map((message) => ({ message }))
+										];
 										if (
 											infrastructureLogErrors.length &&
 											checkArrayExpectation(
@@ -357,6 +361,7 @@ const describeCases = (config) => {
 										"cache2"
 									);
 									infraStructureLog.length = 0;
+									infraStructureErrors.length = 0;
 									const deprecationTracker = deprecationTracking.start();
 
 									const webpack = require("..");
@@ -365,13 +370,13 @@ const describeCases = (config) => {
 										deprecationTracker();
 										output2.path = oldPath;
 										if (err) return done(err);
-										const infrastructureLogErrors = filterInfraStructureErrors(
-											infraStructureLog,
-											{
+										const infrastructureLogErrors = [
+											...filterInfraStructureErrors(infraStructureLog, {
 												run: 2,
 												options
-											}
-										);
+											}),
+											...infraStructureErrors.map((message) => ({ message }))
+										];
 										if (
 											infrastructureLogErrors.length &&
 											checkArrayExpectation(
@@ -407,13 +412,13 @@ const describeCases = (config) => {
 										const stats = /** @type {import("../").Stats} */ (_stats);
 										const deprecations = deprecationTracker();
 										if (err) return done(err);
-										const infrastructureLogErrors = filterInfraStructureErrors(
-											infraStructureLog,
-											{
+										const infrastructureLogErrors = [
+											...filterInfraStructureErrors(infraStructureLog, {
 												run: 3,
 												options
-											}
-										);
+											}),
+											...infraStructureErrors.map((message) => ({ message }))
+										];
 										if (
 											infrastructureLogErrors.length &&
 											checkArrayExpectation(

--- a/test/helpers/infrastructureLogErrors.js
+++ b/test/helpers/infrastructureLogErrors.js
@@ -17,27 +17,7 @@ const PERSISTENCE_CACHE_INVALIDATE_ERROR = (log, config) => {
 		return `Pack got invalid because of write to: ${match[1].trim()}`;
 	}
 };
-
-// Filesystem cache store/restore failures are logged as warnings; surface them
-// as errors so a broken disk cache fails the test instead of passing silently.
-/**
- * @param {string} log log line
- * @returns {string | undefined} error message
- */
-const PERSISTENCE_CACHE_FAILED_ERROR = (log) => {
-	const match =
-		/^\[webpack\.cache\.PackFileCacheStrategy\] (Caching failed for pack: .+|Restoring pack failed from .+|Restoring failed for .+ from pack: .+|Restoring pack from .+ failed: .+|Skipped not serializable cache item .+)$/.exec(
-			log
-		);
-	if (match) {
-		return match[1].trim();
-	}
-};
-
-const errorsFilter = [
-	PERSISTENCE_CACHE_INVALIDATE_ERROR,
-	PERSISTENCE_CACHE_FAILED_ERROR
-];
+const errorsFilter = [PERSISTENCE_CACHE_INVALIDATE_ERROR];
 
 /**
  * @param {string[]} logs logs

--- a/test/helpers/infrastructureLogErrors.js
+++ b/test/helpers/infrastructureLogErrors.js
@@ -17,7 +17,23 @@ const PERSISTENCE_CACHE_INVALIDATE_ERROR = (log, config) => {
 		return `Pack got invalid because of write to: ${match[1].trim()}`;
 	}
 };
-const errorsFilter = [PERSISTENCE_CACHE_INVALIDATE_ERROR];
+
+// Filesystem cache store/restore failures are logged as warnings; surface them
+// as errors so a broken disk cache fails the test instead of passing silently.
+const PERSISTENCE_CACHE_FAILED_ERROR = (log) => {
+	const match =
+		/^\[webpack\.cache\.PackFileCacheStrategy\] (Caching failed for pack: .+|Restoring pack failed from .+|Restoring failed for .+ from pack: .+|Restoring pack from .+ failed: .+|Skipped not serializable cache item .+)$/.exec(
+			log
+		);
+	if (match) {
+		return match[1].trim();
+	}
+};
+
+const errorsFilter = [
+	PERSISTENCE_CACHE_INVALIDATE_ERROR,
+	PERSISTENCE_CACHE_FAILED_ERROR
+];
 
 /**
  * @param {string[]} logs logs

--- a/test/helpers/infrastructureLogErrors.js
+++ b/test/helpers/infrastructureLogErrors.js
@@ -20,6 +20,10 @@ const PERSISTENCE_CACHE_INVALIDATE_ERROR = (log, config) => {
 
 // Filesystem cache store/restore failures are logged as warnings; surface them
 // as errors so a broken disk cache fails the test instead of passing silently.
+/**
+ * @param {string} log log line
+ * @returns {string | undefined} error message
+ */
 const PERSISTENCE_CACHE_FAILED_ERROR = (log) => {
 	const match =
 		/^\[webpack\.cache\.PackFileCacheStrategy\] (Caching failed for pack: .+|Restoring pack failed from .+|Restoring failed for .+ from pack: .+|Restoring pack from .+ failed: .+|Skipped not serializable cache item .+)$/.exec(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Filesystem cache store/restore failures are logged via `logger.warn` (e.g. `Caching failed for pack`, `Restoring pack failed from …`), but the cache test harness never failed on them: in `createLogger`, `warn`/`error` went to `console.warn`/`console.error` (buffered by jest, never reaching the captured `process.stderr`) and were never pushed into the inspected infrastructure-log array, while the `pre-compile` phases checked `stderr` *before* `compiler.close()` — i.e. before the disk store actually runs. A broken disk cache therefore passed green. This routes `warn`/`error` into the inspected log, flags genuine cache store/restore failures as errors, and moves the pre-compile checks after `close()` so the store phase is covered.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

This is a change to the test harness itself (`test/ConfigTestCases.template.js`, `test/TestCases.template.js`, `test/helpers/infrastructureLogErrors.js`); verified locally by forcing `fileSerializer.serialize` to reject — the `pre-compile to fill disk cache (1st)` phase now fails with `Caching failed for pack: …` where it previously passed silently. Full `ConfigCacheTestCases` run is otherwise unchanged (no regressions).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to investigate the harness gap, implement the fix, and run the cache suites locally to confirm the failure is now detected without introducing regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjwCnVmvAJM6byUUtXynR4)_