### PR TITLE
fix(html): skip HTML sentinel render pass for JS-only builds

### DIFF
--- a/.changeset/html-sentinel-render-skip-when-no-html.md
+++ b/.changeset/html-sentinel-render-skip-when-no-html.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip the HTML sentinel-resolve render pass over JS chunks when the compilation has no HTML modules, avoiding per-chunk source materialization in JS-only builds.

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -828,6 +828,8 @@ class HtmlModulesPlugin {
 				const jsHooks =
 					JavascriptModulesPlugin.getCompilationHooks(compilation);
 				jsHooks.render.tap(PLUGIN_NAME, (source, renderContext) => {
+					// No HTML modules ⇒ no sentinels; skip materializing the JS source.
+					if (htmlModules.size === 0) return source;
 					const raw = source.source();
 					if (typeof raw !== "string") return source;
 					if (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This only improves the development experience when the experimental HTML feature is enabled. If the project is purely JavaScript and has a large number of modules, such as `three.js`, it avoids the overhead of calling `.source()` on all of them.

| Variant          |      min |   median |     mean |
| ---------------- | -------: | -------: | -------: |
| Base (gate OFF)  | 444–451 ms | 482–485 ms | 481–487 ms |
| Now (gate ON)    | 426–447 ms | 461–469 ms | 466–474 ms |

Consolidated with the delta:

| Metric  | Base (gate OFF) | Now (gate ON) |     Δ |
| ------- | --------------: | ------------: | ----: |
| Median  |         ~483 ms |       ~465 ms | −3.7% |
| Mean    |         ~484 ms |       ~470 ms | −3.0% |



<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->