### PR TITLE
perf: faster JS, CSS and HTML syntax parsers with less heap churn

### DIFF
--- a/.changeset/css-parser-faster-tokenizer.md
+++ b/.changeset/css-parser-faster-tokenizer.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up JS, CSS and HTML parsing via branchless tokenizer dispatch, pre-sized HTML AST columns, and less per-node allocation.
+Speed up JS, CSS and HTML syntax parsing and reduce parser heap churn.

--- a/.changeset/css-parser-faster-tokenizer.md
+++ b/.changeset/css-parser-faster-tokenizer.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS and HTML parsing via branchless tokenizer dispatch, pre-sized HTML AST columns, and less per-node allocation.
+Speed up JS, CSS and HTML parsing via branchless tokenizer dispatch, pre-sized HTML AST columns, and less per-node allocation.

--- a/.changeset/css-parser-faster-tokenizer.md
+++ b/.changeset/css-parser-faster-tokenizer.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up CSS parsing with branchless tokenizer dispatch and reduce per-rule allocation.

--- a/.changeset/css-parser-faster-tokenizer.md
+++ b/.changeset/css-parser-faster-tokenizer.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS parsing with branchless tokenizer dispatch and reduce per-rule allocation.
+Speed up CSS and HTML parsing via branchless tokenizer dispatch, pre-sized HTML AST columns, and less per-node allocation.

--- a/cspell.json
+++ b/cspell.json
@@ -247,6 +247,7 @@
     "preloading",
     "preparsed",
     "preprocess",
+    "pretenuring",
     "prettierrc",
     "precomposed",
     "prewalking",

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -32,6 +32,12 @@ const {
 	SourceProcessor,
 	buildSkipSet,
 	equalsLowerCase,
+	isDashedIdentifier,
+	isWhitespace,
+	normalizeUrl,
+	rangeEquals,
+	rangeEqualsLowerCase,
+	toLowerCaseIfNeeded,
 	unescapeIdentifier
 } = require("./syntax");
 
@@ -80,13 +86,10 @@ const CC_LEFT_CURLY = "{".charCodeAt(0);
 /** @typedef {{ value: string, range: Range }} Comment */
 
 // Newlines (CSS Syntax 3 §3.3) — listed explicitly since there's no preprocessing stage.
-const STRING_MULTILINE = /\\[\n\r\f]/g;
 // https://www.w3.org/TR/css-syntax-3/#whitespace
-const TRIM_WHITE_SPACES = /(^[ \t\n\r\f]*|[ \t\n\r\f]*$)/g;
 // Pure-mode markers: `cssmodules-pure-ignore` opts a single rule out of the purity check, `cssmodules-pure-no-check` (before the first rule) opts the whole file out.
 const PURE_IGNORE_RE = /^\s*cssmodules-pure-ignore(?:\s|$)/;
 const PURE_NO_CHECK_RE = /^\s*cssmodules-pure-no-check(?:\s|$)/;
-const UNESCAPE = /\\([0-9a-f]{1,6}[ \t\n\r\f]?|[\s\S])/gi;
 const IMAGE_SET_FUNCTION = /^(?:-\w+-)?image-set$/i;
 const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(?:-\w+-)?keyframes$/;
 const VENDOR_PREFIX = /^-\w+-/;
@@ -156,110 +159,6 @@ const matchAll = (regexp, str) => {
 		result.push(match);
 	}
 	return result;
-};
-
-/**
- * Returns normalized url.
- * @param {string} str url string
- * @param {boolean} isString is url wrapped in quotes
- * @returns {string} normalized url
- */
-const normalizeUrl = (str, isString) => {
-	// Fast paths: skip the regex engine for the common URL with no escape and
-	// no edge whitespace (e.g. `./img.png`). Each guard is equivalent to the
-	// regex being a no-op.
-	// Remove escaped newlines from a string-token url like `url("im\<newline>g.png")`.
-	if (isString && str.includes("\\")) {
-		str = str.replace(STRING_MULTILINE, "");
-	}
-
-	// Remove unnecessary spaces from `url("   img.png	 ")`
-	if (
-		str.length !== 0 &&
-		(isCssWhitespace(str.charCodeAt(0)) ||
-			isCssWhitespace(str.charCodeAt(str.length - 1)))
-	) {
-		str = str.replace(TRIM_WHITE_SPACES, "");
-	}
-
-	// Unescape
-	if (str.includes("\\")) {
-		str = str.replace(UNESCAPE, (match) => {
-			if (match.length > 2) {
-				return String.fromCharCode(Number.parseInt(match.slice(1).trim(), 16));
-			}
-			return match[1];
-		});
-	}
-
-	if (/^data:/i.test(str)) {
-		return str;
-	}
-
-	if (str.includes("%")) {
-		// Convert `url('%2E/img.png')` -> `url('./img.png')`
-		try {
-			str = decodeURIComponent(str);
-		} catch (_err) {
-			// Ignore
-		}
-	}
-
-	return str;
-};
-
-// `escapeIdentifier` / `unescapeIdentifier` live in ./syntax.js; they're re-exported at the bottom for back-compat callers.
-
-/**
- * A custom property name (`<dashed-ident>`): a `--`-prefixed identifier other than bare `--`.
- * @param {string} identifier identifier
- * @returns {boolean} true when identifier is dashed, otherwise false
- */
-const isDashedIdentifier = (identifier) =>
-	identifier.startsWith("--") && identifier.length >= 3;
-
-/**
- * `s.toLowerCase()` that returns `s` itself (no allocation) when it can't
- * change — no ASCII uppercase and no non-ASCII (whose Unicode case mapping is
- * left to the real `toLowerCase`).
- * @param {string} s string
- * @returns {string} lowercased string
- */
-const toLowerCaseIfNeeded = (s) => {
-	for (let i = 0; i < s.length; i++) {
-		const c = s.charCodeAt(i);
-		if ((c >= 65 && c <= 90) || c > 127) return s.toLowerCase();
-	}
-	return s;
-};
-
-/**
- * Case-sensitive equality of a source range against a literal — no slice.
- * @param {string} input source
- * @param {number} start range start
- * @param {number} end range end (exclusive)
- * @param {string} lit literal to match
- * @returns {boolean} true when the range equals `lit`
- */
-const rangeEquals = (input, start, end, lit) =>
-	end - start === lit.length && input.startsWith(lit, start);
-
-/**
- * ASCII case-insensitive equality of a source range against a lowercase ASCII literal — no slice.
- * @param {string} input source
- * @param {number} start range start
- * @param {number} end range end (exclusive)
- * @param {string} lit lowercase ASCII literal to match
- * @returns {boolean} true when the range equals `lit` ignoring ASCII case
- */
-const rangeEqualsLowerCase = (input, start, end, lit) => {
-	if (end - start !== lit.length) return false;
-	for (let i = 0; i < lit.length; i++) {
-		let c = input.charCodeAt(start + i);
-		if (c >= 65 && c <= 90) c |= 0x20;
-		if (c !== lit.charCodeAt(i)) return false;
-	}
-	return true;
 };
 
 /**
@@ -606,17 +505,6 @@ const getKnownProperties = (options = {}) => {
 };
 
 // Byte-level source-cursor scans for computing replacement / strip ranges on raw source after parsing.
-
-/**
- * @param {number} cc char code
- * @returns {boolean} true when `cc` is CSS whitespace (space/tab/newline/CR/FF)
- */
-const isCssWhitespace = (cc) =>
-	cc === CC_SPACE ||
-	cc === CC_TAB ||
-	cc === CC_LINE_FEED ||
-	cc === CC_CARRIAGE_RETURN ||
-	cc === CC_FORM_FEED;
 
 /**
  * Skip trailing whitespace + at most one newline (CRLF-aware).
@@ -1987,7 +1875,7 @@ class CssParser extends Parser {
 			if (isLocal) {
 				while (
 					trailStart > 0 &&
-					isCssWhitespace(source.charCodeAt(trailStart - 1))
+					isWhitespace(source.charCodeAt(trailStart - 1))
 				) {
 					trailStart--;
 				}
@@ -2611,7 +2499,7 @@ class CssParser extends Parser {
 			let resumeAt = A.end(decl);
 			if (source.charCodeAt(A.end(decl)) === CC_SEMICOLON) {
 				resumeAt = A.end(decl) + 1;
-				while (isCssWhitespace(source.charCodeAt(resumeAt))) resumeAt++;
+				while (isWhitespace(source.charCodeAt(resumeAt))) resumeAt++;
 			}
 			module.addPresentationalDependency(
 				new ConstDependency("", [A.nameStart(decl), resumeAt])

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1904,10 +1904,19 @@ let _soaListStarts = new Int32Array(0);
 let _soaListLens = new Int32Array(0);
 let _soaFlat = new Int32Array(0);
 let _soaFlatTop = 0;
+// Peak usage of the current parse, and use-once regrow hints: after an
+// over-capacity shrink the next grow jumps straight back to the previous
+// parse's peak (one exact-fit allocation instead of re-doubling up).
+let _soaPeak = 0;
+let _soaFlatPeak = 0;
+let _soaGrowHint = 0;
+let _soaFlatGrowHint = 0;
 
 /** @param {number} need minimum flat-buffer capacity */
 const _soaFlatGrow = (need) => {
 	let cap = _soaFlat.length || 4096;
+	if (_soaFlatGrowHint > cap) cap = _soaFlatGrowHint;
+	_soaFlatGrowHint = 0;
 	while (cap < need) cap *= 2;
 	const next = new Int32Array(cap);
 	next.set(_soaFlat);
@@ -1932,6 +1941,8 @@ const _nodeRef = (i) => /** @type {Node} */ (/** @type {unknown} */ (i));
 /** @param {number} need minimum capacity */
 const _soaGrow = (need) => {
 	let cap = _soaCapacity || 4096;
+	if (_soaGrowHint > cap) cap = _soaGrowHint;
+	_soaGrowHint = 0;
 	while (cap < need) cap *= 2;
 	const ty = new Uint8Array(cap);
 	ty.set(_soaTypes);
@@ -3587,6 +3598,8 @@ const _walkRule = (node, parent) => {
  */
 const _walkTopLevel = (node) => {
 	_walkRule(node, null);
+	if (_soaNodeCount > _soaPeak) _soaPeak = _soaNodeCount;
+	if (_soaFlatTop > _soaFlatPeak) _soaFlatPeak = _soaFlatTop;
 	_soaNodeCount = 0;
 	_soaFlatTop = 0;
 };
@@ -3644,10 +3657,15 @@ const grammar = (input, visitors, options) => {
 		_soaChildRuleLists.length = 0;
 		_soaFlatTop = 0;
 		_listPool.length = 0;
-		if (_soaFlat.length > _SOA_SHRINK_CAPACITY) _soaFlat = new Int32Array(0);
+		if (_soaFlat.length > _SOA_SHRINK_CAPACITY) {
+			_soaFlatGrowHint = _soaFlatPeak;
+			_soaFlat = new Int32Array(0);
+		}
 		_visitors = /** @type {CompiledVisitorMap} */ (/** @type {unknown} */ ([]));
 		_commentBucket = undefined;
 		if (_soaCapacity > _SOA_SHRINK_CAPACITY) {
+			// +1: node ids are 1-based and grow fires at `id >= capacity`.
+			_soaGrowHint = _soaPeak + 1;
 			_soaCapacity = 0;
 			_soaTypes = new Uint8Array(0);
 			_soaStarts = new Int32Array(0);
@@ -3659,6 +3677,8 @@ const grammar = (input, visitors, options) => {
 			_soaListStarts = new Int32Array(0);
 			_soaListLens = new Int32Array(0);
 		}
+		_soaPeak = 0;
+		_soaFlatPeak = 0;
 	}
 };
 

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -341,11 +341,13 @@ const _isIdentStartCodePointCC = (cc) =>
 /**
  * Spec: ident-code = ident-start / digit / hyphen-minus.
  */
-// ASCII lookup built from the predicate so behaviour is identical; non-ASCII
-// (>= 128) keeps the inline check. `_consumeAnIdentSequence` hits this per code
-// point, and class/property names (hyphen + digit heavy) are the longest
-// comparison-chain path — a table load is constant-time instead.
-const _identCharTable = new Uint8Array(128);
+// Full `charCodeAt` range (0..0xFFFF) so the per-code-point ident test is one
+// table load with no `cc < 128` branch — `_consumeAnIdentSequence` runs this on
+// every character of every ident / class / property name (the tokenizer's
+// hottest loop). Every non-ASCII code unit (>= 0x80) is an ident code point per
+// spec, so those default to 1; only the ASCII rows carry real classification.
+// EOF (`charCodeAt` → NaN) indexes to `undefined` → not an ident, ending the run.
+const _identCharTable = new Uint8Array(0x10000).fill(1);
 for (let i = 0; i < 128; i++) {
 	_identCharTable[i] =
 		_isLetter(i) || i === CC_LOW_LINE || _isDigit(i) || i === CC_HYPHEN_MINUS
@@ -356,8 +358,7 @@ for (let i = 0; i < 128; i++) {
  * @param {number} cc char code
  * @returns {boolean} true, if cc is an ident-sequence code point
  */
-const _isIdentCodePoint = (cc) =>
-	cc < 128 ? _identCharTable[cc] === 1 : _isIdentStartCodePointCC(cc);
+const _isIdentCodePoint = (cc) => _identCharTable[cc] === 1;
 
 /**
  * ASCII case-insensitive equality against a lowercase literal — avoids the
@@ -481,12 +482,13 @@ const _ifThreeCodePointsWouldStartANumber = (input, pos, f, s, t) => {
 const _consumeAnIdentSequence = (input, pos) => {
 	// Hot loop (every ident, at-keyword, hash, function name, unit). Both checks
 	// are inlined from `_isIdentCodePoint` / `_ifTwoCodePointsAreValidEscape`: the
-	// ASCII ident test is a single table load, and the escape test reads the
-	// following code point only when `cc` is a `\` (rare) instead of eagerly.
+	// ident test is a single full-range table load (no `cc < 128` branch), and the
+	// escape test reads the following code point only when `cc` is a `\` (rare)
+	// instead of eagerly.
 	for (;;) {
 		const cc = input.charCodeAt(pos);
 		pos++;
-		if (cc < 128 ? _identCharTable[cc] === 1 : _isIdentStartCodePointCC(cc)) {
+		if (_identCharTable[cc] === 1) {
 			continue;
 		}
 		if (cc === CC_REVERSE_SOLIDUS && !_isNewline(input.charCodeAt(pos))) {
@@ -1016,7 +1018,11 @@ const HC_AT_SIGN = 9;
 const HC_REVERSE_SOLIDUS = 10;
 const HC_DIGIT = 11;
 const HC_IDENT = 12;
-const _charClass = new Uint8Array(128);
+// Full `charCodeAt` range so `consumeAToken` dispatches with one table load and
+// no `cc < 128` branch. Every non-ASCII code point (>= 0x80) is an ident-start
+// lead per §4, so those rows are seeded to `HC_IDENT`; the ASCII rows below
+// overwrite 0..127 with their real class.
+const _charClass = new Uint8Array(0x10000).fill(HC_IDENT, 128);
 const _singleTT = new Uint8Array(128);
 _singleTT[CC_LEFT_PARENTHESIS] = TT_LEFT_PARENTHESIS;
 _singleTT[CC_RIGHT_PARENTHESIS] = TT_RIGHT_PARENTHESIS;
@@ -1071,7 +1077,7 @@ for (let i = 0; i < 128; i++) {
 function consumeAToken(input, pos, cc, out) {
 	// `u` / `U` would start a unicode-range token in the spec; those are not
 	// produced, so they map to HC_IDENT and fall through to ident-like.
-	switch (cc < 128 ? _charClass[cc] : HC_IDENT) {
+	switch (_charClass[cc]) {
 		// Run of whitespace → one <whitespace-token>.
 		case HC_WHITESPACE:
 			return consumeSpace(input, pos, out);
@@ -1635,6 +1641,13 @@ let _objLocConverter = /** @type {LocConverter} */ (
 // so it is never walked or read — the caller must only skip what nothing reads.
 // `useObjectBackend` restores the defaults so `parseA*` build the full tree.
 const _NO_SKIP_TYPES = new Uint8Array(32);
+// Shared frozen empty list for block bodies with no decls / no child rules (the
+// common case — most rules carry only declarations). Every consumer reads these
+// lists read-only and null-guards, so one immutable instance replaces ~one empty
+// array allocation per rule; frozen so any errant push fails loud.
+const _EMPTY_LIST = /** @type {Rule[]} */ (
+	/** @type {unknown} */ (Object.freeze([]))
+);
 /** @type {Uint8Array} */
 let _skipTypes = _NO_SKIP_TYPES;
 // Fast-path flag: true only when a real skip set is active, so the (dominant)
@@ -2692,8 +2705,12 @@ const declarationStartLikely = (ts) => {
 const consumeABlocksContents = (ts, onNode) => {
 	/** @type {Declaration[]} */
 	const decls = [];
-	/** @type {Rule[]} */
-	const rules = [];
+	// Child rules are the common empty case (most rules carry only declarations),
+	// so `rules` is allocated lazily and returned as the shared frozen
+	// `_EMPTY_LIST` when nothing was appended — one fewer array per rule. `decls`
+	// stays eager so the hot declaration append keeps a branch-free `push`.
+	/** @type {Rule[] | null} */
+	let rules = null;
 
 	// Process input:
 	for (;;) {
@@ -2707,7 +2724,7 @@ const consumeABlocksContents = (ts, onNode) => {
 		// <EOF-token> / <}-token>
 		// Return decls and rules.
 		else if (t.type === TT_EOF || t.type === TT_RIGHT_CURLY_BRACKET) {
-			return { decls, rules };
+			return { decls, rules: rules || _EMPTY_LIST };
 		}
 		// <at-keyword-token>
 		// Consume an at-rule from input, with nested set to true. If a rule was returned, append it to rules.
@@ -2715,7 +2732,7 @@ const consumeABlocksContents = (ts, onNode) => {
 			const atRule = consumeAnAtRule(ts, true);
 			if (atRule) {
 				if (onNode) onNode(atRule);
-				else rules.push(atRule);
+				else (rules || (rules = [])).push(atRule);
 			}
 		}
 		// anything else
@@ -2738,7 +2755,7 @@ const consumeABlocksContents = (ts, onNode) => {
 			const rule = consumeAQualifiedRule(ts, TT_SEMICOLON, true);
 			if (rule) {
 				if (onNode) onNode(rule);
-				else rules.push(rule);
+				else (rules || (rules = [])).push(rule);
 			}
 		}
 	}

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -379,6 +379,58 @@ const equalsLowerCase = (s, lit) => {
 };
 
 /**
+ * Case-sensitive equality of a source range against a literal — no slice.
+ * @param {string} input source
+ * @param {number} start range start
+ * @param {number} end range end (exclusive)
+ * @param {string} lit literal to match
+ * @returns {boolean} true when the range equals `lit`
+ */
+const rangeEquals = (input, start, end, lit) =>
+	end - start === lit.length && input.startsWith(lit, start);
+
+/**
+ * ASCII case-insensitive equality of a source range against a lowercase ASCII literal — no slice.
+ * @param {string} input source
+ * @param {number} start range start
+ * @param {number} end range end (exclusive)
+ * @param {string} lit lowercase ASCII literal to match
+ * @returns {boolean} true when the range equals `lit` ignoring ASCII case
+ */
+const rangeEqualsLowerCase = (input, start, end, lit) => {
+	if (end - start !== lit.length) return false;
+	for (let i = 0; i < lit.length; i++) {
+		let c = input.charCodeAt(start + i);
+		if (c >= CC_UPPER_A && c <= CC_UPPER_Z) c |= 0x20;
+		if (c !== lit.charCodeAt(i)) return false;
+	}
+	return true;
+};
+
+/**
+ * `s.toLowerCase()` that returns `s` itself (no allocation) when it can't
+ * change — no ASCII uppercase and no non-ASCII (whose Unicode case mapping is
+ * left to the real `toLowerCase`).
+ * @param {string} s string
+ * @returns {string} lowercased string
+ */
+const toLowerCaseIfNeeded = (s) => {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if ((c >= CC_UPPER_A && c <= CC_UPPER_Z) || c > 127) return s.toLowerCase();
+	}
+	return s;
+};
+
+/**
+ * A custom property name (`<dashed-ident>`): a `--`-prefixed identifier other than bare `--`.
+ * @param {string} identifier identifier
+ * @returns {boolean} true when identifier is dashed, otherwise false
+ */
+const isDashedIdentifier = (identifier) =>
+	identifier.startsWith("--") && identifier.length >= 3;
+
+/**
  * Consume an escaped code point.
  * @param {string} input input
  * @param {number} pos position just past the `\`
@@ -3247,6 +3299,66 @@ const _unescapeIdentifier = (str) => {
 const escapeIdentifier = makeCacheable(_escapeIdentifier);
 const unescapeIdentifier = makeCacheable(_unescapeIdentifier);
 
+// A url-token / url-string value's escaped newlines (`url("im\<newline>g.png")`).
+const STRING_MULTILINE = /\\[\n\r\f]/g;
+// Leading / trailing CSS whitespace inside a quoted url value.
+const TRIM_WHITE_SPACES = /(^[ \t\n\r\f]*|[ \t\n\r\f]*$)/g;
+// One CSS escape: `\` + up to 6 hex digits (+ optional whitespace) or any char.
+const UNESCAPE = /\\([0-9a-f]{1,6}[ \t\n\r\f]?|[\s\S])/gi;
+
+/**
+ * Normalize a url value (a url-token's content or a url string's body) into
+ * the form requests are resolved from: escaped newlines removed (string form),
+ * edge whitespace trimmed, CSS escapes and percent-encoding decoded
+ * (`data:` URIs excepted).
+ * @param {string} str url string
+ * @param {boolean} isString is url wrapped in quotes
+ * @returns {string} normalized url
+ */
+const normalizeUrl = (str, isString) => {
+	// Fast paths: skip the regex engine for the common URL with no escape and
+	// no edge whitespace (e.g. `./img.png`). Each guard is equivalent to the
+	// regex being a no-op.
+	// Remove escaped newlines from a string-token url like `url("im\<newline>g.png")`.
+	if (isString && str.includes("\\")) {
+		str = str.replace(STRING_MULTILINE, "");
+	}
+
+	// Remove unnecessary spaces from `url("   img.png	 ")`
+	if (
+		str.length !== 0 &&
+		(_isWhiteSpace(str.charCodeAt(0)) ||
+			_isWhiteSpace(str.charCodeAt(str.length - 1)))
+	) {
+		str = str.replace(TRIM_WHITE_SPACES, "");
+	}
+
+	// Unescape
+	if (str.includes("\\")) {
+		str = str.replace(UNESCAPE, (match) => {
+			if (match.length > 2) {
+				return String.fromCharCode(Number.parseInt(match.slice(1).trim(), 16));
+			}
+			return match[1];
+		});
+	}
+
+	if (/^data:/i.test(str)) {
+		return str;
+	}
+
+	if (str.includes("%")) {
+		// Convert `url('%2E/img.png')` -> `url('./img.png')`
+		try {
+			str = decodeURIComponent(str);
+		} catch (_err) {
+			// Ignore
+		}
+	}
+
+	return str;
+};
+
 // CSS-typed views over the generic visitor machinery (`util/SourceProcessor`),
 // re-exported so consumers keep importing them from this module.
 /**
@@ -3816,6 +3928,11 @@ module.exports.TokenStream = TokenStream;
 module.exports.buildSkipSet = buildSkipSet;
 module.exports.equalsLowerCase = equalsLowerCase;
 module.exports.escapeIdentifier = escapeIdentifier;
+module.exports.isDashedIdentifier = isDashedIdentifier;
+// CSS Syntax §4.2 "whitespace" (space / tab / newline / CR / FF) — the
+// tokenizer's whitespace class, exported under the spec's name.
+module.exports.isWhitespace = _isWhiteSpace;
+module.exports.normalizeUrl = normalizeUrl;
 module.exports.parseABlocksContents = parseABlocksContents;
 module.exports.parseACommaSeparatedListOfComponentValues =
 	parseACommaSeparatedListOfComponentValues;
@@ -3825,5 +3942,8 @@ module.exports.parseAListOfComponentValues = parseAListOfComponentValues;
 module.exports.parseARule = parseARule;
 module.exports.parseAStylesheet = parseAStylesheet;
 module.exports.parseAStylesheetsContents = parseAStylesheetsContents;
+module.exports.rangeEquals = rangeEquals;
+module.exports.rangeEqualsLowerCase = rangeEqualsLowerCase;
 module.exports.readToken = readToken;
+module.exports.toLowerCaseIfNeeded = toLowerCaseIfNeeded;
 module.exports.unescapeIdentifier = unescapeIdentifier;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1748,7 +1748,20 @@ let _nodeValueOf;
 let _nodeTokenOf;
 
 // Child lists are plain arrays in every backend; refs are pushed by value.
-const _list = () => /** @type {Node[]} */ ([]);
+// Content-list allocation slot: the object backend hands out fresh arrays
+// (they are the AST), the SoA backend recycles scratch arrays through a pool —
+// a sealed list is copied into the flat value buffer and its array returned to
+// the pool by `_soaSetValue`, so the streaming parse allocates no per-list
+// array. An abandoned (never-sealed) list simply falls out of the pool.
+/** @type {() => Node[]} */
+let _list;
+const _objList = () => /** @type {Node[]} */ ([]);
+/** @type {Node[][]} */
+const _listPool = [];
+const _soaList = () =>
+	_listPool.length > 0
+		? /** @type {Node[]} */ (_listPool.pop())
+		: /** @type {Node[]} */ ([]);
 
 // -- object backend: builds the retainable class-instance tree --
 /** @type {typeof _makeLeaf} */
@@ -1837,6 +1850,7 @@ const _objNodeTokenOf = (r) =>
 /** @param {LocConverter} lc loc converter for this parse */
 const useObjectBackend = (lc) => {
 	_objLocConverter = lc;
+	_list = _objList;
 	// `parseA*` return the full tree, so nothing is skipped.
 	_skipTypes = _NO_SKIP_TYPES;
 	_skipActive = false;
@@ -1871,8 +1885,8 @@ const useObjectBackend = (lc) => {
 //   at-rule:     aux0 nameEnd, aux1 blockStart, aux2 blockEnd
 //   qualified:   aux1 blockStart, aux2 blockEnd
 // `name` / `nameStart` / a simple block's `token` are derived from the source
-// on read (see the SoA accessors), so they need no slot. `_soaContentLists`
-// holds a node's main content (value | prelude | stylesheet rules).
+// on read (see the SoA accessors), so they need no slot. A node's main content
+// (value | prelude | stylesheet rules) is a `_soaFlat` span (see below).
 // `grammar` resets `_soaNodeCount` to 0 after each top-level rule's walk, so the
 // buffers are reused across rules and the parse allocates almost nothing.
 let _soaCapacity = 0;
@@ -1884,8 +1898,21 @@ let _soaAux0 = new Int32Array(0);
 let _soaAux1 = new Int32Array(0);
 let _soaAux2 = new Int32Array(0);
 let _soaFlags = new Uint8Array(0);
-/** @type {(Node[] | null)[]} */
-const _soaContentLists = [];
+// Content-list spans: a container's value / prelude is `_soaFlat[start, start+len)`
+// (node refs), recycled per top-level rule like the node columns.
+let _soaListStarts = new Int32Array(0);
+let _soaListLens = new Int32Array(0);
+let _soaFlat = new Int32Array(0);
+let _soaFlatTop = 0;
+
+/** @param {number} need minimum flat-buffer capacity */
+const _soaFlatGrow = (need) => {
+	let cap = _soaFlat.length || 4096;
+	while (cap < need) cap *= 2;
+	const next = new Int32Array(cap);
+	next.set(_soaFlat);
+	_soaFlat = next;
+};
 /** @type {(Node[] | null)[]} */
 const _soaDeclarationLists = [];
 /** @type {(Node[] | null)[]} */
@@ -1927,6 +1954,12 @@ const _soaGrow = (need) => {
 	const fl = new Uint8Array(cap);
 	fl.set(_soaFlags);
 	_soaFlags = fl;
+	const ls = new Int32Array(cap);
+	ls.set(_soaListStarts);
+	_soaListStarts = ls;
+	const ll = new Int32Array(cap);
+	ll.set(_soaListLens);
+	_soaListLens = ll;
 	_soaCapacity = cap;
 };
 /** @type {(type: number, start: number, end: number) => Node} */
@@ -1948,8 +1981,9 @@ const _soaAllocContainer = (type, start, end) => {
 	const r = _soaAllocNode(type, start, end);
 	const i = _nodeIndex(r);
 	_soaFlags[i] = 0;
-	// Clear list slots so a reused id never exposes a previous node's children.
-	_soaContentLists[i] = null;
+	// Clear list slots so a reused id never exposes a previous node's children
+	// (content lists are flat spans, so zeroing the length suffices).
+	_soaListLens[i] = 0;
 	_soaDeclarationLists[i] = null;
 	_soaChildRuleLists[i] = null;
 	return r;
@@ -2004,7 +2038,20 @@ const _soaSetImportant = (r) => {
 const _soaSetToken = (r, ch) => {};
 /** @type {typeof _setValue} */
 const _soaSetValue = (r, list) => {
-	_soaContentLists[_nodeIndex(r)] = list;
+	// Seal the finished list: copy its refs into the flat buffer and hand the
+	// scratch array back to the pool. The caller never touches `list` again.
+	const i = _nodeIndex(r);
+	const len = list.length;
+	const start = _soaFlatTop;
+	if (start + len > _soaFlat.length) _soaFlatGrow(start + len);
+	for (let k = 0; k < len; k++) {
+		_soaFlat[start + k] = _nodeIndex(list[k]);
+	}
+	_soaFlatTop = start + len;
+	_soaListStarts[i] = start;
+	_soaListLens[i] = len;
+	list.length = 0;
+	_listPool.push(list);
 };
 /** @type {typeof _setBody} */
 const _soaSetBody = (r, decls, childRules) => {
@@ -2029,6 +2076,8 @@ const useSoaBackend = (input, lc) => {
 	_soaInput = input;
 	_soaLocConverter = lc;
 	_soaNodeCount = 0;
+	_soaFlatTop = 0;
+	_list = _soaList;
 	// The alloc primitives are the slot functions directly — no wrapper hop.
 	_makeLeaf = _soaAllocNode;
 	_makeUrl = _soaMakeUrl;
@@ -2497,8 +2546,9 @@ const consumeAnAtRule = (ts, nested = false) => {
 		_makeContainer(T_AT_RULE, head.start, head.end)
 	);
 	_setName(rule, head.start, head.end);
+	// Sealed (`_setPrelude`) at each return — the SoA backend consumes the
+	// scratch array when sealing, so it must be complete by then.
 	const prelude = _list();
-	_setPrelude(rule, prelude);
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block: the `;` / EOF / nested-`}` at-rule forms).
 
@@ -2516,6 +2566,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 		// Discard a token from input. If rule is valid in the current context, return it; otherwise return nothing.
 		if (t.type === TT_SEMICOLON || t.type === TT_EOF) {
 			ts.discard();
+			_setPrelude(rule, prelude);
 			_setEnd(rule, t.start);
 			return rule;
 		}
@@ -2524,6 +2575,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 		// Otherwise, consume a token and append the result to rule’s prelude.
 		else if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) {
+				_setPrelude(rule, prelude);
 				_setEnd(rule, t.start);
 				return rule;
 			}
@@ -2534,6 +2586,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 		// <{-token>
 		// Consume a block from input, and assign the result to rule's declarations and child rules.
 		else if (t.type === TT_LEFT_CURLY_BRACKET) {
+			_setPrelude(rule, prelude);
 			const block = consumeABlock(ts);
 			_setBody(rule, block.decls, block.rules);
 			_setBlock(rule, block.blockStart, block.blockEnd);
@@ -2582,8 +2635,9 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	const rule = /** @type {QualifiedRule} */ (
 		_makeContainer(T_QUALIFIED_RULE, start, start)
 	);
+	// Sealed (`_setPrelude`) at the `{` exit — the only path that returns the
+	// rule; the parse-error exits abandon the scratch unsealed.
 	const prelude = _list();
-	_setPrelude(rule, prelude);
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block until a `{` is reached).
 
@@ -2659,6 +2713,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				}
 				return undefined;
 			}
+			_setPrelude(rule, prelude);
 			const block = consumeABlock(ts);
 			_setBody(rule, block.decls, block.rules);
 			_setBlock(rule, block.blockStart, block.blockEnd);
@@ -2899,7 +2954,8 @@ const consumeADeclaration = (ts, nested = false) => {
 		nested && !isCustomProperty
 	);
 	if (value === null) return undefined;
-	_setValue(decl, value);
+	// `_setValue` waits until step 9: steps 6-8 still trim / scan the scratch,
+	// and the SoA backend consumes it when sealing.
 	_setEnd(decl, ts.next().start);
 
 	// 6. If the last two non-<whitespace-token>s in decl's value are a <delim-token> with the value "!" followed by an <ident-token> with a value that is an ASCII case-insensitive match for "important", remove them from decl's value and set decl's important flag.
@@ -2944,6 +3000,7 @@ const consumeADeclaration = (ts, nested = false) => {
 	}
 
 	// 9. Return decl.
+	_setValue(decl, value);
 	return decl;
 };
 
@@ -2961,8 +3018,7 @@ const consumeAListOfComponentValues = (
 	nested = false,
 	bailOnCurly = false
 ) => {
-	/** @type {ComponentValue[]} */
-	const values = [];
+	const values = /** @type {ComponentValue[]} */ (_list());
 	// Process input
 	for (;;) {
 		const t = ts.next();
@@ -3053,8 +3109,8 @@ const consumeASimpleBlock = (ts) => {
 		_makeContainer(T_SIMPLE_BLOCK, open.start, open.end)
 	);
 	_setToken(block, token);
+	// Sealed (`_setValue`) at the return, once complete.
 	const val = _list();
-	_setValue(block, val);
 
 	// Discard a token from input.
 	ts.discard();
@@ -3068,6 +3124,7 @@ const consumeASimpleBlock = (ts) => {
 		// Discard a token from input. Return block.
 		if (t.type === TT_EOF || t.type === ending) {
 			ts.discard();
+			_setValue(block, val);
 			_setEnd(block, t.end);
 			return block;
 		}
@@ -3091,8 +3148,8 @@ const consumeAFunction = (ts) => {
 		_makeContainer(T_FUNCTION, tFn.start, tFn.end)
 	);
 	_setName(fn, tFn.start, tFn.end - 1);
+	// Sealed (`_setValue`) at the return, once complete.
 	const val = _list();
-	_setValue(fn, val);
 
 	// Process input
 	for (;;) {
@@ -3103,6 +3160,7 @@ const consumeAFunction = (ts) => {
 			// <)-token>
 			// Discard a token from input. Return function.
 			ts.discard();
+			_setValue(fn, val);
 			_setEnd(fn, t.end);
 			return fn;
 		}
@@ -3459,8 +3517,10 @@ const _walkValue = (node, parent) => {
 		_walkSkip = false;
 	}
 	if (!skip && (ty === T_FUNCTION || ty === T_SIMPLE_BLOCK)) {
-		const v = /** @type {Node[]} */ (_soaContentLists[_nodeIndex(node)]);
-		for (let i = 0; i < v.length; i++) _walkValue(v[i], node);
+		const i0 = _nodeIndex(node);
+		const vs = _soaListStarts[i0];
+		const ve = vs + _soaListLens[i0];
+		for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
 	}
 	if (b !== undefined) {
 		// Rebind: descending into children moved the path.
@@ -3493,8 +3553,9 @@ const _walkRule = (node, parent) => {
 	}
 	if (!skip) {
 		if (ty === T_AT_RULE || ty === T_QUALIFIED_RULE) {
-			const p = /** @type {Node[]} */ (_soaContentLists[i0]);
-			for (let i = 0; i < p.length; i++) _walkValue(p[i], node);
+			const ps = _soaListStarts[i0];
+			const pe = ps + _soaListLens[i0];
+			for (let i = ps; i < pe; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
 			if (_recurseBlocks) {
 				// Declarations then child rules — downstream consumers don't need them strictly interleaved in source order.
 				const decls = _soaDeclarationLists[i0];
@@ -3505,8 +3566,9 @@ const _walkRule = (node, parent) => {
 				if (ch) for (let i = 0; i < ch.length; i++) _walkRule(ch[i], node);
 			}
 		} else if (ty === T_DECLARATION) {
-			const v = /** @type {Node[]} */ (_soaContentLists[i0]);
-			for (let i = 0; i < v.length; i++) _walkValue(v[i], node);
+			const vs = _soaListStarts[i0];
+			const ve = vs + _soaListLens[i0];
+			for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
 		}
 	}
 	if (b !== undefined) {
@@ -3526,6 +3588,7 @@ const _walkRule = (node, parent) => {
 const _walkTopLevel = (node) => {
 	_walkRule(node, null);
 	_soaNodeCount = 0;
+	_soaFlatTop = 0;
 };
 
 // The SoA buffers grow to the largest single top-level rule ever parsed and
@@ -3577,9 +3640,11 @@ const grammar = (input, visitors, options) => {
 		_soaLocConverter = /** @type {LocConverter} */ (
 			/** @type {unknown} */ (null)
 		);
-		_soaContentLists.length = 0;
 		_soaDeclarationLists.length = 0;
 		_soaChildRuleLists.length = 0;
+		_soaFlatTop = 0;
+		_listPool.length = 0;
+		if (_soaFlat.length > _SOA_SHRINK_CAPACITY) _soaFlat = new Int32Array(0);
 		_visitors = /** @type {CompiledVisitorMap} */ (/** @type {unknown} */ ([]));
 		_commentBucket = undefined;
 		if (_soaCapacity > _SOA_SHRINK_CAPACITY) {
@@ -3591,6 +3656,8 @@ const grammar = (input, visitors, options) => {
 			_soaAux1 = new Int32Array(0);
 			_soaAux2 = new Int32Array(0);
 			_soaFlags = new Uint8Array(0);
+			_soaListStarts = new Int32Array(0);
+			_soaListLens = new Int32Array(0);
 		}
 	}
 };
@@ -3638,6 +3705,19 @@ const buildSkipSet = (nodeTypes) => {
  * @typedef {typeof A} CssPath
  */
 /* eslint-enable jsdoc/require-template */
+
+// A fresh (safely retainable) array view of a node's flat content span —
+// visitors that read `A.children` / `A.prelude` may keep the result.
+/** @type {(n: Node) => Node[]} */
+const _materializeList = (n) => {
+	const i = _nodeIndex(n);
+	const start = _soaListStarts[i];
+	const len = _soaListLens[i];
+	/** @type {Node[]} */
+	const out = [];
+	for (let k = 0; k < len; k++) out.push(_nodeRef(_soaFlat[start + k]));
+	return out;
+};
 
 // Babel's `path.skip()`, children-only: set by `A.skipChildren()` during an
 // `enter` dispatch, consumed by the walk.
@@ -3820,14 +3900,14 @@ const A = {
 	 * @returns {ComponentValue[]} function / block children
 	 */
 	children(n = _currentNode) {
-		return /** @type {ComponentValue[]} */ (_soaContentLists[_nodeIndex(n)]);
+		return /** @type {ComponentValue[]} */ (_materializeList(n));
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {ComponentValue[]} rule prelude
 	 */
 	prelude(n = _currentNode) {
-		return /** @type {ComponentValue[]} */ (_soaContentLists[_nodeIndex(n)]);
+		return /** @type {ComponentValue[]} */ (_materializeList(n));
 	},
 	/**
 	 * @param {Node=} n node

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -347,7 +347,9 @@ const _isIdentStartCodePointCC = (cc) =>
 // every character of every ident / class / property name (the tokenizer's
 // hottest loop). Every non-ASCII code unit (>= 0x80) is an ident code point per
 // spec, so those default to 1; only the ASCII rows carry real classification.
-// EOF (`charCodeAt` → NaN) indexes to `undefined` → not an ident, ending the run.
+// Callers must index with `cc | 0`: EOF (`charCodeAt` → NaN) becomes 0 (NUL,
+// not an ident) — a raw NaN index is an out-of-range access that permanently
+// degrades the load site's IC.
 const _identCharTable = new Uint8Array(0x10000).fill(1);
 for (let i = 0; i < 128; i++) {
 	_identCharTable[i] =
@@ -359,7 +361,7 @@ for (let i = 0; i < 128; i++) {
  * @param {number} cc char code
  * @returns {boolean} true, if cc is an ident-sequence code point
  */
-const _isIdentCodePoint = (cc) => _identCharTable[cc] === 1;
+const _isIdentCodePoint = (cc) => _identCharTable[cc | 0] === 1;
 
 /**
  * ASCII case-insensitive equality against a lowercase literal — avoids the
@@ -539,7 +541,7 @@ const _consumeAnIdentSequence = (input, pos) => {
 	// escape test reads the following code point only when `cc` is a `\` (rare)
 	// instead of eagerly.
 	for (;;) {
-		const cc = input.charCodeAt(pos);
+		const cc = input.charCodeAt(pos) | 0;
 		pos++;
 		if (_identCharTable[cc] === 1) {
 			continue;
@@ -1748,14 +1750,14 @@ let _nodeValueOf;
 let _nodeTokenOf;
 
 // Child lists are plain arrays in every backend; refs are pushed by value.
-// Content-list allocation slot: the object backend hands out fresh arrays
-// (they are the AST), the SoA backend recycles scratch arrays through a pool —
-// a sealed list is copied into the flat value buffer and its array returned to
-// the pool by `_soaSetValue`, so the streaming parse allocates no per-list
-// array. An abandoned (never-sealed) list simply falls out of the pool.
-/** @type {() => Node[]} */
-let _list;
-const _objList = () => /** @type {Node[]} */ ([]);
+// Content-list allocation: the object backend uses a per-site `[]` literal
+// (each site keeps its own V8 allocation site — a shared helper collapses them
+// and defeats escape analysis / pretenuring), the SoA backend recycles scratch
+// arrays through a pool — a sealed list is copied into the flat value buffer
+// and its array returned to the pool by `_soaSetValue`, so the streaming parse
+// allocates no per-list array. An abandoned (never-sealed) list simply falls
+// out of the pool. `_soaActive` gates the pool at each site.
+let _soaActive = false;
 /** @type {Node[][]} */
 const _listPool = [];
 const _soaList = () =>
@@ -1850,7 +1852,7 @@ const _objNodeTokenOf = (r) =>
 /** @param {LocConverter} lc loc converter for this parse */
 const useObjectBackend = (lc) => {
 	_objLocConverter = lc;
-	_list = _objList;
+	_soaActive = false;
 	// `parseA*` return the full tree, so nothing is skipped.
 	_skipTypes = _NO_SKIP_TYPES;
 	_skipActive = false;
@@ -2088,7 +2090,7 @@ const useSoaBackend = (input, lc) => {
 	_soaLocConverter = lc;
 	_soaNodeCount = 0;
 	_soaFlatTop = 0;
-	_list = _soaList;
+	_soaActive = true;
 	// The alloc primitives are the slot functions directly — no wrapper hop.
 	_makeLeaf = _soaAllocNode;
 	_makeUrl = _soaMakeUrl;
@@ -2559,7 +2561,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 	_setName(rule, head.start, head.end);
 	// Sealed (`_setPrelude`) at each return — the SoA backend consumes the
 	// scratch array when sealing, so it must be complete by then.
-	const prelude = _list();
+	const prelude = _soaActive ? _soaList() : [];
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block: the `;` / EOF / nested-`}` at-rule forms).
 
@@ -2648,7 +2650,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	);
 	// Sealed (`_setPrelude`) at the `{` exit — the only path that returns the
 	// rule; the parse-error exits abandon the scratch unsealed.
-	const prelude = _list();
+	const prelude = _soaActive ? _soaList() : [];
 	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
 	// defaults (no block until a `{` is reached).
 
@@ -3029,7 +3031,7 @@ const consumeAListOfComponentValues = (
 	nested = false,
 	bailOnCurly = false
 ) => {
-	const values = /** @type {ComponentValue[]} */ (_list());
+	const values = /** @type {ComponentValue[]} */ (_soaActive ? _soaList() : []);
 	// Process input
 	for (;;) {
 		const t = ts.next();
@@ -3121,7 +3123,7 @@ const consumeASimpleBlock = (ts) => {
 	);
 	_setToken(block, token);
 	// Sealed (`_setValue`) at the return, once complete.
-	const val = _list();
+	const val = _soaActive ? _soaList() : [];
 
 	// Discard a token from input.
 	ts.discard();
@@ -3160,7 +3162,7 @@ const consumeAFunction = (ts) => {
 	);
 	_setName(fn, tFn.start, tFn.end - 1);
 	// Sealed (`_setValue`) at the return, once complete.
-	const val = _list();
+	const val = _soaActive ? _soaList() : [];
 
 	// Process input
 	for (;;) {

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -199,6 +199,7 @@ const CC_AT_SIGN = "@".charCodeAt(0);
 
 const CC_LOW_LINE = "_".charCodeAt(0);
 const CC_LOWER_A = "a".charCodeAt(0);
+const CC_LOWER_D = "d".charCodeAt(0);
 const CC_LOWER_F = "f".charCodeAt(0);
 const CC_LOWER_E = "e".charCodeAt(0);
 const CC_LOWER_U = "u".charCodeAt(0);
@@ -3178,13 +3179,18 @@ const _escapeIdentifier = (str) => {
 	}
 	output = lastFlush === 0 ? str : output + str.slice(lastFlush);
 
-	const firstChar = str.charAt(0);
-
-	if (/^-[-\d]/.test(output)) {
+	// `-` and digits are class 0 (never escaped above), so testing `str`'s lead
+	// char codes is equivalent to regexes over `output` — and keeps the common
+	// nothing-to-do call regex-free.
+	const first = str.charCodeAt(0);
+	if (
+		first === CC_HYPHEN_MINUS &&
+		(str.charCodeAt(1) === CC_HYPHEN_MINUS || _isDigit(str.charCodeAt(1)))
+	) {
 		output = `\\-${output.slice(1)}`;
-	} else if (/\d/.test(firstChar)) {
+	} else if (_isDigit(first)) {
 		// A leading digit becomes `\3<digit> `, another `\HEX ` run to clean up.
-		output = `\\3${firstChar} ${output.slice(1)}`;
+		output = `\\3${str.charAt(0)} ${output.slice(1)}`;
 		needSpaceFix = true;
 	}
 
@@ -3343,7 +3349,8 @@ const normalizeUrl = (str, isString) => {
 		});
 	}
 
-	if (/^data:/i.test(str)) {
+	// Char-code gate so the dominant non-`data:` url skips the regex test.
+	if ((str.charCodeAt(0) | 0x20) === CC_LOWER_D && /^data:/i.test(str)) {
 		return str;
 	}
 

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -31,8 +31,6 @@ const {
 	NodeType,
 	SVG_TAG_ADJUST,
 	SourceProcessor,
-	attrSourceSpan,
-	captureIntegrityRange,
 	decodeEntities,
 	escapeAttribute,
 	escapeText,
@@ -151,7 +149,61 @@ const buildHeadTags = (opts) => {
 // source order.
 const COPYABLE_SIBLING_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
 
+const CC_QUOTATION = '"'.charCodeAt(0);
+const CC_APOSTROPHE = "'".charCodeAt(0);
 const CC_SLASH = "/".charCodeAt(0);
+
+/**
+ * Byte-exact source span of an attribute including the single leading
+ * whitespace (` name`, ` name=value`, ` name="value"`), mirroring the
+ * tokenizer's end-of-attribute rule (`valueEnd + 1` past the closing quote).
+ * @param {import("./syntax").HtmlPath} path walk path (used only for attribute-ref reads)
+ * @param {string} source HTML source
+ * @param {import("./syntax").HtmlAttributeRef} attr attribute ref
+ * @returns {string} the attribute's source slice
+ */
+const attrSourceSpan = (path, source, attr) => {
+	const valueStart = path.attributeValueStart(attr);
+	const valueEnd = path.attributeValueEnd(attr);
+	const end =
+		valueStart === -1
+			? path.attributeNameEnd(attr)
+			: source.charCodeAt(valueStart - 1) === CC_QUOTATION ||
+				  source.charCodeAt(valueStart - 1) === CC_APOSTROPHE
+				? valueEnd + 1
+				: valueEnd;
+	return source.slice(path.attributeNameStart(attr) - 1, end);
+};
+
+/**
+ * Source span of a tag's `integrity` attribute (offsets relative to
+ * `elementStart`, leading whitespace and quotes included), so the template can
+ * drop the content-specific author value without re-parsing. Null when absent.
+ * @param {import("./syntax").HtmlPath} path walk path (for attribute reads)
+ * @param {string} source HTML source
+ * @param {number} elementStart offset of the tag's opening `<`
+ * @returns {Range | null} the span, or null when there is no `integrity`
+ */
+const captureIntegrityRange = (path, source, elementStart) => {
+	const integrityAttr = path.findAttribute("integrity");
+	if (integrityAttr === 0 || path.attributeNameStart(integrityAttr) < 0) {
+		return null;
+	}
+	let rs = path.attributeNameStart(integrityAttr);
+	while (rs > 0 && isAsciiWhitespace(source.charCodeAt(rs - 1))) {
+		rs--;
+	}
+	let re;
+	const ivs = path.attributeValueStart(integrityAttr);
+	if (ivs === -1) {
+		re = path.attributeNameEnd(integrityAttr);
+	} else {
+		const q = source.charCodeAt(ivs - 1);
+		const ive = path.attributeValueEnd(integrityAttr);
+		re = q === CC_QUOTATION || q === CC_APOSTROPHE ? ive + 1 : ive;
+	}
+	return [rs - elementStart, re - elementStart];
+};
 
 /**
  * @param {Map<string, string>} attributes attributes

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -5,15 +5,6 @@
 "use strict";
 
 const Parser = require("../Parser");
-const {
-	TT_EOF,
-	TT_FUNCTION,
-	TT_STRING,
-	TT_URL,
-	TT_WHITESPACE,
-	TokenStream,
-	equalsLowerCase
-} = require("../css/syntax");
 const ConstDependency = require("../dependencies/ConstDependency");
 const HtmlEntryDependency = require("../dependencies/HtmlEntryDependency");
 const HtmlInlineHtmlDependency = require("../dependencies/HtmlInlineHtmlDependency");
@@ -40,10 +31,15 @@ const {
 	NodeType,
 	SVG_TAG_ADJUST,
 	SourceProcessor,
+	attrSourceSpan,
+	captureIntegrityRange,
 	decodeEntities,
-	decodeEntitiesWithMap,
 	escapeAttribute,
 	escapeText,
+	isAsciiWhitespace,
+	parseCssUrls,
+	parseMsapplicationTask,
+	parseSrc,
 	parseSrcset
 } = require("./syntax");
 
@@ -70,31 +66,6 @@ const {
  * @property {(error: Error | string) => void} emitError report an error on the module
  */
 /** @typedef {(source: string, context: HtmlTemplateContext) => string} HtmlTemplateFunction */
-
-const HORIZONTAL_TAB = "\u0009".charCodeAt(0);
-const NEWLINE = "\u000A".charCodeAt(0);
-const FORM_FEED = "\u000C".charCodeAt(0);
-const CARRIAGE_RETURN = "\u000D".charCodeAt(0);
-const SPACE = "\u0020".charCodeAt(0);
-
-/**
- * @param {number} char char
- * @returns {boolean} true when ASCII whitespace, otherwise false
- */
-function isASCIIWhitespace(char) {
-	return (
-		// Horizontal tab
-		char === HORIZONTAL_TAB ||
-		// New line
-		char === NEWLINE ||
-		// Form feed
-		char === FORM_FEED ||
-		// Carriage return
-		char === CARRIAGE_RETURN ||
-		// Space
-		char === SPACE
-	);
-}
 
 /** @typedef {import("./syntax").ParsedSource} ParsedSource */
 
@@ -180,181 +151,7 @@ const buildHeadTags = (opts) => {
 // source order.
 const COPYABLE_SIBLING_ATTRS = ["nonce", "crossorigin", "referrerpolicy"];
 
-const CC_QUOTATION = '"'.charCodeAt(0);
-const CC_APOSTROPHE = "'".charCodeAt(0);
 const CC_SLASH = "/".charCodeAt(0);
-
-/**
- * Byte-exact source span of an attribute including the single leading
- * whitespace (` name`, ` name=value`, ` name="value"`), mirroring the
- * tokenizer's end-of-attribute rule (`valueEnd + 1` past the closing quote).
- * @param {import("./syntax").HtmlPath} path walk path (used only for attribute-ref reads)
- * @param {string} source HTML source
- * @param {import("./syntax").HtmlAttributeRef} attr attribute ref
- * @returns {string} the attribute's source slice
- */
-const attrSourceSpan = (path, source, attr) => {
-	const valueStart = path.attributeValueStart(attr);
-	const valueEnd = path.attributeValueEnd(attr);
-	const end =
-		valueStart === -1
-			? path.attributeNameEnd(attr)
-			: source.charCodeAt(valueStart - 1) === CC_QUOTATION ||
-				  source.charCodeAt(valueStart - 1) === CC_APOSTROPHE
-				? valueEnd + 1
-				: valueEnd;
-	return source.slice(path.attributeNameStart(attr) - 1, end);
-};
-
-/**
- * Source span of a tag's `integrity` attribute (offsets relative to
- * `elementStart`, leading whitespace and quotes included), so the template can
- * drop the content-specific author value without re-parsing. Null when absent.
- * @param {import("./syntax").HtmlPath} path walk path (for attribute reads)
- * @param {string} source HTML source
- * @param {number} elementStart offset of the tag's opening `<`
- * @returns {Range | null} the span, or null when there is no `integrity`
- */
-const captureIntegrityRange = (path, source, elementStart) => {
-	const integrityAttr = path.findAttribute("integrity");
-	if (integrityAttr === 0 || path.attributeNameStart(integrityAttr) < 0) {
-		return null;
-	}
-	let rs = path.attributeNameStart(integrityAttr);
-	while (rs > 0 && isASCIIWhitespace(source.charCodeAt(rs - 1))) {
-		rs--;
-	}
-	let re;
-	const ivs = path.attributeValueStart(integrityAttr);
-	if (ivs === -1) {
-		re = path.attributeNameEnd(integrityAttr);
-	} else {
-		const q = source.charCodeAt(ivs - 1);
-		const ive = path.attributeValueEnd(integrityAttr);
-		re = q === CC_QUOTATION || q === CC_APOSTROPHE ? ive + 1 : ive;
-	}
-	return [rs - elementStart, re - elementStart];
-};
-
-// eslint-disable-next-line no-control-regex
-const IGNORE_CHARS_REGEXP = /[\u0000-\u001F\u007F-\u009F\u00A0]/g;
-
-/**
- * @param {string} input input
- * @returns {ParsedSource[]} parsed src
- */
-const parseSrc = (input) => {
-	const len = input.length;
-	if (len === 0) throw new Error("Must be non-empty");
-
-	let start = 0;
-	let end = len;
-
-	while (start < end) {
-		const code = input.charCodeAt(start);
-		if (code > 32 && code !== 160) break;
-		start++;
-	}
-
-	if (start === end) throw new Error("Must be non-empty");
-
-	while (end > start) {
-		const code = input.charCodeAt(end - 1);
-		if (code > 32 && code !== 160) break;
-		end--;
-	}
-
-	let value = input.slice(start, end);
-
-	if (IGNORE_CHARS_REGEXP.test(value)) {
-		value = value.replace(IGNORE_CHARS_REGEXP, "");
-		if (value.length === 0) throw new Error("Must be non-empty");
-	}
-
-	return [[value, start, end]];
-};
-
-/**
- * Extracts the `icon-uri` value of an `msapplication-task` meta content
- * (`name=…;action-uri=…;icon-uri=…`) — the other parts are page URLs, not assets.
- * @param {string} input input
- * @returns {ParsedSource[]} parsed icon-uri
- */
-const parseMsapplicationTask = (input) => {
-	const len = input.length;
-	let pos = 0;
-	while (pos < len) {
-		let sep = input.indexOf(";", pos);
-		if (sep === -1) sep = len;
-		const eq = input.indexOf("=", pos);
-		if (eq !== -1 && eq < sep) {
-			const key = input.slice(pos, eq).trim().toLowerCase();
-			if (key === "icon-uri") {
-				let start = eq + 1;
-				let end = sep;
-				while (start < end && isASCIIWhitespace(input.charCodeAt(start))) {
-					start++;
-				}
-				while (end > start && isASCIIWhitespace(input.charCodeAt(end - 1))) {
-					end--;
-				}
-				if (start === end) return [];
-				return [[input.slice(start, end), start, end]];
-			}
-		}
-		pos = sep + 1;
-	}
-	return [];
-};
-
-/**
- * Extracts `url(...)` references from a CSS value (an SVG presentation
- * attribute). Reuses webpack's CSS lexer so quoting/escaping match the CSS
- * spec; returns the `parseSrc` shape so the shared emit path maps and rewrites
- * the spans. Unquoted `url(path)` rewrites the content span; quoted
- * `url("path")` rewrites the inner string span (quotes preserved).
- * @param {string} input attribute value (a CSS component-value list)
- * @returns {ParsedSource[]} url references
- */
-const parseCssUrls = (input) => {
-	const ts = new TokenStream(input);
-	/** @type {ParsedSource[]} */
-	const result = [];
-	for (;;) {
-		const t = ts.consume();
-		if (t.type === TT_EOF) break;
-		if (t.type === TT_URL) {
-			if (t.contentEnd > t.contentStart) {
-				result.push([
-					input.slice(t.contentStart, t.contentEnd),
-					t.contentStart,
-					t.contentEnd
-				]);
-			}
-		} else if (
-			t.type === TT_FUNCTION &&
-			equalsLowerCase(input.slice(t.start, t.end - 1), "url")
-		) {
-			let s = ts.consume();
-			while (s.type === TT_WHITESPACE) s = ts.consume();
-			if (s.type === TT_STRING) {
-				const quote = input.charCodeAt(s.start);
-				const innerStart = s.start + 1;
-				// Drop the closing quote, unless the string is unterminated at EOF.
-				const innerEnd =
-					input.charCodeAt(s.end - 1) === quote ? s.end - 1 : s.end;
-				if (innerEnd > innerStart) {
-					result.push([
-						input.slice(innerStart, innerEnd),
-						innerStart,
-						innerEnd
-					]);
-				}
-			}
-		}
-	}
-	return result;
-};
 
 /**
  * @param {Map<string, string>} attributes attributes
@@ -1165,7 +962,7 @@ class HtmlParser extends Parser {
 				let attrStart = path.attributeNameStart(typeAttr);
 				if (
 					attrStart > 0 &&
-					isASCIIWhitespace(input.charCodeAt(attrStart - 1))
+					isAsciiWhitespace(input.charCodeAt(attrStart - 1))
 				) {
 					attrStart -= 1;
 				}
@@ -1695,7 +1492,7 @@ class HtmlParser extends Parser {
 									/** @type {number[] | undefined} */
 									let map;
 									if (value.includes("&")) {
-										({ text, map } = decodeEntitiesWithMap(value, true));
+										({ text, map } = decodeEntities(value, true, true));
 										if (!/\S/.test(text)) break;
 									}
 									/** @type {ParsedSource[] | undefined} */

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3865,15 +3865,6 @@ const decodeOneReference = (match, nextCharCode, isAttribute) => {
 	return match;
 };
 
-// Hoisted `replace` callbacks (one per `isAttribute` mode) — no closure
-// per decode call, and the callback stays monomorphic.
-/** @type {(match: string, offset: number, source: string) => string} */
-const _decodeReferenceInText = (match, offset, source) =>
-	decodeOneReference(match, source.charCodeAt(offset + match.length), false);
-/** @type {(match: string, offset: number, source: string) => string} */
-const _decodeReferenceInAttribute = (match, offset, source) =>
-	decodeOneReference(match, source.charCodeAt(offset + match.length), true);
-
 /**
  * Decode HTML character references in a string. Handles all numeric
  * references (with WHATWG remap of 0x00, surrogates, out-of-range, and the
@@ -3890,12 +3881,54 @@ const _decodeReferenceInAttribute = (match, offset, source) =>
  * @returns {string} decoded string
  */
 const decodeEntities = (str, isAttribute) => {
-	if (!str.includes("&")) return str;
-
-	return str.replace(
-		CHARACTER_REFERENCE_REGEXP,
-		isAttribute ? _decodeReferenceInAttribute : _decodeReferenceInText
-	);
+	// Hand-rolled scan of the `CHARACTER_REFERENCE_REGEXP` shape
+	// (`&#x<hex>+` / `&#<dec>+` / `&<alpha><alnum>*`, optional `;`): entity-dense
+	// text pays no regex machinery or per-match object, and a string whose
+	// references all stay literal is returned unchanged without rebuilding.
+	let amp = str.indexOf("&");
+	if (amp === -1) return str;
+	let out = "";
+	let last = 0;
+	do {
+		// `end` stays 0 when the `&` doesn't start a well-formed reference.
+		let end = 0;
+		let cc = str.charCodeAt(amp + 1);
+		if (cc === 0x23 /* # */) {
+			cc = str.charCodeAt(amp + 2);
+			let p;
+			if (cc === 0x78 /* x */ || cc === 0x58 /* X */) {
+				p = amp + 3;
+				while (isAsciiHexDigit(str.charCodeAt(p))) p++;
+				if (p > amp + 3) end = p;
+			} else {
+				p = amp + 2;
+				while (isAsciiDigit(str.charCodeAt(p))) p++;
+				if (p > amp + 2) end = p;
+			}
+		} else if (isAsciiAlpha(cc)) {
+			let p = amp + 2;
+			while (isAsciiAlphanumeric(str.charCodeAt(p))) p++;
+			end = p;
+		}
+		if (end !== 0) {
+			if (str.charCodeAt(end) === 0x3b /* ; */) end++;
+			const match = str.slice(amp, end);
+			const decoded = decodeOneReference(
+				match,
+				str.charCodeAt(end),
+				isAttribute
+			);
+			if (decoded !== match) {
+				out += str.slice(last, amp);
+				out += decoded;
+				last = end;
+			}
+			amp = str.indexOf("&", end);
+		} else {
+			amp = str.indexOf("&", amp + 1);
+		}
+	} while (amp !== -1);
+	return last === 0 ? str : out + str.slice(last);
 };
 
 /**
@@ -5326,7 +5359,7 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	// as the safety net when the estimate is short.
 	const _sizeEstimate = (input.length / 12) | 0;
 	if (_sizeEstimate > _nodeCapacity) _growNodeColumns(_sizeEstimate);
-	if (_sizeEstimate > (_attrCapacity << 2)) {
+	if (_sizeEstimate > _attrCapacity << 2) {
 		_growAttrColumns(_sizeEstimate >> 2);
 	}
 	_htmlSource = source;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8724,58 +8724,6 @@ const parseCssUrls = (input) => {
 	return result;
 };
 
-/**
- * Byte-exact source span of an attribute including the single leading
- * whitespace (` name`, ` name=value`, ` name="value"`), mirroring the
- * tokenizer's end-of-attribute rule (`valueEnd + 1` past the closing quote).
- * @param {HtmlPath} path walk path (used only for attribute-ref reads)
- * @param {string} source HTML source
- * @param {HtmlAttributeRef} attr attribute ref
- * @returns {string} the attribute's source slice
- */
-const attrSourceSpan = (path, source, attr) => {
-	const valueStart = path.attributeValueStart(attr);
-	const valueEnd = path.attributeValueEnd(attr);
-	const end =
-		valueStart === -1
-			? path.attributeNameEnd(attr)
-			: source.charCodeAt(valueStart - 1) === CC_QUOTATION_MARK ||
-				  source.charCodeAt(valueStart - 1) === CC_APOSTROPHE
-				? valueEnd + 1
-				: valueEnd;
-	return source.slice(path.attributeNameStart(attr) - 1, end);
-};
-
-/**
- * Source span of a tag's `integrity` attribute (offsets relative to
- * `elementStart`, leading whitespace and quotes included), so the template can
- * drop the content-specific author value without re-parsing. Null when absent.
- * @param {HtmlPath} path walk path (for attribute reads)
- * @param {string} source HTML source
- * @param {number} elementStart offset of the tag's opening `<`
- * @returns {[number, number] | null} the span, or null when there is no `integrity`
- */
-const captureIntegrityRange = (path, source, elementStart) => {
-	const integrityAttr = path.findAttribute("integrity");
-	if (integrityAttr === 0 || path.attributeNameStart(integrityAttr) < 0) {
-		return null;
-	}
-	let rs = path.attributeNameStart(integrityAttr);
-	while (rs > 0 && isSpace(source.charCodeAt(rs - 1))) {
-		rs--;
-	}
-	let re;
-	const ivs = path.attributeValueStart(integrityAttr);
-	if (ivs === -1) {
-		re = path.attributeNameEnd(integrityAttr);
-	} else {
-		const q = source.charCodeAt(ivs - 1);
-		const ive = path.attributeValueEnd(integrityAttr);
-		re = q === CC_QUOTATION_MARK || q === CC_APOSTROPHE ? ive + 1 : ive;
-	}
-	return [rs - elementStart, re - elementStart];
-};
-
 // Babel's `path.skip()`, children-only: set by `A.skipChildren()` during an
 // `enter` dispatch, consumed by the walk.
 let _walkSkip = false;
@@ -9049,17 +8997,15 @@ module.exports.NodeType = NodeType;
 module.exports.QUOTE_DOUBLE = QUOTE_DOUBLE;
 module.exports.QUOTE_NONE = QUOTE_NONE;
 module.exports.QUOTE_SINGLE = QUOTE_SINGLE;
-// WHATWG "ASCII whitespace" (tab / LF / FF / CR / space) — the tokenizer's
-// whitespace class, exported under the spec's name.
 // Exposed so HtmlParser can map user-configured (lowercased) tag names to
 // the adjusted camelCase names the AST carries for foreign content.
 module.exports.SVG_TAG_ADJUST = SVG_TAG_ADJUST;
 module.exports.SourceProcessor = SourceProcessor;
-module.exports.attrSourceSpan = attrSourceSpan;
-module.exports.captureIntegrityRange = captureIntegrityRange;
 module.exports.decodeEntities = decodeEntities;
 module.exports.escapeAttribute = escapeAttribute;
 module.exports.escapeText = escapeText;
+// WHATWG "ASCII whitespace" (tab / LF / FF / CR / space) — the tokenizer's
+// whitespace class, exported under the spec's name.
 module.exports.isAsciiWhitespace = isSpace;
 module.exports.parseCssUrls = parseCssUrls;
 module.exports.parseHtml = parseHtml;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3775,15 +3775,6 @@ const decodeNumericReference = (code) => {
 	return String.fromCodePoint(code);
 };
 
-// Match one of three forms (each with an optional trailing `;`):
-//   `&#x<hex>` - hex numeric reference (requires the `x`/`X`).
-//   `&#<dec>`  - decimal numeric reference (digits only).
-//   `&<name>`  - named reference (letter followed by alphanumerics).
-// The three alternatives are kept separate so a decimal reference like
-// `&#65b` doesn't greedily eat the trailing `b` as if it were hex.
-const CHARACTER_REFERENCE_REGEXP =
-	/&(?:#[xX][0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);?/g;
-
 /**
  * Decode a single matched character reference.
  * @param {string} match the matched reference text
@@ -3865,6 +3856,8 @@ const decodeOneReference = (match, nextCharCode, isAttribute) => {
 	return match;
 };
 
+/** @typedef {{ text: string, map: number[] | undefined }} DecodedEntitiesWithMap */
+
 /**
  * Decode HTML character references in a string. Handles all numeric
  * references (with WHATWG remap of 0x00, surrogates, out-of-range, and the
@@ -3876,19 +3869,45 @@ const decodeOneReference = (match, nextCharCode, isAttribute) => {
  * trailing `;` whose next character is `=` or ASCII alphanumeric is left
  * undecoded, so e.g. `&amp=foo` stays literal in an attribute value but
  * decodes to `&=foo` in text.
+ *
+ * With `withMap` the result also carries a boundary map from the decoded
+ * string back to raw offsets, so spans computed on the decoded text (e.g.
+ * srcset candidate URLs) can be translated to source ranges. `map[i]` is the
+ * raw offset of decoded boundary `i` (`0..text.length`); boundaries inside a
+ * reference's decoded text map to the reference start. `map` is `undefined`
+ * when nothing was decoded (then `text === str`).
+ * @overload
  * @param {string} str the raw string from the token slice
  * @param {boolean=} isAttribute true if `str` came from an attribute value
  * @returns {string} decoded string
  */
-const decodeEntities = (str, isAttribute) => {
-	// Hand-rolled scan of the `CHARACTER_REFERENCE_REGEXP` shape
-	// (`&#x<hex>+` / `&#<dec>+` / `&<alpha><alnum>*`, optional `;`): entity-dense
-	// text pays no regex machinery or per-match object, and a string whose
-	// references all stay literal is returned unchanged without rebuilding.
+/**
+ * @overload
+ * @param {string} str the raw string from the token slice
+ * @param {boolean | undefined} isAttribute true if `str` came from an attribute value
+ * @param {true} withMap also build the decoded-to-raw boundary map
+ * @returns {DecodedEntitiesWithMap} decoded text and offset map
+ */
+/**
+ * @param {string} str the raw string from the token slice
+ * @param {boolean=} isAttribute true if `str` came from an attribute value
+ * @param {boolean=} withMap also build the decoded-to-raw boundary map
+ * @returns {string | DecodedEntitiesWithMap} decoded string (with map when `withMap`)
+ */
+const decodeEntities = (str, isAttribute, withMap) => {
+	// Hand-rolled scan of one of three reference forms, each with an optional
+	// trailing `;` — `&#x<hex>+` / `&#<dec>+` / `&<alpha><alnum>*` (kept separate
+	// so `&#65b` doesn't eat the `b` as hex): entity-dense text pays no regex
+	// machinery or per-match object, and a string whose references all stay
+	// literal is returned unchanged without rebuilding. Map bookkeeping is
+	// gated on `withMap` at the rare per-decoded-reference points, so the
+	// dominant no-map mode pays nothing for the unified implementation.
 	let amp = str.indexOf("&");
-	if (amp === -1) return str;
+	if (amp === -1) return withMap ? { text: str, map: undefined } : str;
 	let out = "";
 	let last = 0;
+	/** @type {number[] | undefined} */
+	let map;
 	do {
 		// `end` stays 0 when the `&` doesn't start a well-formed reference.
 		let end = 0;
@@ -3919,6 +3938,7 @@ const decodeEntities = (str, isAttribute) => {
 				isAttribute
 			);
 			if (decoded !== match) {
+				if (withMap) map = _mapReference(map, last, amp, decoded.length);
 				out += str.slice(last, amp);
 				out += decoded;
 				last = end;
@@ -3928,51 +3948,40 @@ const decodeEntities = (str, isAttribute) => {
 			amp = str.indexOf("&", amp + 1);
 		}
 	} while (amp !== -1);
-	return last === 0 ? str : out + str.slice(last);
+	if (last === 0) return withMap ? { text: str, map: undefined } : str;
+	const text = out + str.slice(last);
+	return withMap
+		? _finishMap(text, /** @type {number[]} */ (map), last, str.length)
+		: text;
+};
+
+// Map-mode bookkeeping for `decodeEntities`, kept out of the scanner body so
+// the dominant no-map mode stays small enough to inline.
+/**
+ * @param {number[] | undefined} map boundary map so far
+ * @param {number} last raw offset the literal run starts at
+ * @param {number} amp raw offset of the decoded reference
+ * @param {number} decodedLength length of the decoded text
+ * @returns {number[]} the map, with the literal run's and reference's boundaries appended
+ */
+const _mapReference = (map, last, amp, decodedLength) => {
+	if (map === undefined) map = [];
+	for (let r = last; r < amp; r++) map.push(r);
+	for (let i = 0; i < decodedLength; i++) map.push(amp);
+	return map;
 };
 
 /**
- * Like `decodeEntities`, but also returns a boundary map from the
- * decoded string back to raw offsets, so spans computed on the decoded
- * text (e.g. srcset candidate URLs) can be translated to source ranges.
- * `map[i]` is the raw offset of decoded boundary `i` (`0..text.length`);
- * boundaries inside a reference's decoded text map to the reference start.
- * `map` is `undefined` when nothing was decoded (then `text === str`).
- * @param {string} str the raw string from the token slice
- * @param {boolean=} isAttribute true if `str` came from an attribute value
- * @returns {{ text: string, map: number[] | undefined }} decoded text and offset map
+ * @param {string} text decoded text
+ * @param {number[]} map boundary map so far
+ * @param {number} last raw offset of the trailing literal run
+ * @param {number} rawLength raw string length
+ * @returns {DecodedEntitiesWithMap} the finished result
  */
-const decodeEntitiesWithMap = (str, isAttribute) => {
-	/** @type {number[] | undefined} */
-	let map;
-	if (str.includes("&")) {
-		CHARACTER_REFERENCE_REGEXP.lastIndex = 0;
-		let text = "";
-		let last = 0;
-		/** @type {RegExpExecArray | null} */
-		let m;
-		while ((m = CHARACTER_REFERENCE_REGEXP.exec(str)) !== null) {
-			const match = m[0];
-			const decoded = decodeOneReference(
-				match,
-				str.charCodeAt(m.index + match.length),
-				isAttribute
-			);
-			if (decoded === match) continue;
-			if (map === undefined) map = [];
-			for (let r = last; r < m.index; r++) map.push(r);
-			text += str.slice(last, m.index);
-			for (let i = 0; i < decoded.length; i++) map.push(m.index);
-			text += decoded;
-			last = m.index + match.length;
-		}
-		if (map !== undefined) {
-			for (let r = last; r < str.length; r++) map.push(r);
-			map.push(str.length);
-			return { text: text + str.slice(last), map };
-		}
-	}
-	return { text: str, map };
+const _finishMap = (text, map, last, rawLength) => {
+	for (let r = last; r < rawLength; r++) map.push(r);
+	map.push(rawLength);
+	return { text, map };
 };
 
 /**
@@ -8575,6 +8584,198 @@ const parseSrcset = (input) => {
 	}
 };
 
+// The spec's "URL-potentially-surrounded-by-spaces" cleanup: C0 controls,
+// DEL..C1 and U+00A0 are stripped from the value after the whitespace trim.
+// eslint-disable-next-line no-control-regex
+const IGNORE_CHARS_REGEXP = /[\u0000-\u001F\u007F-\u009F\u00A0]/g;
+
+/**
+ * Parse a `src`-like URL attribute value: trim ASCII whitespace / U+00A0 from
+ * both ends (offsets preserved for source rewriting), then strip ignorable
+ * control characters. Throws when nothing remains.
+ * @param {string} input attribute value
+ * @returns {ParsedSource[]} parsed src
+ */
+const parseSrc = (input) => {
+	const len = input.length;
+	if (len === 0) throw new Error("Must be non-empty");
+
+	let start = 0;
+	let end = len;
+
+	while (start < end) {
+		const code = input.charCodeAt(start);
+		if (code > 32 && code !== 160) break;
+		start++;
+	}
+
+	if (start === end) throw new Error("Must be non-empty");
+
+	while (end > start) {
+		const code = input.charCodeAt(end - 1);
+		if (code > 32 && code !== 160) break;
+		end--;
+	}
+
+	let value = input.slice(start, end);
+
+	if (IGNORE_CHARS_REGEXP.test(value)) {
+		value = value.replace(IGNORE_CHARS_REGEXP, "");
+		if (value.length === 0) throw new Error("Must be non-empty");
+	}
+
+	return [[value, start, end]];
+};
+
+/**
+ * Extracts the `icon-uri` value of an `msapplication-task` meta content
+ * (`name=…;action-uri=…;icon-uri=…`) — the other parts are page URLs, not assets.
+ * @param {string} input input
+ * @returns {ParsedSource[]} parsed icon-uri
+ */
+const parseMsapplicationTask = (input) => {
+	const len = input.length;
+	let pos = 0;
+	while (pos < len) {
+		let sep = input.indexOf(";", pos);
+		if (sep === -1) sep = len;
+		const eq = input.indexOf("=", pos);
+		if (eq !== -1 && eq < sep) {
+			const key = input.slice(pos, eq).trim().toLowerCase();
+			if (key === "icon-uri") {
+				let start = eq + 1;
+				let end = sep;
+				while (start < end && isSpace(input.charCodeAt(start))) {
+					start++;
+				}
+				while (end > start && isSpace(input.charCodeAt(end - 1))) {
+					end--;
+				}
+				if (start === end) return [];
+				return [[input.slice(start, end), start, end]];
+			}
+		}
+		pos = sep + 1;
+	}
+	return [];
+};
+
+// CSS syntax is loaded on first `parseCssUrls` call, not at module load —
+// `HtmlGenerator` deliberately defers it the same way, and most documents
+// never carry a URL-bearing SVG presentation attribute.
+/** @type {typeof import("../css/syntax") | undefined} */
+let _cssSyntax;
+
+/**
+ * Extracts `url(...)` references from a CSS value (an SVG presentation
+ * attribute). Reuses webpack's CSS lexer so quoting/escaping match the CSS
+ * spec; returns the `parseSrc` shape so the shared emit path maps and rewrites
+ * the spans. Unquoted `url(path)` rewrites the content span; quoted
+ * `url("path")` rewrites the inner string span (quotes preserved).
+ * @param {string} input attribute value (a CSS component-value list)
+ * @returns {ParsedSource[]} url references
+ */
+const parseCssUrls = (input) => {
+	const {
+		TT_EOF,
+		TT_FUNCTION,
+		TT_STRING,
+		TT_URL,
+		TT_WHITESPACE,
+		TokenStream,
+		equalsLowerCase
+	} = _cssSyntax || (_cssSyntax = require("../css/syntax"));
+	const ts = new TokenStream(input);
+	/** @type {ParsedSource[]} */
+	const result = [];
+	for (;;) {
+		const t = ts.consume();
+		if (t.type === TT_EOF) break;
+		if (t.type === TT_URL) {
+			if (t.contentEnd > t.contentStart) {
+				result.push([
+					input.slice(t.contentStart, t.contentEnd),
+					t.contentStart,
+					t.contentEnd
+				]);
+			}
+		} else if (
+			t.type === TT_FUNCTION &&
+			equalsLowerCase(input.slice(t.start, t.end - 1), "url")
+		) {
+			let s = ts.consume();
+			while (s.type === TT_WHITESPACE) s = ts.consume();
+			if (s.type === TT_STRING) {
+				const quote = input.charCodeAt(s.start);
+				const innerStart = s.start + 1;
+				// Drop the closing quote, unless the string is unterminated at EOF.
+				const innerEnd =
+					input.charCodeAt(s.end - 1) === quote ? s.end - 1 : s.end;
+				if (innerEnd > innerStart) {
+					result.push([
+						input.slice(innerStart, innerEnd),
+						innerStart,
+						innerEnd
+					]);
+				}
+			}
+		}
+	}
+	return result;
+};
+
+/**
+ * Byte-exact source span of an attribute including the single leading
+ * whitespace (` name`, ` name=value`, ` name="value"`), mirroring the
+ * tokenizer's end-of-attribute rule (`valueEnd + 1` past the closing quote).
+ * @param {HtmlPath} path walk path (used only for attribute-ref reads)
+ * @param {string} source HTML source
+ * @param {HtmlAttributeRef} attr attribute ref
+ * @returns {string} the attribute's source slice
+ */
+const attrSourceSpan = (path, source, attr) => {
+	const valueStart = path.attributeValueStart(attr);
+	const valueEnd = path.attributeValueEnd(attr);
+	const end =
+		valueStart === -1
+			? path.attributeNameEnd(attr)
+			: source.charCodeAt(valueStart - 1) === CC_QUOTATION_MARK ||
+				  source.charCodeAt(valueStart - 1) === CC_APOSTROPHE
+				? valueEnd + 1
+				: valueEnd;
+	return source.slice(path.attributeNameStart(attr) - 1, end);
+};
+
+/**
+ * Source span of a tag's `integrity` attribute (offsets relative to
+ * `elementStart`, leading whitespace and quotes included), so the template can
+ * drop the content-specific author value without re-parsing. Null when absent.
+ * @param {HtmlPath} path walk path (for attribute reads)
+ * @param {string} source HTML source
+ * @param {number} elementStart offset of the tag's opening `<`
+ * @returns {[number, number] | null} the span, or null when there is no `integrity`
+ */
+const captureIntegrityRange = (path, source, elementStart) => {
+	const integrityAttr = path.findAttribute("integrity");
+	if (integrityAttr === 0 || path.attributeNameStart(integrityAttr) < 0) {
+		return null;
+	}
+	let rs = path.attributeNameStart(integrityAttr);
+	while (rs > 0 && isSpace(source.charCodeAt(rs - 1))) {
+		rs--;
+	}
+	let re;
+	const ivs = path.attributeValueStart(integrityAttr);
+	if (ivs === -1) {
+		re = path.attributeNameEnd(integrityAttr);
+	} else {
+		const q = source.charCodeAt(ivs - 1);
+		const ive = path.attributeValueEnd(integrityAttr);
+		re = q === CC_QUOTATION_MARK || q === CC_APOSTROPHE ? ive + 1 : ive;
+	}
+	return [rs - elementStart, re - elementStart];
+};
+
 // Babel's `path.skip()`, children-only: set by `A.skipChildren()` during an
 // `enter` dispatch, consumed by the walk.
 let _walkSkip = false;
@@ -8848,14 +9049,21 @@ module.exports.NodeType = NodeType;
 module.exports.QUOTE_DOUBLE = QUOTE_DOUBLE;
 module.exports.QUOTE_NONE = QUOTE_NONE;
 module.exports.QUOTE_SINGLE = QUOTE_SINGLE;
+// WHATWG "ASCII whitespace" (tab / LF / FF / CR / space) — the tokenizer's
+// whitespace class, exported under the spec's name.
 // Exposed so HtmlParser can map user-configured (lowercased) tag names to
 // the adjusted camelCase names the AST carries for foreign content.
 module.exports.SVG_TAG_ADJUST = SVG_TAG_ADJUST;
 module.exports.SourceProcessor = SourceProcessor;
+module.exports.attrSourceSpan = attrSourceSpan;
+module.exports.captureIntegrityRange = captureIntegrityRange;
 module.exports.decodeEntities = decodeEntities;
-module.exports.decodeEntitiesWithMap = decodeEntitiesWithMap;
 module.exports.escapeAttribute = escapeAttribute;
 module.exports.escapeText = escapeText;
+module.exports.isAsciiWhitespace = isSpace;
+module.exports.parseCssUrls = parseCssUrls;
 module.exports.parseHtml = parseHtml;
+module.exports.parseMsapplicationTask = parseMsapplicationTask;
+module.exports.parseSrc = parseSrc;
 module.exports.parseSrcset = parseSrcset;
 module.exports.tokenize = tokenize;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -3782,45 +3782,34 @@ const decodeNumericReference = (code) => {
  * @param {boolean=} isAttribute true when the match came from an attribute value
  * @returns {string} decoded text, or `match` itself when it stays literal
  */
-const decodeOneReference = (match, nextCharCode, isAttribute) => {
-	// Numeric reference: &#65; or &#x41;
-	if (match.charCodeAt(1) === 0x23 /* # */) {
-		const lastChar = match.charAt(match.length - 1);
-		const isHex = match.charCodeAt(2) === 0x78 || match.charCodeAt(2) === 0x58;
-		const body = isHex
-			? lastChar === ";"
-				? match.slice(3, -1)
-				: match.slice(3)
-			: lastChar === ";"
-				? match.slice(2, -1)
-				: match.slice(2);
-		// The regex above guarantees at least one digit in `body`,
-		// so `parseInt` always returns a finite number here.
-		return decodeNumericReference(Number.parseInt(body, isHex ? 16 : 10));
-	}
-
-	// Named reference. Try the full captured name first, then
-	// progressively shorter prefixes - this handles direct matches
-	// like `&amp;` as well as WHATWG longest-prefix semantics where
-	// e.g. `&notpre;` decodes as `&not` (a legacy bare entity)
-	// followed by `pre;` as literal text.
-	const name = match.slice(1);
+/**
+ * Decode a named character reference spanning `[start, end)` of `str` (the
+ * `&` at `start`, the optional `;` included). Slices the name once; WHATWG
+ * longest-prefix and consumed-as-part-of-an-attribute semantics as before.
+ * @param {string} str the raw string
+ * @param {number} start offset of the reference's `&`
+ * @param {number} end offset just past the reference (past the `;` if present)
+ * @param {number} nextCharCode char code following the reference (NaN at the end)
+ * @param {boolean=} isAttribute true when the reference came from an attribute value
+ * @returns {string | undefined} decoded text, or `undefined` when it stays literal
+ */
+const decodeNamedReference = (str, start, end, nextCharCode, isAttribute) => {
+	// Mirrors the old `match.slice(1)`: the name keeps its trailing `;`.
+	const name = str.slice(start + 1, end);
 	const matchEndsWithSemi = name.charCodeAt(name.length - 1) === 0x3b;
 
 	// Attribute-context guard: if the entity match didn't end with `;`
 	// and the next character in the source is `=` or ASCII
 	// alphanumeric, the WHATWG spec says to flush the literal text
-	// rather than decode. The greedy regex already absorbed any
+	// rather than decode. The greedy scan already absorbed any
 	// trailing alphanumerics, so the only candidate "next char" here
 	// is `=` (or any non-alphanumeric).
 	if (isAttribute && !matchEndsWithSemi && nextCharCode === 0x3d /* = */) {
-		return match;
+		return undefined;
 	}
 
-	// Fast path: the regex usually captures exactly one entity (`&amp;`,
-	// `&lt;`, `&nbsp;`, …), so the whole `name` is the match — avoid the
-	// full-length `name.slice(0, name.length)` the loop's first iteration
-	// would allocate. No leftover, so the attribute guard never applies.
+	// Fast path: the scan usually captures exactly one entity (`&amp;`,
+	// `&lt;`, `&nbsp;`, ...), so the whole `name` is the match.
 	if (name.length <= MAX_ENTITY_NAME_LEN) {
 		const full = HTML_ENTITIES[name];
 		if (full !== undefined) return full;
@@ -3839,21 +3828,17 @@ const decodeOneReference = (match, nextCharCode, isAttribute) => {
 			// Attribute-context longest-prefix guard: if the matched
 			// prefix doesn't end with `;` and the leftover starts with
 			// an alphanumeric character, leave literal per WHATWG.
-			// (The regex greedy-consumes alphanumerics, so any leftover
-			// within `name` is itself alphanumeric — we only need to
-			// check non-empty leftover here; the `=` case is handled
-			// above against the source character after the match.)
 			if (
 				isAttribute &&
 				i < name.length &&
 				prefix.charCodeAt(prefix.length - 1) !== 0x3b
 			) {
-				return match;
+				return undefined;
 			}
 			return HTML_ENTITIES[prefix] + name.slice(i);
 		}
 	}
-	return match;
+	return undefined;
 };
 
 /** @typedef {{ text: string, map: number[] | undefined }} DecodedEntitiesWithMap */
@@ -3909,35 +3894,55 @@ const decodeEntities = (str, isAttribute, withMap) => {
 	/** @type {number[] | undefined} */
 	let map;
 	do {
-		// `end` stays 0 when the `&` doesn't start a well-formed reference.
+		// `end` stays 0 when the `&` doesn't start a well-formed reference; a
+		// numeric reference's code point accumulates during the digit scan
+		// (saturating above the code-point range — every overflow decodes the
+		// same replacement) so it needs no slice at all.
 		let end = 0;
+		let code = -1;
 		let cc = str.charCodeAt(amp + 1);
 		if (cc === 0x23 /* # */) {
 			cc = str.charCodeAt(amp + 2);
 			let p;
 			if (cc === 0x78 /* x */ || cc === 0x58 /* X */) {
+				code = 0;
 				p = amp + 3;
-				while (isAsciiHexDigit(str.charCodeAt(p))) p++;
+				while (isAsciiHexDigit((cc = str.charCodeAt(p)))) {
+					code = code * 16 + (cc <= 0x39 ? cc - 0x30 : (cc | 0x20) - 0x57);
+					if (code > 0x10ffff) code = 0x110000;
+					p++;
+				}
 				if (p > amp + 3) end = p;
 			} else {
+				code = 0;
 				p = amp + 2;
-				while (isAsciiDigit(str.charCodeAt(p))) p++;
+				while (isAsciiDigit((cc = str.charCodeAt(p)))) {
+					code = code * 10 + (cc - 0x30);
+					if (code > 0x10ffff) code = 0x110000;
+					p++;
+				}
 				if (p > amp + 2) end = p;
 			}
 		} else if (isAsciiAlpha(cc)) {
+			code = -1;
 			let p = amp + 2;
 			while (isAsciiAlphanumeric(str.charCodeAt(p))) p++;
 			end = p;
 		}
 		if (end !== 0) {
 			if (str.charCodeAt(end) === 0x3b /* ; */) end++;
-			const match = str.slice(amp, end);
-			const decoded = decodeOneReference(
-				match,
-				str.charCodeAt(end),
-				isAttribute
-			);
-			if (decoded !== match) {
+			// Numeric references always decode; named ones may stay literal.
+			const decoded =
+				code >= 0
+					? decodeNumericReference(code)
+					: decodeNamedReference(
+							str,
+							amp,
+							end,
+							str.charCodeAt(end),
+							isAttribute
+						);
+			if (decoded !== undefined) {
 				if (withMap) map = _mapReference(map, last, amp, decoded.length);
 				out += str.slice(last, amp);
 				out += decoded;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4360,8 +4360,9 @@ const _allocNode = (type, start, end) => {
 	_nodeNextSiblings[i] = 0;
 	_nodeAttrStarts[i] = 0;
 	_nodeAttrCounts[i] = 0;
-	// Ids are sequential, so this indexed write appends (array stays packed).
-	_nodeStrings[i] = "";
+	// `_nodeStrings[i]` is written by every caller right after this returns
+	// (tag name / text / comment data; "" at the few string-less sites), as a
+	// packed sequential append — no placeholder double-write here.
 	return i;
 };
 
@@ -5315,8 +5316,22 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	const skipComments = skip.comments === true;
 	const skipDoctype = skip.doctype === true;
 	_resetAstColumns();
+	// Pre-size the columns from the input length: a document big enough to
+	// exceed `_COLUMN_SHRINK_CAPACITY` re-enters with released (empty) columns,
+	// and growing through the doubling cascade re-allocates and copies every
+	// column several times per parse. ~12 bytes/node and ~50 bytes/attribute
+	// are the densest realistic HTML, so `len/12` (`len/48`) reaches the final
+	// capacity in one allocation; a sparser document over-allocates bounded
+	// scratch that the post-walk release frees, and the doubling growth remains
+	// as the safety net when the estimate is short.
+	const _sizeEstimate = (input.length / 12) | 0;
+	if (_sizeEstimate > _nodeCapacity) _growNodeColumns(_sizeEstimate);
+	if (_sizeEstimate > (_attrCapacity << 2)) {
+		_growAttrColumns(_sizeEstimate >> 2);
+	}
 	_htmlSource = source;
 	const doc = _allocNode(NodeType.Document, 0, 0);
+	_nodeStrings[doc] = "";
 	let mode = MODE_INITIAL;
 	// Mode to return to after MODE_TEXT / MODE_IN_TABLE_TEXT (0 = unset).
 	let originalMode = 0;
@@ -6549,6 +6564,7 @@ const parseHtml = (input, pos = 0, options = {}) => {
 				templateModes.push(MODE_IN_TEMPLATE);
 				const el = cur();
 				const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
+				_nodeStrings[fragment] = "";
 				// Parent link so the iterative walk can ascend out of the content.
 				_nodeParents[fragment] = el;
 				_nodeTemplateContents[el] = fragment;
@@ -7929,6 +7945,7 @@ const cloneSubtree = (node) => {
 	const tc = _nodeTemplateContents[node];
 	if (tc !== 0) {
 		const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
+		_nodeStrings[fragment] = "";
 		// Parent link so the iterative walk can ascend out of the content.
 		_nodeParents[fragment] = clone;
 		_nodeTemplateContents[clone] = fragment;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -17,7 +17,13 @@ const {
 	parseCommentOptionsInRange
 } = require("../util/magicComment");
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
-const { LEGACY_ASSERT_ATTRIBUTES, WebpackParser } = require("./syntax");
+const {
+	LEGACY_ASSERT_ATTRIBUTES,
+	WebpackParser,
+	buildLineStarts,
+	hasOctalEscape,
+	positionAt
+} = require("./syntax");
 
 /** @typedef {typeof import("acorn").Parser} AcornParser */
 /** @typedef {import("acorn").Options} AcornOptions */
@@ -172,6 +178,8 @@ let parser = /** @type {AcornParser} */ (WebpackParser);
 
 /** @typedef {Record<string, string> & { _isLegacyAssert?: boolean }} ImportAttributes */
 
+// Conceptually pairs with ./syntax's LEGACY_ASSERT_ATTRIBUTES marker, but is
+// pinned here by its public `JavascriptParser.getImportAttributes` typing.
 /**
  * Gets import attributes.
  * @param {ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration | ImportExpression} node node with assertions
@@ -462,47 +470,6 @@ const isSimpleFunction = (fn) => {
 	return true;
 };
 
-/**
- * Offset of each line's first character. Char-code scan matching acorn's
- * `lineBreak` semantics (CRLF is one break): a regex `exec` loop here
- * allocates a match array per line.
- * @param {string} source source code
- * @returns {number[]} line start offsets
- */
-const buildLineStarts = (source) => {
-	const len = source.length;
-	const lineStarts = [0];
-	for (let i = 0; i < len; i++) {
-		const ch = source.charCodeAt(i);
-		if (ch === 10) {
-			lineStarts.push(i + 1);
-		} else if (ch === 13) {
-			if (source.charCodeAt(i + 1) === 10) i++;
-			lineStarts.push(i + 1);
-		} else if (ch === 0x2028 || ch === 0x2029) {
-			lineStarts.push(i + 1);
-		}
-	}
-	return lineStarts;
-};
-
-/**
- * Binary search for the line containing the offset.
- * @param {number[]} lineStarts line start offsets
- * @param {number} offset source offset
- * @returns {SourcePosition} position (1-based line, 0-based column)
- */
-const positionAt = (lineStarts, offset) => {
-	let lo = 0;
-	let hi = lineStarts.length - 1;
-	while (lo < hi) {
-		const mid = (lo + hi + 1) >>> 1;
-		if (lineStarts[mid] <= offset) lo = mid;
-		else hi = mid - 1;
-	}
-	return { line: lo + 1, column: offset - lineStarts[lo] };
-};
-
 /** @type {ParseOptions} */
 const defaultParserOptions = {
 	sourceType: "module",
@@ -526,33 +493,6 @@ const evaluateAstCaches = new WeakMap();
 const EVALUATE_AST_CACHE_LIMIT = 4096;
 
 const CLASS_NAME = "JavascriptParser";
-
-/**
- * Whether a raw string literal contains a legacy octal (`\47`, `\0` followed by
- * a digit) or non-octal decimal (`\8`, `\9`) escape — all SyntaxErrors in
- * strict mode. Escaped backslashes (`\\`) and `\x` / `\u` escapes are skipped.
- * @param {string} raw raw string literal text, including quotes
- * @returns {boolean} true when a strict-forbidden escape is present
- */
-const hasOctalEscape = (raw) => {
-	for (let i = 0; i < raw.length; i++) {
-		if (raw.charCodeAt(i) !== 92) continue;
-		const next = raw.charCodeAt(i + 1);
-		if (next === 92) {
-			i++;
-			continue;
-		}
-		// `\0` is a valid NUL escape unless a digit follows it.
-		if (next === 48) {
-			const after = raw.charCodeAt(i + 2);
-			if (after >= 48 && after <= 57) return true;
-			i++;
-			continue;
-		}
-		if (next >= 49 && next <= 57) return true;
-	}
-	return false;
-};
 
 class JavascriptParser extends Parser {
 	/**

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -4177,5 +4177,82 @@ class WebpackParser extends BaseParser {
 	}
 }
 
+/** @typedef {import("../Dependency").SourcePosition} SourcePosition */
+
+/**
+ * Whether a raw string literal contains a legacy octal (`\47`, `\0` followed by
+ * a digit) or non-octal decimal (`\8`, `\9`) escape — all SyntaxErrors in
+ * strict mode. Escaped backslashes (`\\`) and `\x` / `\u` escapes are skipped.
+ * @param {string} raw raw string literal text, including quotes
+ * @returns {boolean} true when a strict-forbidden escape is present
+ */
+const hasOctalEscape = (raw) => {
+	for (let i = 0; i < raw.length; i++) {
+		if (raw.charCodeAt(i) !== 92) continue;
+		const next = raw.charCodeAt(i + 1);
+		if (next === 92) {
+			i++;
+			continue;
+		}
+		// `\0` is a valid NUL escape unless a digit follows it.
+		if (next === 48) {
+			const after = raw.charCodeAt(i + 2);
+			if (after >= 48 && after <= 57) return true;
+			i++;
+			continue;
+		}
+		if (next >= 49 && next <= 57) return true;
+	}
+	return false;
+};
+
+// Location decoding for lazy-mode output: nodes carry only offsets (the parser
+// skips acorn's location tracking), so line/column are derived on demand from
+// these two helpers.
+
+/**
+ * Offset of each line's first character. Char-code scan matching acorn's
+ * `lineBreak` semantics (CRLF is one break): a regex `exec` loop here
+ * allocates a match array per line.
+ * @param {string} source source code
+ * @returns {number[]} line start offsets
+ */
+const buildLineStarts = (source) => {
+	const len = source.length;
+	const lineStarts = [0];
+	for (let i = 0; i < len; i++) {
+		const ch = source.charCodeAt(i);
+		if (ch === 10) {
+			lineStarts.push(i + 1);
+		} else if (ch === 13) {
+			if (source.charCodeAt(i + 1) === 10) i++;
+			lineStarts.push(i + 1);
+		} else if (ch === 0x2028 || ch === 0x2029) {
+			lineStarts.push(i + 1);
+		}
+	}
+	return lineStarts;
+};
+
+/**
+ * Binary search for the line containing the offset.
+ * @param {number[]} lineStarts line start offsets
+ * @param {number} offset source offset
+ * @returns {SourcePosition} position (1-based line, 0-based column)
+ */
+const positionAt = (lineStarts, offset) => {
+	let lo = 0;
+	let hi = lineStarts.length - 1;
+	while (lo < hi) {
+		const mid = (lo + hi + 1) >>> 1;
+		if (lineStarts[mid] <= offset) lo = mid;
+		else hi = mid - 1;
+	}
+	return { line: lo + 1, column: offset - lineStarts[lo] };
+};
+
 module.exports.LEGACY_ASSERT_ATTRIBUTES = LEGACY_ASSERT_ATTRIBUTES;
 module.exports.WebpackParser = WebpackParser;
+module.exports.buildLineStarts = buildLineStarts;
+module.exports.hasOctalEscape = hasOctalEscape;
+module.exports.positionAt = positionAt;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -115,7 +115,11 @@ const CLS_UNICODE = 5;
 const CLS_SPACE = 6;
 const CLS_NEWLINE = 7;
 const CLS_SLASH = 8;
-const CHAR_CLASS = new Uint8Array(128);
+// Full `charCodeAt` range so the scan loop needs no `code > 127` branch per
+// character: every non-ASCII code unit classifies as CLS_UNICODE (which sorts
+// below CLS_SPACE, so the loop exits on the same single compare) and the
+// dispatch delegates it to acorn's unicode-aware paths.
+const CHAR_CLASS = new Uint8Array(0x10000).fill(CLS_UNICODE, 128);
 for (let i = 0; i < 128; i++) {
 	if (IDENT_START[i] === 1 || i === 92) CHAR_CLASS[i] = CLS_IDENT;
 	else if (SIMPLE_PUNCT[i] !== undefined) CHAR_CLASS[i] = CLS_PUNCT;
@@ -1277,18 +1281,19 @@ class WebpackParser extends BaseParser {
 		let cls = CLS_OTHER;
 		while (pos < len) {
 			code = input.charCodeAt(pos);
-			if (code > 127) {
-				// unicode whitespace / line terminators: acorn consumes the rest
-				this.pos = pos;
-				base.skipSpace.call(this);
-				pos = this.pos;
-				if (newline === 0) newline = 2;
-				code = pos < len ? input.charCodeAt(pos) : 0;
-				cls = code < 128 ? CHAR_CLASS[code] : CLS_UNICODE;
+			cls = CHAR_CLASS[code];
+			if (cls < CLS_SPACE) {
+				if (cls === CLS_UNICODE) {
+					// unicode whitespace / line terminators: acorn consumes the rest
+					this.pos = pos;
+					base.skipSpace.call(this);
+					pos = this.pos;
+					if (newline === 0) newline = 2;
+					code = pos < len ? input.charCodeAt(pos) : 0;
+					cls = CHAR_CLASS[code];
+				}
 				break;
 			}
-			cls = CHAR_CLASS[code];
-			if (cls < CLS_SPACE) break;
 			if (cls === CLS_SPACE) {
 				// space, tab, VT, FF (no CRLF/line bookkeeping in lazy mode)
 				pos++;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1025,6 +1025,12 @@ const WORD_CACHE_MAX_LEN = 12;
 /** @type {Map<number, string>} */
 const OP_CACHE = new Map();
 
+// Sticky mirrors of acorn's `skipWhiteSpace` / string-literal / `lineBreak`
+// regexes for the owned `strictDirective` (they scan at an offset, no slice).
+const STRICT_SKIP_WS = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+const STRICT_LITERAL = /(?:'((?:\\[^]|[^'\\])*?)'|"((?:\\[^]|[^"\\])*?)")/y;
+const STRICT_LINE_BREAK = /\r\n?|\n|\u2028|\u2029/;
+
 /**
  * @param {RegExp} re acorn `wordsRegexp` output (`^(?:a|b|c)$`)
  * @returns {Set<string>} the alternation's words
@@ -2012,6 +2018,53 @@ class WebpackParser extends BaseParser {
 		}
 		this.pos = pos;
 		this.finishToken(tokTypes.num, Number.parseFloat(input.slice(start, pos)));
+	}
+
+	/**
+	 * Owned `strictDirective`: acorn's runs an anchored literal regex over
+	 * `this.input.slice(start)` — a fresh sliced string per (sloppy-mode)
+	 * function body. Sticky regexes at the offset scan the same grammar with no
+	 * slice. Same directive-prologue semantics, including the ASI tail checks.
+	 * @param {number} start offset of the function body's first statement
+	 * @returns {boolean} true when a 'use strict' directive leads the prologue
+	 * @this {ParserInternals & { input: string, options: { ecmaVersion: number } }}
+	 */
+	strictDirective(start) {
+		if (/** @type {number} */ (this.options.ecmaVersion) < 5) return false;
+		const input = this.input;
+		for (;;) {
+			// Skip whitespace and comments (acorn's `skipWhiteSpace`, sticky).
+			STRICT_SKIP_WS.lastIndex = start;
+			start += /** @type {RegExpExecArray} */ (STRICT_SKIP_WS.exec(input))[0]
+				.length;
+			STRICT_LITERAL.lastIndex = start;
+			const match = STRICT_LITERAL.exec(input);
+			if (!match) return false;
+			if ((match[1] || match[2]) === "use strict") {
+				STRICT_SKIP_WS.lastIndex = start + match[0].length;
+				const spaceAfter = /** @type {RegExpExecArray} */ (
+					STRICT_SKIP_WS.exec(input)
+				);
+				const end = spaceAfter.index + spaceAfter[0].length;
+				const next = input.charAt(end);
+				return (
+					next === ";" ||
+					next === "}" ||
+					(STRICT_LINE_BREAK.test(spaceAfter[0]) &&
+						!(
+							/[(`.[+\-/*%<>=,?^&]/.test(next) ||
+							(next === "!" && input.charAt(end + 1) === "=")
+						))
+				);
+			}
+			start += match[0].length;
+
+			// Skip semicolon, if any.
+			STRICT_SKIP_WS.lastIndex = start;
+			start += /** @type {RegExpExecArray} */ (STRICT_SKIP_WS.exec(input))[0]
+				.length;
+			if (input[start] === ";") start++;
+		}
 	}
 
 	/**

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -599,6 +599,12 @@ describe("CssSyntax — SourceProcessor", () => {
 			.process(big);
 		// 70000 value idents + the selector ident
 		expect(idents).toBe(70001);
+		// again: the regrow-hint path must restore exactly enough capacity
+		idents = 0;
+		new SourceProcessor()
+			.use({ [NodeType.Ident]: () => idents++ })
+			.process(big);
+		expect(idents).toBe(70001);
 		/** @type {string[]} */
 		const names = [];
 		new SourceProcessor()

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -35,6 +35,7 @@ const {
 	Token,
 	TokenStream,
 	buildSkipSet,
+	normalizeUrl,
 	parseABlocksContents,
 	parseACommaSeparatedListOfComponentValues,
 	parseAComponentValue,
@@ -1131,5 +1132,31 @@ describe("CssSyntax — path accessors", () => {
 			)
 			.process(".b { margin: 0; }");
 		expect(out).toEqual([[true, 1, 0]]);
+	});
+});
+
+describe("CssSyntax — normalizeUrl", () => {
+	it("should return a plain url unchanged", () => {
+		const s = "./images/photo.png";
+		expect(normalizeUrl(s, false)).toBe(s);
+	});
+
+	it("should keep data: URIs verbatim (case-insensitive) without decoding", () => {
+		expect(normalizeUrl("data:image/png;base64,AA%2F", false)).toBe(
+			"data:image/png;base64,AA%2F"
+		);
+		expect(normalizeUrl("DATA:text/plain,x%41", false)).toBe(
+			"DATA:text/plain,x%41"
+		);
+	});
+
+	it("should trim whitespace, strip escaped newlines and decode escapes", () => {
+		expect(normalizeUrl("  img.png\t ", true)).toBe("img.png");
+		expect(normalizeUrl("im\\\ng.png", true)).toBe("img.png");
+		expect(normalizeUrl("./im\\61 ges/a.png", false)).toBe("./images/a.png");
+	});
+
+	it("should decode percent-encoding outside data: URIs", () => {
+		expect(normalizeUrl("./%2E/img.png", false)).toBe("././img.png");
 	});
 });

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -391,6 +391,19 @@ describe("CssSyntax — parser entry points", () => {
 		expect(rules).toHaveLength(1);
 	});
 
+	it("shares one empty child-rules list across rules with only declarations", () => {
+		// A body with no nested rules returns the shared frozen empty list rather
+		// than allocating a fresh `[]` per rule (see `_EMPTY_LIST`).
+		const { rules } = parseABlocksContents("x:1;y:2", 0);
+		expect(rules).toHaveLength(0);
+		const ss = parseAStylesheet(".a{x:1}.b{y:2}");
+		const a = /** @type {import("../lib/css/syntax").Rule} */ (ss.rules[0]);
+		const b = /** @type {import("../lib/css/syntax").Rule} */ (ss.rules[1]);
+		expect(a.childRules).toHaveLength(0);
+		expect(a.childRules).toBe(b.childRules);
+		expect(Object.isFrozen(a.childRules)).toBe(true);
+	});
+
 	it("re-parses a nested rule whose selector starts <ident><colon> as a qualified rule", () => {
 		// consume-a-declaration bails on the top-level `{` (step 8 would reject
 		// it) and the caller re-parses the input as a qualified rule (CSS Nesting)

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -15,7 +15,6 @@ const {
 	QUOTE_NONE,
 	QUOTE_SINGLE,
 	decodeEntities,
-	decodeEntitiesWithMap,
 	escapeAttribute,
 	escapeText,
 	parseHtml: parseHtmlRefs,
@@ -2831,21 +2830,21 @@ describe("tokenize", () => {
 		});
 	});
 
-	describe("decodeEntitiesWithMap", () => {
+	describe("decodeEntities with map", () => {
 		it("should return the input and no map when nothing decodes", () => {
-			expect(decodeEntitiesWithMap("plain text")).toEqual({
+			expect(decodeEntities("plain text", false, true)).toEqual({
 				text: "plain text",
 				map: undefined
 			});
 			// Attribute rule keeps `&amp=1` literal — no map either.
-			expect(decodeEntitiesWithMap("&amp=1", true)).toEqual({
+			expect(decodeEntities("&amp=1", true, true)).toEqual({
 				text: "&amp=1",
 				map: undefined
 			});
 		});
 
 		it("should map decoded boundaries back to raw offsets", () => {
-			const { text, map } = decodeEntitiesWithMap("a&amp;b", true);
+			const { text, map } = decodeEntities("a&amp;b", true, true);
 			expect(text).toBe("a&b");
 			// Boundaries: `a` 0, decoded `&` starts at raw 1, `b` at raw 6, end 7.
 			expect(map).toEqual([0, 1, 6, 7]);
@@ -2859,7 +2858,7 @@ describe("tokenize", () => {
 		});
 
 		it("should map around numeric references and trailing text", () => {
-			const { text, map } = decodeEntitiesWithMap("x&#32;yz", true);
+			const { text, map } = decodeEntities("x&#32;yz", true, true);
 			expect(text).toBe("x yz");
 			expect(map).toEqual([0, 1, 6, 7, 8]);
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21458: profiling the JS/CSS/HTML syntax parsers on real-world inputs surfaced remaining hot-path waste. CSS gets branchless tokenizer dispatch and pooled flat-buffer content lists in the streaming backend (-15% CPU, -72% heap churn on a 1.9 MiB Tailwind sheet); HTML gets pre-sized AST columns, no per-node placeholder string write, and span-based character-reference decoding (-2 to -21% CPU, -28 to -48% churn on a 2.4 MiB document); JS gets branchless char-class dispatch and a sticky-regex `strictDirective` without the per-function input slice (~-8% on large sloppy-mode files). All outputs are byte-identical, verified by differential fuzzing (80k+ cases for entity decoding, AST hash comparisons for JS/CSS) and linearity checks across 38 adversarial input shapes. Also unifies `decodeEntitiesWithMap` into `decodeEntities` and consolidates spec-level parsing helpers into the `syntax.js` files.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new cases in `test/CssSyntax.unittest.js` (shared empty child-rules list, `normalizeUrl`) and updated `test/HtmlSyntax.unittest.js` for the unified `decodeEntities`; all changed lines are covered by the existing unit/spec/integration suites (html5lib, css-parsing-tests, test262 all pass).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — parser outputs are byte-identical; the only API change is internal (`decodeEntitiesWithMap` folded into `decodeEntities(str, isAttribute, withMap)`, not part of the public types).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a (side finding worth a perf-docs note someday: `--max-semi-space-size=64` speeds parsing of very large files ~13% due to V8 young-gen scaling).

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was developed with AI assistance (Claude, via Claude Code) under human direction: profiling, implementation, differential fuzzing and benchmark verification were AI-executed; every change was gated on full test-suite runs and equivalence proofs, and regressing experiments were discarded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpjHnTULxuPk1VZmzH8zK8)_