### PR TITLE
feat: expose active MultiWatching on MultiCompiler.watching

### DIFF
--- a/.changeset/multicompiler-watching.md
+++ b/.changeset/multicompiler-watching.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Expose the active `MultiWatching` on `MultiCompiler.watching`.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -102,6 +102,8 @@ module.exports = class MultiCompiler {
 		this.dependencies = new WeakMap();
 		/** @type {boolean} */
 		this.running = false;
+		/** @type {MultiWatching | undefined} */
+		this.watching = undefined;
 
 		/** @type {(Stats | null)[]} */
 		const compilerStats = this.compilers.map(() => null);
@@ -662,10 +664,12 @@ module.exports = class MultiCompiler {
 				},
 				handler
 			);
-			return new MultiWatching(watchings, this);
+			this.watching = new MultiWatching(watchings, this);
+			return this.watching;
 		}
 
-		return new MultiWatching([], this);
+		this.watching = new MultiWatching([], this);
+		return this.watching;
 	}
 
 	/**
@@ -709,6 +713,13 @@ module.exports = class MultiCompiler {
 	 * @returns {void}
 	 */
 	close(callback) {
+		if (this.watching) {
+			// When there is still an active watching, close this first
+			this.watching.close((_err) => {
+				this.close(callback);
+			});
+			return;
+		}
 		asyncLib.each(
 			this.compilers,
 			(compiler, callback) => {

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -69,6 +69,7 @@ class MultiWatching {
 				watching.close(finishedCallback);
 			},
 			(err) => {
+				if (this.compiler.watching === this) this.compiler.watching = undefined;
 				this.compiler.hooks.watchClose.call();
 				if (typeof callback === "function") {
 					this.compiler.running = false;

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -290,6 +290,75 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should expose the active MultiWatching on `watching`", (done) => {
+		const compiler = createMultiCompiler();
+		expect(compiler.watching).toBeUndefined();
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (err, _stats) => {
+					if (err) return done(err);
+				})
+			)
+		);
+		expect(compiler.watching).toBe(watching);
+		watching.close(() => {
+			expect(compiler.watching).toBeUndefined();
+			compiler.close(done);
+		});
+	});
+
+	it("should close the active watching and clear `watching` when the compiler is closed directly", (done) => {
+		const compiler = createMultiCompiler();
+		let watchCloseCalled = 0;
+		compiler.hooks.watchClose.tap("MultiCompiler test", () => {
+			watchCloseCalled++;
+		});
+		compiler.watch({}, (err, _stats) => {
+			if (err) return done(err);
+		});
+		expect(compiler.watching).toBeDefined();
+		compiler.close(() => {
+			expect(compiler.watching).toBeUndefined();
+			expect(watchCloseCalled).toBe(1);
+			done();
+		});
+	});
+
+	it("should expose `watching` when dependency validation fails", (done) => {
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ ([
+					{
+						name: "a",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./a.js",
+						dependencies: ["missing"]
+					},
+					{
+						name: "b",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./b.js"
+					}
+				])
+			)
+		);
+		/** @type {Error | null | undefined} */
+		let error;
+		const watching = /** @type {import("../lib/MultiWatching")} */ (
+			/** @type {unknown} */ (
+				compiler.watch({}, (err) => {
+					error = err;
+				})
+			)
+		);
+		expect(error).toBeInstanceOf(Error);
+		expect(compiler.watching).toBe(watching);
+		watching.close(() => {
+			expect(compiler.watching).toBeUndefined();
+			compiler.close(done);
+		});
+	});
+
 	it("should respect parallelism and dependencies for running", (done) => {
 		const compiler = createMultiCompiler(
 			/** @type {import("../").MultiCompilerOptions} */ ({

--- a/types.d.ts
+++ b/types.d.ts
@@ -16900,6 +16900,7 @@ declare class MultiCompiler {
 	compilers: Compiler[];
 	dependencies: WeakMap<Compiler, string[]>;
 	running: boolean;
+	watching?: MultiWatching;
 	get options(): WebpackOptionsNormalized[] & MultiCompilerOptions;
 	get outputPath(): string;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Expose the active `MultiWatching` on `MultiCompiler.watching` (mirroring `Compiler.watching`) so consumers like webpack-dev-middleware can detect and reuse an existing watch instead of starting a duplicate one. Supersedes #21467 with a single clearing site: `MultiCompiler.close()` now delegates to the active watching first (like `Compiler.close()`), so `watchClose` also fires on that path.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes, `test/MultiCompiler.test.js` covers exposing/clearing `watching` via `watching.close()`, via `compiler.close()`, and on the failed dependency-validation path.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Document the new `MultiCompiler.watching` property on the Node API page.

**Use of AI**

This PR was implemented with AI assistance (Claude Code) under maintainer direction and review; tests were written first and verified to fail before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn3SpXgRjoaGdv9t7YpZeC)_