### PR TITLE
fix: keep ESM live bindings for a module library's inlined entry exports

### DIFF
--- a/.changeset/module-library-entry-live-bindings.md
+++ b/.changeset/module-library-entry-live-bindings.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep ESM live bindings for a module library's inlined entry exports instead of snapshotting them.

--- a/.changeset/module-library-entry-live-bindings.md
+++ b/.changeset/module-library-entry-live-bindings.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep ESM live bindings for a module library's inlined entry exports instead of snapshotting them.
+Keep ESM live bindings for a module library's entry exports instead of snapshotting them, including when the runtime is emitted as a separate chunk.

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -27,6 +27,8 @@ const { getUndoPath } = require("../util/identifier");
 /** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Entrypoint")} Entrypoint */
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../javascript/JavascriptModulesPlugin").ChunkRenderContext} ChunkRenderContext */
 
 /**
  * Gets relative path.
@@ -78,7 +80,9 @@ const getRelativePath = (compilation, chunk, runtimeChunk) => {
  * @returns {string} the import source
  */
 function renderChunkImport(compilation, chunk, namedImport, runtimeChunk) {
-	return `import ${namedImport ? `* as ${namedImport}` : `{ ${RuntimeGlobals.require} }`} from ${JSON.stringify(
+	return `import ${
+		namedImport ? `* as ${namedImport}` : `{ ${RuntimeGlobals.require} }`
+	} from ${JSON.stringify(
 		getRelativePath(compilation, chunk, runtimeChunk || chunk)
 	)};\n`;
 }
@@ -182,10 +186,14 @@ class ModuleChunkFormatPlugin {
 				const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
 				const source = new ConcatSource();
 				source.add(
-					`export const ${RuntimeGlobals.esmId} = ${JSON.stringify(chunk.id)};\n`
+					`export const ${RuntimeGlobals.esmId} = ${JSON.stringify(
+						chunk.id
+					)};\n`
 				);
 				source.add(
-					`export const ${RuntimeGlobals.esmIds} = ${JSON.stringify(chunk.ids)};\n`
+					`export const ${RuntimeGlobals.esmIds} = ${JSON.stringify(
+						chunk.ids
+					)};\n`
 				);
 				source.add(`export const ${RuntimeGlobals.esmModules} = `);
 				source.add(modules);
@@ -202,6 +210,8 @@ class ModuleChunkFormatPlugin {
 				}
 				const { entries, runtimeChunk } = getChunkInfo(chunk, chunkGraph);
 				if (runtimeChunk) {
+					const { inlinedEntryModule, inlinedEntrySource } =
+						/** @type {ChunkRenderContext} */ (renderContext);
 					const entrySource = new ConcatSource();
 					entrySource.add(source);
 					entrySource.add(";\n\n// load runtime\n");
@@ -209,12 +219,21 @@ class ModuleChunkFormatPlugin {
 						renderChunkImport(compilation, runtimeChunk, "", chunk)
 					);
 					const startupSource = new ConcatSource();
-					startupSource.add(
-						`var __webpack_exec__ = ${runtimeTemplate.returningFunction(
-							`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
-							"moduleId"
-						)}\n`
+					// The `__webpack_exec__` helper is only needed for entries that
+					// are executed through the registry, not for inlined entries.
+					const needExec = entries.some(
+						([module]) =>
+							module !== inlinedEntryModule &&
+							chunkGraph.getModuleSourceTypes(module).has(JAVASCRIPT_TYPE)
 					);
+					if (needExec) {
+						startupSource.add(
+							`var __webpack_exec__ = ${runtimeTemplate.returningFunction(
+								`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
+								"moduleId"
+							)}\n`
+						);
+					}
 
 					/** @type {Set<Chunk>} */
 					const loadedChunks = new Set();
@@ -248,18 +267,32 @@ class ModuleChunkFormatPlugin {
 							startupSource.add("\n");
 							startupSource.add(sourceWithDependentChunks);
 						}
-						startupSource.add(
-							`${
-								final ? `var ${RuntimeGlobals.exports} = ` : ""
-							}__webpack_exec__(${JSON.stringify(moduleId)});\n`
-						);
+						if (module === inlinedEntryModule && inlinedEntrySource) {
+							// Inline the entry at the top level so its declarations stay
+							// live ESM bindings (exports appended by `renderStartup`).
+							startupSource.add(
+								`${runtimeTemplate.renderLet()} ${
+									RuntimeGlobals.exports
+								} = {};\n`
+							);
+							startupSource.add(inlinedEntrySource);
+							startupSource.add("\n");
+						} else {
+							startupSource.add(
+								`${
+									final ? `var ${RuntimeGlobals.exports} = ` : ""
+								}__webpack_exec__(${JSON.stringify(moduleId)});\n`
+							);
+						}
 					}
 
 					entrySource.add(
 						hooks.renderStartup.call(
 							startupSource,
 							entries[entries.length - 1][0],
-							renderContext
+							inlinedEntryModule
+								? { ...renderContext, inlined: true, inlinedInIIFE: false }
+								: renderContext
 						)
 					);
 					return entrySource;

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -45,6 +45,7 @@ const createHash = require("../util/createHash");
 const { digestNonNumericOnlyWithFull } = require("../util/nonNumericOnlyHash");
 const removeBOM = require("../util/removeBOM");
 const { intersectRuntime } = require("../util/runtime");
+const { getAllChunks } = require("./ChunkHelpers");
 const JavascriptGenerator = require("./JavascriptGenerator");
 const JavascriptModule = require("./JavascriptModule");
 const JavascriptParser = require("./JavascriptParser");
@@ -282,6 +283,8 @@ const printGeneratedCodeForStack = (module, code) => {
  * @property {CodeGenerationResults} codeGenerationResults results of code generation
  * @property {InitFragment<ChunkRenderContext>[]} chunkInitFragments init fragments for the chunk
  * @property {boolean | undefined} strictMode rendering in strict context
+ * @property {Module=} inlinedEntryModule entry module inlined at the chunk top level instead of the registry
+ * @property {Source=} inlinedEntrySource rendered body of the inlined entry module
  */
 
 /**
@@ -997,10 +1000,30 @@ class JavascriptModulesPlugin {
 			chunkInitFragments: [],
 			strictMode: allStrict
 		};
+		// ESM entry chunk whose runtime lives in a separate chunk: inline the
+		// single entry module at the top level (instead of the module registry)
+		// so its own top-level declarations stay live ESM bindings for consumers.
+		const inlinedEntryModule = this._getEsmEntryModuleToInline(
+			renderContext,
+			allModules
+		);
+		let registryModules = allModules;
+		if (inlinedEntryModule) {
+			const inlinedEntrySource = this.renderModule(
+				inlinedEntryModule,
+				{ ...chunkRenderContext, factory: false },
+				hooks
+			);
+			if (inlinedEntrySource) {
+				registryModules = allModules.filter((m) => m !== inlinedEntryModule);
+				chunkRenderContext.inlinedEntryModule = inlinedEntryModule;
+				chunkRenderContext.inlinedEntrySource = inlinedEntrySource;
+			}
+		}
 		const moduleSources =
 			Template.renderChunkModules(
 				chunkRenderContext,
-				allModules,
+				registryModules,
 				(module, renderInObject) =>
 					this.renderModule(
 						module,
@@ -1041,6 +1064,100 @@ class JavascriptModulesPlugin {
 			: renderContext.runtimeTemplate.isModule()
 				? source
 				: new ConcatSource(source, ";");
+	}
+
+	/**
+	 * Decides whether an entry chunk's single entry module can be inlined at the
+	 * top level of an ESM output chunk (instead of the registry), which keeps its
+	 * exports as live ESM bindings. Returns the module when safe, else `undefined`.
+	 * @param {RenderContext} renderContext render context
+	 * @param {Module[]} allModules all javascript modules of the chunk
+	 * @returns {Module | undefined} the entry module to inline, if any
+	 */
+	_getEsmEntryModuleToInline(renderContext, allModules) {
+		const {
+			chunk,
+			chunkGraph,
+			moduleGraph,
+			runtimeTemplate,
+			codeGenerationResults
+		} = renderContext;
+		// Only ESM entry chunks whose runtime lives in a separate chunk.
+		if (
+			!runtimeTemplate.isModule() ||
+			chunk.hasRuntime() ||
+			chunkGraph.getNumberOfEntryModules(chunk) !== 1
+		) {
+			return undefined;
+		}
+		const [entryEntry] =
+			chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk);
+		const [entryModule, entrypoint] = /** @type {[Module, Entrypoint]} */ (
+			entryEntry
+		);
+		// `dependOn` entries share execution ordering with their parents; keep
+		// them on the registry path rather than reasoning about inline ordering.
+		if (entrypoint.getParents().length > 0) {
+			return undefined;
+		}
+		// When the entry depends on chunks other than this one and the runtime
+		// (e.g. split chunks), its execution must be delayed, so it can't be
+		// inlined at the top level.
+		if (
+			getAllChunks(entrypoint, chunk, entrypoint.getRuntimeChunk()).size > 0
+		) {
+			return undefined;
+		}
+		// Needs standard exports binding and known top-level declarations to be
+		// safely lifted to the chunk scope.
+		if (
+			entryModule.exportsArgument !== RuntimeGlobals.exports ||
+			!codeGenerationResults.has(entryModule, chunk.runtime)
+		) {
+			return undefined;
+		}
+		const runtimeRequirements = chunkGraph.getModuleRuntimeRequirements(
+			entryModule,
+			chunk.runtime
+		);
+		// `module`/`this`-as-exports modules need the factory wrapper.
+		if (
+			runtimeRequirements.has(RuntimeGlobals.module) ||
+			runtimeRequirements.has(RuntimeGlobals.thisAsExports)
+		) {
+			return undefined;
+		}
+		const { data } = codeGenerationResults.get(entryModule, chunk.runtime);
+		const topLevelDeclarations =
+			(data && data.get("topLevelDeclarations")) ||
+			(entryModule.buildInfo && entryModule.buildInfo.topLevelDeclarations);
+		if (!topLevelDeclarations || topLevelDeclarations.size === 0) {
+			return undefined;
+		}
+		// A declaration that collides with a runtime/startup identifier would be
+		// shadowed once lifted to the chunk scope, so bail instead of renaming.
+		for (const name of topLevelDeclarations) {
+			if (RESERVED_NAMES.has(name) || name.startsWith("__webpack_")) {
+				return undefined;
+			}
+		}
+		// If another active in-chunk module imports the entry, it must stay in the
+		// registry so `__webpack_require__` can resolve it.
+		const referenced = someInIterable(
+			moduleGraph.getIncomingConnectionsByOriginModule(entryModule),
+			([originModule, connections]) =>
+				originModule &&
+				originModule !== entryModule &&
+				connections.some((c) => c.isTargetActive(chunk.runtime)) &&
+				someInIterable(
+					chunkGraph.getModuleRuntimes(originModule),
+					(runtime) => intersectRuntime(runtime, chunk.runtime) !== undefined
+				)
+		);
+		if (referenced) {
+			return undefined;
+		}
+		return entryModule;
 	}
 
 	/**
@@ -1096,9 +1213,7 @@ class JavascriptModulesPlugin {
 			const strictBailout = hooks.strictRuntimeBailout.call(renderContext);
 			if (strictBailout) {
 				source.add(
-					`${
-						prefix
-					}// runtime can't be in strict mode because ${strictBailout}.\n`
+					`${prefix}// runtime can't be in strict mode because ${strictBailout}.\n`
 				);
 			} else {
 				allStrict = true;
@@ -1272,7 +1387,9 @@ class JavascriptModulesPlugin {
 							);
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
 							startupSource.add(
-								`${runtimeTemplate.renderLet()} ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
+								`${runtimeTemplate.renderLet()} ${m.exportsArgument} = ${
+									RuntimeGlobals.exports
+								};\n`
 							);
 						}
 					}
@@ -1712,9 +1829,13 @@ class JavascriptModulesPlugin {
 								(() => {
 									if (needThisAsExports) {
 										const comma = args.length ? "," : "";
-										return `__webpack_modules__[${moduleIdExpr}].call(${RuntimeGlobals.exports}${comma}${args.join(",")});`;
+										return `__webpack_modules__[${moduleIdExpr}].call(${
+											RuntimeGlobals.exports
+										}${comma}${args.join(",")});`;
 									}
-									return `__webpack_modules__[${moduleIdExpr}](${args.join(",")});`;
+									return `__webpack_modules__[${moduleIdExpr}](${args.join(
+										","
+									)});`;
 								})()
 							)
 						);

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1067,9 +1067,11 @@ class JavascriptModulesPlugin {
 	}
 
 	/**
-	 * Decides whether an entry chunk's single entry module can be inlined at the
-	 * top level of an ESM output chunk (instead of the registry), which keeps its
-	 * exports as live ESM bindings. Returns the module when safe, else `undefined`.
+	 * Returns the chunk's single entry module when it can be inlined at the top
+	 * level of an ESM output chunk (instead of the module registry), which keeps
+	 * its exports as live ESM bindings. Only a self-contained ESM entry whose
+	 * top-level declarations can be lifted into the chunk scope qualifies;
+	 * otherwise `undefined` is returned and the registry path is used.
 	 * @param {RenderContext} renderContext render context
 	 * @param {Module[]} allModules all javascript modules of the chunk
 	 * @returns {Module | undefined} the entry module to inline, if any
@@ -1082,7 +1084,8 @@ class JavascriptModulesPlugin {
 			runtimeTemplate,
 			codeGenerationResults
 		} = renderContext;
-		// Only ESM entry chunks whose runtime lives in a separate chunk.
+
+		// Only a single ESM entry whose runtime lives in a separate chunk.
 		if (
 			!runtimeTemplate.isModule() ||
 			chunk.hasRuntime() ||
@@ -1095,33 +1098,16 @@ class JavascriptModulesPlugin {
 		const [entryModule, entrypoint] = /** @type {[Module, Entrypoint]} */ (
 			entryEntry
 		);
-		// `dependOn` entries share execution ordering with their parents; keep
-		// them on the registry path rather than reasoning about inline ordering.
-		if (entrypoint.getParents().length > 0) {
-			return undefined;
-		}
-		// When the entry depends on chunks other than this one and the runtime
-		// (e.g. split chunks), its execution must be delayed, so it can't be
-		// inlined at the top level.
-		if (
-			getAllChunks(entrypoint, chunk, entrypoint.getRuntimeChunk()).size > 0
-		) {
-			return undefined;
-		}
-		// Needs standard exports binding and known top-level declarations to be
-		// safely lifted to the chunk scope.
-		if (
-			entryModule.exportsArgument !== RuntimeGlobals.exports ||
-			!codeGenerationResults.has(entryModule, chunk.runtime)
-		) {
-			return undefined;
-		}
+
+		// Module-local safety: the body is lifted verbatim, so it must use the
+		// standard exports binding (not `module`/`this`) and expose top-level
+		// declarations whose names can't collide with runtime/startup identifiers.
 		const runtimeRequirements = chunkGraph.getModuleRuntimeRequirements(
 			entryModule,
 			chunk.runtime
 		);
-		// `module`/`this`-as-exports modules need the factory wrapper.
 		if (
+			entryModule.exportsArgument !== RuntimeGlobals.exports ||
 			runtimeRequirements.has(RuntimeGlobals.module) ||
 			runtimeRequirements.has(RuntimeGlobals.thisAsExports)
 		) {
@@ -1134,15 +1120,21 @@ class JavascriptModulesPlugin {
 		if (!topLevelDeclarations || topLevelDeclarations.size === 0) {
 			return undefined;
 		}
-		// A declaration that collides with a runtime/startup identifier would be
-		// shadowed once lifted to the chunk scope, so bail instead of renaming.
 		for (const name of topLevelDeclarations) {
 			if (RESERVED_NAMES.has(name) || name.startsWith("__webpack_")) {
 				return undefined;
 			}
 		}
-		// If another active in-chunk module imports the entry, it must stay in the
-		// registry so `__webpack_require__` can resolve it.
+
+		// Self-contained: the entry must not be imported by another module (which
+		// needs it in the registry), and must not require other chunks or
+		// `dependOn` parents to execute first.
+		if (
+			entrypoint.getParents().length > 0 ||
+			getAllChunks(entrypoint, chunk, entrypoint.getRuntimeChunk()).size > 0
+		) {
+			return undefined;
+		}
 		const referenced = someInIterable(
 			moduleGraph.getIncomingConnectionsByOriginModule(entryModule),
 			([originModule, connections]) =>
@@ -1154,10 +1146,7 @@ class JavascriptModulesPlugin {
 					(runtime) => intersectRuntime(runtime, chunk.runtime) !== undefined
 				)
 		);
-		if (referenced) {
-			return undefined;
-		}
-		return entryModule;
+		return referenced ? undefined : entryModule;
 	}
 
 	/**

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -11,6 +11,7 @@ const ExternalModule = require("../ExternalModule");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
+const HarmonyExportSpecifierDependency = require("../dependencies/HarmonyExportSpecifierDependency");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("../optimize/ConcatenatedModule");
 const { InlinedUsedName } = require("../optimize/InlineExports");
@@ -406,6 +407,33 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 				.treatAsCommonJs;
 		const skipRenderDefaultExport = Boolean(treatAsCommonJs);
 
+		// A single (non-concatenated) inlined entry is rendered at the top
+		// level, so its own declarations are top-level bindings we can export
+		// directly — keeping ESM live bindings instead of snapshotting
+		// `__webpack_exports__.x` into a `const`. Concatenated entries already
+		// get direct bindings via `definitions` above.
+		/** @type {Map<string, string> | undefined} */
+		let directBindings;
+		if (isInlinedEntryWithoutIIFE && !treatAsCommonJs) {
+			const { data } = codeGenerationResults.get(module, chunk.runtime);
+			const topLevelDeclarations =
+				(data && data.get("topLevelDeclarations")) ||
+				(module.buildInfo && module.buildInfo.topLevelDeclarations);
+			if (topLevelDeclarations) {
+				for (const dep of module.dependencies) {
+					if (
+						dep instanceof HarmonyExportSpecifierDependency &&
+						topLevelDeclarations.has(dep.id)
+					) {
+						(directBindings || (directBindings = new Map())).set(
+							dep.name,
+							dep.id
+						);
+					}
+				}
+			}
+		}
+
 		const moduleExportsInfo = moduleGraph.getExportsInfo(module);
 
 		// Define ESM compatibility flag will rely on `__webpack_exports__`
@@ -455,10 +483,19 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 			/** @type {string | undefined} */
 			const definition = definitions[usedName];
 			/** @type {string | undefined} */
+			const directLocal =
+				definition === undefined && directBindings
+					? directBindings.get(originalName)
+					: undefined;
+			/** @type {string | undefined} */
 			let finalName;
 
 			if (definition) {
 				finalName = definition;
+			} else if (directLocal !== undefined) {
+				// Live binding to the inlined entry's own top-level declaration
+				finalName = directLocal;
+				needExportsDeclaration = true;
 			} else {
 				// Fallback to `__webpack_exports__` property access
 				// when no direct export binding was found
@@ -498,7 +535,7 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 				}
 			} else {
 				shortHandedExports.push(
-					definition && finalName === originalName
+					finalName === originalName
 						? finalName
 						: `${finalName} as ${originalName}`
 				);

--- a/test/configCases/library/module-live-bindings-0-create/dep.js
+++ b/test/configCases/library/module-live-bindings-0-create/dep.js
@@ -1,0 +1,5 @@
+export let depCount = 0;
+
+export function bumpDep() {
+	depCount += 1;
+}

--- a/test/configCases/library/module-live-bindings-0-create/lib.js
+++ b/test/configCases/library/module-live-bindings-0-create/lib.js
@@ -1,0 +1,7 @@
+export let count = 0;
+
+export function increment() {
+	count++;
+}
+
+export { count as aliased };

--- a/test/configCases/library/module-live-bindings-0-create/lib.js
+++ b/test/configCases/library/module-live-bindings-0-create/lib.js
@@ -1,7 +1,30 @@
-export let count = 0;
+import { bumpDep } from "./dep.js";
+import { bumpStar } from "./star-dep.js";
 
-export function increment() {
-	count++;
+// Direct exports of every declaration kind, plus mutation forms.
+export let mutLet = 0;
+export var mutVar = 1;
+export const constVal = "const";
+export function fn() {
+	return "fn";
 }
+export class Cls {
+	value() {
+		return "cls";
+	}
+}
+export default function defFn() {
+	return "def";
+}
+export { mutLet as aliased };
 
-export { count as aliased };
+// Re-exports (live once concatenated into the entry).
+export { depCount } from "./dep.js";
+export * from "./star-dep.js";
+
+export function mutate() {
+	mutLet += 1;
+	mutVar++;
+	bumpDep();
+	bumpStar();
+}

--- a/test/configCases/library/module-live-bindings-0-create/star-dep.js
+++ b/test/configCases/library/module-live-bindings-0-create/star-dep.js
@@ -1,0 +1,5 @@
+export let starCount = 0;
+
+export function bumpStar() {
+	starCount += 1;
+}

--- a/test/configCases/library/module-live-bindings-0-create/test.config.js
+++ b/test/configCases/library/module-live-bindings-0-create/test.config.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.noTests = true;

--- a/test/configCases/library/module-live-bindings-0-create/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-0-create/webpack.config.js
@@ -1,6 +1,8 @@
 "use strict";
 
 /**
+ * Asserts the emitted entry keeps live ESM bindings (direct top-level
+ * declarations) instead of snapshotting them through `__webpack_exports__`.
  * @param {string} assetName emitted entry asset to assert on
  * @returns {(this: import("../../../../").Compiler) => void} plugin
  */
@@ -9,38 +11,38 @@ const assertLiveBindings = (assetName) =>
 		this.hooks.compilation.tap("testcase", (compilation) => {
 			compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
 				const source = assets[assetName].source();
-				// The entry's own exports must be live bindings to its top-level
-				// declarations, not snapshots of `__webpack_exports__`.
 				expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
-				expect(source).toMatch(/export \{[^}]*\bcount\b/);
+				expect(source).toMatch(/export \{[^}]*\bmutLet\b/);
 			});
 		});
 	};
 
+/**
+ * @param {string} name output sub-directory
+ * @param {string} entryAsset emitted entry asset to assert on
+ * @param {"development" | "production"} mode mode
+ * @param {false | "single"} runtimeChunk runtime chunk option
+ * @returns {import("../../../../").Configuration} config
+ */
+const variant = (name, entryAsset, mode, runtimeChunk) => ({
+	mode,
+	devtool: false,
+	entry: { [entryAsset.replace(/\..*$/, "")]: "./lib.js" },
+	target: "node14",
+	output: {
+		filename: `${name}/[name].mjs`,
+		module: true,
+		library: { type: "module" }
+	},
+	optimization: { concatenateModules: true, runtimeChunk, minimize: false },
+	experiments: { outputModule: true },
+	plugins: [assertLiveBindings(`${name}/${entryAsset}`)]
+});
+
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	{
-		entry: "./lib.js",
-		target: "node14",
-		output: {
-			filename: "lib.js",
-			module: true,
-			library: { type: "module" }
-		},
-		optimization: { concatenateModules: true },
-		experiments: { outputModule: true },
-		plugins: [assertLiveBindings("lib.js")]
-	},
-	{
-		entry: "./lib.js",
-		target: "node14",
-		output: {
-			filename: "runtime-chunk/[name].mjs",
-			module: true,
-			library: { type: "module" }
-		},
-		optimization: { concatenateModules: true, runtimeChunk: "single" },
-		experiments: { outputModule: true },
-		plugins: [assertLiveBindings("runtime-chunk/main.mjs")]
-	}
+	variant("single", "lib.mjs", "development", false),
+	variant("single-prod", "lib.mjs", "production", false),
+	variant("runtime", "main.mjs", "development", "single"),
+	variant("runtime-prod", "main.mjs", "production", "single")
 ];

--- a/test/configCases/library/module-live-bindings-0-create/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-0-create/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./lib.js",
+	target: "node14",
+	output: {
+		filename: "lib.js",
+		module: true,
+		library: { type: "module" }
+	},
+	optimization: { concatenateModules: true },
+	experiments: { outputModule: true },
+	plugins: [
+		/**
+		 * @this {import("../../../../").Compiler} compiler
+		 */
+		function apply() {
+			this.hooks.compilation.tap("testcase", (compilation) => {
+				compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
+					const source = assets["lib.js"].source();
+					// The inlined entry's own exports must be live bindings to its
+					// top-level declarations, not snapshots of `__webpack_exports__`.
+					expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
+					expect(source).toMatch(/export \{[^}]*\bcount\b/);
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/library/module-live-bindings-0-create/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-0-create/webpack.config.js
@@ -1,30 +1,46 @@
 "use strict";
 
-/** @type {import("../../../../").Configuration} */
-module.exports = {
-	entry: "./lib.js",
-	target: "node14",
-	output: {
-		filename: "lib.js",
-		module: true,
-		library: { type: "module" }
-	},
-	optimization: { concatenateModules: true },
-	experiments: { outputModule: true },
-	plugins: [
-		/**
-		 * @this {import("../../../../").Compiler} compiler
-		 */
-		function apply() {
-			this.hooks.compilation.tap("testcase", (compilation) => {
-				compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
-					const source = assets["lib.js"].source();
-					// The inlined entry's own exports must be live bindings to its
-					// top-level declarations, not snapshots of `__webpack_exports__`.
-					expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
-					expect(source).toMatch(/export \{[^}]*\bcount\b/);
-				});
+/**
+ * @param {string} assetName emitted entry asset to assert on
+ * @returns {(this: import("../../../../").Compiler) => void} plugin
+ */
+const assertLiveBindings = (assetName) =>
+	function apply() {
+		this.hooks.compilation.tap("testcase", (compilation) => {
+			compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
+				const source = assets[assetName].source();
+				// The entry's own exports must be live bindings to its top-level
+				// declarations, not snapshots of `__webpack_exports__`.
+				expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
+				expect(source).toMatch(/export \{[^}]*\bcount\b/);
 			});
-		}
-	]
-};
+		});
+	};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		entry: "./lib.js",
+		target: "node14",
+		output: {
+			filename: "lib.js",
+			module: true,
+			library: { type: "module" }
+		},
+		optimization: { concatenateModules: true },
+		experiments: { outputModule: true },
+		plugins: [assertLiveBindings("lib.js")]
+	},
+	{
+		entry: "./lib.js",
+		target: "node14",
+		output: {
+			filename: "runtime-chunk/[name].mjs",
+			module: true,
+			library: { type: "module" }
+		},
+		optimization: { concatenateModules: true, runtimeChunk: "single" },
+		experiments: { outputModule: true },
+		plugins: [assertLiveBindings("runtime-chunk/main.mjs")]
+	}
+];

--- a/test/configCases/library/module-live-bindings-1-use/index.js
+++ b/test/configCases/library/module-live-bindings-1-use/index.js
@@ -1,0 +1,9 @@
+import { count, increment, aliased } from "library";
+
+it("should keep live bindings to a module library's entry exports", () => {
+	expect(count).toBe(0);
+	expect(aliased).toBe(0);
+	increment();
+	expect(count).toBe(1);
+	expect(aliased).toBe(1);
+});

--- a/test/configCases/library/module-live-bindings-1-use/index.js
+++ b/test/configCases/library/module-live-bindings-1-use/index.js
@@ -1,4 +1,9 @@
 import { count, increment, aliased } from "library";
+import {
+	count as rcCount,
+	increment as rcIncrement,
+	aliased as rcAliased
+} from "library-runtime-chunk";
 
 it("should keep live bindings to a module library's entry exports", () => {
 	expect(count).toBe(0);
@@ -6,4 +11,12 @@ it("should keep live bindings to a module library's entry exports", () => {
 	increment();
 	expect(count).toBe(1);
 	expect(aliased).toBe(1);
+});
+
+it("should keep live bindings when the runtime is a separate chunk", () => {
+	expect(rcCount).toBe(0);
+	expect(rcAliased).toBe(0);
+	rcIncrement();
+	expect(rcCount).toBe(1);
+	expect(rcAliased).toBe(1);
 });

--- a/test/configCases/library/module-live-bindings-1-use/index.js
+++ b/test/configCases/library/module-live-bindings-1-use/index.js
@@ -1,22 +1,37 @@
-import { count, increment, aliased } from "library";
-import {
-	count as rcCount,
-	increment as rcIncrement,
-	aliased as rcAliased
-} from "library-runtime-chunk";
+import * as single from "lib-single";
+import * as singleProd from "lib-single-prod";
+import * as runtime from "lib-runtime";
+import * as runtimeProd from "lib-runtime-prod";
 
-it("should keep live bindings to a module library's entry exports", () => {
-	expect(count).toBe(0);
-	expect(aliased).toBe(0);
-	increment();
-	expect(count).toBe(1);
-	expect(aliased).toBe(1);
-});
+/**
+ * @param {EXPECTED_ANY} ns imported library namespace
+ * @param {string} label variant label
+ */
+function checkLiveBindings(ns, label) {
+	it(`should expose live bindings for all export kinds (${label})`, () => {
+		// Initial values across every export kind.
+		expect(ns.mutLet).toBe(0);
+		expect(ns.mutVar).toBe(1);
+		expect(ns.constVal).toBe("const");
+		expect(ns.aliased).toBe(0);
+		expect(ns.depCount).toBe(0);
+		expect(ns.starCount).toBe(0);
+		expect(ns.fn()).toBe("fn");
+		expect(new ns.Cls().value()).toBe("cls");
+		expect(ns.default()).toBe("def");
 
-it("should keep live bindings when the runtime is a separate chunk", () => {
-	expect(rcCount).toBe(0);
-	expect(rcAliased).toBe(0);
-	rcIncrement();
-	expect(rcCount).toBe(1);
-	expect(rcAliased).toBe(1);
-});
+		// Mutations are observed live through the namespace, including across
+		// direct exports, aliases, named re-exports and `export *`.
+		ns.mutate();
+		expect(ns.mutLet).toBe(1);
+		expect(ns.mutVar).toBe(2);
+		expect(ns.aliased).toBe(1);
+		expect(ns.depCount).toBe(1);
+		expect(ns.starCount).toBe(1);
+	});
+}
+
+checkLiveBindings(single, "single chunk");
+checkLiveBindings(singleProd, "single chunk, production");
+checkLiveBindings(runtime, "separate runtime chunk");
+checkLiveBindings(runtimeProd, "separate runtime chunk, production");

--- a/test/configCases/library/module-live-bindings-1-use/test.config.js
+++ b/test/configCases/library/module-live-bindings-1-use/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["bundle.mjs"];
+	}
+};

--- a/test/configCases/library/module-live-bindings-1-use/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-1-use/webpack.config.js
@@ -1,22 +1,17 @@
 "use strict";
 
-const path = require("path");
-
 /** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration} */
-module.exports = (env, { testPath }) => ({
+module.exports = () => ({
 	target: "node14",
 	output: { filename: "bundle.mjs", module: true },
 	experiments: { outputModule: true },
-	resolve: {
-		alias: {
-			library: path.resolve(testPath, "../module-live-bindings-0-create/lib.js")
-		}
-	},
 	externalsType: "module",
-	// The runtime-chunk library is two linked ESM files, so consume it as a real
-	// external module instead of re-bundling it.
+	// Consume each built library as a real external ESM module so the emitted
+	// `export { ... }` statements are exercised natively (live bindings).
 	externals: {
-		"library-runtime-chunk":
-			"../module-live-bindings-0-create/runtime-chunk/main.mjs"
+		"lib-single": "../module-live-bindings-0-create/single/lib.mjs",
+		"lib-single-prod": "../module-live-bindings-0-create/single-prod/lib.mjs",
+		"lib-runtime": "../module-live-bindings-0-create/runtime/main.mjs",
+		"lib-runtime-prod": "../module-live-bindings-0-create/runtime-prod/main.mjs"
 	}
 });

--- a/test/configCases/library/module-live-bindings-1-use/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-1-use/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration} */
+module.exports = (env, { testPath }) => ({
+	target: "node14",
+	resolve: {
+		alias: {
+			library: path.resolve(testPath, "../module-live-bindings-0-create/lib.js")
+		}
+	}
+});

--- a/test/configCases/library/module-live-bindings-1-use/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-1-use/webpack.config.js
@@ -5,9 +5,18 @@ const path = require("path");
 /** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration} */
 module.exports = (env, { testPath }) => ({
 	target: "node14",
+	output: { filename: "bundle.mjs", module: true },
+	experiments: { outputModule: true },
 	resolve: {
 		alias: {
 			library: path.resolve(testPath, "../module-live-bindings-0-create/lib.js")
 		}
+	},
+	externalsType: "module",
+	// The runtime-chunk library is two linked ESM files, so consume it as a real
+	// external module instead of re-bundling it.
+	externals: {
+		"library-runtime-chunk":
+			"../module-live-bindings-0-create/runtime-chunk/main.mjs"
 	}
 });


### PR DESCRIPTION
A single, non-concatenated entry rendered as a "module" library snapshotted
its exports as `const __webpack_exports__x = __webpack_exports__.x`, which
froze the value and broke ESM live bindings for consumers. Reference the
inlined entry's own top-level declarations directly so mutations stay
observable, matching the concatenated-entry behavior.