### PR TITLE
refactor: wrapped CommonJS concatenated modules

### DIFF
--- a/.changeset/commonjs-wrap-runtime-helper.md
+++ b/.changeset/commonjs-wrap-runtime-helper.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Use a shared `__webpack_require__.cjs` helper for wrapped CommonJS modules.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -64,6 +64,11 @@ module.exports.chunkCallback = "webpackChunk";
 module.exports.chunkName = "__webpack_require__.cn";
 
 /**
+ * wrap and eagerly execute a CommonJS module body, returning its exports
+ */
+module.exports.commonJsWrap = "__webpack_require__.cjs";
+
+/**
  * compatibility get default export
  */
 module.exports.compatGetDefaultExport = "__webpack_require__.n";

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -13,6 +13,7 @@ const AsyncModuleGeneratorRuntimeModule = require("./runtime/AsyncModuleGenerato
 const AsyncModuleRuntimeModule = require("./runtime/AsyncModuleRuntimeModule");
 const AutoPublicPathRuntimeModule = require("./runtime/AutoPublicPathRuntimeModule");
 const BaseUriRuntimeModule = require("./runtime/BaseUriRuntimeModule");
+const CommonJsWrapRuntimeModule = require("./runtime/CommonJsWrapRuntimeModule");
 const CompatGetDefaultExportRuntimeModule = require("./runtime/CompatGetDefaultExportRuntimeModule");
 const CompatRuntimeModule = require("./runtime/CompatRuntimeModule");
 const CreateFakeNamespaceObjectRuntimeModule = require("./runtime/CreateFakeNamespaceObjectRuntimeModule");
@@ -262,6 +263,12 @@ class RuntimePlugin {
 						chunk,
 						new CompatGetDefaultExportRuntimeModule()
 					);
+					return true;
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.commonJsWrap)
+				.tap(PLUGIN_NAME, (chunk) => {
+					compilation.addRuntimeModule(chunk, new CommonJsWrapRuntimeModule());
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -157,8 +157,7 @@ if (!ReferencerClass.prototype.PropertyDefinition) {
  * @property {"concatenated"} type
  * @property {Module} module
  * @property {number} index
- * @property {boolean=} cjsWrapped a "weird" CommonJS module rendered inside an IIFE with real module/exports objects
- * @property {string | undefined} moduleObjectName the wrapped module's `{ exports }` object variable
+ * @property {boolean=} cjsWrapped a "weird" CommonJS module executed via the CJS wrapper runtime helper with real module/exports objects
  * @property {Program | undefined} ast
  * @property {Source | undefined} internalSource
  * @property {ReplaceSource | undefined} source
@@ -1731,17 +1730,8 @@ class ConcatenatedModule extends Module {
 			switch (info.type) {
 				case "concatenated": {
 					if (info.cjsWrapped) {
-						// Wrapped modules expose only two shared-scope names: the
-						// `{ exports }` object and a live alias used as the namespace.
-						const moduleObjectName = findNewName(
-							"module",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(moduleObjectName);
-						topLevelDeclarations.add(moduleObjectName);
-						info.moduleObjectName = moduleObjectName;
+						// Wrapped modules expose one shared-scope name: the final
+						// exports object used as the namespace.
 						const namespaceObjectName = findNewName(
 							"namespaceObject",
 							allUsedNames,
@@ -2337,21 +2327,14 @@ ${defineGetters}`
 						`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
 					);
 					if (info.cjsWrapped) {
-						const moduleObjectName = /** @type {string} */ (
-							info.moduleObjectName
-						);
-						const exportsObject = `${moduleObjectName}.exports`;
-						// Real CommonJS semantics: top-level `this` is the exports
-						// object, and consumers read the live `.exports` afterwards.
-						result.add(`var ${moduleObjectName} = { exports: {} };\n`);
+						// Real CommonJS semantics via the runtime helper: it calls the
+						// body with this = exports and returns the final module.exports.
+						runtimeRequirements.add(RuntimeGlobals.commonJsWrap);
 						result.add(
-							`(function(${info.module.moduleArgument}, ${info.module.exportsArgument}) {\n`
+							`var ${info.namespaceObjectName} = /*#__PURE__*/${RuntimeGlobals.commonJsWrap}(function(${info.module.moduleArgument}, ${info.module.exportsArgument}) {\n`
 						);
 						result.add(/** @type {ReplaceSource} */ (info.source));
-						result.add(
-							`\n}).call(${exportsObject}, ${moduleObjectName}, ${exportsObject});\n`
-						);
-						result.add(`var ${info.namespaceObjectName} = ${exportsObject};\n`);
+						result.add("\n});\n");
 					} else {
 						result.add(/** @type {ReplaceSource} */ (info.source));
 					}
@@ -2632,7 +2615,6 @@ ${defineGetters}`
 							cjsWrapped: isCommonJsWrapped(
 								/** @type {NormalModule} */ (info.module)
 							),
-							moduleObjectName: undefined,
 							ast: undefined,
 							chunkInitFragments: undefined,
 							internalSource: undefined,

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -208,7 +208,6 @@ class ModuleConcatenationPlugin {
 							setBailoutReason(module, "Module is async");
 							continue;
 						}
-
 						// Must be in strict mode
 						if (!(/** @type {BuildInfo} */ (module.buildInfo).strict)) {
 							setBailoutReason(module, "Module is not in strict mode");

--- a/lib/runtime/CommonJsWrapRuntimeModule.js
+++ b/lib/runtime/CommonJsWrapRuntimeModule.js
@@ -1,0 +1,37 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
+const HelperRuntimeModule = require("./HelperRuntimeModule");
+
+/** @typedef {import("../Compilation")} Compilation */
+
+class CommonJsWrapRuntimeModule extends HelperRuntimeModule {
+	constructor() {
+		super("wrap commonjs module");
+	}
+
+	/**
+	 * Generates runtime code for this runtime module.
+	 * @returns {string | null} runtime code
+	 */
+	generate() {
+		const compilation = /** @type {Compilation} */ (this.compilation);
+		const { runtimeTemplate } = compilation;
+		const fn = RuntimeGlobals.commonJsWrap;
+		return Template.asString([
+			"// execute a CommonJS module body with real module/exports objects, returning the final exports",
+			`${fn} = ${runtimeTemplate.basicFunction("body", [
+				`${runtimeTemplate.renderConst()} mod = { exports: {} };`,
+				"body.call(mod.exports, mod, mod.exports);",
+				"return mod.exports;"
+			])};`
+		]);
+	}
+}
+
+module.exports = CommonJsWrapRuntimeModule;

--- a/types.d.ts
+++ b/types.d.ts
@@ -27121,6 +27121,7 @@ declare namespace exports {
 		export let baseURI: "__webpack_require__.b";
 		export let chunkCallback: "webpackChunk";
 		export let chunkName: "__webpack_require__.cn";
+		export let commonJsWrap: "__webpack_require__.cjs";
 		export let compatGetDefaultExport: "__webpack_require__.n";
 		export let compileWasm: "__webpack_require__.vs";
 		export let createFakeNamespaceObject: "__webpack_require__.t";
@@ -27202,7 +27203,6 @@ declare namespace exports {
 		export let uncaughtErrorHandler: "__webpack_require__.oe";
 		export let wasmInstances: "__webpack_require__.w";
 		export let worker: "__webpack_require__.wc";
-		export let commonJsWrap: "__webpack_require__.cjs";
 	}
 	export const UsageState: Readonly<{
 		Unused: 0;

--- a/types.d.ts
+++ b/types.d.ts
@@ -4368,14 +4368,9 @@ declare interface ConcatenatedModuleInfo {
 	index: number;
 
 	/**
-	 * a "weird" CommonJS module rendered inside an IIFE with real module/exports objects
+	 * a "weird" CommonJS module executed via the CJS wrapper runtime helper with real module/exports objects
 	 */
 	cjsWrapped?: boolean;
-
-	/**
-	 * the wrapped module's `{ exports }` object variable
-	 */
-	moduleObjectName?: string;
 	ast?: Program;
 	internalSource?: Source;
 	source?: ReplaceSource;
@@ -27207,6 +27202,7 @@ declare namespace exports {
 		export let uncaughtErrorHandler: "__webpack_require__.oe";
 		export let wasmInstances: "__webpack_require__.w";
 		export let worker: "__webpack_require__.wc";
+		export let commonJsWrap: "__webpack_require__.cjs";
 	}
 	export const UsageState: Readonly<{
 		Unused: 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Wrapped CommonJS modules in concatenation (Refs #21436) currently emit a full inline IIFE wrapper per module; this replaces it with one shared `__webpack_require__.cjs` runtime helper, shrinking output and removing the per-module `{ exports }` top-level variable. The helper stays eager (unlike esbuild's lazy `__commonJSMin`) because concatenated modules must evaluate exactly once at their position in module order.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No new tests; the existing `test/configCases/concatenate-modules/commonjs-wrapped` cases build and execute the helper-based output.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with Claude Code (runtime module, wiring, and codegen change) under human direction and review; the helper naming was revised by hand.