### PR TITLE
fix: name the failing key on DefinePlugin typeof evaluation errors

### DIFF
--- a/.changeset/030-define-plugin-eval-error.md
+++ b/.changeset/030-define-plugin-eval-error.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Name the failing key when DefinePlugin fails to evaluate a `typeof` value.

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -629,6 +629,26 @@ const getRuntimeRequirements = (code) => {
 };
 
 /**
+ * Prefixes an evaluation error with the offending define key so a bare
+ * "Unexpected token" becomes actionable. The original error is mutated and
+ * returned (not re-wrapped) so its `loc`/`stack` survive for ModuleParseError's
+ * code frame instead of being dumped into the message.
+ * @param {string} key the defined key
+ * @param {CodeValue} code the defined value
+ * @param {unknown} error the original evaluation error
+ * @returns {Error} the annotated error
+ */
+const annotateEvaluationError = (key, code, error) => {
+	const value = typeof code === "string" ? code : JSON.stringify(code);
+	const prefix = `DefinePlugin: failed to evaluate value for "${key}" (\`${value}\`)`;
+	if (error instanceof Error) {
+		error.message = `${prefix}: ${error.message}`;
+		return error;
+	}
+	return new WebpackError(`${prefix}: ${error}`);
+};
+
+/**
  * Defines the define plugin hooks type used by this module.
  * @typedef {object} DefinePluginHooks
  * @property {SyncWaterfallHook<[Record<string, CodeValue>]>} definitions
@@ -954,17 +974,23 @@ class DefinePlugin {
 						});
 						parser.hooks.typeof.for(key).tap(PLUGIN_NAME, (expr) => {
 							addValueDependency(originalKey);
-							const codeCode = toCode(
-								code,
-								parser,
-								compilation.valueCacheVersions,
-								originalKey,
-								runtimeTemplate,
-								logger,
-								null
-							);
-							const typeofCode = isTypeof ? codeCode : `typeof (${codeCode})`;
-							const res = parser.evaluate(typeofCode);
+							/** @type {BasicEvaluatedExpression} */
+							let res;
+							try {
+								const codeCode = toCode(
+									code,
+									parser,
+									compilation.valueCacheVersions,
+									originalKey,
+									runtimeTemplate,
+									logger,
+									null
+								);
+								const typeofCode = isTypeof ? codeCode : `typeof (${codeCode})`;
+								res = parser.evaluate(typeofCode);
+							} catch (err) {
+								throw annotateEvaluationError(originalKey, code, err);
+							}
 							if (!res.isString()) return;
 							return toConstantDependency(
 								parser,

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/errors.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/errors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/DefinePlugin: failed to evaluate value for "typeof FLAG"[\s\S]*boom-error/],
+	[/DefinePlugin: failed to evaluate value for "typeof MODE"[\s\S]*boom-string/]
+];

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/flag.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/flag.js
@@ -1,0 +1,2 @@
+// `typeof` in a non-evaluated position drives DefinePlugin's typeof hook
+console.log(typeof FLAG);

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/index.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/index.js
@@ -1,0 +1,2 @@
+require("./flag");
+require("./mode");

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/mode.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/mode.js
@@ -1,0 +1,1 @@
+console.log(typeof MODE);

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/test.config.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/test.config.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// the modules fail to parse, so there is no runnable bundle to execute
+module.exports = {
+	noTests: true
+};

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/test.filter.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// the intentionally-erroring modules invalidate the persistent cache
+// ("Pack got invalid"), which is noise here — the non-cache run covers it
+module.exports = (config) => !config.cache;

--- a/test/configCases/plugins/define-plugin-runtime-value-errors/webpack.config.js
+++ b/test/configCases/plugins/define-plugin-runtime-value-errors/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new webpack.DefinePlugin({
+			// generator throws an Error -> reported with the key, message chained
+			"typeof FLAG": webpack.DefinePlugin.runtimeValue(() => {
+				throw new Error("boom-error");
+			}),
+			// generator throws a non-Error -> wrapped in a WebpackError
+			"typeof MODE": webpack.DefinePlugin.runtimeValue(() => {
+				// eslint-disable-next-line no-throw-literal
+				throw "boom-string";
+			})
+		})
+	]
+};

--- a/test/statsCases/define-plugin-error/__snapshots__/StatsTest.snap
+++ b/test/statsCases/define-plugin-error/__snapshots__/StatsTest.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsTestCases define-plugin-error should print correct stats for define-plugin-error 1`] = `
+"asset main.js X KiB [emitted] (name: main)
+./index.js X bytes [built] [code generated] [1 error]
+
+ERROR in ./index.js 1:12
+Module parse failed: DefinePlugin: failed to evaluate value for \\"typeof PRODUCTION\\" (\`(( invalid syntax\`): Unexpected token (1:12)
+File was parsed as module type 'javascript/auto'.
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> 1 | console.log(typeof PRODUCTION);
+    |             ^
+  2 |
+
+webpack x.x.x compiled with 1 error in X ms"
+`;

--- a/test/statsCases/define-plugin-error/index.js
+++ b/test/statsCases/define-plugin-error/index.js
@@ -1,0 +1,1 @@
+console.log(typeof PRODUCTION);

--- a/test/statsCases/define-plugin-error/test.config.js
+++ b/test/statsCases/define-plugin-error/test.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+	/**
+	 * @param {import("../../../").Stats} stats stats
+	 */
+	validate(stats) {
+		const { errors } = stats.toJson();
+		if (errors.length !== 1) {
+			throw new Error(`expected exactly 1 error, got ${errors.length}`);
+		}
+		const { message } = errors[0];
+		if (
+			!message.includes(
+				'DefinePlugin: failed to evaluate value for "typeof PRODUCTION"'
+			)
+		) {
+			throw new Error(
+				`error should name the failing define key, got: ${message}`
+			);
+		}
+	}
+};

--- a/test/statsCases/define-plugin-error/webpack.config.js
+++ b/test/statsCases/define-plugin-error/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const webpack = require("../../../");
+
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: "./index",
+	stats: {
+		errorStack: false
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			// invalid replacement code: the error must name this key
+			"typeof PRODUCTION": "(( invalid syntax"
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #15371. When a `DefinePlugin` `typeof` value cannot be evaluated (e.g. an invalid non-stringified string), webpack reported a bare `Module parse failed: Unexpected token` with no hint of which define caused it. This prefixes the failing define key onto the error so it is actionable. The original error object is reused, so `ModuleParseError` still renders its code frame — no extra `parser.evaluate()` calls are added (hot paths untouched) and no stats serialization is changed. Refs #20260 (a perf-safe, narrower take on that closed PR).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/statsCases/define-plugin-error/` (snapshot of the rendered error) and `test/DefinePlugin.unittest.js` (covers the string, throwing-`runtimeValue`, and non-`Error` throw branches).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to investigate issue #15371 and the closed PR #20260, reproduce the behavior against a source build, implement this narrower perf-safe version, and write the tests. All changes were reviewed and verified by me.