### PR TITLE
feat: drop unused side-effect-free CommonJS require() calls

### DIFF
--- a/.changeset/040-drop-unused-cjs-requires.md
+++ b/.changeset/040-drop-unused-cjs-requires.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Drop unused side-effect-free CommonJS require() calls.

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -111,6 +111,20 @@ const getRequireReferencedExportsFromDestructuring = (parser, expr) => {
 };
 
 /**
+ * Whether `require(...)` is the whole statement expression (result discarded).
+ * @param {JavascriptParser} parser parser
+ * @param {CallExpression | NewExpression} expr require call
+ * @returns {boolean} true when evaluation-only at statement level
+ */
+const isStatementLevelBareRequire = (parser, expr) => {
+	const path = parser.statementPath;
+	if (!path || path.length === 0) return false;
+	const current = path[path.length - 1];
+	if (current === expr) return true;
+	return current.type === "ExpressionStatement" && current.expression === expr;
+};
+
+/**
  * Creates a require cache dependency.
  * @param {JavascriptParser} parser parser
  * @returns {(expr: Expression) => boolean} handler
@@ -185,6 +199,13 @@ const createRequireCallHandler = (
 				// `const NAME = require(LITERAL)` — let later member-access walks
 				// on `NAME` populate the dependency's referenced exports.
 				referencedExports = binding.referencedExports;
+			} else if (
+				referencedExports === null &&
+				!binding &&
+				isStatementLevelBareRequire(parser, expr)
+			) {
+				// Bare `require(...)` as a statement: result discarded → evaluation only.
+				referencedExports = [];
 			}
 			const dep = new CommonJsRequireDependency(
 				/** @type {string} */ (param.string),

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -111,20 +111,6 @@ const getRequireReferencedExportsFromDestructuring = (parser, expr) => {
 };
 
 /**
- * Whether `require(...)` is the whole statement expression (result discarded).
- * @param {JavascriptParser} parser parser
- * @param {CallExpression | NewExpression} expr require call
- * @returns {boolean} true when evaluation-only at statement level
- */
-const isStatementLevelBareRequire = (parser, expr) => {
-	const path = parser.statementPath;
-	if (!path || path.length === 0) return false;
-	const current = path[path.length - 1];
-	if (current === expr) return true;
-	return current.type === "ExpressionStatement" && current.expression === expr;
-};
-
-/**
  * Creates a require cache dependency.
  * @param {JavascriptParser} parser parser
  * @returns {(expr: Expression) => boolean} handler
@@ -184,9 +170,10 @@ const createRequireCallHandler = (
 	 * Process require item.
 	 * @param {CallExpression | NewExpression} expr expression
 	 * @param {BasicEvaluatedExpression} param param
-	 * @returns {boolean | void} true when handled
+	 * @param {boolean=} allowEvaluationOnly when false (conditional require), keep full namespace use
+	 * @returns {CommonJsRequireDependency | void} created dependency when handled
 	 */
-	const processRequireItem = (expr, param) => {
+	const processRequireItem = (expr, param, allowEvaluationOnly = true) => {
 		if (param.isString()) {
 			let referencedExports = getRequireReferencedExportsFromDestructuring(
 				parser,
@@ -200,9 +187,10 @@ const createRequireCallHandler = (
 				// on `NAME` populate the dependency's referenced exports.
 				referencedExports = binding.referencedExports;
 			} else if (
+				allowEvaluationOnly &&
 				referencedExports === null &&
 				!binding &&
-				isStatementLevelBareRequire(parser, expr)
+				parser.isStatementLevelExpression(expr)
 			) {
 				// Bare `require(...)` as a statement: result discarded → evaluation only.
 				referencedExports = [];
@@ -219,7 +207,7 @@ const createRequireCallHandler = (
 			dep.optional = Boolean(parser.scope.inTry);
 			parser.state.current.addDependency(dep);
 			getHarmonyImportGuard().attachDependencyGuards(parser, dep);
-			return true;
+			return dep;
 		}
 	};
 	/**
@@ -294,7 +282,8 @@ const createRequireCallHandler = (
 			for (const p of /** @type {BasicEvaluatedExpression[]} */ (
 				param.options
 			)) {
-				const result = processRequireItem(expr, p);
+				// Shared valueRange across branches: never mark evaluation-only.
+				const result = processRequireItem(expr, p, false);
 				if (result === undefined) {
 					isExpression = true;
 				}
@@ -324,12 +313,13 @@ const createRequireCallHandler = (
 			dep.loc = parser.getLocation(expr);
 			parser.state.module.addPresentationalDependency(dep);
 		} else {
-			const result = processRequireItem(expr, param);
-			if (result === undefined) {
+			const requireDep = processRequireItem(expr, param);
+			if (requireDep === undefined) {
 				processRequireContext(expr, param);
 			} else {
 				const dep = new RequireHeaderDependency(
-					/** @type {Range} */ (expr.callee.range)
+					/** @type {Range} */ (expr.callee.range),
+					requireDep
 				);
 				dep.loc = parser.getLocation(expr);
 				parser.state.module.addPresentationalDependency(dep);

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -88,15 +88,39 @@ class CommonJsRequireDependency extends ModuleDependency {
 	}
 
 	/**
+	 * Whether this require only evaluates the module (no exports read).
+	 * @returns {boolean} true when referencedExports is an empty list
+	 */
+	isEvaluationOnly() {
+		return (
+			Array.isArray(this.referencedExports) &&
+			this.referencedExports.length === 0
+		);
+	}
+
+	/**
 	 * Returns function to determine if the connection is active.
 	 * @param {ModuleGraph} moduleGraph module graph
 	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
 	 */
 	getCondition(moduleGraph) {
 		const guards = this.branchGuards;
-		if (guards === undefined) return null;
-		return (connection, runtime) =>
-			!getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime);
+		const evaluationOnly = this.isEvaluationOnly();
+		if (guards === undefined && !evaluationOnly) return null;
+		return (connection, runtime) => {
+			if (
+				guards !== undefined &&
+				getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime)
+			) {
+				return false;
+			}
+			if (evaluationOnly) {
+				const refModule = connection.resolvedModule;
+				if (!refModule) return true;
+				return refModule.getSideEffectsConnectionState(moduleGraph);
+			}
+			return true;
+		};
 	}
 
 	/**
@@ -116,6 +140,9 @@ class CommonJsRequireDependency extends ModuleDependency {
 			return [{ name: [ESM_MODULE_EXPORTS_NAME], canInline: false }];
 		}
 		if (!this.referencedExports) return Dependency.EXPORTS_OBJECT_REFERENCED;
+		if (this.referencedExports.length === 0) {
+			return Dependency.NO_EXPORTS_REFERENCED;
+		}
 		const exportsInfo = importedModule
 			? moduleGraph.getExportsInfo(importedModule)
 			: undefined;
@@ -170,9 +197,23 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 		const dep = /** @type {CommonJsRequireDependency} */ (dependency);
 		if (!dep.range) return;
 		const connection = moduleGraph.getConnection(dep);
-		// Dead branch: module is excluded and has no id; code is never executed.
 		if (connection && !connection.isTargetActive(runtime)) {
-			source.replace(dep.range[0], dep.range[1] - 1, "null /* dead branch */");
+			const guards = dep.branchGuards;
+			if (
+				guards !== undefined &&
+				getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime)
+			) {
+				// Dead branch: module is excluded and has no id; code is never executed.
+				source.replace(
+					dep.range[0],
+					dep.range[1] - 1,
+					"null /* dead branch */"
+				);
+				return;
+			}
+			// Unused side-effect-free require: drop the whole call expression.
+			const range = dep.valueRange || dep.range;
+			source.replace(range[0], range[1] - 1, "0");
 			return;
 		}
 		const importedModule = /** @type {Module} */ (moduleGraph.getModule(dep));

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -131,6 +131,16 @@ class CommonJsRequireDependency extends ModuleDependency {
 	 */
 	getReferencedExports(moduleGraph, runtime) {
 		const importedModule = moduleGraph.getModule(this);
+		if (this.isEvaluationOnly()) {
+			// Active `require(esm)` with side effects still unwraps `module.exports`.
+			if (
+				importedModule &&
+				isRequireEsmModuleExportsModule(importedModule, moduleGraph)
+			) {
+				return [{ name: [ESM_MODULE_EXPORTS_NAME], canInline: false }];
+			}
+			return Dependency.NO_EXPORTS_REFERENCED;
+		}
 		if (
 			importedModule &&
 			isRequireEsmModuleExportsModule(importedModule, moduleGraph)
@@ -140,9 +150,6 @@ class CommonJsRequireDependency extends ModuleDependency {
 			return [{ name: [ESM_MODULE_EXPORTS_NAME], canInline: false }];
 		}
 		if (!this.referencedExports) return Dependency.EXPORTS_OBJECT_REFERENCED;
-		if (this.referencedExports.length === 0) {
-			return Dependency.NO_EXPORTS_REFERENCED;
-		}
 		const exportsInfo = importedModule
 			? moduleGraph.getExportsInfo(importedModule)
 			: undefined;
@@ -212,8 +219,8 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 				return;
 			}
 			// Unused side-effect-free require: drop the whole call expression.
-			const range = dep.valueRange || dep.range;
-			source.replace(range[0], range[1] - 1, "0");
+			if (!dep.valueRange) return;
+			source.replace(dep.valueRange[0], dep.valueRange[1] - 1, "0");
 			return;
 		}
 		const importedModule = /** @type {Module} */ (moduleGraph.getModule(dep));

--- a/lib/dependencies/RequireHeaderDependency.js
+++ b/lib/dependencies/RequireHeaderDependency.js
@@ -7,14 +7,20 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
+const memoize = require("../util/memoize");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
+/** @typedef {import("../DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range]>} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range]>} ObjectSerializerContext */
+
+const getCommonJsRequireDependency = memoize(() =>
+	require("./CommonJsRequireDependency")
+);
 
 class RequireHeaderDependency extends NullDependency {
 	/**
@@ -63,8 +69,45 @@ RequireHeaderDependency.Template = class RequireHeaderDependencyTemplate extends
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeRequirements }) {
+	apply(
+		dependency,
+		source,
+		{ module, moduleGraph, runtime, runtimeRequirements }
+	) {
 		const dep = /** @type {RequireHeaderDependency} */ (dependency);
+		const CommonJsRequireDependency = getCommonJsRequireDependency();
+		// Skip only when the whole `require(...)` was replaced with `0`
+		// (evaluation-only + side-effect-free). Dead-branch inactive deps still
+		// need the header — they only rewrite the argument to
+		// `null /* dead branch */`. Skipping those yields bare `require(null)`.
+		// Walk blocks too: `require.ensure` / async callbacks put requires there.
+		let skipHeader = false;
+		/** @type {DependenciesBlock[]} */
+		const queue = [module];
+		outer: while (queue.length > 0) {
+			const block = /** @type {DependenciesBlock} */ (queue.pop());
+			for (const b of block.blocks) queue.push(b);
+			for (const d of block.dependencies) {
+				if (
+					!(d instanceof CommonJsRequireDependency) ||
+					!d.valueRange ||
+					d.valueRange[0] !== dep.range[0]
+				) {
+					continue;
+				}
+				const connection = moduleGraph.getConnection(d);
+				if (
+					connection &&
+					!connection.isTargetActive(runtime) &&
+					d.isEvaluationOnly()
+				) {
+					skipHeader = true;
+				}
+				break outer;
+			}
+		}
+		if (skipHeader) return;
+
 		runtimeRequirements.add(RuntimeGlobals.require);
 		source.replace(dep.range[0], dep.range[1] - 1, RuntimeGlobals.require);
 	}

--- a/lib/dependencies/RequireHeaderDependency.js
+++ b/lib/dependencies/RequireHeaderDependency.js
@@ -11,26 +11,27 @@ const memoize = require("../util/memoize");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
-/** @typedef {import("../DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range]>} ObjectSerializerContext */
+/** @typedef {import("./CommonJsRequireDependency")} CommonJsRequireDependency */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, CommonJsRequireDependency | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, CommonJsRequireDependency | undefined]>} ObjectSerializerContext */
 
-const getCommonJsRequireDependency = memoize(() =>
-	require("./CommonJsRequireDependency")
-);
+const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
 class RequireHeaderDependency extends NullDependency {
 	/**
 	 * Creates an instance of RequireHeaderDependency.
-	 * @param {Range} range range
+	 * @param {Range} range range of the `require` callee
+	 * @param {CommonJsRequireDependency=} requireDependency paired require dep (unset for conditional `require(a ? b : c)`)
 	 */
-	constructor(range) {
+	constructor(range, requireDependency) {
 		super();
 		if (!Array.isArray(range)) throw new Error("range must be valid");
 		this.range = range;
+		/** @type {CommonJsRequireDependency | undefined} */
+		this.requireDependency = requireDependency;
 	}
 
 	/**
@@ -38,7 +39,7 @@ class RequireHeaderDependency extends NullDependency {
 	 * @param {ObjectSerializerContext} context context
 	 */
 	serialize(context) {
-		context.write(this.range);
+		context.write(this.range).write(this.requireDependency);
 		super.serialize(context);
 	}
 
@@ -48,8 +49,10 @@ class RequireHeaderDependency extends NullDependency {
 	 * @returns {RequireHeaderDependency} RequireHeaderDependency
 	 */
 	static deserialize(context) {
-		const obj = new RequireHeaderDependency(context.read());
-		obj.deserialize(context);
+		const range = context.read();
+		const c1 = context.rest;
+		const obj = new RequireHeaderDependency(range, c1.read());
+		obj.deserialize(c1.rest);
 		return obj;
 	}
 }
@@ -69,44 +72,26 @@ RequireHeaderDependency.Template = class RequireHeaderDependencyTemplate extends
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(
-		dependency,
-		source,
-		{ module, moduleGraph, runtime, runtimeRequirements }
-	) {
+	apply(dependency, source, { moduleGraph, runtime, runtimeRequirements }) {
 		const dep = /** @type {RequireHeaderDependency} */ (dependency);
-		const CommonJsRequireDependency = getCommonJsRequireDependency();
-		// Skip only when the whole `require(...)` was replaced with `0`
-		// (evaluation-only + side-effect-free). Dead-branch inactive deps still
-		// need the header — they only rewrite the argument to
-		// `null /* dead branch */`. Skipping those yields bare `require(null)`.
-		// Walk blocks too: `require.ensure` / async callbacks put requires there.
-		let skipHeader = false;
-		/** @type {DependenciesBlock[]} */
-		const queue = [module];
-		outer: while (queue.length > 0) {
-			const block = /** @type {DependenciesBlock} */ (queue.pop());
-			for (const b of block.blocks) queue.push(b);
-			for (const d of block.dependencies) {
+		const requireDep = dep.requireDependency;
+		// Skip when the paired call became `0`; dead-branch still needs the header.
+		if (requireDep) {
+			const connection = moduleGraph.getConnection(requireDep);
+			if (
+				connection &&
+				!connection.isTargetActive(runtime) &&
+				requireDep.isEvaluationOnly()
+			) {
+				const guards = requireDep.branchGuards;
 				if (
-					!(d instanceof CommonJsRequireDependency) ||
-					!d.valueRange ||
-					d.valueRange[0] !== dep.range[0]
+					guards === undefined ||
+					!getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime)
 				) {
-					continue;
+					return;
 				}
-				const connection = moduleGraph.getConnection(d);
-				if (
-					connection &&
-					!connection.isTargetActive(runtime) &&
-					d.isEvaluationOnly()
-				) {
-					skipHeader = true;
-				}
-				break outer;
 			}
 		}
-		if (skipHeader) return;
 
 		runtimeRequirements.add(RuntimeGlobals.require);
 		source.replace(dep.range[0], dep.range[1] - 1, RuntimeGlobals.require);

--- a/test/cases/chunks/inline-options/package.json
+++ b/test/cases/chunks/inline-options/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/cases/chunks/weak-dependencies-context/package.json
+++ b/test/cases/chunks/weak-dependencies-context/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/cases/chunks/weak-dependencies/package.json
+++ b/test/cases/chunks/weak-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/effect-ternary.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/effect-ternary.js
@@ -1,0 +1,3 @@
+global.__cjs_ternary_effect_ran = true;
+
+exports.unused = "value";

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/effect.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/effect.js
@@ -1,0 +1,3 @@
+global.__cjs_effect_ran = true;
+
+exports.unused = "value";

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/index.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/index.js
@@ -19,6 +19,18 @@ const { unused: used } = require("./pure?used");
 global.__cjs_effect_ran = false;
 require("./effect");
 
+// Statement-level conditional require: must not rewrite the shared valueRange to "0".
+require(global.__pick_ternary ? "./pure?ternary-a" : "./pure?ternary-b");
+
+global.__cjs_ternary_effect_ran = false;
+require(
+	global.__pick_ternary_effect ? "./effect-ternary" : "./pure?ternary-c"
+);
+
+// Parenthesized / `new` callee: header must stay paired with the require dep.
+(require)("./pure?paren");
+new require("./pure?new");
+
 it("keeps a sibling declarator when an unused require shares its declaration", () => {
 	expect(keep).toBe("kept");
 });
@@ -32,9 +44,26 @@ it("keeps a bare require to a side-effectful module", () => {
 	delete global.__cjs_effect_ran;
 });
 
+it("runs the effect branch of a statement-level conditional require", () => {
+	global.__pick_ternary_effect = true;
+	global.__cjs_ternary_effect_ran = false;
+	require(
+		global.__pick_ternary_effect ? "./effect-ternary" : "./pure?ternary-c"
+	);
+	expect(global.__cjs_ternary_effect_ran).toBe(true);
+	delete global.__pick_ternary_effect;
+	delete global.__cjs_ternary_effect_ran;
+});
+
 if (process.env.NODE_ENV === "production") {
+	const bundledSource = () =>
+		Object.keys(__webpack_modules__)
+			.map((id) => String(__webpack_modules__[id]))
+			.join("\n");
+
 	it("drops a bare require of a side-effect-free module", () => {
 		expect(require.resolveWeak("./pure?bare")).toBe(null);
+		expect(bundledSource()).toMatch(/\b0;/);
 	});
 
 	it("drops an unused require binding of a side-effect-free module", () => {
@@ -59,5 +88,16 @@ if (process.env.NODE_ENV === "production") {
 
 	it("keeps a bare require of a side-effectful module in the graph", () => {
 		expect(require.resolveWeak("./effect")).not.toBe(null);
+	});
+
+	it("keeps both sides of a statement-level ternary require", () => {
+		expect(require.resolveWeak("./pure?ternary-a")).not.toBe(null);
+		expect(require.resolveWeak("./pure?ternary-b")).not.toBe(null);
+		expect(bundledSource()).not.toMatch(/\b00;/);
+	});
+
+	it("drops parenthesized and new require of side-effect-free modules", () => {
+		expect(require.resolveWeak("./pure?paren")).toBe(null);
+		expect(require.resolveWeak("./pure?new")).toBe(null);
 	});
 }

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/index.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/index.js
@@ -1,0 +1,63 @@
+const { keep } = require("./sibling-lib");
+
+// Bare require: result discarded, target side-effect free.
+require("./pure?bare");
+
+// Unused binding to a side-effect-free module.
+const deadBinding = require("./pure?binding");
+
+// Empty destructure: no members read.
+const {} = require("./pure?destructure");
+
+// Conditional bare require with an unknown condition.
+if (global.__unknown_cond) require("./pure?cond");
+
+// Used require must stay (control).
+const { unused: used } = require("./pure?used");
+
+// Side-effectful bare require must stay.
+global.__cjs_effect_ran = false;
+require("./effect");
+
+it("keeps a sibling declarator when an unused require shares its declaration", () => {
+	expect(keep).toBe("kept");
+});
+
+it("keeps a used require binding", () => {
+	expect(used).toBe("unused");
+});
+
+it("keeps a bare require to a side-effectful module", () => {
+	expect(global.__cjs_effect_ran).toBe(true);
+	delete global.__cjs_effect_ran;
+});
+
+if (process.env.NODE_ENV === "production") {
+	it("drops a bare require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?bare")).toBe(null);
+	});
+
+	it("drops an unused require binding of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?binding")).toBe(null);
+	});
+
+	it("drops an unused require that shares a declaration with a kept binding", () => {
+		expect(require.resolveWeak("./pure?sibling")).toBe(null);
+	});
+
+	it("drops an empty destructuring require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?destructure")).toBe(null);
+	});
+
+	it("drops a conditional bare require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?cond")).toBe(null);
+	});
+
+	it("keeps a used require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?used")).not.toBe(null);
+	});
+
+	it("keeps a bare require of a side-effectful module in the graph", () => {
+		expect(require.resolveWeak("./effect")).not.toBe(null);
+	});
+}

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/package.json
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/package.json
@@ -1,5 +1,6 @@
 {
   "sideEffects": [
-    "./effect.js"
+    "./effect.js",
+    "./effect-ternary.js"
   ]
 }

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/package.json
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": [
+    "./effect.js"
+  ]
+}

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/pure.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/pure.js
@@ -1,0 +1,1 @@
+exports.unused = "unused";

--- a/test/cases/cjs-tree-shaking/remove-unused-requires/sibling-lib.js
+++ b/test/cases/cjs-tree-shaking/remove-unused-requires/sibling-lib.js
@@ -1,0 +1,5 @@
+// Unused require shares a declaration with a kept declarator.
+const dead = require("./pure?sibling"),
+	keep = "kept";
+
+exports.keep = keep;

--- a/test/cases/errors/cyclic-reexport-references/index.js
+++ b/test/cases/errors/cyclic-reexport-references/index.js
@@ -1,5 +1,6 @@
 it("should fail with a ReferenceError", () => {
 	expect(() => {
-		require("./cycle");
+		// Keep exports so cyclic TDZ still throws (bare require is evaluation-only).
+		void require("./cycle");
 	}).toThrow();
 });

--- a/test/cases/inner-graph/reexport-namespace-and-default/index.js
+++ b/test/cases/inner-graph/reexport-namespace-and-default/index.js
@@ -3,7 +3,8 @@ import { exportDefaultUsed as export2 } from "./package1/script2";
 import { exportDefaultUsed as export3 } from "./package2/script";
 
 it("should load module correctly", () => {
-	require("./module");
+	// Keep module exports/imports used for default-used tracking.
+	void require("./module");
 });
 
 if (process.env.NODE_ENV === "production") {

--- a/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/env.js
+++ b/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/env.js
@@ -1,0 +1,1 @@
+export const FLAG = IS_FALSE;

--- a/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/index.js
+++ b/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/index.js
@@ -1,0 +1,13 @@
+import { FLAG } from "./env.js";
+
+if (FLAG) {
+	require("./side.js");
+}
+
+it("keeps __webpack_require__ for a dead-branch evaluation-only require", () => {
+	const src = Object.keys(__webpack_modules__)
+		.map((id) => String(__webpack_modules__[id]))
+		.join("\n");
+	expect(src).toMatch(/__webpack_require__\s*\(\s*null\s*\/\*\s*dead branch/);
+	expect(src).not.toMatch(/(?<![$_a-zA-Z0-9.])require\s*\(\s*null/);
+});

--- a/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/side.js
+++ b/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/side.js
@@ -1,0 +1,1 @@
+exports.value = "side";

--- a/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/drop-unused-require-edge-cases/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	entry: "./index.js",
+	plugins: [
+		new webpack.DefinePlugin({
+			IS_FALSE: JSON.stringify(false)
+		})
+	],
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		inlineExports: true,
+		innerGraph: true,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/concatenate-modules/rename-10168/package.json
+++ b/test/configCases/concatenate-modules/rename-10168/package.json
@@ -1,0 +1,6 @@
+{
+  "sideEffects": [
+    "./all.js",
+    "./D.js"
+  ]
+}

--- a/test/configCases/inner-graph/_helpers/entryLoader.js
+++ b/test/configCases/inner-graph/_helpers/entryLoader.js
@@ -2,7 +2,8 @@
 module.exports = function () {
 	const { name, expect, usedExports } = JSON.parse(this.query.slice(1));
 	return [
-		`if (Math.random() < 0) require(${JSON.stringify(
+		// Value use (not bare): harness needs exports marked used for inner-graph tracking.
+		`if (Math.random() < 0) void require(${JSON.stringify(
 			`../_helpers/testModuleLoader?${JSON.stringify(usedExports)}!`
 		)});`,
 		"",

--- a/test/configCases/records/issue-2991/test.js
+++ b/test/configCases/records/issue-2991/test.js
@@ -1,5 +1,7 @@
 try {
-	require("pkgs/somepackage/foo");
+	// IgnoredModule is always sideEffectFree; value use keeps it in records.
+	const ignored = require("pkgs/somepackage/foo");
+	void ignored;
 } catch (e) {}
 
 it("should write relative paths to records", function() {

--- a/test/configCases/source-map/extract-source-map/package.json
+++ b/test/configCases/source-map/extract-source-map/package.json
@@ -1,0 +1,9 @@
+{
+  "sideEffects": [
+    "./test1.js",
+    "./test2.js",
+    "./test3.js",
+    "./test4.js",
+    "./no-source-map.js"
+  ]
+}

--- a/test/configCases/source-map/extract-source-map2/package.json
+++ b/test/configCases/source-map/extract-source-map2/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": [
+    "./a.js"
+  ]
+}

--- a/test/statsCases/aggressive-splitting-entry/package.json
+++ b/test/statsCases/aggressive-splitting-entry/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/statsCases/exclude-with-loader/__snapshots__/StatsTest.snap
+++ b/test/statsCases/exclude-with-loader/__snapshots__/StatsTest.snap
@@ -3,8 +3,8 @@
 exports[`StatsTestCases exclude-with-loader should print correct stats for exclude-with-loader 1`] = `
 "hidden assets X bytes 1 asset
 asset bundle.js X KiB [emitted] (name: main)
-runtime modules X KiB 5 modules
 hidden modules X bytes 2 modules
+runtime modules X KiB 2 modules
 cacheable modules X bytes
   ./index.js X bytes [built] [code generated]
   ./a.txt X bytes [built] [code generated]

--- a/test/statsCases/exclude-with-loader/package.json
+++ b/test/statsCases/exclude-with-loader/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/statsCases/module-reasons/package.json
+++ b/test/statsCases/module-reasons/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/statsCases/optimize-chunks/package.json
+++ b/test/statsCases/optimize-chunks/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/statsCases/resolve-plugin-context/node_modules/abc/node_modules/xyz/package.json
+++ b/test/statsCases/resolve-plugin-context/node_modules/abc/node_modules/xyz/package.json
@@ -1,5 +1,6 @@
 {
   "name": "xyz",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": true
 }

--- a/test/statsCases/resolve-plugin-context/node_modules/def/node_modules/xyz/package.json
+++ b/test/statsCases/resolve-plugin-context/node_modules/def/node_modules/xyz/package.json
@@ -1,5 +1,6 @@
 {
   "name": "xyz",
   "private": true,
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "sideEffects": true
 }

--- a/test/statsCases/resolve-plugin-context/node_modules/xyz/package.json
+++ b/test/statsCases/resolve-plugin-context/node_modules/xyz/package.json
@@ -1,5 +1,6 @@
 {
   "name": "xyz",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": true
 }

--- a/test/statsCases/scope-hoisting-bailouts/__snapshots__/StatsTest.snap
+++ b/test/statsCases/scope-hoisting-bailouts/__snapshots__/StatsTest.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`StatsTestCases scope-hoisting-bailouts should print correct stats for scope-hoisting-bailouts 1`] = `
-"runtime modules X KiB 10 modules
-built modules X bytes [built]
+"runtime modules X KiB 9 modules
+cacheable modules X bytes
   code generated modules X bytes [code generated]
     ./index.js X bytes [built] [code generated]
       Statement (ExpressionStatement) with side effects in source code at 7:0-25
       ModuleConcatenation bailout: Cannot concat with ./cjs.js: Module is not in strict mode
+      ModuleConcatenation bailout: Cannot concat with ./entry.js: Module is an entry point
       ModuleConcatenation bailout: Cannot concat with ./eval.js: Module uses eval()
       ModuleConcatenation bailout: Cannot concat with ./module-id.js: Module uses module.id
       ModuleConcatenation bailout: Cannot concat with ./module-loaded.js: Module uses module.loaded
+      ModuleConcatenation bailout: Cannot concat with ./ref-from-cjs.js: Module ./ref-from-cjs.js is referenced from these modules with unsupported syntax: ./cjs.js (referenced with cjs require)
     ./entry.js X bytes [built] [code generated]
     ./cjs.js X bytes [built] [code generated]
       CommonJS bailout: module.exports is used directly at 3:0-14
@@ -27,11 +29,9 @@ built modules X bytes [built]
       ModuleConcatenation bailout: Module uses module.loaded
     ./concatenated.js + 2 modules X bytes [built] [code generated]
       ModuleConcatenation bailout: Cannot concat with external \\"external\\": Module external \\"external\\" is not in the same chunk(s) (expected in chunk(s) unnamed chunk(s), module is in chunk(s) index)
-    external \\"external\\" X bytes [built] [code generated]
   orphan modules X bytes [orphan]
     ./concatenated1.js X bytes [orphan] [built]
-      Dependency (harmony side effect evaluation) with side effects at 1:0-36
     ./concatenated2.js X bytes [orphan] [built]
-      Dependency (harmony side effect evaluation) with side effects at 1:0-29
+external \\"external\\" X bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
 `;

--- a/test/statsCases/scope-hoisting-bailouts/package.json
+++ b/test/statsCases/scope-hoisting-bailouts/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Drop evaluation-only CommonJS `require()` of side-effect-free modules (rewrite to `0`), aligned with ESM side-effect edges and Turbopack's unused-require removal.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/cases/cjs-tree-shaking/remove-unused-requires/`; also adjusted related configCases (`sideEffects` / harness value-use) so existing suites keep working.

**Does this PR introduce a breaking change?**

No — only unused bare/`const`/`{}` requires of modules already marked or analyzed as side-effect-free are dropped.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Cursor) was used to implement the change, write tests/changeset, diagnose failing configCases, and draft this PR body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CommonJS dependency parsing, module-graph conditions, and emitted require code; behavior only applies to already side-effect-free targets but incorrect edge-case handling could drop needed loads or break dead-branch codegen.
> 
> **Overview**
> Adds **CJS tree-shaking for evaluation-only `require()`** when the target module is side-effect-free: bare statement requires, unused bindings, empty destructuring, and similar cases are treated as **no export reads**, and inactive graph edges rewrite the whole call to **`0`** instead of leaving a real module load.
> 
> **Parser / graph:** Statement-level bare `require(...)` gets `referencedExports: []`; ternary/conditional requires disable that so a shared `valueRange` is not collapsed incorrectly. `RequireHeaderDependency` is **paired** with the `CommonJsRequireDependency` so the `require` callee rewrite is skipped when the call was dropped (dead-branch paths still use `null /* dead branch */`).
> 
> **Runtime codegen:** `CommonJsRequireDependency` gains `isEvaluationOnly()`, ties connection activity to **`getSideEffectsConnectionState`**, and adjusts referenced-export analysis for evaluation-only `require(esm)`.
> 
> New **`test/cases/cjs-tree-shaking/remove-unused-requires/`** and a **DefinePlugin dead-branch** config case cover the behavior; existing tests were updated (`void require`, `sideEffects` in `package.json`, stats snapshots) so harnesses that relied on bare requires still assert the right graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da286916b19aaea6aa241a7a72b9f2038cc21233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->