### PR TITLE
fix: fall back to disk when context symlink cache lacks timestampHash

### DIFF
--- a/.changeset/fix-context-symlink-watchpack-timestamp.md
+++ b/.changeset/fix-context-symlink-watchpack-timestamp.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix watch rebuild crash when context symlink targets lack `timestampHash`.

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1243,6 +1243,17 @@ const isExistenceOnly = (entry) => {
 	);
 };
 
+/**
+ * Watchpack directory entries may carry `safeTime` / `timestamp` but never
+ * `timestampHash`; such object caches cannot back snapshot checks or symlink walks.
+ * @param {ContextFileSystemInfoEntry | null | "ignore" | undefined} entry cache entry
+ * @returns {boolean} true when a non-null object entry lacks `timestampHash`
+ */
+const contextCacheEntryLacksTimestampHash = (entry) =>
+	entry !== null &&
+	typeof entry === "object" &&
+	/** @type {ContextFileSystemInfoEntry} */ (entry).timestampHash === undefined;
+
 /** @typedef {(err?: WebpackError | null, result?: boolean) => void} CheckSnapshotValidCallback */
 
 /**
@@ -1705,7 +1716,13 @@ class FileSystemInfo {
 	 */
 	_getUnresolvedContextTimestamp(path, callback) {
 		const cache = this._contextTimestamps.get(path);
-		if (cache !== undefined && !isExistenceOnly(cache)) {
+		if (
+			cache !== undefined &&
+			!isExistenceOnly(cache) &&
+			!contextCacheEntryLacksTimestampHash(
+				/** @type {ContextFileSystemInfoEntry | null | "ignore"} */ (cache)
+			)
+		) {
 			return callback(
 				null,
 				/** @type {ContextFileSystemInfoEntry | "ignore" | null} */ (cache)
@@ -2814,14 +2831,8 @@ class FileSystemInfo {
 							cache === undefined || isExistenceOnly(cache)
 								? undefined
 								: /** @type {ContextFileSystemInfoEntry | null} */ (cache);
-						// A non-null cache entry without `timestampHash` cannot be
-						// used to populate the snapshot — the snapshot would then
-						// miss directory-change detection, since validity relies on
-						// `timestampHash`. Re-read the directory in that case.
 						const cacheLacksHash =
-							usableCache !== undefined &&
-							usableCache !== null &&
-							usableCache.timestampHash === undefined;
+							contextCacheEntryLacksTimestampHash(usableCache);
 						/** @type {undefined | null | ResolvedContextFileSystemInfoEntry} */
 						let resolved;
 						if (
@@ -3396,13 +3407,8 @@ class FileSystemInfo {
 					cache === undefined || isExistenceOnly(cache)
 						? undefined
 						: /** @type {ContextFileSystemInfoEntry | null} */ (cache);
-				// A non-null cache entry that lacks `timestampHash` while the
-				// snapshot has one cannot be used either; we re-read the
-				// directory through the disk-backed queue instead.
 				const cacheLacksHash =
-					usableCache !== undefined &&
-					usableCache !== null &&
-					usableCache.timestampHash === undefined &&
+					contextCacheEntryLacksTimestampHash(usableCache) &&
 					ts !== null &&
 					ts.timestampHash !== undefined;
 				/** @type {undefined | null | ResolvedContextFileSystemInfoEntry} */
@@ -3513,9 +3519,7 @@ class FileSystemInfo {
 							? undefined
 							: /** @type {ContextFileSystemInfoEntry | null} */ (cache);
 					const cacheLacksHash =
-						usableCache !== undefined &&
-						usableCache !== null &&
-						usableCache.timestampHash === undefined &&
+						contextCacheEntryLacksTimestampHash(usableCache) &&
 						tsh !== null &&
 						tsh.timestampHash !== undefined;
 					/** @type {undefined | null | ResolvedContextFileSystemInfoEntry} */

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -837,6 +837,65 @@ ${details(snapshot)}`)
 				}
 			);
 		});
+
+		// #21378: `_resolveContextTimestamp` walks symlink targets via
+		// `_getUnresolvedContextTimestamp`. Watchpack rebuild entries carry
+		// `{ safeTime, timestamp }` but never `timestampHash`; returning
+		// them for a symlink target makes the hash walk crash. Relative
+		// symlink targets (pnpm-style) resolve to the real directory path.
+		it("checkSnapshotValid resolves context dirs with symlinks when watchpack reports `{ safeTime, timestamp }` for the symlink target (#21378)", (done) => {
+			const fs = createFsFromVolume(new Volume());
+			const ctxDir = "/root/ctx";
+			const realDir = "/root/real";
+			const realSubDir = "/root/real/sub";
+			fs.mkdirSync(`${ctxDir}/sub`, { recursive: true });
+			fs.mkdirSync(realSubDir, { recursive: true });
+			fs.writeFileSync(`${realSubDir}/a.txt`, "hello");
+			fs.writeFileSync(`${ctxDir}/index.txt`, "x");
+			fs.symlinkSync("../real", `${ctxDir}/link`, "dir");
+			const contextDirs = [ctxDir, realDir, realSubDir];
+			const fsInfo = createFsInfo(fs);
+			fsInfo.createSnapshot(
+				Date.now() + 10000,
+				[],
+				contextDirs,
+				[],
+				/** @type {SnapshotOptions} */ (
+					/** @type {unknown} */ (["timestamp", { timestamp: true }])
+				),
+				(err, snapshot) => {
+					if (err) return done(err);
+					const ctxSnap = /** @type {Map<string, EXPECTED_ANY>} */ (
+						/** @type {Snapshot} */ (snapshot).contextTimestamps
+					).get(ctxDir);
+					const fsInfo2 = createFsInfo(fs);
+					// Rebuild: watchpack supplies `{ safeTime, timestamp }` for
+					// context dirs but never `timestampHash`.
+					fsInfo2.addContextTimestamps(
+						new Map([
+							[ctxDir, { safeTime: ctxSnap.safeTime }],
+							[
+								realDir,
+								{ safeTime: ctxSnap.safeTime, timestamp: ctxSnap.safeTime }
+							],
+							[
+								realSubDir,
+								{ safeTime: ctxSnap.safeTime, timestamp: ctxSnap.safeTime }
+							]
+						]),
+						true
+					);
+					fsInfo2.checkSnapshotValid(
+						/** @type {Snapshot} */ (snapshot),
+						(err, valid) => {
+							if (err) return done(err);
+							expect(valid).toBe(true);
+							done();
+						}
+					);
+				}
+			);
+		});
 	});
 
 	// A context directory tracked when the snapshot was created can become


### PR DESCRIPTION
**Summary**
Fixes #21378


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Part