### PR TITLE
feat: annotate schema options with added keywords

### DIFF
--- a/.changeset/experiments-jsdoc-annotations.md
+++ b/.changeset/experiments-jsdoc-annotations.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Annotate experiment options in the generated types with `@experimental`, `@since` and `@default` JSDoc tags.
+Annotate configuration options and public hooks in the generated types with `@since`, `@default` and `@experimental` JSDoc tags.

--- a/.changeset/experiments-jsdoc-annotations.md
+++ b/.changeset/experiments-jsdoc-annotations.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Annotate configuration options and public hooks in the generated types with `@since`, `@default` and `@experimental` JSDoc tags.
+Annotate configuration options and public hooks in the generated types with `@since` and `@default` JSDoc tags.

--- a/.changeset/experiments-jsdoc-annotations.md
+++ b/.changeset/experiments-jsdoc-annotations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Annotate experiment options in the generated types with `@experimental`, `@since` and `@default` JSDoc tags.

--- a/.changeset/experiments-jsdoc-annotations.md
+++ b/.changeset/experiments-jsdoc-annotations.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Annotate configuration options and public hooks in the generated types with `@since` and `@default` JSDoc tags.
+Annotate configuration options and public hooks in the generated types with the `@since` JSDoc tag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,6 @@ Skipping any layer silently breaks the option. After editing schemas, run `yarn 
 **Schema documentation keywords** — option entries in the schemas support these annotation keywords, which become JSDoc tags in the generated declarations:
 
 - `"added": "<version>"` → `@since <version>`. The webpack version that first shipped the option. For a **new option that has not been released yet**, use the upcoming release version (current `package.json` version with the pending changesets applied — e.g. while on `5.108.x` with minor changesets pending, new options get `"added": "5.109.0"`).
-- `"default": <value>` → `@default <value>`. Only annotate defaults that are static and unconditional in `lib/config/defaults.js` (or the schema-level `"auto"` sentinel); skip it when the default depends on other options or the target.
 - `"experimental": true` → `@experimental`. For options under `experiments` or otherwise subject to breaking changes.
 
 These keywords are documentation-only: the tooling strips them from the precompiled validators. A property that is a pure `$ref` cannot carry them (schemas-lint forbids extra keys next to `$ref`) — annotate the referenced definition instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,14 @@ The directory listings below are the canonical map of the repository. **Whenever
 
 Skipping any layer silently breaks the option. After editing schemas, run `yarn fix:special` so `lib/` code can reference the updated types. If you added or modified options, consider updating `examples/` and run `yarn build:examples` to verify.
 
+**Schema documentation keywords** — option entries in the schemas support these annotation keywords, which become JSDoc tags in the generated declarations:
+
+- `"added": "<version>"` → `@since <version>`. The webpack version that first shipped the option. For a **new option that has not been released yet**, use the upcoming release version (current `package.json` version with the pending changesets applied — e.g. while on `5.108.x` with minor changesets pending, new options get `"added": "5.109.0"`).
+- `"default": <value>` → `@default <value>`. Only annotate defaults that are static and unconditional in `lib/config/defaults.js` (or the schema-level `"auto"` sentinel); skip it when the default depends on other options or the target.
+- `"experimental": true` → `@experimental`. For options under `experiments` or otherwise subject to breaking changes.
+
+These keywords are documentation-only: the tooling strips them from the precompiled validators. A property that is a pure `$ref` cannot carry them (schemas-lint forbids extra keys next to `$ref`) — annotate the referenced definition instead.
+
 The two config layers differ: **`normalization.js`** canonicalizes the user-supplied config shape (shorthand → full form); **`defaults.js`** fills in values (often mode/target-dependent). Edit whichever matches your change.
 
 **Adding a new dependency type:** pair the `Dependency` subclass with a `DependencyTemplate` (it emits the generated code), register the class with `makeSerializable(...)`, and wire the template into `compilation.dependencyTemplates`.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -658,10 +658,12 @@ export type Path = string;
 export type Pathinfo = "verbose" | boolean;
 /**
  * Resource-hint (`<link rel="prefetch">` / `<link rel="preload">` / `<link rel="modulepreload">` / `<link rel="preconnect">`) emission for extracted HTML entries and URL-referenced assets. Accepts the initial-graph shorthand (boolean / `"prefetch"` / `"preload"` / `"none"` / `HtmlResourceHint[]` / function — equivalent to `{ initial: <value> }`) or the full object form `{ initial, urlHints, preconnect, modulePreloadPolyfill, manifest }`. `initial` defaults on for ESM output (`output.module`), where native `import()` would otherwise waterfall; classic output stays opt-in.
+ * @since 5.109.0
  */
 export type ResourceHints = ResourceHintsInitial | ResourceHintsOptions;
 /**
  * Initial dependency-graph chunk hints. `true` auto-emits `<link rel="modulepreload">` (ESM output) or `<link rel="preload" as="script">` (classic) for each of the entry's initial dependency chunks; `"prefetch"` uses `<link rel="prefetch">`; `"preload"` is an alias of `true`; `false` disables chunk hints (URL-asset hints from magic comments / `urlHints` still fire); `"none"` is a hard off switch (no `<link>` anywhere, empty stats / manifest); an array of `HtmlResourceHint` descriptors replaces the auto set; a function receives the auto `defaultHints` plus context (`entryName`, `entrypoint`, `hostType: "html" | "js"`, `compilation`) and returns the final list (replaces the removed `resolveDependencies` hook).
+ * @since 5.109.0
  */
 export type ResourceHintsInitial =
 	| HtmlResourceHint[]
@@ -706,6 +708,8 @@ export type StrictModuleResolution = boolean;
 export type UniqueName = string;
 /**
  * Fall back to non-streaming WebAssembly instantiation when streaming compilation fails because the server does not serve `.wasm` files with the `application/wasm` MIME type.
+ * @default true
+ * @since 5.109.0
  */
 export type WasmStreamingFallback = boolean;
 /**
@@ -864,10 +868,14 @@ export type CssParserContainer = boolean;
 export type CssParserCustomIdents = boolean;
 /**
  * Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).
+ * @default true
+ * @since 5.109.0
  */
 export type CssParserCustomMedia = boolean;
 /**
  * Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).
+ * @default true
+ * @since 5.109.0
  */
 export type CssParserCustomSelectors = boolean;
 /**
@@ -880,6 +888,8 @@ export type CssParserDashedIdents = boolean;
 export type CssParserExportType = "link" | "text" | "css-style-sheet" | "style";
 /**
  * Auto-emit `<link rel="preload" as="font">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.
+ * @default false
+ * @since 5.109.0
  */
 export type CssParserFontPreload = boolean;
 /**
@@ -908,6 +918,7 @@ export type CssParserPure = boolean;
 export type CssParserUrl = boolean;
 /**
  * URL-referenced-asset default hint rules for this parser (JavaScript `new URL(...)`, CSS `url(...)`, HTML `<img src>` / `<link href>` / `<script src>`).
+ * @since 5.109.0
  */
 export type UrlHints = UrlHintRule[];
 /**
@@ -947,6 +958,7 @@ export type EntryDynamicNormalized =
 export type EntryNormalized = EntryDynamicNormalized | EntryStaticNormalized;
 /**
  * How an external's exports interoperate with ES module imports, independent of the importing module's strictness (similar to Rollup's `output.interop`). 'default': treat as CommonJS, the default import is the whole exports (Node.js semantics). 'esModule': treat as an ES module namespace, the default import is unboxed to `.default`.
+ * @since 5.109.0
  */
 export type ExternalItemInterop = "default" | "esModule";
 /**
@@ -959,6 +971,7 @@ export type ExternalItemValue =
 	| (ExternalItemValueObjectKnown & ExternalItemValueObjectUnknown);
 /**
  * Configure how the HTML source is parsed: `"document"` (the default) parses a full page; any other value is the tag name of the context element to parse the source as that element's inner HTML (a fragment) — e.g. `"template"` for a neutral fragment, or `"tbody"` so context-sensitive tags like a bare `<tr>`/`<td>` are kept instead of dropped.
+ * @since 5.109.0
  */
 export type HtmlParserAs = "document" | string;
 /**
@@ -968,6 +981,7 @@ export type IgnoreWarningsNormalized =
 	import("../lib/IgnoreWarningsPlugin").IgnoreFn[];
 /**
  * Enable/disable evaluating import.meta fields. Omitted fields are enabled and unknown fields are preserved. Custom fields are allowed.
+ * @since 5.109.0
  */
 export type ImportMetaParserOptions = ImportMetaParserOptionsKnown &
 	ImportMetaParserOptionsUnknown;
@@ -1409,66 +1423,90 @@ export interface LibraryCustomUmdObject {
 export interface Experiments {
 	/**
 	 * Support WebAssembly as asynchronous EcmaScript Module. `"auto"` (the default) enables it unless a loader is registered for WebAssembly files.
+	 * @default "auto"
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	asyncWebAssembly?: "auto" | boolean;
 	/**
 	 * Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.
+	 * @default true
+	 * @since 5.62.0
 	 * @experimental
 	 */
 	backCompat?: boolean;
 	/**
 	 * Build http(s): urls using a lockfile and resource content cache.
+	 * @since 5.49.0
 	 * @experimental
 	 */
 	buildHttp?: HttpUriAllowedUris | HttpUriOptions;
 	/**
 	 * Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.
+	 * @default false
+	 * @since 5.54.0
 	 * @experimental
 	 */
 	cacheUnaffected?: boolean;
 	/**
 	 * Enable css support. `"auto"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.
+	 * @default "auto"
+	 * @since 5.66.0
 	 * @experimental
 	 */
 	css?: "auto" | boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @default false
+	 * @since 5.100.0
 	 * @experimental
 	 */
 	deferImport?: boolean;
 	/**
 	 * Apply defaults of next major version.
+	 * @default false
+	 * @since 5.53.0
 	 * @experimental
 	 */
 	futureDefaults?: boolean;
 	/**
 	 * Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `"auto"` (the default) enables it unless a loader is registered for HTML files.
+	 * @default "auto"
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	html?: "auto" | boolean;
 	/**
 	 * Compile entrypoints and import()s only when they are accessed.
+	 * @since 5.17.0
 	 * @experimental
 	 */
 	lazyCompilation?: boolean | LazyCompilationOptions;
 	/**
 	 * Allow output javascript files as module source type.
+	 * @default false
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	outputModule?: boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.
+	 * @default false
+	 * @since 5.106.0
 	 * @experimental
 	 */
 	sourceImport?: boolean;
 	/**
 	 * Support WebAssembly as synchronous EcmaScript Module (outdated).
+	 * @default false
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	syncWebAssembly?: boolean;
 	/**
 	 * Enable typescript support. `"auto"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.
+	 * @default "auto"
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	typescript?: "auto" | boolean;
@@ -1624,6 +1662,8 @@ export interface InfrastructureLogging {
 	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
 	/**
 	 * Show build progress. `"auto"` shows it only for interactive terminals. This option is only used when no custom console is provided.
+	 * @default false
+	 * @since 5.109.0
 	 */
 	progress?: "auto" | boolean;
 	/**
@@ -2180,10 +2220,12 @@ export interface Optimization {
 }
 /**
  * Advanced options for module concatenation.
+ * @since 5.109.0
  */
 export interface ConcatenateModulesOptions {
 	/**
 	 * Also concatenate CommonJS modules with statically analyzable exports. Defaults to 'true'.
+	 * @default true
 	 */
 	commonjs?: boolean;
 }
@@ -2743,6 +2785,7 @@ export interface Environment {
 	forOf?: boolean;
 	/**
 	 * The environment supports generator functions and yield ('function* () { yield ... }').
+	 * @since 5.109.0
 	 */
 	generator?: boolean;
 	/**
@@ -2775,6 +2818,7 @@ export interface Environment {
 	module?: boolean;
 	/**
 	 * The environment supports `<link rel="modulepreload">` to preload EcmaScript modules.
+	 * @since 5.109.0
 	 */
 	modulePreload?: boolean;
 	/**
@@ -2808,6 +2852,7 @@ export interface Environment {
 export interface OutputHtmlOptions {
 	/**
 	 * Inject a `<base>` element into the page `<head>`. A string sets `href`; an object sets both `href` and optionally `target`. Skipped if the HTML already contains a `<base>` element.
+	 * @since 5.109.0
 	 */
 	base?:
 		| string
@@ -2847,6 +2892,8 @@ export interface OutputHtmlOptions {
 		  };
 	/**
 	 * Favicon(s) for webpack-generated HTML (authored pages are left untouched). `false` (default) injects nothing; `true` injects the webpack logo; a string is a path to an icon; an object maps each `<link rel>` to an icon — a path string, an object with the icon `href` plus extra link attributes (`sizes`, `media`, `color`, `type`, `crossorigin`), or an array of these for multiple icons under the same `rel` (e.g. several `sizes`, or light/dark `media` variants); a function receives the page name and returns one of these. Every icon is emitted as a hashed asset.
+	 * @default false
+	 * @since 5.109.0
 	 */
 	favicon?:
 		| boolean
@@ -2865,14 +2912,17 @@ export interface OutputHtmlOptions {
 				| {[rel: string]: HtmlFaviconIcon | HtmlFaviconIcon[]});
 	/**
 	 * Where to place injected chunk `<script>`/`<link>` tags. `"body"` (default; `"head"` with `output.module`) keeps them next to the entry tag — end of `<body>` on generated pages; `"head"` moves them into `<head>`; `false` suppresses sibling-chunk injection (entry tags and resource hints remain).
+	 * @since 5.109.0
 	 */
 	inject?: ("body" | "head") | false;
 	/**
 	 * Inline the content of matching chunks directly into the HTML instead of emitting a separate `<script>`/`<link>` tag. `true` inlines every chunk; `"script"` inlines only JavaScript, `"style"` only CSS; an array of `RegExp` patterns matches against the chunk name.
+	 * @since 5.109.0
 	 */
 	inline?: RegExp[] | ("script" | "style") | boolean;
 	/**
 	 * Add Subresource Integrity (SRI) `integrity` attributes to injected `<script>`/`<link>` tags. `true` uses `['sha384']`; an array sets the hash algorithms; a function receives each referenced asset and returns the algorithms to use or `false` to skip it.
+	 * @since 5.109.0
 	 */
 	integrity?:
 		| string[]
@@ -2893,6 +2943,7 @@ export interface OutputHtmlOptions {
 		| ((name: string) => false | string | {[key: string]: EXPECTED_ANY});
 	/**
 	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` use the `property` attribute instead of `name`. A tag is skipped if the HTML already contains a meta with the same name.
+	 * @since 5.109.0
 	 */
 	meta?: {
 		/**
@@ -2902,15 +2953,18 @@ export interface OutputHtmlOptions {
 	};
 	/**
 	 * How injected `<script>` tags load. `auto` (default) emits a module script for ES module output and `defer` otherwise; `defer` forces a deferred script; `blocking` emits a plain blocking script.
+	 * @default "auto"
 	 */
 	scriptLoading?: "auto" | "blocking" | "defer";
 	/**
 	 * Sets the `<title>` of the generated HTML page. Skipped if the HTML already contains a `<title>` element.
+	 * @since 5.109.0
 	 */
 	title?: string;
 }
 /**
  * A custom resource-hint `<link>` for `output.html.resourceHints`. Exactly one of `href` / `chunk` / `entry` names the target.
+ * @since 5.109.0
  */
 export interface HtmlResourceHint {
 	/**
@@ -2956,10 +3010,12 @@ export interface HtmlResourceHint {
 }
 /**
  * Full resource-hint configuration.
+ * @since 5.109.0
  */
 export interface ResourceHintsOptions {
 	/**
 	 * Initial dependency-graph chunk hints. `true` auto-emits `<link rel="modulepreload">` (ESM output) or `<link rel="preload" as="script">` (classic) for each of the entry's initial dependency chunks; `"prefetch"` uses `<link rel="prefetch">`; `"preload"` is an alias of `true`; `false` disables chunk hints (URL-asset hints from magic comments / `urlHints` still fire); `"none"` is a hard off switch (no `<link>` anywhere, empty stats / manifest); an array of `HtmlResourceHint` descriptors replaces the auto set; a function receives the auto `defaultHints` plus context (`entryName`, `entrypoint`, `hostType: "html" | "js"`, `compilation`) and returns the final list (replaces the removed `resolveDependencies` hook).
+	 * @since 5.109.0
 	 */
 	initial?: ResourceHintsInitial;
 	/**
@@ -2981,6 +3037,7 @@ export interface ResourceHintsOptions {
 }
 /**
  * One default-hint rule for URL-referenced assets emitted by this parser (JS `new URL(...)`, CSS `url(...)`, HTML `<img src>` / `<link href>` / `<script src>`). `test` / `include` / `exclude` match against the asset's request; omit all three to apply to every asset. Matching rules set the same fields a `webpackPrefetch` / `webpackPreload` / `webpackAs` / `webpackType` / `webpackMedia` / `webpackFetchPriority` magic comment would; explicit magic comments on the same URL still win.
+ * @since 5.109.0
  */
 export interface UrlHintRule {
 	/**
@@ -3191,6 +3248,7 @@ export interface StatsOptions {
 	chunkGroupMaxAssets?: number;
 	/**
 	 * Include the resolved `<link>` resource-hint descriptors for each entrypoint (`entrypoints[name].resourceHints`). Combines `output.resourceHints.chunks` (initial-graph modulepreload/preload/prefetch) with `output.resourceHints.assets` (URL-referenced fonts / images / …). Lets SSR frameworks inject the hints server-side without walking the chunk graph themselves; the analogue of Vite's `build.ssrManifest`.
+	 * @since 5.109.0
 	 */
 	chunkGroupResourceHints?: boolean;
 	/**
@@ -3782,10 +3840,14 @@ export interface CssParserOptions {
 	as?: CssParserAs;
 	/**
 	 * Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).
+	 * @default true
+	 * @since 5.109.0
 	 */
 	customMedia?: CssParserCustomMedia;
 	/**
 	 * Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).
+	 * @default true
+	 * @since 5.109.0
 	 */
 	customSelectors?: CssParserCustomSelectors;
 	/**
@@ -3794,6 +3856,8 @@ export interface CssParserOptions {
 	exportType?: CssParserExportType;
 	/**
 	 * Auto-emit `<link rel="preload" as="font">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.
+	 * @default false
+	 * @since 5.109.0
 	 */
 	fontPreload?: CssParserFontPreload;
 	/**
@@ -3893,66 +3957,79 @@ export interface EntryStaticNormalized {
 export interface ExperimentsNormalized {
 	/**
 	 * Support WebAssembly as asynchronous EcmaScript Module. `"auto"` (the default) enables it unless a loader is registered for WebAssembly files.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	asyncWebAssembly?: "auto" | boolean;
 	/**
 	 * Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.
+	 * @since 5.62.0
 	 * @experimental
 	 */
 	backCompat?: boolean;
 	/**
 	 * Build http(s): urls using a lockfile and resource content cache.
+	 * @since 5.49.0
 	 * @experimental
 	 */
 	buildHttp?: HttpUriOptions;
 	/**
 	 * Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.
+	 * @since 5.54.0
 	 * @experimental
 	 */
 	cacheUnaffected?: boolean;
 	/**
 	 * Enable css support. `"auto"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.
+	 * @since 5.66.0
 	 * @experimental
 	 */
 	css?: "auto" | boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @since 5.100.0
 	 * @experimental
 	 */
 	deferImport?: boolean;
 	/**
 	 * Apply defaults of next major version.
+	 * @since 5.53.0
 	 * @experimental
 	 */
 	futureDefaults?: boolean;
 	/**
 	 * Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `"auto"` (the default) enables it unless a loader is registered for HTML files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	html?: "auto" | boolean;
 	/**
 	 * Compile entrypoints and import()s only when they are accessed.
+	 * @since 5.17.0
 	 * @experimental
 	 */
 	lazyCompilation?: false | LazyCompilationOptions;
 	/**
 	 * Allow output javascript files as module source type.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	outputModule?: boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.
+	 * @since 5.106.0
 	 * @experimental
 	 */
 	sourceImport?: boolean;
 	/**
 	 * Support WebAssembly as synchronous EcmaScript Module (outdated).
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	syncWebAssembly?: boolean;
 	/**
 	 * Enable typescript support. `"auto"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	typescript?: "auto" | boolean;
@@ -3972,6 +4049,7 @@ export interface HtmlGeneratorOptions {
 export interface HtmlParserOptions {
 	/**
 	 * Configure how the HTML source is parsed: `"document"` (the default) parses a full page; any other value is the tag name of the context element to parse the source as that element's inner HTML (a fragment) — e.g. `"template"` for a neutral fragment, or `"tbody"` so context-sensitive tags like a bare `<tr>`/`<td>` are kept instead of dropped.
+	 * @since 5.109.0
 	 */
 	as?: HtmlParserAs;
 	/**
@@ -4055,10 +4133,14 @@ export interface JavascriptParserOptions {
 	createRequire?: boolean | string;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @default false
+	 * @since 5.100.0
 	 */
 	deferImport?: boolean;
 	/**
 	 * Auto-emit `<link rel="preload" as="style">` for the CSS of every dynamically imported (`import()`) chunk, so the stylesheet fetches in parallel with the chunk's JavaScript instead of after it parses. Unlike `dynamicImportPreload`, the JavaScript itself is not preloaded. `true` uses the default order; a number sets the preload order.
+	 * @default false
+	 * @since 5.109.0
 	 */
 	dynamicImportCssPreload?: number | boolean;
 	/**
@@ -4169,6 +4251,8 @@ export interface JavascriptParserOptions {
 	strictExportPresence?: boolean;
 	/**
 	 * Specifies the behavior of constructs that break at runtime in strict mode (e.g. 'with', 'arguments.callee', assigning to read-only globals) when modules are emitted as ES module output.
+	 * @default "warn"
+	 * @since 5.109.0
 	 */
 	strictModeViolations?: "error" | "warn" | false;
 	/**
@@ -4214,6 +4298,8 @@ export interface JavascriptParserOptions {
 	worker?: string[] | boolean;
 	/**
 	 * Disable or configure parsing of Worklet syntax like context.audioWorklet.addModule() or CSS.paintWorklet.addModule().
+	 * @default false
+	 * @since 5.109.0
 	 */
 	worklet?: string[] | boolean;
 	/**
@@ -4799,6 +4885,7 @@ export interface ExternalItemObjectUnknown {
 export interface ExternalItemValueObjectKnown {
 	/**
 	 * How an external's exports interoperate with ES module imports, independent of the importing module's strictness (similar to Rollup's `output.interop`). 'default': treat as CommonJS, the default import is the whole exports (Node.js semantics). 'esModule': treat as an ES module namespace, the default import is unboxed to `.default`.
+	 * @since 5.109.0
 	 */
 	interop?: ExternalItemInterop;
 }
@@ -4889,47 +4976,58 @@ export interface GeneratorOptionsByModuleTypeUnknown {
 }
 /**
  * Enable/disable evaluating import.meta fields. Omitted fields are enabled and unknown fields are preserved. Custom fields are allowed.
+ * @since 5.109.0
  */
 export interface ImportMetaParserOptionsKnown {
 	/**
 	 * Enable/disable evaluating import.meta.dirname.
+	 * @default true
 	 */
 	dirname?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.env.
+	 * @default true
 	 */
 	env?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.filename.
+	 * @default true
 	 */
 	filename?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.main.
+	 * @default true
 	 */
 	main?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.resolve.
+	 * @default true
 	 */
 	resolve?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.url.
+	 * @default true
 	 */
 	url?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpack.
+	 * @default true
 	 */
 	webpack?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpackContext.
+	 * @default true
 	 */
 	webpackContext?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpackHot.
+	 * @default true
 	 */
 	webpackHot?: boolean;
 }
 /**
  * Enable/disable evaluating import.meta fields. Omitted fields are enabled and unknown fields are preserved. Custom fields are allowed.
+ * @since 5.109.0
  */
 export interface ImportMetaParserOptionsUnknown {
 	/**

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -708,7 +708,6 @@ export type StrictModuleResolution = boolean;
 export type UniqueName = string;
 /**
  * Fall back to non-streaming WebAssembly instantiation when streaming compilation fails because the server does not serve `.wasm` files with the `application/wasm` MIME type.
- * @default true
  * @since 5.109.0
  */
 export type WasmStreamingFallback = boolean;
@@ -868,13 +867,11 @@ export type CssParserContainer = boolean;
 export type CssParserCustomIdents = boolean;
 /**
  * Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).
- * @default true
  * @since 5.109.0
  */
 export type CssParserCustomMedia = boolean;
 /**
  * Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).
- * @default true
  * @since 5.109.0
  */
 export type CssParserCustomSelectors = boolean;
@@ -888,7 +885,6 @@ export type CssParserDashedIdents = boolean;
 export type CssParserExportType = "link" | "text" | "css-style-sheet" | "style";
 /**
  * Auto-emit `<link rel="preload" as="font">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.
- * @default false
  * @since 5.109.0
  */
 export type CssParserFontPreload = boolean;
@@ -1423,14 +1419,12 @@ export interface LibraryCustomUmdObject {
 export interface Experiments {
 	/**
 	 * Support WebAssembly as asynchronous EcmaScript Module. `"auto"` (the default) enables it unless a loader is registered for WebAssembly files.
-	 * @default "auto"
 	 * @since 5.0.0
 	 * @experimental
 	 */
 	asyncWebAssembly?: "auto" | boolean;
 	/**
 	 * Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.
-	 * @default true
 	 * @since 5.62.0
 	 * @experimental
 	 */
@@ -1443,35 +1437,30 @@ export interface Experiments {
 	buildHttp?: HttpUriAllowedUris | HttpUriOptions;
 	/**
 	 * Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.
-	 * @default false
 	 * @since 5.54.0
 	 * @experimental
 	 */
 	cacheUnaffected?: boolean;
 	/**
 	 * Enable css support. `"auto"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.
-	 * @default "auto"
 	 * @since 5.66.0
 	 * @experimental
 	 */
 	css?: "auto" | boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
-	 * @default false
 	 * @since 5.100.0
 	 * @experimental
 	 */
 	deferImport?: boolean;
 	/**
 	 * Apply defaults of next major version.
-	 * @default false
 	 * @since 5.53.0
 	 * @experimental
 	 */
 	futureDefaults?: boolean;
 	/**
 	 * Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `"auto"` (the default) enables it unless a loader is registered for HTML files.
-	 * @default "auto"
 	 * @since 5.107.0
 	 * @experimental
 	 */
@@ -1484,28 +1473,24 @@ export interface Experiments {
 	lazyCompilation?: boolean | LazyCompilationOptions;
 	/**
 	 * Allow output javascript files as module source type.
-	 * @default false
 	 * @since 5.0.0
 	 * @experimental
 	 */
 	outputModule?: boolean;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.
-	 * @default false
 	 * @since 5.106.0
 	 * @experimental
 	 */
 	sourceImport?: boolean;
 	/**
 	 * Support WebAssembly as synchronous EcmaScript Module (outdated).
-	 * @default false
 	 * @since 5.0.0
 	 * @experimental
 	 */
 	syncWebAssembly?: boolean;
 	/**
 	 * Enable typescript support. `"auto"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.
-	 * @default "auto"
 	 * @since 5.107.0
 	 * @experimental
 	 */
@@ -1662,7 +1647,6 @@ export interface InfrastructureLogging {
 	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
 	/**
 	 * Show build progress. `"auto"` shows it only for interactive terminals. This option is only used when no custom console is provided.
-	 * @default false
 	 * @since 5.109.0
 	 */
 	progress?: "auto" | boolean;
@@ -2225,7 +2209,6 @@ export interface Optimization {
 export interface ConcatenateModulesOptions {
 	/**
 	 * Also concatenate CommonJS modules with statically analyzable exports. Defaults to 'true'.
-	 * @default true
 	 */
 	commonjs?: boolean;
 }
@@ -2892,7 +2875,6 @@ export interface OutputHtmlOptions {
 		  };
 	/**
 	 * Favicon(s) for webpack-generated HTML (authored pages are left untouched). `false` (default) injects nothing; `true` injects the webpack logo; a string is a path to an icon; an object maps each `<link rel>` to an icon — a path string, an object with the icon `href` plus extra link attributes (`sizes`, `media`, `color`, `type`, `crossorigin`), or an array of these for multiple icons under the same `rel` (e.g. several `sizes`, or light/dark `media` variants); a function receives the page name and returns one of these. Every icon is emitted as a hashed asset.
-	 * @default false
 	 * @since 5.109.0
 	 */
 	favicon?:
@@ -2953,7 +2935,6 @@ export interface OutputHtmlOptions {
 	};
 	/**
 	 * How injected `<script>` tags load. `auto` (default) emits a module script for ES module output and `defer` otherwise; `defer` forces a deferred script; `blocking` emits a plain blocking script.
-	 * @default "auto"
 	 */
 	scriptLoading?: "auto" | "blocking" | "defer";
 	/**
@@ -3840,13 +3821,11 @@ export interface CssParserOptions {
 	as?: CssParserAs;
 	/**
 	 * Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).
-	 * @default true
 	 * @since 5.109.0
 	 */
 	customMedia?: CssParserCustomMedia;
 	/**
 	 * Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).
-	 * @default true
 	 * @since 5.109.0
 	 */
 	customSelectors?: CssParserCustomSelectors;
@@ -3856,7 +3835,6 @@ export interface CssParserOptions {
 	exportType?: CssParserExportType;
 	/**
 	 * Auto-emit `<link rel="preload" as="font">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.
-	 * @default false
 	 * @since 5.109.0
 	 */
 	fontPreload?: CssParserFontPreload;
@@ -4133,13 +4111,11 @@ export interface JavascriptParserOptions {
 	createRequire?: boolean | string;
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
-	 * @default false
 	 * @since 5.100.0
 	 */
 	deferImport?: boolean;
 	/**
 	 * Auto-emit `<link rel="preload" as="style">` for the CSS of every dynamically imported (`import()`) chunk, so the stylesheet fetches in parallel with the chunk's JavaScript instead of after it parses. Unlike `dynamicImportPreload`, the JavaScript itself is not preloaded. `true` uses the default order; a number sets the preload order.
-	 * @default false
 	 * @since 5.109.0
 	 */
 	dynamicImportCssPreload?: number | boolean;
@@ -4251,7 +4227,6 @@ export interface JavascriptParserOptions {
 	strictExportPresence?: boolean;
 	/**
 	 * Specifies the behavior of constructs that break at runtime in strict mode (e.g. 'with', 'arguments.callee', assigning to read-only globals) when modules are emitted as ES module output.
-	 * @default "warn"
 	 * @since 5.109.0
 	 */
 	strictModeViolations?: "error" | "warn" | false;
@@ -4298,7 +4273,6 @@ export interface JavascriptParserOptions {
 	worker?: string[] | boolean;
 	/**
 	 * Disable or configure parsing of Worklet syntax like context.audioWorklet.addModule() or CSS.paintWorklet.addModule().
-	 * @default false
 	 * @since 5.109.0
 	 */
 	worklet?: string[] | boolean;
@@ -4981,47 +4955,38 @@ export interface GeneratorOptionsByModuleTypeUnknown {
 export interface ImportMetaParserOptionsKnown {
 	/**
 	 * Enable/disable evaluating import.meta.dirname.
-	 * @default true
 	 */
 	dirname?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.env.
-	 * @default true
 	 */
 	env?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.filename.
-	 * @default true
 	 */
 	filename?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.main.
-	 * @default true
 	 */
 	main?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.resolve.
-	 * @default true
 	 */
 	resolve?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.url.
-	 * @default true
 	 */
 	url?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpack.
-	 * @default true
 	 */
 	webpack?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpackContext.
-	 * @default true
 	 */
 	webpackContext?: boolean;
 	/**
 	 * Enable/disable evaluating import.meta.webpackHot.
-	 * @default true
 	 */
 	webpackHot?: boolean;
 }

--- a/lib/CleanPlugin.js
+++ b/lib/CleanPlugin.js
@@ -22,10 +22,17 @@ const processAsyncTree = require("./util/processAsyncTree");
 
 /** @typedef {Map<string, number>} Assets */
 
+const createCompilationHooks = () => ({
+	/**
+	 * When returning true the file/directory will be kept during cleaning, returning false will clean it and ignore the following plugins and config.
+	 * @type {SyncBailHook<[string], boolean | void>}
+	 * @since 5.20.0
+	 */
+	keep: new SyncBailHook(["ignore"])
+});
+
 /**
- * Defines the clean plugin compilation hooks type used by this module.
- * @typedef {object} CleanPluginCompilationHooks
- * @property {SyncBailHook<[string], boolean | void>} keep when returning true the file/directory will be kept during cleaning, returning false will clean it and ignore the following plugins and config
+ * @typedef {ReturnType<typeof createCompilationHooks>} CleanPluginCompilationHooks
  */
 
 /**
@@ -484,12 +491,7 @@ class CleanPlugin {
 	}
 }
 
-CleanPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CleanPluginCompilationHooks} */ ({
-			keep: new SyncBailHook(["ignore"])
-		})
-);
+CleanPlugin.getCompilationHooks = createHooksRegistry(createCompilationHooks);
 
 module.exports = CleanPlugin;
 module.exports._getDirectories = getDirectories;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -884,9 +884,15 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				"runtime"
 			]),
 
-			/** @type {SyncHook<[ExecuteModuleArgument, ExecuteModuleContext]>} */
+			/**
+			 * @type {SyncHook<[ExecuteModuleArgument, ExecuteModuleContext]>}
+			 * @since 5.32.0
+			 */
 			executeModule: new SyncHook(["options", "context"]),
-			/** @type {AsyncParallelHook<[ExecuteModuleArgument, ExecuteModuleContext]>} */
+			/**
+			 * @type {AsyncParallelHook<[ExecuteModuleArgument, ExecuteModuleContext]>}
+			 * @since 5.33.0
+			 */
 			prepareModuleExecution: new AsyncParallelHook(["options", "context"]),
 
 			/** @type {AsyncSeriesHook<[Iterable<Module>]>} */
@@ -1090,7 +1096,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 			processAssets: processAssetsHook,
 			afterProcessAssets: afterProcessAssetsHook,
-			/** @type {AsyncSeriesHook<[CompilationAssets]>} */
+			/**
+			 * @type {AsyncSeriesHook<[CompilationAssets]>}
+			 * @since 5.8.0
+			 */
 			processAdditionalAssets: new AsyncSeriesHook(["assets"]),
 
 			/** @type {SyncBailHook<[], boolean | void>} */

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -222,9 +222,15 @@ class Compiler {
 			/** @type {AsyncSeriesHook<[Compilation]>} */
 			afterCompile: new AsyncSeriesHook(["compilation"]),
 
-			/** @type {AsyncSeriesHook<[]>} */
+			/**
+			 * @type {AsyncSeriesHook<[]>}
+			 * @since 5.67.0
+			 */
 			readRecords: new AsyncSeriesHook([]),
-			/** @type {AsyncSeriesHook<[]>} */
+			/**
+			 * @type {AsyncSeriesHook<[]>}
+			 * @since 5.67.0
+			 */
 			emitRecords: new AsyncSeriesHook([]),
 
 			/** @type {AsyncSeriesHook<[Compiler]>} */
@@ -235,7 +241,10 @@ class Compiler {
 			invalid: new SyncHook(["filename", "changeTime"]),
 			/** @type {SyncHook<[]>} */
 			watchClose: new SyncHook([]),
-			/** @type {AsyncSeriesHook<[]>} */
+			/**
+			 * @type {AsyncSeriesHook<[]>}
+			 * @since 5.17.0
+			 */
 			shutdown: new AsyncSeriesHook([]),
 
 			/** @type {SyncBailHook<[string, string, EXPECTED_ANY[] | undefined], true | void>} */
@@ -243,7 +252,10 @@ class Compiler {
 
 			// TODO the following hooks are weirdly located here
 			// TODO move them for webpack 5
-			/** @type {SyncHook<[]>} */
+			/**
+			 * @type {SyncHook<[]>}
+			 * @since 5.106.0
+			 */
 			validate: new SyncHook([]),
 			/** @type {SyncHook<[]>} */
 			environment: new SyncHook([]),

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -628,6 +628,14 @@ const getRuntimeRequirements = (code) => {
 		: [RuntimeGlobals.requireScope];
 };
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[Record<string, CodeValue>]>}
+	 * @since 5.104.0
+	 */
+	definitions: new SyncWaterfallHook(["definitions"])
+});
+
 /**
  * Prefixes an evaluation error with the offending define key so a bare
  * "Unexpected token" becomes actionable. The original error is mutated and
@@ -649,9 +657,7 @@ const annotateEvaluationError = (key, code, error) => {
 };
 
 /**
- * Defines the define plugin hooks type used by this module.
- * @typedef {object} DefinePluginHooks
- * @property {SyncWaterfallHook<[Record<string, CodeValue>]>} definitions
+ * @typedef {ReturnType<typeof createCompilationHooks>} DefinePluginHooks
  */
 
 /** @typedef {Record<string, CodeValue>} Definitions */
@@ -1259,12 +1265,7 @@ class DefinePlugin {
 	}
 }
 
-DefinePlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {DefinePluginHooks} */ ({
-			definitions: new SyncWaterfallHook(["definitions"])
-		})
-);
+DefinePlugin.getCompilationHooks = createHooksRegistry(createCompilationHooks);
 
 module.exports = DefinePlugin;
 module.exports.VALUE_DEP_MAIN = VALUE_DEP_MAIN;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -810,10 +810,16 @@ const getSourceForDefaultCase = (optional, request, runtimeTemplate) => {
 /** @typedef {Record<string, string | string[]>} RequestRecord */
 /** @typedef {string | string[] | RequestRecord} ExternalModuleRequest */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncBailHook<[Chunk, Compilation], boolean>}
+	 * @since 5.106.0
+	 */
+	chunkCondition: new SyncBailHook(["chunk", "compilation"])
+});
+
 /**
- * Defines the external module hooks type used by this module.
- * @typedef {object} ExternalModuleHooks
- * @property {SyncBailHook<[Chunk, Compilation], boolean>} chunkCondition
+ * @typedef {ReturnType<typeof createCompilationHooks>} ExternalModuleHooks
  */
 
 /**
@@ -1486,10 +1492,7 @@ class ExternalModule extends Module {
 }
 
 ExternalModule.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {ExternalModuleHooks} */ ({
-			chunkCondition: new SyncBailHook(["chunk", "compilation"])
-		})
+	createCompilationHooks
 );
 
 makeSerializable(ExternalModule, "webpack/lib/ExternalModule");

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -471,16 +471,79 @@ const asBuffer = (input) => {
  * @typedef {HookMap<FakeHook<AsyncSeriesBailHook<[string, NormalModule], string | Buffer | null>>>} DeprecatedReadResourceForScheme
  */
 
+const createCompilationHooks = () => {
+	/** @type {HookMap<AsyncSeriesBailHook<[AnyLoaderContext], string | Buffer | null>>} */
+	const readResource = new HookMap(
+		() => new AsyncSeriesBailHook(["loaderContext"])
+	);
+	return {
+		// TODO webpack 6 deprecate
+		/**
+		 * @deprecated Use the `readResource` hook instead.
+		 * @type {DeprecatedReadResourceForScheme}
+		 */
+		readResourceForScheme: new HookMap((scheme) => {
+			const hook = readResource.for(scheme);
+			return createFakeHook(
+				/** @type {AsyncSeriesBailHook<[string, NormalModule], string | Buffer | null>} */ ({
+					tap: (options, fn) =>
+						hook.tap(options, (loaderContext) =>
+							fn(
+								loaderContext.resource,
+								/** @type {NormalModule} */ (loaderContext._module)
+							)
+						),
+					tapAsync: (options, fn) =>
+						hook.tapAsync(options, (loaderContext, callback) =>
+							fn(
+								loaderContext.resource,
+								/** @type {NormalModule} */ (loaderContext._module),
+								callback
+							)
+						),
+					tapPromise: (options, fn) =>
+						hook.tapPromise(options, (loaderContext) =>
+							fn(
+								loaderContext.resource,
+								/** @type {NormalModule} */ (loaderContext._module)
+							)
+						)
+				})
+			);
+		}),
+		/**
+		 * @since 5.58.0
+		 */
+		readResource,
+		/** @type {SyncHook<[AnyLoaderContext, NormalModule]>} */
+		loader: new SyncHook(["loaderContext", "module"]),
+		/** @type {SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>} */
+		beforeLoaders: new SyncHook(["loaders", "module", "loaderContext"]),
+		/**
+		 * @type {SyncHook<[NormalModule]>}
+		 * @since 5.59.0
+		 */
+		beforeParse: new SyncHook(["module"]),
+		/**
+		 * @type {SyncHook<[NormalModule]>}
+		 * @since 5.59.0
+		 */
+		beforeSnapshot: new SyncHook(["module"]),
+		/**
+		 * @type {SyncWaterfallHook<[Result, NormalModule]>}
+		 * @since 5.99.0
+		 */
+		processResult: new SyncWaterfallHook(["result", "module"]),
+		/**
+		 * @type {AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>}
+		 * @since 5.49.0
+		 */
+		needBuild: new AsyncSeriesBailHook(["module", "context"])
+	};
+};
+
 /**
- * @typedef {object} NormalModuleCompilationHooks
- * @property {SyncHook<[AnyLoaderContext, NormalModule]>} loader
- * @property {SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>} beforeLoaders
- * @property {SyncHook<[NormalModule]>} beforeParse
- * @property {SyncHook<[NormalModule]>} beforeSnapshot
- * @property {DeprecatedReadResourceForScheme} readResourceForScheme
- * @property {HookMap<AsyncSeriesBailHook<[AnyLoaderContext], string | Buffer | null>>} readResource
- * @property {SyncWaterfallHook<[Result, NormalModule]>} processResult
- * @property {AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>} needBuild
+ * @typedef {ReturnType<typeof createCompilationHooks>} NormalModuleCompilationHooks
  */
 
 /**
@@ -524,52 +587,7 @@ const asBuffer = (input) => {
 
 /** @typedef {BuildInfo & KnownNormalModuleBuildInfo} NormalModuleBuildInfo */
 
-const normalModuleHooksRegistry = createHooksRegistry(() => {
-	// TODO webpack 6 deprecate
-	/** @type {Partial<NormalModuleCompilationHooks>} */
-	const hooks = {};
-	hooks.readResourceForScheme = new HookMap((scheme) => {
-		const hook =
-			/** @type {NormalModuleCompilationHooks} */
-			(hooks).readResource.for(scheme);
-		return createFakeHook(
-			/** @type {AsyncSeriesBailHook<[string, NormalModule], string | Buffer | null>} */ ({
-				tap: (options, fn) =>
-					hook.tap(options, (loaderContext) =>
-						fn(
-							loaderContext.resource,
-							/** @type {NormalModule} */ (loaderContext._module)
-						)
-					),
-				tapAsync: (options, fn) =>
-					hook.tapAsync(options, (loaderContext, callback) =>
-						fn(
-							loaderContext.resource,
-							/** @type {NormalModule} */ (loaderContext._module),
-							callback
-						)
-					),
-				tapPromise: (options, fn) =>
-					hook.tapPromise(options, (loaderContext) =>
-						fn(
-							loaderContext.resource,
-							/** @type {NormalModule} */ (loaderContext._module)
-						)
-					)
-			})
-		);
-	});
-	hooks.readResource = new HookMap(
-		() => new AsyncSeriesBailHook(["loaderContext"])
-	);
-	hooks.loader = new SyncHook(["loaderContext", "module"]);
-	hooks.beforeLoaders = new SyncHook(["loaders", "module", "loaderContext"]);
-	hooks.beforeParse = new SyncHook(["module"]);
-	hooks.beforeSnapshot = new SyncHook(["module"]);
-	hooks.processResult = new SyncWaterfallHook(["result", "module"]);
-	hooks.needBuild = new AsyncSeriesBailHook(["module", "context"]);
-	return /** @type {NormalModuleCompilationHooks} */ (hooks);
-});
+const normalModuleHooksRegistry = createHooksRegistry(createCompilationHooks);
 
 class NormalModule extends Module {
 	/**

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -435,7 +435,10 @@ class NormalModuleFactory extends ModuleFactory {
 			resolveForScheme: new HookMap(
 				() => new AsyncSeriesBailHook(["resourceData", "resolveData"])
 			),
-			/** @type {HookMap<AsyncSeriesBailHook<[ResourceDataWithData, ResolveData], true | void>>} */
+			/**
+			 * @type {HookMap<AsyncSeriesBailHook<[ResourceDataWithData, ResolveData], true | void>>}
+			 * @since 5.49.0
+			 */
 			resolveInScheme: new HookMap(
 				() => new AsyncSeriesBailHook(["resourceData", "resolveData"])
 			),
@@ -461,7 +464,10 @@ class NormalModuleFactory extends ModuleFactory {
 			generator: new HookMap(
 				() => new SyncHook(["generator", "generatorOptions"])
 			),
-			/** @type {HookMap<SyncBailHook<[CreateData, ResolveData], Module | void>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[CreateData, ResolveData], Module | void>>}
+			 * @since 5.81.0
+			 */
 			createModuleClass: new HookMap(
 				() => new SyncBailHook(["createData", "resolveData"])
 			)

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -18,11 +18,21 @@ const HoistContainerReferences = require("./HoistContainerReferencesPlugin");
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Dependency")} Dependency */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncHook<Dependency>}
+	 * @since 5.96.0
+	 */
+	addContainerEntryDependency: new SyncHook(["dependency"]),
+	/**
+	 * @type {SyncHook<Dependency>}
+	 * @since 5.96.0
+	 */
+	addFederationRuntimeDependency: new SyncHook(["dependency"])
+});
+
 /**
- * Defines the compilation hooks type used by this module.
- * @typedef {object} CompilationHooks
- * @property {SyncHook<Dependency>} addContainerEntryDependency
- * @property {SyncHook<Dependency>} addFederationRuntimeDependency
+ * @typedef {ReturnType<typeof createCompilationHooks>} CompilationHooks
  */
 
 const PLUGIN_NAME = "ModuleFederationPlugin";
@@ -111,11 +121,7 @@ class ModuleFederationPlugin {
 }
 
 ModuleFederationPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CompilationHooks} */ ({
-			addContainerEntryDependency: new SyncHook(["dependency"]),
-			addFederationRuntimeDependency: new SyncHook(["dependency"])
-		})
+	createCompilationHooks
 );
 
 module.exports = ModuleFederationPlugin;

--- a/lib/css/CssInjectStyleRuntimeModule.js
+++ b/lib/css/CssInjectStyleRuntimeModule.js
@@ -15,16 +15,9 @@ const createHooksRegistry = require("../util/createHooksRegistry");
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
 
-const createCompilationHooks = () => ({
-	/**
-	 * @type {SyncWaterfallHook<[string, Chunk]>}
-	 * @since 5.106.0
-	 */
-	createStyle: new SyncWaterfallHook(["source", "chunk"])
-});
-
 /**
- * @typedef {ReturnType<typeof createCompilationHooks>} CssInjectCompilationHooks
+ * @typedef {object} CssInjectCompilationHooks
+ * @property {SyncWaterfallHook<[string, Chunk]>} createStyle
  */
 
 class CssInjectStyleRuntimeModule extends RuntimeModule {
@@ -193,7 +186,10 @@ class CssInjectStyleRuntimeModule extends RuntimeModule {
 }
 
 CssInjectStyleRuntimeModule.getCompilationHooks = createHooksRegistry(
-	createCompilationHooks
+	() =>
+		/** @type {CssInjectCompilationHooks} */ ({
+			createStyle: new SyncWaterfallHook(["source", "chunk"])
+		})
 );
 
 module.exports = CssInjectStyleRuntimeModule;

--- a/lib/css/CssInjectStyleRuntimeModule.js
+++ b/lib/css/CssInjectStyleRuntimeModule.js
@@ -15,9 +15,16 @@ const createHooksRegistry = require("../util/createHooksRegistry");
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.106.0
+	 */
+	createStyle: new SyncWaterfallHook(["source", "chunk"])
+});
+
 /**
- * @typedef {object} CssInjectCompilationHooks
- * @property {SyncWaterfallHook<[string, Chunk]>} createStyle
+ * @typedef {ReturnType<typeof createCompilationHooks>} CssInjectCompilationHooks
  */
 
 class CssInjectStyleRuntimeModule extends RuntimeModule {
@@ -186,10 +193,7 @@ class CssInjectStyleRuntimeModule extends RuntimeModule {
 }
 
 CssInjectStyleRuntimeModule.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CssInjectCompilationHooks} */ ({
-			createStyle: new SyncWaterfallHook(["source", "chunk"])
-		})
+	createCompilationHooks
 );
 
 module.exports = CssInjectStyleRuntimeModule;

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -20,12 +20,31 @@ const { chunkHasCss } = require("./CssModulesPlugin");
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.66.0
+	 */
+	createStylesheet: new SyncWaterfallHook(["source", "chunk"]),
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.91.0
+	 */
+	linkPreload: new SyncWaterfallHook(["source", "chunk"]),
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.91.0
+	 */
+	linkPrefetch: new SyncWaterfallHook(["source", "chunk"]),
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.107.0
+	 */
+	linkInsert: new SyncWaterfallHook(["source", "chunk"])
+});
+
 /**
- * @typedef {object} CssLoadingRuntimeModulePluginHooks
- * @property {SyncWaterfallHook<[string, Chunk]>} createStylesheet
- * @property {SyncWaterfallHook<[string, Chunk]>} linkPreload
- * @property {SyncWaterfallHook<[string, Chunk]>} linkPrefetch
- * @property {SyncWaterfallHook<[string, Chunk]>} linkInsert
+ * @typedef {ReturnType<typeof createCompilationHooks>} CssLoadingRuntimeModulePluginHooks
  */
 
 class CssLoadingRuntimeModule extends RuntimeModule {
@@ -577,13 +596,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 }
 
 CssLoadingRuntimeModule.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CssLoadingRuntimeModulePluginHooks} */ ({
-			createStylesheet: new SyncWaterfallHook(["source", "chunk"]),
-			linkPreload: new SyncWaterfallHook(["source", "chunk"]),
-			linkPrefetch: new SyncWaterfallHook(["source", "chunk"]),
-			linkInsert: new SyncWaterfallHook(["source", "chunk"])
-		})
+	createCompilationHooks
 );
 
 module.exports = CssLoadingRuntimeModule;

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -96,14 +96,6 @@ const CssParser = require("./CssParser");
  */
 
 /**
- * Defines the compilation hooks type used by this module.
- * @typedef {object} CompilationHooks
- * @property {SyncWaterfallHook<[Source, Module, ChunkRenderContext]>} renderModulePackage
- * @property {SyncHook<[Chunk, Hash, ChunkHashContext]>} chunkHash
- * @property {SyncBailHook<[Chunk, Module[], Compilation], Module[] | undefined | void>} orderModules called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default
- */
-
-/**
  * Defines the module factory cache entry type used by this module.
  * @typedef {object} ModuleFactoryCacheEntry
  * @property {string} undoPath - The undo path to the CSS file
@@ -219,6 +211,34 @@ const generatorValidationOptions = {
 };
 
 const PLUGIN_NAME = "CssModulesPlugin";
+
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[Source, Module, ChunkRenderContext]>}
+	 * @since 5.94.0
+	 */
+	renderModulePackage: new SyncWaterfallHook([
+		"source",
+		"module",
+		"renderContext"
+	]),
+	/**
+	 * @type {SyncHook<[Chunk, Hash, ChunkHashContext]>}
+	 * @since 5.94.0
+	 */
+	chunkHash: new SyncHook(["chunk", "hash", "context"]),
+	/**
+	 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+	 * @type {SyncBailHook<[Chunk, Module[], Compilation], Module[] | undefined | void>}
+	 * @since 5.107.0
+	 */
+	orderModules: new SyncBailHook(["chunk", "modules", "compilation"])
+});
+
+/**
+ * Defines the compilation hooks type used by this module.
+ * @typedef {ReturnType<typeof createCompilationHooks>} CompilationHooks
+ */
 
 class CssModulesPlugin {
 	constructor() {
@@ -1175,16 +1195,7 @@ class CssModulesPlugin {
 }
 
 CssModulesPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CompilationHooks} */ ({
-			renderModulePackage: new SyncWaterfallHook([
-				"source",
-				"module",
-				"renderContext"
-			]),
-			chunkHash: new SyncHook(["chunk", "hash", "context"]),
-			orderModules: new SyncBailHook(["chunk", "modules", "compilation"])
-		})
+	createCompilationHooks
 );
 
 module.exports = CssModulesPlugin;

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -25,11 +25,21 @@ const { getUndoPath } = require("../util/identifier");
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.41.0
+	 */
+	linkPreload: new SyncWaterfallHook(["source", "chunk"]),
+	/**
+	 * @type {SyncWaterfallHook<[string, Chunk]>}
+	 * @since 5.41.0
+	 */
+	linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
+});
+
 /**
- * Defines the jsonp compilation plugin hooks type used by this module.
- * @typedef {object} JsonpCompilationPluginHooks
- * @property {SyncWaterfallHook<[string, Chunk]>} linkPreload
- * @property {SyncWaterfallHook<[string, Chunk]>} linkPrefetch
+ * @typedef {ReturnType<typeof createCompilationHooks>} JsonpCompilationPluginHooks
  */
 
 class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
@@ -438,11 +448,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 }
 
 ModuleChunkLoadingRuntimeModule.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {JsonpCompilationPluginHooks} */ ({
-			linkPreload: new SyncWaterfallHook(["source", "chunk"]),
-			linkPrefetch: new SyncWaterfallHook(["source", "chunk"])
-		})
+	createCompilationHooks
 );
 
 module.exports = ModuleChunkLoadingRuntimeModule;

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -72,12 +72,36 @@ const { escapeAttribute } = require("./syntax");
  * @property {boolean=} remove set true to delete the whole element
  */
 /** @typedef {{ outputName: string, html: string }} HtmlTransformTagsContext */
+
+const createCompilationHooks = () => ({
+	/**
+	 * Called with the list of extra tags to inject into each page (initially empty) plus the current HTML; push `HtmlTagDescriptor`s and return the list — webpack serializes and places them by `injectTo`. A structured alternative to the string-level `transformHtml` for adding tags; runs before CSP so injected inline tags are hashed.
+	 * @type {AsyncSeriesWaterfallHook<[HtmlTagDescriptor[], HtmlInjectTagsContext]>}
+	 * @since 5.109.0
+	 */
+	injectTags: new AsyncSeriesWaterfallHook(["tags", "context"]),
+	/**
+	 * Called with the page's `<script>`/`<link>`/`<style>`/`<meta>` tags (webpack's own and any injected) as mutable descriptors; mutate `attrs` (add a `nonce`/`data-*`, switch `defer`↔`async`, …), set `remove: true`, or change `injectTo` to move a tag between `<head>` and `<body>`, and webpack rewrites the changed tags. Add new tags with `injectTags` instead.
+	 * @type {AsyncSeriesHook<[HtmlMutableTag[], HtmlTransformTagsContext]>}
+	 * @since 5.109.0
+	 */
+	transformTags: new AsyncSeriesHook(["tags", "context"]),
+	/**
+	 * Called with each emitted page's final HTML (all sentinels resolved) just before it is written; return the (possibly transformed) HTML — e.g. to minify, inject a CSP meta, or rewrite tags.
+	 * @type {AsyncSeriesWaterfallHook<[string, HtmlTransformHtmlContext]>}
+	 * @since 5.109.0
+	 */
+	transformHtml: new AsyncSeriesWaterfallHook(["html", "context"]),
+	/**
+	 * Called once each page's HTML asset has been finalized — a post-emit notification (nothing to return).
+	 * @type {AsyncSeriesHook<[HtmlEmittedContext]>}
+	 * @since 5.109.0
+	 */
+	htmlEmitted: new AsyncSeriesHook(["context"])
+});
+
 /**
- * @typedef {object} HtmlCompilationHooks
- * @property {AsyncSeriesWaterfallHook<[HtmlTagDescriptor[], HtmlInjectTagsContext]>} injectTags called with the list of extra tags to inject into each page (initially empty) plus the current HTML; push `HtmlTagDescriptor`s and return the list — webpack serializes and places them by `injectTo`. A structured alternative to the string-level `transformHtml` for adding tags; runs before CSP so injected inline tags are hashed
- * @property {AsyncSeriesHook<[HtmlMutableTag[], HtmlTransformTagsContext]>} transformTags called with the page's `<script>`/`<link>`/`<style>`/`<meta>` tags (webpack's own and any injected) as mutable descriptors; mutate `attrs` (add a `nonce`/`data-*`, switch `defer`↔`async`, …), set `remove: true`, or change `injectTo` to move a tag between `<head>` and `<body>`, and webpack rewrites the changed tags. Add new tags with `injectTags` instead
- * @property {AsyncSeriesWaterfallHook<[string, HtmlTransformHtmlContext]>} transformHtml called with each emitted page's final HTML (all sentinels resolved) just before it is written; return the (possibly transformed) HTML — e.g. to minify, inject a CSP meta, or rewrite tags
- * @property {AsyncSeriesHook<[HtmlEmittedContext]>} htmlEmitted called once each page's HTML asset has been finalized — a post-emit notification (nothing to return)
+ * @typedef {ReturnType<typeof createCompilationHooks>} HtmlCompilationHooks
  */
 
 const PLUGIN_NAME = "HtmlModulesPlugin";
@@ -1099,13 +1123,7 @@ class HtmlModulesPlugin {
  * @returns {HtmlCompilationHooks} the hooks
  */
 HtmlModulesPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {HtmlCompilationHooks} */ ({
-			injectTags: new AsyncSeriesWaterfallHook(["tags", "context"]),
-			transformTags: new AsyncSeriesHook(["tags", "context"]),
-			transformHtml: new AsyncSeriesWaterfallHook(["html", "context"]),
-			htmlEmitted: new AsyncSeriesHook(["context"])
-		})
+	createCompilationHooks
 );
 
 module.exports = HtmlModulesPlugin;

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -330,23 +330,89 @@ const printGeneratedCodeForStack = (module, code) => {
  * @property {boolean=} renderInObject render module in object container
  */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>}
+	 */
+	renderModuleContent: new SyncWaterfallHook([
+		"source",
+		"module",
+		"moduleRenderContext"
+	]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>}
+	 */
+	renderModuleContainer: new SyncWaterfallHook([
+		"source",
+		"module",
+		"moduleRenderContext"
+	]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>}
+	 */
+	renderModulePackage: new SyncWaterfallHook([
+		"source",
+		"module",
+		"moduleRenderContext"
+	]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, RenderContext]>}
+	 */
+	render: new SyncWaterfallHook(["source", "renderContext"]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, RenderContext]>}
+	 * @since 5.41.0
+	 */
+	renderContent: new SyncWaterfallHook(["source", "renderContext"]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, Module, StartupRenderContext]>}
+	 * @since 5.22.0
+	 */
+	renderStartup: new SyncWaterfallHook([
+		"source",
+		"module",
+		"startupRenderContext"
+	]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, RenderContext]>}
+	 */
+	renderChunk: new SyncWaterfallHook(["source", "renderContext"]),
+	/**
+	 * @type {SyncWaterfallHook<[Source, RenderContext]>}
+	 */
+	renderMain: new SyncWaterfallHook(["source", "renderContext"]),
+	/**
+	 * @type {SyncWaterfallHook<[string, RenderBootstrapContext]>}
+	 */
+	renderRequire: new SyncWaterfallHook(["code", "renderContext"]),
+	/**
+	 * @type {SyncBailHook<[Module, Partial<RenderBootstrapContext>], string | void>}
+	 * @since 5.22.0
+	 */
+	inlineInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
+	/**
+	 * @type {SyncBailHook<[Module, RenderContext], string | void>}
+	 * @since 5.22.0
+	 */
+	embedInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
+	/**
+	 * @type {SyncBailHook<[RenderContext], string | void>}
+	 * @since 5.26.1
+	 */
+	strictRuntimeBailout: new SyncBailHook(["renderContext"]),
+	/**
+	 * @type {SyncHook<[Chunk, Hash, ChunkHashContext]>}
+	 */
+	chunkHash: new SyncHook(["chunk", "hash", "context"]),
+	/**
+	 * @type {SyncBailHook<[Chunk, RenderContext], boolean | void>}
+	 * @since 5.2.1
+	 */
+	useSourceMap: new SyncBailHook(["chunk", "renderContext"])
+});
+
 /**
- * Defines the compilation hooks type used by this module.
- * @typedef {object} CompilationHooks
- * @property {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>} renderModuleContent
- * @property {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>} renderModuleContainer
- * @property {SyncWaterfallHook<[Source, Module, ModuleRenderContext]>} renderModulePackage
- * @property {SyncWaterfallHook<[Source, RenderContext]>} renderChunk
- * @property {SyncWaterfallHook<[Source, RenderContext]>} renderMain
- * @property {SyncWaterfallHook<[Source, RenderContext]>} renderContent
- * @property {SyncWaterfallHook<[Source, RenderContext]>} render
- * @property {SyncWaterfallHook<[Source, Module, StartupRenderContext]>} renderStartup
- * @property {SyncWaterfallHook<[string, RenderBootstrapContext]>} renderRequire
- * @property {SyncBailHook<[Module, Partial<RenderBootstrapContext>], string | void>} inlineInRuntimeBailout
- * @property {SyncBailHook<[Module, RenderContext], string | void>} embedInRuntimeBailout
- * @property {SyncBailHook<[RenderContext], string | void>} strictRuntimeBailout
- * @property {SyncHook<[Chunk, Hash, ChunkHashContext]>} chunkHash
- * @property {SyncBailHook<[Chunk, RenderContext], boolean | void>} useSourceMap
+ * @typedef {ReturnType<typeof createCompilationHooks>} CompilationHooks
  */
 
 /**
@@ -2288,39 +2354,7 @@ class JavascriptModulesPlugin {
 }
 
 JavascriptModulesPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CompilationHooks} */ ({
-			renderModuleContent: new SyncWaterfallHook([
-				"source",
-				"module",
-				"moduleRenderContext"
-			]),
-			renderModuleContainer: new SyncWaterfallHook([
-				"source",
-				"module",
-				"moduleRenderContext"
-			]),
-			renderModulePackage: new SyncWaterfallHook([
-				"source",
-				"module",
-				"moduleRenderContext"
-			]),
-			render: new SyncWaterfallHook(["source", "renderContext"]),
-			renderContent: new SyncWaterfallHook(["source", "renderContext"]),
-			renderStartup: new SyncWaterfallHook([
-				"source",
-				"module",
-				"startupRenderContext"
-			]),
-			renderChunk: new SyncWaterfallHook(["source", "renderContext"]),
-			renderMain: new SyncWaterfallHook(["source", "renderContext"]),
-			renderRequire: new SyncWaterfallHook(["code", "renderContext"]),
-			inlineInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
-			embedInRuntimeBailout: new SyncBailHook(["module", "renderContext"]),
-			strictRuntimeBailout: new SyncBailHook(["renderContext"]),
-			chunkHash: new SyncHook(["chunk", "hash", "context"]),
-			useSourceMap: new SyncBailHook(["chunk", "renderContext"])
-		})
+	createCompilationHooks
 );
 
 module.exports = JavascriptModulesPlugin;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -514,11 +514,17 @@ class JavascriptParser extends Parser {
 			evaluateDefinedIdentifier: new HookMap(
 				() => new SyncBailHook(["expression"])
 			),
-			/** @type {HookMap<SyncBailHook<[NewExpression], BasicEvaluatedExpression | null | undefined>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[NewExpression], BasicEvaluatedExpression | null | undefined>>}
+			 * @since 5.73.0
+			 */
 			evaluateNewExpression: new HookMap(
 				() => new SyncBailHook(["expression"])
 			),
-			/** @type {HookMap<SyncBailHook<[CallExpression], BasicEvaluatedExpression | null | undefined>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[CallExpression], BasicEvaluatedExpression | null | undefined>>}
+			 * @since 5.73.0
+			 */
 			evaluateCallExpression: new HookMap(
 				() => new SyncBailHook(["expression"])
 			),
@@ -532,12 +538,18 @@ class JavascriptParser extends Parser {
 			),
 			/** @type {SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>} */
 			preStatement: new SyncBailHook(["statement"]),
-			/** @type {HookMap<SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>>}
+			 * @since 5.109.0
+			 */
 			preStatementByType: new HookMap(() => new SyncBailHook(["statement"])),
 
 			/** @type {SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>} */
 			blockPreStatement: new SyncBailHook(["declaration"]),
-			/** @type {HookMap<SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[Statement | ModuleDeclaration | MaybeNamedClassDeclaration | MaybeNamedFunctionDeclaration], boolean | void>>}
+			 * @since 5.109.0
+			 */
 			blockPreStatementByType: new HookMap(
 				() => new SyncBailHook(["declaration"])
 			),
@@ -545,7 +557,10 @@ class JavascriptParser extends Parser {
 			statement: new SyncBailHook(["statement"]),
 			/** @type {SyncBailHook<[IfStatement], boolean | void>} */
 			statementIf: new SyncBailHook(["statement"]),
-			/** @type {SyncBailHook<[Expression], GuardCollection | void>} */
+			/**
+			 * @type {SyncBailHook<[Expression], GuardCollection | void>}
+			 * @since 5.105.0
+			 */
 			collectGuards: new SyncBailHook(["expression"]),
 			/** @type {SyncBailHook<[Expression, ClassExpression | ClassDeclaration | MaybeNamedClassDeclaration], boolean | void>} */
 			classExtendsExpression: new SyncBailHook([
@@ -554,7 +569,10 @@ class JavascriptParser extends Parser {
 			]),
 			/** @type {SyncBailHook<[MethodDefinition | PropertyDefinition | StaticBlock, ClassExpression | ClassDeclaration | MaybeNamedClassDeclaration], boolean | void>} */
 			classBodyElement: new SyncBailHook(["element", "classDefinition"]),
-			/** @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition, ClassExpression | ClassDeclaration | MaybeNamedClassDeclaration], boolean | void>} */
+			/**
+			 * @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition, ClassExpression | ClassDeclaration | MaybeNamedClassDeclaration], boolean | void>}
+			 * @since 5.36.0
+			 */
 			classBodyValue: new SyncBailHook([
 				"expression",
 				"element",
@@ -604,13 +622,19 @@ class JavascriptParser extends Parser {
 			varDeclarationLet: new HookMap(() => new SyncBailHook(["declaration"])),
 			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
 			varDeclarationConst: new HookMap(() => new SyncBailHook(["declaration"])),
-			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
+			/**
+			 * @type {HookMap<SyncBailHook<[Identifier], boolean | void>>}
+			 * @since 5.100.0
+			 */
 			varDeclarationUsing: new HookMap(() => new SyncBailHook(["declaration"])),
 			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
 			varDeclarationVar: new HookMap(() => new SyncBailHook(["declaration"])),
 			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
 			pattern: new HookMap(() => new SyncBailHook(["pattern"])),
-			/** @type {SyncBailHook<[Expression], boolean | void>} */
+			/**
+			 * @type {SyncBailHook<[Expression], boolean | void>}
+			 * @since 5.101.3
+			 */
 			collectDestructuringAssignmentProperties: new SyncBailHook([
 				"expression"
 			]),
@@ -671,7 +695,10 @@ class JavascriptParser extends Parser {
 			optionalChaining: new SyncBailHook(["optionalChaining"]),
 			/** @type {HookMap<SyncBailHook<[NewExpression], boolean | void>>} */
 			new: new HookMap(() => new SyncBailHook(["expression"])),
-			/** @type {SyncBailHook<[BinaryExpression], boolean | void>} */
+			/**
+			 * @type {SyncBailHook<[BinaryExpression], boolean | void>}
+			 * @since 5.71.0
+			 */
 			binaryExpression: new SyncBailHook(["binaryExpression"]),
 			/** @type {HookMap<SyncBailHook<[Expression], boolean | void>>} */
 			expression: new HookMap(() => new SyncBailHook(["expression"])),
@@ -695,11 +722,17 @@ class JavascriptParser extends Parser {
 			expressionLogicalOperator: new SyncBailHook(["expression"]),
 			/** @type {SyncBailHook<[Program, Comment[]], boolean | void>} */
 			program: new SyncBailHook(["ast", "comments"]),
-			/** @type {SyncBailHook<[ThrowStatement | ReturnStatement], boolean | void>} */
+			/**
+			 * @type {SyncBailHook<[ThrowStatement | ReturnStatement], boolean | void>}
+			 * @since 5.99.0
+			 */
 			terminate: new SyncBailHook(["statement"]),
 			/** @type {SyncBailHook<[Program, Comment[]], boolean | void>} */
 			finish: new SyncBailHook(["ast", "comments"]),
-			/** @type {SyncBailHook<[Statement], boolean | void>} */
+			/**
+			 * @type {SyncBailHook<[Statement], boolean | void>}
+			 * @since 5.99.9
+			 */
 			unusedStatement: new SyncBailHook(["statement"])
 		});
 		this.sourceType = sourceType;

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -166,10 +166,16 @@ const toCachedSource = (source) => {
  * @property {Hashes} hashes
  */
 
+const createCompilationHooks = () => ({
+	/**
+	 * @type {SyncBailHook<[Buffer[], string], string | void>}
+	 * @since 5.8.0
+	 */
+	updateHash: new SyncBailHook(["content", "oldHash"])
+});
+
 /**
- * Defines the compilation hooks type used by this module.
- * @typedef {object} CompilationHooks
- * @property {SyncBailHook<[Buffer[], string], string | void>} updateHash
+ * @typedef {ReturnType<typeof createCompilationHooks>} CompilationHooks
  */
 
 /**
@@ -554,10 +560,7 @@ ${referencingAssets
 }
 
 RealContentHashPlugin.getCompilationHooks = createHooksRegistry(
-	() =>
-		/** @type {CompilationHooks} */ ({
-			updateHash: new SyncBailHook(["content", "oldHash"])
-		})
+	createCompilationHooks
 );
 
 module.exports = RealContentHashPlugin;

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "three": "^0.185.1",
     "tinybench": "^6.0.1",
     "toml": "^4.1.1",
-    "tooling": "webpack/tooling#v1.26.4",
+    "tooling": "bjohansebas/tooling-webpack#feat/since-default",
     "ts-loader": "^9.6.0",
     "typescript": "^6.0.3",
     "unified": "^11.0.5",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "three": "^0.185.1",
     "tinybench": "^6.0.1",
     "toml": "^4.1.1",
-    "tooling": "bjohansebas/tooling-webpack#feat/since-default",
+    "tooling": "webpack/tooling#v1.27.0",
     "ts-loader": "^9.6.0",
     "typescript": "^6.0.3",
     "unified": "^11.0.5",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -370,8 +370,7 @@
       "properties": {
         "commonjs": {
           "description": "Also concatenate CommonJS modules with statically analyzable exports. Defaults to 'true'.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         }
       },
       "added": "5.109.0"
@@ -612,14 +611,12 @@
     "CssParserCustomMedia": {
       "description": "Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).",
       "type": "boolean",
-      "added": "5.109.0",
-      "default": true
+      "added": "5.109.0"
     },
     "CssParserCustomSelectors": {
       "description": "Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).",
       "type": "boolean",
-      "added": "5.109.0",
-      "default": true
+      "added": "5.109.0"
     },
     "CssParserDashedIdents": {
       "description": "Enable/disable renaming of dashed identifiers, e. g. custom properties.",
@@ -632,8 +629,7 @@
     "CssParserFontPreload": {
       "description": "Auto-emit `<link rel=\"preload\" as=\"font\">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.",
       "type": "boolean",
-      "added": "5.109.0",
-      "default": false
+      "added": "5.109.0"
     },
     "CssParserFunction": {
       "description": "Enable/disable renaming of `@function` names.",
@@ -1238,15 +1234,13 @@
             }
           ],
           "experimental": true,
-          "added": "5.0.0",
-          "default": "auto"
+          "added": "5.0.0"
         },
         "backCompat": {
           "description": "Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.62.0",
-          "default": true
+          "added": "5.62.0"
         },
         "buildHttp": {
           "description": "Build http(s): urls using a lockfile and resource content cache.",
@@ -1265,8 +1259,7 @@
           "description": "Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.54.0",
-          "default": false
+          "added": "5.54.0"
         },
         "css": {
           "description": "Enable css support. `\"auto\"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.",
@@ -1281,22 +1274,19 @@
             }
           ],
           "experimental": true,
-          "added": "5.66.0",
-          "default": "auto"
+          "added": "5.66.0"
         },
         "deferImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.100.0",
-          "default": false
+          "added": "5.100.0"
         },
         "futureDefaults": {
           "description": "Apply defaults of next major version.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.53.0",
-          "default": false
+          "added": "5.53.0"
         },
         "html": {
           "description": "Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `\"auto\"` (the default) enables it unless a loader is registered for HTML files.",
@@ -1311,8 +1301,7 @@
             }
           ],
           "experimental": true,
-          "added": "5.107.0",
-          "default": "auto"
+          "added": "5.107.0"
         },
         "lazyCompilation": {
           "description": "Compile entrypoints and import()s only when they are accessed.",
@@ -1331,22 +1320,19 @@
           "description": "Allow output javascript files as module source type.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.0.0",
-          "default": false
+          "added": "5.0.0"
         },
         "sourceImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.",
           "type": "boolean",
           "experimental": true,
-          "added": "5.106.0",
-          "default": false
+          "added": "5.106.0"
         },
         "syncWebAssembly": {
           "description": "Support WebAssembly as synchronous EcmaScript Module (outdated).",
           "type": "boolean",
           "experimental": true,
-          "added": "5.0.0",
-          "default": false
+          "added": "5.0.0"
         },
         "typescript": {
           "description": "Enable typescript support. `\"auto\"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.",
@@ -1361,8 +1347,7 @@
             }
           ],
           "experimental": true,
-          "added": "5.107.0",
-          "default": "auto"
+          "added": "5.107.0"
         }
       }
     },
@@ -2419,48 +2404,39 @@
       "properties": {
         "dirname": {
           "description": "Enable/disable evaluating import.meta.dirname.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "env": {
           "description": "Enable/disable evaluating import.meta.env.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "filename": {
           "description": "Enable/disable evaluating import.meta.filename.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "main": {
           "description": "Enable/disable evaluating import.meta.main.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "resolve": {
           "description": "Enable/disable evaluating import.meta.resolve.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "url": {
           "description": "Enable/disable evaluating import.meta.url.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "webpack": {
           "description": "Enable/disable evaluating import.meta.webpack.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "webpackContext": {
           "description": "Enable/disable evaluating import.meta.webpackContext.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         },
         "webpackHot": {
           "description": "Enable/disable evaluating import.meta.webpackHot.",
-          "type": "boolean",
-          "default": true
+          "type": "boolean"
         }
       },
       "added": "5.109.0"
@@ -2508,8 +2484,7 @@
               "type": "boolean"
             }
           ],
-          "added": "5.109.0",
-          "default": false
+          "added": "5.109.0"
         },
         "stream": {
           "description": "Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.",
@@ -2555,8 +2530,7 @@
         "deferImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.",
           "type": "boolean",
-          "added": "5.100.0",
-          "default": false
+          "added": "5.100.0"
         },
         "dynamicImportCssPreload": {
           "description": "Auto-emit `<link rel=\"preload\" as=\"style\">` for the CSS of every dynamically imported (`import()`) chunk, so the stylesheet fetches in parallel with the chunk's JavaScript instead of after it parses. Unlike `dynamicImportPreload`, the JavaScript itself is not preloaded. `true` uses the default order; a number sets the preload order.",
@@ -2568,8 +2542,7 @@
               "type": "boolean"
             }
           ],
-          "added": "5.109.0",
-          "default": false
+          "added": "5.109.0"
         },
         "dynamicImportFetchPriority": {
           "description": "Specifies global fetchPriority for dynamic import.",
@@ -2718,8 +2691,7 @@
         "strictModeViolations": {
           "description": "Specifies the behavior of constructs that break at runtime in strict mode (e.g. 'with', 'arguments.callee', assigning to read-only globals) when modules are emitted as ES module output.",
           "enum": ["error", "warn", false],
-          "added": "5.109.0",
-          "default": "warn"
+          "added": "5.109.0"
         },
         "strictThisContextOnImports": {
           "description": "Handle the this context correctly according to the spec for namespace objects.",
@@ -2803,8 +2775,7 @@
               "type": "boolean"
             }
           ],
-          "added": "5.109.0",
-          "default": false
+          "added": "5.109.0"
         },
         "wrappedContextCritical": {
           "description": "Enable warnings for partial dynamic dependencies.",
@@ -4704,8 +4675,7 @@
               "tsType": "((name: string) => boolean | string | { [rel: string]: HtmlFaviconIcon | HtmlFaviconIcon[] })"
             }
           ],
-          "added": "5.109.0",
-          "default": false
+          "added": "5.109.0"
         },
         "inject": {
           "description": "Where to place injected chunk `<script>`/`<link>` tags. `\"body\"` (default; `\"head\"` with `output.module`) keeps them next to the entry tag — end of `<body>` on generated pages; `\"head\"` moves them into `<head>`; `false` suppresses sibling-chunk injection (entry tags and resource hints remain).",
@@ -4792,8 +4762,7 @@
         },
         "scriptLoading": {
           "description": "How injected `<script>` tags load. `auto` (default) emits a module script for ES module output and `defer` otherwise; `defer` forces a deferred script; `blocking` emits a plain blocking script.",
-          "enum": ["auto", "blocking", "defer"],
-          "default": "auto"
+          "enum": ["auto", "blocking", "defer"]
         },
         "title": {
           "description": "Sets the `<title>` of the generated HTML page. Skipped if the HTML already contains a `<title>` element.",
@@ -7011,8 +6980,7 @@
     "WasmStreamingFallback": {
       "description": "Fall back to non-streaming WebAssembly instantiation when streaming compilation fails because the server does not serve `.wasm` files with the `application/wasm` MIME type.",
       "type": "boolean",
-      "added": "5.109.0",
-      "default": true
+      "added": "5.109.0"
     },
     "Watch": {
       "description": "Enter watch mode, which rebuilds on file change.",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -370,9 +370,11 @@
       "properties": {
         "commonjs": {
           "description": "Also concatenate CommonJS modules with statically analyzable exports. Defaults to 'true'.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         }
-      }
+      },
+      "added": "5.109.0"
     },
     "Context": {
       "description": "The base directory (absolute path!) for resolving the `entry` option. If `output.pathinfo` is set, the included pathinfo is shortened to this directory.",
@@ -609,11 +611,15 @@
     },
     "CssParserCustomMedia": {
       "description": "Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).",
-      "type": "boolean"
+      "type": "boolean",
+      "added": "5.109.0",
+      "default": true
     },
     "CssParserCustomSelectors": {
       "description": "Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).",
-      "type": "boolean"
+      "type": "boolean",
+      "added": "5.109.0",
+      "default": true
     },
     "CssParserDashedIdents": {
       "description": "Enable/disable renaming of dashed identifiers, e. g. custom properties.",
@@ -625,7 +631,9 @@
     },
     "CssParserFontPreload": {
       "description": "Auto-emit `<link rel=\"preload\" as=\"font\">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.",
-      "type": "boolean"
+      "type": "boolean",
+      "added": "5.109.0",
+      "default": false
     },
     "CssParserFunction": {
       "description": "Enable/disable renaming of `@function` names.",
@@ -1150,7 +1158,8 @@
         },
         "generator": {
           "description": "The environment supports generator functions and yield ('function* () { yield ... }').",
-          "type": "boolean"
+          "type": "boolean",
+          "added": "5.109.0"
         },
         "globalThis": {
           "description": "The environment supports 'globalThis'.",
@@ -1182,7 +1191,8 @@
         },
         "modulePreload": {
           "description": "The environment supports `<link rel=\"modulepreload\">` to preload EcmaScript modules.",
-          "type": "boolean"
+          "type": "boolean",
+          "added": "5.109.0"
         },
         "nodeBuiltinModuleGetter": {
           "description": "The environment supports `process.getBuiltinModule()` to synchronously load Node.js core modules.",
@@ -1227,12 +1237,16 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0",
+          "default": "auto"
         },
         "backCompat": {
           "description": "Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.62.0",
+          "default": true
         },
         "buildHttp": {
           "description": "Build http(s): urls using a lockfile and resource content cache.",
@@ -1244,12 +1258,15 @@
               "$ref": "#/definitions/HttpUriOptions"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.49.0"
         },
         "cacheUnaffected": {
           "description": "Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.54.0",
+          "default": false
         },
         "css": {
           "description": "Enable css support. `\"auto\"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.",
@@ -1263,17 +1280,23 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.66.0",
+          "default": "auto"
         },
         "deferImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.100.0",
+          "default": false
         },
         "futureDefaults": {
           "description": "Apply defaults of next major version.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.53.0",
+          "default": false
         },
         "html": {
           "description": "Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `\"auto\"` (the default) enables it unless a loader is registered for HTML files.",
@@ -1287,7 +1310,9 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.107.0",
+          "default": "auto"
         },
         "lazyCompilation": {
           "description": "Compile entrypoints and import()s only when they are accessed.",
@@ -1299,22 +1324,29 @@
               "$ref": "#/definitions/LazyCompilationOptions"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.17.0"
         },
         "outputModule": {
           "description": "Allow output javascript files as module source type.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0",
+          "default": false
         },
         "sourceImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.106.0",
+          "default": false
         },
         "syncWebAssembly": {
           "description": "Support WebAssembly as synchronous EcmaScript Module (outdated).",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0",
+          "default": false
         },
         "typescript": {
           "description": "Enable typescript support. `\"auto\"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.",
@@ -1328,7 +1360,9 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.107.0",
+          "default": "auto"
         }
       }
     },
@@ -1349,12 +1383,14 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0"
         },
         "backCompat": {
           "description": "Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.62.0"
         },
         "buildHttp": {
           "description": "Build http(s): urls using a lockfile and resource content cache.",
@@ -1363,12 +1399,14 @@
               "$ref": "#/definitions/HttpUriOptions"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.49.0"
         },
         "cacheUnaffected": {
           "description": "Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.54.0"
         },
         "css": {
           "description": "Enable css support. `\"auto\"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.",
@@ -1382,17 +1420,20 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.66.0"
         },
         "deferImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.100.0"
         },
         "futureDefaults": {
           "description": "Apply defaults of next major version.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.53.0"
         },
         "html": {
           "description": "Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `\"auto\"` (the default) enables it unless a loader is registered for HTML files.",
@@ -1406,7 +1447,8 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.107.0"
         },
         "lazyCompilation": {
           "description": "Compile entrypoints and import()s only when they are accessed.",
@@ -1418,22 +1460,26 @@
               "$ref": "#/definitions/LazyCompilationOptions"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.17.0"
         },
         "outputModule": {
           "description": "Allow output javascript files as module source type.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0"
         },
         "sourceImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.106.0"
         },
         "syncWebAssembly": {
           "description": "Support WebAssembly as synchronous EcmaScript Module (outdated).",
           "type": "boolean",
-          "experimental": true
+          "experimental": true,
+          "added": "5.0.0"
         },
         "typescript": {
           "description": "Enable typescript support. `\"auto\"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.",
@@ -1447,7 +1493,8 @@
               "type": "boolean"
             }
           ],
-          "experimental": true
+          "experimental": true,
+          "added": "5.107.0"
         }
       }
     },
@@ -1533,7 +1580,8 @@
     },
     "ExternalItemInterop": {
       "description": "How an external's exports interoperate with ES module imports, independent of the importing module's strictness (similar to Rollup's `output.interop`). 'default': treat as CommonJS, the default import is the whole exports (Node.js semantics). 'esModule': treat as an ES module namespace, the default import is unboxed to `.default`.",
-      "enum": ["default", "esModule"]
+      "enum": ["default", "esModule"],
+      "added": "5.109.0"
     },
     "ExternalItemValue": {
       "description": "The dependency used for the external.",
@@ -2075,7 +2123,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "added": "5.109.0"
     },
     "HtmlParserOptions": {
       "description": "Parser options for html modules.",
@@ -2221,7 +2270,8 @@
           "type": "string"
         }
       },
-      "required": ["rel"]
+      "required": ["rel"],
+      "added": "5.109.0"
     },
     "HttpUriAllowedUris": {
       "description": "List of allowed URIs for building http resources.",
@@ -2369,41 +2419,51 @@
       "properties": {
         "dirname": {
           "description": "Enable/disable evaluating import.meta.dirname.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "env": {
           "description": "Enable/disable evaluating import.meta.env.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "filename": {
           "description": "Enable/disable evaluating import.meta.filename.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "main": {
           "description": "Enable/disable evaluating import.meta.main.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "resolve": {
           "description": "Enable/disable evaluating import.meta.resolve.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "url": {
           "description": "Enable/disable evaluating import.meta.url.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "webpack": {
           "description": "Enable/disable evaluating import.meta.webpack.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "webpackContext": {
           "description": "Enable/disable evaluating import.meta.webpackContext.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "webpackHot": {
           "description": "Enable/disable evaluating import.meta.webpackHot.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         }
-      }
+      },
+      "added": "5.109.0"
     },
     "InfrastructureLogging": {
       "description": "Options for infrastructure level logging.",
@@ -2447,7 +2507,9 @@
             {
               "type": "boolean"
             }
-          ]
+          ],
+          "added": "5.109.0",
+          "default": false
         },
         "stream": {
           "description": "Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.",
@@ -2492,7 +2554,9 @@
         },
         "deferImport": {
           "description": "Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.",
-          "type": "boolean"
+          "type": "boolean",
+          "added": "5.100.0",
+          "default": false
         },
         "dynamicImportCssPreload": {
           "description": "Auto-emit `<link rel=\"preload\" as=\"style\">` for the CSS of every dynamically imported (`import()`) chunk, so the stylesheet fetches in parallel with the chunk's JavaScript instead of after it parses. Unlike `dynamicImportPreload`, the JavaScript itself is not preloaded. `true` uses the default order; a number sets the preload order.",
@@ -2503,7 +2567,9 @@
             {
               "type": "boolean"
             }
-          ]
+          ],
+          "added": "5.109.0",
+          "default": false
         },
         "dynamicImportFetchPriority": {
           "description": "Specifies global fetchPriority for dynamic import.",
@@ -2651,7 +2717,9 @@
         },
         "strictModeViolations": {
           "description": "Specifies the behavior of constructs that break at runtime in strict mode (e.g. 'with', 'arguments.callee', assigning to read-only globals) when modules are emitted as ES module output.",
-          "enum": ["error", "warn", false]
+          "enum": ["error", "warn", false],
+          "added": "5.109.0",
+          "default": "warn"
         },
         "strictThisContextOnImports": {
           "description": "Handle the this context correctly according to the spec for namespace objects.",
@@ -2734,7 +2802,9 @@
             {
               "type": "boolean"
             }
-          ]
+          ],
+          "added": "5.109.0",
+          "default": false
         },
         "wrappedContextCritical": {
           "description": "Enable warnings for partial dynamic dependencies.",
@@ -4556,7 +4626,8 @@
               },
               "required": ["href"]
             }
-          ]
+          ],
+          "added": "5.109.0"
         },
         "csp": {
           "description": "Inject a `<meta http-equiv=\"Content-Security-Policy\">` into every webpack-emitted HTML page. `false` (default) does nothing; `true` uses a strict baseline (`script-src 'self'`, `style-src 'self'`, `object-src 'none'`, `base-uri 'self'`) and appends a `sha256` hash of every inline `<script>`/`<style>` to `script-src`/`style-src`. An object customizes it. Skipped when the page already declares a CSP.",
@@ -4632,7 +4703,9 @@
               "instanceof": "Function",
               "tsType": "((name: string) => boolean | string | { [rel: string]: HtmlFaviconIcon | HtmlFaviconIcon[] })"
             }
-          ]
+          ],
+          "added": "5.109.0",
+          "default": false
         },
         "inject": {
           "description": "Where to place injected chunk `<script>`/`<link>` tags. `\"body\"` (default; `\"head\"` with `output.module`) keeps them next to the entry tag — end of `<body>` on generated pages; `\"head\"` moves them into `<head>`; `false` suppresses sibling-chunk injection (entry tags and resource hints remain).",
@@ -4644,7 +4717,8 @@
               "type": "boolean",
               "enum": [false]
             }
-          ]
+          ],
+          "added": "5.109.0"
         },
         "inline": {
           "description": "Inline the content of matching chunks directly into the HTML instead of emitting a separate `<script>`/`<link>` tag. `true` inlines every chunk; `\"script\"` inlines only JavaScript, `\"style\"` only CSS; an array of `RegExp` patterns matches against the chunk name.",
@@ -4663,7 +4737,8 @@
             {
               "type": "boolean"
             }
-          ]
+          ],
+          "added": "5.109.0"
         },
         "integrity": {
           "description": "Add Subresource Integrity (SRI) `integrity` attributes to injected `<script>`/`<link>` tags. `true` uses `['sha384']`; an array sets the hash algorithms; a function receives each referenced asset and returns the algorithms to use or `false` to skip it.",
@@ -4683,7 +4758,8 @@
               "instanceof": "Function",
               "tsType": "((asset: { chunk: import('../lib/Chunk'), filename: string }) => string[] | false)"
             }
-          ]
+          ],
+          "added": "5.109.0"
         },
         "manifest": {
           "description": "Web app manifest for webpack-generated HTML (authored pages are left untouched). `false` (default) injects nothing. A string is a path to an existing `.webmanifest` file to link. An object is the manifest contents — serialized, emitted as a hashed `.webmanifest` and linked with `<link rel=\"manifest\">`; its `icons`/`screenshots` `src` paths resolve like any request and are emitted as hashed assets. A function receives the page name and returns one of these.",
@@ -4711,15 +4787,18 @@
           "additionalProperties": {
             "description": "Content string for the meta tag.",
             "type": "string"
-          }
+          },
+          "added": "5.109.0"
         },
         "scriptLoading": {
           "description": "How injected `<script>` tags load. `auto` (default) emits a module script for ES module output and `defer` otherwise; `defer` forces a deferred script; `blocking` emits a plain blocking script.",
-          "enum": ["auto", "blocking", "defer"]
+          "enum": ["auto", "blocking", "defer"],
+          "default": "auto"
         },
         "title": {
           "description": "Sets the `<title>` of the generated HTML page. Skipped if the HTML already contains a `<title>` element.",
-          "type": "string"
+          "type": "string",
+          "added": "5.109.0"
         }
       }
     },
@@ -5541,7 +5620,8 @@
         {
           "$ref": "#/definitions/ResourceHintsOptions"
         }
-      ]
+      ],
+      "added": "5.109.0"
     },
     "ResourceHintsInitial": {
       "description": "Initial dependency-graph chunk hints. `true` auto-emits `<link rel=\"modulepreload\">` (ESM output) or `<link rel=\"preload\" as=\"script\">` (classic) for each of the entry's initial dependency chunks; `\"prefetch\"` uses `<link rel=\"prefetch\">`; `\"preload\"` is an alias of `true`; `false` disables chunk hints (URL-asset hints from magic comments / `urlHints` still fire); `\"none\"` is a hard off switch (no `<link>` anywhere, empty stats / manifest); an array of `HtmlResourceHint` descriptors replaces the auto set; a function receives the auto `defaultHints` plus context (`entryName`, `entrypoint`, `hostType: \"html\" | \"js\"`, `compilation`) and returns the final list (replaces the removed `resolveDependencies` hook).",
@@ -5562,7 +5642,8 @@
           "instanceof": "Function",
           "tsType": "((context: { entryName: string, entrypoint: import('../lib/Entrypoint'), hostType: 'html' | 'js', compilation: import('../lib/Compilation'), defaultHints: (import('../lib/dependencies/HtmlEntryDependency').HtmlResourceHint & { hostChunks: string[] })[] }) => import('../lib/dependencies/HtmlEntryDependency').HtmlResourceHint[])"
         }
-      ]
+      ],
+      "added": "5.109.0"
     },
     "ResourceHintsOptions": {
       "description": "Full resource-hint configuration.",
@@ -5592,7 +5673,8 @@
             "$ref": "#/definitions/UrlHintRule"
           }
         }
-      }
+      },
+      "added": "5.109.0"
     },
     "RuleSetCondition": {
       "description": "A condition matcher.",
@@ -6323,7 +6405,8 @@
         },
         "chunkGroupResourceHints": {
           "description": "Include the resolved `<link>` resource-hint descriptors for each entrypoint (`entrypoints[name].resourceHints`). Combines `output.resourceHints.chunks` (initial-graph modulepreload/preload/prefetch) with `output.resourceHints.assets` (URL-referenced fonts / images / …). Lets SSR frameworks inject the hints server-side without walking the chunk graph themselves; the analogue of Vite's `build.ssrManifest`.",
-          "type": "boolean"
+          "type": "boolean",
+          "added": "5.109.0"
         },
         "chunkGroups": {
           "description": "Display all chunk groups with the corresponding bundles.",
@@ -6843,14 +6926,16 @@
           "description": "Default `type` attribute (MIME).",
           "type": "string"
         }
-      }
+      },
+      "added": "5.109.0"
     },
     "UrlHints": {
       "description": "URL-referenced-asset default hint rules for this parser (JavaScript `new URL(...)`, CSS `url(...)`, HTML `<img src>` / `<link href>` / `<script src>`).",
       "type": "array",
       "items": {
         "$ref": "#/definitions/UrlHintRule"
-      }
+      },
+      "added": "5.109.0"
     },
     "Validate": {
       "description": "Enable validation of webpack configuration. Defaults to true in development mode. In production mode, defaults to true unless futureDefaults is enabled, then defaults to false.",
@@ -6925,7 +7010,9 @@
     },
     "WasmStreamingFallback": {
       "description": "Fall back to non-streaming WebAssembly instantiation when streaming compilation fails because the server does not serve `.wasm` files with the `application/wasm` MIME type.",
-      "type": "boolean"
+      "type": "boolean",
+      "added": "5.109.0",
+      "default": true
     },
     "Watch": {
       "description": "Enter watch mode, which rebuilds on file change.",

--- a/types.d.ts
+++ b/types.d.ts
@@ -3960,21 +3960,6 @@ declare interface CompilationHooksAsyncWebAssemblyModulesPlugin {
 		Source
 	>;
 }
-declare interface CompilationHooksCssModulesPlugin {
-	renderModulePackage: SyncWaterfallHook<
-		[Source, Module, ChunkRenderContextCssModulesPlugin],
-		Source
-	>;
-	chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
-
-	/**
-	 * called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default
-	 */
-	orderModules: SyncBailHook<
-		[Chunk, Module[], Compilation],
-		undefined | void | Module[]
-	>;
-}
 
 /**
  * Renames an inlined module's top-level declaration (and all its references) when
@@ -5465,9 +5450,12 @@ declare interface CssImportDependencyMeta {
 type CssLayer = undefined | string;
 declare class CssLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements: ReadonlySet<string>);
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CssLoadingRuntimeModulePluginHooks;
+	static getCompilationHooks: (compilation: Compilation) => {
+		createStylesheet: SyncWaterfallHook<[string, Chunk], string>;
+		linkPreload: SyncWaterfallHook<[string, Chunk], string>;
+		linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
+		linkInsert: SyncWaterfallHook<[string, Chunk], string>;
+	};
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -5494,12 +5482,6 @@ declare class CssLoadingRuntimeModule extends RuntimeModule {
 	 * @deprecated In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 	 */
 	static getSourceBasicTypes(module: Module): ReadonlySet<string>;
-}
-declare interface CssLoadingRuntimeModulePluginHooks {
-	createStylesheet: SyncWaterfallHook<[string, Chunk], string>;
-	linkPreload: SyncWaterfallHook<[string, Chunk], string>;
-	linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
-	linkInsert: SyncWaterfallHook<[string, Chunk], string>;
 }
 declare abstract class CssModule extends NormalModule {
 	cssLayer: CssLayer;
@@ -5682,7 +5664,20 @@ declare class CssModulesPlugin {
 	 */
 	renderChunk(
 		__0: RenderContextCssModulesPlugin,
-		hooks: CompilationHooksCssModulesPlugin
+		hooks: {
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ChunkRenderContextCssModulesPlugin],
+				Source
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+			 */
+			orderModules: SyncBailHook<
+				[Chunk, Module[], Compilation],
+				undefined | void | Module[]
+			>;
+		}
 	): Source;
 
 	/**
@@ -5691,7 +5686,20 @@ declare class CssModulesPlugin {
 	static renderModule(
 		module: CssModule,
 		renderContext: ChunkRenderContextCssModulesPlugin,
-		hooks: CompilationHooksCssModulesPlugin
+		hooks: {
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ChunkRenderContextCssModulesPlugin],
+				Source
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+			 */
+			orderModules: SyncBailHook<
+				[Chunk, Module[], Compilation],
+				undefined | void | Module[]
+			>;
+		}
 	): null | Source;
 
 	/**
@@ -5706,9 +5714,20 @@ declare class CssModulesPlugin {
 	 * Returns true, when the chunk has css.
 	 */
 	static chunkHasCss(chunk: Chunk, chunkGraph: ChunkGraph): boolean;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CompilationHooksCssModulesPlugin;
+	static getCompilationHooks: (compilation: Compilation) => {
+		renderModulePackage: SyncWaterfallHook<
+			[Source, Module, ChunkRenderContextCssModulesPlugin],
+			Source
+		>;
+		chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+		/**
+		 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+		 */
+		orderModules: SyncBailHook<
+			[Chunk, Module[], Compilation],
+			undefined | void | Module[]
+		>;
+	};
 }
 declare abstract class CssParser extends ParserClass {
 	defaultMode: "global" | "auto" | "local" | "pure";
@@ -9618,33 +9637,6 @@ declare interface HotModuleReplacementPluginLoaderContext {
 declare class HotUpdateChunk extends Chunk {
 	constructor();
 }
-declare interface HtmlCompilationHooks {
-	/**
-	 * called with the list of extra tags to inject into each page (initially empty) plus the current HTML; push `HtmlTagDescriptor`s and return the list — webpack serializes and places them by `injectTo`. A structured alternative to the string-level `transformHtml` for adding tags; runs before CSP so injected inline tags are hashed
-	 */
-	injectTags: AsyncSeriesWaterfallHook<
-		[HtmlTagDescriptor[], HtmlInjectTagsContext],
-		HtmlTagDescriptor[]
-	>;
-
-	/**
-	 * called with the page's `<script>`/`<link>`/`<style>`/`<meta>` tags (webpack's own and any injected) as mutable descriptors; mutate `attrs` (add a `nonce`/`data-*`, switch `defer`↔`async`, …), set `remove: true`, or change `injectTo` to move a tag between `<head>` and `<body>`, and webpack rewrites the changed tags. Add new tags with `injectTags` instead
-	 */
-	transformTags: AsyncSeriesHook<[HtmlMutableTag[], HtmlTransformTagsContext]>;
-
-	/**
-	 * called with each emitted page's final HTML (all sentinels resolved) just before it is written; return the (possibly transformed) HTML — e.g. to minify, inject a CSP meta, or rewrite tags
-	 */
-	transformHtml: AsyncSeriesWaterfallHook<
-		[string, HtmlTransformHtmlContext],
-		string
-	>;
-
-	/**
-	 * called once each page's HTML asset has been finalized — a post-emit notification (nothing to return)
-	 */
-	htmlEmitted: AsyncSeriesHook<[HtmlEmittedContext]>;
-}
 declare interface HtmlEmittedContext {
 	outputName: string;
 }
@@ -9778,9 +9770,32 @@ declare class HtmlModulesPlugin {
 	/**
 	 * Per-compilation hooks for the experimental HTML support.
 	 */
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => HtmlCompilationHooks;
+	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * Called with the list of extra tags to inject into each page (initially empty) plus the current HTML; push `HtmlTagDescriptor`s and return the list — webpack serializes and places them by `injectTo`. A structured alternative to the string-level `transformHtml` for adding tags; runs before CSP so injected inline tags are hashed.
+		 */
+		injectTags: AsyncSeriesWaterfallHook<
+			[HtmlTagDescriptor[], HtmlInjectTagsContext],
+			HtmlTagDescriptor[]
+		>;
+		/**
+		 * Called with the page's `<script>`/`<link>`/`<style>`/`<meta>` tags (webpack's own and any injected) as mutable descriptors; mutate `attrs` (add a `nonce`/`data-*`, switch `defer`↔`async`, …), set `remove: true`, or change `injectTo` to move a tag between `<head>` and `<body>`, and webpack rewrites the changed tags. Add new tags with `injectTags` instead.
+		 */
+		transformTags: AsyncSeriesHook<
+			[HtmlMutableTag[], HtmlTransformTagsContext]
+		>;
+		/**
+		 * Called with each emitted page's final HTML (all sentinels resolved) just before it is written; return the (possibly transformed) HTML — e.g. to minify, inject a CSP meta, or rewrite tags.
+		 */
+		transformHtml: AsyncSeriesWaterfallHook<
+			[string, HtmlTransformHtmlContext],
+			string
+		>;
+		/**
+		 * Called once each page's HTML asset has been finalized — a post-emit notification (nothing to return).
+		 */
+		htmlEmitted: AsyncSeriesHook<[HtmlEmittedContext]>;
+	};
 }
 declare interface HtmlMutableTag {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -2911,6 +2911,7 @@ declare class CleanPlugin {
 	static getCompilationHooks: (compilation: Compilation) => {
 		/**
 		 * When returning true the file/directory will be kept during cleaning, returning false will clean it and ignore the following plugins and config.
+		 * @since 5.20.0
 		 */
 		keep: SyncBailHook<[string], boolean | void>;
 	};
@@ -3218,7 +3219,13 @@ declare class Compilation {
 			[(string[] | ReferencedExport)[], Dependency, RuntimeSpec],
 			(string[] | ReferencedExport)[]
 		>;
+		/**
+		 * @since 5.32.0
+		 */
 		executeModule: SyncHook<[ExecuteModuleArgument, ExecuteModuleContext]>;
+		/**
+		 * @since 5.33.0
+		 */
 		prepareModuleExecution: AsyncParallelHook<
 			[ExecuteModuleArgument, ExecuteModuleContext]
 		>;
@@ -3346,6 +3353,9 @@ declare class Compilation {
 			ProcessAssetsAdditionalOptions
 		>;
 		afterProcessAssets: SyncHook<[CompilationAssets]>;
+		/**
+		 * @since 5.8.0
+		 */
 		processAdditionalAssets: AsyncSeriesHook<[CompilationAssets]>;
 		needAdditionalSeal: SyncBailHook<[], boolean | void>;
 		afterSeal: AsyncSeriesHook<[]>;
@@ -4048,17 +4058,29 @@ declare class Compiler {
 		make: AsyncParallelHook<[Compilation]>;
 		finishMake: AsyncParallelHook<[Compilation]>;
 		afterCompile: AsyncSeriesHook<[Compilation]>;
+		/**
+		 * @since 5.67.0
+		 */
 		readRecords: AsyncSeriesHook<[]>;
+		/**
+		 * @since 5.67.0
+		 */
 		emitRecords: AsyncSeriesHook<[]>;
 		watchRun: AsyncSeriesHook<[Compiler]>;
 		failed: SyncHook<[Error]>;
 		invalid: SyncHook<[null | string, number]>;
 		watchClose: SyncHook<[]>;
+		/**
+		 * @since 5.17.0
+		 */
 		shutdown: AsyncSeriesHook<[]>;
 		infrastructureLog: SyncBailHook<
 			[string, string, undefined | any[]],
 			true | void
 		>;
+		/**
+		 * @since 5.106.0
+		 */
 		validate: SyncHook<[]>;
 		environment: SyncHook<[]>;
 		afterEnvironment: SyncHook<[]>;
@@ -4259,6 +4281,7 @@ type ConcatSourceChild = string | Source | SourceLike;
 
 /**
  * Advanced options for module concatenation.
+ * @since 5.109.0
  */
 declare interface ConcatenateModulesOptions {
 	/**
@@ -5373,9 +5396,21 @@ type CssLayer = undefined | string;
 declare class CssLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements: ReadonlySet<string>);
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.66.0
+		 */
 		createStylesheet: SyncWaterfallHook<[string, Chunk], string>;
+		/**
+		 * @since 5.91.0
+		 */
 		linkPreload: SyncWaterfallHook<[string, Chunk], string>;
+		/**
+		 * @since 5.91.0
+		 */
 		linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
+		/**
+		 * @since 5.107.0
+		 */
 		linkInsert: SyncWaterfallHook<[string, Chunk], string>;
 	};
 
@@ -5587,13 +5622,20 @@ declare class CssModulesPlugin {
 	renderChunk(
 		__0: RenderContextCssModulesPlugin,
 		hooks: {
+			/**
+			 * @since 5.94.0
+			 */
 			renderModulePackage: SyncWaterfallHook<
 				[Source, Module, ChunkRenderContextCssModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.94.0
+			 */
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
 			/**
 			 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+			 * @since 5.107.0
 			 */
 			orderModules: SyncBailHook<
 				[Chunk, Module[], Compilation],
@@ -5609,13 +5651,20 @@ declare class CssModulesPlugin {
 		module: CssModule,
 		renderContext: ChunkRenderContextCssModulesPlugin,
 		hooks: {
+			/**
+			 * @since 5.94.0
+			 */
 			renderModulePackage: SyncWaterfallHook<
 				[Source, Module, ChunkRenderContextCssModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.94.0
+			 */
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
 			/**
 			 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+			 * @since 5.107.0
 			 */
 			orderModules: SyncBailHook<
 				[Chunk, Module[], Compilation],
@@ -5637,13 +5686,20 @@ declare class CssModulesPlugin {
 	 */
 	static chunkHasCss(chunk: Chunk, chunkGraph: ChunkGraph): boolean;
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.94.0
+		 */
 		renderModulePackage: SyncWaterfallHook<
 			[Source, Module, ChunkRenderContextCssModulesPlugin],
 			Source
 		>;
+		/**
+		 * @since 5.94.0
+		 */
 		chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
 		/**
 		 * Called for each CSS source type (CSS_IMPORT_TYPE, CSS_TYPE) with the chunk's modules pre-sorted by full module name; return an ordered `Module[]` to override the default import-order topological sort, or return `undefined` to keep the default.
+		 * @since 5.107.0
 		 */
 		orderModules: SyncBailHook<
 			[Chunk, Module[], Compilation],
@@ -5737,11 +5793,13 @@ declare interface CssParserOptions {
 
 	/**
 	 * Enable/disable resolution of `@custom-media` at-rules (file-local build-time substitution).
+	 * @since 5.109.0
 	 */
 	customMedia?: boolean;
 
 	/**
 	 * Enable/disable resolution of `@custom-selector` at-rules (file-local build-time expansion to `:is(...)`).
+	 * @since 5.109.0
 	 */
 	customSelectors?: boolean;
 
@@ -5752,6 +5810,7 @@ declare interface CssParserOptions {
 
 	/**
 	 * Auto-emit `<link rel="preload" as="font">` for the primary `src` URL of each `@font-face` reachable from an HTML entry's initial CSS. Only the first URL per `@font-face` is preloaded (preloading every format would double-download). Off by default; `parser.css.urlHints` rules and per-URL magic comments still override the seeded defaults. Set `output.crossOriginLoading` so the preload matches the font's CORS fetch.
+	 * @since 5.109.0
 	 */
 	fontPreload?: boolean;
 
@@ -5843,6 +5902,9 @@ declare class DefinePlugin {
 		options?: true | string[] | RuntimeValueOptions
 	): RuntimeValue;
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.104.0
+		 */
 		definitions: SyncWaterfallHook<
 			[Record<string, CodeValue>],
 			Record<string, CodeValue>
@@ -7209,6 +7271,7 @@ declare interface Environment {
 
 	/**
 	 * The environment supports generator functions and yield ('function* () { yield ... }').
+	 * @since 5.109.0
 	 */
 	generator?: boolean;
 
@@ -7249,6 +7312,7 @@ declare interface Environment {
 
 	/**
 	 * The environment supports `<link rel="modulepreload">` to preload EcmaScript modules.
+	 * @since 5.109.0
 	 */
 	modulePreload?: boolean;
 
@@ -7427,78 +7491,91 @@ declare interface Experiments {
 
 	/**
 	 * Support WebAssembly as asynchronous EcmaScript Module. `"auto"` (the default) enables it unless a loader is registered for WebAssembly files.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	asyncWebAssembly?: boolean | "auto";
 
 	/**
 	 * Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.
+	 * @since 5.62.0
 	 * @experimental
 	 */
 	backCompat?: boolean;
 
 	/**
 	 * Build http(s): urls using a lockfile and resource content cache.
+	 * @since 5.49.0
 	 * @experimental
 	 */
 	buildHttp?: HttpUriOptions | (string | RegExp | ((uri: string) => boolean))[];
 
 	/**
 	 * Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.
+	 * @since 5.54.0
 	 * @experimental
 	 */
 	cacheUnaffected?: boolean;
 
 	/**
 	 * Enable css support. `"auto"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.
+	 * @since 5.66.0
 	 * @experimental
 	 */
 	css?: boolean | "auto";
 
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @since 5.100.0
 	 * @experimental
 	 */
 	deferImport?: boolean;
 
 	/**
 	 * Apply defaults of next major version.
+	 * @since 5.53.0
 	 * @experimental
 	 */
 	futureDefaults?: boolean;
 
 	/**
 	 * Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `"auto"` (the default) enables it unless a loader is registered for HTML files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	html?: boolean | "auto";
 
 	/**
 	 * Compile entrypoints and import()s only when they are accessed.
+	 * @since 5.17.0
 	 * @experimental
 	 */
 	lazyCompilation?: boolean | LazyCompilationOptions;
 
 	/**
 	 * Allow output javascript files as module source type.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	outputModule?: boolean;
 
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.
+	 * @since 5.106.0
 	 * @experimental
 	 */
 	sourceImport?: boolean;
 
 	/**
 	 * Support WebAssembly as synchronous EcmaScript Module (outdated).
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	syncWebAssembly?: boolean;
 
 	/**
 	 * Enable typescript support. `"auto"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	typescript?: boolean | "auto";
@@ -7510,78 +7587,91 @@ declare interface Experiments {
 declare interface ExperimentsNormalized {
 	/**
 	 * Support WebAssembly as asynchronous EcmaScript Module. `"auto"` (the default) enables it unless a loader is registered for WebAssembly files.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	asyncWebAssembly?: boolean | "auto";
 
 	/**
 	 * Enable backward-compat layer with deprecation warnings for many webpack 4 APIs.
+	 * @since 5.62.0
 	 * @experimental
 	 */
 	backCompat?: boolean;
 
 	/**
 	 * Build http(s): urls using a lockfile and resource content cache.
+	 * @since 5.49.0
 	 * @experimental
 	 */
 	buildHttp?: HttpUriOptions;
 
 	/**
 	 * Enable additional in memory caching of modules that are unchanged and reference only unchanged modules.
+	 * @since 5.54.0
 	 * @experimental
 	 */
 	cacheUnaffected?: boolean;
 
 	/**
 	 * Enable css support. `"auto"` (the default) enables the built-in CSS support unless a loader is registered for CSS files.
+	 * @since 5.66.0
 	 * @experimental
 	 */
 	css?: boolean | "auto";
 
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @since 5.100.0
 	 * @experimental
 	 */
 	deferImport?: boolean;
 
 	/**
 	 * Apply defaults of next major version.
+	 * @since 5.53.0
 	 * @experimental
 	 */
 	futureDefaults?: boolean;
 
 	/**
 	 * Enable HTML entry support. Treats `.html` files as a first-class module type so they can be used directly as entry points. `"auto"` (the default) enables it unless a loader is registered for HTML files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	html?: boolean | "auto";
 
 	/**
 	 * Compile entrypoints and import()s only when they are accessed.
+	 * @since 5.17.0
 	 * @experimental
 	 */
 	lazyCompilation?: false | LazyCompilationOptions;
 
 	/**
 	 * Allow output javascript files as module source type.
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	outputModule?: boolean;
 
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-source-phase-imports. This allows importing modules at source phase.
+	 * @since 5.106.0
 	 * @experimental
 	 */
 	sourceImport?: boolean;
 
 	/**
 	 * Support WebAssembly as synchronous EcmaScript Module (outdated).
+	 * @since 5.0.0
 	 * @experimental
 	 */
 	syncWebAssembly?: boolean;
 
 	/**
 	 * Enable typescript support. `"auto"` (the default) enables the built-in TypeScript support when Node.js supports it (>= 22.6) and no loader is registered for TypeScript files.
+	 * @since 5.107.0
 	 * @experimental
 	 */
 	typescript?: boolean | "auto";
@@ -8214,6 +8304,7 @@ type ExternalItemValue =
 declare interface ExternalItemValueObjectKnown {
 	/**
 	 * How an external's exports interoperate with ES module imports, independent of the importing module's strictness (similar to Rollup's `output.interop`). 'default': treat as CommonJS, the default import is the whole exports (Node.js semantics). 'esModule': treat as an ES module namespace, the default import is unboxed to `.default`.
+	 * @since 5.109.0
 	 */
 	interop?: "default" | "esModule";
 }
@@ -8251,6 +8342,9 @@ declare class ExternalModule extends Module {
 		normalModuleFactory: NormalModuleFactory
 	): void;
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.106.0
+		 */
 		chunkCondition: SyncBailHook<[Chunk, Compilation], boolean>;
 	};
 	static ModuleExternalInitFragment: typeof ModuleExternalInitFragment;
@@ -9693,6 +9787,7 @@ declare class HtmlModulesPlugin {
 	static getCompilationHooks: (compilation: Compilation) => {
 		/**
 		 * Called with the list of extra tags to inject into each page (initially empty) plus the current HTML; push `HtmlTagDescriptor`s and return the list — webpack serializes and places them by `injectTo`. A structured alternative to the string-level `transformHtml` for adding tags; runs before CSP so injected inline tags are hashed.
+		 * @since 5.109.0
 		 */
 		injectTags: AsyncSeriesWaterfallHook<
 			[HtmlTagDescriptor[], HtmlInjectTagsContext],
@@ -9700,12 +9795,14 @@ declare class HtmlModulesPlugin {
 		>;
 		/**
 		 * Called with the page's `<script>`/`<link>`/`<style>`/`<meta>` tags (webpack's own and any injected) as mutable descriptors; mutate `attrs` (add a `nonce`/`data-*`, switch `defer`↔`async`, …), set `remove: true`, or change `injectTo` to move a tag between `<head>` and `<body>`, and webpack rewrites the changed tags. Add new tags with `injectTags` instead.
+		 * @since 5.109.0
 		 */
 		transformTags: AsyncSeriesHook<
 			[HtmlMutableTag[], HtmlTransformTagsContext]
 		>;
 		/**
 		 * Called with each emitted page's final HTML (all sentinels resolved) just before it is written; return the (possibly transformed) HTML — e.g. to minify, inject a CSP meta, or rewrite tags.
+		 * @since 5.109.0
 		 */
 		transformHtml: AsyncSeriesWaterfallHook<
 			[string, HtmlTransformHtmlContext],
@@ -9713,6 +9810,7 @@ declare class HtmlModulesPlugin {
 		>;
 		/**
 		 * Called once each page's HTML asset has been finalized — a post-emit notification (nothing to return).
+		 * @since 5.109.0
 		 */
 		htmlEmitted: AsyncSeriesHook<[HtmlEmittedContext]>;
 	};
@@ -9760,6 +9858,7 @@ declare abstract class HtmlParser extends ParserClass {
 declare interface HtmlParserOptions {
 	/**
 	 * Configure how the HTML source is parsed: `"document"` (the default) parses a full page; any other value is the tag name of the context element to parse the source as that element's inner HTML (a fragment) — e.g. `"template"` for a neutral fragment, or `"tbody"` so context-sensitive tags like a bare `<tr>`/`<td>` are kept instead of dropped.
+	 * @since 5.109.0
 	 */
 	as?: string;
 
@@ -9870,6 +9969,7 @@ type HtmlResourceHintRel =
 
 /**
  * A custom resource-hint `<link>` for `output.html.resourceHints`. Exactly one of `href` / `chunk` / `entry` names the target.
+ * @since 5.109.0
  */
 declare interface HtmlResourceHintWebpackOptions {
 	/**
@@ -10423,6 +10523,7 @@ type ImportMetaParserOptions = ImportMetaParserOptionsKnown &
 
 /**
  * Enable/disable evaluating import.meta fields. Omitted fields are enabled and unknown fields are preserved. Custom fields are allowed.
+ * @since 5.109.0
  */
 declare interface ImportMetaParserOptionsKnown {
 	/**
@@ -10473,6 +10574,7 @@ declare interface ImportMetaParserOptionsKnown {
 
 /**
  * Enable/disable evaluating import.meta fields. Omitted fields are enabled and unknown fields are preserved. Custom fields are allowed.
+ * @since 5.109.0
  */
 declare interface ImportMetaParserOptionsUnknown {
 	[index: string]: boolean;
@@ -10538,6 +10640,7 @@ declare interface InfrastructureLogging {
 
 	/**
 	 * Show build progress. `"auto"` shows it only for interactive terminals. This option is only used when no custom console is provided.
+	 * @since 5.109.0
 	 */
 	progress?: boolean | "auto";
 
@@ -10878,10 +10981,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -10898,19 +11007,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -10940,10 +11061,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -10960,19 +11087,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -11002,10 +11141,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -11022,19 +11167,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -11066,10 +11223,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -11086,19 +11249,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -11128,10 +11303,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -11148,19 +11329,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -11190,10 +11383,16 @@ declare class JavascriptModulesPlugin {
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.41.0
+			 */
 			renderContent: SyncWaterfallHook<
 				[Source, RenderContextJavascriptModulesPlugin],
 				Source
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			renderStartup: SyncWaterfallHook<
 				[Source, Module, StartupRenderContext],
 				Source
@@ -11210,19 +11409,31 @@ declare class JavascriptModulesPlugin {
 				[string, RenderBootstrapContext],
 				string
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			inlineInRuntimeBailout: SyncBailHook<
 				[Module, Partial<RenderBootstrapContext>],
 				string | void
 			>;
+			/**
+			 * @since 5.22.0
+			 */
 			embedInRuntimeBailout: SyncBailHook<
 				[Module, RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
+			/**
+			 * @since 5.26.1
+			 */
 			strictRuntimeBailout: SyncBailHook<
 				[RenderContextJavascriptModulesPlugin],
 				string | void
 			>;
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			/**
+			 * @since 5.2.1
+			 */
 			useSourceMap: SyncBailHook<
 				[Chunk, RenderContextJavascriptModulesPlugin],
 				boolean | void
@@ -11254,10 +11465,16 @@ declare class JavascriptModulesPlugin {
 			[Source, RenderContextJavascriptModulesPlugin],
 			Source
 		>;
+		/**
+		 * @since 5.41.0
+		 */
 		renderContent: SyncWaterfallHook<
 			[Source, RenderContextJavascriptModulesPlugin],
 			Source
 		>;
+		/**
+		 * @since 5.22.0
+		 */
 		renderStartup: SyncWaterfallHook<
 			[Source, Module, StartupRenderContext],
 			Source
@@ -11271,19 +11488,31 @@ declare class JavascriptModulesPlugin {
 			Source
 		>;
 		renderRequire: SyncWaterfallHook<[string, RenderBootstrapContext], string>;
+		/**
+		 * @since 5.22.0
+		 */
 		inlineInRuntimeBailout: SyncBailHook<
 			[Module, Partial<RenderBootstrapContext>],
 			string | void
 		>;
+		/**
+		 * @since 5.22.0
+		 */
 		embedInRuntimeBailout: SyncBailHook<
 			[Module, RenderContextJavascriptModulesPlugin],
 			string | void
 		>;
+		/**
+		 * @since 5.26.1
+		 */
 		strictRuntimeBailout: SyncBailHook<
 			[RenderContextJavascriptModulesPlugin],
 			string | void
 		>;
 		chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+		/**
+		 * @since 5.2.1
+		 */
 		useSourceMap: SyncBailHook<
 			[Chunk, RenderContextJavascriptModulesPlugin],
 			boolean | void
@@ -11360,9 +11589,15 @@ declare class JavascriptParser extends ParserClass {
 				undefined | null | BasicEvaluatedExpression
 			>
 		>;
+		/**
+		 * @since 5.73.0
+		 */
 		evaluateNewExpression: HookMap<
 			SyncBailHook<[NewExpression], undefined | null | BasicEvaluatedExpression>
 		>;
+		/**
+		 * @since 5.73.0
+		 */
 		evaluateCallExpression: HookMap<
 			SyncBailHook<
 				[CallExpression],
@@ -11451,6 +11686,9 @@ declare class JavascriptParser extends ParserClass {
 			],
 			boolean | void
 		>;
+		/**
+		 * @since 5.109.0
+		 */
 		preStatementByType: HookMap<
 			SyncBailHook<
 				[
@@ -11519,6 +11757,9 @@ declare class JavascriptParser extends ParserClass {
 			],
 			boolean | void
 		>;
+		/**
+		 * @since 5.109.0
+		 */
 		blockPreStatementByType: HookMap<
 			SyncBailHook<
 				[
@@ -11588,6 +11829,9 @@ declare class JavascriptParser extends ParserClass {
 			boolean | void
 		>;
 		statementIf: SyncBailHook<[IfStatement], boolean | void>;
+		/**
+		 * @since 5.105.0
+		 */
 		collectGuards: SyncBailHook<[Expression], void | GuardCollection>;
 		classExtendsExpression: SyncBailHook<
 			[
@@ -11603,6 +11847,9 @@ declare class JavascriptParser extends ParserClass {
 			],
 			boolean | void
 		>;
+		/**
+		 * @since 5.36.0
+		 */
 		classBodyValue: SyncBailHook<
 			[
 				Expression,
@@ -11704,9 +11951,15 @@ declare class JavascriptParser extends ParserClass {
 		varDeclaration: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		varDeclarationLet: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		varDeclarationConst: HookMap<SyncBailHook<[Identifier], boolean | void>>;
+		/**
+		 * @since 5.100.0
+		 */
 		varDeclarationUsing: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		varDeclarationVar: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		pattern: HookMap<SyncBailHook<[Identifier], boolean | void>>;
+		/**
+		 * @since 5.101.3
+		 */
 		collectDestructuringAssignmentProperties: SyncBailHook<
 			[Expression],
 			boolean | void
@@ -11785,6 +12038,9 @@ declare class JavascriptParser extends ParserClass {
 		>;
 		optionalChaining: SyncBailHook<[ChainExpression], boolean | void>;
 		new: HookMap<SyncBailHook<[NewExpression], boolean | void>>;
+		/**
+		 * @since 5.71.0
+		 */
 		binaryExpression: SyncBailHook<[BinaryExpression], boolean | void>;
 		expression: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		expressionMemberChain: HookMap<
@@ -11805,8 +12061,14 @@ declare class JavascriptParser extends ParserClass {
 			boolean | void
 		>;
 		program: SyncBailHook<[Program, CommentJavascriptParser[]], boolean | void>;
+		/**
+		 * @since 5.99.0
+		 */
 		terminate: SyncBailHook<[ReturnStatement | ThrowStatement], boolean | void>;
 		finish: SyncBailHook<[Program, CommentJavascriptParser[]], boolean | void>;
+		/**
+		 * @since 5.99.9
+		 */
 		unusedStatement: SyncBailHook<[Statement], boolean | void>;
 	}>;
 	sourceType: "module" | "auto" | "script";
@@ -13464,11 +13726,13 @@ declare interface JavascriptParserOptions {
 
 	/**
 	 * Enable experimental tc39 proposal https://github.com/tc39/proposal-defer-import-eval. This allows to defer execution of a module until it's first use.
+	 * @since 5.100.0
 	 */
 	deferImport?: boolean;
 
 	/**
 	 * Auto-emit `<link rel="preload" as="style">` for the CSS of every dynamically imported (`import()`) chunk, so the stylesheet fetches in parallel with the chunk's JavaScript instead of after it parses. Unlike `dynamicImportPreload`, the JavaScript itself is not preloaded. `true` uses the default order; a number sets the preload order.
+	 * @since 5.109.0
 	 */
 	dynamicImportCssPreload?: number | boolean;
 
@@ -13606,6 +13870,7 @@ declare interface JavascriptParserOptions {
 
 	/**
 	 * Specifies the behavior of constructs that break at runtime in strict mode (e.g. 'with', 'arguments.callee', assigning to read-only globals) when modules are emitted as ES module output.
+	 * @since 5.109.0
 	 */
 	strictModeViolations?: false | "error" | "warn";
 
@@ -13662,6 +13927,7 @@ declare interface JavascriptParserOptions {
 
 	/**
 	 * Disable or configure parsing of Worklet syntax like context.audioWorklet.addModule() or CSS.paintWorklet.addModule().
+	 * @since 5.109.0
 	 */
 	worklet?: boolean | string[];
 
@@ -16102,7 +16368,13 @@ declare class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 	 */
 	constructor(runtimeRequirements: ReadonlySet<string>);
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.41.0
+		 */
 		linkPreload: SyncWaterfallHook<[string, Chunk], string>;
+		/**
+		 * @since 5.41.0
+		 */
 		linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
 	};
 
@@ -16303,7 +16575,13 @@ declare class ModuleFederationPlugin {
 	 */
 	apply(compiler: Compiler): void;
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.96.0
+		 */
 		addContainerEntryDependency: SyncHook<Dependency>;
+		/**
+		 * @since 5.96.0
+		 */
 		addFederationRuntimeDependency: SyncHook<Dependency>;
 	};
 }
@@ -17740,13 +18018,25 @@ declare class NormalModule extends Module {
 				AsyncSeriesBailHook<[string, NormalModule], null | string | Buffer>
 			>
 		>;
+		/**
+		 * @since 5.58.0
+		 */
 		readResource: HookMap<
 			AsyncSeriesBailHook<[AnyLoaderContext], null | string | Buffer>
 		>;
 		loader: SyncHook<[AnyLoaderContext, NormalModule]>;
 		beforeLoaders: SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>;
+		/**
+		 * @since 5.59.0
+		 */
 		beforeParse: SyncHook<[NormalModule]>;
+		/**
+		 * @since 5.59.0
+		 */
 		beforeSnapshot: SyncHook<[NormalModule]>;
+		/**
+		 * @since 5.99.0
+		 */
 		processResult: SyncWaterfallHook<
 			[
 				[
@@ -17762,6 +18052,9 @@ declare class NormalModule extends Module {
 				undefined | PreparsedAst
 			]
 		>;
+		/**
+		 * @since 5.49.0
+		 */
 		needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
 	};
 	static deserialize(
@@ -17930,6 +18223,9 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		resolveForScheme: HookMap<
 			AsyncSeriesBailHook<[ResourceDataWithData, ResolveData], true | void>
 		>;
+		/**
+		 * @since 5.49.0
+		 */
 		resolveInScheme: HookMap<
 			AsyncSeriesBailHook<[ResourceDataWithData, ResolveData], true | void>
 		>;
@@ -18164,6 +18460,9 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 				> &
 				Record<string, SyncBailHook<[Generator, GeneratorOptions], void>>
 		>;
+		/**
+		 * @since 5.81.0
+		 */
 		createModuleClass: HookMap<
 			SyncBailHook<[CreateData, ResolveData], void | Module>
 		>;
@@ -19853,6 +20152,7 @@ declare interface OutputFileSystem {
 declare interface OutputHtmlOptions {
 	/**
 	 * Inject a `<base>` element into the page `<head>`. A string sets `href`; an object sets both `href` and optionally `target`. Skipped if the HTML already contains a `<base>` element.
+	 * @since 5.109.0
 	 */
 	base?:
 		| string
@@ -19889,6 +20189,7 @@ declare interface OutputHtmlOptions {
 
 	/**
 	 * Favicon(s) for webpack-generated HTML (authored pages are left untouched). `false` (default) injects nothing; `true` injects the webpack logo; a string is a path to an icon; an object maps each `<link rel>` to an icon — a path string, an object with the icon `href` plus extra link attributes (`sizes`, `media`, `color`, `type`, `crossorigin`), or an array of these for multiple icons under the same `rel` (e.g. several `sizes`, or light/dark `media` variants); a function receives the page name and returns one of these. Every icon is emitted as a hashed asset.
+	 * @since 5.109.0
 	 */
 	favicon?:
 		| string
@@ -19961,16 +20262,19 @@ declare interface OutputHtmlOptions {
 
 	/**
 	 * Where to place injected chunk `<script>`/`<link>` tags. `"body"` (default; `"head"` with `output.module`) keeps them next to the entry tag — end of `<body>` on generated pages; `"head"` moves them into `<head>`; `false` suppresses sibling-chunk injection (entry tags and resource hints remain).
+	 * @since 5.109.0
 	 */
 	inject?: false | "body" | "head";
 
 	/**
 	 * Inline the content of matching chunks directly into the HTML instead of emitting a separate `<script>`/`<link>` tag. `true` inlines every chunk; `"script"` inlines only JavaScript, `"style"` only CSS; an array of `RegExp` patterns matches against the chunk name.
+	 * @since 5.109.0
 	 */
 	inline?: boolean | "script" | "style" | RegExp[];
 
 	/**
 	 * Add Subresource Integrity (SRI) `integrity` attributes to injected `<script>`/`<link>` tags. `true` uses `['sha384']`; an array sets the hash algorithms; a function receives each referenced asset and returns the algorithms to use or `false` to skip it.
+	 * @since 5.109.0
 	 */
 	integrity?:
 		| boolean
@@ -19988,6 +20292,7 @@ declare interface OutputHtmlOptions {
 
 	/**
 	 * Inject `<meta>` tags into the page `<head>`. Each key is the `name` attribute (or `"charset"` for a charset declaration); the value is the `content` string. Keys beginning with `og:` use the `property` attribute instead of `name`. A tag is skipped if the HTML already contains a meta with the same name.
+	 * @since 5.109.0
 	 */
 	meta?: { [index: string]: string };
 
@@ -19998,6 +20303,7 @@ declare interface OutputHtmlOptions {
 
 	/**
 	 * Sets the `<title>` of the generated HTML page. Skipped if the HTML already contains a `<title>` element.
+	 * @since 5.109.0
 	 */
 	title?: string;
 }
@@ -21717,6 +22023,9 @@ declare class RealContentHashPlugin {
 	 */
 	apply(compiler: Compiler): void;
 	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * @since 5.8.0
+		 */
 		updateHash: SyncBailHook<[Buffer[], string], string | void>;
 	};
 }
@@ -22908,10 +23217,12 @@ declare interface ResourceDataWithData {
 
 /**
  * Full resource-hint configuration.
+ * @since 5.109.0
  */
 declare interface ResourceHintsOptions {
 	/**
 	 * Initial dependency-graph chunk hints. `true` auto-emits `<link rel="modulepreload">` (ESM output) or `<link rel="preload" as="script">` (classic) for each of the entry's initial dependency chunks; `"prefetch"` uses `<link rel="prefetch">`; `"preload"` is an alias of `true`; `false` disables chunk hints (URL-asset hints from magic comments / `urlHints` still fire); `"none"` is a hard off switch (no `<link>` anywhere, empty stats / manifest); an array of `HtmlResourceHint` descriptors replaces the auto set; a function receives the auto `defaultHints` plus context (`entryName`, `entrypoint`, `hostType: "html" | "js"`, `compilation`) and returns the final list (replaces the removed `resolveDependencies` hook).
+	 * @since 5.109.0
 	 */
 	initial?:
 		| boolean
@@ -25666,6 +25977,7 @@ declare interface StatsOptions {
 
 	/**
 	 * Include the resolved `<link>` resource-hint descriptors for each entrypoint (`entrypoints[name].resourceHints`). Combines `output.resourceHints.chunks` (initial-graph modulepreload/preload/prefetch) with `output.resourceHints.assets` (URL-referenced fonts / images / …). Lets SSR frameworks inject the hints server-side without walking the chunk graph themselves; the analogue of Vite's `build.ssrManifest`.
+	 * @since 5.109.0
 	 */
 	chunkGroupResourceHints?: boolean;
 
@@ -26420,6 +26732,7 @@ declare interface UpdateHashContextGenerator {
 
 /**
  * One default-hint rule for URL-referenced assets emitted by this parser (JS `new URL(...)`, CSS `url(...)`, HTML `<img src>` / `<link href>` / `<script src>`). `test` / `include` / `exclude` match against the asset's request; omit all three to apply to every asset. Matching rules set the same fields a `webpackPrefetch` / `webpackPreload` / `webpackAs` / `webpackType` / `webpackMedia` / `webpackFetchPriority` magic comment would; explicit magic comments on the same URL still win.
+ * @since 5.109.0
  */
 declare interface UrlHintRule {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -675,11 +675,9 @@ declare class AsyncWebAssemblyModulesPlugin {
 	renderModule(
 		module: Module,
 		renderContext: WebAssemblyRenderContext,
-		hooks: CompilationHooksAsyncWebAssemblyModulesPlugin
+		hooks: CompilationHooks
 	): Source;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CompilationHooksAsyncWebAssemblyModulesPlugin;
+	static getCompilationHooks: (compilation: Compilation) => CompilationHooks;
 }
 declare interface AsyncWebAssemblyModulesPluginOptions {
 	/**
@@ -2759,13 +2757,6 @@ declare interface ChunkRenderContextCssModulesPlugin {
 	 */
 	moduleSourceContent: Source;
 }
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface ChunkRenderContextJavascriptModulesPlugin {
 	/**
 	 * the chunk
@@ -2917,15 +2908,12 @@ declare class CleanPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CleanPluginCompilationHooks;
-}
-declare interface CleanPluginCompilationHooks {
-	/**
-	 * when returning true the file/directory will be kept during cleaning, returning false will clean it and ignore the following plugins and config
-	 */
-	keep: SyncBailHook<[string], boolean | void>;
+	static getCompilationHooks: (compilation: Compilation) => {
+		/**
+		 * When returning true the file/directory will be kept during cleaning, returning false will clean it and ignore the following plugins and config.
+		 */
+		keep: SyncBailHook<[string], boolean | void>;
+	};
 }
 declare interface ClearCacheOptions {
 	/**
@@ -3954,77 +3942,11 @@ declare class Compilation {
 declare interface CompilationAssets {
 	[index: string]: Source;
 }
-declare interface CompilationHooksAsyncWebAssemblyModulesPlugin {
+declare interface CompilationHooks {
 	renderModuleContent: SyncWaterfallHook<
 		[Source, Module, WebAssemblyRenderContext],
 		Source
 	>;
-}
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
-declare interface CompilationHooksJavascriptModulesPlugin {
-	renderModuleContent: SyncWaterfallHook<
-		[Source, Module, ModuleRenderContext],
-		Source
-	>;
-	renderModuleContainer: SyncWaterfallHook<
-		[Source, Module, ModuleRenderContext],
-		Source
-	>;
-	renderModulePackage: SyncWaterfallHook<
-		[Source, Module, ModuleRenderContext],
-		Source
-	>;
-	renderChunk: SyncWaterfallHook<
-		[Source, RenderContextJavascriptModulesPlugin],
-		Source
-	>;
-	renderMain: SyncWaterfallHook<
-		[Source, RenderContextJavascriptModulesPlugin],
-		Source
-	>;
-	renderContent: SyncWaterfallHook<
-		[Source, RenderContextJavascriptModulesPlugin],
-		Source
-	>;
-	render: SyncWaterfallHook<
-		[Source, RenderContextJavascriptModulesPlugin],
-		Source
-	>;
-	renderStartup: SyncWaterfallHook<
-		[Source, Module, StartupRenderContext],
-		Source
-	>;
-	renderRequire: SyncWaterfallHook<[string, RenderBootstrapContext], string>;
-	inlineInRuntimeBailout: SyncBailHook<
-		[Module, Partial<RenderBootstrapContext>],
-		string | void
-	>;
-	embedInRuntimeBailout: SyncBailHook<
-		[Module, RenderContextJavascriptModulesPlugin],
-		string | void
-	>;
-	strictRuntimeBailout: SyncBailHook<
-		[RenderContextJavascriptModulesPlugin],
-		string | void
-	>;
-	chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
-	useSourceMap: SyncBailHook<
-		[Chunk, RenderContextJavascriptModulesPlugin],
-		boolean | void
-	>;
-}
-declare interface CompilationHooksModuleFederationPlugin {
-	addContainerEntryDependency: SyncHook<Dependency>;
-	addFederationRuntimeDependency: SyncHook<Dependency>;
-}
-declare interface CompilationHooksRealContentHashPlugin {
-	updateHash: SyncBailHook<[Buffer[], string], string | void>;
 }
 
 /**
@@ -5920,7 +5842,12 @@ declare class DefinePlugin {
 		}) => CodeValuePrimitive,
 		options?: true | string[] | RuntimeValueOptions
 	): RuntimeValue;
-	static getCompilationHooks: (compilation: Compilation) => DefinePluginHooks;
+	static getCompilationHooks: (compilation: Compilation) => {
+		definitions: SyncWaterfallHook<
+			[Record<string, CodeValue>],
+			Record<string, CodeValue>
+		>;
+	};
 	static VALUE_DEP_MAIN: "webpack/DefinePlugin_hash";
 	static VALUE_DEP_PREFIX: "webpack/DefinePlugin ";
 	static getMergedDefinitionNode: (
@@ -5936,12 +5863,6 @@ declare class DefinePlugin {
 		objKeys?: null | Set<string>
 	) => string;
 	static toPropertyKey: (key: string) => string;
-}
-declare interface DefinePluginHooks {
-	definitions: SyncWaterfallHook<
-		[Record<string, CodeValue>],
-		Record<string, CodeValue>
-	>;
 }
 declare interface Definitions {
 	[index: string]: CodeValue;
@@ -8329,7 +8250,9 @@ declare class ExternalModule extends Module {
 		unsafeCacheData: UnsafeCacheData,
 		normalModuleFactory: NormalModuleFactory
 	): void;
-	static getCompilationHooks: (compilation: Compilation) => ExternalModuleHooks;
+	static getCompilationHooks: (compilation: Compilation) => {
+		chunkCondition: SyncBailHook<[Chunk, Compilation], boolean>;
+	};
 	static ModuleExternalInitFragment: typeof ModuleExternalInitFragment;
 	static getExternalModuleNodeCommonjsInitFragment: (
 		runtimeTemplate: RuntimeTemplate,
@@ -8345,9 +8268,6 @@ declare class ExternalModule extends Module {
 type ExternalModuleBuildInfo = KnownBuildInfo &
 	Record<string, any> &
 	KnownExternalModuleBuildInfo;
-declare interface ExternalModuleHooks {
-	chunkCondition: SyncBailHook<[Chunk, Compilation], boolean>;
-}
 declare interface ExternalModuleInfo {
 	type: "external";
 	module: Module;
@@ -10941,7 +10861,61 @@ declare class JavascriptModulesPlugin {
 	renderModule(
 		module: Module,
 		renderContext: ModuleRenderContext,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		}
 	): null | Source;
 
 	/**
@@ -10949,7 +10923,61 @@ declare class JavascriptModulesPlugin {
 	 */
 	renderChunk(
 		renderContext: RenderContextJavascriptModulesPlugin,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		}
 	): Source;
 
 	/**
@@ -10957,7 +10985,61 @@ declare class JavascriptModulesPlugin {
 	 */
 	renderMain(
 		renderContext: MainRenderContext,
-		hooks: CompilationHooksJavascriptModulesPlugin,
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		},
 		compilation: Compilation
 	): Source;
 
@@ -10967,7 +11049,61 @@ declare class JavascriptModulesPlugin {
 	updateHashWithBootstrap(
 		hash: Hash,
 		renderContext: RenderBootstrapContext,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		}
 	): void;
 
 	/**
@@ -10975,7 +11111,61 @@ declare class JavascriptModulesPlugin {
 	 */
 	renderBootstrap(
 		renderContext: RenderBootstrapContext,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		}
 	): Bootstrap;
 
 	/**
@@ -10983,7 +11173,61 @@ declare class JavascriptModulesPlugin {
 	 */
 	renderRequire(
 		renderContext: RenderBootstrapContext,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: {
+			renderModuleContent: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModuleContainer: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			renderModulePackage: SyncWaterfallHook<
+				[Source, Module, ModuleRenderContext],
+				Source
+			>;
+			render: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderContent: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderStartup: SyncWaterfallHook<
+				[Source, Module, StartupRenderContext],
+				Source
+			>;
+			renderChunk: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderMain: SyncWaterfallHook<
+				[Source, RenderContextJavascriptModulesPlugin],
+				Source
+			>;
+			renderRequire: SyncWaterfallHook<
+				[string, RenderBootstrapContext],
+				string
+			>;
+			inlineInRuntimeBailout: SyncBailHook<
+				[Module, Partial<RenderBootstrapContext>],
+				string | void
+			>;
+			embedInRuntimeBailout: SyncBailHook<
+				[Module, RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			strictRuntimeBailout: SyncBailHook<
+				[RenderContextJavascriptModulesPlugin],
+				string | void
+			>;
+			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+			useSourceMap: SyncBailHook<
+				[Chunk, RenderContextJavascriptModulesPlugin],
+				boolean | void
+			>;
+		}
 	): string;
 
 	/**
@@ -10993,9 +11237,58 @@ declare class JavascriptModulesPlugin {
 		chunk: Chunk,
 		outputOptions: OutputNormalizedWithDefaults
 	): ChunkFilenameTemplate;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CompilationHooksJavascriptModulesPlugin;
+	static getCompilationHooks: (compilation: Compilation) => {
+		renderModuleContent: SyncWaterfallHook<
+			[Source, Module, ModuleRenderContext],
+			Source
+		>;
+		renderModuleContainer: SyncWaterfallHook<
+			[Source, Module, ModuleRenderContext],
+			Source
+		>;
+		renderModulePackage: SyncWaterfallHook<
+			[Source, Module, ModuleRenderContext],
+			Source
+		>;
+		render: SyncWaterfallHook<
+			[Source, RenderContextJavascriptModulesPlugin],
+			Source
+		>;
+		renderContent: SyncWaterfallHook<
+			[Source, RenderContextJavascriptModulesPlugin],
+			Source
+		>;
+		renderStartup: SyncWaterfallHook<
+			[Source, Module, StartupRenderContext],
+			Source
+		>;
+		renderChunk: SyncWaterfallHook<
+			[Source, RenderContextJavascriptModulesPlugin],
+			Source
+		>;
+		renderMain: SyncWaterfallHook<
+			[Source, RenderContextJavascriptModulesPlugin],
+			Source
+		>;
+		renderRequire: SyncWaterfallHook<[string, RenderBootstrapContext], string>;
+		inlineInRuntimeBailout: SyncBailHook<
+			[Module, Partial<RenderBootstrapContext>],
+			string | void
+		>;
+		embedInRuntimeBailout: SyncBailHook<
+			[Module, RenderContextJavascriptModulesPlugin],
+			string | void
+		>;
+		strictRuntimeBailout: SyncBailHook<
+			[RenderContextJavascriptModulesPlugin],
+			string | void
+		>;
+		chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
+		useSourceMap: SyncBailHook<
+			[Chunk, RenderContextJavascriptModulesPlugin],
+			boolean | void
+		>;
+	};
 	static chunkHasJs: (chunk: Chunk, chunkGraph: ChunkGraph) => boolean;
 }
 declare class JavascriptParser extends ParserClass {
@@ -14986,13 +15279,6 @@ type LogTypeEnum =
 	| "status";
 declare const MEASURE_END_OPERATION: unique symbol;
 declare const MEASURE_START_OPERATION: unique symbol;
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface MainRenderContext {
 	/**
 	 * the chunk
@@ -15815,9 +16101,10 @@ declare class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 	 * Creates an instance of ModuleChunkLoadingRuntimeModule.
 	 */
 	constructor(runtimeRequirements: ReadonlySet<string>);
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => JsonpCompilationPluginHooks;
+	static getCompilationHooks: (compilation: Compilation) => {
+		linkPreload: SyncWaterfallHook<[string, Chunk], string>;
+		linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
+	};
 
 	/**
 	 * Runtime modules without any dependencies to other runtime modules
@@ -16015,9 +16302,10 @@ declare class ModuleFederationPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CompilationHooksModuleFederationPlugin;
+	static getCompilationHooks: (compilation: Compilation) => {
+		addContainerEntryDependency: SyncHook<Dependency>;
+		addFederationRuntimeDependency: SyncHook<Dependency>;
+	};
 }
 declare interface ModuleFederationPluginOptions {
 	/**
@@ -16837,13 +17125,6 @@ declare interface ModuleReferenceOptions {
 	 */
 	asiSafe?: boolean;
 }
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface ModuleRenderContext {
 	/**
 	 * the chunk
@@ -17449,9 +17730,40 @@ declare class NormalModule extends Module {
 			| (string | RegExp | ((content: string) => boolean))[],
 		request: string
 	): boolean;
-	static getCompilationHooks(
-		compilation: Compilation
-	): NormalModuleCompilationHooks;
+	static getCompilationHooks(compilation: Compilation): {
+		/**
+		 * Use the `readResource` hook instead.
+		 * @deprecated
+		 */
+		readResourceForScheme: HookMap<
+			FakeHook<
+				AsyncSeriesBailHook<[string, NormalModule], null | string | Buffer>
+			>
+		>;
+		readResource: HookMap<
+			AsyncSeriesBailHook<[AnyLoaderContext], null | string | Buffer>
+		>;
+		loader: SyncHook<[AnyLoaderContext, NormalModule]>;
+		beforeLoaders: SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>;
+		beforeParse: SyncHook<[NormalModule]>;
+		beforeSnapshot: SyncHook<[NormalModule]>;
+		processResult: SyncWaterfallHook<
+			[
+				[
+					string | Buffer,
+					undefined | string | RawSourceMap,
+					undefined | PreparsedAst
+				],
+				NormalModule
+			],
+			[
+				string | Buffer,
+				undefined | string | RawSourceMap,
+				undefined | PreparsedAst
+			]
+		>;
+		needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
+	};
 	static deserialize(
 		context: ObjectDeserializerContextObjectMiddlewareObject_4
 	): NormalModule;
@@ -17465,36 +17777,6 @@ declare class NormalModule extends Module {
 type NormalModuleBuildInfo = KnownBuildInfo &
 	Record<string, any> &
 	KnownNormalModuleBuildInfo;
-declare interface NormalModuleCompilationHooks {
-	loader: SyncHook<[AnyLoaderContext, NormalModule]>;
-	beforeLoaders: SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>;
-	beforeParse: SyncHook<[NormalModule]>;
-	beforeSnapshot: SyncHook<[NormalModule]>;
-	readResourceForScheme: HookMap<
-		FakeHook<
-			AsyncSeriesBailHook<[string, NormalModule], null | string | Buffer>
-		>
-	>;
-	readResource: HookMap<
-		AsyncSeriesBailHook<[AnyLoaderContext], null | string | Buffer>
-	>;
-	processResult: SyncWaterfallHook<
-		[
-			[
-				string | Buffer,
-				undefined | string | RawSourceMap,
-				undefined | PreparsedAst
-			],
-			NormalModule
-		],
-		[
-			string | Buffer,
-			undefined | string | RawSourceMap,
-			undefined | PreparsedAst
-		]
-	>;
-	needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
-}
 declare interface NormalModuleCreateDataNormalModuleObject_1<
 	T extends string = string
 > {
@@ -21434,9 +21716,9 @@ declare class RealContentHashPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-	static getCompilationHooks: (
-		compilation: Compilation
-	) => CompilationHooksRealContentHashPlugin;
+	static getCompilationHooks: (compilation: Compilation) => {
+		updateHash: SyncBailHook<[Buffer[], string], string | void>;
+	};
 }
 declare interface RealContentHashPluginOptions {
 	/**
@@ -21651,13 +21933,6 @@ declare interface RemotesConfig {
 declare interface RemotesObject {
 	[index: string]: string | RemotesConfig | string[];
 }
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface RenderBootstrapContext {
 	/**
 	 * the chunk
@@ -21730,13 +22005,6 @@ declare interface RenderContextCssModulesPlugin {
 	 */
 	modules: CssModule[];
 }
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface RenderContextJavascriptModulesPlugin {
 	/**
 	 * the chunk
@@ -24950,13 +25218,6 @@ declare interface StarListSerializerContext {
 		obj?: LazyOptions
 	) => LazyFunction<any, any, any, LazyOptions>;
 }
-
-/**
- * Renames an inlined module's top-level declaration (and all its references) when
- * its name is already taken in the shared startup scope, recording the chosen name
- * in `allUsedNames`. Lets inlined modules be emitted without a per-entry/per-chunk
- * IIFE by resolving name collisions instead of isolating each module.
- */
 declare interface StartupRenderContext {
 	/**
 	 * the chunk

--- a/yarn.lock
+++ b/yarn.lock
@@ -9748,9 +9748,9 @@ toml@^4.1.1:
   resolved "https://registry.yarnpkg.com/toml/-/toml-4.1.2.tgz#11ea52fb9f362a1e54620d0fc875fd7995d8551b"
   integrity sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==
 
-tooling@webpack/tooling#v1.26.4:
-  version "1.26.4"
-  resolved "https://codeload.github.com/webpack/tooling/tar.gz/978dc1c9680ef7d79f5f5c02c3439385d7937c39"
+tooling@bjohansebas/tooling-webpack#feat/since-default:
+  version "1.26.3"
+  resolved "https://codeload.github.com/bjohansebas/tooling-webpack/tar.gz/0c678a93d11bdeeb95aed5b6a29665e9a2f0bd68"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     ajv "^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9748,9 +9748,9 @@ toml@^4.1.1:
   resolved "https://registry.yarnpkg.com/toml/-/toml-4.1.2.tgz#11ea52fb9f362a1e54620d0fc875fd7995d8551b"
   integrity sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==
 
-tooling@bjohansebas/tooling-webpack#feat/since-default:
-  version "1.26.3"
-  resolved "https://codeload.github.com/bjohansebas/tooling-webpack/tar.gz/0c678a93d11bdeeb95aed5b6a29665e9a2f0bd68"
+tooling@webpack/tooling#v1.27.0:
+  version "1.27.0"
+  resolved "https://codeload.github.com/webpack/tooling/tar.gz/c6c3d732db506344c38fed841e03d0e5002af3ea"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     ajv "^8.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated types only; no runtime behavior or config validation changes beyond stripping doc-only schema keywords.
> 
> **Overview**
> Adds **version metadata** to webpack’s public TypeScript surface so IDEs and docs can show when options and hooks were introduced.
> 
> Schema entries gain an **`"added": "<version>"`** keyword (and existing **`experimental`** is documented in **AGENTS.md**); tooling **v1.27.0** turns those into **`@since`** (and **`@experimental`**) on generated **`WebpackOptions`** declarations. Many newer options (resource hints, HTML output, CSS parsers, etc.) are tagged **5.109.0** where appropriate; **`experiments.*`** now carry **`@since`** for their original release versions.
> 
> **Plugin hooks** are refactored to **`createCompilationHooks()`** factories with inline **`@since`** on each hook (e.g. **HtmlModulesPlugin**, **JavascriptModulesPlugin**, **NormalModule**, **Compiler**, **Compilation**), and **`getCompilationHooks`** return types are inlined in **`types.d.ts`** so hook versions appear on the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9018e853fdceb900f0a22cd5aab157db84beca2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->