### PR TITLE
perf: build the experimental HTML parser at module scope

### DIFF
--- a/.changeset/035-hoist-html-parser-static-tables.md
+++ b/.changeset/035-hoist-html-parser-static-tables.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Hoist static HTML parser tables and helpers out of the per-parse hot path.

--- a/.changeset/035-hoist-html-parser-static-tables.md
+++ b/.changeset/035-hoist-html-parser-static-tables.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Hoist static HTML parser tables and helpers out of the per-parse hot path.

--- a/.changeset/035-html-parser-module-scope.md
+++ b/.changeset/035-html-parser-module-scope.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Build the HTML parser's helpers and state at module scope to cut per-parse allocation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,12 @@ Prefer the most specific real type. `EXPECTED_ANY`, `EXPECTED_OBJECT`, and `EXPE
 
 Prefer a generic (`@template`) over a widened type whenever a function's output type depends on its input — it keeps callers precisely typed instead of collapsing to `EXPECTED_ANY`.
 
+### Naming
+
+Spell names out in full — functions, variables, parameters, properties. Prefer `insertHtmlElement` over `insHtmlEl`, `attributeCount` over `attrCnt`, `current` over `cur`, `element` over `el`. Don't truncate or drop vowels to save characters; a clear name is worth the extra keystrokes.
+
+The only exceptions are (1) established abbreviations webpack already uses pervasively (`ast`, `ns` for namespace, `id`, `url`, `css`, `js`, `dir`, `env`, `fs`) or spec-defined ones (`afe` for the HTML spec's "active formatting elements"), and (2) throwaway loop indices (`i`, `j`, `k`). When an abbreviation isn't already common in the codebase or the relevant spec, write the full word.
+
 ### Source file headers
 
 Every source file under `lib/` (and `hot/`, `tooling/`) opens with the MIT license header. When adding a **new** file, set the `Author` line to its actual author (`Author <Name> @<github-handle>`) — don't copy another file's author line.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5448,6 +5448,147 @@ const isQuirky = (name, pub, sys) => {
 	return false;
 };
 
+const mkEl = (
+	/** @type {string} */ tagName,
+	/** @type {number} */ ns,
+	/** @type {AttributeRun} */ attrs,
+	/** @type {TagPos | null | undefined} */ pos
+) => {
+	const el = _allocNode(
+		NodeType.Element,
+		pos ? pos.start : 0,
+		pos ? pos.end : 0
+	);
+	// Void HTML elements are marked self-closing and never receive children.
+	_nodeFlags[el] =
+		ns === NS_HTML && VOID.has(tagName) ? ns | FLAG_SELF_CLOSING : ns;
+	_nodeStrings[el] = tagName;
+	_nodeAttrStarts[el] = attrs.start;
+	_nodeAttrCounts[el] = attrs.count;
+	if (pos) {
+		_nodeTagEnds[el] = pos.tagEnd;
+		_nodeNameEnds[el] = pos.nameEnd;
+		// End of a raw-text element's body under `skip.text` (defaults to the
+		// body start, i.e. empty); lets consumers read `<script>`/`<style>`
+		// content as [`tagEnd`, `contentEnd`] without a `Text` node.
+		_nodeContentEnds[el] = pos.tagEnd;
+	}
+	return el;
+};
+
+/**
+ * A `<template>`'s children live in its content fragment; inserting into a
+ * template really inserts there (the spec's "template contents" redirect).
+ * @param {HtmlNodeRef} parent container
+ * @returns {HtmlNodeRef} effective container to link children into
+ */
+const effParent = (parent) => {
+	const tc = _nodeTemplateContents[parent];
+	return tc !== 0 ? tc : parent;
+};
+
+const isScopeBoundary = (/** @type {HtmlElement} */ el) => {
+	if (_namespaceOf(el) === NS_HTML) return HTML_SCOPE.has(_tagNameOf(el));
+	if (_namespaceOf(el) === NS_MATHML) {
+		return MATHML_SPECIAL.has(_tagNameOf(el));
+	}
+	if (_namespaceOf(el) === NS_SVG) {
+		return SVG_SPECIAL.has(_tagNameOf(el).toLowerCase());
+	}
+	return false;
+};
+
+const sameAttrs = (
+	/** @type {HtmlElement} */ a,
+	/** @type {HtmlElement} */ b
+) => {
+	const aStart = _nodeAttrStarts[a];
+	const aCount = _nodeAttrCounts[a];
+	const bStart = _nodeAttrStarts[b];
+	const bCount = _nodeAttrCounts[b];
+	if (aCount !== bCount) return false;
+	// Names are unique (deduped), counts tiny — a nested scan beats a Map
+	// here on this formatting-element hot path.
+	for (let i = bStart; i < bStart + bCount; i++) {
+		const j = _findAttr(aStart, aCount, _attrNames[i]);
+		if (j === 0 || _attrValueOf(j) !== _attrValueOf(i)) return false;
+	}
+	return true;
+};
+
+const isAllWs = (/** @type {string} */ s) => {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		// HTML whitespace: tab / LF / FF / CR / space. A charCodeAt loop avoids
+		// the `for…of` code-point iterator + per-char string + Set lookup.
+		if (c !== 0x09 && c !== 0x0a && c !== 0x0c && c !== 0x0d && c !== 0x20) {
+			return false;
+		}
+	}
+	return true;
+};
+
+const mathmlTextIntegrationPoint = (/** @type {HtmlElement} */ el) =>
+	_namespaceOf(el) === NS_MATHML &&
+	MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
+
+const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
+	if (_namespaceOf(el) === NS_MATHML && _tagNameOf(el) === "annotation-xml") {
+		const enc = _findAttr(
+			_nodeAttrStarts[el],
+			_nodeAttrCounts[el],
+			"encoding"
+		);
+		if (enc !== 0) {
+			const value = _attrValueOf(enc).toLowerCase();
+			if (value === "text/html" || value === "application/xhtml+xml") {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (
+		_namespaceOf(el) === NS_SVG &&
+		SVG_SPECIAL.has(_tagNameOf(el).toLowerCase())
+	) {
+		return true;
+	}
+	return false;
+};
+
+// Adjust a foreign start tag's attribute run in place (the run is consumed
+// only by this tag's element): SVG camelCase names are rewritten, and
+// namespaced names get the serializer-name flag (see `_attrSerializedName`).
+const adjustForeignAttrs = (
+	/** @type {AttributeRun} */ run,
+	/** @type {number} */ ns
+) => {
+	for (let i = run.start; i < run.start + run.count; i++) {
+		const name = _attrNames[i];
+		if (
+			ns === NS_SVG &&
+			/** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[name]
+		) {
+			_attrNames[i] = /** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[
+				name
+			];
+		}
+		if (/** @type {Record<string, string>} */ (FOREIGN_ATTR_NS)[name]) {
+			_attrFlags[i] |= 1;
+		}
+	}
+	return run;
+};
+
+// Only `definitionurl` is rewritten (in place — the run is consumed only by
+// this tag's element); the camelCase name serializes as itself.
+const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
+	for (let i = run.start; i < run.start + run.count; i++) {
+		if (_attrNames[i] === "definitionurl") _attrNames[i] = "definitionURL";
+	}
+	return run;
+};
+
 /**
  * @param {string} input HTML source
  * @param {number=} pos start byte offset (string input only; default `0`)
@@ -5504,45 +5645,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	const adjustedCurrent = () => {
 		if (open.length === 1 && fragment) return fragment;
 		return cur();
-	};
-
-	const mkEl = (
-		/** @type {string} */ tagName,
-		/** @type {number} */ ns,
-		/** @type {AttributeRun} */ attrs,
-		/** @type {TagPos | null | undefined} */ pos
-	) => {
-		const el = _allocNode(
-			NodeType.Element,
-			pos ? pos.start : 0,
-			pos ? pos.end : 0
-		);
-		// Void HTML elements are marked self-closing and never receive children.
-		_nodeFlags[el] =
-			ns === NS_HTML && VOID.has(tagName) ? ns | FLAG_SELF_CLOSING : ns;
-		_nodeStrings[el] = tagName;
-		_nodeAttrStarts[el] = attrs.start;
-		_nodeAttrCounts[el] = attrs.count;
-		if (pos) {
-			_nodeTagEnds[el] = pos.tagEnd;
-			_nodeNameEnds[el] = pos.nameEnd;
-			// End of a raw-text element's body under `skip.text` (defaults to the
-			// body start, i.e. empty); lets consumers read `<script>`/`<style>`
-			// content as [`tagEnd`, `contentEnd`] without a `Text` node.
-			_nodeContentEnds[el] = pos.tagEnd;
-		}
-		return el;
-	};
-
-	/**
-	 * A `<template>`'s children live in its content fragment; inserting into a
-	 * template really inserts there (the spec's "template contents" redirect).
-	 * @param {HtmlNodeRef} parent container
-	 * @returns {HtmlNodeRef} effective container to link children into
-	 */
-	const effParent = (parent) => {
-		const tc = _nodeTemplateContents[parent];
-		return tc !== 0 ? tc : parent;
 	};
 
 	const appendTo = (
@@ -5758,16 +5860,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	};
 
 	// ---- scopes ----
-	const isScopeBoundary = (/** @type {HtmlElement} */ el) => {
-		if (_namespaceOf(el) === NS_HTML) return HTML_SCOPE.has(_tagNameOf(el));
-		if (_namespaceOf(el) === NS_MATHML) {
-			return MATHML_SPECIAL.has(_tagNameOf(el));
-		}
-		if (_namespaceOf(el) === NS_SVG) {
-			return SVG_SPECIAL.has(_tagNameOf(el).toLowerCase());
-		}
-		return false;
-	};
 	// Scope "kind" selects which extra elements act as boundaries. Passed as a
 	// small int so the scope checks below allocate no per-call predicate closure
 	// (these run several times per body tag).
@@ -5876,23 +5968,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 			}
 		}
 		afe.push(el);
-	};
-	const sameAttrs = (
-		/** @type {HtmlElement} */ a,
-		/** @type {HtmlElement} */ b
-	) => {
-		const aStart = _nodeAttrStarts[a];
-		const aCount = _nodeAttrCounts[a];
-		const bStart = _nodeAttrStarts[b];
-		const bCount = _nodeAttrCounts[b];
-		if (aCount !== bCount) return false;
-		// Names are unique (deduped), counts tiny — a nested scan beats a Map
-		// here on this formatting-element hot path.
-		for (let i = bStart; i < bStart + bCount; i++) {
-			const j = _findAttr(aStart, aCount, _attrNames[i]);
-			if (j === 0 || _attrValueOf(j) !== _attrValueOf(i)) return false;
-		}
-		return true;
 	};
 	const insertMarker = () => afe.push(AFE_MARKER);
 	const clearAfeToMarker = () => {
@@ -6026,18 +6101,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 		return { ...t, data: t.data.slice(ws.length), start: t.start + ws.length };
 	};
 
-	const isAllWs = (/** @type {string} */ s) => {
-		for (let i = 0; i < s.length; i++) {
-			const c = s.charCodeAt(i);
-			// HTML whitespace: tab / LF / FF / CR / space. A charCodeAt loop avoids
-			// the `for…of` code-point iterator + per-char string + Set lookup.
-			if (c !== 0x09 && c !== 0x0a && c !== 0x0c && c !== 0x0d && c !== 0x20) {
-				return false;
-			}
-		}
-		return true;
-	};
-
 	const process = (/** @type {Token} */ t) => {
 		// Track the current token's end so explicit closes can set element `.end`.
 		// Dispatch on `type` instead of the `in` operator, which goes megamorphic
@@ -6091,57 +6154,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 		if (t.type === TOKEN_END_TAG) return true;
 		if (t.type === TOKEN_COMMENT) return true;
 		return false;
-	};
-
-	const mathmlTextIntegrationPoint = (/** @type {HtmlElement} */ el) =>
-		_namespaceOf(el) === NS_MATHML &&
-		MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
-	const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
-		if (_namespaceOf(el) === NS_MATHML && _tagNameOf(el) === "annotation-xml") {
-			const enc = _findAttr(
-				_nodeAttrStarts[el],
-				_nodeAttrCounts[el],
-				"encoding"
-			);
-			if (enc !== 0) {
-				const value = _attrValueOf(enc).toLowerCase();
-				if (value === "text/html" || value === "application/xhtml+xml") {
-					return true;
-				}
-			}
-			return false;
-		}
-		if (
-			_namespaceOf(el) === NS_SVG &&
-			SVG_SPECIAL.has(_tagNameOf(el).toLowerCase())
-		) {
-			return true;
-		}
-		return false;
-	};
-
-	// Adjust a foreign start tag's attribute run in place (the run is consumed
-	// only by this tag's element): SVG camelCase names are rewritten, and
-	// namespaced names get the serializer-name flag (see `_attrSerializedName`).
-	const adjustForeignAttrs = (
-		/** @type {AttributeRun} */ run,
-		/** @type {number} */ ns
-	) => {
-		for (let i = run.start; i < run.start + run.count; i++) {
-			const name = _attrNames[i];
-			if (
-				ns === NS_SVG &&
-				/** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[name]
-			) {
-				_attrNames[i] = /** @type {Record<string, string>} */ (SVG_ATTR_ADJUST)[
-					name
-				];
-			}
-			if (/** @type {Record<string, string>} */ (FOREIGN_ATTR_NS)[name]) {
-				_attrFlags[i] |= 1;
-			}
-		}
-		return run;
 	};
 
 	const foreignContent = (/** @type {Token} */ t) => {
@@ -7094,15 +7106,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 		// any other start tag
 		reconstructAfe();
 		insertHtmlElement(name, t.attrs, t.pos);
-	};
-
-	// Only `definitionurl` is rewritten (in place — the run is consumed only by
-	// this tag's element); the camelCase name serializes as itself.
-	const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
-		for (let i = run.start; i < run.start + run.count; i++) {
-			if (_attrNames[i] === "definitionurl") _attrNames[i] = "definitionURL";
-		}
-		return run;
 	};
 
 	const endTagInBody = (/** @type {EndTagToken} */ t) => {

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5351,6 +5351,104 @@ const EMPTY_SKIP = Object.freeze({});
  */
 
 /**
+ * @param {string} name raw SVG tag name
+ * @returns {string} case-adjusted SVG tag name
+ */
+const adjustSvgTag = (name) =>
+	/** @type {Record<string, string>} */ (SVG_TAG_ADJUST)[name] || name;
+
+// Public-id prefixes that force quirks mode (WHATWG "quirks mode" table).
+// Module-level so the array/Set/closure aren't re-allocated per parse.
+const QUIRKY_PREFIXES = [
+	"+//silmaril//dtd html pro v0r11 19970101//",
+	"-//as//dtd html 3.0 aswedit + extensions//",
+	"-//advasoft ltd//dtd html 3.0 aswedit + extensions//",
+	"-//ietf//dtd html 2.0 level 1//",
+	"-//ietf//dtd html 2.0 level 2//",
+	"-//ietf//dtd html 2.0 strict level 1//",
+	"-//ietf//dtd html 2.0 strict level 2//",
+	"-//ietf//dtd html 2.0 strict//",
+	"-//ietf//dtd html 2.0//",
+	"-//ietf//dtd html 2.1e//",
+	"-//ietf//dtd html 3.0//",
+	"-//ietf//dtd html 3.2 final//",
+	"-//ietf//dtd html 3.2//",
+	"-//ietf//dtd html 3//",
+	"-//ietf//dtd html level 0//",
+	"-//ietf//dtd html level 1//",
+	"-//ietf//dtd html level 2//",
+	"-//ietf//dtd html level 3//",
+	"-//ietf//dtd html strict level 0//",
+	"-//ietf//dtd html strict level 1//",
+	"-//ietf//dtd html strict level 2//",
+	"-//ietf//dtd html strict level 3//",
+	"-//ietf//dtd html strict//",
+	"-//ietf//dtd html//",
+	"-//metrius//dtd metrius presentational//",
+	"-//microsoft//dtd internet explorer 2.0 html strict//",
+	"-//microsoft//dtd internet explorer 2.0 html//",
+	"-//microsoft//dtd internet explorer 2.0 tables//",
+	"-//microsoft//dtd internet explorer 3.0 html strict//",
+	"-//microsoft//dtd internet explorer 3.0 html//",
+	"-//microsoft//dtd internet explorer 3.0 tables//",
+	"-//netscape comm. corp.//dtd html//",
+	"-//netscape comm. corp.//dtd strict html//",
+	"-//o'reilly and associates//dtd html 2.0//",
+	"-//o'reilly and associates//dtd html extended 1.0//",
+	"-//o'reilly and associates//dtd html extended relaxed 1.0//",
+	"-//sq//dtd html 2.0 hotmetal + extensions//",
+	"-//softquad software//dtd hotmetal pro 6.0::19990601::extensions to html 4.0//",
+	"-//softquad//dtd hotmetal pro 4.0::19971010::extensions to html 4.0//",
+	"-//spyglass//dtd html 2.0 extended//",
+	"-//sun microsystems corp.//dtd hotjava html//",
+	"-//sun microsystems corp.//dtd hotjava strict html//",
+	"-//w3c//dtd html 3 1995-03-24//",
+	"-//w3c//dtd html 3.2 draft//",
+	"-//w3c//dtd html 3.2 final//",
+	"-//w3c//dtd html 3.2//",
+	"-//w3c//dtd html 3.2s draft//",
+	"-//w3c//dtd html 4.0 frameset//",
+	"-//w3c//dtd html 4.0 transitional//",
+	"-//w3c//dtd html experimental 19960712//",
+	"-//w3c//dtd html experimental 970421//",
+	"-//w3c//dtd w3 html//",
+	"-//w3o//dtd w3 html 3.0//",
+	"-//webtechs//dtd mozilla html 2.0//",
+	"-//webtechs//dtd mozilla html//"
+];
+const QUIRKY_EXACT = new Set([
+	"-//w3o//dtd w3 html strict 3.0//en//",
+	"-/w3c/dtd html 4.0 transitional/en",
+	"html"
+]);
+/**
+ * @param {string} name doctype name
+ * @param {string | null} pub public id
+ * @param {string | null} sys system id
+ * @returns {boolean} whether the doctype forces quirks mode
+ */
+const isQuirky = (name, pub, sys) => {
+	if (name !== "html") return true;
+	const p = pub ? pub.toLowerCase() : null;
+	const sl = sys ? sys.toLowerCase() : null;
+	if (p !== null) {
+		if (QUIRKY_EXACT.has(p)) return true;
+		for (const pre of QUIRKY_PREFIXES) if (p.startsWith(pre)) return true;
+		if (
+			sl === null &&
+			(p.startsWith("-//w3c//dtd html 4.01 frameset//") ||
+				p.startsWith("-//w3c//dtd html 4.01 transitional//"))
+		) {
+			return true;
+		}
+	}
+	if (sl === "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd") {
+		return true;
+	}
+	return false;
+};
+
+/**
  * @param {string} input HTML source
  * @param {number=} pos start byte offset (string input only; default `0`)
  * @param {HtmlParseOptions=} options parse options (fragment context, AST skips)
@@ -6022,8 +6120,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 		return false;
 	};
 
-	const adjustSvgTag = (/** @type {string} */ name) =>
-		/** @type {Record<string, string>} */ (SVG_TAG_ADJUST)[name] || name;
 	// Adjust a foreign start tag's attribute run in place (the run is consumed
 	// only by this tag's element): SVG camelCase names are rewritten, and
 	// namespaced names get the serializer-name flag (see `_attrSerializedName`).
@@ -6390,93 +6486,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 			default:
 				return modes.afterAfterFrameset(t);
 		}
-	};
-
-	const QUIRKY_PREFIXES = [
-		"+//silmaril//dtd html pro v0r11 19970101//",
-		"-//as//dtd html 3.0 aswedit + extensions//",
-		"-//advasoft ltd//dtd html 3.0 aswedit + extensions//",
-		"-//ietf//dtd html 2.0 level 1//",
-		"-//ietf//dtd html 2.0 level 2//",
-		"-//ietf//dtd html 2.0 strict level 1//",
-		"-//ietf//dtd html 2.0 strict level 2//",
-		"-//ietf//dtd html 2.0 strict//",
-		"-//ietf//dtd html 2.0//",
-		"-//ietf//dtd html 2.1e//",
-		"-//ietf//dtd html 3.0//",
-		"-//ietf//dtd html 3.2 final//",
-		"-//ietf//dtd html 3.2//",
-		"-//ietf//dtd html 3//",
-		"-//ietf//dtd html level 0//",
-		"-//ietf//dtd html level 1//",
-		"-//ietf//dtd html level 2//",
-		"-//ietf//dtd html level 3//",
-		"-//ietf//dtd html strict level 0//",
-		"-//ietf//dtd html strict level 1//",
-		"-//ietf//dtd html strict level 2//",
-		"-//ietf//dtd html strict level 3//",
-		"-//ietf//dtd html strict//",
-		"-//ietf//dtd html//",
-		"-//metrius//dtd metrius presentational//",
-		"-//microsoft//dtd internet explorer 2.0 html strict//",
-		"-//microsoft//dtd internet explorer 2.0 html//",
-		"-//microsoft//dtd internet explorer 2.0 tables//",
-		"-//microsoft//dtd internet explorer 3.0 html strict//",
-		"-//microsoft//dtd internet explorer 3.0 html//",
-		"-//microsoft//dtd internet explorer 3.0 tables//",
-		"-//netscape comm. corp.//dtd html//",
-		"-//netscape comm. corp.//dtd strict html//",
-		"-//o'reilly and associates//dtd html 2.0//",
-		"-//o'reilly and associates//dtd html extended 1.0//",
-		"-//o'reilly and associates//dtd html extended relaxed 1.0//",
-		"-//sq//dtd html 2.0 hotmetal + extensions//",
-		"-//softquad software//dtd hotmetal pro 6.0::19990601::extensions to html 4.0//",
-		"-//softquad//dtd hotmetal pro 4.0::19971010::extensions to html 4.0//",
-		"-//spyglass//dtd html 2.0 extended//",
-		"-//sun microsystems corp.//dtd hotjava html//",
-		"-//sun microsystems corp.//dtd hotjava strict html//",
-		"-//w3c//dtd html 3 1995-03-24//",
-		"-//w3c//dtd html 3.2 draft//",
-		"-//w3c//dtd html 3.2 final//",
-		"-//w3c//dtd html 3.2//",
-		"-//w3c//dtd html 3.2s draft//",
-		"-//w3c//dtd html 4.0 frameset//",
-		"-//w3c//dtd html 4.0 transitional//",
-		"-//w3c//dtd html experimental 19960712//",
-		"-//w3c//dtd html experimental 970421//",
-		"-//w3c//dtd w3 html//",
-		"-//w3o//dtd w3 html 3.0//",
-		"-//webtechs//dtd mozilla html 2.0//",
-		"-//webtechs//dtd mozilla html//"
-	];
-	const QUIRKY_EXACT = new Set([
-		"-//w3o//dtd w3 html strict 3.0//en//",
-		"-/w3c/dtd html 4.0 transitional/en",
-		"html"
-	]);
-	const isQuirky = (
-		/** @type {string} */ name,
-		/** @type {string | null} */ pub,
-		/** @type {string | null} */ sys
-	) => {
-		if (name !== "html") return true;
-		const p = pub ? pub.toLowerCase() : null;
-		const sl = sys ? sys.toLowerCase() : null;
-		if (p !== null) {
-			if (QUIRKY_EXACT.has(p)) return true;
-			for (const pre of QUIRKY_PREFIXES) if (p.startsWith(pre)) return true;
-			if (
-				sl === null &&
-				(p.startsWith("-//w3c//dtd html 4.01 frameset//") ||
-					p.startsWith("-//w3c//dtd html 4.01 transitional//"))
-			) {
-				return true;
-			}
-		}
-		if (sl === "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd") {
-			return true;
-		}
-		return false;
 	};
 
 	modes.initial = (t) => {

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -4133,11 +4133,11 @@ const EMPTY_ATTRS = /** @type {AttributeRun} */ (
 // lives in the four link columns (parent / firstChild / lastChild /
 // nextSibling); the only heap references are the string payload / attribute
 // name-and-value side arrays. Columns are module-level and reused
-// across parses (grown, shrunk on release only past `_COLUMN_SHRINK_CAPACITY` —
-// the CSS parser's `_soa*` strategy), so a steady-state parse allocates almost
-// nothing per node; consumers must fully read a tree before the next
-// `parseHtml` call. Id 0 is reserved as "no node" so the link columns can use
-// 0 as null.
+// across parses (grown, shrunk on release only past `_COLUMN_SHRINK_CAPACITY`,
+// mirroring the CSS parser's column backend), so a steady-state parse
+// allocates almost nothing per node; consumers must fully read a tree before
+// the next `parseHtml` call. Id 0 is reserved as "no node" so the link columns
+// can use 0 as null.
 let _nodeCapacity = 0;
 let _nodeCount = 0;
 /** `NodeType` per node */
@@ -5529,16 +5529,11 @@ const isAllWs = (/** @type {string} */ s) => {
 };
 
 const mathmlTextIntegrationPoint = (/** @type {HtmlElement} */ el) =>
-	_namespaceOf(el) === NS_MATHML &&
-	MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
+	_namespaceOf(el) === NS_MATHML && MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
 
 const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
 	if (_namespaceOf(el) === NS_MATHML && _tagNameOf(el) === "annotation-xml") {
-		const enc = _findAttr(
-			_nodeAttrStarts[el],
-			_nodeAttrCounts[el],
-			"encoding"
-		);
+		const enc = _findAttr(_nodeAttrStarts[el], _nodeAttrCounts[el], "encoding");
 		if (enc !== 0) {
 			const value = _attrValueOf(enc).toLowerCase();
 			if (value === "text/html" || value === "application/xhtml+xml") {
@@ -5589,6 +5584,2101 @@ const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
 	return run;
 };
 
+// ---- HTML tree-construction parser state ----
+// One active parse at a time (results are valid only until the next
+// `parseHtml`); kept at module scope so the helpers below are defined once
+// instead of re-created as closures on every parse.
+let source = "";
+let skipText = false;
+let skipComments = false;
+let skipDoctype = false;
+/** @type {HtmlNodeRef} */
+let doc = 0;
+let mode = 0;
+let originalMode = 0;
+/** @type {HtmlElement[]} stack of open elements (bottom .. top) */
+const open = [];
+/** @type {HtmlNodeRef[]} active formatting elements (AFE_MARKER = marker) */
+const afe = [];
+/** @type {HtmlElement} 0 = none */
+let head = 0;
+/** @type {HtmlElement} 0 = none */
+let form = 0;
+let framesetOk = true;
+let pendAttrStart = 0;
+let fosterParenting = false;
+/** @type {number[]} */
+const templateModes = [];
+let quirks = false;
+/** @type {HtmlElement} fragment context element (0 = document parse) */
+let fragment = 0;
+let tokenEnd = 0;
+let swallowNextNewline = false;
+let eofInTag = false;
+let sawSelectedContent = false;
+const decode = decodeEntities;
+/** @type {MutableToken} */
+const tok = {
+	type: TOKEN_EOF,
+	name: "",
+	data: "",
+	attrs: { start: 0, count: 0 },
+	selfClosing: false,
+	start: 0,
+	end: 0,
+	publicId: null,
+	systemId: null,
+	swallowNewline: false,
+	pos: { start: 0, end: 0, tagEnd: 0, nameEnd: 0 }
+};
+
+const cur = () => /** @type {HtmlElement} */ (open[open.length - 1]);
+const adjustedCurrent = () => {
+	if (open.length === 1 && fragment) return fragment;
+	return cur();
+};
+
+const appendTo = (
+	/** @type {HtmlNodeRef} */ parent,
+	/** @type {HtmlNodeRef} */ node
+) => {
+	const p = effParent(parent);
+	const last = _nodeLastChildren[p];
+	if (
+		_nodeTypes[node] === NodeType.Text &&
+		last !== 0 &&
+		_nodeTypes[last] === NodeType.Text
+	) {
+		_nodeStrings[last] += _nodeStrings[node];
+		_nodeEnds[last] = _nodeEnds[node];
+		return;
+	}
+	_appendChild(p, node);
+};
+
+// Reused result of `appropriatePlace` — consumed synchronously by
+// `insertAtPlace` and never retained, so one shared object avoids an
+// allocation per inserted node.
+/** @type {InsertionPlace} */
+const sharedPlace = { parent: doc, beforeNode: 0 };
+const placeAt = (
+	/** @type {HtmlNodeRef} */ parent,
+	/** @type {HtmlNodeRef} */ beforeNode
+) => {
+	sharedPlace.parent = parent;
+	sharedPlace.beforeNode = beforeNode;
+	return sharedPlace;
+};
+
+// "appropriate place for inserting a node"
+const appropriatePlace = () => {
+	const target = cur();
+	if (
+		fosterParenting &&
+		TABLE_CONTEXT.has(_tagNameOf(target)) &&
+		_namespaceOf(target) === NS_HTML
+	) {
+		// find last template / last table
+		let lastTemplate = -1;
+		let lastTable = -1;
+		for (let i = open.length - 1; i >= 0; i--) {
+			if (
+				_tagNameOf(open[i]) === "template" &&
+				_namespaceOf(open[i]) === NS_HTML &&
+				lastTemplate === -1
+			) {
+				lastTemplate = i;
+			}
+			if (
+				_tagNameOf(open[i]) === "table" &&
+				_namespaceOf(open[i]) === NS_HTML &&
+				lastTable === -1
+			) {
+				lastTable = i;
+			}
+		}
+		if (lastTemplate !== -1 && (lastTable === -1 || lastTemplate > lastTable)) {
+			return placeAt(open[lastTemplate], 0);
+		}
+		if (lastTable === -1) {
+			return placeAt(open[0], 0);
+		}
+		const table = open[lastTable];
+		const tp = _nodeParents[table];
+		if (tp !== 0) return placeAt(tp, table);
+		return placeAt(open[lastTable - 1], 0);
+	}
+	return placeAt(target, 0);
+};
+
+const insertAtPlace = (
+	/** @type {InsertionPlace} */ place,
+	/** @type {HtmlNodeRef} */ node
+) => {
+	const before = place.beforeNode;
+	if (before !== 0) {
+		const p = effParent(place.parent);
+		// Find `before`'s previous sibling (insert-before is a rare foster/
+		// adoption path, so the sibling scan stays off the hot path).
+		let prev = 0;
+		let c = _nodeFirstChildren[p];
+		while (c !== 0 && c !== before) {
+			prev = c;
+			c = _nodeNextSiblings[c];
+		}
+		if (c === 0) {
+			// `before` not under `parent` (not reachable from the spec paths).
+			appendTo(place.parent, node);
+			return;
+		}
+		if (
+			_nodeTypes[node] === NodeType.Text &&
+			prev !== 0 &&
+			_nodeTypes[prev] === NodeType.Text
+		) {
+			// Before-node merge deliberately does not bump the sibling's `end`.
+			_nodeStrings[prev] += _nodeStrings[node];
+			return;
+		}
+		_nodeParents[node] = p;
+		_nodeNextSiblings[node] = before;
+		if (prev === 0) _nodeFirstChildren[p] = node;
+		else _nodeNextSiblings[prev] = node;
+	} else {
+		appendTo(place.parent, node);
+	}
+};
+
+const insertCharacters = (
+	/** @type {string} */ data,
+	/** @type {number} */ start,
+	/** @type {number} */ end
+) => {
+	const place = appropriatePlace();
+	if (_nodeTypes[place.parent] === NodeType.Document) return; // never insert text into document
+	// `skip.text`: drop every `Text` node — construction already used the
+	// decoded token, so removing the node never affects element structure.
+	// For a raw-text element record the body end so a consumer reads the span
+	// [`tagEnd`, `contentEnd`] without a `Text` node (see `HtmlParser`).
+	// Namespace-agnostic: `HtmlParser` extracts `<script>`/`<style>` bodies in
+	// foreign content (e.g. SVG `<style>`) too.
+	if (skipText) {
+		const p = place.parent;
+		if (
+			_nodeTypes[p] === NodeType.Element &&
+			RAW_TEXT_ELEMENTS.has(_tagNameOf(p))
+		) {
+			_nodeContentEnds[p] = end;
+		}
+		return;
+	}
+	// Inlined text insert: when the run merges into the adjacent text sibling
+	// (common with inline formatting) only the string is appended — no
+	// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
+	// including that the before-node merge does not bump `end`.
+	const p = effParent(place.parent);
+	const before = place.beforeNode;
+	if (before !== 0) {
+		let prev = 0;
+		let c = _nodeFirstChildren[p];
+		while (c !== 0 && c !== before) {
+			prev = c;
+			c = _nodeNextSiblings[c];
+		}
+		if (c === 0) {
+			// `before` not under `parent` (not reachable from the spec paths).
+			_appendChild(p, _makeTextNode(data, start, end));
+			return;
+		}
+		if (prev !== 0 && _nodeTypes[prev] === NodeType.Text) {
+			_nodeStrings[prev] += data;
+			return;
+		}
+		const node = _makeTextNode(data, start, end);
+		_nodeParents[node] = p;
+		_nodeNextSiblings[node] = before;
+		if (prev === 0) _nodeFirstChildren[p] = node;
+		else _nodeNextSiblings[prev] = node;
+	} else {
+		const last = _nodeLastChildren[p];
+		if (last !== 0 && _nodeTypes[last] === NodeType.Text) {
+			_nodeStrings[last] += data;
+			_nodeEnds[last] = end;
+			return;
+		}
+		_appendChild(p, _makeTextNode(data, start, end));
+	}
+};
+
+/**
+ * @param {string} data comment data
+ * @param {number} start start offset
+ * @param {number} end end offset
+ * @param {InsertionPlace=} place explicit insertion place
+ */
+const insertComment = (data, start, end, place) => {
+	if (skipComments) return;
+	const p = place || appropriatePlace();
+	insertAtPlace(p, _makeCommentNode(data, start, end));
+};
+
+const insertHtmlElement = (
+	/** @type {string} */ tagName,
+	/** @type {AttributeRun} */ attrs,
+	/** @type {TagPos | null} */ pos
+) => {
+	const el = mkEl(tagName, NS_HTML, attrs, pos);
+	const place = appropriatePlace();
+	insertAtPlace(place, el);
+	open.push(el);
+	return el;
+};
+
+const insertForeignElement = (
+	/** @type {string} */ tagName,
+	/** @type {number} */ ns,
+	/** @type {AttributeRun} */ attrs,
+	/** @type {TagPos | null} */ pos
+) => {
+	const el = mkEl(tagName, ns, attrs, pos);
+	const place = appropriatePlace();
+	insertAtPlace(place, el);
+	open.push(el);
+	return el;
+};
+
+// ---- scopes ----
+// Scope "kind" selects which extra elements act as boundaries. Passed as a
+// small int so the scope checks below allocate no per-call predicate closure
+// (these run several times per body tag).
+const SCOPE_DEFAULT = 0;
+const SCOPE_BUTTON = 1;
+const SCOPE_LIST_ITEM = 2;
+const isBoundaryForKind = (
+	/** @type {HtmlElement} */ el,
+	/** @type {number} */ kind
+) => {
+	if (isScopeBoundary(el)) return true;
+	if (_namespaceOf(el) !== NS_HTML) return false;
+	if (kind === SCOPE_BUTTON) return _tagNameOf(el) === "button";
+	if (kind === SCOPE_LIST_ITEM) {
+		return _tagNameOf(el) === "ol" || _tagNameOf(el) === "ul";
+	}
+	return false;
+};
+// "have an element in scope": walk the open stack from the top until the
+// named HTML element is found (true) or a scope boundary is hit (false).
+const hasNameInScope = (
+	/** @type {string} */ tagName,
+	/** @type {number} */ kind
+) => {
+	for (let i = open.length - 1; i >= 0; i--) {
+		const el = open[i];
+		if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) {
+			return true;
+		}
+		if (isBoundaryForKind(el, kind)) return false;
+	}
+	return false;
+};
+const inScope = (/** @type {string} */ tagName) =>
+	hasNameInScope(tagName, SCOPE_DEFAULT);
+const inButtonScope = (/** @type {string} */ tagName) =>
+	hasNameInScope(tagName, SCOPE_BUTTON);
+const inListItemScope = (/** @type {string} */ tagName) =>
+	hasNameInScope(tagName, SCOPE_LIST_ITEM);
+const inScopeEl = (/** @type {HtmlElement} */ target) => {
+	for (let i = open.length - 1; i >= 0; i--) {
+		const el = open[i];
+		if (el === target) return true;
+		if (isScopeBoundary(el)) return false;
+	}
+	return false;
+};
+// `target` is a single tag name (the common case) or a Set of names.
+const inTableScope = (/** @type {string | Set<string>} */ target) => {
+	const set = typeof target === "string" ? null : target;
+	for (let i = open.length - 1; i >= 0; i--) {
+		const el = open[i];
+		if (_namespaceOf(el) === NS_HTML) {
+			if (set ? set.has(_tagNameOf(el)) : _tagNameOf(el) === target) {
+				return true;
+			}
+			if (TABLE_SCOPE_STOP.has(_tagNameOf(el))) return false;
+		}
+	}
+	return false;
+};
+const generateImpliedEndTags = (except = "") => {
+	while (open.length) {
+		const el = cur();
+		if (
+			_namespaceOf(el) === NS_HTML &&
+			IMPLIED.has(_tagNameOf(el)) &&
+			_tagNameOf(el) !== except
+		) {
+			open.pop();
+		} else {
+			break;
+		}
+	}
+};
+const generateImpliedEndTagsThorough = () => {
+	while (open.length) {
+		const el = cur();
+		if (_namespaceOf(el) === NS_HTML && IMPLIED_THOROUGH.has(_tagNameOf(el))) {
+			open.pop();
+		} else {
+			break;
+		}
+	}
+};
+
+// ---- active formatting elements ----
+const pushAfe = (/** @type {HtmlElement} */ el) => {
+	let count = 0;
+	for (let i = afe.length - 1; i >= 0; i--) {
+		const e = afe[i];
+		if (e === AFE_MARKER) break;
+		if (
+			_tagNameOf(e) === _tagNameOf(el) &&
+			_namespaceOf(e) === _namespaceOf(el) &&
+			sameAttrs(e, el)
+		) {
+			count++;
+			if (count === 3) {
+				afe.splice(i, 1);
+				break;
+			}
+		}
+	}
+	afe.push(el);
+};
+const insertMarker = () => afe.push(AFE_MARKER);
+const clearAfeToMarker = () => {
+	while (afe.length) {
+		if (afe.pop() === AFE_MARKER) break;
+	}
+};
+const reconstructAfe = () => {
+	if (afe.length === 0) return;
+	let i = afe.length - 1;
+	if (afe[i] === AFE_MARKER || open.includes(afe[i])) return;
+	while (i > 0) {
+		i--;
+		if (afe[i] === AFE_MARKER || open.includes(afe[i])) {
+			i++;
+			break;
+		}
+	}
+	for (; i < afe.length; i++) {
+		const e = afe[i];
+		const el = mkEl(_tagNameOf(e), _namespaceOf(e), cloneAttrs(e), null);
+		const place = appropriatePlace();
+		insertAtPlace(place, el);
+		open.push(el);
+		afe[i] = el;
+	}
+};
+
+// ---- close p ----
+const closePElement = () => {
+	generateImpliedEndTags("p");
+	// pop until a p has been popped
+	while (open.length) {
+		const el = /** @type {HtmlElement} */ (open.pop());
+		_nodeEnds[el] = tokenEnd;
+		if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === "p") break;
+	}
+};
+
+const popUntil = (/** @type {string} */ tagName) => {
+	while (open.length) {
+		const el = /** @type {HtmlElement} */ (open.pop());
+		_nodeEnds[el] = tokenEnd;
+		if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) break;
+	}
+};
+const popUntilOneOf = (/** @type {Set<string>} */ set) => {
+	while (open.length) {
+		const el = /** @type {HtmlElement} */ (open.pop());
+		_nodeEnds[el] = tokenEnd;
+		if (_namespaceOf(el) === NS_HTML && set.has(_tagNameOf(el))) break;
+	}
+};
+
+// ---- reset insertion mode appropriately ----
+const resetInsertionMode = () => {
+	let last = false;
+	for (let i = open.length - 1; i >= 0; i--) {
+		let node = open[i];
+		if (i === 0) {
+			last = true;
+			if (fragment) node = fragment;
+		}
+		const tn = _tagNameOf(node);
+		if (_namespaceOf(node) === NS_HTML) {
+			if ((tn === "td" || tn === "th") && !last) {
+				mode = MODE_IN_CELL;
+				return;
+			}
+			if (tn === "tr") {
+				mode = MODE_IN_ROW;
+				return;
+			}
+			if (TBODY_GROUP.has(tn)) {
+				mode = MODE_IN_TABLE_BODY;
+				return;
+			}
+			if (tn === "caption") {
+				mode = MODE_IN_CAPTION;
+				return;
+			}
+			if (tn === "colgroup") {
+				mode = MODE_IN_COLUMN_GROUP;
+				return;
+			}
+			if (tn === "table") {
+				mode = MODE_IN_TABLE;
+				return;
+			}
+			if (tn === "template") {
+				mode = templateModes[templateModes.length - 1];
+				return;
+			}
+			if (tn === "head" && !last) {
+				mode = MODE_IN_HEAD;
+				return;
+			}
+			if (tn === "body") {
+				mode = MODE_IN_BODY;
+				return;
+			}
+			if (tn === "frameset") {
+				mode = MODE_IN_FRAMESET;
+				return;
+			}
+			if (tn === "html") {
+				mode = head ? MODE_AFTER_HEAD : MODE_BEFORE_HEAD;
+				return;
+			}
+		}
+		if (last) {
+			mode = MODE_IN_BODY;
+			return;
+		}
+	}
+};
+
+// ---------- token processing ----------
+// Split a character token's leading whitespace; per the spec each character
+// is its own token, so a mixed run can straddle a mode change. Inserts the
+// leading whitespace when `insert`, returns the non-whitespace remainder
+// token (or null when the token was entirely whitespace).
+const leadingWs = (
+	/** @type {CharToken} */ t,
+	/** @type {boolean} */ insert
+) => {
+	const m = /^[\t\n\f\r ]+/.exec(t.data);
+	const ws = m ? m[0] : "";
+	if (ws && insert) insertCharacters(ws, t.start, t.start + ws.length);
+	if (ws.length === t.data.length) return null;
+	return { ...t, data: t.data.slice(ws.length), start: t.start + ws.length };
+};
+
+const process = (/** @type {Token} */ t) => {
+	// Track the current token's end so explicit closes can set element `.end`.
+	// Dispatch on `type` instead of the `in` operator, which goes megamorphic
+	// across the token union and shows up on the per-token hot path.
+	const ty = t.type;
+	if (ty === TOKEN_START_TAG || ty === TOKEN_END_TAG) tokenEnd = t.pos.end;
+	else if (ty !== TOKEN_EOF) tokenEnd = t.end;
+	// foreign content dispatch
+	const ac = adjustedCurrent();
+	const useForeign =
+		open.length > 0 &&
+		ac &&
+		_namespaceOf(ac) !== NS_HTML &&
+		ty !== TOKEN_EOF &&
+		shouldUseForeignRules(ac, t);
+	if (useForeign) {
+		foreignContent(t);
+		return;
+	}
+	runMode(t);
+};
+
+const shouldUseForeignRules = (
+	/** @type {HtmlElement} */ ac,
+	/** @type {Token} */ t
+) => {
+	if (_namespaceOf(ac) === NS_HTML) return false;
+	if (t.type === TOKEN_START_TAG) {
+		if (
+			mathmlTextIntegrationPoint(ac) &&
+			t.name !== "mglyph" &&
+			t.name !== "malignmark"
+		) {
+			return false;
+		}
+		if (
+			_namespaceOf(ac) === NS_MATHML &&
+			_tagNameOf(ac) === "annotation-xml" &&
+			t.name === "svg"
+		) {
+			return false;
+		}
+		if (htmlIntegrationPoint(ac)) return false;
+		return true;
+	}
+	if (t.type === TOKEN_CHAR) {
+		if (mathmlTextIntegrationPoint(ac)) return false;
+		if (htmlIntegrationPoint(ac)) return false;
+		return true;
+	}
+	if (t.type === TOKEN_END_TAG) return true;
+	if (t.type === TOKEN_COMMENT) return true;
+	return false;
+};
+
+const foreignContent = (/** @type {Token} */ t) => {
+	if (t.type === TOKEN_CHAR) {
+		const data = t.data.replace(/\0/g, "�");
+		insertCharacters(data, t.start, t.end);
+		// eslint-disable-next-line no-control-regex
+		if (/[^\t\n\f\r \u0000]/.test(t.data)) framesetOk = false;
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG) {
+		const acn = _namespaceOf(adjustedCurrent());
+		if (
+			FOREIGN_BREAKOUT.has(t.name) ||
+			(t.name === "font" && hasFontBreakoutAttr(t.attrs))
+		) {
+			// parse error; pop until integration point / html / mathml-text-integration
+			while (open.length > 1) {
+				const c = cur();
+				if (
+					_namespaceOf(c) === NS_HTML ||
+					mathmlTextIntegrationPoint(c) ||
+					htmlIntegrationPoint(c)
+				) {
+					break;
+				}
+				open.pop();
+			}
+			runMode(t);
+			return;
+		}
+		const ns = acn;
+		let name = t.name;
+		let attrs = t.attrs;
+		if (ns === NS_SVG) {
+			name = adjustSvgTag(name);
+		}
+		if (ns === NS_MATHML) {
+			attrs = adjustMathmlAttrs(attrs);
+		}
+		attrs = adjustForeignAttrs(attrs, ns);
+		insertForeignElement(name, ns, attrs, t.pos);
+		if (t.selfClosing) {
+			open.pop();
+		}
+		return;
+	}
+	if (t.type === TOKEN_END_TAG) {
+		if (
+			t.name === "script" &&
+			_tagNameOf(cur()) === "script" &&
+			_namespaceOf(cur()) === NS_SVG
+		) {
+			open.pop();
+			return;
+		}
+		// `</p>` and `</br>` break out: pop foreign elements up to the
+		// nearest HTML element or integration point, then process in HTML.
+		if (t.name === "p" || t.name === "br") {
+			while (
+				open.length > 1 &&
+				_namespaceOf(cur()) !== NS_HTML &&
+				!mathmlTextIntegrationPoint(cur()) &&
+				!htmlIntegrationPoint(cur())
+			) {
+				open.pop();
+			}
+			runMode(t);
+			return;
+		}
+		// any other end tag
+		let i = open.length - 1;
+		let node = open[i];
+		if (_tagNameOf(node).toLowerCase() !== t.name) {
+			/* parse error */
+		}
+		while (i >= 0) {
+			node = open[i];
+			if (i === 0) return;
+			if (
+				_namespaceOf(node) !== NS_HTML &&
+				_tagNameOf(node).toLowerCase() === t.name
+			) {
+				while (open.length > i) open.pop();
+				return;
+			}
+			i--;
+			if (open[i] && _namespaceOf(open[i]) === NS_HTML) {
+				runMode(t);
+				return;
+			}
+		}
+	}
+};
+
+// ---------- adoption agency algorithm ----------
+const adoptionAgency = (
+	/** @type {string} */ subject,
+	/** @type {TagPos | null} */ pos
+) => {
+	// step 1
+	const c = cur();
+	if (
+		_namespaceOf(c) === NS_HTML &&
+		_tagNameOf(c) === subject &&
+		!afe.includes(c)
+	) {
+		open.pop();
+		return true;
+	}
+	let outer = 0;
+	while (outer < 8) {
+		outer++;
+		// find formatting element
+		let fmtIdx = -1;
+		for (let i = afe.length - 1; i >= 0; i--) {
+			if (afe[i] === AFE_MARKER) break;
+			if (_tagNameOf(afe[i]) === subject && _namespaceOf(afe[i]) === NS_HTML) {
+				fmtIdx = i;
+				break;
+			}
+		}
+		if (fmtIdx === -1) return false; // act as any other end tag
+		const fmt = afe[fmtIdx];
+		const openIdx = open.indexOf(fmt);
+		if (openIdx === -1) {
+			afe.splice(fmtIdx, 1);
+			return true;
+		}
+		if (!inScopeEl(fmt)) return true; // parse error, ignore
+		// step: furthest block
+		let furthestIdx = -1;
+		for (let i = openIdx + 1; i < open.length; i++) {
+			if (isSpecial(open[i])) {
+				furthestIdx = i;
+				break;
+			}
+		}
+		if (furthestIdx === -1) {
+			while (open.length > openIdx) open.pop();
+			afe.splice(fmtIdx, 1);
+			return true;
+		}
+		const furthest = open[furthestIdx];
+		const commonAncestor = open[openIdx - 1];
+		let bookmark = fmtIdx;
+		let node = furthest;
+		let lastNode = furthest;
+		let nodeIdx = furthestIdx;
+		let inner = 0;
+		while (true) {
+			inner++;
+			nodeIdx--;
+			node = open[nodeIdx];
+			if (node === fmt) break;
+			let nodeAfeIdx = afe.indexOf(node);
+			if (inner > 3 && nodeAfeIdx !== -1) {
+				afe.splice(nodeAfeIdx, 1);
+				if (nodeAfeIdx < bookmark) bookmark--;
+				nodeAfeIdx = -1;
+			}
+			if (nodeAfeIdx === -1) {
+				open.splice(nodeIdx, 1);
+				continue;
+			}
+			// create clone
+			const clone = mkEl(
+				_tagNameOf(node),
+				_namespaceOf(node),
+				cloneAttrs(node),
+				null
+			);
+			afe[nodeAfeIdx] = clone;
+			open[nodeIdx] = clone;
+			node = clone;
+			if (lastNode === furthest) bookmark = nodeAfeIdx + 1;
+			// append lastNode to node
+			detach(lastNode);
+			appendTo(node, lastNode);
+			lastNode = node;
+		}
+		// insert lastNode into common ancestor (with foster parenting)
+		detach(lastNode);
+		const place = placeForCommonAncestor(commonAncestor);
+		insertAtPlace(place, lastNode);
+		// create element for fmt token, take children of furthest
+		const cloneFmt = mkEl(
+			_tagNameOf(fmt),
+			_namespaceOf(fmt),
+			cloneAttrs(fmt),
+			null
+		);
+		// Take all direct children of `furthest` (a template's content fragment
+		// deliberately stays put — mirrors childrenOf-less spec behavior here).
+		let k = _nodeFirstChildren[furthest];
+		_nodeFirstChildren[furthest] = 0;
+		_nodeLastChildren[furthest] = 0;
+		while (k !== 0) {
+			const next = _nodeNextSiblings[k];
+			_nodeNextSiblings[k] = 0;
+			_nodeParents[k] = 0;
+			appendTo(cloneFmt, k);
+			k = next;
+		}
+		appendTo(furthest, cloneFmt);
+		// remove fmt from afe, insert clone at bookmark
+		const curFmtIdx = afe.indexOf(fmt);
+		if (curFmtIdx !== -1) {
+			afe.splice(curFmtIdx, 1);
+			if (curFmtIdx < bookmark) bookmark--;
+		}
+		afe.splice(bookmark, 0, cloneFmt);
+		// remove fmt from open, insert clone below furthest
+		const ofi = open.indexOf(fmt);
+		if (ofi !== -1) open.splice(ofi, 1);
+		const newFurthestIdx = open.indexOf(furthest);
+		open.splice(newFurthestIdx + 1, 0, cloneFmt);
+	}
+	return true;
+};
+
+const placeForCommonAncestor = (/** @type {HtmlElement} */ commonAncestor) => {
+	if (
+		TABLE_CONTEXT.has(_tagNameOf(commonAncestor)) &&
+		_namespaceOf(commonAncestor) === NS_HTML
+	) {
+		// foster
+		// reuse appropriatePlace logic but rooted differently: emulate
+		let lastTemplate = -1;
+		let lastTable = -1;
+		for (let i = open.length - 1; i >= 0; i--) {
+			if (
+				_tagNameOf(open[i]) === "template" &&
+				_namespaceOf(open[i]) === NS_HTML &&
+				lastTemplate === -1
+			) {
+				lastTemplate = i;
+			}
+			if (
+				_tagNameOf(open[i]) === "table" &&
+				_namespaceOf(open[i]) === NS_HTML &&
+				lastTable === -1
+			) {
+				lastTable = i;
+			}
+		}
+		if (lastTemplate !== -1 && (lastTable === -1 || lastTemplate > lastTable)) {
+			return { parent: open[lastTemplate], beforeNode: 0 };
+		}
+		if (lastTable === -1) return { parent: open[0], beforeNode: 0 };
+		const table = open[lastTable];
+		const tp = _nodeParents[table];
+		if (tp !== 0) return { parent: tp, beforeNode: table };
+		return { parent: open[lastTable - 1], beforeNode: 0 };
+	}
+	return { parent: commonAncestor, beforeNode: 0 };
+};
+
+const detach = (/** @type {HtmlNodeRef} */ node) => {
+	const p = _nodeParents[node];
+	if (p === 0) return;
+	let prev = 0;
+	let c = _nodeFirstChildren[p];
+	while (c !== 0 && c !== node) {
+		prev = c;
+		c = _nodeNextSiblings[c];
+	}
+	if (c === 0) return;
+	if (prev === 0) _nodeFirstChildren[p] = _nodeNextSiblings[node];
+	else _nodeNextSiblings[prev] = _nodeNextSiblings[node];
+	if (_nodeLastChildren[p] === node) _nodeLastChildren[p] = prev;
+	_nodeNextSiblings[node] = 0;
+	_nodeParents[node] = 0;
+};
+
+// ---------- insertion modes ----------
+
+/** @type {Record<string, (t: Token) => void>} */
+const modes = {};
+
+// Dispatch the current insertion mode. An integer switch (cases ordered by
+// frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
+// `modes[mode]` load + indirect call would defeat inlining on the per-token
+// hot path.
+const runMode = (/** @type {Token} */ t) => {
+	switch (mode) {
+		case MODE_IN_BODY:
+			return modes.inBody(t);
+		case MODE_TEXT:
+			return modes.text(t);
+		case MODE_IN_CELL:
+			return modes.inCell(t);
+		case MODE_IN_ROW:
+			return modes.inRow(t);
+		case MODE_IN_TABLE_BODY:
+			return modes.inTableBody(t);
+		case MODE_IN_TABLE:
+			return modes.inTable(t);
+		case MODE_IN_TABLE_TEXT:
+			return modes.inTableText(t);
+		case MODE_IN_CAPTION:
+			return modes.inCaption(t);
+		case MODE_IN_COLUMN_GROUP:
+			return modes.inColumnGroup(t);
+		case MODE_IN_TEMPLATE:
+			return modes.inTemplate(t);
+		case MODE_IN_HEAD:
+			return modes.inHead(t);
+		case MODE_IN_HEAD_NOSCRIPT:
+			return modes.inHeadNoscript(t);
+		case MODE_AFTER_HEAD:
+			return modes.afterHead(t);
+		case MODE_BEFORE_HEAD:
+			return modes.beforeHead(t);
+		case MODE_BEFORE_HTML:
+			return modes.beforeHtml(t);
+		case MODE_INITIAL:
+			return modes.initial(t);
+		case MODE_AFTER_BODY:
+			return modes.afterBody(t);
+		case MODE_AFTER_AFTER_BODY:
+			return modes.afterAfterBody(t);
+		case MODE_IN_FRAMESET:
+			return modes.inFrameset(t);
+		case MODE_AFTER_FRAMESET:
+			return modes.afterFrameset(t);
+		// MODE_AFTER_AFTER_FRAMESET — every mode is enumerated, so the last
+		// one is the `default` (also satisfies exhaustiveness linting).
+		default:
+			return modes.afterAfterFrameset(t);
+	}
+};
+
+modes.initial = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, false);
+		if (!r) return;
+		quirks = true;
+		mode = MODE_BEFORE_HTML;
+		process(r);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) {
+		// `skip.doctype` drops the node only; quirks detection below is unaffected.
+		if (!skipDoctype) {
+			const dt = _allocNode(NodeType.Doctype, t.start, t.end);
+			_nodeStrings[dt] = t.name;
+			// At most one doctype node is ever inserted (later doctype tokens
+			// are ignored), so its ids live in two per-parse scalars.
+			_doctypePublicId = t.publicId;
+			_doctypeSystemId = t.systemId;
+			_appendChild(doc, dt);
+		}
+		quirks = isQuirky(t.name, t.publicId, t.systemId);
+		mode = MODE_BEFORE_HTML;
+		return;
+	}
+	quirks = true;
+	mode = MODE_BEFORE_HTML;
+	process(t);
+};
+
+modes.beforeHtml = (t) => {
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
+		return;
+	}
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, false);
+		if (!r) return;
+		t = r;
+	}
+	if (t.type === TOKEN_START_TAG && t.name === "html") {
+		const el = mkEl("html", NS_HTML, t.attrs, t.pos);
+		_appendChild(doc, el);
+		open.push(el);
+		mode = MODE_BEFORE_HEAD;
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
+		return;
+	}
+	const el = mkEl("html", NS_HTML, EMPTY_ATTRS, null);
+	_appendChild(doc, el);
+	open.push(el);
+	mode = MODE_BEFORE_HEAD;
+	process(t);
+};
+
+modes.beforeHead = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, false);
+		if (!r) return;
+		t = r;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "head") {
+		head = insertHtmlElement("head", t.attrs, t.pos);
+		mode = MODE_IN_HEAD;
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
+		return;
+	}
+	head = insertHtmlElement("head", EMPTY_ATTRS, null);
+	mode = MODE_IN_HEAD;
+	process(t);
+};
+
+modes.inHead = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, true);
+		if (!r) return;
+		open.pop();
+		mode = MODE_AFTER_HEAD;
+		process(r);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG) {
+		if (t.name === "html") return modes.inBody(t);
+		if (HEAD_VOID_ELEMENTS.has(t.name)) {
+			insertHtmlElement(t.name, t.attrs, t.pos);
+			open.pop();
+			return;
+		}
+		if (t.name === "title") {
+			genericRcdata(t);
+			return;
+		}
+		if (NOFRAMES_STYLE_NOSCRIPT.has(t.name)) {
+			if (t.name === "noscript") {
+				insertHtmlElement("noscript", t.attrs, t.pos);
+				mode = MODE_IN_HEAD_NOSCRIPT;
+				return;
+			}
+			genericRawtext(t);
+			return;
+		}
+		if (t.name === "script") {
+			genericRawtext(t);
+			return;
+		}
+		if (t.name === "template") {
+			insertHtmlElement("template", t.attrs, t.pos);
+			insertMarker();
+			framesetOk = false;
+			mode = MODE_IN_TEMPLATE;
+			templateModes.push(MODE_IN_TEMPLATE);
+			const el = cur();
+			const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
+			_nodeStrings[fragment] = "";
+			// Parent link so the iterative walk can ascend out of the content.
+			_nodeParents[fragment] = el;
+			_nodeTemplateContents[el] = fragment;
+			return;
+		}
+		if (t.name === "head") return;
+	}
+	if (t.type === TOKEN_END_TAG) {
+		if (t.name === "head") {
+			open.pop();
+			mode = MODE_AFTER_HEAD;
+			return;
+		}
+		if (BODY_HTML_BR.has(t.name)) {
+			/* fallthrough */
+		} else if (t.name === "template") {
+			if (!open.some(isHtmlTemplateEl)) {
+				return;
+			}
+			generateImpliedEndTagsThorough();
+			popUntil("template");
+			clearAfeToMarker();
+			templateModes.pop();
+			resetInsertionMode();
+			return;
+		} else {
+			return;
+		}
+	}
+	// anything else
+	open.pop();
+	mode = MODE_AFTER_HEAD;
+	process(t);
+};
+
+modes.inHeadNoscript = (t) => {
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_END_TAG && t.name === "noscript") {
+		open.pop();
+		mode = MODE_IN_HEAD;
+		return;
+	}
+	if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inHead(t);
+	if (t.type === TOKEN_COMMENT) return modes.inHead(t);
+	if (t.type === TOKEN_START_TAG && IN_HEAD_NOSCRIPT_PASSTHROUGH.has(t.name)) {
+		return modes.inHead(t);
+	}
+	// A stray end tag other than </br>/</noscript> is ignored (the comment
+	// or content stays inside <noscript>); only </br> and other content fall
+	// back to popping <noscript>.
+	if (t.type === TOKEN_END_TAG && t.name !== "br") return;
+	if (
+		t.type === TOKEN_START_TAG &&
+		(t.name === "head" || t.name === "noscript")
+	) {
+		return;
+	}
+	open.pop();
+	mode = MODE_IN_HEAD;
+	process(t);
+};
+
+modes.afterHead = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, true);
+		if (!r) return;
+		insertHtmlElement("body", EMPTY_ATTRS, null);
+		mode = MODE_IN_BODY;
+		process(r);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG) {
+		if (t.name === "html") return modes.inBody(t);
+		if (t.name === "body") {
+			insertHtmlElement("body", t.attrs, t.pos);
+			framesetOk = false;
+			mode = MODE_IN_BODY;
+			return;
+		}
+		if (t.name === "frameset") {
+			insertHtmlElement("frameset", t.attrs, t.pos);
+			mode = MODE_IN_FRAMESET;
+			return;
+		}
+		if (HEAD_ELEMENTS.has(t.name)) {
+			const headEl = /** @type {HtmlElement} */ (head);
+			open.push(headEl);
+			modes.inHead(t);
+			const idx = open.indexOf(headEl);
+			if (idx !== -1) open.splice(idx, 1);
+			return;
+		}
+		if (t.name === "head") return;
+	}
+	if (t.type === TOKEN_END_TAG) {
+		if (t.name === "template") return modes.inHead(t);
+		if (!BODY_HTML_BR.has(t.name)) return;
+	}
+	insertHtmlElement("body", EMPTY_ATTRS, null);
+	mode = MODE_IN_BODY;
+	process(t);
+};
+
+modes.inBody = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		if (t.data.includes("\0")) t = { ...t, data: t.data.replace(/\0/g, "") };
+		if (t.data === "") return;
+		reconstructAfe();
+		insertCharacters(t.data, t.start, t.end);
+		// `framesetOk` only ever goes true→false, so once it's false skip the
+		// per-text-token whitespace scan entirely (it flips false very early in
+		// real documents).
+		if (framesetOk && !isAllWs(t.data)) framesetOk = false;
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG) return startTagInBody(t);
+	if (t.type === TOKEN_END_TAG) return endTagInBody(t);
+	if (t.type === TOKEN_EOF && templateModes.length) {
+		return modes.inTemplate(t);
+	}
+};
+
+const closeIfPInButtonScope = () => {
+	if (inButtonScope("p")) closePElement();
+};
+
+// "any other end tag" in body: pop to the matching open element, stopping at
+// the first special element; also the adoption agency's no-element fallback.
+const anyOtherEndTag = (/** @type {string} */ name) => {
+	for (let i = open.length - 1; i >= 0; i--) {
+		const node = open[i];
+		if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === name) {
+			generateImpliedEndTags(name);
+			while (open.length > i) {
+				_nodeEnds[open[open.length - 1]] = tokenEnd;
+				open.pop();
+			}
+			return;
+		}
+		if (isSpecial(node)) return;
+	}
+};
+
+const startTagInBody = (/** @type {StartTagToken} */ t) => {
+	const name = t.name;
+	if (name === "html") {
+		if (open.some(isHtmlTemplateEl)) {
+			return;
+		}
+		mergeAttrs(open[0], t.attrs);
+		return;
+	}
+	if (HEAD_ELEMENTS.has(name)) {
+		return modes.inHead(t);
+	}
+	if (name === "body") {
+		const second = open[1];
+		if (
+			!second ||
+			_tagNameOf(second) !== "body" ||
+			open.some(isHtmlTemplateEl)
+		) {
+			return;
+		}
+		framesetOk = false;
+		mergeAttrs(second, t.attrs);
+		return;
+	}
+	if (name === "frameset") {
+		const second = open[1];
+		if (!second || _tagNameOf(second) !== "body") return;
+		if (!framesetOk) return;
+		detach(second);
+		while (open.length > 1) open.pop();
+		insertHtmlElement("frameset", t.attrs, t.pos);
+		mode = MODE_IN_FRAMESET;
+		return;
+	}
+	if (BLOCK_START.has(name)) {
+		closeIfPInButtonScope();
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (HEADING.has(name)) {
+		closeIfPInButtonScope();
+		if (_namespaceOf(cur()) === NS_HTML && HEADING.has(_tagNameOf(cur()))) {
+			open.pop();
+		}
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (name === "pre" || name === "listing") {
+		closeIfPInButtonScope();
+		insertHtmlElement(name, t.attrs, t.pos);
+		t.swallowNewline = true;
+		framesetOk = false;
+		return;
+	}
+	if (name === "form") {
+		if (form && !open.some(isHtmlTemplateEl)) {
+			return;
+		}
+		closeIfPInButtonScope();
+		const el = insertHtmlElement("form", t.attrs, t.pos);
+		if (!open.some(isHtmlTemplateEl)) {
+			form = el;
+		}
+		return;
+	}
+	if (name === "li") {
+		framesetOk = false;
+		for (let i = open.length - 1; i >= 0; i--) {
+			const node = open[i];
+			if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === "li") {
+				generateImpliedEndTags("li");
+				popUntil("li");
+				break;
+			}
+			if (
+				isSpecial(node) &&
+				!(_namespaceOf(node) === NS_HTML && ADDRESS_DIV_P.has(_tagNameOf(node)))
+			) {
+				break;
+			}
+		}
+		closeIfPInButtonScope();
+		insertHtmlElement("li", t.attrs, t.pos);
+		return;
+	}
+	if (name === "dd" || name === "dt") {
+		framesetOk = false;
+		for (let i = open.length - 1; i >= 0; i--) {
+			const node = open[i];
+			if (
+				_namespaceOf(node) === NS_HTML &&
+				(_tagNameOf(node) === "dd" || _tagNameOf(node) === "dt")
+			) {
+				generateImpliedEndTags(_tagNameOf(node));
+				popUntil(_tagNameOf(node));
+				break;
+			}
+			if (
+				isSpecial(node) &&
+				!(_namespaceOf(node) === NS_HTML && ADDRESS_DIV_P.has(_tagNameOf(node)))
+			) {
+				break;
+			}
+		}
+		closeIfPInButtonScope();
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (name === "plaintext") {
+		closeIfPInButtonScope();
+		insertHtmlElement("plaintext", t.attrs, t.pos);
+		return;
+	}
+	if (name === "button") {
+		if (inScope("button")) {
+			generateImpliedEndTags();
+			popUntil("button");
+		}
+		reconstructAfe();
+		insertHtmlElement("button", t.attrs, t.pos);
+		framesetOk = false;
+		return;
+	}
+	if (name === "a") {
+		// if there's an <a> in afe after last marker
+		for (let i = afe.length - 1; i >= 0; i--) {
+			if (afe[i] === AFE_MARKER) break;
+			if (_tagNameOf(afe[i]) === "a") {
+				adoptionAgency("a", t.pos);
+				const idx = afe.findIndex(
+					(e) => e !== AFE_MARKER && _tagNameOf(e) === "a"
+				);
+				if (idx !== -1) {
+					const el = afe[idx];
+					afe.splice(idx, 1);
+					const oi = open.indexOf(el);
+					if (oi !== -1) open.splice(oi, 1);
+				}
+				break;
+			}
+		}
+		reconstructAfe();
+		const el = insertHtmlElement("a", t.attrs, t.pos);
+		pushAfe(el);
+		return;
+	}
+	if (FORMATTING.has(name) && name !== "a" && name !== "nobr") {
+		reconstructAfe();
+		const el = insertHtmlElement(name, t.attrs, t.pos);
+		pushAfe(el);
+		return;
+	}
+	if (name === "nobr") {
+		reconstructAfe();
+		if (inScope("nobr")) {
+			// The adoption agency returns false when a marker shields the nobr
+			// from the active formatting list; then act as "any other end tag".
+			if (!adoptionAgency("nobr", t.pos)) anyOtherEndTag("nobr");
+			reconstructAfe();
+		}
+		const el = insertHtmlElement("nobr", t.attrs, t.pos);
+		pushAfe(el);
+		return;
+	}
+	if (APPLET_MARQUEE_OBJECT.has(name)) {
+		reconstructAfe();
+		insertHtmlElement(name, t.attrs, t.pos);
+		insertMarker();
+		framesetOk = false;
+		return;
+	}
+	if (name === "table") {
+		if (!quirks) closeIfPInButtonScope();
+		insertHtmlElement("table", t.attrs, t.pos);
+		framesetOk = false;
+		mode = MODE_IN_TABLE;
+		return;
+	}
+	if (VOID_FORMATTING.has(name)) {
+		reconstructAfe();
+		insertHtmlElement(name, t.attrs, t.pos);
+		open.pop();
+		framesetOk = false;
+		return;
+	}
+	if (name === "input") {
+		// `<input>` inside a select is dropped; if a select is open it is
+		// closed first (keygen/textarea no longer behave this way).
+		if (inScope("select")) {
+			popUntil("select");
+			resetInsertionMode();
+		} else if (
+			fragment &&
+			_namespaceOf(fragment) === NS_HTML &&
+			_tagNameOf(fragment) === "select"
+		) {
+			return;
+		}
+		reconstructAfe();
+		insertHtmlElement("input", t.attrs, t.pos);
+		open.pop();
+		const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
+		if (ty === 0 || _attrValueOf(ty).toLowerCase() !== "hidden") {
+			framesetOk = false;
+		}
+		return;
+	}
+	if (PARAM_SOURCE_TRACK.has(name)) {
+		insertHtmlElement(name, t.attrs, t.pos);
+		open.pop();
+		return;
+	}
+	if (name === "hr") {
+		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
+			open.pop();
+		}
+		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
+			open.pop();
+		}
+		closeIfPInButtonScope();
+		insertHtmlElement("hr", t.attrs, t.pos);
+		open.pop();
+		framesetOk = false;
+		return;
+	}
+	if (name === "image") {
+		return startTagInBody({ ...t, name: "img" });
+	}
+	if (name === "textarea") {
+		genericRcdata(t, true);
+		framesetOk = false;
+		return;
+	}
+	if (name === "xmp") {
+		closeIfPInButtonScope();
+		reconstructAfe();
+		framesetOk = false;
+		genericRawtext(t);
+		return;
+	}
+	if (name === "iframe") {
+		framesetOk = false;
+		genericRawtext(t);
+		return;
+	}
+	if (name === "noembed") {
+		genericRawtext(t);
+		return;
+	}
+	if (name === "select") {
+		reconstructAfe();
+		if (inScope("select")) {
+			generateImpliedEndTags();
+			popUntil("select");
+			resetInsertionMode();
+			return;
+		}
+		insertHtmlElement("select", t.attrs, t.pos);
+		// Marker so a stray formatting end tag (e.g. `</font>`) can't adopt
+		// across the select boundary now that select has no own insertion mode.
+		insertMarker();
+		framesetOk = false;
+		return;
+	}
+	if (name === "optgroup" || name === "option") {
+		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
+			open.pop();
+		}
+		if (
+			name === "optgroup" &&
+			_namespaceOf(cur()) === NS_HTML &&
+			_tagNameOf(cur()) === "optgroup"
+		) {
+			open.pop();
+		}
+		reconstructAfe();
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (name === "rb" || name === "rtc") {
+		if (inScope("ruby")) generateImpliedEndTags();
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (name === "rp" || name === "rt") {
+		if (inScope("ruby")) generateImpliedEndTags("rtc");
+		insertHtmlElement(name, t.attrs, t.pos);
+		return;
+	}
+	if (name === "math") {
+		reconstructAfe();
+		const attrs = adjustForeignAttrs(adjustMathmlAttrs(t.attrs), NS_MATHML);
+		insertForeignElement("math", NS_MATHML, attrs, t.pos);
+		if (t.selfClosing) open.pop();
+		return;
+	}
+	if (name === "svg") {
+		reconstructAfe();
+		const attrs = adjustForeignAttrs(t.attrs, NS_SVG);
+		insertForeignElement("svg", NS_SVG, attrs, t.pos);
+		if (t.selfClosing) open.pop();
+		return;
+	}
+	if (IGNORED_BODY_TABLE_STARTS.has(name)) {
+		return;
+	}
+	// any other start tag
+	reconstructAfe();
+	insertHtmlElement(name, t.attrs, t.pos);
+};
+
+const endTagInBody = (/** @type {EndTagToken} */ t) => {
+	const name = t.name;
+	if (name === "template") return modes.inHead(t);
+	if (name === "select") {
+		if (!inScope("select")) return;
+		generateImpliedEndTags();
+		popUntil("select");
+		return;
+	}
+	if (name === "body" || name === "html") {
+		if (!inScope("body")) return;
+		mode = MODE_AFTER_BODY;
+		if (name === "html") process(t);
+		return;
+	}
+	if (BLOCK_END.has(name)) {
+		if (!inScope(name)) return;
+		generateImpliedEndTags();
+		popUntil(name);
+		return;
+	}
+	if (name === "form") {
+		if (!open.some(isHtmlTemplateEl)) {
+			const node = form;
+			form = 0;
+			if (!node || !inScopeEl(node)) return;
+			generateImpliedEndTags();
+			const idx = open.indexOf(node);
+			if (idx !== -1) open.splice(idx, 1);
+		} else {
+			if (!inScope("form")) return;
+			generateImpliedEndTags();
+			popUntil("form");
+		}
+		return;
+	}
+	if (name === "p") {
+		if (!inButtonScope("p")) insertHtmlElement("p", EMPTY_ATTRS, t.pos);
+		closePElement();
+		return;
+	}
+	if (name === "li") {
+		if (!inListItemScope("li")) return;
+		generateImpliedEndTags("li");
+		popUntil("li");
+		return;
+	}
+	if (name === "dd" || name === "dt") {
+		if (!inScope(name)) return;
+		generateImpliedEndTags(name);
+		popUntil(name);
+		return;
+	}
+	if (HEADING.has(name)) {
+		let anyHeadingInScope = false;
+		for (const h of HEADING) {
+			if (inScope(h)) {
+				anyHeadingInScope = true;
+				break;
+			}
+		}
+		if (!anyHeadingInScope) return;
+		generateImpliedEndTags();
+		popUntilOneOf(HEADING);
+		return;
+	}
+	if (name === "sarcasm") {
+		/* take a deep breath */
+	}
+	if (FORMATTING.has(name)) {
+		adoptionAgency(name, t.pos);
+		return;
+	}
+	if (APPLET_MARQUEE_OBJECT.has(name)) {
+		if (!inScope(name)) return;
+		generateImpliedEndTags();
+		popUntil(name);
+		clearAfeToMarker();
+		return;
+	}
+	if (name === "br") {
+		reconstructAfe();
+		insertHtmlElement("br", EMPTY_ATTRS, t.pos);
+		open.pop();
+		framesetOk = false;
+		return;
+	}
+	anyOtherEndTag(name);
+};
+
+// generic RCDATA/RAWTEXT: tokenizer already emits the text + end tag, so we
+// just insert the element and switch to "text" mode; text mode appends chars
+// and the matching end tag pops.
+const genericRawtext = (/** @type {StartTagToken} */ t) => {
+	insertHtmlElement(t.name, t.attrs, t.pos);
+	originalMode = mode;
+	mode = MODE_TEXT;
+};
+const genericRcdata = (/** @type {StartTagToken} */ t, swallow = false) => {
+	insertHtmlElement(t.name, t.attrs, t.pos);
+	if (swallow) t.swallowNewline = true;
+	originalMode = mode;
+	mode = MODE_TEXT;
+};
+
+modes.text = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		insertCharacters(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_EOF) {
+		if (open.length) open.pop();
+		mode = originalMode;
+		process(t);
+		return;
+	}
+	if (t.type === TOKEN_END_TAG) {
+		// Treat as rawtext rather than an end tag when it can't close the
+		// current element: a non-matching name (e.g. a fragment context), or
+		// a name that ran straight to EOF with no delimiter (`</script` at
+		// EOF — the tokenizer still emits a partial tag there).
+		if (
+			cur() &&
+			(t.name !== _tagNameOf(cur()) || t.pos.end === t.pos.nameEnd)
+		) {
+			insertCharacters(
+				source.slice(t.pos.start, t.pos.end),
+				t.pos.start,
+				t.pos.end
+			);
+			return;
+		}
+		// span the close tag, like every other explicit-close pop
+		_nodeEnds[/** @type {HtmlElement} */ (open.pop())] = tokenEnd;
+		mode = originalMode;
+	}
+};
+
+// ---------- table modes ----------
+/** @type {{ list: CharToken[], hasNonWs: boolean } | null} */
+let pendingTableChars = null;
+
+modes.inTable = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const c = cur();
+		if (TABLE_CONTEXT.has(_tagNameOf(c)) && _namespaceOf(c) === NS_HTML) {
+			pendingTableChars = { list: [], hasNonWs: false };
+			originalMode = mode;
+			mode = MODE_IN_TABLE_TEXT;
+			return process(t);
+		}
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG) {
+		const name = t.name;
+		if (name === "caption") {
+			clearStackToTableContext();
+			insertMarker();
+			insertHtmlElement("caption", t.attrs, t.pos);
+			mode = MODE_IN_CAPTION;
+			return;
+		}
+		if (name === "colgroup") {
+			clearStackToTableContext();
+			insertHtmlElement("colgroup", t.attrs, t.pos);
+			mode = MODE_IN_COLUMN_GROUP;
+			return;
+		}
+		if (name === "col") {
+			clearStackToTableContext();
+			insertHtmlElement("colgroup", EMPTY_ATTRS, t.pos);
+			mode = MODE_IN_COLUMN_GROUP;
+			return process(t);
+		}
+		if (TBODY_GROUP.has(name)) {
+			clearStackToTableContext();
+			insertHtmlElement(name, t.attrs, t.pos);
+			mode = MODE_IN_TABLE_BODY;
+			return;
+		}
+		if (TD_TH_TR.has(name)) {
+			clearStackToTableContext();
+			insertHtmlElement("tbody", EMPTY_ATTRS, t.pos);
+			mode = MODE_IN_TABLE_BODY;
+			return process(t);
+		}
+		if (name === "table") {
+			if (!inTableScope("table")) return;
+			popUntil("table");
+			resetInsertionMode();
+			return process(t);
+		}
+		if (STYLE_SCRIPT_TEMPLATE.has(name)) {
+			return modes.inHead(t);
+		}
+		if (name === "input") {
+			const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
+			if (ty !== 0 && _attrValueOf(ty).toLowerCase() === "hidden") {
+				insertHtmlElement("input", t.attrs, t.pos);
+				open.pop();
+				return;
+			}
+		}
+		if (name === "form") {
+			if (form || open.some(isHtmlTemplateEl)) {
+				return;
+			}
+			form = insertHtmlElement("form", t.attrs, t.pos);
+			open.pop();
+			return;
+		}
+	}
+	if (t.type === TOKEN_END_TAG) {
+		if (t.name === "table") {
+			if (!inTableScope("table")) return;
+			popUntil("table");
+			resetInsertionMode();
+			return;
+		}
+		if (IN_TABLE_IGNORED_ENDS.has(t.name)) {
+			return;
+		}
+		if (t.name === "template") return modes.inHead(t);
+	}
+	if (t.type === TOKEN_EOF) return modes.inBody(t);
+	// anything else: foster parenting
+	fosterParenting = true;
+	modes.inBody(t);
+	fosterParenting = false;
+};
+
+modes.inTableText = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const data = t.data.includes("\0") ? t.data.replace(/\0/g, "") : t.data;
+		if (data === "") return;
+		// Snapshot into a fresh token: these are buffered and replayed after
+		// later tokens arrive, so they must not alias the reused token.
+		/** @type {CharToken} */
+		const tc = { type: TOKEN_CHAR, data, start: t.start, end: t.end };
+		const pending = /** @type {{ list: CharToken[], hasNonWs: boolean }} */ (
+			pendingTableChars
+		);
+		pending.list.push(tc);
+		if (!isAllWs(tc.data)) pending.hasNonWs = true;
+		return;
+	}
+	// flush
+	const chars = /** @type {{ list: CharToken[], hasNonWs: boolean }} */ (
+		pendingTableChars
+	);
+	pendingTableChars = null;
+	mode = originalMode;
+	for (const ct of chars.list) {
+		if (chars.hasNonWs) {
+			fosterParenting = true;
+			modes.inBody(ct);
+			fosterParenting = false;
+		} else {
+			insertCharacters(ct.data, ct.start, ct.end);
+		}
+	}
+	process(t);
+};
+
+const clearStackToTableContext = () => {
+	while (open.length) {
+		const c = cur();
+		if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE.has(_tagNameOf(c))) {
+			break;
+		}
+		open.pop();
+	}
+};
+const clearStackToTableBodyContext = () => {
+	while (open.length) {
+		const c = cur();
+		if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_BODY.has(_tagNameOf(c))) {
+			break;
+		}
+		open.pop();
+	}
+};
+const clearStackToTableRowContext = () => {
+	while (open.length) {
+		const c = cur();
+		if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_ROW.has(_tagNameOf(c))) {
+			break;
+		}
+		open.pop();
+	}
+};
+
+modes.inCaption = (t) => {
+	if (
+		(t.type === TOKEN_END_TAG && t.name === "caption") ||
+		(t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) ||
+		(t.type === TOKEN_END_TAG && t.name === "table")
+	) {
+		if (!inTableScope("caption")) return;
+		generateImpliedEndTags();
+		popUntil("caption");
+		clearAfeToMarker();
+		mode = MODE_IN_TABLE;
+		if (!(t.type === TOKEN_END_TAG && t.name === "caption")) {
+			return process(t);
+		}
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && CAPTION_IGNORED_ENDS.has(t.name)) {
+		return;
+	}
+	return modes.inBody(t);
+};
+
+modes.inColumnGroup = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const r = leadingWs(t, true);
+		if (!r) return;
+		if (_tagNameOf(cur()) !== "colgroup") return;
+		open.pop();
+		mode = MODE_IN_TABLE;
+		process(r);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "col") {
+		insertHtmlElement("col", t.attrs, t.pos);
+		open.pop();
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && t.name === "colgroup") {
+		if (_tagNameOf(cur()) !== "colgroup") return;
+		open.pop();
+		mode = MODE_IN_TABLE;
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && t.name === "col") return;
+	if (
+		(t.type === TOKEN_START_TAG || t.type === TOKEN_END_TAG) &&
+		t.name === "template"
+	) {
+		return modes.inHead(t);
+	}
+	if (t.type === TOKEN_EOF) return modes.inBody(t);
+	if (_tagNameOf(cur()) !== "colgroup") return;
+	open.pop();
+	mode = MODE_IN_TABLE;
+	process(t);
+};
+
+modes.inTableBody = (t) => {
+	if (t.type === TOKEN_START_TAG && t.name === "tr") {
+		clearStackToTableBodyContext();
+		insertHtmlElement("tr", t.attrs, t.pos);
+		mode = MODE_IN_ROW;
+		return;
+	}
+	if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
+		clearStackToTableBodyContext();
+		insertHtmlElement("tr", EMPTY_ATTRS, t.pos);
+		mode = MODE_IN_ROW;
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
+		if (!inTableScope(t.name)) return;
+		clearStackToTableBodyContext();
+		open.pop();
+		mode = MODE_IN_TABLE;
+		return;
+	}
+	if (
+		(t.type === TOKEN_START_TAG && TBODY_TRIGGER_STARTS.has(t.name)) ||
+		(t.type === TOKEN_END_TAG && t.name === "table")
+	) {
+		if (!inTableScope(TBODY_GROUP)) return;
+		clearStackToTableBodyContext();
+		open.pop();
+		mode = MODE_IN_TABLE;
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && TBODY_IGNORED_ENDS.has(t.name)) {
+		return;
+	}
+	return modes.inTable(t);
+};
+
+modes.inRow = (t) => {
+	if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
+		clearStackToTableRowContext();
+		insertHtmlElement(t.name, t.attrs, t.pos);
+		mode = MODE_IN_CELL;
+		insertMarker();
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && t.name === "tr") {
+		if (!inTableScope("tr")) return;
+		clearStackToTableRowContext();
+		open.pop();
+		mode = MODE_IN_TABLE_BODY;
+		return;
+	}
+	if (
+		(t.type === TOKEN_START_TAG && ROW_TRIGGER_STARTS.has(t.name)) ||
+		(t.type === TOKEN_END_TAG && t.name === "table")
+	) {
+		if (!inTableScope("tr")) return;
+		clearStackToTableRowContext();
+		open.pop();
+		mode = MODE_IN_TABLE_BODY;
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
+		if (!inTableScope(t.name)) return;
+		if (!inTableScope("tr")) return;
+		clearStackToTableRowContext();
+		open.pop();
+		mode = MODE_IN_TABLE_BODY;
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && ROW_IGNORED_ENDS.has(t.name)) {
+		return;
+	}
+	return modes.inTable(t);
+};
+
+modes.inCell = (t) => {
+	if (t.type === TOKEN_END_TAG && (t.name === "td" || t.name === "th")) {
+		if (!inTableScope(t.name)) return;
+		generateImpliedEndTags();
+		popUntil(t.name);
+		clearAfeToMarker();
+		mode = MODE_IN_ROW;
+		return;
+	}
+	if (t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) {
+		if (!inTableScope("td") && !inTableScope("th")) return;
+		closeCell();
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && TABLE_CONTEXT.has(t.name)) {
+		if (!inTableScope(t.name)) return;
+		closeCell();
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG && CELL_IGNORED_ENDS.has(t.name)) {
+		return;
+	}
+	return modes.inBody(t);
+};
+const closeCell = () => {
+	generateImpliedEndTags();
+	popUntilOneOf(TD_TH);
+	clearAfeToMarker();
+	mode = MODE_IN_ROW;
+};
+
+modes.inTemplate = (t) => {
+	if (
+		t.type === TOKEN_CHAR ||
+		t.type === TOKEN_COMMENT ||
+		t.type === TOKEN_DOCTYPE
+	) {
+		return modes.inBody(t);
+	}
+	if (t.type === TOKEN_START_TAG) {
+		if (HEAD_ELEMENTS.has(t.name)) {
+			return modes.inHead(t);
+		}
+		const target = TEMPLATE_START_TAG_MODES.get(t.name) || MODE_IN_BODY;
+		templateModes[templateModes.length - 1] = target;
+		mode = target;
+		return process(t);
+	}
+	if (t.type === TOKEN_END_TAG) {
+		if (t.name === "template") return modes.inHead(t);
+		return;
+	}
+	if (t.type === TOKEN_EOF) {
+		if (!open.some(isHtmlTemplateEl)) {
+			return;
+		}
+		popUntil("template");
+		clearAfeToMarker();
+		templateModes.pop();
+		resetInsertionMode();
+		return process(t);
+	}
+};
+
+modes.afterBody = (t) => {
+	if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end, {
+			parent: open[0],
+			beforeNode: 0
+		});
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_END_TAG && t.name === "html") {
+		if (fragment) return;
+		mode = MODE_AFTER_AFTER_BODY;
+		return;
+	}
+	if (t.type === TOKEN_EOF) return;
+	mode = MODE_IN_BODY;
+	process(t);
+};
+
+modes.inFrameset = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
+		if (ws) insertCharacters(ws, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "frameset") {
+		insertHtmlElement("frameset", t.attrs, t.pos);
+		return;
+	}
+	if (t.type === TOKEN_END_TAG && t.name === "frameset") {
+		if (_tagNameOf(cur()) === "html") return;
+		open.pop();
+		if (!fragment && _tagNameOf(cur()) !== "frameset") {
+			mode = MODE_AFTER_FRAMESET;
+		}
+		return;
+	}
+	if (t.type === TOKEN_START_TAG && t.name === "frame") {
+		insertHtmlElement("frame", t.attrs, t.pos);
+		open.pop();
+		return;
+	}
+	if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+		return modes.inHead(t);
+	}
+};
+
+modes.afterFrameset = (t) => {
+	if (t.type === TOKEN_CHAR) {
+		const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
+		if (ws) insertCharacters(ws, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end);
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return;
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_END_TAG && t.name === "html") {
+		mode = MODE_AFTER_AFTER_FRAMESET;
+		return;
+	}
+	if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+		return modes.inHead(t);
+	}
+};
+
+modes.afterAfterBody = (t) => {
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
+	if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_EOF) return;
+	mode = MODE_IN_BODY;
+	process(t);
+};
+
+modes.afterAfterFrameset = (t) => {
+	if (t.type === TOKEN_COMMENT) {
+		insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
+		return;
+	}
+	if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
+	if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
+	if (t.type === TOKEN_START_TAG && t.name === "noframes") {
+		return modes.inHead(t);
+	}
+};
+
+const dispatch = () =>
+	process(/** @type {Token} */ (/** @type {unknown} */ (tok)));
+
 /**
  * @param {string} input HTML source
  * @param {number=} pos start byte offset (string input only; default `0`)
@@ -5596,11 +7686,11 @@ const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
  * @returns {HtmlDocument} ref to the document node — read through `A`; valid until the next parse
  */
 const parseHtml = (input, pos = 0, options = {}) => {
-	const source = input;
+	source = input;
 	const { fragmentContext, skip = EMPTY_SKIP } = options;
-	const skipText = skip.text === true;
-	const skipComments = skip.comments === true;
-	const skipDoctype = skip.doctype === true;
+	skipText = skip.text === true;
+	skipComments = skip.comments === true;
+	skipDoctype = skip.doctype === true;
 	_resetAstColumns();
 	// Pre-size the columns from the input length: a document big enough to
 	// exceed `_COLUMN_SHRINK_CAPACITY` re-enters with released (empty) columns,
@@ -5616,2097 +7706,27 @@ const parseHtml = (input, pos = 0, options = {}) => {
 		_growAttrColumns(_sizeEstimate >> 2);
 	}
 	_htmlSource = source;
-	const doc = _allocNode(NodeType.Document, 0, 0);
+	doc = _allocNode(NodeType.Document, 0, 0);
 	_nodeStrings[doc] = "";
-	let mode = MODE_INITIAL;
-	// Mode to return to after MODE_TEXT / MODE_IN_TABLE_TEXT (0 = unset).
-	let originalMode = 0;
-	/** @type {HtmlElement[]} stack of open elements (bottom .. top) */
-	const open = [];
-	/** @type {HtmlNodeRef[]} active formatting elements (AFE_MARKER = marker) */
-	const afe = [];
-	/** @type {HtmlElement} 0 = none */
-	let head = 0;
-	/** @type {HtmlElement} 0 = none */
-	let form = 0;
-	let framesetOk = true;
-	// First attribute id of the tag currently being tokenized (0 = none).
-	let pendAttrStart = 0;
-	let fosterParenting = false;
-	/** @type {number[]} */
-	const templateModes = [];
-	let quirks = false;
-	/** @type {HtmlElement} fragment context element (0 = document parse) */
-	let fragment = 0;
-	// End offset of the token currently being processed (for element `.end`).
-	let tokenEnd = 0;
-
-	const cur = () => /** @type {HtmlElement} */ (open[open.length - 1]);
-	const adjustedCurrent = () => {
-		if (open.length === 1 && fragment) return fragment;
-		return cur();
-	};
-
-	const appendTo = (
-		/** @type {HtmlNodeRef} */ parent,
-		/** @type {HtmlNodeRef} */ node
-	) => {
-		const p = effParent(parent);
-		const last = _nodeLastChildren[p];
-		if (
-			_nodeTypes[node] === NodeType.Text &&
-			last !== 0 &&
-			_nodeTypes[last] === NodeType.Text
-		) {
-			_nodeStrings[last] += _nodeStrings[node];
-			_nodeEnds[last] = _nodeEnds[node];
-			return;
-		}
-		_appendChild(p, node);
-	};
-
-	// Reused result of `appropriatePlace` — consumed synchronously by
-	// `insertAtPlace` and never retained, so one shared object avoids an
-	// allocation per inserted node.
-	/** @type {InsertionPlace} */
-	const sharedPlace = { parent: doc, beforeNode: 0 };
-	const placeAt = (
-		/** @type {HtmlNodeRef} */ parent,
-		/** @type {HtmlNodeRef} */ beforeNode
-	) => {
-		sharedPlace.parent = parent;
-		sharedPlace.beforeNode = beforeNode;
-		return sharedPlace;
-	};
-
-	// "appropriate place for inserting a node"
-	const appropriatePlace = () => {
-		const target = cur();
-		if (
-			fosterParenting &&
-			TABLE_CONTEXT.has(_tagNameOf(target)) &&
-			_namespaceOf(target) === NS_HTML
-		) {
-			// find last template / last table
-			let lastTemplate = -1;
-			let lastTable = -1;
-			for (let i = open.length - 1; i >= 0; i--) {
-				if (
-					_tagNameOf(open[i]) === "template" &&
-					_namespaceOf(open[i]) === NS_HTML &&
-					lastTemplate === -1
-				) {
-					lastTemplate = i;
-				}
-				if (
-					_tagNameOf(open[i]) === "table" &&
-					_namespaceOf(open[i]) === NS_HTML &&
-					lastTable === -1
-				) {
-					lastTable = i;
-				}
-			}
-			if (
-				lastTemplate !== -1 &&
-				(lastTable === -1 || lastTemplate > lastTable)
-			) {
-				return placeAt(open[lastTemplate], 0);
-			}
-			if (lastTable === -1) {
-				return placeAt(open[0], 0);
-			}
-			const table = open[lastTable];
-			const tp = _nodeParents[table];
-			if (tp !== 0) return placeAt(tp, table);
-			return placeAt(open[lastTable - 1], 0);
-		}
-		return placeAt(target, 0);
-	};
-
-	const insertAtPlace = (
-		/** @type {InsertionPlace} */ place,
-		/** @type {HtmlNodeRef} */ node
-	) => {
-		const before = place.beforeNode;
-		if (before !== 0) {
-			const p = effParent(place.parent);
-			// Find `before`'s previous sibling (insert-before is a rare foster/
-			// adoption path, so the sibling scan stays off the hot path).
-			let prev = 0;
-			let c = _nodeFirstChildren[p];
-			while (c !== 0 && c !== before) {
-				prev = c;
-				c = _nodeNextSiblings[c];
-			}
-			if (c === 0) {
-				// `before` not under `parent` (not reachable from the spec paths).
-				appendTo(place.parent, node);
-				return;
-			}
-			if (
-				_nodeTypes[node] === NodeType.Text &&
-				prev !== 0 &&
-				_nodeTypes[prev] === NodeType.Text
-			) {
-				// Before-node merge deliberately does not bump the sibling's `end`.
-				_nodeStrings[prev] += _nodeStrings[node];
-				return;
-			}
-			_nodeParents[node] = p;
-			_nodeNextSiblings[node] = before;
-			if (prev === 0) _nodeFirstChildren[p] = node;
-			else _nodeNextSiblings[prev] = node;
-		} else {
-			appendTo(place.parent, node);
-		}
-	};
-
-	const insertCharacters = (
-		/** @type {string} */ data,
-		/** @type {number} */ start,
-		/** @type {number} */ end
-	) => {
-		const place = appropriatePlace();
-		if (_nodeTypes[place.parent] === NodeType.Document) return; // never insert text into document
-		// `skip.text`: drop every `Text` node — construction already used the
-		// decoded token, so removing the node never affects element structure.
-		// For a raw-text element record the body end so a consumer reads the span
-		// [`tagEnd`, `contentEnd`] without a `Text` node (see `HtmlParser`).
-		// Namespace-agnostic: `HtmlParser` extracts `<script>`/`<style>` bodies in
-		// foreign content (e.g. SVG `<style>`) too.
-		if (skipText) {
-			const p = place.parent;
-			if (
-				_nodeTypes[p] === NodeType.Element &&
-				RAW_TEXT_ELEMENTS.has(_tagNameOf(p))
-			) {
-				_nodeContentEnds[p] = end;
-			}
-			return;
-		}
-		// Inlined text insert: when the run merges into the adjacent text sibling
-		// (common with inline formatting) only the string is appended — no
-		// throwaway text node is allocated. Mirrors `insertAtPlace`/`appendTo`,
-		// including that the before-node merge does not bump `end`.
-		const p = effParent(place.parent);
-		const before = place.beforeNode;
-		if (before !== 0) {
-			let prev = 0;
-			let c = _nodeFirstChildren[p];
-			while (c !== 0 && c !== before) {
-				prev = c;
-				c = _nodeNextSiblings[c];
-			}
-			if (c === 0) {
-				// `before` not under `parent` (not reachable from the spec paths).
-				_appendChild(p, _makeTextNode(data, start, end));
-				return;
-			}
-			if (prev !== 0 && _nodeTypes[prev] === NodeType.Text) {
-				_nodeStrings[prev] += data;
-				return;
-			}
-			const node = _makeTextNode(data, start, end);
-			_nodeParents[node] = p;
-			_nodeNextSiblings[node] = before;
-			if (prev === 0) _nodeFirstChildren[p] = node;
-			else _nodeNextSiblings[prev] = node;
-		} else {
-			const last = _nodeLastChildren[p];
-			if (last !== 0 && _nodeTypes[last] === NodeType.Text) {
-				_nodeStrings[last] += data;
-				_nodeEnds[last] = end;
-				return;
-			}
-			_appendChild(p, _makeTextNode(data, start, end));
-		}
-	};
-
-	/**
-	 * @param {string} data comment data
-	 * @param {number} start start offset
-	 * @param {number} end end offset
-	 * @param {InsertionPlace=} place explicit insertion place
-	 */
-	const insertComment = (data, start, end, place) => {
-		if (skipComments) return;
-		const p = place || appropriatePlace();
-		insertAtPlace(p, _makeCommentNode(data, start, end));
-	};
-
-	const insertHtmlElement = (
-		/** @type {string} */ tagName,
-		/** @type {AttributeRun} */ attrs,
-		/** @type {TagPos | null} */ pos
-	) => {
-		const el = mkEl(tagName, NS_HTML, attrs, pos);
-		const place = appropriatePlace();
-		insertAtPlace(place, el);
-		open.push(el);
-		return el;
-	};
-
-	const insertForeignElement = (
-		/** @type {string} */ tagName,
-		/** @type {number} */ ns,
-		/** @type {AttributeRun} */ attrs,
-		/** @type {TagPos | null} */ pos
-	) => {
-		const el = mkEl(tagName, ns, attrs, pos);
-		const place = appropriatePlace();
-		insertAtPlace(place, el);
-		open.push(el);
-		return el;
-	};
-
-	// ---- scopes ----
-	// Scope "kind" selects which extra elements act as boundaries. Passed as a
-	// small int so the scope checks below allocate no per-call predicate closure
-	// (these run several times per body tag).
-	const SCOPE_DEFAULT = 0;
-	const SCOPE_BUTTON = 1;
-	const SCOPE_LIST_ITEM = 2;
-	const isBoundaryForKind = (
-		/** @type {HtmlElement} */ el,
-		/** @type {number} */ kind
-	) => {
-		if (isScopeBoundary(el)) return true;
-		if (_namespaceOf(el) !== NS_HTML) return false;
-		if (kind === SCOPE_BUTTON) return _tagNameOf(el) === "button";
-		if (kind === SCOPE_LIST_ITEM) {
-			return _tagNameOf(el) === "ol" || _tagNameOf(el) === "ul";
-		}
-		return false;
-	};
-	// "have an element in scope": walk the open stack from the top until the
-	// named HTML element is found (true) or a scope boundary is hit (false).
-	const hasNameInScope = (
-		/** @type {string} */ tagName,
-		/** @type {number} */ kind
-	) => {
-		for (let i = open.length - 1; i >= 0; i--) {
-			const el = open[i];
-			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) {
-				return true;
-			}
-			if (isBoundaryForKind(el, kind)) return false;
-		}
-		return false;
-	};
-	const inScope = (/** @type {string} */ tagName) =>
-		hasNameInScope(tagName, SCOPE_DEFAULT);
-	const inButtonScope = (/** @type {string} */ tagName) =>
-		hasNameInScope(tagName, SCOPE_BUTTON);
-	const inListItemScope = (/** @type {string} */ tagName) =>
-		hasNameInScope(tagName, SCOPE_LIST_ITEM);
-	const inScopeEl = (/** @type {HtmlElement} */ target) => {
-		for (let i = open.length - 1; i >= 0; i--) {
-			const el = open[i];
-			if (el === target) return true;
-			if (isScopeBoundary(el)) return false;
-		}
-		return false;
-	};
-	// `target` is a single tag name (the common case) or a Set of names.
-	const inTableScope = (/** @type {string | Set<string>} */ target) => {
-		const set = typeof target === "string" ? null : target;
-		for (let i = open.length - 1; i >= 0; i--) {
-			const el = open[i];
-			if (_namespaceOf(el) === NS_HTML) {
-				if (set ? set.has(_tagNameOf(el)) : _tagNameOf(el) === target) {
-					return true;
-				}
-				if (TABLE_SCOPE_STOP.has(_tagNameOf(el))) return false;
-			}
-		}
-		return false;
-	};
-	const generateImpliedEndTags = (except = "") => {
-		while (open.length) {
-			const el = cur();
-			if (
-				_namespaceOf(el) === NS_HTML &&
-				IMPLIED.has(_tagNameOf(el)) &&
-				_tagNameOf(el) !== except
-			) {
-				open.pop();
-			} else {
-				break;
-			}
-		}
-	};
-	const generateImpliedEndTagsThorough = () => {
-		while (open.length) {
-			const el = cur();
-			if (
-				_namespaceOf(el) === NS_HTML &&
-				IMPLIED_THOROUGH.has(_tagNameOf(el))
-			) {
-				open.pop();
-			} else {
-				break;
-			}
-		}
-	};
-
-	// ---- active formatting elements ----
-	const pushAfe = (/** @type {HtmlElement} */ el) => {
-		let count = 0;
-		for (let i = afe.length - 1; i >= 0; i--) {
-			const e = afe[i];
-			if (e === AFE_MARKER) break;
-			if (
-				_tagNameOf(e) === _tagNameOf(el) &&
-				_namespaceOf(e) === _namespaceOf(el) &&
-				sameAttrs(e, el)
-			) {
-				count++;
-				if (count === 3) {
-					afe.splice(i, 1);
-					break;
-				}
-			}
-		}
-		afe.push(el);
-	};
-	const insertMarker = () => afe.push(AFE_MARKER);
-	const clearAfeToMarker = () => {
-		while (afe.length) {
-			if (afe.pop() === AFE_MARKER) break;
-		}
-	};
-	const reconstructAfe = () => {
-		if (afe.length === 0) return;
-		let i = afe.length - 1;
-		if (afe[i] === AFE_MARKER || open.includes(afe[i])) return;
-		while (i > 0) {
-			i--;
-			if (afe[i] === AFE_MARKER || open.includes(afe[i])) {
-				i++;
-				break;
-			}
-		}
-		for (; i < afe.length; i++) {
-			const e = afe[i];
-			const el = mkEl(_tagNameOf(e), _namespaceOf(e), cloneAttrs(e), null);
-			const place = appropriatePlace();
-			insertAtPlace(place, el);
-			open.push(el);
-			afe[i] = el;
-		}
-	};
-
-	// ---- close p ----
-	const closePElement = () => {
-		generateImpliedEndTags("p");
-		// pop until a p has been popped
-		while (open.length) {
-			const el = /** @type {HtmlElement} */ (open.pop());
-			_nodeEnds[el] = tokenEnd;
-			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === "p") break;
-		}
-	};
-
-	const popUntil = (/** @type {string} */ tagName) => {
-		while (open.length) {
-			const el = /** @type {HtmlElement} */ (open.pop());
-			_nodeEnds[el] = tokenEnd;
-			if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) break;
-		}
-	};
-	const popUntilOneOf = (/** @type {Set<string>} */ set) => {
-		while (open.length) {
-			const el = /** @type {HtmlElement} */ (open.pop());
-			_nodeEnds[el] = tokenEnd;
-			if (_namespaceOf(el) === NS_HTML && set.has(_tagNameOf(el))) break;
-		}
-	};
-
-	// ---- reset insertion mode appropriately ----
-	const resetInsertionMode = () => {
-		let last = false;
-		for (let i = open.length - 1; i >= 0; i--) {
-			let node = open[i];
-			if (i === 0) {
-				last = true;
-				if (fragment) node = fragment;
-			}
-			const tn = _tagNameOf(node);
-			if (_namespaceOf(node) === NS_HTML) {
-				if ((tn === "td" || tn === "th") && !last) {
-					mode = MODE_IN_CELL;
-					return;
-				}
-				if (tn === "tr") {
-					mode = MODE_IN_ROW;
-					return;
-				}
-				if (TBODY_GROUP.has(tn)) {
-					mode = MODE_IN_TABLE_BODY;
-					return;
-				}
-				if (tn === "caption") {
-					mode = MODE_IN_CAPTION;
-					return;
-				}
-				if (tn === "colgroup") {
-					mode = MODE_IN_COLUMN_GROUP;
-					return;
-				}
-				if (tn === "table") {
-					mode = MODE_IN_TABLE;
-					return;
-				}
-				if (tn === "template") {
-					mode = templateModes[templateModes.length - 1];
-					return;
-				}
-				if (tn === "head" && !last) {
-					mode = MODE_IN_HEAD;
-					return;
-				}
-				if (tn === "body") {
-					mode = MODE_IN_BODY;
-					return;
-				}
-				if (tn === "frameset") {
-					mode = MODE_IN_FRAMESET;
-					return;
-				}
-				if (tn === "html") {
-					mode = head ? MODE_AFTER_HEAD : MODE_BEFORE_HEAD;
-					return;
-				}
-			}
-			if (last) {
-				mode = MODE_IN_BODY;
-				return;
-			}
-		}
-	};
-
-	// ---------- token processing ----------
-	// Split a character token's leading whitespace; per the spec each character
-	// is its own token, so a mixed run can straddle a mode change. Inserts the
-	// leading whitespace when `insert`, returns the non-whitespace remainder
-	// token (or null when the token was entirely whitespace).
-	const leadingWs = (
-		/** @type {CharToken} */ t,
-		/** @type {boolean} */ insert
-	) => {
-		const m = /^[\t\n\f\r ]+/.exec(t.data);
-		const ws = m ? m[0] : "";
-		if (ws && insert) insertCharacters(ws, t.start, t.start + ws.length);
-		if (ws.length === t.data.length) return null;
-		return { ...t, data: t.data.slice(ws.length), start: t.start + ws.length };
-	};
-
-	const process = (/** @type {Token} */ t) => {
-		// Track the current token's end so explicit closes can set element `.end`.
-		// Dispatch on `type` instead of the `in` operator, which goes megamorphic
-		// across the token union and shows up on the per-token hot path.
-		const ty = t.type;
-		if (ty === TOKEN_START_TAG || ty === TOKEN_END_TAG) tokenEnd = t.pos.end;
-		else if (ty !== TOKEN_EOF) tokenEnd = t.end;
-		// foreign content dispatch
-		const ac = adjustedCurrent();
-		const useForeign =
-			open.length > 0 &&
-			ac &&
-			_namespaceOf(ac) !== NS_HTML &&
-			ty !== TOKEN_EOF &&
-			shouldUseForeignRules(ac, t);
-		if (useForeign) {
-			foreignContent(t);
-			return;
-		}
-		runMode(t);
-	};
-
-	const shouldUseForeignRules = (
-		/** @type {HtmlElement} */ ac,
-		/** @type {Token} */ t
-	) => {
-		if (_namespaceOf(ac) === NS_HTML) return false;
-		if (t.type === TOKEN_START_TAG) {
-			if (
-				mathmlTextIntegrationPoint(ac) &&
-				t.name !== "mglyph" &&
-				t.name !== "malignmark"
-			) {
-				return false;
-			}
-			if (
-				_namespaceOf(ac) === NS_MATHML &&
-				_tagNameOf(ac) === "annotation-xml" &&
-				t.name === "svg"
-			) {
-				return false;
-			}
-			if (htmlIntegrationPoint(ac)) return false;
-			return true;
-		}
-		if (t.type === TOKEN_CHAR) {
-			if (mathmlTextIntegrationPoint(ac)) return false;
-			if (htmlIntegrationPoint(ac)) return false;
-			return true;
-		}
-		if (t.type === TOKEN_END_TAG) return true;
-		if (t.type === TOKEN_COMMENT) return true;
-		return false;
-	};
-
-	const foreignContent = (/** @type {Token} */ t) => {
-		if (t.type === TOKEN_CHAR) {
-			const data = t.data.replace(/\0/g, "�");
-			insertCharacters(data, t.start, t.end);
-			// eslint-disable-next-line no-control-regex
-			if (/[^\t\n\f\r \u0000]/.test(t.data)) framesetOk = false;
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG) {
-			const acn = _namespaceOf(adjustedCurrent());
-			if (
-				FOREIGN_BREAKOUT.has(t.name) ||
-				(t.name === "font" && hasFontBreakoutAttr(t.attrs))
-			) {
-				// parse error; pop until integration point / html / mathml-text-integration
-				while (open.length > 1) {
-					const c = cur();
-					if (
-						_namespaceOf(c) === NS_HTML ||
-						mathmlTextIntegrationPoint(c) ||
-						htmlIntegrationPoint(c)
-					) {
-						break;
-					}
-					open.pop();
-				}
-				runMode(t);
-				return;
-			}
-			const ns = acn;
-			let name = t.name;
-			let attrs = t.attrs;
-			if (ns === NS_SVG) {
-				name = adjustSvgTag(name);
-			}
-			if (ns === NS_MATHML) {
-				attrs = adjustMathmlAttrs(attrs);
-			}
-			attrs = adjustForeignAttrs(attrs, ns);
-			insertForeignElement(name, ns, attrs, t.pos);
-			if (t.selfClosing) {
-				open.pop();
-			}
-			return;
-		}
-		if (t.type === TOKEN_END_TAG) {
-			if (
-				t.name === "script" &&
-				_tagNameOf(cur()) === "script" &&
-				_namespaceOf(cur()) === NS_SVG
-			) {
-				open.pop();
-				return;
-			}
-			// `</p>` and `</br>` break out: pop foreign elements up to the
-			// nearest HTML element or integration point, then process in HTML.
-			if (t.name === "p" || t.name === "br") {
-				while (
-					open.length > 1 &&
-					_namespaceOf(cur()) !== NS_HTML &&
-					!mathmlTextIntegrationPoint(cur()) &&
-					!htmlIntegrationPoint(cur())
-				) {
-					open.pop();
-				}
-				runMode(t);
-				return;
-			}
-			// any other end tag
-			let i = open.length - 1;
-			let node = open[i];
-			if (_tagNameOf(node).toLowerCase() !== t.name) {
-				/* parse error */
-			}
-			while (i >= 0) {
-				node = open[i];
-				if (i === 0) return;
-				if (
-					_namespaceOf(node) !== NS_HTML &&
-					_tagNameOf(node).toLowerCase() === t.name
-				) {
-					while (open.length > i) open.pop();
-					return;
-				}
-				i--;
-				if (open[i] && _namespaceOf(open[i]) === NS_HTML) {
-					runMode(t);
-					return;
-				}
-			}
-		}
-	};
-
-	// ---------- adoption agency algorithm ----------
-	const adoptionAgency = (
-		/** @type {string} */ subject,
-		/** @type {TagPos | null} */ pos
-	) => {
-		// step 1
-		const c = cur();
-		if (
-			_namespaceOf(c) === NS_HTML &&
-			_tagNameOf(c) === subject &&
-			!afe.includes(c)
-		) {
-			open.pop();
-			return true;
-		}
-		let outer = 0;
-		while (outer < 8) {
-			outer++;
-			// find formatting element
-			let fmtIdx = -1;
-			for (let i = afe.length - 1; i >= 0; i--) {
-				if (afe[i] === AFE_MARKER) break;
-				if (
-					_tagNameOf(afe[i]) === subject &&
-					_namespaceOf(afe[i]) === NS_HTML
-				) {
-					fmtIdx = i;
-					break;
-				}
-			}
-			if (fmtIdx === -1) return false; // act as any other end tag
-			const fmt = afe[fmtIdx];
-			const openIdx = open.indexOf(fmt);
-			if (openIdx === -1) {
-				afe.splice(fmtIdx, 1);
-				return true;
-			}
-			if (!inScopeEl(fmt)) return true; // parse error, ignore
-			// step: furthest block
-			let furthestIdx = -1;
-			for (let i = openIdx + 1; i < open.length; i++) {
-				if (isSpecial(open[i])) {
-					furthestIdx = i;
-					break;
-				}
-			}
-			if (furthestIdx === -1) {
-				while (open.length > openIdx) open.pop();
-				afe.splice(fmtIdx, 1);
-				return true;
-			}
-			const furthest = open[furthestIdx];
-			const commonAncestor = open[openIdx - 1];
-			let bookmark = fmtIdx;
-			let node = furthest;
-			let lastNode = furthest;
-			let nodeIdx = furthestIdx;
-			let inner = 0;
-			while (true) {
-				inner++;
-				nodeIdx--;
-				node = open[nodeIdx];
-				if (node === fmt) break;
-				let nodeAfeIdx = afe.indexOf(node);
-				if (inner > 3 && nodeAfeIdx !== -1) {
-					afe.splice(nodeAfeIdx, 1);
-					if (nodeAfeIdx < bookmark) bookmark--;
-					nodeAfeIdx = -1;
-				}
-				if (nodeAfeIdx === -1) {
-					open.splice(nodeIdx, 1);
-					continue;
-				}
-				// create clone
-				const clone = mkEl(
-					_tagNameOf(node),
-					_namespaceOf(node),
-					cloneAttrs(node),
-					null
-				);
-				afe[nodeAfeIdx] = clone;
-				open[nodeIdx] = clone;
-				node = clone;
-				if (lastNode === furthest) bookmark = nodeAfeIdx + 1;
-				// append lastNode to node
-				detach(lastNode);
-				appendTo(node, lastNode);
-				lastNode = node;
-			}
-			// insert lastNode into common ancestor (with foster parenting)
-			detach(lastNode);
-			const place = placeForCommonAncestor(commonAncestor);
-			insertAtPlace(place, lastNode);
-			// create element for fmt token, take children of furthest
-			const cloneFmt = mkEl(
-				_tagNameOf(fmt),
-				_namespaceOf(fmt),
-				cloneAttrs(fmt),
-				null
-			);
-			// Take all direct children of `furthest` (a template's content fragment
-			// deliberately stays put — mirrors childrenOf-less spec behavior here).
-			let k = _nodeFirstChildren[furthest];
-			_nodeFirstChildren[furthest] = 0;
-			_nodeLastChildren[furthest] = 0;
-			while (k !== 0) {
-				const next = _nodeNextSiblings[k];
-				_nodeNextSiblings[k] = 0;
-				_nodeParents[k] = 0;
-				appendTo(cloneFmt, k);
-				k = next;
-			}
-			appendTo(furthest, cloneFmt);
-			// remove fmt from afe, insert clone at bookmark
-			const curFmtIdx = afe.indexOf(fmt);
-			if (curFmtIdx !== -1) {
-				afe.splice(curFmtIdx, 1);
-				if (curFmtIdx < bookmark) bookmark--;
-			}
-			afe.splice(bookmark, 0, cloneFmt);
-			// remove fmt from open, insert clone below furthest
-			const ofi = open.indexOf(fmt);
-			if (ofi !== -1) open.splice(ofi, 1);
-			const newFurthestIdx = open.indexOf(furthest);
-			open.splice(newFurthestIdx + 1, 0, cloneFmt);
-		}
-		return true;
-	};
-
-	const placeForCommonAncestor = (
-		/** @type {HtmlElement} */ commonAncestor
-	) => {
-		if (
-			TABLE_CONTEXT.has(_tagNameOf(commonAncestor)) &&
-			_namespaceOf(commonAncestor) === NS_HTML
-		) {
-			// foster
-			// reuse appropriatePlace logic but rooted differently: emulate
-			let lastTemplate = -1;
-			let lastTable = -1;
-			for (let i = open.length - 1; i >= 0; i--) {
-				if (
-					_tagNameOf(open[i]) === "template" &&
-					_namespaceOf(open[i]) === NS_HTML &&
-					lastTemplate === -1
-				) {
-					lastTemplate = i;
-				}
-				if (
-					_tagNameOf(open[i]) === "table" &&
-					_namespaceOf(open[i]) === NS_HTML &&
-					lastTable === -1
-				) {
-					lastTable = i;
-				}
-			}
-			if (
-				lastTemplate !== -1 &&
-				(lastTable === -1 || lastTemplate > lastTable)
-			) {
-				return { parent: open[lastTemplate], beforeNode: 0 };
-			}
-			if (lastTable === -1) return { parent: open[0], beforeNode: 0 };
-			const table = open[lastTable];
-			const tp = _nodeParents[table];
-			if (tp !== 0) return { parent: tp, beforeNode: table };
-			return { parent: open[lastTable - 1], beforeNode: 0 };
-		}
-		return { parent: commonAncestor, beforeNode: 0 };
-	};
-
-	const detach = (/** @type {HtmlNodeRef} */ node) => {
-		const p = _nodeParents[node];
-		if (p === 0) return;
-		let prev = 0;
-		let c = _nodeFirstChildren[p];
-		while (c !== 0 && c !== node) {
-			prev = c;
-			c = _nodeNextSiblings[c];
-		}
-		if (c === 0) return;
-		if (prev === 0) _nodeFirstChildren[p] = _nodeNextSiblings[node];
-		else _nodeNextSiblings[prev] = _nodeNextSiblings[node];
-		if (_nodeLastChildren[p] === node) _nodeLastChildren[p] = prev;
-		_nodeNextSiblings[node] = 0;
-		_nodeParents[node] = 0;
-	};
-
-	// ---------- insertion modes ----------
-
-	/** @type {Record<string, (t: Token) => void>} */
-	const modes = {};
-
-	// Dispatch the current insertion mode. An integer switch (cases ordered by
-	// frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
-	// `modes[mode]` load + indirect call would defeat inlining on the per-token
-	// hot path.
-	const runMode = (/** @type {Token} */ t) => {
-		switch (mode) {
-			case MODE_IN_BODY:
-				return modes.inBody(t);
-			case MODE_TEXT:
-				return modes.text(t);
-			case MODE_IN_CELL:
-				return modes.inCell(t);
-			case MODE_IN_ROW:
-				return modes.inRow(t);
-			case MODE_IN_TABLE_BODY:
-				return modes.inTableBody(t);
-			case MODE_IN_TABLE:
-				return modes.inTable(t);
-			case MODE_IN_TABLE_TEXT:
-				return modes.inTableText(t);
-			case MODE_IN_CAPTION:
-				return modes.inCaption(t);
-			case MODE_IN_COLUMN_GROUP:
-				return modes.inColumnGroup(t);
-			case MODE_IN_TEMPLATE:
-				return modes.inTemplate(t);
-			case MODE_IN_HEAD:
-				return modes.inHead(t);
-			case MODE_IN_HEAD_NOSCRIPT:
-				return modes.inHeadNoscript(t);
-			case MODE_AFTER_HEAD:
-				return modes.afterHead(t);
-			case MODE_BEFORE_HEAD:
-				return modes.beforeHead(t);
-			case MODE_BEFORE_HTML:
-				return modes.beforeHtml(t);
-			case MODE_INITIAL:
-				return modes.initial(t);
-			case MODE_AFTER_BODY:
-				return modes.afterBody(t);
-			case MODE_AFTER_AFTER_BODY:
-				return modes.afterAfterBody(t);
-			case MODE_IN_FRAMESET:
-				return modes.inFrameset(t);
-			case MODE_AFTER_FRAMESET:
-				return modes.afterFrameset(t);
-			// MODE_AFTER_AFTER_FRAMESET — every mode is enumerated, so the last
-			// one is the `default` (also satisfies exhaustiveness linting).
-			default:
-				return modes.afterAfterFrameset(t);
-		}
-	};
-
-	modes.initial = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, false);
-			if (!r) return;
-			quirks = true;
-			mode = MODE_BEFORE_HTML;
-			process(r);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) {
-			// `skip.doctype` drops the node only; quirks detection below is unaffected.
-			if (!skipDoctype) {
-				const dt = _allocNode(NodeType.Doctype, t.start, t.end);
-				_nodeStrings[dt] = t.name;
-				// At most one doctype node is ever inserted (later doctype tokens
-				// are ignored), so its ids live in two per-parse scalars.
-				_doctypePublicId = t.publicId;
-				_doctypeSystemId = t.systemId;
-				_appendChild(doc, dt);
-			}
-			quirks = isQuirky(t.name, t.publicId, t.systemId);
-			mode = MODE_BEFORE_HTML;
-			return;
-		}
-		quirks = true;
-		mode = MODE_BEFORE_HTML;
-		process(t);
-	};
-
-	modes.beforeHtml = (t) => {
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
-			return;
-		}
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, false);
-			if (!r) return;
-			t = r;
-		}
-		if (t.type === TOKEN_START_TAG && t.name === "html") {
-			const el = mkEl("html", NS_HTML, t.attrs, t.pos);
-			_appendChild(doc, el);
-			open.push(el);
-			mode = MODE_BEFORE_HEAD;
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
-			return;
-		}
-		const el = mkEl("html", NS_HTML, EMPTY_ATTRS, null);
-		_appendChild(doc, el);
-		open.push(el);
-		mode = MODE_BEFORE_HEAD;
-		process(t);
-	};
-
-	modes.beforeHead = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, false);
-			if (!r) return;
-			t = r;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "head") {
-			head = insertHtmlElement("head", t.attrs, t.pos);
-			mode = MODE_IN_HEAD;
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && !HEAD_BODY_HTML_BR.has(t.name)) {
-			return;
-		}
-		head = insertHtmlElement("head", EMPTY_ATTRS, null);
-		mode = MODE_IN_HEAD;
-		process(t);
-	};
-
-	modes.inHead = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, true);
-			if (!r) return;
-			open.pop();
-			mode = MODE_AFTER_HEAD;
-			process(r);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG) {
-			if (t.name === "html") return modes.inBody(t);
-			if (HEAD_VOID_ELEMENTS.has(t.name)) {
-				insertHtmlElement(t.name, t.attrs, t.pos);
-				open.pop();
-				return;
-			}
-			if (t.name === "title") {
-				genericRcdata(t);
-				return;
-			}
-			if (NOFRAMES_STYLE_NOSCRIPT.has(t.name)) {
-				if (t.name === "noscript") {
-					insertHtmlElement("noscript", t.attrs, t.pos);
-					mode = MODE_IN_HEAD_NOSCRIPT;
-					return;
-				}
-				genericRawtext(t);
-				return;
-			}
-			if (t.name === "script") {
-				genericRawtext(t);
-				return;
-			}
-			if (t.name === "template") {
-				insertHtmlElement("template", t.attrs, t.pos);
-				insertMarker();
-				framesetOk = false;
-				mode = MODE_IN_TEMPLATE;
-				templateModes.push(MODE_IN_TEMPLATE);
-				const el = cur();
-				const fragment = _allocNode(NodeType.DocumentFragment, 0, 0);
-				_nodeStrings[fragment] = "";
-				// Parent link so the iterative walk can ascend out of the content.
-				_nodeParents[fragment] = el;
-				_nodeTemplateContents[el] = fragment;
-				return;
-			}
-			if (t.name === "head") return;
-		}
-		if (t.type === TOKEN_END_TAG) {
-			if (t.name === "head") {
-				open.pop();
-				mode = MODE_AFTER_HEAD;
-				return;
-			}
-			if (BODY_HTML_BR.has(t.name)) {
-				/* fallthrough */
-			} else if (t.name === "template") {
-				if (!open.some(isHtmlTemplateEl)) {
-					return;
-				}
-				generateImpliedEndTagsThorough();
-				popUntil("template");
-				clearAfeToMarker();
-				templateModes.pop();
-				resetInsertionMode();
-				return;
-			} else {
-				return;
-			}
-		}
-		// anything else
-		open.pop();
-		mode = MODE_AFTER_HEAD;
-		process(t);
-	};
-
-	modes.inHeadNoscript = (t) => {
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_END_TAG && t.name === "noscript") {
-			open.pop();
-			mode = MODE_IN_HEAD;
-			return;
-		}
-		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inHead(t);
-		if (t.type === TOKEN_COMMENT) return modes.inHead(t);
-		if (
-			t.type === TOKEN_START_TAG &&
-			IN_HEAD_NOSCRIPT_PASSTHROUGH.has(t.name)
-		) {
-			return modes.inHead(t);
-		}
-		// A stray end tag other than </br>/</noscript> is ignored (the comment
-		// or content stays inside <noscript>); only </br> and other content fall
-		// back to popping <noscript>.
-		if (t.type === TOKEN_END_TAG && t.name !== "br") return;
-		if (
-			t.type === TOKEN_START_TAG &&
-			(t.name === "head" || t.name === "noscript")
-		) {
-			return;
-		}
-		open.pop();
-		mode = MODE_IN_HEAD;
-		process(t);
-	};
-
-	modes.afterHead = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, true);
-			if (!r) return;
-			insertHtmlElement("body", EMPTY_ATTRS, null);
-			mode = MODE_IN_BODY;
-			process(r);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG) {
-			if (t.name === "html") return modes.inBody(t);
-			if (t.name === "body") {
-				insertHtmlElement("body", t.attrs, t.pos);
-				framesetOk = false;
-				mode = MODE_IN_BODY;
-				return;
-			}
-			if (t.name === "frameset") {
-				insertHtmlElement("frameset", t.attrs, t.pos);
-				mode = MODE_IN_FRAMESET;
-				return;
-			}
-			if (HEAD_ELEMENTS.has(t.name)) {
-				const headEl = /** @type {HtmlElement} */ (head);
-				open.push(headEl);
-				modes.inHead(t);
-				const idx = open.indexOf(headEl);
-				if (idx !== -1) open.splice(idx, 1);
-				return;
-			}
-			if (t.name === "head") return;
-		}
-		if (t.type === TOKEN_END_TAG) {
-			if (t.name === "template") return modes.inHead(t);
-			if (!BODY_HTML_BR.has(t.name)) return;
-		}
-		insertHtmlElement("body", EMPTY_ATTRS, null);
-		mode = MODE_IN_BODY;
-		process(t);
-	};
-
-	modes.inBody = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			if (t.data.includes("\0")) t = { ...t, data: t.data.replace(/\0/g, "") };
-			if (t.data === "") return;
-			reconstructAfe();
-			insertCharacters(t.data, t.start, t.end);
-			// `framesetOk` only ever goes true→false, so once it's false skip the
-			// per-text-token whitespace scan entirely (it flips false very early in
-			// real documents).
-			if (framesetOk && !isAllWs(t.data)) framesetOk = false;
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG) return startTagInBody(t);
-		if (t.type === TOKEN_END_TAG) return endTagInBody(t);
-		if (t.type === TOKEN_EOF && templateModes.length) {
-			return modes.inTemplate(t);
-		}
-	};
-
-	const closeIfPInButtonScope = () => {
-		if (inButtonScope("p")) closePElement();
-	};
-
-	// "any other end tag" in body: pop to the matching open element, stopping at
-	// the first special element; also the adoption agency's no-element fallback.
-	const anyOtherEndTag = (/** @type {string} */ name) => {
-		for (let i = open.length - 1; i >= 0; i--) {
-			const node = open[i];
-			if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === name) {
-				generateImpliedEndTags(name);
-				while (open.length > i) {
-					_nodeEnds[open[open.length - 1]] = tokenEnd;
-					open.pop();
-				}
-				return;
-			}
-			if (isSpecial(node)) return;
-		}
-	};
-
-	const startTagInBody = (/** @type {StartTagToken} */ t) => {
-		const name = t.name;
-		if (name === "html") {
-			if (open.some(isHtmlTemplateEl)) {
-				return;
-			}
-			mergeAttrs(open[0], t.attrs);
-			return;
-		}
-		if (HEAD_ELEMENTS.has(name)) {
-			return modes.inHead(t);
-		}
-		if (name === "body") {
-			const second = open[1];
-			if (
-				!second ||
-				_tagNameOf(second) !== "body" ||
-				open.some(isHtmlTemplateEl)
-			) {
-				return;
-			}
-			framesetOk = false;
-			mergeAttrs(second, t.attrs);
-			return;
-		}
-		if (name === "frameset") {
-			const second = open[1];
-			if (!second || _tagNameOf(second) !== "body") return;
-			if (!framesetOk) return;
-			detach(second);
-			while (open.length > 1) open.pop();
-			insertHtmlElement("frameset", t.attrs, t.pos);
-			mode = MODE_IN_FRAMESET;
-			return;
-		}
-		if (BLOCK_START.has(name)) {
-			closeIfPInButtonScope();
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (HEADING.has(name)) {
-			closeIfPInButtonScope();
-			if (_namespaceOf(cur()) === NS_HTML && HEADING.has(_tagNameOf(cur()))) {
-				open.pop();
-			}
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (name === "pre" || name === "listing") {
-			closeIfPInButtonScope();
-			insertHtmlElement(name, t.attrs, t.pos);
-			t.swallowNewline = true;
-			framesetOk = false;
-			return;
-		}
-		if (name === "form") {
-			if (form && !open.some(isHtmlTemplateEl)) {
-				return;
-			}
-			closeIfPInButtonScope();
-			const el = insertHtmlElement("form", t.attrs, t.pos);
-			if (!open.some(isHtmlTemplateEl)) {
-				form = el;
-			}
-			return;
-		}
-		if (name === "li") {
-			framesetOk = false;
-			for (let i = open.length - 1; i >= 0; i--) {
-				const node = open[i];
-				if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === "li") {
-					generateImpliedEndTags("li");
-					popUntil("li");
-					break;
-				}
-				if (
-					isSpecial(node) &&
-					!(
-						_namespaceOf(node) === NS_HTML &&
-						ADDRESS_DIV_P.has(_tagNameOf(node))
-					)
-				) {
-					break;
-				}
-			}
-			closeIfPInButtonScope();
-			insertHtmlElement("li", t.attrs, t.pos);
-			return;
-		}
-		if (name === "dd" || name === "dt") {
-			framesetOk = false;
-			for (let i = open.length - 1; i >= 0; i--) {
-				const node = open[i];
-				if (
-					_namespaceOf(node) === NS_HTML &&
-					(_tagNameOf(node) === "dd" || _tagNameOf(node) === "dt")
-				) {
-					generateImpliedEndTags(_tagNameOf(node));
-					popUntil(_tagNameOf(node));
-					break;
-				}
-				if (
-					isSpecial(node) &&
-					!(
-						_namespaceOf(node) === NS_HTML &&
-						ADDRESS_DIV_P.has(_tagNameOf(node))
-					)
-				) {
-					break;
-				}
-			}
-			closeIfPInButtonScope();
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (name === "plaintext") {
-			closeIfPInButtonScope();
-			insertHtmlElement("plaintext", t.attrs, t.pos);
-			return;
-		}
-		if (name === "button") {
-			if (inScope("button")) {
-				generateImpliedEndTags();
-				popUntil("button");
-			}
-			reconstructAfe();
-			insertHtmlElement("button", t.attrs, t.pos);
-			framesetOk = false;
-			return;
-		}
-		if (name === "a") {
-			// if there's an <a> in afe after last marker
-			for (let i = afe.length - 1; i >= 0; i--) {
-				if (afe[i] === AFE_MARKER) break;
-				if (_tagNameOf(afe[i]) === "a") {
-					adoptionAgency("a", t.pos);
-					const idx = afe.findIndex(
-						(e) => e !== AFE_MARKER && _tagNameOf(e) === "a"
-					);
-					if (idx !== -1) {
-						const el = afe[idx];
-						afe.splice(idx, 1);
-						const oi = open.indexOf(el);
-						if (oi !== -1) open.splice(oi, 1);
-					}
-					break;
-				}
-			}
-			reconstructAfe();
-			const el = insertHtmlElement("a", t.attrs, t.pos);
-			pushAfe(el);
-			return;
-		}
-		if (FORMATTING.has(name) && name !== "a" && name !== "nobr") {
-			reconstructAfe();
-			const el = insertHtmlElement(name, t.attrs, t.pos);
-			pushAfe(el);
-			return;
-		}
-		if (name === "nobr") {
-			reconstructAfe();
-			if (inScope("nobr")) {
-				// The adoption agency returns false when a marker shields the nobr
-				// from the active formatting list; then act as "any other end tag".
-				if (!adoptionAgency("nobr", t.pos)) anyOtherEndTag("nobr");
-				reconstructAfe();
-			}
-			const el = insertHtmlElement("nobr", t.attrs, t.pos);
-			pushAfe(el);
-			return;
-		}
-		if (APPLET_MARQUEE_OBJECT.has(name)) {
-			reconstructAfe();
-			insertHtmlElement(name, t.attrs, t.pos);
-			insertMarker();
-			framesetOk = false;
-			return;
-		}
-		if (name === "table") {
-			if (!quirks) closeIfPInButtonScope();
-			insertHtmlElement("table", t.attrs, t.pos);
-			framesetOk = false;
-			mode = MODE_IN_TABLE;
-			return;
-		}
-		if (VOID_FORMATTING.has(name)) {
-			reconstructAfe();
-			insertHtmlElement(name, t.attrs, t.pos);
-			open.pop();
-			framesetOk = false;
-			return;
-		}
-		if (name === "input") {
-			// `<input>` inside a select is dropped; if a select is open it is
-			// closed first (keygen/textarea no longer behave this way).
-			if (inScope("select")) {
-				popUntil("select");
-				resetInsertionMode();
-			} else if (
-				fragment &&
-				_namespaceOf(fragment) === NS_HTML &&
-				_tagNameOf(fragment) === "select"
-			) {
-				return;
-			}
-			reconstructAfe();
-			insertHtmlElement("input", t.attrs, t.pos);
-			open.pop();
-			const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
-			if (ty === 0 || _attrValueOf(ty).toLowerCase() !== "hidden") {
-				framesetOk = false;
-			}
-			return;
-		}
-		if (PARAM_SOURCE_TRACK.has(name)) {
-			insertHtmlElement(name, t.attrs, t.pos);
-			open.pop();
-			return;
-		}
-		if (name === "hr") {
-			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
-				open.pop();
-			}
-			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
-				open.pop();
-			}
-			closeIfPInButtonScope();
-			insertHtmlElement("hr", t.attrs, t.pos);
-			open.pop();
-			framesetOk = false;
-			return;
-		}
-		if (name === "image") {
-			return startTagInBody({ ...t, name: "img" });
-		}
-		if (name === "textarea") {
-			genericRcdata(t, true);
-			framesetOk = false;
-			return;
-		}
-		if (name === "xmp") {
-			closeIfPInButtonScope();
-			reconstructAfe();
-			framesetOk = false;
-			genericRawtext(t);
-			return;
-		}
-		if (name === "iframe") {
-			framesetOk = false;
-			genericRawtext(t);
-			return;
-		}
-		if (name === "noembed") {
-			genericRawtext(t);
-			return;
-		}
-		if (name === "select") {
-			reconstructAfe();
-			if (inScope("select")) {
-				generateImpliedEndTags();
-				popUntil("select");
-				resetInsertionMode();
-				return;
-			}
-			insertHtmlElement("select", t.attrs, t.pos);
-			// Marker so a stray formatting end tag (e.g. `</font>`) can't adopt
-			// across the select boundary now that select has no own insertion mode.
-			insertMarker();
-			framesetOk = false;
-			return;
-		}
-		if (name === "optgroup" || name === "option") {
-			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
-				open.pop();
-			}
-			if (
-				name === "optgroup" &&
-				_namespaceOf(cur()) === NS_HTML &&
-				_tagNameOf(cur()) === "optgroup"
-			) {
-				open.pop();
-			}
-			reconstructAfe();
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (name === "rb" || name === "rtc") {
-			if (inScope("ruby")) generateImpliedEndTags();
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (name === "rp" || name === "rt") {
-			if (inScope("ruby")) generateImpliedEndTags("rtc");
-			insertHtmlElement(name, t.attrs, t.pos);
-			return;
-		}
-		if (name === "math") {
-			reconstructAfe();
-			const attrs = adjustForeignAttrs(adjustMathmlAttrs(t.attrs), NS_MATHML);
-			insertForeignElement("math", NS_MATHML, attrs, t.pos);
-			if (t.selfClosing) open.pop();
-			return;
-		}
-		if (name === "svg") {
-			reconstructAfe();
-			const attrs = adjustForeignAttrs(t.attrs, NS_SVG);
-			insertForeignElement("svg", NS_SVG, attrs, t.pos);
-			if (t.selfClosing) open.pop();
-			return;
-		}
-		if (IGNORED_BODY_TABLE_STARTS.has(name)) {
-			return;
-		}
-		// any other start tag
-		reconstructAfe();
-		insertHtmlElement(name, t.attrs, t.pos);
-	};
-
-	const endTagInBody = (/** @type {EndTagToken} */ t) => {
-		const name = t.name;
-		if (name === "template") return modes.inHead(t);
-		if (name === "select") {
-			if (!inScope("select")) return;
-			generateImpliedEndTags();
-			popUntil("select");
-			return;
-		}
-		if (name === "body" || name === "html") {
-			if (!inScope("body")) return;
-			mode = MODE_AFTER_BODY;
-			if (name === "html") process(t);
-			return;
-		}
-		if (BLOCK_END.has(name)) {
-			if (!inScope(name)) return;
-			generateImpliedEndTags();
-			popUntil(name);
-			return;
-		}
-		if (name === "form") {
-			if (!open.some(isHtmlTemplateEl)) {
-				const node = form;
-				form = 0;
-				if (!node || !inScopeEl(node)) return;
-				generateImpliedEndTags();
-				const idx = open.indexOf(node);
-				if (idx !== -1) open.splice(idx, 1);
-			} else {
-				if (!inScope("form")) return;
-				generateImpliedEndTags();
-				popUntil("form");
-			}
-			return;
-		}
-		if (name === "p") {
-			if (!inButtonScope("p")) insertHtmlElement("p", EMPTY_ATTRS, t.pos);
-			closePElement();
-			return;
-		}
-		if (name === "li") {
-			if (!inListItemScope("li")) return;
-			generateImpliedEndTags("li");
-			popUntil("li");
-			return;
-		}
-		if (name === "dd" || name === "dt") {
-			if (!inScope(name)) return;
-			generateImpliedEndTags(name);
-			popUntil(name);
-			return;
-		}
-		if (HEADING.has(name)) {
-			let anyHeadingInScope = false;
-			for (const h of HEADING) {
-				if (inScope(h)) {
-					anyHeadingInScope = true;
-					break;
-				}
-			}
-			if (!anyHeadingInScope) return;
-			generateImpliedEndTags();
-			popUntilOneOf(HEADING);
-			return;
-		}
-		if (name === "sarcasm") {
-			/* take a deep breath */
-		}
-		if (FORMATTING.has(name)) {
-			adoptionAgency(name, t.pos);
-			return;
-		}
-		if (APPLET_MARQUEE_OBJECT.has(name)) {
-			if (!inScope(name)) return;
-			generateImpliedEndTags();
-			popUntil(name);
-			clearAfeToMarker();
-			return;
-		}
-		if (name === "br") {
-			reconstructAfe();
-			insertHtmlElement("br", EMPTY_ATTRS, t.pos);
-			open.pop();
-			framesetOk = false;
-			return;
-		}
-		anyOtherEndTag(name);
-	};
-
-	// generic RCDATA/RAWTEXT: tokenizer already emits the text + end tag, so we
-	// just insert the element and switch to "text" mode; text mode appends chars
-	// and the matching end tag pops.
-	const genericRawtext = (/** @type {StartTagToken} */ t) => {
-		insertHtmlElement(t.name, t.attrs, t.pos);
-		originalMode = mode;
-		mode = MODE_TEXT;
-	};
-	const genericRcdata = (/** @type {StartTagToken} */ t, swallow = false) => {
-		insertHtmlElement(t.name, t.attrs, t.pos);
-		if (swallow) t.swallowNewline = true;
-		originalMode = mode;
-		mode = MODE_TEXT;
-	};
-
-	modes.text = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			insertCharacters(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_EOF) {
-			if (open.length) open.pop();
-			mode = originalMode;
-			process(t);
-			return;
-		}
-		if (t.type === TOKEN_END_TAG) {
-			// Treat as rawtext rather than an end tag when it can't close the
-			// current element: a non-matching name (e.g. a fragment context), or
-			// a name that ran straight to EOF with no delimiter (`</script` at
-			// EOF — the tokenizer still emits a partial tag there).
-			if (
-				cur() &&
-				(t.name !== _tagNameOf(cur()) || t.pos.end === t.pos.nameEnd)
-			) {
-				insertCharacters(
-					source.slice(t.pos.start, t.pos.end),
-					t.pos.start,
-					t.pos.end
-				);
-				return;
-			}
-			// span the close tag, like every other explicit-close pop
-			_nodeEnds[/** @type {HtmlElement} */ (open.pop())] = tokenEnd;
-			mode = originalMode;
-		}
-	};
-
-	// ---------- table modes ----------
-	/** @type {{ list: CharToken[], hasNonWs: boolean } | null} */
-	let pendingTableChars = null;
-
-	modes.inTable = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const c = cur();
-			if (TABLE_CONTEXT.has(_tagNameOf(c)) && _namespaceOf(c) === NS_HTML) {
-				pendingTableChars = { list: [], hasNonWs: false };
-				originalMode = mode;
-				mode = MODE_IN_TABLE_TEXT;
-				return process(t);
-			}
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG) {
-			const name = t.name;
-			if (name === "caption") {
-				clearStackToTableContext();
-				insertMarker();
-				insertHtmlElement("caption", t.attrs, t.pos);
-				mode = MODE_IN_CAPTION;
-				return;
-			}
-			if (name === "colgroup") {
-				clearStackToTableContext();
-				insertHtmlElement("colgroup", t.attrs, t.pos);
-				mode = MODE_IN_COLUMN_GROUP;
-				return;
-			}
-			if (name === "col") {
-				clearStackToTableContext();
-				insertHtmlElement("colgroup", EMPTY_ATTRS, t.pos);
-				mode = MODE_IN_COLUMN_GROUP;
-				return process(t);
-			}
-			if (TBODY_GROUP.has(name)) {
-				clearStackToTableContext();
-				insertHtmlElement(name, t.attrs, t.pos);
-				mode = MODE_IN_TABLE_BODY;
-				return;
-			}
-			if (TD_TH_TR.has(name)) {
-				clearStackToTableContext();
-				insertHtmlElement("tbody", EMPTY_ATTRS, t.pos);
-				mode = MODE_IN_TABLE_BODY;
-				return process(t);
-			}
-			if (name === "table") {
-				if (!inTableScope("table")) return;
-				popUntil("table");
-				resetInsertionMode();
-				return process(t);
-			}
-			if (STYLE_SCRIPT_TEMPLATE.has(name)) {
-				return modes.inHead(t);
-			}
-			if (name === "input") {
-				const ty = _findAttr(t.attrs.start, t.attrs.count, "type");
-				if (ty !== 0 && _attrValueOf(ty).toLowerCase() === "hidden") {
-					insertHtmlElement("input", t.attrs, t.pos);
-					open.pop();
-					return;
-				}
-			}
-			if (name === "form") {
-				if (form || open.some(isHtmlTemplateEl)) {
-					return;
-				}
-				form = insertHtmlElement("form", t.attrs, t.pos);
-				open.pop();
-				return;
-			}
-		}
-		if (t.type === TOKEN_END_TAG) {
-			if (t.name === "table") {
-				if (!inTableScope("table")) return;
-				popUntil("table");
-				resetInsertionMode();
-				return;
-			}
-			if (IN_TABLE_IGNORED_ENDS.has(t.name)) {
-				return;
-			}
-			if (t.name === "template") return modes.inHead(t);
-		}
-		if (t.type === TOKEN_EOF) return modes.inBody(t);
-		// anything else: foster parenting
-		fosterParenting = true;
-		modes.inBody(t);
-		fosterParenting = false;
-	};
-
-	modes.inTableText = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const data = t.data.includes("\0") ? t.data.replace(/\0/g, "") : t.data;
-			if (data === "") return;
-			// Snapshot into a fresh token: these are buffered and replayed after
-			// later tokens arrive, so they must not alias the reused token.
-			/** @type {CharToken} */
-			const tc = { type: TOKEN_CHAR, data, start: t.start, end: t.end };
-			const pending = /** @type {{ list: CharToken[], hasNonWs: boolean }} */ (
-				pendingTableChars
-			);
-			pending.list.push(tc);
-			if (!isAllWs(tc.data)) pending.hasNonWs = true;
-			return;
-		}
-		// flush
-		const chars = /** @type {{ list: CharToken[], hasNonWs: boolean }} */ (
-			pendingTableChars
-		);
-		pendingTableChars = null;
-		mode = originalMode;
-		for (const ct of chars.list) {
-			if (chars.hasNonWs) {
-				fosterParenting = true;
-				modes.inBody(ct);
-				fosterParenting = false;
-			} else {
-				insertCharacters(ct.data, ct.start, ct.end);
-			}
-		}
-		process(t);
-	};
-
-	const clearStackToTableContext = () => {
-		while (open.length) {
-			const c = cur();
-			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE.has(_tagNameOf(c))) {
-				break;
-			}
-			open.pop();
-		}
-	};
-	const clearStackToTableBodyContext = () => {
-		while (open.length) {
-			const c = cur();
-			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_BODY.has(_tagNameOf(c))) {
-				break;
-			}
-			open.pop();
-		}
-	};
-	const clearStackToTableRowContext = () => {
-		while (open.length) {
-			const c = cur();
-			if (_namespaceOf(c) === NS_HTML && CLEAR_TABLE_ROW.has(_tagNameOf(c))) {
-				break;
-			}
-			open.pop();
-		}
-	};
-
-	modes.inCaption = (t) => {
-		if (
-			(t.type === TOKEN_END_TAG && t.name === "caption") ||
-			(t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) ||
-			(t.type === TOKEN_END_TAG && t.name === "table")
-		) {
-			if (!inTableScope("caption")) return;
-			generateImpliedEndTags();
-			popUntil("caption");
-			clearAfeToMarker();
-			mode = MODE_IN_TABLE;
-			if (!(t.type === TOKEN_END_TAG && t.name === "caption")) {
-				return process(t);
-			}
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && CAPTION_IGNORED_ENDS.has(t.name)) {
-			return;
-		}
-		return modes.inBody(t);
-	};
-
-	modes.inColumnGroup = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const r = leadingWs(t, true);
-			if (!r) return;
-			if (_tagNameOf(cur()) !== "colgroup") return;
-			open.pop();
-			mode = MODE_IN_TABLE;
-			process(r);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "col") {
-			insertHtmlElement("col", t.attrs, t.pos);
-			open.pop();
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && t.name === "colgroup") {
-			if (_tagNameOf(cur()) !== "colgroup") return;
-			open.pop();
-			mode = MODE_IN_TABLE;
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && t.name === "col") return;
-		if (
-			(t.type === TOKEN_START_TAG || t.type === TOKEN_END_TAG) &&
-			t.name === "template"
-		) {
-			return modes.inHead(t);
-		}
-		if (t.type === TOKEN_EOF) return modes.inBody(t);
-		if (_tagNameOf(cur()) !== "colgroup") return;
-		open.pop();
-		mode = MODE_IN_TABLE;
-		process(t);
-	};
-
-	modes.inTableBody = (t) => {
-		if (t.type === TOKEN_START_TAG && t.name === "tr") {
-			clearStackToTableBodyContext();
-			insertHtmlElement("tr", t.attrs, t.pos);
-			mode = MODE_IN_ROW;
-			return;
-		}
-		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
-			clearStackToTableBodyContext();
-			insertHtmlElement("tr", EMPTY_ATTRS, t.pos);
-			mode = MODE_IN_ROW;
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
-			if (!inTableScope(t.name)) return;
-			clearStackToTableBodyContext();
-			open.pop();
-			mode = MODE_IN_TABLE;
-			return;
-		}
-		if (
-			(t.type === TOKEN_START_TAG && TBODY_TRIGGER_STARTS.has(t.name)) ||
-			(t.type === TOKEN_END_TAG && t.name === "table")
-		) {
-			if (!inTableScope(TBODY_GROUP)) return;
-			clearStackToTableBodyContext();
-			open.pop();
-			mode = MODE_IN_TABLE;
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && TBODY_IGNORED_ENDS.has(t.name)) {
-			return;
-		}
-		return modes.inTable(t);
-	};
-
-	modes.inRow = (t) => {
-		if (t.type === TOKEN_START_TAG && (t.name === "th" || t.name === "td")) {
-			clearStackToTableRowContext();
-			insertHtmlElement(t.name, t.attrs, t.pos);
-			mode = MODE_IN_CELL;
-			insertMarker();
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && t.name === "tr") {
-			if (!inTableScope("tr")) return;
-			clearStackToTableRowContext();
-			open.pop();
-			mode = MODE_IN_TABLE_BODY;
-			return;
-		}
-		if (
-			(t.type === TOKEN_START_TAG && ROW_TRIGGER_STARTS.has(t.name)) ||
-			(t.type === TOKEN_END_TAG && t.name === "table")
-		) {
-			if (!inTableScope("tr")) return;
-			clearStackToTableRowContext();
-			open.pop();
-			mode = MODE_IN_TABLE_BODY;
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && TBODY_GROUP.has(t.name)) {
-			if (!inTableScope(t.name)) return;
-			if (!inTableScope("tr")) return;
-			clearStackToTableRowContext();
-			open.pop();
-			mode = MODE_IN_TABLE_BODY;
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && ROW_IGNORED_ENDS.has(t.name)) {
-			return;
-		}
-		return modes.inTable(t);
-	};
-
-	modes.inCell = (t) => {
-		if (t.type === TOKEN_END_TAG && (t.name === "td" || t.name === "th")) {
-			if (!inTableScope(t.name)) return;
-			generateImpliedEndTags();
-			popUntil(t.name);
-			clearAfeToMarker();
-			mode = MODE_IN_ROW;
-			return;
-		}
-		if (t.type === TOKEN_START_TAG && CAPTION_TABLE_STARTS.has(t.name)) {
-			if (!inTableScope("td") && !inTableScope("th")) return;
-			closeCell();
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && TABLE_CONTEXT.has(t.name)) {
-			if (!inTableScope(t.name)) return;
-			closeCell();
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG && CELL_IGNORED_ENDS.has(t.name)) {
-			return;
-		}
-		return modes.inBody(t);
-	};
-	const closeCell = () => {
-		generateImpliedEndTags();
-		popUntilOneOf(TD_TH);
-		clearAfeToMarker();
-		mode = MODE_IN_ROW;
-	};
-
-	modes.inTemplate = (t) => {
-		if (
-			t.type === TOKEN_CHAR ||
-			t.type === TOKEN_COMMENT ||
-			t.type === TOKEN_DOCTYPE
-		) {
-			return modes.inBody(t);
-		}
-		if (t.type === TOKEN_START_TAG) {
-			if (HEAD_ELEMENTS.has(t.name)) {
-				return modes.inHead(t);
-			}
-			const target = TEMPLATE_START_TAG_MODES.get(t.name) || MODE_IN_BODY;
-			templateModes[templateModes.length - 1] = target;
-			mode = target;
-			return process(t);
-		}
-		if (t.type === TOKEN_END_TAG) {
-			if (t.name === "template") return modes.inHead(t);
-			return;
-		}
-		if (t.type === TOKEN_EOF) {
-			if (!open.some(isHtmlTemplateEl)) {
-				return;
-			}
-			popUntil("template");
-			clearAfeToMarker();
-			templateModes.pop();
-			resetInsertionMode();
-			return process(t);
-		}
-	};
-
-	modes.afterBody = (t) => {
-		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end, {
-				parent: open[0],
-				beforeNode: 0
-			});
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_END_TAG && t.name === "html") {
-			if (fragment) return;
-			mode = MODE_AFTER_AFTER_BODY;
-			return;
-		}
-		if (t.type === TOKEN_EOF) return;
-		mode = MODE_IN_BODY;
-		process(t);
-	};
-
-	modes.inFrameset = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
-			if (ws) insertCharacters(ws, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "frameset") {
-			insertHtmlElement("frameset", t.attrs, t.pos);
-			return;
-		}
-		if (t.type === TOKEN_END_TAG && t.name === "frameset") {
-			if (_tagNameOf(cur()) === "html") return;
-			open.pop();
-			if (!fragment && _tagNameOf(cur()) !== "frameset") {
-				mode = MODE_AFTER_FRAMESET;
-			}
-			return;
-		}
-		if (t.type === TOKEN_START_TAG && t.name === "frame") {
-			insertHtmlElement("frame", t.attrs, t.pos);
-			open.pop();
-			return;
-		}
-		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
-			return modes.inHead(t);
-		}
-	};
-
-	modes.afterFrameset = (t) => {
-		if (t.type === TOKEN_CHAR) {
-			const ws = t.data.replace(/[^\t\n\f\r ]/g, "");
-			if (ws) insertCharacters(ws, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end);
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return;
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_END_TAG && t.name === "html") {
-			mode = MODE_AFTER_AFTER_FRAMESET;
-			return;
-		}
-		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
-			return modes.inHead(t);
-		}
-	};
-
-	modes.afterAfterBody = (t) => {
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
-		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_EOF) return;
-		mode = MODE_IN_BODY;
-		process(t);
-	};
-
-	modes.afterAfterFrameset = (t) => {
-		if (t.type === TOKEN_COMMENT) {
-			insertComment(t.data, t.start, t.end, { parent: doc, beforeNode: 0 });
-			return;
-		}
-		if (t.type === TOKEN_DOCTYPE) return modes.inBody(t);
-		if (t.type === TOKEN_CHAR && isAllWs(t.data)) return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "html") return modes.inBody(t);
-		if (t.type === TOKEN_START_TAG && t.name === "noframes") {
-			return modes.inHead(t);
-		}
-	};
+	mode = MODE_INITIAL;
+	originalMode = 0;
+	open.length = 0;
+	afe.length = 0;
+	head = 0;
+	form = 0;
+	framesetOk = true;
+	pendAttrStart = 0;
+	fosterParenting = false;
+	templateModes.length = 0;
+	quirks = false;
+	fragment = 0;
+	tokenEnd = 0;
+	sharedPlace.parent = doc;
+	sharedPlace.beforeNode = 0;
+	pendingTableChars = null;
+	swallowNextNewline = false;
+	eofInTag = false;
+	sawSelectedContent = false;
 
 	// ---------- fragment setup ----------
 	if (fragmentContext) {
@@ -7747,34 +7767,6 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	}
 
 	// ---------- tokenizer callbacks ----------
-	const decode = decodeEntities;
-
-	let swallowNextNewline = false;
-	// Set by the tokenizer when it hits EOF mid-tag; such a partial tag is
-	// dropped (matching the spec's eof-in-tag handling).
-	let eofInTag = false;
-	// Set when a `<selectedcontent>` is seen, gating the post-parse mirror pass.
-	let sawSelectedContent = false;
-
-	// Single reused token (see `MutableToken`). The tokenizer callbacks below
-	// fill it and call `dispatch`; processing is synchronous, so the next
-	// callback only runs after the current token is fully consumed.
-	/** @type {MutableToken} */
-	const tok = {
-		type: TOKEN_EOF,
-		name: "",
-		data: "",
-		attrs: { start: 0, count: 0 },
-		selfClosing: false,
-		start: 0,
-		end: 0,
-		publicId: null,
-		systemId: null,
-		swallowNewline: false,
-		pos: { start: 0, end: 0, tagEnd: 0, nameEnd: 0 }
-	};
-	const dispatch = () =>
-		process(/** @type {Token} */ (/** @type {unknown} */ (tok)));
 
 	tokenize(source, pos, {
 		isForeign: () => {


### PR DESCRIPTION
**Summary**

The experimental HTML tree-construction parser (`lib/html/syntax.js`) declared all of its per-parse data inside `parseHtml`: the static quirks-mode public-id tables, ~55 tree-construction helpers, the 21 insertion-mode handlers, and the per-parse state (open/AFE stacks, insertion mode, head/form pointers, quirks, fragment, table/token scratch). Every `parseHtml` call therefore re-allocated the tables and re-created every helper as a fresh closure. This PR moves them to module scope — holding the per-parse state in module-level variables reset at the top of each parse, the same single-active-parse pattern the node/attribute columns already use — so `parseHtml` shrinks to a thin driver (state reset + fragment setup + the tokenizer callback loop). Behavior is unchanged. For a build parsing many HTML files this cuts parse time ~25% and peak parse memory ~15–18%. Also adds a `Naming` subsection to the coding standards (`AGENTS.md`). n/a issue.

**What kind of change does this PR introduce?**

perf (with a small docs addition to `AGENTS.md`).

**Did you add tests for your changes?**

No new tests — this is a behavior-preserving refactor with no new branches. It is covered by the existing `test/html5lib.spectest.js` tree-construction conformance suite and `test/HtmlSyntax.unittest.js`; locally I verified byte-identical serialized output over an adversarial corpus plus a state-reset-contamination check (parsing each case after a state-leaving parse matches parsing it fresh).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — internal parser structure only; no public API or option changes.

**Use of AI**

AI (Claude) was used to perform the mechanical relocation of the helpers/state to module scope, to build the differential + reset-contamination validation harness, and to run the before/after CPU and memory benchmarks. All changes were reviewed and validated (byte-identical parser output) before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra8taYiCybL53eKkksTjRS)_