### PR TITLE
Respect the node: prefix for node.js core modules used as externals

### DIFF
--- a/.changeset/node-prefix-externals-matching.md
+++ b/.changeset/node-prefix-externals-matching.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Match `node:`-prefixed and bare core module externals interchangeably.

--- a/.changeset/node-prefix-externals-matching.md
+++ b/.changeset/node-prefix-externals-matching.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Match `node:`-prefixed and bare core module externals interchangeably.

--- a/.changeset/node-prefix-externals.md
+++ b/.changeset/node-prefix-externals.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Strip `node:` prefix from externalized core modules on unsupported targets.

--- a/.changeset/node-prefix-externals.md
+++ b/.changeset/node-prefix-externals.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Strip `node:` prefix from externalized core modules on unsupported targets.
+Respect the `node:` prefix for node.js core modules used as externals.

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -25,6 +25,7 @@ const { DEFAULTS } = require("./config/defaults");
 const { ImportPhaseUtils } = require("./dependencies/ImportPhase");
 const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
 const EnvironmentNotSupportAsyncWarning = require("./errors/EnvironmentNotSupportAsyncWarning");
+const { coreModules } = require("./node/nodeBuiltins");
 const createHash = require("./util/createHash");
 const extractUrlAndGlobal = require("./util/extractUrlAndGlobal");
 const makeSerializable = require("./util/makeSerializable");
@@ -100,6 +101,41 @@ const RUNTIME_REQUIREMENTS_FOR_MODULE = new Set([
 ]);
 /** @type {RuntimeRequirements} */
 const EMPTY_RUNTIME_REQUIREMENTS = new Set();
+
+const NODE_PREFIX = "node:";
+// External types that emit a node.js-resolvable specifier (`require`/`import`).
+const NODE_RESOLVING_EXTERNAL_TYPES = new Set([
+	"commonjs",
+	"commonjs2",
+	"commonjs-module",
+	"commonjs-static",
+	"node-commonjs",
+	"import",
+	"module"
+]);
+
+/**
+ * Drops the `node:` prefix from a core module specifier when the target can't
+ * resolve it (`output.environment.nodePrefixForCoreModules === false`).
+ * @param {string | string[]} request the external request
+ * @param {ExternalsType} externalType the resolved external type
+ * @param {RuntimeTemplate} runtimeTemplate the runtime template
+ * @returns {string | string[]} the request, with the prefix stripped when unsupported
+ */
+const stripUnsupportedNodePrefix = (request, externalType, runtimeTemplate) => {
+	if (
+		runtimeTemplate.outputOptions.environment.nodePrefixForCoreModules !==
+			false ||
+		!NODE_RESOLVING_EXTERNAL_TYPES.has(externalType)
+	) {
+		return request;
+	}
+	const name = Array.isArray(request) ? request[0] : request;
+	if (typeof name !== "string" || !name.startsWith(NODE_PREFIX)) return request;
+	const stripped = name.slice(NODE_PREFIX.length);
+	if (!coreModules.has(stripped)) return request;
+	return Array.isArray(request) ? [stripped, ...request.slice(1)] : stripped;
+};
 
 /**
  * Gets source for global variable external.
@@ -1042,6 +1078,11 @@ class ExternalModule extends Module {
 		dependencyMeta,
 		concatenationScope
 	) {
+		request = stripUnsupportedNodePrefix(
+			request,
+			externalType,
+			runtimeTemplate
+		);
 		switch (externalType) {
 			case "this":
 			case "window":

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -115,26 +115,41 @@ const NODE_RESOLVING_EXTERNAL_TYPES = new Set([
 ]);
 
 /**
- * Drops the `node:` prefix from a core module specifier when the target can't
- * resolve it (`output.environment.nodePrefixForCoreModules === false`).
+ * Normalizes a node.js core module specifier for the target. Strips `node:`
+ * when the target can't resolve a prefixed request, adds `node:` for a universal
+ * bundle (which may run on deno/bun where the prefix is required), and otherwise
+ * keeps the author's original notation.
  * @param {string | string[]} request the external request
  * @param {ExternalsType} externalType the resolved external type
  * @param {RuntimeTemplate} runtimeTemplate the runtime template
- * @returns {string | string[]} the request, with the prefix stripped when unsupported
+ * @returns {string | string[]} the normalized request
  */
-const stripUnsupportedNodePrefix = (request, externalType, runtimeTemplate) => {
-	if (
-		runtimeTemplate.outputOptions.environment.nodePrefixForCoreModules !==
-			false ||
-		!NODE_RESOLVING_EXTERNAL_TYPES.has(externalType)
-	) {
-		return request;
-	}
+const normalizeNodeCoreModuleRequest = (
+	request,
+	externalType,
+	runtimeTemplate
+) => {
+	if (!NODE_RESOLVING_EXTERNAL_TYPES.has(externalType)) return request;
 	const name = Array.isArray(request) ? request[0] : request;
-	if (typeof name !== "string" || !name.startsWith(NODE_PREFIX)) return request;
-	const stripped = name.slice(NODE_PREFIX.length);
-	if (!coreModules.has(stripped)) return request;
-	return Array.isArray(request) ? [stripped, ...request.slice(1)] : stripped;
+	if (typeof name !== "string") return request;
+	/**
+	 * @param {string} next replacement specifier
+	 * @returns {string | string[]} request with the specifier swapped
+	 */
+	const withName = (next) =>
+		Array.isArray(request) ? [next, ...request.slice(1)] : next;
+
+	if (
+		runtimeTemplate.outputOptions.environment.nodePrefixForCoreModules === false
+	) {
+		if (!name.startsWith(NODE_PREFIX)) return request;
+		const stripped = name.slice(NODE_PREFIX.length);
+		return coreModules.has(stripped) ? withName(stripped) : request;
+	}
+	if (runtimeTemplate.isUniversalTarget() && !name.startsWith(NODE_PREFIX)) {
+		return coreModules.has(name) ? withName(NODE_PREFIX + name) : request;
+	}
+	return request;
 };
 
 /**
@@ -1078,7 +1093,7 @@ class ExternalModule extends Module {
 		dependencyMeta,
 		concatenationScope
 	) {
-		request = stripUnsupportedNodePrefix(
+		request = normalizeNodeCoreModuleRequest(
 			request,
 			externalType,
 			runtimeTemplate

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -13,6 +13,7 @@ const CssImportDependency = require("./dependencies/CssImportDependency");
 const CssUrlDependency = require("./dependencies/CssUrlDependency");
 const HarmonyImportDependency = require("./dependencies/HarmonyImportDependency");
 const ImportDependency = require("./dependencies/ImportDependency");
+const { coreModules } = require("./node/nodeBuiltins");
 const { cachedSetProperty, resolveByProperty } = require("./util/cleverMerge");
 
 /** @typedef {import("enhanced-resolve").ResolveContext} ResolveContext */
@@ -48,6 +49,21 @@ const { cachedSetProperty, resolveByProperty } = require("./util/cleverMerge");
 
 const UNSPECIFIED_EXTERNAL_TYPE_REGEXP = /^[a-z0-9-]+ /;
 const EMPTY_RESOLVE_OPTIONS = {};
+const NODE_PREFIX = "node:";
+
+/**
+ * For a node.js core module request, returns its `node:`-prefixed/unprefixed
+ * counterpart so externals match regardless of which form the code uses.
+ * @param {string} request the request as written in the import/require
+ * @returns {string | undefined} the alternate form, or undefined when not a core module
+ */
+const getAlternateCoreModuleRequest = (request) => {
+	if (request.startsWith(NODE_PREFIX)) {
+		const name = request.slice(NODE_PREFIX.length);
+		return coreModules.has(name) ? name : undefined;
+	}
+	return coreModules.has(request) ? NODE_PREFIX + request : undefined;
+};
 
 // TODO webpack 6 remove this
 const callDeprecatedExternals = util.deprecate(
@@ -236,7 +252,10 @@ class ExternalModuleFactoryPlugin {
 				 */
 				const handleExternals = (externals, callback) => {
 					if (typeof externals === "string") {
-						if (externals === dependency.request) {
+						if (
+							externals === dependency.request ||
+							externals === getAlternateCoreModuleRequest(dependency.request)
+						) {
 							return handleExternal(dependency.request, undefined, callback);
 						}
 					} else if (Array.isArray(externals)) {
@@ -370,6 +389,23 @@ class ExternalModuleFactoryPlugin {
 						) {
 							return handleExternal(
 								resolvedExternals[dependency.request],
+								undefined,
+								callback
+							);
+						}
+						// Fall back to the `node:`-prefixed/unprefixed core module form.
+						const alternateRequest = getAlternateCoreModuleRequest(
+							dependency.request
+						);
+						if (
+							alternateRequest !== undefined &&
+							Object.prototype.hasOwnProperty.call(
+								resolvedExternals,
+								alternateRequest
+							)
+						) {
+							return handleExternal(
+								resolvedExternals[alternateRequest],
 								undefined,
 								callback
 							);

--- a/lib/bun/BunTargetPlugin.js
+++ b/lib/bun/BunTargetPlugin.js
@@ -6,18 +6,12 @@
 "use strict";
 
 const ExternalsPlugin = require("../ExternalsPlugin");
-const NodeTargetPlugin = require("../node/NodeTargetPlugin");
+const { coreModules } = require("../node/nodeBuiltins");
 
 /** @typedef {import("../Compiler")} Compiler */
 
 // Bun exposes the node.js core modules; externalize them with the `node:`
 // specifier (Bun resolves both forms) like the deno target.
-// cspell:word pnpapi
-const coreModules = new Set(
-	NodeTargetPlugin.builtins.filter(
-		(builtin) => typeof builtin === "string" && builtin !== "pnpapi"
-	)
-);
 
 // Bun's own built-in modules (`bun`, `bun:sqlite`, ...) are provided by the
 // runtime, never bundled.

--- a/lib/deno/DenoTargetPlugin.js
+++ b/lib/deno/DenoTargetPlugin.js
@@ -6,18 +6,12 @@
 "use strict";
 
 const ExternalsPlugin = require("../ExternalsPlugin");
-const NodeTargetPlugin = require("../node/NodeTargetPlugin");
+const { coreModules } = require("../node/nodeBuiltins");
 
 /** @typedef {import("../Compiler")} Compiler */
 
 // Deno only resolves node.js core modules through the `node:` specifier, so the
 // prefix is baked into the external request for both `import` and `require`.
-// cspell:word pnpapi
-const coreModules = new Set(
-	NodeTargetPlugin.builtins.filter(
-		(builtin) => typeof builtin === "string" && builtin !== "pnpapi"
-	)
-);
 
 // Deno's own import protocols are resolved by the runtime, never bundled.
 const DENO_PROTOCOLS = /^(?:npm|jsr|https?):/;

--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -6,79 +6,10 @@
 "use strict";
 
 const ExternalsPlugin = require("../ExternalsPlugin");
+const { builtins, coreModules } = require("./nodeBuiltins");
 
 /** @typedef {import("../../declarations/WebpackOptions").ExternalsType} ExternalsType */
 /** @typedef {import("../Compiler")} Compiler */
-
-const builtins = [
-	"assert",
-	"assert/strict",
-	"async_hooks",
-	"buffer",
-	"child_process",
-	"cluster",
-	"console",
-	"constants",
-	"crypto",
-	"dgram",
-	"diagnostics_channel",
-	"dns",
-	"dns/promises",
-	"domain",
-	"events",
-	"fs",
-	"fs/promises",
-	"http",
-	"http2",
-	"https",
-	"inspector",
-	"inspector/promises",
-	"module",
-	"net",
-	"os",
-	"path",
-	"path/posix",
-	"path/win32",
-	"perf_hooks",
-	"process",
-	"punycode",
-	"querystring",
-	"readline",
-	"readline/promises",
-	"repl",
-	"stream",
-	"stream/consumers",
-	"stream/promises",
-	"stream/web",
-	"string_decoder",
-	"sys",
-	"timers",
-	"timers/promises",
-	"tls",
-	"trace_events",
-	"tty",
-	"url",
-	"util",
-	"util/types",
-	"v8",
-	"vm",
-	"wasi",
-	"worker_threads",
-	"zlib",
-	/^node:/,
-
-	// cspell:word pnpapi
-	// Yarn PnP adds pnpapi as "builtin"
-	"pnpapi"
-];
-
-// Core module names (no `node:` prefix, no regex, no pnpapi) used to recognize a
-// stripped request that may carry the prefix.
-const coreModules = new Set(
-	builtins.filter(
-		(builtin) => typeof builtin === "string" && builtin !== "pnpapi"
-	)
-);
 
 const NODE_PREFIX = "node:";
 
@@ -94,6 +25,7 @@ const externalsWithoutNodePrefix = ({ request }, callback) => {
 		// Strip the prefix from core modules, keep other `node:` requests as-is.
 		return callback(null, coreModules.has(name) ? name : request);
 	}
+	// cspell:word pnpapi
 	if (coreModules.has(request) || request === "pnpapi") {
 		return callback(null, request);
 	}

--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -6,31 +6,10 @@
 "use strict";
 
 const ExternalsPlugin = require("../ExternalsPlugin");
-const { builtins, coreModules } = require("./nodeBuiltins");
+const { builtins } = require("./nodeBuiltins");
 
 /** @typedef {import("../../declarations/WebpackOptions").ExternalsType} ExternalsType */
 /** @typedef {import("../Compiler")} Compiler */
-
-const NODE_PREFIX = "node:";
-
-/**
- * Externalizes node.js core modules while stripping the `node:` prefix, since
- * the target runtime can't resolve a prefixed request.
- * @type {import("../ExternalModuleFactoryPlugin").ExternalItemFunctionCallback}
- */
-const externalsWithoutNodePrefix = ({ request }, callback) => {
-	if (!request) return callback();
-	if (request.startsWith(NODE_PREFIX)) {
-		const name = request.slice(NODE_PREFIX.length);
-		// Strip the prefix from core modules, keep other `node:` requests as-is.
-		return callback(null, coreModules.has(name) ? name : request);
-	}
-	// cspell:word pnpapi
-	if (coreModules.has(request) || request === "pnpapi") {
-		return callback(null, request);
-	}
-	callback();
-};
 
 class NodeTargetPlugin {
 	/**
@@ -48,21 +27,15 @@ class NodeTargetPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		// Targets predating the `node:` specifier can't resolve a prefixed request.
-		const supportsNodePrefix =
-			compiler.options.output.environment.nodePrefixForCoreModules !== false;
-		new ExternalsPlugin(
-			(dependency) => {
-				// When `require` node.js built-in modules with module output
-				// we should still emit `createRequire` for compatibility
-				if (dependency.category === "commonjs") {
-					return "node-commonjs";
-				}
+		new ExternalsPlugin((dependency) => {
+			// When `require` node.js built-in modules with module output
+			// we should still emit `createRequire` for compatibility
+			if (dependency.category === "commonjs") {
+				return "node-commonjs";
+			}
 
-				return this.type;
-			},
-			supportsNodePrefix ? builtins : externalsWithoutNodePrefix
-		).apply(compiler);
+			return this.type;
+		}, builtins).apply(compiler);
 	}
 }
 

--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -72,6 +72,34 @@ const builtins = [
 	"pnpapi"
 ];
 
+// Core module names (no `node:` prefix, no regex, no pnpapi) used to recognize a
+// stripped request that may carry the prefix.
+const coreModules = new Set(
+	builtins.filter(
+		(builtin) => typeof builtin === "string" && builtin !== "pnpapi"
+	)
+);
+
+const NODE_PREFIX = "node:";
+
+/**
+ * Externalizes node.js core modules while stripping the `node:` prefix, since
+ * the target runtime can't resolve a prefixed request.
+ * @type {import("../ExternalModuleFactoryPlugin").ExternalItemFunctionCallback}
+ */
+const externalsWithoutNodePrefix = ({ request }, callback) => {
+	if (!request) return callback();
+	if (request.startsWith(NODE_PREFIX)) {
+		const name = request.slice(NODE_PREFIX.length);
+		// Strip the prefix from core modules, keep other `node:` requests as-is.
+		return callback(null, coreModules.has(name) ? name : request);
+	}
+	if (coreModules.has(request) || request === "pnpapi") {
+		return callback(null, request);
+	}
+	callback();
+};
+
 class NodeTargetPlugin {
 	/**
 	 * Creates an instance of NodeTargetPlugin.
@@ -88,15 +116,21 @@ class NodeTargetPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		new ExternalsPlugin((dependency) => {
-			// When `require` node.js built-in modules with module output
-			// we should still emit `createRequire` for compatibility
-			if (dependency.category === "commonjs") {
-				return "node-commonjs";
-			}
+		// Targets predating the `node:` specifier can't resolve a prefixed request.
+		const supportsNodePrefix =
+			compiler.options.output.environment.nodePrefixForCoreModules !== false;
+		new ExternalsPlugin(
+			(dependency) => {
+				// When `require` node.js built-in modules with module output
+				// we should still emit `createRequire` for compatibility
+				if (dependency.category === "commonjs") {
+					return "node-commonjs";
+				}
 
-			return this.type;
-		}, builtins).apply(compiler);
+				return this.type;
+			},
+			supportsNodePrefix ? builtins : externalsWithoutNodePrefix
+		).apply(compiler);
 	}
 }
 

--- a/lib/node/nodeBuiltins.js
+++ b/lib/node/nodeBuiltins.js
@@ -1,0 +1,80 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author sheo13666q @sheo13666q
+*/
+
+"use strict";
+
+// node.js built-in modules externalized by the node/deno/bun target presets.
+const builtins = [
+	"assert",
+	"assert/strict",
+	"async_hooks",
+	"buffer",
+	"child_process",
+	"cluster",
+	"console",
+	"constants",
+	"crypto",
+	"dgram",
+	"diagnostics_channel",
+	"dns",
+	"dns/promises",
+	"domain",
+	"events",
+	"fs",
+	"fs/promises",
+	"http",
+	"http2",
+	"https",
+	"inspector",
+	"inspector/promises",
+	"module",
+	"net",
+	"os",
+	"path",
+	"path/posix",
+	"path/win32",
+	"perf_hooks",
+	"process",
+	"punycode",
+	"querystring",
+	"readline",
+	"readline/promises",
+	"repl",
+	"stream",
+	"stream/consumers",
+	"stream/promises",
+	"stream/web",
+	"string_decoder",
+	"sys",
+	"timers",
+	"timers/promises",
+	"tls",
+	"trace_events",
+	"tty",
+	"url",
+	"util",
+	"util/types",
+	"v8",
+	"vm",
+	"wasi",
+	"worker_threads",
+	"zlib",
+	/^node:/,
+
+	// cspell:word pnpapi
+	// Yarn PnP adds pnpapi as "builtin"
+	"pnpapi"
+];
+
+// Bare core module names (no `node:` prefix, no regex, no pnpapi), used to
+// recognize a request that has a `node:`-prefixed equivalent.
+const coreModules = new Set(
+	builtins.filter(
+		(builtin) => typeof builtin === "string" && builtin !== "pnpapi"
+	)
+);
+
+module.exports.builtins = builtins;
+module.exports.coreModules = coreModules;

--- a/test/configCases/externals/node-prefix-matching/index.js
+++ b/test/configCases/externals/node-prefix-matching/index.js
@@ -1,0 +1,14 @@
+// `node:`-prefixed and bare core module requests resolve to the same external
+// regardless of which form the developer keyed in `externals`. A mismatch would
+// fail the build (unresolved request / unhandled scheme) before this runs.
+const bareFs = require("fs");
+const prefixedFs = require("node:fs");
+const barePath = require("path");
+const prefixedPath = require("node:path");
+
+it("should match a `node:` import against a bare external and vice versa", () => {
+	expect(typeof bareFs.readFileSync).toBe("function");
+	expect(typeof prefixedFs.readFileSync).toBe("function");
+	expect(typeof barePath.join).toBe("function");
+	expect(typeof prefixedPath.join).toBe("function");
+});

--- a/test/configCases/externals/node-prefix-matching/webpack.config.js
+++ b/test/configCases/externals/node-prefix-matching/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "bare-key",
+		// external keyed without the prefix must still match a `node:` import
+		target: "web",
+		externals: { fs: "commonjs fs", path: "commonjs path" },
+		output: { libraryTarget: "commonjs2" }
+	},
+	{
+		name: "prefixed-key",
+		// external keyed with the prefix must still match a bare import
+		target: "web",
+		externals: {
+			"node:fs": "commonjs node:fs",
+			"node:path": "commonjs node:path"
+		},
+		output: { libraryTarget: "commonjs2" }
+	}
+];

--- a/test/configCases/externals/node-prefix-universal/index.js
+++ b/test/configCases/externals/node-prefix-universal/index.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+const outputPath = __STATS__.outputPath;
+const source = fs.readFileSync(path.join(outputPath, "bundle0.mjs"), "utf-8");
+
+// Built dynamically so the asserted phrase never appears verbatim in this file,
+// which is itself embedded into the bundle being inspected.
+const ext = (name) => `createRequire_require(${JSON.stringify(name)})`;
+const prefixed = (name) => `${"node"}:${name}`;
+
+it("should resolve the node built-ins at runtime", () => {
+	expect(typeof fs.readFileSync).toBe("function");
+	expect(typeof path.join).toBe("function");
+});
+
+it("should add the `node:` prefix in a universal bundle (deno/bun compat)", () => {
+	// bare `require("fs")` in the source is emitted with the prefix for portability
+	expect(source).toContain(ext(prefixed("fs")));
+	expect(source).toContain(ext(prefixed("path")));
+	expect(source).not.toContain(ext("fs"));
+	expect(source).not.toContain(ext("path"));
+});

--- a/test/configCases/externals/node-prefix-universal/test.filter.js
+++ b/test/configCases/externals/node-prefix-universal/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsProcessGetBuiltinModule = require("../../../helpers/supportsProcessGetBuiltinModule");
+
+// The universal external loads core modules through `process.getBuiltinModule`
+// / `createRequire`, only available at runtime on node with that API.
+module.exports = () => supportsProcessGetBuiltinModule();

--- a/test/configCases/externals/node-prefix-universal/webpack.config.js
+++ b/test/configCases/externals/node-prefix-universal/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// universal bundle (node + web, ESM): may run on deno/bun, which require the
+	// `node:` specifier to resolve a core module
+	target: ["node18", "web"],
+	output: { module: true },
+	experiments: { outputModule: true }
+};

--- a/test/configCases/externals/node-prefix-user-externals/index.js
+++ b/test/configCases/externals/node-prefix-user-externals/index.js
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outputPath = __STATS__.children[__STATS_I__].outputPath;
+const source = fs.readFileSync(
+	path.join(outputPath, `bundle${__STATS_I__}.js`),
+	"utf-8"
+);
+
+// Built dynamically so the forbidden phrase never appears verbatim in this file,
+// which is itself embedded into the bundle being inspected.
+const ext = (name) => `module.exports = require(${JSON.stringify(name)})`;
+const prefixed = (name) => `${"node"}:${name}`;
+
+it("should resolve the developer-provided node externals at runtime", () => {
+	expect(typeof fs.readFileSync).toBe("function");
+	expect(typeof path.join).toBe("function");
+});
+
+if (__STATS_I__ === 0) {
+	it("should strip `node:` from external values when the target lacks support", () => {
+		expect(source).toContain(ext("fs"));
+		expect(source).toContain(ext("path"));
+		expect(source).not.toContain(ext(prefixed("fs")));
+		expect(source).not.toContain(ext(prefixed("path")));
+	});
+} else {
+	it("should keep the developer-provided `node:` value when supported", () => {
+		expect(source).toContain(ext(prefixed("fs")));
+		expect(source).toContain(ext(prefixed("path")));
+	});
+}

--- a/test/configCases/externals/node-prefix-user-externals/webpack.config.js
+++ b/test/configCases/externals/node-prefix-user-externals/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "strip",
+		// developer-provided `node:` external value on a target without prefix support
+		target: "web",
+		externals: {
+			"node:fs": "commonjs node:fs",
+			"node:path": "commonjs node:path"
+		},
+		output: {
+			libraryTarget: "commonjs2",
+			environment: { nodePrefixForCoreModules: false }
+		}
+	},
+	{
+		name: "keep",
+		// same config, but the target supports the `node:` prefix
+		target: "web",
+		externals: {
+			"node:fs": "commonjs node:fs",
+			"node:path": "commonjs node:path"
+		},
+		output: {
+			libraryTarget: "commonjs2",
+			environment: { nodePrefixForCoreModules: true }
+		}
+	}
+];

--- a/test/configCases/externals/node-prefix/index.js
+++ b/test/configCases/externals/node-prefix/index.js
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outputPath = __STATS__.children[__STATS_I__].outputPath;
+const source = fs.readFileSync(
+	path.join(outputPath, `bundle${__STATS_I__}.js`),
+	"utf-8"
+);
+
+// Built dynamically so the forbidden phrase never appears verbatim in this file,
+// which is itself embedded into the bundle being inspected.
+const ext = (name) => `module.exports = require(${JSON.stringify(name)})`;
+const prefixed = (name) => `${"node"}:${name}`;
+
+it("should resolve the node built-ins at runtime regardless of the prefix", () => {
+	expect(typeof fs.readFileSync).toBe("function");
+	expect(typeof path.join).toBe("function");
+});
+
+if (__STATS_I__ === 0) {
+	it("should strip the `node:` prefix when the target lacks support", () => {
+		expect(source).toContain(ext("fs"));
+		expect(source).toContain(ext("path"));
+		expect(source).not.toContain(ext(prefixed("fs")));
+		expect(source).not.toContain(ext(prefixed("path")));
+	});
+} else {
+	it("should keep the `node:` prefix verbatim when the target supports it", () => {
+		expect(source).toContain(ext(prefixed("fs")));
+		expect(source).toContain(ext(prefixed("path")));
+	});
+}

--- a/test/configCases/externals/node-prefix/webpack.config.js
+++ b/test/configCases/externals/node-prefix/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "no-prefix",
+		// target without `node:` support -> the prefix must be stripped from externals
+		target: "node",
+		output: {
+			libraryTarget: "commonjs2",
+			environment: { nodePrefixForCoreModules: false }
+		}
+	},
+	{
+		name: "prefix",
+		// target with `node:` support -> the authored request is kept verbatim
+		target: "node",
+		output: {
+			libraryTarget: "commonjs2",
+			environment: { nodePrefixForCoreModules: true }
+		}
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Externals ignored the `node:` prefix capability for node.js core modules. This PR makes them respect it in three ways: strip the prefix when the target can't resolve it (`output.environment.nodePrefixForCoreModules === false`), match the prefixed and bare forms interchangeably so a developer-provided external keyed `node:fs` also matches a bare `require("fs")` (and vice versa), and add the prefix for a universal (`["node", "web"]` + `output.module`) bundle, which may run on Deno/Bun where the prefix is required. Supported single-runtime targets keep the author's original notation unchanged.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/externals/node-prefix` (capability stripping for automatic externals), `node-prefix-matching` (prefixed/bare matching), `node-prefix-user-externals` (stripping developer-provided external values), and `node-prefix-universal` (prefixing for universal bundles).

**Does this PR introduce a breaking change?**

No. On supported single-runtime targets the author's notation is preserved verbatim; output only changes toward correctness (stripping on unsupported targets, prefixing for universal bundles).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the behavior follows the existing `output.environment.nodePrefixForCoreModules` capability.

**Use of AI**

AI (Claude) was used to investigate the codebase, implement the changes, and write the test cases; all output was reviewed and verified against the test suite by the author.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CipsD3YfzUe4PztiDCs73A)_