### PR TITLE
feat: add support for ignoring immutable paths in watch options

### DIFF
--- a/.changeset/watch-ignore-managed-paths.md
+++ b/.changeset/watch-ignore-managed-paths.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Skip watching immutable paths (node_modules) and .git under futureDefaults.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -73,6 +73,7 @@ const {
 /** @typedef {import("../../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("../../declarations/WebpackOptions").RuleSetRules} RuleSetRules */
 /** @typedef {import("../../declarations/WebpackOptions").SnapshotOptions} SnapshotOptions */
+/** @typedef {import("../../declarations/WebpackOptions").WatchOptions} WatchOptions */
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptionsNormalized */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../javascript/EnableChunkLoadingPlugin").ChunkLoadingTypes} ChunkLoadingTypes */
@@ -397,6 +398,11 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 	applySnapshotDefaults(options.snapshot, {
 		production,
 		futureDefaults
+	});
+
+	applyWatchDefaults(options.watchOptions, {
+		managedPaths: options.snapshot.managedPaths,
+		immutablePaths: options.snapshot.immutablePaths
 	});
 
 	applyOutputDefaults(options.output, {
@@ -770,6 +776,31 @@ const applySnapshotDefaults = (snapshot, { production, futureDefaults }) => {
 	F(snapshot, "resolve", () =>
 		production ? { timestamp: true, hash: true } : { timestamp: true }
 	);
+};
+
+/**
+ * Apply watch options defaults.
+ * @param {WatchOptions} watchOptions watch options to be modified
+ * @param {object} options options
+ * @param {SnapshotOptions["managedPaths"]} options.managedPaths paths assumed immutable unless versioned
+ * @param {SnapshotOptions["immutablePaths"]} options.immutablePaths paths assumed always immutable
+ * @returns {void}
+ */
+const applyWatchDefaults = (watchOptions, { managedPaths, immutablePaths }) => {
+	// Don't watch paths declared immutable (node_modules under `futureDefaults`).
+	// Symlinked workspace packages resolve to their real path via `resolve.symlinks`,
+	// so they stay watched. Only the broad RegExp matchers map onto a watcher
+	// `ignored`; narrow string prefixes are left watched.
+	if (watchOptions.ignored === undefined) {
+		const sources = [...(managedPaths || []), ...(immutablePaths || [])]
+			.filter((p) => p instanceof RegExp)
+			.map((p) => /** @type {RegExp} */ (p).source);
+		if (sources.length > 0) {
+			// `.git` churns on every git operation and is never a source dependency.
+			sources.push(/[\\/]\.git([\\/]|$)/.source);
+			watchOptions.ignored = new RegExp(sources.join("|"));
+		}
+	}
 };
 
 /**

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -3475,8 +3475,6 @@ describe("snapshots", () => {
 			+       },
 			+       "html": Object {},
 			@@ ... @@
-			+         },
-			+       },
 			+       "css": Object {
 			+         "import": true,
 			+         "namedExports": true,
@@ -3505,9 +3503,10 @@ describe("snapshots", () => {
 			+         "dashedIdents": true,
 			+         "function": true,
 			+         "grid": true,
-			@@ ... @@
+			+       },
 			+       "html": Object {
 			+         "sources": true,
+			+       },
 			@@ ... @@
 			+         "exportsPresence": "error",
 			@@ ... @@
@@ -3556,11 +3555,10 @@ describe("snapshots", () => {
 			+         ],
 			+         "mainFields": Array [
 			+           "style",
-			+           "...",
-			+         ],
+			@@ ... @@
 			+         "mainFiles": Array [],
 			+         "preferRelative": true,
-			+       },
+			@@ ... @@
 			+       "css-import-global-module": Object {
 			+         "conditionNames": Array [
 			+           "webpack",
@@ -3588,9 +3586,11 @@ describe("snapshots", () => {
 			+         ],
 			+         "mainFields": Array [
 			+           "style",
-			@@ ... @@
+			+           "...",
+			+         ],
 			+         "mainFiles": Array [],
 			+         "preferRelative": true,
+			+       },
 			@@ ... @@
 			+           "typescript",
 			@@ ... @@
@@ -3635,6 +3635,7 @@ describe("snapshots", () => {
 			-     "cache": false,
 			+     "cache": true,
 			@@ ... @@
+			+     ],
 			+     "extensionAlias": Object {
 			+       ".cjs": Array [
 			+         ".cjs",
@@ -3647,7 +3648,7 @@ describe("snapshots", () => {
 			+       ".mjs": Array [
 			+         ".mjs",
 			+         ".mts",
-			+       ],
+			@@ ... @@
 			+     },
 			@@ ... @@
 			+     "tsconfig": true,
@@ -3657,6 +3658,11 @@ describe("snapshots", () => {
 			@@ ... @@
 			-       "<cwd>/node_modules/",
 			+       /^(.+?[\\\\/]node_modules[\\\\/])/,
+			@@ ... @@
+			-   "watchOptions": Object {},
+			+   "watchOptions": Object {
+			+     "ignored": /^(.+?[\\\\/]node_modules[\\\\/])|[\\\\/]\\.git([\\\\/]|$)/,
+			+   },
 		`)
 	);
 
@@ -4037,6 +4043,7 @@ describe("snapshots", () => {
 			-     "typescript": undefined,
 			+     "typescript": true,
 			@@ ... @@
+			+           ],
 			+         },
 			+         "resolve": Object {
 			+           "byDependency": Object {
@@ -4072,7 +4079,7 @@ describe("snapshots", () => {
 			+               "fullySpecified": true,
 			+             },
 			+           },
-			+         ],
+			@@ ... @@
 			+         "type": "webassembly/async",
 			+       },
 			+       Object {
@@ -4116,7 +4123,7 @@ describe("snapshots", () => {
 			+           "preferRelative": true,
 			+         },
 			+         "type": "css/global",
-			+       },
+			@@ ... @@
 			+       Object {
 			+         "parser": Object {
 			+           "exportType": "css-style-sheet",
@@ -4161,6 +4168,7 @@ describe("snapshots", () => {
 			+         "dependency": "html-style",
 			+         "parser": Object {
 			+           "exportType": "text",
+			+         },
 			@@ ... @@
 			+           "fullySpecified": true,
 			+           "preferRelative": true,
@@ -4179,23 +4187,23 @@ describe("snapshots", () => {
 			+       },
 			+       Object {
 			+         "resolve": Object {
+			@@ ... @@
+			+         "test": /\\.mts$/i,
+			@@ ... @@
+			+         "descriptionData": Object {
+			+           "type": "module",
+			+         },
+			+         "resolve": Object {
 			+           "byDependency": Object {
 			+             "esm": Object {
 			+               "fullySpecified": true,
 			+             },
 			+           },
 			+         },
-			+         "test": /\\.mts$/i,
+			+         "test": /\\.ts$/i,
 			+         "type": "javascript/esm",
 			+       },
 			+       Object {
-			+         "descriptionData": Object {
-			+           "type": "module",
-			+         },
-			+         "resolve": Object {
-			@@ ... @@
-			+         "test": /\\.ts$/i,
-			@@ ... @@
 			+         "test": /\\.cts$/i,
 			+         "type": "javascript/dynamic",
 			+       },
@@ -4254,11 +4262,13 @@ describe("snapshots", () => {
 			+       },
 			+       "html": Object {},
 			@@ ... @@
+			+         },
+			+       },
 			+       "css": Object {
 			+         "import": true,
 			+         "namedExports": true,
 			+         "url": true,
-			+       },
+			@@ ... @@
 			+       "css/auto": Object {
 			+         "animation": true,
 			+         "container": true,
@@ -4274,7 +4284,7 @@ describe("snapshots", () => {
 			+         "dashedIdents": true,
 			+         "function": true,
 			+         "grid": true,
-			+       },
+			@@ ... @@
 			+       "css/module": Object {
 			+         "animation": true,
 			+         "container": true,
@@ -4317,9 +4327,6 @@ describe("snapshots", () => {
 			@@ ... @@
 			+           ".ts",
 			@@ ... @@
-			+           "...",
-			+         ],
-			+       },
 			+       "css-import": Object {
 			+         "conditionNames": Array [
 			+           "webpack",
@@ -4363,9 +4370,11 @@ describe("snapshots", () => {
 			+         ],
 			+         "mainFields": Array [
 			+           "style",
-			@@ ... @@
+			+           "...",
+			+         ],
 			+         "mainFiles": Array [],
 			+         "preferRelative": true,
+			+       },
 			@@ ... @@
 			+           "typescript",
 			@@ ... @@
@@ -4412,7 +4421,7 @@ describe("snapshots", () => {
 			+       ".cjs": Array [
 			+         ".cjs",
 			+         ".cts",
-			@@ ... @@
+			+       ],
 			+       ".js": Array [
 			+         ".js",
 			+         ".ts",
@@ -4420,13 +4429,18 @@ describe("snapshots", () => {
 			+       ".mjs": Array [
 			+         ".mjs",
 			+         ".mts",
-			+       ],
+			@@ ... @@
 			+     },
 			@@ ... @@
 			+     "tsconfig": true,
 			@@ ... @@
 			-       "<cwd>/node_modules/",
 			+       /^(.+?[\\\\/]node_modules[\\\\/])/,
+			@@ ... @@
+			-   "watchOptions": Object {},
+			+   "watchOptions": Object {
+			+     "ignored": /^(.+?[\\\\/]node_modules[\\\\/])|[\\\\/]\\.git([\\\\/]|$)/,
+			+   },
 		`)
 	);
 
@@ -4561,8 +4575,7 @@ describe("snapshots", () => {
 			@@ ... @@
 			+       "html": Object {},
 			@@ ... @@
-			+         },
-			@@ ... @@
+			+       },
 			+       "html": Object {
 			+         "sources": true,
 			@@ ... @@
@@ -4635,17 +4648,22 @@ describe("snapshots", () => {
 			+       ".js": Array [
 			+         ".js",
 			+         ".ts",
-			@@ ... @@
+			+       ],
 			+       ".mjs": Array [
 			+         ".mjs",
 			+         ".mts",
-			+       ],
+			@@ ... @@
 			+     },
 			@@ ... @@
 			+     "tsconfig": true,
 			@@ ... @@
 			-       "<cwd>/node_modules/",
 			+       /^(.+?[\\\\/]node_modules[\\\\/])/,
+			@@ ... @@
+			-   "watchOptions": Object {},
+			+   "watchOptions": Object {
+			+     "ignored": /^(.+?[\\\\/]node_modules[\\\\/])|[\\\\/]\\.git([\\\\/]|$)/,
+			+   },
 		`)
 	);
 
@@ -4850,6 +4868,44 @@ describe("snapshots", () => {
 			+   "target": "node14",
 		`)
 	);
+});
+
+describe("watchOptions.ignored", () => {
+	it("is unset by default (node_modules stays watched)", () => {
+		expect(getDefaultConfig({}).watchOptions.ignored).toBeUndefined();
+	});
+
+	it("ignores node_modules and .git under futureDefaults", () => {
+		const { ignored } = getDefaultConfig({
+			experiments: { futureDefaults: true }
+		}).watchOptions;
+		expect(ignored).toBeInstanceOf(RegExp);
+		const re = /** @type {RegExp} */ (ignored);
+		expect(re.test("/app/node_modules/foo/index.js")).toBe(true);
+		expect(re.test("/app/.git/HEAD")).toBe(true);
+		expect(re.test("/app/.gitignore")).toBe(false);
+		expect(re.test("/app/src/index.js")).toBe(false);
+	});
+
+	it("does not override a user-provided ignored", () => {
+		const ignored = ["**/dist/**"];
+		expect(
+			getDefaultConfig({
+				experiments: { futureDefaults: true },
+				watchOptions: { ignored }
+			}).watchOptions.ignored
+		).toBe(ignored);
+	});
+
+	it("is derived from custom managedPaths", () => {
+		const ignored = getDefaultConfig({
+			snapshot: { managedPaths: [/^(.+?[\\/]vendor[\\/])/] }
+		}).watchOptions.ignored;
+		expect(ignored).toBeInstanceOf(RegExp);
+		expect(/** @type {RegExp} */ (ignored).test("/app/vendor/foo.js")).toBe(
+			true
+		);
+	});
 });
 
 describe("Targets", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This would only reduce memory usage in watch mode, since we don't need to watch things like `node_modules` by default. If someone wants to do that, they can configure it manually, but I don't think it should be the default. We also add `.git`, similar to how Rspack handles it.


**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->