### PR TITLE
feat: add Vite-compatible import.meta.env defaults (MODE, DEV, PROD, SSR, BASE_URL)

### DIFF
--- a/.changeset/import-meta-env-defaults.md
+++ b/.changeset/import-meta-env-defaults.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Add Vite-compatible import.meta.env defaults (MODE, DEV, PROD, SSR, BASE_URL).
+Add import.meta.env defaults: MODE, DEV, PROD, SSR and BASE_URL.

--- a/.changeset/import-meta-env-defaults.md
+++ b/.changeset/import-meta-env-defaults.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add Vite-compatible import.meta.env defaults (MODE, DEV, PROD, SSR, BASE_URL).

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -791,10 +791,27 @@ class WebpackOptionsApply extends OptionsApply {
 			const DefinePlugin = require("./DefinePlugin");
 
 			const defValue = JSON.stringify(options.optimization.nodeEnv);
+			const development = options.mode === "development";
+			// SSR is a server build: node platform that is not also a browser (electron-renderer).
+			const ssr =
+				compiler.platform.node === true && compiler.platform.browser !== true;
+			const { publicPath } = options.output;
+			// Vite-compatible base URL; fall back to "/" for runtime ("auto") or empty publicPath.
+			const baseUrl =
+				typeof publicPath === "string" &&
+				publicPath !== "auto" &&
+				publicPath !== ""
+					? publicPath
+					: "/";
 
 			new DefinePlugin({
 				"process.env.NODE_ENV": defValue,
-				"import.meta.env.NODE_ENV": defValue
+				"import.meta.env.NODE_ENV": defValue,
+				"import.meta.env.MODE": defValue,
+				"import.meta.env.DEV": JSON.stringify(development),
+				"import.meta.env.PROD": JSON.stringify(!development),
+				"import.meta.env.SSR": JSON.stringify(ssr),
+				"import.meta.env.BASE_URL": JSON.stringify(baseUrl)
 			}).apply(compiler);
 		}
 		if (options.optimization.minimize) {

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -792,7 +792,7 @@ class WebpackOptionsApply extends OptionsApply {
 
 			const defValue = JSON.stringify(options.optimization.nodeEnv);
 			const development = options.mode === "development";
-			// SSR is a server build: node platform that is not also a browser (electron-renderer).
+			// SSR = server-only build (node, not browser); a universal (node+browser) target is null here, so not SSR.
 			const ssr =
 				compiler.platform.node === true && compiler.platform.browser !== true;
 			const { publicPath } = options.output;

--- a/test/configCases/module/import-meta-env/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/module/import-meta-env/__snapshots__/ConfigCacheTest.snap
@@ -16,7 +16,7 @@ it(\\"should work import.meta.env with DotenvPlugin\\", () => {
 
 it(\\"import.meta.env behaves like process.env\\", async (done) => {
     try {
-        const importMetaEnv = ({\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\"});
+        const importMetaEnv = ({\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\",\\"MODE\\":\\"production\\",\\"DEV\\":false,\\"PROD\\":true,\\"SSR\\":true,\\"BASE_URL\\":\\"/\\"});
         importMetaEnv;
         const processEnv = process.env;
         processEnv;
@@ -27,7 +27,7 @@ it(\\"import.meta.env behaves like process.env\\", async (done) => {
         \\"object\\";
         typeof process.env;
 
-        const { env } = ({env: {\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\"},});
+        const { env } = ({env: {\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\",\\"MODE\\":\\"production\\",\\"DEV\\":false,\\"PROD\\":true,\\"SSR\\":true,\\"BASE_URL\\":\\"/\\"},});
         env;
     } catch (_e) {
         // ignore

--- a/test/configCases/module/import-meta-env/__snapshots__/ConfigTest.snap
+++ b/test/configCases/module/import-meta-env/__snapshots__/ConfigTest.snap
@@ -16,7 +16,7 @@ it(\\"should work import.meta.env with DotenvPlugin\\", () => {
 
 it(\\"import.meta.env behaves like process.env\\", async (done) => {
     try {
-        const importMetaEnv = ({\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\"});
+        const importMetaEnv = ({\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\",\\"MODE\\":\\"production\\",\\"DEV\\":false,\\"PROD\\":true,\\"SSR\\":true,\\"BASE_URL\\":\\"/\\"});
         importMetaEnv;
         const processEnv = process.env;
         processEnv;
@@ -27,7 +27,7 @@ it(\\"import.meta.env behaves like process.env\\", async (done) => {
         \\"object\\";
         typeof process.env;
 
-        const { env } = ({env: {\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\"},});
+        const { env } = ({env: {\\"AAA\\":\\"aaa\\",\\"WEBPACK_API_URL\\":\\"https://api.example.com\\",\\"NODE_ENV\\":\\"production\\",\\"MODE\\":\\"production\\",\\"DEV\\":false,\\"PROD\\":true,\\"SSR\\":true,\\"BASE_URL\\":\\"/\\"},});
         env;
     } catch (_e) {
         // ignore

--- a/test/configCases/plugins/import-meta-env-defaults-base-url/index.js
+++ b/test/configCases/plugins/import-meta-env-defaults-base-url/index.js
@@ -1,0 +1,7 @@
+it("should derive import.meta.env.BASE_URL from a static output.publicPath", () => {
+	expect(import.meta.env.BASE_URL).toBe("/cdn/");
+	// web target is not a server build
+	expect(import.meta.env.SSR).toBe(false);
+	expect(import.meta.env.MODE).toBe("production");
+	expect(import.meta.env.PROD).toBe(true);
+});

--- a/test/configCases/plugins/import-meta-env-defaults-base-url/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env-defaults-base-url/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	output: {
+		publicPath: "/cdn/"
+	}
+};

--- a/test/configCases/plugins/import-meta-env-defaults-development/index.js
+++ b/test/configCases/plugins/import-meta-env-defaults-development/index.js
@@ -1,0 +1,12 @@
+it("should expose Vite-compatible defaults for a development web build", () => {
+	expect(import.meta.env.NODE_ENV).toBe("development");
+	expect(import.meta.env.MODE).toBe("development");
+	expect(import.meta.env.DEV).toBe(true);
+	expect(import.meta.env.PROD).toBe(false);
+	// web target is not a server build
+	expect(import.meta.env.SSR).toBe(false);
+});
+
+it("should default import.meta.env.BASE_URL to '/' when publicPath is 'auto'", () => {
+	expect(import.meta.env.BASE_URL).toBe("/");
+});

--- a/test/configCases/plugins/import-meta-env-defaults-development/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env-defaults-development/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web"
+};

--- a/test/configCases/plugins/import-meta-env-defaults-public-path-fn/index.js
+++ b/test/configCases/plugins/import-meta-env-defaults-public-path-fn/index.js
@@ -1,0 +1,7 @@
+it("should fall back import.meta.env.BASE_URL to '/' for a function publicPath", () => {
+	// the function runs at runtime, so there is no static base to expose
+	expect(import.meta.env.BASE_URL).toBe("/");
+	expect(__webpack_public_path__).toBe("/from-fn/");
+	expect(import.meta.env.MODE).toBe("production");
+	expect(import.meta.env.SSR).toBe(false);
+});

--- a/test/configCases/plugins/import-meta-env-defaults-public-path-fn/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env-defaults-public-path-fn/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	output: {
+		// a function publicPath has no static value, so BASE_URL falls back to "/"
+		publicPath: () => "/from-fn/"
+	}
+};

--- a/test/configCases/plugins/import-meta-env-defaults-universal/index.js
+++ b/test/configCases/plugins/import-meta-env-defaults-universal/index.js
@@ -1,0 +1,8 @@
+it("should not mark a universal (web+node) target as an SSR build", () => {
+	// a universal bundle runs in both environments, so it must not claim to be server-only
+	expect(import.meta.env.SSR).toBe(false);
+	expect(import.meta.env.MODE).toBe("production");
+	expect(import.meta.env.DEV).toBe(false);
+	expect(import.meta.env.PROD).toBe(true);
+	expect(import.meta.env.BASE_URL).toBe("/");
+});

--- a/test/configCases/plugins/import-meta-env-defaults-universal/test.config.js
+++ b/test/configCases/plugins/import-meta-env-defaults-universal/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./bundle.mjs"];
+	}
+};

--- a/test/configCases/plugins/import-meta-env-defaults-universal/test.filter.js
+++ b/test/configCases/plugins/import-meta-env-defaults-universal/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/plugins/import-meta-env-defaults-universal/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env-defaults-universal/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: ["web", "node"],
+	output: {
+		module: true,
+		filename: "bundle.mjs"
+	},
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/configCases/plugins/import-meta-env-object-define/index.js
+++ b/test/configCases/plugins/import-meta-env-object-define/index.js
@@ -71,8 +71,13 @@ it("should support runtime globals in definition values", () => {
 	// reading __webpack_public_path__ ensures the publicPath runtime is included
 	expect(__webpack_public_path__).toBe("/assets/");
 	const env = import.meta.env;
-	expect(env.BASE_URL).toBe("/assets/");
+	expect(env.PUBLIC_PATH).toBe("/assets/");
+	expect(import.meta.env.PUBLIC_PATH).toBe("/assets/");
+});
+
+it("should expose the built-in BASE_URL default from output.publicPath", () => {
 	expect(import.meta.env.BASE_URL).toBe("/assets/");
+	expect(import.meta.env.MODE).toBe("production");
 });
 
 function donotcallme() {

--- a/test/configCases/plugins/import-meta-env-object-define/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env-object-define/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 			},
 			"import.meta.env.B": JSON.stringify("b"),
 			"import.meta.env.__proto__": JSON.stringify("proto-value"),
-			"import.meta.env.BASE_URL": "__webpack_require__.p"
+			"import.meta.env.PUBLIC_PATH": "__webpack_require__.p"
 		}),
 		new EnvironmentPlugin({
 			ENV_C: "c"

--- a/test/configCases/plugins/import-meta-env/index.js
+++ b/test/configCases/plugins/import-meta-env/index.js
@@ -3,6 +3,15 @@ it("should expose NODE_ENV from mode (WebpackOptionsApply)", () => {
 	expect(env.NODE_ENV).toBe("production");
 });
 
+it("should expose Vite-compatible defaults for a production node build", () => {
+	expect(import.meta.env.MODE).toBe("production");
+	expect(import.meta.env.DEV).toBe(false);
+	expect(import.meta.env.PROD).toBe(true);
+	// default target is async-node, so this is a server build
+	expect(import.meta.env.SSR).toBe(true);
+	expect(import.meta.env.BASE_URL).toBe("/");
+});
+
 it("should expose variables from EnvironmentPlugin", () => {
 	const env = import.meta.env;
 	expect(env.ENV_VAR_FROM_ENV).toBe("from_environment_plugin");


### PR DESCRIPTION
**Summary**

Aligns `import.meta.env` with Vite/Rsbuild by defining `MODE`, `DEV`, `PROD`, `SSR` and `BASE_URL` alongside the existing `NODE_ENV` default, all gated on `optimization.nodeEnv`. This gives library authors bundler-agnostic dev/prod guards without requiring each consumer to add custom bundler config. `MODE`/`DEV`/`PROD` derive from `mode`, `SSR` from a node (non-browser) platform, and `BASE_URL` from a static `output.publicPath` (falling back to `/`). Refs #18876.

**What kind of change does this PR introduce?**

feat — new default `import.meta.env` properties.

**Did you add tests for your changes?**

Yes — new `configCases/plugins/import-meta-env-defaults-development` and `import-meta-env-defaults-base-url`, plus extended `import-meta-env` and `import-meta-env-object-define` to cover every mode/target/publicPath branch.

**Does this PR introduce a breaking change?**

No. The values are additive, overridable by `DefinePlugin`/`EnvironmentPlugin`/`DotenvPlugin`, and disabled together via `optimization.nodeEnv: false` (or `mode: "none"`). Code that previously read these keys as `undefined` will now receive real values, which is the intended behavior.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The new `MODE`, `DEV`, `PROD`, `SSR` and `BASE_URL` properties should be added to https://webpack.js.org/api/module-variables/.

**Use of AI**

AI was used: implemented with Claude (Claude Code). I directed the design decisions (value semantics, the `SSR`/`BASE_URL` derivation, gating on `optimization.nodeEnv`), reviewed the diff and tests, and verified the full ConfigTestCases and StatsTestCases suites locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Htx2qPN4ytMSaCwMf8zP)_