### PR TITLE
test: skip test262 dynamic import of fulfilled member of errored TLA cycle

### DIFF
--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1063,6 +1063,9 @@ const knownBugs = [
 	"module-code/top-level-await/await-dynamic-import-resolution.js",
 	"module-code/top-level-await/fulfillment-order.js",
 	"module-code/top-level-await/module-graphs-does-not-hang.js",
+	// Dynamic import of a fulfilled member of an errored TLA cycle must reject
+	// with the cycle root's evaluation error; webpack fulfills it instead.
+	"expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js",
 
 	// Same root cause as the postfix variants above: getter on a global `this`
 	// property must run before the increment writes back, but webpack scopes


### PR DESCRIPTION
**Summary**

Bumping `test/test262-cases` to `f2d1435` adds `expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js`, which fails: it expects `import()` of a fulfilled member of an errored top-level-await cycle to reject with the cycle root's evaluation error, but webpack inlines TLA into a per-module runtime promise chain (`__webpack_require__.a`) with no shared `[[CycleRoot]]`, so it fulfills instead. This skips the new case alongside the existing TLA-cycle divergences in `knownBugs`. Supersedes #21427 (carries the same submodule bump plus the skip needed to keep CI green).

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

No — it adds a skip-list entry in `test/test262.spectest.js` for a new upstream test262 case that exercises an already-known TLA-cycle limitation; no runtime behavior changed.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — used Claude Code to investigate the failing `test262 (2/2)` CI job, diagnose the root cause in the async-module runtime, and author the skip-list entry and this PR description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG6iVEcU1sySHy8gWfsJxS)_