### PR TITLE
perf(css): single struct-of-arrays node store for the CSS parser, drop node classes

### DIFF
--- a/.changeset/050-css-syntax-soa-parsea.md
+++ b/.changeset/050-css-syntax-soa-parsea.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Build the CSS `parseA*` AST on the SoA store instead of node classes, cutting parse memory and time.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1617,15 +1617,20 @@ const _makeContainer = (type, start, end) => {
 	const r = _makeLeaf(type, start, end);
 	const i = _nodeIndex(r);
 	_flags[i] = 0;
-	// Clear list slots so a reused id never exposes a previous node's children
-	// (content lists are flat spans, so zeroing the length suffices).
-	// `blockStart` / `blockEnd` (aux1 / aux2) are NOT defaulted here: only at-rules
-	// and qualified rules carry a block, and they set it on every return path
-	// (`_setBlock`, or `-1` for the no-block forms), so functions / simple blocks /
-	// declarations — the common containers — skip those two writes.
+	// Clear the content-span length so a reused id never exposes a previous
+	// node's children (content lists are flat spans, so zeroing the length
+	// suffices). `blockStart` / `blockEnd` (aux1 / aux2) are NOT defaulted here:
+	// only at-rules and qualified rules carry a block, and they set it on every
+	// return path (`_setBlock`, or `-1` for the no-block forms).
 	_listLens[i] = 0;
-	_declarationLists[i] = null;
-	_childRuleLists[i] = null;
+	// The decl / child-rule slots are read only for rules (the walk guards on
+	// type; readers treat a missing slot as `null`), so only rules clear them —
+	// clearing every container would write these `id`-indexed arrays at scattered
+	// ids and degrade them to slow dictionary mode on large non-recycling parses.
+	if (type === T_AT_RULE || type === T_QUALIFIED_RULE) {
+		_declarationLists[i] = null;
+		_childRuleLists[i] = null;
+	}
 	return r;
 };
 // Raw token value (the lazy `Token.value` form): hash / at-keyword drop their
@@ -2176,7 +2181,10 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 	},
 	get declarations() {
 		const store = this._store;
-		const list = store.declLists[this._i];
+		// Non-rule containers never populate this slot (see `_makeContainer`), so a
+		// missing entry (`undefined`) is normalized to `null` — same as a rule with
+		// no block.
+		const list = store.declLists[this._i] || null;
 		return list === null
 			? null
 			: /** @type {Declaration[]} */ (
@@ -2185,7 +2193,7 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 	},
 	get childRules() {
 		const store = this._store;
-		const list = store.childLists[this._i];
+		const list = store.childLists[this._i] || null;
 		return list === null
 			? null
 			: /** @type {Rule[]} */ (
@@ -3914,8 +3922,10 @@ const A = {
 	 * @returns {Declaration[] | null} block declarations
 	 */
 	declarations(n = _currentNode) {
+		// `_makeContainer` only populates this slot for rules; a non-rule node
+		// reads `undefined`, normalized to `null` to keep the documented contract.
 		return /** @type {Declaration[] | null} */ (
-			_declarationLists[_nodeIndex(n)]
+			_declarationLists[_nodeIndex(n)] || null
 		);
 	},
 	/**
@@ -3923,7 +3933,9 @@ const A = {
 	 * @returns {Rule[] | null} block child rules
 	 */
 	childRules(n = _currentNode) {
-		return /** @type {Rule[] | null} */ (_childRuleLists[_nodeIndex(n)]);
+		return /** @type {Rule[] | null} */ (
+			_childRuleLists[_nodeIndex(n)] || null
+		);
 	},
 	/**
 	 * @param {Node=} n node

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1289,78 +1289,23 @@ const {
 } = NodeType;
 
 /**
- * Base AST node. All concrete nodes (tokens, simple blocks, functions,
- * declarations) inherit from this and carry the `[start, end)` byte `range`
- * of the source slice they cover. `loc` is computed on demand from a
- * shared `LocConverter` so we don't pay for line/column conversion until
- * a consumer (warning, error, dependency) actually needs it.
+ * Base AST node — the property-accessor view the `parseA*` entry points return
+ * (see `_makeReader`). Every concrete node carries the `[start, end)` byte
+ * `range` of the source slice it covers; `loc` is computed on demand from the
+ * shared `LocConverter`, so line/column conversion is only paid when a consumer
+ * needs it. The concrete node typedefs below extend this via `&`.
+ *
+ * Inside the parser a node ref is an integer id into the columns; the reader
+ * exposes this property shape over a retained snapshot of those columns.
+ * @typedef {object} Node
+ * @property {number} type node-type discriminator
+ * @property {number} start byte offset of the node's first code point
+ * @property {number} end byte offset just past the node's last code point
+ * @property {[number, number]} range the `[start, end)` byte range
+ * @property {{ start: { line: number, column: number }, end: { line: number, column: number } }} loc source location (1-based line, 0-based column)
+ * @property {() => string} toString source slice for this node
+ * @property {string} unescapedName name with CSS escapes resolved (name-bearing nodes only)
  */
-class Node {
-	/**
-	 * @param {number} type node type discriminator
-	 * @param {number} start byte offset of the node's first code point
-	 * @param {number} end byte offset just past the node's last code point
-	 * @param {LocConverter} locConverter shared loc converter
-	 */
-	constructor(type, start, end, locConverter) {
-		/** @type {number} */
-		this.type = type;
-		// Byte range as two inline fields rather than a `[start, end]` array —
-		// one fewer allocation per node and ~56 bytes lighter (×100k+ nodes).
-		/** @type {number} */
-		this.start = start;
-		/** @type {number} */
-		this.end = end;
-		/** @type {LocConverter} */
-		this._locConverter = locConverter;
-	}
-
-	/**
-	 * The `[start, end)` byte range as a tuple — compatibility view over
-	 * `start` / `end` (builds the array lazily; hot code reads the
-	 * fields directly).
-	 * @returns {[number, number]} the byte range
-	 */
-	get range() {
-		return [this.start, this.end];
-	}
-
-	get loc() {
-		const lc = this._locConverter;
-		// `LocConverter#get` mutates and returns the converter itself, so we
-		// must snapshot `line`/`column` between the two calls.
-		const s = lc.get(this.start);
-		const sl = s.line;
-		const sc = s.column;
-		const e = lc.get(this.end);
-		return {
-			start: { line: sl, column: sc },
-			end: { line: e.line, column: e.column }
-		};
-	}
-
-	/**
-	 * Serialize back to source — re-slices the original input (zero-alloc for
-	 * untouched nodes).
-	 * @returns {string} the source slice for this node
-	 */
-	toString() {
-		return this._locConverter._input.slice(this.start, this.end);
-	}
-
-	/**
-	 * For name-bearing nodes (function / at-rule): the `name` with CSS escapes
-	 * resolved, for case-insensitive keyword matching (`\75 rl` → `url`). Computed
-	 * on read via `unescapeIdentifier`'s no-escape fast path. Callers without a
-	 * `name` must not read this.
-	 * @returns {string} the unescaped name
-	 */
-	get unescapedName() {
-		return unescapeIdentifier(
-			/** @type {{ name: string }} */ (/** @type {unknown} */ (this)).name
-		);
-	}
-}
 
 /**
  * @param {string} s numeric text
@@ -1379,175 +1324,15 @@ const _typeFlagOf = (s) =>
 	s.includes(".") || s.includes("e") || s.includes("E") ? "number" : "integer";
 
 /**
- * Leaf token node — the only `Node` subclass. `value` is the raw source slice
+ * Leaf token node (property-accessor view) — `value` is the raw source slice
  * (identifier text, quoted string including quotes, a dimension's full `123px`,
- * …). Token-specific extras are named by the `HashToken` / `UrlToken` /
- * `NumberToken` / `DimensionToken` shape typedefs below.
- *
- * The numeric accessors (`numericValue` / `typeFlag` / `sign` / `unit`) are
- * getters, not stored fields: a number / dimension / percentage token costs
- * nothing beyond the base node unless a consumer reads them, and every leaf
- * token keeps a single object shape so the walker's `node.type` dispatch stays
- * monomorphic. They are only meaningful on the matching token type.
+ * …; hash / at-keyword drop their `#` / `@` prefix, url uses its content range).
+ * The `NumberToken` / `HashToken` / `UrlToken` / `DimensionToken` typedefs below
+ * narrow the value accessors. `numericValue` / `typeFlag` / `sign` / `unit` are
+ * derived from the source on read and are only meaningful on the matching token
+ * type; `contentStart` / `contentEnd` mark a url token's inner content range.
+ * @typedef {Node & { value: string, unescaped: string, numericValue: number, typeFlag: "integer" | "number" | "id" | "unrestricted", sign: "+" | "-" | "", unit: string, contentStart: number, contentEnd: number }} Token
  */
-class Token extends Node {
-	/**
-	 * @param {number} type node type
-	 * @param {number} start byte offset of the token's first code point
-	 * @param {number} end byte offset just past the token's last code point
-	 * @param {LocConverter} locConverter shared loc converter
-	 */
-	// No own fields: a leaf token is exactly a `Node` plus the value getters
-	// below. `value` is derived from the byte range on read instead of cached in
-	// a `_value` slot — most tokens (whitespace, punctuation) never read it, and
-	// dropping the slot is ~8 bytes saved on every token (the bulk of all nodes).
-	// hash / at-keyword strip their `#` / `@` prefix; url uses its content range
-	// (`contentStart` / `contentEnd`, the token's only own fields).
-
-	/**
-	 * @returns {string} the token's value (raw source slice unless overridden)
-	 */
-	get value() {
-		const input = this._locConverter._input;
-		const type = this.type;
-		// hash (`#name` → `name`) and at-keyword (`@name` → `name`) drop one char.
-		if (type === T_HASH || type === T_AT_KEYWORD) {
-			return input.slice(this.start + 1, this.end);
-		}
-		if (type === T_URL) {
-			const u = /** @type {UrlToken} */ (/** @type {unknown} */ (this));
-			return input.slice(u.contentStart, u.contentEnd);
-		}
-		return input.slice(this.start, this.end);
-	}
-
-	/**
-	 * The token's value with CSS escapes resolved (`\2d` → `-`, `\75 rl` → `url`),
-	 * per https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point — the
-	 * form to match keywords / export as a CSS-Modules name against. For a string
-	 * token it is the content between the quotes (the spec string value). Computed
-	 * on read; `unescapeIdentifier` fast-returns the value unchanged when it has no
-	 * escapes (the common case), so nothing is stored per token.
-	 * @returns {string} the unescaped value
-	 */
-	get unescaped() {
-		const v = this.value;
-		// A string token's `value` carries its delimiting quotes; its value is the content between them.
-		return this.type === T_STRING
-			? unescapeIdentifier(v.slice(1, -1))
-			: unescapeIdentifier(v);
-	}
-
-	/**
-	 * Parsed numeric value (number / percentage / dimension tokens). Derived from
-	 * `value` on access — the `%` is dropped for percentages and the unit for
-	 * dimensions (split with `_consumeANumber`, recomputed here so nothing is
-	 * stored per token).
-	 * @returns {number} the parsed numeric value
-	 */
-	get numericValue() {
-		const v = this.value;
-		if (this.type === T_DIMENSION) {
-			return Number(v.slice(0, _consumeANumber(v, 0)));
-		}
-		if (this.type === T_PERCENTAGE) return Number(v.slice(0, -1));
-		return Number(v);
-	}
-
-	/**
-	 * Spec type flag. For number / dimension tokens it's "integer" / "number"
-	 * (derived from `value`); for hash tokens it's "id" / "unrestricted" (re-derived
-	 * from the source). The two senses share the name in the spec; both are computed
-	 * on read so every leaf token keeps the same object shape (no own `typeFlag`).
-	 * @returns {"integer" | "number" | "id" | "unrestricted"} the spec type flag
-	 */
-	get typeFlag() {
-		if (this.type === T_HASH) {
-			// Re-derive id-ness from the source (whether the name after `#` starts an
-			// ident sequence) rather than storing an `_isId` slot — keeps hash tokens
-			// the same shape as every other leaf token. Matches the lexer's
-			// `consumeNumberSign`, which sets `isId` from the same check.
-			const input = this._locConverter._input;
-			const p = this.start + 1;
-			return _ifThreeCodePointsWouldStartAnIdentSequence(
-				input,
-				p,
-				input.charCodeAt(p),
-				input.charCodeAt(p + 1),
-				input.charCodeAt(p + 2)
-			)
-				? "id"
-				: "unrestricted";
-		}
-		const v = this.value;
-		return _typeFlagOf(
-			this.type === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
-		);
-	}
-
-	/**
-	 * @returns {"+" | "-" | ""} the spec sign (number / percentage / dimension tokens)
-	 */
-	get sign() {
-		return _signOf(this.value);
-	}
-
-	/**
-	 * @returns {string} the unit, lower-cased per spec (dimension tokens)
-	 */
-	get unit() {
-		const v = this.value;
-		return v.slice(_consumeANumber(v, 0)).toLowerCase();
-	}
-}
-
-/**
- * The non-leaf `Node` subclass: functions, simple blocks, declarations, at-rules
- * and qualified rules. It declares the union of every container field up front so
- * all five share **one** hidden class — the consume algorithms only overwrite the
- * slots relevant to their type, never adding a property, so the shape never
- * transitions. This caps the shape count: the walker's hot `.type` / `.value` /
- * `.prelude` loads otherwise see eight distinct node maps (five container types
- * plus the token / hash / url token maps), tipping V8's inline cache into the
- * slow megamorphic path; folding the five containers into one leaves four maps
- * (token, hash, url, container) — within the polymorphic limit, so those loads
- * stay inline-cached. Unused-for-the-type slots keep their defaults (the field
- * typedefs below document which fields each type uses). The stylesheet node is
- * rare (one per parse) and stays a bare `Node`.
- */
-class Container extends Node {
-	/**
-	 * @param {number} type node type
-	 * @param {number} start byte offset of the node's first code point
-	 * @param {number} end byte offset just past the node's last code point
-	 * @param {LocConverter} locConverter shared loc converter
-	 */
-	constructor(type, start, end, locConverter) {
-		super(type, start, end, locConverter);
-		/** @type {string} name (function / at-rule / declaration) */
-		this.name = "";
-		/** @type {number} */
-		this.nameStart = start;
-		/** @type {number} */
-		this.nameEnd = start;
-		/** @type {ComponentValue[] | null} component values (function / block / declaration) */
-		this.value = null;
-		/** @type {ComponentValue[] | null} prelude (at-rule / qualified rule) */
-		this.prelude = null;
-		/** @type {Declaration[] | null} */
-		this.declarations = null;
-		/** @type {Rule[] | null} */
-		this.childRules = null;
-		/** @type {number} `{` start offset, or -1 (at-rule / qualified rule) */
-		this.blockStart = -1;
-		/** @type {number} `}` end offset, or -1 (at-rule / qualified rule) */
-		this.blockEnd = -1;
-		/** @type {boolean} stripped `!important` (declaration) */
-		this.important = false;
-		/** @type {SimpleBlockToken | undefined} opening char (simple block) */
-		this.token = undefined;
-	}
-}
 
 /**
  * Number token (`123`, `-1.5`, `+2e3`). `value` is the raw source slice (the spec's "value"); `numericValue` / `typeFlag` / `sign` are lazy getters derived from it (see `Token`).
@@ -1646,10 +1431,10 @@ class Container extends Node {
  * @typedef {Node & { rules: Rule[] }} Stylesheet
  */
 
-// Lexer-token-type → AST-node-type map. A single \`new Token\` construct site
-// (vs a ~20-case switch with a \`new Token\` in each arm) keeps V8 on the fast
-// monomorphic allocation path — the switch form showed up as generic construct
-// stubs in profiles. URL is the one type with extra own state, handled first.
+// Lexer-token-type → AST-node-type map. A single `_makeLeaf` call site (vs a
+// ~20-case switch with an alloc in each arm) keeps V8 on the fast monomorphic
+// path — the switch form showed up as generic stubs in profiles. URL is the one
+// type with extra own state, handled first.
 const _ttToNodeType = new Uint8Array(27);
 _ttToNodeType[TT_WHITESPACE] = T_WHITESPACE;
 _ttToNodeType[TT_IDENTIFIER] = T_IDENT;
@@ -1671,21 +1456,14 @@ _ttToNodeType[TT_RIGHT_CURLY_BRACKET] = T_RIGHT_CURLY_BRACKET;
 _ttToNodeType[TT_CDO] = T_CDO;
 _ttToNodeType[TT_CDC] = T_CDC;
 
-// === AST construction backend ===
-// The consume algorithms build nodes through these module-level primitives
-// rather than `new Token` / `new Container` directly, so the node
-// representation can be swapped under the parser. The object backend below
-// builds the retainable `Node` / `Token` / `Container` tree the `parseA*`
-// entry points return; the Struct-of-Arrays backend (added separately) writes
-// the same nodes into reused typed arrays for the streaming `grammar`, where
-// per-node allocation dominates cost. Child lists are plain arrays in both
-// backends (a node ref is an object or an integer index); only node creation /
-// field access differs, so only those ops are swapped.
-
-// Current loc converter for the active parse (object backend reads it).
-let _objLocConverter = /** @type {LocConverter} */ (
-	/** @type {unknown} */ (null)
-);
+// === AST construction ===
+// Nodes live in one struct-of-arrays node store: a node ref is an integer id
+// into parallel typed-array columns, so per-node allocation is avoided entirely.
+// The consume algorithms build nodes through the `_make*` / `_set*` primitives
+// below, which write those columns directly. The streaming `grammar` walks each
+// top-level node and recycles the columns; the `parseA*` entry points instead
+// retain the columns as a snapshot and hand back property-accessor nodes over it
+// (see `_makeReader`). Child lists are plain arrays of node ids in both modes.
 
 // Active skip state (from `CssProcessOptions.skip`), applied by the grammar.
 // `_skipTypes` is indexed by `NodeType` (1 = skip): drop that component-value
@@ -1694,7 +1472,7 @@ let _objLocConverter = /** @type {LocConverter} */ (
 // / functions kept, so `url()` in a selector or `@import url(…)` still resolves).
 // A skipped node is still tokenized (positions stay correct) but never pushed,
 // so it is never walked or read — the caller must only skip what nothing reads.
-// `useObjectBackend` restores the defaults so `parseA*` build the full tree.
+// `parseA*` leave these at their no-skip defaults so they build the full tree.
 const _NO_SKIP_TYPES = new Uint8Array(32);
 // Shared frozen empty list for block bodies with no decls / no child rules (the
 // common case — most rules carry only declarations). Every consumer reads these
@@ -1711,175 +1489,20 @@ let _skipActive = false;
 let _skipSelectorPrelude = false;
 let _skipAtRulePrelude = false;
 
-/** @type {(type: number, start: number, end: number) => Node} */
-let _makeLeaf;
-/** @type {(start: number, end: number, contentStart: number, contentEnd: number) => Node} */
-let _makeUrl;
-/** @type {(type: number, start: number, end: number) => Node} */
-let _makeContainer;
-/** @type {(start: number) => Node} */
-let _makeStylesheet;
-// Offsets only — the object backend derives the name string itself (an
-// at-rule's name skips its `@`), so the SoA backend never pays for a slice
-// it would immediately discard (it re-derives names from offsets on read).
-/** @type {(r: Node, nameStart: number, nameEnd: number) => void} */
-let _setName;
-/** @type {(r: Node, v: number) => void} */
-let _setEnd;
-/** @type {(r: Node, blockStart: number, blockEnd: number) => void} */
-let _setBlock;
-/** @type {(r: Node) => void} */
-let _setImportant;
-/** @type {(r: Node, ch: SimpleBlockToken) => void} */
-let _setToken;
-/** @type {(r: Node, list: Node[]) => void} */
-let _setValue;
-/** @type {(r: Node, list: Node[]) => void} */
-let _setPrelude;
-/** @type {(r: Node, decls: Node[], childRules: Node[]) => void} */
-let _setBody;
-/** @type {(r: Node, list: Node[]) => void} */
-let _setRules;
-/** @type {(r: Node) => number} */
-let _nodeTypeOf;
-/** @type {(r: Node) => number} */
-let _nodeStartOf;
-/** @type {(r: Node) => string} */
-let _nodeValueOf;
-/** @type {(r: Node) => SimpleBlockToken} */
-let _nodeTokenOf;
-
-// Child lists are plain arrays in every backend; refs are pushed by value.
-// Content-list allocation: the object backend uses a per-site `[]` literal
-// (each site keeps its own V8 allocation site — a shared helper collapses them
-// and defeats escape analysis / pretenuring), the SoA backend recycles scratch
-// arrays through a pool — a sealed list is copied into the flat value buffer
-// and its array returned to the pool by `_soaSetValue`, so the streaming parse
-// allocates no per-list array. An abandoned (never-sealed) list simply falls
-// out of the pool. `_soaActive` gates the pool at each site.
-let _soaActive = false;
+// Scratch content-list pool: a container's value / prelude is built in a plain
+// array, then sealed into the flat value buffer by `_setValue`, which returns
+// the array to the pool — so a parse allocates almost no per-list arrays. An
+// abandoned (never-sealed) list simply falls out of the pool.
 /** @type {Node[][]} */
 const _listPool = [];
-const _soaList = () =>
+const _takeList = () =>
 	_listPool.length > 0
 		? /** @type {Node[]} */ (_listPool.pop())
 		: /** @type {Node[]} */ ([]);
 
-// -- object backend: builds the retainable class-instance tree --
-/** @type {typeof _makeLeaf} */
-const _objLeaf = (type, start, end) =>
-	new Token(type, start, end, _objLocConverter);
-/** @type {typeof _makeUrl} */
-const _objUrl = (start, end, cs, ce) => {
-	const u = /** @type {UrlToken} */ (
-		new Token(T_URL, start, end, _objLocConverter)
-	);
-	u.contentStart = cs;
-	u.contentEnd = ce;
-	return u;
-};
-/** @type {typeof _makeContainer} */
-const _objContainer = (type, start, end) =>
-	new Container(type, start, end, _objLocConverter);
-/** @type {typeof _makeStylesheet} */
-const _objStylesheet = (start) => {
-	const s = /** @type {Stylesheet} */ (
-		new Node(T_STYLESHEET, start, start, _objLocConverter)
-	);
-	s.rules = [];
-	return s;
-};
-// The backend function sets are module-level constants (not closures rebuilt
-// per parse): the dispatch slots keep one function identity forever, so the
-// per-node call sites in the consume algorithms stay monomorphic instead of
-// seeing a fresh closure per parse. They capture only module-level state.
-/** @type {typeof _setName} */
-const _objSetName = (r, ns, ne) => {
-	const c = /** @type {Container} */ (r);
-	// An at-rule's `nameStart` points at its `@`, which the name excludes.
-	c.name = _objLocConverter._input.slice(
-		r.type === T_AT_RULE ? ns + 1 : ns,
-		ne
-	);
-	c.nameStart = ns;
-	c.nameEnd = ne;
-};
-/** @type {typeof _setEnd} */
-const _objSetEnd = (r, v) => {
-	r.end = v;
-};
-/** @type {typeof _setBlock} */
-const _objSetBlock = (r, bs, be) => {
-	const c = /** @type {Container} */ (r);
-	c.blockStart = bs;
-	c.blockEnd = be;
-};
-/** @type {typeof _setImportant} */
-const _objSetImportant = (r) => {
-	/** @type {Container} */ (r).important = true;
-};
-/** @type {typeof _setToken} */
-const _objSetToken = (r, ch) => {
-	/** @type {Container} */ (r).token = ch;
-};
-/** @type {typeof _setValue} */
-const _objSetValue = (r, list) => {
-	/** @type {Container} */ (r).value = /** @type {ComponentValue[]} */ (list);
-};
-/** @type {typeof _setPrelude} */
-const _objSetPrelude = (r, list) => {
-	/** @type {Container} */ (r).prelude = /** @type {ComponentValue[]} */ (list);
-};
-/** @type {typeof _setBody} */
-const _objSetBody = (r, decls, childRules) => {
-	const c = /** @type {Container} */ (r);
-	c.declarations = /** @type {Declaration[]} */ (decls);
-	c.childRules = /** @type {Rule[]} */ (childRules);
-};
-/** @type {typeof _setRules} */
-const _objSetRules = (r, list) => {
-	/** @type {Stylesheet} */ (r).rules = /** @type {Rule[]} */ (list);
-};
-/** @type {typeof _nodeTypeOf} */
-const _objNodeTypeOf = (r) => r.type;
-/** @type {typeof _nodeStartOf} */
-const _objNodeStartOf = (r) => r.start;
-/** @type {typeof _nodeValueOf} */
-const _objNodeValueOf = (r) => /** @type {Token} */ (r).value;
-/** @type {typeof _nodeTokenOf} */
-const _objNodeTokenOf = (r) =>
-	/** @type {SimpleBlockToken} */ (/** @type {Container} */ (r).token);
-/** @param {LocConverter} lc loc converter for this parse */
-const useObjectBackend = (lc) => {
-	_objLocConverter = lc;
-	_soaActive = false;
-	// `parseA*` return the full tree, so nothing is skipped.
-	_skipTypes = _NO_SKIP_TYPES;
-	_skipActive = false;
-	_skipSelectorPrelude = false;
-	_skipAtRulePrelude = false;
-	_makeLeaf = _objLeaf;
-	_makeUrl = _objUrl;
-	_makeContainer = _objContainer;
-	_makeStylesheet = _objStylesheet;
-	_setName = _objSetName;
-	_setEnd = _objSetEnd;
-	_setBlock = _objSetBlock;
-	_setImportant = _objSetImportant;
-	_setToken = _objSetToken;
-	_setValue = _objSetValue;
-	_setPrelude = _objSetPrelude;
-	_setBody = _objSetBody;
-	_setRules = _objSetRules;
-	_nodeTypeOf = _objNodeTypeOf;
-	_nodeStartOf = _objNodeStartOf;
-	_nodeValueOf = _objNodeValueOf;
-	_nodeTokenOf = _objNodeTokenOf;
-};
-
-// -- struct-of-arrays backend: writes nodes into reused typed arrays --
+// -- struct-of-arrays store: nodes live in reused typed-array columns --
 // A node ref is its integer id; fields live in parallel arrays indexed by id.
-// Three reused int slots (`_soaAux0/1/2`) plus a flags byte carry the per-type
+// Three reused int slots (`_aux0/1/2`) plus a flags byte carry the per-type
 // extras; child lists hang off three object arrays. Aux slot meaning by type:
 //   url:         aux0 contentStart, aux1 contentEnd
 //   function:    aux0 nameEnd
@@ -1887,51 +1510,51 @@ const useObjectBackend = (lc) => {
 //   at-rule:     aux0 nameEnd, aux1 blockStart, aux2 blockEnd
 //   qualified:   aux1 blockStart, aux2 blockEnd
 // `name` / `nameStart` / a simple block's `token` are derived from the source
-// on read (see the SoA accessors), so they need no slot. A node's main content
-// (value | prelude | stylesheet rules) is a `_soaFlat` span (see below).
-// `grammar` resets `_soaNodeCount` to 0 after each top-level rule's walk, so the
+// on read (see the accessors), so they need no slot. A node's main content
+// (value | prelude | stylesheet rules) is a `_flat` span (see below).
+// `grammar` resets `_nodeCount` to 0 after each top-level rule's walk, so the
 // buffers are reused across rules and the parse allocates almost nothing.
-let _soaCapacity = 0;
-let _soaNodeCount = 0;
-let _soaTypes = new Uint8Array(0);
-let _soaStarts = new Int32Array(0);
-let _soaEnds = new Int32Array(0);
-let _soaAux0 = new Int32Array(0);
-let _soaAux1 = new Int32Array(0);
-let _soaAux2 = new Int32Array(0);
-let _soaFlags = new Uint8Array(0);
-// Content-list spans: a container's value / prelude is `_soaFlat[start, start+len)`
+let _capacity = 0;
+let _nodeCount = 0;
+let _types = new Uint8Array(0);
+let _starts = new Int32Array(0);
+let _ends = new Int32Array(0);
+let _aux0 = new Int32Array(0);
+let _aux1 = new Int32Array(0);
+let _aux2 = new Int32Array(0);
+let _flags = new Uint8Array(0);
+// Content-list spans: a container's value / prelude is `_flat[start, start+len)`
 // (node refs), recycled per top-level rule like the node columns.
-let _soaListStarts = new Int32Array(0);
-let _soaListLens = new Int32Array(0);
-let _soaFlat = new Int32Array(0);
-let _soaFlatTop = 0;
+let _listStarts = new Int32Array(0);
+let _listLens = new Int32Array(0);
+let _flat = new Int32Array(0);
+let _flatTop = 0;
 // Peak usage of the current parse, and use-once regrow hints: after an
 // over-capacity shrink the next grow jumps straight back to the previous
 // parse's peak (one exact-fit allocation instead of re-doubling up).
-let _soaPeak = 0;
-let _soaFlatPeak = 0;
-let _soaGrowHint = 0;
-let _soaFlatGrowHint = 0;
+let _peak = 0;
+let _flatPeak = 0;
+let _growHint = 0;
+let _flatGrowHint = 0;
 
 /** @param {number} need minimum flat-buffer capacity */
-const _soaFlatGrow = (need) => {
-	let cap = _soaFlat.length || 4096;
-	if (_soaFlatGrowHint > cap) cap = _soaFlatGrowHint;
-	_soaFlatGrowHint = 0;
+const _flatGrow = (need) => {
+	let cap = _flat.length || 4096;
+	if (_flatGrowHint > cap) cap = _flatGrowHint;
+	_flatGrowHint = 0;
 	while (cap < need) cap *= 2;
 	const next = new Int32Array(cap);
-	next.set(_soaFlat);
-	_soaFlat = next;
+	next.set(_flat);
+	_flat = next;
 };
+// Reassigned (not mutated) when a `parseA*` parse hands its columns to a
+// retained snapshot, so the next parse starts on fresh arrays.
 /** @type {(Node[] | null)[]} */
-const _soaDeclarationLists = [];
+let _declarationLists = [];
 /** @type {(Node[] | null)[]} */
-const _soaChildRuleLists = [];
-let _soaInput = "";
-let _soaLocConverter = /** @type {LocConverter} */ (
-	/** @type {unknown} */ (null)
-);
+let _childRuleLists = [];
+let _input = "";
+let _locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
 // Node refs are integers here but typed `Node` across the parser; these are
 // identity casts that just satisfy the type system at the boundary.
@@ -1941,175 +1564,172 @@ const _nodeIndex = (n) => /** @type {number} */ (/** @type {unknown} */ (n));
 const _nodeRef = (i) => /** @type {Node} */ (/** @type {unknown} */ (i));
 
 /** @param {number} need minimum capacity */
-const _soaGrow = (need) => {
-	let cap = _soaCapacity || 4096;
-	if (_soaGrowHint > cap) cap = _soaGrowHint;
-	_soaGrowHint = 0;
+const _grow = (need) => {
+	let cap = _capacity || 4096;
+	if (_growHint > cap) cap = _growHint;
+	_growHint = 0;
 	while (cap < need) cap *= 2;
 	const ty = new Uint8Array(cap);
-	ty.set(_soaTypes);
-	_soaTypes = ty;
+	ty.set(_types);
+	_types = ty;
 	const st = new Int32Array(cap);
-	st.set(_soaStarts);
-	_soaStarts = st;
+	st.set(_starts);
+	_starts = st;
 	const en = new Int32Array(cap);
-	en.set(_soaEnds);
-	_soaEnds = en;
+	en.set(_ends);
+	_ends = en;
 	const a0 = new Int32Array(cap);
-	a0.set(_soaAux0);
-	_soaAux0 = a0;
+	a0.set(_aux0);
+	_aux0 = a0;
 	const a1 = new Int32Array(cap);
-	a1.set(_soaAux1);
-	_soaAux1 = a1;
+	a1.set(_aux1);
+	_aux1 = a1;
 	const a2 = new Int32Array(cap);
-	a2.set(_soaAux2);
-	_soaAux2 = a2;
+	a2.set(_aux2);
+	_aux2 = a2;
 	const fl = new Uint8Array(cap);
-	fl.set(_soaFlags);
-	_soaFlags = fl;
+	fl.set(_flags);
+	_flags = fl;
 	const ls = new Int32Array(cap);
-	ls.set(_soaListStarts);
-	_soaListStarts = ls;
+	ls.set(_listStarts);
+	_listStarts = ls;
 	const ll = new Int32Array(cap);
-	ll.set(_soaListLens);
-	_soaListLens = ll;
-	_soaCapacity = cap;
+	ll.set(_listLens);
+	_listLens = ll;
+	_capacity = cap;
 };
 /** @type {(type: number, start: number, end: number) => Node} */
-const _soaAllocNode = (type, start, end) => {
+const _makeLeaf = (type, start, end) => {
 	// Ids are 1-based: a node ref is used in truthiness checks (`if (!parent)`),
 	// so 0 must stay reserved for "no node".
-	// Leaves never read the flag / list slots — `_soaAllocContainer` clears
+	// Leaves never read the flag / list slots — `_makeContainer` clears
 	// them instead, keeping the dominant leaf allocation at three writes.
-	const i = _soaNodeCount + 1;
-	if (i >= _soaCapacity) _soaGrow(i + 1);
-	_soaTypes[i] = type;
-	_soaStarts[i] = start;
-	_soaEnds[i] = end;
-	_soaNodeCount = i;
+	const i = _nodeCount + 1;
+	if (i >= _capacity) _grow(i + 1);
+	_types[i] = type;
+	_starts[i] = start;
+	_ends[i] = end;
+	_nodeCount = i;
 	return _nodeRef(i);
 };
 /** @type {(type: number, start: number, end: number) => Node} */
-const _soaAllocContainer = (type, start, end) => {
-	const r = _soaAllocNode(type, start, end);
+const _makeContainer = (type, start, end) => {
+	const r = _makeLeaf(type, start, end);
 	const i = _nodeIndex(r);
-	_soaFlags[i] = 0;
+	_flags[i] = 0;
 	// Clear list slots so a reused id never exposes a previous node's children
 	// (content lists are flat spans, so zeroing the length suffices).
-	_soaListLens[i] = 0;
-	_soaDeclarationLists[i] = null;
-	_soaChildRuleLists[i] = null;
+	// `blockStart` / `blockEnd` (aux1 / aux2) are NOT defaulted here: only at-rules
+	// and qualified rules carry a block, and they set it on every return path
+	// (`_setBlock`, or `-1` for the no-block forms), so functions / simple blocks /
+	// declarations — the common containers — skip those two writes.
+	_listLens[i] = 0;
+	_declarationLists[i] = null;
+	_childRuleLists[i] = null;
 	return r;
 };
 // Raw token value (the lazy `Token.value` form): hash / at-keyword drop their
 // one-char prefix, url uses its content range. Shared by the parser's
-// mid-parse reads and the SoA accessor.
+// mid-parse reads and the accessor.
 /**
  * @param {number} i node id
  * @returns {string} raw token value
  */
-const _soaValueOf = (i) => {
-	const ty = _soaTypes[i];
+const _valueOf = (i) => {
+	const ty = _types[i];
 	if (ty === T_HASH || ty === T_AT_KEYWORD) {
-		return _soaInput.slice(_soaStarts[i] + 1, _soaEnds[i]);
+		return _input.slice(_starts[i] + 1, _ends[i]);
 	}
-	if (ty === T_URL) return _soaInput.slice(_soaAux0[i], _soaAux1[i]);
-	return _soaInput.slice(_soaStarts[i], _soaEnds[i]);
+	if (ty === T_URL) return _input.slice(_aux0[i], _aux1[i]);
+	return _input.slice(_starts[i], _ends[i]);
 };
-// Module-level constants for the same reason as the `_objSet*` set above.
-/** @type {typeof _makeUrl} */
-const _soaMakeUrl = (start, end, cs, ce) => {
-	const r = _soaAllocNode(T_URL, start, end);
-	_soaAux0[_nodeIndex(r)] = cs;
-	_soaAux1[_nodeIndex(r)] = ce;
+// Module-level constants (not per-parse closures), so each consume-algorithm
+// call site keeps one function identity and stays monomorphic.
+/** @type {(start: number, end: number, contentStart: number, contentEnd: number) => Node} */
+const _makeUrl = (start, end, cs, ce) => {
+	const r = _makeLeaf(T_URL, start, end);
+	_aux0[_nodeIndex(r)] = cs;
+	_aux1[_nodeIndex(r)] = ce;
 	return r;
 };
-/** @type {typeof _makeStylesheet} */
-const _soaMakeStylesheet = (start) =>
-	_soaAllocContainer(T_STYLESHEET, start, start);
+/** @type {(start: number) => Node} */
+const _makeStylesheet = (start) => _makeContainer(T_STYLESHEET, start, start);
 // name / nameStart are derived from start + nameEnd; only nameEnd is stored.
-/** @type {typeof _setName} */
-const _soaSetName = (r, ns, ne) => {
-	_soaAux0[_nodeIndex(r)] = ne;
+/** @type {(r: Node, nameStart: number, nameEnd: number) => void} */
+const _setName = (r, ns, ne) => {
+	_aux0[_nodeIndex(r)] = ne;
 };
-/** @type {typeof _setEnd} */
-const _soaSetEnd = (r, v) => {
-	_soaEnds[_nodeIndex(r)] = v;
+/** @type {(r: Node, v: number) => void} */
+const _setEnd = (r, v) => {
+	_ends[_nodeIndex(r)] = v;
 };
-/** @type {typeof _setBlock} */
-const _soaSetBlock = (r, bs, be) => {
+/** @type {(r: Node, blockStart: number, blockEnd: number) => void} */
+const _setBlock = (r, bs, be) => {
 	const i = _nodeIndex(r);
-	_soaAux1[i] = bs;
-	_soaAux2[i] = be;
+	_aux1[i] = bs;
+	_aux2[i] = be;
 };
-/** @type {typeof _setImportant} */
-const _soaSetImportant = (r) => {
-	_soaFlags[_nodeIndex(r)] |= 1;
+/** @type {(r: Node) => void} */
+const _setImportant = (r) => {
+	_flags[_nodeIndex(r)] |= 1;
 };
 // A simple block's token is derived from its opening char on read.
-/** @type {typeof _setToken} */
-const _soaSetToken = (r, ch) => {};
-/** @type {typeof _setValue} */
-const _soaSetValue = (r, list) => {
+/** @type {(r: Node, ch: SimpleBlockToken) => void} */
+const _setToken = (r, ch) => {};
+/** @type {(r: Node, list: Node[]) => void} */
+const _setValue = (r, list) => {
 	// Seal the finished list: copy its refs into the flat buffer and hand the
 	// scratch array back to the pool. The caller never touches `list` again.
 	const i = _nodeIndex(r);
 	const len = list.length;
-	const start = _soaFlatTop;
-	if (start + len > _soaFlat.length) _soaFlatGrow(start + len);
+	const start = _flatTop;
+	if (start + len > _flat.length) _flatGrow(start + len);
 	for (let k = 0; k < len; k++) {
-		_soaFlat[start + k] = _nodeIndex(list[k]);
+		_flat[start + k] = _nodeIndex(list[k]);
 	}
-	_soaFlatTop = start + len;
-	_soaListStarts[i] = start;
-	_soaListLens[i] = len;
+	_flatTop = start + len;
+	_listStarts[i] = start;
+	_listLens[i] = len;
 	list.length = 0;
 	_listPool.push(list);
 };
-/** @type {typeof _setBody} */
-const _soaSetBody = (r, decls, childRules) => {
+/** @type {(r: Node, decls: Node[], childRules: Node[]) => void} */
+const _setBody = (r, decls, childRules) => {
 	const i = _nodeIndex(r);
-	_soaDeclarationLists[i] = decls;
-	_soaChildRuleLists[i] = childRules;
+	_declarationLists[i] = decls;
+	_childRuleLists[i] = childRules;
 };
-/** @type {typeof _nodeTypeOf} */
-const _soaNodeTypeOf = (r) => _soaTypes[_nodeIndex(r)];
-/** @type {typeof _nodeStartOf} */
-const _soaNodeStartOf = (r) => _soaStarts[_nodeIndex(r)];
-/** @type {typeof _nodeValueOf} */
-const _soaNodeValueOf = (r) => _soaValueOf(_nodeIndex(r));
-/** @type {typeof _nodeTokenOf} */
-const _soaNodeTokenOf = (r) =>
-	/** @type {SimpleBlockToken} */ (_soaInput[_soaStarts[_nodeIndex(r)]]);
+/** @type {(r: Node) => number} */
+const _nodeTypeOf = (r) => _types[_nodeIndex(r)];
+/** @type {(r: Node) => number} */
+const _nodeStartOf = (r) => _starts[_nodeIndex(r)];
+/** @type {(r: Node) => string} */
+const _nodeValueOf = (r) => _valueOf(_nodeIndex(r));
+/** @type {(r: Node) => SimpleBlockToken} */
+const _nodeTokenOf = (r) =>
+	/** @type {SimpleBlockToken} */ (_input[_starts[_nodeIndex(r)]]);
+// A container's value, a rule's prelude, and a stylesheet's rules all seal into
+// the one content-list writer, so `_setPrelude` / `_setRules` are named views of
+// `_setValue` that keep the consume algorithms reading in spec terms.
+const _setPrelude = _setValue;
+const _setRules = _setValue;
+
 /**
+ * Start a parse into the store: point it at this source, reset the node /
+ * flat cursors so nodes accumulate from id 1, and clear skip state (`grammar`
+ * sets its own afterwards; `parseA*` leave it off to build the full tree).
  * @param {string} input source
  * @param {LocConverter} lc loc converter
  */
-const useSoaBackend = (input, lc) => {
-	_soaInput = input;
-	_soaLocConverter = lc;
-	_soaNodeCount = 0;
-	_soaFlatTop = 0;
-	_soaActive = true;
-	// The alloc primitives are the slot functions directly — no wrapper hop.
-	_makeLeaf = _soaAllocNode;
-	_makeUrl = _soaMakeUrl;
-	_makeContainer = _soaAllocContainer;
-	_makeStylesheet = _soaMakeStylesheet;
-	_setName = _soaSetName;
-	_setEnd = _soaSetEnd;
-	_setBlock = _soaSetBlock;
-	_setImportant = _soaSetImportant;
-	_setToken = _soaSetToken;
-	_setValue = _soaSetValue;
-	// value / prelude / rules all land in the one content-list slot.
-	_setPrelude = _soaSetValue;
-	_setBody = _soaSetBody;
-	_setRules = _soaSetValue;
-	_nodeTypeOf = _soaNodeTypeOf;
-	_nodeStartOf = _soaNodeStartOf;
-	_nodeValueOf = _soaNodeValueOf;
-	_nodeTokenOf = _soaNodeTokenOf;
+const _setupParse = (input, lc) => {
+	_input = input;
+	_locConverter = lc;
+	_nodeCount = 0;
+	_flatTop = 0;
+	_skipTypes = _NO_SKIP_TYPES;
+	_skipActive = false;
+	_skipSelectorPrelude = false;
+	_skipAtRulePrelude = false;
 };
 
 /**
@@ -2306,6 +1926,344 @@ const normalizeIntoTokenStream = (input, pos, onComment) =>
  * @property {((input: string, start: number, end: number) => number)=} comment optional comment-token callback; the public `parse*` entry points use it to build the `TokenStream` so the outer parser's comment tracker still sees magic comments inside the consumed range
  */
 
+// === parseA* retained store + property-accessor readers ===
+// `grammar` recycles the columns per top-level rule, but the `parseA*` entry
+// points must hand back a tree that outlives the parse. Each `parseA*` run parses
+// into the columns without recycling, then `_finishStore` hands them to a
+// snapshot object and resets the module columns to fresh arrays so the next parse
+// can't clobber it. Nodes are exposed as `parseA*` readers: plain objects sharing
+// one per-store prototype whose getters index the snapshot by node id — no
+// per-node class, no eager string slices, child readers built lazily on access.
+
+/**
+ * @typedef {object} NodeReader
+ * @property {number} _i node id into the snapshot columns
+ * @property {number} type node type
+ * @property {number} start start offset
+ * @property {number} end end offset
+ * @property {[number, number]} range start / end offsets
+ * @property {{ start: { line: number, column: number }, end: { line: number, column: number } }} loc source location
+ * @property {() => string} toString source slice
+ * @property {string | ComponentValue[]} value token value (leaf) or component-value list (function / block / declaration)
+ * @property {string} unescaped unescaped token value
+ * @property {number} numericValue parsed numeric value
+ * @property {"integer" | "number" | "id" | "unrestricted"} typeFlag spec type flag
+ * @property {"+" | "-" | ""} sign spec sign
+ * @property {string} unit dimension unit (lower-cased)
+ * @property {number} contentStart url content start offset
+ * @property {number} contentEnd url content end offset
+ * @property {string} name rule / declaration / function name
+ * @property {number} nameStart name start offset
+ * @property {number} nameEnd name end offset
+ * @property {string} unescapedName unescaped name
+ * @property {ComponentValue[]} prelude rule prelude
+ * @property {Declaration[] | null} declarations block declarations
+ * @property {Rule[] | null} childRules block child rules
+ * @property {number} blockStart `{` start offset
+ * @property {number} blockEnd `}` end offset
+ * @property {boolean} important `!important` flag
+ * @property {SimpleBlockToken} token simple-block opening char
+ * @property {Rule[]} rules stylesheet rules
+ */
+
+/**
+ * @typedef {object} NodeStore
+ * @property {string} input source
+ * @property {LocConverter} lc loc converter
+ * @property {Uint8Array} types node-type column
+ * @property {Int32Array} starts start-offset column
+ * @property {Int32Array} ends end-offset column
+ * @property {Int32Array} aux0 aux slot 0
+ * @property {Int32Array} aux1 aux slot 1
+ * @property {Int32Array} aux2 aux slot 2
+ * @property {Uint8Array} flags flags column
+ * @property {Int32Array} listStarts content-span start column
+ * @property {Int32Array} listLens content-span length column
+ * @property {Int32Array} flat flat node-ref buffer
+ * @property {(Node[] | null)[]} declLists per-node declaration lists
+ * @property {(Node[] | null)[]} childLists per-node child-rule lists
+ * @property {NodeReader} proto shared reader prototype for this store
+ */
+
+// Shared frozen empty list for a block body with no declarations / child rules,
+// so equal-empty reads return one reference (mirrors `_EMPTY_LIST`).
+const _READER_EMPTY = /** @type {Rule[]} */ (
+	/** @type {unknown} */ (Object.freeze([]))
+);
+
+/**
+ * Raw token value over a snapshot (the lazy `Token.value` form): hash / at-keyword
+ * drop their one-char prefix, url uses its content range.
+ * @param {NodeStore} store snapshot
+ * @param {number} i node id
+ * @returns {string} raw token value
+ */
+const _storeValueOf = (store, i) => {
+	const ty = store.types[i];
+	if (ty === T_HASH || ty === T_AT_KEYWORD) {
+		return store.input.slice(store.starts[i] + 1, store.ends[i]);
+	}
+	if (ty === T_URL) return store.input.slice(store.aux0[i], store.aux1[i]);
+	return store.input.slice(store.starts[i], store.ends[i]);
+};
+
+/**
+ * @param {NodeStore} store snapshot
+ * @param {number} i node id
+ * @returns {Node} reader over node `i`
+ */
+const _readerAt = (store, i) => {
+	const o = Object.create(store.proto);
+	o._i = i;
+	return /** @type {Node} */ (o);
+};
+
+/**
+ * Readers over a container's flat content span (value / prelude / rules).
+ * @param {NodeStore} store snapshot
+ * @param {number} i container id
+ * @returns {Node[]} child readers
+ */
+const _readList = (store, i) => {
+	const s = store.listStarts[i];
+	const len = store.listLens[i];
+	const flat = store.flat;
+	/** @type {Node[]} */
+	const out = [];
+	for (let k = 0; k < len; k++) out.push(_readerAt(store, flat[s + k]));
+	return out;
+};
+
+/**
+ * Readers over a node-id list (declarations / child rules).
+ * @param {NodeStore} store snapshot
+ * @param {Node[]} list node-id list
+ * @returns {Node[]} child readers
+ */
+const _readRefList = (store, list) => {
+	/** @type {Node[]} */
+	const out = [];
+	for (let k = 0; k < list.length; k++) {
+		out.push(_readerAt(store, _nodeIndex(list[k])));
+	}
+	return out;
+};
+
+/**
+ * Build the reader prototype for one store: getters index the snapshot columns
+ * by the reader's `_i` node id. One prototype per store, shared by all its
+ * readers, so a reader is a two-slot object with no per-node closures.
+ * @param {NodeStore} store snapshot
+ * @returns {NodeReader} the shared reader prototype
+ */
+const _makeReaderProto = (store) =>
+	/** @type {NodeReader} */ ({
+		_i: 0,
+		get type() {
+			return store.types[this._i];
+		},
+		get start() {
+			return store.starts[this._i];
+		},
+		get end() {
+			return store.ends[this._i];
+		},
+		get range() {
+			const i = this._i;
+			return /** @type {[number, number]} */ ([store.starts[i], store.ends[i]]);
+		},
+		get loc() {
+			const i = this._i;
+			const lc = store.lc;
+			// `LocConverter#get` mutates and returns itself, so snapshot the first.
+			const s = lc.get(store.starts[i]);
+			const sl = s.line;
+			const sc = s.column;
+			const e = lc.get(store.ends[i]);
+			return {
+				start: { line: sl, column: sc },
+				end: { line: e.line, column: e.column }
+			};
+		},
+		toString() {
+			const i = this._i;
+			return store.input.slice(store.starts[i], store.ends[i]);
+		},
+		get value() {
+			const i = this._i;
+			const ty = store.types[i];
+			// function / simple-block / declaration expose their component-value
+			// list; every leaf token exposes its raw string value.
+			return ty === T_FUNCTION || ty === T_SIMPLE_BLOCK || ty === T_DECLARATION
+				? /** @type {ComponentValue[]} */ (_readList(store, i))
+				: _storeValueOf(store, i);
+		},
+		get unescaped() {
+			const i = this._i;
+			const v = _storeValueOf(store, i);
+			return store.types[i] === T_STRING
+				? unescapeIdentifier(v.slice(1, -1))
+				: unescapeIdentifier(v);
+		},
+		get numericValue() {
+			const i = this._i;
+			const v = _storeValueOf(store, i);
+			if (store.types[i] === T_DIMENSION) {
+				return Number(v.slice(0, _consumeANumber(v, 0)));
+			}
+			if (store.types[i] === T_PERCENTAGE) return Number(v.slice(0, -1));
+			return Number(v);
+		},
+		get typeFlag() {
+			const i = this._i;
+			if (store.types[i] === T_HASH) {
+				const input = store.input;
+				const p = store.starts[i] + 1;
+				return _ifThreeCodePointsWouldStartAnIdentSequence(
+					input,
+					p,
+					input.charCodeAt(p),
+					input.charCodeAt(p + 1),
+					input.charCodeAt(p + 2)
+				)
+					? "id"
+					: "unrestricted";
+			}
+			const v = _storeValueOf(store, i);
+			return _typeFlagOf(
+				store.types[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
+			);
+		},
+		get sign() {
+			return _signOf(_storeValueOf(store, this._i));
+		},
+		get unit() {
+			const v = _storeValueOf(store, this._i);
+			return v.slice(_consumeANumber(v, 0)).toLowerCase();
+		},
+		get contentStart() {
+			return store.aux0[this._i];
+		},
+		get contentEnd() {
+			return store.aux1[this._i];
+		},
+		get name() {
+			const i = this._i;
+			// An at-rule's name skips its `@`; others start at the node.
+			return store.types[i] === T_AT_RULE
+				? store.input.slice(store.starts[i] + 1, store.aux0[i])
+				: store.input.slice(store.starts[i], store.aux0[i]);
+		},
+		get nameStart() {
+			return store.starts[this._i];
+		},
+		get nameEnd() {
+			return store.aux0[this._i];
+		},
+		get unescapedName() {
+			return unescapeIdentifier(this.name);
+		},
+		get prelude() {
+			return /** @type {ComponentValue[]} */ (_readList(store, this._i));
+		},
+		get declarations() {
+			const list = store.declLists[this._i];
+			return list === null
+				? null
+				: /** @type {Declaration[]} */ (
+						list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
+					);
+		},
+		get childRules() {
+			const list = store.childLists[this._i];
+			return list === null
+				? null
+				: /** @type {Rule[]} */ (
+						list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
+					);
+		},
+		get blockStart() {
+			return store.aux1[this._i];
+		},
+		get blockEnd() {
+			return store.aux2[this._i];
+		},
+		get important() {
+			return (store.flags[this._i] & 1) !== 0;
+		},
+		get token() {
+			return /** @type {SimpleBlockToken} */ (
+				store.input[store.starts[this._i]]
+			);
+		},
+		get rules() {
+			return /** @type {Rule[]} */ (_readList(store, this._i));
+		}
+	});
+
+/**
+ * Hand the module's live columns to a retained snapshot, then reset the
+ * module columns to fresh empty arrays so the next parse starts clean and can't
+ * mutate this store. Called once per `parseA*` after all consuming is done.
+ * @returns {NodeStore} the retained snapshot
+ */
+const _finishStore = () => {
+	/** @type {NodeStore} */
+	const store = {
+		input: _input,
+		lc: _locConverter,
+		types: _types,
+		starts: _starts,
+		ends: _ends,
+		aux0: _aux0,
+		aux1: _aux1,
+		aux2: _aux2,
+		flags: _flags,
+		listStarts: _listStarts,
+		listLens: _listLens,
+		flat: _flat,
+		declLists: _declarationLists,
+		childLists: _childRuleLists,
+		proto: /** @type {NodeReader} */ (/** @type {unknown} */ (null))
+	};
+	store.proto = _makeReaderProto(store);
+	// Carry this parse's size forward as a one-shot grow hint so the next parse
+	// allocates its columns once instead of re-doubling from scratch (node ids
+	// are 1-based, so `+1`).
+	_growHint = _nodeCount + 1;
+	_flatGrowHint = _flatTop;
+	// Reset module state — the columns now belong to `store`.
+	_capacity = 0;
+	_nodeCount = 0;
+	_flatTop = 0;
+	_types = new Uint8Array(0);
+	_starts = new Int32Array(0);
+	_ends = new Int32Array(0);
+	_aux0 = new Int32Array(0);
+	_aux1 = new Int32Array(0);
+	_aux2 = new Int32Array(0);
+	_flags = new Uint8Array(0);
+	_listStarts = new Int32Array(0);
+	_listLens = new Int32Array(0);
+	_flat = new Int32Array(0);
+	_declarationLists = [];
+	_childRuleLists = [];
+	_listPool.length = 0;
+	_input = "";
+	_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
+	return store;
+};
+
+/**
+ * Finish the parse and wrap one consumed node ref as a `parseA*` reader, keeping
+ * the caller's node type.
+ * @template {Node} T
+ * @param {T} ref consumed node ref
+ * @returns {T} reader over the retained snapshot
+ */
+const _finishOne = (ref) =>
+	/** @type {T} */ (_readerAt(_finishStore(), _nodeIndex(ref)));
+
 /**
  * Parse a stylesheet, CSS Syntax Level 3
  * [§5.3.4](https://drafts.csswg.org/css-syntax/#parse-stylesheet).
@@ -2318,15 +2276,17 @@ const parseAStylesheet = (input, pos = 0, options = {}) => {
 	// 1. If input is a byte stream for a stylesheet, decode bytes from input, and set input to the result.
 	// 2. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 3. Create a new stylesheet, with its location set to location (or null, if location was not passed).
 	const start = ts.next().start;
-	const stylesheet = /** @type {Stylesheet} */ (_makeStylesheet(start));
+	const stylesheet = _makeStylesheet(start);
 	// 4. Consume a stylesheet's contents from input, and set the stylesheet's rules to the result.
 	_setRules(stylesheet, consumeAStylesheetsContents(ts));
 	_setEnd(stylesheet, ts.next().start);
 	// 5. Return the stylesheet.
-	return stylesheet;
+	return /** @type {Stylesheet} */ (
+		_readerAt(_finishStore(), _nodeIndex(stylesheet))
+	);
 };
 
 /**
@@ -2343,9 +2303,11 @@ const parseAStylesheet = (input, pos = 0, options = {}) => {
 const parseAStylesheetsContents = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Consume a stylesheet’s contents from input, and return the result.
-	return consumeAStylesheetsContents(ts);
+	const rules = consumeAStylesheetsContents(ts);
+	const store = _finishStore();
+	return /** @type {Rule[]} */ (_readRefList(store, rules));
 };
 
 /**
@@ -2359,9 +2321,17 @@ const parseAStylesheetsContents = (input, pos = 0, options = {}) => {
 const parseABlocksContents = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Consume a block’s contents from input, and return the result.
-	return consumeABlocksContents(ts);
+	const { decls, rules } = consumeABlocksContents(ts);
+	const store = _finishStore();
+	return {
+		decls: /** @type {Declaration[]} */ (_readRefList(store, decls)),
+		rules:
+			rules.length > 0
+				? /** @type {Rule[]} */ (_readRefList(store, rules))
+				: _READER_EMPTY
+	};
 };
 
 /**
@@ -2377,7 +2347,7 @@ const parseABlocksContents = (input, pos = 0, options = {}) => {
 const parseARule = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
 	while (ts.next().type === TT_WHITESPACE) ts.discard();
 	// 3. If the next token from input is an <EOF-token>, return a syntax error.
@@ -2394,7 +2364,7 @@ const parseARule = (input, pos = 0, options = {}) => {
 	// 4. Discard whitespace from input.
 	while (ts.next().type === TT_WHITESPACE) ts.discard();
 	// 5. If the next token from input is an <EOF-token>, return rule. Otherwise, return a syntax error.
-	return ts.next().type === TT_EOF ? rule : undefined;
+	return ts.next().type === TT_EOF ? _finishOne(rule) : undefined;
 };
 
 /**
@@ -2408,11 +2378,12 @@ const parseARule = (input, pos = 0, options = {}) => {
 const parseADeclaration = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
 	while (ts.next().type === TT_WHITESPACE) ts.discard();
 	// 3. Consume a declaration from input. If anything was returned, return it. Otherwise, return a syntax error.
-	return consumeADeclaration(ts);
+	const decl = consumeADeclaration(ts);
+	return decl === undefined ? undefined : _finishOne(decl);
 };
 
 /**
@@ -2425,7 +2396,7 @@ const parseADeclaration = (input, pos = 0, options = {}) => {
 const parseAComponentValue = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
 	while (ts.next().type === TT_WHITESPACE) ts.discard();
 	// 3. If input is empty, return a syntax error.
@@ -2435,8 +2406,7 @@ const parseAComponentValue = (input, pos = 0, options = {}) => {
 	// 5. Discard whitespace from input.
 	while (ts.next().type === TT_WHITESPACE) ts.discard();
 	// 6. If input is empty, return value. Otherwise, return a syntax error.
-	if (ts.next().type === TT_EOF) return result;
-	return undefined;
+	return ts.next().type === TT_EOF ? _finishOne(result) : undefined;
 };
 
 /**
@@ -2450,10 +2420,12 @@ const parseAComponentValue = (input, pos = 0, options = {}) => {
 const parseAListOfComponentValues = (input, pos = 0, options = {}) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Consume a list of component values from input, and return the result.
 	// (`null` needs `bailOnCurly`, which is not passed here.)
-	return /** @type {ComponentValue[]} */ (consumeAListOfComponentValues(ts));
+	const values = /** @type {Node[]} */ (consumeAListOfComponentValues(ts));
+	const store = _finishStore();
+	return /** @type {ComponentValue[]} */ (_readRefList(store, values));
 };
 
 /**
@@ -2470,23 +2442,24 @@ const parseACommaSeparatedListOfComponentValues = (
 ) => {
 	// 1. Normalize input, and set input to the result.
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
-	useObjectBackend(ts.locConverter);
+	_setupParse(ts.input, ts.locConverter);
 	// 2. Let groups be an empty list.
-	/** @type {ComponentValue[][]} */
+	/** @type {Node[][]} */
 	const groups = [];
 	// 3. While input is not empty:
 	while (ts.next().type !== TT_EOF) {
 		// 3.1. Consume a list of component values from input, with <comma-token> as the stop token, and append the result to groups.
 		groups.push(
-			/** @type {ComponentValue[]} */ (
-				consumeAListOfComponentValues(ts, TT_COMMA)
-			)
+			/** @type {Node[]} */ (consumeAListOfComponentValues(ts, TT_COMMA))
 		);
 		// 3.2 Discard a token from input.
 		ts.discard();
 	}
-	// 4. Return groups.
-	return groups;
+	// 4. Return groups — wrap each group's refs against the retained snapshot.
+	const store = _finishStore();
+	return groups.map(
+		(g) => /** @type {ComponentValue[]} */ (_readRefList(store, g))
+	);
 };
 
 // === Parser algorithms (CSS Syntax Level 3 §5.4) ===
@@ -2559,11 +2532,11 @@ const consumeAnAtRule = (ts, nested = false) => {
 		_makeContainer(T_AT_RULE, head.start, head.end)
 	);
 	_setName(rule, head.start, head.end);
-	// Sealed (`_setPrelude`) at each return — the SoA backend consumes the
+	// Sealed (`_setPrelude`) at each return — the store consumes the
 	// scratch array when sealing, so it must be complete by then.
-	const prelude = _soaActive ? _soaList() : [];
-	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
-	// defaults (no block: the `;` / EOF / nested-`}` at-rule forms).
+	const prelude = _takeList();
+	// declarations / childRules stay null (no block); the `;` / EOF / nested-`}`
+	// forms set blockStart / blockEnd to -1 explicitly at their return below.
 
 	// Like `consumeAQualifiedRule`: skip mode scans the prelude without
 	// materializing it (url tokens / functions kept so `@import url(…)` still
@@ -2580,6 +2553,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 		if (t.type === TT_SEMICOLON || t.type === TT_EOF) {
 			ts.discard();
 			_setPrelude(rule, prelude);
+			_setBlock(rule, -1, -1);
 			_setEnd(rule, t.start);
 			return rule;
 		}
@@ -2589,6 +2563,7 @@ const consumeAnAtRule = (ts, nested = false) => {
 		else if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) {
 				_setPrelude(rule, prelude);
+				_setBlock(rule, -1, -1);
 				_setEnd(rule, t.start);
 				return rule;
 			}
@@ -2650,9 +2625,9 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	);
 	// Sealed (`_setPrelude`) at the `{` exit — the only path that returns the
 	// rule; the parse-error exits abandon the scratch unsealed.
-	const prelude = _soaActive ? _soaList() : [];
-	// declarations / childRules / blockStart (-1) / blockEnd (-1) keep their
-	// defaults (no block until a `{` is reached).
+	const prelude = _takeList();
+	// A returned qualified rule always has a block (only the `{` exit returns a
+	// rule), so `_setBlock` always runs — no blockStart / blockEnd default needed.
 
 	// Skip mode leaves `prelude` empty (selector text is recovered from the
 	// rule's byte range, not its nodes); `first`/`second` still track the first
@@ -2921,8 +2896,8 @@ const consumeADeclaration = (ts, nested = false) => {
 	const { input } = ts;
 	// Let decl be a new declaration, with an initially empty name and a value set to an empty list.
 	const start = ts.next().start;
-	// name "" / nameStart / nameEnd (= start) / important (false) keep their
-	// `Container` defaults; `value` is set unconditionally at step 5 below.
+	// nameEnd (= start) / important (unset) keep their container defaults;
+	// `value` is set unconditionally at step 5 below.
 	const decl = /** @type {Declaration} */ (
 		_makeContainer(T_DECLARATION, start, start)
 	);
@@ -2968,7 +2943,7 @@ const consumeADeclaration = (ts, nested = false) => {
 	);
 	if (value === null) return undefined;
 	// `_setValue` waits until step 9: steps 6-8 still trim / scan the scratch,
-	// and the SoA backend consumes it when sealing.
+	// and the store consumes it when sealing.
 	_setEnd(decl, ts.next().start);
 
 	// 6. If the last two non-<whitespace-token>s in decl's value are a <delim-token> with the value "!" followed by an <ident-token> with a value that is an ASCII case-insensitive match for "important", remove them from decl's value and set decl's important flag.
@@ -3031,7 +3006,7 @@ const consumeAListOfComponentValues = (
 	nested = false,
 	bailOnCurly = false
 ) => {
-	const values = /** @type {ComponentValue[]} */ (_soaActive ? _soaList() : []);
+	const values = /** @type {ComponentValue[]} */ (_takeList());
 	// Process input
 	for (;;) {
 		const t = ts.next();
@@ -3060,7 +3035,7 @@ const consumeAListOfComponentValues = (
 		if (bailOnCurly && t.type === TT_LEFT_CURLY_BRACKET) return null;
 		// anything else
 		// Consume a component value from input, and append the result to values.
-		// Skipped leaf types short-circuit before materializing: no SoA slot is
+		// Skipped leaf types short-circuit before materializing: no column slot is
 		// written and no node is built (blocks / functions never skip here).
 		const tt = t.type;
 		if (
@@ -3123,7 +3098,7 @@ const consumeASimpleBlock = (ts) => {
 	);
 	_setToken(block, token);
 	// Sealed (`_setValue`) at the return, once complete.
-	const val = _soaActive ? _soaList() : [];
+	const val = _takeList();
 
 	// Discard a token from input.
 	ts.discard();
@@ -3162,7 +3137,7 @@ const consumeAFunction = (ts) => {
 	);
 	_setName(fn, tFn.start, tFn.end - 1);
 	// Sealed (`_setValue`) at the return, once complete.
-	const val = _soaActive ? _soaList() : [];
+	const val = _takeList();
 
 	// Process input
 	for (;;) {
@@ -3493,12 +3468,12 @@ let _commentBucket;
 
 // Comments reach the visitor map through `NodeType.Comment` instead of a
 // side callback. They fire during tokenization — in source order among
-// comments, not interleaved with the node walk — on a transient SoA node so
+// comments, not interleaved with the node walk — on a transient store node so
 // `A.start`/`end`/`loc`/`source` work. No comment visitor → no callback →
 // the tokenizer skips comments with zero overhead.
 /** @type {(input: string, start: number, end: number) => number} */
-const _grammarOnComment = (_input, start, end) => {
-	const node = _soaAllocNode(T_COMMENT, start, end);
+const _grammarOnComment = (_src, start, end) => {
+	const node = _makeLeaf(T_COMMENT, start, end);
 	_currentNode = node;
 	_currentParent = null;
 	const bucket = /** @type {CompiledVisitorBucket} */ (_commentBucket);
@@ -3517,7 +3492,7 @@ const _grammarOnComment = (_input, start, end) => {
  * @param {Node | null} parent enclosing node
  */
 const _walkValue = (node, parent) => {
-	const ty = _soaTypes[_nodeIndex(node)];
+	const ty = _types[_nodeIndex(node)];
 	const b = _visitors[ty];
 	let skip = false;
 	if (b !== undefined && b.enter.length !== 0) {
@@ -3531,9 +3506,9 @@ const _walkValue = (node, parent) => {
 	}
 	if (!skip && (ty === T_FUNCTION || ty === T_SIMPLE_BLOCK)) {
 		const i0 = _nodeIndex(node);
-		const vs = _soaListStarts[i0];
-		const ve = vs + _soaListLens[i0];
-		for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
+		const vs = _listStarts[i0];
+		const ve = vs + _listLens[i0];
+		for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_flat[i]), node);
 	}
 	if (b !== undefined) {
 		// Rebind: descending into children moved the path.
@@ -3552,7 +3527,7 @@ const _walkValue = (node, parent) => {
  */
 const _walkRule = (node, parent) => {
 	const i0 = _nodeIndex(node);
-	const ty = _soaTypes[i0];
+	const ty = _types[i0];
 	const b = _visitors[ty];
 	let skip = false;
 	if (b !== undefined && b.enter.length !== 0) {
@@ -3566,22 +3541,22 @@ const _walkRule = (node, parent) => {
 	}
 	if (!skip) {
 		if (ty === T_AT_RULE || ty === T_QUALIFIED_RULE) {
-			const ps = _soaListStarts[i0];
-			const pe = ps + _soaListLens[i0];
-			for (let i = ps; i < pe; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
+			const ps = _listStarts[i0];
+			const pe = ps + _listLens[i0];
+			for (let i = ps; i < pe; i++) _walkValue(_nodeRef(_flat[i]), node);
 			if (_recurseBlocks) {
 				// Declarations then child rules — downstream consumers don't need them strictly interleaved in source order.
-				const decls = _soaDeclarationLists[i0];
+				const decls = _declarationLists[i0];
 				if (decls) {
 					for (let i = 0; i < decls.length; i++) _walkRule(decls[i], node);
 				}
-				const ch = _soaChildRuleLists[i0];
+				const ch = _childRuleLists[i0];
 				if (ch) for (let i = 0; i < ch.length; i++) _walkRule(ch[i], node);
 			}
 		} else if (ty === T_DECLARATION) {
-			const vs = _soaListStarts[i0];
-			const ve = vs + _soaListLens[i0];
-			for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_soaFlat[i]), node);
+			const vs = _listStarts[i0];
+			const ve = vs + _listLens[i0];
+			for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_flat[i]), node);
 		}
 	}
 	if (b !== undefined) {
@@ -3594,22 +3569,22 @@ const _walkRule = (node, parent) => {
 };
 
 /**
- * The `grammar` streaming sink: walk one top-level node, then recycle the SoA
+ * The `grammar` streaming sink: walk one top-level node, then recycle the
  * buffers for the next.
  * @param {Rule | Declaration} node top-level node
  */
 const _walkTopLevel = (node) => {
 	_walkRule(node, null);
-	if (_soaNodeCount > _soaPeak) _soaPeak = _soaNodeCount;
-	if (_soaFlatTop > _soaFlatPeak) _soaFlatPeak = _soaFlatTop;
-	_soaNodeCount = 0;
-	_soaFlatTop = 0;
+	if (_nodeCount > _peak) _peak = _nodeCount;
+	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
+	_nodeCount = 0;
+	_flatTop = 0;
 };
 
-// The SoA buffers grow to the largest single top-level rule ever parsed and
+// The store buffers grow to the largest single top-level rule ever parsed and
 // live at module level; above this capacity they are re-shrunk after a parse
 // so one pathological rule can't pin megabytes for the process lifetime.
-const _SOA_SHRINK_CAPACITY = 65536;
+const _SHRINK_CAPACITY = 65536;
 
 /**
  * The CSS `SourceProcessor` grammar: consume top-level rules one at a time
@@ -3623,7 +3598,7 @@ const _SOA_SHRINK_CAPACITY = 65536;
  */
 const grammar = (input, visitors, options) => {
 	const locConverter = options.locConverter || new LocConverter(input);
-	useSoaBackend(input, locConverter);
+	_setupParse(input, locConverter);
 	const skip = options.skip;
 	_skipTypes = (skip && skip.types) || _NO_SKIP_TYPES;
 	_skipActive = _skipTypes !== _NO_SKIP_TYPES;
@@ -3648,39 +3623,37 @@ const grammar = (input, visitors, options) => {
 	try {
 		consume(ts, _walkTopLevel);
 	} finally {
-		// Drop the module-level SoA references so the last parsed source (and
+		// Drop the module-level column references so the last parsed source (and
 		// its LocConverter / child lists / visitors) don't stay alive between
 		// parses.
-		_soaInput = "";
-		_soaLocConverter = /** @type {LocConverter} */ (
-			/** @type {unknown} */ (null)
-		);
-		_soaDeclarationLists.length = 0;
-		_soaChildRuleLists.length = 0;
-		_soaFlatTop = 0;
+		_input = "";
+		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
+		_declarationLists.length = 0;
+		_childRuleLists.length = 0;
+		_flatTop = 0;
 		_listPool.length = 0;
-		if (_soaFlat.length > _SOA_SHRINK_CAPACITY) {
-			_soaFlatGrowHint = _soaFlatPeak;
-			_soaFlat = new Int32Array(0);
+		if (_flat.length > _SHRINK_CAPACITY) {
+			_flatGrowHint = _flatPeak;
+			_flat = new Int32Array(0);
 		}
 		_visitors = /** @type {CompiledVisitorMap} */ (/** @type {unknown} */ ([]));
 		_commentBucket = undefined;
-		if (_soaCapacity > _SOA_SHRINK_CAPACITY) {
+		if (_capacity > _SHRINK_CAPACITY) {
 			// +1: node ids are 1-based and grow fires at `id >= capacity`.
-			_soaGrowHint = _soaPeak + 1;
-			_soaCapacity = 0;
-			_soaTypes = new Uint8Array(0);
-			_soaStarts = new Int32Array(0);
-			_soaEnds = new Int32Array(0);
-			_soaAux0 = new Int32Array(0);
-			_soaAux1 = new Int32Array(0);
-			_soaAux2 = new Int32Array(0);
-			_soaFlags = new Uint8Array(0);
-			_soaListStarts = new Int32Array(0);
-			_soaListLens = new Int32Array(0);
+			_growHint = _peak + 1;
+			_capacity = 0;
+			_types = new Uint8Array(0);
+			_starts = new Int32Array(0);
+			_ends = new Int32Array(0);
+			_aux0 = new Int32Array(0);
+			_aux1 = new Int32Array(0);
+			_aux2 = new Int32Array(0);
+			_flags = new Uint8Array(0);
+			_listStarts = new Int32Array(0);
+			_listLens = new Int32Array(0);
 		}
-		_soaPeak = 0;
-		_soaFlatPeak = 0;
+		_peak = 0;
+		_flatPeak = 0;
 	}
 };
 
@@ -3733,11 +3706,11 @@ const buildSkipSet = (nodeTypes) => {
 /** @type {(n: Node) => Node[]} */
 const _materializeList = (n) => {
 	const i = _nodeIndex(n);
-	const start = _soaListStarts[i];
-	const len = _soaListLens[i];
+	const start = _listStarts[i];
+	const len = _listLens[i];
 	/** @type {Node[]} */
 	const out = [];
-	for (let k = 0; k < len; k++) out.push(_nodeRef(_soaFlat[start + k]));
+	for (let k = 0; k < len; k++) out.push(_nodeRef(_flat[start + k]));
 	return out;
 };
 
@@ -3752,12 +3725,10 @@ let _currentNode = /** @type {Node} */ (/** @type {unknown} */ (0));
 let _currentParent = null;
 
 // AST field-access seam. Every AST-node field read by `CssParser` goes through
-// one of these accessors so the node representation can change underneath the
-// consumer without touching it. Today they are backed by the `Node` / `Token` /
-// `Container` objects (`n` is a node); the Struct-of-Arrays migration rewrites
-// the bodies to index typed arrays (`n` becomes an integer node id) without any
-// consumer edit. `value` is the leaf-token string; container child lists are
-// `children` / `prelude` / `declarations` / `childRules`.
+// one of these accessors (`n` is an integer node id into the columns), so
+// the storage stays behind the accessor without any consumer edit. `value` is
+// the leaf-token string; container child lists are `children` / `prelude` /
+// `declarations` / `childRules`.
 const A = {
 	// === path position (rebound by the walk before every visitor call) ===
 	/**
@@ -3782,21 +3753,21 @@ const A = {
 	 * @returns {number} node type
 	 */
 	type(n = _currentNode) {
-		return _soaTypes[_nodeIndex(n)];
+		return _types[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} start offset
 	 */
 	start(n = _currentNode) {
-		return _soaStarts[_nodeIndex(n)];
+		return _starts[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} end offset
 	 */
 	end(n = _currentNode) {
-		return _soaEnds[_nodeIndex(n)];
+		return _ends[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
@@ -3804,7 +3775,7 @@ const A = {
 	 */
 	range(n = _currentNode) {
 		const i = _nodeIndex(n);
-		return [_soaStarts[i], _soaEnds[i]];
+		return [_starts[i], _ends[i]];
 	},
 	/**
 	 * @param {Node=} n node
@@ -3812,11 +3783,11 @@ const A = {
 	 */
 	loc(n = _currentNode) {
 		const i = _nodeIndex(n);
-		const lc = _soaLocConverter;
-		const s = lc.get(_soaStarts[i]);
+		const lc = _locConverter;
+		const s = lc.get(_starts[i]);
 		const sl = s.line;
 		const sc = s.column;
-		const e = lc.get(_soaEnds[i]);
+		const e = lc.get(_ends[i]);
 		return {
 			start: { line: sl, column: sc },
 			end: { line: e.line, column: e.column }
@@ -3828,14 +3799,14 @@ const A = {
 	 */
 	source(n = _currentNode) {
 		const i = _nodeIndex(n);
-		return _soaInput.slice(_soaStarts[i], _soaEnds[i]);
+		return _input.slice(_starts[i], _ends[i]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {string} raw token value
 	 */
 	value(n = _currentNode) {
-		return _soaValueOf(_nodeIndex(n));
+		return _valueOf(_nodeIndex(n));
 	},
 	/**
 	 * @param {Node=} n node
@@ -3843,8 +3814,8 @@ const A = {
 	 */
 	unescaped(n = _currentNode) {
 		const i = _nodeIndex(n);
-		const v = _soaValueOf(i);
-		return _soaTypes[i] === T_STRING
+		const v = _valueOf(i);
+		return _types[i] === T_STRING
 			? unescapeIdentifier(v.slice(1, -1))
 			: unescapeIdentifier(v);
 	},
@@ -3854,9 +3825,9 @@ const A = {
 	 */
 	typeFlag(n = _currentNode) {
 		const i = _nodeIndex(n);
-		if (_soaTypes[i] === T_HASH) {
-			const input = _soaInput;
-			const p = _soaStarts[i] + 1;
+		if (_types[i] === T_HASH) {
+			const input = _input;
+			const p = _starts[i] + 1;
 			return _ifThreeCodePointsWouldStartAnIdentSequence(
 				input,
 				p,
@@ -3867,9 +3838,9 @@ const A = {
 				? "id"
 				: "unrestricted";
 		}
-		const v = _soaValueOf(i);
+		const v = _valueOf(i);
 		return _typeFlagOf(
-			_soaTypes[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
+			_types[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
 		);
 	},
 	/**
@@ -3877,14 +3848,14 @@ const A = {
 	 * @returns {number} url content start offset
 	 */
 	contentStart(n = _currentNode) {
-		return _soaAux0[_nodeIndex(n)];
+		return _aux0[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} url content end offset
 	 */
 	contentEnd(n = _currentNode) {
-		return _soaAux1[_nodeIndex(n)];
+		return _aux1[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
@@ -3892,23 +3863,23 @@ const A = {
 	 */
 	name(n = _currentNode) {
 		const i = _nodeIndex(n);
-		return _soaTypes[i] === T_AT_RULE
-			? _soaInput.slice(_soaStarts[i] + 1, _soaAux0[i])
-			: _soaInput.slice(_soaStarts[i], _soaAux0[i]);
+		return _types[i] === T_AT_RULE
+			? _input.slice(_starts[i] + 1, _aux0[i])
+			: _input.slice(_starts[i], _aux0[i]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} name start offset
 	 */
 	nameStart(n = _currentNode) {
-		return _soaStarts[_nodeIndex(n)];
+		return _starts[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} name end offset
 	 */
 	nameEnd(n = _currentNode) {
-		return _soaAux0[_nodeIndex(n)];
+		return _aux0[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
@@ -3937,7 +3908,7 @@ const A = {
 	 */
 	declarations(n = _currentNode) {
 		return /** @type {Declaration[] | null} */ (
-			_soaDeclarationLists[_nodeIndex(n)]
+			_declarationLists[_nodeIndex(n)]
 		);
 	},
 	/**
@@ -3945,37 +3916,35 @@ const A = {
 	 * @returns {Rule[] | null} block child rules
 	 */
 	childRules(n = _currentNode) {
-		return /** @type {Rule[] | null} */ (_soaChildRuleLists[_nodeIndex(n)]);
+		return /** @type {Rule[] | null} */ (_childRuleLists[_nodeIndex(n)]);
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} block start offset
 	 */
 	blockStart(n = _currentNode) {
-		return _soaAux1[_nodeIndex(n)];
+		return _aux1[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {number} block end offset
 	 */
 	blockEnd(n = _currentNode) {
-		return _soaAux2[_nodeIndex(n)];
+		return _aux2[_nodeIndex(n)];
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {boolean} `!important` flag
 	 */
 	important(n = _currentNode) {
-		return (_soaFlags[_nodeIndex(n)] & 1) !== 0;
+		return (_flags[_nodeIndex(n)] & 1) !== 0;
 	},
 	/**
 	 * @param {Node=} n node
 	 * @returns {SimpleBlockToken} block opening token
 	 */
 	blockToken(n = _currentNode) {
-		return /** @type {SimpleBlockToken} */ (
-			_soaInput[_soaStarts[_nodeIndex(n)]]
-		);
+		return /** @type {SimpleBlockToken} */ (_input[_starts[_nodeIndex(n)]]);
 	},
 	// Writers — `CssParser` rewrites a rule's end / block-end when it folds an
 	// inline ICSS `:import` / `:export` body into a single dependency. The
@@ -3985,25 +3954,24 @@ const A = {
 	 * @param {number} v new end offset
 	 */
 	setEnd(n, v) {
-		_soaEnds[_nodeIndex(n)] = v;
+		_ends[_nodeIndex(n)] = v;
 	},
 	/**
 	 * @param {Node} n node
 	 * @param {number} v new block end offset
 	 */
 	setBlockEnd(n, v) {
-		_soaAux2[_nodeIndex(n)] = v;
+		_aux2[_nodeIndex(n)] = v;
 	}
 };
 
-// The two AST runtime classes — `Node` and its sole subclass `Token` (the
-// other node shapes are `@typedef`s over `Node`, exported as types only). Plus
-// the full CSS-Syntax-3 §5.3 `parseA*` entry-point surface, `consumeASimpleBlock`
-// (the one §5.4 algorithm exposed as a byte entry point for `CssParser`), the
-// `TokenStream` (so callers can pass a pre-built stream to any `parseA*`), and
-// the `escape` / `unescapeIdentifier` string utils.
+// The AST node shapes (`Node`, `Token`, and the container typedefs) are types
+// only — nodes are integer ids into the store, surfaced by the `A` visitor
+// accessor and the `parseA*` readers. Runtime exports: the `A` accessor, the
+// full CSS-Syntax-3 §5.3 `parseA*` entry-point surface, the `TokenStream` (so
+// callers can pass a pre-built stream to any `parseA*`), and the `escape` /
+// `unescapeIdentifier` string utils.
 module.exports.A = A;
-module.exports.Node = Node;
 module.exports.NodeType = NodeType;
 module.exports.SourceProcessor = SourceProcessor;
 module.exports.TT_AT_KEYWORD = TT_AT_KEYWORD;
@@ -4032,7 +4000,6 @@ module.exports.TT_SEMICOLON = TT_SEMICOLON;
 module.exports.TT_STRING = TT_STRING;
 module.exports.TT_URL = TT_URL;
 module.exports.TT_WHITESPACE = TT_WHITESPACE;
-module.exports.Token = Token;
 module.exports.TokenStream = TokenStream;
 module.exports.buildSkipSet = buildSkipSet;
 module.exports.equalsLowerCase = equalsLowerCase;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1932,11 +1932,14 @@ const normalizeIntoTokenStream = (input, pos, onComment) =>
 // into the columns without recycling, then `_finishStore` hands them to a
 // snapshot object and resets the module columns to fresh arrays so the next parse
 // can't clobber it. Nodes are exposed as `parseA*` readers: plain objects sharing
-// one per-store prototype whose getters index the snapshot by node id — no
-// per-node class, no eager string slices, child readers built lazily on access.
+// one module-level prototype whose getters index the reader's own snapshot by node
+// id — no per-node class, no eager string slices, child readers built lazily on
+// access. A single shared prototype (rather than one per store) keeps the readers
+// monomorphic across parses, so `_readerAt` and every getter stay on the fast path.
 
 /**
  * @typedef {object} NodeReader
+ * @property {NodeStore} _store snapshot this reader indexes
  * @property {number} _i node id into the snapshot columns
  * @property {number} type node type
  * @property {number} start start offset
@@ -1982,7 +1985,6 @@ const normalizeIntoTokenStream = (input, pos, onComment) =>
  * @property {Int32Array} flat flat node-ref buffer
  * @property {(Node[] | null)[]} declLists per-node declaration lists
  * @property {(Node[] | null)[]} childLists per-node child-rule lists
- * @property {NodeReader} proto shared reader prototype for this store
  */
 
 // Shared frozen empty list for a block body with no declarations / child rules,
@@ -2013,7 +2015,8 @@ const _storeValueOf = (store, i) => {
  * @returns {Node} reader over node `i`
  */
 const _readerAt = (store, i) => {
-	const o = Object.create(store.proto);
+	const o = Object.create(NODE_READER_PROTO);
+	o._store = store;
 	o._i = i;
 	return /** @type {Node} */ (o);
 };
@@ -2049,157 +2052,163 @@ const _readRefList = (store, list) => {
 	return out;
 };
 
-/**
- * Build the reader prototype for one store: getters index the snapshot columns
- * by the reader's `_i` node id. One prototype per store, shared by all its
- * readers, so a reader is a two-slot object with no per-node closures.
- * @param {NodeStore} store snapshot
- * @returns {NodeReader} the shared reader prototype
- */
-const _makeReaderProto = (store) =>
-	/** @type {NodeReader} */ ({
-		_i: 0,
-		get type() {
-			return store.types[this._i];
-		},
-		get start() {
-			return store.starts[this._i];
-		},
-		get end() {
-			return store.ends[this._i];
-		},
-		get range() {
-			const i = this._i;
-			return /** @type {[number, number]} */ ([store.starts[i], store.ends[i]]);
-		},
-		get loc() {
-			const i = this._i;
-			const lc = store.lc;
-			// `LocConverter#get` mutates and returns itself, so snapshot the first.
-			const s = lc.get(store.starts[i]);
-			const sl = s.line;
-			const sc = s.column;
-			const e = lc.get(store.ends[i]);
-			return {
-				start: { line: sl, column: sc },
-				end: { line: e.line, column: e.column }
-			};
-		},
-		toString() {
-			const i = this._i;
-			return store.input.slice(store.starts[i], store.ends[i]);
-		},
-		get value() {
-			const i = this._i;
-			const ty = store.types[i];
-			// function / simple-block / declaration expose their component-value
-			// list; every leaf token exposes its raw string value.
-			return ty === T_FUNCTION || ty === T_SIMPLE_BLOCK || ty === T_DECLARATION
-				? /** @type {ComponentValue[]} */ (_readList(store, i))
-				: _storeValueOf(store, i);
-		},
-		get unescaped() {
-			const i = this._i;
-			const v = _storeValueOf(store, i);
-			return store.types[i] === T_STRING
-				? unescapeIdentifier(v.slice(1, -1))
-				: unescapeIdentifier(v);
-		},
-		get numericValue() {
-			const i = this._i;
-			const v = _storeValueOf(store, i);
-			if (store.types[i] === T_DIMENSION) {
-				return Number(v.slice(0, _consumeANumber(v, 0)));
-			}
-			if (store.types[i] === T_PERCENTAGE) return Number(v.slice(0, -1));
-			return Number(v);
-		},
-		get typeFlag() {
-			const i = this._i;
-			if (store.types[i] === T_HASH) {
-				const input = store.input;
-				const p = store.starts[i] + 1;
-				return _ifThreeCodePointsWouldStartAnIdentSequence(
-					input,
-					p,
-					input.charCodeAt(p),
-					input.charCodeAt(p + 1),
-					input.charCodeAt(p + 2)
-				)
-					? "id"
-					: "unrestricted";
-			}
-			const v = _storeValueOf(store, i);
-			return _typeFlagOf(
-				store.types[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
-			);
-		},
-		get sign() {
-			return _signOf(_storeValueOf(store, this._i));
-		},
-		get unit() {
-			const v = _storeValueOf(store, this._i);
-			return v.slice(_consumeANumber(v, 0)).toLowerCase();
-		},
-		get contentStart() {
-			return store.aux0[this._i];
-		},
-		get contentEnd() {
-			return store.aux1[this._i];
-		},
-		get name() {
-			const i = this._i;
-			// An at-rule's name skips its `@`; others start at the node.
-			return store.types[i] === T_AT_RULE
-				? store.input.slice(store.starts[i] + 1, store.aux0[i])
-				: store.input.slice(store.starts[i], store.aux0[i]);
-		},
-		get nameStart() {
-			return store.starts[this._i];
-		},
-		get nameEnd() {
-			return store.aux0[this._i];
-		},
-		get unescapedName() {
-			return unescapeIdentifier(this.name);
-		},
-		get prelude() {
-			return /** @type {ComponentValue[]} */ (_readList(store, this._i));
-		},
-		get declarations() {
-			const list = store.declLists[this._i];
-			return list === null
-				? null
-				: /** @type {Declaration[]} */ (
-						list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-					);
-		},
-		get childRules() {
-			const list = store.childLists[this._i];
-			return list === null
-				? null
-				: /** @type {Rule[]} */ (
-						list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-					);
-		},
-		get blockStart() {
-			return store.aux1[this._i];
-		},
-		get blockEnd() {
-			return store.aux2[this._i];
-		},
-		get important() {
-			return (store.flags[this._i] & 1) !== 0;
-		},
-		get token() {
-			return /** @type {SimpleBlockToken} */ (
-				store.input[store.starts[this._i]]
-			);
-		},
-		get rules() {
-			return /** @type {Rule[]} */ (_readList(store, this._i));
+// Module-level reader prototype shared by every `parseA*` reader. Getters index
+// the reader's own `_store` snapshot by its `_i` node id; because the prototype is
+// created once (not per store), all readers share one hidden map and stay
+// monomorphic across parses.
+const NODE_READER_PROTO = /** @type {NodeReader} */ ({
+	_store: /** @type {NodeStore} */ (/** @type {unknown} */ (null)),
+	_i: 0,
+	get type() {
+		return this._store.types[this._i];
+	},
+	get start() {
+		return this._store.starts[this._i];
+	},
+	get end() {
+		return this._store.ends[this._i];
+	},
+	get range() {
+		const store = this._store;
+		const i = this._i;
+		return /** @type {[number, number]} */ ([store.starts[i], store.ends[i]]);
+	},
+	get loc() {
+		const store = this._store;
+		const i = this._i;
+		const lc = store.lc;
+		// `LocConverter#get` mutates and returns itself, so snapshot the first.
+		const s = lc.get(store.starts[i]);
+		const sl = s.line;
+		const sc = s.column;
+		const e = lc.get(store.ends[i]);
+		return {
+			start: { line: sl, column: sc },
+			end: { line: e.line, column: e.column }
+		};
+	},
+	toString() {
+		const store = this._store;
+		const i = this._i;
+		return store.input.slice(store.starts[i], store.ends[i]);
+	},
+	get value() {
+		const store = this._store;
+		const i = this._i;
+		const ty = store.types[i];
+		// function / simple-block / declaration expose their component-value
+		// list; every leaf token exposes its raw string value.
+		return ty === T_FUNCTION || ty === T_SIMPLE_BLOCK || ty === T_DECLARATION
+			? /** @type {ComponentValue[]} */ (_readList(store, i))
+			: _storeValueOf(store, i);
+	},
+	get unescaped() {
+		const store = this._store;
+		const i = this._i;
+		const v = _storeValueOf(store, i);
+		return store.types[i] === T_STRING
+			? unescapeIdentifier(v.slice(1, -1))
+			: unescapeIdentifier(v);
+	},
+	get numericValue() {
+		const store = this._store;
+		const i = this._i;
+		const v = _storeValueOf(store, i);
+		if (store.types[i] === T_DIMENSION) {
+			return Number(v.slice(0, _consumeANumber(v, 0)));
 		}
-	});
+		if (store.types[i] === T_PERCENTAGE) return Number(v.slice(0, -1));
+		return Number(v);
+	},
+	get typeFlag() {
+		const store = this._store;
+		const i = this._i;
+		if (store.types[i] === T_HASH) {
+			const input = store.input;
+			const p = store.starts[i] + 1;
+			return _ifThreeCodePointsWouldStartAnIdentSequence(
+				input,
+				p,
+				input.charCodeAt(p),
+				input.charCodeAt(p + 1),
+				input.charCodeAt(p + 2)
+			)
+				? "id"
+				: "unrestricted";
+		}
+		const v = _storeValueOf(store, i);
+		return _typeFlagOf(
+			store.types[i] === T_DIMENSION ? v.slice(0, _consumeANumber(v, 0)) : v
+		);
+	},
+	get sign() {
+		return _signOf(_storeValueOf(this._store, this._i));
+	},
+	get unit() {
+		const v = _storeValueOf(this._store, this._i);
+		return v.slice(_consumeANumber(v, 0)).toLowerCase();
+	},
+	get contentStart() {
+		return this._store.aux0[this._i];
+	},
+	get contentEnd() {
+		return this._store.aux1[this._i];
+	},
+	get name() {
+		const store = this._store;
+		const i = this._i;
+		// An at-rule's name skips its `@`; others start at the node.
+		return store.types[i] === T_AT_RULE
+			? store.input.slice(store.starts[i] + 1, store.aux0[i])
+			: store.input.slice(store.starts[i], store.aux0[i]);
+	},
+	get nameStart() {
+		return this._store.starts[this._i];
+	},
+	get nameEnd() {
+		return this._store.aux0[this._i];
+	},
+	get unescapedName() {
+		return unescapeIdentifier(this.name);
+	},
+	get prelude() {
+		return /** @type {ComponentValue[]} */ (_readList(this._store, this._i));
+	},
+	get declarations() {
+		const store = this._store;
+		const list = store.declLists[this._i];
+		return list === null
+			? null
+			: /** @type {Declaration[]} */ (
+					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
+				);
+	},
+	get childRules() {
+		const store = this._store;
+		const list = store.childLists[this._i];
+		return list === null
+			? null
+			: /** @type {Rule[]} */ (
+					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
+				);
+	},
+	get blockStart() {
+		return this._store.aux1[this._i];
+	},
+	get blockEnd() {
+		return this._store.aux2[this._i];
+	},
+	get important() {
+		return (this._store.flags[this._i] & 1) !== 0;
+	},
+	get token() {
+		const store = this._store;
+		return /** @type {SimpleBlockToken} */ (store.input[store.starts[this._i]]);
+	},
+	get rules() {
+		return /** @type {Rule[]} */ (_readList(this._store, this._i));
+	}
+});
 
 /**
  * Hand the module's live columns to a retained snapshot, then reset the
@@ -2223,10 +2232,8 @@ const _finishStore = () => {
 		listLens: _listLens,
 		flat: _flat,
 		declLists: _declarationLists,
-		childLists: _childRuleLists,
-		proto: /** @type {NodeReader} */ (/** @type {unknown} */ (null))
+		childLists: _childRuleLists
 	};
-	store.proto = _makeReaderProto(store);
 	// Carry this parse's size forward as a one-shot grow hint so the next parse
 	// allocates its columns once instead of re-doubling from scratch (node ids
 	// are 1-based, so `+1`).

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -300,7 +300,9 @@ describe("CssSyntax — component values (tokenToNode)", () => {
 	it("reads declarations / childRules as null on non-rule nodes", () => {
 		// Only rules populate the decl / child-rule slots; a function (or any
 		// non-rule container) has no entry and must read back `null`.
-		const fn = parseAComponentValue("calc(1 + 2)");
+		const fn = /** @type {import("../lib/css/syntax").QualifiedRule} */ (
+			/** @type {unknown} */ (parseAComponentValue("calc(1 + 2)"))
+		);
 		expect(fn.declarations).toBeNull();
 		expect(fn.childRules).toBeNull();
 	});

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -3,7 +3,6 @@
 const fs = require("fs");
 const path = require("path");
 const {
-	Node,
 	NodeType,
 	SourceProcessor,
 	TT_AT_KEYWORD,
@@ -32,7 +31,6 @@ const {
 	TT_STRING,
 	TT_URL,
 	TT_WHITESPACE,
-	Token,
 	TokenStream,
 	buildSkipSet,
 	normalizeUrl,
@@ -468,7 +466,7 @@ describe("CssSyntax — Node / Token", () => {
 		const decl = /** @type {import("../lib/css/syntax").Declaration} */ (
 			parseADeclaration("color: red")
 		);
-		expect(decl).toBeInstanceOf(Node);
+		expect(decl.type).toBe(NodeType.Declaration);
 		expect(decl.range).toEqual([decl.start, decl.end]);
 		expect(decl.toString()).toBe("color: red");
 	});
@@ -497,13 +495,105 @@ describe("CssSyntax — Node / Token", () => {
 		const ident = /** @type {import("../lib/css/syntax").Token} */ (
 			parseAComponentValue("foo")
 		);
-		expect(ident).toBeInstanceOf(Token);
+		expect(ident.type).toBe(NodeType.Ident);
 		expect(ident.value).toBe("foo");
 		expect(ident.value).toBe("foo");
+	});
+
+	it("exposes every parseA* reader accessor", () => {
+		/**
+		 * @param {string} src source
+		 * @returns {import("../lib/css/syntax").Token} the component value as a token
+		 */
+		const tok = (src) =>
+			/** @type {import("../lib/css/syntax").Token} */ (
+				parseAComponentValue(src)
+			);
+
+		// loc over the source
+		const decl = /** @type {import("../lib/css/syntax").Declaration} */ (
+			parseADeclaration("color: red")
+		);
+		expect(decl.loc.start).toEqual({ line: 1, column: 0 });
+		expect(decl.loc.end.line).toBe(1);
+
+		// unescaped: ident escapes resolved; string drops its quotes
+		expect(tok("a\\62 c").unescaped).toBe("abc");
+		expect(tok('"x"').unescaped).toBe("x");
+
+		// hash value drops the `#` prefix (raw-value slice)
+		expect(tok("#id").value).toBe("id");
+
+		// function name offsets + unescapedName
+		const fn = /** @type {import("../lib/css/syntax").FunctionNode} */ (
+			parseAComponentValue("foo(1)")
+		);
+		expect([fn.nameStart, fn.nameEnd]).toEqual([0, 3]);
+		expect(fn.unescapedName).toBe("foo");
+
+		// simple-block opening token
+		expect(
+			/** @type {import("../lib/css/syntax").SimpleBlock} */ (
+				parseAComponentValue("[a]")
+			).token
+		).toBe("[");
+
+		// prelude + blockEnd on a qualified rule
+		const src = "a { x: 1 }";
+		const rule = /** @type {import("../lib/css/syntax").QualifiedRule} */ (
+			parseARule(src)
+		);
+		expect(rule.prelude.length).toBeGreaterThan(0);
+		expect(rule.blockEnd).toBe(src.length);
 	});
 });
 
 describe("CssSyntax — SourceProcessor", () => {
+	it("exposes range / unescaped / typeFlag / setEnd / setBlockEnd on the path", () => {
+		/** @type {Record<string, unknown>} */
+		const seen = {};
+		new SourceProcessor()
+			.use(
+				/** @type {import("../lib/css/syntax").VisitorMap} */ ({
+					[NodeType.Hash]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						seen.typeFlag = path.typeFlag();
+						// `A.value` on a hash drops the `#` (raw-value slice).
+						seen.hashValue = path.value();
+					},
+					[NodeType.Number]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						seen.numFlag = path.typeFlag();
+					},
+					[NodeType.String]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						seen.unescaped = path.unescaped();
+					},
+					[NodeType.Ident]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						seen.range = path.range();
+					},
+					[NodeType.QualifiedRule]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						// Round-trip the writers (set each field back to its own value).
+						path.setEnd(path.node, path.end());
+						path.setBlockEnd(path.node, path.blockEnd());
+					}
+				})
+			)
+			.process('a { z-index: 5; content: "x"; color: #123 }');
+		expect(seen.typeFlag).toBe("unrestricted");
+		expect(seen.numFlag).toBe("integer");
+		expect(seen.hashValue).toBe("123");
+		expect(seen.unescaped).toBe("x");
+		expect(Array.isArray(seen.range)).toBe(true);
+	});
+
 	it("fires enter / exit visitors in source order", () => {
 		/** @type {string[]} */
 		const log = [];

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -297,6 +297,14 @@ describe("CssSyntax — component values (tokenToNode)", () => {
 		).toBe(true);
 	});
 
+	it("reads declarations / childRules as null on non-rule nodes", () => {
+		// Only rules populate the decl / child-rule slots; a function (or any
+		// non-rule container) has no entry and must read back `null`.
+		const fn = parseAComponentValue("calc(1 + 2)");
+		expect(fn.declarations).toBeNull();
+		expect(fn.childRules).toBeNull();
+	});
+
 	it("preserves stray closers, CDO and CDC as component values", () => {
 		expect(cvTypes(")]}")).toEqual([
 			NodeType.RightParenthesis,


### PR DESCRIPTION
**Summary**

The CSS syntax parser kept two node representations behind mutable dispatch slots: a struct-of-arrays store for the streaming `grammar` (what `CssParser` and the visitors actually use), and an object backend that built a `Node` / `Token` / `Container` class tree solely for the standalone `parseA*` entry points (used only by the unit tests and the parser benchmark).

This collapses it to a single struct-of-arrays backend. The `parseA*` entry points now parse into the columns and hand back lazy property-accessor readers over a retained snapshot, so the node classes and the whole object backend are removed. With one backend the dispatch primitives become `const` (no mutable-binding indirection), block-offset defaults are written only where a block is actually decided (at-rule / qualified-rule return paths) rather than on every container, and the internal `soa`-prefixed identifiers are dropped now that there is nothing to disambiguate from.

Measured on a 1.9 MiB stylesheet: `parseAStylesheet` ~112 → ~84 ms (~26% faster) and ~46 → ~21 MiB retained (~54% less); the streaming `process` parse+walk core ~67 → ~58 ms (~13% faster). Real-world full CSS builds (with and without CSS Modules) are neutral on wall time and identical on peak memory — they already ran the struct-of-arrays path and never built the classes — so this is a simplification plus a parser-core / standalone-API win at no build-path cost.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

This is a behavior-preserving refactor, covered by the existing `test/CssSyntax.unittest.js` (99 cases, which exercise the new reader accessors by reading `node.type` / `node.value` / `node.declarations` / etc.), the `cssParsing-webpack` spec suite, and the CSS `ConfigTestCases` integration builds (761 cases) — all green, plus the full unit suite (28,084). `test/CssSyntax.unittest.js` was updated to the class-free API: the `Node` / `Token` runtime exports are gone, so the two `toBeInstanceOf(Node|Token)` assertions now check `node.type`.

**Does this PR introduce a breaking change?**

No. `lib/css/syntax.js` is an internal module — `Node` / `Token` were never part of webpack's public API — so removing their runtime exports is not user-visible. The public config / API surface is unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — this change was developed with AI assistance (Claude Code). The refactor design, the code edits, the before/after CPU and memory benchmarking, and the test updates were carried out in an AI-assisted workflow, with each step reviewed and validated against the full test suite (unit, spec, and integration). Nothing was committed without verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEyNTrLowB7kicfPvADeW5)_