### PR TITLE
refactor: merge createDefaultHandler params into one

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -159,18 +159,21 @@ const DEFAULT_PROGRESS_BAR = {
 	width: BAR_LENGTH
 };
 
-/** @typedef {{ estimatedTime?: boolean, phaseTimings?: boolean }} TimingOptions */
+/** @typedef {{ progressBar?: ProgressBarOptions | false, estimatedTime?: boolean, phaseTimings?: boolean }} DefaultHandlerOptions */
 
 /**
  * Creates a default handler.
  * @param {boolean | null | undefined} profile need profile
  * @param {Logger} logger logger
- * @param {ProgressBarOptions | false=} progressBar render bar
- * @param {TimingOptions=} timing show estimated time and/or phase timings
+ * @param {DefaultHandlerOptions=} options display options
  * @returns {HandlerFn} default handler
  */
-const createDefaultHandler = (profile, logger, progressBar, timing = {}) => {
-	const { estimatedTime = false, phaseTimings = false } = timing;
+const createDefaultHandler = (profile, logger, options = {}) => {
+	const {
+		progressBar = false,
+		estimatedTime = false,
+		phaseTimings = false
+	} = options;
 	const trackTime = estimatedTime || phaseTimings;
 
 	/** @type {{ value: string | undefined, time: number }[]} */
@@ -435,8 +438,8 @@ class ProgressPlugin {
 			createDefaultHandler(
 				this.profile,
 				compiler.getInfrastructureLogger("webpack.Progress"),
-				progressBar,
 				{
+					progressBar,
 					estimatedTime: this.estimatedTime,
 					phaseTimings: this.phaseTimings
 				}

--- a/types.d.ts
+++ b/types.d.ts
@@ -5821,6 +5821,26 @@ declare interface CssParserOptions {
 	urlHints?: UrlHintRule[];
 }
 type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration;
+declare interface DefaultHandlerOptions {
+	progressBar?:
+		| false
+		| Required<{
+				/**
+				 * Color used for the filled portion of the bar.
+				 */
+				color?: string;
+				/**
+				 * Name shown before the progress bar.
+				 */
+				name?: string;
+				/**
+				 * Width of the progress bar in characters. Default: 25.
+				 */
+				width?: number;
+		  }>;
+	estimatedTime?: boolean;
+	phaseTimings?: boolean;
+}
 type DefineConfigInput =
 	| Configuration
 	| MultiConfiguration
@@ -20367,23 +20387,7 @@ declare class ProgressPlugin {
 	static createDefaultHandler: (
 		profile: undefined | null | boolean,
 		logger: WebpackLogger,
-		progressBar?:
-			| false
-			| Required<{
-					/**
-					 * Color used for the filled portion of the bar.
-					 */
-					color?: string;
-					/**
-					 * Name shown before the progress bar.
-					 */
-					name?: string;
-					/**
-					 * Width of the progress bar in characters. Default: 25.
-					 */
-					width?: number;
-			  }>,
-		timing?: TimingOptions
+		options?: DefaultHandlerOptions
 	) => (percentage: number, msg: string, ...args: string[]) => void;
 }
 type ProgressPluginArgument =
@@ -25758,10 +25762,6 @@ declare interface TimestampAndHash {
 	safeTime: number;
 	timestamp?: number;
 	hash: string;
-}
-declare interface TimingOptions {
-	estimatedTime?: boolean;
-	phaseTimings?: boolean;
 }
 declare class TopLevelSymbol {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Consolidates `ProgressPlugin.createDefaultHandler`'s separate `progressBar` and `timing` parameters into a single `options` object so future display options don't keep growing the positional signature.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No, existing ProgressPlugin tests cover the default handler behavior, which is unchanged.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Technically it could be, but as far as I know users rarely call `createDefaultHandler` with progressBar(newly introduced) directly, and `webpack-cli` doesn't call it with progressBar for now either. so I think this is relatively safe.

**If relevant, what needs to be documented once your changes ou already documented?**

<!-- List all the information that needs to be added to the dthat has already been documented in this PR. -->

n/a

**Use of AI**
<!-- If you have used AI, please state so here. Explain how you Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes