### PR TITLE
refactor: derive ASI positions from source instead of acorn's onInsertedSemicolon

### DIFF
--- a/.changeset/derive-asi-from-source.md
+++ b/.changeset/derive-asi-from-source.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Derive ASI positions from the source text instead of acorn's onInsertedSemicolon, so custom parsers no longer need to collect semicolons.

--- a/examples/custom-javascript-parser/README.md
+++ b/examples/custom-javascript-parser/README.md
@@ -27,7 +27,6 @@ const acorn = require("acorn");
 /** @typedef {import("estree").SourceLocation} SourceLocation */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseOptions} ParseOptions */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
-/** @typedef {Set<number>} Semicolons */
 
 /**
  * @param {string} sourceCode the source code
@@ -37,27 +36,17 @@ const acorn = require("acorn");
 const acornParse = (sourceCode, options) => {
 	/** @type {(Comment & { start: number, end: number, loc: SourceLocation })[]} */
 	const comments = [];
-	/** @type {Semicolons} */
-	const semicolons = new Set();
 
 	const ast =
 		/** @type {import("estree").Program} */
 		(
 			acorn.parse(sourceCode, {
 				...options,
-				onComment: options.comments ? comments : undefined,
-				onInsertedSemicolon: options.semicolons
-					? // Set semicolons
-						/**
-						 * @param {number} pos a position of semicolon
-						 * @returns {Semicolons} set with semicolon positions
-						 */
-						(pos) => semicolons.add(pos)
-					: undefined
+				onComment: options.comments ? comments : undefined
 			})
 		);
 
-	return { ast, comments, semicolons };
+	return { ast, comments };
 };
 
 module.exports = acornParse;
@@ -78,35 +67,14 @@ const oxc = require("oxc-parser");
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
 
 /**
- * @param {string} sourceCode source code
- * @returns {Set<number>} semicolons
- */
-const collectSemicolons = (sourceCode) => {
-	const semiSet = new Set();
-	let pos = sourceCode.indexOf(";");
-
-	while (pos !== -1) {
-		semiSet.add(pos);
-		pos = sourceCode.indexOf(";", pos + 1);
-	}
-
-	return semiSet;
-};
-
-/**
  * Oxc has no location API — none is needed: webpack derives line/column
- * locations from node offsets and the source text itself.
+ * locations from node offsets and the source text itself. ASI positions are
+ * likewise read from the source, so no semicolon collection is required.
  * @param {string} sourceCode the source code
  * @param {ParseOptions} options options
  * @returns {ParseResult} the parsed result
  */
 const oxcParse = (sourceCode, options) => {
-	// We need only automatic semicolon insertion position, but there is no API, so let's collect all semicolons
-	// But there are rooms to improve it
-	const semicolons = options.semicolons
-		? collectSemicolons(sourceCode)
-		: new Set();
-
 	const result = oxc.parseSync("file.js", sourceCode, {
 		astType: "js",
 		range: true,
@@ -126,8 +94,7 @@ const oxcParse = (sourceCode, options) => {
 
 	return {
 		ast: /** @type {Program} */ (/** @type {unknown} */ (result.program)),
-		comments,
-		semicolons
+		comments
 	};
 };
 
@@ -149,7 +116,6 @@ const meriyah = require("meriyah");
 /** @typedef {import("estree").SourceLocation} SourceLocation */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseOptions} ParseOptions */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
-/** @typedef {Set<number>} Semicolons */
 
 /**
  * @param {string} sourceCode the source code
@@ -159,8 +125,6 @@ const meriyah = require("meriyah");
 const meriyahParse = (sourceCode, options) => {
 	/** @type {(Comment & { start: number, end: number, loc: SourceLocation })[]} */
 	const comments = [];
-	/** @type {Semicolons} */
-	const semicolons = new Set();
 
 	const ast =
 		/** @type {import("estree").Program} */
@@ -182,19 +146,11 @@ const meriyahParse = (sourceCode, options) => {
 								});
 							}
 						}
-					: undefined,
-				onInsertedSemicolon: options.semicolons
-					? // Set semicolons
-						/**
-						 * @param {number} pos a position of semicolon
-						 * @returns {Semicolons} set with semicolon positions
-						 */
-						(pos) => semicolons.add(pos)
 					: undefined
 			})
 		);
 
-	return { ast, comments, semicolons };
+	return { ast, comments };
 };
 
 module.exports = meriyahParse;

--- a/examples/custom-javascript-parser/internals/acorn-parse.js
+++ b/examples/custom-javascript-parser/internals/acorn-parse.js
@@ -7,7 +7,6 @@ const acorn = require("acorn");
 /** @typedef {import("estree").SourceLocation} SourceLocation */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseOptions} ParseOptions */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
-/** @typedef {Set<number>} Semicolons */
 
 /**
  * @param {string} sourceCode the source code
@@ -17,27 +16,17 @@ const acorn = require("acorn");
 const acornParse = (sourceCode, options) => {
 	/** @type {(Comment & { start: number, end: number, loc: SourceLocation })[]} */
 	const comments = [];
-	/** @type {Semicolons} */
-	const semicolons = new Set();
 
 	const ast =
 		/** @type {import("estree").Program} */
 		(
 			acorn.parse(sourceCode, {
 				...options,
-				onComment: options.comments ? comments : undefined,
-				onInsertedSemicolon: options.semicolons
-					? // Set semicolons
-						/**
-						 * @param {number} pos a position of semicolon
-						 * @returns {Semicolons} set with semicolon positions
-						 */
-						(pos) => semicolons.add(pos)
-					: undefined
+				onComment: options.comments ? comments : undefined
 			})
 		);
 
-	return { ast, comments, semicolons };
+	return { ast, comments };
 };
 
 module.exports = acornParse;

--- a/examples/custom-javascript-parser/internals/bench.mjs
+++ b/examples/custom-javascript-parser/internals/bench.mjs
@@ -13,8 +13,7 @@ const options = {
 	locations: true,
 	comments: true,
 	allowHashBang: true,
-	allowReturnOutsideFunction: false,
-	semicolons: true
+	allowReturnOutsideFunction: false
 };
 
 const bench = new Bench({ name: "simple benchmark", time: 100 });

--- a/examples/custom-javascript-parser/internals/meriyah-parse.js
+++ b/examples/custom-javascript-parser/internals/meriyah-parse.js
@@ -8,7 +8,6 @@ const meriyah = require("meriyah");
 /** @typedef {import("estree").SourceLocation} SourceLocation */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseOptions} ParseOptions */
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
-/** @typedef {Set<number>} Semicolons */
 
 /**
  * @param {string} sourceCode the source code
@@ -18,8 +17,6 @@ const meriyah = require("meriyah");
 const meriyahParse = (sourceCode, options) => {
 	/** @type {(Comment & { start: number, end: number, loc: SourceLocation })[]} */
 	const comments = [];
-	/** @type {Semicolons} */
-	const semicolons = new Set();
 
 	const ast =
 		/** @type {import("estree").Program} */
@@ -41,19 +38,11 @@ const meriyahParse = (sourceCode, options) => {
 								});
 							}
 						}
-					: undefined,
-				onInsertedSemicolon: options.semicolons
-					? // Set semicolons
-						/**
-						 * @param {number} pos a position of semicolon
-						 * @returns {Semicolons} set with semicolon positions
-						 */
-						(pos) => semicolons.add(pos)
 					: undefined
 			})
 		);
 
-	return { ast, comments, semicolons };
+	return { ast, comments };
 };
 
 module.exports = meriyahParse;

--- a/examples/custom-javascript-parser/internals/oxc-parse.js
+++ b/examples/custom-javascript-parser/internals/oxc-parse.js
@@ -8,35 +8,14 @@ const oxc = require("oxc-parser");
 /** @typedef {import("../../../lib/javascript/JavascriptParser").ParseResult} ParseResult */
 
 /**
- * @param {string} sourceCode source code
- * @returns {Set<number>} semicolons
- */
-const collectSemicolons = (sourceCode) => {
-	const semiSet = new Set();
-	let pos = sourceCode.indexOf(";");
-
-	while (pos !== -1) {
-		semiSet.add(pos);
-		pos = sourceCode.indexOf(";", pos + 1);
-	}
-
-	return semiSet;
-};
-
-/**
  * Oxc has no location API — none is needed: webpack derives line/column
- * locations from node offsets and the source text itself.
+ * locations from node offsets and the source text itself. ASI positions are
+ * likewise read from the source, so no semicolon collection is required.
  * @param {string} sourceCode the source code
  * @param {ParseOptions} options options
  * @returns {ParseResult} the parsed result
  */
 const oxcParse = (sourceCode, options) => {
-	// We need only automatic semicolon insertion position, but there is no API, so let's collect all semicolons
-	// But there are rooms to improve it
-	const semicolons = options.semicolons
-		? collectSemicolons(sourceCode)
-		: new Set();
-
 	const result = oxc.parseSync("file.js", sourceCode, {
 		astType: "js",
 		range: true,
@@ -56,8 +35,7 @@ const oxcParse = (sourceCode, options) => {
 
 	return {
 		ast: /** @type {Program} */ (/** @type {unknown} */ (result.program)),
-		comments,
-		semicolons
+		comments
 	};
 };
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -307,7 +307,6 @@ class VariableInfo {
  * @property {boolean=} locations
  * @property {boolean=} comments
  * @property {boolean=} ranges
- * @property {boolean=} semicolons
  * @property {boolean=} allowHashBang
  * @property {boolean=} allowReturnOutsideFunction
  * @property {boolean=} lazyNodes internal: serve `range` lazily and skip acorn's location/range tracking
@@ -320,7 +319,6 @@ class VariableInfo {
  * @typedef {object} ParseResult
  * @property {Program} ast
  * @property {Comment[]} comments
- * @property {Set<number>} semicolons
  */
 
 /**
@@ -772,7 +770,10 @@ class JavascriptParser extends Parser {
 		this.state = /** @type {EXPECTED_ANY} */ (undefined);
 		/** @type {Comment[] | undefined} */
 		this.comments = undefined;
-		/** @type {Set<number> | undefined} */
+		// ASI overrides keyed by statement-end offset: true forces an ASI
+		// position, false forces a real semicolon. Absent offsets are derived
+		// from the source text. Allocated lazily by set/unsetAsiPosition.
+		/** @type {Map<number, boolean> | undefined} */
 		this.semicolons = undefined;
 		/** @type {StatementPath | undefined} */
 		this.statementPath = undefined;
@@ -5236,23 +5237,12 @@ class JavascriptParser extends Parser {
 		let ast;
 		/** @type {Comment[]} */
 		let comments;
-		/** @type {Set<number>} */
-		let semicolons;
 
 		if (typeof source === "object") {
-			semicolons = new Set();
-
 			ast = /** @type {Program} */ (source);
 			comments = source.comments;
-			if (source.semicolons) {
-				// Forward semicolon information from the preparsed AST if present
-				// This ensures the output is consistent with that of a fresh AST
-				for (const pos of source.semicolons) {
-					semicolons.add(pos);
-				}
-			}
 		} else {
-			({ ast, comments, semicolons } = JavascriptParser._parse(
+			({ ast, comments } = JavascriptParser._parse(
 				source,
 				{
 					sourceType: this.sourceType,
@@ -5261,7 +5251,6 @@ class JavascriptParser extends Parser {
 					locations: false,
 					ranges: true,
 					comments: true,
-					semicolons: true,
 					importPhases: this.options.importPhases === true
 				},
 				this.options.parse
@@ -5298,7 +5287,7 @@ class JavascriptParser extends Parser {
 		};
 		this.state = state;
 		this.comments = comments;
-		this.semicolons = semicolons;
+		this.semicolons = undefined;
 		// evaluating a defined, untagged identifier can only fall through when
 		// every `evaluate.for("Identifier")` tap is the parser's own — plugins
 		// tapping or intercepting it disable the callee/rename fast paths
@@ -5695,6 +5684,81 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
+	 * First significant char code at or after `pos`, skipping whitespace and
+	 * comments, or -1 at end of source.
+	 * @param {string} source source text
+	 * @param {number} pos start offset
+	 * @returns {number} char code of the next token, or -1
+	 */
+	_nextTokenCharCode(source, pos) {
+		const len = source.length;
+		for (let i = pos; i < len; i++) {
+			const c = source.charCodeAt(i);
+			// whitespace and line terminators acorn skips between tokens
+			if (
+				c === 32 ||
+				c === 9 ||
+				c === 10 ||
+				c === 13 ||
+				c === 11 ||
+				c === 12 ||
+				c === 0xa0 ||
+				c === 0xfeff ||
+				c === 0x2028 ||
+				c === 0x2029
+			) {
+				continue;
+			}
+			if (c === 47 /* / */) {
+				const n = source.charCodeAt(i + 1);
+				if (n === 47 /* / */) {
+					i += 2;
+					while (i < len) {
+						const cc = source.charCodeAt(i);
+						if (cc === 10 || cc === 13 || cc === 0x2028 || cc === 0x2029) break;
+						i++;
+					}
+					continue;
+				}
+				if (n === 42 /* * */) {
+					i += 2;
+					while (
+						i < len &&
+						!(source.charCodeAt(i) === 42 && source.charCodeAt(i + 1) === 47)
+					) {
+						i++;
+					}
+					i++;
+					continue;
+				}
+			}
+			return c;
+		}
+		return -1;
+	}
+
+	/**
+	 * Whether a statement ending at `pos` relies on ASI (no real separator).
+	 * Derived from the source text unless overridden by set/unsetAsiPosition.
+	 * A statement terminated by a real `;` or continued by a `,` (a sequence
+	 * element) is not an ASI position; anything else (newline, `}`, eof) is.
+	 * @param {number} pos statement end offset
+	 * @returns {boolean} true when ASI inserts a semicolon at this position
+	 */
+	_isAsiPosition(pos) {
+		if (this.semicolons !== undefined) {
+			const override = this.semicolons.get(pos);
+			if (override !== undefined) return override;
+		}
+		const source = this._source;
+		if (source === undefined) return true;
+		// a real semicolon is the statement's last char (exclusive end at pos)
+		if (source.charCodeAt(pos - 1) === 59 /* ; */) return false;
+		const next = this._nextTokenCharCode(source, pos);
+		return next !== 44 /* , */ && next !== 59; /* ; */
+	}
+
+	/**
 	 * Checks whether this javascript parser is asi position.
 	 * @param {number} pos source code position
 	 * @returns {boolean} true when a semicolon has been inserted before this position, false if not
@@ -5711,17 +5775,14 @@ class JavascriptParser extends Parser {
 
 		return (
 			// Either asking directly for the end position of the current statement
-			(range[1] === pos &&
-				/** @type {Set<number>} */ (this.semicolons).has(pos)) ||
+			(range[1] === pos && this._isAsiPosition(pos)) ||
 			// Or asking for the start position of the current statement,
 			// here we have to check multiple things
 			(range[0] === pos &&
 				// is there a previous statement which might be relevant?
 				this.prevStatement !== undefined &&
 				// is the end position of the previous statement an ASI position?
-				/** @type {Set<number>} */ (this.semicolons).has(
-					/** @type {Range} */ (this.prevStatement.range)[1]
-				))
+				this._isAsiPosition(/** @type {Range} */ (this.prevStatement.range)[1]))
 		);
 	}
 
@@ -5731,7 +5792,7 @@ class JavascriptParser extends Parser {
 	 * @returns {void}
 	 */
 	setAsiPosition(pos) {
-		/** @type {Set<number>} */ (this.semicolons).add(pos);
+		(this.semicolons || (this.semicolons = new Map())).set(pos, true);
 	}
 
 	/**
@@ -5740,7 +5801,7 @@ class JavascriptParser extends Parser {
 	 * @returns {void}
 	 */
 	unsetAsiPosition(pos) {
-		/** @type {Set<number>} */ (this.semicolons).delete(pos);
+		(this.semicolons || (this.semicolons = new Map())).set(pos, false);
 	}
 
 	/**
@@ -6184,7 +6245,6 @@ class JavascriptParser extends Parser {
 			// skip re-materializing it per module; acorn copies it via getOptions.
 			// Every non-default key a caller may pass must be reset here.
 			parserOptions = REUSED_PARSER_OPTIONS;
-			parserOptions.semicolons = false;
 			parserOptions.importPhases = false;
 			Object.assign(parserOptions, defaultParserOptions);
 			parserOptions.allowReturnOutsideFunction = type === "script";
@@ -6231,31 +6291,21 @@ class JavascriptParser extends Parser {
 				}
 			}
 
-			/** @type {Set<number>} */
-			const semicolons = new Set();
-
-			if (options.semicolons) {
-				/** @type {AcornOptions} */
-				(options).onInsertedSemicolon = (pos) => semicolons.add(pos);
-			}
-
 			const ast =
 				/** @type {Program} */
 				(parser.parse(code, /** @type {AcornOptions} */ (options)));
 
-			return { ast, comments, semicolons };
+			return { ast, comments };
 		};
 
 		/** @type {Program | undefined} */
 		let ast;
 		/** @type {Comment[] | undefined} */
 		let comments;
-		/** @type {Set<number> | undefined} */
-		let semicolons;
 		let error;
 		let threw = false;
 		try {
-			({ ast, comments, semicolons } = internalParse(code, parserOptions));
+			({ ast, comments } = internalParse(code, parserOptions));
 		} catch (err) {
 			error = err;
 			threw = true;
@@ -6266,7 +6316,7 @@ class JavascriptParser extends Parser {
 			parserOptions.allowReturnOutsideFunction = true;
 
 			try {
-				({ ast, comments, semicolons } = internalParse(code, parserOptions));
+				({ ast, comments } = internalParse(code, parserOptions));
 				threw = false;
 			} catch (_err) {
 				// we use the error from first parse try
@@ -6279,14 +6329,12 @@ class JavascriptParser extends Parser {
 		parserOptions.lazyComments = undefined;
 		/** @type {AcornOptions} */
 		(parserOptions).onComment = undefined;
-		/** @type {AcornOptions} */
-		(parserOptions).onInsertedSemicolon = undefined;
 
 		if (threw) {
 			throw error;
 		}
 
-		return /** @type {ParseResult} */ ({ ast, comments, semicolons });
+		return /** @type {ParseResult} */ ({ ast, comments });
 	}
 
 	/**

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -27,7 +27,6 @@ const parse = (code, options) =>
 			ecmaVersion: "latest",
 			comments: true,
 			ranges: true,
-			semicolons: true,
 			allowHashBang: true,
 			...options
 		})
@@ -280,21 +279,86 @@ describe("WebpackParser", () => {
 	});
 
 	describe("automatic semicolon insertion", () => {
-		it("should insert semicolons across line breaks and at eof", () => {
-			expect([...parse("x").semicolons]).toHaveLength(1);
-			expect([...parse("a\nb").semicolons]).toHaveLength(2);
-			expect([...parse("x;\ny;").semicolons]).toHaveLength(0);
-			expect(
-				[...parse("function f() { return\n5 }").semicolons].length
-			).toBeGreaterThan(0);
+		/**
+		 * @param {string} code source the parser maps
+		 * @param {[number, number]} current current statement range
+		 * @param {[number, number]=} prev previous statement range
+		 * @returns {JavascriptParser} parser positioned in `current`
+		 */
+		const asiParserFor = (code, current, prev) => {
+			const parser = new JavascriptParser("auto");
+			parser._source = code;
+			parser.statementPath = [/** @type {EXPECTED_ANY} */ ({ range: current })];
+			if (prev) {
+				parser.prevStatement = /** @type {EXPECTED_ANY} */ ({ range: prev });
+			}
+			return parser;
+		};
+
+		it("should derive ASI positions from the source text", () => {
+			// no real semicolon → end and (via prev) start are ASI positions
+			const asi = asiParserFor("a\nb", [2, 3], [0, 1]);
+			expect(asi.isAsiPosition(3)).toBe(true);
+			expect(asi.isAsiPosition(2)).toBe(true);
+			// a real semicolon terminates the statement → not an ASI position
+			const term = asiParserFor("x;\ny;", [3, 5], [0, 2]);
+			expect(term.isAsiPosition(5)).toBe(false);
+			expect(term.isAsiPosition(3)).toBe(false);
+			// a position that is neither statement boundary is never ASI
+			expect(term.isAsiPosition(4)).toBe(false);
 		});
 
-		it("should parse numbers and insert semicolons without ranges", () => {
-			const { ast, semicolons } = parse("var x = 1.5\nvar y = 0", {
-				ranges: false
-			});
+		it("should honor set/unsetAsiPosition overrides over the source", () => {
+			const term = asiParserFor("x;\ny;", [3, 5]);
+			// force ASI even though a real semicolon is present
+			term.setAsiPosition(5);
+			expect(term.isAsiPosition(5)).toBe(true);
+			const asi = asiParserFor("a\nb", [2, 3]);
+			// force a real semicolon even though the source relies on ASI
+			asi.unsetAsiPosition(3);
+			expect(asi.isAsiPosition(3)).toBe(false);
+		});
+
+		it("should treat a comma-continued sequence element as non-ASI", () => {
+			// the separator can trail whitespace, line and block comments
+			for (const code of ["a,b", "a ,b", "a\t,b", "a//c\n,b", "a/* c */,b"]) {
+				const parser = new JavascriptParser("auto");
+				parser._source = code;
+				expect(parser._isAsiPosition(1)).toBe(false);
+			}
+			// a genuine line break with no separator is an ASI position; a lone
+			// slash (division) is a token, not a comment, so it stays ASI too
+			for (const code of [
+				"a\nb",
+				"a//c\nb",
+				"a/* c */\nb",
+				"a",
+				"a/* c */",
+				"a/b"
+			]) {
+				const parser = new JavascriptParser("auto");
+				parser._source = code;
+				expect(parser._isAsiPosition(1)).toBe(true);
+			}
+		});
+
+		it("should assume ASI when no source text is available", () => {
+			const parser = new JavascriptParser("auto");
+			parser.statementPath = [/** @type {EXPECTED_ANY} */ ({ range: [0, 1] })];
+			expect(parser.isAsiPosition(1)).toBe(true);
+		});
+
+		it("should throw when queried outside of a statement", () => {
+			const parser = new JavascriptParser("auto");
+			parser.statementPath = [];
+			expect(() => parser.isAsiPosition(0)).toThrow("Not in statement");
+		});
+
+		it("should keep splitting statements at ASI boundaries", () => {
+			expect(parse("x").ast.body).toHaveLength(1);
+			expect(parse("a\nb").ast.body).toHaveLength(2);
+			const { ast } = parse("var x = 1.5\nvar y = 0", { ranges: false });
 			expect(ast.body).toHaveLength(2);
-			expect([...semicolons]).toHaveLength(2);
 		});
 
 		it("should tokenize non-ASCII identifiers and unicode whitespace", () => {

--- a/test/benchmarkCases/js-parser-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-unit/index.bench.mjs
@@ -80,7 +80,6 @@ export default (bench) => {
 			locations: true,
 			ranges: true,
 			comments: true,
-			semicolons: true,
 			importPhases: false
 		});
 	});

--- a/test/cases/parsing/precreated-ast/ast-loader.js
+++ b/test/cases/parsing/precreated-ast/ast-loader.js
@@ -8,15 +8,13 @@ module.exports = function (source) {
 	/** @type {acorn.Comment[]} */
 	const comments = [];
 
-	const semicolons = new Set();
 	//@ts-ignore
 	const ast = acornParser.parse(source, {
 		ranges: true,
 		locations: true,
 		ecmaVersion: 11,
 		sourceType: "module",
-		onComment: comments,
-		onInsertedSemicolon: (pos) => semicolons.add(pos)
+		onComment: comments
 	});
 
 	// change something to test if it's really used
@@ -27,8 +25,6 @@ module.exports = function (source) {
 
 	//@ts-ignore
 	ast.comments = comments;
-	//@ts-ignore
-	ast.semicolons = semicolons;
 	this.callback(null, source, null, {
 		webpackAST: ast
 	});

--- a/test/configCases/module/custom-javascript-parser/webpack.config.js
+++ b/test/configCases/module/custom-javascript-parser/webpack.config.js
@@ -10,25 +10,17 @@ let counter = 0;
 
 /**
  * @param {string} sourceCode source code
- * @param {{ sourceType: "module", comments: boolean, locations: boolean, semicolons: boolean }} options options
- * @returns {{ ast: Program, comments: Comment[], semicolons: Set<number> }} parsed source code
+ * @param {{ sourceType: "module", comments: boolean, locations: boolean }} options options
+ * @returns {{ ast: Program, comments: Comment[] }} parsed source code
  */
 const parse = (sourceCode, options) => {
 	/** @type {Comment[]} */
 	const comments = [];
-	const semicolons = new Set();
-	/**
-	 * @param {number} pos pos
-	 */
-	const addSemicolons = (pos) => {
-		semicolons.add(pos);
-	};
 	const parseOptions = {
 		...options,
 		module: options.sourceType === "module",
 		loc: options.locations,
-		onComment: options.comments ? comments : undefined,
-		onInsertedSemicolon: options.semicolons ? addSemicolons : undefined
+		onComment: options.comments ? comments : undefined
 	};
 	// @ts-expect-error meriyah types for comments are not align with estree
 	const ast = meriyah.parse(sourceCode, parseOptions);
@@ -36,7 +28,7 @@ const parse = (sourceCode, options) => {
 	counter++;
 
 	// @ts-expect-error meriyah types for ClassExpression is not align with estree
-	return { ast, comments, semicolons };
+	return { ast, comments };
 };
 
 /** @type {import("../../../../types").Configuration} */

--- a/test/configCases/parsing/custom-parser-no-locations/webpack.config.js
+++ b/test/configCases/parsing/custom-parser-no-locations/webpack.config.js
@@ -19,8 +19,6 @@ module.exports = {
 				parse: (code, options) => {
 					/** @type {ParseResult["comments"]} */
 					const comments = [];
-					/** @type {Set<number>} */
-					const semicolons = new Set();
 					const ast = acorn.parse(code, {
 						sourceType: options.sourceType,
 						ecmaVersion: "latest",
@@ -28,13 +26,11 @@ module.exports = {
 						ranges: true,
 						allowHashBang: true,
 						allowReturnOutsideFunction: options.allowReturnOutsideFunction,
-						onComment: /** @type {EXPECTED_ANY} */ (comments),
-						onInsertedSemicolon: (pos) => semicolons.add(pos)
+						onComment: /** @type {EXPECTED_ANY} */ (comments)
 					});
 					return {
 						ast: /** @type {ParseResult["ast"]} */ (ast),
-						comments,
-						semicolons
+						comments
 					};
 				}
 			}

--- a/types.d.ts
+++ b/types.d.ts
@@ -11285,7 +11285,7 @@ declare class JavascriptParser extends ParserClass {
 	scope: ScopeInfo;
 	state: JavascriptParserState;
 	comments?: CommentJavascriptParser[];
-	semicolons?: Set<number>;
+	semicolons?: Map<number, boolean>;
 	statementPath?: StatementPathItem[];
 	prevStatement?:
 		| ImportDeclaration
@@ -19723,7 +19723,6 @@ declare interface ParseOptions {
 	locations?: boolean;
 	comments?: boolean;
 	ranges?: boolean;
-	semicolons?: boolean;
 	allowHashBang?: boolean;
 	allowReturnOutsideFunction?: boolean;
 
@@ -19745,7 +19744,6 @@ declare interface ParseOptions {
 declare interface ParseResult {
 	ast: Program;
 	comments: CommentJavascriptParser[];
-	semicolons: Set<number>;
 }
 declare interface ParsedIdentifier {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Now that the parser has the module source available during the walk (locations are derived from node offsets), automatic-semicolon-insertion positions can be read straight from the source text instead of being collected via acorn's `onInsertedSemicolon` callback. This drops the `semicolons` option/callback from the parse path and, more importantly, means custom parsers no longer have to collect and return a `semicolons` set — so the oxc example loses its "scan the whole source for every semicolon" workaround. `isAsiPosition` now treats a statement terminated by a real `;` or continued by a `,` (a sequence element) as non-ASI, and `set/unsetAsiPosition` record overrides in a lazily-allocated map.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — rewrote the ASI unit tests in `test/WebpackParser.unittest.js` to cover source-derived positions, set/unset overrides, whitespace/comment skipping and the no-source fallback; existing integration cases (`parsing/harmony*`, `module/custom-javascript-parser`, `parsing/precreated-ast`) exercise the behavior end-to-end.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Custom `parse` functions may still return a `semicolons` set (it is simply ignored) and no longer need to; output is unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the in-repo `custom-javascript-parser` example (README + parser sources) is updated in this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to help implement the refactor, write the tests, and run the before/after parse/build/GC benchmarks; all changes were reviewed and verified against the existing test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bg3THo84b9Fj6bkYXM7q3)_