### PR TITLE
fix: resolve directory requests to index module in scoped DllReferencePlugin

### DIFF
--- a/.changeset/dll-scope-directory-index.md
+++ b/.changeset/dll-scope-directory-index.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve directory requests to their index module in scoped DllReferencePlugin.

--- a/lib/dll/DelegatedModuleFactoryPlugin.js
+++ b/lib/dll/DelegatedModuleFactoryPlugin.js
@@ -93,6 +93,25 @@ class DelegatedModuleFactoryPlugin {
 								);
 							}
 						}
+						// Directory request: resolve to its index file, like the default resolver.
+						for (let i = 0; i < extensions.length; i++) {
+							const extension = extensions[i];
+							const requestPlusExt = `${innerRequest}/index${extension}`;
+							if (requestPlusExt in this.options.content) {
+								resolved = this.options.content[requestPlusExt];
+								return callback(
+									null,
+									new DelegatedModule(
+										this.options.source,
+										resolved,
+										/** @type {DelegatedModuleType} */
+										(this.options.type),
+										requestPlusExt,
+										`${request}/index${extension}`
+									)
+								);
+							}
+						}
 					}
 					return callback();
 				}

--- a/test/configCases/dll-plugin/0-create-dll-scope-index/dir/index.js
+++ b/test/configCases/dll-plugin/0-create-dll-scope-index/dir/index.js
@@ -1,0 +1,1 @@
+module.exports = "dir-index";

--- a/test/configCases/dll-plugin/0-create-dll-scope-index/dirx/index.jsx
+++ b/test/configCases/dll-plugin/0-create-dll-scope-index/dirx/index.jsx
@@ -1,0 +1,1 @@
+export default "dirx-index";

--- a/test/configCases/dll-plugin/0-create-dll-scope-index/index.js
+++ b/test/configCases/dll-plugin/0-create-dll-scope-index/index.js
@@ -1,0 +1,2 @@
+import "./dir";
+import "./dirx";

--- a/test/configCases/dll-plugin/0-create-dll-scope-index/test.config.js
+++ b/test/configCases/dll-plugin/0-create-dll-scope-index/test.config.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.noTests = true;

--- a/test/configCases/dll-plugin/0-create-dll-scope-index/webpack.config.js
+++ b/test/configCases/dll-plugin/0-create-dll-scope-index/webpack.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: ["./index"],
+	resolve: {
+		extensions: [".js", ".jsx"]
+	},
+	output: {
+		filename: "dll.js",
+		chunkFilename: "[id].dll.js",
+		libraryTarget: "commonjs2"
+	},
+	plugins: [
+		new webpack.DllPlugin({
+			path: path.resolve(
+				__dirname,
+				"../../../js/config/dll-plugin/manifest-scope-index.json"
+			),
+			entryOnly: false
+		})
+	]
+};

--- a/test/configCases/dll-plugin/5-use-dll-scope-index/index.js
+++ b/test/configCases/dll-plugin/5-use-dll-scope-index/index.js
@@ -1,0 +1,7 @@
+it("should resolve a directory request to its index module from a scoped dll", function () {
+	expect(require("scope/dir")).toBe("dir-index");
+});
+
+it("should resolve a directory index using a later extension from a scoped dll", function () {
+	expect(require("scope/dirx").default).toBe("dirx-index");
+});

--- a/test/configCases/dll-plugin/5-use-dll-scope-index/webpack.config.js
+++ b/test/configCases/dll-plugin/5-use-dll-scope-index/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		moduleIds: "named"
+	},
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: require("../../../js/config/dll-plugin/manifest-scope-index.json"),
+			name: "../0-create-dll-scope-index/dll.js",
+			scope: "scope",
+			sourceType: "commonjs2",
+			extensions: [".js", ".jsx"]
+		})
+	]
+};


### PR DESCRIPTION
**Summary**

Closes #15668. A scoped `DllReferencePlugin` resolved a request only as a file (with and without an extension), so a directory request like `require("scope/dir")` never matched `./dir/index.js` in the manifest and failed with "Module not found". It now also tries the directory index variants (`request/index` + extension), mirroring the default resolver.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — a new config case pair `test/configCases/dll-plugin/0-create-dll-scope-index` (builds a DLL with `dir/index.js` and `dirx/index.jsx`) and `5-use-dll-scope-index` (consumes them via scope). They cover both a first-extension match and a match on a later extension, and fail without the fix.

**Does this PR introduce a breaking change?**

No — the new lookup only runs after the existing file lookups miss, so previously-resolving requests are unaffected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to reproduce the issue, locate the gap in `DelegatedModuleFactoryPlugin`, implement the fix, and write the regression tests. All changes were reviewed and verified by running the DLL test suites locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AQsEWWkj3XcXtxmUn33vd)_