### PR TITLE
test: dynamic import of scoped namespaced packages

### DIFF
--- a/test/cases/context/issue-6360/index.js
+++ b/test/cases/context/issue-6360/index.js
@@ -1,0 +1,19 @@
+// Dynamic import of third-party scoped/namespaced packages, see #6360.
+
+it("should dynamically import a scoped package with the slash in the literal", async () => {
+	const results = [];
+	for (const name of ["pkg-a", "pkg-b"]) {
+		const m = await import(`@scope/${name}`);
+		results.push(m.name);
+	}
+	expect(results).toEqual(["pkg-a", "pkg-b"]);
+});
+
+it("should dynamically import a scoped package with the slash in the expression", async () => {
+	const results = [];
+	for (const segment of ["/pkg-a", "/pkg-b"]) {
+		const m = await import(`@scope${segment}`);
+		results.push(m.name);
+	}
+	expect(results).toEqual(["pkg-a", "pkg-b"]);
+});

--- a/test/cases/context/issue-6360/index.js
+++ b/test/cases/context/issue-6360/index.js
@@ -4,7 +4,7 @@ it("should dynamically import a scoped package with the slash in the literal", a
 	const results = [];
 	for (const name of ["pkg-a", "pkg-b"]) {
 		const m = await import(`@scope/${name}`);
-		results.push(m.name);
+		results.push(m.default.name);
 	}
 	expect(results).toEqual(["pkg-a", "pkg-b"]);
 });
@@ -13,7 +13,7 @@ it("should dynamically import a scoped package with the slash in the expression"
 	const results = [];
 	for (const segment of ["/pkg-a", "/pkg-b"]) {
 		const m = await import(`@scope${segment}`);
-		results.push(m.name);
+		results.push(m.default.name);
 	}
 	expect(results).toEqual(["pkg-a", "pkg-b"]);
 });

--- a/test/cases/context/issue-6360/node_modules/@scope/pkg-a/index.js
+++ b/test/cases/context/issue-6360/node_modules/@scope/pkg-a/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "pkg-a"
+};

--- a/test/cases/context/issue-6360/node_modules/@scope/pkg-a/package.json
+++ b/test/cases/context/issue-6360/node_modules/@scope/pkg-a/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "@scope/pkg-a",
+	"version": "1.0.0",
+	"main": "index.js"
+}

--- a/test/cases/context/issue-6360/node_modules/@scope/pkg-b/index.js
+++ b/test/cases/context/issue-6360/node_modules/@scope/pkg-b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "pkg-b"
+};

--- a/test/cases/context/issue-6360/node_modules/@scope/pkg-b/package.json
+++ b/test/cases/context/issue-6360/node_modules/@scope/pkg-b/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "@scope/pkg-b",
+	"version": "1.0.0",
+	"main": "index.js"
+}


### PR DESCRIPTION
**Summary**

Adds a regression test confirming that dynamic `import()` of third-party scoped/namespaced packages resolves from `node_modules` via context modules. This behavior — originally reported as broken on webpack 3 — works in webpack 5, so the test locks it in. Both `` import(`@scope/${name}`) `` (slash in the literal) and `` import(`@scope${seg}`) `` (slash supplied by the expression, the exact form from the issue) compile without errors/warnings and resolve at runtime. Closes #6360.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/cases/context/issue-6360/` with `@scope/pkg-a` and `@scope/pkg-b` fixtures covering both import forms.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to investigate the issue, reproduce the behavior against the current codebase, and author the regression test; all changes were reviewed and verified by building and executing the emitted bundles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKaa7P1HpAVDEhsc6A1tc1)_