### PR TITLE
fix: emit plain-JSON HMR manifest for module output with non-import chunk loading

### DIFF
--- a/.changeset/hmr-jsonp-module-manifest.md
+++ b/.changeset/hmr-jsonp-module-manifest.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix broken HMR with `output.module` and non-`import` chunk loading (e.g. jsonp/array-push) by emitting a plain-JSON hot-update manifest.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1991,7 +1991,9 @@ const applyOutputDefaults = (
 	D(
 		output,
 		"hotUpdateMainFilename",
-		`[runtime].[fullhash].hot-update.${output.module ? "json.mjs" : "json"}`
+		// Only `chunkLoading: "import"` loads the manifest via `import()` (needs an
+		// `export default` ES module); every other loader fetches it as raw JSON.
+		`[runtime].[fullhash].hot-update.${output.chunkLoading === "import" ? "json.mjs" : "json"}`
 	);
 	D(output, "crossOriginLoading", false);
 	F(output, "scriptType", () => (output.module ? "module" : false));

--- a/test/hotCases/esm-output/jsonp-array-push-chunk-loading/index.js
+++ b/test/hotCases/esm-output/jsonp-array-push-chunk-loading/index.js
@@ -1,0 +1,19 @@
+import { greeting } from "./module.js";
+import update from "../../update.esm.js";
+
+import.meta.webpackHot.accept(["./module.js"]);
+
+it("should apply an HMR update with jsonp/array-push ES module output", (done) => {
+	expect(greeting).toBe("Hello World!");
+
+	NEXT(
+		update(done, true, () => {
+			import("./module.js")
+				.then((updatedModule) => {
+					expect(updatedModule.greeting).toBe("Hello HMR!");
+					done();
+				})
+				.catch(done);
+		})
+	);
+});

--- a/test/hotCases/esm-output/jsonp-array-push-chunk-loading/module.js
+++ b/test/hotCases/esm-output/jsonp-array-push-chunk-loading/module.js
@@ -1,0 +1,3 @@
+export const greeting = "Hello World!";
+---
+export const greeting = "Hello HMR!";

--- a/test/hotCases/esm-output/jsonp-array-push-chunk-loading/test.filter.js
+++ b/test/hotCases/esm-output/jsonp-array-push-chunk-loading/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// jsonp chunk loading and the fetch-based manifest download need the web
+// target's simulated `document`/`fetch`.
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/esm-output/jsonp-array-push-chunk-loading/webpack.config.js
+++ b/test/hotCases/esm-output/jsonp-array-push-chunk-loading/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+// Regression test for https://github.com/webpack/webpack/issues/21459:
+// `output.module` with jsonp/array-push must emit a plain-JSON hot-update
+// manifest (fetched via `fetch().json()`), not an `export default` ES module.
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "development",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		chunkLoading: "jsonp",
+		chunkFormat: "array-push",
+		library: {
+			type: "module"
+		}
+	},
+	optimization: {
+		minimize: false
+	}
+};


### PR DESCRIPTION
**Summary**

Fixes #21459. Since 5.100.0, HMR breaks with `output.module: true` + `chunkLoading: 'jsonp'` + `chunkFormat: 'array-push'` (`[HMR] Update failed: ... is not valid JSON`). The hot-update manifest filename was keyed on `output.module`, so module output always emitted a `.json.mjs` `export default` ES module — but only `chunkLoading: "import"` loads the manifest via `import()`; jsonp/import-scripts/readFile fetch it as raw JSON. This keys the extension on `chunkLoading` instead, so non-import loaders get plain `.json`.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/hotCases/esm-output/jsonp-array-push-chunk-loading/` (reproduces the exact `is not valid JSON` failure without the fix, passes with it).

**Does this PR introduce a breaking change?**

No. The default `output.module` case still resolves `chunkLoading: "import"`, so its manifest stays `.json.mjs`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. I used Claude (Claude Code) to investigate the regression, locate the root cause in `lib/config/defaults.js`, implement the one-line fix, and write the regression test. All changes were reviewed and verified by running the HMR test suites locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_012kW6Phz9f1di1UcGMJ675c)_