### PR TITLE
test: add JavascriptParser unit benchmark parsing typescript.js

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -190,7 +190,8 @@ export default defineConfig([
 			"test/*.benchmark.mjs",
 			"test/benchmarkCases/_helpers/**/*.mjs",
 			"test/benchmarkCases/**/webpack.config.mjs",
-			"test/benchmarkCases/**/options.mjs"
+			"test/benchmarkCases/**/options.mjs",
+			"test/benchmarkCases/**/index.bench.mjs"
 		],
 		languageOptions: {
 			ecmaVersion: 2022

--- a/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
@@ -17,7 +17,6 @@ const source = fs.readFileSync(
  */
 export default (bench) => {
 	bench.add('unit benchmark "js-parser-typescript-unit"', () => {
-		// fresh parser per run: no cross-run caches
 		const parser = new JavascriptParser("auto");
 		parser.parse(source, {});
 	});

--- a/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
@@ -1,0 +1,24 @@
+import fs from "fs";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+/** @type {typeof import("../../../lib/javascript/JavascriptParser")} */
+const JavascriptParser = require("../../../lib/javascript/JavascriptParser.js");
+
+const source = fs.readFileSync(
+	require.resolve("typescript/lib/typescript.js"),
+	"utf8"
+);
+
+/**
+ * @param {import("tinybench").Bench} bench bench
+ * @returns {void}
+ */
+export default (bench) => {
+	bench.add('unit benchmark "js-parser-typescript-unit"', () => {
+		// fresh parser per run: no cross-run caches
+		const parser = new JavascriptParser("auto");
+		parser.parse(source, {});
+	});
+};

--- a/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
@@ -1,13 +1,21 @@
 import fs from "fs";
 import { createRequire } from "module";
+import { fileURLToPath } from "url";
 
 const require = createRequire(import.meta.url);
 
 /** @type {typeof import("../../../lib/javascript/JavascriptParser")} */
 const JavascriptParser = require("../../../lib/javascript/JavascriptParser.js");
 
-const source = fs.readFileSync(
+const typescriptSource = fs.readFileSync(
 	require.resolve("typescript/lib/typescript.js"),
+	"utf8"
+);
+// "three" import condition resolves to build/three.module.js
+const threeEsmPath = fileURLToPath(import.meta.resolve("three"));
+const threeEsmSource = fs.readFileSync(threeEsmPath, "utf8");
+const threeEsmMinSource = fs.readFileSync(
+	threeEsmPath.replace(/\.js$/, ".min.js"),
 	"utf8"
 );
 
@@ -16,8 +24,42 @@ const source = fs.readFileSync(
  * @returns {void}
  */
 export default (bench) => {
+	// script-flavored CJS, parse + walk
 	bench.add('unit benchmark "js-parser-typescript-unit"', () => {
 		const parser = new JavascriptParser("auto");
-		parser.parse(source, {});
+		parser.parse(typescriptSource, {});
 	});
+
+	// acorn only, no walk; same options as parse() to isolate walker changes
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", mode 'parse-only'",
+		() => {
+			JavascriptParser._parse(typescriptSource, {
+				sourceType: "auto",
+				locations: true,
+				ranges: true,
+				comments: true,
+				semicolons: true,
+				importPhases: false
+			});
+		}
+	);
+
+	// large ESM, exercises harmony import/export paths
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", source 'three.module.js'",
+		() => {
+			const parser = new JavascriptParser("module");
+			parser.parse(threeEsmSource, {});
+		}
+	);
+
+	// minified ESM, stresses short identifiers and single-line source
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", source 'three.module.min.js'",
+		() => {
+			const parser = new JavascriptParser("module");
+			parser.parse(threeEsmMinSource, {});
+		}
+	);
 };

--- a/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs
@@ -24,11 +24,32 @@ const threeEsmMinSource = fs.readFileSync(
  * @returns {void}
  */
 export default (bench) => {
-	// script-flavored CJS, parse + walk
-	bench.add('unit benchmark "js-parser-typescript-unit"', () => {
-		const parser = new JavascriptParser("auto");
-		parser.parse(typescriptSource, {});
-	});
+	// auto mode
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", sourceType 'auto'",
+		() => {
+			const parser = new JavascriptParser("auto");
+			parser.parse(typescriptSource, {});
+		}
+	);
+
+	// forced ecma module mode, strict parse, no fallback
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", sourceType 'module'",
+		() => {
+			const parser = new JavascriptParser("module");
+			parser.parse(typescriptSource, {});
+		}
+	);
+
+	// forced classic script mode
+	bench.add(
+		"unit benchmark \"js-parser-typescript-unit\", sourceType 'script'",
+		() => {
+			const parser = new JavascriptParser("script");
+			parser.parse(typescriptSource, {});
+		}
+	);
 
 	// acorn only, no walk; same options as parse() to isolate walker changes
 	bench.add(


### PR DESCRIPTION

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Add a unit benchmark case that runs `JavascriptParser` over `typescript/lib/typescript.js` (~8.7 MiB), so parser performance changes (e.g. #21338) are tracked in the benchmark CI without the noise of a full build. This is the first case using the harness's `-unit` support; `eslint.config.mjs` now also covers `index.bench.mjs` files.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/benchmarkCases/js-parser-typescript-unit/index.bench.mjs` (the benchmark case itself).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to write the benchmark case, the eslint config update, and this PR description; all changes were reviewed and the benchmark was verified locally by the author.
