### PR TITLE
fix: don't resolve new URL() directory references as modules

### DIFF
--- a/.changeset/url-import-meta-directory.md
+++ b/.changeset/url-import-meta-directory.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Pass through `new URL(...)` directory references instead of resolving them.

--- a/lib/url/URLParserPlugin.js
+++ b/lib/url/URLParserPlugin.js
@@ -56,6 +56,32 @@ const isMetaUrl = (parser, arg) => {
 	return true;
 };
 
+/**
+ * Whether the request points to a directory and thus can't be an asset.
+ * @param {string} request request
+ * @returns {boolean} true when the request is a directory reference
+ */
+const isDirectoryRequest = (request) =>
+	request === "." || request === ".." || request.endsWith("/");
+
+/**
+ * Replaces `import.meta.url` with the runtime base URI, leaving the
+ * `new URL(...)` construction untouched so it's evaluated at runtime.
+ * @param {JavascriptParser} parser parser
+ * @param {NewExpressionNode} expr expression
+ * @returns {void}
+ */
+const keepNewURL = (parser, expr) => {
+	const [, arg2] = expr.arguments;
+	const dep = new ConstDependency(
+		RuntimeGlobals.baseURI,
+		/** @type {Range} */ (arg2.range),
+		[RuntimeGlobals.baseURI]
+	);
+	dep.loc = /** @type {DependencyLocation} */ (expr.loc);
+	parser.state.module.addPresentationalDependency(dep);
+};
+
 /** @type {WeakMap<NewExpressionNode, BasicEvaluatedExpression | undefined>} */
 const getEvaluatedExprCache = new WeakMap();
 
@@ -157,13 +183,7 @@ class URLParserPlugin {
 						return;
 					}
 
-					const dep = new ConstDependency(
-						RuntimeGlobals.baseURI,
-						/** @type {Range} */ (arg2.range),
-						[RuntimeGlobals.baseURI]
-					);
-					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
-					parser.state.module.addPresentationalDependency(dep);
+					keepNewURL(parser, expr);
 
 					return true;
 				}
@@ -177,6 +197,12 @@ class URLParserPlugin {
 
 			// static URL
 			if ((request = evaluatedExpr.asString())) {
+				// A directory is not an asset; keep `new URL(...)` as-is, matching Node/browsers.
+				if (isDirectoryRequest(request)) {
+					keepNewURL(parser, expr);
+					return true;
+				}
+
 				const [arg1, arg2] = expr.arguments;
 				const dep = new URLDependency(
 					request,

--- a/test/configCases/url/import-meta-url-directory/index.js
+++ b/test/configCases/url/import-meta-url-directory/index.js
@@ -1,0 +1,13 @@
+it("should not resolve a directory reference as a module and keep `new URL(...)` as-is", () => {
+	const dotSlash = new URL("./", import.meta.url);
+	expect(dotSlash.href.endsWith("/")).toBe(true);
+
+	const dot = new URL(".", import.meta.url);
+	expect(dot.href.endsWith("/")).toBe(true);
+
+	const parent = new URL("../", import.meta.url);
+	expect(parent.href.endsWith("/")).toBe(true);
+
+	const subDir = new URL("./folder/", import.meta.url);
+	expect(subDir.href.endsWith("/folder/")).toBe(true);
+});

--- a/test/configCases/url/import-meta-url-directory/webpack.config.js
+++ b/test/configCases/url/import-meta-url-directory/webpack.config.js
@@ -1,0 +1,6 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web"
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #16878. `new URL("./", import.meta.url)` (and `.`, `..`, or any trailing-slash request) points at a directory, not an asset. Webpack resolved it as a module, which either errored (`Parsed request is a directory`) or bundled the directory's entry module with a wrong content-hash URL. Now such directory references are kept as-is and only `import.meta.url` is evaluated to the runtime base URI, matching Node and browsers.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/url/import-meta-url-directory`.

**Does this PR introduce a breaking change?**

No. Only affects directory requests that previously failed to build (or produced a wrong URL); dynamic/context `new URL(...)` and static asset references are unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to help locate the relevant code in `URLParserPlugin`, draft the fix and test case, and run the suite. All changes were reviewed and verified by me.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkfVqywNz6w6qGo7CDvwwd)_