### PR TITLE
fix: skip anonymous default export `.name` fix-up when the property is non-configurable

### DIFF
--- a/.changeset/skip-non-configurable-function-name.md
+++ b/.changeset/skip-non-configurable-function-name.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip the anonymous default export `.name` fix-up when the function's `name` property is non-configurable (pre-ES2015 engines such as Chrome <= 42) instead of throwing `TypeError: Cannot redefine property: name` and breaking bundle evaluation.

--- a/lib/runtime/SetAnonymousDefaultNameRuntimeModule.js
+++ b/lib/runtime/SetAnonymousDefaultNameRuntimeModule.js
@@ -25,8 +25,11 @@ class SetAnonymousDefaultNameRuntimeModule extends HelperRuntimeModule {
 		const fn = RuntimeGlobals.setAnonymousDefaultName;
 		return Template.asString([
 			"// set .name for anonymous default exports per ES spec",
+			"// skipped when the property is non-configurable (pre-ES2015 engines),",
+			"// where Object.defineProperty would throw",
 			`${fn} = ${runtimeTemplate.basicFunction("x", [
-				'(Object.getOwnPropertyDescriptor(x, "name") || {}).writable || Object.defineProperty(x, "name", { value: "default", configurable: true });'
+				'var descriptor = Object.getOwnPropertyDescriptor(x, "name");',
+				'if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, "name", { value: "default", configurable: true });'
 			])};`
 		]);
 	}

--- a/test/configCases/anonymous-default-export-name/non-configurable-name/dep.js
+++ b/test/configCases/anonymous-default-export-name/non-configurable-name/dep.js
@@ -1,0 +1,1 @@
+export default () => 42;

--- a/test/configCases/anonymous-default-export-name/non-configurable-name/index.js
+++ b/test/configCases/anonymous-default-export-name/non-configurable-name/index.js
@@ -1,0 +1,18 @@
+import {
+	originalDefineProperty,
+	originalGetOwnPropertyDescriptor
+} from "./simulate-pre-es2015-name";
+import value from "./dep";
+
+Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+Object.defineProperty = originalDefineProperty;
+
+it("should not throw when a function's name property is non-configurable (pre-ES2015 engines)", () => {
+	// Regression test for https://github.com/webpack/webpack/issues/21369
+	// On pre-ES2015 engines (e.g. Chrome <= 42) a function's `name` property is
+	// non-writable AND non-configurable, so the anonymous-default `.name`
+	// fix-up must be skipped instead of letting `Object.defineProperty` throw
+	// and take down the whole bundle evaluation.
+	expect(typeof value).toBe("function");
+	expect(value()).toBe(42);
+});

--- a/test/configCases/anonymous-default-export-name/non-configurable-name/simulate-pre-es2015-name.js
+++ b/test/configCases/anonymous-default-export-name/non-configurable-name/simulate-pre-es2015-name.js
@@ -1,0 +1,22 @@
+// Simulates pre-ES2015 engines (e.g. Chrome <= 42), where a function's `name`
+// property is non-writable AND non-configurable and redefining it throws.
+// Imported first, so the simulation is active while `./dep` initializes;
+// `index.js` restores the originals afterwards.
+export const originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+export const originalDefineProperty = Object.defineProperty;
+
+Object.getOwnPropertyDescriptor = function (obj, prop) {
+	const descriptor = originalGetOwnPropertyDescriptor.apply(this, arguments);
+	if (prop === "name" && typeof obj === "function" && descriptor) {
+		descriptor.writable = false;
+		descriptor.configurable = false;
+	}
+	return descriptor;
+};
+
+Object.defineProperty = function (obj, prop, _attributes) {
+	if (prop === "name" && typeof obj === "function") {
+		throw new TypeError("Cannot redefine property: name");
+	}
+	return originalDefineProperty.apply(this, arguments);
+};

--- a/test/configCases/anonymous-default-export-name/non-configurable-name/webpack.config.js
+++ b/test/configCases/anonymous-default-export-name/non-configurable-name/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false
+};

--- a/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigCacheTest.snap
@@ -470,8 +470,11 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/set anonymous default export name */
 /******/ 	(() => {
 /******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		// skipped when the property is non-configurable (pre-ES2015 engines),
+/******/ 		// where Object.defineProperty would throw
 /******/ 		__webpack_require__.dn = (x) => {
-/******/ 			(Object.getOwnPropertyDescriptor(x, \\"name\\") || {}).writable || Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
+/******/ 			var descriptor = Object.getOwnPropertyDescriptor(x, \\"name\\");
+/******/ 			if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
 /******/ 		};
 /******/ 	})();
 /******/ 	
@@ -1168,8 +1171,11 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/set anonymous default export name */
 /******/ 	(() => {
 /******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		// skipped when the property is non-configurable (pre-ES2015 engines),
+/******/ 		// where Object.defineProperty would throw
 /******/ 		__webpack_require__.dn = (x) => {
-/******/ 			(Object.getOwnPropertyDescriptor(x, \\"name\\") || {}).writable || Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
+/******/ 			var descriptor = Object.getOwnPropertyDescriptor(x, \\"name\\");
+/******/ 			if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
 /******/ 		};
 /******/ 	})();
 /******/ 	
@@ -1866,8 +1872,11 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/set anonymous default export name */
 /******/ 	(() => {
 /******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		// skipped when the property is non-configurable (pre-ES2015 engines),
+/******/ 		// where Object.defineProperty would throw
 /******/ 		__webpack_require__.dn = (x) => {
-/******/ 			(Object.getOwnPropertyDescriptor(x, \\"name\\") || {}).writable || Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
+/******/ 			var descriptor = Object.getOwnPropertyDescriptor(x, \\"name\\");
+/******/ 			if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
 /******/ 		};
 /******/ 	})();
 /******/ 	
@@ -2564,8 +2573,11 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/set anonymous default export name */
 /******/ 	(() => {
 /******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		// skipped when the property is non-configurable (pre-ES2015 engines),
+/******/ 		// where Object.defineProperty would throw
 /******/ 		__webpack_require__.dn = (x) => {
-/******/ 			(Object.getOwnPropertyDescriptor(x, \\"name\\") || {}).writable || Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
+/******/ 			var descriptor = Object.getOwnPropertyDescriptor(x, \\"name\\");
+/******/ 			if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
 /******/ 		};
 /******/ 	})();
 /******/ 	

--- a/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigTest.snap
+++ b/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigTest.snap
@@ -470,8 +470,11 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/set anonymous default export name */
 /******/ 	(() => {
 /******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		// skipped when the property is non-configurable (pre-ES2015 engines),
+/******/ 		// where Object.defineProperty would throw
 /******/ 		__webpack_require__.dn = (x) => {
-/******/ 			(Object.getOwnPropertyDescriptor(x, \\"name\\") || {}).writable || Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
+/******/ 			var descriptor = Object.getOwnPropertyDescriptor(x, \\"name\\");
+/******/ 			if (!descriptor || (!descriptor.writable && descriptor.configurable)) Object.defineProperty(x, \\"name\\", { value: \\"default\\", configurable: true });
 /******/ 		};
 /******/ 	})();
 /******/ 	


### PR DESCRIPTION
**Summary**

Fixes #21369

On pre-ES2015 engines (e.g. Chrome ≤ 42, still shipping in LG webOS ≤ 3 TVs) a function's `name` property is non-writable **and non-configurable**. The `setAnonymousDefaultName` runtime helper only checked `writable` before calling `Object.defineProperty(x, "name", ...)`, which throws `TypeError: Cannot redefine property: name` on those engines and takes down the whole bundle evaluation at module init.

This changes the guard to only perform the fix-up when it can succeed: when there is no own `name` descriptor, or when the descriptor is non-writable and configurable. Behavior on modern engines is unchanged (the fix-up still runs); on engines where the property is locked, the cosmetic fix-up is skipped instead of throwing — those engines don't implement ES2015 `Function.name` semantics anyway.

The added test simulates the pre-ES2015 descriptor semantics around the dependency's module init and verifies the bundle evaluates and the export works. Verified on real hardware as well (LG B7, webOS 3.x, Chrome 38): with this guard the previously white-screening application boots normally.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes (`test/configCases/anonymous-default-export-name/non-configurable-name/`)

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing
