### PR TITLE
feat(html): bundle local <iframe src> as an HTML page

### DIFF
--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -377,9 +377,9 @@ const ALLOWED_LINK_RELS = new Set([
 	"apple-touch-icon",
 	"apple-touch-icon-precomposed",
 	"apple-touch-startup-image",
-	// TODO the manifest file is emitted as an asset, but its JSON
-	// `icons`/`screenshots`/`shortcuts[].icons` URLs aren't parsed — needs a
-	// dedicated webmanifest module type (parser + generator), not a table entry.
+	// The manifest file is emitted as an asset; its JSON
+	// `icons`/`screenshots`/`shortcuts[].icons` URLs are parsed by the
+	// `asset/webmanifest` module type (see `WebManifestParser`).
 	"manifest",
 	"prefetch",
 	"preload",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`<iframe srcdoc>` is already handled, but a local `<iframe src="./page.html">` was left untouched. This adds a default `iframe[src]` source that links a **relative** local page as its own emitted HTML page entry (reusing the existing `html` source type), matching Parcel. Only relative URLs are bundled — external (`https:`), protocol-relative (`//host`), and root-relative (`/route`) navigable URLs are left untouched, so external embeds (YouTube, maps) and SPA routes are unaffected. That same skip now also applies to the opt-in `a[href]` `html` type. Refs #5582.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/configCases/html/iframe-src/` covers a local page bundled and its `src` rewritten, its embedded `<img src>` processed through the pipeline, and external / protocol-relative / root-relative srcs left untouched.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The HTML module docs (webpack.js.org) should note that a relative `<iframe src>` is bundled as a linked page, like `<a href>` via `type: "html"`.

**Use of AI**

AI (Claude) was used to implement the change, test, and changeset, following the existing `srcdoc` / `html`-type pattern and Parcel's behavior; I reviewed the approach and the resulting code.

---
_Generated by [Claude Code](https://claude.ai/code/session_011r9Sz4mhsecmGjNnCUY2MJ)_