### PR TITLE
fix: accept compilations from another webpack copy in getCompilationHooks

### DIFF
--- a/.changeset/fix-hooks-registry-foreign-compilation.md
+++ b/.changeset/fix-hooks-registry-foreign-compilation.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Accept compilations from another webpack copy in getCompilationHooks again.

--- a/lib/util/createHooksRegistry.js
+++ b/lib/util/createHooksRegistry.js
@@ -17,11 +17,19 @@ const createHooksRegistry = (createHooks) => {
 	/** @type {WeakMap<import("../Compilation"), T>} */
 	const map = new WeakMap();
 	return (compilation) => {
-		const Compilation = getCompilation();
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
+		if (!(compilation instanceof getCompilation())) {
+			// a compilation from another webpack copy fails instanceof — match the class name
+			const candidate =
+				/** @type {{ constructor?: { name: string } } | null} */ (compilation);
+			if (
+				!candidate ||
+				!candidate.constructor ||
+				candidate.constructor.name !== "Compilation"
+			) {
+				throw new TypeError(
+					"The 'compilation' argument must be an instance of Compilation"
+				);
+			}
 		}
 		let hooks = map.get(compilation);
 		if (hooks === undefined) {

--- a/test/configCases/plugins/compilation-hooks-registry/index.js
+++ b/test/configCases/plugins/compilation-hooks-registry/index.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/test/configCases/plugins/compilation-hooks-registry/webpack.config.js
+++ b/test/configCases/plugins/compilation-hooks-registry/webpack.config.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const { Compilation, DefinePlugin } = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(
+					"CompilationHooksRegistryTest",
+					(compilation) => {
+						const hooks = DefinePlugin.getCompilationHooks(compilation);
+						expect(DefinePlugin.getCompilationHooks(compilation)).toBe(hooks);
+
+						// a compilation from another webpack copy fails instanceof but is accepted by class name
+						const ForeignCompilation = class Compilation {};
+						const foreign =
+							/** @type {Compilation} */
+							(/** @type {unknown} */ (new ForeignCompilation()));
+						expect(foreign).not.toBeInstanceOf(Compilation);
+						expect(() =>
+							DefinePlugin.getCompilationHooks(foreign)
+						).not.toThrow();
+
+						for (const value of /** @type {Compilation[]} */ (
+							/** @type {unknown[]} */ ([
+								null,
+								{ hooks: {} },
+								Object.create(null)
+							])
+						)) {
+							expect(() => DefinePlugin.getCompilationHooks(value)).toThrow(
+								"The 'compilation' argument must be an instance of Compilation"
+							);
+						}
+					}
+				);
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #21405. The `createHooksRegistry` refactor (#21224) added a strict `instanceof Compilation` check to `DefinePlugin`, `ExternalModule` and `ConcatenatedModule`, which historically accepted compilations from another webpack copy (e.g. `webpack.DefinePlugin` applied to Next.js's bundled webpack); the check now falls back to matching the class name, so such compilations pass again while wrong arguments (e.g. a `Compiler`) still throw.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, an integration case (`test/configCases/plugins/compilation-hooks-registry/`) covering the fallback and rejection paths; also verified manually with a build driven by the real `next/dist/compiled/webpack` bundle.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to investigate the regression and implement the fix, tests and verification under human direction and review.