### PR TITLE
feat: extend import.meta.glob with caseSensitive option and fix parity gaps

### DIFF
--- a/.changeset/import-meta-glob-parity.md
+++ b/.changeset/import-meta-glob-parity.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Improve import.meta.glob: add caseSensitive option, match explicitly targeted hidden/node_modules dirs consistently, decouple from importMetaContext, and warn on non-relative patterns.

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -95,6 +95,7 @@ const { propertyAccess } = require("./util/property");
  * @property {string=} requestContext importer context for import.meta.glob
  * @property {string=} importName import selection for import.meta.glob
  * @property {boolean=} exhaustive exhaustive mode for import.meta.glob
+ * @property {boolean=} caseSensitive case-sensitive matching for import.meta.glob
  */
 
 /**
@@ -287,6 +288,9 @@ class ContextModule extends Module {
 		if (this.options.exhaustive) {
 			identifier += "|exhaustive";
 		}
+		if (this.options.caseSensitive === false) {
+			identifier += "|case-insensitive";
+		}
 		if (this.options.chunkName) {
 			identifier += `|chunkName: ${this.options.chunkName}`;
 		}
@@ -363,6 +367,9 @@ class ContextModule extends Module {
 		}
 		if (this.options.exhaustive) {
 			identifier += " exhaustive";
+		}
+		if (this.options.caseSensitive === false) {
+			identifier += " case-insensitive";
 		}
 		if (this.options.include) {
 			identifier += ` include: ${this._prettyRegExp(this.options.include)}`;
@@ -450,6 +457,9 @@ class ContextModule extends Module {
 		}
 		if (this.options.exhaustive) {
 			identifier += " exhaustive";
+		}
+		if (this.options.caseSensitive === false) {
+			identifier += " case-insensitive";
 		}
 		if (this.options.include) {
 			identifier += ` include: ${this._prettyRegExp(this.options.include)}`;

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -15,6 +15,7 @@ const { cachedSetProperty } = require("./util/cleverMerge");
 const { createFakeHook } = require("./util/deprecation");
 const { join } = require("./util/fs");
 const {
+	globPatternBaseReachesDir,
 	globUserRequest,
 	isNonExhaustiveImportMetaGlobSkippedDir,
 	resolveContextModuleGlobPattern
@@ -333,6 +334,7 @@ class ContextModuleFactory extends ModuleFactory {
 			patterns,
 			requestContext,
 			exhaustive,
+			caseSensitive,
 			include,
 			exclude,
 			referencedExports,
@@ -442,7 +444,14 @@ class ContextModuleFactory extends ModuleFactory {
 									if (
 										isImportMetaGlob &&
 										!exhaustive &&
-										isNonExhaustiveImportMetaGlobSkippedDir(segment)
+										isNonExhaustiveImportMetaGlobSkippedDir(segment) &&
+										!(
+											resolvedGlobPatterns &&
+											globPatternBaseReachesDir(
+												resolvedGlobPatterns,
+												subResource
+											)
+										)
 									) {
 										return callback();
 									}
@@ -468,7 +477,8 @@ class ContextModuleFactory extends ModuleFactory {
 										const exposedUserRequest = globUserRequest(
 											resolvedGlobPatterns,
 											subResource,
-											exhaustive === true
+											exhaustive === true,
+											caseSensitive !== false
 										);
 										if (
 											exposedUserRequest &&

--- a/lib/dependencies/ImportMetaContextPlugin.js
+++ b/lib/dependencies/ImportMetaContextPlugin.js
@@ -38,21 +38,11 @@ const isImportMetaContextEnabled = (parserOptions) => {
 	return isImportMetaFieldEnabled(importMeta, "webpackContext");
 };
 
+// Gated only by the `importMeta.glob` field — independent of the legacy
+// `importMetaContext` toggle, which controls `import.meta.webpackContext`.
 /** @type {(parserOptions: JavascriptParserOptions) => boolean} */
-const isImportMetaGlobEnabled = (parserOptions) => {
-	const importMeta = parserOptions.importMeta;
-	if (
-		Boolean(importMeta) &&
-		typeof importMeta === "object" &&
-		Object.prototype.hasOwnProperty.call(importMeta, "glob")
-	) {
-		return isImportMetaFieldEnabled(importMeta, "glob");
-	}
-	if (parserOptions.importMetaContext === false) {
-		return false;
-	}
-	return isImportMetaFieldEnabled(importMeta, "glob");
-};
+const isImportMetaGlobEnabled = (parserOptions) =>
+	isImportMetaFieldEnabled(parserOptions.importMeta, "glob");
 
 class ImportMetaContextPlugin {
 	/**

--- a/lib/dependencies/ImportMetaGlobDependency.js
+++ b/lib/dependencies/ImportMetaGlobDependency.js
@@ -18,6 +18,7 @@ const ModuleDependencyTemplateAsRequireId = require("./ModuleDependencyTemplateA
  * requestContext: string,
  * importName?: string,
  * exhaustive?: boolean,
+ * caseSensitive?: boolean,
  * }} ImportMetaGlobDependencyOptions
  */
 
@@ -51,6 +52,7 @@ class ImportMetaGlobDependency extends ContextDependency {
 			recursive,
 			mode,
 			exhaustive,
+			caseSensitive,
 			importName,
 			referencedExports
 		} = /** @type {ImportMetaGlobDependencyOptions} */ (this.options);
@@ -58,6 +60,7 @@ class ImportMetaGlobDependency extends ContextDependency {
 			`context${this.getContext() || ""}|glob request${request} ` +
 			`${recursive} ${patterns.join(",")} ` +
 			`${mode}${exhaustive ? " exhaustive" : ""}` +
+			`${caseSensitive === false ? " case-insensitive" : ""}` +
 			`${importName ? ` import:${importName}` : ""}` +
 			`${
 				referencedExports

--- a/lib/dependencies/ImportMetaGlobDependencyParserPlugin.js
+++ b/lib/dependencies/ImportMetaGlobDependencyParserPlugin.js
@@ -57,6 +57,7 @@ module.exports = class ImportMetaGlobDependencyParserPlugin {
 					requestContext: globOptions.requestContext,
 					importName: globOptions.importName,
 					exhaustive: globOptions.exhaustive,
+					caseSensitive: globOptions.caseSensitive,
 					referencedExports: globOptions.referencedExports,
 					namespaceObject:
 						/** @type {import("../Module").BuildMeta} */

--- a/lib/dependencies/ImportMetaGlobHelpers.js
+++ b/lib/dependencies/ImportMetaGlobHelpers.js
@@ -51,12 +51,13 @@ const relativePathToRequest = (relativePath) => {
  * @property {string | undefined} importName import name
  * @property {string} query query
  * @property {boolean} exhaustive exhaustive
+ * @property {boolean} caseSensitive case sensitive
  * @property {RawReferencedExports | undefined} referencedExports referenced exports
  * @property {Range} range range
  */
 
 const SUPPORTED_IMPORT_META_GLOB_OPTIONS =
-	"eager, import, query, base, exhaustive";
+	"eager, import, query, base, exhaustive, caseSensitive";
 
 /**
  * @param {string} msg message
@@ -295,7 +296,7 @@ const parseStaticImportMetaGlobQueryFromExpr = (expr, parser, warnings) => {
  * @param {ObjectExpression | undefined} globOptions options object
  * @param {JavascriptParser} parser parser
  * @param {UnsupportedFeatureWarning[]} warnings warnings
- * @returns {{ eager: boolean, importName: string | undefined, query: string, base: string | undefined, exhaustive: boolean }} parsed options
+ * @returns {{ eager: boolean, importName: string | undefined, query: string, base: string | undefined, exhaustive: boolean, caseSensitive: boolean }} parsed options
  */
 const parseImportMetaGlobOptionsObject = (globOptions, parser, warnings) => {
 	let eager = false;
@@ -305,9 +306,10 @@ const parseImportMetaGlobOptionsObject = (globOptions, parser, warnings) => {
 	/** @type {string | undefined} */
 	let base;
 	let exhaustive = false;
+	let caseSensitive = true;
 
 	if (!globOptions) {
-		return { eager, importName, query, base, exhaustive };
+		return { eager, importName, query, base, exhaustive, caseSensitive };
 	}
 
 	for (const prop of globOptions.properties) {
@@ -406,6 +408,20 @@ const parseImportMetaGlobOptionsObject = (globOptions, parser, warnings) => {
 				}
 				break;
 			}
+			case "caseSensitive": {
+				const evaluated = parser.evaluateExpression(valueExpr);
+				if (evaluated.isBoolean()) {
+					caseSensitive = /** @type {boolean} */ (evaluated.bool);
+				} else {
+					warnings.push(
+						createImportMetaGlobWarning(
+							"import.meta.glob() 'caseSensitive' option must be a constant boolean (true or false), defaulting to true",
+							/** @type {DependencyLocation} */ (valueExpr.loc)
+						)
+					);
+				}
+				break;
+			}
 			case "as":
 				warnings.push(
 					createImportMetaGlobWarning(
@@ -424,7 +440,7 @@ const parseImportMetaGlobOptionsObject = (globOptions, parser, warnings) => {
 		}
 	}
 
-	return { eager, importName, query, base, exhaustive };
+	return { eager, importName, query, base, exhaustive, caseSensitive };
 };
 
 /**
@@ -546,6 +562,23 @@ const parseImportMetaGlobCall = (expr, parser) => {
 		return { options: undefined, errors, warnings };
 	}
 
+	for (const pattern of rawGlobPatterns) {
+		const body = pattern.startsWith("!") ? pattern.slice(1) : pattern;
+		if (
+			!body.startsWith("/") &&
+			!body.startsWith("./") &&
+			!body.startsWith("../") &&
+			!body.startsWith("**")
+		) {
+			warnings.push(
+				createImportMetaGlobWarning(
+					`import.meta.glob() pattern '${pattern}' must be relative (start with './' or '../'), absolute (start with '/'), or a globstar ('**'); aliases are not resolved`,
+					/** @type {DependencyLocation} */ (directoryNode.loc)
+				)
+			);
+		}
+	}
+
 	const optionsNode = expr.arguments[1];
 	if (optionsNode) {
 		if (optionsNode.type === "SpreadElement") {
@@ -577,7 +610,7 @@ const parseImportMetaGlobCall = (expr, parser) => {
 		optionsNode && optionsNode.type === "ObjectExpression"
 			? /** @type {ObjectExpression} */ (optionsNode)
 			: undefined;
-	const { eager, importName, query, base, exhaustive } =
+	const { eager, importName, query, base, exhaustive, caseSensitive } =
 		parseImportMetaGlobOptionsObject(globOptions, parser, warnings);
 	/** @type {ContextModuleOptions["mode"]} */
 	const mode = eager ? "sync" : "lazy";
@@ -613,6 +646,7 @@ const parseImportMetaGlobCall = (expr, parser) => {
 			importName,
 			query,
 			exhaustive,
+			caseSensitive,
 			referencedExports,
 			range: /** @type {Range} */ (expr.range)
 		},

--- a/lib/util/globUtils.js
+++ b/lib/util/globUtils.js
@@ -581,33 +581,47 @@ const commonGlobBaseDir = (patterns, fallback) => {
  * @param {ResolvedContextModuleGlobPattern} pattern pattern
  * @param {string} normalizedPath path
  * @param {boolean} exhaustive exhaustive
+ * @param {boolean} caseSensitive case sensitive
  * @returns {boolean} matches
  */
-const globPatternMatches = (pattern, normalizedPath, exhaustive) =>
+const globPatternMatches = (
+	pattern,
+	normalizedPath,
+	exhaustive,
+	caseSensitive
+) =>
 	globMatchNormalizedWithExplicitDot(
 		pattern.absolutePattern,
 		normalizedPath,
 		pattern.absoluteBase,
-		{ requireLiteralLeadingDot: !exhaustive }
+		{ requireLiteralLeadingDot: !exhaustive, caseSensitive }
 	);
 
 /**
  * @param {ResolvedContextModuleGlobPattern[]} patterns patterns
  * @param {string} filePath path
  * @param {boolean} exhaustive exhaustive
+ * @param {boolean=} caseSensitive case sensitive (default true)
  * @returns {string | undefined} user request
  */
-const globUserRequest = (patterns, filePath, exhaustive) => {
+const globUserRequest = (
+	patterns,
+	filePath,
+	exhaustive,
+	caseSensitive = true
+) => {
 	const normalizedPath = normalizePathSeparatorsForPath(filePath);
 	const matched = patterns
 		.filter((pattern) => !pattern.negative)
-		.find((pattern) => globPatternMatches(pattern, normalizedPath, exhaustive));
+		.find((pattern) =>
+			globPatternMatches(pattern, normalizedPath, exhaustive, caseSensitive)
+		);
 	if (!matched) return;
 	if (
 		patterns
 			.filter((pattern) => pattern.negative)
 			.some((pattern) =>
-				globPatternMatches(pattern, normalizedPath, exhaustive)
+				globPatternMatches(pattern, normalizedPath, exhaustive, caseSensitive)
 			)
 	) {
 		return;
@@ -651,6 +665,28 @@ const globPatternsAreRecursive = (patterns, commonBaseDir) => {
 const isNonExhaustiveImportMetaGlobSkippedDir = (dirname) =>
 	dirname === "node_modules" || dirname.startsWith(".");
 
+/**
+ * A dot/node_modules directory is still traversed in non-exhaustive mode when
+ * it lies within the literal base of some positive pattern — the user named it
+ * explicitly — so combined patterns behave like that pattern used alone.
+ * @param {ResolvedContextModuleGlobPattern[]} patterns patterns
+ * @param {string} dirPath absolute directory path
+ * @returns {boolean} directory is within a positive pattern's literal base
+ */
+const globPatternBaseReachesDir = (patterns, dirPath) => {
+	const normalizedDir = normalizePathSeparatorsForPath(dirPath);
+	const dirWithSlash = normalizedDir.endsWith("/")
+		? normalizedDir
+		: `${normalizedDir}/`;
+	return patterns.some((pattern) => {
+		if (pattern.negative) return false;
+		const base = pattern.absoluteBase.endsWith("/")
+			? pattern.absoluteBase
+			: `${pattern.absoluteBase}/`;
+		return base.startsWith(dirWithSlash);
+	});
+};
+
 module.exports = {
 	commonGlobBaseDir,
 	escapeGlobPattern,
@@ -658,6 +694,7 @@ module.exports = {
 	globMatchNormalizedWithExplicitDot,
 	globMatchWithExplicitDot,
 	globMatchWithOptions,
+	globPatternBaseReachesDir,
 	globPatternsAreRecursive,
 	globUserRequest,
 	importMetaGlobPathParts,

--- a/module.d.ts
+++ b/module.d.ts
@@ -168,6 +168,7 @@ declare namespace webpack {
 		query?: ImportMetaGlobQuery;
 		exhaustive?: boolean;
 		base?: string;
+		caseSensitive?: boolean;
 	};
 }
 

--- a/test/ContextModule.unittest.js
+++ b/test/ContextModule.unittest.js
@@ -110,6 +110,25 @@ describe("contextModule", () => {
 			expect(moduleA.identifier()).toContain(contextA);
 			expect(moduleB.identifier()).toContain(contextB);
 		});
+
+		it("marks case-insensitive glob modules across identifier forms", () => {
+			const mod = new ContextModule(
+				() => {},
+				/** @type {import("../lib/ContextModule").ContextModuleOptions} */ ({
+					resource: "/root",
+					mode: "lazy",
+					recursive: true,
+					regExp: false,
+					patterns: ["./*.js"],
+					requestContext: "/root",
+					caseSensitive: false
+				})
+			);
+			const shortener = new RequestShortener("/root");
+			expect(mod.identifier()).toContain("case-insensitive");
+			expect(mod.readableIdentifier(shortener)).toContain("case-insensitive");
+			expect(mod.libIdent({ context: "/root" })).toContain("case-insensitive");
+		});
 	});
 
 	describe("getGlobSyncSource", () => {

--- a/test/cases/context/import-meta-glob-parity/dedupe/one.js
+++ b/test/cases/context/import-meta-glob-parity/dedupe/one.js
@@ -1,0 +1,1 @@
+export default 'one'

--- a/test/cases/context/import-meta-glob-parity/dedupe/two.js
+++ b/test/cases/context/import-meta-glob-parity/dedupe/two.js
@@ -1,0 +1,1 @@
+export default 'two'

--- a/test/cases/context/import-meta-glob-parity/deep/a/b/c/leaf.js
+++ b/test/cases/context/import-meta-glob-parity/deep/a/b/c/leaf.js
@@ -1,0 +1,1 @@
+export default 'leaf'

--- a/test/cases/context/import-meta-glob-parity/deep/top.js
+++ b/test/cases/context/import-meta-glob-parity/deep/top.js
@@ -1,0 +1,1 @@
+export default 'shallow'

--- a/test/cases/context/import-meta-glob-parity/index.js
+++ b/test/cases/context/import-meta-glob-parity/index.js
@@ -1,0 +1,83 @@
+// Behaviors ported from other bundlers' import.meta.glob / glob-import suites:
+//   Vite      - playground/glob-import + src/node/__tests__/plugins/importGlob
+//   Turbopack - turbopack-tests/.../resolving/import-meta-glob
+//   Rspack    - tests/rspack-test/normalCases/context/import-meta-glob
+// Each case exercises a behavior not already covered by ../import-meta-glob.
+
+// Vite/Turbopack/Rspack all return keys sorted by request; assert the raw
+// order is already sorted, without the test applying its own .sort().
+const orderModules = import.meta.glob('./order/*.js', { eager: true })
+
+// Overlapping patterns must expose a matched file under a single key.
+const dedupeModules = import.meta.glob(['./dedupe/*.js', './dedupe/one.js'], {
+  eager: true,
+})
+
+// Vite #22170: sibling dirs sharing a name prefix (foo vs foobar) must not be
+// merged/pruned by the common-base scan.
+const prefixModules = import.meta.glob(
+  ['./pfx/foo/*.js', './pfx/foobar/*.js'],
+  { eager: true },
+)
+
+// `**` crosses multiple directory levels and also matches a top-level file.
+const deepModules = import.meta.glob('./deep/**/*.js', { eager: true })
+
+// Negating every match yields an empty object (not an error) when the base
+// directory exists (Vite: empty match set -> {}).
+const emptyModules = import.meta.glob(['./order/*.js', '!./order/**'], {
+  eager: true,
+})
+
+import { modules as selfModules, withoutSelf } from './self/importer'
+
+it('returns keys already sorted by request (Vite/Turbopack/Rspack parity)', () => {
+  expect(Object.keys(orderModules)).toEqual([
+    './order/a.js',
+    './order/b.js',
+    './order/c.js',
+    './order/d.js',
+  ])
+})
+
+it('dedupes a file matched by overlapping patterns', () => {
+  expect(Object.keys(dedupeModules)).toEqual([
+    './dedupe/one.js',
+    './dedupe/two.js',
+  ])
+  expect(dedupeModules['./dedupe/one.js'].default).toBe('one')
+})
+
+it('does not merge sibling directories sharing a name prefix (Vite #22170)', () => {
+  expect(Object.keys(prefixModules).sort()).toEqual([
+    './pfx/foo/one.js',
+    './pfx/foobar/two.js',
+  ])
+  expect(prefixModules['./pfx/foo/one.js'].default).toBe('foo-one')
+  expect(prefixModules['./pfx/foobar/two.js'].default).toBe('foobar-two')
+})
+
+it('matches ** across multiple directory levels', () => {
+  expect(Object.keys(deepModules).sort()).toEqual([
+    './deep/a/b/c/leaf.js',
+    './deep/top.js',
+  ])
+  expect(deepModules['./deep/a/b/c/leaf.js'].default).toBe('leaf')
+  expect(deepModules['./deep/top.js'].default).toBe('shallow')
+})
+
+it('returns an empty object when every match is negated', () => {
+  expect(emptyModules).toEqual({})
+})
+
+// Divergence: being ContextModule-based, webpack includes the importing
+// module itself (like Turbopack, which negates `!./index.js` in its own test);
+// Vite auto-excludes it. Exclude it explicitly with a negative pattern.
+it('includes the importer in ./*.js, excludable via negation (Turbopack parity)', () => {
+  expect(Object.keys(selfModules).sort()).toEqual([
+    './importer.js',
+    './sibling.js',
+  ])
+  expect(Object.keys(withoutSelf)).toEqual(['./sibling.js'])
+  expect(withoutSelf['./sibling.js'].default).toBe('sibling')
+})

--- a/test/cases/context/import-meta-glob-parity/order/a.js
+++ b/test/cases/context/import-meta-glob-parity/order/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/test/cases/context/import-meta-glob-parity/order/b.js
+++ b/test/cases/context/import-meta-glob-parity/order/b.js
@@ -1,0 +1,1 @@
+export default 'b'

--- a/test/cases/context/import-meta-glob-parity/order/c.js
+++ b/test/cases/context/import-meta-glob-parity/order/c.js
@@ -1,0 +1,1 @@
+export default 'c'

--- a/test/cases/context/import-meta-glob-parity/order/d.js
+++ b/test/cases/context/import-meta-glob-parity/order/d.js
@@ -1,0 +1,1 @@
+export default 'd'

--- a/test/cases/context/import-meta-glob-parity/pfx/foo/one.js
+++ b/test/cases/context/import-meta-glob-parity/pfx/foo/one.js
@@ -1,0 +1,1 @@
+export default 'foo-one'

--- a/test/cases/context/import-meta-glob-parity/pfx/foobar/two.js
+++ b/test/cases/context/import-meta-glob-parity/pfx/foobar/two.js
@@ -1,0 +1,1 @@
+export default 'foobar-two'

--- a/test/cases/context/import-meta-glob-parity/self/importer.js
+++ b/test/cases/context/import-meta-glob-parity/self/importer.js
@@ -1,0 +1,4 @@
+export const modules = import.meta.glob('./*.js', { eager: true })
+export const withoutSelf = import.meta.glob(['./*.js', '!./importer.js'], {
+	eager: true
+})

--- a/test/cases/context/import-meta-glob-parity/self/sibling.js
+++ b/test/cases/context/import-meta-glob-parity/self/sibling.js
@@ -1,0 +1,1 @@
+export default 'sibling'

--- a/test/cases/context/import-meta-glob/case-test/alpha.js
+++ b/test/cases/context/import-meta-glob/case-test/alpha.js
@@ -1,0 +1,1 @@
+export default 'alpha'

--- a/test/cases/context/import-meta-glob/exhaustive-scan/.hidden-dir/deep.js
+++ b/test/cases/context/import-meta-glob/exhaustive-scan/.hidden-dir/deep.js
@@ -1,0 +1,1 @@
+export default 'deep hidden'

--- a/test/cases/context/import-meta-glob/exhaustive-scan/node_modules/dep.js
+++ b/test/cases/context/import-meta-glob/exhaustive-scan/node_modules/dep.js
@@ -1,0 +1,1 @@
+export default 'nm dep'

--- a/test/cases/context/import-meta-glob/exhaustive-scan/visible.js
+++ b/test/cases/context/import-meta-glob/exhaustive-scan/visible.js
@@ -1,0 +1,1 @@
+export default 'visible'

--- a/test/cases/context/import-meta-glob/index.js
+++ b/test/cases/context/import-meta-glob/index.js
@@ -12,12 +12,23 @@ const eagerNamespaceModules = import.meta.glob('./dir/*.js', {
 const explicitNodeModulesModules = import.meta.glob('./dir/node_modules/*.js', {
   eager: true,
 })
-const skippedExhaustiveModules = import.meta.glob(
+const explicitHiddenModules = import.meta.glob(
   ['./dot/.*.js', './.foo/*.js', './dir/node_modules/**'],
   { eager: true },
 )
-const exhaustiveModules = import.meta.glob(
+const explicitHiddenModulesExhaustive = import.meta.glob(
   ['./dot/.*.js', './.foo/*.js', './dir/node_modules/**'],
+  { eager: true, exhaustive: true },
+)
+const soloFooModules = import.meta.glob('./.foo/*.js', { eager: true })
+const combinedFooModules = import.meta.glob(['./dot/.*.js', './.foo/*.js'], {
+  eager: true,
+})
+const wildcardScanModules = import.meta.glob('./exhaustive-scan/**/*.js', {
+  eager: true,
+})
+const wildcardScanExhaustiveModules = import.meta.glob(
+  './exhaustive-scan/**/*.js',
   { eager: true, exhaustive: true },
 )
 const filteredModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], { eager: true })
@@ -118,6 +129,11 @@ const filteredDefaultModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
 const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
   import: 'named',
 })
+const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
+const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})
 const quotedModules = import.meta.glob("./quoted/*.js", { eager: true })
 const escapeModules = import.meta.glob('./escape/**/glob.js', { eager: true })
 
@@ -192,17 +208,37 @@ it('should allow explicit glob roots inside node_modules', () => {
   )
 })
 
-it('should only search hidden directories and node_modules in exhaustive mode', () => {
-  expect(Object.keys(skippedExhaustiveModules)).toEqual(['./dot/.hidden.js'])
-  expect(skippedExhaustiveModules['./dot/.hidden.js'].default).toBe('hidden')
-  expect(Object.keys(exhaustiveModules).sort()).toEqual([
+it('should search explicitly targeted hidden and node_modules dirs regardless of exhaustive', () => {
+  const expected = [
     './.foo/test.js',
     './dir/node_modules/hoge.js',
     './dot/.hidden.js',
+  ]
+  expect(Object.keys(explicitHiddenModules).sort()).toEqual(expected)
+  expect(Object.keys(explicitHiddenModulesExhaustive).sort()).toEqual(expected)
+  expect(explicitHiddenModules['./dot/.hidden.js'].default).toBe('hidden')
+  expect(explicitHiddenModules['./.foo/test.js'].default).toBe('dot folder')
+  expect(explicitHiddenModules['./dir/node_modules/hoge.js'].default).toBe('hoge')
+})
+
+it('should match an explicit dot-directory pattern the same alone or combined', () => {
+  expect(Object.keys(soloFooModules)).toEqual(['./.foo/test.js'])
+  expect(Object.keys(combinedFooModules).sort()).toEqual([
+    './.foo/test.js',
+    './dot/.hidden.js',
   ])
-  expect(exhaustiveModules['./dot/.hidden.js'].default).toBe('hidden')
-  expect(exhaustiveModules['./.foo/test.js'].default).toBe('dot folder')
-  expect(exhaustiveModules['./dir/node_modules/hoge.js'].default).toBe('hoge')
+  expect(combinedFooModules['./.foo/test.js'].default).toBe('dot folder')
+})
+
+it('should descend wildcard-reached hidden and node_modules dirs only when exhaustive', () => {
+  expect(Object.keys(wildcardScanModules)).toEqual([
+    './exhaustive-scan/visible.js',
+  ])
+  expect(Object.keys(wildcardScanExhaustiveModules).sort()).toEqual([
+    './exhaustive-scan/.hidden-dir/deep.js',
+    './exhaustive-scan/node_modules/dep.js',
+    './exhaustive-scan/visible.js',
+  ])
 })
 
 it('should support negative patterns and import selection in glob arrays', async () => {
@@ -365,6 +401,12 @@ it('should parse glob calls with comments in the argument list', async () => {
 it('should work when glob results are wrapped with Object.keys and Object.values', () => {
   expect(objectKeyModules.sort()).toEqual(dirKeys)
   expect(objectValueModules.map(mod => mod.default).sort()).toEqual(['bar', 'foo'])
+})
+
+it('should match case-insensitively only when caseSensitive is false', () => {
+  expect(Object.keys(caseSensitiveModules)).toEqual([])
+  expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
+  expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
 })
 
 it('should handle matched paths containing single quotes', () => {

--- a/test/configCases/parsing/import-meta-glob-context-disabled/index.js
+++ b/test/configCases/parsing/import-meta-glob-context-disabled/index.js
@@ -1,0 +1,7 @@
+const modules = import.meta.glob("./mods/*.js", { eager: true });
+
+it("keeps import.meta.glob working when importMetaContext is disabled", () => {
+	expect(Object.keys(modules).sort()).toEqual(["./mods/a.js", "./mods/b.js"]);
+	expect(modules["./mods/a.js"].default).toBe("a");
+	expect(modules["./mods/b.js"].default).toBe("b");
+});

--- a/test/configCases/parsing/import-meta-glob-context-disabled/mods/a.js
+++ b/test/configCases/parsing/import-meta-glob-context-disabled/mods/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/test/configCases/parsing/import-meta-glob-context-disabled/mods/b.js
+++ b/test/configCases/parsing/import-meta-glob-context-disabled/mods/b.js
@@ -1,0 +1,1 @@
+export default 'b'

--- a/test/configCases/parsing/import-meta-glob-context-disabled/webpack.config.js
+++ b/test/configCases/parsing/import-meta-glob-context-disabled/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		parser: {
+			javascript: {
+				importMetaContext: false
+			}
+		}
+	}
+};

--- a/test/configCases/parsing/import-meta-glob/__snapshots__/errors.snap
+++ b/test/configCases/parsing/import-meta-glob/__snapshots__/errors.snap
@@ -6,5 +6,6 @@ Array [
   "import.meta.glob() second argument must be an object literal",
   "Module not found: Error: Can't resolve '<TEST_DIR>/missing/' in '<TEST_DIR>'",
   "Module not found: Error: Can't resolve '<TEST_DIR>/missing/' in '<TEST_DIR>'",
+  "Module not found: Error: Can't resolve '<TEST_DIR>/@/alias/' in '<TEST_DIR>'",
 ]
 `;

--- a/test/configCases/parsing/import-meta-glob/__snapshots__/warnings.snap
+++ b/test/configCases/parsing/import-meta-glob/__snapshots__/warnings.snap
@@ -11,7 +11,7 @@ Array [
   "import.meta.glob() 'base' option must be a constant string, ignoring",
   "import.meta.glob() 'exhaustive' option must be a constant boolean (true or false), defaulting to false",
   "import.meta.glob() 'as' option is not supported. Use 'query' instead (e.g. { query: '?raw' })",
-  "import.meta.glob() unsupported option 'caseSensitive'. Supported options are: eager, import, query, base, exhaustive",
   "import.meta.glob() option keys must be constant strings",
+  "import.meta.glob() pattern '@/alias/*.js' must be relative (start with './' or '../'), absolute (start with '/'), or a globstar ('**'); aliases are not resolved",
 ]
 `;

--- a/test/configCases/parsing/import-meta-glob/__snapshots__/warnings.snap
+++ b/test/configCases/parsing/import-meta-glob/__snapshots__/warnings.snap
@@ -11,6 +11,7 @@ Array [
   "import.meta.glob() 'base' option must be a constant string, ignoring",
   "import.meta.glob() 'exhaustive' option must be a constant boolean (true or false), defaulting to false",
   "import.meta.glob() 'as' option is not supported. Use 'query' instead (e.g. { query: '?raw' })",
+  "import.meta.glob() 'caseSensitive' option must be a constant boolean (true or false), defaulting to true",
   "import.meta.glob() option keys must be constant strings",
   "import.meta.glob() pattern '@/alias/*.js' must be relative (start with './' or '../'), absolute (start with '/'), or a globstar ('**'); aliases are not resolved",
 ]

--- a/test/configCases/parsing/import-meta-glob/diagnostics.js
+++ b/test/configCases/parsing/import-meta-glob/diagnostics.js
@@ -15,3 +15,4 @@ import.meta.glob("./missing/*.js", { caseSensitive: true });
 import.meta.glob("./missing/*.js", { eager: true, import: "default" });
 const eagerOptionKey = "eager";
 import.meta.glob("./missing/*.js", { [eagerOptionKey]: true });
+import.meta.glob("@/alias/*.js");

--- a/test/configCases/parsing/import-meta-glob/diagnostics.js
+++ b/test/configCases/parsing/import-meta-glob/diagnostics.js
@@ -12,6 +12,7 @@ import.meta.glob("./missing/*.js", { base: 1 });
 import.meta.glob("./missing/*.js", { exhaustive: "true" });
 import.meta.glob("./missing/*.js", { as: "raw" });
 import.meta.glob("./missing/*.js", { caseSensitive: true });
+import.meta.glob("./missing/*.js", { caseSensitive: "yes" });
 import.meta.glob("./missing/*.js", { eager: true, import: "default" });
 const eagerOptionKey = "eager";
 import.meta.glob("./missing/*.js", { [eagerOptionKey]: true });

--- a/test/globUtils.unittest.js
+++ b/test/globUtils.unittest.js
@@ -6,6 +6,7 @@ const {
 	extractGlobBaseDir,
 	globMatchWithExplicitDot,
 	globMatchWithOptions,
+	globPatternBaseReachesDir,
 	globPatternsAreRecursive,
 	globUserRequest,
 	normalizePathSeparators,
@@ -354,6 +355,49 @@ describe("globUtils", () => {
 			const patterns = [resolveContextModuleGlobPattern("./*.js", root, root)];
 			const file = path.join(root, "日.js");
 			expect(globUserRequest(patterns, file, false)).toBe("./日.js");
+		});
+
+		it("honors the caseSensitive flag", () => {
+			const root = path.resolve("test/cases/context/import-meta-glob/dir");
+			const patterns = [resolveContextModuleGlobPattern("./*.JS", root, root)];
+			const file = path.join(root, "foo.js");
+			expect(globUserRequest(patterns, file, false, true)).toBeUndefined();
+			expect(globUserRequest(patterns, file, false, false)).toBe("./foo.js");
+		});
+	});
+
+	describe("globPatternBaseReachesDir", () => {
+		const root = path.resolve("test/cases/context/import-meta-glob");
+
+		it("is true when a dir is within a positive pattern's literal base", () => {
+			const patterns = [
+				resolveContextModuleGlobPattern("./.foo/*.js", root, root),
+				resolveContextModuleGlobPattern("./dir/node_modules/**", root, root)
+			];
+			expect(globPatternBaseReachesDir(patterns, path.join(root, ".foo"))).toBe(
+				true
+			);
+			expect(
+				globPatternBaseReachesDir(patterns, path.join(root, "dir/node_modules"))
+			).toBe(true);
+		});
+
+		it("is false for dirs only reachable through a wildcard segment", () => {
+			const patterns = [
+				resolveContextModuleGlobPattern("./**/*.js", root, root)
+			];
+			expect(globPatternBaseReachesDir(patterns, path.join(root, ".foo"))).toBe(
+				false
+			);
+		});
+
+		it("ignores negative patterns", () => {
+			const patterns = [
+				resolveContextModuleGlobPattern("!./.foo/*.js", root, root)
+			];
+			expect(globPatternBaseReachesDir(patterns, path.join(root, ".foo"))).toBe(
+				false
+			);
 		});
 	});
 

--- a/test/globUtils.unittest.js
+++ b/test/globUtils.unittest.js
@@ -410,6 +410,17 @@ describe("globUtils", () => {
 			];
 			expect(commonGlobBaseDir(patterns, root)).toBe(`${root}/`);
 		});
+
+		// Vite #22170 / getCommonBase: a shared name prefix (foo vs foobar) must
+		// not collapse the common base into the shorter directory.
+		it("does not treat a name prefix as a shared directory", () => {
+			const root = path.resolve("test/cases/context/import-meta-glob-parity");
+			const patterns = [
+				resolveContextModuleGlobPattern("./pfx/foo/*.js", root, root),
+				resolveContextModuleGlobPattern("./pfx/foobar/*.js", root, root)
+			];
+			expect(commonGlobBaseDir(patterns, root)).toBe(`${root}/pfx/`);
+		});
 	});
 
 	describe("parse and factory resolve consistency", () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -5113,6 +5113,11 @@ declare interface ContextOptions {
 	 * exhaustive mode for import.meta.glob
 	 */
 	exhaustive?: boolean;
+
+	/**
+	 * case-sensitive matching for import.meta.glob
+	 */
+	caseSensitive?: boolean;
 }
 declare class ContextReplacementPlugin {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #21333 that closes remaining `import.meta.glob` gaps found while comparing against Vite, Turbopack and Rspack:

- Adds the Vite `caseSensitive` option (default `true`), threaded through the parser, dependency, `ContextModule` and glob matcher.
- Matches explicitly targeted hidden / `node_modules` directories consistently whether a pattern is used alone or combined with sibling patterns (previously the same pattern matched or not depending on the common base of its siblings).
- Decouples `import.meta.glob` from the legacy `importMetaContext` toggle, which previously disabled it as a side effect.
- Warns when a pattern is not relative (`./`, `../`), absolute (`/`) or a globstar (`**`) — e.g. an unresolved alias like `@/…` — instead of only failing with an opaque "Module not found".

**What kind of change does this PR introduce?**

feat (new `caseSensitive` option), together with related bug fixes to hidden-dir matching and the parser toggle.

**Did you add tests for your changes?**

Yes. `test/globUtils.unittest.js` (matcher/base-dir units), `test/cases/context/import-meta-glob/` (caseSensitive + hidden-dir consistency), a new `test/cases/context/import-meta-glob-parity/` porting cases from Vite/Turbopack/Rspack (sorted keys, dedupe, deep `**`, common-base prefix, self-inclusion), and `test/configCases/parsing/import-meta-glob*` (diagnostics + the `importMetaContext: false` case).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Document the `caseSensitive` option on webpack.js.org, and note that a hidden / `node_modules` directory named explicitly in a pattern's base is matched without `exhaustive`. Type declarations are updated in `module.d.ts` / `types.d.ts`.

**Use of AI**

Yes. AI was used to compare webpack's implementation and tests against the Vite, Turbopack and Rspack documentation and test suites, to draft the code and the ported test cases, and to write this description. All code and tests were reviewed and verified against the local test suite before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G96q72YMmQi518B2Fhoy2c)_