### PR TITLE
feat: deprecate parser importMetaContext in favor of importMeta.webpackContext

### DIFF
--- a/.changeset/deprecate-import-meta-context.md
+++ b/.changeset/deprecate-import-meta-context.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Deprecate importMetaContext parser option in favor of importMeta.webpackContext.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -3744,7 +3744,8 @@ export interface JavascriptParserOptions {
 	 */
 	importMeta?: boolean | "preserve-unknown" | ImportMetaParserOptions;
 	/**
-	 * Enable/disable evaluating import.meta.webpackContext.
+	 * @deprecated
+	 * Deprecated in favor of "importMeta" object option with a "webpackContext" field. Enable/disable evaluating import.meta.webpackContext.
 	 */
 	importMetaContext?: boolean;
 	/**

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2271,8 +2271,9 @@
           ]
         },
         "importMetaContext": {
-          "description": "Enable/disable evaluating import.meta.webpackContext.",
-          "type": "boolean"
+          "description": "Deprecated in favor of \"importMeta\" object option with a \"webpackContext\" field. Enable/disable evaluating import.meta.webpackContext.",
+          "type": "boolean",
+          "deprecated": true
         },
         "node": {
           "$ref": "#/definitions/Node"

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -3243,13 +3243,13 @@ Object {
   "module-parser-javascript-auto-import-meta-context": Object {
     "configs": Array [
       Object {
-        "description": "Enable/disable evaluating import.meta.webpackContext.",
+        "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
         "multiple": false,
         "path": "module.parser.javascript/auto.importMetaContext",
         "type": "boolean",
       },
     ],
-    "description": "Enable/disable evaluating import.meta.webpackContext.",
+    "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -4189,13 +4189,13 @@ Object {
   "module-parser-javascript-dynamic-import-meta-context": Object {
     "configs": Array [
       Object {
-        "description": "Enable/disable evaluating import.meta.webpackContext.",
+        "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
         "multiple": false,
         "path": "module.parser.javascript/dynamic.importMetaContext",
         "type": "boolean",
       },
     ],
-    "description": "Enable/disable evaluating import.meta.webpackContext.",
+    "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -5108,13 +5108,13 @@ Object {
   "module-parser-javascript-esm-import-meta-context": Object {
     "configs": Array [
       Object {
-        "description": "Enable/disable evaluating import.meta.webpackContext.",
+        "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
         "multiple": false,
         "path": "module.parser.javascript/esm.importMetaContext",
         "type": "boolean",
       },
     ],
-    "description": "Enable/disable evaluating import.meta.webpackContext.",
+    "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -5775,13 +5775,13 @@ Object {
   "module-parser-javascript-import-meta-context": Object {
     "configs": Array [
       Object {
-        "description": "Enable/disable evaluating import.meta.webpackContext.",
+        "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
         "multiple": false,
         "path": "module.parser.javascript.importMetaContext",
         "type": "boolean",
       },
     ],
-    "description": "Enable/disable evaluating import.meta.webpackContext.",
+    "description": "Deprecated in favor of \\"importMeta\\" object option with a \\"webpackContext\\" field. Enable/disable evaluating import.meta.webpackContext.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/configCases/module/import-meta-context-priority/context-import-meta-false.js
+++ b/test/configCases/module/import-meta-context-priority/context-import-meta-false.js
@@ -1,0 +1,5 @@
+export default () => {
+	import.meta.webpackContext("./context", {
+		regExp: /value/
+	});
+};

--- a/test/configCases/module/import-meta-context-priority/context-legacy-overridden.js
+++ b/test/configCases/module/import-meta-context-priority/context-legacy-overridden.js
@@ -1,0 +1,5 @@
+export default () => {
+	import.meta.webpackContext("./context", {
+		regExp: /value/
+	});
+};

--- a/test/configCases/module/import-meta-context-priority/index.js
+++ b/test/configCases/module/import-meta-context-priority/index.js
@@ -1,9 +1,17 @@
 import fieldDisabledContext from "./context-field-disabled";
 import fieldEnabledContext from "./context-field-enabled";
+import importMetaFalseContext from "./context-import-meta-false";
 import legacyDisabledContext from "./context-legacy-disabled";
+import legacyOverriddenContext from "./context-legacy-overridden";
 
 it("should prefer importMeta.webpackContext over importMetaContext", () => {
 	expect(legacyDisabledContext).toThrow();
 	expect(fieldEnabledContext).toBe("context-value");
 	expect(fieldDisabledContext).toThrow();
+});
+
+it("should disable import.meta.webpackContext when importMeta is false", () => {
+	expect(importMetaFalseContext).toThrow();
+	// importMeta: false wins over importMetaContext: true
+	expect(legacyOverriddenContext).toThrow();
 });

--- a/test/configCases/module/import-meta-context-priority/webpack.config.js
+++ b/test/configCases/module/import-meta-context-priority/webpack.config.js
@@ -38,6 +38,19 @@ module.exports = {
 					},
 					importMetaContext: true
 				}
+			},
+			{
+				test: /context-import-meta-false\.js$/,
+				parser: {
+					importMeta: false
+				}
+			},
+			{
+				test: /context-legacy-overridden\.js$/,
+				parser: {
+					importMeta: false,
+					importMetaContext: true
+				}
 			}
 		]
 	}

--- a/test/configCases/module/import-meta-hot-priority/hot-default.js
+++ b/test/configCases/module/import-meta-hot-priority/hot-default.js
@@ -1,0 +1,4 @@
+export const hotType = typeof import.meta.webpackHot;
+export const acceptType = typeof import.meta.webpackHot.accept;
+
+import.meta.webpackHot.accept();

--- a/test/configCases/module/import-meta-hot-priority/hot-field-disabled.js
+++ b/test/configCases/module/import-meta-hot-priority/hot-field-disabled.js
@@ -1,0 +1,1 @@
+export const hotType = typeof import.meta.webpackHot;

--- a/test/configCases/module/import-meta-hot-priority/hot-import-meta-false.js
+++ b/test/configCases/module/import-meta-hot-priority/hot-import-meta-false.js
@@ -1,0 +1,1 @@
+export const hotType = typeof import.meta.webpackHot;

--- a/test/configCases/module/import-meta-hot-priority/index.js
+++ b/test/configCases/module/import-meta-hot-priority/index.js
@@ -1,0 +1,16 @@
+import { acceptType, hotType as defaultHotType } from "./hot-default";
+import { hotType as fieldDisabledHotType } from "./hot-field-disabled";
+import { hotType as importMetaFalseHotType } from "./hot-import-meta-false";
+
+it("should keep import.meta.webpackHot enabled by default", () => {
+	expect(defaultHotType).toBe("object");
+	expect(acceptType).toBe("function");
+});
+
+it("should disable import.meta.webpackHot when importMeta is false", () => {
+	expect(importMetaFalseHotType).toBe("undefined");
+});
+
+it("should disable import.meta.webpackHot via object-form webpackHot:false", () => {
+	expect(fieldDisabledHotType).toBe("undefined");
+});

--- a/test/configCases/module/import-meta-hot-priority/webpack.config.js
+++ b/test/configCases/module/import-meta-hot-priority/webpack.config.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { HotModuleReplacementPlugin } = require("../../../../");
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	target: "node",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module"
+	},
+	optimization: {
+		usedExports: false,
+		sideEffects: false
+	},
+	module: {
+		rules: [
+			{
+				test: /hot-import-meta-false\.js$/,
+				parser: {
+					importMeta: false
+				}
+			},
+			{
+				test: /hot-field-disabled\.js$/,
+				parser: {
+					importMeta: {
+						webpackHot: false
+					}
+				}
+			}
+		]
+	},
+	plugins: [new HotModuleReplacementPlugin()]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -12717,7 +12717,8 @@ declare interface JavascriptParserOptions {
 	importMeta?: boolean | "preserve-unknown" | ImportMetaParserOptions;
 
 	/**
-	 * Enable/disable evaluating import.meta.webpackContext.
+	 * Deprecated in favor of "importMeta" object option with a "webpackContext" field. Enable/disable evaluating import.meta.webpackContext.
+	 * @deprecated
 	 */
 	importMetaContext?: boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21327. That PR gave `parser.javascript.importMeta` an object form with a `webpackContext` field, which makes the separate `parser.javascript.importMetaContext` option redundant. This marks `importMetaContext` as deprecated in the schema so the generated types carry an `@deprecated` JSDoc tag; the option still works for backward compatibility. It also adds integration coverage (missing from #21327) for how `importMeta: false` and the object-form fields govern `import.meta.webpackContext` and `import.meta.webpackHot`. Refs #21298.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat (deprecation of a public config option; no behavior change).

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — extended `test/configCases/module/import-meta-context-priority` and added `test/configCases/module/import-meta-hot-priority`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `importMetaContext` keeps working; it is only marked deprecated.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Note that `module.parser.javascript.importMetaContext` is deprecated; use `module.parser.javascript.importMeta: { webpackContext: false }` instead.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to analyze the merged import.meta parser options, implement the deprecation, write the tests, and draft this description. All changes were reviewed by the author.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDrs4VRNRCGSXdQYwwPD5G)_