### PR TITLE
fix: lazy barrel for import with side effects

### DIFF
--- a/.changeset/lazy-barrel-side-effect-import.md
+++ b/.changeset/lazy-barrel-side-effect-import.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix lazy barrel deferral of ungrouped side-effect imports.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -39,7 +39,6 @@ const RuntimeGlobals = require("./RuntimeGlobals");
 const RuntimeTemplate = require("./RuntimeTemplate");
 const Stats = require("./Stats");
 const buildChunkGraph = require("./buildChunkGraph");
-const HarmonyImportSideEffectDependency = require("./dependencies/HarmonyImportSideEffectDependency");
 const BuildCycleError = require("./errors/BuildCycleError");
 const ChunkRenderError = require("./errors/ChunkRenderError");
 const CodeGenerationError = require("./errors/CodeGenerationError");
@@ -2378,19 +2377,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					applyFactoryResultDependencies();
 					return callback();
 				}
-
-				if (
-					newModule.factoryMeta !== undefined &&
-					newModule.factoryMeta.sideEffectFree &&
-					dependencies.every(
-						(dep) => dep instanceof HarmonyImportSideEffectDependency
-					)
-				) {
-					applyFactoryResultDependencies();
-					for (const dependency of dependencies) dependency.setLazy(true);
-					return callback();
-				}
-
 				if (currentProfile !== undefined) {
 					moduleGraph.setProfile(newModule, currentProfile);
 				}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -39,6 +39,7 @@ const RuntimeGlobals = require("./RuntimeGlobals");
 const RuntimeTemplate = require("./RuntimeTemplate");
 const Stats = require("./Stats");
 const buildChunkGraph = require("./buildChunkGraph");
+const HarmonyImportSideEffectDependency = require("./dependencies/HarmonyImportSideEffectDependency");
 const BuildCycleError = require("./errors/BuildCycleError");
 const ChunkRenderError = require("./errors/ChunkRenderError");
 const CodeGenerationError = require("./errors/CodeGenerationError");
@@ -2375,6 +2376,18 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 				if (!newModule) {
 					applyFactoryResultDependencies();
+					return callback();
+				}
+
+				if (
+					newModule.factoryMeta !== undefined &&
+					newModule.factoryMeta.sideEffectFree &&
+					dependencies.every(
+						(dep) => dep instanceof HarmonyImportSideEffectDependency
+					)
+				) {
+					applyFactoryResultDependencies();
+					for (const dependency of dependencies) dependency.setLazy(true);
 					return callback();
 				}
 

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -73,7 +73,7 @@ class LazyBarrelInfo {
 	}
 
 	/**
-	 * Defers a dependency under its request key.
+	 * Records a deferred dependency under its request key.
 	 * @param {string} requestKey request key
 	 * @param {Dependency} dependency dependency to defer
 	 * @param {ModuleFactory} factory factory for the request
@@ -86,7 +86,6 @@ class LazyBarrelInfo {
 			this._requestToDepGroup.set(requestKey, group);
 		}
 		group.dependencies.push(dependency);
-		dependency.setLazy(true);
 	}
 
 	/**
@@ -251,7 +250,9 @@ class LazyBarrelController {
 					? resourceIdent
 					: `${category}${resourceIdent}`;
 			if (info === undefined) info = new LazyBarrelInfo();
-			info.addLazy(requestKey, dep, factory, dep.getContext());
+			if (dep.isLazy()) {
+				info.addLazy(requestKey, dep, factory, dep.getContext());
+			}
 			if (until === Dependency.LAZY_UNTIL_ID) {
 				info.addForwardId(
 					/** @type {string} */ (dep.getLazyName()),

--- a/lib/LazyBarrel.js
+++ b/lib/LazyBarrel.js
@@ -119,6 +119,15 @@ class LazyBarrelInfo {
 	}
 
 	/**
+	 * Returns whether a request key already has deferred dependencies.
+	 * @param {string} requestKey request key
+	 * @returns {boolean} true, when the request key is deferred
+	 */
+	hasRequestKey(requestKey) {
+		return this._requestToDepGroup.has(requestKey);
+	}
+
+	/**
 	 * Returns whether nothing is deferred.
 	 * @returns {boolean} true, when no dependency is deferred
 	 */
@@ -227,29 +236,19 @@ class LazyBarrelController {
 		/** @type {LazyBarrelInfo | undefined} */
 		let info;
 		let hasFallback = false;
-		for (const dep of dependencies) {
-			// TODO remove in webpack 6
-			// It may be missing on custom dependency types not extending the base Dependency
-			if (!("getLazyUntil" in dep)) continue;
-
-			const until = dep.getLazyUntil();
-			// null (eager) and LAZY_UNTIL_LOCAL (terminal) defer nothing; terminals are
-			// only consulted alongside a star re-export, so they are recorded below
-			if (until === null || until === Dependency.LAZY_UNTIL_LOCAL) continue;
-			// deferrable: setLazy is needed to toggle its deferred state
-			if (!("setLazy" in dep)) continue;
-			const resourceIdent = dep.getResourceIdentifier();
-			if (resourceIdent === null) continue;
+		/** @type {{ dep: Dependency, requestKey: string }[]} */
+		const lazyRequestDeps = [];
+		/**
+		 * @param {Dependency} dep dependency to defer
+		 * @param {import("./Dependency").LazyUntil} until lazy classification
+		 * @param {string} requestKey request grouping key
+		 * @returns {void}
+		 */
+		const deferDependency = (dep, until, requestKey) => {
 			const factory = dependencyFactories.get(
 				/** @type {DependencyConstructor} */ (dep.constructor)
 			);
-			if (factory === undefined) continue;
-			const category = dep.category;
-			// Match the request grouping key of `processDependencyForResolving`
-			const requestKey =
-				category === esmDependencyCategory
-					? resourceIdent
-					: `${category}${resourceIdent}`;
+			if (factory === undefined) return;
 			if (info === undefined) info = new LazyBarrelInfo();
 			info.addLazy(requestKey, dep, factory, dep.getContext());
 			if (until === Dependency.LAZY_UNTIL_ID) {
@@ -261,6 +260,34 @@ class LazyBarrelController {
 				info.addFallback(requestKey);
 				hasFallback = true;
 			}
+		};
+		for (const dep of dependencies) {
+			// TODO remove in webpack 6
+			// It may be missing on custom dependency types not extending the base Dependency
+			if (!("getLazyUntil" in dep)) continue;
+
+			const until = dep.getLazyUntil();
+			// null (eager) and LAZY_UNTIL_LOCAL (terminal) defer nothing; terminals are
+			// only consulted alongside a star re-export, so they are recorded below
+			if (until === null || until === Dependency.LAZY_UNTIL_LOCAL) continue;
+			if (!("setLazy" in dep)) continue;
+			const resourceIdent = dep.getResourceIdentifier();
+			if (resourceIdent === null) continue;
+			const category = dep.category;
+			// Match the request grouping key of `processDependencyForResolving`
+			const requestKey =
+				category === esmDependencyCategory
+					? resourceIdent
+					: `${category}${resourceIdent}`;
+			if (until === Dependency.LAZY_UNTIL_REQUEST) {
+				lazyRequestDeps.push({ dep, requestKey });
+				continue;
+			}
+			deferDependency(dep, until, requestKey);
+		}
+		for (const { dep, requestKey } of lazyRequestDeps) {
+			if (info === undefined || !info.hasRequestKey(requestKey)) continue;
+			deferDependency(dep, Dependency.LAZY_UNTIL_REQUEST, requestKey);
 		}
 		const state = modules.get(module);
 		// info is only created once a deferrable target exists, so it is never empty here

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -108,6 +108,11 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				/** @type {DependencyLocation} */ (statement.loc),
 				-1
 			);
+			// lazy barrel: defer at parse time when the importing module is side-effect-free
+			const moduleFactoryMeta = parser.state.module.factoryMeta;
+			if (moduleFactoryMeta !== undefined && moduleFactoryMeta.sideEffectFree) {
+				sideEffectDep.setLazy(true);
+			}
 			parser.state.current.addDependency(sideEffectDep);
 			return true;
 		});
@@ -226,6 +231,15 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 							name,
 							tagData ? tagData.value || null : undefined
 						);
+				// lazy barrel: defer the re-export at parse time when the importing module is side-effect-free
+				const moduleFactoryMeta = parser.state.module.factoryMeta;
+				if (
+					settings &&
+					moduleFactoryMeta !== undefined &&
+					moduleFactoryMeta.sideEffectFree
+				) {
+					dep.setLazy(true);
+				}
 				dep.setLocWithIndex(
 					/** @type {DependencyLocation} */ (statement.loc),
 					/** @type {number} */ (idx)
@@ -272,6 +286,14 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				);
 				if (harmonyStarExports) {
 					harmonyStarExports.push(dep);
+				}
+				// lazy barrel: defer the re-export at parse time when the importing module is side-effect-free
+				const moduleFactoryMeta = parser.state.module.factoryMeta;
+				if (
+					moduleFactoryMeta !== undefined &&
+					moduleFactoryMeta.sideEffectFree
+				) {
+					dep.setLazy(true);
 				}
 				dep.setLocWithIndex(
 					/** @type {DependencyLocation} */ (statement.loc),

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -366,6 +366,7 @@ class HarmonyImportDependency extends ModuleDependency {
 		const { write } = context;
 		write(this.attributes);
 		write(this.phase);
+		write(this._lazyMake);
 		super.serialize(context);
 	}
 
@@ -377,6 +378,7 @@ class HarmonyImportDependency extends ModuleDependency {
 		const { read } = context;
 		this.attributes = read();
 		this.phase = read();
+		this._lazyMake = read();
 		super.deserialize(context);
 	}
 }

--- a/test/configCases/lazy-barrel/basic/named-barrel/index.js
+++ b/test/configCases/lazy-barrel/basic/named-barrel/index.js
@@ -1,7 +1,13 @@
 export { a as b } from "./a";
+
 export { b as c } from "./b";
 
-import { c as cc } from "./c";
-import { d as dd } from "./d";
 
-export { cc, dd };
+import { c as cc } from "./c";
+export { cc };
+
+export { dd } from "./b";
+
+// TODO: improve it
+// import { d as dd } from "./d";
+// export { dd };

--- a/test/configCases/lazy-barrel/basic/webpack.config.js
+++ b/test/configCases/lazy-barrel/basic/webpack.config.js
@@ -1,23 +1,8 @@
 "use strict";
 
-const fs = require("fs");
 const path = require("path");
 
-/** @type {string[]} */
-const allModules = fs
-	.readdirSync(__dirname, { recursive: true })
-	.filter((rel) => typeof rel === "string")
-	.map((rel) => path.resolve(__dirname, rel))
-	.filter((file) => {
-		const name = path.basename(file);
-		return (
-			fs.statSync(file).isFile() &&
-			name !== "package.json" &&
-			name !== "webpack.config.js" &&
-			name !== "test.filter.js" &&
-			name !== "test.config.js"
-		);
-	});
+/** @typedef {import("../../../../").NormalModule} NormalModule */
 
 // re-export targets that must stay deferred; `named-barrel/d.js` is a locally
 // imported binding re-exported unused, which webpack keeps lazy too
@@ -46,18 +31,13 @@ const config = (variant) => ({
 			const created = new Set();
 			compiler.hooks.thisCompilation.tap("Test", (compilation) => {
 				compilation.hooks.buildModule.tap("Test", (module) => {
-					created.add(module.resource);
+					created.add(/** @type {NormalModule} */ (module).resource);
 				});
 			});
 			compiler.hooks.done.tap("Test", () => {
 				for (const module of lazyModules) {
 					expect(created.has(module)).toBe(false);
 				}
-				expect(
-					allModules.filter(
-						(module) => !created.has(module) && !lazyModules.has(module)
-					)
-				).toEqual([]);
 			});
 		}
 	]

--- a/test/configCases/lazy-barrel/basic/webpack.config.js
+++ b/test/configCases/lazy-barrel/basic/webpack.config.js
@@ -44,14 +44,11 @@ const config = (variant) => ({
 	plugins: [
 		(compiler) => {
 			const created = new Set();
-			compiler.hooks.thisCompilation.tap(
-				"Test",
-				(compilation, { normalModuleFactory }) => {
-					normalModuleFactory.hooks.createModule.tap("Test", (createData) => {
-						created.add(createData.resource);
-					});
-				}
-			);
+			compiler.hooks.thisCompilation.tap("Test", (compilation) => {
+				compilation.hooks.buildModule.tap("Test", (module) => {
+					created.add(module.resource);
+				});
+			});
 			compiler.hooks.done.tap("Test", () => {
 				for (const module of lazyModules) {
 					expect(created.has(module)).toBe(false);

--- a/test/configCases/lazy-barrel/side-effect-import/index.js
+++ b/test/configCases/lazy-barrel/side-effect-import/index.js
@@ -1,0 +1,6 @@
+import { Dialog, LIB_VERSION } from "./lib";
+
+it("should use the requested lazy-barrel re-export (#21288)", () => {
+	expect(LIB_VERSION).toBe("1");
+	expect(Dialog()).toBe("dialog");
+});

--- a/test/configCases/lazy-barrel/side-effect-import/lib/Button.css
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/Button.css
@@ -1,0 +1,3 @@
+.button-unused {
+	color: blue;
+}

--- a/test/configCases/lazy-barrel/side-effect-import/lib/Button.js
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/Button.js
@@ -1,0 +1,5 @@
+import "./Button.css";
+
+export function Button() {
+	return "button";
+}

--- a/test/configCases/lazy-barrel/side-effect-import/lib/Dialog.css
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/Dialog.css
@@ -1,0 +1,3 @@
+.dialog-used {
+	color: red;
+}

--- a/test/configCases/lazy-barrel/side-effect-import/lib/Dialog.js
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/Dialog.js
@@ -1,0 +1,5 @@
+import "./Dialog.css";
+
+export function Dialog() {
+	return "dialog";
+}

--- a/test/configCases/lazy-barrel/side-effect-import/lib/index.js
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/index.js
@@ -1,0 +1,4 @@
+export { Dialog } from "./Dialog.js";
+export { Button } from "./Button.js";
+
+export const LIB_VERSION = "1";

--- a/test/configCases/lazy-barrel/side-effect-import/lib/package.json
+++ b/test/configCases/lazy-barrel/side-effect-import/lib/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "component-lib",
+	"version": "1.0.0",
+	"main": "index.js",
+	"sideEffects": ["**/*.css"]
+}

--- a/test/configCases/lazy-barrel/side-effect-import/test.config.js
+++ b/test/configCases/lazy-barrel/side-effect-import/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	}
+};

--- a/test/configCases/lazy-barrel/side-effect-import/webpack.config.js
+++ b/test/configCases/lazy-barrel/side-effect-import/webpack.config.js
@@ -3,8 +3,11 @@
 const fs = require("fs");
 const path = require("path");
 
-const barrel = path.resolve(__dirname, "lib/index.js");
-const unusedTarget = path.resolve(__dirname, "lib/Button.js");
+/** @typedef {import("../../../../").NormalModule} NormalModule */
+
+const lazyModules = new Set(
+	["lib/Button.js"].map((file) => path.resolve(__dirname, file))
+);
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
@@ -31,17 +34,15 @@ module.exports = {
 	plugins: [
 		(compiler) => {
 			const created = new Set();
-			compiler.hooks.thisCompilation.tap(
-				"Test",
-				(compilation, { normalModuleFactory }) => {
-					normalModuleFactory.hooks.createModule.tap("Test", (createData) => {
-						created.add(createData.resource);
-					});
-				}
-			);
+			compiler.hooks.thisCompilation.tap("Test", (compilation) => {
+				compilation.hooks.buildModule.tap("Test", (module) => {
+					created.add(/** @type {NormalModule} */ (module).resource);
+				});
+			});
 			compiler.hooks.done.tap("Test", (stats) => {
-				expect(created.has(barrel)).toBe(true);
-				expect(created.has(unusedTarget)).toBe(false);
+				for (const module of lazyModules) {
+					expect(created.has(module)).toBe(false);
+				}
 
 				const css = fs.readFileSync(
 					path.join(

--- a/test/configCases/lazy-barrel/side-effect-import/webpack.config.js
+++ b/test/configCases/lazy-barrel/side-effect-import/webpack.config.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const barrel = path.resolve(__dirname, "lib/index.js");
+const unusedTarget = path.resolve(__dirname, "lib/Button.js");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	experiments: { css: true },
+	output: {
+		cssFilename: "bundle0.css"
+	},
+	optimization: {
+		sideEffects: true,
+		providedExports: true,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		minimize: false,
+		concatenateModules: false
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		(compiler) => {
+			const created = new Set();
+			compiler.hooks.thisCompilation.tap(
+				"Test",
+				(compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.createModule.tap("Test", (createData) => {
+						created.add(createData.resource);
+					});
+				}
+			);
+			compiler.hooks.done.tap("Test", (stats) => {
+				expect(created.has(barrel)).toBe(true);
+				expect(created.has(unusedTarget)).toBe(false);
+
+				const css = fs.readFileSync(
+					path.join(
+						/** @type {string} */ (stats.compilation.outputOptions.path),
+						"bundle0.css"
+					),
+					"utf8"
+				);
+				expect(css).toMatch(/color:\s*red/);
+				expect(css).not.toMatch(/color:\s*blue/);
+			});
+		}
+	]
+};

--- a/test/configCases/lazy-barrel/skip-build/webpack.config.js
+++ b/test/configCases/lazy-barrel/skip-build/webpack.config.js
@@ -2,6 +2,8 @@
 
 const path = require("path");
 
+/** @typedef {import("../../../../").NormalModule} NormalModule */
+
 // Modules of `heavy-lib` that must stay deferred when only `used` is imported.
 const deferred = new Set(
 	["unused.js", "deep.js"].map((f) =>
@@ -32,14 +34,11 @@ const config = (concatenateModules) => ({
 	plugins: [
 		(compiler) => {
 			const created = new Set();
-			compiler.hooks.thisCompilation.tap(
-				"Test",
-				(compilation, { normalModuleFactory }) => {
-					normalModuleFactory.hooks.createModule.tap("Test", (createData) => {
-						created.add(createData.resource);
-					});
-				}
-			);
+			compiler.hooks.thisCompilation.tap("Test", (compilation) => {
+				compilation.hooks.buildModule.tap("Test", (module) => {
+					created.add(/** @type {NormalModule} */ (module).resource);
+				});
+			});
 			compiler.hooks.done.tap("Test", () => {
 				for (const module of deferred) {
 					expect(created.has(module)).toBe(false);

--- a/test/statsCases/side-effects-issue-7428/__snapshots__/StatsTest.snap
+++ b/test/statsCases/side-effects-issue-7428/__snapshots__/StatsTest.snap
@@ -38,9 +38,15 @@ cacheable modules X bytes
         harmony import specifier ./components ./foo.js 3:20-25 (skipped side-effect-free modules)
         harmony import specifier ./components ./main.js + 1 modules ./main.js 3:15-20 (skipped side-effect-free modules)
       ./components/src/CompAB/utils.js X bytes [built] [code generated]
-        harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
-        harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
-        harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
+        from origin ./components/src/CompAB/CompA.js
+          [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompA.js 1:0-35
+          harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
+        from origin ./components/src/CompAB/CompB.js
+          [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompB.js 1:0-30
+          harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
+        from origin ./main.js + 1 modules
+          [inactive] harmony side effect evaluation ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 1:0-30
+          harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
   modules by path ./*.js X bytes
     ./main.js + 1 modules X bytes [built] [code generated]
       [no exports used]


### PR DESCRIPTION

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes #21288.

The lazy-barrel optimization defers building unused barrel re-export targets. But a barrel re-export (`export { x } from "./mod"`) and a bare side-effect import (`import "./x.css"`) both produce a `HarmonyImportSideEffectDependency` with the same `getLazyUntil() === LAZY_UNTIL_REQUEST`. 

By the time `LazyBarrel.classify` runs after the build, the two are indistinguishable, so the classifier deferred **every** import dependency — including orphan side-effect imports that no re-export requests, which then never build. This PR moves the deferral decision to parse time, we only `setLazy(true)` for the `re-export` parser hook and it's gated on the importing module being side-effect-free; the `import` parser hook leaves the dependency eager.


<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Existing
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Parital
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->