### PR TITLE
refactor: use logical assignment in array-push chunk loading

### DIFF
--- a/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
+++ b/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
@@ -65,12 +65,11 @@ class ArrayPushCallbackChunkFormatPlugin {
 				} else {
 					const chunkLoadingGlobal =
 						runtimeTemplate.outputOptions.chunkLoadingGlobal;
+					const chunkLoadingGlobalExpr = `${globalObject}[${JSON.stringify(
+						chunkLoadingGlobal
+					)}]`;
 					source.add(
-						`(${globalObject}[${JSON.stringify(
-							chunkLoadingGlobal
-						)}] = ${globalObject}[${JSON.stringify(
-							chunkLoadingGlobal
-						)}] || []).push([`
+						`(${runtimeTemplate.assignOr(chunkLoadingGlobalExpr, "[]")}).push([`
 					);
 					source.add(`${JSON.stringify(chunk.ids)},`);
 					source.add(modules);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Use the existing `RuntimeTemplate.assignOr()` helper for the chunk loading global in `ArrayPushCallbackChunkFormatPlugin`, so the chunk prelude emits the shorter `(self["webpackChunk…"] ||= []).push(…)` when `output.environment.logicalAssignment` is enabled, and falls back to the previous `x = x || []` form otherwise.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes