### PR TITLE
fix(html): run the any-other-end-tag fallback for a marker-shielded nobr

### DIFF
--- a/.changeset/html-nobr-adoption-agency.md
+++ b/.changeset/html-nobr-adoption-agency.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix HTML parser adoption agency to handle a `nobr` shielded by a marker.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5957,6 +5957,23 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (inButtonScope("p")) closePElement();
 	};
 
+	// "any other end tag" in body: pop to the matching open element, stopping at
+	// the first special element; also the adoption agency's no-element fallback.
+	const anyOtherEndTag = (/** @type {string} */ name) => {
+		for (let i = open.length - 1; i >= 0; i--) {
+			const node = open[i];
+			if (node.namespace === NS_HTML && node.tagName === name) {
+				generateImpliedEndTags(name);
+				while (open.length > i) {
+					open[open.length - 1].end = tokenEnd;
+					open.pop();
+				}
+				return;
+			}
+			if (isSpecial(node)) return;
+		}
+	};
+
 	const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		const name = t.name;
 		if (name === "html") {
@@ -6116,7 +6133,9 @@ const buildHtmlAst = (source, fragmentContext) => {
 		if (name === "nobr") {
 			reconstructAfe();
 			if (inScope("nobr")) {
-				adoptionAgency("nobr", t.pos);
+				// The adoption agency returns false when a marker shields the nobr
+				// from the active formatting list; then act as "any other end tag".
+				if (!adoptionAgency("nobr", t.pos)) anyOtherEndTag("nobr");
 				reconstructAfe();
 			}
 			const el = insertHtmlElement("nobr", t.attrs, t.pos);
@@ -6367,19 +6386,7 @@ const buildHtmlAst = (source, fragmentContext) => {
 			framesetOk = false;
 			return;
 		}
-		// any other end tag
-		for (let i = open.length - 1; i >= 0; i--) {
-			const node = open[i];
-			if (node.namespace === NS_HTML && node.tagName === name) {
-				generateImpliedEndTags(name);
-				while (open.length > i) {
-					open[open.length - 1].end = tokenEnd;
-					open.pop();
-				}
-				return;
-			}
-			if (isSpecial(node)) return;
-		}
+		anyOtherEndTag(name);
 	};
 
 	// generic RCDATA/RAWTEXT: tokenizer already emits the text + end tag, so we


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The html5lib-tests bump in #21271 adds an adoption-agency tree-construction case (`<nobr><table><marquee></table><nobr>`) that webpack's HTML parser failed: the second `<nobr>` nested inside the first instead of being a body-level sibling. When `<marquee>` (or `<table>`) inserts a marker into the list of active formatting elements, that marker shields the open `<nobr>`, so the adoption agency algorithm finds no formatting element and must "act as the any-other-end-tag entry" and pop the `<nobr>`; the `nobr` start-tag handler ignored that case. This PR fixes the handler and bumps the submodule so the new case runs in CI. Refs #21271.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — bumps `test/html5lib-tests` to `9329e64`, which adds the tree-construction case exercised by `test/html5lib.spectest.js`; locally the full tree-construction corpus passes with no regressions.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to locate the divergence against the html5lib expected tree, identify the missing any-other-end-tag fallback in the adoption agency path, implement the fix, and validate it against the tree-construction corpus. All changes were reviewed by a maintainer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBeM3XKmimNGYxuEz9FnVA)_