### PR TITLE
feat: skip `require().prop` in dead branches

### DIFF
--- a/.changeset/065-cjs-full-require-dead-branch.md
+++ b/.changeset/065-cjs-full-require-dead-branch.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip `require().prop` in dead branches gated by inlined imported constants.

--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -9,6 +9,7 @@ const Template = require("../Template");
 const { equals } = require("../util/ArrayHelpers");
 const { getTrimmedIdsAndRange } = require("../util/chainedImports");
 const makeSerializable = require("../util/makeSerializable");
+const memoize = require("../util/memoize");
 const { propertyAccess } = require("../util/property");
 const {
 	ESM_MODULE_EXPORTS_NAME,
@@ -19,6 +20,7 @@ const ModuleDependency = require("./ModuleDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../Dependency").GetConditionFn} GetConditionFn */
 /** @typedef {import("../Dependency").ReferencedExports} ReferencedExports */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
@@ -26,8 +28,11 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("../util/chainedImports").IdRanges} IdRanges */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean]>} ObjectSerializerContext */
+/** @typedef {import("./HarmonyImportGuard").DependencyGuard} DependencyGuard */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined]>} ObjectSerializerContext */
+
+const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
 class CommonJsFullRequireDependency extends ModuleDependency {
 	/**
@@ -53,6 +58,20 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this.call = false;
 		/** @type {undefined | boolean} */
 		this.asiSafe = undefined;
+		/** @type {DependencyGuard[] | undefined} */
+		this.branchGuards = undefined;
+	}
+
+	/**
+	 * Returns function to determine if the connection is active.
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
+	 */
+	getCondition(moduleGraph) {
+		const guards = this.branchGuards;
+		if (guards === undefined) return null;
+		return (connection, runtime) =>
+			!getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime);
 	}
 
 	/**
@@ -92,7 +111,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 			.write(this.names)
 			.write(this.idRanges)
 			.write(this.call)
-			.write(this.asiSafe);
+			.write(this.asiSafe)
+			.write(this.branchGuards);
 		super.serialize(context);
 	}
 
@@ -108,7 +128,9 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this.call = c2.read();
 		const c3 = c2.rest;
 		this.asiSafe = c3.read();
-		super.deserialize(c3.rest);
+		const c4 = c3.rest;
+		this.branchGuards = c4.read();
+		super.deserialize(c4.rest);
 	}
 
 	get type() {
@@ -137,6 +159,13 @@ CommonJsFullRequireDependency.Template = class CommonJsFullRequireDependencyTemp
 	) {
 		const dep = /** @type {CommonJsFullRequireDependency} */ (dependency);
 		if (!dep.range) return;
+		const connection = moduleGraph.getConnection(dep);
+		// Dead branch: module is excluded and has no id; code is never executed.
+		if (connection && !connection.isTargetActive(runtime)) {
+			// Replaces the whole member chain, so no property access is left dangling
+			source.replace(dep.range[0], dep.range[1] - 1, "null /* dead branch */");
+			return;
+		}
 		const importedModule = moduleGraph.getModule(dep);
 		let requireExpr = runtimeTemplate.moduleExports({
 			module: importedModule,

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -642,6 +642,7 @@ class CommonJsImportsParserPlugin {
 				dep.optional = Boolean(parser.scope.inTry);
 				dep.loc = parser.getLocation(expr);
 				parser.state.current.addDependency(dep);
+				getHarmonyImportGuard().attachDependencyGuards(parser, dep);
 				return true;
 			}
 		};
@@ -680,6 +681,7 @@ class CommonJsImportsParserPlugin {
 				dep.optional = Boolean(parser.scope.inTry);
 				dep.loc = parser.getLocation(expr.callee);
 				parser.state.current.addDependency(dep);
+				getHarmonyImportGuard().attachDependencyGuards(parser, dep);
 				parser.walkExpressions(expr.arguments);
 				return true;
 			}

--- a/lib/dependencies/HarmonyImportGuard.js
+++ b/lib/dependencies/HarmonyImportGuard.js
@@ -14,6 +14,7 @@ const memoize = require("../util/memoize");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
+/** @typedef {import("./CommonJsFullRequireDependency")} CommonJsFullRequireDependency */
 /** @typedef {import("./CommonJsRequireDependency")} CommonJsRequireDependency */
 /** @typedef {import("./HarmonyEvaluatedImportSpecifierDependency")} HarmonyEvaluatedImportSpecifierDependency */
 /** @typedef {import("./HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
@@ -29,7 +30,7 @@ const memoize = require("../util/memoize");
 /** @typedef {["&&" | "||" | "??", GuardFormula, GuardFormula]} GuardLogical */
 /** @typedef {GuardAtom | GuardPresenceAtom | GuardUnknown | GuardNot | GuardLogical} GuardFormula */
 /** @typedef {{ formula: GuardFormula, value: boolean }} DependencyGuard branch guard: the dependency is live only when the formula evaluates to `value` */
-/** @typedef {HarmonyImportSpecifierDependency | CommonJsRequireDependency | ImportDependency} GuardableDependency */
+/** @typedef {HarmonyImportSpecifierDependency | CommonJsRequireDependency | CommonJsFullRequireDependency | ImportDependency} GuardableDependency */
 
 /**
  * A guard frame pushed onto `parser.state.guardStack` for the duration of one

--- a/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_call.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_call.js
@@ -1,0 +1,1 @@
+exports.get = () => "DEAD_CJS_FULL_CALL";

--- a/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_if.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_if.js
@@ -1,0 +1,1 @@
+exports.value = "DEAD_CJS_FULL_IF";

--- a/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_nested.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_nested.js
@@ -1,0 +1,1 @@
+exports.value = "DEAD_CJS_FULL_NESTED";

--- a/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_ternary.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/dead_cjs_full_ternary.js
@@ -1,0 +1,1 @@
+exports.value = "DEAD_CJS_FULL_TERNARY";

--- a/test/configCases/inline-exports/cross-module-dead-branch/index.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/index.js
@@ -153,6 +153,51 @@ it("keeps require() in both branches when the test is not statically known", () 
 	expect(hasModule("./kept_cjs_b.js")).toBe(true);
 });
 
+it("ternary: imported boolean gates the dead branch require().prop", () => {
+	const v = isDEV
+		? require("./dead_cjs_full_ternary.js").value
+		: require("./live_cjs_full.js").value;
+	expect(v).toBe("LIVE_CJS_FULL");
+	expect(hasModule("./dead_cjs_full_ternary.js")).toBe(false);
+	expect(hasModule("./live_cjs_full.js")).toBe(true);
+});
+
+it("if-statement: imported boolean gates the dead branch require().prop", () => {
+	let v;
+	if (isProd) {
+		v = require("./live_cjs_full.js").value;
+	} else {
+		v = require("./dead_cjs_full_if.js").value;
+	}
+	expect(v).toBe("LIVE_CJS_FULL");
+	expect(hasModule("./dead_cjs_full_if.js")).toBe(false);
+});
+
+it("imported boolean gates the dead branch require().prop()", () => {
+	const v = isDEV
+		? require("./dead_cjs_full_call.js").get()
+		: require("./live_cjs_full.js").get();
+	expect(v).toBe("LIVE_CJS_FULL_CALL");
+	expect(hasModule("./dead_cjs_full_call.js")).toBe(false);
+});
+
+it("nested if: dead inner branch under an unknown outer branch drops its require().prop", () => {
+	let v = require("./live_cjs_full.js").value;
+	if (obj.flag) {
+		if (isDEV) {
+			v = require("./dead_cjs_full_nested.js").value;
+		}
+	}
+	expect(v).toBe("LIVE_CJS_FULL");
+	expect(hasModule("./dead_cjs_full_nested.js")).toBe(false);
+});
+
+it("keeps require().prop when the test is not statically known", () => {
+	const v = obj.flag ? require("./kept_cjs_full.js").value : "fallback";
+	expect(v).toBe("fallback");
+	expect(hasModule("./kept_cjs_full.js")).toBe(true);
+});
+
 it("ternary: imported boolean gates the dead branch import()", async () => {
 	const ns = await (isDEV ? import("./dead_dyn.js") : import("./live_dyn.js"));
 	expect(ns.V).toBe("LIVE_DYN");

--- a/test/configCases/inline-exports/cross-module-dead-branch/kept_cjs_full.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/kept_cjs_full.js
@@ -1,0 +1,2 @@
+exports.value = "KEPT_CJS_FULL";
+exports.get = () => "KEPT_CJS_FULL_CALL";

--- a/test/configCases/inline-exports/cross-module-dead-branch/live_cjs_full.js
+++ b/test/configCases/inline-exports/cross-module-dead-branch/live_cjs_full.js
@@ -1,0 +1,2 @@
+exports.value = "LIVE_CJS_FULL";
+exports.get = () => "LIVE_CJS_FULL_CALL";


### PR DESCRIPTION
**Summary**

`require()` and `import()` calls in provably dead conditional branches are already skipped (#21136), but a `require("./x").prop` member chain was not — `CommonJsFullRequireDependency` carried no branch guards, so its module stayed in the bundle. This attaches the guard stack to that dependency and emits `null /* dead branch */` when the connection is inactive. Refs #21136.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — new cases in `test/configCases/inline-exports/cross-module-dead-branch/` covering `require().prop`, `require().prop()`, nested branches, and a control case with a non-static test.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code was used to locate the existing guard infrastructure, write the dependency/parser changes and the test cases, and run the targeted test suites; all output was reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CommonJS dependency graph conditions and codegen; behavior is aligned with existing `require()` dead-branch logic but affects bundle membership and emitted member chains.
> 
> **Overview**
> Extends **dead-branch elimination** for inlined imported constants so **`require("./m").prop`** (and **`require().prop()`**) behave like plain **`require()`**: modules only referenced on provably dead paths are dropped from the graph.
> 
> **`CommonJsFullRequireDependency`** now stores **`branchGuards`**, implements **`getCondition`** via **`HarmonyImportGuard.isDeadByGuards`**, serializes guards, and in the template replaces the full member chain with **`null /* dead branch */`** when the module connection is inactive. **`CommonJsImportsParserPlugin`** calls **`attachDependencyGuards`** for member-chain and call-member-chain handlers; **`HarmonyImportGuard`** treats full require deps as guardable.
> 
> Config-case tests cover ternary, `if`, nested branches, **`require().prop()`**, and a non-static test that still keeps the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422ae9b459c54f513183f6f9190cba9326b6b629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->