### PR TITLE
test: emit async CSS chunk for a used lazy re-export (#21306)

### DIFF
--- a/test/configCases/lazy-barrel/side-effect-css-async/index.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/index.js
@@ -1,0 +1,4 @@
+it("should emit the CSS of a used lazy re-export into the async chunk (#21306)", () =>
+	import(/* webpackChunkName: "page" */ "./page").then(({ default: page }) => {
+		expect(page()).toBe("used");
+	}));

--- a/test/configCases/lazy-barrel/side-effect-css-async/lib/Unused.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/lib/Unused.js
@@ -1,0 +1,5 @@
+import "./unused.css";
+
+export default function Unused() {
+	return "unused";
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/lib/Used.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/lib/Used.js
@@ -1,0 +1,5 @@
+import "./used.css";
+
+export default function Used() {
+	return "used";
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/lib/index.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/lib/index.js
@@ -1,0 +1,2 @@
+export { default as Used } from "./Used";
+export { default as Unused } from "./Unused";

--- a/test/configCases/lazy-barrel/side-effect-css-async/lib/unused.css
+++ b/test/configCases/lazy-barrel/side-effect-css-async/lib/unused.css
@@ -1,0 +1,3 @@
+.unused {
+	color: blue;
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/lib/used.css
+++ b/test/configCases/lazy-barrel/side-effect-css-async/lib/used.css
@@ -1,0 +1,3 @@
+.used {
+	color: red;
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/package.json
+++ b/test/configCases/lazy-barrel/side-effect-css-async/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "side-effect-css-async",
+	"version": "1.0.0",
+	"sideEffects": ["**/*.css"]
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/page.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/page.js
@@ -1,0 +1,5 @@
+import { Used } from "./lib";
+
+export default function page() {
+	return Used();
+}

--- a/test/configCases/lazy-barrel/side-effect-css-async/test.config.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["page.bundle0.js", "bundle0.js"];
+	}
+};

--- a/test/configCases/lazy-barrel/side-effect-css-async/webpack.config.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/webpack.config.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+/** @typedef {import("../../../../").NormalModule} NormalModule */
+
+const usedModule = path.resolve(__dirname, "lib/Used.js");
+const unusedModule = path.resolve(__dirname, "lib/Unused.js");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	externalsPresets: { web: false, webAsync: true },
+	experiments: { css: true },
+	optimization: { chunkIds: "named", minimize: false },
+	plugins: [
+		(compiler) => {
+			const built = new Set();
+			compiler.hooks.thisCompilation.tap("Test", (compilation) => {
+				compilation.hooks.buildModule.tap("Test", (module) => {
+					built.add(/** @type {NormalModule} */ (module).resource);
+				});
+			});
+			compiler.hooks.done.tap("Test", (stats) => {
+				// requested re-export is built, unused sibling stays deferred
+				expect(built.has(usedModule)).toBe(true);
+				expect(built.has(unusedModule)).toBe(false);
+
+				// read the emitted assets from disk (assets are size-only in `done`)
+				const outputPath = /** @type {string} */ (
+					stats.compilation.outputOptions.path
+				);
+				let css = "";
+				for (const name of fs.readdirSync(outputPath)) {
+					if (name.endsWith(".css")) {
+						css += fs.readFileSync(path.join(outputPath, name), "utf8");
+					}
+				}
+				// the used component's CSS must be emitted, the unused one's must not
+				expect(css).toMatch(/\.used/);
+				expect(css).not.toMatch(/\.unused/);
+			});
+		}
+	]
+};

--- a/test/configCases/lazy-barrel/side-effect-css-async/webpack.config.js
+++ b/test/configCases/lazy-barrel/side-effect-css-async/webpack.config.js
@@ -5,7 +5,6 @@ const path = require("path");
 
 /** @typedef {import("../../../../").NormalModule} NormalModule */
 
-const usedModule = path.resolve(__dirname, "lib/Used.js");
 const unusedModule = path.resolve(__dirname, "lib/Unused.js");
 
 /** @type {import("../../../../").Configuration} */
@@ -25,8 +24,8 @@ module.exports = {
 				});
 			});
 			compiler.hooks.done.tap("Test", (stats) => {
-				// requested re-export is built, unused sibling stays deferred
-				expect(built.has(usedModule)).toBe(true);
+				// unused sibling stays deferred (never built); the requested one's
+				// `buildModule` is unreliable here since a cached run skips it
 				expect(built.has(unusedModule)).toBe(false);
 
 				// read the emitted assets from disk (assets are size-only in `done`)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Regression coverage for #21306: a side-effect-free barrel (`sideEffects: ["**/*.css"]`) that re-exports a component importing CSS dropped that component's stylesheet from its async chunk when only that export was requested by name. The behaviour was fixed by the lazy-barrel change in #21291; the existing `lazy-barrel/side-effect-import` test only covers a sync/initial CSS chunk, so this adds explicit coverage for the async CSS-chunk emission case. The test fails before #21291 (no `.css` asset is emitted) and passes on current `main`. Closes #21306.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/configCases/lazy-barrel/side-effect-css-async/` (asserts the used re-export's CSS is emitted into the async chunk, the unused sibling's CSS is not, and the unused module stays deferred).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to investigate the regression, build the minimal reproduction, and author the test case; all changes were reviewed before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_011WbLo6dE6Hw5XjzoeEjP5n)_