### PR TITLE
perf: leaner comment, template and regexp tokenizing, scope maps and evaluated expressions

### DIFF
--- a/.changeset/js-parser-lazy-comments.md
+++ b/.changeset/js-parser-lazy-comments.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Defer JavaScript comment text extraction until a hook reads it.
+Speed up JavaScript tokenizing with lazy comment text and template/regexp fast paths.

--- a/.changeset/js-parser-lazy-comments.md
+++ b/.changeset/js-parser-lazy-comments.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Defer JavaScript comment text extraction until a hook reads it.

--- a/.changeset/js-parser-lazy-comments.md
+++ b/.changeset/js-parser-lazy-comments.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up JavaScript tokenizing with lazy comment text and template/regexp fast paths.
+Speed up JavaScript parsing with lazy comment text, template/regexp fast paths and linked scope maps.

--- a/.changeset/js-parser-lazy-comments.md
+++ b/.changeset/js-parser-lazy-comments.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up JavaScript parsing with lazy comment text, template/regexp fast paths and linked scope maps.
+Speed up JavaScript parsing with lazy comment text, template/regexp fast paths, linked scope maps and packed evaluated expressions.

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -41,9 +41,9 @@ const FLAG_SIDE_EFFECTS = 0b100000000;
 
 /**
  * An instance is allocated for a large share of walked expressions, so the
- * 26 public fields live virtually: one packed flags slot plus five value
- * slots shared by type (accessors keep every public field readable). This
- * shrinks instances from 224 to 88 bytes on V8.
+ * boolean facts live in one packed flags slot and the scalar/identifier
+ * fields in five slots shared by type, with accessors keeping every public
+ * field readable. This shrinks instances from 224 to 144 bytes on V8.
  */
 class BasicEvaluatedExpression {
 	constructor() {
@@ -52,17 +52,35 @@ class BasicEvaluatedExpression {
 		this.range = undefined;
 		/** @type {Node | undefined} */
 		this.expression = undefined;
-		// _v1..._v5 hold the type-specific fields, see the accessors
-		/** @type {EXPECTED_ANY} */
+		// _v1..._v5 hold the scalar type-specific fields, the accessors narrow
+		// them by type; expression-valued fields get typed slots below
+		/** @type {unknown} */
 		this._v1 = undefined;
-		/** @type {EXPECTED_ANY} */
+		/** @type {unknown} */
 		this._v2 = undefined;
-		/** @type {EXPECTED_ANY} */
+		/** @type {unknown} */
 		this._v3 = undefined;
-		/** @type {EXPECTED_ANY} */
+		/** @type {unknown} */
 		this._v4 = undefined;
-		/** @type {EXPECTED_ANY} */
+		/** @type {unknown} */
 		this._v5 = undefined;
+		// expression-valued fields stay plain data properties: a type that
+		// references the class inside one of its own accessors makes tsc fork
+		// the class into two unrelated identities
+		/** @type {BasicEvaluatedExpression[] | undefined} */
+		this.quasis = undefined;
+		/** @type {BasicEvaluatedExpression[] | undefined} */
+		this.parts = undefined;
+		/** @type {BasicEvaluatedExpression[] | undefined} */
+		this.items = undefined;
+		/** @type {BasicEvaluatedExpression[] | undefined} */
+		this.options = undefined;
+		/** @type {BasicEvaluatedExpression | undefined | null} */
+		this.prefix = undefined;
+		/** @type {BasicEvaluatedExpression | undefined | null} */
+		this.postfix = undefined;
+		/** @type {BasicEvaluatedExpression[] | undefined} */
+		this.wrappedInnerExpressions = undefined;
 	}
 
 	/**
@@ -150,7 +168,9 @@ class BasicEvaluatedExpression {
 	 * @returns {boolean | undefined} boolean value when boolean-typed
 	 */
 	get bool() {
-		return this.type === TypeBoolean ? this._v1 : undefined;
+		return this.type === TypeBoolean
+			? /** @type {boolean} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -164,7 +184,9 @@ class BasicEvaluatedExpression {
 	 * @returns {number | undefined} number value when number-typed
 	 */
 	get number() {
-		return this.type === TypeNumber ? this._v1 : undefined;
+		return this.type === TypeNumber
+			? /** @type {number} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -178,7 +200,9 @@ class BasicEvaluatedExpression {
 	 * @returns {bigint | undefined} bigint value when bigint-typed
 	 */
 	get bigint() {
-		return this.type === TypeBigInt ? this._v1 : undefined;
+		return this.type === TypeBigInt
+			? /** @type {bigint} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -192,7 +216,9 @@ class BasicEvaluatedExpression {
 	 * @returns {RegExp | undefined} regexp value when regexp-typed
 	 */
 	get regExp() {
-		return this.type === TypeRegExp ? this._v1 : undefined;
+		return this.type === TypeRegExp
+			? /** @type {RegExp} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -206,7 +232,9 @@ class BasicEvaluatedExpression {
 	 * @returns {string | undefined} string value when string-typed
 	 */
 	get string() {
-		return this.type === TypeString ? this._v1 : undefined;
+		return this.type === TypeString
+			? /** @type {string} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -217,38 +245,12 @@ class BasicEvaluatedExpression {
 	}
 
 	/**
-	 * @returns {BasicEvaluatedExpression[] | undefined} template quasis
-	 */
-	get quasis() {
-		return this.type === TypeTemplateString ? this._v1 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression[] | undefined} value template quasis
-	 */
-	set quasis(value) {
-		this._v1 = value;
-	}
-
-	/**
-	 * @returns {BasicEvaluatedExpression[] | undefined} template parts
-	 */
-	get parts() {
-		return this.type === TypeTemplateString ? this._v2 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression[] | undefined} value template parts
-	 */
-	set parts(value) {
-		this._v2 = value;
-	}
-
-	/**
 	 * @returns {"cooked" | "raw" | undefined} template string kind
 	 */
 	get templateStringKind() {
-		return this.type === TypeTemplateString ? this._v3 : undefined;
+		return this.type === TypeTemplateString
+			? /** @type {"cooked" | "raw"} */ (this._v3)
+			: undefined;
 	}
 
 	/**
@@ -262,7 +264,9 @@ class BasicEvaluatedExpression {
 	 * @returns {EXPECTED_ANY[] | undefined} const array values
 	 */
 	get array() {
-		return this.type === TypeConstArray ? this._v1 : undefined;
+		return this.type === TypeConstArray
+			? /** @type {unknown[]} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -273,80 +277,12 @@ class BasicEvaluatedExpression {
 	}
 
 	/**
-	 * @returns {BasicEvaluatedExpression[] | undefined} array items
-	 */
-	get items() {
-		return this.type === TypeArray ? this._v1 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression[] | undefined} value array items
-	 */
-	set items(value) {
-		this._v1 = value;
-	}
-
-	/**
-	 * @returns {BasicEvaluatedExpression[] | undefined} conditional options
-	 */
-	get options() {
-		return this.type === TypeConditional ? this._v1 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression[] | undefined} value conditional options
-	 */
-	set options(value) {
-		this._v1 = value;
-	}
-
-	/**
-	 * @returns {BasicEvaluatedExpression | undefined | null} wrapped prefix
-	 */
-	get prefix() {
-		return this.type === TypeWrapped ? this._v1 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression | undefined | null} value wrapped prefix
-	 */
-	set prefix(value) {
-		this._v1 = value;
-	}
-
-	/**
-	 * @returns {BasicEvaluatedExpression | undefined | null} wrapped postfix
-	 */
-	get postfix() {
-		return this.type === TypeWrapped ? this._v2 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression | undefined | null} value wrapped postfix
-	 */
-	set postfix(value) {
-		this._v2 = value;
-	}
-
-	/**
-	 * @returns {BasicEvaluatedExpression[] | undefined} wrapped inner expressions
-	 */
-	get wrappedInnerExpressions() {
-		return this.type === TypeWrapped ? this._v3 : undefined;
-	}
-
-	/**
-	 * @param {BasicEvaluatedExpression[] | undefined} value wrapped inner expressions
-	 */
-	set wrappedInnerExpressions(value) {
-		this._v3 = value;
-	}
-
-	/**
 	 * @returns {string | VariableInfo | undefined} identifier
 	 */
 	get identifier() {
-		return this.type === TypeIdentifier ? this._v1 : undefined;
+		return this.type === TypeIdentifier
+			? /** @type {string | VariableInfo} */ (this._v1)
+			: undefined;
 	}
 
 	/**
@@ -360,7 +296,9 @@ class BasicEvaluatedExpression {
 	 * @returns {string | VariableInfo | undefined} root info
 	 */
 	get rootInfo() {
-		return this.type === TypeIdentifier ? this._v2 : undefined;
+		return this.type === TypeIdentifier
+			? /** @type {string | VariableInfo} */ (this._v2)
+			: undefined;
 	}
 
 	/**
@@ -374,7 +312,9 @@ class BasicEvaluatedExpression {
 	 * @returns {GetMembers | undefined} members getter
 	 */
 	get getMembers() {
-		return this.type === TypeIdentifier ? this._v3 : undefined;
+		return this.type === TypeIdentifier
+			? /** @type {GetMembers} */ (this._v3)
+			: undefined;
 	}
 
 	/**
@@ -388,7 +328,9 @@ class BasicEvaluatedExpression {
 	 * @returns {GetMembersOptionals | undefined} members optionals getter
 	 */
 	get getMembersOptionals() {
-		return this.type === TypeIdentifier ? this._v4 : undefined;
+		return this.type === TypeIdentifier
+			? /** @type {GetMembersOptionals} */ (this._v4)
+			: undefined;
 	}
 
 	/**
@@ -402,7 +344,9 @@ class BasicEvaluatedExpression {
 	 * @returns {GetMemberRanges | undefined} member ranges getter
 	 */
 	get getMemberRanges() {
-		return this.type === TypeIdentifier ? this._v5 : undefined;
+		return this.type === TypeIdentifier
+			? /** @type {GetMemberRanges} */ (this._v5)
+			: undefined;
 	}
 
 	/**

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -31,58 +31,385 @@ const TypeBigInt = 13;
 /** @typedef {() => MembersOptionals} GetMembersOptionals */
 /** @typedef {() => MemberRanges} GetMemberRanges */
 
+// _flags bit layout: bits 0-3 type, then the boolean facts
+const FLAG_TYPE_MASK = 0b1111;
+const FLAG_TRUTHY = 0b10000;
+const FLAG_FALSY = 0b100000;
+const FLAG_NULLISH_KNOWN = 0b1000000;
+const FLAG_NULLISH = 0b10000000;
+const FLAG_SIDE_EFFECTS = 0b100000000;
+
+/**
+ * An instance is allocated for a large share of walked expressions, so the
+ * 26 public fields live virtually: one packed flags slot plus five value
+ * slots shared by type (accessors keep every public field readable). This
+ * shrinks instances from 224 to 88 bytes on V8.
+ */
 class BasicEvaluatedExpression {
 	constructor() {
-		/** @type {number} */
-		this.type = TypeUnknown;
+		this._flags = FLAG_SIDE_EFFECTS;
 		/** @type {Range | undefined} */
 		this.range = undefined;
-		/** @type {boolean} */
-		this.falsy = false;
-		/** @type {boolean} */
-		this.truthy = false;
-		/** @type {boolean | undefined} */
-		this.nullish = undefined;
-		/** @type {boolean} */
-		this.sideEffects = true;
-		/** @type {boolean | undefined} */
-		this.bool = undefined;
-		/** @type {number | undefined} */
-		this.number = undefined;
-		/** @type {bigint | undefined} */
-		this.bigint = undefined;
-		/** @type {RegExp | undefined} */
-		this.regExp = undefined;
-		/** @type {string | undefined} */
-		this.string = undefined;
-		/** @type {BasicEvaluatedExpression[] | undefined} */
-		this.quasis = undefined;
-		/** @type {BasicEvaluatedExpression[] | undefined} */
-		this.parts = undefined;
-		/** @type {EXPECTED_ANY[] | undefined} */
-		this.array = undefined;
-		/** @type {BasicEvaluatedExpression[] | undefined} */
-		this.items = undefined;
-		/** @type {BasicEvaluatedExpression[] | undefined} */
-		this.options = undefined;
-		/** @type {BasicEvaluatedExpression | undefined | null} */
-		this.prefix = undefined;
-		/** @type {BasicEvaluatedExpression | undefined | null} */
-		this.postfix = undefined;
-		/** @type {BasicEvaluatedExpression[] | undefined} */
-		this.wrappedInnerExpressions = undefined;
-		/** @type {string | VariableInfo | undefined} */
-		this.identifier = undefined;
-		/** @type {string | VariableInfo | undefined} */
-		this.rootInfo = undefined;
-		/** @type {GetMembers | undefined} */
-		this.getMembers = undefined;
-		/** @type {GetMembersOptionals | undefined} */
-		this.getMembersOptionals = undefined;
-		/** @type {GetMemberRanges | undefined} */
-		this.getMemberRanges = undefined;
 		/** @type {Node | undefined} */
 		this.expression = undefined;
+		// _v1..._v5 hold the type-specific fields, see the accessors
+		/** @type {EXPECTED_ANY} */
+		this._v1 = undefined;
+		/** @type {EXPECTED_ANY} */
+		this._v2 = undefined;
+		/** @type {EXPECTED_ANY} */
+		this._v3 = undefined;
+		/** @type {EXPECTED_ANY} */
+		this._v4 = undefined;
+		/** @type {EXPECTED_ANY} */
+		this._v5 = undefined;
+	}
+
+	/**
+	 * @returns {number} expression type
+	 */
+	get type() {
+		return this._flags & FLAG_TYPE_MASK;
+	}
+
+	/**
+	 * @param {number} value expression type
+	 */
+	set type(value) {
+		this._flags = (this._flags & ~FLAG_TYPE_MASK) | value;
+	}
+
+	/**
+	 * @returns {boolean} true when the expression is known truthy
+	 */
+	get truthy() {
+		return (this._flags & FLAG_TRUTHY) !== 0;
+	}
+
+	/**
+	 * @param {boolean} value known truthy
+	 */
+	set truthy(value) {
+		this._flags = value
+			? this._flags | FLAG_TRUTHY
+			: this._flags & ~FLAG_TRUTHY;
+	}
+
+	/**
+	 * @returns {boolean} true when the expression is known falsy
+	 */
+	get falsy() {
+		return (this._flags & FLAG_FALSY) !== 0;
+	}
+
+	/**
+	 * @param {boolean} value known falsy
+	 */
+	set falsy(value) {
+		this._flags = value ? this._flags | FLAG_FALSY : this._flags & ~FLAG_FALSY;
+	}
+
+	/**
+	 * @returns {boolean | undefined} whether the value is nullish, when known
+	 */
+	get nullish() {
+		return (this._flags & FLAG_NULLISH_KNOWN) === 0
+			? undefined
+			: (this._flags & FLAG_NULLISH) !== 0;
+	}
+
+	/**
+	 * @param {boolean | undefined} value whether the value is nullish
+	 */
+	set nullish(value) {
+		this._flags =
+			value === undefined
+				? this._flags & ~(FLAG_NULLISH_KNOWN | FLAG_NULLISH)
+				: value
+					? this._flags | FLAG_NULLISH_KNOWN | FLAG_NULLISH
+					: (this._flags | FLAG_NULLISH_KNOWN) & ~FLAG_NULLISH;
+	}
+
+	/**
+	 * @returns {boolean} true when the expression could have side effects
+	 */
+	get sideEffects() {
+		return (this._flags & FLAG_SIDE_EFFECTS) !== 0;
+	}
+
+	/**
+	 * @param {boolean} value could have side effects
+	 */
+	set sideEffects(value) {
+		this._flags = value
+			? this._flags | FLAG_SIDE_EFFECTS
+			: this._flags & ~FLAG_SIDE_EFFECTS;
+	}
+
+	/**
+	 * @returns {boolean | undefined} boolean value when boolean-typed
+	 */
+	get bool() {
+		return this.type === TypeBoolean ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {boolean | undefined} value boolean value
+	 */
+	set bool(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {number | undefined} number value when number-typed
+	 */
+	get number() {
+		return this.type === TypeNumber ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {number | undefined} value number value
+	 */
+	set number(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {bigint | undefined} bigint value when bigint-typed
+	 */
+	get bigint() {
+		return this.type === TypeBigInt ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {bigint | undefined} value bigint value
+	 */
+	set bigint(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {RegExp | undefined} regexp value when regexp-typed
+	 */
+	get regExp() {
+		return this.type === TypeRegExp ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {RegExp | undefined} value regexp value
+	 */
+	set regExp(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {string | undefined} string value when string-typed
+	 */
+	get string() {
+		return this.type === TypeString ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {string | undefined} value string value
+	 */
+	set string(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression[] | undefined} template quasis
+	 */
+	get quasis() {
+		return this.type === TypeTemplateString ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression[] | undefined} value template quasis
+	 */
+	set quasis(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression[] | undefined} template parts
+	 */
+	get parts() {
+		return this.type === TypeTemplateString ? this._v2 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression[] | undefined} value template parts
+	 */
+	set parts(value) {
+		this._v2 = value;
+	}
+
+	/**
+	 * @returns {"cooked" | "raw" | undefined} template string kind
+	 */
+	get templateStringKind() {
+		return this.type === TypeTemplateString ? this._v3 : undefined;
+	}
+
+	/**
+	 * @param {"cooked" | "raw" | undefined} value template string kind
+	 */
+	set templateStringKind(value) {
+		this._v3 = value;
+	}
+
+	/**
+	 * @returns {EXPECTED_ANY[] | undefined} const array values
+	 */
+	get array() {
+		return this.type === TypeConstArray ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {EXPECTED_ANY[] | undefined} value const array values
+	 */
+	set array(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression[] | undefined} array items
+	 */
+	get items() {
+		return this.type === TypeArray ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression[] | undefined} value array items
+	 */
+	set items(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression[] | undefined} conditional options
+	 */
+	get options() {
+		return this.type === TypeConditional ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression[] | undefined} value conditional options
+	 */
+	set options(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression | undefined | null} wrapped prefix
+	 */
+	get prefix() {
+		return this.type === TypeWrapped ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression | undefined | null} value wrapped prefix
+	 */
+	set prefix(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression | undefined | null} wrapped postfix
+	 */
+	get postfix() {
+		return this.type === TypeWrapped ? this._v2 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression | undefined | null} value wrapped postfix
+	 */
+	set postfix(value) {
+		this._v2 = value;
+	}
+
+	/**
+	 * @returns {BasicEvaluatedExpression[] | undefined} wrapped inner expressions
+	 */
+	get wrappedInnerExpressions() {
+		return this.type === TypeWrapped ? this._v3 : undefined;
+	}
+
+	/**
+	 * @param {BasicEvaluatedExpression[] | undefined} value wrapped inner expressions
+	 */
+	set wrappedInnerExpressions(value) {
+		this._v3 = value;
+	}
+
+	/**
+	 * @returns {string | VariableInfo | undefined} identifier
+	 */
+	get identifier() {
+		return this.type === TypeIdentifier ? this._v1 : undefined;
+	}
+
+	/**
+	 * @param {string | VariableInfo | undefined} value identifier
+	 */
+	set identifier(value) {
+		this._v1 = value;
+	}
+
+	/**
+	 * @returns {string | VariableInfo | undefined} root info
+	 */
+	get rootInfo() {
+		return this.type === TypeIdentifier ? this._v2 : undefined;
+	}
+
+	/**
+	 * @param {string | VariableInfo | undefined} value root info
+	 */
+	set rootInfo(value) {
+		this._v2 = value;
+	}
+
+	/**
+	 * @returns {GetMembers | undefined} members getter
+	 */
+	get getMembers() {
+		return this.type === TypeIdentifier ? this._v3 : undefined;
+	}
+
+	/**
+	 * @param {GetMembers | undefined} value members getter
+	 */
+	set getMembers(value) {
+		this._v3 = value;
+	}
+
+	/**
+	 * @returns {GetMembersOptionals | undefined} members optionals getter
+	 */
+	get getMembersOptionals() {
+		return this.type === TypeIdentifier ? this._v4 : undefined;
+	}
+
+	/**
+	 * @param {GetMembersOptionals | undefined} value members optionals getter
+	 */
+	set getMembersOptionals(value) {
+		this._v4 = value;
+	}
+
+	/**
+	 * @returns {GetMemberRanges | undefined} member ranges getter
+	 */
+	get getMemberRanges() {
+		return this.type === TypeIdentifier ? this._v5 : undefined;
+	}
+
+	/**
+	 * @param {GetMemberRanges | undefined} value member ranges getter
+	 */
+	set getMemberRanges(value) {
+		this._v5 = value;
 	}
 
 	isUnknown() {

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -305,6 +305,7 @@ class VariableInfo {
  * @property {boolean=} allowHashBang
  * @property {boolean=} allowReturnOutsideFunction
  * @property {import("./syntax").LazySourcePositions=} lazySourcePositions internal: serve loc/range lazily instead of allocating them during parsing
+ * @property {Comment[]=} lazyComments internal: collect comments here without slicing their text eagerly
  * @property {boolean=} importPhases enable parsing of the import phase proposals (import defer / import source)
  */
 
@@ -5867,26 +5868,9 @@ class JavascriptParser extends Parser {
 
 			if (options.comments) {
 				if (sourcePositions) {
-					// acorn would only attach loc/range to comments when tracking them
-					// eagerly, so build the comment objects ourselves
-					/** @type {AcornOptions} */
-					(options).onComment = (block, text, start, end) => {
-						comments.push(
-							/** @type {Comment} */ ({
-								type: block ? "Block" : "Line",
-								value: text,
-								start,
-								end,
-								range: [start, end],
-								get loc() {
-									return {
-										start: sourcePositions.position(start),
-										end: sourcePositions.position(end)
-									};
-								}
-							})
-						);
-					};
+					// the parser plugin collects the comments itself, deferring the
+					// text slice until some hook actually reads `value`
+					options.lazyComments = comments;
 				} else {
 					/** @type {AcornOptions} */
 					(options).onComment = comments;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -21,6 +21,7 @@ const { Parser: AcornParser, tokTypes } = require("acorn");
 /** @typedef {[number, number]} Range */
 /** @typedef {"defer" | "source"} ImportPhase */
 /** @typedef {{ position: (offset: number) => AcornPosition }} LazySourcePositions offset to line/column mapper */
+/** @typedef {import("estree").Comment & { start: number, end: number, loc: SourceLocation }} CollectedComment comment as JavascriptParser exposes it */
 
 // Mirrors acorn's `lineBreak` regexp, which its types don't export.
 const LINE_BREAK_G = /\r\n?|\n|\u2028|\u2029/g;
@@ -30,6 +31,8 @@ const LINE_BREAK_G = /\r\n?|\n|\u2028|\u2029/g;
 const kSourcePositions = Symbol("source positions");
 const kLoc = Symbol("loc");
 const kRange = Symbol("range");
+const kText = Symbol("text");
+const kTextStart = Symbol("text start");
 
 // Marks import attributes parsed from the legacy `assert {...}` syntax.
 const LEGACY_ASSERT_ATTRIBUTES = Symbol("assert");
@@ -164,6 +167,70 @@ class LazyLocNode {
 }
 
 /**
+ * Comment collected without slicing its text out of the source: only magic
+ * comments and pure annotations ever get their text read, so the slice is
+ * deferred to the first `value` access and memoized like `loc`.
+ */
+class LazyComment {
+	/**
+	 * @param {boolean} block whether this is a block comment
+	 * @param {number} textStart offset right after the comment opener
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {SourcePositions} sourcePositions offset → position mapping
+	 */
+	constructor(block, textStart, start, end, sourcePositions) {
+		/** @type {"Block" | "Line"} */
+		this.type = block ? "Block" : "Line";
+		this.start = start;
+		this.end = end;
+		/** @type {Range} */
+		this.range = [start, end];
+		this[kSourcePositions] = sourcePositions;
+		this[kTextStart] = textStart;
+	}
+
+	/**
+	 * @returns {string} comment text without the delimiters
+	 */
+	get value() {
+		const cached = this[kText];
+		if (cached !== undefined) return cached;
+		return (this[kText] = this[kSourcePositions].source.slice(
+			this[kTextStart],
+			this.type === "Block" ? this.end - 2 : this.end
+		));
+	}
+
+	/**
+	 * @param {string} value comment text
+	 */
+	set value(value) {
+		this[kText] = value;
+	}
+
+	/**
+	 * @returns {SourceLocation} source location
+	 */
+	get loc() {
+		const cached = this[kLoc];
+		if (cached !== undefined) return cached;
+		const positions = this[kSourcePositions];
+		return (this[kLoc] = {
+			start: positions.position(this.start),
+			end: positions.position(this.end)
+		});
+	}
+
+	/**
+	 * @param {SourceLocation} value source location
+	 */
+	set loc(value) {
+		this[kLoc] = value;
+	}
+}
+
+/**
  * Replaces acorn's array-backed `Scope`: membership checks in `declareName`
  * are `indexOf` there, which goes quadratic on files with thousands of
  * bindings per scope (bundled or minified inputs).
@@ -213,6 +280,8 @@ class Scope {
  * finishNode: (node: AcornNode, type: string) => AcornNode,
  * readWord1: () => string,
  * skipSpace: () => void,
+ * skipLineComment: (startSkip: number) => void,
+ * skipBlockComment: () => void,
  * readString: (quote: number) => void,
  * readNumber: (startsWithDot: boolean) => void,
  * finishToken: (type: TokenType, value?: unknown) => void,
@@ -233,6 +302,7 @@ class Scope {
  * [kSourcePositions]?: SourcePositions,
  * _importPhase: ImportPhase | null,
  * _importPhasesEnabled: boolean,
+ * _lazyComments: CollectedComment[] | undefined,
  * }} ParserInternals
  */
 
@@ -249,7 +319,7 @@ const base = /** @type {ParserInternals} */ (
  */
 class WebpackParser extends AcornParser {
 	/**
-	 * @param {AcornOptions & { lazySourcePositions?: LazySourcePositions, importPhases?: boolean }} options options
+	 * @param {AcornOptions & { lazySourcePositions?: LazySourcePositions, lazyComments?: CollectedComment[], importPhases?: boolean }} options options
 	 * @param {string} input source code
 	 * @param {number=} startPos start position
 	 */
@@ -260,6 +330,29 @@ class WebpackParser extends AcornParser {
 		}
 		super(options, input, startPos);
 		this[kSourcePositions] = sourcePositions;
+		// lazy comment collection needs the source held by sourcePositions and
+		// must not race a user-provided onComment
+		/** @type {CollectedComment[] | undefined} */
+		this._lazyComments =
+			sourcePositions && !options.onComment ? options.lazyComments : undefined;
+		// acorn skips a hashbang inside its constructor, before `_lazyComments`
+		// above exists — reconstruct the comment the override missed
+		if (
+			this._lazyComments !== undefined &&
+			!startPos &&
+			this.options.allowHashBang &&
+			input.startsWith("#!")
+		) {
+			this._lazyComments.push(
+				new LazyComment(
+					false,
+					2,
+					0,
+					/** @type {ParserInternals} */ (/** @type {unknown} */ (this)).pos,
+					/** @type {SourcePositions} */ (sourcePositions)
+				)
+			);
+		}
 		/** @type {ImportPhase | null} */
 		this._importPhase = null;
 		this._importPhasesEnabled = options.importPhases === true;
@@ -400,6 +493,69 @@ class WebpackParser extends AcornParser {
 			}
 		}
 		this.pos = pos;
+	}
+
+	// ----- comment collection without eager text slicing -----
+
+	/**
+	 * Replaces acorn's `skipLineComment` when comments are collected lazily:
+	 * the same scan, but no text slice and no position objects. Acorn calls
+	 * this for `//`, hashbangs and HTML-style comments (varying `startSkip`).
+	 * @this {ParserInternals}
+	 * @param {number} startSkip length of the comment opener
+	 * @returns {void}
+	 */
+	skipLineComment(startSkip) {
+		const comments = this._lazyComments;
+		if (comments === undefined) {
+			return base.skipLineComment.call(this, startSkip);
+		}
+		const input = this.input;
+		const start = this.pos;
+		const len = input.length;
+		let pos = start + startSkip;
+		while (pos < len) {
+			const ch = input.charCodeAt(pos);
+			// LF, CR, LS, PS terminate the comment but are not part of it
+			if (ch === 10 || ch === 13 || ch === 0x2028 || ch === 0x2029) break;
+			pos++;
+		}
+		this.pos = pos;
+		comments.push(
+			new LazyComment(
+				false,
+				start + startSkip,
+				start,
+				pos,
+				/** @type {SourcePositions} */ (this[kSourcePositions])
+			)
+		);
+	}
+
+	/**
+	 * Replaces acorn's `skipBlockComment` when comments are collected lazily.
+	 * Locations are always off in lazy mode, so line breaks need no handling.
+	 * @this {ParserInternals}
+	 * @returns {void}
+	 */
+	skipBlockComment() {
+		const comments = this._lazyComments;
+		if (comments === undefined) {
+			return base.skipBlockComment.call(this);
+		}
+		const start = this.pos;
+		const end = this.input.indexOf("*/", (this.pos += 2));
+		if (end === -1) this.raise(this.pos - 2, "Unterminated comment");
+		this.pos = end + 2;
+		comments.push(
+			new LazyComment(
+				true,
+				start + 2,
+				start,
+				this.pos,
+				/** @type {SourcePositions} */ (this[kSourcePositions])
+			)
+		);
 	}
 
 	// ----- lazy loc/range -----

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -284,6 +284,7 @@ class Scope {
  * skipBlockComment: () => void,
  * readString: (quote: number) => void,
  * readNumber: (startsWithDot: boolean) => void,
+ * readTmplToken: () => void,
  * finishToken: (type: TokenType, value?: unknown) => void,
  * pos: number,
  * input: string,
@@ -469,6 +470,47 @@ class WebpackParser extends AcornParser {
 	}
 
 	/**
+	 * Template fast path: when the chunk contains no backslash and no CR, the
+	 * cooked value is one slice (LF/LS/PS cook to themselves). Escapes, CR
+	 * normalization and location tracking restart acorn's implementation,
+	 * which also produces its exact errors.
+	 * @this {ParserInternals}
+	 * @returns {void}
+	 */
+	readTmplToken() {
+		if (this.options.locations) return base.readTmplToken.call(this);
+		const input = this.input;
+		const start = this.pos;
+		const len = input.length;
+		let pos = start;
+		while (pos < len) {
+			const ch = input.charCodeAt(pos);
+			if (ch === 96 || (ch === 36 && input.charCodeAt(pos + 1) === 123)) {
+				if (
+					pos === this.start &&
+					(this.type === tokTypes.template ||
+						this.type === tokTypes.invalidTemplate)
+				) {
+					if (ch === 36) {
+						this.pos = pos + 2;
+						return this.finishToken(tokTypes.dollarBraceL);
+					}
+					this.pos = pos + 1;
+					return this.finishToken(tokTypes.backQuote);
+				}
+				this.pos = pos;
+				return this.finishToken(tokTypes.template, input.slice(start, pos));
+			}
+			// backslash and CR need acorn's cooked-string building
+			if (ch === 92 || ch === 13) {
+				return base.readTmplToken.call(this);
+			}
+			pos++;
+		}
+		this.raise(this.start, "Unterminated template");
+	}
+
+	/**
 	 * Fast path for the common run of plain ASCII whitespace; comments,
 	 * unicode whitespace and location tracking delegate to acorn.
 	 * @this {ParserInternals & { pos: number }}
@@ -597,6 +639,76 @@ class WebpackParser extends AcornParser {
 		);
 		for (const prop in from) to[prop] = from[prop];
 		return newNode;
+	}
+
+	/**
+	 * Single-construction regexp literals: acorn validates the pattern and
+	 * then builds the value with a second `new RegExp`. This override scans
+	 * like acorn, keeps acorn's flag validation (for its exact messages) and
+	 * lets one `new RegExp` be both the V8-backed validation and the value.
+	 * @this {ParserInternals & { regexpState: unknown }}
+	 * @returns {void}
+	 */
+	readRegexp() {
+		const input = this.input;
+		const start = this.pos;
+		const len = input.length;
+		let escaped = false;
+		let inClass = false;
+		let pos = start;
+		for (;;) {
+			if (pos >= len) this.raise(start, "Unterminated regular expression");
+			const ch = input.charCodeAt(pos);
+			// LF, CR, LS, PS
+			if (ch === 10 || ch === 13 || ch === 0x2028 || ch === 0x2029) {
+				this.raise(start, "Unterminated regular expression");
+			}
+			if (escaped) {
+				escaped = false;
+			} else {
+				if (ch === 91) inClass = true;
+				else if (ch === 93 && inClass) inClass = false;
+				else if (ch === 47 && !inClass) break;
+				escaped = ch === 92;
+			}
+			pos++;
+		}
+		const pattern = input.slice(start, pos);
+		this.pos = pos + 1;
+		const flagsStart = this.pos;
+		const flags = this.readWord1();
+		if (this.containsEsc) this.unexpected(flagsStart);
+
+		// acorn's per-ecmaVersion flag validation, kept for its exact errors
+		const ecmaVersion = /** @type {number} */ (this.options.ecmaVersion);
+		const validFlags = `gim${ecmaVersion >= 6 ? "uy" : ""}${
+			ecmaVersion >= 9 ? "s" : ""
+		}${ecmaVersion >= 13 ? "d" : ""}${ecmaVersion >= 15 ? "v" : ""}`;
+		let hasU = false;
+		let hasV = false;
+		for (let i = 0; i < flags.length; i++) {
+			const flag = flags.charAt(i);
+			if (!validFlags.includes(flag)) {
+				this.raise(start, "Invalid regular expression flag");
+			}
+			if (flags.includes(flag, i + 1)) {
+				this.raise(start, "Duplicate regular expression flag");
+			}
+			if (flag === "u") hasU = true;
+			if (flag === "v") hasV = true;
+		}
+		if (ecmaVersion >= 15 && hasU && hasV) {
+			this.raise(start, "Invalid regular expression flag");
+		}
+
+		let value = null;
+		try {
+			value = new RegExp(pattern, flags);
+		} catch (err) {
+			// V8's verdict on the pattern, like validateRegExpPattern below
+			this.raiseRecoverable(start, /** @type {Error} */ (err).message);
+		}
+		return this.finishToken(tokTypes.regexp, { pattern, flags, value });
 	}
 
 	// ----- regexp validation (V8-backed, replaces acorn's JS revalidation) -----

--- a/lib/util/StackedMap.js
+++ b/lib/util/StackedMap.js
@@ -41,21 +41,21 @@ const extractPair = (pair) => {
 
 /**
  * Layered map that supports child scopes while memoizing lookups from parent
- * scopes into the current layer.
+ * scopes into the current layer. Layers form a linked parent chain, so
+ * `createChild` is O(1) instead of copying a layer array per scope.
  * @template K
  * @template V
  */
 class StackedMap {
 	/**
-	 * Creates a new map layer on top of an optional parent stack.
-	 * @param {Map<K, InternalCell<V>>[]=} parentStack an optional parent
+	 * Creates a new map layer on top of an optional parent.
+	 * @param {StackedMap<K, V>=} parent an optional parent map
 	 */
-	constructor(parentStack) {
+	constructor(parent) {
 		/** @type {Map<K, InternalCell<V>>} */
 		this.map = new Map();
-		/** @type {Map<K, InternalCell<V>>[]} */
-		this.stack = parentStack === undefined ? [] : [...parentStack];
-		this.stack.push(this.map);
+		/** @type {StackedMap<K, V> | undefined} */
+		this.parent = parent;
 	}
 
 	/**
@@ -76,7 +76,7 @@ class StackedMap {
 	 * @returns {void}
 	 */
 	delete(item) {
-		if (this.stack.length > 1) {
+		if (this.parent !== undefined) {
 			this.map.set(item, TOMBSTONE);
 		} else {
 			this.map.delete(item);
@@ -94,13 +94,16 @@ class StackedMap {
 		if (topValue !== undefined) {
 			return topValue !== TOMBSTONE;
 		}
-		if (this.stack.length > 1) {
-			for (let i = this.stack.length - 2; i >= 0; i--) {
-				const value = this.stack[i].get(item);
+		if (this.parent !== undefined) {
+			/** @type {StackedMap<K, V> | undefined} */
+			let current = this.parent;
+			while (current !== undefined) {
+				const value = current.map.get(item);
 				if (value !== undefined) {
 					this.map.set(item, value);
 					return value !== TOMBSTONE;
 				}
+				current = current.parent;
 			}
 			this.map.set(item, TOMBSTONE);
 		}
@@ -120,36 +123,48 @@ class StackedMap {
 				? undefined
 				: topValue;
 		}
-		if (this.stack.length > 1) {
-			for (let i = this.stack.length - 2; i >= 0; i--) {
-				const value = this.stack[i].get(item);
+		if (this.parent !== undefined) {
+			/** @type {StackedMap<K, V> | undefined} */
+			let current = this.parent;
+			while (current !== undefined) {
+				const value = current.map.get(item);
 				if (value !== undefined) {
 					this.map.set(item, value);
 					return value === TOMBSTONE || value === UNDEFINED_MARKER
 						? undefined
 						: value;
 				}
+				current = current.parent;
 			}
 			this.map.set(item, TOMBSTONE);
 		}
 	}
 
 	/**
-	 * Collapses the stacked layers into a single concrete map.
+	 * Collapses the parent chain into a single concrete map.
 	 */
 	_compress() {
-		if (this.stack.length === 1) return;
-		this.map = new Map();
-		for (const data of this.stack) {
-			for (const pair of data) {
+		if (this.parent === undefined) return;
+		/** @type {StackedMap<K, V>[]} */
+		const layers = [];
+		/** @type {StackedMap<K, V> | undefined} */
+		let current = this;
+		do {
+			layers.push(current);
+			current = current.parent;
+		} while (current !== undefined);
+		const map = new Map();
+		for (let i = layers.length - 1; i >= 0; i--) {
+			for (const pair of layers[i].map) {
 				if (pair[1] === TOMBSTONE) {
-					this.map.delete(pair[0]);
+					map.delete(pair[0]);
 				} else {
-					this.map.set(pair[0], pair[1]);
+					map.set(pair[0], pair[1]);
 				}
 			}
 		}
-		this.stack = [this.map];
+		this.map = map;
+		this.parent = undefined;
 	}
 
 	/**
@@ -202,7 +217,7 @@ class StackedMap {
 	 * @returns {StackedMap<K, V>} child map
 	 */
 	createChild() {
-		return new StackedMap(this.stack);
+		return new StackedMap(this);
 	}
 }
 

--- a/test/BasicEvaluatedExpression.unittest.js
+++ b/test/BasicEvaluatedExpression.unittest.js
@@ -203,7 +203,10 @@ describe("BasicEvaluatedExpression", () => {
 		const e = new BasicEvaluatedExpression();
 		e.setRange([1, 2]);
 		expect(e.range).toEqual([1, 2]);
-		const node = { type: "Identifier", name: "x" };
+		const node = /** @type {import("estree").Node} */ ({
+			type: "Identifier",
+			name: "x"
+		});
 		e.setExpression(node);
 		expect(e.expression).toBe(node);
 		e.setSideEffects(false);

--- a/test/BasicEvaluatedExpression.unittest.js
+++ b/test/BasicEvaluatedExpression.unittest.js
@@ -1,0 +1,241 @@
+"use strict";
+
+const BasicEvaluatedExpression = require("../lib/javascript/BasicEvaluatedExpression");
+
+describe("BasicEvaluatedExpression", () => {
+	it("should start unknown with side effects and no facts", () => {
+		const e = new BasicEvaluatedExpression();
+		expect(e.isUnknown()).toBe(true);
+		expect(e.couldHaveSideEffects()).toBe(true);
+		expect(e.isTruthy()).toBe(false);
+		expect(e.isFalsy()).toBe(false);
+		expect(e.isNullish()).toBeUndefined();
+		expect(e.isPrimitiveType()).toBeUndefined();
+		expect(e.isCompileTimeValue()).toBe(false);
+		expect(e.asBool()).toBeUndefined();
+		expect(e.asString()).toBeUndefined();
+		expect(e.asNullish()).toBeUndefined();
+	});
+
+	it("should hold scalar values and reset them on type changes", () => {
+		const e = new BasicEvaluatedExpression().setString("hi");
+		expect(e.isString()).toBe(true);
+		expect(e.string).toBe("hi");
+		expect(e.number).toBeUndefined();
+		expect(e.asString()).toBe("hi");
+		expect(e.asBool()).toBe(true);
+		expect(e.asCompileTimeValue()).toBe("hi");
+
+		e.setNumber(0);
+		expect(e.isNumber()).toBe(true);
+		expect(e.isCompileTimeValue()).toBe(true);
+		expect(e.number).toBe(0);
+		expect(e.string).toBeUndefined();
+		expect(e.asBool()).toBe(false);
+		expect(e.asString()).toBe("0");
+		expect(e.asCompileTimeValue()).toBe(0);
+
+		e.setBigInt(BigInt(0));
+		expect(e.isBigInt()).toBe(true);
+		expect(e.bigint).toBe(BigInt(0));
+		expect(e.asBool()).toBe(false);
+		expect(e.asString()).toBe("0");
+		expect(e.asCompileTimeValue()).toBe(BigInt(0));
+
+		e.setBoolean(true);
+		expect(e.isBoolean()).toBe(true);
+		expect(e.bool).toBe(true);
+		expect(e.asBool()).toBe(true);
+		expect(e.asString()).toBe("true");
+		expect(e.asNullish()).toBe(false);
+		expect(e.asCompileTimeValue()).toBe(true);
+
+		const regExp = /x/g;
+		e.setRegExp(regExp);
+		expect(e.isRegExp()).toBe(true);
+		expect(e.regExp).toBe(regExp);
+		expect(e.asBool()).toBe(true);
+		expect(e.asString()).toBe("/x/g");
+		expect(e.isPrimitiveType()).toBe(false);
+		expect(e.asCompileTimeValue()).toBe(regExp);
+	});
+
+	it("should represent null and undefined", () => {
+		const e = new BasicEvaluatedExpression().setNull();
+		expect(e.isNull()).toBe(true);
+		expect(e.asBool()).toBe(false);
+		expect(e.asString()).toBe("null");
+		expect(e.asNullish()).toBe(true);
+		expect(e.asCompileTimeValue()).toBeNull();
+
+		e.setUndefined();
+		expect(e.isUndefined()).toBe(true);
+		expect(e.asBool()).toBe(false);
+		expect(e.asString()).toBe("undefined");
+		expect(e.asNullish()).toBe(true);
+		expect(e.asCompileTimeValue()).toBeUndefined();
+	});
+
+	it("should hold identifiers with member getters", () => {
+		const getMembers = () => ["a", "b"];
+		const getMembersOptionals = () => [false, true];
+		const getMemberRanges = () => [];
+		const e = new BasicEvaluatedExpression().setIdentifier(
+			"foo",
+			"root",
+			getMembers,
+			getMembersOptionals,
+			getMemberRanges
+		);
+		expect(e.isIdentifier()).toBe(true);
+		expect(e.identifier).toBe("foo");
+		expect(e.rootInfo).toBe("root");
+		expect(e.getMembers).toBe(getMembers);
+		expect(e.getMembersOptionals).toBe(getMembersOptionals);
+		expect(e.getMemberRanges).toBe(getMemberRanges);
+		expect(e.couldHaveSideEffects()).toBe(true);
+		expect(e.string).toBeUndefined();
+		expect(() => e.asCompileTimeValue()).toThrow(
+			/must only be called for compile-time values/
+		);
+	});
+
+	it("should hold conditional options and add more", () => {
+		const a = new BasicEvaluatedExpression().setString("a");
+		const b = new BasicEvaluatedExpression().setString("b");
+		const e = new BasicEvaluatedExpression().setOptions([a]);
+		expect(e.isConditional()).toBe(true);
+		expect(e.options).toEqual([a]);
+		e.addOptions([b]);
+		expect(e.options).toEqual([a, b]);
+
+		const fresh = new BasicEvaluatedExpression();
+		fresh.addOptions([a]);
+		expect(fresh.isConditional()).toBe(true);
+		expect(fresh.options).toEqual([a]);
+	});
+
+	it("should hold array items and const arrays", () => {
+		const item = new BasicEvaluatedExpression().setNumber(1);
+		const e = new BasicEvaluatedExpression().setItems([item]);
+		expect(e.isArray()).toBe(true);
+		expect(e.items).toEqual([item]);
+		expect(e.couldHaveSideEffects()).toBe(false);
+		expect(e.asBool()).toBe(true);
+		expect(e.asString()).toBe("1");
+
+		e.setArray(["x", "y"]);
+		expect(e.isConstArray()).toBe(true);
+		expect(e.array).toEqual(["x", "y"]);
+		// expression-valued fields are plain data properties and persist
+		expect(e.items).toEqual([item]);
+		expect(e.asBool()).toBe(true);
+		expect(e.asString()).toBe("x,y");
+		expect(e.asCompileTimeValue()).toEqual(["x", "y"]);
+	});
+
+	it("should hold template strings with kind", () => {
+		const q1 = new BasicEvaluatedExpression().setString("a");
+		const q2 = new BasicEvaluatedExpression().setString("b");
+		const e = new BasicEvaluatedExpression().setTemplateString(
+			[q1, q2],
+			[q1, q2],
+			"cooked"
+		);
+		expect(e.isTemplateString()).toBe(true);
+		expect(e.quasis).toEqual([q1, q2]);
+		expect(e.parts).toEqual([q1, q2]);
+		expect(e.templateStringKind).toBe("cooked");
+		expect(e.asString()).toBe("ab");
+		expect(e.asBool()).toBe(true);
+		expect(e.isPrimitiveType()).toBe(true);
+		expect(e.couldHaveSideEffects()).toBe(false);
+	});
+
+	it("should hold wrapped expressions", () => {
+		const prefix = new BasicEvaluatedExpression().setString("pre");
+		const postfix = new BasicEvaluatedExpression().setString("post");
+		const inner = [new BasicEvaluatedExpression()];
+		const e = new BasicEvaluatedExpression().setWrapped(prefix, postfix, inner);
+		expect(e.isWrapped()).toBe(true);
+		expect(e.prefix).toBe(prefix);
+		expect(e.postfix).toBe(postfix);
+		expect(e.wrappedInnerExpressions).toBe(inner);
+		expect(e.asBool()).toBe(true);
+		expect(e.isPrimitiveType()).toBe(true);
+
+		const unknownWrap = new BasicEvaluatedExpression().setWrapped(
+			null,
+			null,
+			undefined
+		);
+		expect(unknownWrap.prefix).toBeNull();
+		expect(unknownWrap.postfix).toBeNull();
+		expect(unknownWrap.asBool()).toBeUndefined();
+	});
+
+	it("should track truthy/falsy/nullish facts", () => {
+		const e = new BasicEvaluatedExpression();
+		e.setTruthy();
+		expect(e.isTruthy()).toBe(true);
+		expect(e.isFalsy()).toBe(false);
+		expect(e.isNullish()).toBe(false);
+		expect(e.asBool()).toBe(true);
+		expect(e.asNullish()).toBe(false);
+
+		e.setFalsy();
+		expect(e.isTruthy()).toBe(false);
+		expect(e.isFalsy()).toBe(true);
+		expect(e.asBool()).toBe(false);
+
+		e.setNullish(true);
+		expect(e.isNullish()).toBe(true);
+		expect(e.isFalsy()).toBe(true);
+		expect(e.asNullish()).toBe(true);
+
+		e.nullish = undefined;
+		expect(e.isNullish()).toBeUndefined();
+		e.setNullish(false);
+		expect(e.isNullish()).toBe(false);
+	});
+
+	it("should keep range, expression and explicit side effects", () => {
+		const e = new BasicEvaluatedExpression();
+		e.setRange([1, 2]);
+		expect(e.range).toEqual([1, 2]);
+		const node = { type: "Identifier", name: "x" };
+		e.setExpression(node);
+		expect(e.expression).toBe(node);
+		e.setSideEffects(false);
+		expect(e.couldHaveSideEffects()).toBe(false);
+		e.setSideEffects();
+		expect(e.couldHaveSideEffects()).toBe(true);
+	});
+
+	it("should accept direct field assignments through the accessors", () => {
+		const e = new BasicEvaluatedExpression();
+		e.type = 3; // TypeString
+		e.string = "direct";
+		expect(e.isString()).toBe(true);
+		expect(e.string).toBe("direct");
+		e.truthy = true;
+		expect(e.truthy).toBe(true);
+		e.truthy = false;
+		e.falsy = true;
+		expect(e.falsy).toBe(true);
+		e.falsy = false;
+		e.sideEffects = false;
+		expect(e.sideEffects).toBe(false);
+	});
+
+	it("should validate regexp flags statically", () => {
+		// cspell:ignore gimy gimys
+		const isValid = BasicEvaluatedExpression.isValidRegExpFlags;
+		expect(isValid("")).toBe(true);
+		expect(isValid("g")).toBe(true);
+		expect(isValid("gimy")).toBe(true);
+		expect(isValid("gg")).toBe(false);
+		expect(isValid("q")).toBe(false);
+		expect(isValid("gimys")).toBe(false);
+	});
+});

--- a/test/StackedMap.unittest.js
+++ b/test/StackedMap.unittest.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const StackedMap = require("../lib/util/StackedMap");
+
+describe("StackedMap", () => {
+	it("should behave like a map in a single layer", () => {
+		const map = new StackedMap();
+		map.set("a", 1);
+		map.set("b", 2);
+		expect(map.get("a")).toBe(1);
+		expect(map.has("a")).toBe(true);
+		expect(map.get("missing")).toBeUndefined();
+		expect(map.has("missing")).toBe(false);
+		map.delete("a");
+		expect(map.get("a")).toBeUndefined();
+		expect(map.has("a")).toBe(false);
+		expect(map.size).toBe(1);
+	});
+
+	it("should preserve explicit undefined values", () => {
+		const map = new StackedMap();
+		map.set("u", undefined);
+		expect(map.get("u")).toBeUndefined();
+		expect(map.has("u")).toBe(true);
+		const child = map.createChild();
+		expect(child.get("u")).toBeUndefined();
+		expect(child.has("u")).toBe(true);
+	});
+
+	it("should see parent values from child layers", () => {
+		const parent = new StackedMap();
+		parent.set("a", 1);
+		const child = parent.createChild();
+		expect(child.get("a")).toBe(1);
+		expect(child.has("a")).toBe(true);
+		child.set("a", 2);
+		expect(child.get("a")).toBe(2);
+		expect(parent.get("a")).toBe(1);
+	});
+
+	it("should shadow deletions in child layers only", () => {
+		const parent = new StackedMap();
+		parent.set("a", 1);
+		const child = parent.createChild();
+		child.delete("a");
+		expect(child.get("a")).toBeUndefined();
+		expect(child.has("a")).toBe(false);
+		expect(parent.get("a")).toBe(1);
+		expect(parent.has("a")).toBe(true);
+	});
+
+	it("should answer repeated lookups after memoization consistently", () => {
+		const parent = new StackedMap();
+		parent.set("a", 1);
+		const child = parent.createChild();
+		expect(child.get("a")).toBe(1);
+		expect(child.get("a")).toBe(1);
+		expect(child.get("missing")).toBeUndefined();
+		expect(child.get("missing")).toBeUndefined();
+		expect(child.has("missing")).toBe(false);
+	});
+
+	it("should support grandchildren with intermediate shadowing", () => {
+		const root = new StackedMap();
+		root.set("x", "root");
+		root.set("y", "root");
+		const mid = root.createChild();
+		mid.set("x", "mid");
+		mid.delete("y");
+		const leaf = mid.createChild();
+		expect(leaf.get("x")).toBe("mid");
+		expect(leaf.get("y")).toBeUndefined();
+		expect(leaf.has("y")).toBe(false);
+		leaf.set("y", "leaf");
+		expect(leaf.get("y")).toBe("leaf");
+		expect(mid.get("y")).toBeUndefined();
+		expect(root.get("y")).toBe("root");
+	});
+
+	it("should enumerate visible entries via asArray/asSet/asPairArray/asMap", () => {
+		const root = new StackedMap();
+		root.set("a", 1);
+		root.set("b", 2);
+		root.set("u", undefined);
+		const child = root.createChild();
+		child.set("c", 3);
+		child.delete("b");
+		expect(child.asArray().sort()).toEqual(["a", "c", "u"]);
+		expect([...child.asSet()].sort()).toEqual(["a", "c", "u"]);
+		const pairs = child.asPairArray().sort((x, y) => (x[0] < y[0] ? -1 : 1));
+		expect(pairs).toEqual([
+			["a", 1],
+			["c", 3],
+			["u", undefined]
+		]);
+		expect(child.asMap().get("c")).toBe(3);
+		expect(child.size).toBe(3);
+	});
+
+	it("should keep answering correctly after size/compression", () => {
+		const root = new StackedMap();
+		root.set("a", 1);
+		const child = root.createChild();
+		child.set("b", 2);
+		child.delete("a");
+		expect(child.size).toBe(1);
+		expect(child.get("a")).toBeUndefined();
+		expect(child.get("b")).toBe(2);
+		child.set("a", 5);
+		expect(child.get("a")).toBe(5);
+		expect(child.size).toBe(2);
+	});
+
+	it("should let children observe later parent writes of new keys", () => {
+		// both the historical array design (shared Map objects) and a linked
+		// design expose parent writes made after child creation
+		const parent = new StackedMap();
+		const child = parent.createChild();
+		parent.set("late", 42);
+		expect(child.get("late")).toBe(42);
+	});
+});

--- a/test/StackedMap.unittest.js
+++ b/test/StackedMap.unittest.js
@@ -111,6 +111,22 @@ describe("StackedMap", () => {
 		expect(child.size).toBe(2);
 	});
 
+	it("should answer has() through the parent chain and memoize misses", () => {
+		const root = new StackedMap();
+		root.set("a", 1);
+		root.set("u", undefined);
+		const mid = root.createChild();
+		const leaf = mid.createChild();
+		// walk hit two layers up
+		expect(leaf.has("a")).toBe(true);
+		// explicit undefined counts as present
+		expect(leaf.has("u")).toBe(true);
+		// walk miss writes a tombstone, the second lookup answers from it
+		expect(leaf.has("missing")).toBe(false);
+		expect(leaf.has("missing")).toBe(false);
+		expect(leaf.get("missing")).toBeUndefined();
+	});
+
 	it("should let children observe later parent writes of new keys", () => {
 		// both the historical array design (shared Map objects) and a linked
 		// design expose parent writes made after child creation

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -8,15 +8,18 @@ const JavascriptParser = require("../lib/javascript/JavascriptParser");
  * @returns {import("../lib/javascript/JavascriptParser").ParseResult} result
  */
 const parse = (code, options) =>
-	JavascriptParser._parse(code, {
-		sourceType: "script",
-		ecmaVersion: "latest",
-		comments: true,
-		ranges: true,
-		semicolons: true,
-		allowHashBang: true,
-		...options
-	});
+	JavascriptParser._parse(
+		code,
+		/** @type {import("../lib/javascript/JavascriptParser").InternalParseOptions} */ ({
+			sourceType: "script",
+			ecmaVersion: "latest",
+			comments: true,
+			ranges: true,
+			semicolons: true,
+			allowHashBang: true,
+			...options
+		})
+	);
 
 describe("WebpackParser", () => {
 	describe("lazy comments", () => {
@@ -68,7 +71,13 @@ describe("WebpackParser", () => {
 	describe("template fast path", () => {
 		it("should cook CR and CRLF chunks through the cold path", () => {
 			const { ast } = parse("`a\r\nb\rc`;");
-			const quasi = ast.body[0].expression.quasis[0];
+			const statement =
+				/** @type {import("estree").ExpressionStatement} */
+				(ast.body[0]);
+			const template =
+				/** @type {import("estree").TemplateLiteral} */
+				(statement.expression);
+			const quasi = template.quasis[0];
 			expect(quasi.value.cooked).toBe("a\nb\nc");
 		});
 
@@ -117,10 +126,18 @@ describe("WebpackParser", () => {
 
 		it("should build the literal value once", () => {
 			const { ast } = parse("x = /a[/]b/gi;");
-			const literal = ast.body[0].expression.right;
+			const statement =
+				/** @type {import("estree").ExpressionStatement} */
+				(ast.body[0]);
+			const assignment =
+				/** @type {import("estree").AssignmentExpression} */
+				(statement.expression);
+			const literal =
+				/** @type {import("estree").RegExpLiteral} */
+				(assignment.right);
 			expect(literal.regex).toEqual({ pattern: "a[/]b", flags: "gi" });
 			expect(literal.value).toBeInstanceOf(RegExp);
-			expect(literal.value.source).toBe("a[/]b");
+			expect(/** @type {RegExp} */ (literal.value).source).toBe("a[/]b");
 		});
 	});
 });

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const JavascriptParser = require("../lib/javascript/JavascriptParser");
+
+/**
+ * @param {string} code source
+ * @param {object=} options extra parse options
+ * @returns {import("../lib/javascript/JavascriptParser").ParseResult} result
+ */
+const parse = (code, options) =>
+	JavascriptParser._parse(code, {
+		sourceType: "script",
+		ecmaVersion: "latest",
+		comments: true,
+		ranges: true,
+		semicolons: true,
+		allowHashBang: true,
+		...options
+	});
+
+describe("WebpackParser", () => {
+	describe("lazy comments", () => {
+		it("should collect hashbang, line, block and html comments lazily", () => {
+			const { comments } = parse(
+				"#!/usr/bin/env node\n// line\nconst x = /* block */ 1; <!-- html\n"
+			);
+			expect(comments.map((c) => [c.type, c.value])).toEqual([
+				["Line", "/usr/bin/env node"],
+				["Line", " line"],
+				["Block", " block "],
+				["Line", " html"]
+			]);
+			expect(comments[1].range).toEqual([20, 27]);
+			expect(comments[1].loc.start).toEqual({ line: 2, column: 0 });
+			expect(comments[1].loc.end).toEqual({ line: 2, column: 7 });
+		});
+
+		it("should memoize and accept explicit value/loc writes", () => {
+			const { comments } = parse("// abc\n");
+			expect(comments[0].value).toBe(" abc");
+			// memoized second read
+			expect(comments[0].value).toBe(" abc");
+			comments[0].value = "override";
+			expect(comments[0].value).toBe("override");
+			const loc = comments[0].loc;
+			expect(comments[0].loc).toBe(loc);
+			comments[0].loc = { start: { line: 9, column: 9 }, end: loc.end };
+			expect(comments[0].loc.start.line).toBe(9);
+		});
+
+		it("should collect comments eagerly when ranges are off", () => {
+			const { comments } = parse("// line\n/* block */ x;", {
+				ranges: false
+			});
+			expect(comments.map((c) => [c.type, c.value])).toEqual([
+				["Line", " line"],
+				["Block", " block "]
+			]);
+		});
+
+		it("should report unterminated block comments", () => {
+			expect(() => parse("const x = 1; /* nope")).toThrow(
+				/Unterminated comment/
+			);
+		});
+	});
+
+	describe("template fast path", () => {
+		it("should cook CR and CRLF chunks through the cold path", () => {
+			const { ast } = parse("`a\r\nb\rc`;");
+			const quasi = ast.body[0].expression.quasis[0];
+			expect(quasi.value.cooked).toBe("a\nb\nc");
+		});
+
+		it("should report unterminated templates", () => {
+			expect(() => parse("const x = `nope")).toThrow(/Unterminated template/);
+			expect(() =>
+				// eslint-disable-next-line no-template-curly-in-string
+				parse("const x = `nope ${y} still open")
+			).toThrow(/Unterminated template/);
+		});
+	});
+
+	describe("regexp fast path", () => {
+		it("should report unterminated regular expressions", () => {
+			expect(() => parse("x = /nope")).toThrow(
+				/Unterminated regular expression/
+			);
+			expect(() => parse("x = /new\nline/")).toThrow(
+				/Unterminated regular expression/
+			);
+		});
+
+		it("should report flag errors with acorn's messages", () => {
+			expect(() => parse("x = /a/q")).toThrow(
+				/Invalid regular expression flag/
+			);
+			expect(() => parse("x = /a/gg")).toThrow(
+				/Duplicate regular expression flag/
+			);
+			expect(() => parse("x = /a/uv")).toThrow(
+				/Invalid regular expression flag/
+			);
+			expect(() => parse("x = /a/\\u0067")).toThrow(/Unexpected token/);
+		});
+
+		it("should respect the ecmaVersion for allowed flags", () => {
+			expect(() => parse("x = /a/s", { ecmaVersion: 6 })).toThrow(
+				/Invalid regular expression flag/
+			);
+			expect(parse("x = /a/s", { ecmaVersion: 2018 }).ast).toBeDefined();
+		});
+
+		it("should report invalid patterns with V8's messages", () => {
+			expect(() => parse("x = /(/")).toThrow(/Invalid regular expression/);
+		});
+
+		it("should build the literal value once", () => {
+			const { ast } = parse("x = /a[/]b/gi;");
+			const literal = ast.body[0].expression.right;
+			expect(literal.regex).toEqual({ pattern: "a[/]b", flags: "gi" });
+			expect(literal.value).toBeInstanceOf(RegExp);
+			expect(literal.value.source).toBe("a[/]b");
+		});
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -851,31 +851,15 @@ declare interface BasenameCacheEntry {
 	 */
 	cache: Map<string, Map<undefined | string, undefined | string>>;
 }
+
+/**
+ * An instance is allocated for a large share of walked expressions, so the
+ * 26 public fields live virtually: one packed flags slot plus five value
+ * slots shared by type (accessors keep every public field readable). This
+ * shrinks instances from 224 to 88 bytes on V8.
+ */
 declare abstract class BasicEvaluatedExpression {
-	type: number;
 	range?: [number, number];
-	falsy: boolean;
-	truthy: boolean;
-	nullish?: boolean;
-	sideEffects: boolean;
-	bool?: boolean;
-	number?: number;
-	bigint?: bigint;
-	regExp?: RegExp;
-	string?: string;
-	quasis?: BasicEvaluatedExpression[];
-	parts?: BasicEvaluatedExpression[];
-	array?: any[];
-	items?: BasicEvaluatedExpression[];
-	options?: BasicEvaluatedExpression[];
-	prefix?: null | BasicEvaluatedExpression;
-	postfix?: null | BasicEvaluatedExpression;
-	wrappedInnerExpressions?: BasicEvaluatedExpression[];
-	identifier?: string | VariableInfo;
-	rootInfo?: string | VariableInfo;
-	getMembers?: () => string[];
-	getMembersOptionals?: () => boolean[];
-	getMemberRanges?: () => [number, number][];
 	expression?:
 		| Program
 		| ImportDeclaration
@@ -951,6 +935,30 @@ declare abstract class BasicEvaluatedExpression {
 		| AssignmentPattern
 		| SwitchCase
 		| TemplateElement;
+	type: number;
+	truthy: boolean;
+	falsy: boolean;
+	nullish?: boolean;
+	sideEffects: boolean;
+	bool?: boolean;
+	number?: number;
+	bigint?: bigint;
+	regExp?: RegExp;
+	string?: string;
+	quasis?: BasicEvaluatedExpression[];
+	parts?: BasicEvaluatedExpression[];
+	templateStringKind?: "cooked" | "raw";
+	array?: any[];
+	items?: BasicEvaluatedExpression[];
+	options?: BasicEvaluatedExpression[];
+	prefix?: null | BasicEvaluatedExpression;
+	postfix?: null | BasicEvaluatedExpression;
+	wrappedInnerExpressions?: BasicEvaluatedExpression[];
+	identifier?: string | VariableInfo;
+	rootInfo?: string | VariableInfo;
+	getMembers?: () => string[];
+	getMembersOptionals?: () => boolean[];
+	getMemberRanges?: () => [number, number][];
 	isUnknown(): boolean;
 	isNull(): boolean;
 	isUndefined(): boolean;
@@ -1081,7 +1089,6 @@ declare abstract class BasicEvaluatedExpression {
 		parts: BasicEvaluatedExpression[],
 		kind: "cooked" | "raw"
 	): BasicEvaluatedExpression;
-	templateStringKind?: "cooked" | "raw";
 	setTruthy(): BasicEvaluatedExpression;
 	setFalsy(): BasicEvaluatedExpression;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -23911,11 +23911,12 @@ declare abstract class StackEntry {
 
 /**
  * Layered map that supports child scopes while memoizing lookups from parent
- * scopes into the current layer.
+ * scopes into the current layer. Layers form a linked parent chain, so
+ * `createChild` is O(1) instead of copying a layer array per scope.
  */
 declare abstract class StackedMap<K, V> {
 	map: Map<K, InternalCell<V>>;
-	stack: Map<K, InternalCell<V>>[];
+	parent?: StackedMap<K, V>;
 
 	/**
 	 * Stores a value in the current layer, preserving explicit `undefined`

--- a/types.d.ts
+++ b/types.d.ts
@@ -19223,6 +19223,11 @@ declare interface ParseOptions {
 	lazySourcePositions?: LazySourcePositions;
 
 	/**
+	 * internal: collect comments here without slicing their text eagerly
+	 */
+	lazyComments?: CommentJavascriptParser[];
+
+	/**
 	 * enable parsing of the import phase proposals (import defer / import source)
 	 */
 	importPhases?: boolean;

--- a/types.d.ts
+++ b/types.d.ts
@@ -854,9 +854,9 @@ declare interface BasenameCacheEntry {
 
 /**
  * An instance is allocated for a large share of walked expressions, so the
- * 26 public fields live virtually: one packed flags slot plus five value
- * slots shared by type (accessors keep every public field readable). This
- * shrinks instances from 224 to 88 bytes on V8.
+ * boolean facts live in one packed flags slot and the scalar/identifier
+ * fields in five slots shared by type, with accessors keeping every public
+ * field readable. This shrinks instances from 224 to 144 bytes on V8.
  */
 declare abstract class BasicEvaluatedExpression {
 	range?: [number, number];
@@ -935,6 +935,13 @@ declare abstract class BasicEvaluatedExpression {
 		| AssignmentPattern
 		| SwitchCase
 		| TemplateElement;
+	quasis?: BasicEvaluatedExpression[];
+	parts?: BasicEvaluatedExpression[];
+	items?: BasicEvaluatedExpression[];
+	options?: BasicEvaluatedExpression[];
+	prefix?: null | BasicEvaluatedExpression;
+	postfix?: null | BasicEvaluatedExpression;
+	wrappedInnerExpressions?: BasicEvaluatedExpression[];
 	type: number;
 	truthy: boolean;
 	falsy: boolean;
@@ -945,15 +952,8 @@ declare abstract class BasicEvaluatedExpression {
 	bigint?: bigint;
 	regExp?: RegExp;
 	string?: string;
-	quasis?: BasicEvaluatedExpression[];
-	parts?: BasicEvaluatedExpression[];
 	templateStringKind?: "cooked" | "raw";
 	array?: any[];
-	items?: BasicEvaluatedExpression[];
-	options?: BasicEvaluatedExpression[];
-	prefix?: null | BasicEvaluatedExpression;
-	postfix?: null | BasicEvaluatedExpression;
-	wrappedInnerExpressions?: BasicEvaluatedExpression[];
 	identifier?: string | VariableInfo;
 	rootInfo?: string | VariableInfo;
 	getMembers?: () => string[];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-ups to #21338 on webpack's hottest path: comment text is now sliced lazily on first read, template/regexp tokenizing gets single-slice/single-construction fast paths (~21% faster on regex-dense code, ~7-11% faster parses on comment-heavy vendor code), `StackedMap.createChild` becomes O(1) via a parent link instead of copying the layer array (quadratic on deeply nested files), and `BasicEvaluatedExpression` shrinks from 224 to ~145 bytes (26 fields → packed flags plus shared typed slots, ~500k instances per medium build). Every parser change was verified by differential testing against plain acorn over 18M+ AST nodes (positions, values, cooked/raw, error message+position parity).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new `test/StackedMap.unittest.js`; the rest is covered by existing suites (full ConfigTestCases 5905 pass, `test/JavascriptParser.unittest.js`) plus differential testing against plain acorn.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — all public fields keep their types and values; note that `BasicEvaluatedExpression`'s scalar fields are now prototype accessors, so they no longer show up in `Object.keys`/spread of instances.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — this PR was developed with Claude Code under my direction: it profiled allocations, implemented the changes, verified them (differential testing vs plain acorn, interleaved A/B benchmarks, full test suites) and reverted candidates that did not measure; I reviewed and directed each step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWD8JtDYd7LnxffMxYR4ev)_