### PR TITLE
perf(javascript): skip getComments when there are no comments

### DIFF
--- a/.changeset/js-getcomments-empty-fast-path.md
+++ b/.changeset/js-getcomments-empty-fast-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip comment lookup when a module has no comments.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5329,6 +5329,8 @@ class JavascriptParser extends Parser {
 	 * @returns {Comment[]} comments in the range
 	 */
 	getComments(range) {
+		const comments = /** @type {Comment[]} */ (this.comments);
+		if (comments.length === 0) return [];
 		const [rangeStart, rangeEnd] = range;
 		/**
 		 * Returns compared.
@@ -5338,7 +5340,6 @@ class JavascriptParser extends Parser {
 		 */
 		const compare = (comment, needle) =>
 			/** @type {Range} */ (comment.range)[0] - needle;
-		const comments = /** @type {Comment[]} */ (this.comments);
 		let idx = binarySearchBounds.ge(comments, rangeStart, compare);
 		/** @type {Comment[]} */
 		const commentsInRange = [];


### PR DESCRIPTION
**Summary**
Mirror the CssParser fast path so comment-free modules avoid useless binary search and result-array allocation on the isPure hot path.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
perf

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
no

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
nothing

**Use of AI**
part