### PR TITLE
fix: rename nested const/let __webpack_require__ declarations

### DIFF
--- a/.changeset/685-fix-nested-runtime-const-let.md
+++ b/.changeset/685-fix-nested-runtime-const-let.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Rename nested `const`/`let __webpack_require__` and `__webpack_exports__` declarations in bundled webpack output.

--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -181,6 +181,37 @@ class CompatibilityPlugin {
 							});
 							return true;
 						});
+					// `const`/`let` are block-pre-walked, by which point the name is no
+					// longer free and `hooks.pattern` is not dispatched for it — tag
+					// them through the kind-specific declaration hooks instead.
+					// Returning nothing lets the variable be defined, keeping the tag.
+					for (const hookMap of [
+						parser.hooks.varDeclarationConst,
+						parser.hooks.varDeclarationLet
+					]) {
+						hookMap.for(RuntimeGlobals.require).tap(PLUGIN_NAME, (ident) => {
+							parser.tagVariable(ident.name, nestedWebpackIdentifierTag, {
+								name: `__nested_webpack_require_${
+									/** @type {Range} */ (ident.range)[0]
+								}__`,
+								declaration: {
+									updated: false,
+									loc: parser.getLocation(ident),
+									range: /** @type {Range} */ (ident.range)
+								}
+							});
+						});
+						hookMap.for(RuntimeGlobals.exports).tap(PLUGIN_NAME, (ident) => {
+							parser.tagVariable(ident.name, nestedWebpackIdentifierTag, {
+								name: "__nested_webpack_exports__",
+								declaration: {
+									updated: false,
+									loc: parser.getLocation(ident),
+									range: /** @type {Range} */ (ident.range)
+								}
+							});
+						});
+					}
 					// Update single `var __webpack_require__ = {};` and `var __webpack_exports__ = {};` without expression
 					parser.hooks.declarator.tap(PLUGIN_NAME, (declarator) => {
 						if (

--- a/test/configCases/module/consume-webpack-runtime/index.js
+++ b/test/configCases/module/consume-webpack-runtime/index.js
@@ -3,6 +3,7 @@ import defaultUse from './runtime-export-default'
 import { __webpack_require__ as namedDeclUse } from './runtime-export-decl'
 import { __webpack_require__ as objectRequire, __webpack_exports__ as objectExport } from './runtime-single-require-and-export'
 import defaultUseNested from './runtime-multiple-nested'
+import { constRequire, constExports } from './runtime-const-require'
 import "./runtime-arrow-scope";
 
 it("should compile and run", () => {
@@ -12,13 +13,15 @@ it("should compile and run", () => {
 	expect(objectRequire.foo).toBe(42);
 	expect(objectExport.foo).toBe(42);
 	expect(defaultUseNested().foo).toBe(42);
+	expect(constRequire.foo).toBe(42);
+	expect(constExports.foo).toBe(42);
 
 	const path = __non_webpack_require__('path')
 	const fs = __non_webpack_require__('fs')
 	{
 		const content = fs.readFileSync(path.resolve(__dirname, './bundle0.js'), 'utf-8');
 		const NESTED_RE = /__nested_webpack_require_([^_]+)__/g;
-		expect(content.match(NESTED_RE).length).toBe(17);
+		expect(content.match(NESTED_RE).length).toBe(19);
 	}
 
 	{
@@ -30,36 +33,36 @@ it("should compile and run", () => {
 	{
 		const content = fs.readFileSync(path.resolve(__dirname, './bundle1.js'), 'utf-8');
 		const NESTED_RE = /__nested_webpack_require_([^_]+)__/g;
-		expect(content.match(NESTED_RE).length).toBe(19);
+		expect(content.match(NESTED_RE).length).toBe(21);
 	}
 
 	{
 		const content = fs.readFileSync(path.resolve(__dirname, './bundle1.js'), 'utf-8');
 		const NESTED_RE = /__[n]ested_webpack_exports__/g;
-		expect(content.match(NESTED_RE).length).toBe(2);
+		expect(content.match(NESTED_RE).length).toBe(4);
 	}
 
 	{
 		const content = fs.readFileSync(path.resolve(__dirname, './bundle2.js'), 'utf-8');
-		const NESTED_RE = /__nested_webpack_require_([^_]+)__/g;
-		expect(content.match(NESTED_RE).length).toBe(17);
-	}
-
-	{
-		const content = fs.readFileSync(path.resolve(__dirname, './bundle2.js'), 'utf-8');
-		const NESTED_RE = /__[n]ested_webpack_exports__/g;
-		expect(content.match(NESTED_RE).length).toBe(2);
-	}
-
-	{
-		const content = fs.readFileSync(path.resolve(__dirname, './bundle3.js'), 'utf-8');
 		const NESTED_RE = /__nested_webpack_require_([^_]+)__/g;
 		expect(content.match(NESTED_RE).length).toBe(19);
 	}
 
 	{
-		const content = fs.readFileSync(path.resolve(__dirname, './bundle3.js'), 'utf-8');
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle2.js'), 'utf-8');
 		const NESTED_RE = /__[n]ested_webpack_exports__/g;
 		expect(content.match(NESTED_RE).length).toBe(2);
+	}
+
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle3.js'), 'utf-8');
+		const NESTED_RE = /__nested_webpack_require_([^_]+)__/g;
+		expect(content.match(NESTED_RE).length).toBe(21);
+	}
+
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle3.js'), 'utf-8');
+		const NESTED_RE = /__[n]ested_webpack_exports__/g;
+		expect(content.match(NESTED_RE).length).toBe(4);
 	}
 });

--- a/test/configCases/module/consume-webpack-runtime/runtime-const-require.js
+++ b/test/configCases/module/consume-webpack-runtime/runtime-const-require.js
@@ -1,0 +1,6 @@
+// webpack emits `const __webpack_require__ = {}` for its require scope when
+// the output environment allows ES6, so a nested bundle uses `const`, not `var`
+const __webpack_require__ = { foo: 42 };
+const __webpack_exports__ = { foo: 42 };
+
+export { __webpack_require__ as constRequire, __webpack_exports__ as constExports };


### PR DESCRIPTION
**Summary**

When a bundled webpack output declares its runtime scope with `const`/`let __webpack_require__` (as webpack emits for an ES6 output environment) instead of `var`, `CompatibilityPlugin` never renamed it, because block-pre-walking defines the name before `hooks.pattern` runs, so the nested runtime collided with the outer one. The kind-specific `varDeclarationConst`/`varDeclarationLet` hooks now tag these bindings the same way `var` declarations are already tagged.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

A fix.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — `test/configCases/module/consume-webpack-runtime/runtime-const-require.js` plus updated expectations in that case's `index.js`.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

AI (Claude Code) was used to help locate the missing parser hooks and to draft the regression test; the fix and test were reviewed and verified by me.
