### PR TITLE
refactor(html): avoid regexp HTML parsing in dependencies; add <iframe srcdoc> script tests

### DIFF
--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -10,6 +10,7 @@ const {
 	JAVASCRIPT_TYPE
 } = require("../ModuleSourceTypeConstants");
 const HtmlGenerator = require("../html/HtmlGenerator");
+const { NodeType, buildHtmlAst, findAttr } = require("../html/syntax");
 const makeSerializable = require("../util/makeSerializable");
 const ModuleDependency = require("./ModuleDependency");
 
@@ -19,6 +20,7 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Entrypoint")} Entrypoint */
+/** @typedef {import("../html/syntax").HtmlAttribute} HtmlAttribute */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {"script" | "script-module" | "modulepreload" | "stylesheet"} HtmlEntryElementKind */
 
@@ -342,6 +344,54 @@ const buildScriptTag = (extra, src, isModule, crossOrigin) => {
 	} src="${safeSrc}"${extra}${crossOrigin}></script>`;
 };
 
+// ASCII whitespace per the HTML spec (tab, LF, FF, CR, space).
+const isHtmlWhitespace = (/** @type {number} */ c) =>
+	c === 0x09 || c === 0x0a || c === 0x0c || c === 0x0d || c === 0x20;
+
+/**
+ * Parse a `<script>`/`<link>` opening tag with the real HTML tokenizer (not a
+ * regex) and return its attributes — so attribute edits below work off true
+ * syntax rather than pattern-matching the tag text.
+ * @param {string} tag the opening tag's source text
+ * @param {string} tagName native tag name to locate (`script` / `link`)
+ * @returns {HtmlAttribute[]} the tag's attributes (empty when not found)
+ */
+const parseOpeningTagAttrs = (tag, tagName) => {
+	const ast = buildHtmlAst(tag);
+	/** @type {HtmlAttribute[]} */
+	let attrs = [];
+	const visit = (/** @type {EXPECTED_ANY} */ node) => {
+		if (attrs.length > 0 || !node) return;
+		if (node.type === NodeType.Element && node.tagName === tagName) {
+			attrs = node.attributes;
+			return;
+		}
+		if (node.children) for (const child of node.children) visit(child);
+	};
+	visit(ast);
+	return attrs;
+};
+
+/**
+ * Source span of a full attribute including its single leading whitespace and
+ * any surrounding quotes — i.e. the slice to delete to remove the attribute.
+ * @param {string} tag the opening tag's source text
+ * @param {HtmlAttribute} attr the attribute
+ * @returns {{ start: number, end: number, text: string }} a removal edit
+ */
+const attrRemovalEdit = (tag, attr) => {
+	let start = attr.nameStart;
+	while (start > 0 && isHtmlWhitespace(tag.charCodeAt(start - 1))) start--;
+	let end;
+	if (attr.valueStart === -1) {
+		end = attr.nameEnd;
+	} else {
+		const quote = tag.charCodeAt(attr.valueStart - 1);
+		end = quote === 0x22 || quote === 0x27 ? attr.valueEnd + 1 : attr.valueEnd;
+	}
+	return { start, end, text: "" };
+};
+
 /**
  * Clone the original `<script>`/`<link>` opening tag with its `src`/`href`
  * value swapped for a different chunk URL. Reusing the source text verbatim
@@ -351,7 +401,9 @@ const buildScriptTag = (extra, src, isModule, crossOrigin) => {
  * content-specific. When the original tag was upgraded to a module script
  * (either by the author or by the `output.module` auto-upgrade in
  * `HtmlParser`), the sibling is forced to `type="module"` regardless of what
- * the source originally said.
+ * the source originally said. Attribute edits are located by parsing the tag
+ * (`parseOpeningTagAttrs`), then applied right-to-left so earlier offsets stay
+ * valid.
  * @param {string} originalTag the opening tag's source text including `>`
  * @param {number} srcStartInTag offset of the src/href value start within `originalTag`
  * @param {number} srcEndInTag offset of the src/href value end within `originalTag`
@@ -370,50 +422,66 @@ const cloneTagWithUrl = (
 	crossOrigin,
 	tagNameEndInTag
 ) => {
-	let body =
-		originalTag.slice(0, srcStartInTag) +
-		newUrl +
-		originalTag.slice(srcEndInTag);
+	const isLink =
+		elementKind === "modulepreload" || elementKind === "stylesheet";
+	const isModule = elementKind === "script-module";
 
-	// Strip dangerous-to-copy attributes from the cloned tag — currently
-	// just `integrity`, which is content-specific and would be wrong for a
-	// different chunk's file. The match handles all three quoting styles
-	// (`"…"`, `'…'`, unquoted) and the bare-attribute form. The `includes`
-	// gate skips the regex engine for the common no-SRI tag.
+	/** @type {{ start: number, end: number, text: string }[]} */
+	const edits = [{ start: srcStartInTag, end: srcEndInTag, text: newUrl }];
+
+	// Inserted right after the tag name: `crossorigin` from
+	// `output.crossOriginLoading`, then a forced `type="module"` when the tag
+	// has no `type` to rewrite in place.
+	let afterName = crossOrigin;
+
+	// Parse only when an attribute edit is actually needed — dropping the
+	// content-specific `integrity` or forcing `type="module"`. The common
+	// clone needs neither and skips parsing entirely.
 	// TODO: emit a correct per-chunk `integrity` once a core SRI output
 	// option exists, instead of dropping it.
-	if (body.includes("integrity")) {
-		body = body.replace(
-			/\s+integrity(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=[\s/>])/gi,
-			""
-		);
-	}
-
-	if (elementKind === "script-module") {
-		if (/\stype\s*=/i.test(body)) {
-			body = body.replace(
-				/(\stype\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s>]+)/i,
-				'$1"module"'
-			);
-		} else {
-			body = body.replace(/^<script\b/i, '<script type="module"');
+	const needsIntegrity = originalTag.includes("integrity");
+	if (isModule || needsIntegrity) {
+		const attrs = parseOpeningTagAttrs(originalTag, isLink ? "link" : "script");
+		if (needsIntegrity) {
+			const integrity = findAttr(attrs, "integrity");
+			if (integrity) edits.push(attrRemovalEdit(originalTag, integrity));
+		}
+		if (isModule) {
+			const typeAttr = findAttr(attrs, "type");
+			if (typeAttr && typeAttr.valueStart !== -1) {
+				edits.push({
+					start: typeAttr.valueStart,
+					end: typeAttr.valueEnd,
+					text: "module"
+				});
+			} else if (typeAttr) {
+				edits.push({
+					start: typeAttr.nameStart,
+					end: typeAttr.nameEnd,
+					text: 'type="module"'
+				});
+			} else {
+				afterName += ' type="module"';
+			}
 		}
 	}
 
-	// Insert `crossorigin` from `output.crossOriginLoading` right after the tag
-	// name (its parse-time offset). The type/integrity edits above only touch
-	// text at or after the name boundary, so the offset stays valid.
-	if (crossOrigin) {
-		body =
-			body.slice(0, tagNameEndInTag) +
-			crossOrigin +
-			body.slice(tagNameEndInTag);
+	if (afterName) {
+		edits.push({
+			start: tagNameEndInTag,
+			end: tagNameEndInTag,
+			text: afterName
+		});
+	}
+
+	edits.sort((a, b) => b.start - a.start);
+	let body = originalTag;
+	for (const edit of edits) {
+		body = body.slice(0, edit.start) + edit.text + body.slice(edit.end);
 	}
 
 	// `<link>` is a void element — no closing tag. `<script>` needs `</script>`.
-	return elementKind === "modulepreload" || elementKind === "stylesheet"
-		? body
-		: `${body}</script>`;
+	return isLink ? body : `${body}</script>`;
 };
 
 HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -10,7 +10,6 @@ const {
 	JAVASCRIPT_TYPE
 } = require("../ModuleSourceTypeConstants");
 const HtmlGenerator = require("../html/HtmlGenerator");
-const { NodeType, buildHtmlAst, findAttr } = require("../html/syntax");
 const makeSerializable = require("../util/makeSerializable");
 const ModuleDependency = require("./ModuleDependency");
 
@@ -20,12 +19,11 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Entrypoint")} Entrypoint */
-/** @typedef {import("../html/syntax").HtmlAttribute} HtmlAttribute */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {"script" | "script-module" | "modulepreload" | "stylesheet"} HtmlEntryElementKind */
 
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[string, string, HtmlEntryElementKind, number, number, boolean, string, number, boolean, number]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[string, string, HtmlEntryElementKind, number, number, boolean, string, number, boolean, number]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[string, string, HtmlEntryElementKind, number, number, boolean, string, number, boolean, number, (Range | null), (Range | null)]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[string, string, HtmlEntryElementKind, number, number, boolean, string, number, boolean, number, (Range | null), (Range | null)]>} ObjectSerializerContext */
 
 class HtmlEntryDependency extends ModuleDependency {
 	/**
@@ -42,6 +40,8 @@ class HtmlEntryDependency extends ModuleDependency {
 	 * @param {number=} tagNameEnd position right after the originating tag's name (e.g. after `<script`), captured at parse time so the template can insert a `crossorigin` attribute without re-scanning the tag text for the name boundary
 	 * @param {boolean=} hasOwnCrossOrigin whether the originating tag already carries a `crossorigin` attribute; when true the author's value wins and `output.crossOriginLoading` is not applied
 	 * @param {number=} cssAnchor source offset of the first `<script>` tag; a later entry's injected stylesheet `<link>`s are inserted here so CSS loads before any script. -1 when the document has no script
+	 * @param {Range | null=} integrityRange source span of the originating tag's `integrity` attribute (offsets relative to `tagStart`, leading whitespace and quotes included), captured at parse time so cloned sibling tags can drop it without re-parsing; null when absent
+	 * @param {Range | null=} typeValueRange source span of the originating tag's `type` attribute value (offsets relative to `tagStart`), captured at parse time so `script-module` sibling clones can force `type="module"` in place; null when there is no value to rewrite (a `type="module"` is then inserted instead)
 	 */
 	constructor(
 		request,
@@ -55,7 +55,9 @@ class HtmlEntryDependency extends ModuleDependency {
 		copyableAttrsText,
 		tagNameEnd,
 		hasOwnCrossOrigin,
-		cssAnchor
+		cssAnchor,
+		integrityRange,
+		typeValueRange
 	) {
 		super(request);
 		this.range = range;
@@ -78,6 +80,10 @@ class HtmlEntryDependency extends ModuleDependency {
 		this.hasOwnCrossOrigin = hasOwnCrossOrigin === true;
 		/** @type {number} */
 		this.cssAnchor = cssAnchor === undefined ? -1 : cssAnchor;
+		/** @type {Range | null} */
+		this.integrityRange = integrityRange || null;
+		/** @type {Range | null} */
+		this.typeValueRange = typeValueRange || null;
 	}
 
 	get type() {
@@ -103,7 +109,9 @@ class HtmlEntryDependency extends ModuleDependency {
 			.write(this.copyableAttrsText)
 			.write(this.tagNameEnd)
 			.write(this.hasOwnCrossOrigin)
-			.write(this.cssAnchor);
+			.write(this.cssAnchor)
+			.write(this.integrityRange)
+			.write(this.typeValueRange);
 		super.serialize(context);
 	}
 
@@ -131,7 +139,11 @@ class HtmlEntryDependency extends ModuleDependency {
 		this.hasOwnCrossOrigin = c8.read();
 		const c9 = c8.rest;
 		this.cssAnchor = c9.read();
-		super.deserialize(c9.rest);
+		const c10 = c9.rest;
+		this.integrityRange = c10.read();
+		const c11 = c10.rest;
+		this.typeValueRange = c11.read();
+		super.deserialize(c11.rest);
 	}
 }
 
@@ -344,54 +356,6 @@ const buildScriptTag = (extra, src, isModule, crossOrigin) => {
 	} src="${safeSrc}"${extra}${crossOrigin}></script>`;
 };
 
-// ASCII whitespace per the HTML spec (tab, LF, FF, CR, space).
-const isHtmlWhitespace = (/** @type {number} */ c) =>
-	c === 0x09 || c === 0x0a || c === 0x0c || c === 0x0d || c === 0x20;
-
-/**
- * Parse a `<script>`/`<link>` opening tag with the real HTML tokenizer (not a
- * regex) and return its attributes — so attribute edits below work off true
- * syntax rather than pattern-matching the tag text.
- * @param {string} tag the opening tag's source text
- * @param {string} tagName native tag name to locate (`script` / `link`)
- * @returns {HtmlAttribute[]} the tag's attributes (empty when not found)
- */
-const parseOpeningTagAttrs = (tag, tagName) => {
-	const ast = buildHtmlAst(tag);
-	/** @type {HtmlAttribute[]} */
-	let attrs = [];
-	const visit = (/** @type {EXPECTED_ANY} */ node) => {
-		if (attrs.length > 0 || !node) return;
-		if (node.type === NodeType.Element && node.tagName === tagName) {
-			attrs = node.attributes;
-			return;
-		}
-		if (node.children) for (const child of node.children) visit(child);
-	};
-	visit(ast);
-	return attrs;
-};
-
-/**
- * Source span of a full attribute including its single leading whitespace and
- * any surrounding quotes — i.e. the slice to delete to remove the attribute.
- * @param {string} tag the opening tag's source text
- * @param {HtmlAttribute} attr the attribute
- * @returns {{ start: number, end: number, text: string }} a removal edit
- */
-const attrRemovalEdit = (tag, attr) => {
-	let start = attr.nameStart;
-	while (start > 0 && isHtmlWhitespace(tag.charCodeAt(start - 1))) start--;
-	let end;
-	if (attr.valueStart === -1) {
-		end = attr.nameEnd;
-	} else {
-		const quote = tag.charCodeAt(attr.valueStart - 1);
-		end = quote === 0x22 || quote === 0x27 ? attr.valueEnd + 1 : attr.valueEnd;
-	}
-	return { start, end, text: "" };
-};
-
 /**
  * Clone the original `<script>`/`<link>` opening tag with its `src`/`href`
  * value swapped for a different chunk URL. Reusing the source text verbatim
@@ -401,9 +365,9 @@ const attrRemovalEdit = (tag, attr) => {
  * content-specific. When the original tag was upgraded to a module script
  * (either by the author or by the `output.module` auto-upgrade in
  * `HtmlParser`), the sibling is forced to `type="module"` regardless of what
- * the source originally said. Attribute edits are located by parsing the tag
- * (`parseOpeningTagAttrs`), then applied right-to-left so earlier offsets stay
- * valid.
+ * the source originally said. The `integrity`/`type` spans come from the
+ * parser (`HtmlParser` captured them off the AST); edits are applied
+ * right-to-left so earlier offsets stay valid — no re-parsing of the tag.
  * @param {string} originalTag the opening tag's source text including `>`
  * @param {number} srcStartInTag offset of the src/href value start within `originalTag`
  * @param {number} srcEndInTag offset of the src/href value end within `originalTag`
@@ -411,6 +375,8 @@ const attrRemovalEdit = (tag, attr) => {
  * @param {HtmlEntryElementKind} elementKind shape of the originating tag
  * @param {string} crossOrigin ` crossorigin="…"` to insert from `output.crossOriginLoading`, or `""`
  * @param {number} tagNameEndInTag offset right after the tag name within `originalTag`, where `crossOrigin` is inserted
+ * @param {Range | null} integrityRange `integrity` attribute span within `originalTag` to drop, or null
+ * @param {Range | null} typeValueRange `type` value span within `originalTag` to overwrite with `module`, or null to insert `type="module"`
  * @returns {string} the sibling tag's HTML (including a closing `</script>` for script tags)
  */
 const cloneTagWithUrl = (
@@ -420,49 +386,36 @@ const cloneTagWithUrl = (
 	newUrl,
 	elementKind,
 	crossOrigin,
-	tagNameEndInTag
+	tagNameEndInTag,
+	integrityRange,
+	typeValueRange
 ) => {
 	const isLink =
 		elementKind === "modulepreload" || elementKind === "stylesheet";
-	const isModule = elementKind === "script-module";
 
 	/** @type {{ start: number, end: number, text: string }[]} */
 	const edits = [{ start: srcStartInTag, end: srcEndInTag, text: newUrl }];
 
-	// Inserted right after the tag name: `crossorigin` from
-	// `output.crossOriginLoading`, then a forced `type="module"` when the tag
-	// has no `type` to rewrite in place.
-	let afterName = crossOrigin;
-
-	// Parse only when an attribute edit is actually needed — dropping the
-	// content-specific `integrity` or forcing `type="module"`. The common
-	// clone needs neither and skips parsing entirely.
+	// `integrity` is content-specific — drop it from the clone.
 	// TODO: emit a correct per-chunk `integrity` once a core SRI output
 	// option exists, instead of dropping it.
-	const needsIntegrity = originalTag.includes("integrity");
-	if (isModule || needsIntegrity) {
-		const attrs = parseOpeningTagAttrs(originalTag, isLink ? "link" : "script");
-		if (needsIntegrity) {
-			const integrity = findAttr(attrs, "integrity");
-			if (integrity) edits.push(attrRemovalEdit(originalTag, integrity));
-		}
-		if (isModule) {
-			const typeAttr = findAttr(attrs, "type");
-			if (typeAttr && typeAttr.valueStart !== -1) {
-				edits.push({
-					start: typeAttr.valueStart,
-					end: typeAttr.valueEnd,
-					text: "module"
-				});
-			} else if (typeAttr) {
-				edits.push({
-					start: typeAttr.nameStart,
-					end: typeAttr.nameEnd,
-					text: 'type="module"'
-				});
-			} else {
-				afterName += ' type="module"';
-			}
+	if (integrityRange) {
+		edits.push({ start: integrityRange[0], end: integrityRange[1], text: "" });
+	}
+
+	// Inserted right after the tag name: `crossorigin` from
+	// `output.crossOriginLoading`, then a forced `type="module"` when the tag
+	// has no `type` value to rewrite in place.
+	let afterName = crossOrigin;
+	if (elementKind === "script-module") {
+		if (typeValueRange) {
+			edits.push({
+				start: typeValueRange[0],
+				end: typeValueRange[1],
+				text: "module"
+			});
+		} else {
+			afterName += ' type="module"';
 		}
 	}
 
@@ -586,7 +539,9 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 						url,
 						dep.elementKind,
 						crossOrigin,
-						tagNameEndInTag
+						tagNameEndInTag,
+						dep.integrityRange,
+						dep.typeValueRange
 					);
 				}
 				return buildStylesheetLink(dep.copyableAttrsText, url, crossOrigin);
@@ -602,7 +557,9 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 					url,
 					dep.elementKind,
 					crossOrigin,
-					tagNameEndInTag
+					tagNameEndInTag,
+					dep.integrityRange,
+					dep.typeValueRange
 				);
 			}
 			return buildScriptTag(

--- a/lib/dependencies/HtmlInlineHtmlDependency.js
+++ b/lib/dependencies/HtmlInlineHtmlDependency.js
@@ -62,9 +62,10 @@ class HtmlInlineHtmlDependency extends ModuleDependency {
 	 */
 	updateHash(hash, context) {
 		// Recurse so the inline HTML's transitive deps (assets) propagate up.
-		const { chunkGraph } = context;
-		const module = chunkGraph.moduleGraph.getModule(this);
-		if (!module) return;
+		// The module is guaranteed — it is registered as a code-generation dependency.
+		const module = /** @type {Module} */ (
+			context.chunkGraph.moduleGraph.getModule(this)
+		);
 		module.updateHash(hash, context);
 	}
 }
@@ -81,24 +82,18 @@ HtmlInlineHtmlDependency.Template = class HtmlInlineHtmlDependencyTemplate exten
 	 */
 	apply(dependency, source, { moduleGraph, runtime, codeGenerationResults }) {
 		const dep = /** @type {HtmlInlineHtmlDependency} */ (dependency);
+		// The module is guaranteed — it is registered as a code-generation dependency.
 		const module = /** @type {Module} */ (moduleGraph.getModule(dep));
-
-		/** @type {string} */
-		let htmlText = "";
-
-		if (module) {
-			const codeGen =
-				/** @type {CodeGenerationResults} */
-				(codeGenerationResults).get(module, runtime);
-			const htmlSource = codeGen.sources.get(HTML_TYPE);
-			if (htmlSource) {
-				htmlText = /** @type {string} */ (htmlSource.source());
-			}
-		}
+		const codeGen =
+			/** @type {CodeGenerationResults} */
+			(codeGenerationResults).get(module, runtime);
+		const htmlSource = codeGen.sources.get(HTML_TYPE);
 
 		// The attribute value was entity-decoded before parsing, so re-escape the
 		// processed HTML to keep the surrounding `srcdoc="..."` attribute valid.
-		htmlText = htmlText.replace(ATTR_ESCAPE_REGEXP, escapeAttrChar);
+		const htmlText = (
+			htmlSource ? /** @type {string} */ (htmlSource.source()) : ""
+		).replace(ATTR_ESCAPE_REGEXP, escapeAttrChar);
 
 		source.replace(dep.range[0], dep.range[1] - 1, htmlText);
 	}

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -47,6 +47,7 @@ const {
 } = require("./syntax");
 
 /** @typedef {import("../../declarations/WebpackOptions").HtmlParserOptions} HtmlParserOptions */
+/** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").BuildInfo} BuildInfo */
 /** @typedef {import("../Compilation").FileSystemDependencies} FileSystemDependencies */
@@ -1362,6 +1363,49 @@ class HtmlParser extends Parser {
 											) {
 												firstScriptStart = node.start;
 											}
+											// Sibling-clone attribute edits, captured from the parsed
+											// attributes (offsets relative to the tag) so the template
+											// needn't re-parse the tag text: `integrity` is dropped
+											// (content-specific) and `script-module` clones are forced
+											// to `type="module"` (its value range, else inserted).
+											/** @type {Range | null} */
+											let integrityRange = null;
+											/** @type {Range | null} */
+											let typeValueRange = null;
+											if (node.start >= 0 && elementName === nativeTag) {
+												const integrityAttr = findAttr(attrs, "integrity");
+												if (integrityAttr && integrityAttr.nameStart >= 0) {
+													let rs = integrityAttr.nameStart;
+													while (
+														rs > 0 &&
+														isASCIIWhitespace(source.charCodeAt(rs - 1))
+													) {
+														rs--;
+													}
+													let re;
+													if (integrityAttr.valueStart === -1) {
+														re = integrityAttr.nameEnd;
+													} else {
+														const q = source.charCodeAt(
+															integrityAttr.valueStart - 1
+														);
+														re =
+															q === CC_QUOTATION || q === CC_APOSTROPHE
+																? integrityAttr.valueEnd + 1
+																: integrityAttr.valueEnd;
+													}
+													integrityRange = [rs - node.start, re - node.start];
+												}
+												if (elementKind === "script-module") {
+													const typeAttr = findAttr(attrs, "type");
+													if (typeAttr && typeAttr.valueStart >= 0) {
+														typeValueRange = [
+															typeAttr.valueStart - node.start,
+															typeAttr.valueEnd - node.start
+														];
+													}
+												}
+											}
 											const dep = new HtmlEntryDependency(
 												url,
 												[s, e],
@@ -1374,7 +1418,9 @@ class HtmlParser extends Parser {
 												copyableAttrsText,
 												node.nameEnd,
 												hasOwnCrossOrigin,
-												firstScriptStart
+												firstScriptStart,
+												integrityRange,
+												typeValueRange
 											);
 											setLoc(dep, s, e);
 											module.addPresentationalDependency(dep);

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html iframe-srcdoc-script exported tests should bundle <script> inside <iframe srcdoc> as an entry chunk 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>srcdoc script</title></head>
+<body>
+<iframe srcdoc=\\"<script src=&quot;__html_60417bb2_0.bundle0.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.bundle0.js&quot;></script>\\"></iframe>
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html iframe-srcdoc-script exported tests should bundle <script> inside <iframe srcdoc> as an entry chunk 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>srcdoc script</title></head>
+<body>
+<iframe srcdoc=\\"<script src=&quot;__html_60417bb2_0.bundle0.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.bundle0.js&quot;></script>\\"></iframe>
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/iframe-srcdoc-script/app.js
+++ b/test/configCases/html/iframe-srcdoc-script/app.js
@@ -1,0 +1,1 @@
+globalThis.__SRCDOC_SCRIPT__ = "loaded";

--- a/test/configCases/html/iframe-srcdoc-script/index.js
+++ b/test/configCases/html/iframe-srcdoc-script/index.js
@@ -1,0 +1,28 @@
+import page from "./page.html";
+
+it("should bundle <script> inside <iframe srcdoc> as an entry chunk", () => {
+	expect(typeof page).toBe("string");
+	expect(page).toMatchSnapshot();
+
+	// External `<script src="./app.js">` is rewritten away from the source path
+	// to a bundled chunk URL — the same pipeline as a top-level `<script src>`.
+	expect(page).not.toContain("./app.js");
+	expect(page).toMatch(
+		/srcdoc="<script[^"]*src=&quot;[^"]+\.js&quot;[^"]*><\/script>"/
+	);
+
+	// Inline `<script>var marker = 1;</script>` body is bundled too (it passes the
+	// `SRCDOC_ASSET_REGEXP` pre-filter via the `=`), so its raw body is gone.
+	expect(page).not.toContain("var marker = 1;");
+
+	// Each script-bearing srcdoc spins up a nested data:text/html module.
+	const ids = __STATS__.modules.map((m) => m.identifier || m.name || "");
+	expect(
+		ids.filter((id) => id.includes("data:text/html")).length
+	).toBeGreaterThanOrEqual(2);
+
+	// The bundled scripts become their own emitted JS chunks (named
+	// `__html_<hash>_<index>`).
+	const names = __STATS__.assets.map((a) => a.name);
+	expect(names.some((n) => /__html_[0-9a-f]+_\d+\./.test(n))).toBe(true);
+});

--- a/test/configCases/html/iframe-srcdoc-script/page.html
+++ b/test/configCases/html/iframe-srcdoc-script/page.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>srcdoc script</title></head>
+<body>
+<iframe srcdoc="<script src=&quot;./app.js&quot;></script>"></iframe>
+<iframe srcdoc="<script>var marker = 1;</script>"></iframe>
+</body>
+</html>

--- a/test/configCases/html/iframe-srcdoc-script/webpack.config.js
+++ b/test/configCases/html/iframe-srcdoc-script/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	output: {
+		pathinfo: false,
+		assetModuleFilename: "handled-[name][ext]"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html module-sibling-type exported tests rewrites type=module in place when cloning a native module <script> sibling 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>module sibling type</title>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.mjs\\"></script>
+</head>
+<body><h1>Hello</h1></body>
+</html>
+"
+`;

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html module-sibling-type exported tests rewrites type=module in place when cloning a native module <script> sibling 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>module sibling type</title>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.mjs\\"></script>
+</head>
+<body><h1>Hello</h1></body>
+</html>
+"
+`;

--- a/test/configCases/html/module-sibling-type/entry.js
+++ b/test/configCases/html/module-sibling-type/entry.js
@@ -1,0 +1,1 @@
+export default "entry";

--- a/test/configCases/html/module-sibling-type/index.js
+++ b/test/configCases/html/module-sibling-type/index.js
@@ -1,0 +1,21 @@
+import page from "./page.html";
+
+it("rewrites type=module in place when cloning a native module <script> sibling", () => {
+	expect(typeof page).toBe("string");
+	expect(page).toMatchSnapshot();
+
+	// The split-out runtime is injected as a sibling <script>, cloned from the
+	// original `<script type="module" src>`. Its `src` is swapped and its `type`
+	// value is rewritten in place to `module` (the `typeValueRange` branch).
+	expect(page).toMatch(
+		/<script[^>]*\btype="module"[^>]*\bsrc="[^"]*html-runtime[^"]*\.mjs"/
+	);
+
+	// The entry chunk tag is a module script too.
+	expect(page).toMatch(
+		/<script[^>]*\btype="module"[^>]*\bsrc="[^"]*__html_[^"]*\.mjs"/
+	);
+
+	// No unresolved source path survives.
+	expect(page).not.toContain("./entry.js");
+});

--- a/test/configCases/html/module-sibling-type/page.html
+++ b/test/configCases/html/module-sibling-type/page.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>module sibling type</title>
+<script type="module" src="./entry.js"></script>
+</head>
+<body><h1>Hello</h1></body>
+</html>

--- a/test/configCases/html/module-sibling-type/test.config.js
+++ b/test/configCases/html/module-sibling-type/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./main.mjs"];
+	}
+};

--- a/test/configCases/html/module-sibling-type/webpack.config.js
+++ b/test/configCases/html/module-sibling-type/webpack.config.js
@@ -1,0 +1,44 @@
+"use strict";
+
+// A native `<script type="module" src>` entry that gains a sibling chunk (the
+// split-out runtime) exercises the in-place `type="module"` rewrite: the parser
+// captures the original `type` value range and the sibling-clone template
+// overwrites it instead of re-parsing the tag. `output.module` keeps the whole
+// graph ESM so the cloned module tag is consistent with the entry tag. The
+// `runtimeChunk` name function only splits the synthetic `__html_*` entries, so
+// the test's own bundle keeps its inline runtime and stays loadable.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "es2022"],
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	externalsPresets: {
+		node: true
+	},
+	module: {
+		parser: {
+			javascript: {
+				importMeta: false
+			}
+		}
+	},
+	output: {
+		filename: "[name].mjs",
+		chunkFilename: "[name].chunk.mjs",
+		module: true
+	},
+	optimization: {
+		chunkIds: "named",
+		runtimeChunk: {
+			name: (entrypoint) =>
+				entrypoint.name.startsWith("__html_") ? "html-runtime" : undefined
+		}
+	},
+	experiments: {
+		html: true,
+		outputModule: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up improvements to the `<iframe srcdoc>` support added in #21226:

- `HtmlEntryDependency` cloned sibling `<script>`/`<link>` tags by running regexes over the tag text to drop `integrity` and force `type="module"`. Those spans are now captured off the AST in `HtmlParser` (where the tag is already parsed) and threaded through the dependency, so the template applies offset-based edits with no regexp and no re-parsing at generate time.
- Drop a redundant `module` null guard in `HtmlInlineHtmlDependency` — it's registered as a code-generation dependency, so the module is always present.
- Add a config case covering `<script>` (external and inline) inside `<iframe srcdoc>`, which previously had no test.

Output is byte-identical (all existing HTML snapshots unchanged).

**What kind of change does this PR introduce?**

refactor (plus added test coverage).

**Did you add tests for your changes?**

Yes — added `test/configCases/html/iframe-srcdoc-script`. The refactor is covered by the existing HTML config cases (301 cases + snapshots, incl. the `integrity`/runtime-chunk and module-sibling paths) and the persistent-cache variant, all unchanged.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Implemented with Claude Code — it performed the review, the refactor, and wrote the test. Every change was verified against the existing webpack test suite (HTML config cases + cache variant), `tsc`, ESLint, and Prettier; the refactor was checked to produce byte-identical output via the snapshot tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhH8aPURtof3Tc6KCwfmZX)_