### PR TITLE
fix: guard null hash in _readContextHash reduce

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -4150,6 +4150,9 @@ class FileSystemInfo {
 					for (const entry of fileHashes) {
 						if (typeof entry === "string") {
 							hash.update(entry);
+						} else if (!entry || entry.hash == null) {
+							// Match _readContextTimestamp: absent/null hashes must not reach hash.update.
+							hash.update("n");
 						} else {
 							hash.update(entry.hash);
 							if (entry.symlinks) {


### PR DESCRIPTION
## Summary
- `_readContextHash`'s reduce called `hash.update(entry.hash)` without checking for a missing or null hash, which can crash builds with `ERR_INVALID_ARG_TYPE` / similar TypeErrors under parallel load.
- Guard the same way `_readContextTimestamp` already handles absent entries: treat null/missing hashes as `"n"` instead of passing them to `hash.update`.

Fixes #21482.

## Test plan
- [ ] Review the reduce path in `lib/FileSystemInfo.js` against `_readContextTimestamp`'s null handling
- [ ] Existing FileSystemInfo unit tests still pass