### PR TITLE
fix: don't cache incomplete exports of lazy-barrel-deferred re-exports

### DIFF
--- a/.changeset/lazy-barrel-persistent-cache-exports.md
+++ b/.changeset/lazy-barrel-persistent-cache-exports.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix stale exports for lazy-barrel modules restored from persistent cache.

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -148,6 +148,12 @@ class FlagDependencyExportsPlugin {
 							 * @returns {void}
 							 */
 							const processDependency = (dep) => {
+								// lazy barrel deferred this re-export: its target is not built, so
+								// the provided exports are incomplete and must not be cached
+								if ("isLazy" in dep && dep.isLazy()) {
+									cacheable = false;
+									return;
+								}
 								const exportDesc = dep.getExports(moduleGraph);
 								if (!exportDesc) return;
 								exportsSpecsFromDependencies.set(dep, exportDesc);

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -304,4 +304,39 @@ import 'lodash';
 		await compile(configAdditions);
 		await expect(getCacheFileTimes()).resolves.toEqual(firstCacheFileTimes);
 	}, 20000);
+
+	it("should provide re-exports deferred by the lazy barrel after restore", async () => {
+		// A side-effect-free barrel with a local export and a star re-export whose
+		// target is unused: the star stays deferred, so the barrel is cacheable and
+		// gets persisted as a closed export set omitting the star's exports. A later
+		// build that imports one of those names must recompute, not restore the stale
+		// exports and report the name as missing.
+		const configAdditions = {
+			mode: "development",
+			entry: "./src/main.js",
+			optimization: {
+				sideEffects: true,
+				providedExports: true,
+				usedExports: true,
+				innerGraph: true
+			}
+		};
+		await mkdir(path.resolve(srcPath, "pkg"), { recursive: true });
+		await updateSrc({
+			"pkg/package.json": '{ "name": "pkg", "sideEffects": false }',
+			"pkg/extra.js": "export const b = 'b';",
+			"pkg/index.js": "export const a = 'a';\nexport * from './extra';",
+			"main.js": "import { a } from './pkg';\nexport default a;"
+		});
+		await compile(configAdditions);
+		expect(execute()).toBe("a");
+
+		await updateSrc({
+			"main.js": "import { a, b } from './pkg';\nexport default a + b;"
+		});
+		const stats = await compile(configAdditions);
+		expect(stats.hasErrors()).toBe(false);
+		expect(stats.hasWarnings()).toBe(false);
+		expect(execute()).toBe("ab");
+	}, 60000);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #21318. A side-effect-free barrel whose re-export target is deferred by the lazy barrel (e.g. `mobx-react`'s `export * from "mobx-react-lite"`) reports no exports for that dependency, so `FlagDependencyExportsPlugin` flagged the module cacheable and persisted a closed export set omitting those names. A later build that imports one of them (typical with `lazyCompilation` where an entry activates afterwards) restored the stale provided exports from the filesystem cache instead of recomputing, and reported the name as missing (`export 'X' ... was not found`). A resolved re-export already makes the module non-cacheable; this treats a lazy-deferred dependency the same way.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/PersistentCaching.test.js` (two filesystem-cache runs where the deferred star re-export's name is imported only on the second run). It fails on the old code and passes with the fix.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used to help investigate the regression and draft the fix and test; the change and test were reviewed and verified locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mbSVC1GWbLgZVycxncPft)_