### PR TITLE
feat: tree shake destructuring of cjs require binding

### DIFF
--- a/.changeset/375-cjs-binding-destructuring-shake.md
+++ b/.changeset/375-cjs-binding-destructuring-shake.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Tree shake exports destructured from a `require()` binding.

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -458,6 +458,13 @@ class CommonJsImportsParserPlugin {
 			PLUGIN_NAME,
 			(expr) => {
 				if (isRequireCallExpression(expr)) return true;
+				// `const NAME = require(…); const { a } = NAME;`
+				if (
+					expr.type === "Identifier" &&
+					parser.getTagData(expr.name, REQUIRE_BINDING_TAG)
+				) {
+					return true;
+				}
 			}
 		);
 
@@ -734,20 +741,31 @@ class CommonJsImportsParserPlugin {
 			return true;
 		});
 
-		parser.hooks.expression.for(REQUIRE_BINDING_TAG).tap(PLUGIN_NAME, () => {
-			const binding =
-				/** @type {RequireBindingData} */
-				(parser.currentTagData);
-			if (binding) {
-				// `NAME` is read as a value (not as the object of a static member
-				// chain), so we have to assume the whole exports object is used.
-				binding.referencedExports = null;
-				if (binding.dep) {
-					binding.dep.referencedExports = null;
+		parser.hooks.expression
+			.for(REQUIRE_BINDING_TAG)
+			.tap(PLUGIN_NAME, (expr) => {
+				const binding =
+					/** @type {RequireBindingData} */
+					(parser.currentTagData);
+				if (binding) {
+					const properties = parser.destructuringAssignmentPropertiesFor(expr);
+					if (properties && binding.referencedExports) {
+						// `const { a } = NAME` — only the destructured keys are read.
+						const referencedExports = binding.referencedExports;
+						traverseDestructuringAssignmentProperties(properties, (stack) =>
+							referencedExports.push(stack.map((p) => p.id))
+						);
+					} else {
+						// `NAME` is read as a value (not as the object of a static member
+						// chain), so we have to assume the whole exports object is used.
+						binding.referencedExports = null;
+						if (binding.dep) {
+							binding.dep.referencedExports = null;
+						}
+					}
 				}
-			}
-			return true;
-		});
+				return true;
+			});
 
 		parser.hooks.expressionMemberChain
 			.for(REQUIRE_BINDING_TAG)

--- a/test/cases/cjs-tree-shaking/require-destructuring/index.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/index.js
@@ -30,6 +30,44 @@ it("should static analyze require destructuring with default values", () => {
 	expect(usedExports).toEqual(["a", "usedExports"]);
 });
 
+it("should static analyze destructuring of a require binding", () => {
+	const m = require("./module-binding");
+	const { a, usedExports } = m;
+	expect(a).toBe("a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should static analyze aliased destructuring of a require binding", () => {
+	const m = require("./module-binding");
+	const { a: renamedA, usedExports } = m;
+	expect(renamedA).toBe("a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should collect every destructuring of the same require binding", () => {
+	const m = require("./module-binding-multi");
+	const { a } = m;
+	const { b, usedExports } = m;
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(usedExports).toEqual(["a", "b", "usedExports"]);
+});
+
+it("should combine destructuring and member access on a require binding", () => {
+	const m = require("./module-binding-mixed");
+	const { a } = m;
+	expect(a).toBe("a");
+	expect(m.b).toBe("b");
+	expect(m.usedExports).toEqual(["a", "b", "usedExports"]);
+});
+
+it("should bail on rest element when destructuring a require binding", () => {
+	const m = require("./module-binding-rest");
+	const { usedExports, ...rest } = m;
+	expect(usedExports).toBe(true);
+	expect(rest).toEqual({ a: "a", b: "b" });
+});
+
 it("should bail on rest element in require destructuring", () => {
 	const { usedExports, ...rest } = require("./module-rest");
 	expect(usedExports).toBe(true);

--- a/test/cases/cjs-tree-shaking/require-destructuring/module-binding-mixed.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/module-binding-mixed.js
@@ -1,0 +1,4 @@
+exports.a = "a";
+exports.b = "b";
+exports.c = "c";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-destructuring/module-binding-multi.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/module-binding-multi.js
@@ -1,0 +1,4 @@
+exports.a = "a";
+exports.b = "b";
+exports.c = "c";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-destructuring/module-binding-rest.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/module-binding-rest.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/cjs-tree-shaking/require-destructuring/module-binding.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/module-binding.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;


### PR DESCRIPTION

**Summary**

`const m = require("./mod"); const { a } = m;` marked the entire exports object as used, so nothing in `./mod` could be tree-shaken, while the equivalent `const { a } = require("./mod")` shakes correctly. The require-binding tag now takes part in destructuring-property collection, so both forms reference only the destructured keys.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — four cases in `test/cases/cjs-tree-shaking/require-destructuring/` (plain, aliased, repeated destructuring, destructuring combined with member access), plus a rest-element case asserting the bail-out is kept.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Claude Code was used to investigate the gap (including a comparison against rspack's CommonJS parser plugin), draft the parser-plugin change, and write the test cases; all output was reviewed and verified locally by the author.
