### PR TITLE
fix(security): update json5 to fix CVE-2022-46175

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "jest-junit": "^17.0.0",
     "jest-snapshot": "^30.3.0",
     "json-loader": "^0.5.7",
-    "json5": "^2.1.3",
+    "json5": "^2.2.2",
     "less": "^4.6.4",
     "less-loader": "^13.0.0",
     "lint-staged": "^17.0.7",


### PR DESCRIPTION
Updates the json5 devDependency range from `^2.1.3` to `^2.2.2` to ensure patched versions (>=2.2.2) are installed, addressing CVE-2022-46175 (prototype pollution).