### PR TITLE
feat(perf): use v8 for serialization

### DIFF
--- a/.changeset/060-serializer-v8-value-serializer.md
+++ b/.changeset/060-serializer-v8-value-serializer.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Encode the persistent cache with V8's value serializer
+Encode the persistent cache with V8's value serializer.

--- a/.changeset/060-serializer-v8-value-serializer.md
+++ b/.changeset/060-serializer-v8-value-serializer.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Encode the persistent cache with V8's value serializer

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -41,6 +41,9 @@ const ESTIMATED_VALUE_SIZE = 4;
 
 const EMPTY_BUFFER = Buffer.alloc(0);
 
+/** Highest V8 value serialization format version this Node.js can read. */
+const V8_FORMAT_VERSION = v8Serialize(null)[1];
+
 const MEASURE_START_OPERATION = Symbol("MEASURE_START_OPERATION");
 const MEASURE_END_OPERATION = Symbol("MEASURE_END_OPERATION");
 
@@ -217,9 +220,14 @@ const readValuesSection = (state) => {
 	/** @type {number[]} */
 	const bufferInfo = [];
 	for (let i = 0; i < bufferCount * 2; i++) bufferInfo.push(state.readU32());
-	const values =
-		/** @type {DeserializedType} */
-		(v8Deserialize(state.read(payloadSize)));
+	const payload = state.read(payloadSize);
+	// a V8 payload opens with 0xff and its format version, which only ever grows
+	if (payload[0] === 0xff && payload[1] > V8_FORMAT_VERSION) {
+		throw new Error(
+			`Data was written with V8 serialization format version ${payload[1]}, but this Node.js (${process.version}) only reads up to version ${V8_FORMAT_VERSION}`
+		);
+	}
+	const values = /** @type {DeserializedType} */ (v8Deserialize(payload));
 	for (let i = 0; i < bufferCount; i++) {
 		values[bufferInfo[i * 2]] = state.retainedBuffer(
 			state.read(bufferInfo[i * 2 + 1])

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -389,6 +389,8 @@ class BinaryMiddleware extends SerializerMiddleware {
 					}
 					bufferIndices.push(i);
 					buffers.push(thing);
+					// count placeholder + bytes so buffer-heavy runs still split
+					sectionSize += ESTIMATED_VALUE_SIZE + thing.length;
 				} else {
 					sectionSize += ESTIMATED_VALUE_SIZE;
 				}

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -348,11 +348,16 @@ class BinaryMiddleware extends SerializerMiddleware {
 		 */
 		const flush = (end) => {
 			if (end > sectionStart) {
-				if (sectionStart === 0 && end === data.length) {
+				if (
+					sectionStart === 0 &&
+					end === data.length &&
+					// a frozen input can't take the placeholders, so it needs the copy
+					(bufferIndices.length === 0 || !Object.isFrozen(data))
+				) {
 					// the section covers all values: swap the buffers out and back in
 					// instead of copying the whole array to place the placeholders
-					for (const index of bufferIndices) data[index] = null;
 					try {
+						for (const index of bufferIndices) data[index] = null;
 						writeValuesSection(data, bufferIndices, buffers);
 					} finally {
 						for (let i = 0; i < bufferIndices.length; i++) {

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+const { deserialize: v8Deserialize, serialize: v8Serialize } = require("v8");
 const memoize = require("../util/memoize");
 const SerializerMiddleware = require("./SerializerMiddleware");
 
@@ -15,129 +16,36 @@ Format:
 
 File -> Section*
 
-Section -> NullsSection |
-					 BooleansSection |
-					 F64NumbersSection |
-					 I32NumbersSection |
-					 I8NumbersSection |
-					 ShortStringSection |
-					 BigIntSection |
-					 I32BigIntSection |
-					 I8BigIntSection
-					 StringSection |
-					 BufferSection |
-					 NopSection
+Section -> ValuesSection | LazySection
 
+ValuesSection ->
+	ValuesHeaderByte u32:payloadSize u32:bufferCount (u32:valueIndex u32:bufferSize)*
+	payload buffer*
+LazySection ->
+	LazyHeaderByte u32:count u32:size*
 
-
-NullsSection ->
-	NullHeaderByte | Null2HeaderByte | Null3HeaderByte |
-	Nulls8HeaderByte 0xnn (n:count - 4) |
-	Nulls32HeaderByte n:ui32 (n:count - 260) |
-BooleansSection -> TrueHeaderByte | FalseHeaderByte | BooleansSectionHeaderByte BooleansCountAndBitsByte
-F64NumbersSection -> F64NumbersSectionHeaderByte f64*
-I32NumbersSection -> I32NumbersSectionHeaderByte i32*
-I8NumbersSection -> I8NumbersSectionHeaderByte i8*
-ShortStringSection -> ShortStringSectionHeaderByte ascii-byte*
-StringSection -> StringSectionHeaderByte i32:length utf8-byte*
-BufferSection -> BufferSectionHeaderByte i32:length byte*
-NopSection --> NopSectionHeaderByte
-BigIntSection -> BigIntSectionHeaderByte i32:length ascii-byte*
-I32BigIntSection -> I32BigIntSectionHeaderByte i32
-I8BigIntSection -> I8BigIntSectionHeaderByte i8
-
-ShortStringSectionHeaderByte -> 0b1nnn_nnnn (n:length)
-
-F64NumbersSectionHeaderByte -> 0b001n_nnnn (n:count - 1)
-I32NumbersSectionHeaderByte -> 0b010n_nnnn (n:count - 1)
-I8NumbersSectionHeaderByte -> 0b011n_nnnn (n:count - 1)
-
-NullsSectionHeaderByte -> 0b0001_nnnn (n:count - 1)
-BooleansCountAndBitsByte ->
-	0b0000_1xxx (count = 3) |
-	0b0001_xxxx (count = 4) |
-	0b001x_xxxx (count = 5) |
-	0b01xx_xxxx (count = 6) |
-	0b1nnn_nnnn (n:count - 7, 7 <= count <= 133)
-	0xff n:ui32 (n:count, 134 <= count < 2^32)
-
-StringSectionHeaderByte -> 0b0000_1110
-BufferSectionHeaderByte -> 0b0000_1111
-NopSectionHeaderByte -> 0b0000_1011
-BigIntSectionHeaderByte -> 0b0001_1010
-I32BigIntSectionHeaderByte -> 0b0001_1100
-I8BigIntSectionHeaderByte -> 0b0001_1011
-FalseHeaderByte -> 0b0000_1100
-TrueHeaderByte -> 0b0000_1101
-
-RawNumber -> n (n <= 10)
-
+ValuesHeaderByte -> 0xf1
+LazyHeaderByte -> 0xf2
 */
 
-const LAZY_HEADER = 0x0b;
-const TRUE_HEADER = 0x0c;
-const FALSE_HEADER = 0x0d;
-const BOOLEANS_HEADER = 0x0e;
-const NULL_HEADER = 0x10;
-const NULL2_HEADER = 0x11;
-const NULL3_HEADER = 0x12;
-const NULLS8_HEADER = 0x13;
-const NULLS32_HEADER = 0x14;
-const NULL_AND_I8_HEADER = 0x15;
-const NULL_AND_I16_HEADER = 0x19;
-const NULL_AND_I32_HEADER = 0x16;
-const NULL_AND_TRUE_HEADER = 0x17;
-const NULL_AND_FALSE_HEADER = 0x18;
-const BIGINT_HEADER = 0x1a;
-const BIGINT_I8_HEADER = 0x1b;
-const BIGINT_I32_HEADER = 0x1c;
-const STRING_HEADER = 0x1e;
-const BUFFER_HEADER = 0x1f;
-const I8_HEADER = 0x60;
-const I32_HEADER = 0x40;
-const F64_HEADER = 0x20;
-const SHORT_STRING_HEADER = 0x80;
-
-/** Uplift high-order bits */
-const NUMBERS_HEADER_MASK = 0xe0; // 0b1010_0000
-const NUMBERS_COUNT_MASK = 0x1f; // 0b0001_1111
-const SHORT_STRING_LENGTH_MASK = 0x7f; // 0b0111_1111
+const VALUES_HEADER = 0xf1;
+const LAZY_HEADER = 0xf2;
 
 const HEADER_SIZE = 1;
-const I8_SIZE = 1;
-const I16_SIZE = 2;
 const I32_SIZE = 4;
-const F64_SIZE = 8;
+
+/** A values section is closed once its payload is estimated to reach this size. */
+const MAX_SECTION_SIZE = 16 * 1024 * 1024;
+/** Assumed encoded size of a value that isn't a string, for that estimate. */
+const ESTIMATED_VALUE_SIZE = 4;
+
+const EMPTY_BUFFER = Buffer.alloc(0);
 
 const MEASURE_START_OPERATION = Symbol("MEASURE_START_OPERATION");
 const MEASURE_END_OPERATION = Symbol("MEASURE_END_OPERATION");
 
 /** @typedef {typeof MEASURE_START_OPERATION} MEASURE_START_OPERATION_TYPE */
 /** @typedef {typeof MEASURE_END_OPERATION} MEASURE_END_OPERATION_TYPE */
-
-/**
- * Returns type of number for serialization.
- * @param {number} n number
- * @returns {0 | 1 | 2} type of number for serialization
- */
-const identifyNumber = (n) => {
-	if (n === (n | 0)) {
-		if (n <= 127 && n >= -128) return 0;
-		if (n <= 2147483647 && n >= -2147483648) return 1;
-	}
-	return 2;
-};
-
-/**
- * Returns type of bigint for serialization.
- * @param {bigint} n bigint
- * @returns {0 | 1 | 2} type of bigint for serialization
- */
-const identifyBigInt = (n) => {
-	if (n <= BigInt(127) && n >= BigInt(-128)) return 0;
-	if (n <= BigInt(2147483647) && n >= BigInt(-2147483648)) return 1;
-	return 2;
-};
 
 /** @typedef {PrimitiveSerializableType[]} DeserializedType */
 /** @typedef {BufferSerializableType[]} SerializedType} */
@@ -150,34 +58,24 @@ const identifyBigInt = (n) => {
  * @typedef {import("./SerializerMiddleware").LazyFunction<LazyInputValue, LazyOutputValue, BinaryMiddleware, undefined>} LazyFunction
  */
 
-/**
- * Mutable read state of one `_deserialize` run; the module-level dispatch
- * table operates on this instead of per-call closures.
- */
+/** Mutable read state of one `_deserialize` run. */
 class ReadState {
 	/**
 	 * @param {SerializedType} data data
 	 * @param {Context} context context object
-	 * @param {BinaryMiddleware} middleware binary middleware
 	 */
-	constructor(data, context, middleware) {
+	constructor(data, context) {
 		/** @type {SerializedType} */
 		this.data = data;
-		/** @type {Context} */
-		this.context = context;
-		/** @type {BinaryMiddleware} */
-		this.middleware = middleware;
 		this.retainedBuffer = context.retainedBuffer || ((x) => x);
 		/** @type {number} */
 		this.currentDataItem = 0;
 		/** @type {BufferSerializableType | null} */
-		this.currentBuffer = data[0];
+		this.currentBuffer = data.length > 0 ? data[0] : null;
 		/** @type {boolean} */
 		this.currentIsBuffer = Buffer.isBuffer(this.currentBuffer);
 		/** @type {number} */
 		this.currentPosition = 0;
-		/** @type {DeserializedType} */
-		this.result = [];
 	}
 
 	/** Advances to the next data item (does not reset the position). */
@@ -228,6 +126,7 @@ class ReadState {
 	 * @returns {Buffer} buffer with bytes
 	 */
 	read(n) {
+		if (n === 0) return EMPTY_BUFFER;
 		this.ensureBuffer();
 		const rem =
 			/** @type {Buffer} */ (this.currentBuffer).length - this.currentPosition;
@@ -284,7 +183,7 @@ class ReadState {
 		const byte =
 			/** @type {Buffer} */
 			(this.currentBuffer).readUInt8(this.currentPosition);
-		this.currentPosition += I8_SIZE;
+		this.currentPosition += HEADER_SIZE;
 		this.checkOverflow();
 		return byte;
 	}
@@ -305,365 +204,59 @@ class ReadState {
 		}
 		return this.read(I32_SIZE).readUInt32LE(0);
 	}
-
-	/**
-	 * Pushes the lowest n bits of data as booleans.
-	 * @param {number} data data
-	 * @param {number} n n
-	 */
-	readBits(data, n) {
-		let mask = 1;
-		while (n !== 0) {
-			this.result.push((data & mask) !== 0);
-			mask <<= 1;
-			n--;
-		}
-	}
 }
 
 /**
- * Deserialize handlers indexed by header byte; built once so each
- * `_deserialize` call doesn't rebuild 256 closures (hot on cache restore).
- * @type {((s: ReadState) => void)[]}
+ * Reads a section of values written by V8's value serializer.
+ * @param {ReadState} state read state
+ * @returns {DeserializedType} values of the section
  */
-const dispatchTable = Array.from({ length: 256 }, (_, header) => {
-	switch (header) {
-		case LAZY_HEADER:
-			return (s) => {
-				const count = s.readU32();
-				/** @type {number[]} */
-				const lengths = [];
-				for (let i = 0; i < count; i++) lengths.push(s.readU32());
-				/** @type {(Buffer | LazyFunction<SerializedType, DeserializedType>)[]} */
-				const content = [];
-				for (let l of lengths) {
-					if (l === 0) {
-						if (typeof s.currentBuffer !== "function") {
-							throw new Error("Unexpected non-lazy element in stream");
-						}
-						content.push(s.currentBuffer);
-						s.nextDataItem();
-					} else {
-						do {
-							const buf = s.readUpTo(l);
-							l -= buf.length;
-							content.push(s.retainedBuffer(buf));
-						} while (l > 0);
-					}
-				}
-				s.result.push(s.middleware._createLazyDeserialized(content, s.context));
-			};
-		case BUFFER_HEADER:
-			return (s) => {
-				const len = s.readU32();
-				s.result.push(s.retainedBuffer(s.read(len)));
-			};
-		case TRUE_HEADER:
-			return (s) => s.result.push(true);
-		case FALSE_HEADER:
-			return (s) => s.result.push(false);
-		case NULL3_HEADER:
-			return (s) => s.result.push(null, null, null);
-		case NULL2_HEADER:
-			return (s) => s.result.push(null, null);
-		case NULL_HEADER:
-			return (s) => s.result.push(null);
-		case NULL_AND_TRUE_HEADER:
-			return (s) => s.result.push(null, true);
-		case NULL_AND_FALSE_HEADER:
-			return (s) => s.result.push(null, false);
-		case NULL_AND_I8_HEADER:
-			return (s) => {
-				if (s.currentIsBuffer) {
-					s.result.push(
-						null,
-						/** @type {Buffer} */ (s.currentBuffer).readInt8(s.currentPosition)
-					);
-					s.currentPosition += I8_SIZE;
-					s.checkOverflow();
-				} else {
-					s.result.push(null, s.read(I8_SIZE).readInt8(0));
-				}
-			};
-		case NULL_AND_I16_HEADER:
-			return (s) => {
-				s.result.push(null);
-				if (s.isInCurrentBuffer(I16_SIZE)) {
-					s.result.push(
-						/** @type {Buffer} */ (s.currentBuffer).readInt16LE(
-							s.currentPosition
-						)
-					);
-					s.currentPosition += I16_SIZE;
-					s.checkOverflow();
-				} else {
-					s.result.push(s.read(I16_SIZE).readInt16LE(0));
-				}
-			};
-		case NULL_AND_I32_HEADER:
-			return (s) => {
-				s.result.push(null);
-				if (s.isInCurrentBuffer(I32_SIZE)) {
-					s.result.push(
-						/** @type {Buffer} */ (s.currentBuffer).readInt32LE(
-							s.currentPosition
-						)
-					);
-					s.currentPosition += I32_SIZE;
-					s.checkOverflow();
-				} else {
-					s.result.push(s.read(I32_SIZE).readInt32LE(0));
-				}
-			};
-		case NULLS8_HEADER:
-			return (s) => {
-				const len = s.readU8() + 4;
-				for (let i = 0; i < len; i++) {
-					s.result.push(null);
-				}
-			};
-		case NULLS32_HEADER:
-			return (s) => {
-				const len = s.readU32() + 260;
-				for (let i = 0; i < len; i++) {
-					s.result.push(null);
-				}
-			};
-		case BOOLEANS_HEADER:
-			return (s) => {
-				const innerHeader = s.readU8();
-				if ((innerHeader & 0xf0) === 0) {
-					s.readBits(innerHeader, 3);
-				} else if ((innerHeader & 0xe0) === 0) {
-					s.readBits(innerHeader, 4);
-				} else if ((innerHeader & 0xc0) === 0) {
-					s.readBits(innerHeader, 5);
-				} else if ((innerHeader & 0x80) === 0) {
-					s.readBits(innerHeader, 6);
-				} else if (innerHeader !== 0xff) {
-					let count = (innerHeader & 0x7f) + 7;
-					while (count > 8) {
-						s.readBits(s.readU8(), 8);
-						count -= 8;
-					}
-					s.readBits(s.readU8(), count);
-				} else {
-					let count = s.readU32();
-					while (count > 8) {
-						s.readBits(s.readU8(), 8);
-						count -= 8;
-					}
-					s.readBits(s.readU8(), count);
-				}
-			};
-		case STRING_HEADER:
-			return (s) => {
-				const len = s.readU32();
-				if (s.isInCurrentBuffer(len) && s.currentPosition + len < 0x7fffffff) {
-					s.result.push(
-						/** @type {Buffer} */
-						(s.currentBuffer).toString(
-							undefined,
-							s.currentPosition,
-							s.currentPosition + len
-						)
-					);
-					s.currentPosition += len;
-					s.checkOverflow();
-				} else {
-					s.result.push(s.read(len).toString());
-				}
-			};
-		case SHORT_STRING_HEADER:
-			return (s) => s.result.push("");
-		case SHORT_STRING_HEADER | 1:
-			return (s) => {
-				if (s.currentIsBuffer && s.currentPosition < 0x7ffffffe) {
-					s.result.push(
-						/** @type {Buffer} */
-						(s.currentBuffer).toString(
-							"latin1",
-							s.currentPosition,
-							s.currentPosition + 1
-						)
-					);
-					s.currentPosition++;
-					s.checkOverflow();
-				} else {
-					s.result.push(s.read(1).toString("latin1"));
-				}
-			};
-		case I8_HEADER:
-			return (s) => {
-				if (s.currentIsBuffer) {
-					s.result.push(
-						/** @type {Buffer} */ (s.currentBuffer).readInt8(s.currentPosition)
-					);
-					s.currentPosition++;
-					s.checkOverflow();
-				} else {
-					s.result.push(s.read(1).readInt8(0));
-				}
-			};
-		case BIGINT_I8_HEADER: {
-			const len = 1;
-			return (s) => {
-				const need = I8_SIZE * len;
-
-				if (s.isInCurrentBuffer(need)) {
-					for (let i = 0; i < len; i++) {
-						const value =
-							/** @type {Buffer} */
-							(s.currentBuffer).readInt8(s.currentPosition);
-						s.result.push(BigInt(value));
-						s.currentPosition += I8_SIZE;
-					}
-					s.checkOverflow();
-				} else {
-					const buf = s.read(need);
-					for (let i = 0; i < len; i++) {
-						const value = buf.readInt8(i * I8_SIZE);
-						s.result.push(BigInt(value));
-					}
-				}
-			};
-		}
-		case BIGINT_I32_HEADER: {
-			const len = 1;
-			return (s) => {
-				const need = I32_SIZE * len;
-				if (s.isInCurrentBuffer(need)) {
-					for (let i = 0; i < len; i++) {
-						const value = /** @type {Buffer} */ (s.currentBuffer).readInt32LE(
-							s.currentPosition
-						);
-						s.result.push(BigInt(value));
-						s.currentPosition += I32_SIZE;
-					}
-					s.checkOverflow();
-				} else {
-					const buf = s.read(need);
-					for (let i = 0; i < len; i++) {
-						const value = buf.readInt32LE(i * I32_SIZE);
-						s.result.push(BigInt(value));
-					}
-				}
-			};
-		}
-		case BIGINT_HEADER: {
-			return (s) => {
-				const len = s.readU32();
-				if (s.isInCurrentBuffer(len) && s.currentPosition + len < 0x7fffffff) {
-					const value =
-						/** @type {Buffer} */
-						(s.currentBuffer).toString(
-							undefined,
-							s.currentPosition,
-							s.currentPosition + len
-						);
-
-					s.result.push(BigInt(value));
-					s.currentPosition += len;
-					s.checkOverflow();
-				} else {
-					const value = s.read(len).toString();
-					s.result.push(BigInt(value));
-				}
-			};
-		}
-		default:
-			if (header <= 10) {
-				return (s) => s.result.push(header);
-			} else if ((header & SHORT_STRING_HEADER) === SHORT_STRING_HEADER) {
-				const len = header & SHORT_STRING_LENGTH_MASK;
-				return (s) => {
-					if (
-						s.isInCurrentBuffer(len) &&
-						s.currentPosition + len < 0x7fffffff
-					) {
-						s.result.push(
-							/** @type {Buffer} */
-							(s.currentBuffer).toString(
-								"latin1",
-								s.currentPosition,
-								s.currentPosition + len
-							)
-						);
-						s.currentPosition += len;
-						s.checkOverflow();
-					} else {
-						s.result.push(s.read(len).toString("latin1"));
-					}
-				};
-			} else if ((header & NUMBERS_HEADER_MASK) === F64_HEADER) {
-				const len = (header & NUMBERS_COUNT_MASK) + 1;
-				return (s) => {
-					const need = F64_SIZE * len;
-					if (s.isInCurrentBuffer(need)) {
-						for (let i = 0; i < len; i++) {
-							s.result.push(
-								/** @type {Buffer} */ (s.currentBuffer).readDoubleLE(
-									s.currentPosition
-								)
-							);
-							s.currentPosition += F64_SIZE;
-						}
-						s.checkOverflow();
-					} else {
-						const buf = s.read(need);
-						for (let i = 0; i < len; i++) {
-							s.result.push(buf.readDoubleLE(i * F64_SIZE));
-						}
-					}
-				};
-			} else if ((header & NUMBERS_HEADER_MASK) === I32_HEADER) {
-				const len = (header & NUMBERS_COUNT_MASK) + 1;
-				return (s) => {
-					const need = I32_SIZE * len;
-					if (s.isInCurrentBuffer(need)) {
-						for (let i = 0; i < len; i++) {
-							s.result.push(
-								/** @type {Buffer} */ (s.currentBuffer).readInt32LE(
-									s.currentPosition
-								)
-							);
-							s.currentPosition += I32_SIZE;
-						}
-						s.checkOverflow();
-					} else {
-						const buf = s.read(need);
-						for (let i = 0; i < len; i++) {
-							s.result.push(buf.readInt32LE(i * I32_SIZE));
-						}
-					}
-				};
-			} else if ((header & NUMBERS_HEADER_MASK) === I8_HEADER) {
-				const len = (header & NUMBERS_COUNT_MASK) + 1;
-				return (s) => {
-					const need = I8_SIZE * len;
-					if (s.isInCurrentBuffer(need)) {
-						for (let i = 0; i < len; i++) {
-							s.result.push(
-								/** @type {Buffer} */ (s.currentBuffer).readInt8(
-									s.currentPosition
-								)
-							);
-							s.currentPosition += I8_SIZE;
-						}
-						s.checkOverflow();
-					} else {
-						const buf = s.read(need);
-						for (let i = 0; i < len; i++) {
-							s.result.push(buf.readInt8(i * I8_SIZE));
-						}
-					}
-				};
-			}
-			return (s) => {
-				throw new Error(`Unexpected header byte 0x${header.toString(16)}`);
-			};
+const readValuesSection = (state) => {
+	const payloadSize = state.readU32();
+	const bufferCount = state.readU32();
+	/** @type {number[]} */
+	const bufferInfo = [];
+	for (let i = 0; i < bufferCount * 2; i++) bufferInfo.push(state.readU32());
+	const values =
+		/** @type {DeserializedType} */
+		(v8Deserialize(state.read(payloadSize)));
+	for (let i = 0; i < bufferCount; i++) {
+		values[bufferInfo[i * 2]] = state.retainedBuffer(
+			state.read(bufferInfo[i * 2 + 1])
+		);
 	}
-});
+	return values;
+};
+
+/**
+ * Reads the content items of a lazy section.
+ * @param {ReadState} state read state
+ * @returns {SerializedType} content of the lazy value
+ */
+const readLazySection = (state) => {
+	const count = state.readU32();
+	/** @type {number[]} */
+	const sizes = [];
+	for (let i = 0; i < count; i++) sizes.push(state.readU32());
+	/** @type {SerializedType} */
+	const content = [];
+	for (let size of sizes) {
+		if (size === 0) {
+			if (typeof state.currentBuffer !== "function") {
+				throw new Error("Unexpected non-lazy element in stream");
+			}
+			content.push(state.currentBuffer);
+			state.nextDataItem();
+		} else {
+			do {
+				const buf = state.readUpTo(size);
+				size -= buf.length;
+				content.push(state.retainedBuffer(buf));
+			} while (size > 0);
+		}
+	}
+	return content;
+};
 
 /**
  * Represents BinaryMiddleware.
@@ -696,497 +289,200 @@ class BinaryMiddleware extends SerializerMiddleware {
 	 * Returns serialized data.
 	 * @param {DeserializedType} data data
 	 * @param {Context} context context object
-	 * @param {{ leftOverBuffer: Buffer | null, allocationSize: number, increaseCounter: number }} allocationScope allocation scope
 	 * @returns {SerializedType} serialized data
 	 */
-	_serialize(
-		data,
-		context,
-		allocationScope = {
-			allocationSize: 1024,
-			increaseCounter: 0,
-			leftOverBuffer: null
-		}
-	) {
-		/** @type {Buffer | null} */
-		let leftOverBuffer = null;
-		/** @type {BufferSerializableType[]} */
-		let buffers = [];
-		/** @type {Buffer | null} */
-		let currentBuffer = allocationScope ? allocationScope.leftOverBuffer : null;
-		allocationScope.leftOverBuffer = null;
-		let currentPosition = 0;
-		if (currentBuffer === null) {
-			currentBuffer = Buffer.allocUnsafe(allocationScope.allocationSize);
-		}
-		/**
-		 * Processes the provided bytes needed.
-		 * @param {number} bytesNeeded bytes needed
-		 */
-		const allocate = (bytesNeeded) => {
-			if (currentBuffer !== null) {
-				if (currentBuffer.length - currentPosition >= bytesNeeded) return;
-				flush();
-			}
-			if (leftOverBuffer && leftOverBuffer.length >= bytesNeeded) {
-				currentBuffer = leftOverBuffer;
-				leftOverBuffer = null;
-			} else {
-				currentBuffer = Buffer.allocUnsafe(
-					Math.max(bytesNeeded, allocationScope.allocationSize)
-				);
-				if (
-					!(allocationScope.increaseCounter =
-						(allocationScope.increaseCounter + 1) % 4) &&
-					allocationScope.allocationSize < 16777216
-				) {
-					allocationScope.allocationSize <<= 1;
-				}
-			}
-		};
-		const flush = () => {
-			if (currentBuffer !== null) {
-				if (currentPosition > 0) {
-					buffers.push(
-						Buffer.from(
-							currentBuffer.buffer,
-							currentBuffer.byteOffset,
-							currentPosition
-						)
-					);
-				}
-				if (
-					!leftOverBuffer ||
-					leftOverBuffer.length < currentBuffer.length - currentPosition
-				) {
-					leftOverBuffer = Buffer.from(
-						currentBuffer.buffer,
-						currentBuffer.byteOffset + currentPosition,
-						currentBuffer.byteLength - currentPosition
-					);
-				}
-
-				currentBuffer = null;
-				currentPosition = 0;
-			}
-		};
-		/**
-		 * Processes the provided byte.
-		 * @param {number} byte byte
-		 */
-		const writeU8 = (byte) => {
-			/** @type {Buffer} */
-			(currentBuffer).writeUInt8(byte, currentPosition++);
-		};
-		/**
-		 * Processes the provided ui32.
-		 * @param {number} ui32 ui32
-		 */
-		const writeU32 = (ui32) => {
-			/** @type {Buffer} */
-			(currentBuffer).writeUInt32LE(ui32, currentPosition);
-			currentPosition += 4;
-		};
+	_serialize(data, context) {
+		/** @type {SerializedType} */
+		const result = [];
 		/** @type {number[]} */
 		const measureStack = [];
-		const measureStart = () => {
-			measureStack.push(buffers.length, currentPosition);
+		let writtenBytes = 0;
+		/** Index of the first value of the open section. */
+		let sectionStart = 0;
+		/** Estimated payload size of the open section. */
+		let sectionSize = 0;
+		/**
+		 * Positions of the buffers of the open section, relative to `data`.
+		 * @type {number[]}
+		 */
+		let bufferIndices = [];
+		/** @type {Buffer[]} */
+		let buffers = [];
+		/**
+		 * Appends a buffer to the output.
+		 * @param {Buffer} buffer buffer
+		 */
+		const write = (buffer) => {
+			writtenBytes += buffer.length;
+			result.push(buffer);
 		};
 		/**
-		 * Returns size.
-		 * @returns {number} size
+		 * Writes a values section for the given values.
+		 * @param {DeserializedType} values values without their buffers
+		 * @param {number[]} indices position of each buffer within `values`
+		 * @param {Buffer[]} bufferList buffers in the order of `indices`
 		 */
-		const measureEnd = () => {
-			const oldPos = /** @type {number} */ (measureStack.pop());
-			const buffersIndex = /** @type {number} */ (measureStack.pop());
-			let size = currentPosition - oldPos;
-			for (let i = buffersIndex; i < buffers.length; i++) {
-				size += buffers[i].length;
+		const writeValuesSection = (values, indices, bufferList) => {
+			const payload = v8Serialize(values);
+			const header = Buffer.allocUnsafe(
+				HEADER_SIZE + I32_SIZE * (2 + indices.length * 2)
+			);
+			header[0] = VALUES_HEADER;
+			header.writeUInt32LE(payload.length, HEADER_SIZE);
+			header.writeUInt32LE(indices.length, HEADER_SIZE + I32_SIZE);
+			let offset = HEADER_SIZE + I32_SIZE * 2;
+			for (let i = 0; i < indices.length; i++) {
+				header.writeUInt32LE(indices[i], offset);
+				header.writeUInt32LE(bufferList[i].length, offset + I32_SIZE);
+				offset += I32_SIZE * 2;
 			}
-			return size;
+			write(header);
+			write(payload);
+			for (const buffer of bufferList) {
+				if (buffer.length > 0) write(buffer);
+			}
+		};
+		/**
+		 * Closes the open values section before the value at `end`.
+		 * @param {number} end index of the first value not in the section
+		 */
+		const flush = (end) => {
+			if (end > sectionStart) {
+				if (sectionStart === 0 && end === data.length) {
+					// the section covers all values: swap the buffers out and back in
+					// instead of copying the whole array to place the placeholders
+					for (const index of bufferIndices) data[index] = null;
+					try {
+						writeValuesSection(data, bufferIndices, buffers);
+					} finally {
+						for (let i = 0; i < bufferIndices.length; i++) {
+							data[bufferIndices[i]] = buffers[i];
+						}
+					}
+				} else {
+					const values = data.slice(sectionStart, end);
+					for (let i = 0; i < bufferIndices.length; i++) {
+						const index = bufferIndices[i] - sectionStart;
+						bufferIndices[i] = index;
+						values[index] = null;
+					}
+					writeValuesSection(values, bufferIndices, buffers);
+				}
+				if (bufferIndices.length > 0) {
+					bufferIndices = [];
+					buffers = [];
+				}
+			}
+			sectionStart = end;
+			sectionSize = 0;
 		};
 		for (let i = 0; i < data.length; i++) {
 			const thing = data[i];
-			switch (typeof thing) {
-				case "function": {
-					if (!SerializerMiddleware.isLazy(thing)) {
-						throw new Error(`Unexpected function ${thing}`);
+			const type = typeof thing;
+			if (type === "string") {
+				sectionSize += /** @type {string} */ (thing).length;
+			} else if (type === "object") {
+				// buffers are appended to the section instead of entering the payload
+				if (thing !== null) {
+					if (!Buffer.isBuffer(thing)) {
+						throw new Error(`Unexpected object ${thing} in binary middleware`);
 					}
-					/** @type {SerializedType | LazyFunction<SerializedType, DeserializedType> | undefined} */
-					let serializedData =
-						SerializerMiddleware.getLazySerializedValue(thing);
-					if (serializedData === undefined) {
-						if (SerializerMiddleware.isLazy(thing, this)) {
-							flush();
-							allocationScope.leftOverBuffer = leftOverBuffer;
-							const result =
-								/** @type {PrimitiveSerializableType[]} */
-								(thing());
-							const data = this._serialize(result, context, allocationScope);
-							leftOverBuffer = allocationScope.leftOverBuffer;
-							allocationScope.leftOverBuffer = null;
-							SerializerMiddleware.setLazySerializedValue(thing, data);
-							serializedData = data;
-						} else {
-							serializedData = this._serializeLazy(thing, context);
-							flush();
-							buffers.push(serializedData);
-							break;
-						}
-					} else if (typeof serializedData === "function") {
-						flush();
-						buffers.push(serializedData);
-						break;
-					}
-					/** @type {number[]} */
-					const lengths = [];
-					for (const item of serializedData) {
-						/** @type {undefined | number} */
-						let last;
-						if (typeof item === "function") {
-							lengths.push(0);
-						} else if (item.length === 0) {
-							// ignore
-						} else if (
-							lengths.length > 0 &&
-							(last = lengths[lengths.length - 1]) !== 0
-						) {
-							const remaining = 0xffffffff - last;
-							if (remaining >= item.length) {
-								lengths[lengths.length - 1] += item.length;
-							} else {
-								lengths.push(item.length - remaining);
-								lengths[lengths.length - 2] = 0xffffffff;
-							}
-						} else {
-							lengths.push(item.length);
-						}
-					}
-					allocate(5 + lengths.length * 4);
-					writeU8(LAZY_HEADER);
-					writeU32(lengths.length);
-					for (const l of lengths) {
-						writeU32(l);
-					}
-					flush();
-					for (const item of serializedData) {
-						buffers.push(item);
-					}
-					break;
+					bufferIndices.push(i);
+					buffers.push(thing);
+				} else {
+					sectionSize += ESTIMATED_VALUE_SIZE;
 				}
-				case "string": {
-					const len = Buffer.byteLength(thing);
-					if (len >= 128 || len !== thing.length) {
-						allocate(len + HEADER_SIZE + I32_SIZE);
-						writeU8(STRING_HEADER);
-						writeU32(len);
-						currentBuffer.write(thing, currentPosition);
-						currentPosition += len;
-					} else if (len >= 70) {
-						allocate(len + HEADER_SIZE);
-						writeU8(SHORT_STRING_HEADER | len);
-
-						currentBuffer.write(thing, currentPosition, "latin1");
-						currentPosition += len;
-					} else {
-						allocate(len + HEADER_SIZE);
-						writeU8(SHORT_STRING_HEADER | len);
-
-						for (let i = 0; i < len; i++) {
-							currentBuffer[currentPosition++] = thing.charCodeAt(i);
-						}
-					}
-					break;
+			} else if (type === "function") {
+				flush(i);
+				sectionStart = i + 1;
+				if (!SerializerMiddleware.isLazy(thing)) {
+					throw new Error(`Unexpected function ${thing}`);
 				}
-				case "bigint": {
-					const type = identifyBigInt(thing);
-					if (type === 0 && thing >= 0 && thing <= BigInt(10)) {
-						// shortcut for very small bigints
-						allocate(HEADER_SIZE + I8_SIZE);
-						writeU8(BIGINT_I8_HEADER);
-						writeU8(Number(thing));
-						break;
-					}
-
-					switch (type) {
-						case 0: {
-							let n = 1;
-							allocate(HEADER_SIZE + I8_SIZE * n);
-							writeU8(BIGINT_I8_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt8(
-									Number(/** @type {bigint} */ (data[i])),
-									currentPosition
-								);
-								currentPosition += I8_SIZE;
-								n--;
-								i++;
-							}
-							i--;
-							break;
-						}
-						case 1: {
-							let n = 1;
-							allocate(HEADER_SIZE + I32_SIZE * n);
-							writeU8(BIGINT_I32_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt32LE(
-									Number(/** @type {bigint} */ (data[i])),
-									currentPosition
-								);
-								currentPosition += I32_SIZE;
-								n--;
-								i++;
-							}
-							i--;
-							break;
-						}
-						default: {
-							const value = thing.toString();
-							const len = Buffer.byteLength(value);
-							allocate(len + HEADER_SIZE + I32_SIZE);
-							writeU8(BIGINT_HEADER);
-							writeU32(len);
-							currentBuffer.write(value, currentPosition);
-							currentPosition += len;
-							break;
-						}
-					}
-					break;
-				}
-				case "number": {
-					const type = identifyNumber(thing);
-					if (type === 0 && thing >= 0 && thing <= 10) {
-						// shortcut for very small numbers
-						allocate(I8_SIZE);
-						writeU8(thing);
-						break;
-					}
-					/**
-					 * amount of numbers to write
-					 * @type {number}
-					 */
-					let n = 1;
-					for (; n < 32 && i + n < data.length; n++) {
-						const item = data[i + n];
-						if (typeof item !== "number") break;
-						if (identifyNumber(item) !== type) break;
-					}
-					switch (type) {
-						case 0:
-							allocate(HEADER_SIZE + I8_SIZE * n);
-							writeU8(I8_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt8(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition += I8_SIZE;
-								n--;
-								i++;
-							}
-							break;
-						case 1:
-							allocate(HEADER_SIZE + I32_SIZE * n);
-							writeU8(I32_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt32LE(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition += I32_SIZE;
-								n--;
-								i++;
-							}
-							break;
-						case 2:
-							allocate(HEADER_SIZE + F64_SIZE * n);
-							writeU8(F64_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeDoubleLE(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition += F64_SIZE;
-								n--;
-								i++;
-							}
-							break;
-					}
-
-					i--;
-					break;
-				}
-				case "boolean": {
-					let lastByte = thing === true ? 1 : 0;
-					/** @type {number[]} */
-					const bytes = [];
-					let count = 1;
-					/** @type {undefined | number} */
-					let n;
-					for (n = 1; n < 0xffffffff && i + n < data.length; n++) {
-						const item = data[i + n];
-						if (typeof item !== "boolean") break;
-						const pos = count & 0x7;
-						if (pos === 0) {
-							bytes.push(lastByte);
-							lastByte = item === true ? 1 : 0;
-						} else if (item === true) {
-							lastByte |= 1 << pos;
-						}
-						count++;
-					}
-					i += count - 1;
-					if (count === 1) {
-						allocate(HEADER_SIZE);
-						writeU8(lastByte === 1 ? TRUE_HEADER : FALSE_HEADER);
-					} else if (count === 2) {
-						allocate(HEADER_SIZE * 2);
-						writeU8(lastByte & 1 ? TRUE_HEADER : FALSE_HEADER);
-						writeU8(lastByte & 2 ? TRUE_HEADER : FALSE_HEADER);
-					} else if (count <= 6) {
-						allocate(HEADER_SIZE + I8_SIZE);
-						writeU8(BOOLEANS_HEADER);
-						writeU8((1 << count) | lastByte);
-					} else if (count <= 133) {
-						allocate(HEADER_SIZE + I8_SIZE + I8_SIZE * bytes.length + I8_SIZE);
-						writeU8(BOOLEANS_HEADER);
-						writeU8(0x80 | (count - 7));
-						for (const byte of bytes) writeU8(byte);
-						writeU8(lastByte);
-					} else {
-						allocate(
-							HEADER_SIZE +
-								I8_SIZE +
-								I32_SIZE +
-								I8_SIZE * bytes.length +
-								I8_SIZE
+				/** @type {SerializedType | LazyFunction<SerializedType, DeserializedType> | undefined} */
+				let serializedData = SerializerMiddleware.getLazySerializedValue(thing);
+				if (serializedData === undefined) {
+					if (SerializerMiddleware.isLazy(thing, this)) {
+						serializedData = this._serialize(
+							/** @type {DeserializedType} */ (thing()),
+							context
 						);
-						writeU8(BOOLEANS_HEADER);
-						writeU8(0xff);
-						writeU32(count);
-						for (const byte of bytes) writeU8(byte);
-						writeU8(lastByte);
+						SerializerMiddleware.setLazySerializedValue(thing, serializedData);
+					} else {
+						result.push(
+							this._serializeLazy(
+								/** @type {LazyFunction<DeserializedType, SerializedType>} */
+								(thing),
+								context
+							)
+						);
+						continue;
 					}
-					break;
+				} else if (typeof serializedData === "function") {
+					result.push(serializedData);
+					continue;
 				}
-				case "object": {
-					if (thing === null) {
-						/** @type {number} */
-						let n;
-						for (n = 1; n < 0x100000104 && i + n < data.length; n++) {
-							const item = data[i + n];
-							if (item !== null) break;
-						}
-						i += n - 1;
-						if (n === 1) {
-							if (i + 1 < data.length) {
-								const next = data[i + 1];
-								if (next === true) {
-									allocate(HEADER_SIZE);
-									writeU8(NULL_AND_TRUE_HEADER);
-									i++;
-								} else if (next === false) {
-									allocate(HEADER_SIZE);
-									writeU8(NULL_AND_FALSE_HEADER);
-									i++;
-								} else if (typeof next === "number") {
-									const type = identifyNumber(next);
-									if (type === 0) {
-										allocate(HEADER_SIZE + I8_SIZE);
-										writeU8(NULL_AND_I8_HEADER);
-										currentBuffer.writeInt8(next, currentPosition);
-										currentPosition += I8_SIZE;
-										i++;
-									} else if (type === 1) {
-										// `null` + i32 is 5 bytes; if the value also fits an
-										// i16, fuse it as 3 bytes instead (helps back-references)
-										if (next >= -32768 && next <= 32767) {
-											allocate(HEADER_SIZE + I16_SIZE);
-											writeU8(NULL_AND_I16_HEADER);
-											currentBuffer.writeInt16LE(next, currentPosition);
-											currentPosition += I16_SIZE;
-										} else {
-											allocate(HEADER_SIZE + I32_SIZE);
-											writeU8(NULL_AND_I32_HEADER);
-											currentBuffer.writeInt32LE(next, currentPosition);
-											currentPosition += I32_SIZE;
-										}
-										i++;
-									} else {
-										allocate(HEADER_SIZE);
-										writeU8(NULL_HEADER);
-									}
-								} else {
-									allocate(HEADER_SIZE);
-									writeU8(NULL_HEADER);
-								}
-							} else {
-								allocate(HEADER_SIZE);
-								writeU8(NULL_HEADER);
-							}
-						} else if (n === 2) {
-							allocate(HEADER_SIZE);
-							writeU8(NULL2_HEADER);
-						} else if (n === 3) {
-							allocate(HEADER_SIZE);
-							writeU8(NULL3_HEADER);
-						} else if (n < 260) {
-							allocate(HEADER_SIZE + I8_SIZE);
-							writeU8(NULLS8_HEADER);
-							writeU8(n - 4);
+				/** @type {number[]} */
+				const sizes = [];
+				for (const item of serializedData) {
+					/** @type {undefined | number} */
+					let last;
+					if (typeof item === "function") {
+						sizes.push(0);
+					} else if (item.length === 0) {
+						// ignore
+					} else if (
+						sizes.length > 0 &&
+						(last = sizes[sizes.length - 1]) !== 0
+					) {
+						const remaining = 0xffffffff - last;
+						if (remaining >= item.length) {
+							sizes[sizes.length - 1] += item.length;
 						} else {
-							allocate(HEADER_SIZE + I32_SIZE);
-							writeU8(NULLS32_HEADER);
-							writeU32(n - 260);
+							sizes.push(item.length - remaining);
+							sizes[sizes.length - 2] = 0xffffffff;
 						}
-					} else if (Buffer.isBuffer(thing)) {
-						if (thing.length < 8192) {
-							allocate(HEADER_SIZE + I32_SIZE + thing.length);
-							writeU8(BUFFER_HEADER);
-							writeU32(thing.length);
-							thing.copy(currentBuffer, currentPosition);
-							currentPosition += thing.length;
-						} else {
-							allocate(HEADER_SIZE + I32_SIZE);
-							writeU8(BUFFER_HEADER);
-							writeU32(thing.length);
-							flush();
-							buffers.push(thing);
-						}
+					} else {
+						sizes.push(item.length);
 					}
-					break;
 				}
-				case "symbol": {
-					if (thing === MEASURE_START_OPERATION) {
-						measureStart();
-					} else if (thing === MEASURE_END_OPERATION) {
-						const size = measureEnd();
-						allocate(HEADER_SIZE + I32_SIZE);
-						writeU8(I32_HEADER);
-						currentBuffer.writeInt32LE(size, currentPosition);
-						currentPosition += I32_SIZE;
+				const header = Buffer.allocUnsafe(
+					HEADER_SIZE + I32_SIZE * (1 + sizes.length)
+				);
+				header[0] = LAZY_HEADER;
+				header.writeUInt32LE(sizes.length, HEADER_SIZE);
+				for (let j = 0; j < sizes.length; j++) {
+					header.writeUInt32LE(sizes[j], HEADER_SIZE + I32_SIZE * (1 + j));
+				}
+				write(header);
+				for (const item of serializedData) {
+					if (typeof item === "function") {
+						result.push(item);
+					} else {
+						write(item);
 					}
-					break;
 				}
-				default: {
-					throw new Error(
-						`Unknown typeof "${typeof thing}" in binary middleware`
-					);
+				continue;
+			} else if (type === "symbol") {
+				flush(i);
+				sectionStart = i + 1;
+				const operation =
+					/** @type {MEASURE_START_OPERATION_TYPE | MEASURE_END_OPERATION_TYPE} */
+					(/** @type {unknown} */ (thing));
+				if (operation === MEASURE_START_OPERATION) {
+					measureStack.push(writtenBytes);
+				} else if (operation === MEASURE_END_OPERATION) {
+					const size =
+						writtenBytes - /** @type {number} */ (measureStack.pop());
+					writeValuesSection([size], [], []);
 				}
+				continue;
+			} else {
+				sectionSize += ESTIMATED_VALUE_SIZE;
 			}
+			if (sectionSize >= MAX_SECTION_SIZE) flush(i + 1);
 		}
-		flush();
-
-		allocationScope.leftOverBuffer = leftOverBuffer;
-
-		// avoid leaking memory
-		currentBuffer = null;
-		leftOverBuffer = null;
-		allocationScope = /** @type {EXPECTED_ANY} */ (undefined);
-		const _buffers = buffers;
-		buffers = /** @type {EXPECTED_ANY} */ (undefined);
-		return _buffers;
+		flush(data.length);
+		return result;
 	}
 
 	/**
@@ -1200,7 +496,7 @@ class BinaryMiddleware extends SerializerMiddleware {
 	}
 
 	/**
-	 * Create lazy deserialized. Internal, but called from the dispatch table.
+	 * Create lazy deserialized.
 	 * @param {SerializedType} content content
 	 * @param {Context} context context object
 	 * @returns {LazyFunction<DeserializedType, SerializedType>} lazy function
@@ -1234,16 +530,37 @@ class BinaryMiddleware extends SerializerMiddleware {
 	 * @returns {DeserializedType} deserialized data
 	 */
 	_deserialize(data, context) {
-		const state = new ReadState(data, context, this);
+		const state = new ReadState(data, context);
+		/** @type {DeserializedType[]} */
+		const parts = [];
 		while (state.currentBuffer !== null) {
+			/** @type {DeserializedType} */
+			let part;
 			if (typeof state.currentBuffer === "function") {
-				state.result.push(this._deserializeLazy(state.currentBuffer, context));
+				part = [this._deserializeLazy(state.currentBuffer, context)];
 				state.nextDataItem();
 			} else {
-				dispatchTable[state.readU8()](state);
+				const header = state.readU8();
+				if (header === VALUES_HEADER) {
+					part = readValuesSection(state);
+				} else if (header === LAZY_HEADER) {
+					part = [
+						this._createLazyDeserialized(readLazySection(state), context)
+					];
+				} else {
+					throw new Error(`Unexpected header byte 0x${header.toString(16)}`);
+				}
 			}
+			parts.push(part);
 		}
-		return state.result;
+		if (parts.length === 0) return [];
+		// a stream without lazy values is a single section and needs no copying
+		const result = parts[0];
+		for (let i = 1; i < parts.length; i++) {
+			const part = parts[i];
+			for (let j = 0; j < part.length; j++) result.push(part[j]);
+		}
+		return result;
 	}
 }
 

--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -174,6 +174,7 @@ describe("BinaryMiddleware", () => {
 			BigInt(100000),
 			BigInt("123456789012345678901234567890"),
 			Buffer.from("hello"),
+			Buffer.alloc(0),
 			Buffer.alloc(10000, 1)
 		];
 		for (const chunkSize of [1, 2, 3, 5, 8, 13, 64]) {
@@ -210,6 +211,61 @@ describe("BinaryMiddleware", () => {
 		}
 	});
 
+	describe("large streams", () => {
+		it("should split values exceeding the section size into several sections", () => {
+			// 20 MiB of strings, above the 16 MiB at which a section is closed
+			const data = [];
+			for (let i = 0; i < 20; i++) data.push(`${i}`.repeat(1024 * 1024));
+			data.push(Buffer.from("tail"), 42);
+			const serialized =
+				/** @type {import("../lib/serialization/BinaryMiddleware").SerializedType} */
+				(mw.serialize(data, {}));
+			// two values sections, each with its own header and payload
+			expect(
+				serialized.filter((item) => Buffer.isBuffer(item) && item[0] === 0xf1)
+			).toHaveLength(2);
+			expect(mw.deserialize(serialized, {})).toEqual(data);
+		});
+	});
+
+	describe("measure operations", () => {
+		it("should write the size of the measured section", () => {
+			const data = [
+				"before",
+				BinaryMiddleware.MEASURE_START_OPERATION,
+				"measured",
+				42,
+				BinaryMiddleware.MEASURE_END_OPERATION,
+				"after"
+			];
+			const serialized =
+				/** @type {import("../lib/serialization/BinaryMiddleware").SerializedType} */
+				(mw.serialize(data, {}));
+			const result =
+				/** @type {import("../lib/serialization/BinaryMiddleware").DeserializedType} */
+				(mw.deserialize(serialized, {}));
+			// the symbols are replaced by the byte size of what they enclose
+			expect(result.slice(0, 3)).toEqual(["before", "measured", 42]);
+			expect(typeof result[3]).toBe("number");
+			expect(result[3]).toBeGreaterThan(0);
+			expect(result[4]).toBe("after");
+		});
+	});
+
+	describe("invalid data", () => {
+		it("should throw on a non-buffer object", () => {
+			expect(() =>
+				mw.serialize(/** @type {EXPECTED_ANY} */ ([{ a: 1 }]), {})
+			).toThrow(/Unexpected object/);
+		});
+
+		it("should throw on a non-lazy function", () => {
+			expect(() =>
+				mw.serialize(/** @type {EXPECTED_ANY} */ ([() => 1]), {})
+			).toThrow(/Unexpected function/);
+		});
+	});
+
 	describe("invalid streams", () => {
 		it("should throw on an unexpected header byte", () => {
 			expect(() => mw.deserialize([Buffer.from([0x1d])], {})).toThrow(
@@ -218,9 +274,12 @@ describe("BinaryMiddleware", () => {
 		});
 
 		it("should throw on unexpected end of stream", () => {
-			// string section claiming 10 content bytes with only 2 present
+			// values section claiming a 10 byte payload with only 2 bytes present
 			expect(() =>
-				mw.deserialize([Buffer.from([0x1e, 10, 0, 0, 0, 0x61, 0x62])], {})
+				mw.deserialize(
+					[Buffer.from([0xf1, 10, 0, 0, 0, 0, 0, 0, 0, 0x61, 0x62])],
+					{}
+				)
 			).toThrow(/Unexpected end of stream/);
 		});
 
@@ -229,7 +288,7 @@ describe("BinaryMiddleware", () => {
 			expect(() =>
 				mw.deserialize(
 					[
-						Buffer.from([0x1e, 10, 0, 0, 0, 0x61, 0x62]),
+						Buffer.from([0xf1, 10, 0, 0, 0, 0, 0, 0, 0, 0x61, 0x62]),
 						/** @type {EXPECTED_ANY} */ (lazy)
 					],
 					{}
@@ -241,7 +300,7 @@ describe("BinaryMiddleware", () => {
 			// lazy section with one zero-length entry must be followed by a lazy fn
 			expect(() =>
 				mw.deserialize(
-					[Buffer.from([0x0b, 1, 0, 0, 0, 0, 0, 0, 0]), Buffer.from([0x0c])],
+					[Buffer.from([0xf2, 1, 0, 0, 0, 0, 0, 0, 0]), Buffer.from([0xf1])],
 					{}
 				)
 			).toThrow(/Unexpected non-lazy element in stream/);

--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const v8 = require("v8");
 const BinaryMiddleware = require("../lib/serialization/BinaryMiddleware");
 const SerializerMiddleware = require("../lib/serialization/SerializerMiddleware");
 
@@ -243,6 +244,18 @@ describe("BinaryMiddleware", () => {
 	});
 
 	describe("invalid streams", () => {
+		it("should throw on a payload from a newer V8 format version", () => {
+			const payload = v8.serialize([1, "x"]);
+			payload[1] = 0x7f; // pretend it was written by a newer V8
+			const header = Buffer.alloc(9);
+			header[0] = 0xf1;
+			header.writeUInt32LE(payload.length, 1);
+			header.writeUInt32LE(0, 5);
+			expect(() => mw.deserialize([header, payload], {})).toThrow(
+				/V8 serialization format version 127/
+			);
+		});
+
 		it("should throw on an unexpected header byte", () => {
 			expect(() => mw.deserialize([Buffer.from([0x1d])], {})).toThrow(
 				/Unexpected header byte/

--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -228,30 +228,6 @@ describe("BinaryMiddleware", () => {
 		});
 	});
 
-	describe("measure operations", () => {
-		it("should write the size of the measured section", () => {
-			const data = [
-				"before",
-				BinaryMiddleware.MEASURE_START_OPERATION,
-				"measured",
-				42,
-				BinaryMiddleware.MEASURE_END_OPERATION,
-				"after"
-			];
-			const serialized =
-				/** @type {import("../lib/serialization/BinaryMiddleware").SerializedType} */
-				(mw.serialize(data, {}));
-			const result =
-				/** @type {import("../lib/serialization/BinaryMiddleware").DeserializedType} */
-				(mw.deserialize(serialized, {}));
-			// the symbols are replaced by the byte size of what they enclose
-			expect(result.slice(0, 3)).toEqual(["before", "measured", 42]);
-			expect(typeof result[3]).toBe("number");
-			expect(result[3]).toBeGreaterThan(0);
-			expect(result[4]).toBe("after");
-		});
-	});
-
 	describe("invalid data", () => {
 		it("should throw on a non-buffer object", () => {
 			expect(() =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Simplifies `BinaryMiddleware` to use V8's `[de]serialize` functions for improved performance.

**Does this PR introduce a breaking change?**

No. While this invalidates cache entries generated with the old format, it does not break webpack's API or substantially alter the ability to cache.

For the following data:
```mjs
const createData = () => {
	const data = [];
	for (let i = 0; i < 2000; i++) {
		data.push(
			i % 16,
			-(i % 16),
			i + 0.25,
			i % 2 === 0,
			i % 7 === 0 ? null : `module-${i % 100}`,
			BigInt(i % 16)
		);
		if (i % 32 === 0) data.push(Buffer.alloc(256, i));
	}
	return data;
};
```

Improvement:
```
current serialize          0.167 ms/op      5981 ops/s  ±0.66%
current deserialize        0.285 ms/op      3505 ops/s  ±13.65%
old        serialize       0.380 ms/op      2634 ops/s  ±1.75%
old        deserialize     0.313 ms/op      3200 ops/s  ±0.33%
```