### PR TITLE
fix: test262 conformance for import defer and dynamic import() options

### DIFF
--- a/.changeset/defer-module-evaluation-error.md
+++ b/.changeset/defer-module-evaluation-error.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix deferred-namespace evaluation errors: re-throw a deferred module's cached evaluation error, and throw when forcing evaluation of an already-evaluating module.
+Fix deferred-namespace evaluation errors: re-throw a deferred module's cached evaluation error, and throw when forcing evaluation of a module (or one of its transitive static dependencies) that is still evaluating.

--- a/.changeset/defer-module-evaluation-error.md
+++ b/.changeset/defer-module-evaluation-error.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Cache and re-throw a deferred module's evaluation error so repeated deferred-namespace access reports the same error.
+Fix deferred-namespace evaluation errors: re-throw a deferred module's cached evaluation error, and throw when forcing evaluation of an already-evaluating module.

--- a/.changeset/defer-module-evaluation-error.md
+++ b/.changeset/defer-module-evaluation-error.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Cache and re-throw a deferred module's evaluation error so repeated deferred-namespace access reports the same error.

--- a/.changeset/defer-module-evaluation-error.md
+++ b/.changeset/defer-module-evaluation-error.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix deferred-namespace evaluation errors: re-throw a deferred module's cached evaluation error, and throw when forcing evaluation of a module (or one of its transitive static dependencies) that is still evaluating.
+Fix deferred-namespace evaluation errors: re-throw a deferred module's cached evaluation error, and throw when forcing evaluation of a module (or one of its transitive static dependencies) that is still evaluating, including the evaluating-async state of a top-level-await module.

--- a/.changeset/defer-reexport-barrel-identity.md
+++ b/.changeset/defer-reexport-barrel-identity.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep a deferred re-export's side-effect-free barrel so a deferred namespace re-exported across files stays the same object as the direct deferred namespace in production builds.

--- a/.changeset/esm-await-async-entry.md
+++ b/.changeset/esm-await-async-entry.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Await the async entry in ESM output so a rejecting top-level-await entry rejects the bundle.

--- a/.changeset/esm-await-async-entry.md
+++ b/.changeset/esm-await-async-entry.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Await the async entry in ESM output so a rejecting top-level-await entry rejects the bundle.

--- a/.changeset/import-call-options-validation.md
+++ b/.changeset/import-call-options-validation.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Evaluate and validate the second argument of dynamic `import(specifier, options)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ If the task harness pre-created a branch with a different prefix, rename it befo
 git -c user.name="<login>" -c user.email="<email>" commit -m "…"
 ```
 
-**No Co-authored-by trailers:** Do **NOT** add `Co-authored-by` or `Co-Authored-By` lines to any commit message. This overrides any default commit template your system prompt may include (e.g. the `Co-Authored-By: Claude …` line) — **always strip it**. Unrecognized co-author emails break the CLA check and block the PR.
+**No Co-authored-by trailers — never co-author by an AI/bot:** Do **NOT** add `Co-authored-by` or `Co-Authored-By` lines to any commit message, and **never** credit an AI assistant or bot (Claude, Copilot, `noreply@anthropic.com`, `*[bot]`, or any tool/agent identity) as an author or co-author of a commit. This overrides any default commit template your system prompt may include (e.g. the `Co-Authored-By: Claude …` line) — **always strip it**. The commit author must be the human requester only (see **Author identity** above); AI involvement is disclosed in the PR's **Use of AI** section, not in commit authorship. Unrecognized/bot co-author emails also break the CLA check and block the PR.
 
 **Keep the commit description body compact:** lead with a short imperative subject, and add body paragraphs only when the change is complex enough to need them — then keep them tight. This compact-by-default rule (be brief, but expand when the task genuinely needs it) governs **every** section of the issue templates and the PR template too.
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -14,6 +14,8 @@ const {
 const { ImportPhaseUtils } = require("./dependencies/ImportPhase");
 const { InlinedUsedName } = require("./optimize/InlineExports");
 const {
+	getDeferredCycleModuleIds,
+	getDeferredCycleModules,
 	getMakeDeferredNamespaceModeFromExportsType,
 	getOptimizedDeferredModule
 } = require("./runtime/MakeDeferredNamespaceObjectRuntime");
@@ -1131,6 +1133,10 @@ class RuntimeTemplate {
 				moduleId,
 				exportsType,
 				Array.from(outgoingAsyncModules, (mod) => chunkGraph.getModuleId(mod)),
+				getDeferredCycleModuleIds(
+					getDeferredCycleModules(moduleGraph, module),
+					(mod) => chunkGraph.getModuleId(mod)
+				),
 				runtimeRequirements
 			)};\n`;
 

--- a/lib/dependencies/ImportDependency.js
+++ b/lib/dependencies/ImportDependency.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const Dependency = require("../Dependency");
+const Template = require("../Template");
 const makeSerializable = require("../util/makeSerializable");
 const memoize = require("../util/memoize");
 const { ImportPhaseUtils } = require("./ImportPhase");
@@ -50,6 +51,11 @@ class ImportDependency extends ModuleDependency {
 		this.attributes = attributes;
 		/** @type {DependencyGuard[] | undefined} */
 		this.branchGuards = undefined;
+		// Range of the `import(specifier, options)` second argument, set only when
+		// it is not a statically extractable attributes object and must therefore
+		// be evaluated and validated at runtime.
+		/** @type {Range | undefined} */
+		this.optionsRange = undefined;
 	}
 
 	get type() {
@@ -137,6 +143,7 @@ class ImportDependency extends ModuleDependency {
 		context.write(this.phase);
 		context.write(this.attributes);
 		context.write(this.branchGuards);
+		context.write(this.optionsRange);
 		super.serialize(context);
 	}
 
@@ -150,6 +157,7 @@ class ImportDependency extends ModuleDependency {
 		this.phase = context.read();
 		this.attributes = context.read();
 		this.branchGuards = context.read();
+		this.optionsRange = context.read();
 		super.deserialize(context);
 	}
 }
@@ -210,6 +218,39 @@ ImportDependency.Template = class ImportDependencyTemplate extends (
 				'm["default"]',
 				"m"
 			)})`;
+		}
+
+		// A non-static second argument must still be evaluated (for its side
+		// effects and evaluation order) and validated per spec. Keep it in place
+		// and wrap it in an inline validator that mirrors the runtime checks of
+		// the spec's `import(specifier, options)` evaluation.
+		if (dep.optionsRange) {
+			const validator = runtimeTemplate.basicFunction("o", [
+				"try {",
+				Template.indent([
+					"if (o !== undefined) {",
+					Template.indent([
+						'if ((typeof o !== "object" && typeof o !== "function") || o === null) throw new TypeError("The second argument to import() must be an object");',
+						'var a = o["with"];',
+						"if (a !== undefined) {",
+						Template.indent([
+							'if ((typeof a !== "object" && typeof a !== "function") || a === null) throw new TypeError("The \'with\' option must be an object");',
+							"for (var k = Object.keys(a), i = 0; i < k.length; i++) {",
+							Template.indent([
+								'if (typeof a[k[i]] !== "string") throw new TypeError("Import attribute values must be strings");'
+							]),
+							"}"
+						]),
+						"}"
+					]),
+					"}"
+				]),
+				"} catch (e) { return Promise.reject(e); }",
+				`return ${content};`
+			]);
+			source.replace(dep.range[0], dep.optionsRange[0] - 1, `(${validator})(`);
+			source.replace(dep.optionsRange[1], dep.range[1] - 1, ")");
+			return;
 		}
 
 		source.replace(dep.range[0], dep.range[1] - 1, content);

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -174,6 +174,47 @@ const exportsFromEnumerable = (enumerable) =>
 
 const PLUGIN_NAME = "ImportParserPlugin";
 
+/**
+ * Whether an `import()` second argument is a fully static attributes object
+ * (every `with`/`assert` value is a string literal). Only then can webpack use
+ * the attributes at build time; otherwise the argument must be evaluated and
+ * validated at runtime per spec.
+ * @param {import("estree").Expression | null | undefined} node the second-argument AST node
+ * @returns {boolean} true if statically extractable
+ */
+const isStaticStringAttributes = (node) => {
+	if (!node || node.type !== "ObjectExpression") return false;
+	for (const prop of node.properties) {
+		if (prop.type !== "Property" || prop.kind !== "init" || prop.computed) {
+			return false;
+		}
+		const key = prop.key;
+		const keyName =
+			key.type === "Identifier"
+				? key.name
+				: key.type === "Literal"
+					? key.value
+					: undefined;
+		if (keyName === "with" || keyName === "assert") {
+			const value = prop.value;
+			if (value.type !== "ObjectExpression") return false;
+			for (const attr of value.properties) {
+				if (attr.type !== "Property" || attr.kind !== "init" || attr.computed) {
+					return false;
+				}
+				const attrValue = attr.value;
+				if (
+					attrValue.type !== "Literal" ||
+					typeof attrValue.value !== "string"
+				) {
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+};
+
 class ImportParserPlugin {
 	/**
 	 * Creates an instance of ImportParserPlugin.
@@ -555,13 +596,27 @@ class ImportParserPlugin {
 						/** @type {DependencyLocation} */ (expr.loc),
 						param.string
 					);
+					// A second argument that isn't a statically extractable attributes
+					// object still has to be evaluated and validated at runtime, so
+					// drop the (unreliable) static attributes for it.
+					const optionsNode = expr.options;
+					const runtimeValidateOptions = Boolean(
+						optionsNode && !isStaticStringAttributes(optionsNode)
+					);
 					const dep = new ImportDependency(
 						/** @type {string} */ (param.string),
 						/** @type {Range} */ (expr.range),
 						exports,
 						phase,
-						attributes
+						runtimeValidateOptions ? undefined : attributes
 					);
+					if (runtimeValidateOptions && optionsNode && optionsNode.range) {
+						dep.optionsRange = /** @type {Range} */ (optionsNode.range);
+						// The options expression stays in the output, so walk it to
+						// register its variable references and keep them from being
+						// tree-shaken away.
+						parser.walkExpression(optionsNode);
+					}
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					dep.optional = Boolean(parser.scope.inTry);
 					depBlock.addDependency(dep);

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1942,6 +1942,17 @@ class JavascriptModulesPlugin {
 		const needModuleDefer = runtimeRequirements.has(
 			RuntimeGlobals.makeDeferredNamespaceObject
 		);
+		// Both deferred-namespace runtimes re-invoke `__webpack_require__` on
+		// access, so a module's evaluation error must be retained and re-thrown
+		// (a Cyclic Module Record's [[EvaluationError]]); the optimized variant
+		// does not use `__webpack_module_deferred_exports__`, so it is tracked
+		// separately from `needModuleDefer`.
+		const needModuleErrorCaching =
+			outputOptions.strictModuleErrorHandling ||
+			needModuleDefer ||
+			runtimeRequirements.has(
+				RuntimeGlobals.makeOptimizedDeferredNamespaceObject
+			);
 		// `module` is reassigned by the interceptModuleExecution path; use `let`.
 		const moduleDecl = runtimeRequirements.has(
 			RuntimeGlobals.interceptModuleExecution
@@ -1952,7 +1963,7 @@ class JavascriptModulesPlugin {
 			"// Check if module is in cache",
 			`${cst} cachedModule = __webpack_module_cache__[moduleId];`,
 			"if (cachedModule !== undefined) {",
-			outputOptions.strictModuleErrorHandling
+			needModuleErrorCaching
 				? Template.indent([
 						"if (cachedModule.error !== undefined) throw cachedModule.error;",
 						"return cachedModule.exports;"
@@ -1970,7 +1981,7 @@ class JavascriptModulesPlugin {
 			]),
 			"};",
 			"",
-			outputOptions.strictModuleExceptionHandling
+			outputOptions.strictModuleExceptionHandling && !needModuleErrorCaching
 				? Template.asString([
 						"// Execute the module function",
 						`${lt} threw = true;`,
@@ -1988,7 +1999,7 @@ class JavascriptModulesPlugin {
 						]),
 						"}"
 					])
-				: outputOptions.strictModuleErrorHandling
+				: needModuleErrorCaching
 					? Template.asString([
 							"// Execute the module function",
 							"try {",

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1947,12 +1947,13 @@ class JavascriptModulesPlugin {
 		// (a Cyclic Module Record's [[EvaluationError]]); the optimized variant
 		// does not use `__webpack_module_deferred_exports__`, so it is tracked
 		// separately from `needModuleDefer`.
-		const needModuleErrorCaching =
-			outputOptions.strictModuleErrorHandling ||
+		const needModuleDeferAny =
 			needModuleDefer ||
 			runtimeRequirements.has(
 				RuntimeGlobals.makeOptimizedDeferredNamespaceObject
 			);
+		const needModuleErrorCaching =
+			outputOptions.strictModuleErrorHandling || needModuleDeferAny;
 		// `module` is reassigned by the interceptModuleExecution path; use `let`.
 		const moduleDecl = runtimeRequirements.has(
 			RuntimeGlobals.interceptModuleExecution
@@ -2002,17 +2003,24 @@ class JavascriptModulesPlugin {
 				: needModuleErrorCaching
 					? Template.asString([
 							"// Execute the module function",
+							// Mark the module as evaluating so a deferred namespace that
+							// forces evaluation of an already-evaluating module can throw
+							// instead of exposing its partial exports.
+							...(needModuleDeferAny ? ["module.evaluating = true;"] : []),
 							"try {",
-							Template.indent(
-								needModuleDefer
-									? [
-											moduleExecution,
-											"delete __webpack_module_deferred_exports__[moduleId];"
-										]
-									: moduleExecution
-							),
+							Template.indent([
+								moduleExecution,
+								...(needModuleDefer
+									? ["delete __webpack_module_deferred_exports__[moduleId];"]
+									: []),
+								...(needModuleDeferAny ? ["module.evaluating = false;"] : [])
+							]),
 							"} catch(e) {",
-							Template.indent(["module.error = e;", "throw e;"]),
+							Template.indent([
+								...(needModuleDeferAny ? ["module.evaluating = false;"] : []),
+								"module.error = e;",
+								"throw e;"
+							]),
 							"}"
 						])
 					: Template.asString([

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1642,6 +1642,19 @@ class JavascriptModulesPlugin {
 						continue;
 					}
 				}
+				// In ESM output the startup runs at the module top level (no IIFE),
+				// unless it is moved into the `__webpack_require__.x` startup
+				// function. There top-level `await` is available, so an async entry
+				// can be awaited — otherwise its rejection would be orphaned as an
+				// unhandled rejection instead of rejecting the bundle module.
+				const startupInFunction =
+					runtimeRequirements.has(RuntimeGlobals.startup) ||
+					(runtimeRequirements.has(RuntimeGlobals.startupOnlyBefore) &&
+						runtimeRequirements.has(RuntimeGlobals.startupOnlyAfter));
+				const canAwaitEntry =
+					runtimeTemplate.isModule() &&
+					!runtimeTemplate.isIIFE() &&
+					!startupInFunction;
 				let i = jsEntries.length;
 				for (const [entryModule, entrypoint] of jsEntries) {
 					const chunks =
@@ -1751,8 +1764,10 @@ class JavascriptModulesPlugin {
 							)})`
 						);
 					} else if (useRequire) {
+						const awaitEntry =
+							canAwaitEntry && moduleGraph.isAsync(entryModule) ? "await " : "";
 						buf2.push(
-							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${
+							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${awaitEntry}${
 								RuntimeGlobals.require
 							}(${moduleIdExpr});`
 						);

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1642,19 +1642,6 @@ class JavascriptModulesPlugin {
 						continue;
 					}
 				}
-				// In ESM output the startup runs at the module top level (no IIFE),
-				// unless it is moved into the `__webpack_require__.x` startup
-				// function. There top-level `await` is available, so an async entry
-				// can be awaited — otherwise its rejection would be orphaned as an
-				// unhandled rejection instead of rejecting the bundle module.
-				const startupInFunction =
-					runtimeRequirements.has(RuntimeGlobals.startup) ||
-					(runtimeRequirements.has(RuntimeGlobals.startupOnlyBefore) &&
-						runtimeRequirements.has(RuntimeGlobals.startupOnlyAfter));
-				const canAwaitEntry =
-					runtimeTemplate.isModule() &&
-					!runtimeTemplate.isIIFE() &&
-					!startupInFunction;
 				let i = jsEntries.length;
 				for (const [entryModule, entrypoint] of jsEntries) {
 					const chunks =
@@ -1764,10 +1751,8 @@ class JavascriptModulesPlugin {
 							)})`
 						);
 					} else if (useRequire) {
-						const awaitEntry =
-							canAwaitEntry && moduleGraph.isAsync(entryModule) ? "await " : "";
 						buf2.push(
-							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${awaitEntry}${
+							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${
 								RuntimeGlobals.require
 							}(${moduleIdExpr});`
 						);

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -29,6 +29,8 @@ const { ImportPhaseUtils } = require("../dependencies/ImportPhase");
 const { isCommonJsWrapped } = require("../javascript/JavascriptGenerator");
 const JavascriptParser = require("../javascript/JavascriptParser");
 const {
+	getDeferredCycleModuleIds,
+	getDeferredCycleModules,
 	getMakeDeferredNamespaceModeFromExportsType,
 	getOptimizedDeferredModule
 } = require("../runtime/MakeDeferredNamespaceObjectRuntime");
@@ -2287,6 +2289,16 @@ ${defineGetters}`
 					),
 					// an async module will opt-out of the concat module optimization.
 					[],
+					// A closure member absorbed into this concatenation shares this
+					// module's runtime id (and thus its `evaluating` flag); resolve it
+					// to that id instead of the member's now-absent standalone id.
+					getDeferredCycleModuleIds(
+						getDeferredCycleModules(moduleGraph, info.module),
+						(mod) =>
+							moduleToInfoMap.has(mod)
+								? chunkGraph.getModuleId(this)
+								: chunkGraph.getModuleId(mod)
+					),
 					runtimeRequirements
 				);
 				runtimeRequirements.add(RuntimeGlobals.require);

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -13,6 +13,8 @@ const ModuleGraph = require("../ModuleGraph");
 const { JAVASCRIPT_TYPE } = require("../ModuleSourceTypeConstants");
 const { STAGE_DEFAULT } = require("../OptimizationStages");
 const CommonJsSelfReferenceDependency = require("../dependencies/CommonJsSelfReferenceDependency");
+const HarmonyImportDependency = require("../dependencies/HarmonyImportDependency");
+const { ImportPhaseUtils } = require("../dependencies/ImportPhase");
 const { compareModulesByIdentifier } = require("../util/comparators");
 const {
 	filterRuntime,
@@ -581,6 +583,26 @@ class ModuleConcatenationPlugin {
 	}
 
 	/**
+	 * Checks whether the module `import defer`s a module already in the config.
+	 * @param {ModuleGraph} moduleGraph the module graph
+	 * @param {Module} module the candidate module
+	 * @param {ConcatConfiguration} config the concat configuration
+	 * @returns {boolean} true when a deferred import targets a module in the config
+	 */
+	_defersModuleIn(moduleGraph, module, config) {
+		for (const dep of module.dependencies) {
+			if (
+				dep instanceof HarmonyImportDependency &&
+				ImportPhaseUtils.isDefer(dep.phase)
+			) {
+				const target = moduleGraph.getModule(dep);
+				if (target && config.has(target)) return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Returns the imported modules.
 	 * @param {Compilation} compilation the compilation
 	 * @param {Module} module the module to be added
@@ -669,6 +691,26 @@ class ModuleConcatenationPlugin {
 			statistics.invalidModule++;
 			failureCache.set(module, module); // cache failures for performance
 			return module;
+		}
+
+		// A deferred import must stay a concatenation boundary: concatenating a
+		// module with a module it `import defer`s (a cycle) would erase the
+		// deferred namespace's lazy-evaluation and exotic-object semantics.
+		if (
+			compilation.options.experiments.deferImport &&
+			this._defersModuleIn(compilation.moduleGraph, module, config)
+		) {
+			/**
+			 * @param {RequestShortener} requestShortener request shortener
+			 * @returns {string} problem description
+			 */
+			const problem = (requestShortener) =>
+				`Module ${module.readableIdentifier(
+					requestShortener
+				)} imports a module in this configuration via import defer`;
+			statistics.incorrectDependency++;
+			failureCache.set(module, problem); // cache failures for performance
+			return problem;
 		}
 
 		// Module must be in the correct chunks

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -13,7 +13,9 @@ const {
 } = require("../ModuleTypeConstants");
 const { STAGE_DEFAULT } = require("../OptimizationStages");
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
+const HarmonyImportDependency = require("../dependencies/HarmonyImportDependency");
 const HarmonyImportSpecifierDependency = require("../dependencies/HarmonyImportSpecifierDependency");
+const { ImportPhaseUtils } = require("../dependencies/ImportPhase");
 const formatLocation = require("../util/formatLocation");
 const { CompilerHintNotationRegExp } = require("../util/magicComment");
 
@@ -47,6 +49,20 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @typedef {string | boolean | string[] | undefined} SideEffectsFlagValue */
 
 /** @typedef {Map<string, RegExp>} CacheItem */
+
+/**
+ * Whether a resolved re-export target is reached through an `import defer` edge.
+ * Such edges must not be collapsed by the side-effect-free barrel optimization:
+ * the source module has to keep being reached through the barrel's cached
+ * deferred namespace so deferred-namespace identity and evaluation semantics are
+ * preserved.
+ * @param {ModuleGraphConnection | undefined} connection the target connection
+ * @returns {boolean} true when the target connection is a deferred import
+ */
+const isDeferredTargetConnection = (connection) =>
+	connection !== undefined &&
+	connection.dependency instanceof HarmonyImportDependency &&
+	ImportPhaseUtils.isDefer(connection.dependency.phase);
 
 /** @type {WeakMap<Compiler, CacheItem>} */
 const globToRegexpCache = new WeakMap();
@@ -504,6 +520,11 @@ class SideEffectsFlagPlugin {
 						/** @type {Set<Module>} */
 						const optimizedModules = new Set();
 
+						// Only defer builds must protect deferred re-export barrels;
+						// skip the per-target check entirely otherwise.
+						const deferEnabled =
+							compilation.options.experiments.deferImport === true;
+
 						// Re-export resolution is idempotent within a pass, so cache it
 						// per export info: a shared barrel imported by many modules
 						// resolves each name once instead of once per consumer.
@@ -585,13 +606,18 @@ class SideEffectsFlagPlugin {
 
 												exportInfo.moveTarget(
 													moduleGraph,
-													({ module }) =>
-														module.getSideEffectsConnectionState(
+													(candidate) =>
+														candidate.module.getSideEffectsConnectionState(
 															moduleGraph
 														) === false &&
+														// Keep a deferred re-export's barrel (see below).
+														(!deferEnabled ||
+															!isDeferredTargetConnection(
+																candidate.connection
+															)) &&
 														(Boolean(dep.name) ||
 															hasSingleStarReexport(
-																/** @type {Module} */ (module)
+																/** @type {Module} */ (candidate.module)
 															)),
 													({
 														module: newModule,
@@ -642,6 +668,18 @@ class SideEffectsFlagPlugin {
 												reexportTargetCache.set(exportInfo, target);
 											}
 											if (!target) continue;
+
+											// A deferred re-export must keep its side-effect-free
+											// barrel: collapsing it here would turn the cached
+											// deferred namespace (`.z`) into an eager import of the
+											// source module, breaking deferred-namespace identity
+											// and evaluation semantics.
+											if (
+												deferEnabled &&
+												isDeferredTargetConnection(target.connection)
+											) {
+												continue;
+											}
 
 											moduleGraph.updateModule(dep, target.module);
 											moduleGraph.updateParent(

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -196,10 +196,18 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 				])}`,
 				`${cst} done = ${runtimeTemplate.expressionFunction(
 					`(err ? reject(promise[webpackError] = err) : outerResolve(exports)), resolveQueue(queue)${
-						defer ? ", promise[webpackDone] = true" : ""
+						defer
+							? ", promise[webpackDone] = true, module.evaluatingAsync = false"
+							: ""
 					}`,
 					"err"
 				)}`,
+				// Track the async body's whole lifetime (evaluating +
+				// evaluating-async states) with a dedicated flag — the sync require
+				// wrapper clears `module.evaluating` as soon as `.a` returns, so a
+				// deferred namespace reaching this module through a cycle relies on
+				// `evaluatingAsync` to keep throwing until it is fully evaluated.
+				defer ? "module.evaluatingAsync = true;" : "",
 				"body(handle, done);",
 				`${runtimeTemplate.optionalChaining("queue", "d < 0")} && (queue.d = 0);`
 			])};`

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -174,11 +174,11 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 						// cyclic deferred modules) carries the transitive static closure,
 						// so an evaluating dependency is caught before any evaluation.
 						`${cst} cachedModule = __webpack_module_cache__[moduleId];`,
-						'if (cachedModule !== undefined && cachedModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
+						'if (cachedModule !== undefined && (cachedModule.evaluating || cachedModule.evaluatingAsync)) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
 						"if (syncDeps) for (var i = 0; i < syncDeps.length; i++) {",
 						Template.indent([
 							`${cst} depModule = __webpack_module_cache__[syncDeps[i]];`,
-							'if (depModule !== undefined && depModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while a dependency is being evaluated");'
+							'if (depModule !== undefined && (depModule.evaluating || depModule.evaluatingAsync)) throw new TypeError("Cannot access a deferred module namespace while a dependency is being evaluated");'
 						]),
 						"}",
 						`${lt} exports = r(moduleId);`,
@@ -269,7 +269,7 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 				// already evaluating (a cycle) must throw rather than expose its
 				// partial exports.
 				`${cst} evaluatingModule = __webpack_module_cache__[moduleId];`,
-				'if (evaluatingModule !== undefined && evaluatingModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
+				'if (evaluatingModule !== undefined && (evaluatingModule.evaluating || evaluatingModule.evaluatingAsync)) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
 				`ns = ${RuntimeGlobals.require}(moduleId);`,
 				hasAsync
 					? `if (${RuntimeGlobals.asyncModuleExportSymbol} in ns) ns = ns[${RuntimeGlobals.asyncModuleExportSymbol}];`

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -6,11 +6,90 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const HarmonyImportDependency = require("../dependencies/HarmonyImportDependency");
 const HelperRuntimeModule = require("./HelperRuntimeModule");
 
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../Module").RuntimeRequirements} RuntimeRequirements */
 /** @typedef {import("../Module").ExportsType} ExportsType */
 /** @typedef {import("../ChunkGraph").ModuleId} ModuleId */
+
+/** @type {WeakMap<ModuleGraph, Map<Module, Set<Module> | null>>} */
+const deferredCycleCache = new WeakMap();
+
+/**
+ * Per the TC39 import-defer spec's `ReadyForSyncExecution`, forcing evaluation
+ * of a deferred module must throw when any module in its transitive static
+ * import closure is currently evaluating. Only a deferred module that is part
+ * of an import cycle can ever observe such an evaluating dependency, so the
+ * closure (and the extra runtime check that consumes it) is emitted only then.
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} module the deferred module
+ * @returns {Set<Module> | null} closure modules when cyclic, otherwise null
+ */
+function getDeferredCycleModules(moduleGraph, module) {
+	let perGraph = deferredCycleCache.get(moduleGraph);
+	if (perGraph === undefined) {
+		perGraph = new Map();
+		deferredCycleCache.set(moduleGraph, perGraph);
+	}
+	const cached = perGraph.get(module);
+	if (cached !== undefined) return cached;
+	// `reachable` doubles as the visited set; the deferred module seeds it.
+	const reachable = new Set([module]);
+	let cyclic = false;
+	const stack = [module];
+	while (stack.length > 0) {
+		const current = /** @type {Module} */ (stack.pop());
+		const connections = moduleGraph.getOutgoingConnectionsByModule(current);
+		if (!connections) continue;
+		for (const [dep, moduleConnections] of connections) {
+			if (
+				!dep ||
+				!moduleConnections.some(
+					(c) =>
+						c.dependency instanceof HarmonyImportDependency &&
+						c.isTargetActive(undefined)
+				)
+			) {
+				continue;
+			}
+			if (dep === module) {
+				cyclic = true;
+			} else if (!reachable.has(dep)) {
+				reachable.add(dep);
+				stack.push(dep);
+			}
+		}
+	}
+	reachable.delete(module);
+	const result = cyclic ? reachable : null;
+	perGraph.set(module, result);
+	return result;
+}
+
+/**
+ * Maps a defer-cycle closure to the runtime module ids whose `evaluating` flag
+ * the deferred namespace must check. `resolveId` maps a closure module to the
+ * runtime id that carries its evaluation state (its own id, or the id of the
+ * concatenated module that absorbed it); unresolved (`null`) members are
+ * dropped. Returns `null` when there is nothing to check.
+ * @param {Set<Module> | null} closure closure modules, or null when not cyclic
+ * @param {(module: Module) => ModuleId | null} resolveId maps a module to its runtime id
+ * @returns {ModuleId[] | null} deduplicated runtime ids, or null
+ */
+function getDeferredCycleModuleIds(closure, resolveId) {
+	if (closure === null) return null;
+	/** @type {Set<ModuleId>} */
+	const ids = new Set();
+	for (const module of closure) {
+		const id = resolveId(module);
+		if (id !== null) ids.add(id);
+	}
+	return ids.size > 0 ? [...ids] : null;
+}
 
 /**
  * @param {ExportsType} exportsType exports type
@@ -29,6 +108,7 @@ function getMakeDeferredNamespaceModeFromExportsType(exportsType) {
  * @param {string} moduleId moduleId
  * @param {ExportsType} exportsType exportsType
  * @param {(ModuleId | null)[]} asyncDepsIds asyncDepsIds
+ * @param {ModuleId[] | null} syncCycleDepsIds transitive static closure ids when the module is part of a defer cycle
  * @param {RuntimeRequirements} runtimeRequirements runtime requirements
  * @returns {string} call make optimized deferred namespace object
  */
@@ -36,17 +116,23 @@ function getOptimizedDeferredModule(
 	moduleId,
 	exportsType,
 	asyncDepsIds,
+	syncCycleDepsIds,
 	runtimeRequirements
 ) {
 	runtimeRequirements.add(RuntimeGlobals.makeOptimizedDeferredNamespaceObject);
 	const mode = getMakeDeferredNamespaceModeFromExportsType(exportsType);
-	return `${
-		RuntimeGlobals.makeOptimizedDeferredNamespaceObject
-	}(${moduleId}, ${mode}${
-		asyncDepsIds.length > 0
-			? `, ${JSON.stringify(asyncDepsIds.filter((x) => x !== null))}`
-			: ""
-	})`;
+	const asyncDeps = asyncDepsIds.filter((x) => x !== null);
+	const hasSync = syncCycleDepsIds !== null && syncCycleDepsIds.length > 0;
+	// `syncDeps` is passed positionally after `asyncDeps`, so a `0` placeholder
+	// keeps the slot when the module has cycle deps but no async deps.
+	const args = [moduleId, mode];
+	if (asyncDeps.length > 0 || hasSync) {
+		args.push(asyncDeps.length > 0 ? JSON.stringify(asyncDeps) : "0");
+	}
+	if (hasSync) args.push(JSON.stringify(syncCycleDepsIds));
+	return `${RuntimeGlobals.makeOptimizedDeferredNamespaceObject}(${args.join(
+		", "
+	)})`;
 }
 
 class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
@@ -72,7 +158,9 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 		const hasAsync = this.hasAsyncRuntime;
 		return Template.asString([
 			// Note: must be a function (not arrow), because this is used in body!
-			`${fn} = function(moduleId, mode${hasAsync ? ", asyncDeps" : ""}) {`,
+			// `asyncDeps` keeps a fixed positional slot even without async runtime
+			// so the trailing `syncDeps` (defer-cycle closure) always lines up.
+			`${fn} = function(moduleId, mode, asyncDeps, syncDeps) {`,
 			Template.indent([
 				`${cst} r = this;`,
 				hasAsync ? `${cst} isAsync = asyncDeps && asyncDeps.length;` : "",
@@ -82,9 +170,17 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 					Template.indent([
 						// Forcing evaluation of a module that is currently evaluating
 						// (a cycle reached through a deferred import) must throw rather
-						// than expose its partial exports.
+						// than expose its partial exports. `syncDeps` (present only for
+						// cyclic deferred modules) carries the transitive static closure,
+						// so an evaluating dependency is caught before any evaluation.
 						`${cst} cachedModule = __webpack_module_cache__[moduleId];`,
 						'if (cachedModule !== undefined && cachedModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
+						"if (syncDeps) for (var i = 0; i < syncDeps.length; i++) {",
+						Template.indent([
+							`${cst} depModule = __webpack_module_cache__[syncDeps[i]];`,
+							'if (depModule !== undefined && depModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while a dependency is being evaluated");'
+						]),
+						"}",
 						`${lt} exports = r(moduleId);`,
 						hasAsync
 							? `if(isAsync) exports = exports[${RuntimeGlobals.asyncModuleExportSymbol}];`
@@ -358,6 +454,8 @@ module.exports.MakeDeferredNamespaceObjectRuntimeModule =
 	MakeDeferredNamespaceObjectRuntimeModule;
 module.exports.MakeOptimizedDeferredNamespaceObjectRuntimeModule =
 	MakeOptimizedDeferredNamespaceObjectRuntimeModule;
+module.exports.getDeferredCycleModuleIds = getDeferredCycleModuleIds;
+module.exports.getDeferredCycleModules = getDeferredCycleModules;
 module.exports.getMakeDeferredNamespaceModeFromExportsType =
 	getMakeDeferredNamespaceModeFromExportsType;
 module.exports.getOptimizedDeferredModule = getOptimizedDeferredModule;

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -80,6 +80,11 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 				Template.indent([
 					"get a() {",
 					Template.indent([
+						// Forcing evaluation of a module that is currently evaluating
+						// (a cycle reached through a deferred import) must throw rather
+						// than expose its partial exports.
+						`${cst} cachedModule = __webpack_module_cache__[moduleId];`,
+						'if (cachedModule !== undefined && cachedModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
 						`${lt} exports = r(moduleId);`,
 						hasAsync
 							? `if(isAsync) exports = exports[${RuntimeGlobals.asyncModuleExportSymbol}];`
@@ -164,6 +169,11 @@ class MakeDeferredNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 			"}",
 			"",
 			`${lt} init = ${runtimeTemplate.basicFunction("", [
+				// A deferred namespace that forces evaluation of a module that is
+				// already evaluating (a cycle) must throw rather than expose its
+				// partial exports.
+				`${cst} evaluatingModule = __webpack_module_cache__[moduleId];`,
+				'if (evaluatingModule !== undefined && evaluatingModule.evaluating) throw new TypeError("Cannot access a deferred module namespace while the module is being evaluated");',
 				`ns = ${RuntimeGlobals.require}(moduleId);`,
 				hasAsync
 					? `if (${RuntimeGlobals.asyncModuleExportSymbol} in ns) ns = ns[${RuntimeGlobals.asyncModuleExportSymbol}];`

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -16,57 +16,145 @@ const HelperRuntimeModule = require("./HelperRuntimeModule");
 /** @typedef {import("../Module").ExportsType} ExportsType */
 /** @typedef {import("../ChunkGraph").ModuleId} ModuleId */
 
-/** @type {WeakMap<ModuleGraph, Map<Module, Set<Module> | null>>} */
+/**
+ * @typedef {object} DeferredCycleState
+ * @property {Map<Module, Set<Module>>} sccOf strongly-connected component per module (shared object per component)
+ * @property {Map<Module, Set<Module> | null>} peers memoized SCC peers (component minus the module) per deferred module
+ */
+
+/** @type {WeakMap<ModuleGraph, DeferredCycleState>} */
 const deferredCycleCache = new WeakMap();
+
+/**
+ * Materializes the active harmony-import targets of a module (deferred edges
+ * included, matching the spec's `RequestedModules` recursion).
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} module the module
+ * @returns {Module[]} imported modules
+ */
+function harmonyImportTargets(moduleGraph, module) {
+	const connections = moduleGraph.getOutgoingConnectionsByModule(module);
+	if (!connections) return [];
+	/** @type {Module[]} */
+	const targets = [];
+	for (const [dep, moduleConnections] of connections) {
+		if (
+			dep &&
+			moduleConnections.some(
+				(c) =>
+					c.dependency instanceof HarmonyImportDependency &&
+					c.isTargetActive(undefined)
+			)
+		) {
+			targets.push(dep);
+		}
+	}
+	return targets;
+}
+
+/**
+ * Assigns every module reachable from `seed` (through active harmony imports)
+ * to its strongly-connected component via an iterative Tarjan pass, writing the
+ * results into `sccOf`. Modules already assigned by an earlier pass are treated
+ * as finished, so across all deferred imports every edge is visited once
+ * (O(V + E) total) rather than re-walked per import.
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} seed the module to explore from
+ * @param {Map<Module, Set<Module>>} sccOf module-to-component map to populate
+ * @returns {void}
+ */
+function assignStronglyConnectedComponents(moduleGraph, seed, sccOf) {
+	if (sccOf.has(seed)) return;
+	/** @type {Map<Module, number>} */
+	const index = new Map();
+	/** @type {Map<Module, number>} */
+	const low = new Map();
+	/** @type {Set<Module>} */
+	const onStack = new Set();
+	/** @type {Module[]} */
+	const componentStack = [];
+	/** @type {{ node: Module, targets: Module[], i: number }[]} */
+	const work = [];
+	let counter = 0;
+	/**
+	 * @param {Module} node node to open
+	 */
+	const open = (node) => {
+		index.set(node, counter);
+		low.set(node, counter);
+		counter++;
+		componentStack.push(node);
+		onStack.add(node);
+		work.push({ node, targets: harmonyImportTargets(moduleGraph, node), i: 0 });
+	};
+	open(seed);
+	while (work.length > 0) {
+		const frame = work[work.length - 1];
+		if (frame.i < frame.targets.length) {
+			const next = frame.targets[frame.i++];
+			// Already in a finished component (from this or a prior pass): skip.
+			if (sccOf.has(next)) continue;
+			if (!index.has(next)) {
+				open(next);
+			} else if (onStack.has(next)) {
+				const nodeLow = /** @type {number} */ (low.get(frame.node));
+				const nextIndex = /** @type {number} */ (index.get(next));
+				if (nextIndex < nodeLow) low.set(frame.node, nextIndex);
+			}
+			continue;
+		}
+		work.pop();
+		const node = frame.node;
+		const nodeLow = /** @type {number} */ (low.get(node));
+		if (work.length > 0) {
+			const parent = work[work.length - 1].node;
+			if (nodeLow < /** @type {number} */ (low.get(parent))) {
+				low.set(parent, nodeLow);
+			}
+		}
+		if (nodeLow === index.get(node)) {
+			/** @type {Set<Module>} */
+			const component = new Set();
+			let member;
+			do {
+				member = /** @type {Module} */ (componentStack.pop());
+				onStack.delete(member);
+				component.add(member);
+			} while (member !== node);
+			for (const m of component) sccOf.set(m, component);
+		}
+	}
+}
 
 /**
  * Per the TC39 import-defer spec's `ReadyForSyncExecution`, forcing evaluation
  * of a deferred module must throw when any module in its transitive static
- * import closure is currently evaluating. Only a deferred module that is part
- * of an import cycle can ever observe such an evaluating dependency, so the
- * closure (and the extra runtime check that consumes it) is emitted only then.
+ * import closure is currently evaluating. Only a module in `module`'s own
+ * strongly-connected component can be evaluating at that point (anything else it
+ * imports is either already evaluated or not started), so we emit just the SCC
+ * peers instead of the whole (potentially huge) forward closure.
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {Module} module the deferred module
- * @returns {Set<Module> | null} closure modules when cyclic, otherwise null
+ * @returns {Set<Module> | null} the SCC peers when cyclic, otherwise null
  */
 function getDeferredCycleModules(moduleGraph, module) {
-	let perGraph = deferredCycleCache.get(moduleGraph);
-	if (perGraph === undefined) {
-		perGraph = new Map();
-		deferredCycleCache.set(moduleGraph, perGraph);
+	let state = deferredCycleCache.get(moduleGraph);
+	if (state === undefined) {
+		state = { sccOf: new Map(), peers: new Map() };
+		deferredCycleCache.set(moduleGraph, state);
 	}
-	const cached = perGraph.get(module);
+	const cached = state.peers.get(module);
 	if (cached !== undefined) return cached;
-	// `reachable` doubles as the visited set; the deferred module seeds it.
-	const reachable = new Set([module]);
-	let cyclic = false;
-	const stack = [module];
-	while (stack.length > 0) {
-		const current = /** @type {Module} */ (stack.pop());
-		const connections = moduleGraph.getOutgoingConnectionsByModule(current);
-		if (!connections) continue;
-		for (const [dep, moduleConnections] of connections) {
-			if (
-				!dep ||
-				!moduleConnections.some(
-					(c) =>
-						c.dependency instanceof HarmonyImportDependency &&
-						c.isTargetActive(undefined)
-				)
-			) {
-				continue;
-			}
-			if (dep === module) {
-				cyclic = true;
-			} else if (!reachable.has(dep)) {
-				reachable.add(dep);
-				stack.push(dep);
-			}
-		}
+	assignStronglyConnectedComponents(moduleGraph, module, state.sccOf);
+	const component = state.sccOf.get(module);
+	// A trivial component (size 1, no self-cycle peers) means no cycle; a direct
+	// self-loop is already covered by the `evaluating` check on `module` itself.
+	let result = null;
+	if (component !== undefined && component.size > 1) {
+		result = new Set(component);
+		result.delete(module);
 	}
-	reachable.delete(module);
-	const result = cyclic ? reachable : null;
-	perGraph.set(module, result);
+	state.peers.set(module, result);
 	return result;
 }
 

--- a/test/configCases/defer-import/defer-cycle-async-throw/a.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/a.js
@@ -1,0 +1,5 @@
+import "./b.js";
+
+await Promise.resolve();
+
+export const done = 1;

--- a/test/configCases/defer-import/defer-cycle-async-throw/b.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/b.js
@@ -1,0 +1,9 @@
+import defer * as ns from "./c.js";
+
+// `a.js` (a top-level-await module) is still evaluating; forcing `ns` reaches
+// it through the c -> a cycle, so the access must throw a TypeError.
+try {
+	ns.foo;
+} catch (error) {
+	globalThis.deferAsyncError = error;
+}

--- a/test/configCases/defer-import/defer-cycle-async-throw/c.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/c.js
@@ -1,0 +1,3 @@
+import "./a.js";
+
+export const foo = 1;

--- a/test/configCases/defer-import/defer-cycle-async-throw/index.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/index.js
@@ -1,0 +1,5 @@
+import "./a.js";
+
+it("should throw when a deferred namespace reaches a module that is still evaluating-async", () => {
+	expect(globalThis.deferAsyncError).toBeInstanceOf(TypeError);
+});

--- a/test/configCases/defer-import/defer-cycle-async-throw/test.filter.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsAsync = require("../../../helpers/supportsAsync");
+
+module.exports = () => supportsAsync();

--- a/test/configCases/defer-import/defer-cycle-async-throw/webpack.config.js
+++ b/test/configCases/defer-import/defer-cycle-async-throw/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	experiments: {
+		deferImport: true,
+		topLevelAwait: true
+	}
+};

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/dep1.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/dep1.js
@@ -1,0 +1,12 @@
+import defer * as dep2 from "./dep2.js";
+
+globalThis.dep3Evaluated = false;
+
+// `dep2` is only linked, but its transitive static dependency `index.js` is
+// still evaluating (index -> dep1 -> defer dep2 -> index), so forcing the
+// deferred namespace must throw without evaluating dep3.
+try {
+	dep2.foo;
+} catch (error) {
+	globalThis.deferTransitiveError = error;
+}

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/dep2.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/dep2.js
@@ -1,0 +1,4 @@
+import "./dep3.js";
+import "./index.js";
+
+export const foo = 1;

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/dep3.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/dep3.js
@@ -1,0 +1,1 @@
+globalThis.dep3Evaluated = true;

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/index.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/index.js
@@ -1,0 +1,7 @@
+import "./dep1.js";
+
+it("should throw before evaluating a dependency when a transitive dep of a deferred module is still evaluating", () => {
+	expect(globalThis.deferTransitiveError).toBeInstanceOf(TypeError);
+	// The throw must happen before any evaluation, so dep3 must not have run.
+	expect(globalThis.dep3Evaluated).toBe(false);
+});

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/test.filter.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsAsync = require("../../../helpers/supportsAsync");
+
+module.exports = () => supportsAsync();

--- a/test/configCases/defer-import/defer-cycle-transitive-throw/webpack.config.js
+++ b/test/configCases/defer-import/defer-cycle-transitive-throw/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	mode: "production",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	experiments: {
+		deferImport: true
+	}
+};

--- a/test/configCases/defer-import/defer-cyclic-concat/a.js
+++ b/test/configCases/defer-import/defer-cyclic-concat/a.js
@@ -1,0 +1,3 @@
+import "./b.js";
+
+export const foo = 1;

--- a/test/configCases/defer-import/defer-cyclic-concat/b.js
+++ b/test/configCases/defer-import/defer-cyclic-concat/b.js
@@ -1,0 +1,9 @@
+import defer * as a from "./a.js";
+
+// `a` is still evaluating (a -> b -> defer a cycle), so forcing evaluation
+// through the deferred namespace must throw a TypeError per the TC39 spec.
+try {
+	a.foo;
+} catch (error) {
+	globalThis.deferCyclicError = error;
+}

--- a/test/configCases/defer-import/defer-cyclic-concat/index.js
+++ b/test/configCases/defer-import/defer-cyclic-concat/index.js
@@ -1,0 +1,5 @@
+import "./a.js";
+
+it("should throw when a deferred namespace forces evaluation of an already-evaluating module (even with scope hoisting)", () => {
+	expect(globalThis.deferCyclicError).toBeInstanceOf(TypeError);
+});

--- a/test/configCases/defer-import/defer-cyclic-concat/test.filter.js
+++ b/test/configCases/defer-import/defer-cyclic-concat/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsAsync = require("../../../helpers/supportsAsync");
+
+module.exports = () => supportsAsync();

--- a/test/configCases/defer-import/defer-cyclic-concat/webpack.config.js
+++ b/test/configCases/defer-import/defer-cyclic-concat/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	mode: "production",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	experiments: {
+		deferImport: true
+	}
+};

--- a/test/configCases/defer-import/defer-reexport-identity/barrel.js
+++ b/test/configCases/defer-import/defer-reexport-identity/barrel.js
@@ -1,0 +1,3 @@
+import defer * as reexported from "./dep.js";
+
+export { reexported };

--- a/test/configCases/defer-import/defer-reexport-identity/dep.js
+++ b/test/configCases/defer-import/defer-reexport-identity/dep.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/defer-import/defer-reexport-identity/index.js
+++ b/test/configCases/defer-import/defer-reexport-identity/index.js
@@ -1,0 +1,8 @@
+import defer * as direct from "./dep.js";
+import { reexported } from "./barrel.js";
+
+it("a deferred namespace re-exported through a side-effect-free barrel keeps its identity", () => {
+	// Same deferred module, reached directly and via the barrel: one object.
+	expect(direct).toBe(reexported);
+	expect(direct.value).toBe(42);
+});

--- a/test/configCases/defer-import/defer-reexport-identity/package.json
+++ b/test/configCases/defer-import/defer-reexport-identity/package.json
@@ -1,0 +1,1 @@
+{ "sideEffects": false }

--- a/test/configCases/defer-import/defer-reexport-identity/test.filter.js
+++ b/test/configCases/defer-import/defer-reexport-identity/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsAsync = require("../../../helpers/supportsAsync");
+
+module.exports = () => supportsAsync();

--- a/test/configCases/defer-import/defer-reexport-identity/webpack.config.js
+++ b/test/configCases/defer-import/defer-reexport-identity/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: [`async-node${process.versions.node.split(".").map(Number)[0]}`],
+	mode: "production",
+	optimization: {
+		concatenateModules: true,
+		usedExports: true,
+		sideEffects: true,
+		minimize: false
+	},
+	experiments: {
+		deferImport: true
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1025,31 +1025,15 @@ const knownBugs = [
 	//   require dynamic specifiers webpack cannot resolve at build time.
 	// - `import(<UnaryExpression>)` (e.g. `import(typeof {})`): non-string
 	//   specifiers are emitted by the parser but webpack rejects them.
-	// - The `import-defer/*/main.js` cases interleave defer and eager loads of
-	//   the same module graph; webpack currently produces a single shared
-	//   module record so ordering and async-vs-sync semantics differ.
 	"expressions/dynamic-import/eval-self-once-script.js",
 	"expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js",
 	"expressions/dynamic-import/import-errored-module.js",
 	"expressions/dynamic-import/reuse-namespace-object-from-script.js",
 	"expressions/dynamic-import/usage-from-eval.js",
 	"expressions/dynamic-import/assignment-expression/unary-expr.js",
-	"expressions/dynamic-import/import-defer/sync/main.js",
-	"expressions/dynamic-import/import-defer/import-defer-transitive-async-module/main.js",
+	// `.then` is expected not to be called on the deferred namespace's promise.
 	"expressions/dynamic-import/import-defer/import-defer-transitive-async-module/promise-prototype-then-not-called.js",
-	"expressions/dynamic-import/import-defer/import-defer-async-module/main.js",
-	"expressions/dynamic-import/import-defer/sync-dependency-of-deferred-async-module/main.js",
 
-	// Top-level-await ordering/observability: webpack inlines TLA into a
-	// promise chain inside the runtime, so V8/Node's Module Record evaluation
-	// order (rejection-order, fulfillment-order, async-evaluation-count reset)
-	// and "module graph does not hang on cycle" semantics are not preserved.
-	"module-code/top-level-await/unobservable-global-async-evaluation-count-reset.js",
-	"module-code/top-level-await/dynamic-import-resolution.js",
-	"module-code/top-level-await/rejection-order.js",
-	"module-code/top-level-await/await-dynamic-import-resolution.js",
-	"module-code/top-level-await/fulfillment-order.js",
-	"module-code/top-level-await/module-graphs-does-not-hang.js",
 	// Dynamic import of a fulfilled member of an errored TLA cycle must reject
 	// with the cycle root's evaluation error; webpack fulfills it instead.
 	"expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js",

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1043,12 +1043,10 @@ const knownProductionBuildBugs = [
 	// Production provided exports misses namespace re-exports
 	"module-code/instn-star-props-nrml.js",
 	"module-code/namespace/internals/get-nested-namespace-props-nrml.js",
-	// Production concatenation orders eager import after defer
+	// A module imported both `import defer` and eagerly must evaluate at the
+	// eager position; production concatenation evaluates it at the earlier
+	// deferred position instead, changing the observable evaluation order.
 	"import/import-defer/evaluation-sync/module-imported-defer-and-eager.js",
-	// Production concatenation inlines a re-exported deferred namespace as
-	// the eager namespace of the underlying module, so cross-file deferred
-	// namespaces are no longer the same object as the local Proxy.
-	"import/import-defer/deferred-namespace-object/identity.js",
 
 	// Production InlineExports:
 	// TODO: Support disable inline export annotation to keep the TDZ

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1059,14 +1059,11 @@ const knownBugs = [
 	// Weird test
 	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js",
 
-	// Looks like a bug in webpack
+	// Dynamic `import()` of a rejecting module inside a top-level-await module:
+	// the runtime import promise never settles in the test runner, so the test
+	// times out.
 	"module-code/top-level-await/dynamic-import-rejection.js",
-
-	// Need improve our test runner, nested Promise is not catching
-	"module-code/top-level-await/module-import-rejection.js",
-	"module-code/top-level-await/module-import-rejection-body.js",
-	"module-code/top-level-await/await-dynamic-import-rejection.js",
-	"module-code/top-level-await/module-import-rejection-tick.js"
+	"module-code/top-level-await/await-dynamic-import-rejection.js"
 ];
 
 const knownProductionBuildBugs = [

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -737,16 +737,7 @@ const knownBugs = [
 	"eval-code/direct/var-env-var-init-global-exstng.js",
 
 	// acorn bugs
-	"identifiers/part-unicode-17.0.0-class-escaped.js",
-	"identifiers/part-unicode-17.0.0-class.js",
-	"identifiers/part-unicode-17.0.0-escaped.js",
-	"identifiers/part-unicode-17.0.0.js",
-	"identifiers/start-unicode-17.0.0-class-escaped.js",
-	"identifiers/start-unicode-17.0.0-class.js",
-	"identifiers/start-unicode-17.0.0-escaped.js",
-	"identifiers/start-unicode-17.0.0.js",
 	"statements/using/syntax/using-for-statement.js",
-	"statements/await-using/syntax/await-using-invalid-arraybindingpattern-does-not-break-element-access.js",
 	"statements/await-using/syntax/await-using-valid-for-await-using-of-of.js",
 
 	// Expected error because we use `Promise` to load modules, but this test overrides global `Promise`
@@ -817,8 +808,6 @@ const knownBugs = [
 	// the exported `valueOf`. Setting the prototype to `null` would impact
 	// other webpack-generated code paths.
 	"expressions/dynamic-import/custom-primitive.js",
-	// `import.meta` in script context should throw SyntaxError
-	"expressions/import.meta/syntax/goal-script.js",
 	// `with { type: 'text' }`: asset/source modules use module.exports, preventing pure ESM output for vm.SourceTextModule
 	"import/import-attributes/text-via-namespace.js",
 	// Bundler limitation: all modules share a single bundle-level import.meta, so distinct-per-module cannot be satisfied
@@ -832,9 +821,6 @@ const knownBugs = [
 
 	// Replacing `export default` will remove `default` name by spec, need to `static name = "default";` if doesn't exist
 	"expressions/class/elements/class-name-static-initializer-default-export.js",
-
-	// improve test runner to keep dynamic import for such case
-	"expressions/dynamic-import/assign-expr-get-value-abrupt-throws.js",
 
 	"eval-code/indirect/var-env-func-init-global-update-configurable.js",
 	"eval-code/indirect/var-env-var-init-global-exstng.js",
@@ -853,8 +839,6 @@ const knownBugs = [
 	"global-code/script-decl-func-err-non-configurable.js",
 	"global-code/script-decl-func-err-non-extensible.js",
 	"global-code/script-decl-func.js",
-	"global-code/script-decl-lex-deletion.js",
-	"global-code/script-decl-lex.js",
 	"global-code/script-decl-var-collision.js",
 	"global-code/script-decl-var-err.js",
 	"global-code/script-decl-var.js",
@@ -927,7 +911,6 @@ const knownBugs = [
 	"expressions/dynamic-import/syntax/valid/nested-if-nested-imports.js",
 	"expressions/dynamic-import/syntax/valid/nested-while-nested-imports.js",
 	"expressions/dynamic-import/syntax/valid/nested-with-expression-nested-imports.js",
-	"expressions/dynamic-import/syntax/valid/nested-with-expression-script-code-valid.js",
 	"expressions/dynamic-import/syntax/valid/top-level-nested-imports.js",
 
 	// Module Namespace Exotic Object semantics for the dynamically imported
@@ -1075,9 +1058,6 @@ const knownBugs = [
 
 	// Weird test
 	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js",
-
-	// We need to handle `import.meta` in `import`
-	"expressions/dynamic-import/assignment-expression/import-meta.js",
 
 	// Looks like a bug in webpack
 	"module-code/top-level-await/dynamic-import-rejection.js",

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -768,9 +768,6 @@ const knownBugs = [
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// Complex examples, need to think how to resolve it
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
-	// Async variant: needs `evaluating-async` tracking through the async-module
-	// runtime, which the sync closure check below does not cover.
-	"import/import-defer/errors/get-other-while-dep-evaluating-async/main.js",
 	// Just bugs, need to fix
 	// `Reflect.preventExtensions(ns)` should return true and the deferred
 	// namespace should report `isExtensible() === false` per the TC39 spec —

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -762,12 +762,18 @@ const knownBugs = [
 	// target is mutable until init runs and cannot be frozen up-front
 	// because the underlying module's exports aren't yet known.
 	"import/import-defer/evaluation-triggers/ignore-private-name-access.js",
-	// Bugs with defer and evaluation
+	// Host resolution errors must be reported eagerly even for deferred imports;
+	// webpack turns a missing module into a build error resolved lazily instead.
 	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
+	// The deferred module itself has top-level await, so webpack evaluates it
+	// eagerly through the async-dependency system and never builds a deferred
+	// namespace for it — throwing on self/other access during its own
+	// evaluating-async state would require routing async defer imports through a
+	// deferred namespace while preserving eager awaiting (a larger change).
 	"import/import-defer/errors/get-self-while-evaluating-async/main.js",
-	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
-	// Complex examples, need to think how to resolve it
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
+	// Exact interleaving of top-level-await and deferred evaluation order.
+	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// Just bugs, need to fix
 	// `Reflect.preventExtensions(ns)` should return true and the deferred
 	// namespace should report `isExtensible() === false` per the TC39 spec —

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -766,10 +766,6 @@ const knownBugs = [
 	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
 	"import/import-defer/errors/get-self-while-evaluating-async/main.js",
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
-	// Bugs with using the same module require with defer and without - should we generate two modules here?
-	"import/import-defer/errors/module-throws/defer-import-after-evaluation.js",
-	"import/import-defer/errors/module-throws/third-party-evaluation-after-defer-import.js",
-	"import/import-defer/errors/module-throws/trigger-evaluation.js",
 	// Complex examples, need to think how to resolve it
 	"import/import-defer/errors/get-self-while-defer-evaluating/main.js",
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1028,7 +1028,17 @@ const knownBugs = [
 	"expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js",
 
 	// Weird test
-	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js"
+	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js",
+
+	// A rejecting top-level-await entry can only reject the ESM bundle module
+	// via top-level `await`, which webpack intentionally does not emit (async
+	// output stays runnable on engines without top-level await), so the
+	// rejection is orphaned instead of failing the module.
+	"module-code/top-level-await/module-import-rejection.js",
+	"module-code/top-level-await/module-import-rejection-body.js",
+	"module-code/top-level-await/module-import-rejection-tick.js",
+	"module-code/top-level-await/dynamic-import-rejection.js",
+	"module-code/top-level-await/await-dynamic-import-rejection.js"
 ];
 
 const knownProductionBuildBugs = [

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -768,7 +768,8 @@ const knownBugs = [
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// Complex examples, need to think how to resolve it
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
-	"import/import-defer/errors/get-other-while-evaluating/main.js",
+	// These require a transitive ReadyForSyncExecution check (the deferred
+	// module itself is only linked, but one of its static deps is evaluating).
 	"import/import-defer/errors/get-other-while-dep-evaluating-async/main.js",
 	"import/import-defer/errors/get-other-while-dep-evaluating/main.js",
 	// Just bugs, need to fix

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -658,6 +658,10 @@ const createImportModuleDynamically =
 		await module.link(
 			createImportModuleDynamically(context, testFile, moduleCache)
 		);
+		// Evaluate here so `import()` resolves to a fully evaluated module (the
+		// Node.js contract for `importModuleDynamically`); otherwise a top-level
+		// `await import(...)` never settles.
+		await module.evaluate();
 
 		return module;
 	};
@@ -1057,13 +1061,7 @@ const knownBugs = [
 	"expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js",
 
 	// Weird test
-	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js",
-
-	// Dynamic `import()` of a rejecting module inside a top-level-await module:
-	// the runtime import promise never settles in the test runner, so the test
-	// times out.
-	"module-code/top-level-await/dynamic-import-rejection.js",
-	"module-code/top-level-await/await-dynamic-import-rejection.js"
+	"expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js"
 ];
 
 const knownProductionBuildBugs = [
@@ -1261,9 +1259,14 @@ describe("test262", () => {
 							};
 						}
 
-						const context = vm.createContext(sandbox, {
-							microtaskMode: "afterEvaluate"
-						});
+						const context = vm.createContext(
+							sandbox,
+							// `afterEvaluate` drains microtasks only at evaluate/runInContext
+							// boundaries; in the module scenario that deadlocks a top-level
+							// `await import(...)`, whose resolution needs a microtask
+							// checkpoint while `evaluate()` is still running.
+							scenario === "module" ? {} : { microtaskMode: "afterEvaluate" }
+						);
 
 						sandbox.globalThis = sandbox;
 						sandbox.Buffer = Buffer;

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -767,7 +767,6 @@ const knownBugs = [
 	"import/import-defer/errors/get-self-while-evaluating-async/main.js",
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// Complex examples, need to think how to resolve it
-	"import/import-defer/errors/get-self-while-defer-evaluating/main.js",
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
 	"import/import-defer/errors/get-other-while-evaluating/main.js",
 	"import/import-defer/errors/get-other-while-dep-evaluating-async/main.js",
@@ -780,8 +779,6 @@ const knownBugs = [
 	// known. Pre-knowing exports would require a larger architectural
 	// change, so this remains skipped.
 	"import/import-defer/deferred-namespace-object/exotic-object-behavior.js",
-	// Bug when import itself
-	"import/import-defer/errors/get-self-while-evaluating.js",
 	// Bug with place of `__webpack_require__`, it hoists, but should not
 	"module-code/instn-star-binding.js",
 	// Improvement- bug with `delete` and `ns[0] = something` when using `import * as ns from "...";`
@@ -1130,14 +1127,10 @@ describe("test262", () => {
 				}
 
 				if (
-					// Decorators are not supported
 					meta.features.includes("decorators") ||
-					// V8 optimization bugs
 					meta.features.includes("Symbol.unscopables") ||
-					// TODO Not implemented
 					meta.features.includes("source-phase-imports") ||
 					meta.features.includes("source-phase-imports-module-source") ||
-					// TODO improve in our test runner
 					(meta.negative && meta.negative.phase === "resolution") ||
 					knownBugs.includes(name) ||
 					(mode === "production" && knownProductionBuildBugs.includes(name))

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -750,26 +750,13 @@ const knownBugs = [
 	// webpack bugs and improvements
 	// With namespace import we export and value and `default`, by spec we should export only `default`
 	"import/import-attributes/json-via-namespace.js",
-	// `import(spec, options)` cases where the second argument cannot be lifted
-	// to a static `with`/`assert` attributes object. webpack's
-	// `ImportDependency` template overwrites the entire `import(...)` source
-	// range with the runtime require chain and so drops the second
-	// argument's evaluation entirely (`yield`, sequence expressions, getters
-	// that throw, ToString conversion, etc). The spec also requires runtime
-	// validation of the options object (must be Object, `with`/`assert`
-	// keys, value type checks).
-	"expressions/dynamic-import/import-attributes/2nd-param-yield-ident-invalid.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-yield-expr.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-return.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-throw.js",
+	// `import(spec, options)` with a dynamic specifier: the options argument
+	// goes through the context-dependency path, which still drops its
+	// evaluation, so the sequenced side effects are not observed.
 	"expressions/dynamic-import/import-attributes/2nd-param-evaluation-sequence.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-get-with-error.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-non-object.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-abrupt.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-enumerable.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-with-non-object.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-with-value-abrupt.js",
-	"expressions/dynamic-import/import-attributes/2nd-param-with-value-non-string.js",
+	// `yield` as a strict-mode reserved word: webpack parses the source in
+	// sloppy mode, so the expected parse-time SyntaxError is not raised.
+	"expressions/dynamic-import/import-attributes/2nd-param-yield-ident-invalid.js",
 	// `#mark in obj` requires the deferred namespace target to report
 	// `isExtensible() === false` to throw a TypeError. webpack's proxy
 	// target is mutable until init runs and cannot be frozen up-front

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1130,10 +1130,14 @@ describe("test262", () => {
 				}
 
 				if (
+					// Decorators are not supported
 					meta.features.includes("decorators") ||
+					// V8 optimization bugs
 					meta.features.includes("Symbol.unscopables") ||
+					// TODO Not implemented
 					meta.features.includes("source-phase-imports") ||
 					meta.features.includes("source-phase-imports-module-source") ||
+					// TODO improve in our test runner
 					(meta.negative && meta.negative.phase === "resolution") ||
 					knownBugs.includes(name) ||
 					(mode === "production" && knownProductionBuildBugs.includes(name))

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -768,10 +768,9 @@ const knownBugs = [
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// Complex examples, need to think how to resolve it
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
-	// These require a transitive ReadyForSyncExecution check (the deferred
-	// module itself is only linked, but one of its static deps is evaluating).
+	// Async variant: needs `evaluating-async` tracking through the async-module
+	// runtime, which the sync closure check below does not cover.
 	"import/import-defer/errors/get-other-while-dep-evaluating-async/main.js",
-	"import/import-defer/errors/get-other-while-dep-evaluating/main.js",
 	// Just bugs, need to fix
 	// `Reflect.preventExtensions(ns)` should return true and the deferred
 	// namespace should report `isExtensible() === false` per the TC39 spec —


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Improves webpack's conformance with the test262 suite by fixing several spec-behavior gaps found while running it, and unskips the now-passing cases. Main fixes:

- **`import defer` evaluation semantics**: retain and re-throw a deferred module's evaluation error; throw a `TypeError` when a deferred namespace forces evaluation of a module that is still evaluating — including one whose transitive static dependency is evaluating (spec `ReadyForSyncExecution`) or is a still-running top-level-await module (`evaluating-async`).
- **Deferred namespaces survive optimization**: keep a deferred import as a module-concatenation boundary, and keep a deferred re-export's side-effect-free barrel, so deferred-namespace identity and lazy-evaluation semantics are preserved under scope hoisting and `sideEffects` tree-shaking. The extra defer-cycle readiness data is emitted only for deferred modules actually in a cycle (SCC-scoped, one shared Tarjan pass), so bundle size and build time don't regress.
- **Dynamic `import()` second argument**: evaluate and validate the options argument that could previously be dropped.
- **Test harness**: handle top-level-await dynamic-import evaluation correctly and tighten skip-list documentation.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix (with a small perf commit that keeps the defer-cycle change from regressing bundle size / build time).

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. New `configCases/defer-import/*` cases (`defer-cyclic-concat`, `defer-cycle-transitive-throw`, `defer-cycle-async-throw`, `defer-reexport-identity`) drive real `webpack()` builds for each fix, and the correspondingly fixed test262 cases were unskipped in `test/test262.spectest.js`. Verified against the full `ConfigTestCases`, `StatsTestCases` (no snapshot changes), and `test262` suites.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — all changes are spec-conformance fixes to existing behavior (the deferred-namespace readiness data is internal runtime, gated on the existing `experiments.deferImport`).

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to help investigate the failing test262 cases, draft the fixes, and write the tests. Every change was reviewed, run against the test262 / config / stats suites, and benchmarked for build-time and memory impact before inclusion.