### PR TITLE
refactor: stabilize the NormalModule instance shape

### DIFF
--- a/.changeset/060-stable-instance-shapes.md
+++ b/.changeset/060-stable-instance-shapes.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Initialize `NormalModule._ast` in the constructor so each instance keeps a single hidden-class shape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,12 @@ JSDoc on exported symbols stays as-is — that's the type contract, not commenta
 
 webpack is a bundler — users measure it by build time and peak heap usage. Many changes in `lib/` end up on per-module hot paths (sometimes per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so large compilation data structures are not retained longer than necessary. See #15521 for an example of how this class of memory issue can surface.
 
+### Keep instance shapes stable
+
+Initialize **every** instance field in the constructor, including ones first assigned later in a method — default them to `undefined`/`null`. Assigning `this.newField` for the first time outside the constructor forces a V8 hidden-class (Shape) transition, so instances of one class end up split across shapes and the inline caches reading them go polymorphic/megamorphic — a hot property read can cost ~2× at two shapes and more when megamorphic, and code already optimized for the first shape deopts with a `wrong map` bailout. Never `delete` an instance field (it forces the object into dictionary mode); set it to `undefined` instead. The win per field is small for a single trailing field, but the rule is uniform on purpose so reviewers don't judge it case by case — it is why, for example, `Dependency` sets all its `_loc*` slots up front. Deliberate symbol-keyed sparse slots are the documented exception.
+
+When adding a field to a class whose fields are compiled into `types.d.ts` (public, non-`_`-prefixed), re-run `yarn fix:special` — constructor order determines member order in the generated declarations.
+
 ## Auto-generated files
 
 > [!REQUIRED]

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -651,6 +651,12 @@ class NormalModule extends Module {
 		 * @type {Source | null}
 		 */
 		this._source = null;
+		// Set at build time; declared here so the instance shape is fixed at construction
+		/**
+		 * @private
+		 * @type {PreparsedAst | null}
+		 */
+		this._ast = null;
 		/**
 		 * @private
 		 * @type {Map<undefined | SourceType, number> | undefined}


### PR DESCRIPTION
**Summary**

webpack keeps V8 hidden-class (Shape) transitions stable by initializing every instance field in the constructor (e.g. `Dependency`'s `_loc*` slots), but `NormalModule._ast` was still added *after* construction (assigned in `_doBuild`/`build`). Declaring it in the constructor keeps each `NormalModule` on a single shape from creation and removes a `wrong map` deopt on the per-module read path. `_ast` is private, so `types.d.ts` is unaffected. This is a consistency/hygiene change — an isolated micro-benchmark shows the late-added field spilled to an out-of-line property array (constructor-init objects are ~8 B/instance lighter and construct no slower), but on a full 4000-module build the difference stays inside run-to-run noise, so it is intentionally submitted as `refactor`, not `perf`.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No — the change only moves field initialization into the constructor and does not alter behavior: `_ast` is read only via `this._ast || source`, and no code does `in`/`hasOwnProperty`/`=== undefined` on it, so the pre-initialized `null` default is indistinguishable from the previous absent-property read. Existing `NormalModule` coverage applies.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude (Claude Code) was used to scan the core classes (`Module`, `NormalModule`, `Dependency` + subclasses, `Chunk`, `ChunkGraph`, `ModuleGraph`, `Compilation`, …) for fields assigned after construction, to write the constructor initialization, and to run the benchmarks that confirmed the change is behavior- and build-time-neutral. All changes were reviewed by the author before submitting.