### PR TITLE
chore(benchmark): increase iterations

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     permissions:
       issues: write
       pull-requests: write
@@ -53,53 +53,7 @@ jobs:
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
           run: yarn benchmark --ci
-          mode: "simulation"
-        env:
-          LAST_COMMIT: 1
-          NEGATIVE_FILTER: on-schedule
-          SHARD: ${{ matrix.shard }}
-          # Single libuv thread → deterministic fs-completion order, removing the
-          # last I/O race that perturbs allocation counts between runs.
-          UV_THREADPOOL_SIZE: 1
-  benchmark-memory:
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-tags: true
-          fetch-depth: 0
-
-      - name: Use Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: lts/*
-          cache: yarn
-
-      - run: yarn --frozen-lockfile
-
-      - run: yarn link --frozen-lockfile || true
-
-      - run: yarn link webpack --frozen-lockfile
-
-      - name: Check Memory Status
-        run: >
-          node -e 'const os=require("os");
-          const toGb=b=>(b/1024**3).toFixed(2)+" GB";
-          console.log(`--- Memory Status ---\nTotal: ${toGb(os.totalmem())}\nFree:  ${toGb(os.freemem())}\nUsed:  ${toGb(os.totalmem()-os.freemem())}`)'
-
-      - name: Run memory benchmarks
-        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
-        with:
-          run: yarn benchmark --ci
-          mode: "memory"
-          token: ${{ secrets.CODSPEED_TOKEN }}
+          mode: "walltime,memory"
         env:
           LAST_COMMIT: 1
           NEGATIVE_FILTER: on-schedule

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -1045,9 +1045,6 @@ function createBenchInstance() {
 		new Bench({
 			now: hrtimeNow,
 			throws: true,
-			warmup: true,
-			warmupIterations: 2,
-			iterations: 8,
 			setup(task, mode) {
 				if (!task) {
 					return;


### PR DESCRIPTION
One of the reasons benchmarks are unreliable is likely because we are running them very few times. While this makes for faster benchmarks, it _also_ makes for unreliable benchmarks.

By removing our limit (8), we run the benchmarks 64 times, with 16 warm ups, for a total of 80 runs.

**Note**: This slows down benchmarks significantly once we switch to Walltime