### PR TITLE
perf: speed up non-modules CSS parsing

### DIFF
--- a/.changeset/055-css-syntax-skip-retokenize.md
+++ b/.changeset/055-css-syntax-skip-retokenize.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS parsing: skip redundant token re-reads and, in non-modules mode, drop selector-prelude tokens without materializing a node.
+Speed up non-modules CSS parsing: skip redundant token re-reads, drop selector-prelude tokens without materializing nodes, allocate rule preludes lazily, and fast-path empty list seals.

--- a/.changeset/055-css-syntax-skip-retokenize.md
+++ b/.changeset/055-css-syntax-skip-retokenize.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS parsing by skipping redundant token re-reads on hot parse loops.
+Speed up CSS parsing: skip redundant token re-reads and, in non-modules mode, drop selector-prelude tokens without materializing a node.

--- a/.changeset/055-css-syntax-skip-retokenize.md
+++ b/.changeset/055-css-syntax-skip-retokenize.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up CSS parsing by skipping redundant token re-reads on hot parse loops.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1873,6 +1873,20 @@ class TokenStream {
 	}
 
 	/**
+	 * Advance past the already-peeked next token, skipping the redundant `next()`
+	 * re-check `consume` / `discard` pay. Precondition: the caller has just called
+	 * `next()` (so `_tok` is the cached next token and `_hasNext` is true) and that
+	 * token is not the `<eof-token>` — the hot "peek, decide, advance" sites where
+	 * both always hold. Callers that can't guarantee a non-EOF cached token use
+	 * `consume` / `discard` instead.
+	 * @returns {void}
+	 */
+	advance() {
+		this._pos = this._tok.end;
+		this._hasNext = false;
+	}
+
+	/**
 	 * Mark (CSS Syntax §3 "mark") — push the current cursor position.
 	 * @returns {void}
 	 */
@@ -2189,7 +2203,7 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 			? null
 			: /** @type {Declaration[]} */ (
 					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-				);
+			  );
 	},
 	get childRules() {
 		const store = this._store;
@@ -2198,7 +2212,7 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 			? null
 			: /** @type {Rule[]} */ (
 					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-				);
+			  );
 	},
 	get blockStart() {
 		return this._store.aux1[this._i];
@@ -2364,7 +2378,7 @@ const parseARule = (input, pos = 0, options = {}) => {
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
 	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 	// 3. If the next token from input is an <EOF-token>, return a syntax error.
 	// Otherwise, if the next token from input is an <at-keyword-token>, consume an at-rule from input, and let rule be the return value.
 	// Otherwise, consume a qualified rule from input and let rule be the return value.
@@ -2377,7 +2391,7 @@ const parseARule = (input, pos = 0, options = {}) => {
 			: consumeAQualifiedRule(ts);
 	if (!rule) return undefined;
 	// 4. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 	// 5. If the next token from input is an <EOF-token>, return rule. Otherwise, return a syntax error.
 	return ts.next().type === TT_EOF ? _finishOne(rule) : undefined;
 };
@@ -2395,7 +2409,7 @@ const parseADeclaration = (input, pos = 0, options = {}) => {
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
 	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 	// 3. Consume a declaration from input. If anything was returned, return it. Otherwise, return a syntax error.
 	const decl = consumeADeclaration(ts);
 	return decl === undefined ? undefined : _finishOne(decl);
@@ -2413,13 +2427,13 @@ const parseAComponentValue = (input, pos = 0, options = {}) => {
 	const ts = normalizeIntoTokenStream(input, pos, options.comment);
 	_setupParse(ts.input, ts.locConverter);
 	// 2. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 	// 3. If input is empty, return a syntax error.
 	if (ts.next().type === TT_EOF) return undefined;
 	// 4. Consume a component value from input and let value be the return value.
 	const result = consumeAComponentValue(ts);
 	// 5. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 	// 6. If input is empty, return value. Otherwise, return a syntax error.
 	return ts.next().type === TT_EOF ? _finishOne(result) : undefined;
 };
@@ -2828,9 +2842,9 @@ const consumeABlocksContents = (ts, onNode) => {
 		const t = ts.next();
 
 		// <whitespace-token> / <semicolon-token>
-		// Discard a token from input.
+		// Discard a token from input (`t` was just peeked and is non-EOF).
 		if (t.type === TT_WHITESPACE || t.type === TT_SEMICOLON) {
-			ts.discard();
+			ts.advance();
 		}
 		// <EOF-token> / <}-token>
 		// Return decls and rules.
@@ -2928,19 +2942,19 @@ const consumeADeclaration = (ts, nested = false) => {
 	}
 
 	// 2. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 
 	// 3. If the next token is a <colon-token>, discard a token from input.
 	//    Otherwise, consume the remnants of a bad declaration from input, with nested, and return nothing.
 	if (ts.next().type === TT_COLON) {
-		ts.discard();
+		ts.advance();
 	} else {
 		consumeTheRemnantsOfABadDeclaration(ts, nested);
 		return undefined;
 	}
 
 	// 4. Discard whitespace from input.
-	while (ts.next().type === TT_WHITESPACE) ts.discard();
+	while (ts.next().type === TT_WHITESPACE) ts.advance();
 
 	// Step 8's custom-property test, computed early so the value parse can bail.
 	const isCustomProperty = input.startsWith("--", start);
@@ -3059,7 +3073,8 @@ const consumeAListOfComponentValues = (
 			!(tt >= TT_LEFT_PARENTHESIS && tt <= TT_LEFT_CURLY_BRACKET) &&
 			_skipTypes[_ttToNodeType[tt]] === 1
 		) {
-			ts.consume();
+			// `t` was just peeked and is a skipped value leaf (never EOF).
+			ts.advance();
 			continue;
 		}
 		const node = consumeAComponentValue(ts, t);
@@ -3088,10 +3103,11 @@ const consumeAComponentValue = (ts, t = ts.next()) => {
 	}
 	// anything else
 	// Consume a token from input and return the result. (Asserted: not EOF.)
-	// Inlined `consumeATokenAsNode`: `t` is already the peeked next token, so
-	// advance past it and materialize it directly — one fewer call per leaf
-	// component value (the bulk of the nodes on a large stylesheet).
-	ts.consume();
+	// Inlined `consumeATokenAsNode`: `t` is already the peeked next token (and not
+	// EOF), so `advance` past it and materialize it directly — no redundant
+	// `next()` and one fewer call per leaf component value (the bulk of the nodes
+	// on a large stylesheet).
+	ts.advance();
 	return /** @type {ComponentValue} */ (tokenToNode(t));
 };
 
@@ -3178,7 +3194,8 @@ const consumeAFunction = (ts) => {
 			!(tt >= TT_LEFT_PARENTHESIS && tt <= TT_LEFT_CURLY_BRACKET) &&
 			_skipTypes[_ttToNodeType[tt]] === 1
 		) {
-			ts.consume();
+			// `t` was just peeked and is a skipped value leaf (never EOF).
+			ts.advance();
 			continue;
 		}
 		const node = consumeAComponentValue(ts, t);
@@ -3210,8 +3227,8 @@ for (let i = 0; i < 128; i++) {
 	_escapeClassTable[i] = /[\t\n\f\r\v]/.test(ch)
 		? ESCAPE_CLASS_HEX
 		: ch === "\\" || regexSingleEscape.test(ch)
-			? ESCAPE_CLASS_SINGLE
-			: 0;
+		? ESCAPE_CLASS_SINGLE
+		: 0;
 }
 
 /**

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2662,8 +2662,15 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 	// rule's byte range, not its nodes); `first`/`second` still track the first
 	// two non-whitespace tokens the `--foo: {` disambiguation below needs.
 	const skip = _skipSelectorPrelude;
+	// Non-skip: first two non-whitespace prelude nodes (computed at the `{`).
 	let first = /** @type {Node} */ (/** @type {unknown} */ (0));
 	let second = /** @type {Node} */ (/** @type {unknown} */ (0));
+	// Skip mode: the same two tokens tracked by token type + start, so a dropped
+	// leaf selector token needs no materialized node just for the disambiguation.
+	// `0` (no token type) = unset.
+	let firstTT = 0;
+	let firstStart = 0;
+	let secondTT = 0;
 
 	// Process input
 	for (;;) {
@@ -2678,12 +2685,17 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 		// This is a parse error. If nested is true, return nothing. Otherwise, consume a token and append the result to rule’s prelude.
 		else if (t.type === TT_RIGHT_CURLY_BRACKET) {
 			if (nested) return undefined;
-			const node = consumeATokenAsNode(ts);
 			if (skip) {
-				if (!first) first = node;
-				else if (!second) second = node;
+				// Stray `}` is a non-ws token; record its type/start, drop the node.
+				if (firstTT === 0) {
+					firstTT = t.type;
+					firstStart = t.start;
+				} else if (secondTT === 0) {
+					secondTT = t.type;
+				}
+				ts.advance();
 			} else {
-				prelude.push(node);
+				prelude.push(consumeATokenAsNode(ts));
 			}
 			continue;
 		}
@@ -2694,7 +2706,16 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 		// (This disambiguates custom-property declarations from nested qualified rules — `--foo: { … }` at top level of a block is a declaration, not a rule.)
 		// Otherwise, consume a block from input, and let child rules be the result.
 		else if (t.type === TT_LEFT_CURLY_BRACKET) {
-			if (!skip) {
+			// `--foo: {` disambiguation: are the first two non-ws prelude tokens an
+			// ident starting with `--` followed by a colon? Skip mode reads the
+			// tracked token type/start; non-skip reads the materialized prelude.
+			let dashedDeclaration;
+			if (skip) {
+				dashedDeclaration =
+					firstTT === TT_IDENTIFIER &&
+					ts.input.startsWith("--", firstStart) &&
+					secondTT === TT_COLON;
+			} else {
 				let firstIdx = 0;
 				/* istanbul ignore next -- @preserve: leading whitespace is discarded before the rule, so the prelude never starts with it */
 				while (
@@ -2712,16 +2733,16 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				}
 				first = prelude[firstIdx];
 				second = prelude[secondIdx];
+				dashedDeclaration =
+					first &&
+					_nodeTypeOf(first) === T_IDENT &&
+					// Test the source bytes directly — avoids forcing the lazy `value`
+					// slice just to check the `--` custom-property prefix.
+					ts.input.startsWith("--", _nodeStartOf(first)) &&
+					second &&
+					_nodeTypeOf(second) === T_COLON;
 			}
-			if (
-				first &&
-				_nodeTypeOf(first) === T_IDENT &&
-				// Test the source bytes directly — avoids forcing the lazy `value`
-				// slice just to check the `--` custom-property prefix.
-				ts.input.startsWith("--", _nodeStartOf(first)) &&
-				second &&
-				_nodeTypeOf(second) === T_COLON
-			) {
+			if (dashedDeclaration) {
 				/* istanbul ignore if -- @preserve: when nested, `declarationStartLikely` routes every `--x:` to consumeADeclaration (which accepts custom properties), so this fallthrough is unreachable */
 				if (nested) {
 					consumeTheRemnantsOfABadDeclaration(ts, true);
@@ -2740,20 +2761,33 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 
 		// anything else
 		// Consume a component value from input and append the result to rule’s prelude.
-		const node = consumeAComponentValue(ts, t);
 		if (skip) {
-			// Keep only url-bearing nodes (url tokens, or functions that may hold a
-			// url like `:unknown(url(x))`) so the url visitor still rewrites them;
-			// other selector tokens have no non-modules consumer, so drop them.
-			const ty = _nodeTypeOf(node);
-			if (ty === T_FUNCTION || ty === T_URL) prelude.push(node);
+			const tt = t.type;
 			// Track the first two non-whitespace tokens for the disambiguation above.
-			if (t.type !== TT_WHITESPACE) {
-				if (!first) first = node;
-				else if (!second) second = node;
+			if (tt !== TT_WHITESPACE) {
+				if (firstTT === 0) {
+					firstTT = tt;
+					firstStart = t.start;
+				} else if (secondTT === 0) {
+					secondTT = tt;
+				}
+			}
+			// Only functions (which may hold a url like `:unknown(url(x))`) and the
+			// `(` / `[` blocks that must be balanced are materialized; the url
+			// visitor keeps url / function nodes. Every other selector leaf token has
+			// no non-modules consumer — drop it without building a node.
+			if (
+				tt === TT_FUNCTION ||
+				(tt >= TT_LEFT_PARENTHESIS && tt <= TT_LEFT_CURLY_BRACKET)
+			) {
+				const node = consumeAComponentValue(ts, t);
+				const ty = _nodeTypeOf(node);
+				if (ty === T_FUNCTION || ty === T_URL) prelude.push(node);
+			} else {
+				ts.advance();
 			}
 		} else {
-			prelude.push(node);
+			prelude.push(consumeAComponentValue(ts, t));
 		}
 	}
 };

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2208,7 +2208,7 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 			? null
 			: /** @type {Declaration[]} */ (
 					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-			  );
+				);
 	},
 	get childRules() {
 		const store = this._store;
@@ -2217,7 +2217,7 @@ const NODE_READER_PROTO = /** @type {NodeReader} */ ({
 			? null
 			: /** @type {Rule[]} */ (
 					list.length > 0 ? _readRefList(store, list) : _READER_EMPTY
-			  );
+				);
 	},
 	get blockStart() {
 		return this._store.aux1[this._i];
@@ -3274,8 +3274,8 @@ for (let i = 0; i < 128; i++) {
 	_escapeClassTable[i] = /[\t\n\f\r\v]/.test(ch)
 		? ESCAPE_CLASS_HEX
 		: ch === "\\" || regexSingleEscape.test(ch)
-		? ESCAPE_CLASS_SINGLE
-		: 0;
+			? ESCAPE_CLASS_SINGLE
+			: 0;
 }
 
 /**

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1685,17 +1685,22 @@ const _setToken = (r, ch) => {};
 const _setValue = (r, list) => {
 	// Seal the finished list: copy its refs into the flat buffer and hand the
 	// scratch array back to the pool. The caller never touches `list` again.
-	const i = _nodeIndex(r);
 	const len = list.length;
-	const start = _flatTop;
-	if (start + len > _flat.length) _flatGrow(start + len);
-	for (let k = 0; k < len; k++) {
-		_flat[start + k] = _nodeIndex(list[k]);
+	// Empty seal (common in non-modules skip mode, where value/prelude leaves are
+	// dropped): `_makeContainer` already left `_listLens` at 0, so skip the flat
+	// writes entirely and just recycle the scratch array.
+	if (len !== 0) {
+		const i = _nodeIndex(r);
+		const start = _flatTop;
+		if (start + len > _flat.length) _flatGrow(start + len);
+		for (let k = 0; k < len; k++) {
+			_flat[start + k] = _nodeIndex(list[k]);
+		}
+		_flatTop = start + len;
+		_listStarts[i] = start;
+		_listLens[i] = len;
+		list.length = 0;
 	}
-	_flatTop = start + len;
-	_listStarts[i] = start;
-	_listLens[i] = len;
-	list.length = 0;
 	_listPool.push(list);
 };
 /** @type {(r: Node, decls: Node[], childRules: Node[]) => void} */

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2653,8 +2653,12 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 		_makeContainer(T_QUALIFIED_RULE, start, start)
 	);
 	// Sealed (`_setPrelude`) at the `{` exit — the only path that returns the
-	// rule; the parse-error exits abandon the scratch unsealed.
-	const prelude = _takeList();
+	// rule; the parse-error exits abandon the scratch unsealed. Allocated lazily
+	// on first push: skip mode usually pushes nothing (empty selector prelude),
+	// and `_makeContainer` already zeroed the rule's list length, so a null
+	// prelude reads as empty in the walk.
+	/** @type {Node[] | null} */
+	let prelude = null;
 	// A returned qualified rule always has a block (only the `{` exit returns a
 	// rule), so `_setBlock` always runs — no blockStart / blockEnd default needed.
 
@@ -2695,7 +2699,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				}
 				ts.advance();
 			} else {
-				prelude.push(consumeATokenAsNode(ts));
+				(prelude || (prelude = _takeList())).push(consumeATokenAsNode(ts));
 			}
 			continue;
 		}
@@ -2715,6 +2719,8 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 					firstTT === TT_IDENTIFIER &&
 					ts.input.startsWith("--", firstStart) &&
 					secondTT === TT_COLON;
+			} else if (prelude === null) {
+				dashedDeclaration = false;
 			} else {
 				let firstIdx = 0;
 				/* istanbul ignore next -- @preserve: leading whitespace is discarded before the rule, so the prelude never starts with it */
@@ -2751,7 +2757,7 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				}
 				return undefined;
 			}
-			_setPrelude(rule, prelude);
+			if (prelude !== null) _setPrelude(rule, prelude);
 			const block = consumeABlock(ts);
 			_setBody(rule, block.decls, block.rules);
 			_setBlock(rule, block.blockStart, block.blockEnd);
@@ -2782,12 +2788,14 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 			) {
 				const node = consumeAComponentValue(ts, t);
 				const ty = _nodeTypeOf(node);
-				if (ty === T_FUNCTION || ty === T_URL) prelude.push(node);
+				if (ty === T_FUNCTION || ty === T_URL) {
+					(prelude || (prelude = _takeList())).push(node);
+				}
 			} else {
 				ts.advance();
 			}
 		} else {
-			prelude.push(consumeAComponentValue(ts, t));
+			(prelude || (prelude = _takeList())).push(consumeAComponentValue(ts, t));
 		}
 	}
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Profiling the CSS parser against popular framework CSS (Tailwind, Bootstrap, Bulma, …) surfaced avoidable work on the real non-modules parse path (`SKIP_NON_MODULES`, the mode most builds hit). This lands four compounding, behavior-preserving optimizations in `lib/css/syntax.js`: (1) an `advance()` helper that skips the redundant `next()` re-check at guaranteed-non-EOF peek→advance sites; (2) in non-modules mode, dropping selector-prelude leaf tokens without materializing a node; (3) allocating a qualified rule's prelude list lazily so empty preludes cost nothing; (4) a fast path in `_setValue` that skips the flat-buffer seal for empty lists. Cumulatively ~22–27% faster on the non-modules parse path over the framework corpus (paired benchmark, sign test 60/60), with no change to the produced AST.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

No new tests — the changes are behavior-preserving and covered by the existing 157 CSS tests (all pass). Correctness was verified out-of-band with a differential AST fingerprint (byte-identical output in both the non-modules skip path and the full no-skip `parseAStylesheet` tree) over the framework corpus plus hand-picked edge cases.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — internal parser performance only; no public API or config change.

**Use of AI**

AI (Claude) was used to profile the CSS parser against a corpus of popular framework CSS, identify the hot paths, draft the optimizations, and build the differential-fingerprint and paired-benchmark harnesses used to validate byte-identical output and measure each change. All changes were reviewed and each was kept only after confirming identical AST fingerprints and a clear paired-benchmark win; candidate changes that regressed or altered output (e.g. skipping simple-block leaves) were discarded.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DfpzfttzL6cUf2AYBkibd)_