### PR TITLE
feat: analyzable new URL(import.meta.url) output for fetch-based WebAssembly

### DIFF
--- a/.changeset/020-analyzable-wasm-esm.md
+++ b/.changeset/020-analyzable-wasm-esm.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Emit analyzable `fetch(new URL(..., import.meta.url))` for fetch-based async WebAssembly under ESM output.

--- a/.changeset/020-analyzable-wasm-esm.md
+++ b/.changeset/020-analyzable-wasm-esm.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Emit analyzable `fetch(new URL(..., import.meta.url))` for fetch-based async WebAssembly under ESM output.
+Emit analyzable `fetch(new URL(..., import.meta.url))` for fetch-based WebAssembly under ESM output.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -301,6 +301,18 @@ class RuntimeTemplate {
 		);
 	}
 
+	/**
+	 * Builds the analyzable `new URL(specifier, import.meta.url)` expression the ESM
+	 * wasm/asset loader backends use to reference an emitted binary relative to the
+	 * current module (via `output.importMetaName`) instead of the runtime public-path
+	 * global — the form other bundlers and webpack itself can statically follow.
+	 * @param {string} specifier already-rendered URL argument (a literal or expression)
+	 * @returns {string} the `new URL(...)` expression
+	 */
+	importMetaUrl(specifier) {
+		return `new URL(${specifier}, ${this.outputOptions.importMetaName}.url)`;
+	}
+
 	supportTemplateLiteral() {
 		return this.outputOptions.environment.templateLiteral;
 	}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -285,6 +285,22 @@ class RuntimeTemplate {
 		);
 	}
 
+	/**
+	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm
+	 * binary path built from `wasmModuleId`) may be referenced with the analyzable
+	 * chunk-relative `new URL(path, import.meta.url)` form. Requires ESM output
+	 * (`supportsAnalyzableEsm`) and an `auto` public path — only then is the bare
+	 * relative URL equivalent to the runtime `__webpack_require__.p + path` form.
+	 * Callers that can bake the public path into a static literal specifier should
+	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
+	 * @returns {boolean} true when the analyzable chunk-relative URL applies
+	 */
+	supportsAnalyzableEsmUrl() {
+		return (
+			this.supportsAnalyzableEsm() && this.outputOptions.publicPath === "auto"
+		);
+	}
+
 	supportTemplateLiteral() {
 		return this.outputOptions.environment.templateLiteral;
 	}

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -54,8 +54,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				crossOriginLoading,
 				uniqueName,
 				chunkLoadTimeout: loadTimeout,
-				charset,
-				importMetaName
+				charset
 			}
 		} = compilation;
 		const fn = RuntimeGlobals.ensureChunkHandlers;
@@ -328,7 +327,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 															`Promise.all([import('fs'), import('url')]).then(${runtimeTemplate.basicFunction(
 																"[{ readFile }, { URL }]",
 																[
-																	`readFile(new URL(url, ${importMetaName}.url), 'utf8', ${runtimeTemplate.basicFunction(
+																	`readFile(${runtimeTemplate.importMetaUrl("url")}, 'utf8', ${runtimeTemplate.basicFunction(
 																		"err, content",
 																		[
 																			`if (!err) ${runtimeTemplate.cssServerStyleRegistry()}["chunk-" + chunkId] = content;`,
@@ -499,7 +498,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 																		// best-effort: a non-file publicPath (e.g. a CDN) can't be read from disk, so skip
 																		"try {",
 																		Template.indent([
-																			`readFile(new URL(url, ${importMetaName}.url), 'utf8', ${runtimeTemplate.basicFunction(
+																			`readFile(${runtimeTemplate.importMetaUrl("url")}, 'utf8', ${runtimeTemplate.basicFunction(
 																				"err, content",
 																				[
 																					"if (!err) registry[key] = content;",

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -71,7 +71,7 @@ class ReadFileCompileAsyncWasmPlugin {
 						Template.asString([
 							"Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 							Template.indent([
-								`readFile(new URL(${path}, ${compilation.outputOptions.importMetaName}.url), (err, buffer) => {`,
+								`readFile(${compilation.runtimeTemplate.importMetaUrl(path)}, (err, buffer) => {`,
 								Template.indent([
 									"if (err) return reject(err);",
 									"",

--- a/lib/node/ReadFileCompileWasmPlugin.js
+++ b/lib/node/ReadFileCompileWasmPlugin.js
@@ -71,7 +71,7 @@ class ReadFileCompileWasmPlugin {
 						Template.asString([
 							"Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 							Template.indent([
-								`readFile(new URL(${path}, ${compilation.outputOptions.importMetaName}.url), (err, buffer) => {`,
+								`readFile(${compilation.runtimeTemplate.importMetaUrl(path)}, (err, buffer) => {`,
 								Template.indent([
 									"if (err) return reject(err);",
 									"",

--- a/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
+++ b/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
@@ -70,12 +70,12 @@ class UniversalCompileAsyncWasmPlugin {
 				Template.asString([
 					"(useFetch",
 					Template.indent([
-						`? fetch(new URL(wasmUrl, ${compilation.outputOptions.importMetaName}.url))`
+						`? fetch(${compilation.runtimeTemplate.importMetaUrl("wasmUrl")})`
 					]),
 					Template.indent([
 						": Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 						Template.indent([
-							`readFile(new URL(wasmUrl, ${compilation.outputOptions.importMetaName}.url), (err, buffer) => {`,
+							`readFile(${compilation.runtimeTemplate.importMetaUrl("wasmUrl")}, (err, buffer) => {`,
 							Template.indent([
 								"if (err) return reject(err);",
 								"",

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -53,13 +53,30 @@ class FetchCompileAsyncWasmPlugin {
 				return wasmLoading === "fetch";
 			};
 			/**
-			 * Generates the runtime expression that downloads the emitted wasm
-			 * binary for an async WebAssembly module.
+			 * Downloads the emitted wasm binary through the runtime
+			 * `__webpack_require__.p` public path.
 			 * @param {string} path path to the wasm file
 			 * @returns {string} code to load the wasm file
 			 */
 			const generateLoadBinaryCode = (path) =>
 				`fetch(${RuntimeGlobals.publicPath} + ${path})`;
+			/**
+			 * ESM-output variant: the analyzable `fetch(new URL(path, import.meta.url))`
+			 * form (relative to the chunk, no runtime public-path global) that other
+			 * bundlers and webpack itself can statically follow to the emitted wasm.
+			 * @param {string} path path to the wasm file
+			 * @returns {string} code to load the wasm file
+			 */
+			const generateAnalyzableLoadBinaryCode = (path) =>
+				`fetch(new URL(${path}, ${compilation.outputOptions.importMetaName}.url))`;
+			/**
+			 * The analyzable literal form only applies to ESM output with `auto`
+			 * public path; a custom public path keeps the runtime form.
+			 * @returns {boolean} true when the analyzable form should be emitted
+			 */
+			const isAnalyzable = () =>
+				compilation.runtimeTemplate.supportsAnalyzableEsm() &&
+				compilation.outputOptions.publicPath === "auto";
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.instantiateWasm)
@@ -73,7 +90,8 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					set.add(RuntimeGlobals.publicPath);
+					const analyzable = isAnalyzable();
+					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
@@ -82,7 +100,9 @@ class FetchCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmLoadingRuntimeModule({
-							generateLoadBinaryCode,
+							generateLoadBinaryCode: analyzable
+								? generateAnalyzableLoadBinaryCode
+								: generateLoadBinaryCode,
 							supportsStreaming: true
 						})
 					);
@@ -100,7 +120,8 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					set.add(RuntimeGlobals.publicPath);
+					const analyzable = isAnalyzable();
+					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
@@ -109,7 +130,9 @@ class FetchCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmCompileRuntimeModule({
-							generateLoadBinaryCode,
+							generateLoadBinaryCode: analyzable
+								? generateAnalyzableLoadBinaryCode
+								: generateLoadBinaryCode,
 							supportsStreaming: true
 						})
 					);

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -68,7 +68,7 @@ class FetchCompileAsyncWasmPlugin {
 			 * @returns {string} code to load the wasm file
 			 */
 			const generateAnalyzableLoadBinaryCode = (path) =>
-				`fetch(new URL(${path}, ${compilation.outputOptions.importMetaName}.url))`;
+				`fetch(${compilation.runtimeTemplate.importMetaUrl(path)})`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.instantiateWasm)

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -69,14 +69,6 @@ class FetchCompileAsyncWasmPlugin {
 			 */
 			const generateAnalyzableLoadBinaryCode = (path) =>
 				`fetch(new URL(${path}, ${compilation.outputOptions.importMetaName}.url))`;
-			/**
-			 * The analyzable literal form only applies to ESM output with `auto`
-			 * public path; a custom public path keeps the runtime form.
-			 * @returns {boolean} true when the analyzable form should be emitted
-			 */
-			const isAnalyzable = () =>
-				compilation.runtimeTemplate.supportsAnalyzableEsm() &&
-				compilation.outputOptions.publicPath === "auto";
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.instantiateWasm)
@@ -90,7 +82,8 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const analyzable = isAnalyzable();
+					const analyzable =
+						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
 					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
@@ -120,7 +113,8 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const analyzable = isAnalyzable();
+					const analyzable =
+						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
 					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -83,7 +83,7 @@ class FetchCompileWasmPlugin {
 			 * @returns {string} code to load the wasm file
 			 */
 			const generateAnalyzableLoadBinaryCode = (path) =>
-				`fetch(new URL(${path}, ${compilation.outputOptions.importMetaName}.url))`;
+				`fetch(${compilation.runtimeTemplate.importMetaUrl(path)})`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunkHandlers)

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -68,13 +68,22 @@ class FetchCompileWasmPlugin {
 				return wasmLoading === "fetch";
 			};
 			/**
-			 * Generates the runtime expression that downloads the emitted wasm
-			 * binary for a module.
+			 * Downloads the emitted wasm binary through the runtime
+			 * `__webpack_require__.p` public path.
 			 * @param {string} path path to the wasm file
 			 * @returns {string} code to load the wasm file
 			 */
 			const generateLoadBinaryCode = (path) =>
 				`fetch(${RuntimeGlobals.publicPath} + ${path})`;
+			/**
+			 * ESM-output variant: the analyzable `fetch(new URL(path, import.meta.url))`
+			 * form (relative to the chunk, no runtime public-path global) that other
+			 * bundlers and webpack itself can statically follow to the emitted wasm.
+			 * @param {string} path path to the wasm file
+			 * @returns {string} code to load the wasm file
+			 */
+			const generateAnalyzableLoadBinaryCode = (path) =>
+				`fetch(new URL(${path}, ${compilation.outputOptions.importMetaName}.url))`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunkHandlers)
@@ -89,7 +98,9 @@ class FetchCompileWasmPlugin {
 						return;
 					}
 					set.add(RuntimeGlobals.moduleCache);
-					set.add(RuntimeGlobals.publicPath);
+					const analyzable =
+						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
+					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
@@ -98,7 +109,9 @@ class FetchCompileWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new WasmChunkLoadingRuntimeModule({
-							generateLoadBinaryCode,
+							generateLoadBinaryCode: analyzable
+								? generateAnalyzableLoadBinaryCode
+								: generateLoadBinaryCode,
 							supportsStreaming: true,
 							mangleImports: this.options.mangleImports,
 							runtimeRequirements: set

--- a/test/configCases/wasm/analyzable/index.js
+++ b/test/configCases/wasm/analyzable/index.js
@@ -1,0 +1,18 @@
+it("should load an async WebAssembly module referenced by an analyzable new URL", async () => {
+	const { run } = await import("./module");
+	expect(run()).toBe(84);
+});
+
+it("should emit the analyzable fetch(new URL(..., import.meta.url)) form without a runtime publicPath global", () => {
+	// `fs`/`path` come from `moduleScope` (web target has no node built-ins).
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+	// Built at runtime so the assertion doesn't self-match this file's source.
+	const publicPath = `${"__webpack_require__"}.p`;
+
+	expect(bundle).toMatch(/fetch\(new URL\([^;]*import\.meta\.url\)\)/);
+	// The wasm URL is relative to `import.meta.url`, so no runtime publicPath global.
+	expect(bundle).not.toContain(publicPath);
+});

--- a/test/configCases/wasm/analyzable/module.js
+++ b/test/configCases/wasm/analyzable/module.js
@@ -1,0 +1,6 @@
+import { getNumber } from "./wasm.wat?1";
+import { getNumber as getNumber2 } from "./wasm.wat?2";
+
+export function run() {
+	return getNumber() + getNumber2();
+}

--- a/test/configCases/wasm/analyzable/test.config.js
+++ b/test/configCases/wasm/analyzable/test.config.js
@@ -5,7 +5,6 @@ const path = require("path");
 
 module.exports = {
 	moduleScope(scope) {
-		scope.URL = URL;
 		scope.fs = fs;
 		scope.path = path;
 	}

--- a/test/configCases/wasm/analyzable/wasm.wat
+++ b/test/configCases/wasm/analyzable/wasm.wat
@@ -1,0 +1,9 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))

--- a/test/configCases/wasm/analyzable/webpack.config.js
+++ b/test/configCases/wasm/analyzable/webpack.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: false,
+	optimization: {
+		chunkIds: "named"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.wat$/,
+				loader: "wast-loader",
+				type: "webassembly/async"
+			}
+		]
+	},
+	output: {
+		module: true,
+		publicPath: "auto"
+	},
+	experiments: {
+		outputModule: true,
+		asyncWebAssembly: true
+	}
+};

--- a/test/configCases/worker/universal/index.js
+++ b/test/configCases/worker/universal/index.js
@@ -21,3 +21,20 @@ it("should allow to share chunks", async () => {
 	const { upper } = await import("./module");
 	expect(upper("ok")).toBe("OK");
 });
+
+it("should emit the analyzable literal worker URL for the universal target", () => {
+	// `fs`/`path` come from `moduleScope` (universal target has no node built-ins).
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+	// Built at runtime so the assertions don't self-match this file's source.
+	const workerCtor = `${"__webpack_require__"}.wc`;
+
+	// Analyzable literal `new URL("./worker.<chunk>.mjs", import.meta.url)`.
+	expect(bundle).toMatch(
+		/new URL\(\/\* worker import \*\/ "\.\/[^"]*\.mjs", import\.meta\.url\)/
+	);
+	// The universal target routes `Worker` through `__webpack_require__.wc`.
+	expect(bundle).toContain(workerCtor);
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -23355,6 +23355,17 @@ declare abstract class RuntimeTemplate {
 	supportsEcmaScriptModuleSyntax(): boolean;
 	supportsModulePreload(): boolean;
 	supportsAnalyzableEsm(): boolean;
+
+	/**
+	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm
+	 * binary path built from `wasmModuleId`) may be referenced with the analyzable
+	 * chunk-relative `new URL(path, import.meta.url)` form. Requires ESM output
+	 * (`supportsAnalyzableEsm`) and an `auto` public path — only then is the bare
+	 * relative URL equivalent to the runtime `__webpack_require__.p + path` form.
+	 * Callers that can bake the public path into a static literal specifier should
+	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
+	 */
+	supportsAnalyzableEsmUrl(): boolean;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -23366,6 +23366,14 @@ declare abstract class RuntimeTemplate {
 	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
 	 */
 	supportsAnalyzableEsmUrl(): boolean;
+
+	/**
+	 * Builds the analyzable `new URL(specifier, import.meta.url)` expression the ESM
+	 * wasm/asset loader backends use to reference an emitted binary relative to the
+	 * current module (via `output.importMetaName`) instead of the runtime public-path
+	 * global — the form other bundlers and webpack itself can statically follow.
+	 */
+	importMetaUrl(specifier: string): string;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Under ESM output, fetch-based WebAssembly now loads binaries via the analyzable `fetch(new URL(path, import.meta.url))` form — relative to the chunk, with no `__webpack_require__.p` runtime global — instead of `fetch(__webpack_require__.p + path)`. This matches the universal and node read-file wasm backends and webpack's existing analyzable `new URL` / `new Worker` / `import()` output, so other bundlers and webpack itself can statically follow the emitted wasm. The form is gated to ESM output with an `auto` public path (a custom public path keeps the runtime form) and applies to both async and sync fetch wasm.

It also verifies and covers that the universal target already emits the analyzable literal worker URL through `__webpack_require__.wc`, and consolidates the analyzability decision and the `new URL(..., import.meta.url)` construction into shared `RuntimeTemplate` helpers (`supportsAnalyzableEsmUrl`, `importMetaUrl`) reused across the wasm and node CSS ESM backends.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new `test/configCases/wasm/analyzable/` (runs an async wasm module and asserts the `fetch(new URL(..., import.meta.url))` form with no runtime public-path global), and an analyzable-output assertion added to `test/configCases/worker/universal/`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — output-format detail only; non-ESM and custom-public-path builds keep the previous runtime form.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Implemented with Claude Code (Anthropic): the plugin changes, the `RuntimeTemplate` helpers, tests, and changeset were drafted and iterated with AI assistance, then reviewed and verified locally (wasm/css/worker config suites, round-trip, `tsc`, lint) before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgTSaorShDnHzhDLribgo1)_