### PR TITLE
perf: skip CachedSource wrap when code-generation cache is disabled

### DIFF
--- a/.changeset/skip-cached-source-without-cache.md
+++ b/.changeset/skip-cached-source-without-cache.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip CachedSource wrapping in NormalModule code generation when the code-generation cache is disabled.

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1803,7 +1803,8 @@ class NormalModule extends Module {
 		runtime,
 		concatenationScope,
 		codeGenerationResults,
-		sourceTypes
+		sourceTypes,
+		compilation
 	}) {
 		/** @type {RuntimeRequirements} */
 		const runtimeRequirements = new Set();
@@ -1817,6 +1818,11 @@ class NormalModule extends Module {
 		}
 
 		const getData = () => this._codeGeneratorData;
+
+		// CachedSource is only needed when codegen results are stored in the cache.
+		const useCachedSource =
+			compilation &&
+			compilation.getCache("Compilation/codeGeneration").isEnabled();
 
 		/** @type {Sources} */
 		const sources = new Map();
@@ -1856,7 +1862,7 @@ class NormalModule extends Module {
 					});
 
 			if (source) {
-				sources.set(type, new CachedSource(source));
+				sources.set(type, useCachedSource ? new CachedSource(source) : source);
 			}
 		}
 

--- a/test/NormalModule.unittest.js
+++ b/test/NormalModule.unittest.js
@@ -3,6 +3,7 @@
 const SourceMapSource = require("webpack-sources").SourceMapSource;
 const OriginalSource = require("webpack-sources").OriginalSource;
 const RawSource = require("webpack-sources").RawSource;
+const CachedSource = require("webpack-sources").CachedSource;
 const NormalModule = require("../lib/NormalModule");
 const HarmonyImportSideEffectDependency = require("../lib/dependencies/HarmonyImportSideEffectDependency");
 
@@ -781,6 +782,109 @@ describe("NormalModule", () => {
 			for (let i = 0; i < N; i++) {
 				expect(modules[i]._isEvaluatingSideEffects).toBe(false);
 			}
+		});
+	});
+
+	describe("#codeGeneration", () => {
+		/** @returns {import("../lib/Generator")} mock generator */
+		const makeGenerator = () =>
+			/** @type {import("../lib/Generator")} */ (
+				/** @type {unknown} */ ({
+					generate() {
+						return new RawSource("module.exports = 1;");
+					}
+				})
+			);
+
+		/**
+		 * @param {boolean} cacheEnabled whether the codegen cache is active
+		 * @returns {import("../lib/Compilation")} mock compilation
+		 */
+		const makeCompilation = (cacheEnabled) =>
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ ({
+					getCache() {
+						return { isEnabled: () => cacheEnabled };
+					}
+				})
+			);
+
+		/** @type {import("../lib/ChunkGraph")} */
+		const chunkGraph = /** @type {import("../lib/ChunkGraph")} */ (
+			/** @type {unknown} */ ({
+				getModuleSourceTypes: () => ["javascript"]
+			})
+		);
+
+		/** @type {import("../lib/DependencyTemplates")} */
+		const dependencyTemplates =
+			/** @type {import("../lib/DependencyTemplates")} */ (
+				/** @type {unknown} */ ({
+					get: () => undefined
+				})
+			);
+
+		/** @type {import("../lib/RuntimeTemplate")} */
+		const runtimeTemplate = /** @type {import("../lib/RuntimeTemplate")} */ (
+			/** @type {unknown} */ ({})
+		);
+
+		/** @type {import("../lib/ModuleGraph")} */
+		const moduleGraph = /** @type {import("../lib/ModuleGraph")} */ (
+			/** @type {unknown} */ ({})
+		);
+
+		/**
+		 * @param {boolean | undefined} cacheEnabled codegen cache state
+		 * @returns {import("../lib/Module").CodeGenerationResult} codegen result
+		 */
+		const runCodeGeneration = (cacheEnabled) => {
+			const mod = new NormalModule(
+				/** @type {import("../lib/NormalModule").NormalModuleCreateData} */ (
+					/** @type {unknown} */ ({
+						type: "javascript/auto",
+						request: "/codegen.js",
+						userRequest: "/codegen.js",
+						rawRequest: "./codegen.js",
+						loaders: [],
+						resource: "/codegen.js",
+						parser: { parse() {} },
+						generator: makeGenerator(),
+						resolveOptions: {}
+					})
+				)
+			);
+			mod.buildInfo = { parsed: true };
+			return mod.codeGeneration({
+				dependencyTemplates,
+				runtimeTemplate,
+				moduleGraph,
+				chunkGraph,
+				runtime: undefined,
+				runtimes: [],
+				compilation:
+					cacheEnabled === undefined ? undefined : makeCompilation(cacheEnabled)
+			});
+		};
+
+		it("skips CachedSource when the code-generation cache is disabled", () => {
+			const result = runCodeGeneration(false);
+			const source = result.sources.get("javascript");
+			expect(source).toBeInstanceOf(RawSource);
+			expect(source).not.toBeInstanceOf(CachedSource);
+		});
+
+		it("wraps in CachedSource when the code-generation cache is enabled", () => {
+			const result = runCodeGeneration(true);
+			const source = result.sources.get("javascript");
+			expect(source).toBeInstanceOf(CachedSource);
+		});
+
+		it("skips CachedSource when no compilation is provided", () => {
+			const result = runCodeGeneration(undefined);
+			const source = result.sources.get("javascript");
+			expect(source).toBeInstanceOf(RawSource);
+			expect(source).not.toBeInstanceOf(CachedSource);
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #21341: when the code-generation cache is inactive (production default), skip wrapping every module source in `CachedSource` during `NormalModule.codeGeneration`, removing one allocation per module × source type.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes, in `test/NormalModule.unittest.js` (`#codeGeneration` describe block).

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

Partial