### PR TITLE
perf: share magic comment parsing in JS and CSS parsers

### DIFF
--- a/.changeset/js-parse-magic-comment-fast-path.md
+++ b/.changeset/js-parse-magic-comment-fast-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Use shared comment-range lookup and magic-comment parsing in the JavaScript and CSS parsers.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -6,7 +6,6 @@
 "use strict";
 
 const path = require("path");
-const vm = require("vm");
 const { CSS_MODULE_TYPE_AUTO } = require("../ModuleTypeConstants");
 const Parser = require("../Parser");
 const ConstDependency = require("../dependencies/ConstDependency");
@@ -21,11 +20,10 @@ const ModuleDependencyWarning = require("../errors/ModuleDependencyWarning");
 const UnsupportedFeatureWarning = require("../errors/UnsupportedFeatureWarning");
 const WebpackError = require("../errors/WebpackError");
 const LocConverter = require("../util/LocConverter");
-const binarySearchBounds = require("../util/binarySearchBounds");
 const { parseResource } = require("../util/identifier");
 const {
 	createMagicCommentContext,
-	webpackCommentRegExp
+	parseCommentOptionsInRange
 } = require("../util/magicComment");
 const topologicalSort = require("../util/topologicalSort");
 const {
@@ -90,9 +88,6 @@ const PURE_IGNORE_RE = /^\s*cssmodules-pure-ignore(?:\s|$)/;
 const PURE_NO_CHECK_RE = /^\s*cssmodules-pure-no-check(?:\s|$)/;
 const UNESCAPE = /\\([0-9a-f]{1,6}[ \t\n\r\f]?|[\s\S])/gi;
 const IMAGE_SET_FUNCTION = /^(?:-\w+-)?image-set$/i;
-// `parseCommentOptions` fast path: a whole-comment `webpackXxx: <bool|number|null>`; every other (and every failing) shape falls back to the `vm.runInContext` path.
-const MAGIC_COMMENT_FAST_PATH =
-	/^\s*(webpack[A-Z][A-Za-z]+)\s*:\s*(true|false|null|-?\d+(?:\.\d+)?)\s*$/;
 const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(?:-\w+-)?keyframes$/;
 const VENDOR_PREFIX = /^-\w+-/;
 const COMPOSES_PROPERTY = /^(?:composes|compose-with)$/i;
@@ -311,16 +306,6 @@ const knownPropertyForRange = (index, input, start, end) => {
 	}
 	return undefined;
 };
-
-/**
- * `binarySearchBounds` comparator for `getComments` — hoisted so the lookup
- * doesn't allocate a fresh closure per call.
- * @param {Comment} comment comment
- * @param {number} needle needle (byte offset)
- * @returns {number} comparison
- */
-const compareCommentStart = (comment, needle) =>
-	/** @type {Range} */ (comment.range)[0] - needle;
 
 /** @type {Record<string, number>} */
 const PREDEFINED_COUNTER_STYLES = {
@@ -604,11 +589,6 @@ const getKnownProperties = (options = {}) => {
 		KNOWN_PROPERTIES_CACHE.set(key, table);
 	}
 	return table;
-};
-
-const EMPTY_COMMENT_OPTIONS = {
-	options: null,
-	errors: null
 };
 
 // Byte-level source-cursor scans for computing replacement / strip ranges on raw source after parsing.
@@ -1169,7 +1149,14 @@ class CssParser extends Parser {
 		 * @returns {boolean} true when `webpackIgnore: true`
 		 */
 		const webpackIgnored = (range, warnStart, warnEnd) => {
-			const { options, errors } = parseCommentOptions(range);
+			/** @type {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: Comment })[] | null }} */
+			const { options, errors } = parseCommentOptionsInRange(
+				/** @type {(Comment & { range: [number, number], value: string })[]} */ (
+					comments
+				),
+				range,
+				this.magicCommentContext
+			);
 			if (errors) {
 				for (const e of errors) {
 					state.module.addWarning(
@@ -1393,7 +1380,7 @@ class CssParser extends Parser {
 			modeData ? modeData === "local" : mode === "local";
 
 		/**
-		 * Comment visitor (`NodeType.Comment`): push every comment (in source order) onto the local `comments`, read back by `advanceCommentCursor` (pure-mode flags) and `parseCommentOptions` (magic comments).
+		 * Comment visitor (`NodeType.Comment`): push every comment (in source order) onto the local `comments`, read back by `advanceCommentCursor` (pure-mode flags) and `parseCommentOptionsInRange` (magic comments).
 		 * @param {import("./syntax").CssPath} path walk path at the comment node
 		 */
 		const commentVisitor = (path) => {
@@ -1423,88 +1410,6 @@ class CssParser extends Parser {
 				}
 			};
 		})();
-
-		const magicCommentContext = this.magicCommentContext;
-
-		/**
-		 * Comments fully inside `range`, via binary search over the source-ordered `comments`.
-		 * @param {Range} range range
-		 * @returns {Comment[]} comments in the range
-		 */
-		const getComments = (range) => {
-			// No comments: skip the binary search + result-array allocation (the common case — most CSS has no magic comments).
-			if (comments.length === 0) return [];
-			const [start, end] = range;
-			let idx = binarySearchBounds.ge(comments, start, compareCommentStart);
-			/** @type {Comment[]} */
-			const commentsInRange = [];
-			while (comments[idx] && comments[idx].range[1] <= end) {
-				commentsInRange.push(comments[idx]);
-				idx++;
-			}
-			return commentsInRange;
-		};
-
-		/**
-		 * Parse webpack magic-comment options from any comment inside `range`.
-		 * @param {Range} range range of the comment
-		 * @returns {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: Comment })[] | null }} result
-		 */
-		const parseCommentOptions = (range) => {
-			const found = getComments(range);
-			if (found.length === 0) {
-				return EMPTY_COMMENT_OPTIONS;
-			}
-			/** @type {Record<string, EXPECTED_ANY>} */
-			const options = {};
-			/** @type {(Error & { comment: Comment })[]} */
-			const errors = [];
-			for (const c of found) {
-				const { value } = c;
-				if (value && webpackCommentRegExp.test(value)) {
-					// Fast path for the common `webpackXxx: <bool|number|null>` pair, keeping it out of `vm.runInContext`.
-					const fast = MAGIC_COMMENT_FAST_PATH.exec(value);
-					if (fast !== null) {
-						const key = fast[1];
-						const raw = fast[2];
-						options[key] =
-							raw === "true"
-								? true
-								: raw === "false"
-									? false
-									: raw === "null"
-										? null
-										: Number(raw);
-						continue;
-					}
-					// try compile only if webpack options comment is present
-					try {
-						for (let [key, val] of Object.entries(
-							vm.runInContext(
-								`(function(){return {${value}};})()`,
-								magicCommentContext
-							)
-						)) {
-							if (typeof val === "object" && val !== null) {
-								val =
-									val.constructor.name === "RegExp"
-										? new RegExp(val)
-										: JSON.parse(JSON.stringify(val));
-							}
-							options[key] = val;
-						}
-					} catch (err) {
-						const newErr = new Error(
-							String(/** @type {Error} */ (err).message)
-						);
-						newErr.stack = String(/** @type {Error} */ (err).stack);
-						Object.assign(newErr, { comment: c });
-						errors.push(/** @type {(Error & { comment: Comment })} */ (newErr));
-					}
-				}
-			}
-			return { options, errors };
-		};
 
 		// CSS modules stuff
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5,16 +5,15 @@
 
 "use strict";
 
-const vm = require("vm");
 const { HookMap, SyncBailHook } = require("tapable");
 const NormalModule = require("../NormalModule");
 const Parser = require("../Parser");
 const StackedMap = require("../util/StackedMap");
-const binarySearchBounds = require("../util/binarySearchBounds");
 const {
 	CompilerHintNotationRegExp,
 	createMagicCommentContext,
-	webpackCommentRegExp
+	getCommentsInRange,
+	parseCommentOptionsInRange
 } = require("../util/magicComment");
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 const {
@@ -476,11 +475,6 @@ const defaultParserOptions = {
 // reused by _parse for every non-custom parse — all fields are reset per parse
 /** @type {ParseOptions} */
 const REUSED_PARSER_OPTIONS = { ...defaultParserOptions };
-
-const EMPTY_COMMENT_OPTIONS = {
-	options: null,
-	errors: null
-};
 
 // Read-only snippet ASTs for `evaluate()`, released with the compilation;
 // DefinePlugin evaluates the same strings once per usage per module.
@@ -5334,29 +5328,10 @@ class JavascriptParser extends Parser {
 	 * @returns {Comment[]} comments in the range
 	 */
 	getComments(range) {
-		const comments = /** @type {Comment[]} */ (this.comments);
-		if (comments.length === 0) return [];
-		const [rangeStart, rangeEnd] = range;
-		/**
-		 * Returns compared.
-		 * @param {Comment} comment comment
-		 * @param {number} needle needle
-		 * @returns {number} compared
-		 */
-		const compare = (comment, needle) =>
-			/** @type {Range} */ (comment.range)[0] - needle;
-		let idx = binarySearchBounds.ge(comments, rangeStart, compare);
-		/** @type {Comment[]} */
-		const commentsInRange = [];
-		while (
-			comments[idx] &&
-			/** @type {Range} */ (comments[idx].range)[1] <= rangeEnd
-		) {
-			commentsInRange.push(comments[idx]);
-			idx++;
-		}
-
-		return commentsInRange;
+		return getCommentsInRange(
+			/** @type {(Comment & { range: [number, number] })[]} */ (this.comments),
+			range
+		);
 	}
 
 	/**
@@ -5579,42 +5554,13 @@ class JavascriptParser extends Parser {
 	 * @returns {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: Comment })[] | null }} result
 	 */
 	parseCommentOptions(range) {
-		const comments = this.getComments(range);
-		if (comments.length === 0) {
-			return EMPTY_COMMENT_OPTIONS;
-		}
-		/** @type {Record<string, EXPECTED_ANY>} */
-		const options = {};
-		/** @type {(Error & { comment: Comment })[]} */
-		const errors = [];
-		for (const comment of comments) {
-			const { value } = comment;
-			if (value && webpackCommentRegExp.test(value)) {
-				// try compile only if webpack options comment is present
-				try {
-					for (let [key, val] of Object.entries(
-						vm.runInContext(
-							`(function(){return {${value}};})()`,
-							this.magicCommentContext
-						)
-					)) {
-						if (typeof val === "object" && val !== null) {
-							val =
-								val.constructor.name === "RegExp"
-									? new RegExp(val)
-									: JSON.parse(JSON.stringify(val));
-						}
-						options[key] = val;
-					}
-				} catch (err) {
-					const newErr = new Error(String(/** @type {Error} */ (err).message));
-					newErr.stack = String(/** @type {Error} */ (err).stack);
-					Object.assign(newErr, { comment });
-					errors.push(/** @type {(Error & { comment: Comment })} */ (newErr));
-				}
-			}
-		}
-		return { options, errors };
+		return parseCommentOptionsInRange(
+			/** @type {(Comment & { range: [number, number], value: string })[]} */ (
+				this.comments
+			),
+			range,
+			this.magicCommentContext
+		);
 	}
 
 	/**

--- a/lib/util/magicComment.js
+++ b/lib/util/magicComment.js
@@ -5,54 +5,60 @@
 
 "use strict";
 
+const binarySearchBounds = require("./binarySearchBounds");
 const memoize = require("./memoize");
 
 const getVm = memoize(() => require("vm"));
 
-module.exports.CompilerHintNotationRegExp = Object.freeze({
+const CompilerHintNotationRegExp = Object.freeze({
 	Pure: /^\s*(?:#|@)__PURE__\s*$/,
 	NoSideEffects: /^\s*[#@]__NO_SIDE_EFFECTS__\s*$/
 });
-
-/**
- * regexp to match at least one "magic comment"
- * @returns {import("vm").Context} magic comment context
- */
-module.exports.createMagicCommentContext = () =>
-	getVm().createContext(undefined, {
-		name: "Webpack Magic Comment Parser",
-		codeGeneration: { strings: false, wasm: false }
-	});
 
 // Whole-comment `webpackXxx: <bool|number|null>` pair — parsed without `vm`.
 const MAGIC_COMMENT_FAST_PATH =
 	/^\s*(webpack[A-Z][A-Za-z]+)\s*:\s*(true|false|null|-?\d+(?:\.\d+)?)\s*$/;
 
+const webpackCommentRegExp = new RegExp(/(^|\W)webpack[A-Z][A-Za-z]+:/);
+
+/** @type {Readonly<{ options: null, errors: null }>} */
+const EMPTY_COMMENT_OPTIONS = Object.freeze({
+	options: null,
+	errors: null
+});
+
 /**
- * Parse one magic comment's text into its options object. Values are detached
+ * @returns {import("vm").Context} magic comment context
+ */
+const createMagicCommentContext = () =>
+	getVm().createContext(undefined, {
+		name: "Webpack Magic Comment Parser",
+		codeGeneration: { strings: false, wasm: false }
+	});
+
+/**
+ * Parse one magic comment's text and merge into `options`. Values are detached
  * from the vm context (RegExps recreated, other objects JSON-cloned). Throws
  * when the comment body fails to evaluate.
+ * @param {Record<string, EXPECTED_ANY>} options target to merge into
  * @param {string} value comment text (should already match `webpackCommentRegExp`)
  * @param {import("vm").Context} context context from `createMagicCommentContext`
- * @returns {Record<string, EXPECTED_ANY>} parsed options
+ * @returns {void}
  */
-module.exports.parseMagicComment = (value, context) => {
+const assignMagicCommentOptions = (options, value, context) => {
 	const fast = MAGIC_COMMENT_FAST_PATH.exec(value);
 	if (fast !== null) {
 		const raw = fast[2];
-		return {
-			[fast[1]]:
-				raw === "true"
-					? true
-					: raw === "false"
-						? false
-						: raw === "null"
-							? null
-							: Number(raw)
-		};
+		options[fast[1]] =
+			raw === "true"
+				? true
+				: raw === "false"
+					? false
+					: raw === "null"
+						? null
+						: Number(raw);
+		return;
 	}
-	/** @type {Record<string, EXPECTED_ANY>} */
-	const options = {};
 	for (let [key, val] of Object.entries(
 		getVm().runInContext(`(function(){return {${value}};})()`, context)
 	)) {
@@ -64,8 +70,98 @@ module.exports.parseMagicComment = (value, context) => {
 		}
 		options[key] = val;
 	}
+};
+
+/**
+ * Parse one magic comment's text into its options object.
+ * @param {string} value comment text (should already match `webpackCommentRegExp`)
+ * @param {import("vm").Context} context context from `createMagicCommentContext`
+ * @returns {Record<string, EXPECTED_ANY>} parsed options
+ */
+const parseMagicComment = (value, context) => {
+	/** @type {Record<string, EXPECTED_ANY>} */
+	const options = {};
+	assignMagicCommentOptions(options, value, context);
 	return options;
 };
-module.exports.webpackCommentRegExp = new RegExp(
-	/(^|\W)webpack[A-Z][A-Za-z]+:/
-);
+
+/**
+ * `binarySearchBounds` comparator for `getCommentsInRange`.
+ * @param {{ range: [number, number] }} comment comment
+ * @param {number} needle needle (byte offset)
+ * @returns {number} comparison
+ */
+const compareCommentStart = (comment, needle) => comment.range[0] - needle;
+
+/**
+ * Comments fully inside `range`, via binary search over source-ordered `comments`.
+ * @template {object} TComment
+ * @param {(TComment & { range: [number, number] })[]} comments source-ordered comments
+ * @param {[number, number]} range range
+ * @returns {TComment[]} comments in the range
+ */
+const getCommentsInRange = (comments, range) => {
+	if (comments.length === 0) return [];
+	const [start, end] = range;
+	let idx = binarySearchBounds.ge(comments, start, compareCommentStart);
+	/** @type {TComment[]} */
+	const commentsInRange = [];
+	while (comments[idx] && comments[idx].range[1] <= end) {
+		commentsInRange.push(comments[idx]);
+		idx++;
+	}
+	return commentsInRange;
+};
+
+/**
+ * Merge webpack magic-comment options from `comments` in source order.
+ * @template {object} TComment
+ * @param {(TComment & { value: string })[]} comments comments fully inside the range
+ * @param {import("vm").Context} context context from `createMagicCommentContext`
+ * @returns {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: TComment })[] | null }} result
+ */
+const parseMagicCommentOptions = (comments, context) => {
+	if (comments.length === 0) {
+		return /** @type {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: TComment })[] | null }} */ (
+			EMPTY_COMMENT_OPTIONS
+		);
+	}
+	/** @type {Record<string, EXPECTED_ANY>} */
+	const options = {};
+	/** @type {(Error & { comment: TComment })[]} */
+	const errors = [];
+	for (const comment of comments) {
+		const { value } = comment;
+		if (value && webpackCommentRegExp.test(value)) {
+			try {
+				assignMagicCommentOptions(options, value, context);
+			} catch (err) {
+				const newErr = new Error(String(/** @type {Error} */ (err).message));
+				newErr.stack = String(/** @type {Error} */ (err).stack);
+				Object.assign(newErr, { comment });
+				errors.push(/** @type {Error & { comment: TComment }} */ (newErr));
+			}
+		}
+	}
+	return { options, errors };
+};
+
+/**
+ * Merge webpack magic-comment options from comments inside `range`.
+ * @template {object} TComment
+ * @param {(TComment & { range: [number, number], value: string })[]} comments source-ordered comments
+ * @param {[number, number]} range range
+ * @param {import("vm").Context} context context from `createMagicCommentContext`
+ * @returns {{ options: Record<string, EXPECTED_ANY> | null, errors: (Error & { comment: TComment })[] | null }} result
+ */
+const parseCommentOptionsInRange = (comments, range, context) =>
+	parseMagicCommentOptions(getCommentsInRange(comments, range), context);
+
+module.exports = {
+	CompilerHintNotationRegExp,
+	createMagicCommentContext,
+	getCommentsInRange,
+	parseCommentOptionsInRange,
+	parseMagicComment,
+	webpackCommentRegExp
+};

--- a/test/magicComment.unittest.js
+++ b/test/magicComment.unittest.js
@@ -2,6 +2,8 @@
 
 const {
 	createMagicCommentContext,
+	getCommentsInRange,
+	parseCommentOptionsInRange,
 	parseMagicComment
 } = require("../lib/util/magicComment");
 
@@ -52,5 +54,38 @@ describe("parseMagicComment", () => {
 		expect(() => parseMagicComment("webpackIgnore: )", context)).toThrow(
 			/Unexpected token/
 		);
+	});
+});
+
+describe("getCommentsInRange", () => {
+	/** @type {{ value: string, range: [number, number] }[]} */
+	const comments = [
+		{ value: " a ", range: [0, 5] },
+		{ value: " b ", range: [10, 15] },
+		{ value: " c ", range: [20, 25] }
+	];
+
+	it("returns an empty array when there are no comments", () => {
+		expect(getCommentsInRange([], [0, 100])).toEqual([]);
+	});
+
+	it("returns comments fully inside the range", () => {
+		expect(getCommentsInRange(comments, [8, 22])).toEqual([comments[1]]);
+	});
+});
+
+describe("parseCommentOptionsInRange", () => {
+	const context = createMagicCommentContext();
+
+	it("merges webpack magic comments inside the range", () => {
+		/** @type {{ value: string, range: [number, number] }[]} */
+		const comments = [
+			{ value: " note ", range: [0, 8] },
+			{ value: " webpackIgnore: true ", range: [10, 33] }
+		];
+		expect(parseCommentOptionsInRange(comments, [0, 40], context)).toEqual({
+			options: { webpackIgnore: true },
+			errors: []
+		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Extract duplicated comment-range lookup and magic-comment parsing from `JavascriptParser` and `CssParser` into `lib/util/magicComment.js`, so both parsers share `getCommentsInRange` and `parseCommentOptionsInRange`. `JavascriptParser` also adopts the existing simple-literal fast path that `CssParser` already used, which is semantically equivalent and faster for common cases like `webpackIgnore: true`.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — extended `test/magicComment.unittest.js` with coverage for `getCommentsInRange` and `parseCommentOptionsInRange`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used to review the branch diff and draft this PR description.