### PR TITLE
fix: restore internalSerializables entry for Module

### DIFF
--- a/.changeset/internal-serializables-module.md
+++ b/.changeset/internal-serializables-module.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Restore the internalSerializables entry for webpack/lib/Module.

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -203,6 +203,7 @@ module.exports = {
 	FileSystemInfo: () => require("../FileSystemInfo"),
 	InitFragment: () => require("../InitFragment"),
 	ModuleGraph: () => require("../ModuleGraph"),
+	Module: () => require("../Module"),
 	NormalModule: () => require("../NormalModule"),
 	CssModule: () => require("../css/CssModule"),
 	RawDataUrlModule: () => require("../asset/RawDataUrlModule"),
@@ -221,7 +222,6 @@ module.exports = {
 	"errors/WebpackError": () => require("../errors/WebpackError"),
 	"errors/InvalidDependenciesModuleWarning": () =>
 		require("../errors/InvalidDependenciesModuleWarning"),
-	"errors/Module": () => require("../Module"),
 	"errors/ModuleParseError": () => require("../errors/ModuleParseError"),
 	"errors/ModuleWarning": () => require("../errors/ModuleWarning"),
 	"errors/ModuleBuildError": () => require("../errors/ModuleBuildError"),

--- a/test/internalSerializables.unittest.js
+++ b/test/internalSerializables.unittest.js
@@ -3,6 +3,19 @@
 const internalSerializables = require("../lib/util/internalSerializables");
 
 describe("internalSerializables", () => {
+	it('should map "Module" to webpack/lib/Module', () => {
+		expect(internalSerializables.Module).toBeDefined();
+	});
+
+	it('should not expose a stale "errors/Module" entry', () => {
+		expect(
+			Object.prototype.hasOwnProperty.call(
+				internalSerializables,
+				"errors/Module"
+			)
+		).toBe(false);
+	});
+
 	// Guards against entries whose `require` path doesn't resolve — such a typo
 	// only surfaces when deserializing a cold cache without the owning plugin loaded
 	for (const [request, loader] of Object.entries(internalSerializables)) {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
The errors/Module entry mapped to the wrong request path after #20867.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Part