### PR TITLE
refactor: annotate constructor fields with @type to improve type coverage

### DIFF
--- a/lib/CacheFacade.js
+++ b/lib/CacheFacade.js
@@ -39,6 +39,7 @@ class MultiItemCache {
 	 * @param {ItemCacheFacade[]} items item caches
 	 */
 	constructor(items) {
+		/** @type {ItemCacheFacade[]} */
 		this._items = items;
 		// @ts-expect-error expected - returns the single ItemCacheFacade when passed an array of length 1
 		// eslint-disable-next-line no-constructor-return
@@ -110,8 +111,11 @@ class ItemCacheFacade {
 	 * @param {Etag | null} etag the etag
 	 */
 	constructor(cache, name, etag) {
+		/** @type {Cache} */
 		this._cache = cache;
+		/** @type {string} */
 		this._name = name;
+		/** @type {Etag | null} */
 		this._etag = etag;
 	}
 
@@ -215,8 +219,11 @@ class CacheFacade {
 	 * @param {HashFunction=} hashFunction the hash function to use
 	 */
 	constructor(cache, name, hashFunction) {
+		/** @type {Cache} */
 		this._cache = cache;
+		/** @type {string} */
 		this._name = name;
+		/** @type {HashFunction | undefined} */
 		this._hashFunction = hashFunction;
 	}
 

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -315,6 +315,7 @@ class ChunkGraph {
 		/** @type {ModuleGraph} */
 		this.moduleGraph = moduleGraph;
 
+		/** @type {HashFunction} */
 		this._hashFunction = hashFunction;
 
 		this._getGraphRoots = this._getGraphRoots.bind(this);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -594,6 +594,7 @@ class Compilation {
 	 * @param {CompilationParams} params the compilation parameters
 	 */
 	constructor(compiler, params) {
+		/** @type {boolean} */
 		this._backCompat = compiler._backCompat;
 
 		const getNormalModuleLoader = () => deprecatedNormalModuleLoaderHook(this);
@@ -1154,6 +1155,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.inputFileSystem =
 			/** @type {InputFileSystem} */
 			(compiler.inputFileSystem);
+		/** @type {FileSystemInfo} */
 		this.fileSystemInfo = new FileSystemInfo(this.inputFileSystem, {
 			unmanagedPaths: compiler.unmanagedPaths,
 			managedPaths: compiler.managedPaths,
@@ -1172,7 +1174,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		}
 		/** @type {ValueCacheVersions} */
 		this.valueCacheVersions = new Map();
+		/** @type {RequestShortener} */
 		this.requestShortener = compiler.requestShortener;
+		/** @type {string} */
 		this.compilerPath = compiler.compilerPath;
 
 		this.logger = this.getLogger("webpack.Compilation");
@@ -1187,9 +1191,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		/** @type {boolean} */
 		this.profile = (options && options.profile) || false;
 
+		/** @type {CompilationParams} */
 		this.params = params;
+		/** @type {MainTemplate} */
 		this.mainTemplate = new MainTemplate(this.outputOptions, this);
+		/** @type {ChunkTemplate} */
 		this.chunkTemplate = new ChunkTemplate(this.outputOptions, this);
+		/** @type {RuntimeTemplate} */
 		this.runtimeTemplate = new RuntimeTemplate(
 			this,
 			this.outputOptions,
@@ -1365,8 +1373,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			)
 		};
 
+		/** @type {CacheFacade} */
 		this._modulesCache = this.getCache("Compilation/modules");
+		/** @type {CacheFacade} */
 		this._assetsCache = this.getCache("Compilation/assets");
+		/** @type {CacheFacade} */
 		this._codeGenerationCache = this.getCache("Compilation/codeGeneration");
 
 		const unsafeCache = options.module.unsafeCache;

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -324,15 +324,19 @@ class Compiler {
 
 		this.options = options;
 
+		/** @type {string} */
 		this.context = context;
 
+		/** @type {RequestShortener} */
 		this.requestShortener = new RequestShortener(context, this.root);
 
+		/** @type {Cache} */
 		this.cache = new Cache();
 
 		/** @type {Map<Module, ModuleMemCachesItem> | undefined} */
 		this.moduleMemCaches = undefined;
 
+		/** @type {string} */
 		this.compilerPath = "";
 
 		/** @type {boolean} */
@@ -344,6 +348,7 @@ class Compiler {
 		/** @type {boolean} */
 		this.watchMode = false;
 
+		/** @type {boolean} */
 		this._backCompat = this.options.experiments.backCompat !== false;
 
 		/** @type {Compilation | undefined} */

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -43,6 +43,7 @@ class ConcatenationScope {
 	 * @param {Set<string>} usedNames all used names
 	 */
 	constructor(modulesMap, currentModule, usedNames) {
+		/** @type {ConcatenatedModuleInfo} */
 		this._currentModule = currentModule;
 		if (Array.isArray(modulesMap)) {
 			/** @type {Map<Module, ConcatenatedModuleInfo>} */
@@ -52,7 +53,9 @@ class ConcatenationScope {
 			}
 			modulesMap = map;
 		}
+		/** @type {Set<string>} */
 		this.usedNames = usedNames;
+		/** @type {Map<Module, ModuleInfo>} */
 		this._modulesMap = modulesMap;
 	}
 

--- a/lib/ContextExclusionPlugin.js
+++ b/lib/ContextExclusionPlugin.js
@@ -14,6 +14,7 @@ class ContextExclusionPlugin {
 	 * @param {RegExp} negativeMatcher Matcher regular expression
 	 */
 	constructor(negativeMatcher) {
+		/** @type {RegExp} */
 		this.negativeMatcher = negativeMatcher;
 	}
 

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -173,6 +173,7 @@ class ContextModule extends Module {
 		/** @type {ResolveDependencies | undefined} */
 		this.resolveDependencies = resolveDependencies;
 		if (options && options.resolveOptions !== undefined) {
+			/** @type {ResolveOptions | undefined} */
 			this.resolveOptions = options.resolveOptions;
 		}
 
@@ -180,7 +181,9 @@ class ContextModule extends Module {
 			throw new Error("options.mode is a required option");
 		}
 
+		/** @type {string} */
 		this._identifier = this._createIdentifier();
+		/** @type {boolean} */
 		this._forceBuild = true;
 	}
 

--- a/lib/ContextReplacementPlugin.js
+++ b/lib/ContextReplacementPlugin.js
@@ -32,6 +32,7 @@ class ContextReplacementPlugin {
 		newContentRecursive,
 		newContentRegExp
 	) {
+		/** @type {RegExp} */
 		this.resourceRegExp = resourceRegExp;
 
 		// new webpack.ContextReplacementPlugin(/selector/, (context) => { /* Logic */ });
@@ -43,6 +44,7 @@ class ContextReplacementPlugin {
 			typeof newContentResource === "string" &&
 			typeof newContentRecursive === "object"
 		) {
+			/** @type {string | undefined} */
 			this.newContentResource = newContentResource;
 			/**
 			 * Stores new content create context map.
@@ -79,9 +81,11 @@ class ContextReplacementPlugin {
 			this.newContentResource =
 				/** @type {string | undefined} */
 				(newContentResource);
+			/** @type {boolean | undefined} */
 			this.newContentRecursive =
 				/** @type {boolean | undefined} */
 				(newContentRecursive);
+			/** @type {RegExp | undefined} */
 			this.newContentRegExp =
 				/** @type {RegExp | undefined} */
 				(newContentRegExp);

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -133,9 +133,13 @@ class Dependency {
 		// stays on base: also set on ContextDependency, which is not a ModuleDependency
 		/** @type {boolean | undefined} */
 		this.optional = false;
+		/** @type {number} */
 		this._locSL = 0;
+		/** @type {number} */
 		this._locSC = 0;
+		/** @type {number} */
 		this._locEL = 0;
+		/** @type {number} */
 		this._locEC = 0;
 		/** @type {undefined | number} */
 		this._locI = undefined;

--- a/lib/EntryPlugin.js
+++ b/lib/EntryPlugin.js
@@ -20,7 +20,9 @@ class EntryPlugin {
 	 * @param {EntryOptions | string=} options entry options (passing a string is deprecated)
 	 */
 	constructor(context, entry, options) {
+		/** @type {string} */
 		this.context = context;
+		/** @type {string} */
 		this.entry = entry;
 		this.options = options || "";
 	}

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -88,9 +88,13 @@ class RestoreProvidedData {
 		otherCanMangleProvide,
 		otherTerminalBinding
 	) {
+		/** @type {RestoreProvidedDataExports[]} */
 		this.exports = exports;
+		/** @type {ExportInfoProvided | undefined} */
 		this.otherProvided = otherProvided;
+		/** @type {boolean | undefined} */
 		this.otherCanMangleProvide = otherCanMangleProvide;
+		/** @type {boolean} */
 		this.otherTerminalBinding = otherTerminalBinding;
 	}
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -330,10 +330,15 @@ class ModuleExternalInitFragment extends InitFragment {
 				imported === true ? imported : imported.join(" ")
 			}`
 		);
+		/** @type {string} */
 		this._ident = ident;
+		/** @type {string} */
 		this._request = request;
+		/** @type {ImportDependencyMeta | undefined} */
 		this._dependencyMeta = dependencyMeta;
+		/** @type {string} */
 		this._identifier = this.buildIdentifier(ident);
+		/** @type {Imported} */
 		this._imported = this.buildImported(imported);
 	}
 

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -110,6 +110,7 @@ class ExternalModuleFactoryPlugin {
 	 */
 	constructor(type, externals) {
 		this.type = type;
+		/** @type {Externals} */
 		this.externals = externals;
 	}
 

--- a/lib/ExternalsPlugin.js
+++ b/lib/ExternalsPlugin.js
@@ -25,6 +25,7 @@ class ExternalsPlugin {
 	 */
 	constructor(type, externals) {
 		this.type = type;
+		/** @type {Externals} */
 		this.externals = externals;
 	}
 

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -201,7 +201,9 @@ class SnapshotIterable {
 	 * @param {GetMapsFunction<T>} getMaps get maps function
 	 */
 	constructor(snapshot, getMaps) {
+		/** @type {Snapshot} */
 		this.snapshot = snapshot;
+		/** @type {GetMapsFunction<T>} */
 		this.getMaps = getMaps;
 	}
 
@@ -297,6 +299,7 @@ class SnapshotIterable {
 
 class Snapshot {
 	constructor() {
+		/** @type {number} */
 		this._flags = 0;
 		/** @type {Iterable<string> | undefined} */
 		this._cachedFileIterable = undefined;
@@ -672,14 +675,19 @@ class SnapshotOptimization {
 		this._has = has;
 		this._get = get;
 		this._set = set;
+		/** @type {boolean} */
 		this._useStartTime = useStartTime;
 		/** @type {U} */
 		this._isSet = isSet;
 		/** @type {Map<string, SnapshotOptimizationEntry>} */
 		this._map = new Map();
+		/** @type {number} */
 		this._statItemsShared = 0;
+		/** @type {number} */
 		this._statItemsUnshared = 0;
+		/** @type {number} */
 		this._statSharedSnapshots = 0;
+		/** @type {number} */
 		this._statReusedSharedSnapshots = 0;
 	}
 
@@ -1261,52 +1269,63 @@ class FileSystemInfo {
 			hashFunction = DEFAULTS.HASH_FUNCTION
 		} = {}
 	) {
+		/** @type {InputFileSystem} */
 		this.fs = fs;
 		this.logger = logger;
+		/** @type {number} */
 		this._remainingLogs = logger ? 40 : 0;
 		/** @type {LoggedPaths | undefined} */
 		this._loggedPaths = logger ? new Set() : undefined;
+		/** @type {HashFunction} */
 		this._hashFunction = hashFunction;
 		/** @type {WeakMap<Snapshot, boolean | CheckSnapshotValidCallback[]>} */
 		this._snapshotCache = new WeakMap();
+		/** @type {SnapshotOptimization<FileSystemInfoEntry | null, false>} */
 		this._fileTimestampsOptimization = new SnapshotOptimization(
 			(s) => s.hasFileTimestamps(),
 			(s) => s.fileTimestamps,
 			(s, v) => s.setFileTimestamps(v)
 		);
+		/** @type {SnapshotOptimization<string | null, false>} */
 		this._fileHashesOptimization = new SnapshotOptimization(
 			(s) => s.hasFileHashes(),
 			(s) => s.fileHashes,
 			(s, v) => s.setFileHashes(v),
 			false
 		);
+		/** @type {SnapshotOptimization<string | TimestampAndHash | null, false>} */
 		this._fileTshsOptimization = new SnapshotOptimization(
 			(s) => s.hasFileTshs(),
 			(s) => s.fileTshs,
 			(s, v) => s.setFileTshs(v)
 		);
+		/** @type {SnapshotOptimization<ResolvedContextFileSystemInfoEntry | null, false>} */
 		this._contextTimestampsOptimization = new SnapshotOptimization(
 			(s) => s.hasContextTimestamps(),
 			(s) => s.contextTimestamps,
 			(s, v) => s.setContextTimestamps(v)
 		);
+		/** @type {SnapshotOptimization<string | null, false>} */
 		this._contextHashesOptimization = new SnapshotOptimization(
 			(s) => s.hasContextHashes(),
 			(s) => s.contextHashes,
 			(s, v) => s.setContextHashes(v),
 			false
 		);
+		/** @type {SnapshotOptimization<ResolvedContextTimestampAndHash | null, false>} */
 		this._contextTshsOptimization = new SnapshotOptimization(
 			(s) => s.hasContextTshs(),
 			(s) => s.contextTshs,
 			(s, v) => s.setContextTshs(v)
 		);
+		/** @type {SnapshotOptimization<boolean, false>} */
 		this._missingExistenceOptimization = new SnapshotOptimization(
 			(s) => s.hasMissingExistence(),
 			(s) => s.missingExistence,
 			(s, v) => s.setMissingExistence(v),
 			false
 		);
+		/** @type {SnapshotOptimization<string, false>} */
 		this._managedItemInfoOptimization = new SnapshotOptimization(
 			(s) => s.hasManagedItemInfo(),
 			(s) => s.managedItemInfo,
@@ -1420,16 +1439,25 @@ class FileSystemInfo {
 			(p) => typeof p !== "string"
 		);
 
+		/** @type {Map<string, number | null> | undefined} */
 		this._cachedDeprecatedFileTimestamps = undefined;
+		/** @type {Map<string, number | null> | undefined} */
 		this._cachedDeprecatedContextTimestamps = undefined;
 
+		/** @type {boolean} */
 		this._warnAboutExperimentalEsmTracking = false;
 
+		/** @type {number} */
 		this._statCreatedSnapshots = 0;
+		/** @type {number} */
 		this._statTestedSnapshotsCached = 0;
+		/** @type {number} */
 		this._statTestedSnapshotsNotCached = 0;
+		/** @type {number} */
 		this._statTestedChildrenCached = 0;
+		/** @type {number} */
 		this._statTestedChildrenNotCached = 0;
+		/** @type {number} */
 		this._statTestedEntries = 0;
 	}
 

--- a/lib/FlagAllModulesAsUsedPlugin.js
+++ b/lib/FlagAllModulesAsUsedPlugin.js
@@ -18,6 +18,7 @@ class FlagAllModulesAsUsedPlugin {
 	 * @param {string} explanation explanation
 	 */
 	constructor(explanation) {
+		/** @type {string} */
 		this.explanation = explanation;
 	}
 

--- a/lib/FlagEntryExportAsUsedPlugin.js
+++ b/lib/FlagEntryExportAsUsedPlugin.js
@@ -18,7 +18,9 @@ class FlagEntryExportAsUsedPlugin {
 	 * @param {string} explanation explanation for the reason
 	 */
 	constructor(nsObjectUsed, explanation) {
+		/** @type {boolean} */
 		this.nsObjectUsed = nsObjectUsed;
+		/** @type {string} */
 		this.explanation = explanation;
 	}
 

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -163,6 +163,7 @@ class ByTypeGenerator extends Generator {
 	constructor(map) {
 		super();
 		this.map = map;
+		/** @type {SourceTypes} */
 		this._types = /** @type {SourceTypes} */ (new Set(Object.keys(map)));
 		/** @type {GenerateErrorFn | undefined} */
 		this.generateError = generateError.bind(this);

--- a/lib/IgnorePlugin.js
+++ b/lib/IgnorePlugin.js
@@ -23,6 +23,7 @@ class IgnorePlugin {
 	 * @param {IgnorePluginOptions} options IgnorePlugin options
 	 */
 	constructor(options) {
+		/** @type {IgnorePluginOptions} */
 		this.options = options;
 		this.checkIgnore = this.checkIgnore.bind(this);
 	}

--- a/lib/InitFragment.js
+++ b/lib/InitFragment.js
@@ -67,10 +67,15 @@ class InitFragment {
 	 * @param {string | Source=} endContent the source code that will be included at the end of the module
 	 */
 	constructor(content, stage, position, key, endContent) {
+		/** @type {string | Source | undefined} */
 		this.content = content;
+		/** @type {number} */
 		this.stage = stage;
+		/** @type {number} */
 		this.position = position;
+		/** @type {string | undefined} */
 		this.key = key;
+		/** @type {string | Source | undefined} */
 		this.endContent = endContent;
 	}
 

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -196,6 +196,7 @@ class LazyBarrelController {
 	 * @param {Compilation} compilation the owning compilation
 	 */
 	constructor(compilation) {
+		/** @type {Compilation} */
 		this._compilation = compilation;
 		/** @type {WeakMap<Module, LazyBarrelState>} */
 		this._modules = new WeakMap();

--- a/lib/LoaderTargetPlugin.js
+++ b/lib/LoaderTargetPlugin.js
@@ -17,6 +17,7 @@ class LoaderTargetPlugin {
 	 * @param {string} target the target
 	 */
 	constructor(target) {
+		/** @type {string} */
 		this.target = target;
 	}
 

--- a/lib/ModuleProfile.js
+++ b/lib/ModuleProfile.js
@@ -7,39 +7,65 @@
 
 class ModuleProfile {
 	constructor() {
+		/** @type {number} */
 		this.startTime = Date.now();
 
+		/** @type {number} */
 		this.factoryStartTime = 0;
+		/** @type {number} */
 		this.factoryEndTime = 0;
+		/** @type {number} */
 		this.factory = 0;
+		/** @type {number} */
 		this.factoryParallelismFactor = 0;
 
+		/** @type {number} */
 		this.restoringStartTime = 0;
+		/** @type {number} */
 		this.restoringEndTime = 0;
+		/** @type {number} */
 		this.restoring = 0;
+		/** @type {number} */
 		this.restoringParallelismFactor = 0;
 
+		/** @type {number} */
 		this.integrationStartTime = 0;
+		/** @type {number} */
 		this.integrationEndTime = 0;
+		/** @type {number} */
 		this.integration = 0;
+		/** @type {number} */
 		this.integrationParallelismFactor = 0;
 
+		/** @type {number} */
 		this.buildingStartTime = 0;
+		/** @type {number} */
 		this.buildingEndTime = 0;
+		/** @type {number} */
 		this.building = 0;
+		/** @type {number} */
 		this.buildingParallelismFactor = 0;
 
+		/** @type {number} */
 		this.storingStartTime = 0;
+		/** @type {number} */
 		this.storingEndTime = 0;
+		/** @type {number} */
 		this.storing = 0;
+		/** @type {number} */
 		this.storingParallelismFactor = 0;
 
 		/** @type {{ start: number, end: number }[] | undefined} */
 		this.additionalFactoryTimes = undefined;
+		/** @type {number} */
 		this.additionalFactories = 0;
+		/** @type {number} */
 		this.additionalFactoriesParallelismFactor = 0;
 
-		/** @deprecated */
+		/**
+		 * @deprecated
+		 * @type {number}
+		 */
 		this.additionalIntegration = 0;
 	}
 

--- a/lib/ModuleTemplate.js
+++ b/lib/ModuleTemplate.js
@@ -37,7 +37,9 @@ class ModuleTemplate {
 	 * @param {Compilation} compilation the compilation
 	 */
 	constructor(runtimeTemplate, compilation) {
+		/** @type {RuntimeTemplate} */
 		this._runtimeTemplate = runtimeTemplate;
+		/** @type {string} */
 		this.type = "javascript";
 		this.hooks = Object.freeze({
 			content: {

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -92,6 +92,7 @@ module.exports = class MultiCompiler {
 				compilers.map((c) => c.hooks.infrastructureLog)
 			)
 		});
+		/** @type {Compiler[]} */
 		this.compilers = compilers;
 		/** @type {MultiCompilerOptions} */
 		this._options = {
@@ -99,6 +100,7 @@ module.exports = class MultiCompiler {
 		};
 		/** @type {WeakMap<Compiler, string[]>} */
 		this.dependencies = new WeakMap();
+		/** @type {boolean} */
 		this.running = false;
 
 		/** @type {(Stats | null)[]} */

--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -36,6 +36,7 @@ class MultiStats {
 	 * @param {Stats[]} stats the child stats
 	 */
 	constructor(stats) {
+		/** @type {Stats[]} */
 		this.stats = stats;
 	}
 

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -18,7 +18,9 @@ class MultiWatching {
 	 * @param {MultiCompiler} compiler the compiler
 	 */
 	constructor(watchings, compiler) {
+		/** @type {Watching[]} */
 		this.watchings = watchings;
+		/** @type {MultiCompiler} */
 		this.compiler = compiler;
 	}
 

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -42,6 +42,7 @@ class NodeStuffPlugin {
 	 * @param {NodeOptions} options options
 	 */
 	constructor(options) {
+		/** @type {NodeOptions} */
 		this.options = options;
 	}
 

--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -22,7 +22,9 @@ class NormalModuleReplacementPlugin {
 	 * @param {string | ModuleReplacer} newResource the resource replacement
 	 */
 	constructor(resourceRegExp, newResource) {
+		/** @type {RegExp} */
 		this.resourceRegExp = resourceRegExp;
+		/** @type {string | ModuleReplacer} */
 		this.newResource = newResource;
 	}
 

--- a/lib/PrefetchPlugin.js
+++ b/lib/PrefetchPlugin.js
@@ -19,7 +19,9 @@ class PrefetchPlugin {
 	 */
 	constructor(context, request) {
 		if (request) {
+			/** @type {string | null} */
 			this.context = context;
+			/** @type {string} */
 			this.request = request;
 		} else {
 			this.context = null;

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -242,13 +242,21 @@ class ProgressPlugin {
 		this.options = options;
 
 		const merged = { ...DEFAULT_OPTIONS, ...options };
+		/** @type {boolean | null} */
 		this.profile = merged.profile;
+		/** @type {HandlerFn | undefined} */
 		this.handler = merged.handler;
+		/** @type {number} */
 		this.modulesCount = merged.modulesCount;
+		/** @type {number} */
 		this.dependenciesCount = merged.dependenciesCount;
+		/** @type {boolean} */
 		this.showEntries = merged.entries;
+		/** @type {boolean} */
 		this.showModules = merged.modules;
+		/** @type {boolean} */
 		this.showDependencies = merged.dependencies;
+		/** @type {boolean} */
 		this.showActiveModules = merged.activeModules;
 		this.percentBy = merged.percentBy;
 

--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -28,6 +28,7 @@ class ProvidePlugin {
 	 * @param {Record<string, string | string[]>} definitions the provided identifiers
 	 */
 	constructor(definitions) {
+		/** @type {Record<string, string | string[]>} */
 		this.definitions = definitions;
 	}
 

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -44,9 +44,13 @@ class RawModule extends Module {
 	 */
 	constructor(source, identifier, readableIdentifier, runtimeRequirements) {
 		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
+		/** @type {string} */
 		this.sourceStr = source;
+		/** @type {string} */
 		this.identifierStr = identifier || this.sourceStr;
+		/** @type {string} */
 		this.readableIdentifierStr = readableIdentifier || this.identifierStr;
+		/** @type {ReadOnlyRuntimeRequirements | null} */
 		this.runtimeRequirements = runtimeRequirements || null;
 	}
 

--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -50,6 +50,7 @@ class RecordIdsPlugin {
 	 * @param {RecordIdsPluginOptions=} options object
 	 */
 	constructor(options) {
+		/** @type {RecordIdsPluginOptions} */
 		this.options = options || {};
 	}
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -103,12 +103,16 @@ class RuntimeTemplate {
 	 * @param {RequestShortener} requestShortener the request shortener
 	 */
 	constructor(compilation, outputOptions, requestShortener) {
+		/** @type {Compilation} */
 		this.compilation = compilation;
 		this.outputOptions = /** @type {OutputOptions} */ (outputOptions || {});
+		/** @type {RequestShortener} */
 		this.requestShortener = requestShortener;
+		/** @type {string} */
 		this.globalObject =
 			/** @type {string} */
 			(getGlobalObject(outputOptions.globalObject));
+		/** @type {string} */
 		this.contentHashReplacement = "X".repeat(outputOptions.hashDigestLength);
 	}
 

--- a/lib/SelfModuleFactory.js
+++ b/lib/SelfModuleFactory.js
@@ -15,6 +15,7 @@ class SelfModuleFactory {
 	 * @param {ModuleGraph} moduleGraph module graph
 	 */
 	constructor(moduleGraph) {
+		/** @type {ModuleGraph} */
 		this.moduleGraph = moduleGraph;
 	}
 

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -16,6 +16,7 @@ class Stats {
 	 * @param {Compilation} compilation webpack compilation
 	 */
 	constructor(compilation) {
+		/** @type {Compilation} */
 		this.compilation = compilation;
 	}
 

--- a/lib/WarnCaseSensitiveModulesPlugin.js
+++ b/lib/WarnCaseSensitiveModulesPlugin.js
@@ -75,6 +75,7 @@ ${modulesList}`);
 
 		/** @type {string} */
 		this.name = "CaseSensitiveModulesWarning";
+		/** @type {Module} */
 		this.module = sortedModules[0];
 	}
 }

--- a/lib/WarnDeprecatedOptionPlugin.js
+++ b/lib/WarnDeprecatedOptionPlugin.js
@@ -19,8 +19,11 @@ class WarnDeprecatedOptionPlugin {
 	 * @param {string} suggestion the suggestion replacement
 	 */
 	constructor(option, value, suggestion) {
+		/** @type {string} */
 		this.option = option;
+		/** @type {string | number} */
 		this.value = value;
+		/** @type {string} */
 		this.suggestion = suggestion;
 	}
 
@@ -50,6 +53,7 @@ class DeprecatedOptionWarning extends WebpackError {
 
 		/** @type {string} */
 		this.name = "DeprecatedOptionWarning";
+		/** @type {string} */
 		this.message =
 			"configuration\n" +
 			`The value '${value}' for option '${option}' is deprecated. ` +

--- a/lib/WarnNoModeSetPlugin.js
+++ b/lib/WarnNoModeSetPlugin.js
@@ -13,6 +13,7 @@ class NoModeWarning extends WebpackError {
 
 		/** @type {string} */
 		this.name = "NoModeWarning";
+		/** @type {string} */
 		this.message =
 			"configuration\n" +
 			"The 'mode' option has not been set, webpack will fallback to 'production' for this value.\n" +

--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -23,6 +23,7 @@ class IgnoringWatchFileSystem {
 	 * @param {WatchIgnorePluginOptions["paths"]} paths ignored paths
 	 */
 	constructor(wfs, paths) {
+		/** @type {WatchFileSystem} */
 		this.wfs = wfs;
 		this.paths = paths;
 	}

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -35,6 +35,7 @@ class Watching {
 	constructor(compiler, watchOptions, handler) {
 		/** @type {null | number} */
 		this.startTime = null;
+		/** @type {boolean} */
 		this.invalid = false;
 		/** @type {Callback<Stats>} */
 		this.handler = handler;
@@ -42,8 +43,11 @@ class Watching {
 		this.callbacks = [];
 		/** @type {ErrorCallback[] | undefined} */
 		this._closeCallbacks = undefined;
+		/** @type {boolean} */
 		this.closed = false;
+		/** @type {boolean} */
 		this.suspended = false;
+		/** @type {boolean} */
 		this.blocked = false;
 		this._isBlocked = () => false;
 		this._onChange = () => {};
@@ -63,10 +67,15 @@ class Watching {
 		if (typeof this.watchOptions.aggregateTimeout !== "number") {
 			this.watchOptions.aggregateTimeout = 20;
 		}
+		/** @type {Compiler} */
 		this.compiler = compiler;
+		/** @type {boolean} */
 		this.running = false;
+		/** @type {boolean} */
 		this._initial = true;
+		/** @type {boolean} */
 		this._invalidReported = true;
+		/** @type {boolean} */
 		this._needRecords = true;
 		/** @type {undefined | null | Watcher} */
 		this.watcher = undefined;

--- a/lib/asset/AssetBytesGenerator.js
+++ b/lib/asset/AssetBytesGenerator.js
@@ -36,6 +36,7 @@ class AssetBytesGenerator extends Generator {
 	constructor(moduleGraph) {
 		super();
 
+		/** @type {ModuleGraph} */
 		this._moduleGraph = moduleGraph;
 	}
 

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -73,6 +73,7 @@ class AssetModulesPlugin {
 	 * @param {AssetModulesPluginOptions} options options
 	 */
 	constructor(options) {
+		/** @type {AssetModulesPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/asset/AssetSourceGenerator.js
+++ b/lib/asset/AssetSourceGenerator.js
@@ -36,6 +36,7 @@ class AssetSourceGenerator extends Generator {
 	constructor(moduleGraph) {
 		super();
 
+		/** @type {ModuleGraph} */
 		this._moduleGraph = moduleGraph;
 	}
 

--- a/lib/cache/AddBuildDependenciesPlugin.js
+++ b/lib/cache/AddBuildDependenciesPlugin.js
@@ -15,6 +15,7 @@ class AddBuildDependenciesPlugin {
 	 * @param {Iterable<string>} buildDependencies list of build dependencies
 	 */
 	constructor(buildDependencies) {
+		/** @type {Set<string>} */
 		this.buildDependencies = new Set(buildDependencies);
 	}
 

--- a/lib/cache/AddManagedPathsPlugin.js
+++ b/lib/cache/AddManagedPathsPlugin.js
@@ -15,8 +15,11 @@ class AddManagedPathsPlugin {
 	 * @param {Iterable<string | RegExp>} unmanagedPaths list of unmanaged paths
 	 */
 	constructor(managedPaths, immutablePaths, unmanagedPaths) {
+		/** @type {Set<string | RegExp>} */
 		this.managedPaths = new Set(managedPaths);
+		/** @type {Set<string | RegExp>} */
 		this.immutablePaths = new Set(immutablePaths);
+		/** @type {Set<string | RegExp>} */
 		this.unmanagedPaths = new Set(unmanagedPaths);
 	}
 

--- a/lib/cache/IdleFileCachePlugin.js
+++ b/lib/cache/IdleFileCachePlugin.js
@@ -28,9 +28,13 @@ class IdleFileCachePlugin {
 		idleTimeoutForInitialStore,
 		idleTimeoutAfterLargeChanges
 	) {
+		/** @type {PackFileCacheStrategy} */
 		this.strategy = strategy;
+		/** @type {number} */
 		this.idleTimeout = idleTimeout;
+		/** @type {number} */
 		this.idleTimeoutForInitialStore = idleTimeoutForInitialStore;
+		/** @type {number} */
 		this.idleTimeoutAfterLargeChanges = idleTimeoutAfterLargeChanges;
 	}
 

--- a/lib/cache/MemoryWithGcCachePlugin.js
+++ b/lib/cache/MemoryWithGcCachePlugin.js
@@ -25,6 +25,7 @@ class MemoryWithGcCachePlugin {
 	 * @param {MemoryWithGcCachePluginOptions} options options
 	 */
 	constructor({ maxGenerations }) {
+		/** @type {number} */
 		this._maxGenerations = maxGenerations;
 	}
 

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -710,6 +710,7 @@ class PackContentItems {
 	 * @param {Content} map items
 	 */
 	constructor(map) {
+		/** @type {Content} */
 		this.map = map;
 	}
 

--- a/lib/cache/ResolverCachePlugin.js
+++ b/lib/cache/ResolverCachePlugin.js
@@ -36,7 +36,9 @@ class CacheEntry {
 	 * @param {Snapshot} snapshot snapshot
 	 */
 	constructor(result, snapshot) {
+		/** @type {ResolveRequest} */
 		this.result = result;
+		/** @type {Snapshot} */
 		this.snapshot = snapshot;
 	}
 

--- a/lib/cache/mergeEtags.js
+++ b/lib/cache/mergeEtags.js
@@ -14,7 +14,9 @@ class MergedEtag {
 	 * @param {Etag} b second
 	 */
 	constructor(a, b) {
+		/** @type {Etag} */
 		this.a = a;
+		/** @type {Etag} */
 		this.b = b;
 	}
 

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -148,9 +148,13 @@ class CssGenerator extends Generator {
 	 */
 	constructor(options, moduleGraph) {
 		super();
+		/** @type {CssModuleGeneratorOptions} */
 		this.options = options;
+		/** @type {boolean | undefined} */
 		this._exportsOnly = options.exportsOnly;
+		/** @type {boolean | undefined} */
 		this._esModule = options.esModule;
+		/** @type {ModuleGraph} */
 		this._moduleGraph = moduleGraph;
 		/** @type {WeakMap<Source, ModuleFactoryCacheEntry>} */
 		this._moduleFactoryCache = new WeakMap();
@@ -162,9 +166,11 @@ class CssGenerator extends Generator {
 			typeof localIdentName === "string"
 				? getPresentKinds(localIdentName)
 				: undefined;
+		/** @type {boolean} */
 		this._localIdentNeedsHash =
 			isFn ||
 			(kinds !== undefined && (kinds.has("fullhash") || kinds.has("hash")));
+		/** @type {boolean} */
 		this._localIdentNeedsContentHash =
 			isFn || (kinds !== undefined && kinds.has("contenthash"));
 	}

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -60,6 +60,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements) {
 		super("css loading", 10);
 
+		/** @type {ReadOnlyRuntimeRequirements} */
 		this._runtimeRequirements = runtimeRequirements;
 	}
 

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1146,11 +1146,15 @@ class Node {
 	 * @param {LocConverter} locConverter shared loc converter
 	 */
 	constructor(type, start, end, locConverter) {
+		/** @type {number} */
 		this.type = type;
 		// Byte range as two inline fields rather than a `[start, end]` array —
 		// one fewer allocation per node and ~56 bytes lighter (×100k+ nodes).
+		/** @type {number} */
 		this.start = start;
+		/** @type {number} */
 		this.end = end;
+		/** @type {LocConverter} */
 		this._locConverter = locConverter;
 	}
 
@@ -1538,17 +1542,22 @@ class TokenStream {
 		locConverter = new LocConverter(input),
 		onComment = undefined
 	) {
+		/** @type {string} */
 		this.input = input;
+		/** @type {LocConverter} */
 		this.locConverter = locConverter;
 		this._onComment = onComment;
 		// Byte offset where the next token is tokenized from.
+		/** @type {number} */
 		this._pos = pos;
 		// Comments before this offset have already fired `onComment`; a
 		// re-tokenized (backtracked) span never re-fires them.
+		/** @type {number} */
 		this._commentHigh = pos;
 		// Single reused token the lexer writes into on the `next` path — see
 		// `MutableToken`. `_next` points at it when a token is cached, else
 		// `undefined` (re-tokenize on next read).
+		/** @type {MutableToken} */
 		this._tok = createToken();
 		/** @type {MutableToken | undefined} the next token, lazily tokenized */
 		this._next = undefined;

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -67,7 +67,9 @@ class Profiler {
 	constructor(inspector) {
 		/** @type {undefined | Session} */
 		this.session = undefined;
+		/** @type {Inspector} */
 		this.inspector = inspector;
+		/** @type {number} */
 		this._startTime = 0;
 	}
 

--- a/lib/dependencies/AMDDefineDependency.js
+++ b/lib/dependencies/AMDDefineDependency.js
@@ -121,6 +121,7 @@ class AMDDefineDependency extends NullDependency {
 		this.arrayRange = arrayRange;
 		this.functionRange = functionRange;
 		this.objectRange = objectRange;
+		/** @type {string | null} */
 		this.namedModule = namedModule;
 		/** @type {LocalModule | null} */
 		this.localModule = null;

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -83,6 +83,7 @@ class AMDDefineDependencyParserPlugin {
 	 * @param {JavascriptParserOptions} options parserOptions
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -40,6 +40,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 	 * @param {JavascriptParserOptions} options parserOptions
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -32,7 +32,9 @@ class AMDRequireDependency extends NullDependency {
 		this.arrayRange = arrayRange;
 		this.functionRange = functionRange;
 		this.errorCallbackRange = errorCallbackRange;
+		/** @type {boolean} */
 		this.functionBindThis = false;
+		/** @type {boolean} */
 		this.errorCallbackBindThis = false;
 	}
 

--- a/lib/dependencies/CachedConstDependency.js
+++ b/lib/dependencies/CachedConstDependency.js
@@ -35,9 +35,12 @@ class CachedConstDependency extends NullDependency {
 	) {
 		super();
 
+		/** @type {string} */
 		this.expression = expression;
 		this.range = range;
+		/** @type {string} */
 		this.identifier = identifier;
+		/** @type {number} */
 		this.place = place;
 		/** @type {undefined | string} */
 		this._hashUpdate = undefined;

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -61,14 +61,19 @@ class CommonJsExportRequireDependency extends ModuleDependency {
 		super(request);
 		this.range = range;
 		this.valueRange = valueRange;
+		/** @type {CommonJSDependencyBaseKeywords} */
 		this.base = base;
+		/** @type {string[]} */
 		this.names = names;
+		/** @type {string[]} */
 		this.ids = ids;
+		/** @type {boolean} */
 		this.resultUsed = resultUsed;
 		/** @type {undefined | boolean} */
 		this.asiSafe = undefined;
 		// true when the reexport is a lazy `{ get: () => require(...) }` accessor
 		// (as produced by `Object.defineProperty`) rather than an eager value.
+		/** @type {boolean} */
 		this.getter = false;
 	}
 

--- a/lib/dependencies/CommonJsExportsDependency.js
+++ b/lib/dependencies/CommonJsExportsDependency.js
@@ -36,7 +36,9 @@ class CommonJsExportsDependency extends NullDependency {
 		super();
 		this.range = range;
 		this.valueRange = valueRange;
+		/** @type {CommonJSDependencyBaseKeywords} */
 		this.base = base;
+		/** @type {string[]} */
 		this.names = names;
 	}
 

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -287,6 +287,7 @@ class CommonJsExportsParserPlugin {
 	 * @param {ModuleGraph} moduleGraph module graph
 	 */
 	constructor(moduleGraph) {
+		/** @type {ModuleGraph} */
 		this.moduleGraph = moduleGraph;
 	}
 

--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -45,7 +45,9 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 	) {
 		super(request);
 		this.range = range;
+		/** @type {string[]} */
 		this.names = names;
+		/** @type {IdRanges | undefined} */
 		this.idRanges = idRanges;
 		/** @type {boolean} */
 		this.call = false;

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -443,6 +443,7 @@ class CommonJsImportsParserPlugin {
 	 * @param {JavascriptParserOptions} options parser options
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/CommonJsRequireContextDependency.js
+++ b/lib/dependencies/CommonJsRequireContextDependency.js
@@ -34,6 +34,7 @@ class CommonJsRequireContextDependency extends ContextDependency {
 		this.range = range;
 		this.valueRange = valueRange;
 		// inShorthand must be serialized by subclasses that use it
+		/** @type {string | boolean | undefined} */
 		this.inShorthand = inShorthand;
 	}
 

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -48,7 +48,9 @@ class CommonJsRequireDependency extends ModuleDependency {
 	) {
 		super(request);
 		this.range = range;
+		/** @type {string | undefined} */
 		this._context = context;
+		/** @type {RawReferencedExports | null} */
 		this.referencedExports = referencedExports;
 		this.valueRange = valueRange;
 		/** @type {DependencyGuard[] | undefined} */

--- a/lib/dependencies/CommonJsSelfReferenceDependency.js
+++ b/lib/dependencies/CommonJsSelfReferenceDependency.js
@@ -34,8 +34,11 @@ class CommonJsSelfReferenceDependency extends NullDependency {
 	constructor(range, base, names, call) {
 		super();
 		this.range = range;
+		/** @type {CommonJSDependencyBaseKeywords} */
 		this.base = base;
+		/** @type {string[]} */
 		this.names = names;
+		/** @type {boolean} */
 		this.call = call;
 	}
 

--- a/lib/dependencies/ConstDependency.js
+++ b/lib/dependencies/ConstDependency.js
@@ -29,8 +29,10 @@ class ConstDependency extends NullDependency {
 	 */
 	constructor(expression, range, runtimeRequirements) {
 		super();
+		/** @type {string} */
 		this.expression = expression;
 		this.range = range;
+		/** @type {Set<string> | null} */
 		this.runtimeRequirements = runtimeRequirements
 			? new Set(runtimeRequirements)
 			: null;

--- a/lib/dependencies/ContextDependency.js
+++ b/lib/dependencies/ContextDependency.js
@@ -42,10 +42,13 @@ class ContextDependency extends Dependency {
 	constructor(options, context) {
 		super();
 
+		/** @type {ContextDependencyOptions} */
 		this.options = options;
+		/** @type {string} */
 		this.userRequest = this.options && this.options.request;
 		/** @type {false | undefined | string} */
 		this.critical = false;
+		/** @type {boolean} */
 		this.hadGlobalOrStickyRegExp = false;
 
 		if (
@@ -67,6 +70,7 @@ class ContextDependency extends Dependency {
 		this.inShorthand = undefined;
 		/** @type {Replaces | undefined} */
 		this.replaces = undefined;
+		/** @type {string | undefined} */
 		this._requestContext = context;
 	}
 

--- a/lib/dependencies/ContextElementDependency.js
+++ b/lib/dependencies/ContextElementDependency.js
@@ -42,13 +42,19 @@ class ContextElementDependency extends ModuleDependency {
 		super(request);
 
 		if (userRequest) {
+			/** @type {string} */
 			this.userRequest = userRequest;
 		}
 
+		/** @type {string | undefined} */
 		this._typePrefix = typePrefix;
+		/** @type {string} */
 		this._category = category;
+		/** @type {RawReferencedExports | null | undefined} */
 		this.referencedExports = referencedExports;
+		/** @type {string | undefined} */
 		this._context = context || undefined;
+		/** @type {ImportAttributes | undefined} */
 		this.attributes = attributes;
 	}
 

--- a/lib/dependencies/CreateRequireParserPlugin.js
+++ b/lib/dependencies/CreateRequireParserPlugin.js
@@ -50,6 +50,7 @@ class CreateRequireParserPlugin {
 	 * @param {JavascriptParserOptions} options parser options
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/CriticalDependencyWarning.js
+++ b/lib/dependencies/CriticalDependencyWarning.js
@@ -18,6 +18,7 @@ class CriticalDependencyWarning extends WebpackError {
 
 		/** @type {string} */
 		this.name = "CriticalDependencyWarning";
+		/** @type {string} */
 		this.message = `Critical dependency: ${message}`;
 	}
 }

--- a/lib/dependencies/CssIcssImportDependency.js
+++ b/lib/dependencies/CssIcssImportDependency.js
@@ -39,7 +39,9 @@ class CssIcssImportDependency extends CssImportDependency {
 	 */
 	constructor(request, range, mode, importName, localName) {
 		super(request, range, mode);
+		/** @type {string} */
 		this.importName = importName;
+		/** @type {string} */
 		this.localName = localName;
 		/** @type {undefined | string[]} */
 		this._importNameConventionNames = undefined;

--- a/lib/dependencies/CssIcssSymbolDependency.js
+++ b/lib/dependencies/CssIcssSymbolDependency.js
@@ -34,10 +34,14 @@ class CssIcssSymbolDependency extends NullDependency {
 	 */
 	constructor(localName, range, value, importName, request) {
 		super();
+		/** @type {string} */
 		this.localName = localName;
 		this.range = range;
+		/** @type {string | undefined} */
 		this.value = value;
+		/** @type {string | undefined} */
 		this.importName = importName;
+		/** @type {string | undefined} */
 		this.request = request;
 		/** @type {undefined | string} */
 		this._hashUpdate = undefined;

--- a/lib/dependencies/CssImportDependency.js
+++ b/lib/dependencies/CssImportDependency.js
@@ -43,10 +43,15 @@ class CssImportDependency extends ModuleDependency {
 		super(request);
 		this.range = range;
 		this.mode = mode;
+		/** @type {string | undefined} */
 		this.layer = layer;
+		/** @type {string | undefined} */
 		this.supports = supports;
+		/** @type {string | undefined} */
 		this.media = media;
+		/** @type {Inheritance | undefined} */
 		this.inheritance = inheritance;
+		/** @type {CssParserExportType | undefined} */
 		this.exportType = exportType;
 	}
 

--- a/lib/dependencies/DllEntryDependency.js
+++ b/lib/dependencies/DllEntryDependency.js
@@ -21,7 +21,9 @@ class DllEntryDependency extends Dependency {
 	constructor(dependencies, name) {
 		super();
 
+		/** @type {EntryDependency[]} */
 		this.dependencies = dependencies;
+		/** @type {string} */
 		this.name = name;
 	}
 

--- a/lib/dependencies/ExportsInfoDependency.js
+++ b/lib/dependencies/ExportsInfoDependency.js
@@ -99,7 +99,9 @@ class ExportsInfoDependency extends NullDependency {
 	constructor(range, exportName, property) {
 		super();
 		this.range = range;
+		/** @type {string[] | null} */
 		this.exportName = exportName;
+		/** @type {string | null} */
 		this.property = property;
 	}
 

--- a/lib/dependencies/ExternalModuleDependency.js
+++ b/lib/dependencies/ExternalModuleDependency.js
@@ -39,8 +39,11 @@ class ExternalModuleDependency extends CachedConstDependency {
 	) {
 		super(expression, range, identifier, place);
 
+		/** @type {string} */
 		this.importedModule = module;
+		/** @type {ArrayImportSpecifiers} */
 		this.specifiers = importSpecifiers;
+		/** @type {string | undefined} */
 		this.default = defaultImport;
 	}
 

--- a/lib/dependencies/ExternalModuleInitFragment.js
+++ b/lib/dependencies/ExternalModuleInitFragment.js
@@ -32,6 +32,7 @@ class ExternalModuleInitFragment extends InitFragment {
 			0,
 			`external module imports|${importedModule}|${defaultImport || "null"}`
 		);
+		/** @type {string} */
 		this.importedModule = importedModule;
 		if (Array.isArray(specifiers)) {
 			/** @type {ImportSpecifiers} */
@@ -48,6 +49,7 @@ class ExternalModuleInitFragment extends InitFragment {
 		} else {
 			this.specifiers = specifiers;
 		}
+		/** @type {string | undefined} */
 		this.defaultImport = defaultImport;
 	}
 

--- a/lib/dependencies/ExternalModuleInitFragmentDependency.js
+++ b/lib/dependencies/ExternalModuleInitFragmentDependency.js
@@ -27,8 +27,11 @@ class ExternalModuleInitFragmentDependency extends NullDependency {
 	 */
 	constructor(module, importSpecifiers, defaultImport) {
 		super();
+		/** @type {string} */
 		this.importedModule = module;
+		/** @type {ArrayImportSpecifiers} */
 		this.specifiers = importSpecifiers;
+		/** @type {string | undefined} */
 		this.default = defaultImport;
 	}
 

--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -32,7 +32,9 @@ class HarmonyAcceptDependency extends NullDependency {
 	constructor(range, dependencies, hasCallback) {
 		super();
 		this.range = range;
+		/** @type {HarmonyAcceptImportDependency[]} */
 		this.dependencies = dependencies;
+		/** @type {boolean} */
 		this.hasCallback = hasCallback;
 	}
 

--- a/lib/dependencies/HarmonyAcceptImportDependency.js
+++ b/lib/dependencies/HarmonyAcceptImportDependency.js
@@ -17,6 +17,7 @@ class HarmonyAcceptImportDependency extends HarmonyImportDependency {
 	 */
 	constructor(request) {
 		super(request, Infinity, ImportPhase.Evaluation);
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/HarmonyEvaluatedImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyEvaluatedImportSpecifierDependency.js
@@ -57,6 +57,7 @@ class HarmonyEvaluatedImportSpecifierDependency extends HarmonyImportSpecifierDe
 			attributes,
 			[]
 		);
+		/** @type {string} */
 		this.operator = operator;
 	}
 

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -43,6 +43,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 	 * @param {JavascriptParserOptions} options options
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 		this.exportPresenceMode = ExportPresenceModes.resolveFromOptions(
 			options.reexportExportsPresence,

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -45,9 +45,11 @@ class HarmonyExportExpressionDependency extends NullDependency {
 		super();
 		this.range = range;
 		this.rangeStatement = rangeStatement;
+		/** @type {string} */
 		this.prefix = prefix;
 		this.declarationId = declarationId;
 		this.constValue = constValue;
+		/** @type {boolean} */
 		this.isAnonymousDefault = false;
 	}
 

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -88,10 +88,15 @@ class NormalReexportItem {
 	 * @param {boolean} hidden true, if it is hidden behind another active export in the same module
 	 */
 	constructor(name, ids, exportInfo, checked, hidden) {
+		/** @type {string} */
 		this.name = name;
+		/** @type {Ids} */
 		this.ids = ids;
+		/** @type {ExportInfo} */
 		this.exportInfo = exportInfo;
+		/** @type {boolean} */
 		this.checked = checked;
+		/** @type {boolean} */
 		this.hidden = hidden;
 	}
 }
@@ -496,11 +501,16 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	) {
 		super(request, sourceOrder, phase, attributes);
 
+		/** @type {Ids} */
 		this.ids = ids;
+		/** @type {string | null} */
 		this.name = name;
+		/** @type {Set<string>} */
 		this.activeExports = activeExports;
 		this.otherStarExports = otherStarExports;
+		/** @type {ExportPresenceMode} */
 		this.exportPresenceMode = exportPresenceMode;
+		/** @type {HarmonyStarExportsList | null} */
 		this.allStarExports = allStarExports;
 	}
 

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -34,8 +34,11 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 	 */
 	constructor(id, name, constValue) {
 		super();
+		/** @type {string} */
 		this.id = id;
+		/** @type {string} */
 		this.name = name;
+		/** @type {InlinedValue | null | undefined} */
 		this.constValue = constValue;
 	}
 

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -104,8 +104,11 @@ class HarmonyImportDependency extends ModuleDependency {
 		attributes = undefined
 	) {
 		super(request, sourceOrder);
+		/** @type {ImportPhaseType} */
 		this.phase = phase;
+		/** @type {ImportAttributes | undefined} */
 		this.attributes = attributes;
+		/** @type {boolean} */
 		this._lazyMake = false;
 	}
 

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -148,12 +148,14 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 	 * @param {JavascriptParserOptions} options options
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 		/** @type {ExportPresenceMode} */
 		this.exportPresenceMode = ExportPresenceModes.resolveFromOptions(
 			options.importExportsPresence,
 			options
 		);
+		/** @type {boolean | undefined} */
 		this.strictThisContextOnImports = options.strictThisContextOnImports;
 	}
 

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -81,10 +81,14 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		idRanges // TODO webpack 6 make this non-optional. It must always be set to properly trim ids.
 	) {
 		super(request, sourceOrder, phase, attributes);
+		/** @type {Ids} */
 		this.ids = ids;
+		/** @type {string} */
 		this.name = name;
 		this.range = range;
+		/** @type {IdRanges | undefined} */
 		this.idRanges = idRanges;
+		/** @type {ExportPresenceMode} */
 		this.exportPresenceMode = exportPresenceMode;
 		/** @type {undefined | boolean} */
 		this.namespaceObjectAsContext = false;

--- a/lib/dependencies/HarmonyLinkingError.js
+++ b/lib/dependencies/HarmonyLinkingError.js
@@ -12,6 +12,7 @@ class HarmonyLinkingError extends WebpackError {
 		super(message);
 		/** @type {string} */
 		this.name = "HarmonyLinkingError";
+		/** @type {boolean} */
 		this.hideStack = true;
 	}
 }

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -44,6 +44,7 @@ class HarmonyModulesPlugin {
 	 * @param {HarmonyModulesPluginOptions} options options
 	 */
 	constructor(options) {
+		/** @type {HarmonyModulesPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -57,6 +57,7 @@ class HtmlEntryDependency extends ModuleDependency {
 	) {
 		super(request);
 		this.range = range;
+		/** @type {string} */
 		this.entryName = entryName;
 		/** @type {string} */
 		this._category = category || "commonjs";

--- a/lib/dependencies/HtmlInlineScriptDependency.js
+++ b/lib/dependencies/HtmlInlineScriptDependency.js
@@ -34,9 +34,11 @@ class HtmlInlineScriptDependency extends ModuleDependency {
 	 */
 	constructor(request, insertPos, contentRange, entryName, category) {
 		super(request);
+		/** @type {number} */
 		this.insertPos = insertPos;
 		this.contentRange = contentRange;
 		this.range = contentRange;
+		/** @type {string} */
 		this.entryName = entryName;
 		/** @type {string} */
 		this._category = category || "commonjs";

--- a/lib/dependencies/HtmlInlineStyleDependency.js
+++ b/lib/dependencies/HtmlInlineStyleDependency.js
@@ -54,7 +54,9 @@ class HtmlInlineStyleDependency extends ModuleDependency {
 	constructor(request, range, attribute = false, inAttribute = attribute) {
 		super(request);
 		this.range = range;
+		/** @type {boolean} */
 		this.attribute = attribute;
+		/** @type {boolean} */
 		this.inAttribute = inAttribute;
 	}
 

--- a/lib/dependencies/ImportDependency.js
+++ b/lib/dependencies/ImportDependency.js
@@ -42,8 +42,11 @@ class ImportDependency extends ModuleDependency {
 	constructor(request, range, referencedExports, phase, attributes) {
 		super(request);
 		this.range = range;
+		/** @type {RawReferencedExports | null} */
 		this.referencedExports = referencedExports;
+		/** @type {ImportPhaseType} */
 		this.phase = phase;
+		/** @type {ImportAttributes | undefined} */
 		this.attributes = attributes;
 		/** @type {DependencyGuard[] | undefined} */
 		this.branchGuards = undefined;

--- a/lib/dependencies/ImportMetaHotAcceptDependency.js
+++ b/lib/dependencies/ImportMetaHotAcceptDependency.js
@@ -20,6 +20,7 @@ class ImportMetaHotAcceptDependency extends ModuleDependency {
 	constructor(request, range) {
 		super(request);
 		this.range = range;
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/ImportMetaHotDeclineDependency.js
+++ b/lib/dependencies/ImportMetaHotDeclineDependency.js
@@ -21,6 +21,7 @@ class ImportMetaHotDeclineDependency extends ModuleDependency {
 		super(request);
 
 		this.range = range;
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -180,6 +180,7 @@ class ImportParserPlugin {
 	 * @param {JavascriptParserOptions} options options
 	 */
 	constructor(options) {
+		/** @type {JavascriptParserOptions} */
 		this.options = options;
 	}
 

--- a/lib/dependencies/ImportWeakDependency.js
+++ b/lib/dependencies/ImportWeakDependency.js
@@ -29,6 +29,7 @@ class ImportWeakDependency extends ImportDependency {
 	 */
 	constructor(request, range, referencedExports, phase, attributes) {
 		super(request, range, referencedExports, phase, attributes);
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -79,7 +79,9 @@ class JsonExportsDependency extends NullDependency {
 	 */
 	constructor(data, exportsDepth) {
 		super();
+		/** @type {JsonData} */
 		this.data = data;
+		/** @type {number} */
 		this.exportsDepth = exportsDepth;
 	}
 

--- a/lib/dependencies/LoaderImportDependency.js
+++ b/lib/dependencies/LoaderImportDependency.js
@@ -17,6 +17,7 @@ class LoaderImportDependency extends ModuleDependency {
 	 */
 	constructor(request) {
 		super(request);
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/LocalModule.js
+++ b/lib/dependencies/LocalModule.js
@@ -17,8 +17,11 @@ class LocalModule {
 	 * @param {number} idx index
 	 */
 	constructor(name, idx) {
+		/** @type {string} */
 		this.name = name;
+		/** @type {number} */
 		this.idx = idx;
+		/** @type {boolean} */
 		this.used = false;
 	}
 

--- a/lib/dependencies/LocalModuleDependency.js
+++ b/lib/dependencies/LocalModuleDependency.js
@@ -26,8 +26,10 @@ class LocalModuleDependency extends NullDependency {
 	constructor(localModule, range, callNew) {
 		super();
 
+		/** @type {LocalModule} */
 		this.localModule = localModule;
 		this.range = range;
+		/** @type {boolean} */
 		this.callNew = callNew;
 	}
 

--- a/lib/dependencies/ModuleDecoratorDependency.js
+++ b/lib/dependencies/ModuleDecoratorDependency.js
@@ -29,7 +29,9 @@ class ModuleDecoratorDependency extends NullDependency {
 	 */
 	constructor(decorator, allowExportsAccess) {
 		super();
+		/** @type {string} */
 		this.decorator = decorator;
+		/** @type {boolean} */
 		this.allowExportsAccess = allowExportsAccess;
 		/** @type {undefined | string} */
 		this._hashUpdate = undefined;

--- a/lib/dependencies/ModuleDependency.js
+++ b/lib/dependencies/ModuleDependency.js
@@ -23,8 +23,11 @@ class ModuleDependency extends Dependency {
 	 */
 	constructor(request, sourceOrder) {
 		super();
+		/** @type {string} */
 		this.request = request;
+		/** @type {string} */
 		this.userRequest = request;
+		/** @type {number | undefined} */
 		this.sourceOrder = sourceOrder;
 		/** @type {Range | undefined} */
 		this.range = undefined;

--- a/lib/dependencies/ModuleHotAcceptDependency.js
+++ b/lib/dependencies/ModuleHotAcceptDependency.js
@@ -20,6 +20,7 @@ class ModuleHotAcceptDependency extends ModuleDependency {
 	constructor(request, range) {
 		super(request, Infinity);
 		this.range = range;
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/ModuleHotDeclineDependency.js
+++ b/lib/dependencies/ModuleHotDeclineDependency.js
@@ -21,6 +21,7 @@ class ModuleHotDeclineDependency extends ModuleDependency {
 		super(request);
 
 		this.range = range;
+		/** @type {boolean} */
 		this.weak = true;
 	}
 

--- a/lib/dependencies/ModuleInitFragmentDependency.js
+++ b/lib/dependencies/ModuleInitFragmentDependency.js
@@ -26,8 +26,11 @@ class ModuleInitFragmentDependency extends NullDependency {
 	 */
 	constructor(initCode, runtimeRequirements, key) {
 		super();
+		/** @type {string} */
 		this.initCode = initCode;
+		/** @type {string[]} */
 		this.runtimeRequirements = runtimeRequirements;
+		/** @type {string | undefined} */
 		this.key = key;
 	}
 

--- a/lib/dependencies/ProvidedDependency.js
+++ b/lib/dependencies/ProvidedDependency.js
@@ -36,7 +36,9 @@ class ProvidedDependency extends ModuleDependency {
 	 */
 	constructor(request, identifier, ids, range) {
 		super(request);
+		/** @type {string} */
 		this.identifier = identifier;
+		/** @type {string[]} */
 		this.ids = ids;
 		this.range = range;
 		/** @type {undefined | string} */

--- a/lib/dependencies/RequireIncludeDependencyParserPlugin.js
+++ b/lib/dependencies/RequireIncludeDependencyParserPlugin.js
@@ -25,6 +25,7 @@ module.exports = class RequireIncludeDependencyParserPlugin {
 	 * @param {boolean} warn true: warn about deprecation, false: don't warn
 	 */
 	constructor(warn) {
+		/** @type {boolean} */
 		this.warn = warn;
 	}
 
@@ -90,8 +91,10 @@ class RequireIncludeDeprecationWarning extends WebpackError {
 	constructor(loc) {
 		super("require.include() is deprecated and will be removed soon.");
 
+		/** @type {string} */
 		this.name = "RequireIncludeDeprecationWarning";
 
+		/** @type {DependencyLocation} */
 		this.loc = loc;
 	}
 }

--- a/lib/dependencies/RequireResolveDependency.js
+++ b/lib/dependencies/RequireResolveDependency.js
@@ -26,6 +26,7 @@ class RequireResolveDependency extends ModuleDependency {
 		super(request);
 
 		this.range = range;
+		/** @type {string | undefined} */
 		this._context = context;
 	}
 

--- a/lib/dependencies/RuntimeRequirementsDependency.js
+++ b/lib/dependencies/RuntimeRequirementsDependency.js
@@ -24,6 +24,7 @@ class RuntimeRequirementsDependency extends NullDependency {
 	 */
 	constructor(runtimeRequirements) {
 		super();
+		/** @type {Set<string>} */
 		this.runtimeRequirements = new Set(runtimeRequirements);
 		/** @type {undefined | string} */
 		this._hashUpdate = undefined;

--- a/lib/dependencies/StaticExportsDependency.js
+++ b/lib/dependencies/StaticExportsDependency.js
@@ -23,7 +23,9 @@ class StaticExportsDependency extends NullDependency {
 	 */
 	constructor(exports, canMangle) {
 		super();
+		/** @type {Exports} */
 		this.exports = exports;
+		/** @type {boolean} */
 		this.canMangle = canMangle;
 	}
 

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -155,8 +155,10 @@ class SystemImportDeprecationWarning extends WebpackError {
 				"For more info visit https://webpack.js.org/guides/code-splitting/"
 		);
 
+		/** @type {string} */
 		this.name = "SystemImportDeprecationWarning";
 
+		/** @type {DependencyLocation} */
 		this.loc = loc;
 	}
 }

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -41,6 +41,7 @@ class URLDependency extends ModuleDependency {
 		super(request);
 		this.range = range;
 		this.outerRange = outerRange;
+		/** @type {boolean} */
 		this.relative = relative || false;
 		/** @type {UsedByExports | undefined} */
 		this.usedByExports = undefined;

--- a/lib/dependencies/UnsupportedDependency.js
+++ b/lib/dependencies/UnsupportedDependency.js
@@ -24,6 +24,7 @@ class UnsupportedDependency extends NullDependency {
 	constructor(request, range) {
 		super();
 
+		/** @type {string} */
 		this.request = request;
 		this.range = range;
 	}

--- a/lib/dependencies/WebpackIsIncludedDependency.js
+++ b/lib/dependencies/WebpackIsIncludedDependency.js
@@ -26,6 +26,7 @@ class WebpackIsIncludedDependency extends ModuleDependency {
 	constructor(request, range) {
 		super(request);
 
+		/** @type {boolean} */
 		this.weak = true;
 		this.range = range;
 	}

--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -77,9 +77,13 @@ class WorkerPlugin {
 	 * @param {WorkerPublicPath=} workerPublicPath worker public path
 	 */
 	constructor(chunkLoading, wasmLoading, module, workerPublicPath) {
+		/** @type {ChunkLoading | undefined} */
 		this._chunkLoading = chunkLoading;
+		/** @type {WasmLoading | undefined} */
 		this._wasmLoading = wasmLoading;
+		/** @type {boolean | undefined} */
 		this._module = module;
+		/** @type {string | undefined} */
 		this._workerPublicPath = workerPublicPath;
 	}
 

--- a/lib/dll/DelegatedModule.js
+++ b/lib/dll/DelegatedModule.js
@@ -72,11 +72,17 @@ class DelegatedModule extends Module {
 		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
 
 		// Info from Factory
+		/** @type {string} */
 		this.sourceRequest = sourceRequest;
+		/** @type {ModuleId} */
 		this.request = data.id;
+		/** @type {DelegatedModuleType} */
 		this.delegationType = type;
+		/** @type {string} */
 		this.userRequest = userRequest;
+		/** @type {string | Module} */
 		this.originalRequest = originalRequest;
+		/** @type {DelegatedModuleData} */
 		this.delegateData = data;
 
 		// Build info

--- a/lib/dll/DelegatedModuleFactoryPlugin.js
+++ b/lib/dll/DelegatedModuleFactoryPlugin.js
@@ -35,6 +35,7 @@ class DelegatedModuleFactoryPlugin {
 	 * @param {Options} options options
 	 */
 	constructor(options) {
+		/** @type {Options} */
 		this.options = options;
 		options.type = options.type || "require";
 		options.extensions = options.extensions || ["", ".js", ".json", ".wasm"];

--- a/lib/dll/DelegatedPlugin.js
+++ b/lib/dll/DelegatedPlugin.js
@@ -19,6 +19,7 @@ class DelegatedPlugin {
 	 * @param {Options} options options
 	 */
 	constructor(options) {
+		/** @type {Options} */
 		this.options = options;
 	}
 

--- a/lib/dll/DllEntryPlugin.js
+++ b/lib/dll/DllEntryPlugin.js
@@ -25,8 +25,11 @@ class DllEntryPlugin {
 	 * @param {Options} options options
 	 */
 	constructor(context, entries, options) {
+		/** @type {string} */
 		this.context = context;
+		/** @type {Entries} */
 		this.entries = entries;
+		/** @type {Options} */
 		this.options = options;
 	}
 

--- a/lib/dll/DllModule.js
+++ b/lib/dll/DllModule.js
@@ -51,6 +51,7 @@ class DllModule extends Module {
 		// Info from Factory
 		/** @type {Dependency[]} */
 		this.dependencies = dependencies;
+		/** @type {string} */
 		this.name = name;
 	}
 

--- a/lib/dll/DllReferencePlugin.js
+++ b/lib/dll/DllReferencePlugin.js
@@ -30,6 +30,7 @@ class DllReferencePlugin {
 	 * @param {DllReferencePluginOptions} options options object
 	 */
 	constructor(options) {
+		/** @type {DllReferencePluginOptions} */
 		this.options = options;
 	}
 
@@ -188,7 +189,9 @@ class DllManifestError extends WebpackError {
 	constructor(filename, message) {
 		super();
 
+		/** @type {string} */
 		this.name = "DllManifestError";
+		/** @type {string} */
 		this.message = `Dll manifest ${filename}\n${message}`;
 	}
 }

--- a/lib/dll/LibManifestPlugin.js
+++ b/lib/dll/LibManifestPlugin.js
@@ -44,6 +44,7 @@ class LibManifestPlugin {
 	 * @param {LibManifestPluginOptions} options the options
 	 */
 	constructor(options) {
+		/** @type {LibManifestPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/errors/ConcurrentCompilationError.js
+++ b/lib/errors/ConcurrentCompilationError.js
@@ -13,6 +13,7 @@ class ConcurrentCompilationError extends WebpackError {
 			"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
 		);
 
+		/** @type {string} */
 		this.name = "ConcurrentCompilationError";
 	}
 }

--- a/lib/errors/HookWebpackError.js
+++ b/lib/errors/HookWebpackError.js
@@ -29,12 +29,16 @@ class HookWebpackError extends WebpackError {
 	constructor(error, hook) {
 		super(error ? error.message : undefined, error ? { cause: error } : {});
 
+		/** @type {string} */
 		this.hook = hook;
+		/** @type {Error} */
 		this.error = error;
 		/** @type {string} */
 		this.name = "HookWebpackError";
+		/** @type {boolean} */
 		this.hideStack = true;
 		this.stack += `\n-- inner error --\n${error ? error.stack : ""}`;
+		/** @type {string} */
 		this.details = `caused by plugins in ${hook}\n${error ? error.stack : ""}`;
 	}
 

--- a/lib/errors/IgnoreErrorModuleFactory.js
+++ b/lib/errors/IgnoreErrorModuleFactory.js
@@ -22,6 +22,7 @@ class IgnoreErrorModuleFactory extends ModuleFactory {
 	constructor(normalModuleFactory) {
 		super();
 
+		/** @type {NormalModuleFactory} */
 		this.normalModuleFactory = normalModuleFactory;
 	}
 

--- a/lib/errors/InvalidDependenciesModuleWarning.js
+++ b/lib/errors/InvalidDependenciesModuleWarning.js
@@ -32,7 +32,9 @@ ${depsList.slice(0, 3).join("\n")}${
 
 		/** @type {string} */
 		this.name = "InvalidDependenciesModuleWarning";
+		/** @type {string} */
 		this.details = depsList.slice(3).join("\n");
+		/** @type {Module} */
 		this.module = module;
 	}
 }

--- a/lib/errors/ModuleBuildError.js
+++ b/lib/errors/ModuleBuildError.js
@@ -59,7 +59,9 @@ class ModuleBuildError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleBuildError";
+		/** @type {string | undefined} */
 		this.details = details;
+		/** @type {string | ErrorWithHideStack} */
 		this.error = err;
 	}
 

--- a/lib/errors/ModuleDependencyError.js
+++ b/lib/errors/ModuleDependencyError.js
@@ -23,16 +23,23 @@ class ModuleDependencyError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleDependencyError";
+		/** @type {string | undefined} */
 		this.details =
 			err && !err.hideStack
 				? /** @type {string} */ (err.stack).split("\n").slice(1).join("\n")
 				: undefined;
+		/** @type {Module} */
 		this.module = module;
+		/** @type {DependencyLocation} */
 		this.loc = loc;
-		/** error is not (de)serialized, so it might be undefined after deserialization */
+		/**
+		 * error is not (de)serialized, so it might be undefined after deserialization
+		 * @type {ErrorWithHideStack}
+		 */
 		this.error = err;
 
 		if (err && err.hideStack && err.stack) {
+			/** @type {string | undefined} */
 			this.stack = /** @type {string} */ `${err.stack
 				.split("\n")
 				.slice(1)

--- a/lib/errors/ModuleDependencyWarning.js
+++ b/lib/errors/ModuleDependencyWarning.js
@@ -24,16 +24,23 @@ class ModuleDependencyWarning extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleDependencyWarning";
+		/** @type {string | undefined} */
 		this.details =
 			err && !err.hideStack
 				? /** @type {string} */ (err.stack).split("\n").slice(1).join("\n")
 				: undefined;
+		/** @type {Module} */
 		this.module = module;
+		/** @type {DependencyLocation} */
 		this.loc = loc;
-		/** error is not (de)serialized, so it might be undefined after deserialization */
+		/**
+		 * error is not (de)serialized, so it might be undefined after deserialization
+		 * @type {ErrorWithHideStack}
+		 */
 		this.error = err;
 
 		if (err && err.hideStack && err.stack) {
+			/** @type {string | undefined} */
 			this.stack = /** @type {string} */ `${err.stack
 				.split("\n")
 				.slice(1)

--- a/lib/errors/ModuleHashingError.js
+++ b/lib/errors/ModuleHashingError.js
@@ -20,9 +20,13 @@ class ModuleHashingError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleHashingError";
+		/** @type {Error} */
 		this.error = error;
+		/** @type {string} */
 		this.message = error.message;
+		/** @type {string | undefined} */
 		this.details = error.stack;
+		/** @type {Module} */
 		this.module = module;
 	}
 }

--- a/lib/errors/ModuleNotFoundError.js
+++ b/lib/errors/ModuleNotFoundError.js
@@ -81,9 +81,12 @@ class ModuleNotFoundError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleNotFoundError";
+		/** @type {string | undefined} */
 		this.details = err.details;
+		/** @type {Module | null} */
 		this.module = module;
 		this.error = err;
+		/** @type {DependencyLocation} */
 		this.loc = loc;
 	}
 }

--- a/lib/errors/ModuleRestoreError.js
+++ b/lib/errors/ModuleRestoreError.js
@@ -38,7 +38,9 @@ class ModuleRestoreError extends WebpackError {
 		this.name = "ModuleRestoreError";
 		/** @type {string | undefined} */
 		this.details = details;
+		/** @type {Module} */
 		this.module = module;
+		/** @type {string | Error} */
 		this.error = err;
 	}
 }

--- a/lib/errors/ModuleStoreError.js
+++ b/lib/errors/ModuleStoreError.js
@@ -36,8 +36,11 @@ class ModuleStoreError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleStoreError";
+		/** @type {string | undefined} */
 		this.details = /** @type {string | undefined} */ (details);
+		/** @type {Module} */
 		this.module = module;
+		/** @type {string | Error} */
 		this.error = err;
 	}
 }

--- a/lib/errors/ModuleWarning.js
+++ b/lib/errors/ModuleWarning.js
@@ -33,7 +33,9 @@ class ModuleWarning extends WebpackError {
 
 		/** @type {string} */
 		this.name = "ModuleWarning";
+		/** @type {Error} */
 		this.warning = warning;
+		/** @type {string | undefined} */
 		this.details =
 			warning && typeof warning === "object" && warning.stack
 				? cleanUp(warning.stack, this.message)

--- a/lib/errors/NodeStuffInWebError.js
+++ b/lib/errors/NodeStuffInWebError.js
@@ -27,6 +27,7 @@ ${description}`
 
 		/** @type {string} */
 		this.name = "NodeStuffInWebError";
+		/** @type {DependencyLocation} */
 		this.loc = loc;
 	}
 }

--- a/lib/errors/NonErrorEmittedError.js
+++ b/lib/errors/NonErrorEmittedError.js
@@ -15,7 +15,9 @@ class NonErrorEmittedError extends WebpackError {
 	constructor(error) {
 		super();
 
+		/** @type {string} */
 		this.name = "NonErrorEmittedError";
+		/** @type {string} */
 		this.message = `(Emitted value instead of an instance of Error) ${error}`;
 	}
 }

--- a/lib/errors/UnhandledSchemeError.js
+++ b/lib/errors/UnhandledSchemeError.js
@@ -25,6 +25,7 @@ class UnhandledSchemeError extends WebpackError {
 				'\nWebpack supports "data:" and "file:" URIs by default.' +
 				`\nYou may need an additional plugin to handle "${scheme}:" URIs.`
 		);
+		/** @type {string} */
 		this.file = resource;
 		/** @type {string} */
 		this.name = "UnhandledSchemeError";

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -180,6 +180,7 @@ class LazyCompilationDependency extends Dependency {
 	 */
 	constructor(proxyModule) {
 		super();
+		/** @type {LazyCompilationProxyModule} */
 		this.proxyModule = proxyModule;
 	}
 
@@ -229,10 +230,15 @@ class LazyCompilationProxyModule extends Module {
 		// Redeclared with the lazy compilation proxy specific shape
 		/** @type {LazyCompilationProxyModuleBuildInfo | undefined} */
 		this.buildInfo = undefined;
+		/** @type {Module} */
 		this.originalModule = originalModule;
+		/** @type {string} */
 		this.request = request;
+		/** @type {string} */
 		this.client = client;
+		/** @type {string} */
 		this.data = data;
+		/** @type {boolean} */
 		this.active = active;
 	}
 
@@ -506,9 +512,13 @@ class LazyCompilationPlugin {
 	 * @param {Options} options options
 	 */
 	constructor({ backend, entries, imports, test }) {
+		/** @type {BackEnd} */
 		this.backend = backend;
+		/** @type {boolean | undefined} */
 		this.entries = entries;
+		/** @type {boolean | undefined} */
 		this.imports = imports;
+		/** @type {string | RegExp | TestFn | undefined} */
 		this.test = test;
 	}
 

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -127,6 +127,7 @@ class HtmlGenerator extends Generator {
 	 */
 	constructor(options, moduleGraph) {
 		super();
+		/** @type {HtmlGeneratorOptions} */
 		this.options = options || {};
 		/** @type {ModuleGraph | undefined} */
 		this._moduleGraph = moduleGraph;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -728,6 +728,7 @@ class HtmlParser extends Parser {
 		this.template = options.template;
 		// One source model: a per-tag table that also holds the any-tag sources
 		// under `ANY_TAG`. The common cases reference precomputed tables.
+		/** @type {Record<string, Record<string, SourceItem>>} */
 		this.sourcesByTag = DEFAULT_SOURCES_FOLDED;
 
 		const sources = options.sources;
@@ -773,6 +774,7 @@ class HtmlParser extends Parser {
 				}
 			}
 		}
+		/** @type {Record<string, Record<string, SourceItem>>} */
 		this.sourcesByTag = foldAnySources(byTag, any);
 	}
 

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -33,6 +33,7 @@ const TypeBigInt = 13;
 
 class BasicEvaluatedExpression {
 	constructor() {
+		/** @type {number} */
 		this.type = TypeUnknown;
 		/** @type {Range | undefined} */
 		this.range = undefined;

--- a/lib/javascript/EnableChunkLoadingPlugin.js
+++ b/lib/javascript/EnableChunkLoadingPlugin.js
@@ -34,6 +34,7 @@ class EnableChunkLoadingPlugin {
 	 * @param {ChunkLoadingType} type library type that should be available
 	 */
 	constructor(type) {
+		/** @type {string} */
 		this.type = type;
 	}
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -319,9 +319,13 @@ class VariableInfo {
 	 * @param {TagInfo | undefined} tagInfo info about tags
 	 */
 	constructor(declaredScope, name, flags, tagInfo) {
+		/** @type {ScopeInfo} */
 		this.declaredScope = declaredScope;
+		/** @type {string | undefined} */
 		this.name = name;
+		/** @type {VariableInfoFlagsType} */
 		this.flags = flags;
+		/** @type {TagInfo | undefined} */
 		this.tagInfo = tagInfo;
 	}
 

--- a/lib/library/FalseIIFEUmdWarning.js
+++ b/lib/library/FalseIIFEUmdWarning.js
@@ -12,6 +12,7 @@ class FalseIIFEUmdWarning extends WebpackError {
 		super();
 		/** @type {string} */
 		this.name = "FalseIIFEUmdWarning";
+		/** @type {string} */
 		this.message =
 			"Configuration:\nSetting 'output.iife' to 'false' is incompatible with 'output.library.type' set to 'umd'. This configuration may cause unexpected behavior, as UMD libraries are expected to use an IIFE (Immediately Invoked Function Expression) to support various module formats. Consider setting 'output.iife' to 'true' or choosing a different 'library.type' to ensure compatibility.\nLearn more: https://webpack.js.org/configuration/output/";
 	}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -899,6 +899,7 @@ class ConcatenatedModule extends Module {
 		this.rootModule = rootModule;
 		/** @type {Set<Module>} */
 		this._modules = modules;
+		/** @type {RuntimeSpec} */
 		this._runtime = runtime;
 		this.factoryMeta = rootModule && rootModule.factoryMeta;
 		/** @type {Compilation} */

--- a/lib/optimize/ConstExportsPlugin.js
+++ b/lib/optimize/ConstExportsPlugin.js
@@ -37,6 +37,7 @@ class ConstExportsPlugin {
 	 * @param {ConstValueParserPluginOptions} options plugin options
 	 */
 	constructor(options) {
+		/** @type {ConstValueParserPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -24,7 +24,9 @@ class InlinedValue {
 	 * @param {null | undefined | boolean | number | string} value raw value
 	 */
 	constructor(kind, value) {
+		/** @type {InlinedValueKind} */
 		this.kind = kind;
+		/** @type {string | number | boolean | null | undefined} */
 		this.value = value;
 	}
 
@@ -83,7 +85,9 @@ class InlinedUsedName {
 	 * @param {string[]=} suffix nested property access after the literal
 	 */
 	constructor(value, suffix) {
+		/** @type {InlinedValue} */
 		this.value = value;
+		/** @type {string[]} */
 		this.suffix = suffix || [];
 	}
 

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -161,14 +161,20 @@ class ReadState {
 	 * @param {BinaryMiddleware} middleware binary middleware
 	 */
 	constructor(data, context, middleware) {
+		/** @type {SerializedType} */
 		this.data = data;
+		/** @type {Context} */
 		this.context = context;
+		/** @type {BinaryMiddleware} */
 		this.middleware = middleware;
 		this.retainedBuffer = context.retainedBuffer || ((x) => x);
+		/** @type {number} */
 		this.currentDataItem = 0;
 		/** @type {BufferSerializableType | null} */
 		this.currentBuffer = data[0];
+		/** @type {boolean} */
 		this.currentIsBuffer = Buffer.isBuffer(this.currentBuffer);
+		/** @type {number} */
 		this.currentPosition = 0;
 		/** @type {DeserializedType} */
 		this.result = [];

--- a/lib/serialization/Serializer.js
+++ b/lib/serialization/Serializer.js
@@ -25,6 +25,7 @@ class Serializer {
 	constructor(middlewares, context) {
 		this.serializeMiddlewares = [...middlewares];
 		this.deserializeMiddlewares = [...middlewares].reverse();
+		/** @type {Context | undefined} */
 		this.context = context;
 	}
 

--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -68,6 +68,7 @@ class ConsumeSharedModule extends Module {
 	 */
 	constructor(context, options) {
 		super(WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE, context);
+		/** @type {ConsumeOptions} */
 		this.options = options;
 	}
 

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -41,6 +41,7 @@ class ConsumeSharedPlugin {
 	 * @param {ConsumeSharedPluginOptions} options options
 	 */
 	constructor(options) {
+		/** @type {ConsumeSharedPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -32,6 +32,7 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 	 */
 	constructor(runtimeRequirements) {
 		super("consumes", RuntimeModule.STAGE_ATTACH);
+		/** @type {ReadOnlyRuntimeRequirements} */
 		this._runtimeRequirements = runtimeRequirements;
 	}
 

--- a/lib/sharing/ProvideSharedDependency.js
+++ b/lib/sharing/ProvideSharedDependency.js
@@ -22,10 +22,15 @@ class ProvideSharedDependency extends Dependency {
 	 */
 	constructor(shareScope, name, version, request, eager) {
 		super();
+		/** @type {string} */
 		this.shareScope = shareScope;
+		/** @type {string} */
 		this.name = name;
+		/** @type {string | false} */
 		this.version = version;
+		/** @type {string} */
 		this.request = request;
+		/** @type {boolean} */
 		this.eager = eager;
 	}
 

--- a/lib/sharing/ProvideSharedModule.js
+++ b/lib/sharing/ProvideSharedModule.js
@@ -42,10 +42,15 @@ class ProvideSharedModule extends Module {
 	 */
 	constructor(shareScope, name, version, request, eager) {
 		super(WEBPACK_MODULE_TYPE_PROVIDE);
+		/** @type {string} */
 		this._shareScope = shareScope;
+		/** @type {string} */
 		this._name = name;
+		/** @type {string | false} */
 		this._version = version;
+		/** @type {string} */
 		this._request = request;
+		/** @type {boolean} */
 		this._eager = eager;
 	}
 

--- a/lib/sharing/ProvideSharedPlugin.js
+++ b/lib/sharing/ProvideSharedPlugin.js
@@ -36,6 +36,7 @@ class ProvideSharedPlugin {
 	 * @param {ProvideSharedPluginOptions} options options
 	 */
 	constructor(options) {
+		/** @type {ProvideSharedPluginOptions} */
 		this.options = options;
 	}
 

--- a/lib/sharing/SharePlugin.js
+++ b/lib/sharing/SharePlugin.js
@@ -67,8 +67,11 @@ class SharePlugin {
 					eager: options.eager
 				}
 			}));
+		/** @type {string | undefined} */
 		this._shareScope = options.shareScope;
+		/** @type {Record<string, ConsumesConfig>[]} */
 		this._consumes = consumes;
+		/** @type {Record<string, ProvidesConfig>[]} */
 		this._provides = provides;
 	}
 

--- a/lib/stats/StatsFactory.js
+++ b/lib/stats/StatsFactory.js
@@ -135,6 +135,7 @@ class StatsFactory {
 		for (const key of Object.keys(hooks)) {
 			this._caches[/** @type {keyof StatsFactoryHooks} */ (key)] = new Map();
 		}
+		/** @type {boolean} */
 		this._inCreate = false;
 	}
 

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -115,6 +115,7 @@ class StatsPrinter {
 		});
 		/** @type {Map<StatsPrintHooks[keyof StatsPrintHooks], Map<string, HookMapHook<StatsPrintHooks[keyof StatsPrintHooks]>[]>>} */
 		this._levelHookCache = new Map();
+		/** @type {boolean} */
 		this._inPrint = false;
 	}
 

--- a/lib/util/AsyncQueue.js
+++ b/lib/util/AsyncQueue.js
@@ -38,6 +38,7 @@ class AsyncQueueEntry {
 	 * @param {Callback<R>} callback the callback
 	 */
 	constructor(item, callback) {
+		/** @type {T} */
 		this.item = item;
 		/** @type {typeof QUEUED_STATE | typeof PROCESSING_STATE | typeof DONE_STATE} */
 		this.state = QUEUED_STATE;
@@ -82,10 +83,15 @@ class AsyncQueue {
 	 * @param {Processor<T, R>} options.processor async function to process items
 	 */
 	constructor({ name, context, parallelism, parent, processor, getKey }) {
+		/** @type {string | undefined} */
 		this._name = name;
+		/** @type {string} */
 		this._context = context || "normal";
+		/** @type {number} */
 		this._parallelism = parallelism || 1;
+		/** @type {Processor<T, R>} */
 		this._processor = processor;
+		/** @type {getKey<T, K>} */
 		this._getKey =
 			getKey ||
 			/** @type {getKey<T, K>} */ ((item) => /** @type {T & K} */ (item));
@@ -95,9 +101,13 @@ class AsyncQueue {
 		this._queued = new ArrayQueue();
 		/** @type {AsyncQueue<T, K, R>[] | undefined} */
 		this._children = undefined;
+		/** @type {number} */
 		this._activeTasks = 0;
+		/** @type {boolean} */
 		this._willEnsureProcessing = false;
+		/** @type {boolean} */
 		this._needProcessing = false;
+		/** @type {boolean} */
 		this._stopped = false;
 		/** @type {AsyncQueue<T, K, R>} */
 		this._root = parent ? parent._root : this;

--- a/lib/util/LazyBucketSortedSet.js
+++ b/lib/util/LazyBucketSortedSet.js
@@ -57,14 +57,19 @@ class LazyBucketSortedSet {
 	 * @param {...Arg<T, K>} args more pairs of getKey and comparator plus optional final comparator for the last layer
 	 */
 	constructor(getKey, comparator, ...args) {
+		/** @type {GetKey<T, K>} */
 		this._getKey = getKey;
+		/** @type {Arg<T, K>[]} */
 		this._innerArgs = args;
+		/** @type {boolean} */
 		this._leaf = args.length <= 1;
+		/** @type {SortableSet<K>} */
 		this._keys = new SortableSet(undefined, comparator);
 		/** @type {Map<K, Entry<T, K>>} */
 		this._map = new Map();
 		/** @type {Set<T>} */
 		this._unsortedItems = new Set();
+		/** @type {number} */
 		this.size = 0;
 	}
 

--- a/lib/util/LazySet.js
+++ b/lib/util/LazySet.js
@@ -67,7 +67,9 @@ class LazySet {
 		this._toMerge = new Set();
 		/** @type {LazySet<T>[]} */
 		this._toDeepMerge = [];
+		/** @type {boolean} */
 		this._needMerge = false;
+		/** @type {boolean} */
 		this._deopt = false;
 	}
 

--- a/lib/util/LocConverter.js
+++ b/lib/util/LocConverter.js
@@ -11,9 +11,13 @@ class LocConverter {
 	 * @param {string} input input
 	 */
 	constructor(input) {
+		/** @type {string} */
 		this._input = input;
+		/** @type {number} */
 		this.line = 1;
+		/** @type {number} */
 		this.column = 0;
+		/** @type {number} */
 		this.pos = 0;
 	}
 

--- a/lib/util/Semaphore.js
+++ b/lib/util/Semaphore.js
@@ -17,6 +17,7 @@ class Semaphore {
 	 * in the Semaphore
 	 */
 	constructor(available) {
+		/** @type {number} */
 		this.available = available;
 		/** @type {(() => void)[]} */
 		this.waiters = [];

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -55,6 +55,7 @@ class SourceProcessor {
 	 * @param {Grammar<TNode, TProcessOptions>} grammar the grammar to drive over the source
 	 */
 	constructor(grammar) {
+		/** @type {Grammar<TNode, TProcessOptions>} */
 		this._grammar = grammar;
 		/** @type {CompiledVisitorMap<TNode>} */
 		this._visitors = [];

--- a/lib/util/TupleSet.js
+++ b/lib/util/TupleSet.js
@@ -27,6 +27,7 @@ class TupleSet {
 	constructor(init) {
 		/** @type {InnerMap<T, V>} */
 		this._map = new Map();
+		/** @type {number} */
 		this.size = 0;
 		if (init) {
 			for (const tuple of init) {

--- a/lib/util/WeakTupleMap.js
+++ b/lib/util/WeakTupleMap.js
@@ -45,7 +45,10 @@ class WeakTupleMap {
 	 * Initializes an empty tuple trie node with optional value and child maps.
 	 */
 	constructor() {
-		/** @private */
+		/**
+		 * @private
+		 * @type {number}
+		 */
 		this.f = 0;
 		/**
 		 * @private

--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -207,8 +207,11 @@ class Node {
 	 * @param {Sizes} size size
 	 */
 	constructor(item, key, size) {
+		/** @type {T} */
 		this.item = item;
+		/** @type {string} */
 		this.key = key;
+		/** @type {Sizes} */
 		this.size = size;
 	}
 }
@@ -227,8 +230,11 @@ class Group {
 	 * @param {Sizes=} size size of the group
 	 */
 	constructor(nodes, similarities, size) {
+		/** @type {Node<T>[]} */
 		this.nodes = nodes;
+		/** @type {Similarities | null} */
 		this.similarities = similarities;
+		/** @type {Sizes} */
 		this.size = size || sumSize(nodes);
 		/** @type {string | undefined} */
 		this.key = undefined;

--- a/lib/util/findGraphRoots.js
+++ b/lib/util/findGraphRoots.js
@@ -26,6 +26,7 @@ class Node {
 	 * @param {T} item the value of the node
 	 */
 	constructor(item) {
+		/** @type {T} */
 		this.item = item;
 		/** @type {Nodes<T>} */
 		this.dependencies = new Set();
@@ -46,6 +47,7 @@ class SCC {
 	constructor() {
 		/** @type {Nodes<T>} */
 		this.nodes = new Set();
+		/** @type {number} */
 		this.marker = NO_MARKER;
 	}
 }

--- a/lib/util/hash/DebugHash.js
+++ b/lib/util/hash/DebugHash.js
@@ -13,6 +13,7 @@ const Hash = require("../Hash");
 class DebugHash extends Hash {
 	constructor() {
 		super();
+		/** @type {string} */
 		this.string = "";
 	}
 

--- a/lib/util/makeSerializable.js
+++ b/lib/util/makeSerializable.js
@@ -27,6 +27,7 @@ class ClassSerializer {
 	 * @param {SerializableClassConstructor<T>} Constructor constructor
 	 */
 	constructor(Constructor) {
+		/** @type {SerializableClassConstructor<T>} */
 		this.Constructor = Constructor;
 	}
 

--- a/lib/wasm-async/AsyncWasmModule.js
+++ b/lib/wasm-async/AsyncWasmModule.js
@@ -22,6 +22,7 @@ class AsyncWasmModule extends NormalModule {
 	 */
 	constructor(options) {
 		super(options);
+		/** @type {ImportPhaseName | undefined} */
 		this.phase = options.phase;
 	}
 

--- a/lib/wasm-sync/UnsupportedWebAssemblyFeatureError.js
+++ b/lib/wasm-sync/UnsupportedWebAssemblyFeatureError.js
@@ -16,6 +16,7 @@ class UnsupportedWebAssemblyFeatureError extends WebpackError {
 
 		/** @type {string} */
 		this.name = "UnsupportedWebAssemblyFeatureError";
+		/** @type {boolean} */
 		this.hideStack = true;
 	}
 }

--- a/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
+++ b/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
@@ -239,8 +239,11 @@ class WasmChunkLoadingRuntimeModule extends RuntimeModule {
 	}) {
 		super("wasm chunk loading", RuntimeModule.STAGE_ATTACH);
 		this.generateLoadBinaryCode = generateLoadBinaryCode;
+		/** @type {boolean | undefined} */
 		this.supportsStreaming = supportsStreaming;
+		/** @type {boolean | undefined} */
 		this.mangleImports = mangleImports;
+		/** @type {ReadOnlyRuntimeRequirements} */
 		this._runtimeRequirements = runtimeRequirements;
 	}
 

--- a/lib/wasm-sync/WebAssemblyGenerator.js
+++ b/lib/wasm-sync/WebAssemblyGenerator.js
@@ -426,6 +426,7 @@ class WebAssemblyGenerator extends Generator {
 	 */
 	constructor(options) {
 		super();
+		/** @type {WebAssemblyGeneratorOptions} */
 		this.options = options;
 	}
 

--- a/lib/wasm-sync/WebAssemblyInInitialChunkError.js
+++ b/lib/wasm-sync/WebAssemblyInInitialChunkError.js
@@ -107,7 +107,9 @@ ${moduleChains.map((s) => `* ${s}`).join("\n")}`;
 
 		/** @type {string} */
 		this.name = "WebAssemblyInInitialChunkError";
+		/** @type {boolean} */
 		this.hideStack = true;
+		/** @type {Module} */
 		this.module = module;
 	}
 }

--- a/lib/wasm-sync/WebAssemblyModulesPlugin.js
+++ b/lib/wasm-sync/WebAssemblyModulesPlugin.js
@@ -48,6 +48,7 @@ class WebAssemblyModulesPlugin {
 	 * @param {WebAssemblyModulesPluginOptions} options options
 	 */
 	constructor(options) {
+		/** @type {WebAssemblyModulesPluginOptions} */
 		this.options = options;
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Raises JSDoc type coverage from 97.94% to 98.19% (4,152 → 3,655 uncovered identifiers) by adding explicit `@type` annotations to class field assignments in `lib/`. At the first `this.x = …` assignment site TypeScript widens the property to `any` due to circular inference, so these identifiers counted as uncovered even though the field's resolved type is concrete; annotating them with their already-inferred type closes the gap. The remaining uncovered identifiers are dominated by intentional `EXPECTED_ANY` and irreducibly dynamic code (serialization contexts, CLI config traversal), so they are intentionally left untouched.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No — this is a type-only JSDoc change with no runtime behavior change. The generated `types.d.ts` is byte-for-byte unchanged and `yarn tsc` introduces no new errors, so existing type tests already cover it.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. Claude Code (Anthropic) analyzed the `yarn types:cover` report, identified the constructor/field first-assignment `any` pattern as the dominant safe gap, generated the `@type` annotations from each field's already-inferred type, and verified every batch with `yarn tsc`, `yarn fix:special` (types regeneration), ESLint and Prettier. All changes were reviewed for correctness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDJg9uZPzChAur8YkyqhiT)_