### PR TITLE
ci: retry GitHub API calls in changelog generator

### DIFF
--- a/.changeset/changelog-generator.mjs
+++ b/.changeset/changelog-generator.mjs
@@ -11,6 +11,30 @@ function readEnv() {
 	return { GITHUB_SERVER_URL };
 }
 
+// Retry GitHub API calls so a transient drop (e.g. GraphQL "Premature close") doesn't fail the release.
+/**
+ * @template T
+ * @param {() => Promise<T>} fn operation to retry
+ * @returns {Promise<T>} result
+ */
+async function withRetry(fn) {
+	const maxAttempts = 5;
+	let lastError;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastError = err;
+			if (attempt === maxAttempts) break;
+			const delay = Math.min(1000 * 2 ** (attempt - 1), 8000);
+			await new Promise((resolve) => {
+				setTimeout(resolve, delay);
+			});
+		}
+	}
+	throw lastError;
+}
+
 /** @type {ChangelogFunctions} */
 const changelogFunctions = {
 	getDependencyReleaseLine: async (
@@ -29,10 +53,12 @@ const changelogFunctions = {
 			await Promise.all(
 				changesets.map(async (cs) => {
 					if (cs.commit) {
-						const { links } = await getInfo({
-							repo: options.repo,
-							commit: cs.commit
-						});
+						const { links } = await withRetry(() =>
+							getInfo({
+								repo: options.repo,
+								commit: cs.commit
+							})
+						);
 						return links.commit;
 					}
 				})
@@ -84,10 +110,12 @@ const changelogFunctions = {
 
 		const links = await (async () => {
 			if (prFromSummary !== undefined) {
-				let { links } = await getInfoFromPullRequest({
-					repo: options.repo,
-					pull: prFromSummary
-				});
+				let { links } = await withRetry(() =>
+					getInfoFromPullRequest({
+						repo: options.repo,
+						pull: prFromSummary
+					})
+				);
 				if (commitFromSummary) {
 					const shortCommitId = commitFromSummary.slice(0, 7);
 					links = {
@@ -99,10 +127,12 @@ const changelogFunctions = {
 			}
 			const commitToFetchFrom = commitFromSummary || changeset.commit;
 			if (commitToFetchFrom) {
-				const { links } = await getInfo({
-					repo: options.repo,
-					commit: commitToFetchFrom
-				});
+				const { links } = await withRetry(() =>
+					getInfo({
+						repo: options.repo,
+						commit: commitToFetchFrom
+					})
+				);
 				return links;
 			}
 			return {


### PR DESCRIPTION
The release job calls @changesets/get-github-info to build changelog entries; a single dropped GraphQL connection ("Premature close") failed the whole release. Wrap the lookups in retry-with-backoff.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->