### PR TITLE
refactor: readable CSS/HTML parser SoA names and faster hot paths

### DIFF
--- a/.changeset/css-html-parser-hot-paths.md
+++ b/.changeset/css-html-parser-hot-paths.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up the CSS and HTML parsers' tokenizer and AST hot paths.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1605,7 +1605,9 @@ _ttToNodeType[TT_CDC] = T_CDC;
 // field access differs, so only those ops are swapped.
 
 // Current loc converter for the active parse (object backend reads it).
-let _lc = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
+let _objLocConverter = /** @type {LocConverter} */ (
+	/** @type {unknown} */ (null)
+);
 
 // Active skip state (from `CssProcessOptions.skip`), applied by the grammar.
 // `_skipTypes` is indexed by `NodeType` (1 = skip): drop that component-value
@@ -1625,13 +1627,13 @@ let _skipSelectorPrelude = false;
 let _skipAtRulePrelude = false;
 
 /** @type {(type: number, start: number, end: number) => Node} */
-let _mkLeaf;
+let _makeLeaf;
 /** @type {(start: number, end: number, contentStart: number, contentEnd: number) => Node} */
-let _mkUrl;
+let _makeUrl;
 /** @type {(type: number, start: number, end: number) => Node} */
-let _mkContainer;
+let _makeContainer;
 /** @type {(start: number) => Node} */
-let _mkStylesheet;
+let _makeStylesheet;
 /** @type {(r: Node, v: string, nameStart: number, nameEnd: number) => void} */
 let _setName;
 /** @type {(r: Node, v: number) => void} */
@@ -1651,50 +1653,53 @@ let _setBody;
 /** @type {(r: Node, list: Node[]) => void} */
 let _setRules;
 /** @type {(r: Node) => number} */
-let _nType;
+let _nodeTypeOf;
 /** @type {(r: Node) => number} */
-let _nStart;
+let _nodeStartOf;
 /** @type {(r: Node) => string} */
-let _nValue;
+let _nodeValueOf;
 /** @type {(r: Node) => SimpleBlockToken} */
-let _nToken;
+let _nodeTokenOf;
 
 // Child lists are plain arrays in every backend; refs are pushed by value.
 const _list = () => /** @type {Node[]} */ ([]);
 
 // -- object backend: builds the retainable class-instance tree --
-/** @type {typeof _mkLeaf} */
-const _objLeaf = (type, start, end) => new Token(type, start, end, _lc);
-/** @type {typeof _mkUrl} */
+/** @type {typeof _makeLeaf} */
+const _objLeaf = (type, start, end) =>
+	new Token(type, start, end, _objLocConverter);
+/** @type {typeof _makeUrl} */
 const _objUrl = (start, end, cs, ce) => {
-	const u = /** @type {UrlToken} */ (new Token(T_URL, start, end, _lc));
+	const u = /** @type {UrlToken} */ (
+		new Token(T_URL, start, end, _objLocConverter)
+	);
 	u.contentStart = cs;
 	u.contentEnd = ce;
 	return u;
 };
-/** @type {typeof _mkContainer} */
+/** @type {typeof _makeContainer} */
 const _objContainer = (type, start, end) =>
-	new Container(type, start, end, _lc);
-/** @type {typeof _mkStylesheet} */
+	new Container(type, start, end, _objLocConverter);
+/** @type {typeof _makeStylesheet} */
 const _objStylesheet = (start) => {
 	const s = /** @type {Stylesheet} */ (
-		new Node(T_STYLESHEET, start, start, _lc)
+		new Node(T_STYLESHEET, start, start, _objLocConverter)
 	);
 	s.rules = [];
 	return s;
 };
 /** @param {LocConverter} lc loc converter for this parse */
 const useObjectBackend = (lc) => {
-	_lc = lc;
+	_objLocConverter = lc;
 	// `parseA*` return the full tree, so nothing is skipped.
 	_skipTypes = _NO_SKIP_TYPES;
 	_skipActive = false;
 	_skipSelectorPrelude = false;
 	_skipAtRulePrelude = false;
-	_mkLeaf = _objLeaf;
-	_mkUrl = _objUrl;
-	_mkContainer = _objContainer;
-	_mkStylesheet = _objStylesheet;
+	_makeLeaf = _objLeaf;
+	_makeUrl = _objUrl;
+	_makeContainer = _objContainer;
+	_makeStylesheet = _objStylesheet;
 	_setName = (r, v, ns, ne) => {
 		const c = /** @type {Container} */ (r);
 		c.name = v;
@@ -1731,102 +1736,104 @@ const useObjectBackend = (lc) => {
 	_setRules = (r, list) => {
 		/** @type {Stylesheet} */ (r).rules = /** @type {Rule[]} */ (list);
 	};
-	_nType = (r) => r.type;
-	_nStart = (r) => r.start;
-	_nValue = (r) => /** @type {Token} */ (r).value;
-	_nToken = (r) =>
+	_nodeTypeOf = (r) => r.type;
+	_nodeStartOf = (r) => r.start;
+	_nodeValueOf = (r) => /** @type {Token} */ (r).value;
+	_nodeTokenOf = (r) =>
 		/** @type {SimpleBlockToken} */ (/** @type {Container} */ (r).token);
 };
 
 // -- struct-of-arrays backend: writes nodes into reused typed arrays --
 // A node ref is its integer id; fields live in parallel arrays indexed by id.
-// Three reused int slots (`_soaA0/1/2`) plus a flags byte carry the per-type
-// extras; child lists hang off three object arrays. Slot meaning by type:
-//   url:         a0 contentStart, a1 contentEnd
-//   function:    a0 nameEnd
-//   declaration: a0 nameEnd, flags bit0 important
-//   at-rule:     a0 nameEnd, a1 blockStart, a2 blockEnd
-//   qualified:   a1 blockStart, a2 blockEnd
+// Three reused int slots (`_soaAux0/1/2`) plus a flags byte carry the per-type
+// extras; child lists hang off three object arrays. Aux slot meaning by type:
+//   url:         aux0 contentStart, aux1 contentEnd
+//   function:    aux0 nameEnd
+//   declaration: aux0 nameEnd, flags bit0 important
+//   at-rule:     aux0 nameEnd, aux1 blockStart, aux2 blockEnd
+//   qualified:   aux1 blockStart, aux2 blockEnd
 // `name` / `nameStart` / a simple block's `token` are derived from the source
-// on read (see the SoA accessors), so they need no slot. Lists: l0 =
-// value | prelude | stylesheet rules, l1 = declarations, l2 = childRules.
-// `grammar` resets `_soaN` to 0 after each top-level rule's walk, so the
+// on read (see the SoA accessors), so they need no slot. `_soaContentLists`
+// holds a node's main content (value | prelude | stylesheet rules).
+// `grammar` resets `_soaNodeCount` to 0 after each top-level rule's walk, so the
 // buffers are reused across rules and the parse allocates almost nothing.
-let _soaCap = 0;
-let _soaN = 0;
-let _soaTy = new Uint8Array(0);
-let _soaSt = new Int32Array(0);
-let _soaEn = new Int32Array(0);
-let _soaA0 = new Int32Array(0);
-let _soaA1 = new Int32Array(0);
-let _soaA2 = new Int32Array(0);
-let _soaFl = new Uint8Array(0);
+let _soaCapacity = 0;
+let _soaNodeCount = 0;
+let _soaTypes = new Uint8Array(0);
+let _soaStarts = new Int32Array(0);
+let _soaEnds = new Int32Array(0);
+let _soaAux0 = new Int32Array(0);
+let _soaAux1 = new Int32Array(0);
+let _soaAux2 = new Int32Array(0);
+let _soaFlags = new Uint8Array(0);
 /** @type {(Node[] | null)[]} */
-const _soaL0 = [];
+const _soaContentLists = [];
 /** @type {(Node[] | null)[]} */
-const _soaL1 = [];
+const _soaDeclarationLists = [];
 /** @type {(Node[] | null)[]} */
-const _soaL2 = [];
+const _soaChildRuleLists = [];
 let _soaInput = "";
-let _soaLC = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
+let _soaLocConverter = /** @type {LocConverter} */ (
+	/** @type {unknown} */ (null)
+);
 
 // Node refs are integers here but typed `Node` across the parser; these are
 // identity casts that just satisfy the type system at the boundary.
 /** @type {(n: Node) => number} */
-const _ix = (n) => /** @type {number} */ (/** @type {unknown} */ (n));
+const _nodeIndex = (n) => /** @type {number} */ (/** @type {unknown} */ (n));
 /** @type {(i: number) => Node} */
-const _ref = (i) => /** @type {Node} */ (/** @type {unknown} */ (i));
+const _nodeRef = (i) => /** @type {Node} */ (/** @type {unknown} */ (i));
 
 /** @param {number} need minimum capacity */
 const _soaGrow = (need) => {
-	let cap = _soaCap || 4096;
+	let cap = _soaCapacity || 4096;
 	while (cap < need) cap *= 2;
 	const ty = new Uint8Array(cap);
-	ty.set(_soaTy);
-	_soaTy = ty;
+	ty.set(_soaTypes);
+	_soaTypes = ty;
 	const st = new Int32Array(cap);
-	st.set(_soaSt);
-	_soaSt = st;
+	st.set(_soaStarts);
+	_soaStarts = st;
 	const en = new Int32Array(cap);
-	en.set(_soaEn);
-	_soaEn = en;
+	en.set(_soaEnds);
+	_soaEnds = en;
 	const a0 = new Int32Array(cap);
-	a0.set(_soaA0);
-	_soaA0 = a0;
+	a0.set(_soaAux0);
+	_soaAux0 = a0;
 	const a1 = new Int32Array(cap);
-	a1.set(_soaA1);
-	_soaA1 = a1;
+	a1.set(_soaAux1);
+	_soaAux1 = a1;
 	const a2 = new Int32Array(cap);
-	a2.set(_soaA2);
-	_soaA2 = a2;
+	a2.set(_soaAux2);
+	_soaAux2 = a2;
 	const fl = new Uint8Array(cap);
-	fl.set(_soaFl);
-	_soaFl = fl;
-	_soaCap = cap;
+	fl.set(_soaFlags);
+	_soaFlags = fl;
+	_soaCapacity = cap;
 };
 /** @type {(type: number, start: number, end: number) => Node} */
-const _soaAlloc = (type, start, end) => {
+const _soaAllocNode = (type, start, end) => {
 	// Ids are 1-based: a node ref is used in truthiness checks (`if (!parent)`),
 	// so 0 must stay reserved for "no node".
 	// Leaves never read the flag / list slots — `_soaAllocContainer` clears
 	// them instead, keeping the dominant leaf allocation at three writes.
-	const i = _soaN + 1;
-	if (i >= _soaCap) _soaGrow(i + 1);
-	_soaTy[i] = type;
-	_soaSt[i] = start;
-	_soaEn[i] = end;
-	_soaN = i;
-	return _ref(i);
+	const i = _soaNodeCount + 1;
+	if (i >= _soaCapacity) _soaGrow(i + 1);
+	_soaTypes[i] = type;
+	_soaStarts[i] = start;
+	_soaEnds[i] = end;
+	_soaNodeCount = i;
+	return _nodeRef(i);
 };
 /** @type {(type: number, start: number, end: number) => Node} */
 const _soaAllocContainer = (type, start, end) => {
-	const r = _soaAlloc(type, start, end);
-	const i = _ix(r);
-	_soaFl[i] = 0;
+	const r = _soaAllocNode(type, start, end);
+	const i = _nodeIndex(r);
+	_soaFlags[i] = 0;
 	// Clear list slots so a reused id never exposes a previous node's children.
-	_soaL0[i] = null;
-	_soaL1[i] = null;
-	_soaL2[i] = null;
+	_soaContentLists[i] = null;
+	_soaDeclarationLists[i] = null;
+	_soaChildRuleLists[i] = null;
 	return r;
 };
 // Raw token value (the lazy `Token.value` form): hash / at-keyword drop their
@@ -1837,12 +1844,12 @@ const _soaAllocContainer = (type, start, end) => {
  * @returns {string} raw token value
  */
 const _soaValueOf = (i) => {
-	const ty = _soaTy[i];
+	const ty = _soaTypes[i];
 	if (ty === T_HASH || ty === T_AT_KEYWORD) {
-		return _soaInput.slice(_soaSt[i] + 1, _soaEn[i]);
+		return _soaInput.slice(_soaStarts[i] + 1, _soaEnds[i]);
 	}
-	if (ty === T_URL) return _soaInput.slice(_soaA0[i], _soaA1[i]);
-	return _soaInput.slice(_soaSt[i], _soaEn[i]);
+	if (ty === T_URL) return _soaInput.slice(_soaAux0[i], _soaAux1[i]);
+	return _soaInput.slice(_soaStarts[i], _soaEnds[i]);
 };
 /**
  * @param {string} input source
@@ -1850,52 +1857,53 @@ const _soaValueOf = (i) => {
  */
 const useSoaBackend = (input, lc) => {
 	_soaInput = input;
-	_soaLC = lc;
-	_soaN = 0;
-	_mkLeaf = (type, start, end) => _soaAlloc(type, start, end);
-	_mkUrl = (start, end, cs, ce) => {
-		const r = _soaAlloc(T_URL, start, end);
-		_soaA0[_ix(r)] = cs;
-		_soaA1[_ix(r)] = ce;
+	_soaLocConverter = lc;
+	_soaNodeCount = 0;
+	_makeLeaf = (type, start, end) => _soaAllocNode(type, start, end);
+	_makeUrl = (start, end, cs, ce) => {
+		const r = _soaAllocNode(T_URL, start, end);
+		_soaAux0[_nodeIndex(r)] = cs;
+		_soaAux1[_nodeIndex(r)] = ce;
 		return r;
 	};
-	_mkContainer = (type, start, end) => _soaAllocContainer(type, start, end);
-	_mkStylesheet = (start) => _soaAllocContainer(T_STYLESHEET, start, start);
+	_makeContainer = (type, start, end) => _soaAllocContainer(type, start, end);
+	_makeStylesheet = (start) => _soaAllocContainer(T_STYLESHEET, start, start);
 	// name / nameStart are derived from start + nameEnd; only nameEnd is stored.
 	_setName = (r, v, ns, ne) => {
-		_soaA0[_ix(r)] = ne;
+		_soaAux0[_nodeIndex(r)] = ne;
 	};
 	_setEnd = (r, v) => {
-		_soaEn[_ix(r)] = v;
+		_soaEnds[_nodeIndex(r)] = v;
 	};
 	_setBlock = (r, bs, be) => {
-		const i = _ix(r);
-		_soaA1[i] = bs;
-		_soaA2[i] = be;
+		const i = _nodeIndex(r);
+		_soaAux1[i] = bs;
+		_soaAux2[i] = be;
 	};
 	_setImportant = (r) => {
-		_soaFl[_ix(r)] |= 1;
+		_soaFlags[_nodeIndex(r)] |= 1;
 	};
 	// A simple block's token is derived from its opening char on read.
 	_setToken = (r, ch) => {};
 	_setValue = (r, list) => {
-		_soaL0[_ix(r)] = list;
+		_soaContentLists[_nodeIndex(r)] = list;
 	};
 	_setPrelude = (r, list) => {
-		_soaL0[_ix(r)] = list;
+		_soaContentLists[_nodeIndex(r)] = list;
 	};
 	_setBody = (r, decls, childRules) => {
-		const i = _ix(r);
-		_soaL1[i] = decls;
-		_soaL2[i] = childRules;
+		const i = _nodeIndex(r);
+		_soaDeclarationLists[i] = decls;
+		_soaChildRuleLists[i] = childRules;
 	};
 	_setRules = (r, list) => {
-		_soaL0[_ix(r)] = list;
+		_soaContentLists[_nodeIndex(r)] = list;
 	};
-	_nType = (r) => _soaTy[_ix(r)];
-	_nStart = (r) => _soaSt[_ix(r)];
-	_nValue = (r) => _soaValueOf(_ix(r));
-	_nToken = (r) => /** @type {SimpleBlockToken} */ (_soaInput[_soaSt[_ix(r)]]);
+	_nodeTypeOf = (r) => _soaTypes[_nodeIndex(r)];
+	_nodeStartOf = (r) => _soaStarts[_nodeIndex(r)];
+	_nodeValueOf = (r) => _soaValueOf(_nodeIndex(r));
+	_nodeTokenOf = (r) =>
+		/** @type {SimpleBlockToken} */ (_soaInput[_soaStarts[_nodeIndex(r)]]);
 };
 
 /**
@@ -1909,9 +1917,9 @@ const tokenToNode = (t) => {
 	// plain leaf whose node type comes from the map.
 	if (tt === TT_URL) {
 		const ut = /** @type {CssUrlToken} */ (t);
-		return _mkUrl(t.start, t.end, ut.contentStart, ut.contentEnd);
+		return _makeUrl(t.start, t.end, ut.contentStart, ut.contentEnd);
 	}
-	return _mkLeaf(_ttToNodeType[tt], t.start, t.end);
+	return _makeLeaf(_ttToNodeType[tt], t.start, t.end);
 };
 
 /**
@@ -2106,7 +2114,7 @@ const parseAStylesheet = (input, comment) => {
 	useObjectBackend(ts.locConverter);
 	// 3. Create a new stylesheet, with its location set to location (or null, if location was not passed).
 	const start = ts.next().start;
-	const stylesheet = /** @type {Stylesheet} */ (_mkStylesheet(start));
+	const stylesheet = /** @type {Stylesheet} */ (_makeStylesheet(start));
 	// 4. Consume a stylesheet's contents from input, and set the stylesheet's rules to the result.
 	_setRules(stylesheet, consumeAStylesheetsContents(ts));
 	_setEnd(stylesheet, ts.next().start);
@@ -2335,7 +2343,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 	// Consume a token from input, and let rule be a new at-rule with its name set to the returned token’s value, its prelude initially set to an empty list, and no declarations or child rules.
 	const head = ts.consume();
 	const rule = /** @type {AtRule} */ (
-		_mkContainer(T_AT_RULE, head.start, head.end)
+		_makeContainer(T_AT_RULE, head.start, head.end)
 	);
 	_setName(
 		rule,
@@ -2392,7 +2400,10 @@ const consumeAnAtRule = (ts, nested = false) => {
 		const node = consumeAComponentValue(ts, t);
 		if (!skip) {
 			prelude.push(node);
-		} else if (_nType(node) === T_FUNCTION || _nType(node) === T_URL) {
+		} else if (
+			_nodeTypeOf(node) === T_FUNCTION ||
+			_nodeTypeOf(node) === T_URL
+		) {
 			prelude.push(node);
 		}
 	}
@@ -2423,7 +2434,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	const start = ts.next().start;
 	// Let rule be a new qualified rule with its prelude, declarations, and child rules all initially set to empty lists.
 	const rule = /** @type {QualifiedRule} */ (
-		_mkContainer(T_QUALIFIED_RULE, start, start)
+		_makeContainer(T_QUALIFIED_RULE, start, start)
 	);
 	const prelude = _list();
 	_setPrelude(rule, prelude);
@@ -2471,14 +2482,14 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				/* istanbul ignore next -- @preserve: leading whitespace is discarded before the rule, so the prelude never starts with it */
 				while (
 					firstIdx < prelude.length &&
-					_nType(prelude[firstIdx]) === T_WHITESPACE
+					_nodeTypeOf(prelude[firstIdx]) === T_WHITESPACE
 				) {
 					firstIdx++;
 				}
 				let secondIdx = firstIdx + 1;
 				while (
 					secondIdx < prelude.length &&
-					_nType(prelude[secondIdx]) === T_WHITESPACE
+					_nodeTypeOf(prelude[secondIdx]) === T_WHITESPACE
 				) {
 					secondIdx++;
 				}
@@ -2487,12 +2498,12 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 			}
 			if (
 				first &&
-				_nType(first) === T_IDENT &&
+				_nodeTypeOf(first) === T_IDENT &&
 				// Test the source bytes directly — avoids forcing the lazy `value`
 				// slice just to check the `--` custom-property prefix.
-				ts.input.startsWith("--", _nStart(first)) &&
+				ts.input.startsWith("--", _nodeStartOf(first)) &&
 				second &&
-				_nType(second) === T_COLON
+				_nodeTypeOf(second) === T_COLON
 			) {
 				/* istanbul ignore if -- @preserve: when nested, `declarationStartLikely` routes every `--x:` to consumeADeclaration (which accepts custom properties), so this fallthrough is unreachable */
 				if (nested) {
@@ -2516,7 +2527,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 			// Keep only url-bearing nodes (url tokens, or functions that may hold a
 			// url like `:unknown(url(x))`) so the url visitor still rewrites them;
 			// other selector tokens have no non-modules consumer, so drop them.
-			const ty = _nType(node);
+			const ty = _nodeTypeOf(node);
 			if (ty === T_FUNCTION || ty === T_URL) prelude.push(node);
 			// Track the first two non-whitespace tokens for the disambiguation above.
 			if (t.type !== TT_WHITESPACE) {
@@ -2695,7 +2706,7 @@ const consumeADeclaration = (ts, nested = false) => {
 	// name "" / nameStart / nameEnd (= start) / important (false) keep their
 	// `Container` defaults; `value` is set unconditionally at step 5 below.
 	const decl = /** @type {Declaration} */ (
-		_mkContainer(T_DECLARATION, start, start)
+		_makeContainer(T_DECLARATION, start, start)
 	);
 
 	// 1. If the next token is an <ident-token>, consume a token from input and set decl's name to the returned token's value.
@@ -2731,15 +2742,15 @@ const consumeADeclaration = (ts, nested = false) => {
 	// 6. If the last two non-<whitespace-token>s in decl's value are a <delim-token> with the value "!" followed by an <ident-token> with a value that is an ASCII case-insensitive match for "important", remove them from decl's value and set decl's important flag.
 	{
 		let last = value.length - 1;
-		while (last >= 0 && _nType(value[last]) === T_WHITESPACE) last--;
+		while (last >= 0 && _nodeTypeOf(value[last]) === T_WHITESPACE) last--;
 		let prev = last - 1;
-		while (prev >= 0 && _nType(value[prev]) === T_WHITESPACE) prev--;
+		while (prev >= 0 && _nodeTypeOf(value[prev]) === T_WHITESPACE) prev--;
 		if (
 			prev >= 0 &&
-			_nType(value[last]) === T_IDENT &&
-			equalsLowerCase(_nValue(value[last]), "important") &&
-			_nType(value[prev]) === T_DELIM &&
-			input.charCodeAt(_nStart(value[prev])) === CC_EXCLAMATION
+			_nodeTypeOf(value[last]) === T_IDENT &&
+			equalsLowerCase(_nodeValueOf(value[last]), "important") &&
+			_nodeTypeOf(value[prev]) === T_DELIM &&
+			input.charCodeAt(_nodeStartOf(value[prev])) === CC_EXCLAMATION
 		) {
 			_setImportant(decl);
 			value.length = prev;
@@ -2747,7 +2758,10 @@ const consumeADeclaration = (ts, nested = false) => {
 	}
 
 	// 7. While the last item in decl's value is a <whitespace-token>, remove that token.
-	while (value.length > 0 && _nType(value[value.length - 1]) === T_WHITESPACE) {
+	while (
+		value.length > 0 &&
+		_nodeTypeOf(value[value.length - 1]) === T_WHITESPACE
+	) {
 		value.pop();
 	}
 
@@ -2759,7 +2773,7 @@ const consumeADeclaration = (ts, nested = false) => {
 	if (!isCustomProperty) {
 		for (let i = 0; i < value.length; i++) {
 			const v = value[i];
-			if (_nType(v) === T_SIMPLE_BLOCK && _nToken(v) === "{") {
+			if (_nodeTypeOf(v) === T_SIMPLE_BLOCK && _nodeTokenOf(v) === "{") {
 				return undefined;
 			}
 		}
@@ -2797,7 +2811,9 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 			const closer = consumeATokenAsNode(ts);
 			// Keep unless the type is explicitly marked skip (1); an out-of-range
 			// lookup on a short `skip.types` yields `undefined`, which must not drop.
-			if (!_skipActive || _skipTypes[_nType(closer)] !== 1) values.push(closer);
+			if (!_skipActive || _skipTypes[_nodeTypeOf(closer)] !== 1) {
+				values.push(closer);
+			}
 			continue;
 		}
 		// anything else
@@ -2815,7 +2831,7 @@ const consumeAListOfComponentValues = (ts, stopToken, nested = false) => {
 			continue;
 		}
 		const node = consumeAComponentValue(ts, t);
-		if (!_skipActive || _skipTypes[_nType(node)] !== 1) values.push(node);
+		if (!_skipActive || _skipTypes[_nodeTypeOf(node)] !== 1) values.push(node);
 	}
 };
 
@@ -2861,7 +2877,7 @@ const consumeASimpleBlock = (ts) => {
 
 	// Let block be a new simple block with its associated token set to the next token and with its value initially set to an empty list.
 	const block = /** @type {SimpleBlock} */ (
-		_mkContainer(T_SIMPLE_BLOCK, open.start, open.end)
+		_makeContainer(T_SIMPLE_BLOCK, open.start, open.end)
 	);
 	_setToken(block, token);
 	const val = _list();
@@ -2900,7 +2916,7 @@ const consumeAFunction = (ts) => {
 	// Consume a token from input, and let function be a new function with its name equal the returned token’s value, and a value set to an empty list.
 	const tFn = ts.consume();
 	const fn = /** @type {FunctionNode} */ (
-		_mkContainer(T_FUNCTION, tFn.start, tFn.end)
+		_makeContainer(T_FUNCTION, tFn.start, tFn.end)
 	);
 	_setName(fn, input.slice(tFn.start, tFn.end - 1), tFn.start, tFn.end - 1);
 	const val = _list();
@@ -2933,7 +2949,7 @@ const consumeAFunction = (ts) => {
 			continue;
 		}
 		const node = consumeAComponentValue(ts, t);
-		if (!_skipActive || _skipTypes[_nType(node)] !== 1) val.push(node);
+		if (!_skipActive || _skipTypes[_nodeTypeOf(node)] !== 1) val.push(node);
 	}
 };
 
@@ -3186,9 +3202,9 @@ const grammar = (input, visitors, options) => {
 			? undefined
 			: /** @type {(input: string, start: number, end: number) => number} */ (
 					(_input, start, end) => {
-						const node = _soaAlloc(T_COMMENT, start, end);
-						_curNode = node;
-						_curParent = null;
+						const node = _soaAllocNode(T_COMMENT, start, end);
+						_currentNode = node;
+						_currentParent = null;
 						const e = commentBucket.enter;
 						for (let i = 0; i < e.length; i++) e[i](A);
 						const x = commentBucket.exit;
@@ -3205,26 +3221,26 @@ const grammar = (input, visitors, options) => {
 	 * @param {Node | null} parent enclosing node
 	 */
 	const walkValue = (node, parent) => {
-		const ty = _soaTy[_ix(node)];
+		const ty = _soaTypes[_nodeIndex(node)];
 		const b = visitors[ty];
 		let skip = false;
 		if (b !== undefined && b.enter.length !== 0) {
 			_walkSkip = false;
-			_curNode = node;
-			_curParent = parent;
+			_currentNode = node;
+			_currentParent = parent;
 			const e = b.enter;
 			for (let i = 0; i < e.length; i++) e[i](A);
 			skip = _walkSkip;
 			_walkSkip = false;
 		}
 		if (!skip && (ty === T_FUNCTION || ty === T_SIMPLE_BLOCK)) {
-			const v = /** @type {Node[]} */ (_soaL0[_ix(node)]);
+			const v = /** @type {Node[]} */ (_soaContentLists[_nodeIndex(node)]);
 			for (let i = 0; i < v.length; i++) walkValue(v[i], node);
 		}
 		if (b !== undefined) {
 			// Rebind: descending into children moved the path.
-			_curNode = node;
-			_curParent = parent;
+			_currentNode = node;
+			_currentParent = parent;
 			const x = b.exit;
 			for (let i = 0; i < x.length; i++) x[i](A);
 		}
@@ -3237,14 +3253,14 @@ const grammar = (input, visitors, options) => {
 	 * @param {Node | null} parent enclosing node
 	 */
 	const walkRule = (node, parent) => {
-		const i0 = _ix(node);
-		const ty = _soaTy[i0];
+		const i0 = _nodeIndex(node);
+		const ty = _soaTypes[i0];
 		const b = visitors[ty];
 		let skip = false;
 		if (b !== undefined && b.enter.length !== 0) {
 			_walkSkip = false;
-			_curNode = node;
-			_curParent = parent;
+			_currentNode = node;
+			_currentParent = parent;
 			const e = b.enter;
 			for (let i = 0; i < e.length; i++) e[i](A);
 			skip = _walkSkip;
@@ -3252,26 +3268,26 @@ const grammar = (input, visitors, options) => {
 		}
 		if (!skip) {
 			if (ty === T_AT_RULE || ty === T_QUALIFIED_RULE) {
-				const p = /** @type {Node[]} */ (_soaL0[i0]);
+				const p = /** @type {Node[]} */ (_soaContentLists[i0]);
 				for (let i = 0; i < p.length; i++) walkValue(p[i], node);
 				if (recurseBlocks) {
 					// Declarations then child rules — downstream consumers don't need them strictly interleaved in source order.
-					const decls = _soaL1[i0];
+					const decls = _soaDeclarationLists[i0];
 					if (decls) {
 						for (let i = 0; i < decls.length; i++) walkRule(decls[i], node);
 					}
-					const ch = _soaL2[i0];
+					const ch = _soaChildRuleLists[i0];
 					if (ch) for (let i = 0; i < ch.length; i++) walkRule(ch[i], node);
 				}
 			} else if (ty === T_DECLARATION) {
-				const v = /** @type {Node[]} */ (_soaL0[i0]);
+				const v = /** @type {Node[]} */ (_soaContentLists[i0]);
 				for (let i = 0; i < v.length; i++) walkValue(v[i], node);
 			}
 		}
 		if (b !== undefined) {
 			// Rebind: descending into children moved the path.
-			_curNode = node;
-			_curParent = parent;
+			_currentNode = node;
+			_currentParent = parent;
 			const x = b.exit;
 			for (let i = 0; i < x.length; i++) x[i](A);
 		}
@@ -3287,16 +3303,18 @@ const grammar = (input, visitors, options) => {
 	try {
 		consume(ts, (node) => {
 			walkRule(node, null);
-			_soaN = 0;
+			_soaNodeCount = 0;
 		});
 	} finally {
 		// Drop the module-level SoA references so the last parsed source (and
 		// its LocConverter / child lists) don't stay alive between parses.
 		_soaInput = "";
-		_soaLC = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
-		_soaL0.length = 0;
-		_soaL1.length = 0;
-		_soaL2.length = 0;
+		_soaLocConverter = /** @type {LocConverter} */ (
+			/** @type {unknown} */ (null)
+		);
+		_soaContentLists.length = 0;
+		_soaDeclarationLists.length = 0;
+		_soaChildRuleLists.length = 0;
 	}
 };
 
@@ -3350,9 +3368,9 @@ let _walkSkip = false;
 // The walk's current position (`A.node` / `A.parent` read these; module-level
 // so the accessor methods' defaults avoid self-referential `this` typing).
 /** @type {Node} */
-let _curNode = /** @type {Node} */ (/** @type {unknown} */ (0));
+let _currentNode = /** @type {Node} */ (/** @type {unknown} */ (0));
 /** @type {Node | null} */
-let _curParent = null;
+let _currentParent = null;
 
 // AST field-access seam. Every AST-node field read by `CssParser` goes through
 // one of these accessors so the node representation can change underneath the
@@ -3367,13 +3385,13 @@ const A = {
 	 * @returns {Node} current node — only valid during a visitor callback
 	 */
 	get node() {
-		return _curNode;
+		return _currentNode;
 	},
 	/**
 	 * @returns {Node | null} enclosing node (null = a top-level node)
 	 */
 	get parent() {
-		return _curParent;
+		return _currentParent;
 	},
 	/** Stop the walk descending into the current node (enter only). */
 	skipChildren() {
@@ -3384,42 +3402,42 @@ const A = {
 	 * @param {Node=} n node
 	 * @returns {number} node type
 	 */
-	type(n = _curNode) {
-		return _soaTy[_ix(n)];
+	type(n = _currentNode) {
+		return _soaTypes[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} start offset
 	 */
-	start(n = _curNode) {
-		return _soaSt[_ix(n)];
+	start(n = _currentNode) {
+		return _soaStarts[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} end offset
 	 */
-	end(n = _curNode) {
-		return _soaEn[_ix(n)];
+	end(n = _currentNode) {
+		return _soaEnds[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {[number, number]} start / end offsets
 	 */
-	range(n = _curNode) {
-		const i = _ix(n);
-		return [_soaSt[i], _soaEn[i]];
+	range(n = _currentNode) {
+		const i = _nodeIndex(n);
+		return [_soaStarts[i], _soaEnds[i]];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {{ start: { line: number, column: number }, end: { line: number, column: number } }} source location
 	 */
-	loc(n = _curNode) {
-		const i = _ix(n);
-		const lc = _soaLC;
-		const s = lc.get(_soaSt[i]);
+	loc(n = _currentNode) {
+		const i = _nodeIndex(n);
+		const lc = _soaLocConverter;
+		const s = lc.get(_soaStarts[i]);
 		const sl = s.line;
 		const sc = s.column;
-		const e = lc.get(_soaEn[i]);
+		const e = lc.get(_soaEnds[i]);
 		return {
 			start: { line: sl, column: sc },
 			end: { line: e.line, column: e.column }
@@ -3429,25 +3447,25 @@ const A = {
 	 * @param {Node=} n node
 	 * @returns {string} raw source slice
 	 */
-	source(n = _curNode) {
-		const i = _ix(n);
-		return _soaInput.slice(_soaSt[i], _soaEn[i]);
+	source(n = _currentNode) {
+		const i = _nodeIndex(n);
+		return _soaInput.slice(_soaStarts[i], _soaEnds[i]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {string} raw token value
 	 */
-	value(n = _curNode) {
-		return _soaValueOf(_ix(n));
+	value(n = _currentNode) {
+		return _soaValueOf(_nodeIndex(n));
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {string} unescaped token value
 	 */
-	unescaped(n = _curNode) {
-		const i = _ix(n);
+	unescaped(n = _currentNode) {
+		const i = _nodeIndex(n);
 		const v = _soaValueOf(i);
-		return _soaTy[i] === T_STRING
+		return _soaTypes[i] === T_STRING
 			? unescapeIdentifier(v.slice(1, -1))
 			: unescapeIdentifier(v);
 	},
@@ -3455,11 +3473,11 @@ const A = {
 	 * @param {Node=} n node
 	 * @returns {string} hash / numeric type flag
 	 */
-	typeFlag(n = _curNode) {
-		const i = _ix(n);
-		if (_soaTy[i] === T_HASH) {
+	typeFlag(n = _currentNode) {
+		const i = _nodeIndex(n);
+		if (_soaTypes[i] === T_HASH) {
 			const input = _soaInput;
-			const p = _soaSt[i] + 1;
+			const p = _soaStarts[i] + 1;
 			return _ifThreeCodePointsWouldStartAnIdentSequence(
 				input,
 				p,
@@ -3472,109 +3490,113 @@ const A = {
 		}
 		const v = _soaValueOf(i);
 		return _typeFlagOf(
-			_soaTy[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
+			_soaTypes[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
 		);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} url content start offset
 	 */
-	contentStart(n = _curNode) {
-		return _soaA0[_ix(n)];
+	contentStart(n = _currentNode) {
+		return _soaAux0[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} url content end offset
 	 */
-	contentEnd(n = _curNode) {
-		return _soaA1[_ix(n)];
+	contentEnd(n = _currentNode) {
+		return _soaAux1[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {string} rule / declaration / function name
 	 */
-	name(n = _curNode) {
-		const i = _ix(n);
-		return _soaTy[i] === T_AT_RULE
-			? _soaInput.slice(_soaSt[i] + 1, _soaA0[i])
-			: _soaInput.slice(_soaSt[i], _soaA0[i]);
+	name(n = _currentNode) {
+		const i = _nodeIndex(n);
+		return _soaTypes[i] === T_AT_RULE
+			? _soaInput.slice(_soaStarts[i] + 1, _soaAux0[i])
+			: _soaInput.slice(_soaStarts[i], _soaAux0[i]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} name start offset
 	 */
-	nameStart(n = _curNode) {
-		return _soaSt[_ix(n)];
+	nameStart(n = _currentNode) {
+		return _soaStarts[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} name end offset
 	 */
-	nameEnd(n = _curNode) {
-		return _soaA0[_ix(n)];
+	nameEnd(n = _currentNode) {
+		return _soaAux0[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {string} unescaped name
 	 */
-	unescapedName(n = _curNode) {
+	unescapedName(n = _currentNode) {
 		return unescapeIdentifier(A.name(n));
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {ComponentValue[]} function / block children
 	 */
-	children(n = _curNode) {
-		return /** @type {ComponentValue[]} */ (_soaL0[_ix(n)]);
+	children(n = _currentNode) {
+		return /** @type {ComponentValue[]} */ (_soaContentLists[_nodeIndex(n)]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {ComponentValue[]} rule prelude
 	 */
-	prelude(n = _curNode) {
-		return /** @type {ComponentValue[]} */ (_soaL0[_ix(n)]);
+	prelude(n = _currentNode) {
+		return /** @type {ComponentValue[]} */ (_soaContentLists[_nodeIndex(n)]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {Declaration[] | null} block declarations
 	 */
-	declarations(n = _curNode) {
-		return /** @type {Declaration[] | null} */ (_soaL1[_ix(n)]);
+	declarations(n = _currentNode) {
+		return /** @type {Declaration[] | null} */ (
+			_soaDeclarationLists[_nodeIndex(n)]
+		);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {Rule[] | null} block child rules
 	 */
-	childRules(n = _curNode) {
-		return /** @type {Rule[] | null} */ (_soaL2[_ix(n)]);
+	childRules(n = _currentNode) {
+		return /** @type {Rule[] | null} */ (_soaChildRuleLists[_nodeIndex(n)]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} block start offset
 	 */
-	blockStart(n = _curNode) {
-		return _soaA1[_ix(n)];
+	blockStart(n = _currentNode) {
+		return _soaAux1[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} block end offset
 	 */
-	blockEnd(n = _curNode) {
-		return _soaA2[_ix(n)];
+	blockEnd(n = _currentNode) {
+		return _soaAux2[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {boolean} `!important` flag
 	 */
-	important(n = _curNode) {
-		return (_soaFl[_ix(n)] & 1) !== 0;
+	important(n = _currentNode) {
+		return (_soaFlags[_nodeIndex(n)] & 1) !== 0;
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {SimpleBlockToken} block opening token
 	 */
-	blockToken(n = _curNode) {
-		return /** @type {SimpleBlockToken} */ (_soaInput[_soaSt[_ix(n)]]);
+	blockToken(n = _currentNode) {
+		return /** @type {SimpleBlockToken} */ (
+			_soaInput[_soaStarts[_nodeIndex(n)]]
+		);
 	},
 	// Writers — `CssParser` rewrites a rule's end / block-end when it folds an
 	// inline ICSS `:import` / `:export` body into a single dependency. The
@@ -3584,14 +3606,14 @@ const A = {
 	 * @param {number} v new end offset
 	 */
 	setEnd(n, v) {
-		_soaEn[_ix(n)] = v;
+		_soaEnds[_nodeIndex(n)] = v;
 	},
 	/**
 	 * @param {Node} n node
 	 * @param {number} v new block end offset
 	 */
 	setBlockEnd(n, v) {
-		_soaA2[_ix(n)] = v;
+		_soaAux2[_nodeIndex(n)] = v;
 	}
 };
 

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1634,7 +1634,10 @@ let _makeUrl;
 let _makeContainer;
 /** @type {(start: number) => Node} */
 let _makeStylesheet;
-/** @type {(r: Node, v: string, nameStart: number, nameEnd: number) => void} */
+// Offsets only — the object backend derives the name string itself (an
+// at-rule's name skips its `@`), so the SoA backend never pays for a slice
+// it would immediately discard (it re-derives names from offsets on read).
+/** @type {(r: Node, nameStart: number, nameEnd: number) => void} */
 let _setName;
 /** @type {(r: Node, v: number) => void} */
 let _setEnd;
@@ -1700,9 +1703,13 @@ const useObjectBackend = (lc) => {
 	_makeUrl = _objUrl;
 	_makeContainer = _objContainer;
 	_makeStylesheet = _objStylesheet;
-	_setName = (r, v, ns, ne) => {
+	_setName = (r, ns, ne) => {
 		const c = /** @type {Container} */ (r);
-		c.name = v;
+		// An at-rule's `nameStart` points at its `@`, which the name excludes.
+		c.name = _objLocConverter._input.slice(
+			r.type === T_AT_RULE ? ns + 1 : ns,
+			ne
+		);
 		c.nameStart = ns;
 		c.nameEnd = ne;
 	};
@@ -1869,7 +1876,7 @@ const useSoaBackend = (input, lc) => {
 	_makeContainer = (type, start, end) => _soaAllocContainer(type, start, end);
 	_makeStylesheet = (start) => _soaAllocContainer(T_STYLESHEET, start, start);
 	// name / nameStart are derived from start + nameEnd; only nameEnd is stored.
-	_setName = (r, v, ns, ne) => {
+	_setName = (r, ns, ne) => {
 		_soaAux0[_nodeIndex(r)] = ne;
 	};
 	_setEnd = (r, v) => {
@@ -2345,12 +2352,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 	const rule = /** @type {AtRule} */ (
 		_makeContainer(T_AT_RULE, head.start, head.end)
 	);
-	_setName(
-		rule,
-		ts.input.slice(head.start + 1, head.end),
-		head.start,
-		head.end
-	);
+	_setName(rule, head.start, head.end);
 	const prelude = _list();
 	_setPrelude(rule, prelude);
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
@@ -2713,7 +2715,7 @@ const consumeADeclaration = (ts, nested = false) => {
 	// Otherwise, consume the remnants of a bad declaration from input, with nested, and return nothing.
 	if (ts.next().type === TT_IDENTIFIER) {
 		const head = ts.consume();
-		_setName(decl, input.slice(head.start, head.end), head.start, head.end);
+		_setName(decl, head.start, head.end);
 	} else {
 		consumeTheRemnantsOfABadDeclaration(ts, nested);
 		return undefined;
@@ -2911,14 +2913,13 @@ const consumeASimpleBlock = (ts) => {
  * @returns {FunctionNode | undefined} the consumed function node
  */
 const consumeAFunction = (ts) => {
-	const { input } = ts;
 	// Assert (spec): the next token is a <function-token>.
 	// Consume a token from input, and let function be a new function with its name equal the returned token’s value, and a value set to an empty list.
 	const tFn = ts.consume();
 	const fn = /** @type {FunctionNode} */ (
 		_makeContainer(T_FUNCTION, tFn.start, tFn.end)
 	);
-	_setName(fn, input.slice(tFn.start, tFn.end - 1), tFn.start, tFn.end - 1);
+	_setName(fn, tFn.start, tFn.end - 1);
 	const val = _list();
 	_setValue(fn, val);
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -368,6 +368,15 @@ const getContentModeForRange = (input, start, end) => {
 	}
 };
 
+// Attribute-name stop set for the fast scanner below: whitespace (incl. CR,
+// see `isSpace`), `/`, `>`, `=` end a name; NUL, `"`, `'`, `<` need the state
+// machine's per-occurrence parse errors. Chars ≥ 0x80 are ordinary name chars.
+const _ATTR_NAME_STOP = new Uint8Array(128);
+for (const cc of [0x09, 0x0a, 0x0c, 0x0d, 0x20, 0x2f, 0x3e, 0x3d]) {
+	_ATTR_NAME_STOP[cc] = 1;
+}
+for (const cc of [0x00, 0x22, 0x27, 0x3c]) _ATTR_NAME_STOP[cc] = 2;
+
 /**
  * @param {string} input input string
  * @param {number} pos current position
@@ -406,6 +415,13 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 	// Tracks whether the current tag has parsed any attributes — used to
 	// fire the `end-tag-with-attributes` parse error when an end tag emits.
 	let tagHasAttributes = false;
+	// Memoized next occurrence of `<` / `&` / NUL for the text-run
+	// fast-forwards: native `indexOf` beats a per-char JS loop, and `pos` only
+	// moves forward, so each memo is refreshed at most once per occurrence
+	// (`len` = no further occurrence).
+	let nextLt = -1;
+	let nextAmp = -1;
+	let nextNul = -1;
 
 	/**
 	 * Reports a tokenizer parse error to the consumer. The offset range and
@@ -627,13 +643,19 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// Fast-forward over the run of ordinary text without re-entering
 					// the per-state switch; stop on the next significant code point.
 					pos++;
-					while (pos < len) {
-						const c2 = input.charCodeAt(pos);
-						if (c2 === CC_LESS_THAN || c2 === CC_AMPERSAND || c2 === CC_NULL) {
-							break;
-						}
-						pos++;
+					if (nextLt < pos) {
+						nextLt = input.indexOf("<", pos);
+						if (nextLt === -1) nextLt = len;
 					}
+					if (nextAmp < pos) {
+						nextAmp = input.indexOf("&", pos);
+						if (nextAmp === -1) nextAmp = len;
+					}
+					if (nextNul < pos) {
+						nextNul = input.indexOf("\0", pos);
+						if (nextNul === -1) nextNul = len;
+					}
+					pos = Math.min(nextLt, nextAmp, nextNul);
 				}
 				break;
 
@@ -814,8 +836,76 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// Start a new attribute in the current tag token. Set that attribute name
 					// and value to the empty string. Reconsume in the attribute name state.
 					attributeNameStart = pos;
-					state = STATE_ATTRIBUTE_NAME;
-					// Reconsume
+					if (cc < 0x80 && _ATTR_NAME_STOP[cc] !== 0) {
+						// NUL / `"` / `'` / `<` first char: per-occurrence parse
+						// errors — take the per-state machine.
+						state = STATE_ATTRIBUTE_NAME;
+						break; // Reconsume
+					}
+					// Fast path — scan the dominant `name`, `name=…`, `name="…"` /
+					// `name='…'` shapes in one pass instead of one switch dispatch
+					// per state; any char needing per-occurrence handling drops
+					// back to the per-state machine at its exact offset.
+					{
+						let p = pos + 1;
+						let c2 = 0;
+						while (
+							p < len &&
+							((c2 = input.charCodeAt(p)) >= 0x80 || _ATTR_NAME_STOP[c2] === 0)
+						) {
+							p++;
+						}
+						if (p >= len || _ATTR_NAME_STOP[c2] === 2) {
+							// EOF or NUL / `"` / `'` / `<` inside the name: the
+							// attribute-name state re-handles from here.
+							state = STATE_ATTRIBUTE_NAME;
+							pos = p;
+							break;
+						}
+						attributeNameEnd = p;
+						if (c2 !== CC_EQUALS) {
+							// Whitespace / `/` / `>` — reconsume in after-attribute-name.
+							state = STATE_AFTER_ATTRIBUTE_NAME;
+							pos = p;
+							break;
+						}
+						p++;
+						const q = p < len ? input.charCodeAt(p) : 0;
+						if (q !== CC_QUOTATION_MARK && q !== CC_APOSTROPHE) {
+							// Unquoted / missing value (or EOF) — reconsume in
+							// before-attribute-value.
+							state = STATE_BEFORE_ATTRIBUTE_VALUE;
+							pos = p;
+							break;
+						}
+						attrQuoteType =
+							q === CC_QUOTATION_MARK ? QUOTE_DOUBLE : QUOTE_SINGLE;
+						attributeValueStart = p + 1;
+						let v = p + 1;
+						let c3 = 0;
+						while (
+							v < len &&
+							(c3 = input.charCodeAt(v)) !== q &&
+							c3 !== CC_AMPERSAND &&
+							c3 !== CC_NULL
+						) {
+							v++;
+						}
+						if (v >= len || c3 !== q) {
+							// `&` / NUL / EOF inside the value: the quoted-value state
+							// re-handles from here (char reference, parse error, EOF).
+							state =
+								q === CC_QUOTATION_MARK
+									? STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED
+									: STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED;
+							pos = v;
+							break;
+						}
+						// Closing quote — same emit + transition as the quoted-value
+						// states.
+						pos = emitAttribute(v);
+						state = STATE_AFTER_ATTRIBUTE_VALUE_QUOTED;
+					}
 				}
 				break;
 
@@ -2332,15 +2422,22 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					reportError("unexpected-null-character", pos, pos + 1, "warning");
 					pos++;
 				} else {
-					// Fast-forward over ordinary RCDATA text.
+					// Fast-forward over ordinary RCDATA text (same memoized
+					// `indexOf` scheme as the data state).
 					pos++;
-					while (pos < len) {
-						const c2 = input.charCodeAt(pos);
-						if (c2 === CC_AMPERSAND || c2 === CC_LESS_THAN || c2 === CC_NULL) {
-							break;
-						}
-						pos++;
+					if (nextLt < pos) {
+						nextLt = input.indexOf("<", pos);
+						if (nextLt === -1) nextLt = len;
 					}
+					if (nextAmp < pos) {
+						nextAmp = input.indexOf("&", pos);
+						if (nextAmp === -1) nextAmp = len;
+					}
+					if (nextNul < pos) {
+						nextNul = input.indexOf("\0", pos);
+						if (nextNul === -1) nextNul = len;
+					}
+					pos = Math.min(nextLt, nextAmp, nextNul);
 				}
 				break;
 
@@ -2467,13 +2564,18 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					reportError("unexpected-null-character", pos, pos + 1, "warning");
 					pos++;
 				} else {
-					// Fast-forward over ordinary RAWTEXT text.
+					// Fast-forward over ordinary RAWTEXT text (same memoized
+					// `indexOf` scheme as the data state).
 					pos++;
-					while (pos < len) {
-						const c2 = input.charCodeAt(pos);
-						if (c2 === CC_LESS_THAN || c2 === CC_NULL) break;
-						pos++;
+					if (nextLt < pos) {
+						nextLt = input.indexOf("<", pos);
+						if (nextLt === -1) nextLt = len;
 					}
+					if (nextNul < pos) {
+						nextNul = input.indexOf("\0", pos);
+						if (nextNul === -1) nextNul = len;
+					}
+					pos = Math.min(nextLt, nextNul);
 				}
 				break;
 
@@ -2596,13 +2698,18 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					reportError("unexpected-null-character", pos, pos + 1, "warning");
 					pos++;
 				} else {
-					// Fast-forward over ordinary script-data text.
+					// Fast-forward over ordinary script-data text (same memoized
+					// `indexOf` scheme as the data state).
 					pos++;
-					while (pos < len) {
-						const c2 = input.charCodeAt(pos);
-						if (c2 === CC_LESS_THAN || c2 === CC_NULL) break;
-						pos++;
+					if (nextLt < pos) {
+						nextLt = input.indexOf("<", pos);
+						if (nextLt === -1) nextLt = len;
 					}
+					if (nextNul < pos) {
+						nextNul = input.indexOf("\0", pos);
+						if (nextNul === -1) nextNul = len;
+					}
+					pos = Math.min(nextLt, nextNul);
 				}
 				break;
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -368,19 +368,6 @@ const getContentModeForRange = (input, start, end) => {
 	}
 };
 
-// Attribute-name stop set for the fast scanner below — exactly the code
-// points with their own arcs in the attribute-name state
-// (https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state):
-// 1 = whitespace (incl. CR, see `isSpace`) / `/` / `>` / `=`, which end a
-// name per spec; 2 = NUL / `"` / `'` / `<`, whose per-occurrence parse
-// errors the scanner leaves to the state machine. Chars ≥ 0x80 fall under
-// the state's "anything else — append" arc, i.e. ordinary name chars.
-const _ATTR_NAME_STOP = new Uint8Array(128);
-for (const cc of [0x09, 0x0a, 0x0c, 0x0d, 0x20, 0x2f, 0x3e, 0x3d]) {
-	_ATTR_NAME_STOP[cc] = 1;
-}
-for (const cc of [0x00, 0x22, 0x27, 0x3c]) _ATTR_NAME_STOP[cc] = 2;
-
 /**
  * @param {string} input input string
  * @param {number} pos current position
@@ -842,84 +829,8 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// Start a new attribute in the current tag token. Set that attribute name
 					// and value to the empty string. Reconsume in the attribute name state.
 					attributeNameStart = pos;
-					if (cc < 0x80 && _ATTR_NAME_STOP[cc] !== 0) {
-						// NUL / `"` / `'` / `<` first char: per-occurrence parse
-						// errors — take the per-state machine.
-						state = STATE_ATTRIBUTE_NAME;
-						break; // Reconsume
-					}
-					// Fast path — scan the dominant `name`, `name=…`, `name="…"` /
-					// `name='…'` shapes in one pass instead of one switch dispatch
-					// per state. Not a new grammar: it only batches the
-					// "Anything else — append to the current attribute" arcs of
-					// the spec states it crosses (attribute-name →
-					// before-attribute-value → attribute-value (double-/single-
-					// quoted), https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
-					// and the three states following it); every code point with
-					// its own spec arc (parse error, `&` reference, EOF, closing
-					// quote) reconsumes in the owning state at its exact offset,
-					// so emitted tokens and parse errors stay byte-identical to
-					// the per-state machine (verified by the html5lib suite).
-					{
-						let p = pos + 1;
-						let c2 = 0;
-						while (
-							p < len &&
-							((c2 = input.charCodeAt(p)) >= 0x80 || _ATTR_NAME_STOP[c2] === 0)
-						) {
-							p++;
-						}
-						if (p >= len || _ATTR_NAME_STOP[c2] === 2) {
-							// EOF or NUL / `"` / `'` / `<` inside the name: the
-							// attribute-name state re-handles from here.
-							state = STATE_ATTRIBUTE_NAME;
-							pos = p;
-							break;
-						}
-						attributeNameEnd = p;
-						if (c2 !== CC_EQUALS) {
-							// Whitespace / `/` / `>` — reconsume in after-attribute-name.
-							state = STATE_AFTER_ATTRIBUTE_NAME;
-							pos = p;
-							break;
-						}
-						p++;
-						const q = p < len ? input.charCodeAt(p) : 0;
-						if (q !== CC_QUOTATION_MARK && q !== CC_APOSTROPHE) {
-							// Unquoted / missing value (or EOF) — reconsume in
-							// before-attribute-value.
-							state = STATE_BEFORE_ATTRIBUTE_VALUE;
-							pos = p;
-							break;
-						}
-						attrQuoteType =
-							q === CC_QUOTATION_MARK ? QUOTE_DOUBLE : QUOTE_SINGLE;
-						attributeValueStart = p + 1;
-						let v = p + 1;
-						let c3 = 0;
-						while (
-							v < len &&
-							(c3 = input.charCodeAt(v)) !== q &&
-							c3 !== CC_AMPERSAND &&
-							c3 !== CC_NULL
-						) {
-							v++;
-						}
-						if (v >= len || c3 !== q) {
-							// `&` / NUL / EOF inside the value: the quoted-value state
-							// re-handles from here (char reference, parse error, EOF).
-							state =
-								q === CC_QUOTATION_MARK
-									? STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED
-									: STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED;
-							pos = v;
-							break;
-						}
-						// Closing quote — the quoted-value states' own arc: "Switch
-						// to the after attribute value (quoted) state."
-						pos = emitAttribute(v);
-						state = STATE_AFTER_ATTRIBUTE_VALUE_QUOTED;
-					}
+					state = STATE_ATTRIBUTE_NAME;
+					// Reconsume
 				}
 				break;
 

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -368,9 +368,13 @@ const getContentModeForRange = (input, start, end) => {
 	}
 };
 
-// Attribute-name stop set for the fast scanner below: whitespace (incl. CR,
-// see `isSpace`), `/`, `>`, `=` end a name; NUL, `"`, `'`, `<` need the state
-// machine's per-occurrence parse errors. Chars ≥ 0x80 are ordinary name chars.
+// Attribute-name stop set for the fast scanner below — exactly the code
+// points with their own arcs in the attribute-name state
+// (https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state):
+// 1 = whitespace (incl. CR, see `isSpace`) / `/` / `>` / `=`, which end a
+// name per spec; 2 = NUL / `"` / `'` / `<`, whose per-occurrence parse
+// errors the scanner leaves to the state machine. Chars ≥ 0x80 fall under
+// the state's "anything else — append" arc, i.e. ordinary name chars.
 const _ATTR_NAME_STOP = new Uint8Array(128);
 for (const cc of [0x09, 0x0a, 0x0c, 0x0d, 0x20, 0x2f, 0x3e, 0x3d]) {
 	_ATTR_NAME_STOP[cc] = 1;
@@ -641,7 +645,9 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					pos++;
 				} else {
 					// Fast-forward over the run of ordinary text without re-entering
-					// the per-state switch; stop on the next significant code point.
+					// the per-state switch — batches only the data state's "Anything
+					// else — emit the current input character" arc; the stops are
+					// exactly the code points with their own arcs (`<`, `&`, NUL).
 					pos++;
 					if (nextLt < pos) {
 						nextLt = input.indexOf("<", pos);
@@ -844,8 +850,16 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					}
 					// Fast path — scan the dominant `name`, `name=…`, `name="…"` /
 					// `name='…'` shapes in one pass instead of one switch dispatch
-					// per state; any char needing per-occurrence handling drops
-					// back to the per-state machine at its exact offset.
+					// per state. Not a new grammar: it only batches the
+					// "Anything else — append to the current attribute" arcs of
+					// the spec states it crosses (attribute-name →
+					// before-attribute-value → attribute-value (double-/single-
+					// quoted), https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+					// and the three states following it); every code point with
+					// its own spec arc (parse error, `&` reference, EOF, closing
+					// quote) reconsumes in the owning state at its exact offset,
+					// so emitted tokens and parse errors stay byte-identical to
+					// the per-state machine (verified by the html5lib suite).
 					{
 						let p = pos + 1;
 						let c2 = 0;
@@ -901,8 +915,8 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 							pos = v;
 							break;
 						}
-						// Closing quote — same emit + transition as the quoted-value
-						// states.
+						// Closing quote — the quoted-value states' own arc: "Switch
+						// to the after attribute value (quoted) state."
 						pos = emitAttribute(v);
 						state = STATE_AFTER_ATTRIBUTE_VALUE_QUOTED;
 					}
@@ -2423,7 +2437,8 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					pos++;
 				} else {
 					// Fast-forward over ordinary RCDATA text (same memoized
-					// `indexOf` scheme as the data state).
+					// `indexOf` scheme as the data state) — batches only this
+					// state's "anything else" arc; `&` / `<` / NUL keep their own.
 					pos++;
 					if (nextLt < pos) {
 						nextLt = input.indexOf("<", pos);
@@ -2565,7 +2580,8 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					pos++;
 				} else {
 					// Fast-forward over ordinary RAWTEXT text (same memoized
-					// `indexOf` scheme as the data state).
+					// `indexOf` scheme as the data state) — batches only this
+					// state's "anything else" arc; `<` / NUL keep their own.
 					pos++;
 					if (nextLt < pos) {
 						nextLt = input.indexOf("<", pos);
@@ -2699,7 +2715,8 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					pos++;
 				} else {
 					// Fast-forward over ordinary script-data text (same memoized
-					// `indexOf` scheme as the data state).
+					// `indexOf` scheme as the data state) — batches only this
+					// state's "anything else" arc; `<` / NUL keep their own.
 					pos++;
 					if (nextLt < pos) {
 						nextLt = input.indexOf("<", pos);

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3832,132 +3832,134 @@ const EMPTY_ATTRS = /** @type {AttributeRun} */ (
 // a steady-state parse allocates almost nothing per node; consumers must fully
 // read a tree before the next `buildHtmlAst` call. Id 0 is reserved as
 // "no node" so the link columns can use 0 as null.
-let _hCap = 0;
-let _hN = 0;
+let _nodeCapacity = 0;
+let _nodeCount = 0;
 /** `NodeType` per node */
-let _hTy = new Uint8Array(0);
+let _nodeTypes = new Uint8Array(0);
 /** bits 0-1 namespace (`NS_*`), bit 2 self-closing (void element) */
-let _hFl = new Uint8Array(0);
-let _hSt = new Int32Array(0);
-let _hEn = new Int32Array(0);
+let _nodeFlags = new Uint8Array(0);
+let _nodeStarts = new Int32Array(0);
+let _nodeEnds = new Int32Array(0);
 /** end offset of an element's opening tag (after `>`) */
-let _hTagEnd = new Int32Array(0);
+let _nodeTagEnds = new Int32Array(0);
 /** end offset of an element's tag name */
-let _hNameEnd = new Int32Array(0);
+let _nodeNameEnds = new Int32Array(0);
 /** under `skip.text`, end offset of a raw-text element's body (`HtmlAstSkip`) */
-let _hCEnd = new Int32Array(0);
+let _nodeContentEnds = new Int32Array(0);
 /** a `<template>`'s content DocumentFragment (0 = none) */
-let _hTc = new Int32Array(0);
-let _hParent = new Int32Array(0);
-let _hFirst = new Int32Array(0);
-let _hLast = new Int32Array(0);
-let _hNext = new Int32Array(0);
+let _nodeTemplateContents = new Int32Array(0);
+let _nodeParents = new Int32Array(0);
+let _nodeFirstChildren = new Int32Array(0);
+let _nodeLastChildren = new Int32Array(0);
+let _nodeNextSiblings = new Int32Array(0);
 /** @type {string[]} tag name / text data / comment data / doctype name */
-const _hStr = [];
+const _nodeStrings = [];
 /** first attribute id of an element's contiguous run */
-let _hAStart = new Int32Array(0);
+let _nodeAttrStarts = new Int32Array(0);
 /** attribute count of an element's run */
-let _hACount = new Int32Array(0);
+let _nodeAttrCounts = new Int32Array(0);
 // The single doctype node's public/system ids (a document inserts at most one
 // doctype node — later doctype tokens are ignored — so no column is needed).
 /** @type {string | null} */
-let _hDocPub = null;
+let _doctypePublicId = null;
 /** @type {string | null} */
-let _hDocSys = null;
+let _doctypeSystemId = null;
 
 const NS_MASK = 3;
 const FLAG_SELF_CLOSING = 4;
 
 /** @type {(el: HtmlNodeRef) => string} */
-const _tag = (el) => _hStr[el];
+const _tagNameOf = (el) => _nodeStrings[el];
 /** @type {(el: HtmlNodeRef) => number} */
-const _ns = (el) => _hFl[el] & NS_MASK;
+const _namespaceOf = (el) => _nodeFlags[el] & NS_MASK;
 
 // === Attribute columns ===
 // One attribute = one integer id into these columns; an element (and a
 // start-tag token) holds a contiguous run. The value string is derived from
-// the source by offset on read — `_aVal` carries an override only for
+// the source by offset on read — `_attrValues` carries an override only for
 // valueless attributes (`""`) and offset-less adoption-agency clones — and the
 // html5lib serializer name is derived from the adjusted name plus one flag
 // bit, so per attribute only the interned name pointer is retained.
-let _aCap = 0;
-let _aN = 0;
-let _aNameStart = new Int32Array(0);
-let _aNameEnd = new Int32Array(0);
-let _aValStart = new Int32Array(0);
-let _aValEnd = new Int32Array(0);
+let _attrCapacity = 0;
+let _attrCount = 0;
+let _attrNameStarts = new Int32Array(0);
+let _attrNameEnds = new Int32Array(0);
+let _attrValueStarts = new Int32Array(0);
+let _attrValueEnds = new Int32Array(0);
 /** bit 0: name has a `FOREIGN_ATTR_NS` serializer name (set on foreign adjust) */
-let _aFl = new Uint8Array(0);
+let _attrFlags = new Uint8Array(0);
 /** @type {string[]} lowercased (foreign-content: adjusted) attribute name */
-const _aName = [];
+const _attrNames = [];
 /** @type {(string | null)[]} value override (null = slice the source by offset) */
-const _aVal = [];
+const _attrValues = [];
 /** source of the current parse, for by-offset attribute values */
-let _hSrc = "";
+let _htmlSource = "";
 
 /** @param {number} need minimum capacity */
-const _aGrow = (need) => {
-	let cap = _aCap || 4096;
+const _growAttrColumns = (need) => {
+	let cap = _attrCapacity || 4096;
 	while (cap < need) cap *= 2;
 	const nameStart = new Int32Array(cap);
-	nameStart.set(_aNameStart);
-	_aNameStart = nameStart;
+	nameStart.set(_attrNameStarts);
+	_attrNameStarts = nameStart;
 	const nameEnd = new Int32Array(cap);
-	nameEnd.set(_aNameEnd);
-	_aNameEnd = nameEnd;
+	nameEnd.set(_attrNameEnds);
+	_attrNameEnds = nameEnd;
 	const valStart = new Int32Array(cap);
-	valStart.set(_aValStart);
-	_aValStart = valStart;
+	valStart.set(_attrValueStarts);
+	_attrValueStarts = valStart;
 	const valEnd = new Int32Array(cap);
-	valEnd.set(_aValEnd);
-	_aValEnd = valEnd;
+	valEnd.set(_attrValueEnds);
+	_attrValueEnds = valEnd;
 	const fl = new Uint8Array(cap);
-	fl.set(_aFl);
-	_aFl = fl;
-	_aCap = cap;
+	fl.set(_attrFlags);
+	_attrFlags = fl;
+	_attrCapacity = cap;
 };
 
 /** @type {(name: string, value: string | null, nameStart: number, nameEnd: number, valueStart: number, valueEnd: number) => number} */
-const _aAlloc = (name, value, nameStart, nameEnd, valueStart, valueEnd) => {
-	const i = ++_aN;
-	if (i >= _aCap) _aGrow(i + 1);
-	_aNameStart[i] = nameStart;
-	_aNameEnd[i] = nameEnd;
-	_aValStart[i] = valueStart;
-	_aValEnd[i] = valueEnd;
-	_aFl[i] = 0;
+const _allocAttr = (name, value, nameStart, nameEnd, valueStart, valueEnd) => {
+	const i = ++_attrCount;
+	if (i >= _attrCapacity) _growAttrColumns(i + 1);
+	_attrNameStarts[i] = nameStart;
+	_attrNameEnds[i] = nameEnd;
+	_attrValueStarts[i] = valueStart;
+	_attrValueEnds[i] = valueEnd;
+	_attrFlags[i] = 0;
 	// Ids are sequential, so these indexed writes append (arrays stay packed).
-	_aName[i] = name;
-	_aVal[i] = value;
+	_attrNames[i] = name;
+	_attrValues[i] = value;
 	return i;
 };
 
 /** @type {(i: number) => string} */
-const _aValueOf = (i) => {
-	const v = _aVal[i];
-	return v !== null ? v : _hSrc.slice(_aValStart[i], _aValEnd[i]);
+const _attrValueOf = (i) => {
+	const v = _attrValues[i];
+	return v !== null
+		? v
+		: _htmlSource.slice(_attrValueStarts[i], _attrValueEnds[i]);
 };
 
 // Linear name lookup in a run — attribute lists are short, a loop beats a Map.
 /** @type {(start: number, count: number, name: string) => number} */
-const _aFind = (start, count, name) => {
+const _findAttr = (start, count, name) => {
 	for (let i = start; i < start + count; i++) {
-		if (_aName[i] === name) return i;
+		if (_attrNames[i] === name) return i;
 	}
 	return 0;
 };
 
 /** @type {(i: number) => number} exact copy of an attribute into a new id */
-const _aCopy = (i) => {
-	const c = _aAlloc(
-		_aName[i],
-		_aVal[i],
-		_aNameStart[i],
-		_aNameEnd[i],
-		_aValStart[i],
-		_aValEnd[i]
+const _copyAttr = (i) => {
+	const c = _allocAttr(
+		_attrNames[i],
+		_attrValues[i],
+		_attrNameStarts[i],
+		_attrNameEnds[i],
+		_attrValueStarts[i],
+		_attrValueEnds[i]
 	);
-	_aFl[c] = _aFl[i];
+	_attrFlags[c] = _attrFlags[i];
 	return c;
 };
 
@@ -3966,135 +3968,135 @@ const _aCopy = (i) => {
 // an uppercase letter (unadjusted names are always lowercased), serializing as
 // itself. Everything else serializes as the plain name (undefined here).
 /** @type {(i: number) => string | undefined} */
-const _aSerializedName = (i) => {
-	if ((_aFl[i] & 1) !== 0) return FOREIGN_ATTR_NS[_aName[i]];
-	const name = _aName[i];
+const _attrSerializedName = (i) => {
+	if ((_attrFlags[i] & 1) !== 0) return FOREIGN_ATTR_NS[_attrNames[i]];
+	const name = _attrNames[i];
 	return /[A-Z]/.test(name) ? name : undefined;
 };
 
 /** @param {number} need minimum capacity */
-const _hGrow = (need) => {
-	let cap = _hCap || 4096;
+const _growNodeColumns = (need) => {
+	let cap = _nodeCapacity || 4096;
 	while (cap < need) cap *= 2;
 	const ty = new Uint8Array(cap);
-	ty.set(_hTy);
-	_hTy = ty;
+	ty.set(_nodeTypes);
+	_nodeTypes = ty;
 	const fl = new Uint8Array(cap);
-	fl.set(_hFl);
-	_hFl = fl;
+	fl.set(_nodeFlags);
+	_nodeFlags = fl;
 	const st = new Int32Array(cap);
-	st.set(_hSt);
-	_hSt = st;
+	st.set(_nodeStarts);
+	_nodeStarts = st;
 	const en = new Int32Array(cap);
-	en.set(_hEn);
-	_hEn = en;
+	en.set(_nodeEnds);
+	_nodeEnds = en;
 	const tagEnd = new Int32Array(cap);
-	tagEnd.set(_hTagEnd);
-	_hTagEnd = tagEnd;
+	tagEnd.set(_nodeTagEnds);
+	_nodeTagEnds = tagEnd;
 	const nameEnd = new Int32Array(cap);
-	nameEnd.set(_hNameEnd);
-	_hNameEnd = nameEnd;
+	nameEnd.set(_nodeNameEnds);
+	_nodeNameEnds = nameEnd;
 	const cEnd = new Int32Array(cap);
-	cEnd.set(_hCEnd);
-	_hCEnd = cEnd;
+	cEnd.set(_nodeContentEnds);
+	_nodeContentEnds = cEnd;
 	const tc = new Int32Array(cap);
-	tc.set(_hTc);
-	_hTc = tc;
+	tc.set(_nodeTemplateContents);
+	_nodeTemplateContents = tc;
 	const parent = new Int32Array(cap);
-	parent.set(_hParent);
-	_hParent = parent;
+	parent.set(_nodeParents);
+	_nodeParents = parent;
 	const first = new Int32Array(cap);
-	first.set(_hFirst);
-	_hFirst = first;
+	first.set(_nodeFirstChildren);
+	_nodeFirstChildren = first;
 	const last = new Int32Array(cap);
-	last.set(_hLast);
-	_hLast = last;
+	last.set(_nodeLastChildren);
+	_nodeLastChildren = last;
 	const next = new Int32Array(cap);
-	next.set(_hNext);
-	_hNext = next;
+	next.set(_nodeNextSiblings);
+	_nodeNextSiblings = next;
 	const aStart = new Int32Array(cap);
-	aStart.set(_hAStart);
-	_hAStart = aStart;
+	aStart.set(_nodeAttrStarts);
+	_nodeAttrStarts = aStart;
 	const aCount = new Int32Array(cap);
-	aCount.set(_hACount);
-	_hACount = aCount;
-	_hCap = cap;
+	aCount.set(_nodeAttrCounts);
+	_nodeAttrCounts = aCount;
+	_nodeCapacity = cap;
 };
 
 /** Start a new parse: invalidate all prior refs, release prior heap refs. */
-const _hReset = () => {
-	_hN = 0;
-	_aN = 0;
-	_hStr.length = 0;
-	_aName.length = 0;
-	_aVal.length = 0;
+const _resetAstColumns = () => {
+	_nodeCount = 0;
+	_attrCount = 0;
+	_nodeStrings.length = 0;
+	_attrNames.length = 0;
+	_attrValues.length = 0;
 	// Keep id 0 ("no node" / "no attribute") occupied so writes stay packed.
-	_hStr.push("");
-	_aName.push("");
-	_aVal.push(null);
-	_hDocPub = null;
-	_hDocSys = null;
+	_nodeStrings.push("");
+	_attrNames.push("");
+	_attrValues.push(null);
+	_doctypePublicId = null;
+	_doctypeSystemId = null;
 };
 
 // Release the side arrays' heap references (strings, attribute names/values)
 // once a walk has consumed the tree, so the retained columns don't pin the
 // parsed source until the next parse.
-const _hRelease = () => {
-	_hN = 0;
-	_aN = 0;
-	_hStr.length = 0;
-	_aName.length = 0;
-	_aVal.length = 0;
-	_hSrc = "";
-	_hDocPub = null;
-	_hDocSys = null;
+const _releaseAstColumns = () => {
+	_nodeCount = 0;
+	_attrCount = 0;
+	_nodeStrings.length = 0;
+	_attrNames.length = 0;
+	_attrValues.length = 0;
+	_htmlSource = "";
+	_doctypePublicId = null;
+	_doctypeSystemId = null;
 };
 
 /** @type {(type: number, start: number, end: number) => HtmlNodeRef} */
-const _hAlloc = (type, start, end) => {
-	const i = ++_hN;
-	if (i >= _hCap) _hGrow(i + 1);
-	_hTy[i] = type;
-	_hFl[i] = 0;
-	_hSt[i] = start;
-	_hEn[i] = end;
-	_hTagEnd[i] = 0;
-	_hNameEnd[i] = 0;
-	_hCEnd[i] = 0;
-	_hTc[i] = 0;
-	_hParent[i] = 0;
-	_hFirst[i] = 0;
-	_hLast[i] = 0;
-	_hNext[i] = 0;
-	_hAStart[i] = 0;
-	_hACount[i] = 0;
+const _allocNode = (type, start, end) => {
+	const i = ++_nodeCount;
+	if (i >= _nodeCapacity) _growNodeColumns(i + 1);
+	_nodeTypes[i] = type;
+	_nodeFlags[i] = 0;
+	_nodeStarts[i] = start;
+	_nodeEnds[i] = end;
+	_nodeTagEnds[i] = 0;
+	_nodeNameEnds[i] = 0;
+	_nodeContentEnds[i] = 0;
+	_nodeTemplateContents[i] = 0;
+	_nodeParents[i] = 0;
+	_nodeFirstChildren[i] = 0;
+	_nodeLastChildren[i] = 0;
+	_nodeNextSiblings[i] = 0;
+	_nodeAttrStarts[i] = 0;
+	_nodeAttrCounts[i] = 0;
 	// Ids are sequential, so this indexed write appends (array stays packed).
-	_hStr[i] = "";
+	_nodeStrings[i] = "";
 	return i;
 };
 
 // Raw child append — no text merging, no `<template>` content redirect (the
 // tree builder layers those on top). `node` must be detached (`next` = 0).
 /** @type {(parent: HtmlNodeRef, node: HtmlNodeRef) => void} */
-const _hAppend = (parent, node) => {
-	_hParent[node] = parent;
-	const last = _hLast[parent];
-	if (last === 0) _hFirst[parent] = node;
-	else _hNext[last] = node;
-	_hLast[parent] = node;
+const _appendChild = (parent, node) => {
+	_nodeParents[node] = parent;
+	const last = _nodeLastChildren[parent];
+	if (last === 0) _nodeFirstChildren[parent] = node;
+	else _nodeNextSiblings[last] = node;
+	_nodeLastChildren[parent] = node;
 };
 
 /** @type {(data: string, start: number, end: number) => HtmlNodeRef} */
-const _mkText = (data, start, end) => {
-	const i = _hAlloc(NodeType.Text, start, end);
-	_hStr[i] = data;
+const _makeTextNode = (data, start, end) => {
+	const i = _allocNode(NodeType.Text, start, end);
+	_nodeStrings[i] = data;
 	return i;
 };
 
 /** @type {(data: string, start: number, end: number) => HtmlNodeRef} */
-const _mkComment = (data, start, end) => {
-	const i = _hAlloc(NodeType.Comment, start, end);
-	_hStr[i] = data;
+const _makeCommentNode = (data, start, end) => {
+	const i = _allocNode(NodeType.Comment, start, end);
+	_nodeStrings[i] = data;
 	return i;
 };
 
@@ -4106,12 +4108,12 @@ const AFE_MARKER = -1;
 // dependency for the reopened element's spans. Values are materialized since
 // the offsets are gone.
 const cloneAttrs = (/** @type {HtmlElement} */ el) => {
-	const start = _hAStart[el];
-	const count = _hACount[el];
-	const newStart = _aN + 1;
+	const start = _nodeAttrStarts[el];
+	const count = _nodeAttrCounts[el];
+	const newStart = _attrCount + 1;
 	for (let i = start; i < start + count; i++) {
-		const c = _aAlloc(_aName[i], _aValueOf(i), -1, -1, -1, -1);
-		_aFl[c] = _aFl[i];
+		const c = _allocAttr(_attrNames[i], _attrValueOf(i), -1, -1, -1, -1);
+		_attrFlags[c] = _attrFlags[i];
 	}
 	return { start: newStart, count };
 };
@@ -4124,20 +4126,20 @@ const mergeAttrs = (
 	/** @type {HtmlElement} */ el,
 	/** @type {AttributeRun} */ run
 ) => {
-	const start = _hAStart[el];
-	const count = _hACount[el];
+	const start = _nodeAttrStarts[el];
+	const count = _nodeAttrCounts[el];
 	let extra = 0;
 	for (let i = run.start; i < run.start + run.count; i++) {
-		if (_aFind(start, count, _aName[i]) === 0) extra++;
+		if (_findAttr(start, count, _attrNames[i]) === 0) extra++;
 	}
 	if (extra === 0) return;
-	const newStart = _aN + 1;
-	for (let i = start; i < start + count; i++) _aCopy(i);
+	const newStart = _attrCount + 1;
+	for (let i = start; i < start + count; i++) _copyAttr(i);
 	for (let i = run.start; i < run.start + run.count; i++) {
-		if (_aFind(start, count, _aName[i]) === 0) _aCopy(i);
+		if (_findAttr(start, count, _attrNames[i]) === 0) _copyAttr(i);
 	}
-	_hAStart[el] = newStart;
-	_hACount[el] = count + extra;
+	_nodeAttrStarts[el] = newStart;
+	_nodeAttrCounts[el] = count + extra;
 };
 
 /**
@@ -4375,8 +4377,8 @@ const FORMATTING = new Set([
 const HEADING = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 
 const isSpecial = (/** @type {HtmlElement} */ el) => {
-	const ns = _ns(el);
-	const tag = _tag(el);
+	const ns = _namespaceOf(el);
+	const tag = _tagNameOf(el);
 	if (ns === NS_HTML) return SPECIAL.has(tag);
 	if (ns === NS_MATHML) return MATHML_SPECIAL.has(tag);
 	if (ns === NS_SVG) return SVG_SPECIAL.has(tag.toLowerCase());
@@ -4830,7 +4832,7 @@ const FONT_BREAKOUT_ATTRS = new Set(["color", "face", "size"]);
 // `<font color|face|size>` breaks out of foreign content (§13.2.6.5).
 const hasFontBreakoutAttr = (/** @type {AttributeRun} */ run) => {
 	for (let i = run.start; i < run.start + run.count; i++) {
-		if (FONT_BREAKOUT_ATTRS.has(_aName[i])) return true;
+		if (FONT_BREAKOUT_ATTRS.has(_attrNames[i])) return true;
 	}
 	return false;
 };
@@ -4969,7 +4971,7 @@ const ATTR_NAME_INTERN = buildNameInternTable(
 // Hoisted so the many `open.some(...)` "is there an open HTML <template>?"
 // checks reuse one predicate instead of allocating an arrow per call.
 const isHtmlTemplateEl = (/** @type {HtmlElement} */ e) =>
-	_tag(e) === "template" && _ns(e) === NS_HTML;
+	_tagNameOf(e) === "template" && _namespaceOf(e) === NS_HTML;
 
 // Raw text / escapable raw text elements (WHATWG §13.1.2) plus the other
 // RAWTEXT/RCDATA/PLAINTEXT-tokenized elements. Under `skip.text` their body's
@@ -5011,9 +5013,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const skipText = skip.text === true;
 	const skipComments = skip.comments === true;
 	const skipDoctype = skip.doctype === true;
-	_hReset();
-	_hSrc = source;
-	const doc = _hAlloc(NodeType.Document, 0, 0);
+	_resetAstColumns();
+	_htmlSource = source;
+	const doc = _allocNode(NodeType.Document, 0, 0);
 	let mode = MODE_INITIAL;
 	// Mode to return to after MODE_TEXT / MODE_IN_TABLE_TEXT (0 = unset).
 	let originalMode = 0;
@@ -5049,24 +5051,24 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {AttributeRun} */ attrs,
 		/** @type {TagPos | null | undefined} */ pos
 	) => {
-		const el = _hAlloc(
+		const el = _allocNode(
 			NodeType.Element,
 			pos ? pos.start : 0,
 			pos ? pos.end : 0
 		);
 		// Void HTML elements are marked self-closing and never receive children.
-		_hFl[el] =
+		_nodeFlags[el] =
 			ns === NS_HTML && VOID.has(tagName) ? ns | FLAG_SELF_CLOSING : ns;
-		_hStr[el] = tagName;
-		_hAStart[el] = attrs.start;
-		_hACount[el] = attrs.count;
+		_nodeStrings[el] = tagName;
+		_nodeAttrStarts[el] = attrs.start;
+		_nodeAttrCounts[el] = attrs.count;
 		if (pos) {
-			_hTagEnd[el] = pos.tagEnd;
-			_hNameEnd[el] = pos.nameEnd;
+			_nodeTagEnds[el] = pos.tagEnd;
+			_nodeNameEnds[el] = pos.nameEnd;
 			// End of a raw-text element's body under `skip.text` (defaults to the
 			// body start, i.e. empty); lets consumers read `<script>`/`<style>`
 			// content as [`tagEnd`, `contentEnd`] without a `Text` node.
-			_hCEnd[el] = pos.tagEnd;
+			_nodeContentEnds[el] = pos.tagEnd;
 		}
 		return el;
 	};
@@ -5078,7 +5080,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	 * @returns {HtmlNodeRef} effective container to link children into
 	 */
 	const effParent = (parent) => {
-		const tc = _hTc[parent];
+		const tc = _nodeTemplateContents[parent];
 		return tc !== 0 ? tc : parent;
 	};
 
@@ -5087,17 +5089,17 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {HtmlNodeRef} */ node
 	) => {
 		const p = effParent(parent);
-		const last = _hLast[p];
+		const last = _nodeLastChildren[p];
 		if (
-			_hTy[node] === NodeType.Text &&
+			_nodeTypes[node] === NodeType.Text &&
 			last !== 0 &&
-			_hTy[last] === NodeType.Text
+			_nodeTypes[last] === NodeType.Text
 		) {
-			_hStr[last] += _hStr[node];
-			_hEn[last] = _hEn[node];
+			_nodeStrings[last] += _nodeStrings[node];
+			_nodeEnds[last] = _nodeEnds[node];
 			return;
 		}
-		_hAppend(p, node);
+		_appendChild(p, node);
 	};
 
 	// Reused result of `appropriatePlace` — consumed synchronously by
@@ -5119,23 +5121,23 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const target = cur();
 		if (
 			fosterParenting &&
-			TABLE_CONTEXT.has(_tag(target)) &&
-			_ns(target) === NS_HTML
+			TABLE_CONTEXT.has(_tagNameOf(target)) &&
+			_namespaceOf(target) === NS_HTML
 		) {
 			// find last template / last table
 			let lastTemplate = -1;
 			let lastTable = -1;
 			for (let i = open.length - 1; i >= 0; i--) {
 				if (
-					_tag(open[i]) === "template" &&
-					_ns(open[i]) === NS_HTML &&
+					_tagNameOf(open[i]) === "template" &&
+					_namespaceOf(open[i]) === NS_HTML &&
 					lastTemplate === -1
 				) {
 					lastTemplate = i;
 				}
 				if (
-					_tag(open[i]) === "table" &&
-					_ns(open[i]) === NS_HTML &&
+					_tagNameOf(open[i]) === "table" &&
+					_namespaceOf(open[i]) === NS_HTML &&
 					lastTable === -1
 				) {
 					lastTable = i;
@@ -5151,7 +5153,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				return placeAt(open[0], 0);
 			}
 			const table = open[lastTable];
-			const tp = _hParent[table];
+			const tp = _nodeParents[table];
 			if (tp !== 0) return placeAt(tp, table);
 			return placeAt(open[lastTable - 1], 0);
 		}
@@ -5168,10 +5170,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// Find `before`'s previous sibling (insert-before is a rare foster/
 			// adoption path, so the sibling scan stays off the hot path).
 			let prev = 0;
-			let c = _hFirst[p];
+			let c = _nodeFirstChildren[p];
 			while (c !== 0 && c !== before) {
 				prev = c;
-				c = _hNext[c];
+				c = _nodeNextSiblings[c];
 			}
 			if (c === 0) {
 				// `before` not under `parent` (not reachable from the spec paths).
@@ -5179,18 +5181,18 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				return;
 			}
 			if (
-				_hTy[node] === NodeType.Text &&
+				_nodeTypes[node] === NodeType.Text &&
 				prev !== 0 &&
-				_hTy[prev] === NodeType.Text
+				_nodeTypes[prev] === NodeType.Text
 			) {
 				// Before-node merge deliberately does not bump the sibling's `end`.
-				_hStr[prev] += _hStr[node];
+				_nodeStrings[prev] += _nodeStrings[node];
 				return;
 			}
-			_hParent[node] = p;
-			_hNext[node] = before;
-			if (prev === 0) _hFirst[p] = node;
-			else _hNext[prev] = node;
+			_nodeParents[node] = p;
+			_nodeNextSiblings[node] = before;
+			if (prev === 0) _nodeFirstChildren[p] = node;
+			else _nodeNextSiblings[prev] = node;
 		} else {
 			appendTo(place.parent, node);
 		}
@@ -5202,7 +5204,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {number} */ end
 	) => {
 		const place = appropriatePlace();
-		if (_hTy[place.parent] === NodeType.Document) return; // never insert text into document
+		if (_nodeTypes[place.parent] === NodeType.Document) return; // never insert text into document
 		// `skip.text`: drop every `Text` node — construction already used the
 		// decoded token, so removing the node never affects element structure.
 		// For a raw-text element record the body end so a consumer reads the span
@@ -5211,8 +5213,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		// foreign content (e.g. SVG `<style>`) too.
 		if (skipText) {
 			const p = place.parent;
-			if (_hTy[p] === NodeType.Element && RAW_TEXT_ELEMENTS.has(_tag(p))) {
-				_hCEnd[p] = end;
+			if (
+				_nodeTypes[p] === NodeType.Element &&
+				RAW_TEXT_ELEMENTS.has(_tagNameOf(p))
+			) {
+				_nodeContentEnds[p] = end;
 			}
 			return;
 		}
@@ -5224,33 +5229,33 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const before = place.beforeNode;
 		if (before !== 0) {
 			let prev = 0;
-			let c = _hFirst[p];
+			let c = _nodeFirstChildren[p];
 			while (c !== 0 && c !== before) {
 				prev = c;
-				c = _hNext[c];
+				c = _nodeNextSiblings[c];
 			}
 			if (c === 0) {
 				// `before` not under `parent` (not reachable from the spec paths).
-				_hAppend(p, _mkText(data, start, end));
+				_appendChild(p, _makeTextNode(data, start, end));
 				return;
 			}
-			if (prev !== 0 && _hTy[prev] === NodeType.Text) {
-				_hStr[prev] += data;
+			if (prev !== 0 && _nodeTypes[prev] === NodeType.Text) {
+				_nodeStrings[prev] += data;
 				return;
 			}
-			const node = _mkText(data, start, end);
-			_hParent[node] = p;
-			_hNext[node] = before;
-			if (prev === 0) _hFirst[p] = node;
-			else _hNext[prev] = node;
+			const node = _makeTextNode(data, start, end);
+			_nodeParents[node] = p;
+			_nodeNextSiblings[node] = before;
+			if (prev === 0) _nodeFirstChildren[p] = node;
+			else _nodeNextSiblings[prev] = node;
 		} else {
-			const last = _hLast[p];
-			if (last !== 0 && _hTy[last] === NodeType.Text) {
-				_hStr[last] += data;
-				_hEn[last] = end;
+			const last = _nodeLastChildren[p];
+			if (last !== 0 && _nodeTypes[last] === NodeType.Text) {
+				_nodeStrings[last] += data;
+				_nodeEnds[last] = end;
 				return;
 			}
-			_hAppend(p, _mkText(data, start, end));
+			_appendChild(p, _makeTextNode(data, start, end));
 		}
 	};
 
@@ -5263,7 +5268,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const insertComment = (data, start, end, place) => {
 		if (skipComments) return;
 		const p = place || appropriatePlace();
-		insertAtPlace(p, _mkComment(data, start, end));
+		insertAtPlace(p, _makeCommentNode(data, start, end));
 	};
 
 	const insertHtmlElement = (
@@ -5293,10 +5298,12 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 
 	// ---- scopes ----
 	const isScopeBoundary = (/** @type {HtmlElement} */ el) => {
-		if (_ns(el) === NS_HTML) return HTML_SCOPE.has(_tag(el));
-		if (_ns(el) === NS_MATHML) return MATHML_SPECIAL.has(_tag(el));
-		if (_ns(el) === NS_SVG) {
-			return SVG_SPECIAL.has(_tag(el).toLowerCase());
+		if (_namespaceOf(el) === NS_HTML) return HTML_SCOPE.has(_tagNameOf(el));
+		if (_namespaceOf(el) === NS_MATHML) {
+			return MATHML_SPECIAL.has(_tagNameOf(el));
+		}
+		if (_namespaceOf(el) === NS_SVG) {
+			return SVG_SPECIAL.has(_tagNameOf(el).toLowerCase());
 		}
 		return false;
 	};
@@ -5311,10 +5318,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {number} */ kind
 	) => {
 		if (isScopeBoundary(el)) return true;
-		if (_ns(el) !== NS_HTML) return false;
-		if (kind === SCOPE_BUTTON) return _tag(el) === "button";
+		if (_namespaceOf(el) !== NS_HTML) return false;
+		if (kind === SCOPE_BUTTON) return _tagNameOf(el) === "button";
 		if (kind === SCOPE_LIST_ITEM) {
-			return _tag(el) === "ol" || _tag(el) === "ul";
+			return _tagNameOf(el) === "ol" || _tagNameOf(el) === "ul";
 		}
 		return false;
 	};
@@ -5326,7 +5333,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	) => {
 		for (let i = open.length - 1; i >= 0; i--) {
 			const el = open[i];
-			if (_ns(el) === NS_HTML && _tag(el) === tagName) return true;
+			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) {
+				return true;
+			}
 			if (isBoundaryForKind(el, kind)) return false;
 		}
 		return false;
@@ -5350,9 +5359,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const set = typeof target === "string" ? null : target;
 		for (let i = open.length - 1; i >= 0; i--) {
 			const el = open[i];
-			if (_ns(el) === NS_HTML) {
-				if (set ? set.has(_tag(el)) : _tag(el) === target) return true;
-				if (TABLE_SCOPE_STOP.has(_tag(el))) return false;
+			if (_namespaceOf(el) === NS_HTML) {
+				if (set ? set.has(_tagNameOf(el)) : _tagNameOf(el) === target) {
+					return true;
+				}
+				if (TABLE_SCOPE_STOP.has(_tagNameOf(el))) return false;
 			}
 		}
 		return false;
@@ -5360,7 +5371,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const generateImpliedEndTags = (except = "") => {
 		while (open.length) {
 			const el = cur();
-			if (_ns(el) === NS_HTML && IMPLIED.has(_tag(el)) && _tag(el) !== except) {
+			if (
+				_namespaceOf(el) === NS_HTML &&
+				IMPLIED.has(_tagNameOf(el)) &&
+				_tagNameOf(el) !== except
+			) {
 				open.pop();
 			} else {
 				break;
@@ -5370,7 +5385,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const generateImpliedEndTagsThorough = () => {
 		while (open.length) {
 			const el = cur();
-			if (_ns(el) === NS_HTML && IMPLIED_THOROUGH.has(_tag(el))) {
+			if (
+				_namespaceOf(el) === NS_HTML &&
+				IMPLIED_THOROUGH.has(_tagNameOf(el))
+			) {
 				open.pop();
 			} else {
 				break;
@@ -5384,7 +5402,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		for (let i = afe.length - 1; i >= 0; i--) {
 			const e = afe[i];
 			if (e === AFE_MARKER) break;
-			if (_tag(e) === _tag(el) && _ns(e) === _ns(el) && sameAttrs(e, el)) {
+			if (
+				_tagNameOf(e) === _tagNameOf(el) &&
+				_namespaceOf(e) === _namespaceOf(el) &&
+				sameAttrs(e, el)
+			) {
 				count++;
 				if (count === 3) {
 					afe.splice(i, 1);
@@ -5398,16 +5420,16 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {HtmlElement} */ a,
 		/** @type {HtmlElement} */ b
 	) => {
-		const aStart = _hAStart[a];
-		const aCount = _hACount[a];
-		const bStart = _hAStart[b];
-		const bCount = _hACount[b];
+		const aStart = _nodeAttrStarts[a];
+		const aCount = _nodeAttrCounts[a];
+		const bStart = _nodeAttrStarts[b];
+		const bCount = _nodeAttrCounts[b];
 		if (aCount !== bCount) return false;
 		// Names are unique (deduped), counts tiny — a nested scan beats a Map
 		// here on this formatting-element hot path.
 		for (let i = bStart; i < bStart + bCount; i++) {
-			const j = _aFind(aStart, aCount, _aName[i]);
-			if (j === 0 || _aValueOf(j) !== _aValueOf(i)) return false;
+			const j = _findAttr(aStart, aCount, _attrNames[i]);
+			if (j === 0 || _attrValueOf(j) !== _attrValueOf(i)) return false;
 		}
 		return true;
 	};
@@ -5430,7 +5452,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		for (; i < afe.length; i++) {
 			const e = afe[i];
-			const el = mkEl(_tag(e), _ns(e), cloneAttrs(e), null);
+			const el = mkEl(_tagNameOf(e), _namespaceOf(e), cloneAttrs(e), null);
 			const place = appropriatePlace();
 			insertAtPlace(place, el);
 			open.push(el);
@@ -5444,23 +5466,23 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		// pop until a p has been popped
 		while (open.length) {
 			const el = /** @type {HtmlElement} */ (open.pop());
-			_hEn[el] = tokenEnd;
-			if (_ns(el) === NS_HTML && _tag(el) === "p") break;
+			_nodeEnds[el] = tokenEnd;
+			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === "p") break;
 		}
 	};
 
 	const popUntil = (/** @type {string} */ tagName) => {
 		while (open.length) {
 			const el = /** @type {HtmlElement} */ (open.pop());
-			_hEn[el] = tokenEnd;
-			if (_ns(el) === NS_HTML && _tag(el) === tagName) break;
+			_nodeEnds[el] = tokenEnd;
+			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) break;
 		}
 	};
 	const popUntilOneOf = (/** @type {Set<string>} */ set) => {
 		while (open.length) {
 			const el = /** @type {HtmlElement} */ (open.pop());
-			_hEn[el] = tokenEnd;
-			if (_ns(el) === NS_HTML && set.has(_tag(el))) break;
+			_nodeEnds[el] = tokenEnd;
+			if (_namespaceOf(el) === NS_HTML && set.has(_tagNameOf(el))) break;
 		}
 	};
 
@@ -5473,8 +5495,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				last = true;
 				if (fragment) node = fragment;
 			}
-			const tn = _tag(node);
-			if (_ns(node) === NS_HTML) {
+			const tn = _tagNameOf(node);
+			if (_namespaceOf(node) === NS_HTML) {
 				if ((tn === "td" || tn === "th") && !last) {
 					mode = MODE_IN_CELL;
 					return;
@@ -5567,7 +5589,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		const useForeign =
 			open.length > 0 &&
 			ac &&
-			_ns(ac) !== NS_HTML &&
+			_namespaceOf(ac) !== NS_HTML &&
 			ty !== TOKEN_EOF &&
 			shouldUseForeignRules(ac, t);
 		if (useForeign) {
@@ -5581,7 +5603,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {HtmlElement} */ ac,
 		/** @type {Token} */ t
 	) => {
-		if (_ns(ac) === NS_HTML) return false;
+		if (_namespaceOf(ac) === NS_HTML) return false;
 		if (t.type === TOKEN_START_TAG) {
 			if (
 				mathmlTextIntegrationPoint(ac) &&
@@ -5591,8 +5613,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				return false;
 			}
 			if (
-				_ns(ac) === NS_MATHML &&
-				_tag(ac) === "annotation-xml" &&
+				_namespaceOf(ac) === NS_MATHML &&
+				_tagNameOf(ac) === "annotation-xml" &&
 				t.name === "svg"
 			) {
 				return false;
@@ -5611,19 +5633,27 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	};
 
 	const mathmlTextIntegrationPoint = (/** @type {HtmlElement} */ el) =>
-		_ns(el) === NS_MATHML && MATHML_TEXT_INTEGRATION.has(_tag(el));
+		_namespaceOf(el) === NS_MATHML &&
+		MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
 	const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
-		if (_ns(el) === NS_MATHML && _tag(el) === "annotation-xml") {
-			const enc = _aFind(_hAStart[el], _hACount[el], "encoding");
+		if (_namespaceOf(el) === NS_MATHML && _tagNameOf(el) === "annotation-xml") {
+			const enc = _findAttr(
+				_nodeAttrStarts[el],
+				_nodeAttrCounts[el],
+				"encoding"
+			);
 			if (enc !== 0) {
-				const value = _aValueOf(enc).toLowerCase();
+				const value = _attrValueOf(enc).toLowerCase();
 				if (value === "text/html" || value === "application/xhtml+xml") {
 					return true;
 				}
 			}
 			return false;
 		}
-		if (_ns(el) === NS_SVG && SVG_SPECIAL.has(_tag(el).toLowerCase())) {
+		if (
+			_namespaceOf(el) === NS_SVG &&
+			SVG_SPECIAL.has(_tagNameOf(el).toLowerCase())
+		) {
 			return true;
 		}
 		return false;
@@ -5633,23 +5663,23 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {Record<string, string>} */ (SVG_TAG_ADJUST)[name] || name;
 	// Adjust a foreign start tag's attribute run in place (the run is consumed
 	// only by this tag's element): SVG camelCase names are rewritten, and
-	// namespaced names get the serializer-name flag (see `_aSerializedName`).
+	// namespaced names get the serializer-name flag (see `_attrSerializedName`).
 	const adjustForeignAttrs = (
 		/** @type {AttributeRun} */ run,
 		/** @type {number} */ ns
 	) => {
 		for (let i = run.start; i < run.start + run.count; i++) {
-			const name = _aName[i];
+			const name = _attrNames[i];
 			if (
 				ns === NS_SVG &&
 				/** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[name]
 			) {
-				_aName[i] = /** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[
+				_attrNames[i] = /** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[
 					name
 				];
 			}
 			if (/** @type {Record<string, string>} */ (FOREIGN_ATTR_NS)[name]) {
-				_aFl[i] |= 1;
+				_attrFlags[i] |= 1;
 			}
 		}
 		return run;
@@ -5669,7 +5699,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		if (t.type === TOKEN_DOCTYPE) return;
 		if (t.type === TOKEN_START_TAG) {
-			const acn = _ns(adjustedCurrent());
+			const acn = _namespaceOf(adjustedCurrent());
 			if (
 				FOREIGN_BREAKOUT.has(t.name) ||
 				(t.name === "font" && hasFontBreakoutAttr(t.attrs))
@@ -5678,7 +5708,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				while (open.length > 1) {
 					const c = cur();
 					if (
-						_ns(c) === NS_HTML ||
+						_namespaceOf(c) === NS_HTML ||
 						mathmlTextIntegrationPoint(c) ||
 						htmlIntegrationPoint(c)
 					) {
@@ -5708,8 +5738,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		if (t.type === TOKEN_END_TAG) {
 			if (
 				t.name === "script" &&
-				_tag(cur()) === "script" &&
-				_ns(cur()) === NS_SVG
+				_tagNameOf(cur()) === "script" &&
+				_namespaceOf(cur()) === NS_SVG
 			) {
 				open.pop();
 				return;
@@ -5719,7 +5749,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			if (t.name === "p" || t.name === "br") {
 				while (
 					open.length > 1 &&
-					_ns(cur()) !== NS_HTML &&
+					_namespaceOf(cur()) !== NS_HTML &&
 					!mathmlTextIntegrationPoint(cur()) &&
 					!htmlIntegrationPoint(cur())
 				) {
@@ -5731,18 +5761,21 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// any other end tag
 			let i = open.length - 1;
 			let node = open[i];
-			if (_tag(node).toLowerCase() !== t.name) {
+			if (_tagNameOf(node).toLowerCase() !== t.name) {
 				/* parse error */
 			}
 			while (i >= 0) {
 				node = open[i];
 				if (i === 0) return;
-				if (_ns(node) !== NS_HTML && _tag(node).toLowerCase() === t.name) {
+				if (
+					_namespaceOf(node) !== NS_HTML &&
+					_tagNameOf(node).toLowerCase() === t.name
+				) {
 					while (open.length > i) open.pop();
 					return;
 				}
 				i--;
-				if (open[i] && _ns(open[i]) === NS_HTML) {
+				if (open[i] && _namespaceOf(open[i]) === NS_HTML) {
 					runMode(t);
 					return;
 				}
@@ -5757,7 +5790,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	) => {
 		// step 1
 		const c = cur();
-		if (_ns(c) === NS_HTML && _tag(c) === subject && !afe.includes(c)) {
+		if (
+			_namespaceOf(c) === NS_HTML &&
+			_tagNameOf(c) === subject &&
+			!afe.includes(c)
+		) {
 			open.pop();
 			return true;
 		}
@@ -5768,7 +5805,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			let fmtIdx = -1;
 			for (let i = afe.length - 1; i >= 0; i--) {
 				if (afe[i] === AFE_MARKER) break;
-				if (_tag(afe[i]) === subject && _ns(afe[i]) === NS_HTML) {
+				if (
+					_tagNameOf(afe[i]) === subject &&
+					_namespaceOf(afe[i]) === NS_HTML
+				) {
 					fmtIdx = i;
 					break;
 				}
@@ -5817,7 +5857,12 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 					continue;
 				}
 				// create clone
-				const clone = mkEl(_tag(node), _ns(node), cloneAttrs(node), null);
+				const clone = mkEl(
+					_tagNameOf(node),
+					_namespaceOf(node),
+					cloneAttrs(node),
+					null
+				);
 				afe[nodeAfeIdx] = clone;
 				open[nodeIdx] = clone;
 				node = clone;
@@ -5832,16 +5877,21 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			const place = placeForCommonAncestor(commonAncestor);
 			insertAtPlace(place, lastNode);
 			// create element for fmt token, take children of furthest
-			const cloneFmt = mkEl(_tag(fmt), _ns(fmt), cloneAttrs(fmt), null);
+			const cloneFmt = mkEl(
+				_tagNameOf(fmt),
+				_namespaceOf(fmt),
+				cloneAttrs(fmt),
+				null
+			);
 			// Take all direct children of `furthest` (a template's content fragment
 			// deliberately stays put — mirrors childrenOf-less spec behavior here).
-			let k = _hFirst[furthest];
-			_hFirst[furthest] = 0;
-			_hLast[furthest] = 0;
+			let k = _nodeFirstChildren[furthest];
+			_nodeFirstChildren[furthest] = 0;
+			_nodeLastChildren[furthest] = 0;
 			while (k !== 0) {
-				const next = _hNext[k];
-				_hNext[k] = 0;
-				_hParent[k] = 0;
+				const next = _nodeNextSiblings[k];
+				_nodeNextSiblings[k] = 0;
+				_nodeParents[k] = 0;
 				appendTo(cloneFmt, k);
 				k = next;
 			}
@@ -5866,8 +5916,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		/** @type {HtmlElement} */ commonAncestor
 	) => {
 		if (
-			TABLE_CONTEXT.has(_tag(commonAncestor)) &&
-			_ns(commonAncestor) === NS_HTML
+			TABLE_CONTEXT.has(_tagNameOf(commonAncestor)) &&
+			_namespaceOf(commonAncestor) === NS_HTML
 		) {
 			// foster
 			// reuse appropriatePlace logic but rooted differently: emulate
@@ -5875,15 +5925,15 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			let lastTable = -1;
 			for (let i = open.length - 1; i >= 0; i--) {
 				if (
-					_tag(open[i]) === "template" &&
-					_ns(open[i]) === NS_HTML &&
+					_tagNameOf(open[i]) === "template" &&
+					_namespaceOf(open[i]) === NS_HTML &&
 					lastTemplate === -1
 				) {
 					lastTemplate = i;
 				}
 				if (
-					_tag(open[i]) === "table" &&
-					_ns(open[i]) === NS_HTML &&
+					_tagNameOf(open[i]) === "table" &&
+					_namespaceOf(open[i]) === NS_HTML &&
 					lastTable === -1
 				) {
 					lastTable = i;
@@ -5897,7 +5947,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			}
 			if (lastTable === -1) return { parent: open[0], beforeNode: 0 };
 			const table = open[lastTable];
-			const tp = _hParent[table];
+			const tp = _nodeParents[table];
 			if (tp !== 0) return { parent: tp, beforeNode: table };
 			return { parent: open[lastTable - 1], beforeNode: 0 };
 		}
@@ -5905,20 +5955,20 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	};
 
 	const detach = (/** @type {HtmlNodeRef} */ node) => {
-		const p = _hParent[node];
+		const p = _nodeParents[node];
 		if (p === 0) return;
 		let prev = 0;
-		let c = _hFirst[p];
+		let c = _nodeFirstChildren[p];
 		while (c !== 0 && c !== node) {
 			prev = c;
-			c = _hNext[c];
+			c = _nodeNextSiblings[c];
 		}
 		if (c === 0) return;
-		if (prev === 0) _hFirst[p] = _hNext[node];
-		else _hNext[prev] = _hNext[node];
-		if (_hLast[p] === node) _hLast[p] = prev;
-		_hNext[node] = 0;
-		_hParent[node] = 0;
+		if (prev === 0) _nodeFirstChildren[p] = _nodeNextSiblings[node];
+		else _nodeNextSiblings[prev] = _nodeNextSiblings[node];
+		if (_nodeLastChildren[p] === node) _nodeLastChildren[p] = prev;
+		_nodeNextSiblings[node] = 0;
+		_nodeParents[node] = 0;
 	};
 
 	// ---------- insertion modes ----------
@@ -6082,13 +6132,13 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		if (t.type === TOKEN_DOCTYPE) {
 			// `skip.doctype` drops the node only; quirks detection below is unaffected.
 			if (!skipDoctype) {
-				const dt = _hAlloc(NodeType.Doctype, t.start, t.end);
-				_hStr[dt] = t.name;
+				const dt = _allocNode(NodeType.Doctype, t.start, t.end);
+				_nodeStrings[dt] = t.name;
 				// At most one doctype node is ever inserted (later doctype tokens
 				// are ignored), so its ids live in two per-parse scalars.
-				_hDocPub = t.publicId;
-				_hDocSys = t.systemId;
-				_hAppend(doc, dt);
+				_doctypePublicId = t.publicId;
+				_doctypeSystemId = t.systemId;
+				_appendChild(doc, dt);
 			}
 			quirks = isQuirky(t.name, t.publicId, t.systemId);
 			mode = MODE_BEFORE_HTML;
@@ -6112,7 +6162,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		if (t.type === TOKEN_START_TAG && t.name === "html") {
 			const el = mkEl("html", NS_HTML, t.attrs, t.pos);
-			_hAppend(doc, el);
+			_appendChild(doc, el);
 			open.push(el);
 			mode = MODE_BEFORE_HEAD;
 			return;
@@ -6121,7 +6171,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return;
 		}
 		const el = mkEl("html", NS_HTML, EMPTY_ATTRS, null);
-		_hAppend(doc, el);
+		_appendChild(doc, el);
 		open.push(el);
 		mode = MODE_BEFORE_HEAD;
 		process(t);
@@ -6197,10 +6247,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				mode = MODE_IN_TEMPLATE;
 				templateModes.push(MODE_IN_TEMPLATE);
 				const el = cur();
-				const fragment = _hAlloc(NodeType.DocumentFragment, 0, 0);
+				const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
 				// Parent link so the iterative walk can ascend out of the content.
-				_hParent[fragment] = el;
-				_hTc[el] = fragment;
+				_nodeParents[fragment] = el;
+				_nodeTemplateContents[el] = fragment;
 				return;
 			}
 			if (t.name === "head") return;
@@ -6343,10 +6393,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const anyOtherEndTag = (/** @type {string} */ name) => {
 		for (let i = open.length - 1; i >= 0; i--) {
 			const node = open[i];
-			if (_ns(node) === NS_HTML && _tag(node) === name) {
+			if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === name) {
 				generateImpliedEndTags(name);
 				while (open.length > i) {
-					_hEn[open[open.length - 1]] = tokenEnd;
+					_nodeEnds[open[open.length - 1]] = tokenEnd;
 					open.pop();
 				}
 				return;
@@ -6369,7 +6419,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		if (name === "body") {
 			const second = open[1];
-			if (!second || _tag(second) !== "body" || open.some(isHtmlTemplateEl)) {
+			if (
+				!second ||
+				_tagNameOf(second) !== "body" ||
+				open.some(isHtmlTemplateEl)
+			) {
 				return;
 			}
 			framesetOk = false;
@@ -6378,7 +6432,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		if (name === "frameset") {
 			const second = open[1];
-			if (!second || _tag(second) !== "body") return;
+			if (!second || _tagNameOf(second) !== "body") return;
 			if (!framesetOk) return;
 			detach(second);
 			while (open.length > 1) open.pop();
@@ -6393,7 +6447,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		if (HEADING.has(name)) {
 			closeIfPInButtonScope();
-			if (_ns(cur()) === NS_HTML && HEADING.has(_tag(cur()))) open.pop();
+			if (_namespaceOf(cur()) === NS_HTML && HEADING.has(_tagNameOf(cur()))) {
+				open.pop();
+			}
 			insertHtmlElement(name, t.attrs, t.pos);
 			return;
 		}
@@ -6419,14 +6475,17 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			framesetOk = false;
 			for (let i = open.length - 1; i >= 0; i--) {
 				const node = open[i];
-				if (_ns(node) === NS_HTML && _tag(node) === "li") {
+				if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === "li") {
 					generateImpliedEndTags("li");
 					popUntil("li");
 					break;
 				}
 				if (
 					isSpecial(node) &&
-					!(_ns(node) === NS_HTML && ADDRESS_DIV_P.has(_tag(node)))
+					!(
+						_namespaceOf(node) === NS_HTML &&
+						ADDRESS_DIV_P.has(_tagNameOf(node))
+					)
 				) {
 					break;
 				}
@@ -6440,16 +6499,19 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			for (let i = open.length - 1; i >= 0; i--) {
 				const node = open[i];
 				if (
-					_ns(node) === NS_HTML &&
-					(_tag(node) === "dd" || _tag(node) === "dt")
+					_namespaceOf(node) === NS_HTML &&
+					(_tagNameOf(node) === "dd" || _tagNameOf(node) === "dt")
 				) {
-					generateImpliedEndTags(_tag(node));
-					popUntil(_tag(node));
+					generateImpliedEndTags(_tagNameOf(node));
+					popUntil(_tagNameOf(node));
 					break;
 				}
 				if (
 					isSpecial(node) &&
-					!(_ns(node) === NS_HTML && ADDRESS_DIV_P.has(_tag(node)))
+					!(
+						_namespaceOf(node) === NS_HTML &&
+						ADDRESS_DIV_P.has(_tagNameOf(node))
+					)
 				) {
 					break;
 				}
@@ -6477,9 +6539,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// if there's an <a> in afe after last marker
 			for (let i = afe.length - 1; i >= 0; i--) {
 				if (afe[i] === AFE_MARKER) break;
-				if (_tag(afe[i]) === "a") {
+				if (_tagNameOf(afe[i]) === "a") {
 					adoptionAgency("a", t.pos);
-					const idx = afe.findIndex((e) => e !== AFE_MARKER && _tag(e) === "a");
+					const idx = afe.findIndex(
+						(e) => e !== AFE_MARKER && _tagNameOf(e) === "a"
+					);
 					if (idx !== -1) {
 						const el = afe[idx];
 						afe.splice(idx, 1);
@@ -6541,16 +6605,16 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				resetInsertionMode();
 			} else if (
 				fragment &&
-				_ns(fragment) === NS_HTML &&
-				_tag(fragment) === "select"
+				_namespaceOf(fragment) === NS_HTML &&
+				_tagNameOf(fragment) === "select"
 			) {
 				return;
 			}
 			reconstructAfe();
 			insertHtmlElement("input", t.attrs, t.pos);
 			open.pop();
-			const ty = _aFind(t.attrs.start, t.attrs.count, "type");
-			if (ty === 0 || _aValueOf(ty).toLowerCase() !== "hidden") {
+			const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
+			if (ty === 0 || _attrValueOf(ty).toLowerCase() !== "hidden") {
 				framesetOk = false;
 			}
 			return;
@@ -6561,8 +6625,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return;
 		}
 		if (name === "hr") {
-			if (_ns(cur()) === NS_HTML && _tag(cur()) === "option") open.pop();
-			if (_ns(cur()) === NS_HTML && _tag(cur()) === "optgroup") {
+			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
+				open.pop();
+			}
+			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
 				open.pop();
 			}
 			closeIfPInButtonScope();
@@ -6611,11 +6677,13 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return;
 		}
 		if (name === "optgroup" || name === "option") {
-			if (_ns(cur()) === NS_HTML && _tag(cur()) === "option") open.pop();
+			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
+				open.pop();
+			}
 			if (
 				name === "optgroup" &&
-				_ns(cur()) === NS_HTML &&
-				_tag(cur()) === "optgroup"
+				_namespaceOf(cur()) === NS_HTML &&
+				_tagNameOf(cur()) === "optgroup"
 			) {
 				open.pop();
 			}
@@ -6659,7 +6727,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	// this tag's element); the camelCase name serializes as itself.
 	const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
 		for (let i = run.start; i < run.start + run.count; i++) {
-			if (_aName[i] === "definitionurl") _aName[i] = "definitionURL";
+			if (_attrNames[i] === "definitionurl") _attrNames[i] = "definitionURL";
 		}
 		return run;
 	};
@@ -6785,7 +6853,10 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// current element: a non-matching name (e.g. a fragment context), or
 			// a name that ran straight to EOF with no delimiter (`</script` at
 			// EOF — the tokenizer still emits a partial tag there).
-			if (cur() && (t.name !== _tag(cur()) || t.pos.end === t.pos.nameEnd)) {
+			if (
+				cur() &&
+				(t.name !== _tagNameOf(cur()) || t.pos.end === t.pos.nameEnd)
+			) {
 				insertCharacters(
 					source.slice(t.pos.start, t.pos.end),
 					t.pos.start,
@@ -6805,7 +6876,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	modes.inTable = (t) => {
 		if (t.type === TOKEN_CHAR) {
 			const c = cur();
-			if (TABLE_CONTEXT.has(_tag(c)) && _ns(c) === NS_HTML) {
+			if (TABLE_CONTEXT.has(_tagNameOf(c)) && _namespaceOf(c) === NS_HTML) {
 				pendingTableChars = { list: [], hasNonWs: false };
 				originalMode = mode;
 				mode = MODE_IN_TABLE_TEXT;
@@ -6860,8 +6931,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				return modes.inHead(t);
 			}
 			if (name === "input") {
-				const ty = _aFind(t.attrs.start, t.attrs.count, "type");
-				if (ty !== 0 && _aValueOf(ty).toLowerCase() === "hidden") {
+				const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
+				if (ty !== 0 && _attrValueOf(ty).toLowerCase() === "hidden") {
 					insertHtmlElement("input", t.attrs, t.pos);
 					open.pop();
 					return;
@@ -6931,7 +7002,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const clearStackToTableContext = () => {
 		while (open.length) {
 			const c = cur();
-			if (_ns(c) === NS_HTML && CLEAR_TABLE.has(_tag(c))) {
+			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE.has(_tagNameOf(c))) {
 				break;
 			}
 			open.pop();
@@ -6940,7 +7011,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const clearStackToTableBodyContext = () => {
 		while (open.length) {
 			const c = cur();
-			if (_ns(c) === NS_HTML && CLEAR_TABLE_BODY.has(_tag(c))) {
+			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_BODY.has(_tagNameOf(c))) {
 				break;
 			}
 			open.pop();
@@ -6949,7 +7020,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const clearStackToTableRowContext = () => {
 		while (open.length) {
 			const c = cur();
-			if (_ns(c) === NS_HTML && CLEAR_TABLE_ROW.has(_tag(c))) {
+			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_ROW.has(_tagNameOf(c))) {
 				break;
 			}
 			open.pop();
@@ -6982,7 +7053,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		if (t.type === TOKEN_CHAR) {
 			const r = leadingWs(t, true);
 			if (!r) return;
-			if (_tag(cur()) !== "colgroup") return;
+			if (_tagNameOf(cur()) !== "colgroup") return;
 			open.pop();
 			mode = MODE_IN_TABLE;
 			process(r);
@@ -7000,7 +7071,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return;
 		}
 		if (t.type === TOKEN_END_TAG && t.name === "colgroup") {
-			if (_tag(cur()) !== "colgroup") return;
+			if (_tagNameOf(cur()) !== "colgroup") return;
 			open.pop();
 			mode = MODE_IN_TABLE;
 			return;
@@ -7013,7 +7084,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return modes.inHead(t);
 		}
 		if (t.type === TOKEN_EOF) return modes.inBody(t);
-		if (_tag(cur()) !== "colgroup") return;
+		if (_tagNameOf(cur()) !== "colgroup") return;
 		open.pop();
 		mode = MODE_IN_TABLE;
 		process(t);
@@ -7196,9 +7267,11 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			return;
 		}
 		if (t.type === TOKEN_END_TAG && t.name === "frameset") {
-			if (_tag(cur()) === "html") return;
+			if (_tagNameOf(cur()) === "html") return;
 			open.pop();
-			if (!fragment && _tag(cur()) !== "frameset") mode = MODE_AFTER_FRAMESET;
+			if (!fragment && _tagNameOf(cur()) !== "frameset") {
+				mode = MODE_AFTER_FRAMESET;
+			}
 			return;
 		}
 		if (t.type === TOKEN_START_TAG && t.name === "frame") {
@@ -7271,7 +7344,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		}
 		fragment = mkEl(ctxName, ctxNs, EMPTY_ATTRS, null);
 		const htmlEl = mkEl("html", NS_HTML, EMPTY_ATTRS, null);
-		_hAppend(doc, htmlEl);
+		_appendChild(doc, htmlEl);
 		open.push(htmlEl);
 		if (ctxNs !== NS_HTML) {
 			mode = MODE_IN_BODY;
@@ -7329,9 +7402,9 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	walkHtmlTokens(source, 0, {
 		isForeign: () => {
 			const ac = adjustedCurrent();
-			return open.length > 0 && ac !== 0 && _ns(ac) !== NS_HTML;
+			return open.length > 0 && ac !== 0 && _namespaceOf(ac) !== NS_HTML;
 		},
-		fragmentContext: fragment ? _tag(fragment) : undefined,
+		fragmentContext: fragment ? _tagNameOf(fragment) : undefined,
 		parseError: (input, code) => {
 			if (code === "eof-in-tag") eofInTag = true;
 		},
@@ -7353,7 +7426,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// The tokenizer emits CDATA sections through this callback too.
 			if (input.startsWith("<![CDATA[", start)) {
 				const ac = adjustedCurrent();
-				if (open.length > 0 && ac && _ns(ac) !== NS_HTML) {
+				if (open.length > 0 && ac && _namespaceOf(ac) !== NS_HTML) {
 					const innerEnd = input.endsWith("]]>", end) ? end - 3 : end;
 					const data = input.slice(start + 9, innerEnd).replace(/\r\n?/g, "\n");
 					if (data !== "") {
@@ -7424,11 +7497,13 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			const top = adjustedCurrent();
 			const rawMode =
 				mode === MODE_TEXT ||
-				(top && _ns(top) === NS_HTML && _tag(top) === "plaintext");
+				(top &&
+					_namespaceOf(top) === NS_HTML &&
+					_tagNameOf(top) === "plaintext");
 			const noDecode =
 				top &&
-				_ns(top) === NS_HTML &&
-				NO_DECODE_TEXT.has(_tag(top)) &&
+				_namespaceOf(top) === NS_HTML &&
+				NO_DECODE_TEXT.has(_tagNameOf(top)) &&
 				(mode === MODE_TEXT || mode === MODE_IN_BODY);
 			let data = noDecode ? s : decode(s, false);
 			// In RAWTEXT/RCDATA/script/PLAINTEXT, NULL becomes U+FFFD (tokenizer
@@ -7449,12 +7524,12 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 		},
 		attribute: (input, nameStart, nameEnd, valueStart, valueEnd, quoteType) => {
 			const name = internLowerName(ATTR_NAME_INTERN, input, nameStart, nameEnd);
-			if (pendAttrStart === 0) pendAttrStart = _aN + 1;
+			if (pendAttrStart === 0) pendAttrStart = _attrCount + 1;
 			// Drop duplicate attribute names (per spec). Plain loop avoids a
 			// per-attribute closure allocation on this hot path.
 			let dup = false;
-			for (let i = pendAttrStart; i <= _aN; i++) {
-				if (_aName[i] === name) {
+			for (let i = pendAttrStart; i <= _attrCount; i++) {
+				if (_attrNames[i] === name) {
 					dup = true;
 					break;
 				}
@@ -7464,7 +7539,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				// demand: consumers re-resolve requests from it and the offsets must
 				// stay aligned with the source. Only a valueless attribute stores an
 				// override ("").
-				_aAlloc(
+				_allocAttr(
 					name,
 					valueStart !== -1 ? null : "",
 					nameStart,
@@ -7491,7 +7566,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 			// The reused token carries the tag's attribute run; every consumer of
 			// `t.attrs` runs synchronously within this dispatch.
 			tok.attrs.start = pendAttrStart;
-			tok.attrs.count = pendAttrStart === 0 ? 0 : _aN + 1 - pendAttrStart;
+			tok.attrs.count =
+				pendAttrStart === 0 ? 0 : _attrCount + 1 - pendAttrStart;
 			pendAttrStart = 0;
 			tok.selfClosing = selfClosing;
 			tok.swallowNewline = false;
@@ -7532,30 +7608,30 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
  * @returns {HtmlNodeRef} clone
  */
 const cloneSubtree = (node) => {
-	const ty = _hTy[node];
-	const clone = _hAlloc(ty, _hSt[node], _hEn[node]);
-	_hStr[clone] = _hStr[node];
+	const ty = _nodeTypes[node];
+	const clone = _allocNode(ty, _nodeStarts[node], _nodeEnds[node]);
+	_nodeStrings[clone] = _nodeStrings[node];
 	if (ty !== NodeType.Element) return clone;
-	_hFl[clone] = _hFl[node];
+	_nodeFlags[clone] = _nodeFlags[node];
 	const attrs = cloneAttrs(node);
-	_hAStart[clone] = attrs.start;
-	_hACount[clone] = attrs.count;
-	_hTagEnd[clone] = _hTagEnd[node];
-	_hNameEnd[clone] = _hNameEnd[node];
+	_nodeAttrStarts[clone] = attrs.start;
+	_nodeAttrCounts[clone] = attrs.count;
+	_nodeTagEnds[clone] = _nodeTagEnds[node];
+	_nodeNameEnds[clone] = _nodeNameEnds[node];
 	// Empty body span: the clone re-emits no raw-text dependency.
-	_hCEnd[clone] = _hTagEnd[node];
-	for (let k = _hFirst[node]; k !== 0; k = _hNext[k]) {
-		_hAppend(clone, cloneSubtree(k));
+	_nodeContentEnds[clone] = _nodeTagEnds[node];
+	for (let k = _nodeFirstChildren[node]; k !== 0; k = _nodeNextSiblings[k]) {
+		_appendChild(clone, cloneSubtree(k));
 	}
 	// Clone `<template>` content into the clone's own fragment.
-	const tc = _hTc[node];
+	const tc = _nodeTemplateContents[node];
 	if (tc !== 0) {
-		const fragment = _hAlloc(NodeType.DocumentFragment, 0, 0);
+		const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
 		// Parent link so the iterative walk can ascend out of the content.
-		_hParent[fragment] = clone;
-		_hTc[clone] = fragment;
-		for (let k = _hFirst[tc]; k !== 0; k = _hNext[k]) {
-			_hAppend(fragment, cloneSubtree(k));
+		_nodeParents[fragment] = clone;
+		_nodeTemplateContents[clone] = fragment;
+		for (let k = _nodeFirstChildren[tc]; k !== 0; k = _nodeNextSiblings[k]) {
+			_appendChild(fragment, cloneSubtree(k));
 		}
 	}
 	return clone;
@@ -7572,17 +7648,19 @@ const selectedOption = (select) => {
 	const options = [];
 	/** @param {HtmlElement} el element */
 	const collect = (el) => {
-		for (let c = _hFirst[el]; c !== 0; c = _hNext[c]) {
-			if (_hTy[c] !== NodeType.Element || _ns(c) !== NS_HTML) continue;
-			if (_hStr[c] === "option") options.push(c);
-			else if (_hStr[c] === "optgroup") collect(c);
+		for (let c = _nodeFirstChildren[el]; c !== 0; c = _nodeNextSiblings[c]) {
+			if (_nodeTypes[c] !== NodeType.Element || _namespaceOf(c) !== NS_HTML) {
+				continue;
+			}
+			if (_nodeStrings[c] === "option") options.push(c);
+			else if (_nodeStrings[c] === "optgroup") collect(c);
 		}
 	};
 	collect(select);
 	if (options.length === 0) return 0;
 	for (let i = options.length - 1; i >= 0; i--) {
 		const el = options[i];
-		if (_aFind(_hAStart[el], _hACount[el], "selected") !== 0) {
+		if (_findAttr(_nodeAttrStarts[el], _nodeAttrCounts[el], "selected") !== 0) {
 			return el;
 		}
 	}
@@ -7597,24 +7675,32 @@ const selectedOption = (select) => {
  */
 const mirrorSelectedContent = (node, select) => {
 	// A `<template>`'s children live in its content fragment.
-	const tc = _hTc[node];
+	const tc = _nodeTemplateContents[node];
 	const container = tc !== 0 ? tc : node;
-	for (let child = _hFirst[container]; child !== 0; child = _hNext[child]) {
-		if (_hTy[child] !== NodeType.Element) continue;
-		if (_ns(child) === NS_HTML && _hStr[child] === "select") {
+	for (
+		let child = _nodeFirstChildren[container];
+		child !== 0;
+		child = _nodeNextSiblings[child]
+	) {
+		if (_nodeTypes[child] !== NodeType.Element) continue;
+		if (_namespaceOf(child) === NS_HTML && _nodeStrings[child] === "select") {
 			mirrorSelectedContent(child, child);
 		} else if (
 			select !== 0 &&
-			_ns(child) === NS_HTML &&
-			_hStr[child] === "selectedcontent"
+			_namespaceOf(child) === NS_HTML &&
+			_nodeStrings[child] === "selectedcontent"
 		) {
 			const option = selectedOption(select);
 			if (option !== 0) {
 				// Replace the children with clones of the option's subtree.
-				_hFirst[child] = 0;
-				_hLast[child] = 0;
-				for (let k = _hFirst[option]; k !== 0; k = _hNext[k]) {
-					_hAppend(child, cloneSubtree(k));
+				_nodeFirstChildren[child] = 0;
+				_nodeLastChildren[child] = 0;
+				for (
+					let k = _nodeFirstChildren[option];
+					k !== 0;
+					k = _nodeNextSiblings[k]
+				) {
+					_appendChild(child, cloneSubtree(k));
 				}
 			}
 		} else {
@@ -7681,19 +7767,19 @@ const grammar = (input, visitors, options) => {
 	// markup can't overflow the call stack (the old recursive walk died at
 	// ~10⁵ nesting). A `<template>`'s content fragment is visited before the
 	// element's children; ascending out of it continues with those children
-	// (the fragment is never in a sibling chain, `_hNext` = 0).
+	// (the fragment is never in a sibling chain, `_nodeNextSiblings` = 0).
 	/**
 	 * Fire a node's `enter` visitors; true when the walk may descend.
 	 * @param {HtmlNodeRef} node node
 	 * @returns {boolean} false when a visitor called `skipChildren()`
 	 */
 	const enter = (node) => {
-		const b = visitors[_hTy[node]];
+		const b = visitors[_nodeTypes[node]];
 		if (b === undefined || b.enter.length === 0) return true;
 		_walkSkip = false;
-		_curNode = node;
-		const p = _hParent[node];
-		_curParent = p === 0 ? null : p;
+		_currentNode = node;
+		const p = _nodeParents[node];
+		_currentParent = p === 0 ? null : p;
 		const e = b.enter;
 		for (let i = 0; i < e.length; i++) e[i](A);
 		const skip = _walkSkip;
@@ -7705,11 +7791,11 @@ const grammar = (input, visitors, options) => {
 	 * @param {HtmlNodeRef} node node
 	 */
 	const exit = (node) => {
-		const b = visitors[_hTy[node]];
+		const b = visitors[_nodeTypes[node]];
 		if (b === undefined) return;
-		_curNode = node;
-		const p = _hParent[node];
-		_curParent = p === 0 ? null : p;
+		_currentNode = node;
+		const p = _nodeParents[node];
+		_currentParent = p === 0 ? null : p;
 		const x = b.exit;
 		for (let i = 0; i < x.length; i++) x[i](A);
 	};
@@ -7719,13 +7805,13 @@ const grammar = (input, visitors, options) => {
 	 * @returns {HtmlNodeRef} first inner node (0 = leaf)
 	 */
 	const firstInner = (node) => {
-		const ty = _hTy[node];
+		const ty = _nodeTypes[node];
 		if (ty === NodeType.Element) {
-			const tc = _hTc[node];
-			return tc !== 0 ? tc : _hFirst[node];
+			const tc = _nodeTemplateContents[node];
+			return tc !== 0 ? tc : _nodeFirstChildren[node];
 		}
 		if (ty === NodeType.Document || ty === NodeType.DocumentFragment) {
-			return _hFirst[node];
+			return _nodeFirstChildren[node];
 		}
 		return 0;
 	};
@@ -7743,16 +7829,16 @@ const grammar = (input, visitors, options) => {
 		for (;;) {
 			exit(node);
 			if (node === root) break descend;
-			const parent = _hParent[node];
+			const parent = _nodeParents[node];
 			// Out of a template's content fragment: the element's children follow.
-			if (_hTc[parent] === node) {
-				const first = _hFirst[parent];
+			if (_nodeTemplateContents[parent] === node) {
+				const first = _nodeFirstChildren[parent];
 				if (first !== 0) {
 					node = first;
 					continue descend;
 				}
 			} else {
-				const sibling = _hNext[node];
+				const sibling = _nodeNextSiblings[node];
 				if (sibling !== 0) {
 					node = sibling;
 					continue descend;
@@ -7764,7 +7850,7 @@ const grammar = (input, visitors, options) => {
 
 	// The walk consumed the tree: release the side arrays' heap references so
 	// the reused columns don't pin this parse's strings until the next parse.
-	_hRelease();
+	_releaseAstColumns();
 };
 
 /**
@@ -8141,9 +8227,9 @@ let _walkSkip = false;
 // The walk's current position (`A.node` / `A.parent` read these; module-level
 // so the accessor methods' defaults avoid self-referential `this` typing).
 /** @type {HtmlNodeRef} */
-let _curNode = 0;
+let _currentNode = 0;
 /** @type {HtmlNodeRef | null} */
-let _curParent = null;
+let _currentParent = null;
 
 /* eslint-disable jsdoc/require-template -- `A` below is the accessor const, not a type parameter */
 /**
@@ -8163,13 +8249,13 @@ const A = {
 	 * @returns {HtmlNodeRef} current node — only valid during a visitor callback
 	 */
 	get node() {
-		return _curNode;
+		return _currentNode;
 	},
 	/**
 	 * @returns {HtmlNodeRef | null} enclosing node (null = the document root)
 	 */
 	get parent() {
-		return _curParent;
+		return _currentParent;
 	},
 	/** Stop the walk descending into the current node (enter only). */
 	skipChildren() {
@@ -8180,43 +8266,43 @@ const A = {
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {number} `NodeType`
 	 */
-	type(n = _curNode) {
-		return _hTy[n];
+	type(n = _currentNode) {
+		return _nodeTypes[n];
 	},
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {number} start offset
 	 */
-	start(n = _curNode) {
-		return _hSt[n];
+	start(n = _currentNode) {
+		return _nodeStarts[n];
 	},
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {number} end offset
 	 */
-	end(n = _curNode) {
-		return _hEn[n];
+	end(n = _currentNode) {
+		return _nodeEnds[n];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {string} lowercased (foreign-content: adjusted) tag name
 	 */
-	tagName(n = _curNode) {
-		return _hStr[n];
+	tagName(n = _currentNode) {
+		return _nodeStrings[n];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {number} `NS_*` namespace
 	 */
-	namespace(n = _curNode) {
-		return _hFl[n] & NS_MASK;
+	namespace(n = _currentNode) {
+		return _nodeFlags[n] & NS_MASK;
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {boolean} true for void elements
 	 */
-	selfClosing(n = _curNode) {
-		return (_hFl[n] & FLAG_SELF_CLOSING) !== 0;
+	selfClosing(n = _currentNode) {
+		return (_nodeFlags[n] & FLAG_SELF_CLOSING) !== 0;
 	},
 	// materialized attribute list — test/tooling convenience, allocates; the
 	// parser reads attributes through the scalar accessors below
@@ -8224,18 +8310,18 @@ const A = {
 	 * @param {HtmlElement=} n element
 	 * @returns {HtmlAttribute[]} materialized attributes
 	 */
-	attributes(n = _curNode) {
+	attributes(n = _currentNode) {
 		const out = [];
-		const start = _hAStart[n];
-		for (let i = start; i < start + _hACount[n]; i++) {
+		const start = _nodeAttrStarts[n];
+		for (let i = start; i < start + _nodeAttrCounts[n]; i++) {
 			out.push({
-				name: _aName[i],
-				value: _aValueOf(i),
-				serializedName: _aSerializedName(i),
-				nameStart: _aNameStart[i],
-				nameEnd: _aNameEnd[i],
-				valueStart: _aValStart[i],
-				valueEnd: _aValEnd[i]
+				name: _attrNames[i],
+				value: _attrValueOf(i),
+				serializedName: _attrSerializedName(i),
+				nameStart: _attrNameStarts[i],
+				nameEnd: _attrNameEnds[i],
+				valueStart: _attrValueStarts[i],
+				valueEnd: _attrValueEnds[i]
 			});
 		}
 		return out;
@@ -8244,8 +8330,8 @@ const A = {
 	 * @param {HtmlElement=} n element
 	 * @returns {number} attribute count
 	 */
-	attributeCount(n = _curNode) {
-		return _hACount[n];
+	attributeCount(n = _currentNode) {
+		return _nodeAttrCounts[n];
 	},
 	/**
 	 * The i-th attribute of an element, as an id for the `attribute*` reads.
@@ -8253,8 +8339,8 @@ const A = {
 	 * @param {HtmlElement=} n element
 	 * @returns {HtmlAttributeRef} attribute ref
 	 */
-	attributeAt(i, n = _curNode) {
-		return _hAStart[n] + i;
+	attributeAt(i, n = _currentNode) {
+		return _nodeAttrStarts[n] + i;
 	},
 	/**
 	 * Linear lookup by (lowercased) name.
@@ -8262,92 +8348,92 @@ const A = {
 	 * @param {HtmlElement=} n element
 	 * @returns {HtmlAttributeRef} attribute ref (0 = not present)
 	 */
-	findAttribute(name, n = _curNode) {
-		return _aFind(_hAStart[n], _hACount[n], name);
+	findAttribute(name, n = _currentNode) {
+		return _findAttr(_nodeAttrStarts[n], _nodeAttrCounts[n], name);
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {string} lowercased (foreign-content: adjusted) attribute name
 	 */
 	attributeName(a) {
-		return _aName[a];
+		return _attrNames[a];
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {string} raw (undecoded) attribute value ("" when valueless)
 	 */
 	attributeValue(a) {
-		return _aValueOf(a);
+		return _attrValueOf(a);
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {number} name start offset
 	 */
 	attributeNameStart(a) {
-		return _aNameStart[a];
+		return _attrNameStarts[a];
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {number} name end offset
 	 */
 	attributeNameEnd(a) {
-		return _aNameEnd[a];
+		return _attrNameEnds[a];
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {number} value start offset (-1 when valueless or on adoption-agency clones)
 	 */
 	attributeValueStart(a) {
-		return _aValStart[a];
+		return _attrValueStarts[a];
 	},
 	/**
 	 * @param {HtmlAttributeRef} a attribute ref
 	 * @returns {number} value end offset
 	 */
 	attributeValueEnd(a) {
-		return _aValEnd[a];
+		return _attrValueEnds[a];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {number} end offset of the opening tag (after `>`)
 	 */
-	tagEnd(n = _curNode) {
-		return _hTagEnd[n];
+	tagEnd(n = _currentNode) {
+		return _nodeTagEnds[n];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {number} end offset of the tag name
 	 */
-	nameEnd(n = _curNode) {
-		return _hNameEnd[n];
+	nameEnd(n = _currentNode) {
+		return _nodeNameEnds[n];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {number} under `skip.text`, end offset of a raw-text element's body (`tagEnd` when empty)
 	 */
-	contentEnd(n = _curNode) {
-		return _hCEnd[n];
+	contentEnd(n = _currentNode) {
+		return _nodeContentEnds[n];
 	},
 	/**
 	 * @param {HtmlElement=} n element
 	 * @returns {HtmlDocumentFragment} `<template>` content fragment (0 = none)
 	 */
-	templateContent(n = _curNode) {
-		return _hTc[n];
+	templateContent(n = _currentNode) {
+		return _nodeTemplateContents[n];
 	},
 	/**
 	 * @param {HtmlText | HtmlComment=} n text / comment node
 	 * @returns {string} decoded text / comment data
 	 */
-	data(n = _curNode) {
-		return _hStr[n];
+	data(n = _currentNode) {
+		return _nodeStrings[n];
 	},
 	/**
 	 * @param {HtmlDoctype=} n doctype node
 	 * @returns {string} doctype name
 	 */
-	doctypeName(n = _curNode) {
-		return _hStr[n];
+	doctypeName(n = _currentNode) {
+		return _nodeStrings[n];
 	},
 	// The doctype ids are per-parse scalars (a document has at most one
 	// doctype node); the node parameter is accepted for call-shape uniformity.
@@ -8356,44 +8442,46 @@ const A = {
 	 * @returns {string | null} doctype public id
 	 */
 	doctypePublicId(_n) {
-		return _hDocPub;
+		return _doctypePublicId;
 	},
 	/**
 	 * @param {HtmlDoctype=} _n doctype node
 	 * @returns {string | null} doctype system id
 	 */
 	doctypeSystemId(_n) {
-		return _hDocSys;
+		return _doctypeSystemId;
 	},
 	// === tree links (0 = none) ===
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {HtmlNodeRef} first child
 	 */
-	firstChild(n = _curNode) {
-		return _hFirst[n];
+	firstChild(n = _currentNode) {
+		return _nodeFirstChildren[n];
 	},
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {HtmlNodeRef} next sibling
 	 */
-	nextSibling(n = _curNode) {
-		return _hNext[n];
+	nextSibling(n = _currentNode) {
+		return _nodeNextSiblings[n];
 	},
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {HtmlNodeRef} parent node (a `<template>`'s content links to its fragment)
 	 */
-	parentOf(n = _curNode) {
-		return _hParent[n];
+	parentOf(n = _currentNode) {
+		return _nodeParents[n];
 	},
 	/**
 	 * @param {HtmlNodeRef=} n node
 	 * @returns {HtmlNodeRef[]} materialized child list — test/tooling convenience, allocates
 	 */
-	children(n = _curNode) {
+	children(n = _currentNode) {
 		const out = [];
-		for (let c = _hFirst[n]; c !== 0; c = _hNext[c]) out.push(c);
+		for (let c = _nodeFirstChildren[n]; c !== 0; c = _nodeNextSiblings[c]) {
+			out.push(c);
+		}
 		return out;
 	}
 };

--- a/test/walkHtmlTokens.unittest.js
+++ b/test/walkHtmlTokens.unittest.js
@@ -175,6 +175,34 @@ describe("walkHtmlTokens", () => {
 		]);
 	});
 
+	it("should route quote/lt-led attribute names through the attribute-name state", () => {
+		/** @type {unknown[]} */
+		const attrs = [];
+		/** @type {unknown[]} */
+		const errors = [];
+		walkHtmlTokens("<div \"x=1 'y>", 0, {
+			attribute: (input, ns, ne, vs, ve, qt) => {
+				attrs.push([
+					input.slice(ns, ne),
+					vs === -1 ? null : input.slice(vs, ve)
+				]);
+				if (vs === -1) return ne;
+				return qt !== QUOTE_NONE ? ve + 1 : ve;
+			},
+			parseError: (input, code) => {
+				errors.push(code);
+			}
+		});
+		expect(attrs).toEqual([
+			['"x', "1"],
+			["'y", null]
+		]);
+		expect(errors).toEqual([
+			"unexpected-character-in-attribute-name",
+			"unexpected-character-in-attribute-name"
+		]);
+	});
+
 	it("should handle all quote types", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
@@ -611,6 +639,45 @@ describe("walkHtmlTokens", () => {
 			["text", ".a{}"],
 			["close", "STYLE"]
 		]);
+	});
+
+	it("should flush unterminated raw-text bodies at EOF (no further `<`)", () => {
+		// Drives the content-mode fast-forwards when `indexOf` finds no next
+		// `<` (RCDATA / RAWTEXT / script data run to end of input).
+		for (const [source, tag, body] of [
+			["<title>left open", "title", "left open"],
+			["<style>.a{color:red}", "style", ".a{color:red}"],
+			["<script>var x = 1;", "script", "var x = 1;"]
+		]) {
+			/** @type {unknown[]} */
+			const results = [];
+			walkHtmlTokens(source, 0, {
+				openTag: (input, start, end, ns, ne) => {
+					results.push(["open", input.slice(ns, ne)]);
+					return end;
+				},
+				text: (input, start, end) => {
+					results.push(["text", input.slice(start, end)]);
+					return end;
+				}
+			});
+			expect(results).toEqual([
+				["open", tag],
+				["text", body]
+			]);
+		}
+	});
+
+	it("should handle character references in RCDATA text", () => {
+		/** @type {unknown[]} */
+		const results = [];
+		walkHtmlTokens("<title>a &amp; b</title>", 0, {
+			text: (input, start, end) => {
+				results.push(input.slice(start, end));
+				return end;
+			}
+		});
+		expect(results).toEqual(["a &amp; b"]);
 	});
 
 	it("should roundtrip HTML with script and style", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

The struct-of-arrays backends in `lib/css/syntax.js` and `lib/html/syntax.js` used cryptic column/helper names (`_soaTy`, `_hSt`, `_aVal`, …); this renames them to descriptive ones (`_soaTypes`, `_nodeStarts`, `_attrValues`, …) so the code explains itself. On top of that, two measured hot-path improvements: the CSS parser no longer allocates a name string per declaration/function/at-rule that the SoA backend immediately discards (names are derived from offsets on read), and the HTML tokenizer fast-forwards text/RCDATA/RAWTEXT/script-data runs via memoized native `indexOf` instead of per-character loops — 3-4x faster on text/script/style-heavy documents, tokenization semantics unchanged (only each state's "anything else" arc is batched; the html5lib suite passes).

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor (with a perf improvement in the second commit)

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new cases in `test/walkHtmlTokens.unittest.js` (unterminated raw-text bodies at EOF, RCDATA character references, quote-led attribute names); the existing CSS/HTML suites (incl. html5lib and css-parsing spec tests) cover the rest.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used, directed and reviewed by the requester: it performed the mechanical rename, profiled and benchmarked the parsers (paired in-process A/B runs), implemented the two hot-path changes, and wrote the added tests. All changes were verified against the full CSS/HTML test suites, lint, and type checks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd77pd2nB2LQ5MmnJxXV6Y)_