### PR TITLE
fix: context hash crash on unsupported directory entries

### DIFF
--- a/.changeset/context-hash-null-entry.md
+++ b/.changeset/context-hash-null-entry.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix context hash crash on unsupported directory entries like FIFOs and sockets.

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -4138,7 +4138,7 @@ class FileSystemInfo {
 				/**
 				 * Returns reduced hash.
 				 * @param {string[]} files files
-				 * @param {(string | ContextHash)[]} fileHashes hashes
+				 * @param {(string | ContextHash | null)[]} fileHashes hashes
 				 * @returns {ContextHash} reduced hash
 				 */
 				reduce: (files, fileHashes) => {
@@ -4148,10 +4148,13 @@ class FileSystemInfo {
 
 					for (const file of files) hash.update(file);
 					for (const entry of fileHashes) {
-						if (typeof entry === "string") {
+						// null for unsupported entry kinds (FIFO, socket); skip like the tsh reduce
+						if (!entry) {
+							continue;
+						} else if (typeof entry === "string") {
 							hash.update(entry);
 						} else {
-							hash.update(entry.hash);
+							if (entry.hash) hash.update(entry.hash);
 							if (entry.symlinks) {
 								if (symlinks === undefined) symlinks = new Set();
 								addAll(entry.symlinks, symlinks);

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -733,18 +733,13 @@ ${details(snapshot)}`)
 			fs.writeFileSync("/path/special/socket", "");
 			const originalLstat = fs.lstat.bind(fs);
 			jest.spyOn(fs, "lstat").mockImplementation((path, callback) => {
-				originalLstat(
-					/** @type {string} */ (path),
-					(/** @type {Error | null} */ err, /** @type {IStats} */ stats) => {
-						if (!err && path === "/path/special/socket") {
-							stats.isFile = () => false;
-							stats.isDirectory = () => false;
-						}
-						/** @type {(err: Error | null, stats?: IStats) => void} */ (
-							callback
-						)(err, stats);
+				originalLstat(path, (err, stats) => {
+					if (!err && stats && path === "/path/special/socket") {
+						stats.isFile = () => false;
+						stats.isDirectory = () => false;
 					}
-				);
+					/** @type {EXPECTED_ANY} */ (callback)(err, stats);
+				});
 			});
 			return fs;
 		};

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -4,6 +4,7 @@
 /** @typedef {import("../lib/FileSystemInfo").SnapshotOptions} SnapshotOptions */
 /** @typedef {import("../lib/errors/WebpackError")} WebpackError */
 /** @typedef {import("memfs").IFs} IFs */
+/** @typedef {import("../lib/util/fs").IStats} IStats */
 
 const util = require("util");
 const { Volume, createFsFromVolume } = require("memfs");
@@ -718,6 +719,47 @@ ${details(snapshot)}`)
 				if (err) return done(err);
 				expect(typeof hash).toBe("string");
 				done();
+			});
+		});
+	});
+
+	describe("unsupported directory entries", () => {
+		// #21482: entries that are neither file, dir nor symlink (FIFO, socket)
+		// reduce to `null`; the hash reduce must skip them like the tsh reduce.
+		const createFsWithSpecialFile = () => {
+			const fs = createFs();
+			fs.mkdirSync("/path/special");
+			fs.writeFileSync("/path/special/file.txt", "Hello World");
+			fs.writeFileSync("/path/special/socket", "");
+			const originalLstat = fs.lstat.bind(fs);
+			jest.spyOn(fs, "lstat").mockImplementation((path, callback) => {
+				originalLstat(
+					/** @type {string} */ (path),
+					(/** @type {Error | null} */ err, /** @type {IStats} */ stats) => {
+						if (!err && path === "/path/special/socket") {
+							stats.isFile = () => false;
+							stats.isDirectory = () => false;
+						}
+						/** @type {(err: Error | null, stats?: IStats) => void} */ (
+							callback
+						)(err, stats);
+					}
+				);
+			});
+			return fs;
+		};
+
+		it("should hash a context containing an unsupported entry", (done) => {
+			const fs = createFsWithSpecialFile();
+			createFsInfo(fs).getContextHash("/path/special", (err, hash) => {
+				if (err) return done(err);
+				expect(typeof hash).toBe("string");
+				// must equal the tsh reduce's hash, which skips the null entry
+				createFsInfo(fs).getContextTsh("/path/special", (err2, tsh) => {
+					if (err2) return done(err2);
+					expect(/** @type {NonNullable<typeof tsh>} */ (tsh).hash).toBe(hash);
+					done();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
**Summary**

Fixes #21482. `_readContextHash`'s `reduce` passed `null` entries — directory entries that are neither a regular file, a directory, nor a symlink (FIFOs, sockets, device nodes) — straight to `hash.update`, crashing snapshot creation, while the timestamp and tsh reduces already guard this case. The null entry is now skipped exactly like in the tsh reduce, so both paths produce identical hash digests, and a missing `entry.hash` is guarded as well.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**                                                                   
fix          
                                                                                                     
**Did you add tests for your changes?**         
                                                                  
Yes — a regression test in `test/FileSystemInfo.unittest.js` (`unsupported directory entries`) that reproduces the crash and asserts the hash matches the tsh

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented ed or what have you already documented?**

n/a

**Use of AI**

Claude Code was used to trace the `null`-enix, and write the regression test; I reviewed and verified all changes and test results myself. 