### PR TITLE
Support inline hash digest/length in path placeholders and CSS localIdentName

### DIFF
--- a/.changeset/css-local-ident-hash-digest-length.md
+++ b/.changeset/css-local-ident-hash-digest-length.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Support inline digest/length in CSS module `localIdentName` hash placeholders.

--- a/.changeset/css-local-ident-hash-digest-length.md
+++ b/.changeset/css-local-ident-hash-digest-length.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Support inline hash digest and length in CSS module `localIdentName` placeholders.

--- a/.changeset/css-local-ident-hash-digest-length.md
+++ b/.changeset/css-local-ident-hash-digest-length.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Support inline digest/length in CSS module `localIdentName` hash placeholders.

--- a/.changeset/css-local-ident-hash-module-hash.md
+++ b/.changeset/css-local-ident-hash-module-hash.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+CSS `localIdentName` `[hash]` now resolves to the local ident hash (matching css-loader); use `[modulehash]` for the module hash.

--- a/.changeset/templated-path-hash-digest.md
+++ b/.changeset/templated-path-hash-digest.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support an inline digest in hash path placeholders, e.g. `[contenthash:base64:8]`.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -372,6 +372,7 @@ const { isSourceEqual } = require("./util/source");
  * @property {HashWithLengthFunction=} contentHashWithLength
  * @property {string=} hashDigest digest the stored hashes are encoded in (for `[hash:<digest>]`)
  * @property {boolean=} realContentHash whether `optimization.realContentHash` recomputes content hashes (rejects an inline digest on `[contenthash]`)
+ * @property {boolean=} hashAsFullHash treat `[hash]` as `[fullhash]` rather than the module hash (CSS local idents)
  * @property {boolean=} noChunkHash
  * @property {string=} url
  * @property {string=} local

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -358,6 +358,7 @@ const { isSourceEqual } = require("./util/source");
  * @typedef {object} PathData
  * @property {ChunkGraph=} chunkGraph
  * @property {string=} hash
+ * @property {string=} fullHash untruncated compilation hash, for re-encoding `[fullhash:<digest>]`
  * @property {HashWithLengthFunction=} hashWithLength
  * @property {(Chunk | ChunkPathData)=} chunk
  * @property {(Module | ModulePathData)=} module

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -368,6 +368,7 @@ const { isSourceEqual } = require("./util/source");
  * @property {string=} contentHashType
  * @property {string=} contentHash
  * @property {HashWithLengthFunction=} contentHashWithLength
+ * @property {string=} hashDigest digest the stored hashes are encoded in (for `[hash:<digest>]`)
  * @property {boolean=} noChunkHash
  * @property {string=} url
  * @property {string=} local

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -370,6 +370,7 @@ const { isSourceEqual } = require("./util/source");
  * @property {string=} contentHash
  * @property {HashWithLengthFunction=} contentHashWithLength
  * @property {string=} hashDigest digest the stored hashes are encoded in (for `[hash:<digest>]`)
+ * @property {boolean=} realContentHash whether `optimization.realContentHash` recomputes content hashes (rejects an inline digest on `[contenthash]`)
  * @property {boolean=} noChunkHash
  * @property {string=} url
  * @property {string=} local

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -359,6 +359,7 @@ const { isSourceEqual } = require("./util/source");
  * @property {ChunkGraph=} chunkGraph
  * @property {string=} hash
  * @property {string=} fullHash untruncated compilation hash, for re-encoding `[fullhash:<digest>]`
+ * @property {string=} fullHashDigest digest `fullHash` is encoded in (defaults to `hashDigest`)
  * @property {HashWithLengthFunction=} hashWithLength
  * @property {(Chunk | ChunkPathData)=} chunk
  * @property {(Module | ModulePathData)=} module

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const RuntimeGlobals = require("./RuntimeGlobals");
+const { getPresentKinds } = require("./TemplatedPathPlugin");
 const RuntimeRequirementsDependency = require("./dependencies/RuntimeRequirementsDependency");
 const JavascriptModulesPlugin = require("./javascript/JavascriptModulesPlugin");
 const AsyncModuleRuntimeModule = require("./runtime/AsyncModuleRuntimeModule");
@@ -114,7 +115,14 @@ const TREE_DEPENDENCIES = {
 	[RuntimeGlobals.shareScopeMap]: [RuntimeGlobals.hasOwnProperty]
 };
 
-const FULLHASH_REGEXP = /\[(?:full)?hash(?::\d+)?\]/;
+/**
+ * @param {string} template path template
+ * @returns {boolean} true when it references the compilation `[fullhash]`/`[hash]`
+ */
+const usesFullHash = (template) => {
+	const kinds = getPresentKinds(template);
+	return kinds.has("fullhash") || kinds.has("hash");
+};
 
 const PLUGIN_NAME = "RuntimePlugin";
 
@@ -280,10 +288,7 @@ class RuntimePlugin {
 					} else {
 						const module = new PublicPathRuntimeModule(publicPath);
 
-						if (
-							typeof publicPath !== "string" ||
-							FULLHASH_REGEXP.test(publicPath)
-						) {
+						if (typeof publicPath !== "string" || usesFullHash(publicPath)) {
 							module.fullHash = true;
 						}
 
@@ -330,7 +335,7 @@ class RuntimePlugin {
 				.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 					if (
 						typeof compilation.outputOptions.chunkFilename === "string" &&
-						FULLHASH_REGEXP.test(compilation.outputOptions.chunkFilename)
+						usesFullHash(compilation.outputOptions.chunkFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
@@ -361,7 +366,7 @@ class RuntimePlugin {
 				.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 					if (
 						typeof compilation.outputOptions.cssChunkFilename === "string" &&
-						FULLHASH_REGEXP.test(compilation.outputOptions.cssChunkFilename)
+						usesFullHash(compilation.outputOptions.cssChunkFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
@@ -390,11 +395,7 @@ class RuntimePlugin {
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getChunkUpdateScriptFilename)
 				.tap(PLUGIN_NAME, (chunk, set) => {
-					if (
-						FULLHASH_REGEXP.test(
-							compilation.outputOptions.hotUpdateChunkFilename
-						)
-					) {
+					if (usesFullHash(compilation.outputOptions.hotUpdateChunkFilename)) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
@@ -412,11 +413,7 @@ class RuntimePlugin {
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getUpdateManifestFilename)
 				.tap(PLUGIN_NAME, (chunk, set) => {
-					if (
-						FULLHASH_REGEXP.test(
-							compilation.outputOptions.hotUpdateMainFilename
-						)
-					) {
+					if (usesFullHash(compilation.outputOptions.hotUpdateMainFilename)) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -11,6 +11,7 @@ const Compilation = require("./Compilation");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 const ProgressPlugin = require("./ProgressPlugin");
 const SourceMapDevToolModuleOptionsPlugin = require("./SourceMapDevToolModuleOptionsPlugin");
+const { getPresentKinds } = require("./TemplatedPathPlugin");
 const createHash = require("./util/createHash");
 const { dirname, relative } = require("./util/fs");
 const generateDebugId = require("./util/generateDebugId");
@@ -46,7 +47,6 @@ const { makePathsAbsolute } = require("./util/identifier");
  */
 
 const METACHARACTERS_REGEXP = /[-[\]\\/{}()*+?.^$|]/g;
-const CONTENT_HASH_DETECT_REGEXP = /\[contenthash(?::\w+)?\]/;
 const CSS_AND_JS_MODULE_EXTENSIONS_REGEXP = /\.((c|m)?js|css)($|\?)/i;
 const CSS_EXTENSION_DETECT_REGEXP = /\.css(?:$|\?)/i;
 const MAP_URL_COMMENT_REGEXP = /\[map\]/g;
@@ -681,10 +681,8 @@ class SourceMapDevToolPlugin {
 									}
 
 									const usesContentHash =
-										sourceMapFilename &&
-										CONTENT_HASH_DETECT_REGEXP.test(sourceMapFilename);
-
-									resetRegexpState(CONTENT_HASH_DETECT_REGEXP);
+										typeof sourceMapFilename === "string" &&
+										getPresentKinds(sourceMapFilename).has("contenthash");
 
 									let outputFile = file;
 									// If SourceMap and asset uses contenthash, avoid a circular dependency by hiding hash in `file`

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -664,4 +664,5 @@ class TemplatedPathPlugin {
 }
 
 module.exports = TemplatedPathPlugin;
+module.exports.getPresentKinds = getPresentKinds;
 module.exports.interpolate = interpolate;

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -442,15 +442,17 @@ const interpolate = (path, data, assetInfo) => {
 			replacements.set("fullhash", hashReplacer);
 		}
 
-		// Legacy
+		// Legacy — but a css-loader-style `[hash]` local ident is not deprecated
 		if (presentKinds.has("hash")) {
 			replacements.set(
 				"hash",
-				deprecated(
-					hashReplacer,
-					"[hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)",
-					"DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH"
-				)
+				data.hashAsFullHash
+					? hashReplacer
+					: deprecated(
+							hashReplacer,
+							"[hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)",
+							"DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH"
+						)
 			);
 		}
 	}
@@ -524,7 +526,9 @@ const interpolate = (path, data, assetInfo) => {
 		const module = data.module;
 		const needId = presentKinds.has("id");
 		const needModuleId = presentKinds.has("moduleid");
-		const needHash = presentKinds.has("hash");
+		// `data.hashAsFullHash` keeps `[hash]` as the `[fullhash]` alias (CSS local
+		// idents) instead of repurposing it to the module hash; `[modulehash]` stays.
+		const needHash = presentKinds.has("hash") && !data.hashAsFullHash;
 
 		if (needId || needModuleId) {
 			const idReplacer = replacer(() =>

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -650,6 +650,11 @@ const interpolate = (path, data, assetInfo) => {
 					digest = arg1;
 					length = undefined;
 				}
+				if (digest && kind === "contenthash" && data.realContentHash) {
+					throw new Error(
+						`Inline hash digest [contenthash:${digest}] is not supported together with optimization.realContentHash, which recomputes content hashes in output.hashDigest. Set optimization.realContentHash: false, or set output.hashDigest: "${digest}".`
+					);
+				}
 				return replacer(match, length, /** @type {string} */ (path), digest);
 			}
 		} else if (match.startsWith("[\\") && match.endsWith("\\]")) {
@@ -683,6 +688,13 @@ class TemplatedPathPlugin {
 				// Untruncated compilation hash, so `[fullhash:<digest>]` keeps full entropy
 				if (data.fullHash === undefined && data.hash === compilation.hash) {
 					data.fullHash = compilation.fullHash;
+				}
+				// `RealContentHashPlugin` rehashes in `output.hashDigest`, so an inline
+				// digest on `[contenthash]` would be silently overwritten — reject it.
+				if (data.realContentHash === undefined) {
+					data.realContentHash = Boolean(
+						compilation.options.optimization.realContentHash
+					);
 				}
 				return interpolate(path, data, assetInfo);
 			});

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -96,6 +96,18 @@ const prepareId = (id) => {
 // `[<digest>]` placeholders may request a digest webpack does not store the
 // hash in; loader-utils calls the URL-safe base64 `base64safe`.
 const BASE_DIGEST = /^base(\d+)$/;
+const SUPPORTED_BASES = new Set(["26", "32", "36", "49", "52", "58", "62"]);
+
+/**
+ * @param {string} digest digest name from a `[<hash>:<digest>]` placeholder
+ * @returns {boolean} whether a hash can be re-encoded into this digest
+ */
+const isSupportedDigest = (digest) => {
+	if (digest === "base64url" || digest === "base64safe") return true;
+	const base = BASE_DIGEST.exec(digest);
+	if (base) return base[1] === "64" || SUPPORTED_BASES.has(base[1]);
+	return Buffer.isEncoding(digest);
+};
 
 /**
  * Decodes an already-digested hash string back into its raw bytes.
@@ -136,9 +148,9 @@ const bufferToDigest = (buffer, digest) => {
 
 /**
  * Re-encodes a digested hash into another digest (e.g. `[contenthash:base64]`).
- * Returns the value unchanged when the digests match or re-encoding fails — the
- * source is already truncated to `output.hashDigestLength`, so the result is
- * derived from those bytes, not the full content.
+ * The source is already truncated to `output.hashDigestLength`, so the result is
+ * derived from those bytes, not the full content. Throws on an unknown digest so
+ * a typo fails loudly rather than silently keeping the original encoding.
  * @param {string} value digested hash
  * @param {string} fromDigest digest the value is encoded in
  * @param {string} toDigest requested digest
@@ -146,11 +158,12 @@ const bufferToDigest = (buffer, digest) => {
  */
 const reEncodeDigest = (value, fromDigest, toDigest) => {
 	if (toDigest === fromDigest) return value;
-	try {
-		return bufferToDigest(digestToBuffer(value, fromDigest), toDigest);
-	} catch (_err) {
-		return value;
+	if (!isSupportedDigest(toDigest)) {
+		throw new Error(
+			`Unsupported hash digest "${toDigest}" in path template (use hex, base64, base64url, or base26/32/36/49/52/58/62)`
+		);
 	}
+	return bufferToDigest(digestToBuffer(value, fromDigest), toDigest);
 };
 
 /**

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -173,9 +173,17 @@ const reEncodeDigest = (value, fromDigest, toDigest) => {
  * @param {AssetInfo | undefined} assetInfo asset info
  * @param {string} hashName hash name
  * @param {string} sourceDigest digest the stored hash is encoded in
+ * @param {string=} fullValue untruncated hash, re-encoded for `[<hash>:<digest>]` so the result carries full entropy instead of the `hashDigestLength`-truncated value
  * @returns {Replacer} hash replacer function
  */
-const hashLength = (replacer, handler, assetInfo, hashName, sourceDigest) => {
+const hashLength = (
+	replacer,
+	handler,
+	assetInfo,
+	hashName,
+	sourceDigest,
+	fullValue
+) => {
 	/** @type {Replacer} */
 	const fn = (match, arg, input, digest) => {
 		/** @type {string} */
@@ -184,7 +192,7 @@ const hashLength = (replacer, handler, assetInfo, hashName, sourceDigest) => {
 
 		if (digest) {
 			const hash = reEncodeDigest(
-				replacer(match, arg, input),
+				fullValue !== undefined ? fullValue : replacer(match, arg, input),
 				sourceDigest,
 				digest
 			);
@@ -426,7 +434,8 @@ const interpolate = (path, data, assetInfo) => {
 			data.hashWithLength,
 			assetInfo,
 			"fullhash",
-			sourceDigest
+			sourceDigest,
+			data.fullHash
 		);
 
 		if (presentKinds.has("fullhash")) {
@@ -471,7 +480,8 @@ const interpolate = (path, data, assetInfo) => {
 					"hashWithLength" in chunk ? chunk.hashWithLength : undefined,
 					assetInfo,
 					"chunkhash",
-					sourceDigest
+					sourceDigest,
+					chunk.hash
 				)
 			);
 		}
@@ -669,6 +679,10 @@ class TemplatedPathPlugin {
 				// Digest the stored hashes use, so `[hash:<digest>]` can re-encode them
 				if (data.hashDigest === undefined) {
 					data.hashDigest = compilation.outputOptions.hashDigest;
+				}
+				// Untruncated compilation hash, so `[fullhash:<digest>]` keeps full entropy
+				if (data.fullHash === undefined && data.hash === compilation.hash) {
+					data.fullHash = compilation.fullHash;
 				}
 				return interpolate(path, data, assetInfo);
 			});

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -434,7 +434,7 @@ const interpolate = (path, data, assetInfo) => {
 			data.hashWithLength,
 			assetInfo,
 			"fullhash",
-			sourceDigest,
+			data.fullHashDigest || sourceDigest,
 			data.fullHash
 		);
 

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -98,6 +98,14 @@ const prepareId = (id) => {
 const BASE_DIGEST = /^base(\d+)$/;
 const SUPPORTED_BASES = new Set(["26", "32", "36", "49", "52", "58", "62"]);
 
+// Node < 14.18 lacks the `base64url` Buffer encoding; fall back to base64 + swap.
+let isBase64UrlSupported = false;
+try {
+	isBase64UrlSupported = Boolean(Buffer.from("", "base64url"));
+} catch (_err) {
+	// Nothing
+}
+
 /**
  * @param {string} digest digest name from a `[<hash>:<digest>]` placeholder
  * @returns {boolean} whether a hash can be re-encoded into this digest
@@ -120,6 +128,12 @@ const digestToBuffer = (value, digest) => {
 	if (base && Number(base[1]) !== 64) {
 		return decodeBase(value, /** @type {Base} */ (base[1]));
 	}
+	if (
+		(digest === "base64url" || digest === "base64safe") &&
+		!isBase64UrlSupported
+	) {
+		return Buffer.from(value.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+	}
 	return Buffer.from(
 		value,
 		/** @type {BufferEncoding} */ (
@@ -138,6 +152,16 @@ const bufferToDigest = (buffer, digest) => {
 	const base = BASE_DIGEST.exec(digest);
 	if (base && Number(base[1]) !== 64) {
 		return encodeBase(buffer, /** @type {Base} */ (base[1]));
+	}
+	if (
+		(digest === "base64url" || digest === "base64safe") &&
+		!isBase64UrlSupported
+	) {
+		return buffer
+			.toString("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/[=]+$/, "");
 	}
 	return buffer.toString(
 		/** @type {BufferEncoding} */ (

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -9,6 +9,10 @@ const { basename, extname } = require("path");
 const util = require("util");
 const Chunk = require("./Chunk");
 const Module = require("./Module");
+const {
+	decode: decodeBase,
+	encode: encodeBase
+} = require("./util/hash/hash-digest");
 const { parseResource } = require("./util/identifier");
 const memoize = require("./util/memoize");
 
@@ -53,7 +57,7 @@ const getPresentKinds = (path) => {
 	while ((m = REGEXP.exec(path)) !== null) {
 		const content = /** @type {string} */ (m[1]);
 		if (content.length + 2 === m[0].length) {
-			const cm = /^(\w+)(?::\w+)?$/.exec(content);
+			const cm = /^(\w+)(?::\w+)?(?::\w+)?$/.exec(content);
 			if (cm) kinds.add(cm[1]);
 		}
 	}
@@ -87,22 +91,92 @@ const prepareId = (id) => {
  * @param {string} input
  */
 
+/** @typedef {"26" | "32" | "36" | "49" | "52" | "58" | "62"} Base */
+
+// `[<digest>]` placeholders may request a digest webpack does not store the
+// hash in; loader-utils calls the URL-safe base64 `base64safe`.
+const BASE_DIGEST = /^base(\d+)$/;
+
+/**
+ * Decodes an already-digested hash string back into its raw bytes.
+ * @param {string} value digested hash
+ * @param {string} digest digest the value is encoded in
+ * @returns {Buffer} raw bytes
+ */
+const digestToBuffer = (value, digest) => {
+	const base = BASE_DIGEST.exec(digest);
+	if (base && Number(base[1]) !== 64) {
+		return decodeBase(value, /** @type {Base} */ (base[1]));
+	}
+	return Buffer.from(
+		value,
+		/** @type {BufferEncoding} */ (
+			digest === "base64safe" ? "base64url" : digest
+		)
+	);
+};
+
+/**
+ * Encodes raw bytes into the requested digest.
+ * @param {Buffer} buffer raw bytes
+ * @param {string} digest target digest
+ * @returns {string} encoded hash
+ */
+const bufferToDigest = (buffer, digest) => {
+	const base = BASE_DIGEST.exec(digest);
+	if (base && Number(base[1]) !== 64) {
+		return encodeBase(buffer, /** @type {Base} */ (base[1]));
+	}
+	return buffer.toString(
+		/** @type {BufferEncoding} */ (
+			digest === "base64safe" ? "base64url" : digest
+		)
+	);
+};
+
+/**
+ * Re-encodes a digested hash into another digest (e.g. `[contenthash:base64]`).
+ * Returns the value unchanged when the digests match or re-encoding fails — the
+ * source is already truncated to `output.hashDigestLength`, so the result is
+ * derived from those bytes, not the full content.
+ * @param {string} value digested hash
+ * @param {string} fromDigest digest the value is encoded in
+ * @param {string} toDigest requested digest
+ * @returns {string} re-encoded hash
+ */
+const reEncodeDigest = (value, fromDigest, toDigest) => {
+	if (toDigest === fromDigest) return value;
+	try {
+		return bufferToDigest(digestToBuffer(value, fromDigest), toDigest);
+	} catch (_err) {
+		return value;
+	}
+};
+
 /**
  * Returns hash replacer function.
  * @param {ReplacerFunction} replacer replacer
  * @param {((arg0: number) => string) | undefined} handler handler
  * @param {AssetInfo | undefined} assetInfo asset info
  * @param {string} hashName hash name
+ * @param {string} sourceDigest digest the stored hash is encoded in
  * @returns {Replacer} hash replacer function
  */
-const hashLength = (replacer, handler, assetInfo, hashName) => {
+const hashLength = (replacer, handler, assetInfo, hashName, sourceDigest) => {
 	/** @type {Replacer} */
-	const fn = (match, arg, input) => {
+	const fn = (match, arg, input, digest) => {
 		/** @type {string} */
 		let result;
 		const length = arg && Number.parseInt(arg, 10);
 
-		if (length && handler) {
+		if (digest) {
+			const hash = reEncodeDigest(
+				replacer(match, arg, input),
+				sourceDigest,
+				digest
+			);
+			result = length ? hash.slice(0, length) : hash;
+		} else if (length && handler) {
 			result = handler(length);
 		} else {
 			const hash = replacer(match, arg, input);
@@ -125,7 +199,7 @@ const hashLength = (replacer, handler, assetInfo, hashName) => {
 	return fn;
 };
 
-/** @typedef {(match: string, arg: string | undefined, input: string) => string} Replacer */
+/** @typedef {(match: string, arg: string | undefined, input: string, digest?: string) => string} Replacer */
 
 /**
  * Returns replacer.
@@ -226,6 +300,8 @@ const interpolate = (path, data, assetInfo) => {
 	const presentKinds = getPresentKinds(path);
 
 	const chunkGraph = data.chunkGraph;
+	// Digest the stored hashes are encoded in, so `[hash:<digest>]` can re-encode.
+	const sourceDigest = data.hashDigest || "hex";
 
 	/** @type {Map<string, Replacer>} */
 	const replacements = new Map();
@@ -336,7 +412,8 @@ const interpolate = (path, data, assetInfo) => {
 			replacer(data.hash),
 			data.hashWithLength,
 			assetInfo,
-			"fullhash"
+			"fullhash",
+			sourceDigest
 		);
 
 		if (presentKinds.has("fullhash")) {
@@ -380,7 +457,8 @@ const interpolate = (path, data, assetInfo) => {
 					replacer(chunk instanceof Chunk ? chunk.renderedHash : chunk.hash),
 					"hashWithLength" in chunk ? chunk.hashWithLength : undefined,
 					assetInfo,
-					"chunkhash"
+					"chunkhash",
+					sourceDigest
 				)
 			);
 		}
@@ -401,7 +479,8 @@ const interpolate = (path, data, assetInfo) => {
 								]
 							: undefined),
 					assetInfo,
-					"contenthash"
+					"contenthash",
+					sourceDigest
 				)
 			);
 		}
@@ -466,7 +545,8 @@ const interpolate = (path, data, assetInfo) => {
 				),
 				"hashWithLength" in module ? module.hashWithLength : undefined,
 				assetInfo,
-				"modulehash"
+				"modulehash",
+				sourceDigest
 			);
 			if (presentKinds.has("modulehash")) {
 				replacements.set("modulehash", moduleHashReplacer);
@@ -477,7 +557,8 @@ const interpolate = (path, data, assetInfo) => {
 				replacer(/** @type {string} */ (data.contentHash)),
 				undefined,
 				assetInfo,
-				"contenthash"
+				"contenthash",
+				sourceDigest
 			);
 			if (presentKinds.has("contenthash")) {
 				replacements.set("contenthash", contentHashReplacer);
@@ -529,12 +610,24 @@ const interpolate = (path, data, assetInfo) => {
 
 	path = path.replace(REGEXP, (match, content) => {
 		if (content.length + 2 === match.length) {
-			const contentMatch = /^(\w+)(?::(\w+))?$/.exec(content);
+			const contentMatch = /^(\w+)(?::(\w+))?(?::(\w+))?$/.exec(content);
 			if (!contentMatch) return match;
-			const [, kind, arg] = contentMatch;
+			const [, kind, arg1, arg2] = contentMatch;
 			const replacer = replacements.get(kind);
 			if (replacer !== undefined) {
-				return replacer(match, arg, /** @type {string} */ (path));
+				// `[kind:length]`, `[kind:digest]` or `[kind:digest:length]`.
+				/** @type {string | undefined} */
+				let digest;
+				/** @type {string | undefined} */
+				let length = arg1;
+				if (arg2 !== undefined) {
+					digest = arg1;
+					length = arg2;
+				} else if (arg1 !== undefined && !/^\d+$/.test(arg1)) {
+					digest = arg1;
+					length = undefined;
+				}
+				return replacer(match, length, /** @type {string} */ (path), digest);
 			}
 		} else if (match.startsWith("[\\") && match.endsWith("\\]")) {
 			return `[${match.slice(2, -2)}]`;
@@ -559,6 +652,10 @@ class TemplatedPathPlugin {
 				// Default from output options so `[uniqueName]` resolves in every template
 				if (data.uniqueName === undefined) {
 					data.uniqueName = compilation.outputOptions.uniqueName;
+				}
+				// Digest the stored hashes use, so `[hash:<digest>]` can re-encode them
+				if (data.hashDigest === undefined) {
+					data.hashDigest = compilation.outputOptions.hashDigest;
 				}
 				return interpolate(path, data, assetInfo);
 			});

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -28,6 +28,7 @@ const {
 } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const { getPresentKinds } = require("../TemplatedPathPlugin");
 const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 
@@ -154,14 +155,18 @@ class CssGenerator extends Generator {
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
 		const localIdentName = options.localIdentName;
+		// Detect hash placeholders via the canonical template parser so this stays
+		// in sync with `interpolate`'s grammar.
+		const isFn = typeof localIdentName === "function";
+		const kinds =
+			typeof localIdentName === "string"
+				? getPresentKinds(localIdentName)
+				: undefined;
 		this._localIdentNeedsHash =
-			typeof localIdentName === "function" ||
-			/\[(?:fullhash|hash)(?::\w+)*\]/.test(
-				/** @type {string} */ (localIdentName)
-			);
+			isFn ||
+			(kinds !== undefined && (kinds.has("fullhash") || kinds.has("hash")));
 		this._localIdentNeedsContentHash =
-			typeof localIdentName === "function" ||
-			/\[contenthash(?::\w+)*\]/.test(/** @type {string} */ (localIdentName));
+			isFn || (kinds !== undefined && kinds.has("contenthash"));
 	}
 
 	/**

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -139,45 +139,6 @@ const buildExportsSourceMap = (
 	};
 };
 
-// css-loader / loader-utils hash placeholders may carry an inline digest and/or
-// length (e.g. `[hash:base64:6]`), which webpack expresses through generator
-// options instead. `base64safe` is loader-utils' name for `base64url`.
-const LOCAL_IDENT_HASH_REGEXP =
-	/\[(hash|fullhash|contenthash)(?::([a-z][a-z0-9]*))?(?::(\d+))?\]/gi;
-
-/**
- * Folds inline digest/length out of a `localIdentName` template into native
- * hash options. `[hash]`/`[fullhash]` become `[fullhash]` so the local ident
- * hash is used (css-loader semantics) rather than the module hash;
- * `[contenthash]` keeps its length inline (its digest comes from output options).
- * @param {string} localIdentName local ident template
- * @returns {{ localIdentName: string, localIdentHashDigest: string | undefined, localIdentHashDigestLength: number | undefined }} normalized template plus folded hash options
- */
-const parseLocalIdentName = (localIdentName) => {
-	/** @type {string | undefined} */
-	let localIdentHashDigest;
-	/** @type {number | undefined} */
-	let localIdentHashDigestLength;
-	const normalized = localIdentName.replace(
-		LOCAL_IDENT_HASH_REGEXP,
-		(match, kind, digest, length) => {
-			if (/** @type {string} */ (kind).toLowerCase() === "contenthash") {
-				return length ? `[contenthash:${length}]` : "[contenthash]";
-			}
-			if (digest) {
-				localIdentHashDigest = digest === "base64safe" ? "base64url" : digest;
-			}
-			if (length) localIdentHashDigestLength = Number(length);
-			return "[fullhash]";
-		}
-	);
-	return {
-		localIdentName: normalized,
-		localIdentHashDigest,
-		localIdentHashDigestLength
-	};
-};
-
 class CssGenerator extends Generator {
 	/**
 	 * Creates an instance of CssGenerator.
@@ -193,32 +154,12 @@ class CssGenerator extends Generator {
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
 		const localIdentName = options.localIdentName;
-		let localIdentHashDigest = options.localIdentHashDigest;
-		let localIdentHashDigestLength = options.localIdentHashDigestLength;
-		if (typeof localIdentName === "string") {
-			const parsed = parseLocalIdentName(localIdentName);
-			this._localIdentName = parsed.localIdentName;
-			if (parsed.localIdentHashDigest !== undefined) {
-				localIdentHashDigest = parsed.localIdentHashDigest;
-			}
-			if (parsed.localIdentHashDigestLength !== undefined) {
-				localIdentHashDigestLength = parsed.localIdentHashDigestLength;
-			}
-		} else {
-			this._localIdentName = localIdentName;
-		}
-		this._localIdentHashDigest = localIdentHashDigest;
-		this._localIdentHashDigestLength = localIdentHashDigestLength;
 		this._localIdentNeedsHash =
-			typeof this._localIdentName === "function" ||
-			/\[(?:fullhash|hash)(?::\w+)*\]/.test(
-				/** @type {string} */ (this._localIdentName)
-			);
+			typeof localIdentName === "function" ||
+			/\[(?:fullhash|hash)\]/.test(/** @type {string} */ (localIdentName));
 		this._localIdentNeedsContentHash =
-			typeof this._localIdentName === "function" ||
-			/\[contenthash(?::\w+)*\]/.test(
-				/** @type {string} */ (this._localIdentName)
-			);
+			typeof localIdentName === "function" ||
+			/\[contenthash\]/.test(/** @type {string} */ (localIdentName));
 	}
 
 	/**

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -139,6 +139,45 @@ const buildExportsSourceMap = (
 	};
 };
 
+// css-loader / loader-utils hash placeholders may carry an inline digest and/or
+// length (e.g. `[hash:base64:6]`), which webpack expresses through generator
+// options instead. `base64safe` is loader-utils' name for `base64url`.
+const LOCAL_IDENT_HASH_REGEXP =
+	/\[(hash|fullhash|contenthash)(?::([a-z][a-z0-9]*))?(?::(\d+))?\]/gi;
+
+/**
+ * Folds inline digest/length out of a `localIdentName` template into native
+ * hash options. `[hash]`/`[fullhash]` become `[fullhash]` so the local ident
+ * hash is used (css-loader semantics) rather than the module hash;
+ * `[contenthash]` keeps its length inline (its digest comes from output options).
+ * @param {string} localIdentName local ident template
+ * @returns {{ localIdentName: string, localIdentHashDigest: string | undefined, localIdentHashDigestLength: number | undefined }} normalized template plus folded hash options
+ */
+const parseLocalIdentName = (localIdentName) => {
+	/** @type {string | undefined} */
+	let localIdentHashDigest;
+	/** @type {number | undefined} */
+	let localIdentHashDigestLength;
+	const normalized = localIdentName.replace(
+		LOCAL_IDENT_HASH_REGEXP,
+		(match, kind, digest, length) => {
+			if (/** @type {string} */ (kind).toLowerCase() === "contenthash") {
+				return length ? `[contenthash:${length}]` : "[contenthash]";
+			}
+			if (digest) {
+				localIdentHashDigest = digest === "base64safe" ? "base64url" : digest;
+			}
+			if (length) localIdentHashDigestLength = Number(length);
+			return "[fullhash]";
+		}
+	);
+	return {
+		localIdentName: normalized,
+		localIdentHashDigest,
+		localIdentHashDigestLength
+	};
+};
+
 class CssGenerator extends Generator {
 	/**
 	 * Creates an instance of CssGenerator.
@@ -154,12 +193,32 @@ class CssGenerator extends Generator {
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
 		const localIdentName = options.localIdentName;
+		let localIdentHashDigest = options.localIdentHashDigest;
+		let localIdentHashDigestLength = options.localIdentHashDigestLength;
+		if (typeof localIdentName === "string") {
+			const parsed = parseLocalIdentName(localIdentName);
+			this._localIdentName = parsed.localIdentName;
+			if (parsed.localIdentHashDigest !== undefined) {
+				localIdentHashDigest = parsed.localIdentHashDigest;
+			}
+			if (parsed.localIdentHashDigestLength !== undefined) {
+				localIdentHashDigestLength = parsed.localIdentHashDigestLength;
+			}
+		} else {
+			this._localIdentName = localIdentName;
+		}
+		this._localIdentHashDigest = localIdentHashDigest;
+		this._localIdentHashDigestLength = localIdentHashDigestLength;
 		this._localIdentNeedsHash =
-			typeof localIdentName === "function" ||
-			/\[(?:fullhash|hash)\]/.test(/** @type {string} */ (localIdentName));
+			typeof this._localIdentName === "function" ||
+			/\[(?:fullhash|hash)(?::\w+)*\]/.test(
+				/** @type {string} */ (this._localIdentName)
+			);
 		this._localIdentNeedsContentHash =
-			typeof localIdentName === "function" ||
-			/\[contenthash\]/.test(/** @type {string} */ (localIdentName));
+			typeof this._localIdentName === "function" ||
+			/\[contenthash(?::\w+)*\]/.test(
+				/** @type {string} */ (this._localIdentName)
+			);
 	}
 
 	/**

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -156,10 +156,12 @@ class CssGenerator extends Generator {
 		const localIdentName = options.localIdentName;
 		this._localIdentNeedsHash =
 			typeof localIdentName === "function" ||
-			/\[(?:fullhash|hash)\]/.test(/** @type {string} */ (localIdentName));
+			/\[(?:fullhash|hash)(?::\w+)*\]/.test(
+				/** @type {string} */ (localIdentName)
+			);
 		this._localIdentNeedsContentHash =
 			typeof localIdentName === "function" ||
-			/\[contenthash\]/.test(/** @type {string} */ (localIdentName));
+			/\[contenthash(?::\w+)*\]/.test(/** @type {string} */ (localIdentName));
 	}
 
 	/**

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -39,7 +39,7 @@ const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
 const { getUndoPath } = require("../util/identifier");
 const memoize = require("../util/memoize");
-const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { digestNonNumericOnly } = require("../util/nonNumericOnlyHash");
 const {
 	PUBLIC_PATH_AUTO,
 	walkFullHashPlaceholders
@@ -573,8 +573,11 @@ class CssModulesPlugin {
 							hash.update(chunkGraph.getModuleHash(module, chunk.runtime));
 						}
 					}
-					const digest = hash.digest(hashDigest);
-					chunk.contentHash.css = nonNumericOnlyHash(digest, hashDigestLength);
+					chunk.contentHash.css = digestNonNumericOnly(
+						hash,
+						hashDigest,
+						hashDigestLength
+					);
 				});
 				compilation.hooks.renderManifest.tap(PLUGIN_NAME, (result, options) => {
 					const { chunkGraph } = compilation;

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -168,6 +168,9 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		prepareId: prepareLocalIdentId,
 		filename: relativeResourcePath,
 		hash: localIdentHash,
+		// `[hash]`/`[contenthash]` are encoded with the output digest, so inline
+		// `[hash:<digest>]` re-encodes from it.
+		hashDigest: runtimeTemplate.outputOptions.hashDigest,
 		local,
 		uniqueName,
 		contentHash,

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -113,6 +113,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 	const { uniqueName } = runtimeTemplate.outputOptions;
 
 	let localIdentHash = "";
+	let localIdentHashFull = "";
 
 	if (generator._localIdentNeedsHash) {
 		const hashSalt = generator.options.localIdentHashSalt;
@@ -137,7 +138,10 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		hash.update(relativeResourcePath);
 		hash.update(local);
 
-		localIdentHash = hash.digest(hashDigest).slice(0, hashDigestLength);
+		// Keep the untruncated digest so an inline `[fullhash:<digest>]` re-encodes
+		// with full entropy (see the `fullHash`/`fullHashDigest` passed below).
+		localIdentHashFull = hash.digest(hashDigest);
+		localIdentHash = localIdentHashFull.slice(0, hashDigestLength);
 	}
 
 	let contentHash = "";
@@ -168,9 +172,14 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		prepareId: prepareLocalIdentId,
 		filename: relativeResourcePath,
 		hash: localIdentHash,
-		// `[hash]`/`[contenthash]` are encoded with the output digest, so inline
-		// `[hash:<digest>]` re-encodes from it.
+		// `[hash]`/`[contenthash]` are encoded with the output digest, but the
+		// `[fullhash]` local ident hash uses `localIdentHashDigest`, so re-encode it
+		// from its own (full) digest.
 		hashDigest: runtimeTemplate.outputOptions.hashDigest,
+		fullHash: localIdentHashFull,
+		fullHashDigest:
+			/** @type {string} */
+			(generator.options.localIdentHashDigest),
 		local,
 		uniqueName,
 		contentHash,

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -102,7 +102,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 	const generator = /** @type {CssGenerator} */ (module.generator);
 	const localIdentName =
 		/** @type {CssGeneratorLocalIdentName} */
-		(generator.options.localIdentName);
+		(generator._localIdentName);
 	const relativeResourcePath = makePathsRelative(
 		/** @type {string} */
 		(runtimeTemplate.compilation.compiler.context),
@@ -118,8 +118,8 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		const hashSalt = generator.options.localIdentHashSalt;
 		const hashDigest =
 			/** @type {string} */
-			(generator.options.localIdentHashDigest);
-		const hashDigestLength = generator.options.localIdentHashDigestLength;
+			(generator._localIdentHashDigest);
+		const hashDigestLength = generator._localIdentHashDigestLength;
 		const hashFunction =
 			/** @type {HashFunction} */
 			(generator.options.localIdentHashFunction);

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -13,7 +13,7 @@ const createHash = require("../util/createHash");
 const { makePathsRelative } = require("../util/identifier");
 const makeSerializable = require("../util/makeSerializable");
 const memoize = require("../util/memoize");
-const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { digestNonNumericOnly } = require("../util/nonNumericOnlyHash");
 const { updateHashFromSource } = require("../util/source");
 const CssIcssImportDependency = require("./CssIcssImportDependency");
 const NullDependency = require("./NullDependency");
@@ -158,13 +158,10 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 			hash.update(module.error.toString());
 		}
 
-		const fullContentHash = hash.digest(
-			runtimeTemplate.outputOptions.hashDigest
-		);
-
-		contentHash = nonNumericOnlyHash(
-			fullContentHash,
-			runtimeTemplate.outputOptions.hashDigestLength
+		contentHash = digestNonNumericOnly(
+			hash,
+			/** @type {string} */ (runtimeTemplate.outputOptions.hashDigest),
+			/** @type {number} */ (runtimeTemplate.outputOptions.hashDigestLength)
 		);
 	}
 

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -169,6 +169,9 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		prepareId: prepareLocalIdentId,
 		filename: relativeResourcePath,
 		hash: localIdentHash,
+		// css-loader semantics: `[hash]` is the local ident hash, not the module
+		// hash (use `[modulehash]` for that).
+		hashAsFullHash: true,
 		// `[hash]`/`[contenthash]` are encoded with the output digest, but the
 		// `[fullhash]` local ident hash uses `localIdentHashDigest`, so re-encode it
 		// from its own (full) digest.

--- a/lib/dependencies/CssIcssExportDependency.js
+++ b/lib/dependencies/CssIcssExportDependency.js
@@ -102,7 +102,7 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 	const generator = /** @type {CssGenerator} */ (module.generator);
 	const localIdentName =
 		/** @type {CssGeneratorLocalIdentName} */
-		(generator._localIdentName);
+		(generator.options.localIdentName);
 	const relativeResourcePath = makePathsRelative(
 		/** @type {string} */
 		(runtimeTemplate.compilation.compiler.context),
@@ -118,8 +118,8 @@ const getLocalIdent = (local, module, chunkGraph, runtimeTemplate) => {
 		const hashSalt = generator.options.localIdentHashSalt;
 		const hashDigest =
 			/** @type {string} */
-			(generator._localIdentHashDigest);
-		const hashDigestLength = generator._localIdentHashDigestLength;
+			(generator.options.localIdentHashDigest);
+		const hashDigestLength = generator.options.localIdentHashDigestLength;
 		const hashFunction =
 			/** @type {HashFunction} */
 			(generator.options.localIdentHashFunction);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -20,7 +20,7 @@ const StaticExportsDependency = require("../dependencies/StaticExportsDependency
 const WebpackError = require("../errors/WebpackError");
 const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
-const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { digestNonNumericOnly } = require("../util/nonNumericOnlyHash");
 const removeBOM = require("../util/removeBOM");
 const HtmlGenerator = require("./HtmlGenerator");
 const HtmlModule = require("./HtmlModule");
@@ -110,10 +110,9 @@ class HtmlModulesPlugin {
 		);
 		if (outputOptions.hashSalt) hash.update(outputOptions.hashSalt);
 		hash.update(content);
-		return nonNumericOnlyHash(
-			/** @type {string} */ (
-				hash.digest(/** @type {string} */ (outputOptions.hashDigest))
-			),
+		return digestNonNumericOnly(
+			hash,
+			/** @type {string} */ (outputOptions.hashDigest),
 			/** @type {number} */ (outputOptions.hashDigestLength)
 		);
 	}

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -42,7 +42,7 @@ const {
 	getUsedNamesInScopeInfo
 } = require("../util/concatenate");
 const createHash = require("../util/createHash");
-const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
+const { digestNonNumericOnly } = require("../util/nonNumericOnlyHash");
 const removeBOM = require("../util/removeBOM");
 const { intersectRuntime } = require("../util/runtime");
 const JavascriptGenerator = require("./JavascriptGenerator");
@@ -717,9 +717,9 @@ class JavascriptModulesPlugin {
 						}
 						xor.updateHash(hash);
 					}
-					const digest = hash.digest(hashDigest);
-					chunk.contentHash.javascript = nonNumericOnlyHash(
-						digest,
+					chunk.contentHash.javascript = digestNonNumericOnly(
+						hash,
+						hashDigest,
 						hashDigestLength
 					);
 				});

--- a/lib/util/nonNumericOnlyHash.js
+++ b/lib/util/nonNumericOnlyHash.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+/** @typedef {import("./Hash")} Hash */
+
 const A_CODE = "a".charCodeAt(0);
 
 /**
@@ -13,7 +15,7 @@ const A_CODE = "a".charCodeAt(0);
  * @param {number} hashLength hash length
  * @returns {string} returns hash that has at least one non numeric char
  */
-module.exports = (hash, hashLength) => {
+const nonNumericOnlyHash = (hash, hashLength) => {
 	if (hashLength < 1) return "";
 	const slice = hash.slice(0, hashLength);
 	if (/[^\d]/.test(slice)) return slice;
@@ -21,3 +23,16 @@ module.exports = (hash, hashLength) => {
 		A_CODE + (Number.parseInt(hash[0], 10) % 6)
 	)}${slice.slice(1)}`;
 };
+
+/**
+ * Digests a hash and truncates it to a content-hash string (non-numeric first char).
+ * @param {Hash} hash hash
+ * @param {string} hashDigest digest encoding
+ * @param {number} hashDigestLength hash length
+ * @returns {string} content hash string
+ */
+const digestNonNumericOnly = (hash, hashDigest, hashDigestLength) =>
+	nonNumericOnlyHash(hash.digest(hashDigest), hashDigestLength);
+
+module.exports = nonNumericOnlyHash;
+module.exports.digestNonNumericOnly = digestNonNumericOnly;

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -44,6 +44,28 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		expect(interpolate("[hash]", data)).toBe("0123456789abcdef");
 	});
 
+	/* cSpell:disable */
+	it("re-encodes a hash placeholder to an inline digest", () => {
+		const data = { hash: "0123456789abcdef" };
+		// [<kind>:<digest>] and [<kind>:<digest>:<length>]
+		expect(interpolate("[fullhash:base64]", data)).toBe("ASNFZ4mrze8=");
+		expect(interpolate("[fullhash:base64url]", data)).toBe("ASNFZ4mrze8");
+		expect(interpolate("[fullhash:base32]", data)).toBe("CI2FM6E2XTPP");
+		expect(interpolate("[fullhash:base62]", data)).toBe("63uFdvrkbZ");
+		expect(interpolate("[fullhash:base64:4]", data)).toBe("ASNF");
+		// [<kind>:<length>] and [<kind>] keep their existing meaning
+		expect(interpolate("[fullhash:4]", data)).toBe("0123");
+		expect(interpolate("[fullhash]", data)).toBe("0123456789abcdef");
+		// honours a non-default source digest
+		expect(
+			interpolate("[fullhash:hex]", {
+				hash: "ASNFZ4mrze8",
+				hashDigest: "base64url"
+			})
+		).toBe("0123456789abcdef");
+	});
+	/* cSpell:enable */
+
 	it("interpolates chunk placeholders", () => {
 		const data = {
 			chunk: {

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -79,6 +79,16 @@ describe("TemplatedPathPlugin.interpolate", () => {
 	});
 	/* cSpell:enable */
 
+	it("re-encodes [fullhash:<digest>] from the untruncated hash when provided", () => {
+		const data = { hash: "0123", fullHash: "0123456789abcdef" };
+		// the digest re-encodes the full hash, not the truncated data.hash
+		expect(interpolate("[fullhash:base64]", data)).toBe(
+			Buffer.from("0123456789abcdef", "hex").toString("base64")
+		);
+		// no-digest keeps using the truncated value
+		expect(interpolate("[fullhash]", data)).toBe("0123");
+	});
+
 	it("throws on an unknown inline digest", () => {
 		expect(() =>
 			interpolate("[fullhash:base40]", { hash: "0123456789abcdef" })

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -79,6 +79,15 @@ describe("TemplatedPathPlugin.interpolate", () => {
 	});
 	/* cSpell:enable */
 
+	it("throws on an unknown inline digest", () => {
+		expect(() =>
+			interpolate("[fullhash:base40]", { hash: "0123456789abcdef" })
+		).toThrow(/Unsupported hash digest "base40"/);
+		expect(() =>
+			interpolate("[fullhash:nope:8]", { hash: "0123456789abcdef" })
+		).toThrow(/Unsupported hash digest "nope"/);
+	});
+
 	it("interpolates chunk placeholders", () => {
 		const data = {
 			chunk: {

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -89,6 +89,20 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		expect(interpolate("[fullhash]", data)).toBe("0123");
 	});
 
+	it("rejects an inline digest on [contenthash] when realContentHash is on", () => {
+		const data = {
+			module: { id: "1", hash: "h" },
+			contentHash: "0123456789abcdef"
+		};
+		expect(() =>
+			interpolate("[contenthash:base64:8]", { ...data, realContentHash: true })
+		).toThrow(/not supported together with optimization\.realContentHash/);
+		// allowed when realContentHash is off
+		expect(interpolate("[contenthash:base64]", data)).toBe(
+			Buffer.from("0123456789abcdef", "hex").toString("base64")
+		);
+	});
+
 	it("throws on an unknown inline digest", () => {
 		expect(() =>
 			interpolate("[fullhash:base40]", { hash: "0123456789abcdef" })

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -163,6 +163,23 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		).toBe("c");
 	});
 
+	it("keeps [hash] as the local hash with hashAsFullHash", () => {
+		const data = {
+			module: { id: "1", hash: "modulehash" },
+			hash: "localValue"
+		};
+		// default: the module context repurposes [hash] to the module hash
+		expect(interpolate("[hash]", data)).toBe("modulehash");
+		// with the flag: [hash] stays the [fullhash]/local hash
+		expect(interpolate("[hash]", { ...data, hashAsFullHash: true })).toBe(
+			"localValue"
+		);
+		// ...and [modulehash] still gives the module hash
+		expect(interpolate("[modulehash]", { ...data, hashAsFullHash: true })).toBe(
+			"modulehash"
+		);
+	});
+
 	it("interpolates [url] and [runtime]", () => {
 		expect(interpolate("[url]", { url: "u" })).toBe("u");
 		expect(interpolate("[runtime]", { runtime: "main" })).toBe("main");

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -89,6 +89,19 @@ describe("TemplatedPathPlugin.interpolate", () => {
 		expect(interpolate("[fullhash]", data)).toBe("0123");
 	});
 
+	/* cSpell:disable */
+	it("re-encodes [fullhash] from its own fullHashDigest", () => {
+		// fullHash carries its own source digest (CSS localIdentHashDigest case)
+		expect(
+			interpolate("[fullhash:hex]", {
+				hash: "x",
+				fullHash: "ASNFZ4mrze8",
+				fullHashDigest: "base64url"
+			})
+		).toBe("0123456789abcdef");
+	});
+	/* cSpell:enable */
+
 	it("rejects an inline digest on [contenthash] when realContentHash is on", () => {
 		const data = {
 			module: { id: "1", hash: "h" },

--- a/test/TemplatedPathPlugin.unittest.js
+++ b/test/TemplatedPathPlugin.unittest.js
@@ -1,6 +1,19 @@
 "use strict";
 
-const { interpolate } = require("../lib/TemplatedPathPlugin");
+const { getPresentKinds, interpolate } = require("../lib/TemplatedPathPlugin");
+
+describe("TemplatedPathPlugin.getPresentKinds", () => {
+	it("reports the placeholder kinds a template references, ignoring args", () => {
+		const kinds = getPresentKinds("[name].[contenthash:base64:8].js");
+		expect(kinds.has("name")).toBe(true);
+		expect(kinds.has("contenthash")).toBe(true);
+		expect(kinds.has("fullhash")).toBe(false);
+	});
+
+	it("returns an empty set for literal templates", () => {
+		expect(getPresentKinds("static/main.js").size).toBe(0);
+	});
+});
 
 describe("TemplatedPathPlugin.interpolate", () => {
 	it("returns literal paths unchanged", () => {

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigCacheTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_1a45088986a4441b80a4",
-  "btn-info_is-disabled": "_1a45088986a4441b80a4",
-  "color-red": "--_1a45088986a4441b80a4",
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
   "foo": "bar",
-  "foo_bar": "_1a45088986a4441b80a4",
+  "foo_bar": "fXKKeh",
   "my-btn-info_is-disabled": "value",
-  "simple": "_1a45088986a4441b80a4",
+  "simple": "BTbMAh",
 }
 `;
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_92db8cf73c3ac16b6115-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_92db8cf73c3ac16b6115-btn-info_is-disabled",
-  "color-red": "--_92db8cf73c3ac16b6115-color-red",
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
   "foo": "bar",
-  "foo_bar": "_92db8cf73c3ac16b6115-foo_bar",
+  "foo_bar": "uKJpHY-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_92db8cf73c3ac16b6115-simple",
+  "simple": "_0P_xqP-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "_4746c07f4f5c7e136661-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_4746c07f4f5c7e136661-btn-info_is-disabled",
-  "color-red": "--_4746c07f4f5c7e136661-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_4746c07f4f5c7e136661-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_4746c07f4f5c7e136661-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
@@ -110,6 +110,66 @@ Object {
 
 exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
+  "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
+  "color-red": "--NdC5-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxs-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_B-simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__CATMK",
+  "btn-info_is-disabled": "btn-info_is-disabled__oDuLA",
+  "color-red": "--color-red__ufedo",
+  "foo": "bar",
+  "foo_bar": "foo_bar__blo73",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__bJYIb",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+Object {
+  "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
+  "color-red": "--Zsy75M42-color-red",
+  "foo": "bar",
+  "foo_bar": "Zsy75M42-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Zsy75M42-simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ZTi_c",
+  "btn-info_is-disabled": "btn-info_is-disabled__fowf8",
+  "color-red": "--color-red__rgLJQ",
+  "foo": "bar",
+  "foo_bar": "foo_bar__OSiNn",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__XKVrb",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+Object {
+  "btn--info_is-disabled_1": "_9510b54fb5f645662e28-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_9510b54fb5f645662e28-btn-info_is-disabled",
+  "color-red": "--_9510b54fb5f645662e28-color-red",
+  "foo": "bar",
+  "foo_bar": "_9510b54fb5f645662e28-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_9510b54fb5f645662e28-simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -120,31 +180,31 @@ Object {
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "_78f85885f7219581fae2",
-  "btn-info_is-disabled": "_78f85885f7219581fae2",
-  "color-red": "--_78f85885f7219581fae2",
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
   "foo": "bar",
-  "foo_bar": "_78f85885f7219581fae2",
+  "foo_bar": "fXKKeh",
   "my-btn-info_is-disabled": "value",
-  "simple": "_78f85885f7219581fae2",
+  "simple": "BTbMAh",
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
 Object {
-  "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
-  "color-red": "--_185fd11f5c30cd30b4d7-color-red",
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
   "foo": "bar",
-  "foo_bar": "_185fd11f5c30cd30b4d7-foo_bar",
+  "foo_bar": "uKJpHY-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_185fd11f5c30cd30b4d7-simple",
+  "simple": "_0P_xqP-simple",
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -156,7 +216,7 @@ Object {
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -168,7 +228,7 @@ Object {
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -180,7 +240,7 @@ Object {
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -192,19 +252,19 @@ Object {
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
 Object {
-  "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
-  "color-red": "--_3593cfd6c0d3a6d04be3-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_3593cfd6c0d3a6d04be3-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_3593cfd6c0d3a6d04be3-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
-exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -213,5 +273,65 @@ Object {
   "foo_bar": "__foo_bar",
   "my-btn-info_is-disabled": "value",
   "simple": "__simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
+Object {
+  "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
+  "color-red": "--NdC5-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxs-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_B-simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 25`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__CATMK",
+  "btn-info_is-disabled": "btn-info_is-disabled__oDuLA",
+  "color-red": "--color-red__ufedo",
+  "foo": "bar",
+  "foo_bar": "foo_bar__blo73",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__bJYIb",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 26`] = `
+Object {
+  "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
+  "color-red": "--Zsy75M42-color-red",
+  "foo": "bar",
+  "foo_bar": "Zsy75M42-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Zsy75M42-simple",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 27`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ZTi_c",
+  "btn-info_is-disabled": "btn-info_is-disabled__fowf8",
+  "color-red": "--color-red__rgLJQ",
+  "foo": "bar",
+  "foo_bar": "foo_bar__OSiNn",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__XKVrb",
+}
+`;
+
+exports[`ConfigCacheTestCases css local-ident-name exported tests should have correct local ident for css export locals 28`] = `
+Object {
+  "btn--info_is-disabled_1": "_5614b0226bd2d583b8d6-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_5614b0226bd2d583b8d6-btn-info_is-disabled",
+  "color-red": "--_5614b0226bd2d583b8d6-color-red",
+  "foo": "bar",
+  "foo_bar": "_5614b0226bd2d583b8d6-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_5614b0226bd2d583b8d6-simple",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -146,6 +146,18 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
 Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ZTi_c",
+  "btn-info_is-disabled": "btn-info_is-disabled__fowf8",
+  "color-red": "--color-red__rgLJQ",
+  "foo": "bar",
+  "foo_bar": "foo_bar__OSiNn",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__XKVrb",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -156,7 +168,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
 Object {
   "btn--info_is-disabled_1": "_78f85885f7219581fae2",
   "btn-info_is-disabled": "_78f85885f7219581fae2",
@@ -168,7 +180,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
   "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
@@ -180,7 +192,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -192,7 +204,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -204,7 +216,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -216,7 +228,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -228,7 +240,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
 Object {
   "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
@@ -240,7 +252,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -252,7 +264,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
 Object {
   "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
@@ -264,7 +276,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
 Object {
   "btn--info_is-disabled_1": "btn--info_is-disabled_1__R0fN9",
   "btn-info_is-disabled": "btn-info_is-disabled__R0fN9",
@@ -276,7 +288,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 25`] = `
 Object {
   "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
   "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
@@ -285,5 +297,17 @@ Object {
   "foo_bar": "Zsy75M42-foo_bar",
   "my-btn-info_is-disabled": "value",
   "simple": "Zsy75M42-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 26`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ZTi_c",
+  "btn-info_is-disabled": "btn-info_is-disabled__fowf8",
+  "color-red": "--color-red__rgLJQ",
+  "foo": "bar",
+  "foo_bar": "foo_bar__OSiNn",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__XKVrb",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_1a45088986a4441b80a4",
-  "btn-info_is-disabled": "_1a45088986a4441b80a4",
-  "color-red": "--_1a45088986a4441b80a4",
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
   "foo": "bar",
-  "foo_bar": "_1a45088986a4441b80a4",
+  "foo_bar": "fXKKeh",
   "my-btn-info_is-disabled": "value",
-  "simple": "_1a45088986a4441b80a4",
+  "simple": "BTbMAh",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_92db8cf73c3ac16b6115-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_92db8cf73c3ac16b6115-btn-info_is-disabled",
-  "color-red": "--_92db8cf73c3ac16b6115-color-red",
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
   "foo": "bar",
-  "foo_bar": "_92db8cf73c3ac16b6115-foo_bar",
+  "foo_bar": "uKJpHY-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_92db8cf73c3ac16b6115-simple",
+  "simple": "_0P_xqP-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "_4746c07f4f5c7e136661-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_4746c07f4f5c7e136661-btn-info_is-disabled",
-  "color-red": "--_4746c07f4f5c7e136661-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_4746c07f4f5c7e136661-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_4746c07f4f5c7e136661-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
@@ -110,6 +110,30 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
+  "btn--info_is-disabled_1": "RNWzRsbH-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJbidfS-btn-info_is-disabled",
+  "color-red": "--NdC5h-HI-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxsz5u2-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_BLH2w-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ies1C",
+  "btn-info_is-disabled": "btn-info_is-disabled__7FQ2n",
+  "color-red": "--color-red__Oy5rG",
+  "foo": "bar",
+  "foo_bar": "foo_bar__3rZld",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__8Cvqv",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -120,31 +144,31 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
-Object {
-  "btn--info_is-disabled_1": "_78f85885f7219581fae2",
-  "btn-info_is-disabled": "_78f85885f7219581fae2",
-  "color-red": "--_78f85885f7219581fae2",
-  "foo": "bar",
-  "foo_bar": "_78f85885f7219581fae2",
-  "my-btn-info_is-disabled": "value",
-  "simple": "_78f85885f7219581fae2",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
-Object {
-  "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
-  "color-red": "--_185fd11f5c30cd30b4d7-color-red",
-  "foo": "bar",
-  "foo_bar": "_185fd11f5c30cd30b4d7-foo_bar",
-  "my-btn-info_is-disabled": "value",
-  "simple": "_185fd11f5c30cd30b4d7-simple",
-}
-`;
-
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
+Object {
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
+  "foo": "bar",
+  "foo_bar": "fXKKeh",
+  "my-btn-info_is-disabled": "value",
+  "simple": "BTbMAh",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+Object {
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
+  "foo": "bar",
+  "foo_bar": "uKJpHY-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_0P_xqP-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -156,7 +180,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -168,7 +192,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -180,7 +204,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -192,19 +216,19 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
 Object {
-  "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
-  "color-red": "--_3593cfd6c0d3a6d04be3-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_3593cfd6c0d3a6d04be3-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_3593cfd6c0d3a6d04be3-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -213,5 +237,29 @@ Object {
   "foo_bar": "__foo_bar",
   "my-btn-info_is-disabled": "value",
   "simple": "__simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
+Object {
+  "btn--info_is-disabled_1": "RNWzRsbH-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJbidfS-btn-info_is-disabled",
+  "color-red": "--NdC5h-HI-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxsz5u2-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_BLH2w-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ies1C",
+  "btn-info_is-disabled": "btn-info_is-disabled__7FQ2n",
+  "color-red": "--color-red__Oy5rG",
+  "foo": "bar",
+  "foo_bar": "foo_bar__3rZld",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__8Cvqv",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -110,6 +110,42 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
+  "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
+  "color-red": "--NdC5-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxs-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_B-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__Z9a2I",
+  "btn-info_is-disabled": "btn-info_is-disabled__Z9a2I",
+  "color-red": "--color-red__Z9a2I",
+  "foo": "bar",
+  "foo_bar": "foo_bar__Z9a2I",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__Z9a2I",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+Object {
+  "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
+  "color-red": "--Zsy75M42-color-red",
+  "foo": "bar",
+  "foo_bar": "Zsy75M42-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Zsy75M42-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
+Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -120,7 +156,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
 Object {
   "btn--info_is-disabled_1": "_78f85885f7219581fae2",
   "btn-info_is-disabled": "_78f85885f7219581fae2",
@@ -132,7 +168,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
 Object {
   "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
@@ -144,7 +180,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -156,7 +192,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -168,7 +204,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -180,7 +216,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -192,7 +228,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
 Object {
   "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
@@ -204,7 +240,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -213,5 +249,41 @@ Object {
   "foo_bar": "__foo_bar",
   "my-btn-info_is-disabled": "value",
   "simple": "__simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
+Object {
+  "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
+  "color-red": "--NdC5-color-red",
+  "foo": "bar",
+  "foo_bar": "YXxs-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Ds_B-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
+Object {
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__R0fN9",
+  "btn-info_is-disabled": "btn-info_is-disabled__R0fN9",
+  "color-red": "--color-red__R0fN9",
+  "foo": "bar",
+  "foo_bar": "foo_bar__R0fN9",
+  "my-btn-info_is-disabled": "value",
+  "simple": "simple__R0fN9",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
+Object {
+  "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
+  "color-red": "--Zsy75M42-color-red",
+  "foo": "bar",
+  "foo_bar": "Zsy75M42-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "Zsy75M42-simple",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "IFi2Y1",
-  "btn-info_is-disabled": "KrqLlq",
-  "color-red": "--DeicrI",
+  "btn--info_is-disabled_1": "_1a45088986a4441b80a4",
+  "btn-info_is-disabled": "_1a45088986a4441b80a4",
+  "color-red": "--_1a45088986a4441b80a4",
   "foo": "bar",
-  "foo_bar": "fXKKeh",
+  "foo_bar": "_1a45088986a4441b80a4",
   "my-btn-info_is-disabled": "value",
-  "simple": "BTbMAh",
+  "simple": "_1a45088986a4441b80a4",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
-  "color-red": "--_lvU1k-color-red",
+  "btn--info_is-disabled_1": "_92db8cf73c3ac16b6115-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_92db8cf73c3ac16b6115-btn-info_is-disabled",
+  "color-red": "--_92db8cf73c3ac16b6115-color-red",
   "foo": "bar",
-  "foo_bar": "uKJpHY-foo_bar",
+  "foo_bar": "_92db8cf73c3ac16b6115-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_0P_xqP-simple",
+  "simple": "_92db8cf73c3ac16b6115-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
-  "color-red": "--bgrnnfrltrvjzeit-color-red",
+  "btn--info_is-disabled_1": "_4746c07f4f5c7e136661-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_4746c07f4f5c7e136661-btn-info_is-disabled",
+  "color-red": "--_4746c07f4f5c7e136661-color-red",
   "foo": "bar",
-  "foo_bar": "bcknxregveukxgtu-foo_bar",
+  "foo_bar": "_4746c07f4f5c7e136661-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "cczbhihlbtjmqesr-simple",
+  "simple": "_4746c07f4f5c7e136661-simple",
 }
 `;
 
@@ -110,30 +110,6 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 10`] = `
 Object {
-  "btn--info_is-disabled_1": "RNWzRsbH-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_1QJbidfS-btn-info_is-disabled",
-  "color-red": "--NdC5h-HI-color-red",
-  "foo": "bar",
-  "foo_bar": "YXxsz5u2-foo_bar",
-  "my-btn-info_is-disabled": "value",
-  "simple": "Ds_BLH2w-simple",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
-Object {
-  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ies1C",
-  "btn-info_is-disabled": "btn-info_is-disabled__7FQ2n",
-  "color-red": "--color-red__Oy5rG",
-  "foo": "bar",
-  "foo_bar": "foo_bar__3rZld",
-  "my-btn-info_is-disabled": "value",
-  "simple": "simple__8Cvqv",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
-Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -144,31 +120,31 @@ Object {
 }
 `;
 
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
+Object {
+  "btn--info_is-disabled_1": "_78f85885f7219581fae2",
+  "btn-info_is-disabled": "_78f85885f7219581fae2",
+  "color-red": "--_78f85885f7219581fae2",
+  "foo": "bar",
+  "foo_bar": "_78f85885f7219581fae2",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_78f85885f7219581fae2",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 12`] = `
+Object {
+  "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
+  "color-red": "--_185fd11f5c30cd30b4d7-color-red",
+  "foo": "bar",
+  "foo_bar": "_185fd11f5c30cd30b4d7-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_185fd11f5c30cd30b4d7-simple",
+}
+`;
+
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 13`] = `
-Object {
-  "btn--info_is-disabled_1": "IFi2Y1",
-  "btn-info_is-disabled": "KrqLlq",
-  "color-red": "--DeicrI",
-  "foo": "bar",
-  "foo_bar": "fXKKeh",
-  "my-btn-info_is-disabled": "value",
-  "simple": "BTbMAh",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
-Object {
-  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
-  "color-red": "--_lvU1k-color-red",
-  "foo": "bar",
-  "foo_bar": "uKJpHY-foo_bar",
-  "my-btn-info_is-disabled": "value",
-  "simple": "_0P_xqP-simple",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -180,7 +156,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -192,7 +168,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -204,7 +180,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -216,19 +192,19 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
 Object {
-  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
-  "color-red": "--bgrnnfrltrvjzeit-color-red",
+  "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
+  "color-red": "--_3593cfd6c0d3a6d04be3-color-red",
   "foo": "bar",
-  "foo_bar": "bcknxregveukxgtu-foo_bar",
+  "foo_bar": "_3593cfd6c0d3a6d04be3-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "cczbhihlbtjmqesr-simple",
+  "simple": "_3593cfd6c0d3a6d04be3-simple",
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -237,29 +213,5 @@ Object {
   "foo_bar": "__foo_bar",
   "my-btn-info_is-disabled": "value",
   "simple": "__simple",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
-Object {
-  "btn--info_is-disabled_1": "RNWzRsbH-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_1QJbidfS-btn-info_is-disabled",
-  "color-red": "--NdC5h-HI-color-red",
-  "foo": "bar",
-  "foo_bar": "YXxsz5u2-foo_bar",
-  "my-btn-info_is-disabled": "value",
-  "simple": "Ds_BLH2w-simple",
-}
-`;
-
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
-Object {
-  "btn--info_is-disabled_1": "btn--info_is-disabled_1__ies1C",
-  "btn-info_is-disabled": "btn-info_is-disabled__7FQ2n",
-  "color-red": "--color-red__Oy5rG",
-  "foo": "bar",
-  "foo_bar": "foo_bar__3rZld",
-  "my-btn-info_is-disabled": "value",
-  "simple": "simple__8Cvqv",
 }
 `;

--- a/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/local-ident-name/__snapshots__/ConfigTest.snap
@@ -14,25 +14,25 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 2`] = `
 Object {
-  "btn--info_is-disabled_1": "_1a45088986a4441b80a4",
-  "btn-info_is-disabled": "_1a45088986a4441b80a4",
-  "color-red": "--_1a45088986a4441b80a4",
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
   "foo": "bar",
-  "foo_bar": "_1a45088986a4441b80a4",
+  "foo_bar": "fXKKeh",
   "my-btn-info_is-disabled": "value",
-  "simple": "_1a45088986a4441b80a4",
+  "simple": "BTbMAh",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 3`] = `
 Object {
-  "btn--info_is-disabled_1": "_92db8cf73c3ac16b6115-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_92db8cf73c3ac16b6115-btn-info_is-disabled",
-  "color-red": "--_92db8cf73c3ac16b6115-color-red",
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
   "foo": "bar",
-  "foo_bar": "_92db8cf73c3ac16b6115-foo_bar",
+  "foo_bar": "uKJpHY-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_92db8cf73c3ac16b6115-simple",
+  "simple": "_0P_xqP-simple",
 }
 `;
 
@@ -86,13 +86,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 8`] = `
 Object {
-  "btn--info_is-disabled_1": "_4746c07f4f5c7e136661-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_4746c07f4f5c7e136661-btn-info_is-disabled",
-  "color-red": "--_4746c07f4f5c7e136661-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_4746c07f4f5c7e136661-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_4746c07f4f5c7e136661-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
@@ -122,13 +122,13 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 11`] = `
 Object {
-  "btn--info_is-disabled_1": "btn--info_is-disabled_1__Z9a2I",
-  "btn-info_is-disabled": "btn-info_is-disabled__Z9a2I",
-  "color-red": "--color-red__Z9a2I",
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__CATMK",
+  "btn-info_is-disabled": "btn-info_is-disabled__oDuLA",
+  "color-red": "--color-red__ufedo",
   "foo": "bar",
-  "foo_bar": "foo_bar__Z9a2I",
+  "foo_bar": "foo_bar__blo73",
   "my-btn-info_is-disabled": "value",
-  "simple": "simple__Z9a2I",
+  "simple": "simple__bJYIb",
 }
 `;
 
@@ -158,6 +158,18 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 14`] = `
 Object {
+  "btn--info_is-disabled_1": "_9510b54fb5f645662e28-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_9510b54fb5f645662e28-btn-info_is-disabled",
+  "color-red": "--_9510b54fb5f645662e28-color-red",
+  "foo": "bar",
+  "foo_bar": "_9510b54fb5f645662e28-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_9510b54fb5f645662e28-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
+Object {
   "btn--info_is-disabled_1": "style_module_css-btn--info_is-disabled_1",
   "btn-info_is-disabled": "style_module_css-btn-info_is-disabled",
   "color-red": "--style_module_css-color-red",
@@ -168,31 +180,31 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 15`] = `
-Object {
-  "btn--info_is-disabled_1": "_78f85885f7219581fae2",
-  "btn-info_is-disabled": "_78f85885f7219581fae2",
-  "color-red": "--_78f85885f7219581fae2",
-  "foo": "bar",
-  "foo_bar": "_78f85885f7219581fae2",
-  "my-btn-info_is-disabled": "value",
-  "simple": "_78f85885f7219581fae2",
-}
-`;
-
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 16`] = `
 Object {
-  "btn--info_is-disabled_1": "_185fd11f5c30cd30b4d7-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_185fd11f5c30cd30b4d7-btn-info_is-disabled",
-  "color-red": "--_185fd11f5c30cd30b4d7-color-red",
+  "btn--info_is-disabled_1": "IFi2Y1",
+  "btn-info_is-disabled": "KrqLlq",
+  "color-red": "--DeicrI",
   "foo": "bar",
-  "foo_bar": "_185fd11f5c30cd30b4d7-foo_bar",
+  "foo_bar": "fXKKeh",
   "my-btn-info_is-disabled": "value",
-  "simple": "_185fd11f5c30cd30b4d7-simple",
+  "simple": "BTbMAh",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 17`] = `
+Object {
+  "btn--info_is-disabled_1": "_228W8K-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "DhvxvG-btn-info_is-disabled",
+  "color-red": "--_lvU1k-color-red",
+  "foo": "bar",
+  "foo_bar": "uKJpHY-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_0P_xqP-simple",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module__btn-info_is-disabled",
@@ -204,7 +216,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 18`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css__btn-info_is-disabled",
@@ -216,7 +228,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 19`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
 Object {
   "btn--info_is-disabled_1": "./style.module.css?q#f__btn--info_is-disabled_1",
   "btn-info_is-disabled": "./style.module.css?q#f__btn-info_is-disabled",
@@ -228,7 +240,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 20`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
 Object {
   "btn--info_is-disabled_1": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
   "btn-info_is-disabled": "-style_module_css_uniqueName-id-contenthash-66ccbbe4ce365e96ef13",
@@ -240,19 +252,19 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 21`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
 Object {
-  "btn--info_is-disabled_1": "_3593cfd6c0d3a6d04be3-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "_3593cfd6c0d3a6d04be3-btn-info_is-disabled",
-  "color-red": "--_3593cfd6c0d3a6d04be3-color-red",
+  "btn--info_is-disabled_1": "tgsjdmmcabgyhove-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bjqahratuciglpyn-btn-info_is-disabled",
+  "color-red": "--bgrnnfrltrvjzeit-color-red",
   "foo": "bar",
-  "foo_bar": "_3593cfd6c0d3a6d04be3-foo_bar",
+  "foo_bar": "bcknxregveukxgtu-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "_3593cfd6c0d3a6d04be3-simple",
+  "simple": "cczbhihlbtjmqesr-simple",
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 22`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
 Object {
   "btn--info_is-disabled_1": "__btn--info_is-disabled_1",
   "btn-info_is-disabled": "__btn-info_is-disabled",
@@ -264,7 +276,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 23`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
 Object {
   "btn--info_is-disabled_1": "RNWz-btn--info_is-disabled_1",
   "btn-info_is-disabled": "_1QJb-btn-info_is-disabled",
@@ -276,19 +288,19 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 24`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 25`] = `
 Object {
-  "btn--info_is-disabled_1": "btn--info_is-disabled_1__R0fN9",
-  "btn-info_is-disabled": "btn-info_is-disabled__R0fN9",
-  "color-red": "--color-red__R0fN9",
+  "btn--info_is-disabled_1": "btn--info_is-disabled_1__CATMK",
+  "btn-info_is-disabled": "btn-info_is-disabled__oDuLA",
+  "color-red": "--color-red__ufedo",
   "foo": "bar",
-  "foo_bar": "foo_bar__R0fN9",
+  "foo_bar": "foo_bar__blo73",
   "my-btn-info_is-disabled": "value",
-  "simple": "simple__R0fN9",
+  "simple": "simple__bJYIb",
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 25`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 26`] = `
 Object {
   "btn--info_is-disabled_1": "Zsy75M42-btn--info_is-disabled_1",
   "btn-info_is-disabled": "Zsy75M42-btn-info_is-disabled",
@@ -300,7 +312,7 @@ Object {
 }
 `;
 
-exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 26`] = `
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 27`] = `
 Object {
   "btn--info_is-disabled_1": "btn--info_is-disabled_1__ZTi_c",
   "btn-info_is-disabled": "btn-info_is-disabled__fowf8",
@@ -309,5 +321,17 @@ Object {
   "foo_bar": "foo_bar__OSiNn",
   "my-btn-info_is-disabled": "value",
   "simple": "simple__XKVrb",
+}
+`;
+
+exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 28`] = `
+Object {
+  "btn--info_is-disabled_1": "_5614b0226bd2d583b8d6-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_5614b0226bd2d583b8d6-btn-info_is-disabled",
+  "color-red": "--_5614b0226bd2d583b8d6-color-red",
+  "foo": "bar",
+  "foo_bar": "_5614b0226bd2d583b8d6-foo_bar",
+  "my-btn-info_is-disabled": "value",
+  "simple": "_5614b0226bd2d583b8d6-simple",
 }
 `;

--- a/test/configCases/css/local-ident-name/index.js
+++ b/test/configCases/css/local-ident-name/index.js
@@ -9,8 +9,10 @@ it("should have correct local ident for css export locals", (done) => {
 		import("./style.module.css?uniqueName-id-contenthash"),
 		import("./style.module.css?hash-local-custom"),
 		import("./style.module.css?uniquename-local"),
+		import("./style.module.css?fullhash-length"),
+		import("./style.module.css?hash-base64"),
 		import("./style.module.less"),
-	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal]) => {
+	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashBase64]) => {
 		expect(idLocal).toMatchSnapshot();
 		expect(hash).toMatchSnapshot();
 		expect(hashLocal).toMatchSnapshot();
@@ -20,6 +22,8 @@ it("should have correct local ident for css export locals", (done) => {
 		expect(uniqueNameIdContenthash).toMatchSnapshot();
 		expect(hashLocalCustom).toMatchSnapshot();
 		expect(uniquenameLocal).toMatchSnapshot();
+		expect(fullhashLength).toMatchSnapshot();
+		expect(hashBase64).toMatchSnapshot();
 		done()
 	}).catch(done)
 });

--- a/test/configCases/css/local-ident-name/index.js
+++ b/test/configCases/css/local-ident-name/index.js
@@ -9,10 +9,8 @@ it("should have correct local ident for css export locals", (done) => {
 		import("./style.module.css?uniqueName-id-contenthash"),
 		import("./style.module.css?hash-local-custom"),
 		import("./style.module.css?uniquename-local"),
-		import("./style.module.css?fullhash-length"),
-		import("./style.module.css?hash-base64"),
 		import("./style.module.less"),
-	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashBase64]) => {
+	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal]) => {
 		expect(idLocal).toMatchSnapshot();
 		expect(hash).toMatchSnapshot();
 		expect(hashLocal).toMatchSnapshot();
@@ -22,8 +20,6 @@ it("should have correct local ident for css export locals", (done) => {
 		expect(uniqueNameIdContenthash).toMatchSnapshot();
 		expect(hashLocalCustom).toMatchSnapshot();
 		expect(uniquenameLocal).toMatchSnapshot();
-		expect(fullhashLength).toMatchSnapshot();
-		expect(hashBase64).toMatchSnapshot();
 		done()
 	}).catch(done)
 });

--- a/test/configCases/css/local-ident-name/index.js
+++ b/test/configCases/css/local-ident-name/index.js
@@ -13,8 +13,9 @@ it("should have correct local ident for css export locals", (done) => {
 		import("./style.module.css?hash-digest"),
 		import("./style.module.css?contenthash-digest"),
 		import("./style.module.css?fullhash-digest"),
+		import("./style.module.css?modulehash"),
 		import("./style.module.less"),
-	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashDigest, contenthashDigest, fullhashDigest]) => {
+	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashDigest, contenthashDigest, fullhashDigest, moduleHash]) => {
 		expect(idLocal).toMatchSnapshot();
 		expect(hash).toMatchSnapshot();
 		expect(hashLocal).toMatchSnapshot();
@@ -28,6 +29,7 @@ it("should have correct local ident for css export locals", (done) => {
 		expect(hashDigest).toMatchSnapshot();
 		expect(contenthashDigest).toMatchSnapshot();
 		expect(fullhashDigest).toMatchSnapshot();
+		expect(moduleHash).toMatchSnapshot();
 		done()
 	}).catch(done)
 });

--- a/test/configCases/css/local-ident-name/index.js
+++ b/test/configCases/css/local-ident-name/index.js
@@ -9,8 +9,11 @@ it("should have correct local ident for css export locals", (done) => {
 		import("./style.module.css?uniqueName-id-contenthash"),
 		import("./style.module.css?hash-local-custom"),
 		import("./style.module.css?uniquename-local"),
+		import("./style.module.css?fullhash-length"),
+		import("./style.module.css?hash-digest"),
+		import("./style.module.css?contenthash-digest"),
 		import("./style.module.less"),
-	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal]) => {
+	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashDigest, contenthashDigest]) => {
 		expect(idLocal).toMatchSnapshot();
 		expect(hash).toMatchSnapshot();
 		expect(hashLocal).toMatchSnapshot();
@@ -20,6 +23,9 @@ it("should have correct local ident for css export locals", (done) => {
 		expect(uniqueNameIdContenthash).toMatchSnapshot();
 		expect(hashLocalCustom).toMatchSnapshot();
 		expect(uniquenameLocal).toMatchSnapshot();
+		expect(fullhashLength).toMatchSnapshot();
+		expect(hashDigest).toMatchSnapshot();
+		expect(contenthashDigest).toMatchSnapshot();
 		done()
 	}).catch(done)
 });

--- a/test/configCases/css/local-ident-name/index.js
+++ b/test/configCases/css/local-ident-name/index.js
@@ -12,8 +12,9 @@ it("should have correct local ident for css export locals", (done) => {
 		import("./style.module.css?fullhash-length"),
 		import("./style.module.css?hash-digest"),
 		import("./style.module.css?contenthash-digest"),
+		import("./style.module.css?fullhash-digest"),
 		import("./style.module.less"),
-	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashDigest, contenthashDigest]) => {
+	]).then(([idLocal, hash, hashLocal, pathNameLocal, fileLocal, queryFragment, uniqueNameIdContenthash, hashLocalCustom, uniquenameLocal, fullhashLength, hashDigest, contenthashDigest, fullhashDigest]) => {
 		expect(idLocal).toMatchSnapshot();
 		expect(hash).toMatchSnapshot();
 		expect(hashLocal).toMatchSnapshot();
@@ -26,6 +27,7 @@ it("should have correct local ident for css export locals", (done) => {
 		expect(fullhashLength).toMatchSnapshot();
 		expect(hashDigest).toMatchSnapshot();
 		expect(contenthashDigest).toMatchSnapshot();
+		expect(fullhashDigest).toMatchSnapshot();
 		done()
 	}).catch(done)
 });

--- a/test/configCases/css/local-ident-name/test.config.js
+++ b/test/configCases/css/local-ident-name/test.config.js
@@ -16,6 +16,7 @@ module.exports = {
 			`style_module_css_hash-digest.bundle${i}.js`,
 			`style_module_css_contenthash-digest.bundle${i}.js`,
 			`style_module_css_fullhash-digest.bundle${i}.js`,
+			`style_module_css_modulehash.bundle${i}.js`,
 			`style_module_less.bundle${i}.js`,
 			`bundle${i}.js`
 		];

--- a/test/configCases/css/local-ident-name/test.config.js
+++ b/test/configCases/css/local-ident-name/test.config.js
@@ -12,6 +12,8 @@ module.exports = {
 			`style_module_css_uniqueName-id-contenthash.bundle${i}.js`,
 			`style_module_css_hash-local-custom.bundle${i}.js`,
 			`style_module_css_uniquename-local.bundle${i}.js`,
+			`style_module_css_fullhash-length.bundle${i}.js`,
+			`style_module_css_hash-base64.bundle${i}.js`,
 			`style_module_less.bundle${i}.js`,
 			`bundle${i}.js`
 		];

--- a/test/configCases/css/local-ident-name/test.config.js
+++ b/test/configCases/css/local-ident-name/test.config.js
@@ -12,6 +12,9 @@ module.exports = {
 			`style_module_css_uniqueName-id-contenthash.bundle${i}.js`,
 			`style_module_css_hash-local-custom.bundle${i}.js`,
 			`style_module_css_uniquename-local.bundle${i}.js`,
+			`style_module_css_fullhash-length.bundle${i}.js`,
+			`style_module_css_hash-digest.bundle${i}.js`,
+			`style_module_css_contenthash-digest.bundle${i}.js`,
 			`style_module_less.bundle${i}.js`,
 			`bundle${i}.js`
 		];

--- a/test/configCases/css/local-ident-name/test.config.js
+++ b/test/configCases/css/local-ident-name/test.config.js
@@ -15,6 +15,7 @@ module.exports = {
 			`style_module_css_fullhash-length.bundle${i}.js`,
 			`style_module_css_hash-digest.bundle${i}.js`,
 			`style_module_css_contenthash-digest.bundle${i}.js`,
+			`style_module_css_fullhash-digest.bundle${i}.js`,
 			`style_module_less.bundle${i}.js`,
 			`bundle${i}.js`
 		];

--- a/test/configCases/css/local-ident-name/test.config.js
+++ b/test/configCases/css/local-ident-name/test.config.js
@@ -12,8 +12,6 @@ module.exports = {
 			`style_module_css_uniqueName-id-contenthash.bundle${i}.js`,
 			`style_module_css_hash-local-custom.bundle${i}.js`,
 			`style_module_css_uniquename-local.bundle${i}.js`,
-			`style_module_css_fullhash-length.bundle${i}.js`,
-			`style_module_css_hash-base64.bundle${i}.js`,
 			`style_module_less.bundle${i}.js`,
 			`bundle${i}.js`
 		];

--- a/test/configCases/css/local-ident-name/webpack.config.js
+++ b/test/configCases/css/local-ident-name/webpack.config.js
@@ -94,6 +94,12 @@ const common = {
 						generator: {
 							localIdentName: "[contenthash:base64:8]-[local]"
 						}
+					},
+					{
+						resourceQuery: /\?fullhash-digest$/,
+						generator: {
+							localIdentName: "[local]__[fullhash:base64url:5]"
+						}
 					}
 				]
 			}

--- a/test/configCases/css/local-ident-name/webpack.config.js
+++ b/test/configCases/css/local-ident-name/webpack.config.js
@@ -76,6 +76,24 @@ const common = {
 							localIdentHashDigestLength: 16,
 							localIdentName: "[hash]-[local]"
 						}
+					},
+					{
+						resourceQuery: /\?fullhash-length$/,
+						generator: {
+							localIdentName: "[fullhash:4]-[local]"
+						}
+					},
+					{
+						resourceQuery: /\?hash-digest$/,
+						generator: {
+							localIdentName: "[local]__[hash:base64:5]"
+						}
+					},
+					{
+						resourceQuery: /\?contenthash-digest$/,
+						generator: {
+							localIdentName: "[contenthash:base64:8]-[local]"
+						}
 					}
 				]
 			}

--- a/test/configCases/css/local-ident-name/webpack.config.js
+++ b/test/configCases/css/local-ident-name/webpack.config.js
@@ -76,18 +76,6 @@ const common = {
 							localIdentHashDigestLength: 16,
 							localIdentName: "[hash]-[local]"
 						}
-					},
-					{
-						resourceQuery: /\?fullhash-length$/,
-						generator: {
-							localIdentName: "[fullhash:8]-[local]"
-						}
-					},
-					{
-						resourceQuery: /\?hash-base64$/,
-						generator: {
-							localIdentName: "[local]__[hash:base64:5]"
-						}
 					}
 				]
 			}

--- a/test/configCases/css/local-ident-name/webpack.config.js
+++ b/test/configCases/css/local-ident-name/webpack.config.js
@@ -100,6 +100,12 @@ const common = {
 						generator: {
 							localIdentName: "[local]__[fullhash:base64url:5]"
 						}
+					},
+					{
+						resourceQuery: /\?modulehash$/,
+						generator: {
+							localIdentName: "[modulehash]-[local]"
+						}
 					}
 				]
 			}

--- a/test/configCases/css/local-ident-name/webpack.config.js
+++ b/test/configCases/css/local-ident-name/webpack.config.js
@@ -76,6 +76,18 @@ const common = {
 							localIdentHashDigestLength: 16,
 							localIdentName: "[hash]-[local]"
 						}
+					},
+					{
+						resourceQuery: /\?fullhash-length$/,
+						generator: {
+							localIdentName: "[fullhash:8]-[local]"
+						}
+					},
+					{
+						resourceQuery: /\?hash-base64$/,
+						generator: {
+							localIdentName: "[local]__[hash:base64:5]"
+						}
 					}
 				]
 			}

--- a/test/configCases/hash-length/digest/index.js
+++ b/test/configCases/hash-length/digest/index.js
@@ -1,0 +1,1 @@
+it("should compile with an inline hash digest in the output filename", () => {});

--- a/test/configCases/hash-length/digest/test.config.js
+++ b/test/configCases/hash-length/digest/test.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const fs = require("fs");
+
+// base64url is filename-safe (A-Z a-z 0-9 - _); base62 is alphanumeric.
+const charsets = [
+	/^bundle0\.[A-Za-z0-9_-]{8}\.js$/,
+	/^bundle1\.[A-Za-z0-9]{10}\.js$/
+];
+
+module.exports = {
+	findBundle(i, options) {
+		const files = fs.readdirSync(options.output.path);
+		const filename = files.find((file) => charsets[i].test(file));
+		if (!filename) {
+			throw new Error(
+				`No bundle matching ${charsets[i]} found in ${files.join(", ")}`
+			);
+		}
+		return `./${filename}`;
+	}
+};

--- a/test/configCases/hash-length/digest/webpack.config.js
+++ b/test/configCases/hash-length/digest/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "contenthash with base64url digest and length",
+		target: "node",
+		output: {
+			filename: "bundle0.[contenthash:base64url:8].js"
+		}
+	},
+	{
+		name: "fullhash with base62 digest and length",
+		target: "node",
+		output: {
+			filename: "bundle1.[fullhash:base62:10].js"
+		}
+	}
+];

--- a/test/configCases/hash-length/digest/webpack.config.js
+++ b/test/configCases/hash-length/digest/webpack.config.js
@@ -5,6 +5,8 @@ module.exports = [
 	{
 		name: "contenthash with base64url digest and length",
 		target: "node",
+		// realContentHash rehashes in output.hashDigest, dropping an inline digest
+		optimization: { realContentHash: false },
 		output: {
 			filename: "bundle0.[contenthash:base64url:8].js"
 		}

--- a/test/nonNumericOnlyHash.unittest.js
+++ b/test/nonNumericOnlyHash.unittest.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const nonNumericOnlyHash = require("../lib/util/nonNumericOnlyHash");
+const { digestNonNumericOnly } = require("../lib/util/nonNumericOnlyHash");
 
 describe("nonNumericOnlyHash", () => {
 	it("hashLength=0", () => {
@@ -33,10 +34,10 @@ describe("nonNumericOnlyHash", () => {
 });
 
 describe("nonNumericOnlyHash.digestNonNumericOnly", () => {
-	const { digestNonNumericOnly } = nonNumericOnlyHash;
-	const fakeHash = (value) => ({
-		digest: (encoding) => `${value}:${encoding}`
-	});
+	const fakeHash = (/** @type {string} */ value) =>
+		/** @type {EXPECTED_ANY} */ ({
+			digest: (/** @type {string} */ encoding) => `${value}:${encoding}`
+		});
 
 	it("digests then truncates with a non-numeric first char", () => {
 		expect(digestNonNumericOnly(fakeHash("abcdef"), "hex", 3)).toBe("abc");

--- a/test/nonNumericOnlyHash.unittest.js
+++ b/test/nonNumericOnlyHash.unittest.js
@@ -31,3 +31,18 @@ describe("nonNumericOnlyHash", () => {
 		expect(nonNumericOnlyHash("511a", 3)).toBe("f11");
 	});
 });
+
+describe("nonNumericOnlyHash.digestNonNumericOnly", () => {
+	const { digestNonNumericOnly } = nonNumericOnlyHash;
+	const fakeHash = (value) => ({
+		digest: (encoding) => `${value}:${encoding}`
+	});
+
+	it("digests then truncates with a non-numeric first char", () => {
+		expect(digestNonNumericOnly(fakeHash("abcdef"), "hex", 3)).toBe("abc");
+		// digit-only slice gets its first char shifted (same as nonNumericOnlyHash)
+		expect(digestNonNumericOnly(fakeHash("0111"), "hex", 3)).toBe(
+			nonNumericOnlyHash("0111:hex", 3)
+		);
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -19426,6 +19426,11 @@ declare interface PathData {
 	 * whether `optimization.realContentHash` recomputes content hashes (rejects an inline digest on `[contenthash]`)
 	 */
 	realContentHash?: boolean;
+
+	/**
+	 * treat `[hash]` as `[fullhash]` rather than the module hash (CSS local idents)
+	 */
+	hashAsFullHash?: boolean;
 	noChunkHash?: boolean;
 	url?: string;
 	local?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -19416,6 +19416,11 @@ declare interface PathData {
 	 * digest the stored hashes are encoded in (for `[hash:<digest>]`)
 	 */
 	hashDigest?: string;
+
+	/**
+	 * whether `optimization.realContentHash` recomputes content hashes (rejects an inline digest on `[contenthash]`)
+	 */
+	realContentHash?: boolean;
 	noChunkHash?: boolean;
 	url?: string;
 	local?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -19406,6 +19406,11 @@ declare interface PathData {
 	contentHashType?: string;
 	contentHash?: string;
 	contentHashWithLength?: (length: number) => string;
+
+	/**
+	 * digest the stored hashes are encoded in (for `[hash:<digest>]`)
+	 */
+	hashDigest?: string;
 	noChunkHash?: boolean;
 	url?: string;
 	local?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -19396,6 +19396,11 @@ declare interface PathCacheFunctions {
 declare interface PathData {
 	chunkGraph?: ChunkGraph;
 	hash?: string;
+
+	/**
+	 * untruncated compilation hash, for re-encoding `[fullhash:<digest>]`
+	 */
+	fullHash?: string;
 	hashWithLength?: (length: number) => string;
 	chunk?: Chunk | ChunkPathData;
 	module?: Module | ModulePathData;

--- a/types.d.ts
+++ b/types.d.ts
@@ -19401,6 +19401,11 @@ declare interface PathData {
 	 * untruncated compilation hash, for re-encoding `[fullhash:<digest>]`
 	 */
 	fullHash?: string;
+
+	/**
+	 * digest `fullHash` is encoded in (defaults to `hashDigest`)
+	 */
+	fullHashDigest?: string;
 	hashWithLength?: (length: number) => string;
 	chunk?: Chunk | ChunkPathData;
 	module?: Module | ModulePathData;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #21141 (both points). Adds css-loader / loader-utils style inline hash **digest** and **length** to webpack's path placeholders — `[<hash>:<digest>:<length>]` (e.g. `[contenthash:base64:8]`, `[fullhash:6]`) — for output filenames and CSS Modules `localIdentName`:

- **Point 1**: `[fullhash:6]` / `[hash:base64:6]` / `[contenthash:…]` now work in `localIdentName`.
- **Point 2**: `[hash]` in `localIdentName` now resolves to the **local ident hash** (matching css-loader) instead of the module hash; `[modulehash]` yields the module hash.

`[fullhash]`/`[chunkhash]` and CSS `[fullhash]`/`[hash]` digests re-encode the **untruncated** hash (full entropy); `[contenthash]` re-encodes the stored hash and is **rejected when `optimization.realContentHash` is enabled** (it recomputes in `output.hashDigest`, which would silently drop the digest). Supported digests: `hex`, `base64`, `base64url`, `base64safe`, `base26/32/36/49/52/58/62`; an unknown digest throws. Placeholder-kind detection is centralized behind an exported `getPresentKinds` (reused by `RuntimePlugin`/`SourceMapDevToolPlugin`).

**What kind of change does this PR introduce?**

feat (also fixes the two bugs in #21141).

**Did you add tests for your changes?**

Yes — `test/TemplatedPathPlugin.unittest.js`, `test/nonNumericOnlyHash.unittest.js`, `test/configCases/hash-length/digest/`, and `test/configCases/css/local-ident-name/`.

**Does this PR introduce a breaking change?**

Yes, for experimental CSS: `[hash]` in `localIdentName` changes from the module hash to the local ident hash — migration: use `[modulehash]` for the previous behavior. Also, an unknown inline digest token now errors instead of being silently ignored.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documented in webpack/docs.webpack.js.org (same branch): `configuration/output.mdx` and `configuration/module.mdx` — inline digest/length, `[hash]`/`[fullhash]` = local ident hash, the new `[modulehash]`, and that `hashDigestLength` is the lever for content-hash entropy.

**Use of AI**

Yes. I used AI (Claude Code) to research loader-utils' placeholder grammar, draft the implementation, tests and docs, and run the test suites; every change was directed and reviewed by me. This complies with the webpack AI policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Dqzs5d8if5LVWEEFp91KEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqzs5d8if5LVWEEFp91KEA)_