### PR TITLE
feat: attach original event to ChunkLoadError

### DIFF
--- a/.changeset/chunk-load-error-event.md
+++ b/.changeset/chunk-load-error-event.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Attach the original DOM event to `ChunkLoadError` (and `ScriptExternalLoadError`) as `error.event` for easier debugging.

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -697,6 +697,7 @@ const getSourceForScriptExternal = (urlAndGlobal, runtimeTemplate) => {
 					"__webpack_error__.name = 'ScriptExternalLoadError';",
 					"__webpack_error__.type = errorType;",
 					"__webpack_error__.request = realSrc;",
+					"__webpack_error__.event = event;",
 					"reject(__webpack_error__);"
 				])}, ${JSON.stringify(globalName)});`
 			]

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -295,6 +295,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 																"error.name = 'ChunkLoadError';",
 																"error.type = errorType;",
 																"error.request = realHref;",
+																"error.event = event;",
 																"installedChunkData[1](error);"
 															]),
 															"} else {",
@@ -548,6 +549,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 														"error.name = 'ChunkLoadError';",
 														"error.type = errorType;",
 														"error.request = realHref;",
+														"error.event = event;",
 														"reject(error);"
 													]),
 													"} else {",

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -175,6 +175,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 																	"error.name = 'ChunkLoadError';",
 																	"error.type = errorType;",
 																	"error.request = realSrc;",
+																	"error.event = event;",
 																	"installedChunkData[1](error);"
 																]),
 																"}"
@@ -315,6 +316,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 												"error.name = 'ChunkLoadError';",
 												"error.type = errorType;",
 												"error.request = realSrc;",
+												"error.event = event;",
 												"reject(error);"
 											]),
 											"}"

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -260,10 +260,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 3310,
+			          "size": 3320,
 			        },
 			      ],
-			      "assetsSize": 3310,
+			      "assetsSize": 3320,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -309,10 +309,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 3310,
+			        "size": 3320,
 			      },
 			      "name": "entryB.js",
-			      "size": 3310,
+			      "size": 3320,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/configCases/css/chunk-load-error-event/index.js
+++ b/test/configCases/css/chunk-load-error-event/index.js
@@ -1,0 +1,24 @@
+it("should expose the original error event on a failed css chunk load", () => {
+	const promise = import(/* webpackChunkName: "the-style" */ "./style.css");
+
+	// the <link> is appended synchronously while the import promise is pending
+	const link = document.head._children.find(
+		child => child.nodeName === "LINK" && child.onerror
+	);
+	expect(link).toBeDefined();
+
+	// simulate the stylesheet failing to load (e.g. a blocked `@import`)
+	const errorEvent = { type: "error", target: link };
+	link.onerror(errorEvent);
+
+	return promise.catch(err => {
+		expect(err.name).toBe("ChunkLoadError");
+		expect(err.type).toBe("error");
+		expect(err.request).toMatch(/the-style.*\.css$/);
+		// the new bit: the untouched DOM event carrying the failing <link>
+		expect(err.event).toBe(errorEvent);
+		expect(err.event.type).toBe("error");
+		expect(err.event.target).toBe(link);
+		expect(err.event.target.href).toBe(err.request);
+	});
+});

--- a/test/configCases/css/chunk-load-error-event/style.css
+++ b/test/configCases/css/chunk-load-error-event/style.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/css/chunk-load-error-event/webpack.config.js
+++ b/test/configCases/css/chunk-load-error-event/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/externals/script-external-load-error-event/index.js
+++ b/test/configCases/externals/script-external-load-error-event/index.js
@@ -1,0 +1,25 @@
+// let queued microtasks run so the script external's `loadScript` has appended
+// its <script> tag before we simulate the failure
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+it("should expose the original event on a failed script external load", async () => {
+	const promise = import("myExternal");
+	await tick();
+
+	const script = document.head._children.find(
+		child => child.nodeName === "SCRIPT" && child.onerror
+	);
+	expect(script).toBeDefined();
+
+	// simulate the external script failing to load
+	const errorEvent = { type: "error", target: script };
+	script.onerror(errorEvent);
+
+	await expect(promise).rejects.toMatchObject({
+		name: "ScriptExternalLoadError",
+		type: "error",
+		request: "https://test.cases/path/external.js",
+		// the new bit: developers can inspect the original DOM event
+		event: errorEvent
+	});
+});

--- a/test/configCases/externals/script-external-load-error-event/webpack.config.js
+++ b/test/configCases/externals/script-external-load-error-event/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	externals: {
+		myExternal: "script myGlobal@https://test.cases/path/external.js"
+	},
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/configCases/web/chunk-load-error-event/chunk.js
+++ b/test/configCases/web/chunk-load-error-event/chunk.js
@@ -1,0 +1,1 @@
+export default "loaded";

--- a/test/configCases/web/chunk-load-error-event/index.js
+++ b/test/configCases/web/chunk-load-error-event/index.js
@@ -1,0 +1,49 @@
+// A developer's own retry/telemetry code can now read the original DOM event
+// off the ChunkLoadError to tell a real network failure apart from a script
+// that loaded but never registered its chunk.
+const reason = err => (err.event ? err.event.type : "no-event");
+
+it("should expose the original error event on a failed chunk load", () => {
+	const promise = import(/* webpackChunkName: "the-chunk" */ "./chunk");
+
+	const script = document.head._children[0];
+	expect(script.onerror).toBeTypeOf("function");
+
+	// simulate a network error while fetching the chunk
+	const errorEvent = { type: "error", target: script };
+	script.onerror(errorEvent);
+
+	return promise.catch(err => {
+		expect(err.name).toBe("ChunkLoadError");
+		expect(err.type).toBe("error");
+		expect(err.request).toBe("https://test.cases/path/the-chunk.js");
+		// the new bit: the untouched DOM event, same way request is exposed
+		expect(err.event).toBe(errorEvent);
+		expect(err.event.type).toBe("error");
+		expect(err.event.target).toBe(script);
+		expect(err.event.target.src).toBe("https://test.cases/path/the-chunk.js");
+		expect(reason(err)).toBe("error");
+	});
+});
+
+it("should expose the original event when a chunk loads but never registers", () => {
+	const promise = import(/* webpackChunkName: "the-chunk" */ "./chunk");
+
+	const script = document.head._children[0];
+	expect(script.onload).toBeTypeOf("function");
+
+	// the script tag fired `load`, yet the chunk was never installed (e.g. an
+	// interfering library or an evaluation error) — reported as `missing`
+	const loadEvent = { type: "load", target: script };
+	script.onload(loadEvent);
+
+	return promise.catch(err => {
+		expect(err.name).toBe("ChunkLoadError");
+		expect(err.type).toBe("missing");
+		expect(err.event).toBe(loadEvent);
+		// a developer can now tell this apart from a network error: the browser
+		// reported `load`, so the file arrived but did not register the chunk
+		expect(err.event.type).toBe("load");
+		expect(reason(err)).toBe("load");
+	});
+});

--- a/test/configCases/web/chunk-load-error-event/webpack.config.js
+++ b/test/configCases/web/chunk-load-error-event/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: {
+		chunkFilename: "[name].js"
+	},
+	performance: {
+		hints: false
+	},
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/configCases/web/retry-failed-import/index.js
+++ b/test/configCases/web/retry-failed-import/index.js
@@ -8,13 +8,15 @@ it("should be able to retry a failed import()", () => {
 	const script = document.head._children[0];
 	expect(script.onerror).toBeTypeOf("function");
 
-	script.onerror({ type: "load", target: script });
+	const loadEvent = { type: "load", target: script };
+	script.onerror(loadEvent);
 
 	return promise.catch(err => {
 		expect(err).toBeInstanceOf(Error);
 		expect(err.name).toBe("ChunkLoadError");
 		expect(err.type).toBe("missing");
 		expect(err.request).toBe("https://test.cases/path/the-chunk.js");
+		expect(err.event).toBe(loadEvent);
 		expect(err.message).toMatch(
 			/^Loading chunk .+ failed\.\n\(missing: https:\/\/test\.cases\/path\/the-chunk\.js\)$/
 		);
@@ -33,6 +35,7 @@ it("should be able to retry a failed import()", () => {
 			expect(err.name).toBe("ChunkLoadError");
 			expect(err.type).toBe(undefined);
 			expect(err.request).toBe(undefined);
+			expect(err.event).toBe(undefined);
 			expect(err.message).toMatch(
 				/^Loading chunk .+ failed\.\n\(undefined: undefined\)$/
 			);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Chunk loading failures surface only a generic message, so a chunk whose script/link fired `load` but never registered (evaluation error, an interfering library, a blocked CSS `@import`) is reported as `missing` and is indistinguishable from a real network failure. This exposes the original DOM event as `error.event` (alongside the existing `error.type`/`error.request`) on `ChunkLoadError` for jsonp and css chunk loading and hot updates, and on `ScriptExternalLoadError`, so `error.event.type === "load"` lets user retry/telemetry code tell those cases apart. Closes #16618.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — new configCases `web/chunk-load-error-event`, `css/chunk-load-error-event`, `externals/script-external-load-error-event`, and extended `web/retry-failed-import`.

**Does this PR introduce a breaking change?**

No — purely additive; existing `error.type`/`error.request`/`error.message` are unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The new `error.event` property on `ChunkLoadError`/`ScriptExternalLoadError` could be noted in the docs alongside `error.request`.

**Use of AI**

AI (Claude) was used to explore the runtime modules, implement the `error.event` additions, and write the test cases; all changes were reviewed and verified against the full ConfigTestCases suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGckGmmYdRgZy5KTKj1UTS)_