### PR TITLE
fix: encode URI-problematic chars in context module regexp identifiers

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -231,7 +231,16 @@ class ContextModule extends Module {
 		const str = stripSlash
 			? regexString.source + regexString.flags
 			: `${regexString}`;
-		return str.replace(/!/g, "%21").replace(/\|/g, "%7C");
+		// The regexp source can itself contain characters that have special
+		// meaning once it becomes part of a module identifier or a source map
+		// name: "!" and "|" are webpack's own loader/segment separators, while
+		// "#", "&", "?", "\" and "/" can be mistaken for a fragment, query
+		// string or path separator by downstream tooling (see #16259). Encode
+		// all of them so a regexp such as /^\.\/.*\.js$/ can't be misread as a
+		// path.
+		return str.replace(/[#&!?|\\/]/g, (match) =>
+			match === "!" ? "%21" : encodeURIComponent(match)
+		);
 	}
 
 	_createIdentifier() {

--- a/test/ContextModule.unittest.js
+++ b/test/ContextModule.unittest.js
@@ -30,7 +30,7 @@ describe("contextModule", () => {
 				)
 			);
 			expect(contextModule.identifier()).toEqual(
-				expect.stringContaining("/a%7Cb/")
+				expect.stringContaining("%2Fa%7Cb%2F")
 			);
 		});
 	});

--- a/test/configCases/source-map/context-module-regexp-uri-chars/images/brands/logo.js
+++ b/test/configCases/source-map/context-module-regexp-uri-chars/images/brands/logo.js
@@ -1,0 +1,1 @@
+module.exports = "logo";

--- a/test/configCases/source-map/context-module-regexp-uri-chars/images/region-flags/flag.js
+++ b/test/configCases/source-map/context-module-regexp-uri-chars/images/region-flags/flag.js
@@ -1,0 +1,1 @@
+module.exports = "flag";

--- a/test/configCases/source-map/context-module-regexp-uri-chars/index.js
+++ b/test/configCases/source-map/context-module-regexp-uri-chars/index.js
@@ -1,0 +1,25 @@
+const name = Math.random() > 0.5 ? "brands/logo.js" : "region-flags/flag.js";
+require.context(
+	"./images",
+	true,
+	/[\\/](?:brands|region-flags)[\\/].*\.js$/
+);
+require(`./images/${name}`);
+
+it("context module regexp with URI-problematic chars should not produce a malformed source map name", () => {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename + ".map", "utf-8");
+	const map = JSON.parse(source);
+
+	const contextModuleSource = map.sources.find((s) => s.includes(" sync "));
+
+	// Issue #16259: a context module regexp containing characters like "?"
+	// (from a non-capturing group "(?:...)") or "/" and "\" used to get
+	// truncated or wrongly absolutified in the emitted source map name,
+	// because those characters were mistaken for a query string separator
+	// or path separator. They must now be percent-encoded and the full
+	// regexp must be present in the source map name.
+	expect(contextModuleSource).toEqual(
+		"webpack:///./images/ sync [%5C%5C%2F](%3F:brands%7Cregion-flags)[%5C%5C%2F].*%5C.js$"
+	);
+});

--- a/test/configCases/source-map/context-module-regexp-uri-chars/webpack.config.js
+++ b/test/configCases/source-map/context-module-regexp-uri-chars/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map"
+};

--- a/test/configCases/source-map/context-module-source-path/index.js
+++ b/test/configCases/source-map/context-module-source-path/index.js
@@ -5,5 +5,5 @@ it("context module should use relative path in source map file", () => {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./foo/ sync ^\\.\\/.*\\.js$");
+	expect(map.sources).toContain("webpack:///./foo/ sync ^%5C.%5C%2F.*%5C.js$");
 });


### PR DESCRIPTION
This continues the approach alexander-akait outlined on #20273: the fix belongs in `_prettyRegExp`, not in `_makePathsAbsolute`. That PR moved in this direction but went stale before landing, so this picks up the same idea with its own tests.

`_prettyRegExp` builds a context module's identifier from the raw source of its `regExp`/`include`/`exclude` options. It only encoded `!` and `|`, so characters like `/`, `\` and `?` passed through untouched. Once that identifier reaches `ModuleFilenameHelpers.createFilename`, a bare `?` gets treated as the start of a query string (`getAfter(resource, "?")`), so a regexp using a non-capturing group like `/(?:brands|region-flags)/` gets truncated right before the `?:`. Everything after it silently disappears from the emitted source map name. An unescaped `/` or `\` can similarly get mistaken for a path separator elsewhere in the pipeline.

I reproduced this with a real webpack build using `require.context` with a regexp containing `(?:...)`: the source map's `sources` array ended up with `"webpack:///./images/ sync [\\/]("` instead of the full pattern.

The fix percent-encodes `#`, `&`, `?`, `\` and `/` in addition to the existing `!` and `|`, in one `.replace()`, using `encodeURIComponent` for everything except `!` (kept as `%21` to match the existing loader-separator convention). This is the same character set and approach the maintainer pointed to via rjgotten's gist on the original issue.

Two existing tests asserted on identifier strings containing literal `/` characters that are now (correctly) percent-encoded too, so I updated their expected values. I also added a new config test case (`test/configCases/source-map/context-module-regexp-uri-chars`) with a regexp containing `(?:...)` that fails before this change and passes after, covering the truncation bug directly.

Ran `test/ContextModule.unittest.js`, `test/ContextModuleFactory.unittest.js`, `test/identifier.unittest.js`, and the `context-module*` config test cases locally; all pass, and the new test fails without the fix.

Credit to samarthsinh2660 for the groundwork on #20273.

Fixes #16259

Written with AI assistance (Claude); reproduced, implemented, and tested against a local clone before opening this PR.
