### PR TITLE
fix: prevent lazy compilation backend leak and exit hang

### DIFF
--- a/.changeset/lazy-compilation-backend-lifecycle.md
+++ b/.changeset/lazy-compilation-backend-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix lazy compilation backend leaking idle module entries and hanging on exit.

--- a/lib/hmr/lazyCompilationBackend.js
+++ b/lib/hmr/lazyCompilationBackend.js
@@ -27,6 +27,9 @@ module.exports = (options) => (compiler, callback) => {
 	const logger = compiler.getInfrastructureLogger("LazyCompilationBackend");
 	/** @type {Map<string, number>} */
 	const activeModules = new Map();
+	/** @type {Set<NodeJS.Timeout>} */
+	const idleTimers = new Set();
+	let isClosing = false;
 	const prefix = "/lazy-compilation-using-";
 
 	const isHttps =
@@ -67,17 +70,29 @@ module.exports = (options) => (compiler, callback) => {
 		if (req.url === undefined) return;
 		const keys = req.url.slice(prefix.length).split("@");
 		req.socket.on("close", () => {
-			setTimeout(() => {
+			// Shutting down: skip the idle-decrement timer entirely.
+			if (isClosing) return;
+			const timer = setTimeout(() => {
+				idleTimers.delete(timer);
 				for (const key of keys) {
 					const oldValue = activeModules.get(key) || 0;
-					activeModules.set(key, oldValue - 1);
-					if (oldValue === 1) {
-						logger.log(
-							`${key} is no longer in use. Next compilation will skip this module.`
-						);
+					// Drop the entry at zero so the map doesn't retain idle modules
+					// and the count can't drift negative.
+					if (oldValue <= 1) {
+						activeModules.delete(key);
+						if (oldValue === 1) {
+							logger.log(
+								`${key} is no longer in use. Next compilation will skip this module.`
+							);
+						}
+					} else {
+						activeModules.set(key, oldValue - 1);
 					}
 				}
 			}, 120000);
+			// Don't keep the process alive just to decrement idle counters.
+			if (timer.unref) timer.unref();
+			idleTimers.add(timer);
 		});
 		req.socket.setNoDelay(true);
 		res.writeHead(200, {
@@ -102,7 +117,6 @@ module.exports = (options) => (compiler, callback) => {
 	const server = createServer();
 	server.on("request", requestListener);
 
-	let isClosing = false;
 	/** @type {Set<import("net").Socket>} */
 	const sockets = new Set();
 	server.on("connection", (socket) => {
@@ -150,6 +164,8 @@ module.exports = (options) => (compiler, callback) => {
 			callback(null, {
 				dispose(callback) {
 					isClosing = true;
+					for (const timer of idleTimers) clearTimeout(timer);
+					idleTimers.clear();
 					// Removing the listener is a workaround for a memory leak in node.js
 					server.off("request", requestListener);
 					server.close((err) => {

--- a/test/LazyCompilationBackend.unittest.js
+++ b/test/LazyCompilationBackend.unittest.js
@@ -1,0 +1,127 @@
+"use strict";
+
+const { EventEmitter } = require("events");
+const createBackend = require("../lib/hmr/lazyCompilationBackend");
+
+const PREFIX = "/lazy-compilation-using-";
+
+const makeServer = () => {
+	const server = new EventEmitter();
+	server.address = () => ({ address: "127.0.0.1", family: "IPv4", port: 1234 });
+	server.close = (cb) => cb && cb();
+	return server;
+};
+
+const makeSocket = () => {
+	const socket = new EventEmitter();
+	socket.setNoDelay = () => {};
+	// mirror http socket teardown: destroy triggers a close event
+	socket.destroy = () => socket.emit("close");
+	return socket;
+};
+
+/**
+ * @param {EXPECTED_ANY} api backend api
+ * @param {EventEmitter} server fake server
+ * @param {string} url request url
+ * @returns {EventEmitter} the request socket
+ */
+const connect = (api, server, url) => {
+	const socket = makeSocket();
+	const req = { url, socket };
+	const res = { writeHead() {}, write() {} };
+	server.emit("connection", socket);
+	server.emit("request", req, res);
+	return socket;
+};
+
+describe("lazyCompilationBackend", () => {
+	beforeEach(() => jest.useFakeTimers());
+
+	afterEach(() => jest.useRealTimers());
+
+	/**
+	 * @returns {{ api: EXPECTED_ANY, server: EventEmitter, invalidate: jest.Mock }} harness
+	 */
+	const setup = () => {
+		const server = makeServer();
+		const invalidate = jest.fn();
+		const compiler = {
+			getInfrastructureLogger: () => ({ log() {}, warn() {} }),
+			watching: { invalidate }
+		};
+		let api;
+		createBackend({
+			client: "client",
+			server: () => server,
+			listen: (s) => s.emit("listening")
+		})(compiler, (err, result) => {
+			if (err) throw err;
+			api = result;
+		});
+		return { api, server, invalidate };
+	};
+
+	it("activates a module while a client is connected and invalidates once", () => {
+		const { api, server, invalidate } = setup();
+		const mod = { identifier: () => "mod-a" };
+		const { data: key } = api.module(mod);
+		expect(api.module(mod).active).toBe(false);
+
+		connect(api, server, PREFIX + key);
+		expect(api.module(mod).active).toBe(true);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+
+		// a second client for the same module doesn't re-invalidate
+		connect(api, server, PREFIX + key);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the module active until the last client disconnects, then drops it", () => {
+		const { api, server } = setup();
+		const mod = { identifier: () => "mod-a" };
+		const { data: key } = api.module(mod);
+		const s1 = connect(api, server, PREFIX + key);
+		const s2 = connect(api, server, PREFIX + key);
+
+		// first disconnect: still one client left after the idle delay
+		s1.emit("close");
+		jest.advanceTimersByTime(120000);
+		expect(api.module(mod).active).toBe(true);
+
+		// last disconnect: module goes idle
+		s2.emit("close");
+		jest.advanceTimersByTime(120000);
+		expect(api.module(mod).active).toBe(false);
+	});
+
+	it("does not schedule idle timers or hang after dispose", () => {
+		const { api, server } = setup();
+		const mod = { identifier: () => "mod-a" };
+		const { data: key } = api.module(mod);
+		connect(api, server, PREFIX + key);
+
+		let disposed = false;
+		api.dispose(() => {
+			disposed = true;
+		});
+		expect(disposed).toBe(true);
+
+		// dispose destroys sockets (emits close); with isClosing set, those must
+		// not schedule new idle timers, so nothing is pending.
+		expect(jest.getTimerCount()).toBe(0);
+	});
+
+	it("clears a pending idle timer on dispose", () => {
+		const { api, server } = setup();
+		const mod = { identifier: () => "mod-a" };
+		const { data: key } = api.module(mod);
+		const s1 = connect(api, server, PREFIX + key);
+
+		s1.emit("close");
+		expect(jest.getTimerCount()).toBe(1);
+
+		api.dispose(() => {});
+		expect(jest.getTimerCount()).toBe(0);
+	});
+});

--- a/test/LazyCompilationBackend.unittest.js
+++ b/test/LazyCompilationBackend.unittest.js
@@ -3,28 +3,47 @@
 const { EventEmitter } = require("events");
 const createBackend = require("../lib/hmr/lazyCompilationBackend");
 
+/** @typedef {import("../lib/hmr/LazyCompilationPlugin").BackendApi} BackendApi */
+/** @typedef {import("http").Server} Server */
+/** @typedef {import("net").Socket} Socket */
+
 const PREFIX = "/lazy-compilation-using-";
 
+/** @returns {Server} a fake http.Server */
 const makeServer = () => {
 	const server = new EventEmitter();
-	server.address = () => ({ address: "127.0.0.1", family: "IPv4", port: 1234 });
-	server.close = (cb) => cb && cb();
-	return server;
+	Object.assign(server, {
+		address: () => ({ address: "127.0.0.1", family: "IPv4", port: 1234 }),
+		close: (/** @type {() => void} */ cb) => cb && cb()
+	});
+	return /** @type {Server} */ (/** @type {unknown} */ (server));
 };
 
+/** @returns {Socket} a fake socket */
 const makeSocket = () => {
 	const socket = new EventEmitter();
-	socket.setNoDelay = () => {};
-	// mirror http socket teardown: destroy triggers a close event
-	socket.destroy = () => socket.emit("close");
-	return socket;
+	Object.assign(socket, {
+		setNoDelay: () => {},
+		// mirror http socket teardown: destroy triggers a close event
+		destroy: () => socket.emit("close")
+	});
+	return /** @type {Socket} */ (/** @type {unknown} */ (socket));
 };
 
 /**
- * @param {EXPECTED_ANY} api backend api
- * @param {EventEmitter} server fake server
+ * @param {string} id module identifier
+ * @returns {import("../lib/Module")} a fake module
+ */
+const makeModule = (id) =>
+	/** @type {import("../lib/Module")} */ (
+		/** @type {unknown} */ ({ identifier: () => id })
+	);
+
+/**
+ * @param {BackendApi} api backend api
+ * @param {Server} server fake server
  * @param {string} url request url
- * @returns {EventEmitter} the request socket
+ * @returns {Socket} the request socket
  */
 const connect = (api, server, url) => {
 	const socket = makeSocket();
@@ -41,30 +60,35 @@ describe("lazyCompilationBackend", () => {
 	afterEach(() => jest.useRealTimers());
 
 	/**
-	 * @returns {{ api: EXPECTED_ANY, server: EventEmitter, invalidate: jest.Mock }} harness
+	 * @returns {{ api: BackendApi, server: Server, invalidate: jest.Mock }} harness
 	 */
 	const setup = () => {
 		const server = makeServer();
 		const invalidate = jest.fn();
-		const compiler = {
-			getInfrastructureLogger: () => ({ log() {}, warn() {} }),
-			watching: { invalidate }
-		};
+		const compiler = /** @type {import("../lib/Compiler")} */ (
+			/** @type {unknown} */ ({
+				getInfrastructureLogger: () => ({ log() {}, warn() {} }),
+				watching: { invalidate }
+			})
+		);
+		/** @type {BackendApi | undefined} */
 		let api;
 		createBackend({
 			client: "client",
 			server: () => server,
-			listen: (s) => s.emit("listening")
+			listen: (/** @type {Server} */ s) => s.emit("listening")
 		})(compiler, (err, result) => {
 			if (err) throw err;
 			api = result;
 		});
+		// listen fires "listening" synchronously, so api is set by now
+		if (!api) throw new Error("backend did not initialize synchronously");
 		return { api, server, invalidate };
 	};
 
 	it("activates a module while a client is connected and invalidates once", () => {
 		const { api, server, invalidate } = setup();
-		const mod = { identifier: () => "mod-a" };
+		const mod = makeModule("mod-a");
 		const { data: key } = api.module(mod);
 		expect(api.module(mod).active).toBe(false);
 
@@ -79,7 +103,7 @@ describe("lazyCompilationBackend", () => {
 
 	it("keeps the module active until the last client disconnects, then drops it", () => {
 		const { api, server } = setup();
-		const mod = { identifier: () => "mod-a" };
+		const mod = makeModule("mod-a");
 		const { data: key } = api.module(mod);
 		const s1 = connect(api, server, PREFIX + key);
 		const s2 = connect(api, server, PREFIX + key);
@@ -97,7 +121,7 @@ describe("lazyCompilationBackend", () => {
 
 	it("does not schedule idle timers or hang after dispose", () => {
 		const { api, server } = setup();
-		const mod = { identifier: () => "mod-a" };
+		const mod = makeModule("mod-a");
 		const { data: key } = api.module(mod);
 		connect(api, server, PREFIX + key);
 
@@ -114,7 +138,7 @@ describe("lazyCompilationBackend", () => {
 
 	it("clears a pending idle timer on dispose", () => {
 		const { api, server } = setup();
-		const mod = { identifier: () => "mod-a" };
+		const mod = makeModule("mod-a");
 		const { data: key } = api.module(mod);
 		const s1 = connect(api, server, PREFIX + key);
 


### PR DESCRIPTION
The SSE backend's activeModules map never dropped keys at zero, retaining one dead entry per module ever activated, and its 120s idle-decrement timers weren't unref'd or cleared on dispose, keeping the process alive after shutdown. Delete keys at zero, unref the timers, and clear pending ones on dispose.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->