### PR TITLE
chore(readme): add codspeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,10 @@ Before we started using OpenCollective, donations were made anonymously. Now tha
 <a href="https://opencollective.com/webpack/backer/99/website?requireActive=false" target="_blank"><img width="30" src="https://opencollective.com/webpack/backer/99/avatar.svg?requireActive=false"></a>
 <a href="https://opencollective.com/webpack/backer/100/website?requireActive=false" target="_blank"><img width="30" src="https://opencollective.com/webpack/backer/100/avatar.svg?requireActive=false"></a>
 
+## Other Partners
+
+- [CodSpeed](https://codspeed.io/?utm_source=webpack&utm_medium=readme) for generously supporting us with benchmarks on their paid runners.
+
 ## Special Thanks to
 
 <p>(In chronological order)</p>


### PR DESCRIPTION
Sister to #21494.

CodSpeed has generously provided webpack with access to extended minutes on their Walltime runners.


cc @webpack/TSC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or build impact.
> 
> **Overview**
> Adds a new **Other Partners** section to `README.md`, placed after the Backers block and before **Special Thanks to**.
> 
> The section credits [CodSpeed](https://codspeed.io/) for supporting webpack with benchmarks on their paid runners (aligned with the related CI/benchmark work in #21494).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49cc4e0ef975cedb1f999671b82f1b0371837d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->