### PR TITLE
feat: add WorkerEntryPlugin to inject entries into Web Worker entrypoints

### DIFF
--- a/.changeset/worker-entry-plugin.md
+++ b/.changeset/worker-entry-plugin.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add `WorkerEntryPlugin` to inject entries into Web Worker entrypoints.

--- a/lib/WorkerEntryPlugin.js
+++ b/lib/WorkerEntryPlugin.js
@@ -1,0 +1,64 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Sebastian Beltran @bjohansebas
+*/
+
+"use strict";
+
+const EntryDependency = require("./dependencies/EntryDependency");
+const WorkerAndWorkletPlugin = require("./dependencies/WorkerAndWorkletPlugin");
+
+/** @typedef {import("./Compiler")} Compiler */
+/** @typedef {import("./Entrypoint").EntryOptions} EntryOptions */
+
+const PLUGIN_NAME = "WorkerEntryPlugin";
+
+/**
+ * Adds an entry that runs inside every Web Worker entrypoint — the worker
+ * counterpart of EntryPlugin's global entry (which only reaches the document's
+ * entrypoints). Used e.g. to inject an HMR client into workers.
+ */
+class WorkerEntryPlugin {
+	/**
+	 * @param {string} context context path
+	 * @param {string} entry entry request
+	 * @param {EntryOptions | string=} options entry options (passing a string is deprecated)
+	 */
+	constructor(context, entry, options) {
+		/** @type {string} */
+		this.context = context;
+		/** @type {string} */
+		this.entry = entry;
+		this.options = options || "";
+	}
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const { entry, options } = this;
+		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+			WorkerAndWorkletPlugin.getCompilationHooks(
+				compilation
+			).additionalEntries.tap(
+				PLUGIN_NAME,
+				(dependencies) => {
+					const dep = new EntryDependency(entry);
+					dep.loc = {
+						name:
+							typeof options === "object"
+								? /** @type {string} */ (options.name)
+								: options
+					};
+					dependencies.push(dep);
+
+					return dependencies;
+				}
+			);
+		});
+	}
+}
+
+module.exports = WorkerEntryPlugin;

--- a/lib/dependencies/WorkerAndWorkletPlugin.js
+++ b/lib/dependencies/WorkerAndWorkletPlugin.js
@@ -6,7 +6,9 @@
 "use strict";
 
 const { pathToFileURL } = require("url");
+const { SyncWaterfallHook } = require("tapable");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const Compilation = require("../Compilation");
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
 	JAVASCRIPT_MODULE_TYPE_ESM
@@ -20,10 +22,12 @@ const { contextify } = require("../util/identifier");
 const EnableWasmLoadingPlugin = require("../wasm/EnableWasmLoadingPlugin");
 const ConstDependency = require("./ConstDependency");
 const CreateScriptUrlDependency = require("./CreateScriptUrlDependency");
+const EntryDependency = require("./EntryDependency");
 const {
 	harmonySpecifierTag
 } = require("./HarmonyImportDependencyParserPlugin");
 const { isImportMetaFieldEnabled } = require("./ImportMetaPlugin");
+const NullDependency = require("./NullDependency");
 const WorkerDependency = require("./WorkerDependency");
 const WorkletDependency = require("./WorkletDependency");
 
@@ -40,14 +44,35 @@ const WorkletDependency = require("./WorkletDependency");
 /** @typedef {import("../../declarations/WebpackOptions").WasmLoading} WasmLoading */
 /** @typedef {import("../../declarations/WebpackOptions").WorkerPublicPath} WorkerPublicPath */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Compilation")} CompilationType */
+/** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("../Entrypoint").EntryOptions} EntryOptions */
+/** @typedef {import("../Module")} Module */
 /** @typedef {import("../NormalModule")} NormalModule */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../javascript/JavascriptParser")} Parser */
 /** @typedef {import("../javascript/JavascriptParser").JavascriptParserState} JavascriptParserState */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("./HarmonyImportDependencyParserPlugin").HarmonySettings} HarmonySettings */
+
+/**
+ * @typedef {object} WorkerEntryContext
+ * @property {EntryOptions} entryOptions resolved entry options of the worker entrypoint
+ * @property {Module} module module instantiating the worker
+ * @property {string} request worker resource url
+ */
+
+/**
+ * @typedef {object} CompilationHooks
+ * @property {SyncWaterfallHook<[Dependency[], WorkerEntryContext]>} additionalEntries extra dependencies executed as entry modules of the worker entrypoint (e.g. an HMR client); runs after the worker entry
+ */
+
+/** @type {WeakMap<CompilationType, CompilationHooks>} */
+const compilationHooksMap = new WeakMap();
+
+/** Compilations whose injected-entry dependency factory/template are set up. */
+const injectedEntryCompilations = new WeakSet();
 
 /**
  * Returns url.
@@ -84,6 +109,26 @@ const workerIndexMap = new WeakMap();
 const PLUGIN_NAME = "WorkerAndWorkletPlugin";
 
 class WorkerAndWorkletPlugin {
+	/**
+	 * @param {CompilationType} compilation the compilation
+	 * @returns {CompilationHooks} the attached hooks
+	 */
+	static getCompilationHooks(compilation) {
+		if (!(compilation instanceof Compilation)) {
+			throw new TypeError(
+				"The 'compilation' argument must be an instance of Compilation"
+			);
+		}
+		let hooks = compilationHooksMap.get(compilation);
+		if (hooks === undefined) {
+			hooks = {
+				additionalEntries: new SyncWaterfallHook(["dependencies", "context"])
+			};
+			compilationHooksMap.set(compilation, hooks);
+		}
+		return hooks;
+	}
+
 	/**
 	 * Creates an instance of WorkerAndWorkletPlugin.
 	 * @param {ChunkLoading=} chunkLoading chunk loading
@@ -487,15 +532,17 @@ class WorkerAndWorkletPlugin {
 
 						ensureRuntime(entryOptions);
 
+						/** @type {EntryOptions} */
+						const workerEntryOptions = {
+							chunkLoading: this._chunkLoading,
+							wasmLoading: this._wasmLoading,
+							...entryOptions,
+							worker: true
+						};
 						const block = new AsyncDependenciesBlock({
 							name: entryOptions.name,
 							circular: false,
-							entryOptions: {
-								chunkLoading: this._chunkLoading,
-								wasmLoading: this._wasmLoading,
-								...entryOptions,
-								worker: true
-							}
+							entryOptions: workerEntryOptions
 						});
 						block.loc = expr.loc;
 						const dep = new WorkerDependency(url, range, {
@@ -506,7 +553,38 @@ class WorkerAndWorkletPlugin {
 								: undefined
 						});
 						dep.loc = /** @type {DependencyLocation} */ (expr.loc);
+						// Keep the worker dependency first: `buildChunkGraph` derives the
+						// entrypoint's identity from `block.dependencies[0]`.
 						block.addDependency(dep);
+						// The hook only exists once a consumer taps it, so non-worker and
+						// plain (no injector) builds do zero extra work here.
+						const hooks = compilationHooksMap.get(compilation);
+						if (hooks !== undefined && hooks.additionalEntries.isUsed()) {
+							const additionalEntries = hooks.additionalEntries.call([], {
+								entryOptions: workerEntryOptions,
+								module: parser.state.module,
+								request: url
+							});
+							if (
+								additionalEntries.length > 0 &&
+								!injectedEntryCompilations.has(compilation)
+							) {
+								injectedEntryCompilations.add(compilation);
+								// Injected entries live in this module's block, so the
+								// dependency needs both a factory and a (no-op) template.
+								compilation.dependencyFactories.set(
+									EntryDependency,
+									normalModuleFactory
+								);
+								compilation.dependencyTemplates.set(
+									EntryDependency,
+									new NullDependency.Template()
+								);
+							}
+							for (const additionalEntry of additionalEntries) {
+								block.addDependency(additionalEntry);
+							}
+						}
 						parser.state.module.addBlock(block);
 
 						if (compilation.outputOptions.trustedTypes) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -403,6 +403,9 @@ module.exports = mergeExports(fn, {
 	get WebpackOptionsValidationError() {
 		return require("schema-utils").ValidationError;
 	},
+	get WorkerEntryPlugin() {
+		return require("./WorkerEntryPlugin");
+	},
 	get ValidationError() {
 		return require("schema-utils").ValidationError;
 	},

--- a/test/configCases/worker/worker-entry-plugin/index.js
+++ b/test/configCases/worker/worker-entry-plugin/index.js
@@ -1,0 +1,10 @@
+it("should execute modules injected via WorkerEntryPlugin inside the worker", async () => {
+	const worker = new Worker(new URL("./worker.js", import.meta.url));
+	worker.postMessage("run");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => resolve(event.data);
+	});
+	// `injected.js` ran exactly once as an entry module of the worker
+	expect(result).toBe(1);
+	await worker.terminate();
+});

--- a/test/configCases/worker/worker-entry-plugin/injected.js
+++ b/test/configCases/worker/worker-entry-plugin/injected.js
@@ -1,0 +1,3 @@
+// Injected as an extra entry module of the worker entrypoint via
+// WorkerAndWorkletPlugin.getCompilationHooks().additionalEntries.
+self.__INJECTED_WORKER_ENTRY__ = (self.__INJECTED_WORKER_ENTRY__ || 0) + 1;

--- a/test/configCases/worker/worker-entry-plugin/test.config.js
+++ b/test/configCases/worker/worker-entry-plugin/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/worker-entry-plugin/test.filter.js
+++ b/test/configCases/worker/worker-entry-plugin/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/worker-entry-plugin/webpack.config.js
+++ b/test/configCases/worker/worker-entry-plugin/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new webpack.WorkerEntryPlugin(
+			__dirname,
+			path.resolve(__dirname, "injected.js")
+		)
+	]
+};

--- a/test/configCases/worker/worker-entry-plugin/worker.js
+++ b/test/configCases/worker/worker-entry-plugin/worker.js
@@ -1,0 +1,3 @@
+self.onmessage = () => {
+	self.postMessage(self.__INJECTED_WORKER_ENTRY__);
+};

--- a/test/hotCases/worker/entry-plugin/client.js
+++ b/test/hotCases/worker/entry-plugin/client.js
@@ -1,0 +1,3 @@
+// Injected into the worker entrypoint by WorkerEntryPlugin — stands in for the
+// dev-server HMR client that drives `check()` from inside the worker.
+self.__checkForUpdate = () => module.hot.check(true);

--- a/test/hotCases/worker/entry-plugin/index.js
+++ b/test/hotCases/worker/entry-plugin/index.js
@@ -1,0 +1,18 @@
+it("should drive HMR in a WebWorker from a WorkerEntryPlugin-injected client", done => {
+	const worker = new Worker(new URL("worker.js", import.meta.url));
+	worker.onmessage = ({ data: msg }) => {
+		switch (msg) {
+			case "next":
+				NEXT(() => {
+					worker.postMessage("next");
+				});
+				break;
+			case "done":
+				Promise.resolve(worker.terminate()).then(() => done(), done);
+				break;
+			default:
+				throw new Error(`Unexpected message: ${msg}`);
+		}
+	};
+	worker.postMessage("test");
+});

--- a/test/hotCases/worker/entry-plugin/module.js
+++ b/test/hotCases/worker/entry-plugin/module.js
@@ -1,0 +1,10 @@
+export default 1;
+
+---
+export default 2;
+
+---
+export default 3;
+
+---
+export default 42;

--- a/test/hotCases/worker/entry-plugin/test.config.js
+++ b/test/hotCases/worker/entry-plugin/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope, options) {
+		const FakeWorker = require("../../../helpers/createFakeWorker")({
+			outputDirectory: options.output.path
+		});
+
+		scope.Worker = FakeWorker;
+	}
+};

--- a/test/hotCases/worker/entry-plugin/test.filter.js
+++ b/test/hotCases/worker/entry-plugin/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/hotCases/worker/entry-plugin/webpack.config.js
+++ b/test/hotCases/worker/entry-plugin/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		environment: {
+			nodePrefixForCoreModules: false
+		}
+	},
+	plugins: [
+		new webpack.WorkerEntryPlugin(
+			__dirname,
+			path.resolve(__dirname, "client.js")
+		)
+	]
+};

--- a/test/hotCases/worker/entry-plugin/worker.js
+++ b/test/hotCases/worker/entry-plugin/worker.js
@@ -1,0 +1,29 @@
+import value from "./module";
+
+let counter = 1;
+
+self.onmessage = async ({ data: msg }) => {
+	try {
+		switch (msg) {
+			case "next":
+				// Update is driven by the WorkerEntryPlugin-injected client.
+				await self.__checkForUpdate();
+			case "test":
+				if (value === 42 && counter === 4) {
+					self.postMessage("done");
+					break;
+				}
+				if (value !== counter)
+					throw new Error(`value (${value}) should be ${counter}`);
+				counter++;
+				self.postMessage("next");
+				break;
+			default:
+				throw new Error("Unexpected message");
+		}
+	} catch (e) {
+		self.postMessage("error: " + e.stack);
+	}
+};
+
+import.meta.webpackHot.accept("./module");

--- a/types.d.ts
+++ b/types.d.ts
@@ -26635,6 +26635,23 @@ declare interface WithOptions {
 		options: Partial<ResolveOptionsWithDependencyType>
 	) => ResolverWithOptions;
 }
+
+/**
+ * Adds an entry that runs inside every Web Worker entrypoint — the worker
+ * counterpart of EntryPlugin's global entry (which only reaches the document's
+ * entrypoints). Used e.g. to inject an HMR client into workers.
+ */
+declare class WorkerEntryPlugin {
+	constructor(context: string, entry: string, options?: string | EntryOptions);
+	context: string;
+	entry: string;
+	options: string | EntryOptions;
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 */
+	apply(compiler: Compiler): void;
+}
 declare interface WriteFile {
 	(
 		file: PathOrFileDescriptorFs,
@@ -27417,6 +27434,7 @@ declare namespace exports {
 		WebpackOptionsApply,
 		WebpackOptionsDefaulter,
 		ValidationError as WebpackOptionsValidationError,
+		WorkerEntryPlugin,
 		ValidationError,
 		DelegatedPlugin,
 		DllPlugin,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

From what I've investigated, we still need a way for workers to have the client and receive events from it in the case of dev-server, since workers created through `EntryPlugin` don't get the `globalEntry` code injected into them. This plugin adds that piece to the worker, allowing it to work properly.


closes: https://github.com/webpack/webpack/issues/14722
ref: https://github.com/webpack/webpack-dev-server/issues/3794
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
Yeah, just to have a bit more context.
