### PR TITLE
fix: report strict-mode-only syntax in ES module output

### DIFF
--- a/.changeset/strict-mode-module-output-errors.md
+++ b/.changeset/strict-mode-module-output-errors.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Warn on strict-mode-only syntax (`delete` of a variable, `with`, octal literals and escapes, duplicate parameters, assigning to `eval`/`arguments`) in modules emitted as ES module output, since it becomes a runtime SyntaxError; the warning becomes an error under `experiments.futureDefaults`.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -9,6 +9,7 @@ const vm = require("vm");
 const { HookMap, SyncBailHook } = require("tapable");
 const NormalModule = require("../NormalModule");
 const Parser = require("../Parser");
+const WebpackError = require("../WebpackError");
 const StackedMap = require("../util/StackedMap");
 const binarySearchBounds = require("../util/binarySearchBounds");
 const {
@@ -37,6 +38,7 @@ const {
 /** @typedef {import("estree").SwitchStatement} SwitchStatement */
 /** @typedef {import("estree").ClassExpression} ClassExpression */
 /** @typedef {import("estree").SourceLocation} SourceLocation */
+/** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("estree").Comment & { start: number, end: number, loc: SourceLocation }} Comment */
 /** @typedef {import("estree").ConditionalExpression} ConditionalExpression */
 /** @typedef {import("estree").Declaration} Declaration */
@@ -487,6 +489,33 @@ const EVALUATE_AST_CACHE_LIMIT = 4096;
 
 const CLASS_NAME = "JavascriptParser";
 
+/**
+ * Whether a raw string literal contains a legacy octal (`\47`, `\0` followed by
+ * a digit) or non-octal decimal (`\8`, `\9`) escape — all SyntaxErrors in
+ * strict mode. Escaped backslashes (`\\`) and `\x` / `\u` escapes are skipped.
+ * @param {string} raw raw string literal text, including quotes
+ * @returns {boolean} true when a strict-forbidden escape is present
+ */
+const hasOctalEscape = (raw) => {
+	for (let i = 0; i < raw.length; i++) {
+		if (raw.charCodeAt(i) !== 92) continue;
+		const next = raw.charCodeAt(i + 1);
+		if (next === 92) {
+			i++;
+			continue;
+		}
+		// `\0` is a valid NUL escape unless a digit follows it.
+		if (next === 48) {
+			const after = raw.charCodeAt(i + 2);
+			if (after >= 48 && after <= 57) return true;
+			i++;
+			continue;
+		}
+		if (next >= 49 && next <= 57) return true;
+	}
+	return false;
+};
+
 class JavascriptParser extends Parser {
 	/**
 	 * Creates an instance of JavascriptParser.
@@ -713,6 +742,8 @@ class JavascriptParser extends Parser {
 		this.destructuringAssignmentProperties = undefined;
 		/** @type {TagData | undefined} */
 		this.currentTagData = undefined;
+		// True while parsing a loose module whose code is emitted as strict ESM.
+		this._strictInModuleOutput = false;
 		this.magicCommentContext = createMagicCommentContext();
 		// Reused for enterPatterns on every scope entry to avoid per-scope closures.
 		/** @type {OnIdentString} */
@@ -2502,6 +2533,12 @@ class JavascriptParser extends Parser {
 	 * @param {WithStatement} statement with statement
 	 */
 	walkWithStatement(statement) {
+		if (this._strictInModuleOutput) {
+			this._reportStrictModeViolation(
+				"`with` statements are not allowed",
+				statement.loc
+			);
+		}
 		this.inBlockScope(() => {
 			this.walkExpression(statement.object);
 			this.walkNestedStatement(statement.body);
@@ -2790,6 +2827,9 @@ class JavascriptParser extends Parser {
 	walkFunctionDeclaration(statement) {
 		const wasTopLevel = this.scope.topLevelScope;
 		this.scope.topLevelScope = false;
+		if (this._strictInModuleOutput) {
+			this._checkStrictModeParams(statement.params);
+		}
 		this.inFunctionScope(true, statement.params, () => {
 			for (const param of statement.params) {
 				this.walkPattern(param);
@@ -3605,6 +3645,40 @@ class JavascriptParser extends Parser {
 			case "YieldExpression":
 				this.walkYieldExpression(expression);
 				break;
+			case "Literal":
+				if (this._strictInModuleOutput) {
+					this._checkStrictModeLiteral(expression);
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Reports octal number literals (`0777`) and octal string escapes (`"\47"`),
+	 * both SyntaxErrors in strict-mode ESM output.
+	 * @param {Literal} expression literal
+	 */
+	_checkStrictModeLiteral(expression) {
+		const raw = /** @type {string | undefined} */ (expression.raw);
+		if (raw === undefined) return;
+		if (typeof expression.value === "number") {
+			// Legacy octal (`0777`) or non-octal decimal (`08`) integer literal.
+			if (
+				raw.length > 1 &&
+				raw.charCodeAt(0) === 48 &&
+				raw.charCodeAt(1) >= 48 &&
+				raw.charCodeAt(1) <= 57
+			) {
+				this._reportStrictModeViolation(
+					"Octal literals are not allowed",
+					expression.loc
+				);
+			}
+		} else if (typeof expression.value === "string" && hasOctalEscape(raw)) {
+			this._reportStrictModeViolation(
+				"Octal escape sequences are not allowed",
+				expression.loc
+			);
 		}
 	}
 
@@ -3691,6 +3765,9 @@ class JavascriptParser extends Parser {
 			? [...expression.params, expression.id]
 			: expression.params;
 
+		if (this._strictInModuleOutput) {
+			this._checkStrictModeParams(expression.params);
+		}
 		this.inFunctionScope(true, scopeParams, () => {
 			for (const param of expression.params) {
 				this.walkPattern(param);
@@ -3714,6 +3791,9 @@ class JavascriptParser extends Parser {
 	walkArrowFunctionExpression(expression) {
 		const wasTopLevel = this.scope.topLevelScope;
 		this.scope.topLevelScope = wasTopLevel ? "arrow" : false;
+		if (this._strictInModuleOutput) {
+			this._checkStrictModeParams(expression.params);
+		}
 		this.inFunctionScope(false, expression.params, () => {
 			for (const param of expression.params) {
 				this.walkPattern(param);
@@ -3775,7 +3855,60 @@ class JavascriptParser extends Parser {
 	 * @param {UpdateExpression} expression the update expression
 	 */
 	walkUpdateExpression(expression) {
+		if (
+			this._strictInModuleOutput &&
+			expression.argument.type === "Identifier"
+		) {
+			this._checkStrictModeAssignTarget(
+				expression.argument.name,
+				expression.loc
+			);
+		}
 		this.walkExpression(expression.argument);
+	}
+
+	/**
+	 * Reports `eval` / `arguments` used as an assignment or update target, which
+	 * is a SyntaxError in strict-mode ESM output.
+	 * @param {string} name target identifier name
+	 * @param {SourceLocation | null | undefined} loc source location
+	 */
+	_checkStrictModeAssignTarget(name, loc) {
+		if (name === "eval" || name === "arguments") {
+			this._reportStrictModeViolation(
+				`Assigning to "${name}" is not allowed`,
+				loc
+			);
+		}
+	}
+
+	/**
+	 * Reports strict-mode-only errors in a function's parameter list: a duplicate
+	 * simple parameter, or a parameter named `eval` / `arguments`.
+	 * @param {(import("estree").Pattern)[]} params function parameters
+	 */
+	_checkStrictModeParams(params) {
+		/** @type {Set<string> | undefined} */
+		let seen;
+		for (const param of params) {
+			if (param.type !== "Identifier") continue;
+			const name = param.name;
+			if (name === "eval" || name === "arguments") {
+				this._reportStrictModeViolation(
+					`"${name}" is not allowed as a parameter name`,
+					param.loc
+				);
+			}
+			if (seen === undefined) seen = new Set();
+			if (seen.has(name)) {
+				this._reportStrictModeViolation(
+					`Duplicate parameter name "${name}" is not allowed`,
+					param.loc
+				);
+			} else {
+				seen.add(name);
+			}
+		}
 	}
 
 	/**
@@ -3798,8 +3931,36 @@ class JavascriptParser extends Parser {
 				);
 				if (result === true) return;
 			}
+		} else if (
+			this._strictInModuleOutput &&
+			expression.operator === "delete" &&
+			expression.argument.type === "Identifier"
+		) {
+			this._reportStrictModeViolation(
+				`Deleting the unqualified identifier "${expression.argument.name}" is not allowed`,
+				expression.loc
+			);
 		}
 		this.walkExpression(expression.argument);
+	}
+
+	/**
+	 * Reports a construct that a loose script allows but that becomes a
+	 * SyntaxError once the module is emitted as strict-mode ESM output. It is a
+	 * warning today and an error under `experiments.futureDefaults`.
+	 * @param {string} reason what is not allowed
+	 * @param {SourceLocation | null | undefined} loc source location
+	 */
+	_reportStrictModeViolation(reason, loc) {
+		const diagnostic = new WebpackError(
+			`${reason}. The output is an ES module, which runs in strict mode.`
+		);
+		diagnostic.loc = /** @type {DependencyLocation} */ (loc);
+		if (this.state.compilation.options.experiments.futureDefaults) {
+			this.state.module.addError(diagnostic);
+		} else {
+			this.state.module.addWarning(diagnostic);
+		}
 	}
 
 	/**
@@ -3840,6 +4001,9 @@ class JavascriptParser extends Parser {
 	 */
 	walkAssignmentExpression(expression) {
 		if (expression.left.type === "Identifier") {
+			if (this._strictInModuleOutput) {
+				this._checkStrictModeAssignTarget(expression.left.name, expression.loc);
+			}
 			const renameIdentifier = this.getRenameIdentifier(expression.right);
 			if (
 				renameIdentifier &&
@@ -4987,6 +5151,7 @@ class JavascriptParser extends Parser {
 		const oldSemicolons = this.semicolons;
 		const oldStatementPath = this.statementPath;
 		const oldPrevStatement = this.prevStatement;
+		const oldStrictInModuleOutput = this._strictInModuleOutput;
 		this.scope = {
 			topLevelScope: true,
 			inTry: false,
@@ -5002,6 +5167,12 @@ class JavascriptParser extends Parser {
 		this.semicolons = semicolons;
 		this.statementPath = [];
 		this.prevStatement = undefined;
+		// The output is emitted as strict-mode ESM, but this module was parsed as
+		// a loose script — acorn skipped the strict early errors that will break
+		// the bundle at runtime. Enables the strict-mode diagnostics below.
+		this._strictInModuleOutput =
+			state.compilation !== undefined &&
+			state.compilation.runtimeTemplate.isModule();
 		if (this.hooks.program.call(ast, comments) === undefined) {
 			this.destructuringAssignmentProperties = new WeakMap();
 			this.detectMode(ast.body);
@@ -5021,6 +5192,7 @@ class JavascriptParser extends Parser {
 		this.semicolons = oldSemicolons;
 		this.statementPath = oldStatementPath;
 		this.prevStatement = oldPrevStatement;
+		this._strictInModuleOutput = oldStrictInModuleOutput;
 		return state;
 	}
 

--- a/test/configCases/parsing/strict-mode-module-output-future-defaults/errors.js
+++ b/test/configCases/parsing/strict-mode-module-output-future-defaults/errors.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = [
+	[
+		{
+			message: /Deleting the unqualified identifier "foo" is not allowed/,
+			moduleName: /mod\.js/
+		}
+	],
+	[{ message: /`with` statements are not allowed/ }],
+	[{ message: /Octal literals are not allowed/ }],
+	[{ message: /Octal escape sequences are not allowed/ }],
+	[{ message: /Octal escape sequences are not allowed/ }],
+	[{ message: /Duplicate parameter name "a" is not allowed/ }],
+	[{ message: /Assigning to "eval" is not allowed/ }],
+	[{ message: /Assigning to "arguments" is not allowed/ }]
+];

--- a/test/configCases/parsing/strict-mode-module-output-future-defaults/index.js
+++ b/test/configCases/parsing/strict-mode-module-output-future-defaults/index.js
@@ -1,0 +1,1 @@
+import "./mod.js";

--- a/test/configCases/parsing/strict-mode-module-output-future-defaults/mod.js
+++ b/test/configCases/parsing/strict-mode-module-output-future-defaults/mod.js
@@ -1,0 +1,26 @@
+// Pure CommonJS module: parsed as a loose script, so acorn does not reject
+// these strict-mode-only violations — but the ESM output runs in strict mode.
+var foo = 2;
+delete foo;
+
+var obj = { x: 1 };
+delete obj.x; // member delete stays valid, must not be reported
+
+with (obj) {
+	foo = x;
+}
+
+var octalNumber = 0777;
+var octalStringA = "\047"; // octal escape (\0 followed by a digit)
+var octalStringB = "\47"; // octal escape (\1-\7)
+var notOctalA = "\\048"; // escaped backslash, not an octal escape
+var notOctalB = "\0"; // NUL escape, valid
+
+function dup(a, a) {
+	return a;
+}
+
+eval = 1;
+arguments = 2;
+
+module.exports = { foo, obj, octalNumber, octalStringA, octalStringB, dup };

--- a/test/configCases/parsing/strict-mode-module-output-future-defaults/test.config.js
+++ b/test/configCases/parsing/strict-mode-module-output-future-defaults/test.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// The bundle intentionally contains a strict-mode `delete`, so it must not run.
+module.exports.noTests = true;

--- a/test/configCases/parsing/strict-mode-module-output-future-defaults/webpack.config.js
+++ b/test/configCases/parsing/strict-mode-module-output-future-defaults/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	output: {
+		module: true,
+		chunkFormat: "module",
+		library: { type: "module" }
+	},
+	experiments: {
+		outputModule: true,
+		futureDefaults: true
+	}
+};

--- a/test/configCases/parsing/strict-mode-module-output/index.js
+++ b/test/configCases/parsing/strict-mode-module-output/index.js
@@ -1,0 +1,1 @@
+import "./mod.js";

--- a/test/configCases/parsing/strict-mode-module-output/mod.js
+++ b/test/configCases/parsing/strict-mode-module-output/mod.js
@@ -1,0 +1,26 @@
+// Pure CommonJS module: parsed as a loose script, so acorn does not reject
+// these strict-mode-only violations — but the ESM output runs in strict mode.
+var foo = 2;
+delete foo;
+
+var obj = { x: 1 };
+delete obj.x; // member delete stays valid, must not be reported
+
+with (obj) {
+	foo = x;
+}
+
+var octalNumber = 0777;
+var octalStringA = "\047"; // octal escape (\0 followed by a digit)
+var octalStringB = "\47"; // octal escape (\1-\7)
+var notOctalA = "\\048"; // escaped backslash, not an octal escape
+var notOctalB = "\0"; // NUL escape, valid
+
+function dup(a, a) {
+	return a;
+}
+
+eval = 1;
+arguments = 2;
+
+module.exports = { foo, obj, octalNumber, octalStringA, octalStringB, dup };

--- a/test/configCases/parsing/strict-mode-module-output/test.config.js
+++ b/test/configCases/parsing/strict-mode-module-output/test.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// The bundle intentionally contains a strict-mode `delete`, so it must not run.
+module.exports.noTests = true;

--- a/test/configCases/parsing/strict-mode-module-output/warnings.js
+++ b/test/configCases/parsing/strict-mode-module-output/warnings.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = [
+	[
+		{
+			message: /Deleting the unqualified identifier "foo" is not allowed/,
+			moduleName: /mod\.js/
+		}
+	],
+	[{ message: /`with` statements are not allowed/ }],
+	[{ message: /Octal literals are not allowed/ }],
+	[{ message: /Octal escape sequences are not allowed/ }],
+	[{ message: /Octal escape sequences are not allowed/ }],
+	[{ message: /Duplicate parameter name "a" is not allowed/ }],
+	[{ message: /Assigning to "eval" is not allowed/ }],
+	[{ message: /Assigning to "arguments" is not allowed/ }]
+];

--- a/test/configCases/parsing/strict-mode-module-output/webpack.config.js
+++ b/test/configCases/parsing/strict-mode-module-output/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	output: {
+		module: true,
+		chunkFormat: "module",
+		library: { type: "module" }
+	},
+	experiments: {
+		outputModule: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A loose (CommonJS/script) module is parsed in sloppy mode, so acorn skips the strict-mode early errors. When such a module is emitted as strict-mode ES module output (`output.module`), constructs like `delete <variable>`, `with`, octal literals/escapes, duplicate parameters, and assigning to `eval`/`arguments` silently produced a bundle that throws a `SyntaxError` at runtime, with no build-time diagnostic. This reports them during the build. Refs #17121 (the "`delete x` should be a build error as code is compiled in strict mode" item).

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/parsing/strict-mode-module-output` (warning by default) and `test/configCases/parsing/strict-mode-module-output-future-defaults` (error under `experiments.futureDefaults`).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The violations are reported as a warning by default; they only become an error under `experiments.futureDefaults` (opt-in today, the default in the next major).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The new strict-mode warnings for `output.module` builds, and their escalation to errors under `experiments.futureDefaults`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. The parser diagnostics, the two integration test cases, and the changeset were drafted with Claude (Claude Code); I verified the behavior (false-positive checks, full config test suite, `tsc`/lint) and reviewed the diff before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJVr6F9tBfrokYP8MnbAc8)_