### PR TITLE
feat: show why a module was marked as not cacheable in stats

### DIFF
--- a/.changeset/show-not-cacheable-reasons.md
+++ b/.changeset/show-not-cacheable-reasons.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Show which loaders marked a module as not cacheable in stats output.
+Show why a module was marked as not cacheable in stats output.

--- a/.changeset/show-not-cacheable-reasons.md
+++ b/.changeset/show-not-cacheable-reasons.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Show which loaders marked a module as not cacheable in stats output.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -251,6 +251,7 @@ const { isSourceEqual } = require("./util/source");
  * @typedef {object} ExecuteModuleResult
  * @property {ExecuteModuleExports} exports
  * @property {boolean} cacheable
+ * @property {string[]} notCacheableReasons reasons why the executed modules are not cacheable
  * @property {ExecuteModuleAssets} assets
  * @property {FileSystemDependencies} fileDependencies
  * @property {FileSystemDependencies} contextDependencies
@@ -6024,6 +6025,8 @@ This prevents using hashes of each other and should be avoided.`);
 								const assets = new Map();
 
 								let cacheable = true;
+								/** @type {ExecuteModuleResult["notCacheableReasons"]} */
+								const notCacheableReasons = [];
 
 								/** @type {ExecuteModuleContext} */
 								const context = {
@@ -6059,11 +6062,18 @@ This prevents using hashes of each other and should be avoided.`);
 											missingDependencies,
 											buildDependencies
 										);
-										if (
-											/** @type {BuildInfo} */ (module.buildInfo).cacheable ===
-											false
-										) {
+										const buildInfo = /** @type {BuildInfo} */ (
+											module.buildInfo
+										);
+										if (buildInfo.cacheable === false) {
 											cacheable = false;
+											if (buildInfo.notCacheableReasons) {
+												for (const reason of buildInfo.notCacheableReasons) {
+													if (!notCacheableReasons.includes(reason)) {
+														notCacheableReasons.push(reason);
+													}
+												}
+											}
 										}
 										if (module.buildInfo && module.buildInfo.assets) {
 											const { assets: moduleAssets, assetsInfo } =
@@ -6215,6 +6225,7 @@ This prevents using hashes of each other and should be avoided.`);
 											exports,
 											assets,
 											cacheable,
+											notCacheableReasons,
 											fileDependencies,
 											contextDependencies,
 											missingDependencies,

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -86,6 +86,10 @@ class RuntimeValue {
 		const buildInfo = /** @type {BuildInfo} */ (parser.state.module.buildInfo);
 		if (this.options === true) {
 			buildInfo.cacheable = false;
+			const reasons =
+				buildInfo.notCacheableReasons || (buildInfo.notCacheableReasons = []);
+			const reason = `DefinePlugin runtime value ${key}`;
+			if (!reasons.includes(reason)) reasons.push(reason);
 		} else {
 			if (this.options.fileDependencies) {
 				for (const dep of this.options.fileDependencies) {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -179,7 +179,7 @@ const makeSerializable = require("./util/makeSerializable");
  * Module type specific properties live in the `Known*BuildInfo` typedef of the dedicated module class.
  * @typedef {object} KnownBuildInfo
  * @property {boolean=} cacheable
- * @property {string[]=} notCacheableReasons paths of the loaders that marked the module as not cacheable
+ * @property {string[]=} notCacheableReasons reasons why the module is not cacheable (e.g. paths of loaders that marked it)
  * @property {boolean=} strict
  * @property {string=} moduleArgument
  * @property {string=} exportsArgument

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -179,6 +179,7 @@ const makeSerializable = require("./util/makeSerializable");
  * Module type specific properties live in the `Known*BuildInfo` typedef of the dedicated module class.
  * @typedef {object} KnownBuildInfo
  * @property {boolean=} cacheable
+ * @property {string[]=} notCacheableReasons paths of the loaders that marked the module as not cacheable
  * @property {boolean=} strict
  * @property {string=} moduleArgument
  * @property {string=} exportsArgument

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1439,6 +1439,9 @@ class NormalModule extends Module {
 					buildDependencies.add(loader.loader);
 				}
 				buildInfo.cacheable = buildInfo.cacheable && result.cacheable;
+				if (result.notCacheableReasons.length > 0) {
+					buildInfo.notCacheableReasons = result.notCacheableReasons;
+				}
 				processResult(err, result.result);
 			}
 		);
@@ -1545,6 +1548,7 @@ class NormalModule extends Module {
 		};
 		this.buildInfo = {
 			cacheable: false,
+			notCacheableReasons: undefined,
 			parsed: true,
 			fileDependencies: undefined,
 			contextDependencies: undefined,

--- a/lib/dependencies/LoaderPlugin.js
+++ b/lib/dependencies/LoaderPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const NormalModule = require("../NormalModule");
+const { markNotCacheable } = require("../loaders/LoaderRunner");
 const LazySet = require("../util/LazySet");
 const LoaderDependency = require("./LoaderDependency");
 const LoaderImportDependency = require("./LoaderImportDependency");
@@ -237,6 +238,7 @@ class LoaderPlugin {
 											missingDependencies,
 											buildDependencies,
 											cacheable,
+											notCacheableReasons,
 											assets,
 											exports
 										} = /** @type {ExecuteModuleResult} */ (result);
@@ -252,7 +254,9 @@ class LoaderPlugin {
 										for (const d of buildDependencies) {
 											loaderContext.addBuildDependency(d);
 										}
-										if (cacheable === false) loaderContext.cacheable(false);
+										if (cacheable === false) {
+											markNotCacheable(loaderContext, notCacheableReasons);
+										}
 										for (const [name, { source, info }] of assets) {
 											const buildInfo =
 												/** @type {BuildInfo} */

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -31,6 +31,7 @@ const loadLoader = require("./loadLoader");
  * @property {EXPECTED_ANY=} result the loader pipeline result
  * @property {Buffer | null=} resourceBuffer the raw resource buffer
  * @property {boolean} cacheable whether the request is cacheable
+ * @property {string[]} notCacheableReasons paths of the loaders that marked the request as not cacheable
  * @property {string[]} fileDependencies file dependencies
  * @property {string[]} contextDependencies context (directory) dependencies
  * @property {string[]} missingDependencies missing dependencies
@@ -441,6 +442,7 @@ module.exports.getContext = function getContext(resource) {
 /**
  * @typedef {object} LoaderState
  * @property {boolean} cacheable whether the request is cacheable
+ * @property {string[]} notCacheableReasons paths of the loaders that marked the request as not cacheable
  * @property {string[]} fileDependencies collected file dependencies
  * @property {string[]} contextDependencies collected context dependencies
  * @property {string[]} missingDependencies collected missing dependencies
@@ -472,6 +474,7 @@ function createLoaderContext(base) {
 	/** @type {LoaderState} */
 	const state = {
 		cacheable: true,
+		notCacheableReasons: [],
 		fileDependencies: [],
 		contextDependencies: [],
 		missingDependencies: []
@@ -491,7 +494,18 @@ function createLoaderContext(base) {
 	// callbacks, e.g. `deps.forEach(this.addDependency)`, so they must not rely on
 	// the receiver
 	loaderContext.cacheable = (flag) => {
-		if (flag === false) state.cacheable = false;
+		if (flag === false) {
+			state.cacheable = false;
+			// attribute the flag to the running loader; absent when the host marks
+			// the request outside the loader run (e.g. in a beforeLoaders hook)
+			const currentLoader = loaderContext.loaders[loaderContext.loaderIndex];
+			if (
+				currentLoader &&
+				!state.notCacheableReasons.includes(currentLoader.path)
+			) {
+				state.notCacheableReasons.push(currentLoader.path);
+			}
+		}
 	};
 	loaderContext.dependency = loaderContext.addDependency = (file) => {
 		state.fileDependencies.push(file);
@@ -510,6 +524,7 @@ function createLoaderContext(base) {
 		state.contextDependencies.length = 0;
 		state.missingDependencies.length = 0;
 		state.cacheable = true;
+		state.notCacheableReasons.length = 0;
 	};
 	Object.defineProperty(loaderContext, LOADER_STATE, { value: state });
 	return loaderContext;
@@ -662,6 +677,7 @@ module.exports.runLoaders = function runLoaders(options, callback) {
 		if (err) {
 			return callback(err, {
 				cacheable: state.cacheable,
+				notCacheableReasons: state.notCacheableReasons,
 				fileDependencies: state.fileDependencies,
 				contextDependencies: state.contextDependencies,
 				missingDependencies: state.missingDependencies
@@ -671,6 +687,7 @@ module.exports.runLoaders = function runLoaders(options, callback) {
 			result,
 			resourceBuffer: processOptions.resourceBuffer,
 			cacheable: state.cacheable,
+			notCacheableReasons: state.notCacheableReasons,
 			fileDependencies: state.fileDependencies,
 			contextDependencies: state.contextDependencies,
 			missingDependencies: state.missingDependencies

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -31,7 +31,7 @@ const loadLoader = require("./loadLoader");
  * @property {EXPECTED_ANY=} result the loader pipeline result
  * @property {Buffer | null=} resourceBuffer the raw resource buffer
  * @property {boolean} cacheable whether the request is cacheable
- * @property {string[]} notCacheableReasons paths of the loaders that marked the request as not cacheable
+ * @property {string[]} notCacheableReasons reasons why the request is not cacheable (e.g. paths of loaders that marked it)
  * @property {string[]} fileDependencies file dependencies
  * @property {string[]} contextDependencies context (directory) dependencies
  * @property {string[]} missingDependencies missing dependencies
@@ -442,7 +442,7 @@ module.exports.getContext = function getContext(resource) {
 /**
  * @typedef {object} LoaderState
  * @property {boolean} cacheable whether the request is cacheable
- * @property {string[]} notCacheableReasons paths of the loaders that marked the request as not cacheable
+ * @property {string[]} notCacheableReasons reasons why the request is not cacheable (e.g. paths of loaders that marked it)
  * @property {string[]} fileDependencies collected file dependencies
  * @property {string[]} contextDependencies collected context dependencies
  * @property {string[]} missingDependencies collected missing dependencies
@@ -529,6 +529,24 @@ function createLoaderContext(base) {
 	Object.defineProperty(loaderContext, LOADER_STATE, { value: state });
 	return loaderContext;
 }
+
+/**
+ * Marks the request as not cacheable with the given reasons instead of
+ * attributing the currently running loader (used by the host when the cause
+ * lives outside the loader, e.g. in a child compilation of `importModule`).
+ * @param {LoaderRunnerLoaderContext} loaderContext loader context
+ * @param {string[]} reasons reasons why the request is not cacheable
+ * @returns {void}
+ */
+module.exports.markNotCacheable = (loaderContext, reasons) => {
+	const state = getState(/** @type {LoaderContext} */ (loaderContext));
+	state.cacheable = false;
+	for (const reason of reasons) {
+		if (!state.notCacheableReasons.includes(reason)) {
+			state.notCacheableReasons.push(reason);
+		}
+	}
+};
 
 /**
  * The `request`-family accessors. Enumerable because loaders serialize the

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -985,8 +985,19 @@ class ConcatenatedModule extends Module {
 
 		for (const m of this._modules) {
 			// populate cacheable
-			if (!(/** @type {BuildInfo} */ (m.buildInfo).cacheable)) {
+			const { cacheable, notCacheableReasons } = /** @type {BuildInfo} */ (
+				m.buildInfo
+			);
+			if (!cacheable) {
 				this.buildInfo.cacheable = false;
+				if (notCacheableReasons) {
+					const reasons =
+						this.buildInfo.notCacheableReasons ||
+						(this.buildInfo.notCacheableReasons = []);
+					for (const reason of notCacheableReasons) {
+						if (!reasons.includes(reason)) reasons.push(reason);
+					}
+				}
 			}
 
 			// populate dependencies

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -176,6 +176,7 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {number=} size
  * @property {Record<string, number>=} sizes
  * @property {boolean=} cacheable
+ * @property {string[]=} notCacheableReasons
  * @property {boolean=} built
  * @property {boolean=} codeGenerated
  * @property {boolean=} buildTimeExecuted
@@ -1300,6 +1301,9 @@ const SIMPLE_EXTRACTORS = {
 			const warnings = module.getWarnings();
 			const warningsCount =
 				warnings !== undefined ? countIterable(warnings) : 0;
+			const { cacheable, notCacheableReasons } = /** @type {BuildInfo} */ (
+				module.buildInfo
+			);
 			/** @type {KnownStatsModule} */
 			const statsModule = {
 				identifier: module.identifier(),
@@ -1313,7 +1317,13 @@ const SIMPLE_EXTRACTORS = {
 				postOrderIndex: /** @type {number} */ (
 					moduleGraph.getPostOrderIndex(module)
 				),
-				cacheable: /** @type {BuildInfo} */ (module.buildInfo).cacheable,
+				cacheable,
+				notCacheableReasons:
+					notCacheableReasons &&
+					notCacheableReasons.map(
+						(request) =>
+							/** @type {string} */ (requestShortener.shorten(request))
+					),
 				optional: module.isOptional(moduleGraph),
 				orphan:
 					!type.endsWith("module.modules[].module$visible") &&

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -508,8 +508,18 @@ const MODULE_SIMPLE_PRINTERS = {
 	"module.chunks[]": (id, { formatChunkId }) => formatChunkId(id),
 	"module.depth": (depth, { formatFlag }) =>
 		depth !== null ? formatFlag(`depth ${depth}`) : undefined,
-	"module.cacheable": (cacheable, { formatFlag, red }) =>
-		cacheable === false ? red(formatFlag("not cacheable")) : undefined,
+	"module.cacheable": (cacheable, { formatFlag, red, module }) =>
+		cacheable === false
+			? red(
+					formatFlag(
+						module.notCacheableReasons && module.notCacheableReasons.length > 0
+							? `not cacheable: ${module.notCacheableReasons.join(", ")}`
+							: "not cacheable"
+					)
+				)
+			: undefined,
+	// rendered as part of the "module.cacheable" flag
+	"module.notCacheableReasons": () => undefined,
 	"module.orphan": (orphan, { formatFlag, yellow }) =>
 		orphan ? yellow(formatFlag("orphan")) : undefined,
 	// "module.runtime": (runtime, { formatFlag, yellow }) =>

--- a/test/LoaderRunner.unittest.js
+++ b/test/LoaderRunner.unittest.js
@@ -358,61 +358,6 @@ describe("runLoaders", () => {
 		run((err) => (err ? done(err) : run(done)));
 	});
 
-	it("should report the loader that marked the request as not cacheable", (done) => {
-		runLoaders(
-			{
-				resource: path.resolve(fixtures, "resource.bin"),
-				loaders: [
-					path.resolve(fixtures, "simple-loader.js"),
-					path.resolve(fixtures, "not-cacheable-loader.js")
-				]
-			},
-			(err, result) => {
-				if (err) return done(err);
-				expect(result.result).toEqual(["resource-not-cacheable-simple"]);
-				expect(result.cacheable).toBe(false);
-				expect(result.notCacheableReasons).toEqual([
-					path.resolve(fixtures, "not-cacheable-loader.js")
-				]);
-				done();
-			}
-		);
-	});
-
-	it("should not attribute a not cacheable reason when marked by the host", (done) => {
-		const loaderContext = createLoaderContext();
-		loaderContext.cacheable(false);
-		runLoaders(
-			{
-				resource: path.resolve(fixtures, "resource.bin"),
-				loaders: [path.resolve(fixtures, "simple-loader.js")],
-				context: loaderContext
-			},
-			(err, result) => {
-				if (err) return done(err);
-				expect(result.result).toEqual(["resource-simple"]);
-				expect(result.cacheable).toBe(false);
-				expect(result.notCacheableReasons).toEqual([]);
-				done();
-			}
-		);
-	});
-
-	it("should reset not cacheable reasons when dependencies are cleared", (done) => {
-		runLoaders(
-			{
-				resource: path.resolve(fixtures, "resource.bin"),
-				loaders: [path.resolve(fixtures, "clear-cacheable-loader.js")]
-			},
-			(err, result) => {
-				if (err) return done(err);
-				expect(result.cacheable).toBe(true);
-				expect(result.notCacheableReasons).toEqual([]);
-				done();
-			}
-		);
-	});
-
 	it("should collect dependencies when methods are passed as detached callbacks", () => {
 		// loaders call these without a receiver, e.g. `deps.forEach(this.addDependency)`
 		const loaderContext = createLoaderContext();

--- a/test/LoaderRunner.unittest.js
+++ b/test/LoaderRunner.unittest.js
@@ -358,6 +358,61 @@ describe("runLoaders", () => {
 		run((err) => (err ? done(err) : run(done)));
 	});
 
+	it("should report the loader that marked the request as not cacheable", (done) => {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [
+					path.resolve(fixtures, "simple-loader.js"),
+					path.resolve(fixtures, "not-cacheable-loader.js")
+				]
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.result).toEqual(["resource-not-cacheable-simple"]);
+				expect(result.cacheable).toBe(false);
+				expect(result.notCacheableReasons).toEqual([
+					path.resolve(fixtures, "not-cacheable-loader.js")
+				]);
+				done();
+			}
+		);
+	});
+
+	it("should not attribute a not cacheable reason when marked by the host", (done) => {
+		const loaderContext = createLoaderContext();
+		loaderContext.cacheable(false);
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [path.resolve(fixtures, "simple-loader.js")],
+				context: loaderContext
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.result).toEqual(["resource-simple"]);
+				expect(result.cacheable).toBe(false);
+				expect(result.notCacheableReasons).toEqual([]);
+				done();
+			}
+		);
+	});
+
+	it("should reset not cacheable reasons when dependencies are cleared", (done) => {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [path.resolve(fixtures, "clear-cacheable-loader.js")]
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.cacheable).toBe(true);
+				expect(result.notCacheableReasons).toEqual([]);
+				done();
+			}
+		);
+	});
+
 	it("should collect dependencies when methods are passed as detached callbacks", () => {
 		// loaders call these without a receiver, e.g. `deps.forEach(this.addDependency)`
 		const loaderContext = createLoaderContext();
@@ -691,6 +746,9 @@ describe("runLoaders", () => {
 				expect(err.message).toMatch(/does-not-exist-loader\.js'/i);
 				expect(result).toEqual({
 					cacheable: false,
+					notCacheableReasons: [
+						path.resolve(fixtures, "does-not-exist-loader.js")
+					],
 					fileDependencies: [],
 					contextDependencies: [],
 					missingDependencies: []
@@ -713,6 +771,9 @@ describe("runLoaders", () => {
 				);
 				expect(result).toEqual({
 					cacheable: false,
+					notCacheableReasons: [
+						path.resolve(fixtures, "module-exports-object-loader.js")
+					],
 					fileDependencies: [],
 					contextDependencies: [],
 					missingDependencies: []
@@ -735,6 +796,9 @@ describe("runLoaders", () => {
 				);
 				expect(result).toEqual({
 					cacheable: false,
+					notCacheableReasons: [
+						path.resolve(fixtures, "module-exports-string-loader.js")
+					],
 					fileDependencies: [],
 					contextDependencies: [],
 					missingDependencies: []
@@ -982,6 +1046,9 @@ describe("runLoaders", () => {
 					expectError(err);
 					expect(result).toEqual({
 						cacheable: false,
+						notCacheableReasons: [
+							path.resolve(fixtures, "does-not-exist-loader.mjs")
+						],
 						fileDependencies: [],
 						contextDependencies: [],
 						missingDependencies: []
@@ -1009,6 +1076,9 @@ describe("runLoaders", () => {
 					);
 					expect(result).toEqual({
 						cacheable: false,
+						notCacheableReasons: [
+							path.resolve(fixtures, "esm-invalid-loader.mjs")
+						],
 						fileDependencies: [],
 						contextDependencies: [],
 						missingDependencies: []

--- a/test/fixtures/loader-runner/clear-cacheable-loader.js
+++ b/test/fixtures/loader-runner/clear-cacheable-loader.js
@@ -1,0 +1,5 @@
+module.exports = function (source) {
+	this.cacheable(false);
+	this.clearDependencies();
+	return source;
+};

--- a/test/fixtures/loader-runner/not-cacheable-loader.js
+++ b/test/fixtures/loader-runner/not-cacheable-loader.js
@@ -1,6 +1,0 @@
-module.exports = function (source) {
-	this.cacheable(false);
-	// second call must not record a duplicate reason
-	this.cacheable(false);
-	return source + "-not-cacheable";
-};

--- a/test/fixtures/loader-runner/not-cacheable-loader.js
+++ b/test/fixtures/loader-runner/not-cacheable-loader.js
@@ -1,0 +1,6 @@
+module.exports = function (source) {
+	this.cacheable(false);
+	// second call must not record a duplicate reason
+	this.cacheable(false);
+	return source + "-not-cacheable";
+};

--- a/test/statsCases/not-cacheable-reasons/__snapshots__/StatsTest.snap
+++ b/test/statsCases/not-cacheable-reasons/__snapshots__/StatsTest.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsTestCases not-cacheable-reasons should print correct stats for not-cacheable-reasons 1`] = `
+"not-concatenated:
+  asset main.js X KiB [emitted] (name: main)
+  runtime modules X KiB 3 modules
+  built modules X bytes [built]
+    ./index.js X bytes [not cacheable: ./loader.js] [built] [code generated]
+    ./flagged.js X bytes [not cacheable: ./loader.js] [built] [code generated]
+    ./host-flagged.js X bytes [not cacheable] [built] [code generated]
+  not-concatenated (webpack x.x.x) compiled successfully in X ms
+
+concatenated:
+  asset main.js X bytes [emitted] (name: main)
+  orphan modules X bytes [orphan] 2 modules
+  ./index.js + 2 modules X bytes [not cacheable: ./loader.js] [built] [code generated]
+  concatenated (webpack x.x.x) compiled successfully in X ms"
+`;

--- a/test/statsCases/not-cacheable-reasons/__snapshots__/StatsTest.snap
+++ b/test/statsCases/not-cacheable-reasons/__snapshots__/StatsTest.snap
@@ -3,16 +3,20 @@
 exports[`StatsTestCases not-cacheable-reasons should print correct stats for not-cacheable-reasons 1`] = `
 "not-concatenated:
   asset main.js X KiB [emitted] (name: main)
-  runtime modules X KiB 3 modules
+  runtime modules X KiB 9 modules
+  orphan modules X bytes [orphan] 2 modules
   built modules X bytes [built]
     ./index.js X bytes [not cacheable: ./loader.js] [built] [code generated]
+    ./cleared.js X bytes [built] [code generated]
+    ./defined.js X bytes [not cacheable: DefinePlugin runtime value RUNTIME_VALUE] [built] [code generated]
     ./flagged.js X bytes [not cacheable: ./loader.js] [built] [code generated]
     ./host-flagged.js X bytes [not cacheable] [built] [code generated]
+    ./imported.js X bytes [not cacheable: ./loader.js] [built] [code generated]
   not-concatenated (webpack x.x.x) compiled successfully in X ms
 
 concatenated:
   asset main.js X bytes [emitted] (name: main)
-  orphan modules X bytes [orphan] 2 modules
-  ./index.js + 2 modules X bytes [not cacheable: ./loader.js] [built] [code generated]
+  orphan modules X bytes (javascript) X KiB (runtime) [orphan] 13 modules
+  ./index.js + 5 modules X bytes [not cacheable: ./loader.js, DefinePlugin runtime value RUNTIME_VALUE] [built] [code generated]
   concatenated (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/not-cacheable-reasons/child-dep.js
+++ b/test/statsCases/not-cacheable-reasons/child-dep.js
@@ -1,0 +1,1 @@
+export const v = 21;

--- a/test/statsCases/not-cacheable-reasons/child.js
+++ b/test/statsCases/not-cacheable-reasons/child.js
@@ -1,0 +1,3 @@
+import { v } from "./child-dep";
+
+export default v;

--- a/test/statsCases/not-cacheable-reasons/clear-loader.js
+++ b/test/statsCases/not-cacheable-reasons/clear-loader.js
@@ -1,5 +1,7 @@
 module.exports = function (source) {
 	this.cacheable(false);
+	// resets the flag and the recorded reasons
 	this.clearDependencies();
+	this.addDependency(this.resourcePath);
 	return source;
 };

--- a/test/statsCases/not-cacheable-reasons/cleared.js
+++ b/test/statsCases/not-cacheable-reasons/cleared.js
@@ -1,0 +1,1 @@
+export const cleared = 3;

--- a/test/statsCases/not-cacheable-reasons/defined.js
+++ b/test/statsCases/not-cacheable-reasons/defined.js
@@ -1,0 +1,1 @@
+export default RUNTIME_VALUE;

--- a/test/statsCases/not-cacheable-reasons/flagged.js
+++ b/test/statsCases/not-cacheable-reasons/flagged.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/test/statsCases/not-cacheable-reasons/host-flagged.js
+++ b/test/statsCases/not-cacheable-reasons/host-flagged.js
@@ -1,0 +1,1 @@
+export const other = 2;

--- a/test/statsCases/not-cacheable-reasons/import-module-loader.js
+++ b/test/statsCases/not-cacheable-reasons/import-module-loader.js
@@ -1,0 +1,6 @@
+module.exports = async function () {
+	const child = await this.importModule("./child.js");
+	// a second import must not record duplicate reasons
+	await this.importModule("./child.js");
+	return `export default ${child.default};`;
+};

--- a/test/statsCases/not-cacheable-reasons/imported.js
+++ b/test/statsCases/not-cacheable-reasons/imported.js
@@ -1,0 +1,1 @@
+export default 0;

--- a/test/statsCases/not-cacheable-reasons/index.js
+++ b/test/statsCases/not-cacheable-reasons/index.js
@@ -1,4 +1,7 @@
+import { cleared } from "./cleared";
+import defined from "./defined";
 import { value } from "./flagged";
 import { other } from "./host-flagged";
+import imported from "./imported";
 
-export default value + other;
+export default value + other + cleared + imported + defined;

--- a/test/statsCases/not-cacheable-reasons/index.js
+++ b/test/statsCases/not-cacheable-reasons/index.js
@@ -1,0 +1,4 @@
+import { value } from "./flagged";
+import { other } from "./host-flagged";
+
+export default value + other;

--- a/test/statsCases/not-cacheable-reasons/loader.js
+++ b/test/statsCases/not-cacheable-reasons/loader.js
@@ -1,0 +1,4 @@
+module.exports = function (source) {
+	this.cacheable(false);
+	return source;
+};

--- a/test/statsCases/not-cacheable-reasons/loader.js
+++ b/test/statsCases/not-cacheable-reasons/loader.js
@@ -1,4 +1,6 @@
 module.exports = function (source) {
 	this.cacheable(false);
+	// second call must not record a duplicate reason
+	this.cacheable(false);
 	return source;
 };

--- a/test/statsCases/not-cacheable-reasons/webpack.config.js
+++ b/test/statsCases/not-cacheable-reasons/webpack.config.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const webpack = require("../../../");
+
+/** @type {import("../../../").WebpackPluginFunction} */
+const markHostFlaggedPlugin = (compiler) => {
+	compiler.hooks.compilation.tap("Test", (compilation) => {
+		webpack.NormalModule.getCompilationHooks(compilation).beforeLoaders.tap(
+			"Test",
+			(loaders, module, loaderContext) => {
+				if (module.resource.endsWith("host-flagged.js")) {
+					loaderContext.cacheable(false);
+				}
+			}
+		);
+	});
+};
+
+/** @type {import("../../../").Configuration} */
+const base = {
+	entry: "./index",
+	module: {
+		rules: [
+			{
+				test: /[\\/](index|flagged)\.js$/,
+				use: require.resolve("./loader")
+			}
+		]
+	},
+	plugins: [markHostFlaggedPlugin]
+};
+
+/** @type {import("../../../").Configuration[]} */
+module.exports = [
+	{
+		...base,
+		name: "not-concatenated",
+		mode: "none"
+	},
+	{
+		...base,
+		name: "concatenated",
+		mode: "production",
+		// keep the imports alive so modules end up in a ConcatenatedModule
+		optimization: { inlineExports: false }
+	}
+];

--- a/test/statsCases/not-cacheable-reasons/webpack.config.js
+++ b/test/statsCases/not-cacheable-reasons/webpack.config.js
@@ -22,12 +22,25 @@ const base = {
 	module: {
 		rules: [
 			{
-				test: /[\\/](index|flagged)\.js$/,
+				test: /[\\/](index|flagged|child(-dep)?)\.js$/,
 				use: require.resolve("./loader")
+			},
+			{
+				test: /[\\/]cleared\.js$/,
+				use: require.resolve("./clear-loader")
+			},
+			{
+				test: /[\\/]imported\.js$/,
+				use: require.resolve("./import-module-loader")
 			}
 		]
 	},
-	plugins: [markHostFlaggedPlugin]
+	plugins: [
+		markHostFlaggedPlugin,
+		new webpack.DefinePlugin({
+			RUNTIME_VALUE: webpack.DefinePlugin.runtimeValue(() => 42, true)
+		})
+	]
 };
 
 /** @type {import("../../../").Configuration[]} */

--- a/types.d.ts
+++ b/types.d.ts
@@ -13144,6 +13144,11 @@ declare interface KnownAssetModuleBuildInfo {
 }
 declare interface KnownBuildInfo {
 	cacheable?: boolean;
+
+	/**
+	 * paths of the loaders that marked the module as not cacheable
+	 */
+	notCacheableReasons?: string[];
 	strict?: boolean;
 	moduleArgument?: string;
 	exportsArgument?: string;
@@ -13561,6 +13566,7 @@ declare interface KnownStatsModule {
 	size?: number;
 	sizes?: Record<string, number>;
 	cacheable?: boolean;
+	notCacheableReasons?: string[];
 	built?: boolean;
 	codeGenerated?: boolean;
 	buildTimeExecuted?: boolean;

--- a/types.d.ts
+++ b/types.d.ts
@@ -7309,6 +7309,11 @@ declare interface ExecuteModuleOptions {
 declare interface ExecuteModuleResult {
 	exports: any;
 	cacheable: boolean;
+
+	/**
+	 * reasons why the executed modules are not cacheable
+	 */
+	notCacheableReasons: string[];
 	assets: Map<string, { source: Source; info?: AssetInfo }>;
 	fileDependencies: LazySet<string>;
 	contextDependencies: LazySet<string>;
@@ -13146,7 +13151,7 @@ declare interface KnownBuildInfo {
 	cacheable?: boolean;
 
 	/**
-	 * paths of the loaders that marked the module as not cacheable
+	 * reasons why the module is not cacheable (e.g. paths of loaders that marked it)
 	 */
 	notCacheableReasons?: string[];
 	strict?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #748. When a loader (or `DefinePlugin.runtimeValue`, or an `importModule` child compilation) marks a module as not cacheable there is no way to find out which one did it, so stats now record and print the reason: `[not cacheable: ./my-loader.js]` (also exposed in stats JSON as `module.notCacheableReasons`).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, an integration stats case (`test/statsCases/not-cacheable-reasons`) covering loader attribution, dedup, host-marked modules, `clearDependencies`, `importModule` propagation, `DefinePlugin.runtimeValue` and module concatenation, plus updated existing assertions in `test/LoaderRunner.unittest.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The new `notCacheableReasons` module field in stats JSON and the extended `[not cacheable: …]` flag should be mentioned on the stats page of webpack.js.org.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was implemented with Claude Code under human direction; the approach, code and tests were reviewed and verified by the requester.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcXv6iHDLM4dzc3dD4856e)_