### PR TITLE
perf: reduce HTML parser memory and CPU with parser-level skip options

### DIFF
--- a/.changeset/html-parser-drop-text-data.md
+++ b/.changeset/html-parser-drop-text-data.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reduce HTML parser memory and CPU by not retaining decoded text node data.
+Reduce HTML parser memory and CPU by skipping unused AST nodes.

--- a/.changeset/html-parser-drop-text-data.md
+++ b/.changeset/html-parser-drop-text-data.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce HTML parser memory and CPU by not retaining decoded text node data.

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1461,11 +1461,11 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			// `skipTextData`: the walk reads text nodes by offset, never their
-			// decoded `data`, so building without it saves heap. The processor
-			// builds the AST internally (like the CSS parser), so no `buildHtmlAst`
-			// call or pre-built `ast` is threaded through here.
-			.process(source, { skipTextData: true });
+			// Skip the AST output this walk never reads: prose `text` nodes (it only
+			// reads `<script>`/`<style>` bodies, by offset) and the `doctype` node.
+			// `comments` are NOT skipped — magic comments (`webpackIgnore`) need them.
+			// The processor builds the AST internally (like the CSS parser).
+			.process(source, { skip: { text: true, doctype: true } });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1461,11 +1461,11 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			// Skip the AST output this walk never reads: prose `text` nodes (it only
+			// Skip the AST output this walk never reads: prose text nodes (it only
 			// reads `<script>`/`<style>` bodies, by offset) and the `doctype` node.
 			// `comments` are NOT skipped — magic comments (`webpackIgnore`) need them.
 			// The processor builds the AST internally (like the CSS parser).
-			.process(source, { skip: { text: true, doctype: true } });
+			.process(source, { skip: { proseText: true, doctype: true } });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1456,11 +1456,9 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			// Skip the AST output this walk never reads: all `text` nodes (it reads
-			// `<script>`/`<style>` bodies by offset, via each element's `contentEnd`)
-			// and the `doctype` node. `comments` are NOT skipped — magic comments
-			// (`webpackIgnore`) need them. The processor builds the AST internally
-			// (like the CSS parser).
+			// Skip AST output this walk never reads: `text` (script/style bodies are
+			// read by offset via `contentEnd`) and `doctype`; keep `comments` for
+			// magic comments (`webpackIgnore`).
 			.process(source, { skip: { text: true, doctype: true } });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -39,7 +39,6 @@ const {
 	NodeType,
 	SVG_TAG_ADJUST,
 	SourceProcessor,
-	buildHtmlAst,
 	decodeHtmlEntities,
 	decodeHtmlEntitiesWithMap,
 	findAttr,
@@ -1462,9 +1461,11 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			// `rawText`: the walk reads text nodes' offsets (not their decoded
-			// `data`), so keep text `data` as cheap source slices to save heap.
-			.process(source, { ast: buildHtmlAst(source, undefined, true) });
+			// `skipTextData`: the walk reads text nodes by offset, never their
+			// decoded `data`, so building without it saves heap. The processor
+			// builds the AST internally (like the CSS parser), so no `buildHtmlAst`
+			// call or pre-built `ast` is threaded through here.
+			.process(source, { skipTextData: true });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1115,16 +1115,11 @@ class HtmlParser extends Parser {
 								if (bodyItem.filter && !bodyItem.filter(getAttributesMap())) {
 									continue;
 								}
-								/** @type {number | undefined} */
-								let bodyStart;
-								let bodyEnd = node.tagEnd;
-								for (const child of node.children) {
-									if (child.type === NodeType.Text) {
-										if (bodyStart === undefined) bodyStart = child.start;
-										bodyEnd = child.end;
-									}
-								}
-								if (bodyStart === undefined) continue;
+								// `skip.text` drops the body `Text` node; the raw content
+								// span is [`tagEnd`, `contentEnd`] on the element.
+								const bodyStart = node.tagEnd;
+								const bodyEnd = node.contentEnd;
+								if (bodyEnd <= bodyStart) continue;
 								value = source.slice(bodyStart, bodyEnd);
 								if (value.trim() === "") continue;
 								start = bodyStart;
@@ -1461,11 +1456,12 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			// Skip the AST output this walk never reads: prose text nodes (it only
-			// reads `<script>`/`<style>` bodies, by offset) and the `doctype` node.
-			// `comments` are NOT skipped — magic comments (`webpackIgnore`) need them.
-			// The processor builds the AST internally (like the CSS parser).
-			.process(source, { skip: { proseText: true, doctype: true } });
+			// Skip the AST output this walk never reads: all `text` nodes (it reads
+			// `<script>`/`<style>` bodies by offset, via each element's `contentEnd`)
+			// and the `doctype` node. `comments` are NOT skipped — magic comments
+			// (`webpackIgnore`) need them. The processor builds the AST internally
+			// (like the CSS parser).
+			.process(source, { skip: { text: true, doctype: true } });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -1462,7 +1462,9 @@ class HtmlParser extends Parser {
 					}
 				}
 			})
-			.process(source, { ast: buildHtmlAst(source) });
+			// `rawText`: the walk reads text nodes' offsets (not their decoded
+			// `data`), so keep text `data` as cheap source slices to save heap.
+			.process(source, { ast: buildHtmlAst(source, undefined, true) });
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7301,9 +7301,8 @@ const NodeType = {
 
 /**
  * @typedef {object} HtmlProcessOptions
- * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`)
- * @property {boolean=} skipTextData omit text nodes' decoded `data` when building the AST (see `buildHtmlAst`); ignored when `ast` is provided
- * @property {(HtmlDocument | HtmlDocumentFragment)=} ast walk this pre-built AST instead of parsing the input
+ * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`); the HTML analog of the CSS parser's `as` parse-mode option
+ * @property {boolean=} skipTextData omit text nodes' decoded `data` when building the AST (see `buildHtmlAst`)
  */
 
 /**
@@ -7362,11 +7361,7 @@ const grammar = (input, visitors, options) => {
 		}
 	};
 
-	walk(
-		options.ast ||
-			buildHtmlAst(input, options.fragmentContext, options.skipTextData),
-		null
-	);
+	walk(buildHtmlAst(input, options.fragmentContext, options.skipTextData), null);
 };
 
 /**

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4503,6 +4503,13 @@ const EMPTY_ATTRS = /** @type {HtmlAttribute[]} */ (
 	/** @type {unknown} */ (Object.freeze([]))
 );
 
+// Shared frozen children array for void elements — they are inserted and
+// immediately popped, so they never receive children. Frozen so any (buggy)
+// append throws instead of corrupting the shared instance.
+const EMPTY_CHILDREN = /** @type {HtmlNode[]} */ (
+	/** @type {unknown} */ (Object.freeze([]))
+);
+
 /**
  * Hash of the ASCII-lowercased `name` for the intern tables below; must stay
  * in sync with the range hash in `internLowerName`.
@@ -4697,14 +4704,16 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {number} */ ns,
 		/** @type {HtmlAttribute[] | undefined} */ attributes,
 		/** @type {TagPos | null | undefined} */ pos
-	) =>
-		/** @type {HtmlElement} */ ({
+	) => {
+		const selfClosing = ns === NS_HTML && VOID.has(tagName);
+		return /** @type {HtmlElement} */ ({
 			type: NodeType.Element,
 			tagName,
 			namespace: ns,
 			attributes: attributes || EMPTY_ATTRS,
-			children: [],
-			selfClosing: ns === NS_HTML && VOID.has(tagName),
+			// Void elements never receive children — share one frozen array.
+			children: selfClosing ? EMPTY_CHILDREN : [],
+			selfClosing,
 			start: pos ? pos.start : 0,
 			end: pos ? pos.end : 0,
 			tagEnd: pos ? pos.tagEnd : 0,
@@ -4717,6 +4726,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// keeps one monomorphic hidden class for the open-stack/scope loops.
 			templateContent: undefined
 		});
+	};
 
 	// Clone of a formatting element's attributes: keep name/value (and the
 	// serializer name) but drop source offsets so the consumer doesn't emit a

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4503,9 +4503,8 @@ const EMPTY_ATTRS = /** @type {HtmlAttribute[]} */ (
 	/** @type {unknown} */ (Object.freeze([]))
 );
 
-// Shared frozen children array for void elements — they are inserted and
-// immediately popped, so they never receive children. Frozen so any (buggy)
-// append throws instead of corrupting the shared instance.
+// Shared frozen children array for void elements (never mutated); frozen so a
+// stray append throws instead of corrupting the shared instance.
 const EMPTY_CHILDREN = /** @type {HtmlNode[]} */ (
 	/** @type {unknown} */ (Object.freeze([]))
 );
@@ -4869,18 +4868,15 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	) => {
 		const place = appropriatePlace();
 		if (place.parent.type === NodeType.Document) return; // never insert text into document
-		// `skip.text`: drop every `Text` node — construction decisions above already
-		// used the decoded token, so removing the node never affects element
-		// structure. For a raw-text element (`<script>`/`<style>`/…) record the
-		// body's end offset so a consumer can still read the content span
+		// `skip.text`: drop every `Text` node — construction already used the
+		// decoded token, so removing the node never affects element structure.
+		// For a raw-text element record the body end so a consumer reads the span
 		// [`tagEnd`, `contentEnd`] without a `Text` node (see `HtmlParser`).
+		// Namespace-agnostic: `HtmlParser` extracts `<script>`/`<style>` bodies in
+		// foreign content (e.g. SVG `<style>`) too.
 		if (skipText) {
 			const p = place.parent;
-			if (
-				p.type === NodeType.Element &&
-				p.namespace === NS_HTML &&
-				RAW_TEXT_ELEMENTS.has(p.tagName)
-			) {
+			if (p.type === NodeType.Element && RAW_TEXT_ELEMENTS.has(p.tagName)) {
 				p.contentEnd = end;
 			}
 			return;
@@ -7099,12 +7095,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return end;
 		},
 		text: (input, start, end) => {
-			// `skip.text` fast path: the node is dropped, so construction only needs
-			// the run's whitespace-ness (`isAllWs` / framesetOk). For plain text —
-			// no `&` (entities), `\0`, `\r`, or a pending leading-newline swallow —
-			// the decoded value equals the raw range, so scan it and dispatch a
-			// canonical marker (`" "` all-whitespace, `"x"` otherwise), skipping the
-			// per-run slice + entity decode. Anything trickier falls through.
+			// `skip.text` fast path: node dropped, so only whitespace-ness matters.
+			// With no `&`/`\0`/`\r` (and no pending newline-swallow) the decoded value
+			// equals the raw range — dispatch a canonical marker (`" "`/`"x"`) without
+			// the slice + entity decode; anything trickier falls through.
 			if (skipText && !swallowNextNewline) {
 				let hasNonWs = false;
 				let i = start;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4618,13 +4618,45 @@ const findAttr = (
 	return undefined;
 };
 
+// Elements whose text content is their raw "value" (RAWTEXT/RCDATA/script/
+// plaintext). Under `skip.text` these bodies are kept (offset-only) so a
+// consumer can still read them; all other (prose) text is dropped.
+const TEXT_CONTENT_ELEMENTS = new Set([
+	"script",
+	"style",
+	"textarea",
+	"title",
+	"xmp",
+	"iframe",
+	"noembed",
+	"noframes",
+	"noscript",
+	"plaintext"
+]);
+
+/** Shared empty skip set so the common (no-skip) call allocates nothing. */
+const EMPTY_SKIP = Object.freeze({});
+
+/**
+ * Optional node kinds a consumer can drop from the AST for speed/memory. Each
+ * is a pure output reduction — tree construction (and quirks detection) runs
+ * unchanged, so element structure and offsets are identical either way.
+ * @typedef {object} HtmlAstSkip
+ * @property {boolean=} text drop prose text nodes; keep only raw-text element bodies (`<script>`/`<style>`/… — see `TEXT_CONTENT_ELEMENTS`), and those offset-only (no decoded `data`). Only for consumers that read text by offset (e.g. `HtmlParser`, which re-slices bodies), never the html5lib serializer.
+ * @property {boolean=} comments drop comment nodes entirely. Not for consumers that read comments (e.g. webpack magic comments).
+ * @property {boolean=} doctype drop the doctype node; quirks-mode detection is unaffected.
+ */
+
 /**
  * @param {string} source HTML source
  * @param {string=} fragmentContext context element name for fragment parsing (e.g. `td`, `svg path`); omit for a full document
- * @param {boolean=} skipTextData omit text nodes' decoded `data` (leaving `data` `undefined`), keeping only their `start`/`end` offsets, to drop the retained text strings (~6% of the tree). Tree-construction decisions still use the decoded value; adjacent text is merged only when contiguous. Only valid for consumers that read text by offset and never read `data` (e.g. `HtmlParser`, which re-slices bodies from offsets). Not for the html5lib serializer.
+ * @param {HtmlAstSkip=} skip node kinds to omit from the AST (see `HtmlAstSkip`); omit to build the full tree
  * @returns {HtmlDocument} document AST
  */
-const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
+const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
+	const skipText = skip.text === true;
+	const skipComments = skip.comments === true;
+	const skipDoctype = skip.doctype === true;
 	/** @type {HtmlDocument} */
 	const doc = { type: NodeType.Document, children: [] };
 	let mode = MODE_INITIAL;
@@ -4710,9 +4742,9 @@ const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
 		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
-			// `skipTextData`: text `data` is unused; merge exactly as the default path
+			// `skip.text`: retained bodies are offset-only; merge as the default path
 			// (same node, same `end` bump) but skip the string concatenation.
-			if (!skipTextData) last.data += node.data;
+			if (!skipText) last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
 		}
@@ -4807,9 +4839,9 @@ const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 				idx > 0 &&
 				arr[idx - 1].type === NodeType.Text
 			) {
-				// `skipTextData` leaves text `data` undefined; merge (absorb the node)
+				// `skip.text` leaves text `data` undefined; merge (absorb the node)
 				// without touching `data`, matching the default path's node result.
-				if (!skipTextData) {
+				if (!skipText) {
 					/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
 				}
 				return;
@@ -4827,31 +4859,43 @@ const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 	) => {
 		const place = appropriatePlace();
 		if (place.parent.type === NodeType.Document) return; // never insert text into document
+		// `skip.text`: drop prose text; keep only raw-text element bodies (so a
+		// consumer can still read `<script>`/`<style>` content). The decision above
+		// (framesetOk / whitespace) already used the decoded token, so dropping the
+		// node here never affects element structure.
+		const p = place.parent;
+		if (
+			skipText &&
+			!(
+				p.type === NodeType.Element &&
+				p.namespace === NS_HTML &&
+				TEXT_CONTENT_ELEMENTS.has(p.tagName)
+			)
+		) {
+			return;
+		}
 		// Inlined text insert: when the run merges into the adjacent text sibling
 		// (common with inline formatting) only the string is appended — no
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
 		// including that the before-node merge does not bump `end`.
 		const arr = childrenOf(place.parent);
-		// `skipTextData`: the consumer reads text nodes by offset, never by `data`, so
-		// store no string (`data: undefined`) — this drops the retained decoded/
-		// coalesced text (~6% of the tree). Decisions above already used the
-		// decoded token value. Merging mirrors the default path exactly (same
-		// nodes and `end` bumps) so only the stored string differs.
-		// Typed `string` though `skipTextData` stores `undefined`: the type contract
-		// holds for every consumer that reads `data` (all run in the default path).
-		const stored = /** @type {string} */ (skipTextData ? undefined : data);
+		// Retained bodies are offset-only under `skip.text`: no decoded `data` is
+		// stored (the consumer re-slices from source), so merging just extends the
+		// span. Typed `string` though the stored value may be `undefined` — only
+		// default-path consumers read `data`.
+		const stored = /** @type {string} */ (skipText ? undefined : data);
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
 			if (prev && prev.type === NodeType.Text) {
-				if (!skipTextData) prev.data += data;
+				if (!skipText) prev.data += data;
 				return;
 			}
 			arr.splice(idx, 0, { type: NodeType.Text, data: stored, start, end });
 		} else {
 			const last = arr[arr.length - 1];
 			if (last && last.type === NodeType.Text) {
-				if (!skipTextData) last.data += data;
+				if (!skipText) last.data += data;
 				last.end = end;
 				return;
 			}
@@ -4866,6 +4910,7 @@ const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 	 * @param {InsertionPlace=} place explicit insertion place
 	 */
 	const insertComment = (data, start, end, place) => {
+		if (skipComments) return;
 		const p = place || appropriatePlace();
 		insertAtPlace(p, { type: NodeType.Comment, data, start, end });
 	};
@@ -5719,14 +5764,17 @@ const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 			return;
 		}
 		if (t.type === TOKEN_DOCTYPE) {
-			doc.children.push({
-				type: NodeType.Doctype,
-				name: t.name,
-				publicId: t.publicId,
-				systemId: t.systemId,
-				start: t.start,
-				end: t.end
-			});
+			// `skip.doctype` drops the node only; quirks detection below is unaffected.
+			if (!skipDoctype) {
+				doc.children.push({
+					type: NodeType.Doctype,
+					name: t.name,
+					publicId: t.publicId,
+					systemId: t.systemId,
+					start: t.start,
+					end: t.end
+				});
+			}
 			quirks = isQuirky(t.name, t.publicId, t.systemId);
 			mode = MODE_BEFORE_HTML;
 			return;
@@ -7302,7 +7350,7 @@ const NodeType = {
 /**
  * @typedef {object} HtmlProcessOptions
  * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`); the HTML analog of the CSS parser's `as` parse-mode option
- * @property {boolean=} skipTextData omit text nodes' decoded `data` when building the AST (see `buildHtmlAst`)
+ * @property {HtmlAstSkip=} skip node kinds to omit from the AST for speed/memory (see `HtmlAstSkip`)
  */
 
 /**
@@ -7361,7 +7409,7 @@ const grammar = (input, visitors, options) => {
 		}
 	};
 
-	walk(buildHtmlAst(input, options.fragmentContext, options.skipTextData), null);
+	walk(buildHtmlAst(input, options.fragmentContext, options.skip), null);
 };
 
 /**

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7266,7 +7266,16 @@ const cloneSubtree = (node) => {
 		start: node.start,
 		end: node.end,
 		tagEnd: node.tagEnd,
-		nameEnd: node.nameEnd
+		nameEnd: node.nameEnd,
+		// Empty body: offsets are dropped so the clone re-emits no dependency.
+		contentEnd: node.tagEnd,
+		// Keep the monomorphic element shape; clone `<template>` content too.
+		templateContent: node.templateContent
+			? {
+					type: NodeType.DocumentFragment,
+					children: node.templateContent.children.map(cloneSubtree)
+				}
+			: undefined
 	};
 };
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4619,7 +4619,7 @@ const findAttr = (
 };
 
 // Elements whose text content is their raw "value" (RAWTEXT/RCDATA/script/
-// plaintext). Under `skip.text` these bodies are kept (offset-only) so a
+// plaintext). Under `skip.proseText` these bodies are kept (offset-only) so a
 // consumer can still read them; all other (prose) text is dropped.
 const TEXT_CONTENT_ELEMENTS = new Set([
 	"script",
@@ -4642,7 +4642,7 @@ const EMPTY_SKIP = Object.freeze({});
  * is a pure output reduction — tree construction (and quirks detection) runs
  * unchanged, so element structure and offsets are identical either way.
  * @typedef {object} HtmlAstSkip
- * @property {boolean=} text drop prose text nodes; keep only raw-text element bodies (`<script>`/`<style>`/… — see `TEXT_CONTENT_ELEMENTS`), and those offset-only (no decoded `data`). Only for consumers that read text by offset (e.g. `HtmlParser`, which re-slices bodies), never the html5lib serializer.
+ * @property {boolean=} proseText drop prose (flow-content) text nodes; keep only raw-text element bodies (`<script>`/`<style>`/… — see `TEXT_CONTENT_ELEMENTS`), and those offset-only (no decoded `data`). Named `proseText` (not `text`) because it keeps element bodies. Only for consumers that read text by offset (e.g. `HtmlParser`, which re-slices bodies), never the html5lib serializer.
  * @property {boolean=} comments drop comment nodes entirely. Not for consumers that read comments (e.g. webpack magic comments).
  * @property {boolean=} doctype drop the doctype node; quirks-mode detection is unaffected.
  */
@@ -4654,7 +4654,7 @@ const EMPTY_SKIP = Object.freeze({});
  * @returns {HtmlDocument} document AST
  */
 const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
-	const skipText = skip.text === true;
+	const skipProseText = skip.proseText === true;
 	const skipComments = skip.comments === true;
 	const skipDoctype = skip.doctype === true;
 	/** @type {HtmlDocument} */
@@ -4742,9 +4742,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
 		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
-			// `skip.text`: retained bodies are offset-only; merge as the default path
+			// `skip.proseText`: retained bodies are offset-only; merge as the default path
 			// (same node, same `end` bump) but skip the string concatenation.
-			if (!skipText) last.data += node.data;
+			if (!skipProseText) last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
 		}
@@ -4839,9 +4839,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				idx > 0 &&
 				arr[idx - 1].type === NodeType.Text
 			) {
-				// `skip.text` leaves text `data` undefined; merge (absorb the node)
+				// `skip.proseText` leaves text `data` undefined; merge (absorb the node)
 				// without touching `data`, matching the default path's node result.
-				if (!skipText) {
+				if (!skipProseText) {
 					/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
 				}
 				return;
@@ -4859,13 +4859,13 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	) => {
 		const place = appropriatePlace();
 		if (place.parent.type === NodeType.Document) return; // never insert text into document
-		// `skip.text`: drop prose text; keep only raw-text element bodies (so a
+		// `skip.proseText`: drop prose text; keep only raw-text element bodies (so a
 		// consumer can still read `<script>`/`<style>` content). The decision above
 		// (framesetOk / whitespace) already used the decoded token, so dropping the
 		// node here never affects element structure.
 		const p = place.parent;
 		if (
-			skipText &&
+			skipProseText &&
 			!(
 				p.type === NodeType.Element &&
 				p.namespace === NS_HTML &&
@@ -4879,23 +4879,23 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
 		// including that the before-node merge does not bump `end`.
 		const arr = childrenOf(place.parent);
-		// Retained bodies are offset-only under `skip.text`: no decoded `data` is
+		// Retained bodies are offset-only under `skip.proseText`: no decoded `data` is
 		// stored (the consumer re-slices from source), so merging just extends the
 		// span. Typed `string` though the stored value may be `undefined` — only
 		// default-path consumers read `data`.
-		const stored = /** @type {string} */ (skipText ? undefined : data);
+		const stored = /** @type {string} */ (skipProseText ? undefined : data);
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
 			if (prev && prev.type === NodeType.Text) {
-				if (!skipText) prev.data += data;
+				if (!skipProseText) prev.data += data;
 				return;
 			}
 			arr.splice(idx, 0, { type: NodeType.Text, data: stored, start, end });
 		} else {
 			const last = arr[arr.length - 1];
 			if (last && last.type === NodeType.Text) {
-				if (!skipText) last.data += data;
+				if (!skipProseText) last.data += data;
 				last.end = end;
 				return;
 			}

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3801,6 +3801,7 @@ const NS_SVG = 2;
  * @property {number} end
  * @property {number} tagEnd end offset of the opening tag (after `>`)
  * @property {number} nameEnd end offset of the tag name
+ * @property {number} contentEnd under `skip.text`, end offset of a raw-text element's body (`tagEnd` when empty); unused otherwise
  * @property {HtmlDocumentFragment=} templateContent `<template>` content fragment
  */
 
@@ -4618,10 +4619,11 @@ const findAttr = (
 	return undefined;
 };
 
-// Elements whose text content is their raw "value" (RAWTEXT/RCDATA/script/
-// plaintext). Under `skip.proseText` these bodies are kept (offset-only) so a
-// consumer can still read them; all other (prose) text is dropped.
-const TEXT_CONTENT_ELEMENTS = new Set([
+// Raw text / escapable raw text elements (WHATWG §13.1.2) plus the other
+// RAWTEXT/RCDATA/PLAINTEXT-tokenized elements. Under `skip.text` their body's
+// end offset is recorded on the element (see `insertCharacters`) so a consumer
+// can read the raw content span without a `Text` node.
+const RAW_TEXT_ELEMENTS = new Set([
 	"script",
 	"style",
 	"textarea",
@@ -4642,7 +4644,7 @@ const EMPTY_SKIP = Object.freeze({});
  * is a pure output reduction — tree construction (and quirks detection) runs
  * unchanged, so element structure and offsets are identical either way.
  * @typedef {object} HtmlAstSkip
- * @property {boolean=} proseText drop prose (flow-content) text nodes; keep only raw-text element bodies (`<script>`/`<style>`/… — see `TEXT_CONTENT_ELEMENTS`), and those offset-only (no decoded `data`). Named `proseText` (not `text`) because it keeps element bodies. Only for consumers that read text by offset (e.g. `HtmlParser`, which re-slices bodies), never the html5lib serializer.
+ * @property {boolean=} text drop every `Text` node. Raw-text element bodies (`<script>`/`<style>`/…) aren't emitted either — their content span is recorded as the element's `contentEnd` (see `RAW_TEXT_ELEMENTS`) so a consumer can read `[tagEnd, contentEnd]` by offset. For consumers that read text by offset (e.g. `HtmlParser`), never the html5lib serializer.
  * @property {boolean=} comments drop comment nodes entirely. Not for consumers that read comments (e.g. webpack magic comments).
  * @property {boolean=} doctype drop the doctype node; quirks-mode detection is unaffected.
  */
@@ -4654,7 +4656,7 @@ const EMPTY_SKIP = Object.freeze({});
  * @returns {HtmlDocument} document AST
  */
 const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
-	const skipProseText = skip.proseText === true;
+	const skipText = skip.text === true;
 	const skipComments = skip.comments === true;
 	const skipDoctype = skip.doctype === true;
 	/** @type {HtmlDocument} */
@@ -4707,6 +4709,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			end: pos ? pos.end : 0,
 			tagEnd: pos ? pos.tagEnd : 0,
 			nameEnd: pos ? pos.nameEnd : 0,
+			// End of a raw-text element's body under `skip.text` (defaults to the
+			// body start, i.e. empty); lets consumers read `<script>`/`<style>`
+			// content as [`tagEnd`, `contentEnd`] without a `Text` node.
+			contentEnd: pos ? pos.tagEnd : 0,
 			// Present from creation (only `<template>` fills it) so every element
 			// keeps one monomorphic hidden class for the open-stack/scope loops.
 			templateContent: undefined
@@ -4742,9 +4748,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
 		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
-			// `skip.proseText`: retained bodies are offset-only; merge as the default path
-			// (same node, same `end` bump) but skip the string concatenation.
-			if (!skipProseText) last.data += node.data;
+			last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
 		}
@@ -4839,11 +4843,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				idx > 0 &&
 				arr[idx - 1].type === NodeType.Text
 			) {
-				// `skip.proseText` leaves text `data` undefined; merge (absorb the node)
-				// without touching `data`, matching the default path's node result.
-				if (!skipProseText) {
-					/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
-				}
+				/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
 				return;
 			}
 			arr.splice(idx, 0, node);
@@ -4859,19 +4859,20 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	) => {
 		const place = appropriatePlace();
 		if (place.parent.type === NodeType.Document) return; // never insert text into document
-		// `skip.proseText`: drop prose text; keep only raw-text element bodies (so a
-		// consumer can still read `<script>`/`<style>` content). The decision above
-		// (framesetOk / whitespace) already used the decoded token, so dropping the
-		// node here never affects element structure.
-		const p = place.parent;
-		if (
-			skipProseText &&
-			!(
+		// `skip.text`: drop every `Text` node — construction decisions above already
+		// used the decoded token, so removing the node never affects element
+		// structure. For a raw-text element (`<script>`/`<style>`/…) record the
+		// body's end offset so a consumer can still read the content span
+		// [`tagEnd`, `contentEnd`] without a `Text` node (see `HtmlParser`).
+		if (skipText) {
+			const p = place.parent;
+			if (
 				p.type === NodeType.Element &&
 				p.namespace === NS_HTML &&
-				TEXT_CONTENT_ELEMENTS.has(p.tagName)
-			)
-		) {
+				RAW_TEXT_ELEMENTS.has(p.tagName)
+			) {
+				p.contentEnd = end;
+			}
 			return;
 		}
 		// Inlined text insert: when the run merges into the adjacent text sibling
@@ -4879,27 +4880,22 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
 		// including that the before-node merge does not bump `end`.
 		const arr = childrenOf(place.parent);
-		// Retained bodies are offset-only under `skip.proseText`: no decoded `data` is
-		// stored (the consumer re-slices from source), so merging just extends the
-		// span. Typed `string` though the stored value may be `undefined` — only
-		// default-path consumers read `data`.
-		const stored = /** @type {string} */ (skipProseText ? undefined : data);
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
 			if (prev && prev.type === NodeType.Text) {
-				if (!skipProseText) prev.data += data;
+				prev.data += data;
 				return;
 			}
-			arr.splice(idx, 0, { type: NodeType.Text, data: stored, start, end });
+			arr.splice(idx, 0, { type: NodeType.Text, data, start, end });
 		} else {
 			const last = arr[arr.length - 1];
 			if (last && last.type === NodeType.Text) {
-				if (!skipProseText) last.data += data;
+				last.data += data;
 				last.end = end;
 				return;
 			}
-			arr.push({ type: NodeType.Text, data: stored, start, end });
+			arr.push({ type: NodeType.Text, data, start, end });
 		}
 	};
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4621,9 +4621,10 @@ const findAttr = (
 /**
  * @param {string} source HTML source
  * @param {string=} fragmentContext context element name for fragment parsing (e.g. `td`, `svg path`); omit for a full document
+ * @param {boolean=} rawText omit text nodes' decoded `data` (leaving `data` `undefined`), keeping only their `start`/`end` offsets, to drop the retained text strings (~6% of the tree). Tree-construction decisions still use the decoded value; adjacent text is merged only when contiguous. Only valid for consumers that read text by offset and never read `data` (e.g. `HtmlParser`, which re-slices bodies from offsets). Not for the html5lib serializer.
  * @returns {HtmlDocument} document AST
  */
-const buildHtmlAst = (source, fragmentContext) => {
+const buildHtmlAst = (source, fragmentContext, rawText = false) => {
 	/** @type {HtmlDocument} */
 	const doc = { type: NodeType.Document, children: [] };
 	let mode = MODE_INITIAL;
@@ -4709,7 +4710,9 @@ const buildHtmlAst = (source, fragmentContext) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
 		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
-			last.data += node.data;
+			// `rawText`: text `data` is unused; merge exactly as the default path
+			// (same node, same `end` bump) but skip the string concatenation.
+			if (!rawText) last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
 		}
@@ -4804,7 +4807,11 @@ const buildHtmlAst = (source, fragmentContext) => {
 				idx > 0 &&
 				arr[idx - 1].type === NodeType.Text
 			) {
-				/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
+				// `rawText` leaves text `data` undefined; merge (absorb the node)
+				// without touching `data`, matching the default path's node result.
+				if (!rawText) {
+					/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
+				}
 				return;
 			}
 			arr.splice(idx, 0, node);
@@ -4825,22 +4832,30 @@ const buildHtmlAst = (source, fragmentContext) => {
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
 		// including that the before-node merge does not bump `end`.
 		const arr = childrenOf(place.parent);
+		// `rawText`: the consumer reads text nodes by offset, never by `data`, so
+		// store no string (`data: undefined`) — this drops the retained decoded/
+		// coalesced text (~6% of the tree). Decisions above already used the
+		// decoded token value. Merging mirrors the default path exactly (same
+		// nodes and `end` bumps) so only the stored string differs.
+		// Typed `string` though `rawText` stores `undefined`: the type contract
+		// holds for every consumer that reads `data` (all run in the default path).
+		const stored = /** @type {string} */ (rawText ? undefined : data);
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
 			if (prev && prev.type === NodeType.Text) {
-				prev.data += data;
+				if (!rawText) prev.data += data;
 				return;
 			}
-			arr.splice(idx, 0, { type: NodeType.Text, data, start, end });
+			arr.splice(idx, 0, { type: NodeType.Text, data: stored, start, end });
 		} else {
 			const last = arr[arr.length - 1];
 			if (last && last.type === NodeType.Text) {
-				last.data += data;
+				if (!rawText) last.data += data;
 				last.end = end;
 				return;
 			}
-			arr.push({ type: NodeType.Text, data, start, end });
+			arr.push({ type: NodeType.Text, data: stored, start, end });
 		}
 	};
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4621,10 +4621,10 @@ const findAttr = (
 /**
  * @param {string} source HTML source
  * @param {string=} fragmentContext context element name for fragment parsing (e.g. `td`, `svg path`); omit for a full document
- * @param {boolean=} rawText omit text nodes' decoded `data` (leaving `data` `undefined`), keeping only their `start`/`end` offsets, to drop the retained text strings (~6% of the tree). Tree-construction decisions still use the decoded value; adjacent text is merged only when contiguous. Only valid for consumers that read text by offset and never read `data` (e.g. `HtmlParser`, which re-slices bodies from offsets). Not for the html5lib serializer.
+ * @param {boolean=} skipTextData omit text nodes' decoded `data` (leaving `data` `undefined`), keeping only their `start`/`end` offsets, to drop the retained text strings (~6% of the tree). Tree-construction decisions still use the decoded value; adjacent text is merged only when contiguous. Only valid for consumers that read text by offset and never read `data` (e.g. `HtmlParser`, which re-slices bodies from offsets). Not for the html5lib serializer.
  * @returns {HtmlDocument} document AST
  */
-const buildHtmlAst = (source, fragmentContext, rawText = false) => {
+const buildHtmlAst = (source, fragmentContext, skipTextData = false) => {
 	/** @type {HtmlDocument} */
 	const doc = { type: NodeType.Document, children: [] };
 	let mode = MODE_INITIAL;
@@ -4710,9 +4710,9 @@ const buildHtmlAst = (source, fragmentContext, rawText = false) => {
 		const arr = childrenOf(parent);
 		const last = arr[arr.length - 1];
 		if (node.type === NodeType.Text && last && last.type === NodeType.Text) {
-			// `rawText`: text `data` is unused; merge exactly as the default path
+			// `skipTextData`: text `data` is unused; merge exactly as the default path
 			// (same node, same `end` bump) but skip the string concatenation.
-			if (!rawText) last.data += node.data;
+			if (!skipTextData) last.data += node.data;
 			if (node.end !== undefined) last.end = node.end;
 			return;
 		}
@@ -4807,9 +4807,9 @@ const buildHtmlAst = (source, fragmentContext, rawText = false) => {
 				idx > 0 &&
 				arr[idx - 1].type === NodeType.Text
 			) {
-				// `rawText` leaves text `data` undefined; merge (absorb the node)
+				// `skipTextData` leaves text `data` undefined; merge (absorb the node)
 				// without touching `data`, matching the default path's node result.
-				if (!rawText) {
+				if (!skipTextData) {
 					/** @type {HtmlText} */ (arr[idx - 1]).data += node.data;
 				}
 				return;
@@ -4832,26 +4832,26 @@ const buildHtmlAst = (source, fragmentContext, rawText = false) => {
 		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
 		// including that the before-node merge does not bump `end`.
 		const arr = childrenOf(place.parent);
-		// `rawText`: the consumer reads text nodes by offset, never by `data`, so
+		// `skipTextData`: the consumer reads text nodes by offset, never by `data`, so
 		// store no string (`data: undefined`) — this drops the retained decoded/
 		// coalesced text (~6% of the tree). Decisions above already used the
 		// decoded token value. Merging mirrors the default path exactly (same
 		// nodes and `end` bumps) so only the stored string differs.
-		// Typed `string` though `rawText` stores `undefined`: the type contract
+		// Typed `string` though `skipTextData` stores `undefined`: the type contract
 		// holds for every consumer that reads `data` (all run in the default path).
-		const stored = /** @type {string} */ (rawText ? undefined : data);
+		const stored = /** @type {string} */ (skipTextData ? undefined : data);
 		if (place.beforeNode) {
 			const idx = arr.indexOf(place.beforeNode);
 			const prev = idx > 0 ? arr[idx - 1] : undefined;
 			if (prev && prev.type === NodeType.Text) {
-				if (!rawText) prev.data += data;
+				if (!skipTextData) prev.data += data;
 				return;
 			}
 			arr.splice(idx, 0, { type: NodeType.Text, data: stored, start, end });
 		} else {
 			const last = arr[arr.length - 1];
 			if (last && last.type === NodeType.Text) {
-				if (!rawText) last.data += data;
+				if (!skipTextData) last.data += data;
 				last.end = end;
 				return;
 			}
@@ -7302,6 +7302,7 @@ const NodeType = {
 /**
  * @typedef {object} HtmlProcessOptions
  * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`)
+ * @property {boolean=} skipTextData omit text nodes' decoded `data` when building the AST (see `buildHtmlAst`); ignored when `ast` is provided
  * @property {(HtmlDocument | HtmlDocumentFragment)=} ast walk this pre-built AST instead of parsing the input
  */
 
@@ -7361,7 +7362,11 @@ const grammar = (input, visitors, options) => {
 		}
 	};
 
-	walk(options.ast || buildHtmlAst(input, options.fragmentContext), null);
+	walk(
+		options.ast ||
+			buildHtmlAst(input, options.fragmentContext, options.skipTextData),
+		null
+	);
 };
 
 /**

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7089,6 +7089,31 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return end;
 		},
 		text: (input, start, end) => {
+			// `skip.text` fast path: the node is dropped, so construction only needs
+			// the run's whitespace-ness (`isAllWs` / framesetOk). For plain text —
+			// no `&` (entities), `\0`, `\r`, or a pending leading-newline swallow —
+			// the decoded value equals the raw range, so scan it and dispatch a
+			// canonical marker (`" "` all-whitespace, `"x"` otherwise), skipping the
+			// per-run slice + entity decode. Anything trickier falls through.
+			if (skipText && !swallowNextNewline) {
+				let hasNonWs = false;
+				let i = start;
+				for (; i < end; i++) {
+					const c = input.charCodeAt(i);
+					if (c === 0x26 || c === 0x00 || c === 0x0d) break; // & / NUL / CR
+					if (c !== 0x09 && c !== 0x0a && c !== 0x0c && c !== 0x20) {
+						hasNonWs = true;
+					}
+				}
+				if (i === end) {
+					tok.type = TOKEN_CHAR;
+					tok.data = hasNonWs ? "x" : " ";
+					tok.start = start;
+					tok.end = end;
+					dispatch();
+					return end;
+				}
+			}
 			const raw = input.slice(start, end);
 			// CR normalization only when a CR is actually present (common case has none).
 			const s = !raw.includes("\r") ? raw : raw.replace(/\r\n?/g, "\n");

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -2,23 +2,16 @@
 
 const path = require("path");
 
-jest.mock("../lib/html/syntax", () => ({
-	...jest.requireActual("../lib/html/syntax"),
-	buildHtmlAst: jest.fn()
-}));
-
-/** @typedef {import("../lib/html/syntax")["buildHtmlAst"] & { mockReturnValue: (val: EXPECTED_ANY) => void }} MockedBuildHtmlAst */
-
+// These tests drive the real tree builder end-to-end (like the CSS parser
+// tests): `HtmlParser` builds the AST inside `SourceProcessor.process`, so
+// there is nothing to mock — each case parses real HTML and asserts the
+// extracted dependencies.
 const HtmlInlineScriptDependency = require("../lib/dependencies/HtmlInlineScriptDependency");
 const HtmlInlineStyleDependency = require("../lib/dependencies/HtmlInlineStyleDependency");
 const HtmlSourceDependency = require("../lib/dependencies/HtmlSourceDependency");
 const CommentCompilationWarning = require("../lib/errors/CommentCompilationWarning");
 const UnsupportedFeatureWarning = require("../lib/errors/UnsupportedFeatureWarning");
 const HtmlParser = require("../lib/html/HtmlParser");
-const buildHtmlAst = /** @type {MockedBuildHtmlAst} */ (
-	require("../lib/html/syntax").buildHtmlAst
-);
-const { NodeType } = require("../lib/html/syntax");
 
 /**
  * @returns {{ module: EXPECTED_ANY, presentationalDependencies: EXPECTED_OBJECT[], dependencies: EXPECTED_OBJECT[], warnings: EXPECTED_OBJECT[], errors: EXPECTED_OBJECT[] }} test doubles
@@ -102,37 +95,6 @@ describe("HtmlParser", () => {
 			}
 		});
 
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Element,
-					tagName: "script",
-					namespace: 0,
-					attributes: [],
-					children: [
-						{
-							type: NodeType.Text,
-							data: firstText,
-							start: firstStart,
-							end: firstStart + firstText.length
-						},
-						{
-							type: NodeType.Text,
-							data: secondText,
-							start: secondStart,
-							end: secondStart + secondText.length
-						}
-					],
-					selfClosing: false,
-					start: 0,
-					end: source.length,
-					tagEnd: source.indexOf(">") + 1,
-					nameEnd: "<script".length
-				}
-			]
-		});
-
 		const parser = new HtmlParser({});
 		parser.parse(
 			source,
@@ -157,7 +119,6 @@ describe("HtmlParser", () => {
 			)
 		);
 
-		expect(buildHtmlAst).toHaveBeenCalledWith(source, undefined, true);
 		expect(dependencies).toHaveLength(1);
 		expect(presentationalDependencies).toHaveLength(1);
 
@@ -213,43 +174,6 @@ describe("HtmlParser", () => {
 				dependencies.push(dependency);
 			},
 			addCodeGenerationDependency() {}
-		});
-
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Element,
-					tagName: "style",
-					namespace: 0,
-					attributes: [],
-					children: [
-						{
-							type: NodeType.Text,
-							data: firstText,
-							start: firstStart,
-							end: firstStart + firstText.length
-						},
-						{
-							type: NodeType.Comment,
-							data: " X ",
-							start: firstStart + firstText.length,
-							end: secondStart
-						},
-						{
-							type: NodeType.Text,
-							data: secondText,
-							start: secondStart,
-							end: secondStart + secondText.length
-						}
-					],
-					selfClosing: false,
-					start: 0,
-					end: source.length,
-					tagEnd: source.indexOf(">") + 1,
-					nameEnd: "<style".length
-				}
-			]
 		});
 
 		const parser = new HtmlParser({});
@@ -366,17 +290,6 @@ describe("HtmlParser", () => {
 	it("warns on a malformed webpackIgnore magic comment", () => {
 		const source = "<!-- webpackIgnore: ) -->";
 		const { module, warnings } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Comment,
-					data: " webpackIgnore: ) ",
-					start: 0,
-					end: source.length
-				}
-			]
-		});
 
 		new HtmlParser({}).parse(source, makeState(module));
 
@@ -387,17 +300,6 @@ describe("HtmlParser", () => {
 	it("warns when webpackIgnore is not a boolean", () => {
 		const source = "<!-- webpackIgnore: 5 -->";
 		const { module, warnings } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Comment,
-					data: " webpackIgnore: 5 ",
-					start: 0,
-					end: source.length
-				}
-			]
-		});
 
 		new HtmlParser({}).parse(source, makeState(module));
 
@@ -408,23 +310,6 @@ describe("HtmlParser", () => {
 	it("does not emit a dependency for a whitespace-only inline <style>", () => {
 		const source = "<style>   </style>";
 		const { module, dependencies } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Element,
-					tagName: "style",
-					namespace: 0,
-					attributes: [],
-					children: [{ type: NodeType.Text, data: "   ", start: 7, end: 10 }],
-					selfClosing: false,
-					start: 0,
-					end: source.length,
-					tagEnd: 7,
-					nameEnd: "<style".length
-				}
-			]
-		});
 
 		new HtmlParser({}).parse(source, makeState(module, { css: true }));
 
@@ -434,17 +319,19 @@ describe("HtmlParser", () => {
 	});
 
 	it("accepts a Buffer source and strips a leading BOM", () => {
-		const { module } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: []
-		});
+		const range = (/** @type {string | Buffer} */ src) => {
+			const { module, dependencies } = makeModule();
+			new HtmlParser({}).parse(src, makeState(module));
+			const dep = dependencies.find((d) => d instanceof HtmlSourceDependency);
+			return /** @type {EXPECTED_ANY} */ (dep).range;
+		};
 
-		new HtmlParser({}).parse(Buffer.from("<div></div>"), makeState(module));
-		expect(buildHtmlAst).toHaveBeenCalledWith("<div></div>", undefined, true);
-
-		new HtmlParser({}).parse("﻿<div></div>", makeState(module));
-		expect(buildHtmlAst).toHaveBeenLastCalledWith("<div></div>", undefined, true);
+		// A Buffer source parses like the equivalent string.
+		expect(range(Buffer.from("<img src=a.png>"))).toEqual(
+			range("<img src=a.png>")
+		);
+		// A leading BOM is stripped, so offsets align with the un-prefixed source.
+		expect(range("﻿<img src=a.png>")).toEqual(range("<img src=a.png>"));
 	});
 
 	it("throws when given a preparsed (object) source", () => {
@@ -460,17 +347,6 @@ describe("HtmlParser", () => {
 	it("ignores a magic comment that has no webpackIgnore key", () => {
 		const source = "<!-- webpackPreload: true -->";
 		const { module, warnings } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Comment,
-					data: " webpackPreload: true ",
-					start: 0,
-					end: source.length
-				}
-			]
-		});
 
 		new HtmlParser({}).parse(source, makeState(module));
 		expect(warnings).toHaveLength(0);
@@ -479,23 +355,6 @@ describe("HtmlParser", () => {
 	it("does not emit a dependency for an empty inline <style>", () => {
 		const source = "<style></style>";
 		const { module, dependencies } = makeModule();
-		buildHtmlAst.mockReturnValue({
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Element,
-					tagName: "style",
-					namespace: 0,
-					attributes: [],
-					children: [],
-					selfClosing: false,
-					start: 0,
-					end: source.length,
-					tagEnd: 7,
-					nameEnd: "<style".length
-				}
-			]
-		});
 
 		new HtmlParser({}).parse(source, makeState(module, { css: true }));
 
@@ -504,49 +363,6 @@ describe("HtmlParser", () => {
 		).toHaveLength(0);
 	});
 
-	// Build a `<script type=… src=…>` AST element with offsets derived from the
-	// source so reconcileScriptTypeAttr sees the real attribute spans.
-	const scriptWithType = (/** @type {string} */ source) => {
-		/**
-		 * @param {string} name attribute name
-		 * @returns {EXPECTED_ANY} attribute
-		 */
-		const attr = (name) => {
-			const nameStart = source.indexOf(`${name}=`);
-			const nameEnd = nameStart + name.length;
-			const afterEq = nameEnd + 1;
-			const quote = source[afterEq] === '"' || source[afterEq] === "'";
-			const valueStart = quote ? afterEq + 1 : afterEq;
-			const end = source.indexOf(quote ? source[afterEq] : " ", valueStart);
-			const valueEnd = end === -1 ? source.indexOf(">") : end;
-			return {
-				name,
-				value: source.slice(valueStart, valueEnd),
-				nameStart,
-				nameEnd,
-				valueStart,
-				valueEnd
-			};
-		};
-		return {
-			type: NodeType.Document,
-			children: [
-				{
-					type: NodeType.Element,
-					tagName: "script",
-					namespace: 0,
-					attributes: [attr("type"), attr("src")],
-					children: [],
-					selfClosing: false,
-					start: 0,
-					end: source.length,
-					tagEnd: source.indexOf(">") + 1,
-					nameEnd: "<script".length
-				}
-			]
-		};
-	};
-
 	it.each([
 		["<script type='module' src='a.js'></script>"],
 		["<script type=module src=b.js></script>"]
@@ -554,7 +370,6 @@ describe("HtmlParser", () => {
 		"drops a single-quoted/unquoted type=module for classic output (%s)",
 		(source) => {
 			const { module, presentationalDependencies } = makeModule();
-			buildHtmlAst.mockReturnValue(scriptWithType(source));
 
 			new HtmlParser({}).parse(source, makeState(module));
 
@@ -564,19 +379,12 @@ describe("HtmlParser", () => {
 	);
 
 	describe("source extraction", () => {
-		// Feed the real tree builder so these exercise genuine offsets/namespaces.
-		const realBuildHtmlAst =
-			/** @type {typeof import("../lib/html/syntax")} */ (
-				jest.requireActual("../lib/html/syntax")
-			).buildHtmlAst;
-
 		/**
 		 * @param {string} source html
 		 * @returns {string[]} the requests of the emitted HtmlSourceDependency-s
 		 */
 		const sourceRequests = (source) => {
 			const { module, dependencies } = makeModule();
-			buildHtmlAst.mockReturnValue(realBuildHtmlAst(source));
 			new HtmlParser({}).parse(source, makeState(module));
 			return dependencies
 				.filter((d) => d instanceof HtmlSourceDependency)

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -2,10 +2,8 @@
 
 const path = require("path");
 
-// These tests drive the real tree builder end-to-end (like the CSS parser
-// tests): `HtmlParser` builds the AST inside `SourceProcessor.process`, so
-// there is nothing to mock — each case parses real HTML and asserts the
-// extracted dependencies.
+// `HtmlParser` builds the AST inside `SourceProcessor.process`, so nothing is
+// mocked: each case parses real HTML and asserts the extracted dependencies.
 const HtmlInlineScriptDependency = require("../lib/dependencies/HtmlInlineScriptDependency");
 const HtmlInlineStyleDependency = require("../lib/dependencies/HtmlInlineStyleDependency");
 const HtmlSourceDependency = require("../lib/dependencies/HtmlSourceDependency");

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -157,7 +157,7 @@ describe("HtmlParser", () => {
 			)
 		);
 
-		expect(buildHtmlAst).toHaveBeenCalledWith(source);
+		expect(buildHtmlAst).toHaveBeenCalledWith(source, undefined, true);
 		expect(dependencies).toHaveLength(1);
 		expect(presentationalDependencies).toHaveLength(1);
 
@@ -441,10 +441,10 @@ describe("HtmlParser", () => {
 		});
 
 		new HtmlParser({}).parse(Buffer.from("<div></div>"), makeState(module));
-		expect(buildHtmlAst).toHaveBeenCalledWith("<div></div>");
+		expect(buildHtmlAst).toHaveBeenCalledWith("<div></div>", undefined, true);
 
 		new HtmlParser({}).parse("﻿<div></div>", makeState(module));
-		expect(buildHtmlAst).toHaveBeenLastCalledWith("<div></div>");
+		expect(buildHtmlAst).toHaveBeenLastCalledWith("<div></div>", undefined, true);
 	});
 
 	it("throws when given a preparsed (object) source", () => {

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -618,21 +618,6 @@ describe("buildHtmlAst — SourceProcessor", () => {
 		expect(log).toEqual(["html", "head", "template", "fragment", "p", "body"]);
 	});
 
-	it("walks a pre-built AST when options.ast is given", () => {
-		/** @type {string[]} */
-		const log = [];
-		const ast = buildHtmlAst("<p>x</p>");
-		new SourceProcessor()
-			.use({
-				[NodeType.Element]: (n) =>
-					log.push(
-						/** @type {import("../lib/html/syntax").HtmlElement} */ (n).tagName
-					)
-			})
-			.process("ignored input", { ast });
-		expect(log).toEqual(["html", "head", "body", "p"]);
-	});
-
 	it("use() chains and accumulates visitors per type", () => {
 		let a = 0;
 		let b = 0;
@@ -983,8 +968,12 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 			for (const c of doc.children) walk(c);
 			return n;
 		};
-		expect(count(buildHtmlAst(src, undefined, { comments: true }), NodeType.Comment)).toBe(0);
-		expect(count(buildHtmlAst(src, undefined, { doctype: true }), NodeType.Doctype)).toBe(0);
+		expect(
+			count(buildHtmlAst(src, undefined, { comments: true }), NodeType.Comment)
+		).toBe(0);
+		expect(
+			count(buildHtmlAst(src, undefined, { doctype: true }), NodeType.Doctype)
+		).toBe(0);
 		// Baseline still has both.
 		expect(count(buildHtmlAst(src), NodeType.Comment)).toBe(1);
 		expect(count(buildHtmlAst(src), NodeType.Doctype)).toBe(1);

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -845,3 +845,118 @@ describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
 		expect(root.attributes.some((a) => a.name === "lang")).toBe(true);
 	});
 });
+
+// The `skip` options are pure output reductions: tree construction (and quirks
+// detection) must run identically, so the ELEMENT tree — tags, nesting, offsets
+// and attributes — is the same with any skip combination as with none. This
+// guards the risky `skip.text` path, which drops text-node insertion.
+describe("buildHtmlAst — skip options preserve element structure", () => {
+	// A spread of construction edge cases: foster parenting, adoption agency,
+	// select/table/ruby scoping, foreign content, raw-text elements, quirks.
+	const cases = [
+		"<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>",
+		"<table>foo<td>bar</td></table>",
+		"a<table>b</table>c",
+		"text<table><tbody><tr>cell<td>real</table>after",
+		"<p>a<b>b<i>c</p>d</i>e",
+		"<b>1<p>2</b>3",
+		"<a>1<a>2<a>3",
+		"<select>x<option>y</option>z</select>",
+		"<ruby>base<rt>anno</rt></ruby>",
+		"<div><table>txt<svg><foreignObject><div>x</div></foreignObject></svg></table></div>",
+		"<math><mtext>t<mglyph>g</math>after",
+		"<script>var a = 1 < 2 && '</x>';</script><style>.a{color:red}</style>",
+		"<pre>\nkeep</pre><textarea>\nx</textarea>",
+		"<!-- c1 --><p>x<!-- c2 --></p><!-- c3 -->",
+		"<frameset>x<frame></frameset>"
+	];
+
+	/**
+	 * @param {import("../lib/html/syntax").HtmlDocument} doc document
+	 * @returns {string} a signature of the element tree (tags, nesting, offsets, attrs)
+	 */
+	const elementSignature = (doc) => {
+		/** @type {string[]} */
+		const out = [];
+		/**
+		 * @param {import("../lib/html/syntax").HtmlNode | import("../lib/html/syntax").HtmlDocument | import("../lib/html/syntax").HtmlDocumentFragment} node node
+		 * @param {number} depth depth
+		 */
+		const walk = (node, depth) => {
+			if (node.type === NodeType.Element) {
+				const attrs = node.attributes
+					.map(
+						(a) =>
+							`${a.name}(${a.nameStart},${a.nameEnd},${a.valueStart},${a.valueEnd})`
+					)
+					.join(",");
+				out.push(
+					`${depth}:${node.tagName}@${node.namespace}[${node.start},${node.end},${node.tagEnd},${node.nameEnd}]{${attrs}}`
+				);
+				if (node.templateContent) {
+					for (const c of node.templateContent.children) walk(c, depth + 1);
+				}
+			}
+			if ("children" in node) {
+				for (const c of node.children) walk(c, depth + 1);
+			}
+		};
+		walk(doc, 0);
+		return out.join("\n");
+	};
+
+	const skipCombos = [
+		{ text: true },
+		{ comments: true },
+		{ doctype: true },
+		{ text: true, comments: true, doctype: true }
+	];
+
+	it.each(cases)("keeps the element tree stable under skip (%s)", (src) => {
+		const baseline = elementSignature(buildHtmlAst(src));
+		for (const skip of skipCombos) {
+			expect(elementSignature(buildHtmlAst(src, undefined, skip))).toBe(
+				baseline
+			);
+		}
+	});
+
+	it("skip.text keeps <script>/<style> bodies (offset-only) and drops prose", () => {
+		const src = "<p>prose</p><script>var x=1;</script>";
+		const doc = buildHtmlAst(src, undefined, { text: true });
+		/** @type {import("../lib/html/syntax").HtmlText[]} */
+		const texts = [];
+		/** @param {import("../lib/html/syntax").HtmlNode} n node */
+		const walk = (n) => {
+			if (n.type === NodeType.Text) texts.push(n);
+			if (n.type === NodeType.Element) for (const c of n.children) walk(c);
+		};
+		for (const c of doc.children) walk(c);
+		// Only the <script> body survives, and it carries offsets but no `data`.
+		expect(texts).toHaveLength(1);
+		expect(texts[0].data).toBeUndefined();
+		expect(src.slice(texts[0].start, texts[0].end)).toBe("var x=1;");
+	});
+
+	it("skip.comments drops comment nodes; skip.doctype drops the doctype node", () => {
+		const src = "<!DOCTYPE html><!-- c --><p></p>";
+		const count = (
+			/** @type {import("../lib/html/syntax").HtmlDocument} */ doc,
+			/** @type {number} */ type
+		) => {
+			let n = 0;
+			/** @param {import("../lib/html/syntax").HtmlNode} node node */
+			const walk = (node) => {
+				if (node.type === type) n++;
+				if ("children" in node) for (const c of node.children) walk(c);
+			};
+			for (const c of doc.children) walk(c);
+			return n;
+		};
+		expect(count(buildHtmlAst(src, undefined, { comments: true }), NodeType.Comment)).toBe(0);
+		expect(count(buildHtmlAst(src, undefined, { doctype: true }), NodeType.Doctype)).toBe(0);
+		// Baseline still has both.
+		expect(count(buildHtmlAst(src), NodeType.Comment)).toBe(1);
+		expect(count(buildHtmlAst(src), NodeType.Doctype)).toBe(1);
+	});
+});

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// cspell:ignore selectedcontent
+// cspell:ignore selectedcontent mtext mglyph
 
 const {
 	NS_HTML,
@@ -934,10 +934,15 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		return out.join("\n");
 	};
 
+	// Every non-empty subset of the skip flags (incl. { text, doctype }, the
+	// combination HtmlParser uses).
 	const skipCombos = [
 		{ text: true },
 		{ comments: true },
 		{ doctype: true },
+		{ text: true, comments: true },
+		{ text: true, doctype: true },
+		{ comments: true, doctype: true },
 		{ text: true, comments: true, doctype: true }
 	];
 
@@ -1030,6 +1035,27 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 			script: "sc",
 			textarea: "ta"
 		});
+	});
+
+	it("skip.text records contentEnd for foreign-content <style>/<script>", () => {
+		// SVG <style>/<script> stay in the SVG namespace and their bodies are plain
+		// text; HtmlParser extracts them regardless of namespace, so contentEnd must
+		// be recorded here too.
+		const src = "<svg><style>.a{}</style><script>x()</script></svg>";
+		const doc = buildHtmlAst(src, undefined, { text: true });
+		/** @type {Record<string, string>} */
+		const bodies = {};
+		/** @param {import("../lib/html/syntax").HtmlNode} n node */
+		const walk = (n) => {
+			if (n.type === NodeType.Element) {
+				if (n.contentEnd > n.tagEnd) {
+					bodies[n.tagName] = src.slice(n.tagEnd, n.contentEnd);
+				}
+				for (const c of n.children) walk(c);
+			}
+		};
+		for (const c of doc.children) walk(c);
+		expect(bodies).toEqual({ style: ".a{}", script: "x()" });
 	});
 
 	it("skip options preserve element structure under fragment parsing", () => {

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -478,6 +478,31 @@ describe("buildHtmlAst", () => {
 		expect(span.attributes[0].valueStart).toBe(-1);
 	});
 
+	it("clones <template> content when mirroring into <selectedcontent>", () => {
+		const select = body(
+			"<select><button><selectedcontent></button><option><template><p>x</p></template>"
+		)[0];
+		const selectedcontent = child(
+			child(select.children, "button").children,
+			"selectedcontent"
+		);
+		const template = /** @type {import("../lib/html/syntax").HtmlElement} */ (
+			selectedcontent.children[0]
+		);
+		expect(template.tagName).toBe("template");
+		// The cloned template keeps its own document-fragment content.
+		const fragment =
+			/** @type {import("../lib/html/syntax").HtmlDocumentFragment} */ (
+				template.templateContent
+			);
+		expect(fragment.type).toBe(NodeType.DocumentFragment);
+		expect(
+			/** @type {import("../lib/html/syntax").HtmlElement} */ (
+				fragment.children[0]
+			).tagName
+		).toBe("p");
+	});
+
 	it("should mirror the last selected <option> into <selectedcontent>", () => {
 		const select = body(
 			"<select><button><selectedcontent></button><option>A<option selected>B"

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -849,7 +849,7 @@ describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
 // The `skip` options are pure output reductions: tree construction (and quirks
 // detection) must run identically, so the ELEMENT tree — tags, nesting, offsets
 // and attributes — is the same with any skip combination as with none. This
-// guards the risky `skip.text` path, which drops text-node insertion.
+// guards the risky `skip.proseText` path, which drops text-node insertion.
 describe("buildHtmlAst — skip options preserve element structure", () => {
 	// A spread of construction edge cases: foster parenting, adoption agency,
 	// select/table/ruby scoping, foreign content, raw-text elements, quirks.
@@ -868,7 +868,19 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		"<script>var a = 1 < 2 && '</x>';</script><style>.a{color:red}</style>",
 		"<pre>\nkeep</pre><textarea>\nx</textarea>",
 		"<!-- c1 --><p>x<!-- c2 --></p><!-- c3 -->",
-		"<frameset>x<frame></frameset>"
+		"<frameset>x<frame></frameset>",
+		// Foreign-content CDATA becomes character data (dropped as prose).
+		"<svg><![CDATA[cdata text]]><rect/></svg>",
+		// No doctype → quirks mode; skip.doctype must not change that.
+		"<table><tr><td>quirks</td></tr></table>",
+		// Entities/whitespace in prose text (whitespace routing in head/table).
+		"  <html>  <head>  </head>  <body> a &amp; b &#60; c </body> </html>",
+		// Escapable raw-text bodies + a title in head.
+		"<title>page &amp; more</title><textarea>form\ntext</textarea>",
+		// Button scope + implied end tags.
+		"<button><p>x</button>y",
+		// Comment-only document.
+		"<!-- only a comment -->"
 	];
 
 	/**
@@ -906,10 +918,10 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 	};
 
 	const skipCombos = [
-		{ text: true },
+		{ proseText: true },
 		{ comments: true },
 		{ doctype: true },
-		{ text: true, comments: true, doctype: true }
+		{ proseText: true, comments: true, doctype: true }
 	];
 
 	it.each(cases)("keeps the element tree stable under skip (%s)", (src) => {
@@ -921,9 +933,9 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		}
 	});
 
-	it("skip.text keeps <script>/<style> bodies (offset-only) and drops prose", () => {
+	it("skip.proseText keeps <script>/<style> bodies (offset-only) and drops prose", () => {
 		const src = "<p>prose</p><script>var x=1;</script>";
-		const doc = buildHtmlAst(src, undefined, { text: true });
+		const doc = buildHtmlAst(src, undefined, { proseText: true });
 		/** @type {import("../lib/html/syntax").HtmlText[]} */
 		const texts = [];
 		/** @param {import("../lib/html/syntax").HtmlNode} n node */
@@ -958,5 +970,52 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		// Baseline still has both.
 		expect(count(buildHtmlAst(src), NodeType.Comment)).toBe(1);
 		expect(count(buildHtmlAst(src), NodeType.Doctype)).toBe(1);
+	});
+
+	it("skip.proseText keeps every raw-text element body (script/style/textarea/title)", () => {
+		// Each body is the element's raw value, so all four survive (offset-only).
+		const src =
+			"<title>ti</title><style>.s{}</style></head><body>prose<script>sc</script><textarea>ta</textarea>";
+		const doc = buildHtmlAst(src, undefined, { proseText: true });
+		/** @type {Record<string, string>} */
+		const bodies = {};
+		/**
+		 * @param {import("../lib/html/syntax").HtmlNode} n node
+		 * @param {import("../lib/html/syntax").HtmlElement | null} parent parent
+		 */
+		const walk = (n, parent) => {
+			if (n.type === NodeType.Text && parent) {
+				expect(n.data).toBeUndefined();
+				bodies[parent.tagName] = src.slice(n.start, n.end);
+			}
+			if (n.type === NodeType.Element) {
+				for (const c of n.children) walk(c, n);
+			}
+		};
+		for (const c of doc.children) walk(c, null);
+		expect(bodies).toEqual({
+			title: "ti",
+			style: ".s{}",
+			script: "sc",
+			textarea: "ta"
+		});
+	});
+
+	it("skip options preserve element structure under fragment parsing", () => {
+		// Fragment contexts drive a different initial insertion mode; skips must
+		// still leave the element tree (and offsets) identical.
+		/** @type {[string, string][]} */
+		const fragments = [
+			["<td>a</td><tr><td>b", "table"],
+			["<li>x<li>y", "ul"],
+			["text<b>bold</b>", "div"],
+			["<rect/>text", "svg"]
+		];
+		for (const [src, ctx] of fragments) {
+			const base = elementSignature(buildHtmlAst(src, ctx));
+			for (const skip of skipCombos) {
+				expect(elementSignature(buildHtmlAst(src, ctx, skip))).toBe(base);
+			}
+		}
 	});
 });

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -880,7 +880,14 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		// Button scope + implied end tags.
 		"<button><p>x</button>y",
 		// Comment-only document.
-		"<!-- only a comment -->"
+		"<!-- only a comment -->",
+		// `skip.text` whitespace fast-path fallbacks: whitespace-producing
+		// character references, CR normalization, and NUL must still route text
+		// exactly (these decide foster-parenting / framesetOk).
+		"<table>&#32;&#9;<td>a</td></table>",
+		"<div>&#32;&#32;</div>plain  text",
+		"a<table>\r\n  <tr><td>b\0c</td></tr></table>d",
+		"<pre>\r\nkeep</pre>"
 	];
 
 	/**

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -849,7 +849,7 @@ describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
 // The `skip` options are pure output reductions: tree construction (and quirks
 // detection) must run identically, so the ELEMENT tree — tags, nesting, offsets
 // and attributes — is the same with any skip combination as with none. This
-// guards the risky `skip.proseText` path, which drops text-node insertion.
+// guards the risky `skip.text` path, which drops text-node insertion.
 describe("buildHtmlAst — skip options preserve element structure", () => {
 	// A spread of construction edge cases: foster parenting, adoption agency,
 	// select/table/ruby scoping, foreign content, raw-text elements, quirks.
@@ -918,10 +918,10 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 	};
 
 	const skipCombos = [
-		{ proseText: true },
+		{ text: true },
 		{ comments: true },
 		{ doctype: true },
-		{ proseText: true, comments: true, doctype: true }
+		{ text: true, comments: true, doctype: true }
 	];
 
 	it.each(cases)("keeps the element tree stable under skip (%s)", (src) => {
@@ -933,21 +933,32 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		}
 	});
 
-	it("skip.proseText keeps <script>/<style> bodies (offset-only) and drops prose", () => {
+	it("skip.text drops every text node; raw-text bodies stay readable via contentEnd", () => {
 		const src = "<p>prose</p><script>var x=1;</script>";
-		const doc = buildHtmlAst(src, undefined, { proseText: true });
+		const doc = buildHtmlAst(src, undefined, { text: true });
 		/** @type {import("../lib/html/syntax").HtmlText[]} */
 		const texts = [];
+		/** @type {import("../lib/html/syntax").HtmlElement | undefined} */
+		let script;
 		/** @param {import("../lib/html/syntax").HtmlNode} n node */
 		const walk = (n) => {
 			if (n.type === NodeType.Text) texts.push(n);
-			if (n.type === NodeType.Element) for (const c of n.children) walk(c);
+			if (n.type === NodeType.Element) {
+				if (n.tagName === "script") script = n;
+				for (const c of n.children) walk(c);
+			}
 		};
 		for (const c of doc.children) walk(c);
-		// Only the <script> body survives, and it carries offsets but no `data`.
-		expect(texts).toHaveLength(1);
-		expect(texts[0].data).toBeUndefined();
-		expect(src.slice(texts[0].start, texts[0].end)).toBe("var x=1;");
+		// No text nodes at all — not even the <script> body.
+		expect(texts).toHaveLength(0);
+		// The body is read by offset from the element's [tagEnd, contentEnd].
+		expect(
+			src.slice(
+				/** @type {import("../lib/html/syntax").HtmlElement} */ (script).tagEnd,
+				/** @type {import("../lib/html/syntax").HtmlElement} */ (script)
+					.contentEnd
+			)
+		).toBe("var x=1;");
 	});
 
 	it("skip.comments drops comment nodes; skip.doctype drops the doctype node", () => {
@@ -972,27 +983,26 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		expect(count(buildHtmlAst(src), NodeType.Doctype)).toBe(1);
 	});
 
-	it("skip.proseText keeps every raw-text element body (script/style/textarea/title)", () => {
-		// Each body is the element's raw value, so all four survive (offset-only).
+	it("skip.text records every raw-text element body span on contentEnd", () => {
+		// script/style (raw text) + textarea/title (escapable raw text): each body
+		// is the element's raw value, recorded as [tagEnd, contentEnd] — no Text node.
 		const src =
 			"<title>ti</title><style>.s{}</style></head><body>prose<script>sc</script><textarea>ta</textarea>";
-		const doc = buildHtmlAst(src, undefined, { proseText: true });
+		const doc = buildHtmlAst(src, undefined, { text: true });
 		/** @type {Record<string, string>} */
 		const bodies = {};
-		/**
-		 * @param {import("../lib/html/syntax").HtmlNode} n node
-		 * @param {import("../lib/html/syntax").HtmlElement | null} parent parent
-		 */
-		const walk = (n, parent) => {
-			if (n.type === NodeType.Text && parent) {
-				expect(n.data).toBeUndefined();
-				bodies[parent.tagName] = src.slice(n.start, n.end);
-			}
+		/** @param {import("../lib/html/syntax").HtmlNode} n node */
+		const walk = (n) => {
+			// No Text nodes are emitted under skip.text.
+			expect(n.type).not.toBe(NodeType.Text);
 			if (n.type === NodeType.Element) {
-				for (const c of n.children) walk(c, n);
+				if (n.contentEnd > n.tagEnd) {
+					bodies[n.tagName] = src.slice(n.tagEnd, n.contentEnd);
+				}
+				for (const c of n.children) walk(c);
 			}
 		};
-		for (const c of doc.children) walk(c, null);
+		for (const c of doc.children) walk(c);
 		expect(bodies).toEqual({
 			title: "ti",
 			style: ".s{}",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The experimental HTML parser (`experiments.html`) built a full object-per-node DOM for every module and retained data the consumer never reads. This PR lets `buildHtmlAst` / the HTML `SourceProcessor` omit AST node kinds a consumer doesn't need, via a `skip` option (`{ text, comments, doctype }`), and wires `HtmlParser` to use it: it drops all `Text` nodes (reading `<script>`/`<style>` bodies by offset via a new `contentEnd`) and the doctype node, while keeping comments for magic comments. It also aligns the HTML parser entry with the CSS parser (the AST is built inside `.process(...)`, so the consumer no longer calls `buildHtmlAst` or passes a pre-built `ast` — that unused process option is removed), adds a plain-text fast path under `skip.text` that avoids a slice + entity-decode of a string that is immediately discarded, and shares one frozen `children` array for void elements. Net on text-heavy documents: **~28% less parser heap and ~10%+ less CPU**, with parse results unchanged.

**What kind of change does this PR introduce?**

perf (with the supporting refactor of the parser's process API).

**Did you add tests for your changes?**

Yes. `test/buildHtmlAst.unittest.js` gains a "skip options preserve element structure" block asserting the element tree + offsets are identical under every `skip` combination across construction edge cases (foster parenting, adoption agency, foreign content, quirks, and the `skip.text` whitespace fast-path fallbacks — character references, CR, NUL). `test/HtmlParser.unittest.js` was converted to drive the real parser on real HTML instead of mocking `buildHtmlAst`.

**Does this PR introduce a breaking change?**

No. The changes are internal to the experimental HTML support; the `skip` options are opt-in and default `buildHtmlAst` output is byte-identical (verified against the previous behavior).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — internal parser change, no public config surface.

**Use of AI**

Yes. AI (Claude) was used to profile the parser, prototype and measure each optimization, and draft the implementation and tests. Every change was verified with byte-identical-AST comparisons against the prior behavior and the added guard tests; the full jest/html5lib/tsc/lint suites should be confirmed green by CI on this PR (they could not be run in the authoring environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_012PaFAMEPD53mz88AmbLpTo)_