### PR TITLE
refactor: reuse the shared resource parser in the loader runner

### DIFF
--- a/.changeset/loader-runner-context-alloc.md
+++ b/.changeset/loader-runner-context-alloc.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reduce loader-context allocation and reuse/harden the shared resource parser.
+Reuse and harden webpack's shared resource parser in the loader runner.

--- a/.changeset/loader-runner-context-alloc.md
+++ b/.changeset/loader-runner-context-alloc.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reduce per-module loader-context allocation and harden request parsing.
+Reduce loader-context allocation and reuse/harden the shared resource parser.

--- a/.changeset/loader-runner-context-alloc.md
+++ b/.changeset/loader-runner-context-alloc.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce per-module loader-context allocation and harden request parsing.

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -458,82 +458,6 @@ function getState(loaderContext) {
 	return /** @type {EXPECTED_ANY} */ (loaderContext)[LOADER_STATE];
 }
 
-// Dependency-tracking methods are module-level and `this`-based so every context
-// shares one function instance instead of allocating a closure per module build
-// (matching the `request`-family accessors below). `this` is the loader context.
-
-/**
- * @this {LoaderContext}
- * @param {boolean=} flag whether the request is cacheable
- * @returns {void}
- */
-function contextCacheable(flag) {
-	if (flag === false) getState(this).cacheable = false;
-}
-
-/**
- * @this {LoaderContext}
- * @param {string} file file dependency
- * @returns {void}
- */
-function contextAddDependency(file) {
-	getState(this).fileDependencies.push(file);
-}
-
-/**
- * @this {LoaderContext}
- * @param {string} context context (directory) dependency
- * @returns {void}
- */
-function contextAddContextDependency(context) {
-	getState(this).contextDependencies.push(context);
-}
-
-/**
- * @this {LoaderContext}
- * @param {string} missing missing dependency
- * @returns {void}
- */
-function contextAddMissingDependency(missing) {
-	getState(this).missingDependencies.push(missing);
-}
-
-/**
- * @this {LoaderContext}
- * @returns {string[]} the file dependencies
- */
-function contextGetDependencies() {
-	return [...getState(this).fileDependencies];
-}
-
-/**
- * @this {LoaderContext}
- * @returns {string[]} the context dependencies
- */
-function contextGetContextDependencies() {
-	return [...getState(this).contextDependencies];
-}
-
-/**
- * @this {LoaderContext}
- * @returns {string[]} the missing dependencies
- */
-function contextGetMissingDependencies() {
-	return [...getState(this).missingDependencies];
-}
-
-/**
- * @this {LoaderContext}
- * @returns {void}
- */
-function contextClearDependencies() {
-	const state = getState(this);
-	state.fileDependencies.length = 0;
-	state.contextDependencies.length = 0;
-	state.missingDependencies.length = 0;
-	state.cacheable = true;
-}
-
 /**
  * Phase 1 of loader-context construction (the single place the context shape is
  * defined): augments `base` in place with fresh result state and the dependency
@@ -563,14 +487,30 @@ function createLoaderContext(base) {
 	loaderContext.resourceFragment = "";
 	loaderContext.async = null;
 	loaderContext.callback = null;
-	loaderContext.cacheable = contextCacheable;
-	loaderContext.dependency = loaderContext.addDependency = contextAddDependency;
-	loaderContext.addContextDependency = contextAddContextDependency;
-	loaderContext.addMissingDependency = contextAddMissingDependency;
-	loaderContext.getDependencies = contextGetDependencies;
-	loaderContext.getContextDependencies = contextGetContextDependencies;
-	loaderContext.getMissingDependencies = contextGetMissingDependencies;
-	loaderContext.clearDependencies = contextClearDependencies;
+	// closures over `state` (not `this`-based): loaders pass these as detached
+	// callbacks, e.g. `deps.forEach(this.addDependency)`, so they must not rely on
+	// the receiver
+	loaderContext.cacheable = (flag) => {
+		if (flag === false) state.cacheable = false;
+	};
+	loaderContext.dependency = loaderContext.addDependency = (file) => {
+		state.fileDependencies.push(file);
+	};
+	loaderContext.addContextDependency = (context) => {
+		state.contextDependencies.push(context);
+	};
+	loaderContext.addMissingDependency = (missing) => {
+		state.missingDependencies.push(missing);
+	};
+	loaderContext.getDependencies = () => [...state.fileDependencies];
+	loaderContext.getContextDependencies = () => [...state.contextDependencies];
+	loaderContext.getMissingDependencies = () => [...state.missingDependencies];
+	loaderContext.clearDependencies = () => {
+		state.fileDependencies.length = 0;
+		state.contextDependencies.length = 0;
+		state.missingDependencies.length = 0;
+		state.cacheable = true;
+	};
 	Object.defineProperty(loaderContext, LOADER_STATE, { value: state });
 	return loaderContext;
 }

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const { readFile } = require("fs");
+const { parseResource } = require("../util/identifier");
 const loadLoader = require("./loadLoader");
 
 /** @typedef {string | ({ loader: string } & Record<string, EXPECTED_ANY>)} LoaderItemInput */
@@ -79,61 +80,6 @@ function escapeHash(str) {
 	return str.includes("#") ? str.replace(HASH_ESCAPE_REGEXP, "\0#") : str;
 }
 
-const PATH_QUERY_FRAGMENT_REGEXP =
-	/^((?:\0.|[^?#\0])*)(\?(?:\0.|[^#\0])*)?(#.*)?$/;
-const ZERO_ESCAPE_REGEXP = /\0(.)/g;
-
-/**
- * @param {string} identifier identifier
- * @returns {[string, string, string]} parsed [path, query, fragment]
- */
-function parseIdentifier(identifier) {
-	// Fast path for inputs that don't use \0 escaping.
-	const firstEscape = identifier.indexOf("\0");
-
-	if (firstEscape < 0) {
-		const queryStart = identifier.indexOf("?");
-		const fragmentStart = identifier.indexOf("#");
-
-		if (fragmentStart < 0) {
-			if (queryStart < 0) {
-				return [identifier, "", ""];
-			}
-
-			return [
-				identifier.slice(0, queryStart),
-				identifier.slice(queryStart),
-				""
-			];
-		}
-
-		if (queryStart < 0 || fragmentStart < queryStart) {
-			return [
-				identifier.slice(0, fragmentStart),
-				"",
-				identifier.slice(fragmentStart)
-			];
-		}
-
-		return [
-			identifier.slice(0, queryStart),
-			identifier.slice(queryStart, fragmentStart),
-			identifier.slice(fragmentStart)
-		];
-	}
-
-	const match = PATH_QUERY_FRAGMENT_REGEXP.exec(identifier);
-
-	// malformed escaping (e.g. a trailing lone \0) never matches; treat as path
-	if (!match) return [identifier, "", ""];
-
-	return [
-		match[1].replace(ZERO_ESCAPE_REGEXP, "$1"),
-		match[2] ? match[2].replace(ZERO_ESCAPE_REGEXP, "$1") : "",
-		match[3] || ""
-	];
-}
-
 /**
  * @param {string} path path
  * @returns {string} directory name
@@ -201,7 +147,7 @@ class LoaderObject {
 	 */
 	set request(value) {
 		if (typeof value === "string") {
-			const [path, query, fragment] = parseIdentifier(value);
+			const { path, query, fragment } = parseResource(value);
 			this.path = path;
 			this.query = query;
 			this.fragment = fragment;
@@ -489,8 +435,7 @@ module.exports.createLoaderContext = createLoaderContext;
  * @returns {string} the context (directory) of the resource
  */
 module.exports.getContext = function getContext(resource) {
-	const [path] = parseIdentifier(resource);
-	return dirname(path);
+	return dirname(parseResource(resource).path);
 };
 
 /**
@@ -648,10 +593,10 @@ const ACCESSORS = {
 			);
 		},
 		set(value) {
-			const splitted = value && parseIdentifier(value);
-			this.resourcePath = splitted ? splitted[0] : "";
-			this.resourceQuery = splitted ? splitted[1] : "";
-			this.resourceFragment = splitted ? splitted[2] : "";
+			const splitted = value && parseResource(value);
+			this.resourcePath = splitted ? splitted.path : "";
+			this.resourceQuery = splitted ? splitted.query : "";
+			this.resourceFragment = splitted ? splitted.fragment : "";
 		}
 	},
 	request: {
@@ -740,10 +685,12 @@ module.exports.runLoaders = function runLoaders(options, callback) {
 	// (e.g. NormalModule's loader/beforeLoaders) have run and may have changed them
 	loaderContext.loaderIndex = 0;
 	const resource = options.resource || "";
-	const splittedResource = resource && parseIdentifier(resource);
-	loaderContext.resourcePath = splittedResource ? splittedResource[0] : "";
-	loaderContext.resourceQuery = splittedResource ? splittedResource[1] : "";
-	loaderContext.resourceFragment = splittedResource ? splittedResource[2] : "";
+	const splittedResource = resource && parseResource(resource);
+	loaderContext.resourcePath = splittedResource ? splittedResource.path : "";
+	loaderContext.resourceQuery = splittedResource ? splittedResource.query : "";
+	loaderContext.resourceFragment = splittedResource
+		? splittedResource.fragment
+		: "";
 	loaderContext.context = loaderContext.resourcePath
 		? dirname(loaderContext.resourcePath)
 		: null;

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -37,34 +37,14 @@ const loadLoader = require("./loadLoader");
 
 /** @typedef {(...args: EXPECTED_ANY[]) => void} LoaderCallback */
 
+/** @typedef {import("../../declarations/LoaderContext").LoaderRunnerLoaderContext<EXPECTED_ANY>} LoaderRunnerLoaderContext */
+
 /**
- * The subset of the loader context that loader-runner itself reads and writes.
- * The caller's context object is augmented with these and passed to loaders.
- * @typedef {object} LoaderContext
- * @property {string | null} context resource directory
- * @property {number} loaderIndex index of the current loader
- * @property {LoaderObject[]} loaders the loaders
- * @property {string} resourcePath resource path
- * @property {string} resourceQuery resource query (including leading `?`)
- * @property {string} resourceFragment resource fragment (including leading `#`)
- * @property {string} resource the resource (accessor)
- * @property {string} request the full request (accessor)
- * @property {string} remainingRequest the remaining request (accessor)
- * @property {string} currentRequest the current request (accessor)
- * @property {string} previousRequest the previous request (accessor)
- * @property {string | { [key: string]: EXPECTED_ANY }} query current loader options or query (accessor)
- * @property {EXPECTED_OBJECT | null=} data current loader data (accessor)
- * @property {LoaderCallback | null} callback the loader callback
- * @property {(() => LoaderCallback | undefined) | null} async switch the loader to async mode
- * @property {(flag?: boolean) => void} cacheable mark the request (non-)cacheable
- * @property {(file: string) => void} dependency add a file dependency
- * @property {(file: string) => void} addDependency add a file dependency
- * @property {(context: string) => void} addContextDependency add a context dependency
- * @property {(missing: string) => void} addMissingDependency add a missing dependency
- * @property {() => string[]} getDependencies get the file dependencies
- * @property {() => string[]} getContextDependencies get the context dependencies
- * @property {() => string[]} getMissingDependencies get the missing dependencies
- * @property {() => void} clearDependencies clear all collected dependencies
+ * The loader context as the runner sees and mutates it: the canonical
+ * `LoaderRunnerLoaderContext` shape (not re-declared here), with only the fields
+ * the runner assigns internally before a loader runs widened to their mutable
+ * form (nullable `context`/`callback`/`async`, `LoaderObject` loaders).
+ * @typedef {Omit<LoaderRunnerLoaderContext, "context" | "callback" | "async" | "loaders"> & { context: string | null, callback: LoaderCallback | null, async: (() => LoaderCallback | undefined) | null, loaders: LoaderObject[] }} LoaderContext
  */
 
 const HASH_ESCAPE_REGEXP = /#/g;
@@ -142,9 +122,10 @@ function parseIdentifier(identifier) {
 		];
 	}
 
-	const match =
-		/** @type {RegExpExecArray} */
-		(PATH_QUERY_FRAGMENT_REGEXP.exec(identifier));
+	const match = PATH_QUERY_FRAGMENT_REGEXP.exec(identifier);
+
+	// malformed escaping (e.g. a trailing lone \0) never matches; treat as path
+	if (!match) return [identifier, "", ""];
 
 	return [
 		match[1].replace(ZERO_ESCAPE_REGEXP, "$1"),
@@ -382,7 +363,10 @@ function iterateNormalLoaders(options, loaderContext, args, callback) {
 		const fn = currentLoaderObject.normal;
 		currentLoaderObject.normalExecuted = true;
 
-		if (!fn) continue;
+		if (!fn) {
+			loaderContext.loaderIndex--;
+			continue;
+		}
 
 		convertArgs(args, currentLoaderObject.raw);
 
@@ -522,14 +506,96 @@ module.exports.getContext = function getContext(resource) {
 const LOADER_STATE = Symbol("loader context state");
 
 /**
- * Build the loader context's iteration state and dependency tracking, augmenting
- * `base` in place. The resource-derived fields (`resourcePath`, `context`, …) and
- * the `request` accessors are set by `runLoaders` once host hooks have run and
- * the context is fully populated. Returned unfrozen.
- *
- * Properties are assigned (not defined as a getter-laden object literal) and the
- * accessors are added last so V8 keeps the context a fast-properties object — it
- * is created once per module and read on every loader, so this matters.
+ * @param {LoaderContext} loaderContext loader context
+ * @returns {LoaderState} the hidden mutable state carried under `LOADER_STATE`
+ */
+function getState(loaderContext) {
+	return /** @type {EXPECTED_ANY} */ (loaderContext)[LOADER_STATE];
+}
+
+// Dependency-tracking methods are module-level and `this`-based so every context
+// shares one function instance instead of allocating a closure per module build
+// (matching the `request`-family accessors below). `this` is the loader context.
+
+/**
+ * @this {LoaderContext}
+ * @param {boolean=} flag whether the request is cacheable
+ * @returns {void}
+ */
+function contextCacheable(flag) {
+	if (flag === false) getState(this).cacheable = false;
+}
+
+/**
+ * @this {LoaderContext}
+ * @param {string} file file dependency
+ * @returns {void}
+ */
+function contextAddDependency(file) {
+	getState(this).fileDependencies.push(file);
+}
+
+/**
+ * @this {LoaderContext}
+ * @param {string} context context (directory) dependency
+ * @returns {void}
+ */
+function contextAddContextDependency(context) {
+	getState(this).contextDependencies.push(context);
+}
+
+/**
+ * @this {LoaderContext}
+ * @param {string} missing missing dependency
+ * @returns {void}
+ */
+function contextAddMissingDependency(missing) {
+	getState(this).missingDependencies.push(missing);
+}
+
+/**
+ * @this {LoaderContext}
+ * @returns {string[]} the file dependencies
+ */
+function contextGetDependencies() {
+	return [...getState(this).fileDependencies];
+}
+
+/**
+ * @this {LoaderContext}
+ * @returns {string[]} the context dependencies
+ */
+function contextGetContextDependencies() {
+	return [...getState(this).contextDependencies];
+}
+
+/**
+ * @this {LoaderContext}
+ * @returns {string[]} the missing dependencies
+ */
+function contextGetMissingDependencies() {
+	return [...getState(this).missingDependencies];
+}
+
+/**
+ * @this {LoaderContext}
+ * @returns {void}
+ */
+function contextClearDependencies() {
+	const state = getState(this);
+	state.fileDependencies.length = 0;
+	state.contextDependencies.length = 0;
+	state.missingDependencies.length = 0;
+	state.cacheable = true;
+}
+
+/**
+ * Phase 1 of loader-context construction (the single place the context shape is
+ * defined): augments `base` in place with fresh result state and the dependency
+ * methods. Phase 2 lives in `runLoaders`, which sets the resource-derived fields
+ * and the `request` accessors once host hooks have populated the context, then
+ * freezes it — the accessors are added last so V8 keeps the context in
+ * fast-properties mode. Returned unfrozen.
  * @param {EXPECTED_ANY=} base object to augment (the caller's context), if any
  * @returns {LoaderContext} the loader context
  */
@@ -552,27 +618,14 @@ function createLoaderContext(base) {
 	loaderContext.resourceFragment = "";
 	loaderContext.async = null;
 	loaderContext.callback = null;
-	loaderContext.cacheable = (flag) => {
-		if (flag === false) state.cacheable = false;
-	};
-	loaderContext.dependency = loaderContext.addDependency = (file) => {
-		state.fileDependencies.push(file);
-	};
-	loaderContext.addContextDependency = (context) => {
-		state.contextDependencies.push(context);
-	};
-	loaderContext.addMissingDependency = (missing) => {
-		state.missingDependencies.push(missing);
-	};
-	loaderContext.getDependencies = () => [...state.fileDependencies];
-	loaderContext.getContextDependencies = () => [...state.contextDependencies];
-	loaderContext.getMissingDependencies = () => [...state.missingDependencies];
-	loaderContext.clearDependencies = () => {
-		state.fileDependencies.length = 0;
-		state.contextDependencies.length = 0;
-		state.missingDependencies.length = 0;
-		state.cacheable = true;
-	};
+	loaderContext.cacheable = contextCacheable;
+	loaderContext.dependency = loaderContext.addDependency = contextAddDependency;
+	loaderContext.addContextDependency = contextAddContextDependency;
+	loaderContext.addMissingDependency = contextAddMissingDependency;
+	loaderContext.getDependencies = contextGetDependencies;
+	loaderContext.getContextDependencies = contextGetContextDependencies;
+	loaderContext.getMissingDependencies = contextGetMissingDependencies;
+	loaderContext.clearDependencies = contextClearDependencies;
 	Object.defineProperty(loaderContext, LOADER_STATE, { value: state });
 	return loaderContext;
 }
@@ -670,16 +723,18 @@ const ACCESSORS = {
  * @returns {void}
  */
 module.exports.runLoaders = function runLoaders(options, callback) {
-	// reuse an already-prepared context (e.g. from NormalModule), else augment the
-	// caller-provided context (or a fresh object) in place
+	// reuse a context already prepared by createLoaderContext (e.g. from
+	// NormalModule), else augment the caller-provided context (or a fresh object)
+	// in place. State is intentionally preserved across the handoff, so host hooks
+	// (e.g. beforeLoaders) can pre-add dependencies or mark the request
+	// non-cacheable before the run; a caller re-running on the same context should
+	// clearDependencies() first to avoid accumulating stale dependencies.
 	const provided = /** @type {EXPECTED_ANY} */ (options.context);
 	const loaderContext =
 		provided && provided[LOADER_STATE]
 			? /** @type {LoaderContext} */ (provided)
 			: createLoaderContext(provided);
-	const state = /** @type {LoaderState} */ (
-		/** @type {EXPECTED_ANY} */ (loaderContext)[LOADER_STATE]
-	);
+	const state = getState(loaderContext);
 
 	// (re)set iteration + resource fields and map loaders now, after host hooks
 	// (e.g. NormalModule's loader/beforeLoaders) have run and may have changed them

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -363,9 +363,10 @@ const _parseResource = (str) => {
 
 	// Handle `\0`
 	if (firstEscape !== -1) {
-		const match =
-			/** @type {[string, string, string | undefined, string | undefined]} */
-			(/** @type {unknown} */ (PATH_QUERY_FRAGMENT_REGEXP.exec(str)));
+		const match = PATH_QUERY_FRAGMENT_REGEXP.exec(str);
+
+		// malformed escaping (e.g. a trailing lone \0) never matches; treat as path
+		if (!match) return { resource: str, path: str, query: "", fragment: "" };
 
 		return {
 			resource: str,
@@ -421,9 +422,10 @@ const _parseResourceWithoutFragment = (str) => {
 
 	// Handle `\0`
 	if (firstEscape !== -1) {
-		const match =
-			/** @type {[string, string, string | undefined]} */
-			(/** @type {unknown} */ (PATH_QUERY_REGEXP.exec(str)));
+		const match = PATH_QUERY_REGEXP.exec(str);
+
+		// malformed escaping (e.g. a trailing lone \0) never matches; treat as path
+		if (!match) return { resource: str, path: str, query: "" };
 
 		return {
 			resource: str,

--- a/test/LoaderRunner.unittest.js
+++ b/test/LoaderRunner.unittest.js
@@ -358,6 +358,21 @@ describe("runLoaders", () => {
 		run((err) => (err ? done(err) : run(done)));
 	});
 
+	it("should collect dependencies when methods are passed as detached callbacks", () => {
+		// loaders call these without a receiver, e.g. `deps.forEach(this.addDependency)`
+		const loaderContext = createLoaderContext();
+		/* eslint-disable unicorn/no-array-for-each -- intentionally exercising the detached forEach-callback pattern */
+		["/a", "/b"].forEach(loaderContext.addDependency);
+		["/c"].forEach(loaderContext.addContextDependency);
+		["/d"].forEach(loaderContext.addMissingDependency);
+		/* eslint-enable unicorn/no-array-for-each */
+		const detachedCacheable = loaderContext.cacheable;
+		detachedCacheable(false);
+		expect(loaderContext.getDependencies()).toEqual(["/a", "/b"]);
+		expect(loaderContext.getContextDependencies()).toEqual(["/c"]);
+		expect(loaderContext.getMissingDependencies()).toEqual(["/d"]);
+	});
+
 	it("should have to correct keys in context (with options)", (done) => {
 		runLoaders(
 			{

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -224,6 +224,27 @@ describe("util/identifier", () => {
 		}
 	});
 
+	describe("parseResource", () => {
+		// [input, expectedPath, expectedQuery, expectedFragment]
+		/** @type {[string, string, string, string][]} */
+		const cases = [
+			["path?query#frag", "path", "?query", "#frag"],
+			["a\0#b?c", "a#b", "?c", ""],
+			// malformed escaping (trailing lone \0) falls back to path
+			["a\0", "a\0", "", ""]
+		];
+		for (const case_ of cases) {
+			it(JSON.stringify(case_[0]), () => {
+				const { resource, path, query, fragment } =
+					identifierUtil.parseResource(case_[0]);
+				expect(case_[0]).toBe(resource);
+				expect(case_[1]).toBe(path);
+				expect(case_[2]).toBe(query);
+				expect(case_[3]).toBe(fragment);
+			});
+		}
+	});
+
 	describe("parseResourceWithoutFragment", () => {
 		// [input, expectedPath, expectedQuery]
 		/** @type {[string, string, string][]} */
@@ -241,7 +262,9 @@ describe("util/identifier", () => {
 				"C:\\Users\\#\\repo\\loader.js",
 				"?"
 			],
-			["/Users/\0#/repo/loader-\0#.js", "/Users/#/repo/loader-#.js", ""]
+			["/Users/\0#/repo/loader-\0#.js", "/Users/#/repo/loader-#.js", ""],
+			// malformed escaping (trailing lone \0) falls back to path
+			["a\0", "a\0", ""]
 		];
 		for (const case_ of cases) {
 			it(case_[0], () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up cleanup on the inlined loader-runner (Refs #21249):

- **Reuse the shared resource parser.** The loader-runner reimplemented path/query/fragment splitting (its own `parseIdentifier` plus a duplicate `PATH_QUERY_FRAGMENT_REGEXP`/`ZERO_ESCAPE_REGEXP`) that already exists as `parseResource` in `lib/util/identifier.js`. It now calls the shared parser (uncached — no behavior change for valid input), and the malformed-escape guard moved into the shared parser so `parseResource`/`parseResourceWithoutFragment` no longer throw on a trailing lone `\0`.
- **Minor cleanups:** drop one redundant loop iteration in `iterateNormalLoaders` for loaders without a `normal` function, and derive the runner's internal `LoaderContext` type from the canonical `LoaderRunnerLoaderContext` instead of re-declaring it.

**What kind of change does this PR introduce?**

refactor — behavior-preserving cleanup; also hardens the shared resource parser against a malformed-escape crash.

**Did you add tests for your changes?**

Yes — `parseResource` unit cases including the malformed-escape guard (`test/identifier.unittest.js`), plus a regression test that the loader context's dependency methods still work when passed as detached callbacks (`test/LoaderRunner.unittest.js`). The existing `test/LoaderRunner.unittest.js` and `test/configCases/loaders/*` cover the rest.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — implemented with AI assistance (Claude). The changes were reviewed and verified with the unit tests and a real webpack build.