### PR TITLE
perf(serialization): reduce allocations in binary middleware hot paths

### DIFF
--- a/.changeset/061-serializer-deserialize-allocations.md
+++ b/.changeset/061-serializer-deserialize-allocations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reduce allocations in the binary serialization hot paths.

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -365,7 +365,9 @@ class BinaryMiddleware extends SerializerMiddleware {
 					// the section covers all values: swap the buffers out and back in
 					// instead of copying the whole array to place the placeholders
 					try {
-						for (const index of bufferIndices) data[index] = null;
+						for (let i = 0; i < bufferIndices.length; i++) {
+							data[bufferIndices[i]] = null;
+						}
 						writeValuesSection(data, bufferIndices, buffers);
 					} finally {
 						for (let i = 0; i < bufferIndices.length; i++) {
@@ -546,8 +548,8 @@ class BinaryMiddleware extends SerializerMiddleware {
 	 */
 	_deserialize(data, context) {
 		const state = new ReadState(data, context);
-		/** @type {DeserializedType[]} */
-		const parts = [];
+		/** @type {DeserializedType | undefined} */
+		let result;
 		while (state.currentBuffer !== null) {
 			/** @type {DeserializedType} */
 			let part;
@@ -566,16 +568,14 @@ class BinaryMiddleware extends SerializerMiddleware {
 					throw new Error(`Unexpected header byte 0x${header.toString(16)}`);
 				}
 			}
-			parts.push(part);
+			// a single-section stream needs no copying: reuse its array as the result
+			if (result === undefined) {
+				result = part;
+			} else {
+				for (let j = 0; j < part.length; j++) result.push(part[j]);
+			}
 		}
-		if (parts.length === 0) return [];
-		// a stream without lazy values is a single section and needs no copying
-		const result = parts[0];
-		for (let i = 1; i < parts.length; i++) {
-			const part = parts[i];
-			for (let j = 0; j < part.length; j++) result.push(part[j]);
-		}
-		return result;
+		return result === undefined ? [] : result;
 	}
 }
 


### PR DESCRIPTION
**Summary**

Follow-up to the V8 serializer rewrite (#21514). That path is bound by native `v8.serialize`/`v8.deserialize` (benchmarking shows ~99% of deserialize is the native call and the JS framing is <1%), so this is not a wall-clock change — it just trims avoidable allocations on the hot path, in the spirit of #21516. `_deserialize` allocated an intermediate `parts` array and made a second concatenation pass even for the dominant single-section stream; it now folds accumulation into the read loop (the first section's array becomes the result, later sections append in place). The full-array buffer null-out also switches from a `for…of` iterator to an indexed loop to match the restore loop beside it. No behavior change. Refs #21514.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

No — there is no behavior change; the existing `test/BinaryMiddleware.unittest.js` round-trip suite already covers the single-section, multi-section split, lazy, and frozen/buffer paths this touches.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to analyze the merged #21514 serializer for memory/performance, benchmark it (isolating native V8 cost from JS framing), and implement these allocation-hygiene cleanups; all changes were reviewed before submission.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtbCD8Hos9CvQWnGScXsBh)_