### PR TITLE
fix(html): harden output.html head tag injection and move it to parse time

### DIFF
--- a/.changeset/html-head-injection-fixes.md
+++ b/.changeset/html-head-injection-fixes.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `output.html` head injection escaping, head detection, and duplicate meta tags.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2752,7 +2752,7 @@ export interface OutputHtmlOptions {
 				filename: string;
 		  }) => string[] | false);
 	/**
-	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` or `twitter:` use the `property` attribute instead of `name`. Tags are always appended; the caller is responsible for avoiding duplicates in authored HTML.
+	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` use the `property` attribute instead of `name`. A tag is skipped if the HTML already contains a meta with the same name.
 	 */
 	meta?: {
 		/**

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -45,53 +45,6 @@ const HTML_REQUEST_RE = /\.html(\?|$)/i;
 const CSS_REQUEST_RE = /\.css(\?|$)/i;
 
 /**
- * @param {string} s string to escape
- * @returns {string} HTML attribute-safe string
- */
-const escAttr = (s) => s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
-/**
- * @param {string} s string to escape
- * @returns {string} HTML text-content-safe string
- */
-const escText = (s) =>
-	s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-/**
- * @param {import("../../declarations/WebpackOptions").OutputHtmlOptions} opts html options
- * @returns {string} head tags string
- */
-const buildHeadTags = (opts) => {
-	let out = "";
-	const meta = opts.meta;
-	if (meta && meta.charset) {
-		out += `<meta charset="${escAttr(meta.charset)}">`;
-	}
-	const base = opts.base;
-	if (base) {
-		const href = typeof base === "string" ? base : base.href;
-		const targetAttr =
-			typeof base === "object" && base.target
-				? ` target="${escAttr(base.target)}"`
-				: "";
-		out += `<base href="${escAttr(href)}"${targetAttr}>`;
-	}
-	if (meta) {
-		for (const [name, content] of Object.entries(meta)) {
-			if (name === "charset") continue;
-			// og: uses property=; all others (including twitter:) use name=
-			const attr = name.startsWith("og:")
-				? `property="${escAttr(name)}"`
-				: `name="${escAttr(name)}"`;
-			out += `<meta ${attr} content="${escAttr(content)}">`;
-		}
-	}
-	if (opts.title) {
-		out += `<title>${escText(opts.title)}</title>`;
-	}
-	return out;
-};
-
-/**
  * Requests an `output.html` page must load for an entry: its `dependOn`
  * ancestors first (transitive, deduped — so a diamond loads each once), then
  * the entry's own imports. `.html` imports are dropped (own HTML entries).
@@ -256,7 +209,7 @@ class HtmlModulesPlugin {
 						: typeof htmlOption === "object"
 							? htmlOption
 							: {};
-				const headTags = buildHeadTags(htmlObj);
+				const headTags = HtmlParser.buildHeadTags(htmlObj);
 				const inject =
 					typeof html === "object" && html.inject !== undefined
 						? html.inject
@@ -294,11 +247,11 @@ class HtmlModulesPlugin {
 		// Per-compilation state: the HTML modules seen during make (so
 		// `finishMake` creates their entries without scanning the whole module
 		// graph) and the stylesheet entry names (read in `afterChunks`).
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string>, syntheticHtmlAssets: Set<string> }>} */
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string>, syntheticHtmlAssets: Set<string> }} per-compilation state
+		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
@@ -306,8 +259,7 @@ class HtmlModulesPlugin {
 				state = {
 					htmlModules: new Set(),
 					stylesheetEntries: new Set(),
-					htmlAssetNames: new Set(),
-					syntheticHtmlAssets: new Set()
+					htmlAssetNames: new Set()
 				};
 				compilationState.set(compilation, state);
 			}
@@ -854,14 +806,7 @@ class HtmlModulesPlugin {
 
 							// Remember HTML pages so the sentinel-resolve pass skips JS chunks
 							// that merely embed the HTML string.
-							const pageState = getState(compilation);
-							pageState.htmlAssetNames.add(filename);
-							// Synthetic wrappers have head tags already baked in — skip processAssets injection.
-							if (
-								(normalModule.getResource() || "").startsWith("data:text/html")
-							) {
-								pageState.syntheticHtmlAssets.add(filename);
-							}
+							getState(compilation).htmlAssetNames.add(filename);
 
 							result.push({
 								render: () => finalSource,
@@ -930,82 +875,6 @@ class HtmlModulesPlugin {
 						if (!live.has(id)) sentinelResolvedSourceCache.delete(id);
 					}
 				});
-
-				if (htmlOption && typeof htmlOption === "object") {
-					const { title, meta, base } = htmlOption;
-					if (title !== undefined || meta !== undefined || base !== undefined) {
-						compilation.hooks.processAssets.tap(
-							{
-								name: PLUGIN_NAME,
-								stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
-							},
-							(assets) => {
-								const { htmlAssetNames, syntheticHtmlAssets } =
-									getState(compilation);
-								for (const name of Object.keys(assets)) {
-									if (!htmlAssetNames.has(name)) continue;
-									if (syntheticHtmlAssets.has(name)) continue;
-									const asset = assets[name];
-									const original = asset.source();
-									if (typeof original !== "string") continue;
-									let content = original;
-									if (
-										meta &&
-										meta.charset &&
-										!/<meta\s[^>]*charset/i.test(content)
-									) {
-										content = content.replace(
-											/(<head[^>]*>)/i,
-											`$1<meta charset="${escAttr(meta.charset)}">`
-										);
-									}
-									// <base> must follow <meta charset> per spec
-									if (base && !/<base[\s>]/i.test(content)) {
-										const href = typeof base === "string" ? base : base.href;
-										const targetAttr =
-											typeof base === "object" && base.target
-												? ` target="${escAttr(base.target)}"`
-												: "";
-										const baseTag = `<base href="${escAttr(href)}"${targetAttr}>`;
-										if (/<meta\s[^>]*charset/i.test(content)) {
-											content = content.replace(
-												/(<meta\s[^>]*charset[^>]*>)/i,
-												`$1${baseTag}`
-											);
-										} else {
-											content = content.replace(
-												/(<head[^>]*>)/i,
-												`$1${baseTag}`
-											);
-										}
-									}
-									if (meta) {
-										let metaTags = "";
-										for (const [mname, value] of Object.entries(meta)) {
-											if (mname === "charset") continue;
-											const attr = mname.startsWith("og:")
-												? `property="${escAttr(mname)}"`
-												: `name="${escAttr(mname)}"`;
-											metaTags += `<meta ${attr} content="${escAttr(value)}">`;
-										}
-										if (metaTags) {
-											content = content.replace(/(<\/head>)/i, `${metaTags}$1`);
-										}
-									}
-									if (title && !/<title[\s>]/i.test(content)) {
-										content = content.replace(
-											/(<\/head>)/i,
-											`<title>${escText(title)}</title>$1`
-										);
-									}
-									if (content !== original) {
-										compilation.updateAsset(name, new RawSource(content));
-									}
-								}
-							}
-						);
-					}
-				}
 			}
 		);
 	}

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -40,8 +40,10 @@ const {
 	NodeType,
 	SVG_TAG_ADJUST,
 	SourceProcessor,
-	decodeHtmlEntities,
-	decodeHtmlEntitiesWithMap,
+	decodeEntities,
+	decodeEntitiesWithMap,
+	escapeAttribute,
+	escapeText,
 	parseSrcset
 } = require("./syntax");
 
@@ -115,6 +117,63 @@ const SRCDOC_ASSET_REGEXP = /[=]|url\(|@import/i;
 // A URL carrying its own scheme (`https:`, `data:`, …) ignores the document
 // base per the URL spec, so `<base href>` never rewrites it.
 const ABSOLUTE_URL_SCHEME_REGEXP = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+// a `charset=` declaration inside an `http-equiv="content-type"` content value
+const CHARSET_DECLARATION_REGEXP = /charset\s*=/i;
+
+/**
+ * @param {string} name meta name
+ * @param {string} content meta content
+ * @returns {string} meta tag
+ */
+const metaTag = (name, content) => {
+	// og: uses property=; all others (including twitter:) use name=
+	const attr = name.startsWith("og:")
+		? `property="${escapeAttribute(name)}"`
+		: `name="${escapeAttribute(name)}"`;
+	return `<meta ${attr} content="${escapeAttribute(content)}">`;
+};
+
+/**
+ * @param {string | { href: string, target?: string }} base base option
+ * @returns {string} base tag
+ */
+const baseTag = (base) => {
+	const href = typeof base === "string" ? base : base.href;
+	const targetAttr =
+		typeof base === "object" && base.target
+			? ` target="${escapeAttribute(base.target)}"`
+			: "";
+	return `<base href="${escapeAttribute(href)}"${targetAttr}>`;
+};
+
+/**
+ * Serializes every head tag an `output.html` options object asks for, in
+ * spec order: charset, base, meta tags, title. Used where a page is created
+ * from scratch (HtmlModulesPlugin's synthetic entry wrapper); authored pages
+ * instead merge the options against their existing tags during `parse` —
+ * existing tags win.
+ * @param {import("../../declarations/WebpackOptions").OutputHtmlOptions} opts html options
+ * @returns {string} head tags string
+ */
+const buildHeadTags = (opts) => {
+	let out = "";
+	const meta = opts.meta;
+	if (meta && meta.charset) {
+		out += `<meta charset="${escapeAttribute(meta.charset)}">`;
+	}
+	if (opts.base) out += baseTag(opts.base);
+	if (meta) {
+		for (const [name, content] of Object.entries(meta)) {
+			if (name === "charset") continue;
+			out += metaTag(name, content);
+		}
+	}
+	if (opts.title) {
+		out += `<title>${escapeText(opts.title)}</title>`;
+	}
+	return out;
+};
 
 // CSP/fetch attributes copied verbatim onto a synthesized sibling `<link>` /
 // `<script>` (`HtmlEntryDependency`). Fixed output order, independent of
@@ -943,6 +1002,38 @@ class HtmlParser extends Parser {
 			.digest("hex")
 			.slice(0, 8);
 
+		// `output.html` head injection: facts are collected during the walk and
+		// become presentational dependencies afterwards — no later asset pass has
+		// to re-parse the page. `data:` documents are skipped: synthetic entry
+		// wrappers already carry the tags and iframe srcdoc pages must stay
+		// untouched.
+		const htmlOutputOptions =
+			compilation.options && compilation.options.output
+				? compilation.options.output.html
+				: undefined;
+		const headOptions =
+			typeof htmlOutputOptions === "object" &&
+			(htmlOutputOptions.title !== undefined ||
+				htmlOutputOptions.meta !== undefined ||
+				htmlOutputOptions.base !== undefined) &&
+			!resource.startsWith("data:")
+				? htmlOutputOptions
+				: undefined;
+		let doctypeEnd = -1;
+		let htmlTagEnd = -1;
+		// insertion offsets just inside the (possibly implicit) head
+		let headStart = 0;
+		let headLastEnd = 0;
+		let headSeen = false;
+		let inHead = false;
+		// `<template>` contents are inert
+		let headTemplateDepth = 0;
+		let headHasTitle = false;
+		let headHasBase = false;
+		let headCharsetEnd = -1;
+		/** @type {Set<string> | undefined} */
+		let headMetaNames;
+
 		// Script src / modulepreload references are collected per-type
 		// during the walk; HtmlModulesPlugin later turns them into real
 		// entries. `script` and `script-module` entries are chained via a
@@ -1085,10 +1176,7 @@ class HtmlParser extends Parser {
 		 * @param {import("./syntax").HtmlAttributeRef} hrefAttr the base's href attribute
 		 */
 		const resolveDocumentBase = (path, hrefAttr) => {
-			documentBase = decodeHtmlEntities(
-				path.attributeValue(hrefAttr),
-				true
-			).trim();
+			documentBase = decodeEntities(path.attributeValue(hrefAttr), true).trim();
 			if (!documentBase) return;
 			if (
 				ABSOLUTE_URL_SCHEME_REGEXP.test(documentBase) ||
@@ -1143,7 +1231,7 @@ class HtmlParser extends Parser {
 				// the browser sees (e.g. `rel="&#105;con"` means `icon`)
 				currentAttributesMap.set(
 					path.attributeName(attr),
-					decodeHtmlEntities(path.attributeValue(attr), true)
+					decodeEntities(path.attributeValue(attr), true)
 				);
 			}
 			return currentAttributesMap;
@@ -1158,6 +1246,10 @@ class HtmlParser extends Parser {
 				[NodeType.Comment]: (path) => {
 					const start = path.start();
 					const end = path.end();
+					// comments count toward the head-end insertion anchor
+					if (inHead && headTemplateDepth === 0 && end > headLastEnd) {
+						headLastEnd = end;
+					}
 					// Only proper `<!-- ... -->` comments carry magic comments.
 					if (
 						end - start < 7 ||
@@ -1250,7 +1342,9 @@ class HtmlParser extends Parser {
 					pendingWebpackIgnore = options.webpackIgnore;
 					pendingWebpackInline = options.webpackInline;
 				},
-				[NodeType.Doctype]: () => {
+				[NodeType.Doctype]: (path) => {
+					// only visited when head injection is active (see `skip` below)
+					if (doctypeEnd === -1) doctypeEnd = path.end();
 					pendingWebpackIgnore = undefined;
 					pendingWebpackInline = undefined;
 				},
@@ -1263,6 +1357,102 @@ class HtmlParser extends Parser {
 						const forceInline = pendingWebpackInline === true;
 						pendingWebpackIgnore = undefined;
 						pendingWebpackInline = undefined;
+
+						// head-injection fact collection — structural, so it runs even
+						// for `webpackIgnore`d elements
+						if (headOptions !== undefined) {
+							const name = path.tagName();
+							if (headTemplateDepth > 0) {
+								if (name === "template" && path.namespace() === NS_HTML) {
+									headTemplateDepth++;
+								}
+							} else if (inHead) {
+								if (path.namespace() === NS_HTML) {
+									switch (name) {
+										case "title":
+											headHasTitle = true;
+											break;
+										case "base":
+											headHasBase = true;
+											break;
+										case "meta": {
+											if (path.findAttribute("charset") !== 0) {
+												headCharsetEnd = path.tagEnd();
+											} else {
+												const httpEquiv = path.findAttribute("http-equiv");
+												const contentAttr =
+													httpEquiv !== 0 &&
+													decodeEntities(
+														path.attributeValue(httpEquiv),
+														true
+													).toLowerCase() === "content-type"
+														? path.findAttribute("content")
+														: 0;
+												if (
+													contentAttr !== 0 &&
+													CHARSET_DECLARATION_REGEXP.test(
+														decodeEntities(
+															path.attributeValue(contentAttr),
+															true
+														)
+													)
+												) {
+													headCharsetEnd = path.tagEnd();
+												}
+											}
+											const nameAttr = path.findAttribute("name");
+											const propertyAttr = path.findAttribute("property");
+											if (nameAttr !== 0 || propertyAttr !== 0) {
+												if (headMetaNames === undefined) {
+													headMetaNames = new Set();
+												}
+												if (nameAttr !== 0) {
+													headMetaNames.add(
+														decodeEntities(
+															path.attributeValue(nameAttr),
+															true
+														).toLowerCase()
+													);
+												}
+												if (propertyAttr !== 0) {
+													headMetaNames.add(
+														decodeEntities(
+															path.attributeValue(propertyAttr),
+															true
+														).toLowerCase()
+													);
+												}
+											}
+											break;
+										}
+										case "template":
+											headTemplateDepth++;
+											break;
+									}
+								}
+								if (path.end() > headLastEnd) headLastEnd = path.end();
+							} else if (!headSeen && path.namespace() === NS_HTML) {
+								if (name === "html") {
+									htmlTagEnd = path.tagEnd();
+								} else if (name === "head") {
+									headSeen = true;
+									inHead = true;
+									// explicit head has real offsets; an implicit one (head
+									// tags are optional in HTML5) anchors after `<html>`,
+									// the doctype, or the document start
+									const tagEnd = path.tagEnd();
+									headStart =
+										tagEnd > 0
+											? tagEnd
+											: htmlTagEnd > 0
+												? htmlTagEnd
+												: doctypeEnd > 0
+													? doctypeEnd
+													: 0;
+									headLastEnd = headStart;
+								}
+							}
+						}
 
 						if (ignore) {
 							return;
@@ -1349,7 +1539,7 @@ class HtmlParser extends Parser {
 									// The filter also sees the decoded value (the browser tokenizes it
 									// decoded, e.g. `&#117;rl(`), so a value-only check needn't re-read it.
 									const decoded = value.includes("&")
-										? decodeHtmlEntities(value, true)
+										? decodeEntities(value, true)
 										: value;
 									if (!filter(getAttributesMap(), decoded)) continue;
 								}
@@ -1369,9 +1559,7 @@ class HtmlParser extends Parser {
 								case "stylesheet-style":
 								case "stylesheet-style-attribute": {
 									if (!css) break;
-									const cssText = content
-										? value
-										: decodeHtmlEntities(value, true);
+									const cssText = content ? value : decodeEntities(value, true);
 									if (cssText.trim() === "") break;
 									const dep = new HtmlInlineStyleDependency(
 										dataUri("text/css", cssText),
@@ -1390,7 +1578,7 @@ class HtmlParser extends Parser {
 								// whose URL is `about:srcdoc`, so its base URL is inherited from
 								// this document — asset URLs resolve against this file's context.
 								case "srcdoc": {
-									const htmlText = decodeHtmlEntities(value, true);
+									const htmlText = decodeEntities(value, true);
 									// Only spin up a nested module when there is markup that can
 									// reference an asset; text/formatting-only markup is identical
 									// after rewriting (see `SRCDOC_ASSET_REGEXP`).
@@ -1468,7 +1656,7 @@ class HtmlParser extends Parser {
 									/** @type {number[] | undefined} */
 									let map;
 									if (value.includes("&")) {
-										({ text, map } = decodeHtmlEntitiesWithMap(value, true));
+										({ text, map } = decodeEntitiesWithMap(value, true));
 										if (!/\S/.test(text)) break;
 									}
 									/** @type {ParsedSource[] | undefined} */
@@ -1715,16 +1903,73 @@ class HtmlParser extends Parser {
 							}
 						}
 					},
-					exit: () => {
+					exit: (path) => {
+						if (headOptions !== undefined && path.namespace() === NS_HTML) {
+							const name = path.tagName();
+							if (name === "template" && headTemplateDepth > 0) {
+								headTemplateDepth--;
+							} else if (name === "head") {
+								inHead = false;
+							}
+						}
 						pendingWebpackIgnore = undefined;
 						pendingWebpackInline = undefined;
 					}
 				}
 			})
 			// Skip AST output this walk never reads: `text` (script/style bodies are
-			// read by offset via `contentEnd`) and `doctype`; keep `comments` for
+			// read by offset via `contentEnd`) and `doctype` — unless head injection
+			// needs the doctype as an insertion anchor; keep `comments` for
 			// magic comments (`webpackIgnore`).
-			.process(source, { skip: { text: true, doctype: true } });
+			.process(source, {
+				skip: { text: true, doctype: headOptions === undefined }
+			});
+
+		// `output.html` head injection: existing tags win, injected values are
+		// escaped, insertions at the same offset are merged to keep their order.
+		if (headOptions !== undefined && headSeen) {
+			const { title, meta, base } = headOptions;
+			let startTags = "";
+			if (meta && meta.charset && headCharsetEnd === -1) {
+				startTags += `<meta charset="${escapeAttribute(meta.charset)}">`;
+			}
+			// <base> must follow the charset declaration per spec
+			let baseAfterCharset = "";
+			if (base && !headHasBase) {
+				if (headCharsetEnd !== -1) baseAfterCharset = baseTag(base);
+				else startTags += baseTag(base);
+			}
+			let endTags = "";
+			if (meta) {
+				for (const [name, value] of Object.entries(meta)) {
+					if (
+						name === "charset" ||
+						(headMetaNames !== undefined &&
+							headMetaNames.has(name.toLowerCase()))
+					) {
+						continue;
+					}
+					endTags += metaTag(name, value);
+				}
+			}
+			if (title && !headHasTitle) {
+				endTags += `<title>${escapeText(title)}</title>`;
+			}
+			/** @type {[number, string][]} */
+			const inserts = [];
+			if (startTags) inserts.push([headStart, startTags]);
+			if (baseAfterCharset) inserts.push([headCharsetEnd, baseAfterCharset]);
+			if (endTags) inserts.push([headLastEnd, endTags]);
+			inserts.sort((a, b) => a[0] - b[0]);
+			for (let i = 0; i < inserts.length; i++) {
+				const at = inserts[i][0];
+				let tags = inserts[i][1];
+				while (i + 1 < inserts.length && inserts[i + 1][0] === at) {
+					tags += inserts[++i][1];
+				}
+				module.addPresentationalDependency(new ConstDependency(tags, at));
+			}
+		}
 
 		const buildInfo = /** @type {HtmlModuleBuildInfo} */ (module.buildInfo);
 		buildInfo.strict = true;
@@ -1764,5 +2009,7 @@ class HtmlParser extends Parser {
 		return state;
 	}
 }
+
+HtmlParser.buildHeadTags = buildHeadTags;
 
 module.exports = HtmlParser;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -147,6 +147,7 @@ const CC_QUESTION_MARK = 0x3f;
 const CC_LEFT_SQUARE_BRACKET = 0x5b;
 const CC_RIGHT_SQUARE_BRACKET = 0x5d;
 const CC_GRAVE_ACCENT = 0x60;
+const CC_NO_BREAK_SPACE = 0xa0;
 
 const QUOTE_DOUBLE = 1;
 const QUOTE_SINGLE = 2;
@@ -317,7 +318,7 @@ const getContentModeForTag = (name) => {
  * @param {string} lit lowercase ASCII literal
  * @returns {boolean} true if the range equals `lit` ignoring ASCII case
  */
-const rangeEqualsLower = (input, start, end, lit) => {
+const rangeEqualsLowerCase = (input, start, end, lit) => {
 	if (end - start !== lit.length) return false;
 	for (let i = 0; i < lit.length; i++) {
 		let c = input.charCodeAt(start + i);
@@ -339,27 +340,37 @@ const rangeEqualsLower = (input, start, end, lit) => {
 const getContentModeForRange = (input, start, end) => {
 	switch (end - start) {
 		case 3:
-			if (rangeEqualsLower(input, start, end, "xmp")) return STATE_RAWTEXT;
+			if (rangeEqualsLowerCase(input, start, end, "xmp")) return STATE_RAWTEXT;
 			return STATE_DATA;
 		case 5:
-			if (rangeEqualsLower(input, start, end, "title")) return STATE_RCDATA;
-			if (rangeEqualsLower(input, start, end, "style")) return STATE_RAWTEXT;
+			if (rangeEqualsLowerCase(input, start, end, "title")) return STATE_RCDATA;
+			if (rangeEqualsLowerCase(input, start, end, "style")) {
+				return STATE_RAWTEXT;
+			}
 			return STATE_DATA;
 		case 6:
-			if (rangeEqualsLower(input, start, end, "script")) {
+			if (rangeEqualsLowerCase(input, start, end, "script")) {
 				return STATE_SCRIPT_DATA;
 			}
-			if (rangeEqualsLower(input, start, end, "iframe")) return STATE_RAWTEXT;
+			if (rangeEqualsLowerCase(input, start, end, "iframe")) {
+				return STATE_RAWTEXT;
+			}
 			return STATE_DATA;
 		case 7:
-			if (rangeEqualsLower(input, start, end, "noembed")) return STATE_RAWTEXT;
+			if (rangeEqualsLowerCase(input, start, end, "noembed")) {
+				return STATE_RAWTEXT;
+			}
 			return STATE_DATA;
 		case 8:
-			if (rangeEqualsLower(input, start, end, "textarea")) return STATE_RCDATA;
-			if (rangeEqualsLower(input, start, end, "noframes")) return STATE_RAWTEXT;
+			if (rangeEqualsLowerCase(input, start, end, "textarea")) {
+				return STATE_RCDATA;
+			}
+			if (rangeEqualsLowerCase(input, start, end, "noframes")) {
+				return STATE_RAWTEXT;
+			}
 			return STATE_DATA;
 		case 9:
-			if (rangeEqualsLower(input, start, end, "plaintext")) {
+			if (rangeEqualsLowerCase(input, start, end, "plaintext")) {
 				return STATE_PLAINTEXT;
 			}
 			return STATE_DATA;
@@ -374,7 +385,7 @@ const getContentModeForRange = (input, start, end) => {
  * @param {HtmlTokenCallbacks} callbacks callbacks
  * @returns {number} final position
  */
-const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
+const walkTokens = (input, pos = 0, callbacks = {}) => {
 	const len = input.length;
 	let state = STATE_DATA;
 	let returnState = STATE_DATA;
@@ -436,7 +447,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 	 * the accumulated `charRefCode`, if any. Used both inline (when the
 	 * reference is terminated by a real next character) and at EOF (when the
 	 * reference runs to the end of input). The scanner only flags the error —
-	 * the spec's U+FFFD / Windows-1252 substitution is done by `decodeHtmlEntities`.
+	 * the spec's U+FFFD / Windows-1252 substitution is done by `decodeEntities`.
 	 * @param {number} endPos offset just past the reference
 	 */
 	const validateNumericReference = (endPos) => {
@@ -607,7 +618,7 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 		// All WHATWG tokenizer states handled. Deliberately omitted parse errors
 		// (need state this offset scanner lacks): duplicate-attribute,
 		// cdata-in-html-content, `*-in-input-stream`. Reference substitution is
-		// left to `decodeHtmlEntities`.
+		// left to `decodeEntities`.
 		switch (state) {
 			// https://html.spec.whatwg.org/multipage/parsing.html#data-state
 			case STATE_DATA:
@@ -2418,7 +2429,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2434,7 +2450,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2450,7 +2471,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2556,7 +2582,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2571,7 +2602,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2586,7 +2622,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2697,7 +2738,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2712,7 +2758,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2727,7 +2778,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -2925,7 +2981,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 				if (isSpace(cc)) {
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_BEFORE_ATTRIBUTE_NAME;
@@ -2940,7 +3001,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_SELF_CLOSING_START_TAG;
@@ -2955,7 +3021,12 @@ const walkHtmlTokens = (input, pos = 0, callbacks = {}) => {
 					// per the "anything else" entry below.
 					tagNameEnd = pos;
 					if (
-						rangeEqualsLower(input, tagNameStart, tagNameEnd, lastOpenTagName)
+						rangeEqualsLowerCase(
+							input,
+							tagNameStart,
+							tagNameEnd,
+							lastOpenTagName
+						)
 					) {
 						flushText(tagStart);
 						state = STATE_DATA;
@@ -3767,7 +3838,7 @@ const _decodeReferenceInAttribute = (match, offset, source) =>
  * @param {boolean=} isAttribute true if `str` came from an attribute value
  * @returns {string} decoded string
  */
-const decodeHtmlEntities = (str, isAttribute) => {
+const decodeEntities = (str, isAttribute) => {
 	if (!str.includes("&")) return str;
 
 	return str.replace(
@@ -3777,7 +3848,7 @@ const decodeHtmlEntities = (str, isAttribute) => {
 };
 
 /**
- * Like `decodeHtmlEntities`, but also returns a boundary map from the
+ * Like `decodeEntities`, but also returns a boundary map from the
  * decoded string back to raw offsets, so spans computed on the decoded
  * text (e.g. srcset candidate URLs) can be translated to source ranges.
  * `map[i]` is the raw offset of decoded boundary `i` (`0..text.length`);
@@ -3787,7 +3858,7 @@ const decodeHtmlEntities = (str, isAttribute) => {
  * @param {boolean=} isAttribute true if `str` came from an attribute value
  * @returns {{ text: string, map: number[] | undefined }} decoded text and offset map
  */
-const decodeHtmlEntitiesWithMap = (str, isAttribute) => {
+const decodeEntitiesWithMap = (str, isAttribute) => {
 	/** @type {number[] | undefined} */
 	let map;
 	if (str.includes("&")) {
@@ -3820,10 +3891,111 @@ const decodeHtmlEntitiesWithMap = (str, isAttribute) => {
 	return { text: str, map };
 };
 
+/**
+ * Escape a string per the WHATWG "escape a string" algorithm
+ * (https://html.spec.whatwg.org/multipage/parsing.html#escapingString) in
+ * attribute mode: `&`, U+00A0 and `"`. CR/LF are additionally encoded as
+ * numeric references so the result stays single-line (usable in a `data:`
+ * URI). Single pass, returns the input unchanged when nothing needs escaping.
+ * @param {string} s string to escape
+ * @returns {string} HTML attribute-safe string
+ */
+const escapeAttribute = (s) => {
+	// fast path: native indexOf scans beat any per-character loop
+	if (
+		!s.includes("&") &&
+		!s.includes('"') &&
+		!s.includes("\u00A0") &&
+		!s.includes("\n") &&
+		!s.includes("\r")
+	) {
+		return s;
+	}
+	let out = "";
+	let last = 0;
+	for (let i = 0; i < s.length; i++) {
+		let rep;
+		switch (s.charCodeAt(i)) {
+			case CC_AMPERSAND:
+				rep = "&amp;";
+				break;
+			case CC_QUOTATION_MARK:
+				rep = "&quot;";
+				break;
+			case CC_NO_BREAK_SPACE:
+				rep = "&nbsp;";
+				break;
+			case CC_LF:
+				rep = "&#10;";
+				break;
+			case CC_CR:
+				rep = "&#13;";
+				break;
+			default:
+				continue;
+		}
+		out += s.slice(last, i) + rep;
+		last = i + 1;
+	}
+	return out + s.slice(last);
+};
+
+/**
+ * Escape a string per the WHATWG "escape a string" algorithm in text mode:
+ * `&`, U+00A0, `<` and `>`. CR/LF are additionally encoded as numeric
+ * references so the result stays single-line (usable in a `data:` URI).
+ * Single pass, returns the input unchanged when nothing needs escaping.
+ * @param {string} s string to escape
+ * @returns {string} HTML text-content-safe string
+ */
+const escapeText = (s) => {
+	// fast path: native indexOf scans beat any per-character loop
+	if (
+		!s.includes("&") &&
+		!s.includes("<") &&
+		!s.includes(">") &&
+		!s.includes("\u00A0") &&
+		!s.includes("\n") &&
+		!s.includes("\r")
+	) {
+		return s;
+	}
+	let out = "";
+	let last = 0;
+	for (let i = 0; i < s.length; i++) {
+		let rep;
+		switch (s.charCodeAt(i)) {
+			case CC_AMPERSAND:
+				rep = "&amp;";
+				break;
+			case CC_LESS_THAN:
+				rep = "&lt;";
+				break;
+			case CC_GREATER_THAN:
+				rep = "&gt;";
+				break;
+			case CC_NO_BREAK_SPACE:
+				rep = "&nbsp;";
+				break;
+			case CC_LF:
+				rep = "&#10;";
+				break;
+			case CC_CR:
+				rep = "&#13;";
+				break;
+			default:
+				continue;
+		}
+		out += s.slice(last, i) + rep;
+		last = i + 1;
+	}
+	return out + s.slice(last);
+};
+
 // cspell:ignore advasoft altglyph altglyphdef altglyphitem animatecolor animatemotion animatetransform arcrole aswedit attributename attributetype basefrequency baseprofile bgsound calcmode clippathunits definitionurl diffuseconstant fedropshadow filterunits glyphref gradienttransform gradientunits hotjava hotmetal kernelmatrix kernelunitlength keypoints keysplines keytimes limitingconeangle malignmark markerheight markerwidth maskcontentunits maskunits metrius mglyph mtext numoctaves pathlength patterncontentunits patterntransform patternunits pointsatx pointsaty pointsatz preservealpha primitiveunits refx refy repeatcount repeatdur requiredextensions requiredfeatures selectedcontent silmaril softquad specularconstant specularexponent startoffset stddeviation stitchtiles surfacescale systemlanguage tablevalues targetx targety textlength viewbox viewtarget webtechs xchannelselector ychannelselector megamorphic attributeless rowspan imagesizes novalidate maxlength
 
 // WHATWG HTML tree construction (https://html.spec.whatwg.org/multipage/parsing.html#tree-construction)
-// on top of walkHtmlTokens. Scripting is always disabled (webpack is a build tool).
+// on top of walkTokens. Scripting is always disabled (webpack is a build tool).
 
 // Namespaces (mirrors swc_html_ast::Namespace)
 const NS_HTML = 0;
@@ -3865,7 +4037,7 @@ const EMPTY_ATTRS = /** @type {AttributeRun} */ (
 // name-and-value side arrays. Columns are module-level and reused
 // across parses (grown, never shrunk — the CSS parser's `_soa*` strategy), so
 // a steady-state parse allocates almost nothing per node; consumers must fully
-// read a tree before the next `buildHtmlAst` call. Id 0 is reserved as
+// read a tree before the next `buildAst` call. Id 0 is reserved as
 // "no node" so the link columns can use 0 as null.
 let _nodeCapacity = 0;
 let _nodeCount = 0;
@@ -4194,7 +4366,7 @@ const mergeAttrs = (
 /**
  * A node reference into the struct-of-arrays AST: an integer id indexing the
  * parallel `_h*` columns. Read fields through the exported accessor `A`. Refs
- * are only valid until the next `buildHtmlAst` call — the columns are reused
+ * are only valid until the next `buildAst` call — the columns are reused
  * across parses — so consume a tree fully before parsing again.
  * @typedef {number} HtmlNodeRef
  */
@@ -4959,10 +5131,10 @@ const internLowerName = (table, input, start, end) => {
 		if (hit === undefined) break;
 		if (hashes[slot] === h) {
 			if (typeof hit === "string") {
-				if (rangeEqualsLower(input, start, end, hit)) return hit;
+				if (rangeEqualsLowerCase(input, start, end, hit)) return hit;
 			} else {
 				for (let i = 0; i < hit.length; i++) {
-					if (rangeEqualsLower(input, start, end, hit[i])) return hit[i];
+					if (rangeEqualsLowerCase(input, start, end, hit[i])) return hit[i];
 				}
 			}
 			break;
@@ -5044,7 +5216,7 @@ const EMPTY_SKIP = Object.freeze({});
  * @param {HtmlAstSkip=} skip node kinds to omit from the AST (see `HtmlAstSkip`); omit to build the full tree
  * @returns {HtmlDocument} ref to the document node — read through `A`; valid until the next parse
  */
-const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
+const buildAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const skipText = skip.text === true;
 	const skipComments = skip.comments === true;
 	const skipDoctype = skip.doctype === true;
@@ -6899,7 +7071,8 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 				);
 				return;
 			}
-			open.pop();
+			// span the close tag, like every other explicit-close pop
+			_nodeEnds[/** @type {HtmlElement} */ (open.pop())] = tokenEnd;
 			mode = originalMode;
 		}
 	};
@@ -7405,7 +7578,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	}
 
 	// ---------- tokenizer callbacks ----------
-	const decode = decodeHtmlEntities;
+	const decode = decodeEntities;
 
 	let swallowNextNewline = false;
 	// Set by the tokenizer when it hits EOF mid-tag; such a partial tag is
@@ -7434,7 +7607,7 @@ const buildHtmlAst = (source, fragmentContext, skip = EMPTY_SKIP) => {
 	const dispatch = () =>
 		process(/** @type {Token} */ (/** @type {unknown} */ (tok)));
 
-	walkHtmlTokens(source, 0, {
+	walkTokens(source, 0, {
 		isForeign: () => {
 			const ac = adjustedCurrent();
 			return open.length > 0 && ac !== 0 && _namespaceOf(ac) !== NS_HTML;
@@ -7782,7 +7955,7 @@ const parseDoctype = (/** @type {string} */ raw) => {
 
 /**
  * @typedef {object} HtmlProcessOptions
- * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildHtmlAst`); the HTML analog of the CSS parser's `as` parse-mode option
+ * @property {string=} fragmentContext context element tag name for fragment parsing (see `buildAst`); the HTML analog of the CSS parser's `as` parse-mode option
  * @property {HtmlAstSkip=} skip node kinds to omit from the AST for speed/memory (see `HtmlAstSkip`)
  */
 
@@ -7795,7 +7968,7 @@ const parseDoctype = (/** @type {string} */ raw) => {
  * @param {HtmlProcessOptions} options process options
  */
 const grammar = (input, visitors, options) => {
-	const root = buildHtmlAst(input, options.fragmentContext, options.skip);
+	const root = buildAst(input, options.fragmentContext, options.skip);
 
 	// Iterative depth-first walk over the link columns: `firstChild`
 	// / `nextSibling` descend, the `parent` column ascends, so arbitrarily deep
@@ -8277,7 +8450,7 @@ let _currentParent = null;
 // AST field-access seam (mirrors the CSS parser's `A`): every AST field a
 // consumer reads goes through one of these accessors, so the node
 // representation can change underneath without touching consumers. `n` is an
-// `HtmlNodeRef`; results are valid until the next `buildHtmlAst` call.
+// `HtmlNodeRef`; results are valid until the next `buildAst` call.
 const A = {
 	// === path position (rebound by the walk before every visitor call) ===
 	/**
@@ -8533,8 +8706,10 @@ module.exports.SVG_TAG_ADJUST = SVG_TAG_ADJUST;
 module.exports.SourceProcessor = SourceProcessor;
 // Exposed so HtmlParser can map user-configured (lowercased) tag names to
 // the adjusted camelCase names the AST carries for foreign content.
-module.exports.buildHtmlAst = buildHtmlAst;
-module.exports.decodeHtmlEntities = decodeHtmlEntities;
-module.exports.decodeHtmlEntitiesWithMap = decodeHtmlEntitiesWithMap;
+module.exports.buildAst = buildAst;
+module.exports.decodeEntities = decodeEntities;
+module.exports.decodeEntitiesWithMap = decodeEntitiesWithMap;
+module.exports.escapeAttribute = escapeAttribute;
+module.exports.escapeText = escapeText;
 module.exports.parseSrcset = parseSrcset;
-module.exports.walkHtmlTokens = walkHtmlTokens;
+module.exports.walkTokens = walkTokens;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -4432,7 +4432,7 @@
           ]
         },
         "meta": {
-          "description": "Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `\"charset\"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` or `twitter:` use the `property` attribute instead of `name`. Tags are always appended; the caller is responsible for avoiding duplicates in authored HTML.",
+          "description": "Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `\"charset\"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` use the `property` attribute instead of `name`. A tag is skipped if the HTML already contains a meta with the same name.",
           "type": "object",
           "additionalProperties": {
             "description": "Content string for the meta tag.",

--- a/test/__snapshots__/walkHtmlTokens.unittest.js.snap
+++ b/test/__snapshots__/walkHtmlTokens.unittest.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`walkHtmlTokens should tokenize and roundtrip "attributes.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "attributes.html" 1`] = `
 Array [
   Array [
     "attribute",
@@ -104,7 +104,7 @@ Array [
 ]
 `;
 
-exports[`walkHtmlTokens should tokenize and roundtrip "basic.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "basic.html" 1`] = `
 Array [
   Array [
     "doctype",
@@ -419,7 +419,7 @@ Array [
 ]
 `;
 
-exports[`walkHtmlTokens should tokenize and roundtrip "character-references.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "character-references.html" 1`] = `
 Array [
   Array [
     "open-tag",
@@ -702,7 +702,7 @@ Array [
 ]
 `;
 
-exports[`walkHtmlTokens should tokenize and roundtrip "comments.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "comments.html" 1`] = `
 Array [
   Array [
     "comment",
@@ -796,7 +796,7 @@ comment -->",
 ]
 `;
 
-exports[`walkHtmlTokens should tokenize and roundtrip "nested.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "nested.html" 1`] = `
 Array [
   Array [
     "open-tag",
@@ -937,7 +937,7 @@ Array [
 ]
 `;
 
-exports[`walkHtmlTokens should tokenize and roundtrip "self-closing.html" 1`] = `
+exports[`walkTokens should tokenize and roundtrip "self-closing.html" 1`] = `
 Array [
   Array [
     "attribute",

--- a/test/buildHtmlAst.unittest.js
+++ b/test/buildHtmlAst.unittest.js
@@ -8,14 +8,14 @@ const {
 	NS_MATHML,
 	NS_SVG,
 	NodeType,
-	buildHtmlAst: buildHtmlAstRefs
+	buildAst: buildAstRefs
 } = require("../lib/html/syntax");
 
 /** @typedef {import("../lib/html/syntax").HtmlNodeRef} HtmlNodeRef */
 /** @typedef {import("../lib/html/syntax").HtmlAttribute} HtmlAttribute */
 /**
  * Materialized plain-object views of the struct-of-arrays AST — the shape
- * `buildHtmlAst` used to return, rebuilt through the accessor `A`.
+ * `buildAst` used to return, rebuilt through the accessor `A`.
  * @typedef {object} MatElement
  * @property {typeof NodeType.Element} type
  * @property {string} tagName
@@ -37,7 +37,7 @@ const {
 /** @typedef {{ type: typeof NodeType.DocumentFragment, children: MatNode[] }} MatFragment */
 /** @typedef {MatElement | MatText | MatComment | MatDoctype} MatNode */
 
-// `buildHtmlAst` returns integer refs into reused module-level columns, valid
+// `buildAst` returns integer refs into reused module-level columns, valid
 // only until the next parse; materialize each tree eagerly (reading every
 // field through `A`, so this suite exercises the whole accessor surface) to
 // keep assertions valid across the multiple parses many tests perform.
@@ -99,8 +99,8 @@ const materialize = (ref) => {
  * @param {import("../lib/html/syntax").HtmlAstSkip=} skip skip options
  * @returns {MatDocument} materialized document
  */
-const buildHtmlAst = (src, fragmentContext, skip) => {
-	const doc = buildHtmlAstRefs(src, fragmentContext, skip);
+const buildAst = (src, fragmentContext, skip) => {
+	const doc = buildAstRefs(src, fragmentContext, skip);
 	return {
 		type: NodeType.Document,
 		children: A.children(doc).map(materialize)
@@ -123,7 +123,7 @@ const child = (children, tagName) =>
  * @param {string} src source
  * @returns {MatElement} html element
  */
-const html = (src) => child(buildHtmlAst(src).children, "html");
+const html = (src) => child(buildAst(src).children, "html");
 /**
  * @param {string} src source
  * @returns {MatElement[]} body children
@@ -154,13 +154,13 @@ const find = (src, tagName) => {
 		}
 		for (const c of node.children) walk(c);
 	};
-	for (const c of buildHtmlAst(src).children) walk(c);
+	for (const c of buildAst(src).children) walk(c);
 	return /** @type {MatElement} */ (found);
 };
 
-describe("buildHtmlAst", () => {
+describe("buildAst", () => {
 	it("should produce an empty document with html/head/body scaffolding", () => {
-		const ast = buildHtmlAst("");
+		const ast = buildAst("");
 		expect(ast.type).toBe(NodeType.Document);
 		const root = child(ast.children, "html");
 		expect(root.tagName).toBe("html");
@@ -209,13 +209,13 @@ describe("buildHtmlAst", () => {
 	});
 
 	it("should parse comments", () => {
-		const ast = buildHtmlAst("<!-- hello -->");
+		const ast = buildAst("<!-- hello -->");
 		expect(ast.children[0].type).toBe(NodeType.Comment);
 		expect(/** @type {MatComment} */ (ast.children[0]).data).toBe(" hello ");
 	});
 
 	it("should parse doctype", () => {
-		const ast = buildHtmlAst("<!DOCTYPE html><html></html>");
+		const ast = buildAst("<!DOCTYPE html><html></html>");
 		expect(ast.children[0].type).toBe(NodeType.Doctype);
 		expect(/** @type {MatDoctype} */ (ast.children[0]).name).toBe("html");
 	});
@@ -348,7 +348,7 @@ describe("buildHtmlAst", () => {
 
 	it("should treat bogus comments as comments", () => {
 		// A leading bogus comment is inserted into the document before <html>.
-		const ast = buildHtmlAst("<?bogus comment>");
+		const ast = buildAst("<?bogus comment>");
 		expect(ast.children[0].type).toBe(NodeType.Comment);
 		expect(/** @type {MatComment} */ (ast.children[0]).data).toBe(
 			"?bogus comment"
@@ -528,7 +528,7 @@ describe("buildHtmlAst", () => {
 		// Context is a `table`, so there is no `<table>` on the open stack: stray
 		// character data is fostered to the fragment root, beside the table rows.
 		const root = /** @type {MatElement} */ (
-			buildHtmlAst("<tr><td>a</td></tr>x", "table").children[0]
+			buildAst("<tr><td>a</td></tr>x", "table").children[0]
 		);
 		const texts = root.children
 			.filter((c) => c.type === NodeType.Text)
@@ -538,7 +538,7 @@ describe("buildHtmlAst", () => {
 	});
 });
 
-describe("buildHtmlAst — SourceProcessor", () => {
+describe("buildAst — SourceProcessor", () => {
 	const { NodeType, SourceProcessor } = require("../lib/html/syntax");
 
 	it("fires enter / exit visitors in source order", () => {
@@ -633,7 +633,7 @@ describe("buildHtmlAst — SourceProcessor", () => {
 	});
 });
 
-describe("buildHtmlAst — insertion-mode edge cases", () => {
+describe("buildAst — insertion-mode edge cases", () => {
 	it("merges foster-parented text runs before a table", () => {
 		const nodes = body("<table>x<tr></tr>y</table>");
 		// Both stray runs are fostered before the table and merged into one node.
@@ -734,7 +734,7 @@ describe("buildHtmlAst — insertion-mode edge cases", () => {
 	});
 
 	it("handles content after </html> (after-after-body)", () => {
-		const ast = buildHtmlAst("<p>a</p></html><!--c-->z");
+		const ast = buildAst("<p>a</p></html><!--c-->z");
 		// Comment after </html> attaches to the document.
 		expect(ast.children.some((c) => c.type === NodeType.Comment)).toBe(true);
 		// Non-whitespace text re-enters the body.
@@ -757,7 +757,7 @@ describe("buildHtmlAst — insertion-mode edge cases", () => {
 			true
 		);
 		// afterFrameset comment + </html> → afterAfterFrameset comment/noframes.
-		const ast = buildHtmlAst(src);
+		const ast = buildAst(src);
 		expect(ast.children.some((c) => c.type === NodeType.Comment)).toBe(true);
 		expect(find(src, "noframes")).toBeDefined();
 	});
@@ -779,7 +779,7 @@ describe("buildHtmlAst — insertion-mode edge cases", () => {
 	});
 });
 
-describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
+describe("buildAst — stray doctype and <html> re-dispatch", () => {
 	it("ignores a mid-document doctype and merges stray <html> attributes", () => {
 		// A stray doctype is dropped and a repeated <html> merges new
 		// attributes in colgroup / table / noscript / frameset modes.
@@ -815,7 +815,7 @@ describe("buildHtmlAst — stray doctype and <html> re-dispatch", () => {
 // detection) must run identically, so the ELEMENT tree — tags, nesting, offsets
 // and attributes — is the same with any skip combination as with none. This
 // guards the risky `skip.text` path, which drops text-node insertion.
-describe("buildHtmlAst — skip options preserve element structure", () => {
+describe("buildAst — skip options preserve element structure", () => {
 	// A spread of construction edge cases: foster parenting, adoption agency,
 	// select/table/ruby scoping, foreign content, raw-text elements, quirks.
 	const cases = [
@@ -902,17 +902,15 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 	];
 
 	it.each(cases)("keeps the element tree stable under skip (%s)", (src) => {
-		const baseline = elementSignature(buildHtmlAst(src));
+		const baseline = elementSignature(buildAst(src));
 		for (const skip of skipCombos) {
-			expect(elementSignature(buildHtmlAst(src, undefined, skip))).toBe(
-				baseline
-			);
+			expect(elementSignature(buildAst(src, undefined, skip))).toBe(baseline);
 		}
 	});
 
 	it("skip.text drops every text node; raw-text bodies stay readable via contentEnd", () => {
 		const src = "<p>prose</p><script>var x=1;</script>";
-		const doc = buildHtmlAst(src, undefined, { text: true });
+		const doc = buildAst(src, undefined, { text: true });
 		/** @type {MatText[]} */
 		const texts = [];
 		/** @type {MatElement | undefined} */
@@ -953,14 +951,14 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 			return n;
 		};
 		expect(
-			count(buildHtmlAst(src, undefined, { comments: true }), NodeType.Comment)
+			count(buildAst(src, undefined, { comments: true }), NodeType.Comment)
 		).toBe(0);
 		expect(
-			count(buildHtmlAst(src, undefined, { doctype: true }), NodeType.Doctype)
+			count(buildAst(src, undefined, { doctype: true }), NodeType.Doctype)
 		).toBe(0);
 		// Baseline still has both.
-		expect(count(buildHtmlAst(src), NodeType.Comment)).toBe(1);
-		expect(count(buildHtmlAst(src), NodeType.Doctype)).toBe(1);
+		expect(count(buildAst(src), NodeType.Comment)).toBe(1);
+		expect(count(buildAst(src), NodeType.Doctype)).toBe(1);
 	});
 
 	it("skip.text records every raw-text element body span on contentEnd", () => {
@@ -968,7 +966,7 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		// is the element's raw value, recorded as [tagEnd, contentEnd] — no Text node.
 		const src =
 			"<title>ti</title><style>.s{}</style></head><body>prose<script>sc</script><textarea>ta</textarea>";
-		const doc = buildHtmlAst(src, undefined, { text: true });
+		const doc = buildAst(src, undefined, { text: true });
 		/** @type {Record<string, string>} */
 		const bodies = {};
 		/** @param {MatNode} n node */
@@ -996,7 +994,7 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 		// text; HtmlParser extracts them regardless of namespace, so contentEnd must
 		// be recorded here too.
 		const src = "<svg><style>.a{}</style><script>x()</script></svg>";
-		const doc = buildHtmlAst(src, undefined, { text: true });
+		const doc = buildAst(src, undefined, { text: true });
 		/** @type {Record<string, string>} */
 		const bodies = {};
 		/** @param {MatNode} n node */
@@ -1023,15 +1021,15 @@ describe("buildHtmlAst — skip options preserve element structure", () => {
 			["<rect/>text", "svg"]
 		];
 		for (const [src, ctx] of fragments) {
-			const base = elementSignature(buildHtmlAst(src, ctx));
+			const base = elementSignature(buildAst(src, ctx));
 			for (const skip of skipCombos) {
-				expect(elementSignature(buildHtmlAst(src, ctx, skip))).toBe(base);
+				expect(elementSignature(buildAst(src, ctx, skip))).toBe(base);
 			}
 		}
 	});
 });
 
-describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
+describe("buildAst — tree-construction edge cases (SoA columns)", () => {
 	/**
 	 * @param {string} src source
 	 * @param {import("../lib/html/syntax").HtmlAstSkip=} skip skip options
@@ -1039,7 +1037,7 @@ describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
 	 */
 	const bodyOf = (src, skip) =>
 		child(
-			child(buildHtmlAst(src, undefined, skip).children, "html").children,
+			child(buildAst(src, undefined, skip).children, "html").children,
 			"body"
 		).children;
 
@@ -1192,7 +1190,7 @@ describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
 	});
 
 	it("merges attributes of a repeated <body> tag", () => {
-		const doc = buildHtmlAst('<body class="a"><body id="b" class="c">x');
+		const doc = buildAst('<body class="a"><body id="b" class="c">x');
 		const bodyEl = child(child(doc.children, "html").children, "body");
 		const byName = new Map(bodyEl.attributes.map((a) => [a.name, a.value]));
 		expect(byName.get("class")).toBe("a");
@@ -1202,7 +1200,7 @@ describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
 	it("replaces an empty <body> with a <frameset>", () => {
 		// An implied body (opened by <div>) leaves frameset-ok set, so the
 		// <frameset> detaches it; an explicit <body> tag would clear the flag.
-		const doc = buildHtmlAst(
+		const doc = buildAst(
 			'<div><frameset rows="1"> <frameset cols="2"><frame></frameset></frameset>'
 		);
 		const htmlEl = child(doc.children, "html");
@@ -1259,18 +1257,18 @@ describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
 	});
 
 	it("attaches comments after </body> to the <html> element", () => {
-		const htmlEl = child(buildHtmlAst("x</body><!--c-->").children, "html");
+		const htmlEl = child(buildAst("x</body><!--c-->").children, "html");
 		expect(htmlEl.children.map((c) => c.type)).toContain(NodeType.Comment);
 	});
 
 	it("parses text in a foreign fragment context", () => {
-		const doc = buildHtmlAstRefs("x<div>y", "svg");
+		const doc = buildAstRefs("x<div>y", "svg");
 		const root = A.firstChild(doc);
 		expect(A.type(A.firstChild(root))).toBe(NodeType.Text);
 	});
 
 	it("runs the adoption agency in a table-row fragment context", () => {
-		const doc = buildHtmlAst("<b>x<tr>y</b>z", "tr");
+		const doc = buildAst("<b>x<tr>y</b>z", "tr");
 		const root = child(doc.children, "html");
 		expect(
 			/** @type {MatText} */ (child(root.children, "b").children[0]).data
@@ -1278,7 +1276,7 @@ describe("buildHtmlAst — tree-construction edge cases (SoA columns)", () => {
 	});
 });
 
-describe("buildHtmlAst — path accessor completeness", () => {
+describe("buildAst — path accessor completeness", () => {
 	const { SourceProcessor } = require("../lib/html/syntax");
 
 	it("exposes node, parent links and attribute spans on the path", () => {

--- a/test/configCases/html/output-html-head/src/page-bare.html
+++ b/test/configCases/html/output-html-head/src/page-bare.html
@@ -1,0 +1,1 @@
+<script src="./main.js"></script>

--- a/test/configCases/html/output-html-head/src/page-charset-word.html
+++ b/test/configCases/html/output-html-head/src/page-charset-word.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta name="description" content="how to pick a charset"></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-comment.html
+++ b/test/configCases/html/output-html-head/src/page-comment.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><!-- <title>Fake</title><base href="/fake/"><meta charset="x"> --></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-doctype-only.html
+++ b/test/configCases/html/output-html-head/src/page-doctype-only.html
@@ -1,0 +1,1 @@
+<!doctype html><script src="./main.js"></script>

--- a/test/configCases/html/output-html-head/src/page-dup-meta.html
+++ b/test/configCases/html/output-html-head/src/page-dup-meta.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta name="viewport" content="width=device-width"><meta name='description' content='authored'><meta name=keywords content=k><meta property="og:title" content="Authored OG"></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-entity-meta.html
+++ b/test/configCases/html/output-html-head/src/page-entity-meta.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta name="de&#115;cription" content="authored entity"></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-httpequiv.html
+++ b/test/configCases/html/output-html-head/src/page-httpequiv.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-implicit-head.html
+++ b/test/configCases/html/output-html-head/src/page-implicit-head.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><header class="top">x</header><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-special-chars.html
+++ b/test/configCases/html/output-html-head/src/page-special-chars.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-svg-title.html
+++ b/test/configCases/html/output-html-head/src/page-svg-title.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head></head><body><svg><title>icon label</title></svg><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/src/page-template.html
+++ b/test/configCases/html/output-html-head/src/page-template.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><template><meta name="viewport" content="inert"><template><div></div></template><meta name="keywords" content="inert"></template><meta name="existing" content="yes"></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-head/test.js
+++ b/test/configCases/html/output-html-head/test.js
@@ -108,3 +108,91 @@ it("authored base-only: base inserted at head start when no charset present", ()
 	expect(html).toMatch(/<base href="\/assets\/">/);
 	expect(html).toMatch(/<head><base href="\/assets\/">/);
 });
+
+it("special chars: $-patterns in option values are not expanded", () => {
+	const html = read("page-special-chars.html");
+	expect(html).toContain("<title>Save $$$ now &amp; more</title>");
+	expect(html).toContain(
+		'<meta name="description" content="worth $&amp; to $` you">'
+	);
+	expect(html).toContain('<meta name="line-break" content="a&#10;b">');
+});
+
+it("implicit head: tags injected into implicit head, not inside <header>", () => {
+	const html = read("page-implicit-head.html");
+	expect(html).toContain(
+		'<html><meta charset="utf-8"><base href="/x/"><title>No Head Doc</title><body>'
+	);
+	expect(html).toContain('<header class="top">x</header>');
+});
+
+it("svg title in body does not suppress page title injection", () => {
+	const html = read("page-svg-title.html");
+	expect(html).toContain("<title>Real Page Title</title>");
+	expect(html).toContain("<svg><title>icon label</title></svg>");
+});
+
+it("meta content mentioning 'charset' does not suppress charset injection", () => {
+	const html = read("page-charset-word.html");
+	expect(html).toContain('<meta charset="utf-8">');
+	expect(html).toContain('content="how to pick a charset"');
+});
+
+it("existing metas win: same-name/property option metas are skipped", () => {
+	const html = read("page-dup-meta.html");
+	expect(html.match(/<meta[^>]*viewport/g)).toHaveLength(1);
+	expect(html).toContain('content="width=device-width"');
+	expect(html.match(/<meta[^>]*description/g)).toHaveLength(1);
+	expect(html).toContain("content='authored'");
+	expect(html.match(/<meta[^>]*keywords/g)).toHaveLength(1);
+	expect(html.match(/<meta[^>]*og:title/g)).toHaveLength(1);
+	expect(html).toContain('content="Authored OG"');
+	expect(html).toContain('<meta name="author" content="Options Author">');
+});
+
+it("http-equiv charset declaration is respected and base follows it", () => {
+	const html = read("page-httpequiv.html");
+	expect(html).not.toContain("<meta charset=");
+	expect(html).toContain(
+		'charset=utf-8"><base href="/after-charset/">'
+	);
+});
+
+it("bare fragment without doctype/html/head still gets tags", () => {
+	const html = read("page-bare.html");
+	expect(html).toContain("<title>Bare Fragment</title>");
+});
+
+it("doctype without html/head tags: tags injected inside the implicit head", () => {
+	const html = read("page-doctype-only.html");
+	expect(html).toMatch(
+		/^<!doctype html><script src="[^"]+"><\/script><title>Doctype Only<\/title>/
+	);
+});
+
+it("synthetic: newline in title is entity-encoded and builds successfully", () => {
+	const html = read("synthetic-newline.html");
+	expect(html).toContain("<title>Line1&#10;Line2</title>");
+});
+
+it("commented-out tags do not count as existing", () => {
+	const html = read("page-comment.html");
+	expect(html).toContain("<title>Comment Proof</title>");
+	expect(html).toContain('<base href="/real/">');
+	expect(html).toContain('<meta charset="utf-8">');
+	expect(html).toContain("<!-- <title>Fake</title>");
+});
+
+it("template contents are inert, metas after the template still count", () => {
+	const html = read("page-template.html");
+	expect(html).toContain('<meta name="viewport" content="vp-from-options">');
+	expect(html.match(/content="inert"/g)).toHaveLength(2);
+	expect(html.match(/<meta[^>]*existing/g)).toHaveLength(1);
+	expect(html).not.toContain('content="no"');
+});
+
+it("entity-encoded meta names are decoded before dedup", () => {
+	const html = read("page-entity-meta.html");
+	expect(html).toContain('content="authored entity"');
+	expect(html).not.toContain('content="from options"');
+});

--- a/test/configCases/html/output-html-head/webpack.config.js
+++ b/test/configCases/html/output-html-head/webpack.config.js
@@ -99,5 +99,126 @@ module.exports = [
 		output: { html: { base: "/assets/" } },
 		experiments: { html: true },
 		plugins: [copyTest]
+	},
+	{
+		name: "special-chars",
+		entry: { "special-chars": "./src/page-special-chars.html" },
+		output: {
+			html: {
+				title: "Save $$$ now & more",
+				meta: { description: "worth $& to $` you", "line-break": "a\nb" }
+			}
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "implicit-head",
+		entry: { "implicit-head": "./src/page-implicit-head.html" },
+		output: {
+			html: {
+				title: "No Head Doc",
+				// eslint-disable-next-line unicorn/text-encoding-identifier-case
+				meta: { charset: "utf-8" },
+				base: "/x/"
+			}
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "svg-title",
+		entry: { "svg-title": "./src/page-svg-title.html" },
+		output: { html: { title: "Real Page Title" } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "charset-word",
+		entry: { "charset-word": "./src/page-charset-word.html" },
+		// eslint-disable-next-line unicorn/text-encoding-identifier-case
+		output: { html: { meta: { charset: "utf-8" } } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "dup-meta",
+		entry: { "dup-meta": "./src/page-dup-meta.html" },
+		output: {
+			html: {
+				meta: {
+					viewport: "width=device-width, initial-scale=1",
+					description: "from options",
+					keywords: "from,options",
+					"og:title": "Options OG",
+					author: "Options Author"
+				}
+			}
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "httpequiv",
+		entry: { httpequiv: "./src/page-httpequiv.html" },
+		output: {
+			// eslint-disable-next-line unicorn/text-encoding-identifier-case
+			html: { meta: { charset: "utf-8" }, base: "/after-charset/" }
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "bare",
+		entry: { bare: "./src/page-bare.html" },
+		output: { html: { title: "Bare Fragment" } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "doctype-only",
+		entry: { "doctype-only": "./src/page-doctype-only.html" },
+		output: { html: { title: "Doctype Only" } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "synthetic-newline",
+		entry: { "synthetic-newline": { import: ["./src/main.js"], html: true } },
+		output: { html: { title: "Line1\nLine2" } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "comment",
+		entry: { comment: "./src/page-comment.html" },
+		output: {
+			html: {
+				title: "Comment Proof",
+				// eslint-disable-next-line unicorn/text-encoding-identifier-case
+				meta: { charset: "utf-8" },
+				base: "/real/"
+			}
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "template",
+		entry: { template: "./src/page-template.html" },
+		output: {
+			html: {
+				meta: { viewport: "vp-from-options", existing: "no" }
+			}
+		},
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "entity-meta",
+		entry: { "entity-meta": "./src/page-entity-meta.html" },
+		output: { html: { meta: { description: "from options" } } },
+		experiments: { html: true },
+		plugins: [copyTest]
 	}
 ];

--- a/test/html5lib.spectest.js
+++ b/test/html5lib.spectest.js
@@ -24,8 +24,8 @@ const {
 	NS_MATHML,
 	NS_SVG,
 	NodeType,
-	buildHtmlAst,
-	decodeHtmlEntities
+	buildAst,
+	decodeEntities
 } = require("../lib/html/syntax");
 const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
@@ -236,7 +236,7 @@ const serialize = (root) => {
 			lines.push(
 				`| ${"  ".repeat(depth + 1)}${
 					a.serializedName || a.name
-				}="${decodeHtmlEntities(a.value, true)}"`
+				}="${decodeEntities(a.value, true)}"`
 			);
 		}
 		const tc = A.templateContent(node);
@@ -328,7 +328,7 @@ const parseDat = (text) => {
  * @returns {string} serialized tree
  */
 const runTreeCase = (c) => {
-	const doc = buildHtmlAst(c.data, c.fragment || undefined);
+	const doc = buildAst(c.data, c.fragment || undefined);
 	// In fragment mode the result is the children of the synthesized root.
 	const first = A.firstChild(doc);
 	return serialize(c.fragment && first !== 0 ? first : doc);

--- a/test/walkHtmlTokens.unittest.js
+++ b/test/walkHtmlTokens.unittest.js
@@ -433,6 +433,32 @@ describe("walkTokens", () => {
 		]);
 	});
 
+	it("should handle RAWTEXT for iframe and noembed elements", () => {
+		for (const tag of ["iframe", "noembed"]) {
+			/** @type {unknown[]} */
+			const results = [];
+			walkTokens(`<${tag}><b>not a tag</b></${tag}>`, 0, {
+				openTag: (input, start, end, ns, ne) => {
+					results.push(["open", input.slice(ns, ne)]);
+					return end;
+				},
+				closeTag: (input, start, end, ns, ne) => {
+					results.push(["close", input.slice(ns, ne)]);
+					return end;
+				},
+				text: (input, start, end) => {
+					results.push(["text", input.slice(start, end)]);
+					return end;
+				}
+			});
+			expect(results).toEqual([
+				["open", tag],
+				["text", "<b>not a tag</b>"],
+				["close", tag]
+			]);
+		}
+	});
+
 	it("should handle script data state", () => {
 		/** @type {unknown[]} */
 		const results = [];

--- a/test/walkHtmlTokens.unittest.js
+++ b/test/walkHtmlTokens.unittest.js
@@ -8,12 +8,14 @@ const {
 	QUOTE_DOUBLE,
 	QUOTE_NONE,
 	QUOTE_SINGLE,
-	decodeHtmlEntities,
-	decodeHtmlEntitiesWithMap,
-	walkHtmlTokens
+	decodeEntities,
+	decodeEntitiesWithMap,
+	escapeAttribute,
+	escapeText,
+	walkTokens
 } = require("../lib/html/syntax");
 
-describe("walkHtmlTokens", () => {
+describe("walkTokens", () => {
 	const casesPath = path.resolve(__dirname, "./fixtures/html/parsing/cases");
 	const tests = fs
 		.readdirSync(casesPath)
@@ -28,7 +30,7 @@ describe("walkHtmlTokens", () => {
 			/** @type {unknown[]} */
 			const results = [];
 
-			walkHtmlTokens(code, 0, {
+			walkTokens(code, 0, {
 				openTag: (input, start, end, nameStart, nameEnd, selfClosing) => {
 					results.push([
 						"open-tag",
@@ -88,7 +90,7 @@ describe("walkHtmlTokens", () => {
 			// Roundtrip: concatenating all token values must reconstruct the original
 			/** @type {unknown[]} */
 			const reconstructed = [];
-			walkHtmlTokens(code, 0, {
+			walkTokens(code, 0, {
 				openTag: (input, start, end) => {
 					reconstructed.push(input.slice(start, end));
 					return end;
@@ -118,7 +120,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle empty input", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("", 0, {
+		walkTokens("", 0, {
 			text: (input, start, end) => {
 				results.push(input.slice(start, end));
 				return end;
@@ -130,7 +132,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle plain text with no tags", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("hello world", 0, {
+		walkTokens("hello world", 0, {
 			text: (input, start, end) => {
 				results.push(input.slice(start, end));
 				return end;
@@ -142,7 +144,7 @@ describe("walkHtmlTokens", () => {
 	it("should detect self-closing tags", () => {
 		/** @type {unknown[]} */
 		const tags = [];
-		walkHtmlTokens("<br/><img src='x'/>", 0, {
+		walkTokens("<br/><img src='x'/>", 0, {
 			openTag: (input, start, end, nameStart, nameEnd, selfClosing) => {
 				tags.push([input.slice(nameStart, nameEnd), selfClosing]);
 				return end;
@@ -157,7 +159,7 @@ describe("walkHtmlTokens", () => {
 	it("should parse boolean attributes", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
-		walkHtmlTokens('<input disabled required type="text">', 0, {
+		walkTokens('<input disabled required type="text">', 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
 				attrs.push([
 					input.slice(ns, ne),
@@ -175,38 +177,10 @@ describe("walkHtmlTokens", () => {
 		]);
 	});
 
-	it("should route quote/lt-led attribute names through the attribute-name state", () => {
-		/** @type {unknown[]} */
-		const attrs = [];
-		/** @type {unknown[]} */
-		const errors = [];
-		walkHtmlTokens("<div \"x=1 'y>", 0, {
-			attribute: (input, ns, ne, vs, ve, qt) => {
-				attrs.push([
-					input.slice(ns, ne),
-					vs === -1 ? null : input.slice(vs, ve)
-				]);
-				if (vs === -1) return ne;
-				return qt !== QUOTE_NONE ? ve + 1 : ve;
-			},
-			parseError: (input, code) => {
-				errors.push(code);
-			}
-		});
-		expect(attrs).toEqual([
-			['"x', "1"],
-			["'y", null]
-		]);
-		expect(errors).toEqual([
-			"unexpected-character-in-attribute-name",
-			"unexpected-character-in-attribute-name"
-		]);
-	});
-
 	it("should handle all quote types", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
-		walkHtmlTokens("<div a=\"1\" b='2' c=3>", 0, {
+		walkTokens("<div a=\"1\" b='2' c=3>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
 				attrs.push([input.slice(ns, ne), input.slice(vs, ve), qt]);
 				if (qt !== QUOTE_NONE) return ve + 1;
@@ -223,7 +197,7 @@ describe("walkHtmlTokens", () => {
 	it("should parse comments", () => {
 		/** @type {unknown[]} */
 		const comments = [];
-		walkHtmlTokens("before<!-- hi -->after", 0, {
+		walkTokens("before<!-- hi -->after", 0, {
 			comment: (input, start, end) => {
 				comments.push(input.slice(start, end));
 				return end;
@@ -235,7 +209,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle lone < at EOF", () => {
 		/** @type {unknown[]} */
 		const texts = [];
-		walkHtmlTokens("hello<", 0, {
+		walkTokens("hello<", 0, {
 			text: (input, start, end) => {
 				texts.push(input.slice(start, end));
 				return end;
@@ -247,7 +221,7 @@ describe("walkHtmlTokens", () => {
 	it("should parse DOCTYPE as doctype", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<!DOCTYPE html><div>hi</div>", 0, {
+		walkTokens("<!DOCTYPE html><div>hi</div>", 0, {
 			doctype: (input, start, end) => {
 				results.push(["doctype", input.slice(start, end)]);
 				return end;
@@ -276,7 +250,7 @@ describe("walkHtmlTokens", () => {
 	it("should parse DOCTYPE case-insensitively", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<!doctype html><!DoCtYpE html>", 0, {
+		walkTokens("<!doctype html><!DoCtYpE html>", 0, {
 			doctype: (input, start, end) => {
 				results.push(input.slice(start, end));
 				return end;
@@ -288,7 +262,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle CDATA sections", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<div><![CDATA[<img src='x'>]]></div>", 0, {
+		walkTokens("<div><![CDATA[<img src='x'>]]></div>", 0, {
 			comment: (input, start, end) => {
 				results.push(["comment", input.slice(start, end)]);
 				return end;
@@ -313,7 +287,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle nested brackets in CDATA", () => {
 		/** @type {unknown[]} */
 		const comments = [];
-		walkHtmlTokens("<![CDATA[a]b]]c]]>", 0, {
+		walkTokens("<![CDATA[a]b]]c]]>", 0, {
 			comment: (input, start, end) => {
 				comments.push(input.slice(start, end));
 				return end;
@@ -325,7 +299,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle nested <!-- inside comments", () => {
 		/** @type {unknown[]} */
 		const comments = [];
-		walkHtmlTokens("<!-- outer <!-- inner -->", 0, {
+		walkTokens("<!-- outer <!-- inner -->", 0, {
 			comment: (input, start, end) => {
 				comments.push(input.slice(start, end));
 				return end;
@@ -337,7 +311,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle EOF in DOCTYPE", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<!DOCTYPE html", 0, {
+		walkTokens("<!DOCTYPE html", 0, {
 			doctype: (input, start, end) => {
 				results.push(input.slice(start, end));
 				return end;
@@ -349,7 +323,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle EOF in CDATA", () => {
 		/** @type {unknown[]} */
 		const comments = [];
-		walkHtmlTokens("<![CDATA[unclosed", 0, {
+		walkTokens("<![CDATA[unclosed", 0, {
 			comment: (input, start, end) => {
 				comments.push(input.slice(start, end));
 				return end;
@@ -362,7 +336,7 @@ describe("walkHtmlTokens", () => {
 		const html = "<!DOCTYPE html><html><body><![CDATA[data]]></body></html>";
 		/** @type {unknown[]} */
 		const parts = [];
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -390,7 +364,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle RCDATA for title element", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<title>Hello <b>World</b></title>", 0, {
+		walkTokens("<title>Hello <b>World</b></title>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -414,7 +388,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle RCDATA for textarea element", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<textarea><p>not a tag</p></textarea>", 0, {
+		walkTokens("<textarea><p>not a tag</p></textarea>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -438,7 +412,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle RAWTEXT for style element", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<style>.a { color: red; }</style>", 0, {
+		walkTokens("<style>.a { color: red; }</style>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -462,7 +436,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle script data state", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<script>var x = 1 < 2;</script>", 0, {
+		walkTokens("<script>var x = 1 < 2;</script>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -486,7 +460,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle script data escaped state (<!-- inside script)", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<script><!--- comment --></script>", 0, {
+		walkTokens("<script><!--- comment --></script>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -510,24 +484,20 @@ describe("walkHtmlTokens", () => {
 	it("should handle script data double escaped state transitions (<script and </script)", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens(
-			"<script><!-- <script> var x = 1; </script> --></script>",
-			0,
-			{
-				openTag: (input, start, end, ns, ne) => {
-					results.push(["open", input.slice(ns, ne)]);
-					return end;
-				},
-				closeTag: (input, start, end, ns, ne) => {
-					results.push(["close", input.slice(ns, ne)]);
-					return end;
-				},
-				text: (input, start, end) => {
-					results.push(["text", input.slice(start, end)]);
-					return end;
-				}
+		walkTokens("<script><!-- <script> var x = 1; </script> --></script>", 0, {
+			openTag: (input, start, end, ns, ne) => {
+				results.push(["open", input.slice(ns, ne)]);
+				return end;
+			},
+			closeTag: (input, start, end, ns, ne) => {
+				results.push(["close", input.slice(ns, ne)]);
+				return end;
+			},
+			text: (input, start, end) => {
+				results.push(["text", input.slice(start, end)]);
+				return end;
 			}
-		);
+		});
 		expect(results).toEqual([
 			["open", "script"],
 			["text", "<!-- <script> var x = 1; </script> -->"],
@@ -543,7 +513,7 @@ describe("walkHtmlTokens", () => {
 		const html = "<script><!--<script>x</scripts>y</script>--></script>";
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -572,7 +542,7 @@ describe("walkHtmlTokens", () => {
 		const html = "<script><!--<script></script></script>";
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -596,7 +566,7 @@ describe("walkHtmlTokens", () => {
 	it("should not match wrong end tag in RCDATA", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<title>text</div></title>", 0, {
+		walkTokens("<title>text</div></title>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -620,7 +590,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle case-insensitive end tags in content modes", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<style>.a{}</STYLE>", 0, {
+		walkTokens("<style>.a{}</STYLE>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -641,51 +611,12 @@ describe("walkHtmlTokens", () => {
 		]);
 	});
 
-	it("should flush unterminated raw-text bodies at EOF (no further `<`)", () => {
-		// Drives the content-mode fast-forwards when `indexOf` finds no next
-		// `<` (RCDATA / RAWTEXT / script data run to end of input).
-		for (const [source, tag, body] of [
-			["<title>left open", "title", "left open"],
-			["<style>.a{color:red}", "style", ".a{color:red}"],
-			["<script>var x = 1;", "script", "var x = 1;"]
-		]) {
-			/** @type {unknown[]} */
-			const results = [];
-			walkHtmlTokens(source, 0, {
-				openTag: (input, start, end, ns, ne) => {
-					results.push(["open", input.slice(ns, ne)]);
-					return end;
-				},
-				text: (input, start, end) => {
-					results.push(["text", input.slice(start, end)]);
-					return end;
-				}
-			});
-			expect(results).toEqual([
-				["open", tag],
-				["text", body]
-			]);
-		}
-	});
-
-	it("should handle character references in RCDATA text", () => {
-		/** @type {unknown[]} */
-		const results = [];
-		walkHtmlTokens("<title>a &amp; b</title>", 0, {
-			text: (input, start, end) => {
-				results.push(input.slice(start, end));
-				return end;
-			}
-		});
-		expect(results).toEqual(["a &amp; b"]);
-	});
-
 	it("should roundtrip HTML with script and style", () => {
 		const html =
 			"<html><head><style>.a{}</style></head><body><script>var x=1;</script></body></html>";
 		/** @type {unknown[]} */
 		const parts = [];
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -705,7 +636,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle PLAINTEXT state", () => {
 		/** @type {unknown[]} */
 		const results = [];
-		walkHtmlTokens("<div><plaintext><p>ignored</p></div>", 0, {
+		walkTokens("<div><plaintext><p>ignored</p></div>", 0, {
 			openTag: (input, start, end, ns, ne) => {
 				results.push(["open", input.slice(ns, ne)]);
 				return end;
@@ -730,7 +661,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>Tom &amp; Jerry</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -750,7 +681,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle named character references in double-quoted attributes", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
-		walkHtmlTokens('<a href="?a=1&amp;b=2">', 0, {
+		walkTokens('<a href="?a=1&amp;b=2">', 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
 				attrs.push([input.slice(ns, ne), input.slice(vs, ve)]);
 				if (qt !== QUOTE_NONE) return ve + 1;
@@ -763,7 +694,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle named character references in single-quoted attributes", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
-		walkHtmlTokens("<a href='?x=1&lt;2'>", 0, {
+		walkTokens("<a href='?x=1&lt;2'>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
 				attrs.push([input.slice(ns, ne), input.slice(vs, ve)]);
 				if (qt !== QUOTE_NONE) return ve + 1;
@@ -776,7 +707,7 @@ describe("walkHtmlTokens", () => {
 	it("should handle character references in unquoted attributes", () => {
 		/** @type {unknown[]} */
 		const attrs = [];
-		walkHtmlTokens("<a href=foo&amp;bar>", 0, {
+		walkTokens("<a href=foo&amp;bar>", 0, {
 			attribute: (input, ns, ne, vs, ve, qt) => {
 				attrs.push([input.slice(ns, ne), input.slice(vs, ve)]);
 				if (qt !== QUOTE_NONE) return ve + 1;
@@ -790,7 +721,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#65;&#66;&#67;</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -811,7 +742,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#x41;&#X42;</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -832,7 +763,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>bare & alone</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -853,7 +784,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&unknown;</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -874,7 +805,7 @@ describe("walkHtmlTokens", () => {
 		/** @type {unknown[]} */
 		const parts = [];
 		const html = "<p>&#;&#x;</p>";
-		walkHtmlTokens(html, 0, {
+		walkTokens(html, 0, {
 			openTag: (input, start, end) => {
 				parts.push(input.slice(start, end));
 				return end;
@@ -899,7 +830,7 @@ describe("walkHtmlTokens", () => {
 		const walk = (html) => {
 			/** @type {[string, ...EXPECTED_ANY[]][]} */
 			const out = [];
-			walkHtmlTokens(html, 0, {
+			walkTokens(html, 0, {
 				openTag: (input, start, end, ns, ne, selfClosing) => {
 					out.push(["open", input.slice(ns, ne), selfClosing]);
 					return end;
@@ -942,7 +873,7 @@ describe("walkHtmlTokens", () => {
 		const roundtrip = (html) => {
 			/** @type {unknown[]} */
 			const parts = [];
-			walkHtmlTokens(html, 0, {
+			walkTokens(html, 0, {
 				openTag: (input, start, end) => {
 					parts.push(input.slice(start, end));
 					return end;
@@ -1974,7 +1905,7 @@ describe("walkHtmlTokens", () => {
 
 		// --- Callback API surface: default arguments + missing callbacks ---
 		it("default arguments: walks with no pos/callbacks provided", () => {
-			expect(() => walkHtmlTokens("<a>hello</a>")).not.toThrow();
+			expect(() => walkTokens("<a>hello</a>")).not.toThrow();
 		});
 
 		it("missing closeTag/comment/doctype callbacks are tolerated", () => {
@@ -1984,7 +1915,7 @@ describe("walkHtmlTokens", () => {
 			/** @type {unknown[]} */
 			const opens = [];
 			expect(() =>
-				walkHtmlTokens("<!DOCTYPE html><!-- c --><a>x</a><![CDATA[ y ]]>", 0, {
+				walkTokens("<!DOCTYPE html><!-- c --><a>x</a><![CDATA[ y ]]>", 0, {
 					openTag: (input, start, end) => {
 						opens.push(input.slice(start, end));
 						return end;
@@ -1996,11 +1927,7 @@ describe("walkHtmlTokens", () => {
 
 		it("missing all callbacks is tolerated", () => {
 			expect(() =>
-				walkHtmlTokens(
-					"<!DOCTYPE html><!-- c --><a>x</a><![CDATA[ y ]]>z",
-					0,
-					{}
-				)
+				walkTokens("<!DOCTYPE html><!-- c --><a>x</a><![CDATA[ y ]]>z", 0, {})
 			).not.toThrow();
 		});
 
@@ -2019,7 +1946,7 @@ describe("walkHtmlTokens", () => {
 				"<!-- eof" // EOF inside comment
 			];
 			for (const html of fragments) {
-				expect(() => walkHtmlTokens(html, 0, {})).not.toThrow();
+				expect(() => walkTokens(html, 0, {})).not.toThrow();
 			}
 		});
 
@@ -2045,7 +1972,7 @@ describe("walkHtmlTokens", () => {
 				"<!DOCTYPE" // EOF inside doctype
 			];
 			for (const html of fragments) {
-				expect(() => walkHtmlTokens(html, 0, {})).not.toThrow();
+				expect(() => walkTokens(html, 0, {})).not.toThrow();
 			}
 		});
 
@@ -2084,7 +2011,7 @@ describe("walkHtmlTokens", () => {
 					// Skip one character past `>` so nextPos > end.
 					return end + 1;
 				};
-			walkHtmlTokens(
+			walkTokens(
 				"<script>x</script>" +
 					"<a foo>y</a>" +
 					"<b foo=bar>z</b>" +
@@ -2141,7 +2068,7 @@ describe("walkHtmlTokens", () => {
 		const collectErrors = (html) => {
 			/** @type {{ code: string, slice: string, severity: string }[]} */
 			const errors = [];
-			walkHtmlTokens(html, 0, {
+			walkTokens(html, 0, {
 				parseError: (input, code, start, end, severity) => {
 					errors.push({ code, slice: input.slice(start, end), severity });
 				}
@@ -2548,7 +2475,7 @@ describe("walkHtmlTokens", () => {
 			const errors = [];
 			/** @type {string[]} */
 			const opens = [];
-			walkHtmlTokens('<div class="x', 0, {
+			walkTokens('<div class="x', 0, {
 				openTag: (input, start, end, ns, ne) => {
 					opens.push(input.slice(ns, ne));
 					return end;
@@ -2571,7 +2498,7 @@ describe("walkHtmlTokens", () => {
 			const codes = [];
 			/** @type {string[]} */
 			const closes = [];
-			walkHtmlTokens("<a></a", 0, {
+			walkTokens("<a></a", 0, {
 				closeTag: (input, start, end, ns, ne) => {
 					closes.push(input.slice(ns, ne));
 					return end;
@@ -2598,7 +2525,7 @@ describe("walkHtmlTokens", () => {
 			]) {
 				/** @type {string[]} */
 				const closes = [];
-				walkHtmlTokens(html, 0, {
+				walkTokens(html, 0, {
 					openTag: (input, start, end) => end,
 					closeTag: (input, start, end, ns, ne) => {
 						closes.push(input.slice(ns, ne));
@@ -2628,7 +2555,7 @@ describe("walkHtmlTokens", () => {
 			const codes = [];
 			/** @type {[string, string][]} */
 			const attrs = [];
-			walkHtmlTokens("<div data-x", 0, {
+			walkTokens("<div data-x", 0, {
 				openTag: (input, start, end) => end,
 				attribute: (input, ns, ne, vs, ve) => {
 					attrs.push([
@@ -2651,7 +2578,7 @@ describe("walkHtmlTokens", () => {
 			// `&amp` mid-attribute-value at EOF: returnState is the attribute
 			// value (double-quoted) state, so the EOF unwinds back to a partial
 			// open tag and emits eof-in-tag.
-			walkHtmlTokens('<a href="x&amp', 0, {
+			walkTokens('<a href="x&amp', 0, {
 				openTag: (input, start, end, ns, ne) => {
 					opens.push(input.slice(ns, ne));
 					return end;
@@ -2681,7 +2608,7 @@ describe("walkHtmlTokens", () => {
 			const codes = [];
 			/** @type {string[]} */
 			const comments = [];
-			walkHtmlTokens("<!x", 0, {
+			walkTokens("<!x", 0, {
 				comment: (input, start, end) => {
 					comments.push(input.slice(start, end));
 					return end;
@@ -2746,9 +2673,9 @@ describe("walkHtmlTokens", () => {
 		});
 	});
 
-	describe("decodeHtmlEntities", () => {
+	describe("decodeEntities", () => {
 		it("should decode core named entities", () => {
-			expect(decodeHtmlEntities("&amp;&lt;&gt;&quot;&apos;&nbsp;")).toBe(
+			expect(decodeEntities("&amp;&lt;&gt;&quot;&apos;&nbsp;")).toBe(
 				"&<>\"'\u00A0"
 			);
 		});
@@ -2756,29 +2683,29 @@ describe("walkHtmlTokens", () => {
 		it("should decode legacy named entities without trailing semicolon", () => {
 			// `&AMP` and `&copy` are legacy bare-form entities in the WHATWG
 			// named character references table.
-			expect(decodeHtmlEntities("&AMP")).toBe("&");
-			expect(decodeHtmlEntities("&copy")).toBe("\u00A9");
+			expect(decodeEntities("&AMP")).toBe("&");
+			expect(decodeEntities("&copy")).toBe("\u00A9");
 		});
 
 		it("should decode entities outside the BMP and multi-codepoint entities", () => {
-			expect(decodeHtmlEntities("&AElig;")).toBe("\u00C6");
+			expect(decodeEntities("&AElig;")).toBe("\u00C6");
 			// `&NotEqualTilde;` is a multi-codepoint named reference (\u2242 + combining slash).
-			expect(decodeHtmlEntities("&NotEqualTilde;")).toBe("\u2242\u0338");
+			expect(decodeEntities("&NotEqualTilde;")).toBe("\u2242\u0338");
 		});
 
 		it("should apply longest-prefix backtrack per WHATWG", () => {
 			// `&notpre;` is not in the table, but `&not` is \u2014 the prefix matches
 			// and the remainder `pre;` is left as literal text.
-			expect(decodeHtmlEntities("&notpre;")).toBe("\u00ACpre;");
+			expect(decodeEntities("&notpre;")).toBe("\u00ACpre;");
 		});
 
 		it("should decode numeric decimal references", () => {
-			expect(decodeHtmlEntities("&#65;&#66;&#67;")).toBe("ABC");
+			expect(decodeEntities("&#65;&#66;&#67;")).toBe("ABC");
 		});
 
 		it("should decode numeric references without trailing semicolon", () => {
-			expect(decodeHtmlEntities("&#65")).toBe("A");
-			expect(decodeHtmlEntities("&#x41")).toBe("A");
+			expect(decodeEntities("&#65")).toBe("A");
+			expect(decodeEntities("&#x41")).toBe("A");
 		});
 
 		it("should not let decimal references swallow trailing hex-letter chars", () => {
@@ -2786,20 +2713,20 @@ describe("walkHtmlTokens", () => {
 			// `&#65b` should decode `&#65` → `A` and leave the trailing `b` as
 			// literal text (the earlier regex matched `[0-9a-fA-F]+` for both
 			// hex and decimal and incorrectly swallowed the `b`).
-			expect(decodeHtmlEntities("&#65b")).toBe("Ab");
-			expect(decodeHtmlEntities("&#1f")).toBe("f");
+			expect(decodeEntities("&#65b")).toBe("Ab");
+			expect(decodeEntities("&#1f")).toBe("f");
 		});
 
 		it("should decode numeric hexadecimal references", () => {
-			expect(decodeHtmlEntities("&#x41;&#x42;&#x43;")).toBe("ABC");
-			expect(decodeHtmlEntities("&#X41;&#X42;&#X43;")).toBe("ABC");
+			expect(decodeEntities("&#x41;&#x42;&#x43;")).toBe("ABC");
+			expect(decodeEntities("&#X41;&#X42;&#X43;")).toBe("ABC");
 		});
 
 		it("should leave unknown or incomplete entities as literals", () => {
-			expect(decodeHtmlEntities("&zzzunknown;")).toBe("&zzzunknown;");
-			expect(decodeHtmlEntities("&#;")).toBe("&#;");
-			expect(decodeHtmlEntities("&#x;")).toBe("&#x;");
-			expect(decodeHtmlEntities("bare & alone")).toBe("bare & alone");
+			expect(decodeEntities("&zzzunknown;")).toBe("&zzzunknown;");
+			expect(decodeEntities("&#;")).toBe("&#;");
+			expect(decodeEntities("&#x;")).toBe("&#x;");
+			expect(decodeEntities("bare & alone")).toBe("bare & alone");
 		});
 
 		it("should not match inherited Object.prototype keys as entities", () => {
@@ -2807,43 +2734,43 @@ describe("walkHtmlTokens", () => {
 			// would return `Object.prototype.toString` and the lookup would
 			// falsely treat the entity as matched. The generated table now uses
 			// a null prototype so these names stay literal.
-			expect(decodeHtmlEntities("&toString;")).toBe("&toString;");
-			expect(decodeHtmlEntities("&constructor;")).toBe("&constructor;");
-			expect(decodeHtmlEntities("&hasOwnProperty;")).toBe("&hasOwnProperty;");
+			expect(decodeEntities("&toString;")).toBe("&toString;");
+			expect(decodeEntities("&constructor;")).toBe("&constructor;");
+			expect(decodeEntities("&hasOwnProperty;")).toBe("&hasOwnProperty;");
 		});
 
 		it("should handle mixed text and entities", () => {
-			expect(decodeHtmlEntities("foo &amp; bar &#x41; baz")).toBe(
+			expect(decodeEntities("foo &amp; bar &#x41; baz")).toBe(
 				"foo & bar A baz"
 			);
 		});
 
 		it("should fast-path strings with no `&`", () => {
-			expect(decodeHtmlEntities("plain text")).toBe("plain text");
+			expect(decodeEntities("plain text")).toBe("plain text");
 		});
 
 		it("should replace numeric references above U+10FFFF with U+FFFD", () => {
-			expect(decodeHtmlEntities("&#x110000;")).toBe("�");
-			expect(decodeHtmlEntities("&#1114112;")).toBe("�");
+			expect(decodeEntities("&#x110000;")).toBe("�");
+			expect(decodeEntities("&#1114112;")).toBe("�");
 		});
 
 		it("should replace NULL and surrogate numeric references with U+FFFD", () => {
-			expect(decodeHtmlEntities("&#0;")).toBe("�");
-			expect(decodeHtmlEntities("&#x0;")).toBe("�");
-			expect(decodeHtmlEntities("&#xD800;")).toBe("�");
-			expect(decodeHtmlEntities("&#xDFFF;")).toBe("�");
-			expect(decodeHtmlEntities("&#55296;")).toBe("�");
+			expect(decodeEntities("&#0;")).toBe("�");
+			expect(decodeEntities("&#x0;")).toBe("�");
+			expect(decodeEntities("&#xD800;")).toBe("�");
+			expect(decodeEntities("&#xDFFF;")).toBe("�");
+			expect(decodeEntities("&#55296;")).toBe("�");
 		});
 
 		it("should remap C1 numeric references via the Windows-1252 table", () => {
 			// `&#x80;` (Windows-1252 euro sign) per WHATWG remaps to U+20AC.
-			expect(decodeHtmlEntities("&#x80;")).toBe("€");
+			expect(decodeEntities("&#x80;")).toBe("€");
 			// `&#x99;` remaps to U+2122 (trade mark sign).
-			expect(decodeHtmlEntities("&#x99;")).toBe("™");
+			expect(decodeEntities("&#x99;")).toBe("™");
 			// `&#x9F;` remaps to U+0178 (Ÿ).
-			expect(decodeHtmlEntities("&#x9F;")).toBe("Ÿ");
+			expect(decodeEntities("&#x9F;")).toBe("Ÿ");
 			// C1 control codepoints with no remap entry pass through.
-			expect(decodeHtmlEntities("&#x81;")).toBe("");
+			expect(decodeEntities("&#x81;")).toBe("");
 		});
 
 		it("should stay linear-time on long alphanumeric runs after `&`", () => {
@@ -2851,41 +2778,41 @@ describe("walkHtmlTokens", () => {
 			// WHATWG entity name, otherwise inputs like `&` + thousands of chars
 			// trigger O(n²) substring allocations.
 			const longRun = "a".repeat(1000);
-			expect(decodeHtmlEntities(`&${longRun}`)).toBe(`&${longRun}`);
+			expect(decodeEntities(`&${longRun}`)).toBe(`&${longRun}`);
 			// `&amp` prefix at the start still decodes; the rest is appended verbatim.
-			expect(decodeHtmlEntities(`&amp${longRun}`)).toBe(`&${longRun}`);
+			expect(decodeEntities(`&amp${longRun}`)).toBe(`&${longRun}`);
 		});
 
 		it("should apply the consumed-as-part-of-an-attribute rule when asked", () => {
 			// In text context, `&amp=foo` decodes to `&=foo`.
-			expect(decodeHtmlEntities("&amp=foo")).toBe("&=foo");
+			expect(decodeEntities("&amp=foo")).toBe("&=foo");
 			// In attribute context, the same input stays literal.
-			expect(decodeHtmlEntities("&amp=foo", true)).toBe("&amp=foo");
+			expect(decodeEntities("&amp=foo", true)).toBe("&amp=foo");
 			// `&amp;=foo` (with semicolon) decodes regardless of context.
-			expect(decodeHtmlEntities("&amp;=foo", true)).toBe("&=foo");
+			expect(decodeEntities("&amp;=foo", true)).toBe("&=foo");
 			// Longest-prefix leftover case: `&ampx` → `&amp` matches but leftover
 			// `x` is alphanumeric, so in attribute context this stays literal.
-			expect(decodeHtmlEntities("&ampX", true)).toBe("&ampX");
+			expect(decodeEntities("&ampX", true)).toBe("&ampX");
 			// In text context it still decodes the prefix.
-			expect(decodeHtmlEntities("&ampX")).toBe("&X");
+			expect(decodeEntities("&ampX")).toBe("&X");
 		});
 	});
 
-	describe("decodeHtmlEntitiesWithMap", () => {
+	describe("decodeEntitiesWithMap", () => {
 		it("should return the input and no map when nothing decodes", () => {
-			expect(decodeHtmlEntitiesWithMap("plain text")).toEqual({
+			expect(decodeEntitiesWithMap("plain text")).toEqual({
 				text: "plain text",
 				map: undefined
 			});
 			// Attribute rule keeps `&amp=1` literal — no map either.
-			expect(decodeHtmlEntitiesWithMap("&amp=1", true)).toEqual({
+			expect(decodeEntitiesWithMap("&amp=1", true)).toEqual({
 				text: "&amp=1",
 				map: undefined
 			});
 		});
 
 		it("should map decoded boundaries back to raw offsets", () => {
-			const { text, map } = decodeHtmlEntitiesWithMap("a&amp;b", true);
+			const { text, map } = decodeEntitiesWithMap("a&amp;b", true);
 			expect(text).toBe("a&b");
 			// Boundaries: `a` 0, decoded `&` starts at raw 1, `b` at raw 6, end 7.
 			expect(map).toEqual([0, 1, 6, 7]);
@@ -2899,9 +2826,53 @@ describe("walkHtmlTokens", () => {
 		});
 
 		it("should map around numeric references and trailing text", () => {
-			const { text, map } = decodeHtmlEntitiesWithMap("x&#32;yz", true);
+			const { text, map } = decodeEntitiesWithMap("x&#32;yz", true);
 			expect(text).toBe("x yz");
 			expect(map).toEqual([0, 1, 6, 7, 8]);
+		});
+	});
+
+	describe("escapeAttribute", () => {
+		it("should return the input unchanged when nothing needs escaping", () => {
+			const s = "plain value with spaces, <tags> and 'quotes'";
+			expect(escapeAttribute(s)).toBe(s);
+		});
+
+		it("should escape the WHATWG attribute-mode set", () => {
+			expect(escapeAttribute('a&b"c\u00A0d')).toBe("a&amp;b&quot;c&nbsp;d");
+		});
+
+		it("should not escape text-mode characters", () => {
+			expect(escapeAttribute("<b>")).toBe("<b>");
+		});
+
+		it("should encode CR/LF as numeric references", () => {
+			expect(escapeAttribute("a\nb\rc")).toBe("a&#10;b&#13;c");
+		});
+
+		it("should handle leading, trailing and consecutive escapes", () => {
+			expect(escapeAttribute('"a""')).toBe("&quot;a&quot;&quot;");
+			expect(escapeAttribute("&")).toBe("&amp;");
+			expect(escapeAttribute("")).toBe("");
+		});
+	});
+
+	describe("escapeText", () => {
+		it("should return the input unchanged when nothing needs escaping", () => {
+			const s = 'plain text with "quotes" and spaces';
+			expect(escapeText(s)).toBe(s);
+		});
+
+		it("should escape the WHATWG text-mode set", () => {
+			expect(escapeText("a&b<c>d\u00A0e")).toBe("a&amp;b&lt;c&gt;d&nbsp;e");
+		});
+
+		it("should not escape quotes", () => {
+			expect(escapeText("\"'")).toBe("\"'");
+		});
+
+		it("should encode CR/LF as numeric references", () => {
+			expect(escapeText("a\nb\rc")).toBe("a&#10;b&#13;c");
 		});
 	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -19189,7 +19189,7 @@ declare interface OutputHtmlOptions {
 		| ((asset: { chunk: Chunk; filename: string }) => false | string[]);
 
 	/**
-	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` or `twitter:` use the `property` attribute instead of `name`. Tags are always appended; the caller is responsible for avoiding duplicates in authored HTML.
+	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` use the `property` attribute instead of `name`. A tag is skipped if the HTML already contains a meta with the same name.
 	 */
 	meta?: { [index: string]: string };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes several bugs in the `output.html` title/meta/base injection from #21394 (`$`-pattern corruption via `String#replace`, `<header>` matched as `<head>`, body/SVG `<title>` suppressing injection, charset false positives, newlines breaking the synthetic `data:` wrapper) and moves injection into HtmlParser as presentational dependencies collected during the regular AST walk — no asset pass re-parses the page, existing tags always win (same-name metas now dedup like title/base/charset, matching other bundlers), and `data:` documents (synthetic wrappers, iframe srcdoc) are skipped. Also rewrites the escape helpers per the WHATWG escape-a-string algorithm as a single regex-free pass (2–6x faster), drops the redundant `Html` infix from the `html/syntax` exports to match the css syntax module, fixes raw-text elements closed via the text insertion mode not spanning their close tag in the AST, and corrects the schema note that claimed `twitter:` keys use `property=`. Refs #21394.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — regression cases in `test/configCases/html/output-html-head/` for every fixed bug and merge rule, plus `escapeAttribute`/`escapeText` unit tests in `test/walkHtmlTokens.unittest.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Document the `output.html` head-option merge semantics (existing tags win; only `og:` keys use `property=`) — the schema descriptions are updated in this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Implemented with Claude Code under my direction; I reviewed the design, code and tests, and all behavior was verified with real builds and benchmarks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NckWz8uMuacAePk8GDmWEj)_