### PR TITLE
fix(html): correct output.html.integrity and extend SRI to preload hints

### DIFF
--- a/.changeset/fix-html-integrity-rewrite-and-errors.md
+++ b/.changeset/fix-html-integrity-rewrite-and-errors.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `output.html.integrity`: rewrite an authored `integrity` attribute instead of duplicating it, keep the sentinel out of JS chunks so their content hashes stay valid, and report an unsupported hash algorithm as a webpack error instead of crashing.

--- a/.changeset/fix-html-integrity-rewrite-and-errors.md
+++ b/.changeset/fix-html-integrity-rewrite-and-errors.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Fix `output.html.integrity`: rewrite an authored `integrity` attribute instead of duplicating it, keep the sentinel out of JS chunks so their content hashes stay valid, and report an unsupported hash algorithm as a webpack error instead of crashing.

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -561,6 +561,16 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 		if (tagIsNative && dep.tagNameEnd >= 0) {
 			if (crossOrigin) source.insert(dep.tagNameEnd, crossOrigin);
 			if (integrityOn) {
+				// Drop the author's `integrity` first (like clones do) — it's
+				// content-specific and wrong for the rewritten chunk URL, and
+				// leaving it would yield two `integrity` attributes on the tag.
+				if (dep.integrityRange) {
+					source.replace(
+						dep.tagStart + dep.integrityRange[0],
+						dep.tagStart + dep.integrityRange[1] - 1,
+						""
+					);
+				}
 				source.insert(
 					dep.tagNameEnd,
 					` integrity="${HtmlGenerator.makeChunkIntegritySentinel(

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -484,15 +484,74 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 		const orderedChunks = getEntrypointChunksInLoadOrder(entrypoint);
 		const entryChunk = orderedChunks[orderedChunks.length - 1];
 
+		// `crossorigin` mirrors `output.crossOriginLoading` onto every injected
+		// tag. Empty when the option is off or the originating tag already set
+		// `crossorigin` (author value wins, flagged at parse time). Mirrors
+		// webpack's runtime, which sets `crossOrigin` on chunk-loading scripts,
+		// and matches Vite, which emits it on every injected script/stylesheet.
+		const crossOrigin =
+			crossOriginLoading && !dep.hasOwnCrossOrigin
+				? ` crossorigin="${crossOriginLoading}"`
+				: "";
+
+		// Per-chunk SRI: emit an `integrity` sentinel resolved late (after the
+		// chunks' final bytes exist) by `resolveChunkIntegritySentinels`. On when
+		// `output.html.integrity` is `true`, a non-empty array, or a function.
+		const htmlOption = compilation.outputOptions.html;
+		const integrity =
+			typeof htmlOption === "object" ? htmlOption.integrity : undefined;
+		const integrityOn =
+			integrity === true ||
+			typeof integrity === "function" ||
+			(Array.isArray(integrity) && integrity.length > 0);
+
+		/**
+		 * Mirror `crossorigin`/`integrity` onto a native entry tag, inserted right
+		 * after the tag name so they sit alongside any `type="module"` the parser
+		 * injected. The author's content-specific `integrity` is dropped first (as
+		 * clones do) so the tag never carries two.
+		 * @param {Chunk} chunk chunk whose SRI hash the tag references
+		 * @param {"javascript" | "css"} contentHashType which chunk asset to hash
+		 * @returns {void}
+		 */
+		const applyEntryTagAttrs = (chunk, contentHashType) => {
+			if (!dep.tagIsNative || dep.tagNameEnd < 0) return;
+			if (crossOrigin) source.insert(dep.tagNameEnd, crossOrigin);
+			if (integrityOn) {
+				if (dep.integrityRange) {
+					source.replace(
+						dep.tagStart + dep.integrityRange[0],
+						dep.tagStart + dep.integrityRange[1] - 1,
+						""
+					);
+				}
+				source.insert(
+					dep.tagNameEnd,
+					` integrity="${HtmlGenerator.makeChunkIntegritySentinel(
+						chunk,
+						contentHashType
+					)}"`
+				);
+			}
+		};
+
 		// `rel="preload"/"prefetch"` is a resource hint: rewrite the `href` to the
 		// built chunk's URL (CSS for `as="style"`, JS otherwise) and stop — no
-		// sibling tags and no execution; the `<link>` itself is left untouched.
+		// sibling tags and no execution.
 		if (dep.elementKind === "preload" || dep.elementKind === "prefetch") {
-			const url = HtmlGenerator.makeChunkUrlSentinel(
-				entryChunk,
-				dep.category === "css-import" ? "css" : "javascript"
+			const contentHashType =
+				dep.category === "css-import" ? "css" : "javascript";
+			source.replace(
+				dep.range[0],
+				dep.range[1] - 1,
+				HtmlGenerator.makeChunkUrlSentinel(entryChunk, contentHashType)
 			);
-			source.replace(dep.range[0], dep.range[1] - 1, url);
+			// `preload` is integrity-eligible per the SRI spec, so mirror
+			// `crossorigin`/`integrity` onto it (SRI requires CORS). `prefetch` is a
+			// navigation cache hint the spec doesn't cover — leave it a bare href.
+			if (dep.elementKind === "preload") {
+				applyEntryTagAttrs(entryChunk, contentHashType);
+			}
 			return;
 		}
 
@@ -531,55 +590,11 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 		// real native tag is synthesized instead. Decided at parse time from the
 		// tag name (`dep.tagIsNative`) rather than re-parsing the source text.
 		const tagIsNative = dep.tagIsNative;
-
-		// `crossorigin` to mirror `output.crossOriginLoading` onto every injected
-		// tag. Empty when the option is off or the originating tag already set
-		// `crossorigin` (author value wins, flagged at parse time). Mirrors
-		// webpack's runtime, which sets `crossOrigin` on chunk-loading scripts,
-		// and matches Vite, which emits it on every injected script/stylesheet.
-		const crossOrigin =
-			crossOriginLoading && !dep.hasOwnCrossOrigin
-				? ` crossorigin="${crossOriginLoading}"`
-				: "";
 		const tagNameEndInTag = dep.tagNameEnd - dep.tagStart;
 
-		// Per-chunk SRI: emit an `integrity` sentinel resolved late (after the
-		// chunks' final bytes exist) by `resolveChunkIntegritySentinels`. On when
-		// `output.html.integrity` is `true`, a non-empty array, or a function.
-		const htmlOption = compilation.outputOptions.html;
-		const integrity =
-			typeof htmlOption === "object" ? htmlOption.integrity : undefined;
-		const integrityOn =
-			integrity === true ||
-			typeof integrity === "function" ||
-			(Array.isArray(integrity) && integrity.length > 0);
-
 		// Mirror `crossorigin`/`integrity` onto the entry tag too (siblings get
-		// them via the builders below), inserted right after the tag name — its
-		// parse-time offset — so they sit alongside any `type="module"` the
-		// parser injected.
-		if (tagIsNative && dep.tagNameEnd >= 0) {
-			if (crossOrigin) source.insert(dep.tagNameEnd, crossOrigin);
-			if (integrityOn) {
-				// Drop the author's `integrity` first (like clones do) — it's
-				// content-specific and wrong for the rewritten chunk URL, and
-				// leaving it would yield two `integrity` attributes on the tag.
-				if (dep.integrityRange) {
-					source.replace(
-						dep.tagStart + dep.integrityRange[0],
-						dep.tagStart + dep.integrityRange[1] - 1,
-						""
-					);
-				}
-				source.insert(
-					dep.tagNameEnd,
-					` integrity="${HtmlGenerator.makeChunkIntegritySentinel(
-						entryChunk,
-						entryContentHashType
-					)}"`
-				);
-			}
-		}
+		// them via the builders below).
+		applyEntryTagAttrs(entryChunk, entryContentHashType);
 
 		/**
 		 * @param {Chunk} chunk chunk to emit a sibling tag for

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -14,6 +14,7 @@ const {
 } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const WebpackError = require("../WebpackError");
 const memoize = require("../util/memoize");
 const { PUBLIC_PATH_AUTO } = require("../util/publicPathPlaceholder");
 
@@ -87,6 +88,11 @@ const HTML_PAGE_URL_SENTINEL_REGEXP =
 // entirely when the per-asset `integrity` function returns `false`.
 const INTEGRITY_SENTINEL_REGEXP =
 	/ integrity="__WEBPACK_HTML_INTEGRITY__([0-9a-f]+)__([a-z]+)__END__"/g;
+
+// Same attribute, but tolerant of the `\"` escaping the surrounding quotes get
+// when the HTML lives inside a JS string literal — used only to strip it there.
+const INTEGRITY_SENTINEL_STRIP_REGEXP =
+	/ integrity=\\?"__WEBPACK_HTML_INTEGRITY__[0-9a-f]+__[a-z]+__END__\\?"/g;
 
 class HtmlGenerator extends Generator {
 	/**
@@ -196,6 +202,20 @@ class HtmlGenerator extends Generator {
 	}
 
 	/**
+	 * Drop every ` integrity="<sentinel>"` from `content`. Used on the HTML
+	 * string embedded in a JS chunk (e.g. `<iframe srcdoc>`), where a real SRI
+	 * hash can't be produced — the chunk's own bytes aren't final at render time
+	 * — and resolving it later would mutate the chunk after its content hash was
+	 * computed. Only real HTML output assets keep the sentinel for late resolution.
+	 * @param {string} content content
+	 * @returns {string} content with integrity sentinels removed
+	 */
+	static stripChunkIntegritySentinels(content) {
+		if (!content.includes("__WEBPACK_HTML_INTEGRITY__")) return content;
+		return content.replace(INTEGRITY_SENTINEL_STRIP_REGEXP, "");
+	}
+
+	/**
 	 * Replace every ` integrity="<sentinel>"` with the chunk's real SRI hashes,
 	 * or drop the attribute when `integrity` (a function) returns `false` for it.
 	 * @param {string} content content
@@ -207,6 +227,9 @@ class HtmlGenerator extends Generator {
 		if (!content.includes("__WEBPACK_HTML_INTEGRITY__")) return content;
 
 		const crypto = require("crypto");
+
+		// Report each bad hash algorithm once, not once per referencing tag.
+		const reportedBadAlgorithms = new Set();
 
 		const chunksById = getChunksById(compilation);
 		return content.replace(
@@ -236,16 +259,33 @@ class HtmlGenerator extends Generator {
 							: integrity;
 				if (!algorithms || algorithms.length === 0) return "";
 				const buffer = asset.source.buffer();
-				const value = algorithms
-					.map(
-						(algorithm) =>
+				const parts = [];
+				for (const algorithm of algorithms) {
+					// `crypto.createHash` throws on an unknown algorithm name — turn
+					// that into a webpack error and skip the algorithm instead of
+					// crashing the whole compilation out of `processAssets`.
+					try {
+						parts.push(
 							`${algorithm}-${crypto
 								.createHash(algorithm)
 								.update(buffer)
 								.digest("base64")}`
-					)
-					.join(" ");
-				return ` integrity="${value}"`;
+						);
+					} catch (_err) {
+						if (!reportedBadAlgorithms.has(algorithm)) {
+							reportedBadAlgorithms.add(algorithm);
+							compilation.errors.push(
+								new WebpackError(
+									`output.html.integrity: unsupported hash algorithm ${JSON.stringify(
+										algorithm
+									)}`
+								)
+							);
+						}
+					}
+				}
+				if (parts.length === 0) return "";
+				return ` integrity="${parts.join(" ")}"`;
 			}
 		);
 	}

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -14,7 +14,7 @@ const {
 } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
-const WebpackError = require("../WebpackError");
+const WebpackError = require("../errors/WebpackError");
 const memoize = require("../util/memoize");
 const { PUBLIC_PATH_AUTO } = require("../util/publicPathPlaceholder");
 

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -226,16 +226,20 @@ class HtmlModulesPlugin {
 		// Per-compilation state: the HTML modules seen during make (so
 		// `finishMake` creates their entries without scanning the whole module
 		// graph) and the stylesheet entry names (read in `afterChunks`).
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string> }>} */
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string> }} per-compilation state
+		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
 			if (state === undefined) {
-				state = { htmlModules: new Set(), stylesheetEntries: new Set() };
+				state = {
+					htmlModules: new Set(),
+					stylesheetEntries: new Set(),
+					htmlAssetNames: new Set()
+				};
 				compilationState.set(compilation, state);
 			}
 			return state;
@@ -367,7 +371,11 @@ class HtmlModulesPlugin {
 							stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH + 1
 						},
 						(assets) => {
+							const { htmlAssetNames } = getState(compilation);
 							for (const name of Object.keys(assets)) {
+								// Only real HTML pages carry SRI sentinels for resolution; a
+								// JS chunk embedding the HTML string must stay untouched.
+								if (!htmlAssetNames.has(name)) continue;
 								const content = assets[name].source();
 								if (
 									typeof content !== "string" ||
@@ -746,6 +754,12 @@ class HtmlModulesPlugin {
 											outputOptions
 										);
 
+							// Remember which emitted assets are HTML pages so the late
+							// integrity pass only rewrites those — never a JS chunk that
+							// merely embeds the HTML string (rewriting it post-hash would
+							// corrupt its content hash and its own SRI).
+							getState(compilation).htmlAssetNames.add(filename);
+
 							result.push({
 								render: () => finalSource,
 								filename,
@@ -770,16 +784,23 @@ class HtmlModulesPlugin {
 					if (typeof raw !== "string") return source;
 					if (
 						!raw.includes("__WEBPACK_HTML_CHUNK_URL__") &&
-						!raw.includes("__WEBPACK_HTML_PAGE_URL__")
+						!raw.includes("__WEBPACK_HTML_PAGE_URL__") &&
+						!raw.includes("__WEBPACK_HTML_INTEGRITY__")
 					) {
 						return source;
 					}
-					const resolved = HtmlGenerator.resolveHtmlPageUrlSentinels(
-						HtmlGenerator.resolveChunkUrlSentinels(raw, compilation),
-						computePageFilenameByEntry
-					)
-						.split(autoPlaceholder)
-						.join("");
+					// Strip integrity sentinels here (not resolve): a chunk can't hold a
+					// real SRI hash for its own not-yet-final bytes, and resolving after
+					// hashing would corrupt its content hash. Real HTML assets keep the
+					// sentinel for the late `resolveChunkIntegritySentinels` pass.
+					const resolved = HtmlGenerator.stripChunkIntegritySentinels(
+						HtmlGenerator.resolveHtmlPageUrlSentinels(
+							HtmlGenerator.resolveChunkUrlSentinels(raw, compilation),
+							computePageFilenameByEntry
+						)
+							.split(autoPlaceholder)
+							.join("")
+					);
 					if (resolved === raw) return source;
 					const chunkId = String(renderContext.chunk.id);
 					const prior = sentinelResolvedSourceCache.get(chunkId);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -365,6 +365,17 @@ class HtmlModulesPlugin {
 				// (`OPTIMIZE_HASH`) so each chunk's bytes are final, and before
 				// `OPTIMIZE_TRANSFER` so any compression sees the resolved tags.
 				if (integrityOn) {
+					// SRI only takes effect on cross-origin subresources fetched
+					// with CORS; without `output.crossOriginLoading` the browser
+					// silently ignores `integrity` on cross-origin loads. Warn once
+					// so a CDN deployment doesn't ship no-op integrity attributes.
+					if (!compilation.outputOptions.crossOriginLoading) {
+						compilation.warnings.push(
+							new WebpackError(
+								'output.html.integrity is set but output.crossOriginLoading is not. Browsers ignore Subresource Integrity on cross-origin requests made without CORS; set output.crossOriginLoading (e.g. "anonymous") if any asset is served from a different origin.'
+							)
+						);
+					}
 					compilation.hooks.processAssets.tap(
 						{
 							name: PLUGIN_NAME,

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -365,7 +365,7 @@ class HtmlModulesPlugin {
 				// (`OPTIMIZE_HASH`) so each chunk's bytes are final, and before
 				// `OPTIMIZE_TRANSFER` so any compression sees the resolved tags.
 				if (integrityOn) {
-					// SRI only takes effect on cross-origin subresources fetched
+					// SRI only takes effect on a cross-origin subresource fetched
 					// with CORS; without `output.crossOriginLoading` the browser
 					// silently ignores `integrity` on cross-origin loads. Warn once
 					// so a CDN deployment doesn't ship no-op integrity attributes.

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -147,6 +147,36 @@ const attrSourceSpan = (path, source, attr) => {
 	return source.slice(path.attributeNameStart(attr) - 1, end);
 };
 
+/**
+ * Source span of a tag's `integrity` attribute (offsets relative to
+ * `elementStart`, leading whitespace and quotes included), so the template can
+ * drop the content-specific author value without re-parsing. Null when absent.
+ * @param {import("./syntax").HtmlPath} path walk path (for attribute reads)
+ * @param {string} source HTML source
+ * @param {number} elementStart offset of the tag's opening `<`
+ * @returns {Range | null} the span, or null when there is no `integrity`
+ */
+const captureIntegrityRange = (path, source, elementStart) => {
+	const integrityAttr = path.findAttribute("integrity");
+	if (integrityAttr === 0 || path.attributeNameStart(integrityAttr) < 0) {
+		return null;
+	}
+	let rs = path.attributeNameStart(integrityAttr);
+	while (rs > 0 && isASCIIWhitespace(source.charCodeAt(rs - 1))) {
+		rs--;
+	}
+	let re;
+	const ivs = path.attributeValueStart(integrityAttr);
+	if (ivs === -1) {
+		re = path.attributeNameEnd(integrityAttr);
+	} else {
+		const q = source.charCodeAt(ivs - 1);
+		const ive = path.attributeValueEnd(integrityAttr);
+		re = q === CC_QUOTATION || q === CC_APOSTROPHE ? ive + 1 : ive;
+	}
+	return [rs - elementStart, re - elementStart];
+};
+
 // eslint-disable-next-line no-control-regex
 const IGNORE_CHARS_REGEXP = /[\u0000-\u001F\u007F-\u009F\u00A0]/g;
 
@@ -1469,12 +1499,28 @@ class HtmlParser extends Parser {
 												? as.trim().toLowerCase() === "style"
 												: false;
 											const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+											// Tag metadata so the template can mirror `crossorigin`/
+											// `integrity` onto a native `preload` `<link>` (integrity-
+											// eligible per the SRI spec). `prefetch` gets none — the spec
+											// doesn't list it — so its `integrity` is left uncaptured.
+											const isNativeLink = elementName === "link";
 											const dep = new HtmlEntryDependency(
 												request,
 												[s, e],
 												entryName,
 												asStyle ? "css-import" : undefined,
-												type
+												type,
+												elementStart,
+												tagEnd,
+												isNativeLink,
+												"",
+												nameEnd,
+												isNativeLink && path.findAttribute("crossorigin") !== 0,
+												-1,
+												type === "preload" && isNativeLink
+													? captureIntegrityRange(path, source, elementStart)
+													: null,
+												null
 											);
 											setLoc(dep, s, e);
 											module.addPresentationalDependency(dep);
@@ -1553,51 +1599,26 @@ class HtmlParser extends Parser {
 											// needn't re-parse the tag text: `integrity` is dropped
 											// (content-specific) and `script-module` clones are forced
 											// to `type="module"` (its value range, else inserted).
-											/** @type {Range | null} */
-											let integrityRange = null;
+											const integrityRange =
+												elementStart >= 0 && elementName === nativeTag
+													? captureIntegrityRange(path, source, elementStart)
+													: null;
 											/** @type {Range | null} */
 											let typeValueRange = null;
-											if (elementStart >= 0 && elementName === nativeTag) {
-												const integrityAttr = path.findAttribute("integrity");
+											if (
+												elementStart >= 0 &&
+												elementName === nativeTag &&
+												elementKind === "script-module"
+											) {
+												const typeAttr = path.findAttribute("type");
 												if (
-													integrityAttr !== 0 &&
-													path.attributeNameStart(integrityAttr) >= 0
+													typeAttr !== 0 &&
+													path.attributeValueStart(typeAttr) >= 0
 												) {
-													let rs = path.attributeNameStart(integrityAttr);
-													while (
-														rs > 0 &&
-														isASCIIWhitespace(source.charCodeAt(rs - 1))
-													) {
-														rs--;
-													}
-													let re;
-													const ivs = path.attributeValueStart(integrityAttr);
-													if (ivs === -1) {
-														re = path.attributeNameEnd(integrityAttr);
-													} else {
-														const q = source.charCodeAt(ivs - 1);
-														const ive = path.attributeValueEnd(integrityAttr);
-														re =
-															q === CC_QUOTATION || q === CC_APOSTROPHE
-																? ive + 1
-																: ive;
-													}
-													integrityRange = [
-														rs - elementStart,
-														re - elementStart
+													typeValueRange = [
+														path.attributeValueStart(typeAttr) - elementStart,
+														path.attributeValueEnd(typeAttr) - elementStart
 													];
-												}
-												if (elementKind === "script-module") {
-													const typeAttr = path.findAttribute("type");
-													if (
-														typeAttr !== 0 &&
-														path.attributeValueStart(typeAttr) >= 0
-													) {
-														typeValueRange = [
-															path.attributeValueStart(typeAttr) - elementStart,
-															path.attributeValueEnd(typeAttr) - elementStart
-														];
-													}
 												}
 											}
 											const dep = new HtmlEntryDependency(

--- a/test/configCases/html/output-html-integrity-invalid-algorithm/errors.js
+++ b/test/configCases/html/output-html-integrity-invalid-algorithm/errors.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/output\.html\.integrity: unsupported hash algorithm "not-a-real-algorithm"/]
+];

--- a/test/configCases/html/output-html-integrity-invalid-algorithm/src/main.js
+++ b/test/configCases/html/output-html-integrity-invalid-algorithm/src/main.js
@@ -1,0 +1,1 @@
+console.log("invalid algorithm");

--- a/test/configCases/html/output-html-integrity-invalid-algorithm/test.js
+++ b/test/configCases/html/output-html-integrity-invalid-algorithm/test.js
@@ -1,0 +1,6 @@
+"use strict";
+
+it("reports an unsupported integrity hash algorithm as a webpack error", () => {
+	// The build fails with a declared error (see errors.js); nothing to run.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/output-html-integrity-invalid-algorithm/test.js
+++ b/test/configCases/html/output-html-integrity-invalid-algorithm/test.js
@@ -1,6 +1,0 @@
-"use strict";
-
-it("reports an unsupported integrity hash algorithm as a webpack error", () => {
-	// The build fails with a declared error (see errors.js); nothing to run.
-	expect(true).toBe(true);
-});

--- a/test/configCases/html/output-html-integrity-invalid-algorithm/webpack.config.js
+++ b/test/configCases/html/output-html-integrity-invalid-algorithm/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./src/main.js" },
+	output: {
+		filename: "[name].[contenthash].js",
+		htmlFilename: "index.html",
+		crossOriginLoading: "anonymous",
+		// An unsupported algorithm must surface as a webpack error, not crash
+		// the compilation out of `processAssets`.
+		html: { integrity: ["not-a-real-algorithm"] }
+	},
+	experiments: { html: true }
+};

--- a/test/configCases/html/output-html-integrity-no-cors/src/main.js
+++ b/test/configCases/html/output-html-integrity-no-cors/src/main.js
@@ -1,0 +1,1 @@
+console.log("integrity without crossOriginLoading");

--- a/test/configCases/html/output-html-integrity-no-cors/test.config.js
+++ b/test/configCases/html/output-html-integrity-no-cors/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/output-html-integrity-no-cors/test.js
+++ b/test/configCases/html/output-html-integrity-no-cors/test.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+it("emits integrity even without crossOriginLoading (warning is advisory)", () => {
+	const html = fs
+		.readFileSync(path.resolve(__dirname, "index.html"))
+		.toString("utf-8");
+	// The feature still works; only the missing-CORS warning is added.
+	expect(html).toMatch(/integrity="sha384-/);
+});

--- a/test/configCases/html/output-html-integrity-no-cors/warnings.js
+++ b/test/configCases/html/output-html-integrity-no-cors/warnings.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = [
+	[
+		/output\.html\.integrity is set but output\.crossOriginLoading is not/
+	]
+];

--- a/test/configCases/html/output-html-integrity-no-cors/warnings.js
+++ b/test/configCases/html/output-html-integrity-no-cors/warnings.js
@@ -1,7 +1,5 @@
 "use strict";
 
 module.exports = [
-	[
-		/output\.html\.integrity is set but output\.crossOriginLoading is not/
-	]
+	[/output\.html\.integrity is set but output\.crossOriginLoading is not/]
 ];

--- a/test/configCases/html/output-html-integrity-no-cors/webpack.config.js
+++ b/test/configCases/html/output-html-integrity-no-cors/webpack.config.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").WebpackPluginInstance} */
+const copyTest = {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "copy-test",
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(
+						"test.js",
+						new webpack.sources.RawSource(
+							fs.readFileSync(path.resolve(__dirname, "test.js"))
+						)
+					);
+				}
+			);
+		});
+	}
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./src/main.js" },
+	// No `crossOriginLoading`: SRI is still emitted but the browser ignores it
+	// on cross-origin loads, so the build must warn (see warnings.js).
+	output: {
+		filename: "[name].[contenthash].js",
+		htmlFilename: "index.html",
+		html: { integrity: true }
+	},
+	experiments: { html: true },
+	plugins: [copyTest]
+};

--- a/test/configCases/html/output-html-integrity/src/authored-entry.js
+++ b/test/configCases/html/output-html-integrity/src/authored-entry.js
@@ -1,0 +1,1 @@
+console.log("authored entry");

--- a/test/configCases/html/output-html-integrity/src/authored.html
+++ b/test/configCases/html/output-html-integrity/src/authored.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script
+			src="./authored-entry.js"
+			integrity="sha384-authorPlaceholderValueThatMustBeReplaced"
+		></script>
+	</head>
+	<body></body>
+</html>

--- a/test/configCases/html/output-html-integrity/src/prefetch-a.js
+++ b/test/configCases/html/output-html-integrity/src/prefetch-a.js
@@ -1,0 +1,1 @@
+console.log("prefetch a");

--- a/test/configCases/html/output-html-integrity/src/preload-a.js
+++ b/test/configCases/html/output-html-integrity/src/preload-a.js
@@ -1,0 +1,1 @@
+console.log("preload a");

--- a/test/configCases/html/output-html-integrity/src/preload-b.js
+++ b/test/configCases/html/output-html-integrity/src/preload-b.js
@@ -1,0 +1,1 @@
+console.log("preload b");

--- a/test/configCases/html/output-html-integrity/src/preload-main.js
+++ b/test/configCases/html/output-html-integrity/src/preload-main.js
@@ -1,0 +1,1 @@
+console.log("preload page main");

--- a/test/configCases/html/output-html-integrity/src/preload.css
+++ b/test/configCases/html/output-html-integrity/src/preload.css
@@ -1,0 +1,3 @@
+.pre {
+	color: blue;
+}

--- a/test/configCases/html/output-html-integrity/src/preload.html
+++ b/test/configCases/html/output-html-integrity/src/preload.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link rel="preload" as="script" href="./preload-a.js" />
+		<link
+			rel="preload"
+			as="script"
+			href="./preload-b.js"
+			integrity="sha384-authorPreloadValueMustBeReplaced"
+		/>
+		<link rel="preload" as="style" href="./preload.css" />
+		<link rel="prefetch" as="script" href="./prefetch-a.js" />
+	</head>
+	<body>
+		<script src="./preload-main.js"></script>
+	</body>
+</html>

--- a/test/configCases/html/output-html-integrity/test.js
+++ b/test/configCases/html/output-html-integrity/test.js
@@ -78,13 +78,17 @@ it("integrity: function decides per asset (false skips, array sets algorithms)",
 it("integrity replaces an authored `integrity` attribute instead of duplicating it", () => {
 	const html = readHtml("authored.html");
 	const tags = tagsWithIntegrity(html);
-	// Exactly one `integrity` on the entry `<script>`: the authored value is
-	// dropped (content-specific) and the correct per-chunk one put in its place.
-	expect(tags).toHaveLength(1);
-	expect((html.match(/integrity=/g) || []).length).toBe(1);
+	// The rewritten entry `<script>` plus the runtime sibling cloned from it.
+	expect(tags.length).toBeGreaterThan(1);
+	// The authored value is dropped (content-specific) on both the rewritten
+	// entry tag and the clone — never left beside the per-chunk one, so the
+	// number of `integrity=` occurrences equals the number of tags (one each).
+	expect((html.match(/integrity=/g) || []).length).toBe(tags.length);
 	expect(html).not.toContain("authorPlaceholder");
-	expect(tags[0].kind).toBe("script");
-	expect(sriMatches(tags[0].url, tags[0].integrity)).toBe(true);
+	for (const tag of tags) {
+		expect(tag.kind).toBe("script");
+		expect(sriMatches(tag.url, tag.integrity)).toBe(true);
+	}
 });
 
 it("no emitted JS ships an unresolved integrity sentinel", () => {

--- a/test/configCases/html/output-html-integrity/test.js
+++ b/test/configCases/html/output-html-integrity/test.js
@@ -91,6 +91,32 @@ it("integrity replaces an authored `integrity` attribute instead of duplicating 
 	}
 });
 
+it("integrity covers preload links (with crossorigin) but not prefetch", () => {
+	const html = readHtml("preload.html");
+	const tags = tagsWithIntegrity(html);
+	// Two `<link rel="preload" as="script">`, one `as="style"`, and the entry
+	// `<script>` — each carrying a correct SRI hash of its referenced file.
+	const links = tags.filter((tag) => tag.kind === "link");
+	expect(links.length).toBe(3);
+	for (const tag of tags) {
+		expect(sriMatches(tag.url, tag.integrity)).toBe(true);
+	}
+	// No duplicated `integrity`, and the authored value was replaced.
+	expect((html.match(/integrity=/g) || []).length).toBe(tags.length);
+	expect(html).not.toContain("authorPreload");
+	// SRI needs CORS: every preload `<link>` carries `crossorigin`.
+	for (const tag of html.match(/<link[^>]*>/g) || []) {
+		if (/rel="preload"/.test(tag)) {
+			expect(tag).toMatch(/crossorigin="anonymous"/);
+		}
+	}
+	// `prefetch` is not integrity-eligible per the SRI spec — left untouched.
+	const prefetch = html.match(/<link[^>]*rel="prefetch"[^>]*>/);
+	expect(prefetch).toBeTruthy();
+	expect(prefetch[0]).not.toMatch(/integrity=/);
+	expect(prefetch[0]).not.toMatch(/crossorigin=/);
+});
+
 it("no emitted JS ships an unresolved integrity sentinel", () => {
 	// A JS chunk can embed the HTML string; its sentinel must be stripped, not
 	// resolved late (that would corrupt the chunk's content hash and its SRI).

--- a/test/configCases/html/output-html-integrity/test.js
+++ b/test/configCases/html/output-html-integrity/test.js
@@ -74,3 +74,28 @@ it("integrity: function decides per asset (false skips, array sets algorithms)",
 	expect(html).toMatch(/<link rel="stylesheet"[^>]*>/);
 	expect(html).not.toMatch(/<link[^>]*integrity/);
 });
+
+it("integrity replaces an authored `integrity` attribute instead of duplicating it", () => {
+	const html = readHtml("authored.html");
+	const tags = tagsWithIntegrity(html);
+	// Exactly one `integrity` on the entry `<script>`: the authored value is
+	// dropped (content-specific) and the correct per-chunk one put in its place.
+	expect(tags).toHaveLength(1);
+	expect((html.match(/integrity=/g) || []).length).toBe(1);
+	expect(html).not.toContain("authorPlaceholder");
+	expect(tags[0].kind).toBe("script");
+	expect(sriMatches(tags[0].url, tags[0].integrity)).toBe(true);
+});
+
+it("no emitted JS ships an unresolved integrity sentinel", () => {
+	// A JS chunk can embed the HTML string; its sentinel must be stripped, not
+	// resolved late (that would corrupt the chunk's content hash and its SRI).
+	for (const file of fs.readdirSync(__dirname)) {
+		// Skip this test file itself — copied in as `test.js`, it mentions the
+		// sentinel in assertions below.
+		if (!file.endsWith(".js") || file === "test.js") continue;
+		expect(read(file).toString("utf-8")).not.toContain(
+			"__WEBPACK_HTML_INTEGRITY__"
+		);
+	}
+});

--- a/test/configCases/html/output-html-integrity/webpack.config.js
+++ b/test/configCases/html/output-html-integrity/webpack.config.js
@@ -55,6 +55,22 @@ module.exports = [
 	// A separate runtime chunk means the entry script gets a cloned sibling
 	// `<script>` — exercises integrity on cloned tags, not just the entry tag.
 	{ ...config("split", true), optimization: { runtimeChunk: "single" } },
+	// An authored `.html` entry whose native `<script>` already carries an
+	// `integrity` attribute — the content-specific author value must be
+	// replaced by the per-chunk one, not left beside it as a duplicate.
+	{
+		name: "authored",
+		target: "web",
+		entry: { authored: "./src/authored.html" },
+		output: {
+			filename: "[name].[contenthash].js",
+			htmlFilename: "authored.html",
+			crossOriginLoading: "anonymous",
+			html: { integrity: true }
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
 	// A custom element mapped to a `script` source type synthesizes a fresh
 	// `<script>` for its runtime sibling — exercises integrity on built (not
 	// cloned) tags. The entry is an authored `.html`, so no wrapping happens.

--- a/test/configCases/html/output-html-integrity/webpack.config.js
+++ b/test/configCases/html/output-html-integrity/webpack.config.js
@@ -57,7 +57,10 @@ module.exports = [
 	{ ...config("split", true), optimization: { runtimeChunk: "single" } },
 	// An authored `.html` entry whose native `<script>` already carries an
 	// `integrity` attribute — the content-specific author value must be
-	// replaced by the per-chunk one, not left beside it as a duplicate.
+	// replaced by the per-chunk one, not left beside it as a duplicate. A
+	// single runtime chunk means that authored `<script>` is also cloned for
+	// the runtime sibling, so both the rewritten entry tag and the cloned tag
+	// are exercised.
 	{
 		name: "authored",
 		target: "web",
@@ -68,6 +71,7 @@ module.exports = [
 			crossOriginLoading: "anonymous",
 			html: { integrity: true }
 		},
+		optimization: { runtimeChunk: "single" },
 		experiments: { html: true },
 		plugins: [copyTest]
 	},

--- a/test/configCases/html/output-html-integrity/webpack.config.js
+++ b/test/configCases/html/output-html-integrity/webpack.config.js
@@ -75,6 +75,22 @@ module.exports = [
 		experiments: { html: true },
 		plugins: [copyTest]
 	},
+	// An authored `.html` with `preload`/`prefetch` resource hints: `preload`
+	// links are integrity-eligible (SRI) and must get `crossorigin`/`integrity`
+	// (including replacing an authored value), while `prefetch` gets neither.
+	{
+		name: "preload",
+		target: "web",
+		entry: { preload: "./src/preload.html" },
+		output: {
+			filename: "[name].[contenthash].js",
+			htmlFilename: "preload.html",
+			crossOriginLoading: "anonymous",
+			html: { integrity: true }
+		},
+		experiments: { html: true, css: true },
+		plugins: [copyTest]
+	},
 	// A custom element mapped to a `script` source type synthesizes a fresh
 	// `<script>` for its runtime sibling — exercises integrity on built (not
 	// cloned) tags. The entry is an authored `.html`, so no wrapping happens.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #21243, which introduced `output.html.integrity` (Subresource Integrity). It corrects three bugs in that feature and extends SRI to the tags it was missing:

- Fixes: an authored `integrity` on the entry `<script>`/`<link>` was duplicated instead of rewritten (two `integrity` attributes on one tag); an unsupported hash algorithm threw out of `processAssets` and crashed the whole compilation instead of reporting a webpack error; and the late resolver rewrote every asset containing the sentinel — including JS chunks that embed the HTML string — mutating them after `RealContentHashPlugin` and so corrupting their `[contenthash]` (and, depending on asset order, the referenced chunk's own SRI).
- Adds: `crossorigin`/`integrity` on native `rel="preload"` resource hints, which are integrity-eligible per the SRI spec (`prefetch` is left untouched since the spec does not cover it; `modulepreload` already flowed through the entry-tag path). Also warns when `output.html.integrity` is enabled but `output.crossOriginLoading` is unset, since browsers ignore SRI on cross-origin requests made without CORS.

Refs #21243.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. Extended `test/configCases/html/output-html-integrity/` (authored-`integrity` rewrite on entry and cloned tags, `preload`/`prefetch` coverage, and a guard that no emitted JS ships an unresolved sentinel), and added `output-html-integrity-no-cors/` (missing-CORS warning) and `output-html-integrity-invalid-algorithm/` (unsupported-algorithm error).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The `output.html.integrity` docs should note that `preload` hints now receive SRI (and `prefetch` does not), and that `output.crossOriginLoading` is recommended alongside it; nothing to document in-repo.

**Use of AI**

AI (Claude) was used to investigate PR #21243, identify the bugs and missing coverage, implement the fixes/features, and write the tests; all changes were reviewed and verified locally (targeted `ConfigTestCases`/`ConfigCacheTestCases` for `html`, ESLint, and `tsc`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018prbXHpozSVQTLJPCg87PV)_