### PR TITLE
fix: correct matchPart JSDoc examples for string tests

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -327,9 +327,9 @@ ModuleFilenameHelpers.replaceDuplicates = (array, fn, comparator) => {
  * ```js
  * ModuleFilenameHelpers.matchPart("foo.js", "foo"); // true
  * ModuleFilenameHelpers.matchPart("foo.js", "foo.js"); // true
- * ModuleFilenameHelpers.matchPart("foo.js", "foo."); // false
+ * ModuleFilenameHelpers.matchPart("foo.js", "foo."); // true, strings only match as a prefix, not a glob
  * ModuleFilenameHelpers.matchPart("foo.js", "foo*"); // false
- * ModuleFilenameHelpers.matchPart("foo.js", "foo.*"); // true
+ * ModuleFilenameHelpers.matchPart("foo.js", "foo.*"); // false, "*" is not a wildcard here
  * ModuleFilenameHelpers.matchPart("foo.js", /^foo/); // true
  * ModuleFilenameHelpers.matchPart("foo.js", [/^foo/, "bar"]); // true
  * ModuleFilenameHelpers.matchPart("foo.js", [/^foo/, "bar"]); // true

--- a/test/ModuleFilenameHelpers.unittest.js
+++ b/test/ModuleFilenameHelpers.unittest.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const ModuleFilenameHelpers = require("../lib/ModuleFilenameHelpers");
+
+describe("ModuleFilenameHelpers", () => {
+	describe("matchPart", () => {
+		it("should return true when no test is given", () => {
+			expect(ModuleFilenameHelpers.matchPart("foo.js", undefined)).toBe(true);
+		});
+
+		it("should match string tests as a prefix, not a glob", () => {
+			expect(ModuleFilenameHelpers.matchPart("foo.js", "foo")).toBe(true);
+			expect(ModuleFilenameHelpers.matchPart("foo.js", "foo.js")).toBe(true);
+			// "foo." is a literal prefix of "foo.js", so this matches
+			expect(ModuleFilenameHelpers.matchPart("foo.js", "foo.")).toBe(true);
+			// "*" has no special meaning for string tests, it's matched literally
+			expect(ModuleFilenameHelpers.matchPart("foo.js", "foo*")).toBe(false);
+			expect(ModuleFilenameHelpers.matchPart("foo.js", "foo.*")).toBe(false);
+		});
+
+		it("should match RegExp tests", () => {
+			expect(ModuleFilenameHelpers.matchPart("foo.js", /^foo/)).toBe(true);
+			expect(ModuleFilenameHelpers.matchPart("foo.js", /\.js$/)).toBe(true);
+			expect(ModuleFilenameHelpers.matchPart("foo.js", /^bar/)).toBe(false);
+		});
+
+		it("should match if any item in an array matches", () => {
+			expect(ModuleFilenameHelpers.matchPart("foo.js", [/^foo/, "bar"])).toBe(
+				true
+			);
+			expect(ModuleFilenameHelpers.matchPart("foo.js", [/^baz/, /^bar/])).toBe(
+				false
+			);
+		});
+	});
+
+	describe("matchObject", () => {
+		it("should not filter by extension for a string test", () => {
+			// documented as matching modules "based on their extension",
+			// but a string test only matches a literal prefix
+			expect(ModuleFilenameHelpers.matchObject({ test: ".js" }, "foo.js")).toBe(
+				false
+			);
+			expect(
+				ModuleFilenameHelpers.matchObject({ test: /\.js$/ }, "foo.js")
+			).toBe(true);
+		});
+
+		it("should respect include/exclude", () => {
+			expect(
+				ModuleFilenameHelpers.matchObject({ include: "foo" }, "foo.js")
+			).toBe(true);
+			expect(
+				ModuleFilenameHelpers.matchObject({ exclude: "foo" }, "foo.js")
+			).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Two of the examples in `matchPart`'s doc comment are backwards. Since string tests just do `str.startsWith(test)`, `matchPart("foo.js", "foo.")` is actually `true` (the doc says `false`), and `matchPart("foo.js", "foo.*")` is `false` (the doc says `true`) — `*` isn't a wildcard here, it's matched literally. Checked this against the pre-#20690-ish `asRegExp` version too, same result, so it's not a recent regression, the examples were just wrong from the start.

This is the same confusion reported in #19360 (string `test` not filtering by extension) — figured it's worth fixing the doc comment too since it's the first thing you see reading the source. Also added a small unit test file since there wasn't one for `ModuleFilenameHelpers` at all.