### PR TITLE
feat: expose active MultiWatching on MultiCompiler.watching

### DIFF
--- a/.changeset/multicompiler-watching.md
+++ b/.changeset/multicompiler-watching.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Expose the active `MultiWatching` on `MultiCompiler.watching`, mirroring `Compiler.watching`.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -102,6 +102,8 @@ module.exports = class MultiCompiler {
 		this.dependencies = new WeakMap();
 		/** @type {boolean} */
 		this.running = false;
+		/** @type {MultiWatching | undefined} */
+		this.watching = undefined;
 
 		/** @type {(Stats | null)[]} */
 		const compilerStats = this.compilers.map(() => null);
@@ -662,10 +664,12 @@ module.exports = class MultiCompiler {
 				},
 				handler
 			);
-			return new MultiWatching(watchings, this);
+			this.watching = new MultiWatching(watchings, this);
+			return this.watching;
 		}
 
-		return new MultiWatching([], this);
+		this.watching = new MultiWatching([], this);
+		return this.watching;
 	}
 
 	/**
@@ -715,6 +719,7 @@ module.exports = class MultiCompiler {
 				compiler.close(callback);
 			},
 			(error) => {
+				this.watching = undefined;
 				callback(/** @type {Error | null} */ (error));
 			}
 		);

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -70,6 +70,7 @@ class MultiWatching {
 			},
 			(err) => {
 				this.compiler.hooks.watchClose.call();
+				if (this.compiler.watching === this) this.compiler.watching = undefined;
 				if (typeof callback === "function") {
 					this.compiler.running = false;
 					callback(/** @type {Error | null} */ (err));

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -290,6 +290,35 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should expose the active MultiWatching on `watching`", (done) => {
+		const compiler = createMultiCompiler();
+		expect(compiler.watching).toBeUndefined();
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (err, _stats) => {
+					if (err) return done(err);
+				})
+			)
+		);
+		expect(compiler.watching).toBe(watching);
+		watching.close(() => {
+			expect(compiler.watching).toBeUndefined();
+			done();
+		});
+	});
+
+	it("should clear `watching` when the compiler is closed directly", (done) => {
+		const compiler = createMultiCompiler();
+		compiler.watch({}, (err, _stats) => {
+			if (err) return done(err);
+		});
+		expect(compiler.watching).toBeDefined();
+		compiler.close(() => {
+			expect(compiler.watching).toBeUndefined();
+			done();
+		});
+	});
+
 	it("should respect parallelism and dependencies for running", (done) => {
 		const compiler = createMultiCompiler(
 			/** @type {import("../").MultiCompilerOptions} */ ({

--- a/types.d.ts
+++ b/types.d.ts
@@ -16900,6 +16900,7 @@ declare class MultiCompiler {
 	compilers: Compiler[];
 	dependencies: WeakMap<Compiler, string[]>;
 	running: boolean;
+	watching?: MultiWatching;
 	get options(): WebpackOptionsNormalized[] & MultiCompilerOptions;
 	get outputPath(): string;
 


### PR DESCRIPTION
Mirror Compiler.watching so consumers (e.g. webpack-dev-middleware) can detect and reuse an existing MultiCompiler watch instead of starting a duplicate one. Set in watch(), cleared on close().

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->