### PR TITLE
perf: avoid quadratic sibling lookahead and per-function name slices in the CSS parser

### DIFF
--- a/.changeset/056-css-parser-walk-index.md
+++ b/.changeset/056-css-parser-walk-index.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up CSS parsing: byte-range function-name checks, indexed sibling lookahead.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -82,6 +82,7 @@ const CC_FORM_FEED = "\f".charCodeAt(0);
 const CC_LEFT_CURLY = "{".charCodeAt(0);
 const CC_LOWER_V = "v".charCodeAt(0);
 const CC_UPPER_V = "V".charCodeAt(0);
+const CC_REVERSE_SOLIDUS = "\\".charCodeAt(0);
 
 // A parsed CSS comment. `loc` is computed on demand — only magic-comment error
 // warnings read it, so comment-heavy CSS skips the per-comment line/col work.
@@ -593,6 +594,20 @@ const isContainerKeyword = (input, start, end) => {
 		default:
 			return false;
 	}
+};
+
+/**
+ * Whether the byte range contains a CSS escape (`\`) — function names are short, so this scan replaces a per-name slice.
+ * @param {string} input source
+ * @param {number} start start offset
+ * @param {number} end end offset (exclusive)
+ * @returns {boolean} true when the range contains a backslash
+ */
+const rangeHasEscape = (input, start, end) => {
+	for (let i = start; i < end; i++) {
+		if (input.charCodeAt(i) === CC_REVERSE_SOLIDUS) return true;
+	}
+	return false;
 };
 
 /**
@@ -1848,26 +1863,6 @@ class CssParser extends Parser {
 			}
 		};
 
-		/**
-		 * The child list of an AST node (a function/block `value` or a rule `prelude`) for sibling lookahead.
-		 * @param {AstNode | null} parent parent node
-		 * @returns {AstNode[] | undefined} the child list, or undefined
-		 */
-		const childrenOf = (parent) => {
-			if (!parent) return undefined;
-			switch (A.type(parent)) {
-				case NodeType.Function:
-				case NodeType.SimpleBlock:
-				case NodeType.Declaration:
-					return A.children(parent);
-				case NodeType.AtRule:
-				case NodeType.QualifiedRule:
-					return A.prelude(parent);
-				default:
-					return undefined;
-			}
-		};
-
 		// `allowImport` mirrors `allowImportAtRule`: true until the first top-level block-bearing rule.
 		let allowImport = true;
 		// Persistent CSS-Modules mode for a top-level rule: set by bare `:local` / `:global`, leaks into sibling rules, reset at each top-level `}`.
@@ -2639,10 +2634,39 @@ class CssParser extends Parser {
 		/**
 		 * Emit url() deps for a `url(...)` / `src(...)` / `image-set(...)` value function.
 		 * @param {FunctionNode} fn the function node
-		 * @param {string} fname the unescaped function name (any case)
+		 * @param {string | undefined} escapedName the unescaped function name when it carries an escape, undefined for the raw byte-range path
 		 */
-		const emitUrlFunction = (fn, fname) => {
-			if (equalsLowerCase(fname, "url") || equalsLowerCase(fname, "src")) {
+		const emitUrlFunction = (fn, escapedName) => {
+			const fnNameStart = A.nameStart(fn);
+			const fnNameEnd = A.nameEnd(fn);
+			let isUrlOrSrc;
+			let isImageSet = false;
+			if (escapedName !== undefined) {
+				isUrlOrSrc =
+					equalsLowerCase(escapedName, "url") ||
+					equalsLowerCase(escapedName, "src");
+				if (!isUrlOrSrc) isImageSet = IMAGE_SET_FUNCTION.test(escapedName);
+			} else {
+				const nameLength = fnNameEnd - fnNameStart;
+				isUrlOrSrc =
+					nameLength === 3 &&
+					(rangeEqualsLowerCase(input, fnNameStart, fnNameEnd, "url") ||
+						rangeEqualsLowerCase(input, fnNameStart, fnNameEnd, "src"));
+				if (!isUrlOrSrc) {
+					// Suffix probe first, so only a vendor-prefixed `…-image-set` pays the slice + regex.
+					isImageSet =
+						nameLength >= 9 &&
+						rangeEqualsLowerCase(
+							input,
+							fnNameEnd - 9,
+							fnNameEnd,
+							"image-set"
+						) &&
+						(nameLength === 9 ||
+							IMAGE_SET_FUNCTION.test(input.slice(fnNameStart, fnNameEnd)));
+				}
+			}
+			if (isUrlOrSrc) {
 				// Quoted `url("…")` / `src("…")`: first non-whitespace value must be the string token.
 				const first = A.children(fn)[nextNonWhitespace(A.children(fn), 0)];
 				if (!first || A.type(first) !== NodeType.String) return;
@@ -2673,9 +2697,9 @@ class CssParser extends Parser {
 				);
 				module.addDependency(dep);
 				module.addCodeGenerationDependency(dep);
-			} else if (IMAGE_SET_FUNCTION.test(fname)) {
+			} else if (isImageSet) {
 				// `image-set(…)`: each comma segment's first string is the URL; advance the magic-comment fence per string.
-				lastTokenEndForComments = A.nameEnd(fn) + 1;
+				lastTokenEndForComments = fnNameEnd + 1;
 				let prevStringEnd = A.start(fn);
 				let firstInSegment = true;
 				for (const cv of A.children(fn)) {
@@ -4052,12 +4076,34 @@ class CssParser extends Parser {
 				enter: (path) => {
 					const node = path.node;
 					const fn = /** @type {FunctionNode} */ (node);
-					const fnameRaw = A.unescapedName(fn);
-					// `equalsLowerCase` keeps this visitor free of a per-function
-					// lowercased copy — functions are the densest value nodes.
-					const isLocalFn = equalsLowerCase(fnameRaw, "local");
-					const isGlobalFn = !isLocalFn && equalsLowerCase(fnameRaw, "global");
-					if (urlActive()) emitUrlFunction(fn, fnameRaw);
+					const fnNameStart = A.nameStart(fn);
+					const fnNameEnd = A.nameEnd(fn);
+					const fnNameLength = fnNameEnd - fnNameStart;
+					// Functions are the densest value nodes, so the name is matched by raw byte range; only a name carrying an escape (rare) pays the unescaped slice.
+					/** @type {string | undefined} */
+					let escapedName;
+					let isLocalFn = false;
+					let isGlobalFn = false;
+					if (rangeHasEscape(input, fnNameStart, fnNameEnd)) {
+						escapedName = A.unescapedName(fn);
+						isLocalFn = equalsLowerCase(escapedName, "local");
+						isGlobalFn = !isLocalFn && equalsLowerCase(escapedName, "global");
+					} else if (fnNameLength === 5) {
+						isLocalFn = rangeEqualsLowerCase(
+							input,
+							fnNameStart,
+							fnNameEnd,
+							"local"
+						);
+					} else if (fnNameLength === 6) {
+						isGlobalFn = rangeEqualsLowerCase(
+							input,
+							fnNameStart,
+							fnNameEnd,
+							"global"
+						);
+					}
+					if (urlActive()) emitUrlFunction(fn, escapedName);
 					if (localGlobalActive() && (isLocalFn || isGlobalFn)) {
 						processLocalOrGlobalFunction(fn, isLocalFn ? 1 : 2);
 					}
@@ -4065,10 +4111,16 @@ class CssParser extends Parser {
 						icssActive() &&
 						!isLocalFn &&
 						!isGlobalFn &&
-						!(dashed.active && isDashedIdentifier(fnameRaw)) &&
-						icssDefinitions.has(fnameRaw)
+						icssDefinitions.size !== 0
 					) {
-						emitICSSSymbol(fnameRaw, A.nameStart(fn), A.nameEnd(fn));
+						// Without an escape the raw name equals the unescaped one — only the `@value`-lookup path needs the string at all.
+						const fname = escapedName === undefined ? A.name(fn) : escapedName;
+						if (
+							!(dashed.active && isDashedIdentifier(fname)) &&
+							icssDefinitions.has(fname)
+						) {
+							emitICSSSymbol(fname, fnNameStart, fnNameEnd);
+						}
 					}
 					// Dashed-ident scoping: handle this function, then set the child nesting level's state for the walk.
 					dashed.push();
@@ -4077,15 +4129,35 @@ class CssParser extends Parser {
 							// `local()` / `global()` dashed args go through the ICSS path above, not here.
 							dashed.active = false;
 						} else if (
-							equalsLowerCase(fnameRaw, "var") ||
-							equalsLowerCase(fnameRaw, "style")
+							escapedName === undefined
+								? (fnNameLength === 3 &&
+										rangeEqualsLowerCase(
+											input,
+											fnNameStart,
+											fnNameEnd,
+											"var"
+										)) ||
+									(fnNameLength === 5 &&
+										rangeEqualsLowerCase(
+											input,
+											fnNameStart,
+											fnNameEnd,
+											"style"
+										))
+								: equalsLowerCase(escapedName, "var") ||
+									equalsLowerCase(escapedName, "style")
 						) {
 							// `var(--foo, …)` / `style(--foo, …)`: emit the first ident; the fallback doesn't self-emit.
 							processDashedIdentInVarFunction(fn);
 							dashed.emit = false;
-						} else if (dashed.emit && isDashedIdentifier(A.name(fn))) {
-							// Custom-function call `--my-func(args)` — the name is the exported dashed-ident.
-							emitDashedIdentExport(A.nameStart(fn), A.nameEnd(fn));
+						} else if (
+							dashed.emit &&
+							fnNameLength >= 3 &&
+							input.charCodeAt(fnNameStart) === CC_HYPHEN_MINUS &&
+							input.charCodeAt(fnNameStart + 1) === CC_HYPHEN_MINUS
+						) {
+							// Custom-function call `--my-func(args)` — the name is the exported dashed-ident (a literal `--` prefix, like the `A.name` string check it replaces).
+							emitDashedIdentExport(fnNameStart, fnNameEnd);
 						}
 					}
 				},
@@ -4107,23 +4179,36 @@ class CssParser extends Parser {
 				if (dashedActive && isDashedIdentifier(identValue)) {
 					// Dashed idents are scoped here, never `@value` ICSS-rewritten.
 					if (!dashed.emit) return;
-					// Resolve the `--foo from "./x.css"` / `--foo from global` import suffix via sibling lookahead.
-					const siblings = childrenOf(path.parent);
-					const i = siblings ? siblings.indexOf(node) : -1;
-					if (siblings && i !== -1) {
-						const j = nextNonWhitespace(siblings, i + 1);
+					// Resolve the `--foo from "./x.css"` / `--foo from global` import suffix via sibling lookahead over the parent's child span (`path.index` avoids materializing the sibling list per dashed ident).
+					const parent = path.parent;
+					if (parent) {
+						const count = A.childCount(parent);
+						let j = path.index + 1;
+						while (
+							j < count &&
+							A.type(A.childAt(parent, j)) === NodeType.Whitespace
+						) {
+							j++;
+						}
+						const fromIdent = j < count ? A.childAt(parent, j) : undefined;
 						if (
-							j < siblings.length &&
-							A.type(siblings[j]) === NodeType.Ident &&
+							fromIdent &&
+							A.type(fromIdent) === NodeType.Ident &&
 							rangeEqualsLowerCase(
 								input,
-								A.start(siblings[j]),
-								A.end(siblings[j]),
+								A.start(fromIdent),
+								A.end(fromIdent),
 								"from"
 							)
 						) {
-							const fromIdent = siblings[j];
-							const sourceNode = siblings[nextNonWhitespace(siblings, j + 1)];
+							j++;
+							while (
+								j < count &&
+								A.type(A.childAt(parent, j)) === NodeType.Whitespace
+							) {
+								j++;
+							}
+							const sourceNode = j < count ? A.childAt(parent, j) : undefined;
 							if (
 								sourceNode &&
 								A.type(sourceNode) === NodeType.Ident &&

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3565,6 +3565,7 @@ const _grammarOnComment = (_src, start, end) => {
 	const node = _makeLeaf(T_COMMENT, start, end);
 	_currentNode = node;
 	_currentParent = null;
+	_currentIndex = 0;
 	const bucket = /** @type {CompiledVisitorBucket} */ (_commentBucket);
 	const e = bucket.enter;
 	for (let i = 0; i < e.length; i++) e[i](A);
@@ -3579,8 +3580,9 @@ const _grammarOnComment = (_src, start, end) => {
  * loops — `for…of` would allocate an iterator per node on this hot path.
  * @param {Node} node component-value root
  * @param {Node | null} parent enclosing node
+ * @param {number} index node's index within its sibling list
  */
-const _walkValue = (node, parent) => {
+const _walkValue = (node, parent, index) => {
 	const ty = _types[_nodeIndex(node)];
 	const b = _visitors[ty];
 	let skip = false;
@@ -3588,6 +3590,7 @@ const _walkValue = (node, parent) => {
 		_walkSkip = false;
 		_currentNode = node;
 		_currentParent = parent;
+		_currentIndex = index;
 		const e = b.enter;
 		for (let i = 0; i < e.length; i++) e[i](A);
 		skip = _walkSkip;
@@ -3597,12 +3600,13 @@ const _walkValue = (node, parent) => {
 		const i0 = _nodeIndex(node);
 		const vs = _listStarts[i0];
 		const ve = vs + _listLens[i0];
-		for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_flat[i]), node);
+		for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_flat[i]), node, i - vs);
 	}
 	if (b !== undefined) {
 		// Rebind: descending into children moved the path.
 		_currentNode = node;
 		_currentParent = parent;
+		_currentIndex = index;
 		const x = b.exit;
 		for (let i = 0; i < x.length; i++) x[i](A);
 	}
@@ -3613,8 +3617,9 @@ const _walkValue = (node, parent) => {
  * eagerly (§5.4.4), so its `value` holds the nested rules / declarations.
  * @param {Node} node structural-tree root
  * @param {Node | null} parent enclosing node
+ * @param {number} index node's index within its sibling list (declarations and child rules index independently)
  */
-const _walkRule = (node, parent) => {
+const _walkRule = (node, parent, index) => {
 	const i0 = _nodeIndex(node);
 	const ty = _types[i0];
 	const b = _visitors[ty];
@@ -3623,6 +3628,7 @@ const _walkRule = (node, parent) => {
 		_walkSkip = false;
 		_currentNode = node;
 		_currentParent = parent;
+		_currentIndex = index;
 		const e = b.enter;
 		for (let i = 0; i < e.length; i++) e[i](A);
 		skip = _walkSkip;
@@ -3632,26 +3638,31 @@ const _walkRule = (node, parent) => {
 		if (ty === T_AT_RULE || ty === T_QUALIFIED_RULE) {
 			const ps = _listStarts[i0];
 			const pe = ps + _listLens[i0];
-			for (let i = ps; i < pe; i++) _walkValue(_nodeRef(_flat[i]), node);
+			for (let i = ps; i < pe; i++) {
+				_walkValue(_nodeRef(_flat[i]), node, i - ps);
+			}
 			if (_recurseBlocks) {
 				// Declarations then child rules — downstream consumers don't need them strictly interleaved in source order.
 				const decls = _declarationLists[i0];
 				if (decls) {
-					for (let i = 0; i < decls.length; i++) _walkRule(decls[i], node);
+					for (let i = 0; i < decls.length; i++) _walkRule(decls[i], node, i);
 				}
 				const ch = _childRuleLists[i0];
-				if (ch) for (let i = 0; i < ch.length; i++) _walkRule(ch[i], node);
+				if (ch) for (let i = 0; i < ch.length; i++) _walkRule(ch[i], node, i);
 			}
 		} else if (ty === T_DECLARATION) {
 			const vs = _listStarts[i0];
 			const ve = vs + _listLens[i0];
-			for (let i = vs; i < ve; i++) _walkValue(_nodeRef(_flat[i]), node);
+			for (let i = vs; i < ve; i++) {
+				_walkValue(_nodeRef(_flat[i]), node, i - vs);
+			}
 		}
 	}
 	if (b !== undefined) {
 		// Rebind: descending into children moved the path.
 		_currentNode = node;
 		_currentParent = parent;
+		_currentIndex = index;
 		const x = b.exit;
 		for (let i = 0; i < x.length; i++) x[i](A);
 	}
@@ -3663,7 +3674,7 @@ const _walkRule = (node, parent) => {
  * @param {Rule | Declaration} node top-level node
  */
 const _walkTopLevel = (node) => {
-	_walkRule(node, null);
+	_walkRule(node, null, 0);
 	if (_nodeCount > _peak) _peak = _nodeCount;
 	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
 	_nodeCount = 0;
@@ -3811,6 +3822,9 @@ let _walkSkip = false;
 let _currentNode = /** @type {Node} */ (/** @type {unknown} */ (0));
 /** @type {Node | null} */
 let _currentParent = null;
+// Index of the current node within its sibling list (a rule body's declarations
+// and child rules are separate lists, so each indexes from 0 independently).
+let _currentIndex = 0;
 
 // AST field-access seam. Every AST-node field read by `CssParser` goes through
 // one of these accessors (`n` is an integer node id into the columns), so
@@ -3830,6 +3844,12 @@ const A = {
 	 */
 	get parent() {
 		return _currentParent;
+	},
+	/**
+	 * @returns {number} index of the current node within its sibling list (0 for a top-level node) — only valid during a visitor callback
+	 */
+	get index() {
+		return _currentIndex;
 	},
 	/** Stop the walk descending into the current node (enter only). */
 	skipChildren() {
@@ -3989,6 +4009,23 @@ const A = {
 	 */
 	prelude(n = _currentNode) {
 		return /** @type {ComponentValue[]} */ (_materializeList(n));
+	},
+	/**
+	 * @param {Node=} n node
+	 * @returns {number} number of children (value / prelude) without materializing the list
+	 */
+	childCount(n = _currentNode) {
+		return _listLens[_nodeIndex(n)];
+	},
+	/**
+	 * @param {Node} n node
+	 * @param {number} i child index (`0 <= i < childCount(n)`)
+	 * @returns {ComponentValue} i-th child (value / prelude) without materializing the list
+	 */
+	childAt(n, i) {
+		return /** @type {ComponentValue} */ (
+			_nodeRef(_flat[_listStarts[_nodeIndex(n)] + i])
+		);
 	},
 	/**
 	 * @param {Node=} n node


### PR DESCRIPTION
The walk now tracks each node's index within its sibling list (path.index) and exposes flat-span accessors (childCount/childAt), so the dashed-ident 'from' lookahead no longer materializes the sibling list and scans it per ident (~80x faster on a 4000-entry timeline-scope list). Function names are matched by byte range instead of slicing an unescaped copy per function node; only names carrying an escape pay the slice (~10% on function-dense CSS Modules).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->