### PR TITLE
perf: speed up non-CSS-Modules CSS parsing by skipping unused AST work

### DIFF
--- a/.changeset/css-skip-selector-prelude.md
+++ b/.changeset/css-skip-selector-prelude.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up non-CSS-Modules parsing by not building unused selector AST nodes.

--- a/.changeset/css-skip-value-leaves.md
+++ b/.changeset/css-skip-value-leaves.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up non-CSS-Modules CSS parsing by dropping value tokens nothing reads.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -32,7 +32,7 @@ const {
 	A,
 	NodeType,
 	SourceProcessor,
-	buildSkipLeafSet,
+	buildSkipSet,
 	equalsLowerCase,
 	unescapeIdentifier
 } = require("./syntax");
@@ -97,14 +97,15 @@ const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(?:-\w+-)?keyframes$/;
 const COMPOSES_PROPERTY = /^(?:composes|compose-with)$/i;
 const IS_MODULES = /\.modules?\.[^.]+$/i;
 
-// Non-CSS-Modules value / function-arg leaf types with no consumer, so they can
-// be dropped from declaration value lists (never walked or read): the `Ident`
-// visitor no-ops and the `Declaration` visitor returns early, and there is no
-// ICSS. `url` / functions / strings / blocks / commas are kept — they carry
-// url() rewrites and image-set fences. CSS-Modules parses skip nothing here:
-// ICSS `:export { k: v }` captures each value's byte range from its first / last
-// value node, so any dropped leaf would drop the export.
-const SKIP_LEAF_NON_MODULES = buildSkipLeafSet([
+// Unified skip set for a non-CSS-Modules parse: drop the selector prelude
+// (`QualifiedRule` — never walked without modules) plus value / function-arg
+// leaves nothing reads (the `Ident` visitor no-ops, the `Declaration` visitor
+// returns early, no ICSS). `url` / functions / strings / blocks / commas are
+// kept — they carry url() rewrites and image-set fences. CSS-Modules parses skip
+// nothing: selectors are walked and ICSS `:export { k: v }` captures each value's
+// byte range from its first / last value node, so any drop would lose output.
+const SKIP_NON_MODULES = buildSkipSet([
+	NodeType.QualifiedRule,
 	NodeType.Number,
 	NodeType.Dimension,
 	NodeType.Percentage,
@@ -3651,10 +3652,9 @@ class CssParser extends Parser {
 			.process(source, {
 				locConverter,
 				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
-				// Non-modules parses never walk selectors, so skip building their preludes.
-				skipSelectorPrelude: !isModules,
-				// Drop value leaves nothing reads (only safe without CSS Modules).
-				skipLeafTypes: isModules ? undefined : SKIP_LEAF_NON_MODULES
+				// One skip set: selector prelude + unread value leaves (non-modules only;
+				// CSS Modules needs its selectors and ICSS-captured values).
+				skip: isModules ? undefined : SKIP_NON_MODULES
 			});
 
 		/** @type {BuildInfo} */

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -1242,18 +1242,16 @@ class CssParser extends Parser {
 			modeData ? modeData === "local" : mode === "local";
 
 		/**
-		 * Comment callback: push every comment-token (in source order) onto the local `comments`, read back by `advanceCommentCursor` (pure-mode flags) and `parseCommentOptions` (magic comments).
-		 * @param {string} input input
-		 * @param {number} start start
-		 * @param {number} end end
-		 * @returns {number} end
+		 * Comment visitor (`NodeType.Comment`): push every comment (in source order) onto the local `comments`, read back by `advanceCommentCursor` (pure-mode flags) and `parseCommentOptions` (magic comments).
+		 * @param {AstNode} node comment node
 		 */
-		const comment = (input, start, end) => {
+		const commentVisitor = (node) => {
+			const start = A.start(node);
+			const end = A.end(node);
 			comments.push({
-				value: input.slice(start + 2, end - 2),
+				value: source.slice(start + 2, end - 2),
 				range: [start, end]
 			});
-			return end;
 		};
 
 		/**
@@ -3101,6 +3099,7 @@ class CssParser extends Parser {
 		// Drive the walk through SourceProcessor: structural enter / exit map to the `walkAst…Enter` / `…Exit` halves; value visitors handle url / ICSS / local-global.
 		/** @type {VisitorMap} */
 		const visitors = {
+			[NodeType.Comment]: commentVisitor,
 			[NodeType.AtRule]: {
 				// At-rule enter: scope save, name dispatch, prelude value context, pure-block push.
 				enter: (node, parent) => {
@@ -3633,7 +3632,6 @@ class CssParser extends Parser {
 			.use(/** @type {VisitorMap} */ (visitors))
 			.process(source, {
 				locConverter,
-				comment,
 				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
 				// Non-modules parses never walk selectors, so skip building their preludes.
 				skipSelectorPrelude: !isModules

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -97,23 +97,25 @@ const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(?:-\w+-)?keyframes$/;
 const COMPOSES_PROPERTY = /^(?:composes|compose-with)$/i;
 const IS_MODULES = /\.modules?\.[^.]+$/i;
 
-// Unified skip set for a non-CSS-Modules parse: drop the selector prelude
-// (`QualifiedRule` — never walked without modules) plus value / function-arg
-// leaves nothing reads (the `Ident` visitor no-ops, the `Declaration` visitor
-// returns early, no ICSS). `url` / functions / strings / blocks / commas are
-// kept — they carry url() rewrites and image-set fences. CSS-Modules parses skip
-// nothing: selectors are walked and ICSS `:export { k: v }` captures each value's
-// byte range from its first / last value node, so any drop would lose output.
-const SKIP_NON_MODULES = buildSkipSet([
-	NodeType.QualifiedRule,
-	NodeType.Number,
-	NodeType.Dimension,
-	NodeType.Percentage,
-	NodeType.Ident,
-	NodeType.Hash,
-	NodeType.Colon,
-	NodeType.Delim
-]);
+// Skip options for a non-CSS-Modules parse: drop the selector prelude (never
+// walked without modules) plus value / function-arg leaves nothing reads (the
+// `Ident` visitor no-ops, the `Declaration` visitor returns early, no ICSS).
+// `url` / functions / strings / blocks / commas are kept — they carry url()
+// rewrites and image-set fences. At-rule preludes are kept (`@media` / `@import`
+// are read). CSS-Modules parses skip nothing: selectors are walked and ICSS
+// `:export { k: v }` captures each value's byte range from its first / last node.
+const SKIP_NON_MODULES = {
+	types: buildSkipSet([
+		NodeType.Number,
+		NodeType.Dimension,
+		NodeType.Percentage,
+		NodeType.Ident,
+		NodeType.Hash,
+		NodeType.Colon,
+		NodeType.Delim
+	]),
+	selectorPrelude: true
+};
 const CSS_COMMENT = /\/\*((?!\*\/)[\s\S]*?)\*\//g;
 // `@value` recognizers (postcss-modules-values shape): the import form `<names> from <source>`, and the `<importName> as <localName>` alias inside it.
 const VALUE_IMPORT_FORM = /from(\/\*|\s)(?:[\s\S]+)$/i;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -3634,7 +3634,9 @@ class CssParser extends Parser {
 			.process(source, {
 				locConverter,
 				comment,
-				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as)
+				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
+				// Non-modules parses never walk selectors, so skip building their preludes.
+				skipSelectorPrelude: !isModules
 			});
 
 		/** @type {BuildInfo} */

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -3648,16 +3648,17 @@ class CssParser extends Parser {
 			}
 		};
 		// `as` selects the top-level production (§5.3): a `style` attribute is a
-		// block's contents, everything else a full stylesheet (the default).
-		new SourceProcessor()
+		// block's contents, everything else a full stylesheet (the default). `as`
+		// and `skip` are per-parse config on the processor; only `locConverter`
+		// (per-source) is passed to `process`. One skip set: selector prelude +
+		// unread value leaves (non-modules only; CSS Modules needs its selectors
+		// and ICSS-captured values).
+		new SourceProcessor({
+			as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
+			skip: isModules ? undefined : SKIP_NON_MODULES
+		})
 			.use(/** @type {VisitorMap} */ (visitors))
-			.process(source, {
-				locConverter,
-				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
-				// One skip set: selector prelude + unread value leaves (non-modules only;
-				// CSS Modules needs its selectors and ICSS-captured values).
-				skip: isModules ? undefined : SKIP_NON_MODULES
-			});
+			.process(source, { locConverter });
 
 		/** @type {BuildInfo} */
 		(module.buildInfo).strict = true;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -32,6 +32,7 @@ const {
 	A,
 	NodeType,
 	SourceProcessor,
+	buildSkipLeafSet,
 	equalsLowerCase,
 	unescapeIdentifier
 } = require("./syntax");
@@ -95,6 +96,23 @@ const MAGIC_COMMENT_FAST_PATH =
 const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(?:-\w+-)?keyframes$/;
 const COMPOSES_PROPERTY = /^(?:composes|compose-with)$/i;
 const IS_MODULES = /\.modules?\.[^.]+$/i;
+
+// Non-CSS-Modules value / function-arg leaf types with no consumer, so they can
+// be dropped from declaration value lists (never walked or read): the `Ident`
+// visitor no-ops and the `Declaration` visitor returns early, and there is no
+// ICSS. `url` / functions / strings / blocks / commas are kept — they carry
+// url() rewrites and image-set fences. CSS-Modules parses skip nothing here:
+// ICSS `:export { k: v }` captures each value's byte range from its first / last
+// value node, so any dropped leaf would drop the export.
+const SKIP_LEAF_NON_MODULES = buildSkipLeafSet([
+	NodeType.Number,
+	NodeType.Dimension,
+	NodeType.Percentage,
+	NodeType.Ident,
+	NodeType.Hash,
+	NodeType.Colon,
+	NodeType.Delim
+]);
 const CSS_COMMENT = /\/\*((?!\*\/)[\s\S]*?)\*\//g;
 // `@value` recognizers (postcss-modules-values shape): the import form `<names> from <source>`, and the `<importName> as <localName>` alias inside it.
 const VALUE_IMPORT_FORM = /from(\/\*|\s)(?:[\s\S]+)$/i;
@@ -3634,7 +3652,9 @@ class CssParser extends Parser {
 				locConverter,
 				as: /** @type {"stylesheet" | "block-contents"} */ (this.options.as),
 				// Non-modules parses never walk selectors, so skip building their preludes.
-				skipSelectorPrelude: !isModules
+				skipSelectorPrelude: !isModules,
+				// Drop value leaves nothing reads (only safe without CSS Modules).
+				skipLeafTypes: isModules ? undefined : SKIP_LEAF_NON_MODULES
 			});
 
 		/** @type {BuildInfo} */

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1166,7 +1166,10 @@ const NodeType = {
 	Declaration: 23,
 	AtRule: 24,
 	QualifiedRule: 25,
-	Stylesheet: 26
+	Stylesheet: 26,
+	// Comments are never tree nodes; this type exists only so a `NodeType.Comment`
+	// visitor can be registered (fired during tokenization — see `grammar`).
+	Comment: 27
 };
 const {
 	Ident: T_IDENT,
@@ -1194,7 +1197,8 @@ const {
 	Declaration: T_DECLARATION,
 	AtRule: T_AT_RULE,
 	QualifiedRule: T_QUALIFIED_RULE,
-	Stylesheet: T_STYLESHEET
+	Stylesheet: T_STYLESHEET,
+	Comment: T_COMMENT
 } = NodeType;
 
 /**
@@ -3064,7 +3068,6 @@ const TOP_LEVEL_CONSUMERS = {
 /**
  * @typedef {object} CssProcessOptions
  * @property {LocConverter=} locConverter shared loc converter (default a fresh one over the input)
- * @property {((input: string, start: number, end: number) => number)=} comment comment-token callback
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
  * @property {boolean=} skipSelectorPrelude don't materialize qualified-rule (selector) preludes — safe only when no visitor reads them (non-CSS-Modules parses); default false
@@ -3081,7 +3084,6 @@ const TOP_LEVEL_CONSUMERS = {
  * @param {CssProcessOptions} options process options
  */
 const grammar = (input, visitors, options) => {
-	const { comment } = options;
 	const locConverter = options.locConverter || new LocConverter(input);
 	useSoaBackend(input, locConverter);
 	_skipSelectorPrelude = options.skipSelectorPrelude === true;
@@ -3094,6 +3096,26 @@ const grammar = (input, visitors, options) => {
 			skipFlag = true;
 		}
 	};
+
+	// Comments reach the visitor map through `NodeType.Comment` instead of a
+	// side callback. They fire during tokenization — in source order among
+	// comments, not interleaved with the node walk — on a transient SoA node so
+	// `A.start`/`end`/`loc`/`source` work. No comment visitor → no callback →
+	// the tokenizer skips comments with zero overhead.
+	const commentBucket = visitors[T_COMMENT];
+	const onComment =
+		commentBucket === undefined
+			? undefined
+			: /** @type {(input: string, start: number, end: number) => number} */ (
+					(_input, start, end) => {
+						const node = _soaAlloc(T_COMMENT, start, end);
+						const e = commentBucket.enter;
+						for (let i = 0; i < e.length; i++) e[i](node, null, visitorCtx);
+						const x = commentBucket.exit;
+						for (let i = 0; i < x.length; i++) x[i](node, null, visitorCtx);
+						return end;
+					}
+				);
 
 	/**
 	 * Walk a component-value subtree; children are already materialized. Fetches
@@ -3168,7 +3190,7 @@ const grammar = (input, visitors, options) => {
 	// Stream each top-level node (selected by `as`) to the walker the moment it's
 	// consumed, rather than collecting them first — so the whole AST is never
 	// held at once; peak heap is ~one top-level node's subtree.
-	const ts = new TokenStream(input, 0, locConverter, comment);
+	const ts = new TokenStream(input, 0, locConverter, onComment);
 	const consume =
 		TOP_LEVEL_CONSUMERS[options.as || "stylesheet"] ||
 		consumeAStylesheetsContents;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2773,13 +2773,15 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 		if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) return values;
 			const closer = consumeATokenAsNode(ts);
-			if (_skipTypes[_nType(closer)] === 0) values.push(closer);
+			// Keep unless the type is explicitly marked skip (1); an out-of-range
+			// lookup on a short `skip.types` yields `undefined`, which must not drop.
+			if (_skipTypes[_nType(closer)] !== 1) values.push(closer);
 			continue;
 		}
 		// anything else
 		// Consume a component value from input, and append the result to values.
 		const node = consumeAComponentValue(ts, t);
-		if (_skipTypes[_nType(node)] === 0) values.push(node);
+		if (_skipTypes[_nType(node)] !== 1) values.push(node);
 	}
 };
 
@@ -2886,7 +2888,7 @@ const consumeAFunction = (ts) => {
 		// anything else
 		// Consume a component value from input and append the result to function’s value.
 		const node = consumeAComponentValue(ts, t);
-		if (_skipTypes[_nType(node)] === 0) val.push(node);
+		if (_skipTypes[_nType(node)] !== 1) val.push(node);
 	}
 };
 

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3240,14 +3240,16 @@ const grammar = (input, visitors, options) => {
  * `grammar`. Babel-style usage:
  *
  * ```
- * processor.use({ [NodeType.AtRule]: (at) => {}, [NodeType.Declaration]: { enter, exit } });
- * processor.process(source);
+ * new SourceProcessor({ skip }).use({ [NodeType.AtRule]: (at) => {} }).process(source);
  * ```
  * @extends {GenericSourceProcessor<Node, CssProcessOptions>}
  */
 class SourceProcessor extends GenericSourceProcessor {
-	constructor() {
-		super(grammar);
+	/**
+	 * @param {CssProcessOptions=} options default process options (`skip`, `as`, …) for every `process` call
+	 */
+	constructor(options) {
+		super(grammar, options);
 	}
 }
 

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1604,6 +1604,16 @@ let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 // to false by `useObjectBackend` so the `parseA*` entry points always build it.
 let _skipSelectorPrelude = false;
 
+// Leaf node types (indexed by `NodeType`) to drop when building declaration
+// value / function-arg lists: a dropped leaf is still tokenized (positions stay
+// correct) but never pushed, so it isn't walked or read. Only types with no
+// consumer in the active parse may be listed — the caller owns that contract.
+// The shared all-zero default skips nothing; `useObjectBackend` restores it so
+// `parseA*` always build the full list.
+const _NO_SKIP_LEAF = new Uint8Array(32);
+/** @type {Uint8Array} */
+let _skipLeaf = _NO_SKIP_LEAF;
+
 /** @type {(type: number, start: number, end: number) => Node} */
 let _mkLeaf;
 /** @type {(start: number, end: number, contentStart: number, contentEnd: number) => Node} */
@@ -1666,8 +1676,9 @@ const _objStylesheet = (start) => {
 /** @param {LocConverter} lc loc converter for this parse */
 const useObjectBackend = (lc) => {
 	_lc = lc;
-	// `parseA*` return the full tree, so selector preludes are always materialized.
+	// `parseA*` return the full tree, so nothing is skipped.
 	_skipSelectorPrelude = false;
+	_skipLeaf = _NO_SKIP_LEAF;
 	_mkLeaf = _objLeaf;
 	_mkUrl = _objUrl;
 	_mkContainer = _objContainer;
@@ -2756,7 +2767,8 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 		}
 		// anything else
 		// Consume a component value from input, and append the result to values.
-		values.push(consumeAComponentValue(ts, t));
+		const node = consumeAComponentValue(ts, t);
+		if (_skipLeaf[_nType(node)] === 0) values.push(node);
 	}
 };
 
@@ -2862,7 +2874,8 @@ const consumeAFunction = (ts) => {
 
 		// anything else
 		// Consume a component value from input and append the result to function’s value.
-		val.push(consumeAComponentValue(ts, t));
+		const node = consumeAComponentValue(ts, t);
+		if (_skipLeaf[_nType(node)] === 0) val.push(node);
 	}
 };
 
@@ -3071,6 +3084,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
  * @property {boolean=} skipSelectorPrelude don't materialize qualified-rule (selector) preludes — safe only when no visitor reads them (non-CSS-Modules parses); default false
+ * @property {Uint8Array=} skipLeafTypes leaf node types (indexed by `NodeType`, 1 = skip) to drop from declaration value / function-arg lists — safe only for types with no consumer in the active parse; default skip nothing
  */
 
 /**
@@ -3087,6 +3101,7 @@ const grammar = (input, visitors, options) => {
 	const locConverter = options.locConverter || new LocConverter(input);
 	useSoaBackend(input, locConverter);
 	_skipSelectorPrelude = options.skipSelectorPrelude === true;
+	_skipLeaf = options.skipLeafTypes || _NO_SKIP_LEAF;
 	const recurseBlocks = options.recurseBlocks !== false;
 
 	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.
@@ -3215,6 +3230,19 @@ class SourceProcessor extends GenericSourceProcessor {
 		super(grammar);
 	}
 }
+
+/**
+ * Build a `CssProcessOptions.skipLeafTypes` set from a list of leaf `NodeType`s.
+ * The caller owns the safety contract: only pass leaf types nothing reads in the
+ * intended parse. Precompute once per configuration and reuse across parses.
+ * @param {number[]} nodeTypes leaf node types to drop from value / function-arg lists
+ * @returns {Uint8Array} skip set indexed by `NodeType`
+ */
+const buildSkipLeafSet = (nodeTypes) => {
+	const set = new Uint8Array(32);
+	for (let i = 0; i < nodeTypes.length; i++) set[nodeTypes[i]] = 1;
+	return set;
+};
 
 // AST field-access seam. Every AST-node field read by `CssParser` goes through
 // one of these accessors so the node representation can change underneath the
@@ -3368,6 +3396,7 @@ module.exports.TT_URL = TT_URL;
 module.exports.TT_WHITESPACE = TT_WHITESPACE;
 module.exports.Token = Token;
 module.exports.TokenStream = TokenStream;
+module.exports.buildSkipLeafSet = buildSkipLeafSet;
 module.exports.equalsLowerCase = equalsLowerCase;
 module.exports.escapeIdentifier = escapeIdentifier;
 module.exports.parseABlocksContents = parseABlocksContents;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1598,21 +1598,19 @@ _ttToNodeType[TT_CDC] = T_CDC;
 // Current loc converter for the active parse (object backend reads it).
 let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
-// When set, `consumeAQualifiedRule` scans its prelude (selector) without
-// materializing the component-value nodes — the streaming `grammar` turns this
-// on for non-CSS-Modules parses, where nothing reads the selector tree. Reset
-// to false by `useObjectBackend` so the `parseA*` entry points always build it.
-let _skipSelectorPrelude = false;
-
-// Leaf node types (indexed by `NodeType`) to drop when building declaration
-// value / function-arg lists: a dropped leaf is still tokenized (positions stay
-// correct) but never pushed, so it isn't walked or read. Only types with no
-// consumer in the active parse may be listed — the caller owns that contract.
-// The shared all-zero default skips nothing; `useObjectBackend` restores it so
-// `parseA*` always build the full list.
-const _NO_SKIP_LEAF = new Uint8Array(32);
+// Unified skip set, indexed by `NodeType` (1 = skip), driving every skip the
+// grammar supports. Two roles by node kind:
+//   - leaf type (Number, Ident, Hash, …): drop that leaf from declaration value
+//     and function-arg lists;
+//   - `QualifiedRule`: scan the rule's prelude (selector) without materializing
+//     its component-value tree (url tokens / functions are still kept for url()).
+// A skipped node is still tokenized (positions stay correct) but never pushed,
+// so it is never walked or read — only entries with no consumer in the active
+// parse may be set (the caller owns that contract). The shared all-zero default
+// skips nothing; `useObjectBackend` restores it so `parseA*` build the full tree.
+const _NO_SKIP = new Uint8Array(32);
 /** @type {Uint8Array} */
-let _skipLeaf = _NO_SKIP_LEAF;
+let _skip = _NO_SKIP;
 
 /** @type {(type: number, start: number, end: number) => Node} */
 let _mkLeaf;
@@ -1677,8 +1675,7 @@ const _objStylesheet = (start) => {
 const useObjectBackend = (lc) => {
 	_lc = lc;
 	// `parseA*` return the full tree, so nothing is skipped.
-	_skipSelectorPrelude = false;
-	_skipLeaf = _NO_SKIP_LEAF;
+	_skip = _NO_SKIP;
 	_mkLeaf = _objLeaf;
 	_mkUrl = _objUrl;
 	_mkContainer = _objContainer;
@@ -2402,7 +2399,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	// Skip mode leaves `prelude` empty (selector text is recovered from the
 	// rule's byte range, not its nodes); `first`/`second` still track the first
 	// two non-whitespace tokens the `--foo: {` disambiguation below needs.
-	const skip = _skipSelectorPrelude;
+	const skip = _skip[T_QUALIFIED_RULE] === 1;
 	let first = /** @type {Node} */ (/** @type {unknown} */ (0));
 	let second = /** @type {Node} */ (/** @type {unknown} */ (0));
 
@@ -2768,7 +2765,7 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 		// anything else
 		// Consume a component value from input, and append the result to values.
 		const node = consumeAComponentValue(ts, t);
-		if (_skipLeaf[_nType(node)] === 0) values.push(node);
+		if (_skip[_nType(node)] === 0) values.push(node);
 	}
 };
 
@@ -2875,7 +2872,7 @@ const consumeAFunction = (ts) => {
 		// anything else
 		// Consume a component value from input and append the result to function’s value.
 		const node = consumeAComponentValue(ts, t);
-		if (_skipLeaf[_nType(node)] === 0) val.push(node);
+		if (_skip[_nType(node)] === 0) val.push(node);
 	}
 };
 
@@ -3083,8 +3080,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {LocConverter=} locConverter shared loc converter (default a fresh one over the input)
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
- * @property {boolean=} skipSelectorPrelude don't materialize qualified-rule (selector) preludes — safe only when no visitor reads them (non-CSS-Modules parses); default false
- * @property {Uint8Array=} skipLeafTypes leaf node types (indexed by `NodeType`, 1 = skip) to drop from declaration value / function-arg lists — safe only for types with no consumer in the active parse; default skip nothing
+ * @property {Uint8Array=} skip unified skip set indexed by `NodeType` (1 = skip): a leaf type drops that leaf from value / function-arg lists, `QualifiedRule` drops selector preludes — safe only for entries with no consumer in the active parse; default skip nothing
  */
 
 /**
@@ -3100,8 +3096,7 @@ const TOP_LEVEL_CONSUMERS = {
 const grammar = (input, visitors, options) => {
 	const locConverter = options.locConverter || new LocConverter(input);
 	useSoaBackend(input, locConverter);
-	_skipSelectorPrelude = options.skipSelectorPrelude === true;
-	_skipLeaf = options.skipLeafTypes || _NO_SKIP_LEAF;
+	_skip = options.skip || _NO_SKIP;
 	const recurseBlocks = options.recurseBlocks !== false;
 
 	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.
@@ -3232,13 +3227,14 @@ class SourceProcessor extends GenericSourceProcessor {
 }
 
 /**
- * Build a `CssProcessOptions.skipLeafTypes` set from a list of leaf `NodeType`s.
- * The caller owns the safety contract: only pass leaf types nothing reads in the
- * intended parse. Precompute once per configuration and reuse across parses.
- * @param {number[]} nodeTypes leaf node types to drop from value / function-arg lists
+ * Build a `CssProcessOptions.skip` set from a list of `NodeType`s. The caller
+ * owns the safety contract: only pass types nothing reads in the intended parse
+ * (leaf types drop from value / function-arg lists; `QualifiedRule` drops selector
+ * preludes). Precompute once per configuration and reuse across parses.
+ * @param {number[]} nodeTypes node types to skip
  * @returns {Uint8Array} skip set indexed by `NodeType`
  */
-const buildSkipLeafSet = (nodeTypes) => {
+const buildSkipSet = (nodeTypes) => {
 	const set = new Uint8Array(32);
 	for (let i = 0; i < nodeTypes.length; i++) set[nodeTypes[i]] = 1;
 	return set;
@@ -3396,7 +3392,7 @@ module.exports.TT_URL = TT_URL;
 module.exports.TT_WHITESPACE = TT_WHITESPACE;
 module.exports.Token = Token;
 module.exports.TokenStream = TokenStream;
-module.exports.buildSkipLeafSet = buildSkipLeafSet;
+module.exports.buildSkipSet = buildSkipSet;
 module.exports.equalsLowerCase = equalsLowerCase;
 module.exports.escapeIdentifier = escapeIdentifier;
 module.exports.parseABlocksContents = parseABlocksContents;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3230,7 +3230,10 @@ class SourceProcessor extends GenericSourceProcessor {
  * Build a `CssProcessOptions.skip` set from a list of `NodeType`s. The caller
  * owns the safety contract: only pass types nothing reads in the intended parse
  * (leaf types drop from value / function-arg lists; `QualifiedRule` drops selector
- * preludes). Precompute once per configuration and reuse across parses.
+ * preludes). Two grammar-internal caveats beyond consumer needs: dropping both
+ * `Delim` and `Ident` loses `!important` detection, and dropping `SimpleBlock`
+ * loses the custom-property `{}`-value check (and its subtree). Precompute once
+ * per configuration and reuse across parses.
  * @param {number[]} nodeTypes node types to skip
  * @returns {Uint8Array} skip set indexed by `NodeType`
  */

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1594,6 +1594,12 @@ _ttToNodeType[TT_CDC] = T_CDC;
 // Current loc converter for the active parse (object backend reads it).
 let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
+// When set, `consumeAQualifiedRule` scans its prelude (selector) without
+// materializing the component-value nodes — the streaming `grammar` turns this
+// on for non-CSS-Modules parses, where nothing reads the selector tree. Reset
+// to false by `useObjectBackend` so the `parseA*` entry points always build it.
+let _skipSelectorPrelude = false;
+
 /** @type {(type: number, start: number, end: number) => Node} */
 let _mkLeaf;
 /** @type {(start: number, end: number, contentStart: number, contentEnd: number) => Node} */
@@ -1656,6 +1662,8 @@ const _objStylesheet = (start) => {
 /** @param {LocConverter} lc loc converter for this parse */
 const useObjectBackend = (lc) => {
 	_lc = lc;
+	// `parseA*` return the full tree, so selector preludes are always materialized.
+	_skipSelectorPrelude = false;
 	_mkLeaf = _objLeaf;
 	_mkUrl = _objUrl;
 	_mkContainer = _objContainer;
@@ -2376,6 +2384,13 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block until a `{` is reached).
 
+	// Skip mode leaves `prelude` empty (selector text is recovered from the
+	// rule's byte range, not its nodes); `first`/`second` still track the first
+	// two non-whitespace tokens the `--foo: {` disambiguation below needs.
+	const skip = _skipSelectorPrelude;
+	let first = /** @type {Node} */ (/** @type {unknown} */ (0));
+	let second = /** @type {Node} */ (/** @type {unknown} */ (0));
+
 	// Process input
 	for (;;) {
 		const t = ts.next();
@@ -2389,7 +2404,13 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 		// This is a parse error. If nested is true, return nothing. Otherwise, consume a token and append the result to rule’s prelude.
 		else if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) return undefined;
-			prelude.push(consumeATokenAsNode(ts));
+			const node = consumeATokenAsNode(ts);
+			if (skip) {
+				if (!first) first = node;
+				else if (!second) second = node;
+			} else {
+				prelude.push(node);
+			}
 			continue;
 		}
 		// <{-token>
@@ -2399,23 +2420,25 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 		// (This disambiguates custom-property declarations from nested qualified rules — `--foo: { … }` at top level of a block is a declaration, not a rule.)
 		// Otherwise, consume a block from input, and let child rules be the result.
 		else if (t.type === TT_LEFT_CURLY_BRACKET) {
-			let firstIdx = 0;
-			/* istanbul ignore next -- @preserve: leading whitespace is discarded before the rule, so the prelude never starts with it */
-			while (
-				firstIdx < prelude.length &&
-				_nType(prelude[firstIdx]) === T_WHITESPACE
-			) {
-				firstIdx++;
+			if (!skip) {
+				let firstIdx = 0;
+				/* istanbul ignore next -- @preserve: leading whitespace is discarded before the rule, so the prelude never starts with it */
+				while (
+					firstIdx < prelude.length &&
+					_nType(prelude[firstIdx]) === T_WHITESPACE
+				) {
+					firstIdx++;
+				}
+				let secondIdx = firstIdx + 1;
+				while (
+					secondIdx < prelude.length &&
+					_nType(prelude[secondIdx]) === T_WHITESPACE
+				) {
+					secondIdx++;
+				}
+				first = prelude[firstIdx];
+				second = prelude[secondIdx];
 			}
-			let secondIdx = firstIdx + 1;
-			while (
-				secondIdx < prelude.length &&
-				_nType(prelude[secondIdx]) === T_WHITESPACE
-			) {
-				secondIdx++;
-			}
-			const first = prelude[firstIdx];
-			const second = prelude[secondIdx];
 			if (
 				first &&
 				_nType(first) === T_IDENT &&
@@ -2442,7 +2465,21 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 
 		// anything else
 		// Consume a component value from input and append the result to rule’s prelude.
-		prelude.push(consumeAComponentValue(ts, t));
+		const node = consumeAComponentValue(ts, t);
+		if (skip) {
+			// Keep only url-bearing nodes (url tokens, or functions that may hold a
+			// url like `:unknown(url(x))`) so the url visitor still rewrites them;
+			// other selector tokens have no non-modules consumer, so drop them.
+			const ty = _nType(node);
+			if (ty === T_FUNCTION || ty === T_URL) prelude.push(node);
+			// Track the first two non-whitespace tokens for the disambiguation above.
+			if (t.type !== TT_WHITESPACE) {
+				if (!first) first = node;
+				else if (!second) second = node;
+			}
+		} else {
+			prelude.push(node);
+		}
 	}
 };
 
@@ -3030,6 +3067,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {((input: string, start: number, end: number) => number)=} comment comment-token callback
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
+ * @property {boolean=} skipSelectorPrelude don't materialize qualified-rule (selector) preludes — safe only when no visitor reads them (non-CSS-Modules parses); default false
  */
 
 /**
@@ -3046,6 +3084,7 @@ const grammar = (input, visitors, options) => {
 	const { comment } = options;
 	const locConverter = options.locConverter || new LocConverter(input);
 	useSoaBackend(input, locConverter);
+	_skipSelectorPrelude = options.skipSelectorPrelude === true;
 	const recurseBlocks = options.recurseBlocks !== false;
 
 	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1598,21 +1598,19 @@ _ttToNodeType[TT_CDC] = T_CDC;
 // Current loc converter for the active parse (object backend reads it).
 let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
-// Unified skip set, indexed by `NodeType` (1 = skip), driving every skip the
-// grammar supports. Roles by node kind:
-//   - leaf type (Number, Ident, Hash, …): drop that leaf from declaration value
-//     and function-arg lists;
-//   - `QualifiedRule` / `AtRule`: scan the rule's prelude (selector / at-rule
-//     prelude) without materializing its component-value tree — url tokens /
-//     functions are still kept, so `url()` in a selector or `@import url(…)`
-//     still resolves.
+// Active skip state (from `CssProcessOptions.skip`), applied by the grammar.
+// `_skipTypes` is indexed by `NodeType` (1 = skip): drop that component-value
+// leaf / container from declaration value and function-arg lists. The two
+// prelude flags scan a rule's prelude without materializing its tree (url tokens
+// / functions kept, so `url()` in a selector or `@import url(…)` still resolves).
 // A skipped node is still tokenized (positions stay correct) but never pushed,
-// so it is never walked or read — only entries with no consumer in the active
-// parse may be set (the caller owns that contract). The shared all-zero default
-// skips nothing; `useObjectBackend` restores it so `parseA*` build the full tree.
-const _NO_SKIP = new Uint8Array(32);
+// so it is never walked or read — the caller must only skip what nothing reads.
+// `useObjectBackend` restores the defaults so `parseA*` build the full tree.
+const _NO_SKIP_TYPES = new Uint8Array(32);
 /** @type {Uint8Array} */
-let _skip = _NO_SKIP;
+let _skipTypes = _NO_SKIP_TYPES;
+let _skipSelectorPrelude = false;
+let _skipAtRulePrelude = false;
 
 /** @type {(type: number, start: number, end: number) => Node} */
 let _mkLeaf;
@@ -1677,7 +1675,9 @@ const _objStylesheet = (start) => {
 const useObjectBackend = (lc) => {
 	_lc = lc;
 	// `parseA*` return the full tree, so nothing is skipped.
-	_skip = _NO_SKIP;
+	_skipTypes = _NO_SKIP_TYPES;
+	_skipSelectorPrelude = false;
+	_skipAtRulePrelude = false;
 	_mkLeaf = _objLeaf;
 	_mkUrl = _objUrl;
 	_mkContainer = _objContainer;
@@ -2330,7 +2330,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 	// Like `consumeAQualifiedRule`: skip mode scans the prelude without
 	// materializing it (url tokens / functions kept so `@import url(…)` still
 	// resolves); the block boundary is found by scanning, not the prelude nodes.
-	const skip = _skip[T_AT_RULE] === 1;
+	const skip = _skipAtRulePrelude;
 
 	// Process input
 	for (;;) {
@@ -2412,7 +2412,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	// Skip mode leaves `prelude` empty (selector text is recovered from the
 	// rule's byte range, not its nodes); `first`/`second` still track the first
 	// two non-whitespace tokens the `--foo: {` disambiguation below needs.
-	const skip = _skip[T_QUALIFIED_RULE] === 1;
+	const skip = _skipSelectorPrelude;
 	let first = /** @type {Node} */ (/** @type {unknown} */ (0));
 	let second = /** @type {Node} */ (/** @type {unknown} */ (0));
 
@@ -2773,13 +2773,13 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 		if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) return values;
 			const closer = consumeATokenAsNode(ts);
-			if (_skip[_nType(closer)] === 0) values.push(closer);
+			if (_skipTypes[_nType(closer)] === 0) values.push(closer);
 			continue;
 		}
 		// anything else
 		// Consume a component value from input, and append the result to values.
 		const node = consumeAComponentValue(ts, t);
-		if (_skip[_nType(node)] === 0) values.push(node);
+		if (_skipTypes[_nType(node)] === 0) values.push(node);
 	}
 };
 
@@ -2886,7 +2886,7 @@ const consumeAFunction = (ts) => {
 		// anything else
 		// Consume a component value from input and append the result to function’s value.
 		const node = consumeAComponentValue(ts, t);
-		if (_skip[_nType(node)] === 0) val.push(node);
+		if (_skipTypes[_nType(node)] === 0) val.push(node);
 	}
 };
 
@@ -3094,7 +3094,15 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {LocConverter=} locConverter shared loc converter (default a fresh one over the input)
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
- * @property {Uint8Array=} skip unified skip set indexed by `NodeType` (1 = skip): a leaf type drops that leaf from value / function-arg lists, `QualifiedRule` / `AtRule` drop selector / at-rule preludes — safe only for entries with no consumer in the active parse; default skip nothing
+ * @property {SkipOptions=} skip what the grammar may leave un-materialized to go faster — safe only for parts nothing reads in the active parse; default skip nothing
+ */
+
+/**
+ * `CssProcessOptions.skip`: two independent axes, so each reads unambiguously.
+ * @typedef {object} SkipOptions
+ * @property {Uint8Array=} types component-value node types to drop from declaration value / function-arg lists (indexed by `NodeType`, 1 = skip; build with `buildSkipSet`)
+ * @property {boolean=} selectorPrelude drop qualified-rule (selector) preludes — the rule and its block are still produced (default false)
+ * @property {boolean=} atRulePrelude drop at-rule preludes — the at-rule and its block are still produced (default false)
  */
 
 /**
@@ -3110,7 +3118,10 @@ const TOP_LEVEL_CONSUMERS = {
 const grammar = (input, visitors, options) => {
 	const locConverter = options.locConverter || new LocConverter(input);
 	useSoaBackend(input, locConverter);
-	_skip = options.skip || _NO_SKIP;
+	const skip = options.skip;
+	_skipTypes = (skip && skip.types) || _NO_SKIP_TYPES;
+	_skipSelectorPrelude = skip !== undefined && skip.selectorPrelude === true;
+	_skipAtRulePrelude = skip !== undefined && skip.atRulePrelude === true;
 	const recurseBlocks = options.recurseBlocks !== false;
 
 	// Babel's `path.skip()`, children-only. Reset per `enter` dispatch.
@@ -3241,15 +3252,16 @@ class SourceProcessor extends GenericSourceProcessor {
 }
 
 /**
- * Build a `CssProcessOptions.skip` set from a list of `NodeType`s. The caller
- * owns the safety contract: only pass types nothing reads in the intended parse
- * (leaf types drop from value / function-arg lists; `QualifiedRule` / `AtRule` drop
- * selector / at-rule preludes). Two grammar-internal caveats beyond consumer needs: dropping both
- * `Delim` and `Ident` loses `!important` detection, and dropping `SimpleBlock`
- * loses the custom-property `{}`-value check (and its subtree). Precompute once
- * per configuration and reuse across parses.
- * @param {number[]} nodeTypes node types to skip
- * @returns {Uint8Array} skip set indexed by `NodeType`
+ * Build a `SkipOptions.types` set (drop these component-value node types from
+ * value / function-arg lists) from a list of `NodeType`s. Preludes are separate
+ * (`SkipOptions.selectorPrelude` / `atRulePrelude`). The caller owns the safety
+ * contract: only pass types nothing reads in the intended parse. Two
+ * grammar-internal caveats beyond consumer needs: dropping both `Delim` and
+ * `Ident` loses `!important` detection, and dropping `SimpleBlock` loses the
+ * custom-property `{}`-value check (and its subtree). Precompute once per
+ * configuration and reuse across parses.
+ * @param {number[]} nodeTypes component-value node types to drop
+ * @returns {Uint8Array} skip-types set indexed by `NodeType`
  */
 const buildSkipSet = (nodeTypes) => {
 	const set = new Uint8Array(32);

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1599,11 +1599,13 @@ _ttToNodeType[TT_CDC] = T_CDC;
 let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
 // Unified skip set, indexed by `NodeType` (1 = skip), driving every skip the
-// grammar supports. Two roles by node kind:
+// grammar supports. Roles by node kind:
 //   - leaf type (Number, Ident, Hash, …): drop that leaf from declaration value
 //     and function-arg lists;
-//   - `QualifiedRule`: scan the rule's prelude (selector) without materializing
-//     its component-value tree (url tokens / functions are still kept for url()).
+//   - `QualifiedRule` / `AtRule`: scan the rule's prelude (selector / at-rule
+//     prelude) without materializing its component-value tree — url tokens /
+//     functions are still kept, so `url()` in a selector or `@import url(…)`
+//     still resolves.
 // A skipped node is still tokenized (positions stay correct) but never pushed,
 // so it is never walked or read — only entries with no consumer in the active
 // parse may be set (the caller owns that contract). The shared all-zero default
@@ -2325,6 +2327,11 @@ const consumeAnAtRule = (ts, nested = false) => {
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block: the `;` / EOF / nested-`}` at-rule forms).
 
+	// Like `consumeAQualifiedRule`: skip mode scans the prelude without
+	// materializing it (url tokens / functions kept so `@import url(…)` still
+	// resolves); the block boundary is found by scanning, not the prelude nodes.
+	const skip = _skip[T_AT_RULE] === 1;
+
 	// Process input
 	for (;;) {
 		const t = ts.next();
@@ -2345,7 +2352,8 @@ const consumeAnAtRule = (ts, nested = false) => {
 				_setEnd(rule, t.start);
 				return rule;
 			}
-			prelude.push(consumeATokenAsNode(ts));
+			const node = consumeATokenAsNode(ts);
+			if (!skip) prelude.push(node);
 			continue;
 		}
 		// <{-token>
@@ -2360,7 +2368,12 @@ const consumeAnAtRule = (ts, nested = false) => {
 
 		// anything else
 		// Consume a component value from input and append the returned value to rule’s prelude.
-		prelude.push(consumeAComponentValue(ts, t));
+		const node = consumeAComponentValue(ts, t);
+		if (!skip) {
+			prelude.push(node);
+		} else if (_nType(node) === T_FUNCTION || _nType(node) === T_URL) {
+			prelude.push(node);
+		}
 	}
 };
 
@@ -2759,7 +2772,8 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 		// Otherwise, this is a parse error. Consume a token from input and append the result to values.
 		if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) return values;
-			values.push(consumeATokenAsNode(ts));
+			const closer = consumeATokenAsNode(ts);
+			if (_skip[_nType(closer)] === 0) values.push(closer);
 			continue;
 		}
 		// anything else
@@ -3080,7 +3094,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {LocConverter=} locConverter shared loc converter (default a fresh one over the input)
  * @property {boolean=} recurseBlocks walk into block bodies' nested rules (default true)
  * @property {("stylesheet" | "block-contents")=} as which top-level production to consume the source as (see `TOP_LEVEL_CONSUMERS`): `"stylesheet"` (default) or `"block-contents"` (a block's contents, e.g. an HTML `style` attribute)
- * @property {Uint8Array=} skip unified skip set indexed by `NodeType` (1 = skip): a leaf type drops that leaf from value / function-arg lists, `QualifiedRule` drops selector preludes — safe only for entries with no consumer in the active parse; default skip nothing
+ * @property {Uint8Array=} skip unified skip set indexed by `NodeType` (1 = skip): a leaf type drops that leaf from value / function-arg lists, `QualifiedRule` / `AtRule` drop selector / at-rule preludes — safe only for entries with no consumer in the active parse; default skip nothing
  */
 
 /**
@@ -3229,8 +3243,8 @@ class SourceProcessor extends GenericSourceProcessor {
 /**
  * Build a `CssProcessOptions.skip` set from a list of `NodeType`s. The caller
  * owns the safety contract: only pass types nothing reads in the intended parse
- * (leaf types drop from value / function-arg lists; `QualifiedRule` drops selector
- * preludes). Two grammar-internal caveats beyond consumer needs: dropping both
+ * (leaf types drop from value / function-arg lists; `QualifiedRule` / `AtRule` drop
+ * selector / at-rule preludes). Two grammar-internal caveats beyond consumer needs: dropping both
  * `Delim` and `Ident` loses `!important` detection, and dropping `SimpleBlock`
  * loses the custom-property `{}`-value check (and its subtree). Precompute once
  * per configuration and reuse across parses.

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -53,12 +53,15 @@
 class SourceProcessor {
 	/**
 	 * @param {Grammar<TNode, TProcessOptions>} grammar the grammar to drive over the source
+	 * @param {TProcessOptions=} options default process options (e.g. `skip`) merged under each `process` call's own options
 	 */
-	constructor(grammar) {
+	constructor(grammar, options) {
 		/** @type {Grammar<TNode, TProcessOptions>} */
 		this._grammar = grammar;
 		/** @type {CompiledVisitorMap<TNode>} */
 		this._visitors = [];
+		/** @type {TProcessOptions | undefined} */
+		this._options = options;
 	}
 
 	/**
@@ -90,15 +93,20 @@ class SourceProcessor {
 
 	/**
 	 * Run the grammar over `input`, firing visitors in source order. No
-	 * AST retained.
+	 * AST retained. Per-call `options` override the instance defaults.
 	 * @param {string} input source text
 	 * @param {TProcessOptions=} options grammar-specific options
 	 */
 	process(input, options) {
+		const defaults = this._options;
 		this._grammar(
 			input,
 			this._visitors,
-			options || /** @type {TProcessOptions} */ ({})
+			defaults
+				? options
+					? { ...defaults, ...options }
+					: defaults
+				: options || /** @type {TProcessOptions} */ ({})
 		);
 	}
 }

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -765,4 +765,24 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 		expect(valueTypes).toContain(NodeType.Number);
 		expect(valueTypes).toContain(NodeType.Dimension);
 	});
+
+	it("accepts skip as SourceProcessor instance options (no per-call skip)", () => {
+		/** @type {string[]} */
+		const seen = [];
+		new SourceProcessor({
+			as: "block-contents",
+			skip: { types: buildSkipSet([NodeType.Number]) }
+		})
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Number]: () => seen.push("num"),
+					[NodeType.Ident]: (
+						/** @type {import("../lib/css/syntax").Node} */ n
+					) => seen.push(A.value(n))
+				})
+			)
+			.process("p: 1 foo");
+		// The instance-level skip drops numbers; `process` needed no options.
+		expect(seen).toEqual(["foo"]);
+	});
 });

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -12,6 +12,7 @@ const {
 	TT_URL,
 	Token,
 	TokenStream,
+	buildSkipSet,
 	parseABlocksContents,
 	parseACommaSeparatedListOfComponentValues,
 	parseAComponentValue,
@@ -560,5 +561,152 @@ describe("walkCssTokens — tokenizer edge cases", () => {
 		// escaped CR/LF line-continuation inside a string exercises the
 		// CRLF-collapsing escaped-newline path.
 		expect(firstTokenType('"a\\\r\nb"')).toBe(TT_STRING);
+	});
+});
+
+describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
+	// A bare declaration (parsed as block-contents, so there is no selector
+	// prelude to pollute the counts). Every leaf type appears both at the top
+	// level of the value and inside `bar(…)`, so one skip proves both the
+	// value-list and the function-arg builders honour it.
+	const VALUE_CSS =
+		'p: foo 10 10px 50% #fff / "s" : , bar(9 baz #aaa 2px "t" %)';
+	// Leaf types present in VALUE_CSS's value (Whitespace too, from the spaces).
+	const LEAF_TYPES = [
+		["Ident", NodeType.Ident],
+		["Number", NodeType.Number],
+		["Dimension", NodeType.Dimension],
+		["Percentage", NodeType.Percentage],
+		["Hash", NodeType.Hash],
+		["Delim", NodeType.Delim],
+		["String", NodeType.String],
+		["Colon", NodeType.Colon],
+		["Comma", NodeType.Comma],
+		["Whitespace", NodeType.Whitespace]
+	];
+
+	/**
+	 * Count visited nodes per type while walking `css`.
+	 * @param {string} css source
+	 * @param {Uint8Array=} skip skip set
+	 * @returns {Record<number, number>} count keyed by node type
+	 */
+	const countByType = (css, skip) => {
+		/** @type {Record<number, number>} */
+		const counts = {};
+		/** @type {import("../lib/css/syntax").VisitorMap} */
+		const map = {};
+		for (const t of Object.values(NodeType)) {
+			map[t] = (/** @type {import("../lib/css/syntax").Node} */ n) => {
+				counts[A.type(n)] = (counts[A.type(n)] || 0) + 1;
+			};
+		}
+		new SourceProcessor().use(map).process(css, { as: "block-contents", skip });
+		return counts;
+	};
+
+	const base = countByType(VALUE_CSS);
+
+	it("baseline (no skip) visits every leaf type in the value", () => {
+		for (const [name, type] of LEAF_TYPES) {
+			expect({ [name]: base[type] || 0 }).toEqual({
+				[name]: expect.any(Number)
+			});
+			expect(base[type]).toBeGreaterThan(0);
+		}
+	});
+
+	it.each(LEAF_TYPES)(
+		"skips every %s leaf (value + function arg) and leaves other types untouched",
+		(name, type) => {
+			const counts = countByType(VALUE_CSS, buildSkipSet([type]));
+			// The skipped type is fully dropped, in both the top-level value list
+			// and the nested function's arg list.
+			expect(counts[type] || 0).toBe(0);
+			// Every other leaf type is unaffected.
+			for (const [, other] of LEAF_TYPES) {
+				if (other === type) continue;
+				expect(counts[other] || 0).toBe(base[other] || 0);
+			}
+			// Structure still parses: the declaration and its function survive.
+			expect(counts[NodeType.Declaration]).toBe(base[NodeType.Declaration]);
+			expect(counts[NodeType.Function]).toBe(base[NodeType.Function]);
+		}
+	);
+
+	it("skipping Function drops the function and its whole arg subtree", () => {
+		const counts = countByType(VALUE_CSS, buildSkipSet([NodeType.Function]));
+		expect(counts[NodeType.Function] || 0).toBe(0);
+		// bar()'s args (9 baz #aaa 2px "t" %) are no longer walked, so the nested
+		// leaves drop out while the top-level value leaves remain.
+		expect(counts[NodeType.Ident]).toBe(1); // only top-level `foo`
+		expect(counts[NodeType.Number]).toBe(1); // only top-level `10`
+		expect(counts[NodeType.Declaration]).toBe(base[NodeType.Declaration]);
+	});
+
+	it("a combined skip set drops every listed type at once", () => {
+		const counts = countByType(
+			VALUE_CSS,
+			buildSkipSet([NodeType.Number, NodeType.Dimension, NodeType.Ident])
+		);
+		expect(counts[NodeType.Number] || 0).toBe(0);
+		expect(counts[NodeType.Dimension] || 0).toBe(0);
+		expect(counts[NodeType.Ident] || 0).toBe(0);
+		// A type left out of the set is still visited.
+		expect(counts[NodeType.Hash]).toBe(base[NodeType.Hash]);
+	});
+
+	it("skipping QualifiedRule drops the selector prelude but keeps the block", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Ident]: (
+						/** @type {import("../lib/css/syntax").Node} */ n
+					) => log.push(`ident:${A.value(n)}`),
+					[NodeType.Declaration]: (
+						/** @type {import("../lib/css/syntax").Declaration} */ n
+					) => log.push(`decl:${A.name(n)}`)
+				})
+			)
+			.process(".foo .bar{color:red}", {
+				skip: buildSkipSet([NodeType.QualifiedRule])
+			});
+		// Selector idents (foo, bar) are never materialized; the value ident (red)
+		// and the declaration still are.
+		expect(log).toEqual(["decl:color", "ident:red"]);
+	});
+
+	it("skipping QualifiedRule still surfaces url() inside a selector prelude", () => {
+		/** @type {string[]} */
+		const urls = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Url]: (
+						/** @type {import("../lib/css/syntax").UrlToken} */ n
+					) => urls.push(A.value(n))
+				})
+			)
+			.process(":x(url(p.png)){color:red}", {
+				skip: buildSkipSet([NodeType.QualifiedRule])
+			});
+		expect(urls).toEqual(["p.png"]);
+	});
+
+	it("the object backend (parseAStylesheet) ignores a prior skip and builds the full tree", () => {
+		// Run a skipping stream parse first, then a full parse — the object backend
+		// must reset the skip state so `parseA*` are never affected.
+		new SourceProcessor()
+			.use({ [NodeType.Declaration]: () => {} })
+			.process("a{p:1 2px}", { skip: buildSkipSet([NodeType.Number]) });
+		const decl = /** @type {import("../lib/css/syntax").Declaration} */ (
+			parseADeclaration("p:1 2px")
+		);
+		// Object-backend nodes expose fields directly (not via the SoA `A` seam).
+		const valueTypes = decl.value.map((n) => n.type);
+		expect(valueTypes).toContain(NodeType.Number);
+		expect(valueTypes).toContain(NodeType.Dimension);
 	});
 });

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -572,6 +572,7 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 	const VALUE_CSS =
 		'p: foo 10 10px 50% #fff / "s" : , bar(9 baz #aaa 2px "t" %)';
 	// Leaf types present in VALUE_CSS's value (Whitespace too, from the spaces).
+	/** @type {[string, number][]} */
 	const LEAF_TYPES = [
 		["Ident", NodeType.Ident],
 		["Number", NodeType.Number],

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -588,10 +588,10 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 	/**
 	 * Count visited nodes per type while walking `css`.
 	 * @param {string} css source
-	 * @param {Uint8Array=} skip skip set
+	 * @param {number[]=} skipTypes component-value node types to drop
 	 * @returns {Record<number, number>} count keyed by node type
 	 */
-	const countByType = (css, skip) => {
+	const countByType = (css, skipTypes) => {
 		/** @type {Record<number, number>} */
 		const counts = {};
 		/** @type {import("../lib/css/syntax").VisitorMap} */
@@ -601,7 +601,10 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				counts[A.type(n)] = (counts[A.type(n)] || 0) + 1;
 			};
 		}
-		new SourceProcessor().use(map).process(css, { as: "block-contents", skip });
+		new SourceProcessor().use(map).process(css, {
+			as: "block-contents",
+			skip: skipTypes ? { types: buildSkipSet(skipTypes) } : undefined
+		});
 		return counts;
 	};
 
@@ -619,7 +622,7 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 	it.each(LEAF_TYPES)(
 		"skips every %s leaf (value + function arg) and leaves other types untouched",
 		(name, type) => {
-			const counts = countByType(VALUE_CSS, buildSkipSet([type]));
+			const counts = countByType(VALUE_CSS, [type]);
 			// The skipped type is fully dropped, in both the top-level value list
 			// and the nested function's arg list.
 			expect(counts[type] || 0).toBe(0);
@@ -635,7 +638,7 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 	);
 
 	it("skipping Function drops the function and its whole arg subtree", () => {
-		const counts = countByType(VALUE_CSS, buildSkipSet([NodeType.Function]));
+		const counts = countByType(VALUE_CSS, [NodeType.Function]);
 		expect(counts[NodeType.Function] || 0).toBe(0);
 		// bar()'s args (9 baz #aaa 2px "t" %) are no longer walked, so the nested
 		// leaves drop out while the top-level value leaves remain.
@@ -646,20 +649,18 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 
 	it("skipping SimpleBlock drops the block and its whole subtree", () => {
 		// `(7 qux)` is a paren simple block holding a Number and an Ident.
-		const counts = countByType(
-			"p: foo (7 qux)",
-			buildSkipSet([NodeType.SimpleBlock])
-		);
+		const counts = countByType("p: foo (7 qux)", [NodeType.SimpleBlock]);
 		expect(counts[NodeType.SimpleBlock] || 0).toBe(0);
 		expect(counts[NodeType.Number] || 0).toBe(0); // nested 7 not walked
 		expect(counts[NodeType.Ident]).toBe(1); // only top-level foo, not qux
 	});
 
 	it("a combined skip set drops every listed type at once", () => {
-		const counts = countByType(
-			VALUE_CSS,
-			buildSkipSet([NodeType.Number, NodeType.Dimension, NodeType.Ident])
-		);
+		const counts = countByType(VALUE_CSS, [
+			NodeType.Number,
+			NodeType.Dimension,
+			NodeType.Ident
+		]);
 		expect(counts[NodeType.Number] || 0).toBe(0);
 		expect(counts[NodeType.Dimension] || 0).toBe(0);
 		expect(counts[NodeType.Ident] || 0).toBe(0);
@@ -667,7 +668,7 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 		expect(counts[NodeType.Hash]).toBe(base[NodeType.Hash]);
 	});
 
-	it("skipping QualifiedRule drops the selector prelude but keeps the block", () => {
+	it("skip.selectorPrelude drops the selector prelude but keeps the block", () => {
 		/** @type {string[]} */
 		const log = [];
 		new SourceProcessor()
@@ -682,14 +683,14 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				})
 			)
 			.process(".foo .bar{color:red}", {
-				skip: buildSkipSet([NodeType.QualifiedRule])
+				skip: { selectorPrelude: true }
 			});
 		// Selector idents (foo, bar) are never materialized; the value ident (red)
 		// and the declaration still are.
 		expect(log).toEqual(["decl:color", "ident:red"]);
 	});
 
-	it("skipping QualifiedRule still surfaces url() inside a selector prelude", () => {
+	it("skip.selectorPrelude still surfaces url() inside a selector prelude", () => {
 		/** @type {string[]} */
 		const urls = [];
 		new SourceProcessor()
@@ -701,12 +702,12 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				})
 			)
 			.process(":x(url(p.png)){color:red}", {
-				skip: buildSkipSet([NodeType.QualifiedRule])
+				skip: { selectorPrelude: true }
 			});
 		expect(urls).toEqual(["p.png"]);
 	});
 
-	it("skipping AtRule drops the at-rule prelude but keeps the block", () => {
+	it("skip.atRulePrelude drops the at-rule prelude but keeps the block", () => {
 		/** @type {string[]} */
 		const log = [];
 		new SourceProcessor()
@@ -724,14 +725,14 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				})
 			)
 			.process("@media (min-width:9px){a{color:red}}", {
-				skip: buildSkipSet([NodeType.AtRule])
+				skip: { atRulePrelude: true }
 			});
 		// The at-rule fires, its prelude ident (min-width) is dropped, and the
 		// block (the nested rule + its declaration + value ident) is still walked.
 		expect(log).toEqual(["at:media", "ident:a", "decl:color", "ident:red"]);
 	});
 
-	it("skipping AtRule still surfaces url() in an at-rule prelude (@import)", () => {
+	it("skip.atRulePrelude still surfaces url() in an at-rule prelude (@import)", () => {
 		/** @type {string[]} */
 		const urls = [];
 		new SourceProcessor()
@@ -743,7 +744,7 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				})
 			)
 			.process("@import url(x.css);", {
-				skip: buildSkipSet([NodeType.AtRule])
+				skip: { atRulePrelude: true }
 			});
 		expect(urls).toEqual(["x.css"]);
 	});
@@ -753,7 +754,9 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 		// must reset the skip state so `parseA*` are never affected.
 		new SourceProcessor()
 			.use({ [NodeType.Declaration]: () => {} })
-			.process("a{p:1 2px}", { skip: buildSkipSet([NodeType.Number]) });
+			.process("a{p:1 2px}", {
+				skip: { types: buildSkipSet([NodeType.Number]) }
+			});
 		const decl = /** @type {import("../lib/css/syntax").Declaration} */ (
 			parseADeclaration("p:1 2px")
 		);

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -644,6 +644,17 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 		expect(counts[NodeType.Declaration]).toBe(base[NodeType.Declaration]);
 	});
 
+	it("skipping SimpleBlock drops the block and its whole subtree", () => {
+		// `(7 qux)` is a paren simple block holding a Number and an Ident.
+		const counts = countByType(
+			"p: foo (7 qux)",
+			buildSkipSet([NodeType.SimpleBlock])
+		);
+		expect(counts[NodeType.SimpleBlock] || 0).toBe(0);
+		expect(counts[NodeType.Number] || 0).toBe(0); // nested 7 not walked
+		expect(counts[NodeType.Ident]).toBe(1); // only top-level foo, not qux
+	});
+
 	it("a combined skip set drops every listed type at once", () => {
 		const counts = countByType(
 			VALUE_CSS,
@@ -693,6 +704,48 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 				skip: buildSkipSet([NodeType.QualifiedRule])
 			});
 		expect(urls).toEqual(["p.png"]);
+	});
+
+	it("skipping AtRule drops the at-rule prelude but keeps the block", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.AtRule]: (
+						/** @type {import("../lib/css/syntax").AtRule} */ n
+					) => log.push(`at:${A.name(n)}`),
+					[NodeType.Ident]: (
+						/** @type {import("../lib/css/syntax").Node} */ n
+					) => log.push(`ident:${A.value(n)}`),
+					[NodeType.Declaration]: (
+						/** @type {import("../lib/css/syntax").Declaration} */ n
+					) => log.push(`decl:${A.name(n)}`)
+				})
+			)
+			.process("@media (min-width:9px){a{color:red}}", {
+				skip: buildSkipSet([NodeType.AtRule])
+			});
+		// The at-rule fires, its prelude ident (min-width) is dropped, and the
+		// block (the nested rule + its declaration + value ident) is still walked.
+		expect(log).toEqual(["at:media", "ident:a", "decl:color", "ident:red"]);
+	});
+
+	it("skipping AtRule still surfaces url() in an at-rule prelude (@import)", () => {
+		/** @type {string[]} */
+		const urls = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Url]: (
+						/** @type {import("../lib/css/syntax").UrlToken} */ n
+					) => urls.push(A.value(n))
+				})
+			)
+			.process("@import url(x.css);", {
+				skip: buildSkipSet([NodeType.AtRule])
+			});
+		expect(urls).toEqual(["x.css"]);
 	});
 
 	it("the object backend (parseAStylesheet) ignores a prior skip and builds the full tree", () => {

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -708,6 +708,28 @@ describe("walkCssTokens — skip set (CssProcessOptions.skip)", () => {
 		expect(urls).toEqual(["p.png"]);
 	});
 
+	it("skip.selectorPrelude recovers from a stray } in the selector prelude", () => {
+		/** @type {string[]} */
+		const log = [];
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Declaration]: (
+						/** @type {import("../lib/css/syntax").Declaration} */ n
+					) => log.push(`decl:${A.name(n)}`),
+					[NodeType.Ident]: (
+						/** @type {import("../lib/css/syntax").Node} */ n
+					) => log.push(`ident:${A.value(n)}`)
+				})
+			)
+			.process("}} a{color:red}", {
+				skip: { selectorPrelude: true }
+			});
+		// Stray `}`s in the prelude are a parse error; skip mode still tracks them as
+		// the disambiguation tokens, recovers, and walks the block (decl + value ident).
+		expect(log).toEqual(["decl:color", "ident:red"]);
+	});
+
 	it("skip.atRulePrelude drops the at-rule prelude but keeps the block", () => {
 		/** @type {string[]} */
 		const log = [];

--- a/test/walkCssTokensParser.unittest.js
+++ b/test/walkCssTokensParser.unittest.js
@@ -391,17 +391,13 @@ describe("walkCssTokens — SourceProcessor", () => {
 		expect([a, b]).toEqual([1, 1]);
 	});
 
-	it("forwards the comment callback", () => {
+	it("surfaces comments through the NodeType.Comment visitor", () => {
 		/** @type {string[]} */
 		const seen = [];
 		new SourceProcessor()
 			.use({ [NodeType.Declaration]: () => {} })
-			.process("a{color:red/*!c*/}", {
-				comment: (input, start, end) => {
-					seen.push(input.slice(start, end));
-					return end;
-				}
-			});
+			.use({ [NodeType.Comment]: (node) => seen.push(A.source(node)) })
+			.process("a{color:red/*!c*/}");
 		expect(seen).toEqual(["/*!c*/"]);
 	});
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The CSS parser builds a full CSS-Syntax component-value tree even for parts nothing downstream reads. This adds a `CssProcessOptions.skip` that lets a parse leave unread parts un-materialized, on two independent axes:

- `skip.types` — a `NodeType`-indexed set of component-value node types to drop from declaration value / function-arg lists (built with the exported `buildSkipSet`);
- `skip.selectorPrelude` / `skip.atRulePrelude` — drop a qualified-rule / at-rule prelude (url tokens and functions are kept, so `url()` in a selector and `@import url(…)` still resolve).

`CssParser` enables this **only for non-CSS-Modules parses**, where the `Ident` visitor no-ops, the `Declaration` visitor returns early, and there is no ICSS — so it drops selector preludes plus numeric/ident/hash/colon/delim value leaves. That trims non-modules parse time ~10–15% on large stylesheets (e.g. Tailwind) with **byte-identical output**. CSS-Modules parses skip nothing (selectors are walked and ICSS `:export` captures arbitrary value ranges).

Supporting refactors: comments now reach the visitor map through a new `NodeType.Comment` instead of an ad-hoc `process({ comment })` callback (fired during tokenization on a transient node), and `SourceProcessor` can carry default process options so `skip` is configured on the instance. Node materialization is unchanged for the `parseA*` entry points and the object backend. Refs the CSS parser performance work.

**What kind of change does this PR introduce?**

perf (with supporting refactors: the unified `skip` API, the `NodeType.Comment` visitor, and `SourceProcessor` instance options).

**Did you add tests for your changes?**

Yes. `test/walkCssTokensParser.unittest.js` gains a `skip set` suite covering every skippable node type (each leaf type in both value and function-arg lists, `Function`/`SimpleBlock` subtree drops, `selectorPrelude`/`atRulePrelude` incl. url-preservation, combined sets, the object-backend reset, and instance-level `skip` options). The existing `ConfigTestCases` CSS cases and the CSS parsing/spec unit suites pass unchanged, and output was verified byte-identical (real `webpack()` build diff) in both modes.

**Does this PR introduce a breaking change?**

No. Output is byte-identical in both modes; the change is internal to the CSS parser.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — `CssProcessOptions.skip`, `buildSkipSet`, and `NodeType` are internal to `lib/css` and not part of the public webpack API surface.

**Use of AI**

Yes. This was developed with Claude (Anthropic) via Claude Code: profiling the parser hot paths, designing/implementing the `skip` mechanism, writing the tests, and benchmarking against postcss / css-tree / cssom / Lightning CSS. All changes were human-reviewed; correctness is backed by the existing CSS test suite (config cases + parser unit/spec tests) and byte-identical build diffs. Per the webpack AI policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoY4N3vgtEqkEguPzwUZnt)_