### PR TITLE
docs: restructure AGENTS.md into standard CLAUDE.md sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,40 @@
 
 A `> [!REQUIRED]` callout placed immediately under a heading marks that whole section as **mandatory and not optional**: follow it exactly, do not paraphrase, do not skip, do not substitute a similar-looking convention from other tooling. Reviewers have repeatedly flagged that REQUIRED sections (especially the [Pull request body](#pull-request-body)) are being skipped or partially filled in — doing so blocks the PR every time. Read each REQUIRED section in full whenever it applies; do not rely on memory or on a previous task's output. Sections without the callout are normal guidance — apply judgement.
 
-## Project Overview
+## Project overview
+
+webpack is a JavaScript module bundler. It builds a dependency graph from entry modules and emits optimized static assets (chunks) for browsers, Node.js, and other targets. The config API is defined by JSON schemas and everything is wired through a `tapable` plugin/hook architecture.
+
+## Tech stack
+
+- **Language:** JavaScript. `lib/` is **CommonJS only**; types are declared via JSDoc `@typedef` and compiled into `types.d.ts`.
+- **Package manager:** **yarn** (not npm).
+- **Parser:** acorn (JavaScript AST).
+- **Tests:** jest, run through the `test:base` wrapper (never bare `jest`).
+- **Type checking / generation:** TypeScript, driven over the JSDoc annotations.
+
+## Commands
+
+All commands are defined in `package.json` `scripts`.
+
+| Command | What it does |
+| --- | --- |
+| `yarn fix` | `fix:code` (ESLint) + `fix:special` (regenerate types/validators) + `fmt` (Prettier). Prefer as the final step. |
+| `yarn fix:special` | Regenerate `types.d.ts`, declarations, schema validators, and generated runtime code. |
+| `yarn tsc` | TypeScript type check (catches type errors in JSDoc annotations). |
+| `yarn test:base --testPathPatterns="<pattern>"` | Run targeted tests. Also `yarn test:base -t "<name>"`. |
+| `yarn test:base -u` | Update snapshots (eyeball the diff first). |
+| `yarn cover:unit` | Unit-test coverage. |
+| `yarn build:examples` | Build the `examples/` (verify after changing options). |
+| `yarn test` | Full suite — don't run unless asked. |
+
+Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. See [TESTING_DOCS.md](TESTING_DOCS.md) for how to run a single case.
+
+## Architecture
 
 > [!REQUIRED]
 
 The directory listings below are the canonical map of the repository. **Whenever you add, rename, or remove a top-level directory** (under the repo root, under `lib/`, under `test/`, or under `schemas/`) you must update the matching bullet here in the same commit. CI does not check this — drift is only caught by humans, which is why it must be part of the change itself. If a new directory does not fit any existing group, add a new group rather than dropping the entry.
-
-webpack is a JavaScript module bundler. Package manager: **yarn**.
 
 **Source**
 
@@ -72,10 +99,6 @@ webpack is a JavaScript module bundler. Package manager: **yarn**.
 - `examples/` — Usage examples (build with `yarn build:examples`).
 - `.changeset/` — Pending changeset files for the next release.
 
-**Auto-generated — do not edit by hand; regenerate via `yarn fix:special`**
-
-- `types.d.ts`, `declarations/**/*.d.ts`, `schemas/**/*.check.{js,d.ts}`, generated runtime code under `lib/`.
-
 **Hand-maintained type declarations (these _are_ editable)**
 
 - `declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`.
@@ -88,7 +111,16 @@ webpack is a JavaScript module bundler. Package manager: **yarn**.
 - `.github/workflows/`, `.github/scripts/` — CI.
 - `test/patches/` — test-only dependency patches (e.g. jest-worker) applied via `git apply` in the CI Bun test job.
 
-## Coding Standards
+**How data flows — adding or renaming a webpack option** requires edits in every layer, in this order:
+
+1. **Schema** — `schemas/WebpackOptions.json` (or `schemas/plugins/<Name>.json`).
+2. **Defaults** — `lib/config/defaults.js`.
+3. **Normalization** — `lib/config/normalization.js`.
+4. **Implementation** — the site that consumes the option.
+
+Skipping any layer silently breaks the option. After editing schemas, run `yarn fix:special` so `lib/` code can reference the updated types. If you added or modified options, consider updating `examples/` and run `yarn build:examples` to verify.
+
+## Code conventions
 
 ### Source language: CommonJS + JSDoc
 
@@ -118,63 +150,21 @@ Comments inside `lib/`, `hot/`, `tooling/`, and `test/` must be **as short as po
 
 JSDoc on exported symbols stays as-is — that's the type contract, not commentary.
 
-## Performance and memory
+## Testing
 
-webpack is a bundler — users measure it by build time and peak heap usage. Many changes in `lib/` end up on per-module hot paths (sometimes per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so large compilation data structures are not retained longer than necessary. See #15521 for an example of how this class of memory issue can surface.
-
-### Keep instance shapes stable
-
-Initialize **every** instance field in the constructor, including ones first assigned later in a method — default them to `undefined`/`null`. Assigning `this.newField` for the first time outside the constructor forces a V8 hidden-class (Shape) transition, so instances of one class end up split across shapes and the inline caches reading them go polymorphic/megamorphic — a hot property read can cost ~2× at two shapes and more when megamorphic, and code already optimized for the first shape deopts with a `wrong map` bailout. Never `delete` an instance field (it forces the object into dictionary mode); set it to `undefined` instead. The win per field is small for a single trailing field, but the rule is uniform on purpose so reviewers don't judge it case by case — it is why, for example, `Dependency` sets all its `_loc*` slots up front. Deliberate symbol-keyed sparse slots are the documented exception.
-
-When adding a field to a class whose fields are compiled into `types.d.ts` (public, non-`_`-prefixed), re-run `yarn fix:special` — constructor order determines member order in the generated declarations.
-
-## Auto-generated files
-
-> [!REQUIRED]
-
-These files are produced by `yarn fix:special` and must not be edited by hand:
-
-- `types.d.ts` — compiled from JSDoc + schemas.
-- `declarations/**/*.d.ts` — per-schema/plugin declarations emitted from `schemas/**/*.json`.
-- `schemas/**/*.check.{js,d.ts}` — precompiled schema validators.
-- Generated runtime code under `lib/` (driven by `tooling/generate-runtime-code.js`).
-
-The hand-maintained type declarations (`declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`) _are_ editable.
-
-Re-run `yarn fix:special` **before the next commit** whenever you touch:
-
-- `schemas/**/*.json` — reshapes validators, declarations, and `types.d.ts`.
-- `lib/**/*.js` JSDoc on anything reachable from a public export — regenerates `types.d.ts`.
-- `tooling/generate-runtime-code.js`, `tooling/generate-wasm-code.js`, or any file they consume.
-
-CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` script runs `fix:code` + `fix:special` + `fmt` in one go; prefer it as the final step.
-
-## Development Workflow
-
-### 1. Making Changes
-
-Modify source code in `lib/` as needed.
-
-**Adding or renaming a webpack option** requires edits in every layer, in this order:
-
-1. **Schema** — `schemas/WebpackOptions.json` (or `schemas/plugins/<Name>.json`).
-2. **Defaults** — `lib/config/defaults.js`.
-3. **Normalization** — `lib/config/normalization.js`.
-4. **Implementation** — the site that consumes the option.
-
-Skipping any layer silently breaks the option. After editing schemas, run `yarn fix:special` so `lib/` code can reference the updated types.
-
-### 2. Writing and Running Tests
+For directory structure, naming, and how to run a single case, see [TESTING_DOCS.md](TESTING_DOCS.md).
 
 **For bug fixes, always write the test case first.** Run the test to confirm it fails, then make the code change and re-run. For new features, tests can be written alongside or after.
 
 **Prefer integration tests over unit tests.** Cover behavior with an integration case (`configCases/`, `watchCases/`, `hotCases/`, `statsCases/`, …) that drives a real `webpack()` build whenever the behavior can be exercised that way — they catch real-world regressions a mocked unit test misses. Reach for a `*.unittest.js` only for pure helpers/utilities that a build can't naturally reach.
 
-Run targeted tests — `yarn test:base --testPathPatterns="<pattern>"` or `yarn test:base -t "<name>"`. Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. Don't run `yarn test` unless asked. When updating snapshots (`yarn test:base -u`), eyeball the diff first. See [TESTING_DOCS.md](TESTING_DOCS.md) for details.
+Run targeted tests — `yarn test:base --testPathPatterns="<pattern>"` or `yarn test:base -t "<name>"`. Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. Don't run `yarn test` unless asked. When updating snapshots (`yarn test:base -u`), eyeball the diff first.
 
 **Cover every line you add or change.** A commit must not lower coverage: each new branch, fast path, and fallback needs a test that exercises it (Codecov enforces this on the patch, target 90%+). When a change adds branches that integration cases don't reach — e.g. tokenizer fast paths and their cold-path fallbacks — add a focused `*.unittest.js` that drives each branch (both the fast and delegated paths). Check `yarn cover:unit` locally, or the PR's Codecov "patch" report, and add cases until no changed line is missing.
 
-### 3. Adding a Changeset
+## Git & PR rules
+
+### Adding a Changeset
 
 Every user-facing change needs a changeset file:
 
@@ -197,20 +187,7 @@ Use `patch` for bug fixes, `minor` for new features, `major` for breaking change
 
 **Filename controls ordering — prefix by importance.** Changesets render grouped by bump level (Major → Minor → Patch); within each section entries appear in **sorted `.changeset` filename order**. Name every changeset `NNN-<description>.md` with a zero-padded numeric prefix (`010-`, `020-`, …) so the lowest number sorts first and lands at the top of its section. Order by importance: user-facing features first, then correctness fixes, then performance, then internal/build/chore. Pick a prefix that slots your entry into the right place relative to the files already there (leave gaps so later entries fit between).
 
-### 4. Updating Examples (if needed)
-
-If WebpackOptions were added or modified, consider updating examples in `examples/`. Run `yarn build:examples` to verify.
-
-### 5. Linting and Formatting
-
-```bash
-yarn fix           # fix:code (ESLint) + fix:special (regenerate types/validators) + fmt (Prettier)
-yarn tsc           # TypeScript type check (catches type errors in JSDoc annotations)
-```
-
-### 6. Git Commit & Pull Request
-
-#### Branch name
+### Branch name
 
 > [!REQUIRED]
 
@@ -238,7 +215,7 @@ Do **not** use `claude/`, `claude-code/`, `bot/`, `ai/`, or any tool/agent ident
 
 If the task harness pre-created a branch with a different prefix, rename it before the first push: `git branch -m <new-name>`.
 
-#### Commit rules
+### Commit rules
 
 > [!REQUIRED]
 
@@ -256,7 +233,7 @@ git -c user.name="<login>" -c user.email="<email>" commit -m "…"
 
 **Keep the commit description body compact:** lead with a short imperative subject, and add body paragraphs only when the change is complex enough to need them — then keep them tight. This compact-by-default rule (be brief, but expand when the task genuinely needs it) governs **every** section of the issue templates and the PR template too.
 
-#### Pull request body
+### Pull request body
 
 > [!REQUIRED]
 
@@ -317,11 +294,11 @@ Required answer per section — **one sentence each is the target, two or three 
 - **If relevant, what needs to be documented…** — list doc updates or write `n/a`.
 - **Use of AI** — state that AI was used and how. Per the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md), omitting or misrepresenting this can get the PR closed.
 
-#### After push — verify PR body
+### After push — verify PR body
 
 After every `git push` of a new branch, check whether a PR was auto-created (webpack has this webhook). If so, `update_pull_request` to install the full template — the auto-created body never matches.
 
-#### After opening the PR — wait for Copilot review
+### After opening the PR — wait for Copilot review
 
 > [!REQUIRED]
 
@@ -333,3 +310,43 @@ Every webpack PR gets an automated **GitHub Copilot code review** on the initial
    - If wrong, reply on the thread with a short reason — never ignore silently.
 3. After every push, Copilot re-reviews. Repeat step 2. The loop ends when Copilot's latest review has zero outstanding threads.
 4. Only `unsubscribe_pr_activity` once all comments are handled and CI is green, or when the user tells you to stop.
+
+## Do not touch
+
+> [!REQUIRED]
+
+These files are produced by `yarn fix:special` and must not be edited by hand:
+
+- `types.d.ts` — compiled from JSDoc + schemas.
+- `declarations/**/*.d.ts` — per-schema/plugin declarations emitted from `schemas/**/*.json`.
+- `schemas/**/*.check.{js,d.ts}` — precompiled schema validators.
+- Generated runtime code under `lib/` (driven by `tooling/generate-runtime-code.js`).
+
+The hand-maintained type declarations (`declarations.d.ts`, `declarations.test.d.ts`, `module.d.ts`) _are_ editable.
+
+Re-run `yarn fix:special` **before the next commit** whenever you touch:
+
+- `schemas/**/*.json` — reshapes validators, declarations, and `types.d.ts`.
+- `lib/**/*.js` JSDoc on anything reachable from a public export — regenerates `types.d.ts`.
+- `tooling/generate-runtime-code.js`, `tooling/generate-wasm-code.js`, or any file they consume.
+
+CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` script runs `fix:code` + `fix:special` + `fmt` in one go; prefer it as the final step.
+
+## Gotchas
+
+### Performance and memory
+
+webpack is a bundler — users measure it by build time and peak heap usage. Many changes in `lib/` end up on per-module hot paths (sometimes per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so large compilation data structures are not retained longer than necessary. See #15521 for an example of how this class of memory issue can surface.
+
+### Keep instance shapes stable
+
+Initialize **every** instance field in the constructor, including ones first assigned later in a method — default them to `undefined`/`null`. Assigning `this.newField` for the first time outside the constructor forces a V8 hidden-class (Shape) transition, so instances of one class end up split across shapes and the inline caches reading them go polymorphic/megamorphic — a hot property read can cost ~2× at two shapes and more when megamorphic, and code already optimized for the first shape deopts with a `wrong map` bailout. Never `delete` an instance field (it forces the object into dictionary mode); set it to `undefined` instead. The win per field is small for a single trailing field, but the rule is uniform on purpose so reviewers don't judge it case by case — it is why, for example, `Dependency` sets all its `_loc*` slots up front. Deliberate symbol-keyed sparse slots are the documented exception.
+
+When adding a field to a class whose fields are compiled into `types.d.ts` (public, non-`_`-prefixed), re-run `yarn fix:special` — constructor order determines member order in the generated declarations.
+
+## @imports
+
+Keep this file short; pull detail in on demand from:
+
+- [TESTING_DOCS.md](TESTING_DOCS.md) — test directory structure, naming, and how to run a single case.
+- [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md) — required reading before disclosing **Use of AI** in a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,10 @@ The directory listings below are the canonical map of the repository. **Whenever
 
 Skipping any layer silently breaks the option. After editing schemas, run `yarn fix:special` so `lib/` code can reference the updated types. If you added or modified options, consider updating `examples/` and run `yarn build:examples` to verify.
 
+The two config layers differ: **`normalization.js`** canonicalizes the user-supplied config shape (shorthand → full form); **`defaults.js`** fills in values (often mode/target-dependent). Edit whichever matches your change.
+
+**Adding a new dependency type:** pair the `Dependency` subclass with a `DependencyTemplate` (it emits the generated code), register the class with `makeSerializable(...)`, and wire the template into `compilation.dependencyTemplates`.
+
 ## Code conventions
 
 ### Source language: CommonJS + JSDoc
@@ -354,6 +358,14 @@ Re-run `yarn fix:special` **before the next commit** whenever you touch:
 CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` script runs `fix:code` + `fix:special` + `fmt` in one go; prefer it as the final step.
 
 ## Gotchas
+
+### Target the Node baseline
+
+`lib/` and `hot/` ship untranspiled and must run on **Node ≥ 10.13** (the CI matrix goes down to Node 10.x). Don't use syntax or runtime APIs newer than that baseline — e.g. no optional chaining (`?.`) or nullish coalescing (`??`) — or the code passes locally and fails the Node 10 CI job.
+
+### Register serializable classes
+
+Persistent caching serializes the module graph, so any new serializable class (a `Module`, `Dependency`, or error subclass, a cached value, …) must call `makeSerializable(...)` — the pattern is used across ~140 files. Run `yarn fix:serializables` to regenerate `internalSerializables`; forgetting silently breaks the persistent cache.
 
 ### Performance and memory
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,22 +23,22 @@ webpack is a JavaScript module bundler. It builds a dependency graph from entry 
 
 All commands are defined in `package.json` `scripts`.
 
-| Command | What it does |
-| --- | --- |
-| `yarn fix` | `fix:code` (ESLint) + `fix:special` (regenerate types/validators) + `fmt` (Prettier). Prefer as the final step. |
-| `yarn fix:special` | Regenerate `types.d.ts`, declarations, schema validators, and generated runtime code. |
-| `yarn lint` | Full lint: ESLint + generated-output checks + every `tsc` project + Prettier + spellcheck (what CI runs). |
-| `yarn tsc` | TypeScript type check of `lib/` JSDoc (catches type errors in annotations). |
-| `yarn validate:changeset` | Validate the pending `.changeset/` files. |
-| `yarn test:base --testPathPatterns="<pattern>"` | Run targeted tests. Also `yarn test:base -t "<name>"`. |
-| `yarn test:unit` | Run all `*.unittest.js`. |
-| `yarn test:integration` | Run the integration suites (`basictest`/`longtest`/`test`). |
-| `yarn test:test262` / `yarn test:html5lib` / `yarn test:css-parsing` | Spec-conformance suites. |
-| `yarn test:base -u` | Update snapshots (eyeball the diff first). |
-| `yarn cover:unit` | Unit-test coverage. |
-| `yarn types:cover` | Type-coverage report (share of `lib/` that is precisely typed). |
-| `yarn build:examples` | Build the `examples/` (verify after changing options). |
-| `yarn test` | Full suite — don't run unless asked. |
+| Command                                                              | What it does                                                                                                    |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `yarn fix`                                                           | `fix:code` (ESLint) + `fix:special` (regenerate types/validators) + `fmt` (Prettier). Prefer as the final step. |
+| `yarn fix:special`                                                   | Regenerate `types.d.ts`, declarations, schema validators, and generated runtime code.                           |
+| `yarn lint`                                                          | Full lint: ESLint + generated-output checks + every `tsc` project + Prettier + spellcheck (what CI runs).       |
+| `yarn tsc`                                                           | TypeScript type check of `lib/` JSDoc (catches type errors in annotations).                                     |
+| `yarn validate:changeset`                                            | Validate the pending `.changeset/` files.                                                                       |
+| `yarn test:base --testPathPatterns="<pattern>"`                      | Run targeted tests. Also `yarn test:base -t "<name>"`.                                                          |
+| `yarn test:unit`                                                     | Run all `*.unittest.js`.                                                                                        |
+| `yarn test:integration`                                              | Run the integration suites (`basictest`/`longtest`/`test`).                                                     |
+| `yarn test:test262` / `yarn test:html5lib` / `yarn test:css-parsing` | Spec-conformance suites.                                                                                        |
+| `yarn test:base -u`                                                  | Update snapshots (eyeball the diff first).                                                                      |
+| `yarn cover:unit`                                                    | Unit-test coverage.                                                                                             |
+| `yarn types:cover`                                                   | Type-coverage report (share of `lib/` that is precisely typed).                                                 |
+| `yarn build:examples`                                                | Build the `examples/` (verify after changing options).                                                          |
+| `yarn test`                                                          | Full suite — don't run unless asked.                                                                            |
 
 Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. See [TESTING_DOCS.md](TESTING_DOCS.md) for how to run a single case.
 
@@ -367,7 +367,7 @@ CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` s
 
 ### Target the Node baseline
 
-`lib/` and `hot/` ship untranspiled and must run on **Node ≥ 10.13** (the CI matrix goes down to Node 10.x). Don't use syntax or runtime APIs newer than that baseline — e.g. no optional chaining (`?.`) or nullish coalescing (`??`) — or the code passes locally and fails the Node 10 CI job.
+`lib/` and `hot/` ship as raw source (no build step) and must run on **Node ≥ 10.13** (the CI matrix goes down to Node 10.x). Don't use syntax or runtime APIs newer than that baseline — e.g. no optional chaining (`?.`) or nullish coalescing (`??`) — or the code passes locally and fails the Node 10 CI job.
 
 ### Register serializable classes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ All commands are defined in `package.json` `scripts`.
 
 Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. See [TESTING_DOCS.md](TESTING_DOCS.md) for how to run a single case.
 
+**CI checks that must pass:** `lint`, `unit`, `basic`, `integration` (Node 10→26 × ubuntu/macOS/windows, sharded `a`/`b`), `test262`, plus **CodSpeed** (performance + memory mode) and a **Bun** job. CodSpeed memory mode is sensitive to fixture size, and the Bun job runs under `--smol` and surfaces OOMs the Node suites don't — watch both when touching hot paths or large test fixtures.
+
 ## Architecture
 
 > [!REQUIRED]
@@ -214,6 +216,8 @@ Valid `<type>` values: `fix`, `feat`, `refactor`, `perf`, `test`, `chore`, `ci`,
 11. `chore` — anything else.
 
 When a change spans several categories, classify by its primary purpose (a bug fix that also adds a test is `fix`, not `test`; a feature with docs is `feat`). The chosen `<type>` is the same value used for the "What kind of change does this PR introduce?" answer, so derive both from this list.
+
+**PR/commit titles** follow conventional-commit `type(scope): subject`, scope optional (e.g. `perf(css): …`, `feat(caching): …`, `fix: …`). The `type` matches the branch prefix above.
 
 Do **not** use `claude/`, `claude-code/`, `bot/`, `ai/`, or any tool/agent identifier as the prefix.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ A `> [!REQUIRED]` callout placed immediately under a heading marks that whole se
 
 webpack is a JavaScript module bundler. It builds a dependency graph from entry modules and emits optimized static assets (chunks) for browsers, Node.js, and other targets. The config API is defined by JSON schemas and everything is wired through a `tapable` plugin/hook architecture.
 
+**Core model:** a `Compiler` drives the build; each run creates a `Compilation` holding the module graph (`Module`s) and output `Chunk`s, which is then `seal`ed and `emit`ted. Plugins expose an `apply(compiler)` method and tap the `tapable` hooks they need.
+
 ## Tech stack
 
 - **Language:** JavaScript. `lib/` is **CommonJS only**; types are declared via JSDoc `@typedef` and compiled into `types.d.ts`.
@@ -166,6 +168,14 @@ For directory structure, naming, and how to run a single case, see [TESTING_DOCS
 **Prefer integration tests over unit tests.** Cover behavior with an integration case (`configCases/`, `watchCases/`, `hotCases/`, `statsCases/`, …) that drives a real `webpack()` build whenever the behavior can be exercised that way — they catch real-world regressions a mocked unit test misses. Reach for a `*.unittest.js` only for pure helpers/utilities that a build can't naturally reach.
 
 Run targeted tests — `yarn test:base --testPathPatterns="<pattern>"` or `yarn test:base -t "<name>"`. Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. Don't run `yarn test` unless asked. When updating snapshots (`yarn test:base -u`), eyeball the diff first.
+
+**Run one integration case** by name (`<category> <case-name>`, e.g. `css basic`):
+
+```sh
+yarn test:basic --testPathPatterns="ConfigTestCases" --testNamePattern="<category> <case>"
+```
+
+Swap `ConfigTestCases` for `StatsTestCases`, `HotTestCases`, `WatchTestCases`, … (full matrix in [TESTING_DOCS.md](TESTING_DOCS.md)). The `test262`/`html5lib`/`css-parsing` suites are git submodules — run `git submodule update --init test/<dir>` first, or they fail confusingly.
 
 **Cover every line you add or change.** A commit must not lower coverage: each new branch, fast path, and fallback needs a test that exercises it (Codecov enforces this on the patch, target 90%+). When a change adds branches that integration cases don't reach — e.g. tokenizer fast paths and their cold-path fallbacks — add a focused `*.unittest.js` that drives each branch (both the fast and delegated paths). Check `yarn cover:unit` locally, or the PR's Codecov "patch" report, and add cases until no changed line is missing.
 
@@ -347,7 +357,7 @@ CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` s
 
 ### Performance and memory
 
-webpack is a bundler — users measure it by build time and peak heap usage. Many changes in `lib/` end up on per-module hot paths (sometimes per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so large compilation data structures are not retained longer than necessary. See #15521 for an example of how this class of memory issue can surface.
+webpack is a bundler — users measure it by build time and peak heap usage. Many changes in `lib/` end up on per-module hot paths (sometimes per module × runtime, or per chunk × module) on user builds, so constant factors compound. Always weigh the time and memory cost of a change, including bug fixes and refactors: less allocation, smaller `Map`/`Set` footprints, and fewer closures retained on hot paths are wins worth pursuing — less is better. When introducing or holding any per-`Compilation` state, ask whether it can be released after seal/emit so large compilation data structures are not retained longer than necessary. See #15521 for an example of how this class of memory issue can surface. Sanity-check a perf change locally with `FILTER="<case-name>" yarn benchmark` before CodSpeed flags a regression in CI.
 
 ### Keep instance shapes stable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,10 @@ CI's `lint` job verifies these outputs are up to date. The combined `yarn fix` s
 
 `lib/` and `hot/` ship as raw source (no build step) and must run on **Node ≥ 10.13** (the CI matrix goes down to Node 10.x). Don't use syntax or runtime APIs newer than that baseline — e.g. no optional chaining (`?.`) or nullish coalescing (`??`) — or the code passes locally and fails the Node 10 CI job.
 
+### Lint covers every file, docs included
+
+The `lint` job runs Prettier (`fmt:check`) and cspell (`lint:spellcheck`) across the **whole repo** — Markdown and this guide too, not just `lib/`. Run `yarn fix` before pushing even a docs-only change: an unaligned Markdown table or a word cspell doesn't know fails `lint` on its own. For a new/unusual word, add it to the `words` list in `cspell.json` (or reword); Prettier reformats Markdown tables, so hand-written columns must match its output.
+
 ### Register serializable classes
 
 Persistent caching serializes the module graph, so any new serializable class (a `Module`, `Dependency`, or error subclass, a cached value, …) must call `makeSerializable(...)` — the pattern is used across ~140 files. Run `yarn fix:serializables` to regenerate `internalSerializables`; forgetting silently breaks the persistent cache.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,13 @@ All commands are defined in `package.json` `scripts`.
 | --- | --- |
 | `yarn fix` | `fix:code` (ESLint) + `fix:special` (regenerate types/validators) + `fmt` (Prettier). Prefer as the final step. |
 | `yarn fix:special` | Regenerate `types.d.ts`, declarations, schema validators, and generated runtime code. |
-| `yarn tsc` | TypeScript type check (catches type errors in JSDoc annotations). |
+| `yarn lint` | Full lint: ESLint + generated-output checks + every `tsc` project + Prettier + spellcheck (what CI runs). |
+| `yarn tsc` | TypeScript type check of `lib/` JSDoc (catches type errors in annotations). |
+| `yarn validate:changeset` | Validate the pending `.changeset/` files. |
 | `yarn test:base --testPathPatterns="<pattern>"` | Run targeted tests. Also `yarn test:base -t "<name>"`. |
+| `yarn test:unit` | Run all `*.unittest.js`. |
+| `yarn test:integration` | Run the integration suites (`basictest`/`longtest`/`test`). |
+| `yarn test:test262` / `yarn test:html5lib` / `yarn test:css-parsing` | Spec-conformance suites. |
 | `yarn test:base -u` | Update snapshots (eyeball the diff first). |
 | `yarn cover:unit` | Unit-test coverage. |
 | `yarn build:examples` | Build the `examples/` (verify after changing options). |
@@ -342,10 +347,3 @@ webpack is a bundler — users measure it by build time and peak heap usage. Man
 Initialize **every** instance field in the constructor, including ones first assigned later in a method — default them to `undefined`/`null`. Assigning `this.newField` for the first time outside the constructor forces a V8 hidden-class (Shape) transition, so instances of one class end up split across shapes and the inline caches reading them go polymorphic/megamorphic — a hot property read can cost ~2× at two shapes and more when megamorphic, and code already optimized for the first shape deopts with a `wrong map` bailout. Never `delete` an instance field (it forces the object into dictionary mode); set it to `undefined` instead. The win per field is small for a single trailing field, but the rule is uniform on purpose so reviewers don't judge it case by case — it is why, for example, `Dependency` sets all its `_loc*` slots up front. Deliberate symbol-keyed sparse slots are the documented exception.
 
 When adding a field to a class whose fields are compiled into `types.d.ts` (public, non-`_`-prefixed), re-run `yarn fix:special` — constructor order determines member order in the generated declarations.
-
-## @imports
-
-Keep this file short; pull detail in on demand from:
-
-- [TESTING_DOCS.md](TESTING_DOCS.md) — test directory structure, naming, and how to run a single case.
-- [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md) — required reading before disclosing **Use of AI** in a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Skipping any layer silently breaks the option. After editing schemas, run `yarn 
 
 ### Type annotations
 
-Prefer the most specific real type. `EXPECTED_ANY`, `EXPECTED_OBJECT`, and `EXPECTED_FUNCTION` (aliases for `any`, `object`, `Function`) are an escape hatch, not a default — use them **only** when the value genuinely can be any value, any object, or any function. When you simply don't know the type yet, reach for `unknown` and narrow it, rather than widening to `EXPECTED_ANY`. This applies in `test/` too: if a real type (e.g. an imported `import("…").Foo`) fits, use it instead of `EXPECTED_ANY`.
+Prefer the most specific real type. `EXPECTED_ANY`, `EXPECTED_OBJECT`, and `EXPECTED_FUNCTION` (aliases for `any`, `object`, `Function`) are an escape hatch, not a default — reach for one **only** when the value genuinely can be any value, any object, or any function, and **never** when a real type fits. `unknown` is the same: use it for a value whose type you can't yet name (then narrow it), but if a real type (e.g. an imported `import("…").Foo`) fits, use that instead. This applies in `test/` too.
 
 Prefer a generic (`@template`) over a widened type whenever a function's output type depends on its input — it keeps callers precisely typed instead of collapsing to `EXPECTED_ANY`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,10 @@ The two config layers differ: **`normalization.js`** canonicalizes the user-supp
 
 **Adding a new dependency type:** pair the `Dependency` subclass with a `DependencyTemplate` (it emits the generated code), register the class with `makeSerializable(...)`, and wire the template into `compilation.dependencyTemplates`.
 
+**Finding a hook:** hook definitions live on the class that owns them — compiler-wide hooks in `lib/Compiler.js`, per-`Compilation` hooks in `lib/Compilation.js`; tap them with a unique plugin-name string.
+
+**Adding a runtime requirement:** declare the symbol in `lib/RuntimeGlobals.js`, emit its code with a `RuntimeModule` subclass, and inject it by tapping `runtimeRequirementInTree`/`additionalTreeRuntimeRequirements` on `compilation.hooks` (the `…InModule` variants for per-module needs).
+
 ## Code conventions
 
 ### Source language: CommonJS + JSDoc
@@ -180,6 +184,8 @@ yarn test:basic --testPathPatterns="ConfigTestCases" --testNamePattern="<categor
 ```
 
 Swap `ConfigTestCases` for `StatsTestCases`, `HotTestCases`, `WatchTestCases`, … (full matrix in [TESTING_DOCS.md](TESTING_DOCS.md)). The `test262`/`html5lib`/`css-parsing` suites are git submodules — run `git submodule update --init test/<dir>` first, or they fail confusingly.
+
+**Writing a `configCases/` case:** a case is a mini project — `index.js` (runs assertions; a thrown error fails the test) plus `webpack.config.js`. The emitted bundle is actually executed, so it must run. Optional per-case files: `errors.js` / `warnings.js` export arrays of matchers for expected build diagnostics (without them, any error/warning fails the case); `test.filter.js` returns `false` to skip the case (e.g. gate by Node version); `test.config.js` customizes the run (e.g. `findBundle`).
 
 **Cover every line you add or change.** A commit must not lower coverage: each new branch, fast path, and fallback needs a test that exercises it (Codecov enforces this on the patch, target 90%+). When a change adds branches that integration cases don't reach — e.g. tokenizer fast paths and their cold-path fallbacks — add a focused `*.unittest.js` that drives each branch (both the fast and delegated paths). Check `yarn cover:unit` locally, or the PR's Codecov "patch" report, and add cases until no changed line is missing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,6 @@ webpack is a JavaScript module bundler. It builds a dependency graph from entry 
 
 - **Language:** JavaScript. `lib/` is **CommonJS only**; types are declared via JSDoc `@typedef` and compiled into `types.d.ts`.
 - **Package manager:** **yarn** (not npm).
-- **Parser:** acorn (JavaScript AST).
 - **Tests:** jest, run through the `test:base` wrapper (never bare `jest`).
 - **Type checking / generation:** TypeScript, driven over the JSDoc annotations.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ All commands are defined in `package.json` `scripts`.
 | `yarn test:test262` / `yarn test:html5lib` / `yarn test:css-parsing` | Spec-conformance suites. |
 | `yarn test:base -u` | Update snapshots (eyeball the diff first). |
 | `yarn cover:unit` | Unit-test coverage. |
+| `yarn types:cover` | Type-coverage report (share of `lib/` that is precisely typed). |
 | `yarn build:examples` | Build the `examples/` (verify after changing options). |
 | `yarn test` | Full suite — don't run unless asked. |
 
@@ -167,6 +168,8 @@ For directory structure, naming, and how to run a single case, see [TESTING_DOCS
 Run targeted tests — `yarn test:base --testPathPatterns="<pattern>"` or `yarn test:base -t "<name>"`. Never invoke `yarn jest`/`npx jest` directly: the required `--experimental-vm-modules` node flag lives only in the `test:base` wrapper, and bare jest crashes ESM/test262 suites. Don't run `yarn test` unless asked. When updating snapshots (`yarn test:base -u`), eyeball the diff first.
 
 **Cover every line you add or change.** A commit must not lower coverage: each new branch, fast path, and fallback needs a test that exercises it (Codecov enforces this on the patch, target 90%+). When a change adds branches that integration cases don't reach — e.g. tokenizer fast paths and their cold-path fallbacks — add a focused `*.unittest.js` that drives each branch (both the fast and delegated paths). Check `yarn cover:unit` locally, or the PR's Codecov "patch" report, and add cases until no changed line is missing.
+
+**Don't lower type coverage either.** webpack tracks how much of `lib/` is precisely typed; CI collects it (`yarn types:cover:report`) and reports the delta on the PR. Keep it from dropping — prefer real types over `EXPECTED_ANY` (see [Type annotations](#type-annotations)), and run `yarn types:cover` locally if you widened any annotations.
 
 ## Git & PR rules
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Restructures the contributor guide (`AGENTS.md`, symlinked as `CLAUDE.md`) under a conventional section taxonomy — Project overview, Tech stack, Commands, Architecture, Code conventions, Testing, Git & PR rules, Do not touch, Gotchas — so it's faster to navigate for both humans and coding agents. Content is preserved; every `> [!REQUIRED]` block is kept verbatim, just moved under its matching heading. Also adds a few high-signal, low-token facts that were previously undocumented (CI check list, type-coverage gate, Node ≥10.13 syntax baseline, serializable-class registration, config-case authoring, hook/runtime-requirement patterns), all verified against `package.json`, `.github/workflows/`, and the test infrastructure.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

n/a — documentation only, no source or behavior changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — this PR is the documentation change itself.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude) was used to reorganize the guide and draft the added notes; every added fact was verified against the repo (scripts, CI workflow, test runner) and reviewed by the author before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ifwzFiGU4AC1C7QSYNLRw)_