### PR TITLE
fix: escape ? and # in context module regexp source map names

### DIFF
--- a/.changeset/context-module-regexp-source-name.md
+++ b/.changeset/context-module-regexp-source-name.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Escape `?` and `#` in context module regexp identifiers so source map names are not truncated.

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -232,7 +232,14 @@ class ContextModule extends Module {
 		const str = stripSlash
 			? regexString.source + regexString.flags
 			: `${regexString}`;
-		return str.replace(/!/g, "%21").replace(/\|/g, "%7C");
+		// Escape chars that are structural in the identifier/source-name URL
+		// (`!`/`|` separators, `?` query, `#` fragment) so a regex like
+		// `(?:a|b)` isn't misread and truncated when it becomes a source name.
+		return str
+			.replace(/!/g, "%21")
+			.replace(/\|/g, "%7C")
+			.replace(/\?/g, "%3F")
+			.replace(/#/g, "%23");
 	}
 
 	_createIdentifier() {

--- a/test/cases/context/issue-10969/index.js
+++ b/test/cases/context/issue-10969/index.js
@@ -1,4 +1,4 @@
-it("should replace ! with %21 in the module id string of the context module", function () {
+it("should replace ! with %21 and ? with %3F in the module id string of the context module", function () {
 	const moduleId = require.context(
 		"./folder",
 		true,
@@ -7,6 +7,6 @@ it("should replace ! with %21 in the module id string of the context module", fu
 	).id;
 	if (typeof moduleId !== "number")
 		expect(moduleId).toBe(
-			"./context/issue-10969/folder lazy recursive ^(?%21file1\\.js$).*$i"
+			"./context/issue-10969/folder lazy recursive ^(%3F%21file1\\.js$).*$i"
 		);
 });

--- a/test/configCases/source-map/context-module-source-path-regexp/foo/a.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/foo/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/source-map/context-module-source-path-regexp/foo/b.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/foo/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/source-map/context-module-source-path-regexp/index.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/index.js
@@ -1,0 +1,12 @@
+const name = Math.random() > 0.5 ? "a" : "b";
+require(`./foo/${name}.js`);
+
+it("context module regexp with `?`/`|` should produce a well-formed source name", () => {
+	const fs = require("fs");
+	const map = JSON.parse(fs.readFileSync(`${__filename}.map`, "utf-8"));
+	// The `?` and `|` inside the regexp are percent-encoded so the name is not
+	// truncated at the query separator and stays a single path segment.
+	expect(map.sources).toContain(
+		"webpack:///./foo/ sync [\\\\/](%3F:a%7Cb)\\.js$"
+	);
+});

--- a/test/configCases/source-map/context-module-source-path-regexp/index.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/index.js
@@ -6,7 +6,9 @@ it("context module regexp with `?`/`|` should produce a well-formed source name"
 	const map = JSON.parse(fs.readFileSync(`${__filename}.map`, "utf-8"));
 	// The `?` and `|` inside the regexp are percent-encoded so the name is not
 	// truncated at the query separator and stays a single path segment.
+	// (Regexp intentionally has no `/`: `RegExp.source` renders `/` differently
+	// across V8 versions, which would make the expected string node-dependent.)
 	expect(map.sources).toContain(
-		"webpack:///./foo/ sync [\\\\/](%3F:a%7Cb)\\.js$"
+		"webpack:///./foo/ sync (%3F:a%7Cb)\\.js$"
 	);
 });

--- a/test/configCases/source-map/context-module-source-path-regexp/webpack.config.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map",
+	plugins: [
+		new webpack.ContextReplacementPlugin(/foo$/, true, /[\\/](?:a|b)\.js$/)
+	]
+};

--- a/test/configCases/source-map/context-module-source-path-regexp/webpack.config.js
+++ b/test/configCases/source-map/context-module-source-path-regexp/webpack.config.js
@@ -8,7 +8,5 @@ module.exports = {
 		__filename: false
 	},
 	devtool: "source-map",
-	plugins: [
-		new webpack.ContextReplacementPlugin(/foo$/, true, /[\\/](?:a|b)\.js$/)
-	]
+	plugins: [new webpack.ContextReplacementPlugin(/foo$/, true, /(?:a|b)\.js$/)]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #16259. A context module embeds its `RegExp` into the identifier that becomes a `webpack://…` source-map name; `createFilename` then strips off a `?query`, so the first `?` in a regexp (e.g. a `(?:…)` group) truncated the name (`webpack:///./foo/ sync [\\/](`). `_prettyRegExp` already escaped `!` and `|`, so this extends it to also encode `?`→`%3F` and `#`→`%23`, keeping the whole regexp in the name.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/source-map/context-module-source-path-regexp/` asserts the full, non-truncated source name for a regexp containing `?` and `|`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Only context modules whose regexp contains `?`/`#` get a changed identifier (a one-time persistent-cache invalidation for those).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to investigate the issue, reproduce it, implement the escaping fix, and write the regression test; all changes were reviewed and verified against the test suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm3SFV8fefVytCVeJJ2g2q)_