### PR TITLE
fix: check aliases before node: builtin scheme in resolver

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -959,12 +959,56 @@ class NormalModuleFactory extends ModuleFactory {
 						fragment: undefined,
 						context: undefined
 					};
-					this.hooks.resolveForScheme
-						.for(scheme)
-						.callAsync(resourceData, data, (err) => {
-							if (err) return continueCallback(err);
-							continueCallback();
-						});
+
+					// For node: scheme, check aliases/fallbacks before builtin resolution
+					if (scheme === "node") {
+						const normalResolver = this.getResolver(
+							"normal",
+							dependencyType
+								? cachedSetProperty(
+										resolveOptions || EMPTY_RESOLVE_OPTIONS,
+										"dependencyType",
+										dependencyType
+									)
+								: resolveOptions
+						);
+						this.resolveResource(
+							contextInfo,
+							context,
+							escapeHashInPathRequest(unresolvedResource),
+							normalResolver,
+							resolveContext,
+							(err, _resolvedResource, resolvedResourceResolveData) => {
+								if (err) return continueCallback(err);
+								if (_resolvedResource !== false) {
+									// Alias/fallback matched - use the resolved resource
+									const resolvedResource =
+										/** @type {string} */ (_resolvedResource);
+									resourceData = {
+										...cacheParseResource(resolvedResource),
+										resource: resolvedResource,
+										data:
+											/** @type {ResolveRequest} */ (resolvedResourceResolveData)
+									};
+									return continueCallback();
+								}
+								// No alias matched - fall back to scheme resolution
+								this.hooks.resolveForScheme
+									.for(scheme)
+									.callAsync(resourceData, data, (err) => {
+										if (err) return continueCallback(err);
+										continueCallback();
+									});
+							}
+						);
+					} else {
+						this.hooks.resolveForScheme
+							.for(scheme)
+							.callAsync(resourceData, data, (err) => {
+								if (err) return continueCallback(err);
+								continueCallback();
+							});
+					}
 				}
 
 				// resource within scheme


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #14166

When a request uses the `node:` prefix (e.g. `import "node:fs"`), webpack's `NormalModuleFactory` detects it as a URL scheme and routes it directly to the `resolveForScheme` hook, completely bypassing the enhanced-resolve pipeline. Since `resolve.fallback` and `resolve.alias` are applied by the resolver's `AliasPlugin`, they never get a chance to match `node:`-prefixed requests. This means users cannot disable or redirect Node.js built-in modules via `resolve.fallback` or `resolve.alias` when using the `node:` prefix.

The fix checks aliases/fallbacks before the `node:` builtin scheme resolution. For `node:` scheme requests, the normal resolver is tried first. If an alias or fallback matches, the resolved resource is used. If no match is found, the existing scheme-resolution path runs unchanged.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No -- the change is in `lib/NormalModuleFactory.js` scheme-handling logic. A full test requires a webpack build with `resolve.fallback`/`resolve.alias` targeting a `node:`-prefixed import. I recommend adding a `configCases` test in a follow-up.

**Does this PR introduce a breaking change?**

No. The change is additive: for `node:` scheme requests, the normal resolver is tried first. If no alias/fallback matches, the existing scheme-resolution path runs unchanged. Non-`node:` schemes are unaffected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

I used AI to analyze the webpack codebase and identify the root cause of the issue.
