### PR TITLE
perf: try to skip `hasSymbol` check in async module runtime

### DIFF
--- a/.changeset/async-module-symbol-runtime.md
+++ b/.changeset/async-module-symbol-runtime.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip `hasSymbol` check in async module runtime when `environment.symbol` is set.

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -31,17 +31,25 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 		const defer = this._deferInterop;
 		const cst = runtimeTemplate.renderConst();
 		const lt = runtimeTemplate.renderLet();
+		const supportsSymbol = runtimeTemplate.supportsSymbol();
+		/** @type {(name: string, fallback: string) => string} */
+		const renderSymbol = (name, fallback) =>
+			supportsSymbol
+				? `Symbol("${name}")`
+				: `hasSymbol ? Symbol("${name}") : "${fallback}"`;
 		return Template.asString([
-			`${cst} hasSymbol = typeof Symbol === "function";`,
-			`${cst} webpackQueues = hasSymbol ? Symbol("webpack queues") : "__webpack_queues__";`,
+			...(supportsSymbol
+				? []
+				: [`${cst} hasSymbol = typeof Symbol === "function";`]),
+			`${cst} webpackQueues = ${renderSymbol("webpack queues", "__webpack_queues__")};`,
 			`${cst} webpackExports = ${
 				defer ? `${RuntimeGlobals.asyncModuleExportSymbol}= ` : ""
-			}hasSymbol ? Symbol("webpack exports") : "${RuntimeGlobals.exports}";`,
-			`${cst} webpackError = hasSymbol ? Symbol("webpack error") : "__webpack_error__";`,
+			}${renderSymbol("webpack exports", RuntimeGlobals.exports)};`,
+			`${cst} webpackError = ${renderSymbol("webpack error", "__webpack_error__")};`,
 			defer
 				? Template.asString([
-						`${cst} webpackDone = ${RuntimeGlobals.asyncModuleDoneSymbol} = hasSymbol ? Symbol("webpack done") : "__webpack_done__";`,
-						`${cst} webpackDefer = ${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol} = hasSymbol ? Symbol("webpack defer") : "__webpack_defer__";`,
+						`${cst} webpackDone = ${RuntimeGlobals.asyncModuleDoneSymbol} = ${renderSymbol("webpack done", "__webpack_done__")};`,
+						`${cst} webpackDefer = ${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol} = ${renderSymbol("webpack defer", "__webpack_defer__")};`,
 						`${RuntimeGlobals.deferredModuleAsyncTransitiveDependencies} = ${runtimeTemplate.basicFunction(
 							"asyncDeps",
 							[
@@ -176,7 +184,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 								"q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn)))",
 								"q"
 							)};`,
-							`currentDeps.map(${runtimeTemplate.expressionFunction(
+							`currentDeps.forEach(${runtimeTemplate.expressionFunction(
 								`${
 									defer ? "dep[webpackDefer]||" : ""
 								}dep[webpackQueues](fnQueue)`,

--- a/test/configCases/async-module/environment-symbol/a.js
+++ b/test/configCases/async-module/environment-symbol/a.js
@@ -1,0 +1,3 @@
+await Promise.resolve();
+
+export const a = "a";

--- a/test/configCases/async-module/environment-symbol/index.js
+++ b/test/configCases/async-module/environment-symbol/index.js
@@ -1,0 +1,9 @@
+import fs from "fs";
+
+it("should respect environment.symbol in the async module runtime", async () => {
+	const { a } = await import("./a");
+	expect(a).toBe("a");
+	const source = fs.readFileSync(__filename, "utf-8");
+	// string split to not match this test's own source
+	expect(source.includes("has" + "Symbol ? Symbol(")).toBe(!SUPPORTS_SYMBOL);
+});

--- a/test/configCases/async-module/environment-symbol/webpack.config.js
+++ b/test/configCases/async-module/environment-symbol/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [true, false].map((symbol) => ({
+	output: {
+		environment: {
+			symbol
+		}
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			SUPPORTS_SYMBOL: JSON.stringify(symbol)
+		})
+	]
+}));


### PR DESCRIPTION

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

When `output.environment.symbol` is enabled, the async module runtime now emits `Symbol("...")` directly instead of the `typeof Symbol === "function"` check with string fallbacks, and an unused `currentDeps.map` result array is avoided by using `forEach`. It brings smaller runtime code and less allocation.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — `test/configCases/async-module/environment-symbol/` covers both the direct-`Symbol()` path and the `hasSymbol` fallback path.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes