### PR TITLE
refactor: build exports-presence guards from formula

### DIFF
--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -12,7 +12,6 @@ const {
 	getImportAttributes
 } = require("../javascript/JavascriptParser");
 const { getInnerGraphUtils } = require("../optimize/InnerGraph");
-const memoize = require("../util/memoize");
 const ConstDependency = require("./ConstDependency");
 const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
 const HarmonyAcceptImportDependency = require("./HarmonyAcceptImportDependency");
@@ -22,6 +21,10 @@ const {
 	ExportPresenceModes,
 	getNonOptionalPart
 } = require("./HarmonyImportDependency");
+const {
+	attachDependencyGuards,
+	isPresentByGuards
+} = require("./HarmonyImportGuard");
 const HarmonyImportSideEffectDependency = require("./HarmonyImportSideEffectDependency");
 const HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
 const { ImportPhaseUtils, createGetImportPhase } = require("./ImportPhase");
@@ -45,10 +48,6 @@ const { ImportPhaseUtils, createGetImportPhase } = require("./ImportPhase");
 /** @typedef {import("./HarmonyImportDependency").ExportPresenceMode} ExportPresenceMode */
 /** @typedef {import("./ImportPhase").ImportPhaseType} ImportPhaseType */
 /** @typedef {import("./HarmonyImportGuard").GuardFrame} GuardFrame */
-
-/** @typedef {Map<string, Set<string>>} Guards Map of import root to guarded member keys */
-
-const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
 const harmonySpecifierTag = Symbol("harmony import");
 
@@ -137,6 +136,12 @@ const findImportSpecifier = (parser, node) => {
 				parser,
 				/** @type {Expression} */ (node.object)
 			);
+		case "BinaryExpression":
+			// `"x" in ns` presence guard
+			return (
+				node.operator === "in" &&
+				findImportSpecifier(parser, /** @type {Expression} */ (node.right))
+			);
 		default:
 			return false;
 	}
@@ -175,21 +180,18 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 		);
 		if (!harmonySettings) return this.exportPresenceMode;
 
+		if (this.exportPresenceMode === ExportPresenceModes.NONE) {
+			return this.exportPresenceMode;
+		}
+
 		const stack = /** @type {GuardFrame[] | undefined} */ (
 			parser.state.guardStack
 		);
-		if (stack !== undefined) {
-			const name = harmonySettings.name;
-			const member = ids[0];
-			for (let i = stack.length - 1; i >= 0; i--) {
-				const presence = stack[i].presence;
-				if (presence !== undefined) {
-					const members = presence.get(name);
-					if (members !== undefined && members.has(member)) {
-						return ExportPresenceModes.NONE;
-					}
-				}
-			}
+		if (
+			stack !== undefined &&
+			isPresentByGuards(parser, stack, harmonySettings.name, ids[0])
+		) {
+			return ExportPresenceModes.NONE;
 		}
 
 		return this.exportPresenceMode;
@@ -354,7 +356,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				dep.call = parser.scope.inTaggedTemplateTag;
 				parser.state.module.addDependency(dep);
-				getHarmonyImportGuard().attachDependencyGuards(parser, dep);
+				attachDependencyGuards(parser, dep);
 				getInnerGraphUtils(parser.state.compilation).onUsage(
 					parser.state,
 					(e) => (dep.usedByExports = e)
@@ -406,7 +408,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					);
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
-					getHarmonyImportGuard().attachDependencyGuards(parser, dep);
+					attachDependencyGuards(parser, dep);
 					getInnerGraphUtils(parser.state.compilation).onUsage(
 						parser.state,
 						(e) => (dep.usedByExports = e)
@@ -463,7 +465,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						/** @type {boolean} */ (this.strictThisContextOnImports);
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addDependency(dep);
-					getHarmonyImportGuard().attachDependencyGuards(parser, dep);
+					attachDependencyGuards(parser, dep);
 					if (args) parser.walkExpressions(args);
 					getInnerGraphUtils(parser.state.compilation).onUsage(
 						parser.state,
@@ -543,90 +545,15 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 		parser.hooks.collectGuards.tap(PLUGIN_NAME, (expression) => {
 			if (parser.scope.isAsmJs) return;
 
-			// Presence guards: `"x" in ns` checks that suppress export-presence errors
-			// (consequent only).
-			/** @type {Guards | undefined} */
-			let presence;
-			if (this.exportPresenceMode !== ExportPresenceModes.NONE) {
-				/** @type {Guards} */
-				const guards = new Map();
-
-				/**
-				 * Processes the provided expression.
-				 * @param {Expression} expression expression
-				 * @param {boolean} needTruthy need to be truthy
-				 */
-				const collect = (expression, needTruthy) => {
-					if (
-						expression.type === "UnaryExpression" &&
-						expression.operator === "!"
-					) {
-						collect(expression.argument, !needTruthy);
-						return;
-					} else if (expression.type === "LogicalExpression" && needTruthy) {
-						if (expression.operator === "&&") {
-							collect(expression.left, true);
-							collect(expression.right, true);
-						} else if (expression.operator === "||") {
-							const leftEvaluation = parser.evaluateExpression(expression.left);
-							const leftBool = leftEvaluation.asBool();
-							if (leftBool === false) {
-								collect(expression.right, true);
-							}
-						} else if (expression.operator === "??") {
-							const leftEvaluation = parser.evaluateExpression(expression.left);
-							const leftNullish = leftEvaluation.asNullish();
-							if (leftNullish === true) {
-								collect(expression.right, true);
-							}
-						}
-						return;
-					}
-					if (!needTruthy) return;
-
-					// Direct `"x" in ns` guards
-					if (
-						expression.type === "BinaryExpression" &&
-						expression.operator === "in"
-					) {
-						if (expression.right.type !== "Identifier") {
-							return;
-						}
-						const info = getInOperatorHarmonyImportInfo(
-							parser,
-							expression.left,
-							expression.right
-						);
-						if (!info) return;
-
-						const { settings, leftPart, members } = info;
-						// Only direct namespace guards
-						if (members.length > 0) return;
-						const guarded = guards.get(settings.name);
-						if (guarded) {
-							guarded.add(leftPart);
-							return;
-						}
-
-						guards.set(settings.name, new Set([leftPart]));
-					}
-				};
-
-				collect(expression, true);
-
-				if (guards.size > 0) presence = guards;
-			}
-
 			const hasSpecifier = findImportSpecifier(parser, expression);
 			const depStart = hasSpecifier
 				? /** @type {Module} */ (parser.state.module).dependencies.length
 				: undefined;
 
-			if (presence === undefined && depStart === undefined) return;
+			if (depStart === undefined) return;
 
 			/** @type {GuardFrame} */
 			const consequent = {
-				presence,
 				test: expression,
 				depStart,
 				condition: true

--- a/lib/dependencies/HarmonyImportGuard.js
+++ b/lib/dependencies/HarmonyImportGuard.js
@@ -15,16 +15,19 @@ const memoize = require("../util/memoize");
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./CommonJsRequireDependency")} CommonJsRequireDependency */
+/** @typedef {import("./HarmonyEvaluatedImportSpecifierDependency")} HarmonyEvaluatedImportSpecifierDependency */
 /** @typedef {import("./HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
 /** @typedef {import("./ImportDependency")} ImportDependency */
 
 // Tuple-encoded boolean formula over guard dependencies. Split into per-shape
 // aliases so the recursive references resolve through array/object types.
+// `v` = dependency-liveness atom, `p` = `"x" in ns` presence atom.
 /** @typedef {["v", Dependency]} GuardAtom */
+/** @typedef {["p", HarmonyEvaluatedImportSpecifierDependency]} GuardPresenceAtom */
 /** @typedef {["?"]} GuardUnknown */
 /** @typedef {["!", GuardFormula]} GuardNot */
 /** @typedef {["&&" | "||" | "??", GuardFormula, GuardFormula]} GuardLogical */
-/** @typedef {GuardAtom | GuardUnknown | GuardNot | GuardLogical} GuardFormula */
+/** @typedef {GuardAtom | GuardPresenceAtom | GuardUnknown | GuardNot | GuardLogical} GuardFormula */
 /** @typedef {{ formula: GuardFormula, value: boolean }} DependencyGuard branch guard: the dependency is live only when the formula evaluates to `value` */
 /** @typedef {HarmonyImportSpecifierDependency | CommonJsRequireDependency | ImportDependency} GuardableDependency */
 
@@ -33,15 +36,18 @@ const memoize = require("../util/memoize");
  * conditional branch body. Carries the `"x" in ns` presence guards and/or the
  * dead-branch dependency guard for that branch.
  * @typedef {object} GuardFrame
- * @property {Map<string, Set<string>>=} presence `"x" in ns` presence guards active in this branch
  * @property {Expression=} test the conditional test (for the lazily built formula)
  * @property {number=} depStart dependency count before the test was walked
  * @property {boolean=} condition branch truthiness the dependency guard is live for
- * @property {GuardFormula | null=} formula memoized formula (null = no knowable atom)
+ * @property {GuardFormula | null=} formula memoized dependency-guard formula (null = no knowable atom)
+ * @property {GuardFormula | null=} presenceFormula memoized presence formula (null = no presence atom)
  */
 
 const getHarmonyImportSpecifierDependency = memoize(() =>
 	require("./HarmonyImportSpecifierDependency")
+);
+const getHarmonyEvaluatedImportSpecifierDependency = memoize(() =>
+	require("./HarmonyEvaluatedImportSpecifierDependency")
 );
 
 // Tri-state truthiness: UNKNOWN means not statically known.
@@ -62,12 +68,12 @@ const flip = (t) => (t === TRUE ? FALSE : t === FALSE ? TRUE : UNKNOWN);
 const fromBool = (b) => (b ? TRUE : FALSE);
 
 /**
- * Build a guard formula from a conditional test AST.
+ * Build a liveness formula from a conditional test AST.
  * @param {Expression} test conditional test expression
  * @param {Map<number, HarmonyImportSpecifierDependency>} depByRangeStart import-specifier deps in the test, keyed by range start
  * @returns {GuardFormula | null} formula, or null when it has no knowable atom
  */
-const buildGuardFormula = (test, depByRangeStart) => {
+const buildLivenessFormula = (test, depByRangeStart) => {
 	/**
 	 * @param {Expression} node ast node
 	 * @returns {GuardFormula} formula node
@@ -104,6 +110,7 @@ const buildGuardFormula = (test, depByRangeStart) => {
 const hasAtom = (formula) => {
 	switch (formula[0]) {
 		case "v":
+		case "p":
 			return true;
 		case "!":
 			return hasAtom(formula[1]);
@@ -122,7 +129,7 @@ const hasAtom = (formula) => {
  * @param {RuntimeSpec} runtime runtime
  * @returns {{ t: number, n: number }} truthy `t` and null `n` tri-states
  */
-const evalNode = (formula, moduleGraph, runtime) => {
+const evalLivenessFormula = (formula, moduleGraph, runtime) => {
 	switch (formula[0]) {
 		case "v": {
 			const dep = /** @type {HarmonyImportSpecifierDependency} */ (formula[1]);
@@ -145,12 +152,12 @@ const evalNode = (formula, moduleGraph, runtime) => {
 		case "!":
 			// `!x` always yields a boolean → never nullish.
 			return {
-				t: flip(evalNode(formula[1], moduleGraph, runtime).t),
+				t: flip(evalLivenessFormula(formula[1], moduleGraph, runtime).t),
 				n: FALSE
 			};
 		case "&&": {
-			const l = evalNode(formula[1], moduleGraph, runtime);
-			const r = evalNode(formula[2], moduleGraph, runtime);
+			const l = evalLivenessFormula(formula[1], moduleGraph, runtime);
+			const r = evalLivenessFormula(formula[2], moduleGraph, runtime);
 			const t =
 				l.t === FALSE || r.t === FALSE
 					? FALSE
@@ -160,8 +167,8 @@ const evalNode = (formula, moduleGraph, runtime) => {
 			return { t, n: UNKNOWN };
 		}
 		case "||": {
-			const l = evalNode(formula[1], moduleGraph, runtime);
-			const r = evalNode(formula[2], moduleGraph, runtime);
+			const l = evalLivenessFormula(formula[1], moduleGraph, runtime);
+			const r = evalLivenessFormula(formula[2], moduleGraph, runtime);
 			const t =
 				l.t === TRUE || r.t === TRUE
 					? TRUE
@@ -171,8 +178,8 @@ const evalNode = (formula, moduleGraph, runtime) => {
 			return { t, n: UNKNOWN };
 		}
 		case "??": {
-			const l = evalNode(formula[1], moduleGraph, runtime);
-			const r = evalNode(formula[2], moduleGraph, runtime);
+			const l = evalLivenessFormula(formula[1], moduleGraph, runtime);
+			const r = evalLivenessFormula(formula[2], moduleGraph, runtime);
 			// `l ?? r` is l when l non-nullish, else r.
 			const t =
 				l.n === FALSE ? l.t : l.n === TRUE ? r.t : l.t === r.t ? l.t : UNKNOWN;
@@ -192,35 +199,199 @@ const evalNode = (formula, moduleGraph, runtime) => {
  */
 const isDeadByGuards = (guards, moduleGraph, runtime) => {
 	for (const guard of guards) {
-		const t = evalNode(guard.formula, moduleGraph, runtime).t;
+		const t = evalLivenessFormula(guard.formula, moduleGraph, runtime).t;
 		if (t !== UNKNOWN && t !== (guard.value ? TRUE : FALSE)) return true;
 	}
 	return false;
 };
 
 /**
- * Builds (once) the dependency-guard formula for a frame from the import
- * specifier deps created while walking the test.
+ * Builds (once) the liveness formula for a frame from the import specifier deps
+ * created while walking the test.
  * @param {JavascriptParser} parser the parser
  * @param {GuardFrame} frame guard frame
  * @returns {GuardFormula | null} formula, or null when it has no knowable atom
  */
-const buildFrameFormula = (parser, frame) => {
+const buildFrameLivenessFormula = (parser, frame) => {
 	const HarmonyImportSpecifierDependency =
 		getHarmonyImportSpecifierDependency();
+	const HarmonyEvaluatedImportSpecifierDependency =
+		getHarmonyEvaluatedImportSpecifierDependency();
 	const deps = /** @type {Module} */ (parser.state.module).dependencies;
 	/** @type {Map<number, HarmonyImportSpecifierDependency>} */
 	const depByRangeStart = new Map();
 	for (let i = /** @type {number} */ (frame.depStart); i < deps.length; i++) {
 		const dep = deps[i];
-		if (dep instanceof HarmonyImportSpecifierDependency && dep.range) {
+		// Exclude `"x" in ns` evaluated deps; those feed the presence formula only.
+		if (
+			dep instanceof HarmonyImportSpecifierDependency &&
+			!(dep instanceof HarmonyEvaluatedImportSpecifierDependency) &&
+			dep.range
+		) {
 			depByRangeStart.set(dep.range[0], dep);
 		}
 	}
-	return buildGuardFormula(
+	return buildLivenessFormula(
 		/** @type {Expression} */ (frame.test),
 		depByRangeStart
 	);
+};
+
+/**
+ * Build a presence formula from a conditional test AST. Statically-decided
+ * `||`/`??` operands are folded away at build time, so the result contains only
+ * `"x" in ns` presence atoms (plus `&&`/`!`).
+ * @param {JavascriptParser} parser the parser
+ * @param {Expression} test conditional test expression
+ * @param {Map<number, HarmonyEvaluatedImportSpecifierDependency>} depByRangeStart in-operator deps in the test, keyed by range start
+ * @returns {GuardFormula | null} formula, or null when it has no presence atom
+ */
+const buildPresenceFormula = (parser, test, depByRangeStart) => {
+	/**
+	 * @param {Expression} node ast node
+	 * @returns {GuardFormula} formula node
+	 */
+	const build = (node) => {
+		if (node.type === "UnaryExpression" && node.operator === "!") {
+			return ["!", build(/** @type {Expression} */ (node.argument))];
+		}
+		if (node.type === "LogicalExpression") {
+			if (node.operator === "&&") {
+				return [
+					"&&",
+					build(/** @type {Expression} */ (node.left)),
+					build(/** @type {Expression} */ (node.right))
+				];
+			}
+
+			if (node.operator === "||") {
+				if (parser.evaluateExpression(node.left).asBool() === false) {
+					return build(/** @type {Expression} */ (node.right));
+				}
+				if (parser.evaluateExpression(node.right).asBool() === false) {
+					return build(/** @type {Expression} */ (node.left));
+				}
+				return ["?"];
+			}
+
+			if (node.operator === "??") {
+				const nullish = parser.evaluateExpression(node.left).asNullish();
+				if (nullish === true) {
+					return build(/** @type {Expression} */ (node.right));
+				}
+				if (nullish === false) {
+					return build(/** @type {Expression} */ (node.left));
+				}
+				return ["?"];
+			}
+		}
+		const dep =
+			node.range && depByRangeStart.get(/** @type {number} */ (node.range[0]));
+		return dep ? ["p", dep] : ["?"];
+	};
+
+	const formula = build(test);
+	return hasAtom(formula) ? formula : null;
+};
+
+/**
+ * Whether a presence formula guarantees `ns.member` is present. "Must be truthy"
+ * semantics: the member is guaranteed when some `"member" in ns` atom must hold
+ * for the branch condition. Statically-dead branches never reach here — the
+ * parser eliminates them before the branch body is walked.
+ * @param {GuardFormula} formula presence formula
+ * @param {string} name namespace binding name
+ * @param {string} member member key
+ * @param {boolean} needTruthy whether the formula must be truthy
+ * @returns {boolean} true when the member is guaranteed present
+ */
+const evalPresenceFormula = (formula, name, member, needTruthy) => {
+	switch (formula[0]) {
+		case "p": {
+			const dep = /** @type {HarmonyEvaluatedImportSpecifierDependency} */ (
+				formula[1]
+			);
+			return (
+				needTruthy &&
+				dep.directImport === true &&
+				dep.name === name &&
+				dep.ids.length === 1 &&
+				dep.ids[0] === member
+			);
+		}
+		case "!":
+			return evalPresenceFormula(formula[1], name, member, !needTruthy);
+		case "&&":
+			return (
+				needTruthy &&
+				(evalPresenceFormula(formula[1], name, member, true) ||
+					evalPresenceFormula(formula[2], name, member, true))
+			);
+		default:
+			return false;
+	}
+};
+
+/**
+ * Builds (once) the presence formula for a frame from the in-operator deps
+ * created while walking the test.
+ * @param {JavascriptParser} parser the parser
+ * @param {GuardFrame} frame guard frame
+ * @returns {GuardFormula | null} formula, or null when it has no presence atom
+ */
+const buildFramePresenceFormula = (parser, frame) => {
+	const HarmonyEvaluatedImportSpecifierDependency =
+		getHarmonyEvaluatedImportSpecifierDependency();
+	const deps = /** @type {Module} */ (parser.state.module).dependencies;
+	/** @type {Map<number, HarmonyEvaluatedImportSpecifierDependency>} */
+	const depByRangeStart = new Map();
+	for (let i = /** @type {number} */ (frame.depStart); i < deps.length; i++) {
+		const dep = deps[i];
+		if (dep instanceof HarmonyEvaluatedImportSpecifierDependency && dep.range) {
+			depByRangeStart.set(dep.range[0], dep);
+		}
+	}
+	return buildPresenceFormula(
+		parser,
+		/** @type {Expression} */ (frame.test),
+		depByRangeStart
+	);
+};
+
+/**
+ * Whether an active presence guard proves `ns.member` present, suppressing
+ * export-presence errors. Each frame is evaluated against its branch condition,
+ * so the `else` of `if (!("x" in ns))` also guards `ns.x`.
+ * @param {JavascriptParser} parser the parser
+ * @param {GuardFrame[]} stack the guard stack
+ * @param {string} name namespace binding name
+ * @param {string} member member key
+ * @returns {boolean} true when a guard proves the member present
+ */
+const isPresentByGuards = (parser, stack, name, member) => {
+	for (let i = stack.length - 1; i >= 0; i--) {
+		const frame = stack[i];
+		if (frame.depStart === undefined) continue;
+		let formula = frame.presenceFormula;
+		if (formula === undefined) {
+			formula = frame.presenceFormula = buildFramePresenceFormula(
+				parser,
+				frame
+			);
+		}
+		if (
+			formula !== null &&
+			evalPresenceFormula(
+				formula,
+				name,
+				member,
+				/** @type {boolean} */ (frame.condition)
+			)
+		) {
+			return true;
+		}
+	}
+	return false;
 };
 
 /**
@@ -239,7 +410,7 @@ const attachDependencyGuards = (parser, dep) => {
 		if (frame.depStart === undefined) continue;
 		let formula = frame.formula;
 		if (formula === undefined) {
-			formula = frame.formula = buildFrameFormula(parser, frame);
+			formula = frame.formula = buildFrameLivenessFormula(parser, frame);
 		}
 		if (formula === null) continue;
 		(guards || (guards = [])).push({
@@ -252,3 +423,4 @@ const attachDependencyGuards = (parser, dep) => {
 
 module.exports.attachDependencyGuards = attachDependencyGuards;
 module.exports.isDeadByGuards = isDeadByGuards;
+module.exports.isPresentByGuards = isPresentByGuards;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1383,6 +1383,16 @@ class JavascriptParser extends Parser {
 				return handleConstOperation((l, r) => l <= r);
 			} else if (expr.operator === ">=") {
 				return handleConstOperation((l, r) => l >= r);
+			} else if (expr.operator === "in") {
+				// `x in y` always evaluates to a boolean, so it is never nullish
+				const left = this.evaluateExpression(expr.left);
+				const right = this.evaluateExpression(expr.right);
+				return new BasicEvaluatedExpression()
+					.setNullish(false)
+					.setSideEffects(
+						left.couldHaveSideEffects() || right.couldHaveSideEffects()
+					)
+					.setRange(/** @type {Range} */ (expr.range));
 			}
 		});
 		this.hooks.evaluate.for("UnaryExpression").tap(CLASS_NAME, (_expr) => {

--- a/test/configCases/compiletime/exports-presence/module.js
+++ b/test/configCases/compiletime/exports-presence/module.js
@@ -24,6 +24,14 @@ describe("should not add additional warnings/errors", () => {
 				fn(ns.a, ns.d);
 			}
 		}
+		// mirror of `0 || "a" in ns`: statically-falsy operand on the right
+		if ("a" in ns || 0) {
+			fn(ns.a);
+		}
+		// `in` is never nullish, so `?? 0` is a no-op guard
+		if ("a" in ns ?? 0) {
+			fn(ns.a);
+		}
 
 		// warning: 31:6-10(a)
 		if (!("a" in ns)) {
@@ -32,6 +40,13 @@ describe("should not add additional warnings/errors", () => {
 		}
 
 		if (!!("a" in ns)) {
+			fn(ns.a);
+		}
+
+		// a negated `in` guard flips for the `else` branch
+		if (!("a" in ns)) {
+			// no access
+		} else {
 			fn(ns.a);
 		}
 	});


### PR DESCRIPTION

**Summary**

**What kind of change does this PR introduce?**

The export-presence guard that suppresses "export not found" warnings for namespace accesses behind an `"x" in ns` check was backed by an eagerly-built `Map<string, Set<string>>`. This PR reworks it into a boolean formula built lazily
from the branch test (atoms are the `"x" in ns` dependencies), sharing the same tuple-formula machinery already used for dead-branch dependency guards. 

It also recognizes guards it missed before: the `else` branch of a negated check (`if (!("a" in ns)) {} else { ns.a }`), a statically-falsy right operand (`"a" in ns || 0`), and `"a" in ns ?? 0` — the last enabled by teaching the evaluator that `in` always yields a (non-nullish) boolean.

**Did you add tests for your changes?**

Yes — extended `test/configCases/compiletime/exports-presence/module.js` with the
`else`-branch, `|| 0`, and `?? 0` guard cases.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes