### PR TITLE
fix(ci): use CodeQL workflow over implicit settings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,23 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    uses: nodejs/web-team/.github/workflows/codeql.yml@9f3c83af227d721768d9dbb63009a47ed4f4282f
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * 1"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: "0 0 * * 1"
 
 permissions:
   contents: read


### PR DESCRIPTION
Ref: https://discord.com/channels/1180618526436888586/1371080839341019237/1529970558001872987

Instead of relying on CodeQL's settings in this repository, we should explicitly define the CodeQL commands we wish to run.

This workflow is defined at https://github.com/nodejs/web-team/blob/main/.github/workflows/codeql.yml.