### PR TITLE
fix: keep loader results as JavaScript when css/html support is implicitly enabled

### DIFF
--- a/.changeset/020-css-html-experiments-auto.md
+++ b/.changeset/020-css-html-experiments-auto.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Default `experiments.css`, `experiments.html` and `experiments.asyncWebAssembly` to `"auto"`, enabling built-in support unless a loader is registered for those files.
+Default `experiments.css`, `experiments.html` and `experiments.asyncWebAssembly` to `"auto"`, enabling built-in support unless a loader is registered for those files; modules with inline or hook-injected loaders (e.g. html-webpack-plugin templates) keep being parsed as JavaScript.

--- a/.changeset/625-module-parse-error-code-frame.md
+++ b/.changeset/625-module-parse-error-code-frame.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Improve module parse errors with a babel-style code frame and the module type.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -657,14 +657,20 @@ const applyExperimentsDefaults = (
 	// enabling them by default does not break existing css-loader/html-loader setups.
 	// The built-in `/\.css$/i` rule also covers `.module.css`, so a loader scoped to
 	// CSS modules must disable the built-in type too — sample both extensions.
+	// When enabled implicitly the value stays `"auto"` (truthy): Css/HtmlModulesPlugin
+	// then step aside per-module for requests that loaders were applied to
+	// (inline requests or loaders injected via hooks, e.g. html-webpack-plugin).
+	// TODO webpack 6: css/html default to `true`, drop the `"auto"` marker.
 	if (experiments.css === "auto") {
-		experiments.css = !(
-			RuleSetCompiler.hasRuleForResource(rules, "/file.css") ||
-			RuleSetCompiler.hasRuleForResource(rules, "/file.module.css")
-		);
+		experiments.css =
+			!(
+				RuleSetCompiler.hasRuleForResource(rules, "/file.css") ||
+				RuleSetCompiler.hasRuleForResource(rules, "/file.module.css")
+			) && "auto";
 	}
 	if (experiments.html === "auto") {
-		experiments.html = !RuleSetCompiler.hasRuleForResource(rules, "/file.html");
+		experiments.html =
+			!RuleSetCompiler.hasRuleForResource(rules, "/file.html") && "auto";
 	}
 	// Auto-enable only when the built-in TypeScript support can actually run:
 	// it needs `module.stripTypeScriptTypes` (Node.js >= 22.6) and must step

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -39,6 +39,7 @@ const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const { getUndoPath } = require("../util/identifier");
+const implicitTypeLoaderFallback = require("../util/implicitTypeLoaderFallback");
 const memoize = require("../util/memoize");
 const { digestNonNumericOnlyWithFull } = require("../util/nonNumericOnlyHash");
 const {
@@ -231,9 +232,21 @@ class CssModulesPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		// `"auto"` marks implicit enablement (no user rule for CSS files) — see
+		// `applyExperimentsDefaults`. Only then loaders win over the built-in type.
+		// TODO webpack 6: css defaults to `true`, drop this implicit-only fallback.
+		const implicitlyEnabled = compiler.options.experiments.css === "auto";
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				if (implicitlyEnabled) {
+					implicitTypeLoaderFallback(
+						normalModuleFactory,
+						PLUGIN_NAME,
+						/\.css$/i,
+						CSS_MODULE_TYPE_AUTO
+					);
+				}
 				const hooks = CssModulesPlugin.getCompilationHooks(compilation);
 				compilation.dependencyFactories.set(
 					CssImportDependency,

--- a/lib/errors/ModuleParseError.js
+++ b/lib/errors/ModuleParseError.js
@@ -41,19 +41,24 @@ class ModuleParseError extends WebpackError {
 				"\nYou need to enable one of the WebAssembly experiments via 'experiments.asyncWebAssembly: true' (based on async modules) or 'experiments.syncWebAssembly: true' (like webpack 4, deprecated).";
 			message +=
 				"\nFor files that transpile to WebAssembly, make sure to set the module type in the 'module.rules' section of the config (e. g. 'type: \"webassembly/async\"').";
-		} else if (!loaders) {
-			message +=
-				"\nYou may need an appropriate loader to handle this file type. " +
-				"See https://webpack.js.org/concepts/loaders";
-		} else if (loaders.length >= 1) {
-			message += `\nFile was processed with these loaders:${loaders
-				.map((loader) => `\n * ${loader}`)
-				.join("")}`;
-			message +=
-				"\nYou may need an additional loader to handle the result of these loaders.";
 		} else {
-			message +=
-				"\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders";
+			message += `\nFile was parsed as module type '${type}'.`;
+			// `loaders` is undefined when the serializer re-runs this constructor
+			// during cache deserialization — keep that branch so it never throws.
+			if (!loaders) {
+				message +=
+					"\nYou may need an appropriate loader to handle this file type. " +
+					"See https://webpack.js.org/concepts/loaders";
+			} else if (loaders.length >= 1) {
+				message += `\nFile was processed with these loaders:${loaders
+					.map((loader) => `\n * ${loader}`)
+					.join("")}`;
+				message +=
+					"\nYou may need an additional loader to handle the result of these loaders.";
+			} else {
+				message +=
+					"\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders";
+			}
 		}
 
 		if (
@@ -73,16 +78,28 @@ class ModuleParseError extends WebpackError {
 				message += "\n(Source code omitted for this binary file)";
 			} else {
 				const sourceLines = source.split(/\r?\n/);
-				const start = Math.max(0, lineNumber - 3);
-				const linesBefore = sourceLines.slice(start, lineNumber - 1);
-				const theLine = sourceLines[lineNumber - 1];
-				const linesAfter = sourceLines.slice(lineNumber, lineNumber + 2);
-
-				message += `${linesBefore
-					.map((l) => `\n| ${l}`)
-					.join(
-						""
-					)}\n> ${theLine}${linesAfter.map((l) => `\n| ${l}`).join("")}`;
+				if (lineNumber >= 1 && lineNumber <= sourceLines.length) {
+					// babel-like code frame: numbered gutter, `>` on the error line
+					// and a `^` caret at the error column
+					const column =
+						typeof err.loc.column === "number" ? err.loc.column : undefined;
+					const start = Math.max(1, lineNumber - 1);
+					const end = Math.min(sourceLines.length, lineNumber + 1);
+					const width = `${end}`.length;
+					for (let n = start; n <= end; n++) {
+						const line = sourceLines[n - 1];
+						const gutter = `${n}`.padStart(width);
+						message +=
+							n === lineNumber
+								? `\n> ${gutter} | ${line}`
+								: `\n  ${gutter} | ${line}`;
+						if (n === lineNumber && column !== undefined) {
+							// keep tabs so the caret stays aligned under tab-indented code
+							const align = line.slice(0, column).replace(/[^\t]/g, " ");
+							message += `\n  ${" ".repeat(width)} | ${align}^`;
+						}
+					}
+				}
 			}
 
 			loc = { start: err.loc };

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -27,6 +27,7 @@ const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const { getUndoPath, makePathsRelative } = require("../util/identifier");
+const implicitTypeLoaderFallback = require("../util/implicitTypeLoaderFallback");
 const memoize = require("../util/memoize");
 const { digestNonNumericOnly } = require("../util/nonNumericOnlyHash");
 const {
@@ -421,9 +422,22 @@ class HtmlModulesPlugin {
 			integrity === true ||
 			typeof integrity === "function" ||
 			(Array.isArray(integrity) && integrity.length > 0);
+		// `"auto"` marks implicit enablement (no user rule for HTML files) — see
+		// `applyExperimentsDefaults`. Only then loaders win over the built-in type
+		// (e.g. html-webpack-plugin's template loader in its child compiler).
+		// TODO webpack 6: html defaults to `true`, drop this implicit-only fallback.
+		const implicitlyEnabled = compiler.options.experiments.html === "auto";
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				if (implicitlyEnabled) {
+					implicitTypeLoaderFallback(
+						normalModuleFactory,
+						PLUGIN_NAME,
+						/\.html$/i,
+						HTML_MODULE_TYPE
+					);
+				}
 				const { htmlModules } = getState(compilation);
 				// Record HTML modules as they appear — freshly built
 				// (`succeedModule`) or restored from cache (`stillValidModule`) —

--- a/lib/util/implicitTypeLoaderFallback.js
+++ b/lib/util/implicitTypeLoaderFallback.js
@@ -1,0 +1,62 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const { JAVASCRIPT_MODULE_TYPE_AUTO } = require("../ModuleTypeConstants");
+const { parseResource } = require("./identifier");
+
+/** @typedef {import("../NormalModuleFactory")} NormalModuleFactory */
+
+/**
+ * When a built-in module type is only enabled implicitly (`experiments.css` /
+ * `experiments.html` resolved from their `"auto"` default), modules that reach
+ * the factory with loaders applied — an inline request or loaders injected via
+ * hooks (e.g. html-webpack-plugin's template loader) — keep the pre-existing
+ * behavior: the loader result is parsed as JavaScript, not as the built-in type.
+ * A `!=!` matchResource is an explicit re-type of the loader result and wins.
+ *
+ * TODO webpack 6: css/html are enabled unconditionally (`experiments.*: true`),
+ * so this implicit-only workaround can be removed together with the `"auto"`
+ * marker in `applyExperimentsDefaults`.
+ * @param {NormalModuleFactory} normalModuleFactory the normal module factory
+ * @param {string} pluginName name of the calling plugin, used for the tap
+ * @param {RegExp} test resource path test of the built-in default rule
+ * @param {string} type built-in module type assigned by that default rule
+ * @returns {void}
+ */
+module.exports = (normalModuleFactory, pluginName, test, type) => {
+	normalModuleFactory.hooks.createModule.tap(
+		pluginName,
+		(createData, _resolveData) => {
+			if (
+				createData.settings.type !== type ||
+				createData.loaders.length === 0 ||
+				createData.matchResource !== undefined ||
+				!test.test(parseResource(createData.resource).path)
+			) {
+				return;
+			}
+			// Drop the default rule's type-specific effects along with the type
+			createData.settings = {
+				...createData.settings,
+				type: JAVASCRIPT_MODULE_TYPE_AUTO,
+				parser: undefined,
+				generator: undefined,
+				resolve: undefined
+			};
+			createData.type = JAVASCRIPT_MODULE_TYPE_AUTO;
+			createData.parser = normalModuleFactory.getParser(
+				JAVASCRIPT_MODULE_TYPE_AUTO
+			);
+			createData.parserOptions = undefined;
+			createData.generator = normalModuleFactory.getGenerator(
+				JAVASCRIPT_MODULE_TYPE_AUTO
+			);
+			createData.generatorOptions = undefined;
+			createData.resolveOptions = undefined;
+		}
+	);
+};

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -140,10 +140,10 @@ describe("snapshots", () => {
 		    "backCompat": true,
 		    "buildHttp": undefined,
 		    "cacheUnaffected": false,
-		    "css": true,
+		    "css": "auto",
 		    "deferImport": false,
 		    "futureDefaults": false,
-		    "html": true,
+		    "html": "auto",
 		    "lazyCompilation": undefined,
 		    "outputModule": false,
 		    "sourceImport": false,
@@ -4011,10 +4011,14 @@ describe("snapshots", () => {
 			+     "backCompat": false,
 			@@ ... @@
 			-     "cacheUnaffected": false,
+			-     "css": "auto",
 			+     "cacheUnaffected": true,
+			+     "css": true,
 			@@ ... @@
 			-     "futureDefaults": false,
+			-     "html": "auto",
 			+     "futureDefaults": true,
+			+     "html": true,
 			@@ ... @@
 			-     "progress": false,
 			+     "progress": "auto",
@@ -4033,10 +4037,11 @@ describe("snapshots", () => {
 			+           Object {
 			+             "resourceQuery": /(\\?|&)no-inline(&|$)/,
 			+             "type": "asset/resource",
-			+           },
+			@@ ... @@
 			+           Object {
 			+             "resourceQuery": /(\\?|&)inline(&|$)/,
 			+             "type": "asset/inline",
+			+           },
 			@@ ... @@
 			+       },
 			+     ],
@@ -4472,21 +4477,24 @@ describe("snapshots", () => {
 			+     "backCompat": false,
 			@@ ... @@
 			-     "cacheUnaffected": false,
+			-     "css": "auto",
 			+     "cacheUnaffected": true,
+			+     "css": true,
 			@@ ... @@
 			-     "futureDefaults": false,
+			-     "html": "auto",
 			+     "futureDefaults": true,
+			+     "html": true,
 			@@ ... @@
 			-     "progress": false,
 			+     "progress": "auto",
 			@@ ... @@
-			+       },
 			+       Object {
 			+         "oneOf": Array [
 			+           Object {
 			+             "resourceQuery": /(\\?|&)raw(&|$)/,
 			+             "type": "asset/source",
-			@@ ... @@
+			+           },
 			+           Object {
 			+             "resourceQuery": /(\\?|&)url(&|$)/,
 			+             "type": "asset/resource",
@@ -4499,8 +4507,9 @@ describe("snapshots", () => {
 			+             "resourceQuery": /(\\?|&)inline(&|$)/,
 			+             "type": "asset/inline",
 			+           },
-			+         ],
+			@@ ... @@
 			+       },
+			+     ],
 			@@ ... @@
 			-         "localIdentHashFunction": "md4",
 			+         "localIdentHashFunction": "xxhash64",
@@ -4570,12 +4579,14 @@ describe("snapshots", () => {
 			+     "backCompat": false,
 			@@ ... @@
 			-     "cacheUnaffected": false,
-			-     "css": true,
+			-     "css": "auto",
 			+     "cacheUnaffected": true,
 			+     "css": false,
 			@@ ... @@
 			-     "futureDefaults": false,
+			-     "html": "auto",
 			+     "futureDefaults": true,
+			+     "html": true,
 			@@ ... @@
 			-     "progress": false,
 			+     "progress": "auto",
@@ -4604,16 +4615,13 @@ describe("snapshots", () => {
 			-           "preferRelative": true,
 			-         },
 			-         "type": "css",
-			-       },
-			-       Object {
+			@@ ... @@
 			-         "dependency": /css-import-local-module/,
 			-         "exclude": /\\.module\\.\\w+$/i,
-			-         "resolve": Object {
-			-           "fullySpecified": true,
-			-           "preferRelative": true,
+			@@ ... @@
 			-         },
 			-         "type": "css/module",
-			-       },
+			@@ ... @@
 			-       Object {
 			-         "dependency": /css-import-global-module/,
 			-         "exclude": /\\.module\\.\\w+$/i,
@@ -4638,7 +4646,7 @@ describe("snapshots", () => {
 			-       Object {
 			-         "assert": Object {
 			-           "type": "css",
-			@@ ... @@
+			-         },
 			-         "parser": Object {
 			-           "exportType": "css-style-sheet",
 			-         },
@@ -4647,12 +4655,24 @@ describe("snapshots", () => {
 			-           "preferRelative": true,
 			-         },
 			-       },
+			-       Object {
+			-         "resolve": Object {
+			-           "fullySpecified": true,
+			-           "preferRelative": true,
+			-         },
 			@@ ... @@
+			-         },
+			-         "resolve": Object {
+			-           "fullySpecified": true,
+			-           "preferRelative": true,
+			-         },
+			-       },
+			-       Object {
 			-         "dependency": "html-style",
 			-         "parser": Object {
 			-           "exportType": "text",
 			-         },
-			@@ ... @@
+			-         "resolve": Object {
 			-           "fullySpecified": true,
 			-           "preferRelative": true,
 			-         },
@@ -4662,14 +4682,6 @@ describe("snapshots", () => {
 			-         "parser": Object {
 			-           "as": "block-contents",
 			-           "exportType": "text",
-			-         },
-			-         "resolve": Object {
-			-           "fullySpecified": true,
-			-           "preferRelative": true,
-			-         },
-			-       },
-			-       Object {
-			-         "resolve": Object {
 			@@ ... @@
 			-     ],
 			-     "generator": Object {
@@ -4692,6 +4704,10 @@ describe("snapshots", () => {
 			+           Object {
 			+             "resourceQuery": /(\\?|&)url(&|$)/,
 			+             "type": "asset/resource",
+			+           },
+			+           Object {
+			+             "resourceQuery": /(\\?|&)no-inline(&|$)/,
+			+             "type": "asset/resource",
 			@@ ... @@
 			-       "css/global": Object {
 			-         "exportsConvention": "as-is",
@@ -4700,10 +4716,6 @@ describe("snapshots", () => {
 			-         "localIdentHashFunction": "md4",
 			-         "localIdentHashSalt": undefined,
 			-         "localIdentName": "[fullhash]",
-			+           Object {
-			+             "resourceQuery": /(\\?|&)no-inline(&|$)/,
-			+             "type": "asset/resource",
-			+           },
 			+           Object {
 			+             "resourceQuery": /(\\?|&)inline(&|$)/,
 			+             "type": "asset/inline",
@@ -4720,6 +4732,8 @@ describe("snapshots", () => {
 			+     ],
 			+     "generator": Object {
 			@@ ... @@
+			-         },
+			-       },
 			-       "css": Object {
 			-         "customMedia": true,
 			-         "customSelectors": true,
@@ -4746,7 +4760,7 @@ describe("snapshots", () => {
 			-         "dashedIdents": true,
 			-         "function": true,
 			-         "grid": true,
-			-       },
+			@@ ... @@
 			-       "css/module": Object {
 			-         "animation": true,
 			-         "container": true,
@@ -4756,7 +4770,6 @@ describe("snapshots", () => {
 			-         "dashedIdents": true,
 			-         "function": true,
 			-         "grid": true,
-			-       },
 			@@ ... @@
 			+         "exportsPresence": "error",
 			@@ ... @@
@@ -5082,9 +5095,11 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 	};
 
 	it("enables the built-in css/html/wasm support by default (no loaders)", () => {
+		// css/html keep the `"auto"` marker (truthy): loaders on a module then
+		// take precedence over the implicitly enabled built-in type.
 		expect(resolve({})).toEqual({
-			css: true,
-			html: true,
+			css: "auto",
+			html: "auto",
 			asyncWebAssembly: true
 		});
 	});
@@ -5092,7 +5107,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 	it("keeps css off when a loader is registered for .css files", () => {
 		expect(
 			resolve({ module: { rules: [{ test: /\.css$/i, use: ["css-loader"] }] } })
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps css off when a loader also covers .module.css", () => {
@@ -5100,7 +5115,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 			resolve({
 				module: { rules: [{ test: /\.module\.css$/i, use: ["css-loader"] }] }
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps html off when a loader is registered for .html files", () => {
@@ -5108,7 +5123,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 			resolve({
 				module: { rules: [{ test: /\.html$/i, loader: "html-loader" }] }
 			})
-		).toEqual({ css: true, html: false, asyncWebAssembly: true });
+		).toEqual({ css: "auto", html: false, asyncWebAssembly: true });
 	});
 
 	it("keeps async wasm off when a loader is registered for .wasm files", () => {
@@ -5116,13 +5131,13 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 			resolve({
 				module: { rules: [{ test: /\.wasm$/i, use: ["wasm-loader"] }] }
 			})
-		).toEqual({ css: true, html: true, asyncWebAssembly: false });
+		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: false });
 	});
 
 	it("keeps async wasm off when syncWebAssembly is enabled", () => {
 		expect(resolve({ experiments: { syncWebAssembly: true } })).toEqual({
-			css: true,
-			html: true,
+			css: "auto",
+			html: "auto",
 			asyncWebAssembly: false
 		});
 	});
@@ -5142,7 +5157,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					]
 				}
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps css off for a loader scoped to specific .css filenames", () => {
@@ -5157,7 +5172,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					]
 				}
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps css off for a combined sass/less rule that also covers .css", () => {
@@ -5174,7 +5189,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					]
 				}
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("leaves css on when sass/less loaders only handle .scss/.less", () => {
@@ -5189,7 +5204,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					]
 				}
 			})
-		).toEqual({ css: true, html: true, asyncWebAssembly: true });
+		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: true });
 	});
 
 	it("stays lenient about include/exclude narrowing", () => {
@@ -5201,7 +5216,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					rules: [{ test: /\.css$/i, include: /src/, use: ["css-loader"] }]
 				}
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps css on when only an enforce:pre loader targets .css", () => {
@@ -5215,7 +5230,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 					]
 				}
 			})
-		).toEqual({ css: true, html: true, asyncWebAssembly: true });
+		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: true });
 	});
 
 	it("ignores loaders registered for unrelated extensions", () => {
@@ -5223,7 +5238,7 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 			resolve({
 				module: { rules: [{ test: /\.js$/i, use: ["babel-loader"] }] }
 			})
-		).toEqual({ css: true, html: true, asyncWebAssembly: true });
+		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: true });
 	});
 
 	it("applies the default dev css source map to auto-enabled css", () => {
@@ -5270,13 +5285,13 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 			resolve({
 				experiments: { css: "auto", html: "auto", asyncWebAssembly: "auto" }
 			})
-		).toEqual({ css: true, html: true, asyncWebAssembly: true });
+		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: true });
 		expect(
 			resolve({
 				experiments: { css: "auto" },
 				module: { rules: [{ test: /\.css$/i, use: ["css-loader"] }] }
 			})
-		).toEqual({ css: false, html: true, asyncWebAssembly: true });
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
 	});
 
 	it("keeps futureDefaults forcing the experiments on even with a loader", () => {

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -393,7 +393,7 @@ describe("Errors", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "2:12",
-		      "message": "Module parse failed: Unexpected token (2:12)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n| window.foo = {\\n>   bar: true,;\\n| };\\n| ",
+		      "message": "Module parse failed: Unexpected token (2:12)\\nFile was parsed as module type 'javascript/auto'.\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n  1 | window.foo = {\\n> 2 |   bar: true,;\\n    |             ^\\n  3 | };",
 		      "moduleId": 0,
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/has-syntax-error.js",
 		      "moduleName": "./has-syntax-error.js",
@@ -797,7 +797,7 @@ describe("Loaders", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0",
-		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was parsed as module type 'javascript/auto'.\\nFile was processed with these loaders:\\n * ./identity-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> 1 | <!DOCTYPE html>\\n    | ^\\n  2 | <html>",
 		      "moduleId": "./abc.html",
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/abc.html",
 		      "moduleName": "./abc.html",
@@ -828,7 +828,7 @@ describe("Loaders", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0",
-		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was parsed as module type 'javascript/auto'.\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> 1 | <!DOCTYPE html>\\n    | ^\\n  2 | <html>",
 		      "moduleId": "./abc.html",
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
 		      "moduleName": "./abc.html",
@@ -857,7 +857,7 @@ describe("Loaders", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0",
-		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was parsed as module type 'javascript/auto'.\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> 1 | <!DOCTYPE html>\\n    | ^\\n  2 | <html>",
 		      "moduleId": "./abc.html",
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
 		      "moduleName": "./abc.html",
@@ -883,7 +883,7 @@ describe("Loaders", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0",
-		      "message": "Module parse failed: Unexpected token (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+		      "message": "Module parse failed: Unexpected token (1:0)\\nFile was parsed as module type 'javascript/auto'.\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n> 1 | <!DOCTYPE html>\\n    | ^\\n  2 | <html>",
 		      "moduleId": "./abc.html",
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/abc.html",
 		      "moduleName": "./abc.html",
@@ -908,7 +908,7 @@ describe("Loaders", () => {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0",
-		      "message": "Module parse failed: Unexpected character ' ' (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n(Source code omitted for this binary file)",
+		      "message": "Module parse failed: Unexpected character ' ' (1:0)\\nFile was parsed as module type 'javascript/auto'.\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n(Source code omitted for this binary file)",
 		      "moduleId": "../font.ttf",
 		      "moduleIdentifier": "<cwd>/test/fixtures/font.ttf",
 		      "moduleName": "../font.ttf",

--- a/test/cases/parsing/context/__snapshots__/errors.snap
+++ b/test/cases/parsing/context/__snapshots__/errors.snap
@@ -3,9 +3,10 @@
 exports[`errors 1`] = `
 Array [
   "Module parse failed: Unexpected token (1:5)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> This is a file!
-| 
-| with some content",
+> 1 | This is a file!
+    |      ^
+  2 |",
 ]
 `;

--- a/test/configCases/css/auto-loader-fallback/content.js
+++ b/test/configCases/css/auto-loader-fallback/content.js
@@ -1,0 +1,2 @@
+// Raw input for the `!=!` matchResource case; replaced by css-loader.js output.
+module.exports = "never used";

--- a/test/configCases/css/auto-loader-fallback/css-loader.js
+++ b/test/configCases/css/auto-loader-fallback/css-loader.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// Stand-in for a loader whose result is CSS text.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function () {
+	return ".generated { color: blue; }";
+};

--- a/test/configCases/css/auto-loader-fallback/index.js
+++ b/test/configCases/css/auto-loader-fallback/index.js
@@ -1,0 +1,23 @@
+import * as asCss from "./as-css.css!=!./css-loader.js!./content.js";
+import * as plain from "./plain.css";
+
+it("should fall back to javascript for an inline loader request", () => {
+	// The loader turns the CSS into a JS module; the built-in css type would
+	// instead export an object, so this value proves the fallback applied.
+	expect(require("./js-loader.js!./inline.css")).toBe(
+		"LOADED_BY_CUSTOM_LOADER"
+	);
+});
+
+it("should fall back to javascript for a hook-injected loader", () => {
+	expect(require("./injected.css")).toBe("LOADED_BY_CUSTOM_LOADER");
+});
+
+it("should keep the built-in css type for loader-free .css files", () => {
+	expect(plain).toEqual({});
+});
+
+it("should keep the built-in css type for an explicit `!=!` matchResource", () => {
+	// `!=!` re-types the loader result as `.css` on purpose — no fallback.
+	expect(asCss).toEqual({});
+});

--- a/test/configCases/css/auto-loader-fallback/injected.css
+++ b/test/configCases/css/auto-loader-fallback/injected.css
@@ -1,0 +1,3 @@
+.injected {
+	color: green;
+}

--- a/test/configCases/css/auto-loader-fallback/inline.css
+++ b/test/configCases/css/auto-loader-fallback/inline.css
@@ -1,0 +1,3 @@
+.inline {
+	color: red;
+}

--- a/test/configCases/css/auto-loader-fallback/js-loader.js
+++ b/test/configCases/css/auto-loader-fallback/js-loader.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// Stand-in for a loader whose result is JavaScript, not CSS.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function () {
+	return `module.exports = ${JSON.stringify("LOADED_BY_CUSTOM_LOADER")};`;
+};

--- a/test/configCases/css/auto-loader-fallback/plain.css
+++ b/test/configCases/css/auto-loader-fallback/plain.css
@@ -1,0 +1,3 @@
+.plain {
+	color: blue;
+}

--- a/test/configCases/css/auto-loader-fallback/webpack.config.js
+++ b/test/configCases/css/auto-loader-fallback/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const path = require("path");
+
+const PLUGIN_NAME = "InjectLoaderPlugin";
+
+// `experiments.css` stays at its "auto" default (no `.css` rule in `module.rules`),
+// but loaders still reach `.css` modules — via an inline request or injected by a
+// plugin hook. Those modules must fall back to javascript so the loader result is
+// not misparsed by the built-in CSS type.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	plugins: [
+		(compiler) => {
+			compiler.hooks.normalModuleFactory.tap(PLUGIN_NAME, (nmf) => {
+				nmf.hooks.afterResolve.tap(PLUGIN_NAME, (resolveData) => {
+					const createData = resolveData.createData;
+					if (/injected\.css$/.test(String(createData.resource))) {
+						/** @type {NonNullable<(typeof createData)["loaders"]>} */
+						(createData.loaders).push({
+							loader: path.resolve(__dirname, "js-loader.js"),
+							options: undefined
+						});
+					}
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/html/template-loader-fallback/index.js
+++ b/test/configCases/html/template-loader-fallback/index.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+it("compiles an html-webpack-plugin-style template through a child compiler with auto html", () => {
+	// The rendered page proves the child module for `template.html` was parsed
+	// as JavaScript (the loader result), not misparsed by the built-in HTML type.
+	const html = fs.readFileSync(path.resolve(__dirname, "index.html"), "utf-8");
+	expect(html).toContain("<title>Hello</title>");
+	// The inline <script> stays part of the template — it must not be extracted
+	// into its own entry by the HTML pipeline.
+	expect(html).toContain("alert(");
+	expect(html).toContain("<h1>Static heading</h1>");
+});

--- a/test/configCases/html/template-loader-fallback/template-loader.js
+++ b/test/configCases/html/template-loader-fallback/template-loader.js
@@ -1,0 +1,13 @@
+"use strict";
+
+// Minimal stand-in for html-webpack-plugin's lodash template loader: turns the
+// HTML source into a JS module exporting a template function. The source is
+// embedded only as a JSON data literal (never into the constructed function
+// body), so this stays an executable JS module without tripping code scanners.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function (source) {
+	return [
+		`var template = ${JSON.stringify(source)};`,
+		'module.exports = function (params) { return template.replace("{title}", params.title); };'
+	].join("\n");
+};

--- a/test/configCases/html/template-loader-fallback/template.html
+++ b/test/configCases/html/template-loader-fallback/template.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+	<head>
+		<title>{title}</title>
+		<script>
+			alert('inline scripts must not be extracted from loader results');
+		</script>
+	</head>
+	<body>
+		<h1>Static heading</h1>
+	</body>
+</html>

--- a/test/configCases/html/template-loader-fallback/webpack.config.js
+++ b/test/configCases/html/template-loader-fallback/webpack.config.js
@@ -1,0 +1,121 @@
+"use strict";
+
+const path = require("path");
+
+const PLUGIN = "MiniHtmlWebpackPlugin";
+const CHILD = "MiniHtmlWebpackCompiler";
+
+/** @typedef {(templateParameters: { title: string }) => string} Render */
+
+// A faithful miniature of html-webpack-plugin: it compiles the HTML template in
+// a *child compiler* via `templateLoader!template.html`, evaluates the resulting
+// JS module to a render function, and emits the rendered page. `experiments.html`
+// stays at its "auto" default (no `.html` rule), so this reproduces the real
+// regression: the child module for `template.html` must be parsed as JavaScript
+// (a loader is applied) and not as the built-in HTML type, or the loader's JS
+// output is misparsed and the build breaks.
+class MiniHtmlWebpackPlugin {
+	/**
+	 * @param {{ template: string, filename: string, templateParameters: { title: string } }} options options
+	 */
+	constructor(options) {
+		this.options = options;
+	}
+
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		const {
+			EntryPlugin,
+			node: { NodeTemplatePlugin, NodeTargetPlugin },
+			library: { EnableLibraryPlugin },
+			LoaderTargetPlugin,
+			optimize: { LimitChunkCountPlugin },
+			Compilation,
+			sources: { RawSource }
+		} = compiler.webpack;
+		const { template, filename, templateParameters } = this.options;
+		const loader = path.resolve(__dirname, "template-loader.js");
+
+		compiler.hooks.thisCompilation.tap(PLUGIN, (compilation) => {
+			compilation.hooks.processAssets.tapAsync(
+				{ name: PLUGIN, stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL },
+				(assets, callback) => {
+					const childCompiler = compilation.createChildCompiler(
+						CHILD,
+						{ filename: "__child-[name]", library: { type: "commonjs2" } },
+						[
+							new NodeTemplatePlugin(),
+							new NodeTargetPlugin(),
+							new EnableLibraryPlugin("commonjs2"),
+							new LoaderTargetPlugin("node"),
+							new EntryPlugin(
+								compiler.context,
+								`${loader}!${template}`,
+								"html"
+							),
+							new LimitChunkCountPlugin({ maxChunks: 1 })
+						]
+					);
+
+					/** @type {string | undefined} */
+					let source;
+					childCompiler.hooks.compilation.tap(CHILD, (childCompilation) => {
+						childCompilation.hooks.processAssets.tap(
+							{
+								name: CHILD,
+								stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+							},
+							() => {
+								const asset = childCompilation.assets["__child-html"];
+								source = asset && asset.source().toString();
+								for (const chunk of childCompilation.chunks) {
+									for (const file of chunk.files) {
+										childCompilation.deleteAsset(file);
+									}
+								}
+							}
+						);
+					});
+
+					childCompiler.runAsChild((err, _entries, childCompilation) => {
+						if (err) return callback(err);
+						if (childCompilation && childCompilation.errors.length > 0) {
+							return callback(childCompilation.errors[0]);
+						}
+						if (!source) {
+							return callback(new Error("No result from child compiler"));
+						}
+						/** @type {{ exports: { default?: Render } & Render }} */
+						const module = { exports: /** @type {EXPECTED_ANY} */ ({}) };
+						// eslint-disable-next-line no-new-func
+						new Function("module", "exports", "require", source)(
+							module,
+							module.exports,
+							require
+						);
+						const render = module.exports.default || module.exports;
+						compilation.emitAsset(
+							filename,
+							new RawSource(render(templateParameters))
+						);
+						callback();
+					});
+				}
+			);
+		});
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	plugins: [
+		new MiniHtmlWebpackPlugin({
+			template: path.resolve(__dirname, "template.html"),
+			filename: "index.html",
+			templateParameters: { title: "Hello" }
+		})
+	]
+};

--- a/test/configCases/parsing/context/__snapshots__/errors.snap
+++ b/test/configCases/parsing/context/__snapshots__/errors.snap
@@ -3,9 +3,10 @@
 exports[`errors 1`] = `
 Array [
   "Module parse failed: Unexpected token (1:5)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> This is a file!
-| 
-| with some content",
+> 1 | This is a file!
+    |      ^
+  2 |",
 ]
 `;

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/identity-loader.js
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/identity-loader.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function (source) {
+	// Passes the TypeScript source through untouched: the built-in strip-types
+	// must still run afterwards even though a loader was applied via an inline
+	// request (not registered in `module.rules`).
+	return source;
+};

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/index.ts
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/index.ts
@@ -1,0 +1,10 @@
+import answer from "!!./identity-loader.js!./typed.ts";
+import product from "!!./js-emitting-loader.js!./replaced.ts";
+
+it("strips types after an inline loader under auto typescript", () => {
+	expect(answer).toBe(42);
+});
+
+it("no-ops strip-types when an inline loader already emits plain JS", () => {
+	expect(product).toBe(21);
+});

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/js-emitting-loader.js
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/js-emitting-loader.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function () {
+	// Emits already-plain JS (no type syntax) for a `.ts` resource — mirrors
+	// html-webpack-plugin's template loader. The built-in strip-types must be a
+	// harmless no-op here, not a misparse.
+	return "module.exports = 7 * 3;";
+};

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/replaced.ts
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/replaced.ts
@@ -1,0 +1,2 @@
+const willBeReplaced: string = "unused";
+export default willBeReplaced;

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/test.filter.js
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/test.filter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = () => "stripTypeScriptTypes" in require("module");

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/tsconfig.json
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true
+	}
+}

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/typed.ts
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/typed.ts
@@ -1,0 +1,4 @@
+const value: number = 41;
+type Answer = number;
+const answer: Answer = value + 1;
+export default answer;

--- a/test/configCases/typescript/experiments-auto-and-inline-loader/webpack.config.js
+++ b/test/configCases/typescript/experiments-auto-and-inline-loader/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// `experiments.typescript` stays at its "auto" default (no `.ts` rule in
+// `module.rules`), so the built-in support auto-enables. A loader applied via
+// an inline request — the html-webpack-plugin-style path that `module.rules`
+// can't see — must still get its output stripped, not misparsed.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.ts"
+};

--- a/test/statsCases/module-trace-disabled-in-error/__snapshots__/StatsTest.snap
+++ b/test/statsCases/module-trace-disabled-in-error/__snapshots__/StatsTest.snap
@@ -12,12 +12,12 @@ Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/module-trace-di
 
 ERROR in ./parse-error.js 3:4
 Module parse failed: Unexpected token (3:4)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-| Here
-| could
-> be :)
-| your
-| code
+  2 | could
+> 3 | be :)
+    |     ^
+  4 | your
 
 webpack x.x.x compiled with 2 errors in X ms"
 `;

--- a/test/statsCases/module-trace-enabled-in-error/__snapshots__/StatsTest.snap
+++ b/test/statsCases/module-trace-enabled-in-error/__snapshots__/StatsTest.snap
@@ -14,12 +14,12 @@ Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/module-trace-en
 
 ERROR in ./parse-error.js 3:4
 Module parse failed: Unexpected token (3:4)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-| Here
-| could
-> be :)
-| your
-| code
+  2 | could
+> 3 | be :)
+    |     ^
+  4 | your
  @ ./inner.js 2:0-24
  @ ./index.js 1:0-18
 

--- a/test/statsCases/parse-error/__snapshots__/StatsTest.snap
+++ b/test/statsCases/parse-error/__snapshots__/StatsTest.snap
@@ -8,12 +8,12 @@ orphan modules X bytes [orphan] 1 module
 
 ERROR in ./b.js 6:7
 Module parse failed: Unexpected token (6:7)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-| includes
-| a
-> parser )
-| error
-| in
+  5 | a
+> 6 | parser )
+    |        ^
+  7 | error
  @ ./a.js 2:0-13
  @ ./index.js 2:0-13
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The `"auto"` default for `experiments.css` / `experiments.html` only checks `module.rules`, so it assigned the built-in css/html module type even to files a loader reached through an inline request or a plugin-injected loader — e.g. html-webpack-plugin compiles its template as `loader.js!template.html` in a child compiler. The loader's JavaScript output was then parsed as CSS/HTML and the build failed with an opaque `Module parse failed: Expecting Unicode escape sequence \uXXXX`. `Css`/`HtmlModulesPlugin` now step aside to `javascript/auto` for modules that have loaders applied (unless a `!=!` matchResource explicitly re-types the result). This PR also makes that class of failure legible: `ModuleParseError` gains a Babel-style code frame and states which module type the file was parsed as. Refs #19748.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix (primary); also includes a feat — richer `ModuleParseError` output — and tests.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/auto-loader-fallback`, `test/configCases/html/template-loader-fallback` (drives a real html-webpack-plugin-style child compiler), `test/configCases/typescript/experiments-auto-and-inline-loader`, and parse-error output assertions in `test/Errors.test.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — it restores the pre-regression behavior for loader-processed css/html files.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code (Anthropic) assisted with implementing the fix, writing the tests, and drafting this description; I reviewed and verified all changes, including reproducing the html-webpack-plugin failure and confirming the fix against a real create-react-app production build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G46PYxtF7AeiNzMnNc3CvD)_