### PR TITLE
fix: merge undersized split chunks modules into the best-matching group

### DIFF
--- a/.changeset/fix-deterministic-grouping-merge-target.md
+++ b/.changeset/fix-deterministic-grouping-merge-target.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix SplitChunks merging undersized modules into the wrong result group.

--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -168,15 +168,14 @@ const getTooSmallTypes = (size, minSize) => {
 
 /**
  * Gets number of matching size types.
- * @template {object} T
- * @param {T} size size
+ * @param {Sizes} size size
  * @param {Types} types types
  * @returns {number} number of matching size types
  */
 const getNumberOfMatchingSizeTypes = (size, types) => {
 	let i = 0;
 	for (const key in size) {
-		if (size[/** @type {keyof T} */ (key)] !== 0 && types.has(key)) i++;
+		if (size[key] !== 0 && types.has(key)) i++;
 	}
 	return i;
 };
@@ -378,9 +377,12 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 				);
 				if (possibleResultGroups.length > 0) {
 					const bestGroup = possibleResultGroups.reduce((min, group) => {
-						const minMatches = getNumberOfMatchingSizeTypes(min, problemTypes);
+						const minMatches = getNumberOfMatchingSizeTypes(
+							min.size,
+							problemTypes
+						);
 						const groupMatches = getNumberOfMatchingSizeTypes(
-							group,
+							group.size,
 							problemTypes
 						);
 						if (minMatches !== groupMatches) {

--- a/test/statsCases/split-chunks-max-size-mixed-types/__snapshots__/StatsTest.snap
+++ b/test/statsCases/split-chunks-max-size-mixed-types/__snapshots__/StatsTest.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsTestCases split-chunks-max-size-mixed-types should print correct stats for split-chunks-max-size-mixed-types 1`] = `
+"Entrypoint main X KiB = main.js
+chunk (runtime: main) grp-XXXXXXXX.css (grp-13f8acea) X bytes <{792}> ={268}= ={710}= ={784}= [rendered]
+  css ./n6.css X bytes [built] [code generated]
+chunk (runtime: main) grp-XXXXXXXX-XXXXXXXX.js (grp-79255960-d809195c) X bytes (asset) X bytes (javascript) <{792}> ={37}= ={710}= ={784}= [rendered]
+  ./n5.bin X bytes (asset) X bytes (javascript) [built] [code generated]
+  ./n7.bin X bytes (asset) X bytes (javascript) [built] [code generated]
+chunk (runtime: main) grp-XXXXXXXX.js, grp-XXXXXXXX.css (grp-cedfdf0c) X bytes (javascript) X bytes (css) <{792}> ={37}= ={268}= ={784}= [rendered]
+  ./n3.js X bytes [built] [code generated]
+  css ./n1.css X bytes (javascript) X bytes (css) [built] [code generated]
+chunk (runtime: main) grp-XXXXXXXX-XXXXXXXX.js (grp-79255960-79255960) X bytes (asset) X bytes (javascript) <{792}> ={37}= ={268}= ={710}= [rendered]
+  ./n2.bin X bytes (asset) X bytes (javascript) [built] [code generated]
+  ./n4.bin X bytes (asset) X bytes (javascript) [built] [code generated]
+chunk (runtime: main) main.js (main) X bytes (javascript) X KiB (runtime) >{37}< >{268}< >{710}< >{784}< [entry] [rendered]
+  runtime modules X KiB 12 modules
+  ./index.js X bytes [built] [code generated]
+webpack x.x.x compiled successfully"
+`;

--- a/test/statsCases/split-chunks-max-size-mixed-types/index.js
+++ b/test/statsCases/split-chunks-max-size-mixed-types/index.js
@@ -1,0 +1,9 @@
+const g = "grp";
+Promise.all([
+  import(/* webpackChunkName: "grp" */ "./n1.css"),
+  import(/* webpackChunkName: "grp" */ "./n2.bin"),
+  import(/* webpackChunkName: "grp" */ "./n3.js"),
+  import(/* webpackChunkName: "grp" */ "./n4.bin"),
+  import(/* webpackChunkName: "grp" */ "./n5.bin"),
+  import(/* webpackChunkName: "grp" */ "./n7.bin")
+]).then(() => console.log(g));

--- a/test/statsCases/split-chunks-max-size-mixed-types/n1.css
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n1.css
@@ -1,0 +1,2 @@
+@import "./n6.css";
+.m{color:red}

--- a/test/statsCases/split-chunks-max-size-mixed-types/n2.bin
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n2.bin
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaa

--- a/test/statsCases/split-chunks-max-size-mixed-types/n3.js
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n3.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/statsCases/split-chunks-max-size-mixed-types/n4.bin
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n4.bin
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/test/statsCases/split-chunks-max-size-mixed-types/n5.bin
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n5.bin
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/test/statsCases/split-chunks-max-size-mixed-types/n6.css
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n6.css
@@ -1,0 +1,1 @@
+.leafaaaaaaaaaaaaaaaaaaaa{color:blue}

--- a/test/statsCases/split-chunks-max-size-mixed-types/n7.bin
+++ b/test/statsCases/split-chunks-max-size-mixed-types/n7.bin
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/test/statsCases/split-chunks-max-size-mixed-types/webpack.config.js
+++ b/test/statsCases/split-chunks-max-size-mixed-types/webpack.config.js
@@ -1,0 +1,43 @@
+"use strict";
+
+// Regression for the deterministicGrouping merge-target bug: when maxSize
+// splitting hits the undersized edge case, problematic modules must merge into
+// the result group sharing the most size types. The async "grp" chunk mixes
+// asset, javascript and css size types so all three participate in grouping.
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		css: true
+	},
+	module: {
+		rules: [{ test: /\.bin$/, type: "asset/resource" }]
+	},
+	optimization: {
+		minimize: false,
+		concatenateModules: false,
+		splitChunks: {
+			chunks: "all",
+			minSize: { javascript: 70, asset: 40, css: 20 },
+			maxSize: { javascript: 110, asset: 90, css: 80 },
+			minSizeReduction: 0,
+			minRemainingSize: 0,
+			cacheGroups: { default: false, defaultVendors: false }
+		}
+	},
+	stats: {
+		hash: false,
+		timings: false,
+		builtAt: false,
+		assets: false,
+		chunks: true,
+		chunkModules: true,
+		chunkRelations: true,
+		entrypoints: true,
+		modules: false
+	}
+};


### PR DESCRIPTION
**Summary**

In `deterministicGrouping` (used by `SplitChunksPlugin` to enforce `maxSize`), when a working set is already smaller than `minSize` the problematic modules are merged into an existing result group, preferring the group that shares the most problematic size types. That tiebreak passed the whole `Group` object to `getNumberOfMatchingSizeTypes` instead of `group.size`, so the helper iterated the `Group`'s own keys (`nodes`, `similarities`, `size`, `key`) and always returned `0`. The preference was dead code, and the merge always fell through to the smallest-size branch — placing modules in a group sharing fewer of the relevant size types. The fix passes `.size` and restores the helper's `Sizes` parameter type so a future regression is caught by `tsc`.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/statsCases/split-chunks-max-size-mixed-types` drives a real build whose async chunk mixes asset, javascript and css size types; before the fix two asset modules were merged into the css/javascript group, after the fix they stay grouped with the other assets.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to locate the defect, brute-force a minimal reproduction for the test, and draft the fix and this description; all changes were reviewed and verified by running the test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MxLadiwVoQmmbaH7cdbVv)_