### PR TITLE
fix: match harmony accept dependencies by module reference

### DIFF
--- a/.changeset/harmony-accept-unresolved-module.md
+++ b/.changeset/harmony-accept-unresolved-module.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Match harmony accept dependencies by module reference so HMR codegen handles imports without a module or chunk id.

--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -19,8 +19,6 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("./HarmonyAcceptImportDependency")} HarmonyAcceptImportDependency */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, HarmonyAcceptImportDependency[], boolean]>} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, HarmonyAcceptImportDependency[], boolean]>} ObjectSerializerContext */
-/** @typedef {import("../Module")} Module */
-/** @typedef {import("../Module").ModuleId} ModuleId */
 
 class HarmonyAcceptDependency extends NullDependency {
 	/**
@@ -92,17 +90,6 @@ HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate extends
 		} = templateContext;
 
 		/**
-		 * Gets dependency module id.
-		 * @param {Dependency} dependency the dependency to get module id for
-		 * @returns {ModuleId | null} the module id or null if not found
-		 */
-		const getDependencyModuleId = (dependency) => {
-			const mod = moduleGraph.getModule(dependency);
-			if (!mod) return null;
-			return chunkGraph.getModuleId(mod);
-		};
-
-		/**
 		 * Checks whether this harmony accept dependency is related harmony import dependency.
 		 * @param {Dependency} a the first dependency
 		 * @param {Dependency} b the second dependency
@@ -110,8 +97,11 @@ HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate extends
 		 */
 		const isRelatedHarmonyImportDependency = (a, b) => {
 			if (a === b || !(b instanceof HarmonyImportDependency)) return false;
-			const idA = getDependencyModuleId(a);
-			return idA !== null && idA === getDependencyModuleId(b);
+			// Compare modules by reference: an unresolved import (ignored/failed, or a
+			// deferred lazy-barrel re-export) has no module, and a module not in any
+			// chunk has a null id — so comparing ids would crash or miss real matches.
+			const moduleA = moduleGraph.getModule(a);
+			return moduleA !== null && moduleA === moduleGraph.getModule(b);
 		};
 
 		/**

--- a/test/hotCases/harmony/accept-import-without-module/broken.js
+++ b/test/hotCases/harmony/accept-import-without-module/broken.js
@@ -1,0 +1,7 @@
+import { value } from "./file";
+
+// "./ignored" is dropped by IgnorePlugin, so its accept dependency resolves to
+// no module. Generating this accept must not crash (issue #21300). This entry
+// is compiled but never executed by the runner, so the missing-module runtime
+// stub is never reached.
+if (value) module.hot.accept(["./file", "./ignored"], function () {});

--- a/test/hotCases/harmony/accept-import-without-module/file.js
+++ b/test/hotCases/harmony/accept-import-without-module/file.js
@@ -1,0 +1,3 @@
+export var value = 1;
+---
+export var value = 2;

--- a/test/hotCases/harmony/accept-import-without-module/index.js
+++ b/test/hotCases/harmony/accept-import-without-module/index.js
@@ -1,0 +1,10 @@
+import { value } from "./file";
+
+it("should compile HMR accept code for a module whose accept references a dependency without a module", function (done) {
+	expect(value).toBe(1);
+	module.hot.accept("./file", function () {
+		expect(value).toBe(2);
+		done();
+	});
+	NEXT(require("../../update")(done));
+});

--- a/test/hotCases/harmony/accept-import-without-module/webpack.config.js
+++ b/test/hotCases/harmony/accept-import-without-module/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// `broken` reproduces the codegen crash; the runner only executes `main`.
+	entry: {
+		main: "./index.js",
+		broken: "./broken.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [new webpack.IgnorePlugin({ resourceRegExp: /ignored/ })]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #21302 (Fixes #21300). The HMR accept template related dependencies via `chunkGraph.getModuleId(moduleGraph.getModule(dep))`. An unresolved import (ignored/failed, or a deferred lazy-barrel re-export) has no module, and a module that is in no chunk has a `null` id — so comparing ids can crash (`Invalid value used as weak map key`) or silently miss real matches. This compares modules **by reference** instead, which is correct in both cases and drops the redundant `getModuleId` lookup on a codegen hot path.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

yes — `test/hotCases/harmony/accept-import-without-module/` reproduces the crash via an unresolved (IgnorePlugin) accept dependency in a non-executed entry; it fails against the original 5.108 codegen and passes with the guard.

**Does this PR introduce a breaking change?**

no

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to locate the crashing comparison, implement the reference-based fix, and write the regression test; all changes were reviewed by me.

---
_Generated by [Claude Code](https://claude.ai/code/session_011bzqvBxebCsUuNakRZJAZA)_