### PR TITLE
fix: delete no longer referenced files from the filesystem cache directory

### DIFF
--- a/.changeset/055-cache-cleanup-unused-files.md
+++ b/.changeset/055-cache-cleanup-unused-files.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Delete no longer referenced files from the filesystem cache directory after storing the cache.

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -7,6 +7,7 @@
 
 const FileSystemInfo = require("../FileSystemInfo");
 const ProgressPlugin = require("../ProgressPlugin");
+const { getReferencedFilenames } = require("../serialization/FileMiddleware");
 const SerializerMiddleware = require("../serialization/SerializerMiddleware");
 const LazySet = require("../util/LazySet");
 const formatSize = require("../util/formatSize");
@@ -34,6 +35,10 @@ const {
 /** @typedef {Set<string>} Items */
 /** @typedef {Set<string>} BuildDependencies */
 /** @typedef {Map<string, PackItemInfo>} ItemInfo */
+
+// Unreferenced files younger than this are kept to not race concurrent builds sharing the cache directory.
+// Kept below typical CI build durations so restored caches with refreshed modification times still get cleaned.
+const CLEANUP_GRACE_PERIOD = 30 * 60 * 1000;
 
 class PackContainer {
 	/**
@@ -1166,6 +1171,8 @@ class PackFileCacheStrategy {
 		});
 		/** @type {Compiler} */
 		this.compiler = compiler;
+		/** @type {IntermediateFileSystem} */
+		this.fs = fs;
 		/** @type {string} */
 		this.context = context;
 		/** @type {string} */
@@ -1182,6 +1189,9 @@ class PackFileCacheStrategy {
 		this.readonly = readonly;
 		/** @type {boolean | undefined} */
 		this.allowCollectingMemory = allowCollectingMemory;
+		// referenced names per on-disk file; a file is immutable until rewritten
+		/** @type {Map<string, string[]>} */
+		this._referencedFilesCache = new Map();
 		/** @type {false | "gzip" | "brotli" | "zstd" | undefined} */
 		this.compression = compression;
 		// eslint-disable-next-line n/no-unsupported-features/node-builtins
@@ -1588,10 +1598,17 @@ class PackFileCacheStrategy {
 						/** @type {Snapshot} */
 						(this.resolveBuildDependenciesSnapshot)
 					);
+					const cleanup = this.fs.unlink !== undefined;
+					/** @type {Set<string> | undefined} */
+					const writtenFiles = cleanup ? new Set() : undefined;
+					/** @type {Set<string> | undefined} */
+					const retainedFiles = cleanup ? new Set() : undefined;
 					return this.fileSerializer
 						.serialize(content, {
 							filename: `${this.cacheLocation}/index${this._extension}`,
 							extension: `${this._extension}`,
+							writtenFiles,
+							retainedFiles,
 							logger: this.logger,
 							profile: this.profile
 						})
@@ -1608,9 +1625,17 @@ class PackFileCacheStrategy {
 								stats.count,
 								Math.round(stats.size / 1024 / 1024)
 							);
+							if (writtenFiles !== undefined) {
+								return this._cleanupUnusedFiles(
+									writtenFiles,
+									/** @type {Set<string>} */ (retainedFiles)
+								);
+							}
 						})
 						.catch((err) => {
 							this.logger.timeEnd("store pack");
+							// files may be in an unknown state after a failed store
+							this._referencedFilesCache.clear();
 							this.logger.warn(`Caching failed for pack: ${err}`);
 							this.logger.debug(err.stack);
 						});
@@ -1620,6 +1645,97 @@ class PackFileCacheStrategy {
 				this.logger.warn(`Caching failed for pack: ${err}`);
 				this.logger.debug(err.stack);
 			}));
+	}
+
+	/**
+	 * Deletes files from the cache directory that are no longer referenced by the
+	 * stored pack. Retained files are walked on disk since nested lazy segments
+	 * reference files not visible during serialization. Errors only log a warning.
+	 * @param {Set<string>} writtenNames names (without extension) written by this store
+	 * @param {Set<string>} retainedNames names (without extension) referenced but not rewritten
+	 * @returns {Promise<void>} promise
+	 */
+	async _cleanupUnusedFiles(writtenNames, retainedNames) {
+		this.logger.time("cleanup unused cache files");
+		const fs = this.fs;
+		const extension = this._extension;
+		const cacheLocation = this.cacheLocation;
+		const referencedFilesCache = this._referencedFilesCache;
+		try {
+			// rewritten files may reference different names now
+			for (const name of writtenNames) referencedFilesCache.delete(name);
+			/** @type {Set<string>} */
+			const liveFiles = new Set([`index${extension}`]);
+			for (const name of writtenNames) liveFiles.add(`${name}${extension}`);
+			/** @type {string[]} */
+			const queue = [];
+			/**
+			 * Marks a file live and queues it for walking its references.
+			 * @param {string} name file name without extension
+			 */
+			const enqueue = (name) => {
+				const file = `${name}${extension}`;
+				if (liveFiles.has(file)) return;
+				liveFiles.add(file);
+				queue.push(name);
+			};
+			for (const name of retainedNames) enqueue(name);
+			while (queue.length > 0) {
+				const name = /** @type {string} */ (queue.pop());
+				let referenced = referencedFilesCache.get(name);
+				if (referenced === undefined) {
+					referenced = await getReferencedFilenames(
+						fs,
+						`${cacheLocation}/${name}${extension}`
+					);
+					referencedFilesCache.set(name, referenced);
+				}
+				for (const referencedName of referenced) enqueue(referencedName);
+			}
+			const files = await new Promise((resolve, reject) => {
+				fs.readdir(cacheLocation, (err, files) => {
+					if (err) return reject(err);
+					resolve(/** @type {string[]} */ (files));
+				});
+			});
+			const expireTime = Date.now() - CLEANUP_GRACE_PERIOD;
+			let deletedCount = 0;
+			for (const file of files) {
+				if (typeof file !== "string" || liveFiles.has(file)) continue;
+				const path = `${cacheLocation}/${file}`;
+				const deleted = await new Promise((resolve) => {
+					fs.stat(path, (err, stats) => {
+						if (
+							err ||
+							!(/** @type {import("../util/fs").IStats} */ (stats).isFile()) ||
+							/** @type {number} */ (
+								/** @type {import("../util/fs").IStats} */ (stats).mtimeMs
+							) > expireTime
+						) {
+							return resolve(false);
+						}
+						/** @type {NonNullable<IntermediateFileSystem["unlink"]>} */
+						(fs.unlink)(path, (err) => resolve(!err));
+					});
+				});
+				if (deleted) deletedCount++;
+			}
+			// drop entries of files that are no longer alive
+			for (const name of referencedFilesCache.keys()) {
+				if (!liveFiles.has(`${name}${extension}`)) {
+					referencedFilesCache.delete(name);
+				}
+			}
+			if (deletedCount > 0) {
+				this.logger.log("Deleted %d unused cache files", deletedCount);
+			}
+		} catch (err) {
+			this.logger.warn(
+				`Cleanup of unused cache files failed: ${/** @type {Error} */ (err)}`
+			);
+			this.logger.debug(/** @type {Error} */ (err).stack);
+		}
+		this.logger.timeEnd("cleanup unused cache files");
 	}
 
 	clear() {

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -1189,8 +1189,9 @@ class PackFileCacheStrategy {
 		this.readonly = readonly;
 		/** @type {boolean | undefined} */
 		this.allowCollectingMemory = allowCollectingMemory;
-		// referenced names per on-disk file; a file is immutable until rewritten
-		/** @type {Map<string, string[]>} */
+		// referenced names per on-disk file, versioned by mtime since concurrent
+		// processes may rewrite packs in place under the same name
+		/** @type {Map<string, { mtimeMs: number, referenced: string[] }>} */
 		this._referencedFilesCache = new Map();
 		/** @type {false | "gzip" | "brotli" | "zstd" | undefined} */
 		this.compression = compression;
@@ -1682,13 +1683,25 @@ class PackFileCacheStrategy {
 			for (const name of retainedNames) enqueue(name);
 			while (queue.length > 0) {
 				const name = /** @type {string} */ (queue.pop());
-				let referenced = referencedFilesCache.get(name);
-				if (referenced === undefined) {
-					referenced = await getReferencedFilenames(
-						fs,
-						`${cacheLocation}/${name}${extension}`
-					);
-					referencedFilesCache.set(name, referenced);
+				const file = `${cacheLocation}/${name}${extension}`;
+				// an unchanged mtime proves the memo entry still matches the disk
+				const mtimeMs = await new Promise((resolve, reject) => {
+					fs.stat(file, (err, stats) => {
+						if (err) return reject(err);
+						resolve(
+							/** @type {number} */ (
+								/** @type {import("../util/fs").IStats} */ (stats).mtimeMs
+							)
+						);
+					});
+				});
+				const entry = referencedFilesCache.get(name);
+				let referenced;
+				if (entry !== undefined && entry.mtimeMs === mtimeMs) {
+					referenced = entry.referenced;
+				} else {
+					referenced = await getReferencedFilenames(fs, file);
+					referencedFilesCache.set(name, { mtimeMs, referenced });
 				}
 				for (const referencedName of referenced) enqueue(referencedName);
 			}

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -7,6 +7,8 @@
 const { constants } = require("buffer");
 const { pipeline } = require("stream");
 const {
+	// eslint-disable-next-line n/no-unsupported-features/node-builtins
+	brotliDecompress,
 	constants: zConstants,
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	createBrotliCompress,
@@ -18,7 +20,10 @@ const {
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	createZstdCompress,
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
-	createZstdDecompress
+	createZstdDecompress,
+	gunzip,
+	// eslint-disable-next-line n/no-unsupported-features/node-builtins
+	zstdDecompress
 } = require("zlib");
 const { DEFAULTS } = require("../config/defaults");
 const createHash = require("../util/createHash");
@@ -111,6 +116,7 @@ const readUInt64LE = Buffer.prototype.readBigUInt64LE
  * @param {string | boolean} name file base name
  * @param {(name: string | false, buffers: Buffer[], size: number) => Promise<void>} writeFile writes a file
  * @param {HashFunction=} hashFunction hash function to use
+ * @param {Set<string>=} retainedNames collects names of files that stay referenced without being rewritten
  * @returns {Promise<SerializeResult>} resulting file pointer and promise
  */
 const serialize = async (
@@ -118,7 +124,8 @@ const serialize = async (
 	data,
 	name,
 	writeFile,
-	hashFunction = DEFAULTS.HASH_FUNCTION
+	hashFunction = DEFAULTS.HASH_FUNCTION,
+	retainedNames = undefined
 ) => {
 	/** @type {(Buffer[] | Buffer | Promise<SerializeResult>)[]} */
 	const processedData = [];
@@ -144,6 +151,10 @@ const serialize = async (
 						"Unexpected lazy value with non-this target (can't pass through lazy values)"
 					);
 				} else {
+					if (retainedNames !== undefined) {
+						// pointer buffer layout: u64 size + utf-8 file name
+						retainedNames.add(serializedInfo.toString("utf8", 8));
+					}
 					processedData.push(serializedInfo);
 				}
 			} else {
@@ -157,7 +168,8 @@ const serialize = async (
 							(content),
 							(options && options.name) || true,
 							writeFile,
-							hashFunction
+							hashFunction,
+							retainedNames
 						).then((result) => {
 							/** @type {LazyOptions} */
 							(item.options).size = result.size;
@@ -444,7 +456,14 @@ const deserialize = async (middleware, name, readFile) => {
 
 /** @typedef {BufferSerializableType[]} DeserializedType */
 /** @typedef {true} SerializedType */
-/** @typedef {{ filename: string, extension?: string }} Context */
+/**
+ * `writtenFiles`/`retainedFiles` collect file names (without extension) during
+ * `serialize`: files written in this run and files that stay referenced by
+ * lazy pointers without being rewritten. Retained files may reference further
+ * files on disk not listed here (nested lazy segments); use
+ * `getReferencedFilenames` to walk them.
+ * @typedef {{ filename: string, extension?: string, writtenFiles?: Set<string>, retainedFiles?: Set<string> }} Context
+ */
 
 /**
  * Represents FileMiddleware.
@@ -471,7 +490,7 @@ class FileMiddleware extends SerializerMiddleware {
 	 * @returns {SerializedType | Promise<SerializedType> | null} serialized data
 	 */
 	serialize(data, context) {
-		const { filename, extension = "" } = context;
+		const { filename, extension = "", writtenFiles, retainedFiles } = context;
 		return new Promise((resolve, reject) => {
 			mkdirp(this.fs, dirname(this.fs, filename), (err) => {
 				if (err) return reject(err);
@@ -581,66 +600,74 @@ class FileMiddleware extends SerializerMiddleware {
 							batchWrite();
 						}
 					);
-					if (name) allWrittenFiles.add(file);
+					if (name) {
+						allWrittenFiles.add(file);
+						if (writtenFiles !== undefined) writtenFiles.add(name);
+					}
 				};
 
 				resolve(
-					serialize(this, data, false, writeFile, this._hashFunction).then(
-						async ({ backgroundJob }) => {
-							await backgroundJob;
+					serialize(
+						this,
+						data,
+						false,
+						writeFile,
+						this._hashFunction,
+						retainedFiles
+					).then(async ({ backgroundJob }) => {
+						await backgroundJob;
 
-							// Rename the index file to disallow access during inconsistent file state
-							await new Promise(
-								/**
-								 * Handles the callback logic for this hook.
-								 * @param {(value?: undefined) => void} resolve resolve
-								 */
-								(resolve) => {
-									this.fs.rename(filename, `${filename}.old`, (_err) => {
-										resolve();
-									});
-								}
-							);
+						// Rename the index file to disallow access during inconsistent file state
+						await new Promise(
+							/**
+							 * Handles the callback logic for this hook.
+							 * @param {(value?: undefined) => void} resolve resolve
+							 */
+							(resolve) => {
+								this.fs.rename(filename, `${filename}.old`, (_err) => {
+									resolve();
+								});
+							}
+						);
 
-							// update all written files
-							await Promise.all(
-								Array.from(
-									allWrittenFiles,
-									(file) =>
-										new Promise(
-											/**
-											 * Handles the callback logic for this hook.
-											 * @param {(value?: undefined) => void} resolve resolve
-											 * @param {(reason?: Error | null) => void} reject reject
-											 * @returns {void}
-											 */
-											(resolve, reject) => {
-												this.fs.rename(`${file}_`, file, (err) => {
-													if (err) return reject(err);
-													resolve();
-												});
-											}
-										)
-								)
-							);
+						// update all written files
+						await Promise.all(
+							Array.from(
+								allWrittenFiles,
+								(file) =>
+									new Promise(
+										/**
+										 * Handles the callback logic for this hook.
+										 * @param {(value?: undefined) => void} resolve resolve
+										 * @param {(reason?: Error | null) => void} reject reject
+										 * @returns {void}
+										 */
+										(resolve, reject) => {
+											this.fs.rename(`${file}_`, file, (err) => {
+												if (err) return reject(err);
+												resolve();
+											});
+										}
+									)
+							)
+						);
 
-							// As final step automatically update the index file to have a consistent pack again
-							await new Promise(
-								/**
-								 * Handles the callback logic for this hook.
-								 * @param {(value?: undefined) => void} resolve resolve
-								 * @returns {void}
-								 */
-								(resolve) => {
-									this.fs.rename(`${filename}_`, filename, (err) => {
-										if (err) return reject(err);
-										resolve();
-									});
-								}
-							);
-							return /** @type {true} */ (true);
-						}
-					)
+						// As final step automatically update the index file to have a consistent pack again
+						await new Promise(
+							/**
+							 * Handles the callback logic for this hook.
+							 * @param {(value?: undefined) => void} resolve resolve
+							 * @returns {void}
+							 */
+							(resolve) => {
+								this.fs.rename(`${filename}_`, filename, (err) => {
+									if (err) return reject(err);
+									resolve();
+								});
+							}
+						);
+						return /** @type {true} */ (true);
+					})
 				);
 			});
 		});
@@ -808,6 +835,191 @@ class FileMiddleware extends SerializerMiddleware {
 	}
 }
 
+/**
+ * Extracts the file names referenced by lazy pointer sections from serialized content.
+ * @param {Buffer} buf decompressed file content
+ * @returns {string[]} referenced file names (without extension)
+ */
+const parsePointerNames = (buf) => {
+	const version = buf.readUInt32LE(0);
+	if (version !== VERSION) {
+		throw new Error(`Invalid file version ${version}`);
+	}
+	const sectionCount = buf.readUInt32LE(4);
+	let offset = 8 + sectionCount * 4;
+	/** @type {string[]} */
+	const names = [];
+	for (let i = 0; i < sectionCount; i++) {
+		const length = buf.readInt32LE(8 + i * 4);
+		if (length < 0) {
+			// pointer section: u64 size + utf-8 file name
+			names.push(buf.toString("utf8", offset + 8, offset - length));
+			offset -= length;
+		} else {
+			offset += length;
+		}
+	}
+	return names;
+};
+
+/**
+ * Reads the pointer names of a compressed file by decompressing it fully
+ * (compressed content cannot be read by byte range).
+ * @param {IntermediateFileSystem} fs a file system
+ * @param {string} file absolute path of the serialized file
+ * @returns {Promise<string[]>} referenced file names (without extension)
+ */
+const getReferencedFilenamesCompressed = (fs, file) =>
+	new Promise((resolve, reject) => {
+		fs.readFile(file, (err, rawContent) => {
+			if (err) return reject(err);
+			/**
+			 * Parses the decompressed content.
+			 * @param {Error | null} err error
+			 * @param {Buffer=} content decompressed content
+			 * @returns {void}
+			 */
+			const onContent = (err, content) => {
+				if (err) return reject(err);
+				try {
+					resolve(parsePointerNames(/** @type {Buffer} */ (content)));
+				} catch (err_) {
+					reject(/** @type {Error} */ (err_));
+				}
+			};
+			const buf = /** @type {Buffer} */ (rawContent);
+			if (file.endsWith(".gz")) {
+				gunzip(buf, onContent);
+			} else if (file.endsWith(".br")) {
+				brotliDecompress(buf, onContent);
+			} else {
+				if (!zstdDecompress) {
+					return reject(
+						new Error("zstd decompression requires Node.js >= 22.15.0")
+					);
+				}
+				zstdDecompress(buf, onContent);
+			}
+		});
+	});
+
+/**
+ * Reads the pointer names of an uncompressed file by reading only the header
+ * and the pointer sections instead of the whole file.
+ * @param {IntermediateFileSystem} fs a file system
+ * @param {string} file absolute path of the serialized file
+ * @returns {Promise<string[]>} referenced file names (without extension)
+ */
+const getReferencedFilenamesUncompressed = (fs, file) =>
+	new Promise((resolve, reject) => {
+		fs.open(file, "r", (err, _fd) => {
+			if (err) return reject(err);
+			const fd = /** @type {number} */ (_fd);
+			/**
+			 * Closes the file descriptor and rejects.
+			 * @param {Error} err error
+			 */
+			const fail = (err) => {
+				fs.close(fd, () => reject(err));
+			};
+			/**
+			 * Reads exactly `length` bytes at `position`.
+			 * @param {number} position file position
+			 * @param {number} length byte count
+			 * @param {(buffer: Buffer) => void} callback called with the filled buffer
+			 * @returns {void}
+			 */
+			const readAt = (position, length, callback) => {
+				/** @type {Buffer} */
+				let buffer;
+				try {
+					// corrupt headers can request absurd sizes; must reject, not crash
+					buffer = Buffer.allocUnsafe(length);
+				} catch (err) {
+					return fail(/** @type {Error} */ (err));
+				}
+				let bytesDone = 0;
+				const readMore = () => {
+					fs.read(
+						fd,
+						buffer,
+						bytesDone,
+						length - bytesDone,
+						position + bytesDone,
+						(err, bytesRead) => {
+							if (err) return fail(err);
+							if (bytesRead === 0) {
+								return fail(new Error(`Unexpected end of file ${file}`));
+							}
+							bytesDone += bytesRead;
+							if (bytesDone < length) return readMore();
+							callback(buffer);
+						}
+					);
+				};
+				readMore();
+			};
+			readAt(0, 8, (header) => {
+				const version = header.readUInt32LE(0);
+				if (version !== VERSION) {
+					return fail(new Error(`Invalid file version ${version}`));
+				}
+				const sectionCount = header.readUInt32LE(4);
+				if (sectionCount === 0) {
+					return fs.close(fd, (err) => (err ? reject(err) : resolve([])));
+				}
+				readAt(8, sectionCount * 4, (lengthsBuffer) => {
+					/** @type {{ position: number, length: number }[]} */
+					const pointerSections = [];
+					let position = 8 + sectionCount * 4;
+					for (let i = 0; i < sectionCount; i++) {
+						const length = lengthsBuffer.readInt32LE(i * 4);
+						if (length < 0) {
+							pointerSections.push({ position, length: -length });
+							position -= length;
+						} else {
+							position += length;
+						}
+					}
+					/** @type {string[]} */
+					const names = [];
+					/**
+					 * Reads the pointer section at `index`, then the next one.
+					 * @param {number} index pointer section index
+					 * @returns {void}
+					 */
+					const readNext = (index) => {
+						if (index >= pointerSections.length) {
+							return fs.close(fd, (err) =>
+								err ? reject(err) : resolve(names)
+							);
+						}
+						const section = pointerSections[index];
+						readAt(section.position, section.length, (buffer) => {
+							// pointer section: u64 size + utf-8 file name
+							names.push(buffer.toString("utf8", 8));
+							readNext(index + 1);
+						});
+					};
+					readNext(0);
+				});
+			});
+		});
+	});
+
+/**
+ * Reads the file names referenced by a serialized file (its lazy pointer sections)
+ * without deserializing its content. Referenced files may reference further files.
+ * @param {IntermediateFileSystem} fs a file system
+ * @param {string} file absolute path of the serialized file
+ * @returns {Promise<string[]>} referenced file names (without extension)
+ */
+const getReferencedFilenames = (fs, file) =>
+	file.endsWith(".gz") || file.endsWith(".br") || file.endsWith(".zst")
+		? getReferencedFilenamesCompressed(fs, file)
+		: getReferencedFilenamesUncompressed(fs, file);
+
 module.exports = FileMiddleware;
 // Exposed for testing the content-buffer boundary handling in `deserialize`.
 module.exports._deserialize = deserialize;
+module.exports.getReferencedFilenames = getReferencedFilenames;

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -56,6 +56,8 @@ Section -> Buffer
 const VERSION = 0x01637077;
 const WRITE_LIMIT_TOTAL = 0x7fff0000;
 const WRITE_LIMIT_CHUNK = 511 * 1024 * 1024;
+// headers and pointer sections are tiny; anything above this is a corrupt file
+const MAX_HEADER_OR_POINTER_SIZE = 256 * 1024 * 1024;
 
 /**
  * Returns hash.
@@ -930,10 +932,13 @@ const getReferencedFilenamesUncompressed = (fs, file) =>
 			 * @returns {void}
 			 */
 			const readAt = (position, length, callback) => {
+				// corrupt headers can request absurd sizes; must reject, not crash
+				if (length > MAX_HEADER_OR_POINTER_SIZE) {
+					return fail(new Error(`Invalid section size ${length} in ${file}`));
+				}
 				/** @type {Buffer} */
 				let buffer;
 				try {
-					// corrupt headers can request absurd sizes; must reject, not crash
 					buffer = Buffer.allocUnsafe(length);
 				} catch (err) {
 					return fail(/** @type {Error} */ (err));

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -1001,7 +1001,8 @@ const getReferencedFilenamesUncompressed = (fs, file) =>
 					// otherwise pointer reads land on wrong bytes and under-report
 					fs.stat(file, (err, stats) => {
 						if (err) return fail(err);
-						if (/** @type {import("../util/fs").IStats} */ (stats).size !== position) {
+						const stat = /** @type {import("../util/fs").IStats} */ (stats);
+						if (stat.size !== position) {
 							return fail(
 								new Error(`Section table does not match size of ${file}`)
 							);

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -997,27 +997,37 @@ const getReferencedFilenamesUncompressed = (fs, file) =>
 							position += length;
 						}
 					}
-					/** @type {string[]} */
-					const names = [];
-					/**
-					 * Reads the pointer section at `index`, then the next one.
-					 * @param {number} index pointer section index
-					 * @returns {void}
-					 */
-					const readNext = (index) => {
-						if (index >= pointerSections.length) {
-							return fs.close(fd, (err) =>
-								err ? reject(err) : resolve(names)
+					// the section table must account for exactly the whole file,
+					// otherwise pointer reads land on wrong bytes and under-report
+					fs.stat(file, (err, stats) => {
+						if (err) return fail(err);
+						if (/** @type {import("../util/fs").IStats} */ (stats).size !== position) {
+							return fail(
+								new Error(`Section table does not match size of ${file}`)
 							);
 						}
-						const section = pointerSections[index];
-						readAt(section.position, section.length, (buffer) => {
-							// pointer section: u64 size + utf-8 file name
-							names.push(buffer.toString("utf8", 8));
-							readNext(index + 1);
-						});
-					};
-					readNext(0);
+						/** @type {string[]} */
+						const names = [];
+						/**
+						 * Reads the pointer section at `index`, then the next one.
+						 * @param {number} index pointer section index
+						 * @returns {void}
+						 */
+						const readNext = (index) => {
+							if (index >= pointerSections.length) {
+								return fs.close(fd, (err) =>
+									err ? reject(err) : resolve(names)
+								);
+							}
+							const section = pointerSections[index];
+							readAt(section.position, section.length, (buffer) => {
+								// pointer section: u64 size + utf-8 file name
+								names.push(buffer.toString("utf8", 8));
+								readNext(index + 1);
+							});
+						};
+						readNext(0);
+					});
 				});
 			});
 		});

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -849,17 +849,28 @@ const parsePointerNames = (buf) => {
 	}
 	const sectionCount = buf.readUInt32LE(4);
 	let offset = 8 + sectionCount * 4;
+	// a corrupt section table must abort the walk, never silently drop a name
+	if (offset > buf.length) {
+		throw new Error(`Invalid section count ${sectionCount}`);
+	}
 	/** @type {string[]} */
 	const names = [];
 	for (let i = 0; i < sectionCount; i++) {
 		const length = buf.readInt32LE(8 + i * 4);
 		if (length < 0) {
 			// pointer section: u64 size + utf-8 file name
-			names.push(buf.toString("utf8", offset + 8, offset - length));
-			offset -= length;
+			const end = offset - length;
+			if (end > buf.length) {
+				throw new Error("Truncated pointer section");
+			}
+			names.push(buf.toString("utf8", offset + 8, end));
+			offset = end;
 		} else {
 			offset += length;
 		}
+	}
+	if (offset !== buf.length) {
+		throw new Error("Section table does not match file size");
 	}
 	return names;
 };

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -234,8 +234,8 @@ describe("FileMiddleware getReferencedFilenames", () => {
 	});
 
 	it("rejects when stat errors", async () => {
+		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
 		const fs = /** @type {EXPECTED_ANY} */ (fsWithFile(content));
-		const fs = fsWithFile(content);
 		fs.stat = (
 			/** @type {string} */ _file,
 			/** @type {EXPECTED_ANY} */ callback

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -174,7 +174,8 @@ describe("FileMiddleware getReferencedFilenames", () => {
 		).resolves.toEqual(["file-a"]);
 	});
 
-	(zlib.zstdCompressSync ? it : it.skip)(
+	// zstd is only available on Node.js >= 22.15
+	("zstdCompressSync" in zlib ? it : it.skip)(
 		"supports zstd compressed files",
 		async () => {
 			const content = buildFile(["file-a"]);

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -222,7 +222,7 @@ describe("FileMiddleware getReferencedFilenames", () => {
 
 	it("rejects when the section table does not match the file size", async () => {
 		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
-		const fs = fsWithFile(content);
+		const fs = /** @type {EXPECTED_ANY} */ (fsWithFile(content));
 		// the table sums to fewer bytes than the file actually has
 		fs.stat = (
 			/** @type {string} */ _file,

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -43,3 +43,175 @@ describe("FileMiddleware deserialize", () => {
 		expect(Buffer.from(/** @type {Buffer} */ (result[0]))).toEqual(content);
 	});
 });
+
+describe("FileMiddleware getReferencedFilenames", () => {
+	const { getReferencedFilenames } = FileMiddleware;
+
+	const zlib = require("zlib");
+
+	/**
+	 * @param {string} name referenced file name
+	 * @returns {Buffer} a lazy pointer section (u64 size + utf-8 name)
+	 */
+	const buildPointer = (name) => {
+		const nameBuffer = Buffer.from(name);
+		const buf = Buffer.alloc(8 + nameBuffer.length);
+		nameBuffer.copy(buf, 8);
+		return buf;
+	};
+
+	/**
+	 * @param {(Buffer | string)[]} sections content buffers or pointer names
+	 * @returns {Buffer} serialized file content
+	 */
+	const buildFile = (sections) => {
+		const buffers = sections.map((s) =>
+			typeof s === "string" ? buildPointer(s) : s
+		);
+		const header = buildHeader(
+			sections.map((s, i) =>
+				typeof s === "string" ? -buffers[i].length : buffers[i].length
+			)
+		);
+		return Buffer.concat([header, ...buffers]);
+	};
+
+	/**
+	 * @param {Buffer} content file content returned for any file
+	 * @param {number=} maxBytesPerRead cap for a single positional read
+	 * @returns {import("../lib/util/fs").IntermediateFileSystem} fake fs
+	 */
+	// callbacks fire asynchronously like a real fs, so a `throw` inside them
+	// is not swallowed by a surrounding Promise executor
+	const fsWithFile = (content, maxBytesPerRead = Infinity) =>
+		/** @type {EXPECTED_ANY} */ ({
+			readFile: (
+				/** @type {string} */ _file,
+				/** @type {(err: Error | null, content?: Buffer) => void} */ callback
+			) => process.nextTick(() => callback(null, content)),
+			open: (
+				/** @type {string} */ _file,
+				/** @type {string} */ _flags,
+				/** @type {(err: Error | null, fd?: number) => void} */ callback
+			) => process.nextTick(() => callback(null, 1)),
+			read: (
+				/** @type {number} */ _fd,
+				/** @type {Buffer} */ buffer,
+				/** @type {number} */ offset,
+				/** @type {number} */ length,
+				/** @type {number} */ position,
+				/** @type {(err: Error | null, bytesRead: number) => void} */ callback
+			) => {
+				const slice = content.subarray(
+					position,
+					position + Math.min(length, maxBytesPerRead)
+				);
+				slice.copy(buffer, offset);
+				process.nextTick(() => callback(null, slice.length));
+			},
+			close: (
+				/** @type {number} */ _fd,
+				/** @type {(err: Error | null) => void} */ callback
+			) => process.nextTick(() => callback(null))
+		});
+
+	it("extracts pointer names between content sections", async () => {
+		const content = buildFile([
+			Buffer.from([1, 2, 3]),
+			"file-a",
+			Buffer.from([4]),
+			"file-b"
+		]);
+		await expect(
+			getReferencedFilenames(fsWithFile(content), "index.pack")
+		).resolves.toEqual(["file-a", "file-b"]);
+	});
+
+	it("returns no names for files without pointers", async () => {
+		const content = buildFile([Buffer.from([1, 2, 3])]);
+		await expect(
+			getReferencedFilenames(fsWithFile(content), "index.pack")
+		).resolves.toEqual([]);
+	});
+
+	it("handles partial positional reads", async () => {
+		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
+		await expect(
+			getReferencedFilenames(fsWithFile(content, 3), "index.pack")
+		).resolves.toEqual(["file-a"]);
+	});
+
+	it("rejects on a truncated file", async () => {
+		const content = buildFile(["file-a"]).subarray(0, 10);
+		await expect(
+			getReferencedFilenames(fsWithFile(content), "index.pack")
+		).rejects.toThrow(/Unexpected end of file/);
+	});
+
+	it("rejects on a corrupt section count instead of crashing", async () => {
+		// valid magic but an absurd section count that must not be allocated
+		const content = Buffer.alloc(8);
+		content.writeUInt32LE(VERSION, 0);
+		content.writeUInt32LE(0xffffffff, 4);
+		await expect(
+			getReferencedFilenames(fsWithFile(content), "index.pack")
+		).rejects.toThrow(/allocate|out of range|Invalid/i);
+	});
+
+	it("supports gzip and brotli compressed files", async () => {
+		const content = buildFile(["file-a"]);
+		await expect(
+			getReferencedFilenames(
+				fsWithFile(zlib.gzipSync(content)),
+				"index.pack.gz"
+			)
+		).resolves.toEqual(["file-a"]);
+		await expect(
+			getReferencedFilenames(
+				fsWithFile(zlib.brotliCompressSync(content)),
+				"index.pack.br"
+			)
+		).resolves.toEqual(["file-a"]);
+	});
+
+	(zlib.zstdCompressSync ? it : it.skip)(
+		"supports zstd compressed files",
+		async () => {
+			const content = buildFile(["file-a"]);
+			await expect(
+				getReferencedFilenames(
+					fsWithFile(zlib.zstdCompressSync(content)),
+					"index.pack.zst"
+				)
+			).resolves.toEqual(["file-a"]);
+		}
+	);
+
+	it("rejects on version mismatch", async () => {
+		const content = buildFile(["file-a"]);
+		content.writeUInt32LE(0, 0);
+		await expect(
+			getReferencedFilenames(fsWithFile(content), "index.pack")
+		).rejects.toThrow(/Invalid file version/);
+	});
+
+	it("rejects on read errors", async () => {
+		const fs = /** @type {EXPECTED_ANY} */ ({
+			readFile: (
+				/** @type {string} */ _file,
+				/** @type {(err: Error | null) => void} */ callback
+			) => callback(new Error("read failed")),
+			open: (
+				/** @type {string} */ _file,
+				/** @type {string} */ _flags,
+				/** @type {(err: Error | null) => void} */ callback
+			) => callback(new Error("open failed"))
+		});
+		await expect(getReferencedFilenames(fs, "index.pack")).rejects.toThrow(
+			/open failed/
+		);
+		await expect(getReferencedFilenames(fs, "index.pack.gz")).rejects.toThrow(
+			/read failed/
+		);
+	});
+});

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -155,7 +155,7 @@ describe("FileMiddleware getReferencedFilenames", () => {
 		content.writeUInt32LE(0xffffffff, 4);
 		await expect(
 			getReferencedFilenames(fsWithFile(content), "index.pack")
-		).rejects.toThrow(/allocate|out of range|Invalid/i);
+		).rejects.toThrow(/Invalid section size/);
 	});
 
 	it("supports gzip and brotli compressed files", async () => {

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -234,7 +234,7 @@ describe("FileMiddleware getReferencedFilenames", () => {
 	});
 
 	it("rejects when stat errors", async () => {
-		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
+		const fs = /** @type {EXPECTED_ANY} */ (fsWithFile(content));
 		const fs = fsWithFile(content);
 		fs.stat = (
 			/** @type {string} */ _file,

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -219,4 +219,29 @@ describe("FileMiddleware getReferencedFilenames", () => {
 			/read failed/
 		);
 	});
+
+	it("rejects when the section table does not match the file size", async () => {
+		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
+		const fs = fsWithFile(content);
+		// the table sums to fewer bytes than the file actually has
+		fs.stat = (
+			/** @type {string} */ _file,
+			/** @type {EXPECTED_ANY} */ callback
+		) => process.nextTick(() => callback(null, { size: content.length + 10 }));
+		await expect(getReferencedFilenames(fs, "index.pack")).rejects.toThrow(
+			/Section table does not match size/
+		);
+	});
+
+	it("rejects when stat errors", async () => {
+		const content = buildFile([Buffer.from([1, 2, 3]), "file-a"]);
+		const fs = fsWithFile(content);
+		fs.stat = (
+			/** @type {string} */ _file,
+			/** @type {EXPECTED_ANY} */ callback
+		) => process.nextTick(() => callback(new Error("stat failed")));
+		await expect(getReferencedFilenames(fs, "index.pack")).rejects.toThrow(
+			/stat failed/
+		);
+	});
 });

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -112,7 +112,11 @@ describe("FileMiddleware getReferencedFilenames", () => {
 			close: (
 				/** @type {number} */ _fd,
 				/** @type {(err: Error | null) => void} */ callback
-			) => process.nextTick(() => callback(null))
+			) => process.nextTick(() => callback(null)),
+			stat: (
+				/** @type {string} */ _file,
+				/** @type {EXPECTED_ANY} */ callback
+			) => process.nextTick(() => callback(null, { size: content.length }))
 		});
 
 	it("extracts pointer names between content sections", async () => {

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+require("./helpers/warmup-webpack");
+
+const path = require("path");
+const rimraf = require("rimraf");
+
+// Matches VERSION in lib/serialization/FileMiddleware.js.
+const VERSION = 0x01637077;
+
+/**
+ * @param {string[]} pointerNames referenced file names
+ * @returns {Buffer} serialized file content with one pointer section per name
+ */
+const buildFileWithPointers = (pointerNames) => {
+	const pointers = pointerNames.map((name) => {
+		const nameBuffer = Buffer.from(name);
+		const buf = Buffer.alloc(8 + nameBuffer.length);
+		nameBuffer.copy(buf, 8);
+		return buf;
+	});
+	const header = Buffer.alloc(8 + pointers.length * 4);
+	header.writeUInt32LE(VERSION, 0);
+	header.writeUInt32LE(pointers.length, 4);
+	for (const [i, pointer] of pointers.entries()) {
+		header.writeInt32LE(-pointer.length, 8 + i * 4);
+	}
+	return Buffer.concat([header, ...pointers]);
+};
+
+describe("PackFileCacheStrategy cleanup", () => {
+	const tempPath = path.resolve(__dirname, "js", "pack-cleanup");
+
+	beforeEach((done) => {
+		rimraf(tempPath, done);
+	});
+
+	it("deletes stale unreferenced files but keeps written, retained and recent ones", async () => {
+		const fs = require("graceful-fs");
+
+		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		// "retained" references "nested" via a lazy pointer; only walking finds it
+		fs.writeFileSync(
+			path.join(tempPath, "retained.pack"),
+			buildFileWithPointers(["nested"])
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "nested.pack"),
+			buildFileWithPointers([])
+		);
+		fs.writeFileSync(path.join(tempPath, "written.pack"), "written");
+		fs.writeFileSync(path.join(tempPath, "orphan-old.pack"), "orphan");
+		fs.writeFileSync(path.join(tempPath, "orphan-new.pack"), "orphan");
+		fs.mkdirSync(path.join(tempPath, "subdir"));
+		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		for (const file of [
+			"retained.pack",
+			"nested.pack",
+			"written.pack",
+			"orphan-old.pack",
+			"subdir"
+		]) {
+			fs.utimesSync(path.join(tempPath, file), oldTime, oldTime);
+		}
+
+		/** @type {EXPECTED_ANY} */
+		const logger = {
+			time: () => {},
+			timeEnd: () => {},
+			log: () => {},
+			debug: () => {},
+			warn: () => {},
+			error: () => {},
+			getChildLogger: () => logger
+		};
+		const strategy = new PackFileCacheStrategy({
+			compiler: /** @type {EXPECTED_ANY} */ ({
+				options: { output: { hashFunction: "md4" } }
+			}),
+			fs,
+			context: tempPath,
+			cacheLocation: tempPath,
+			version: "test",
+			logger,
+			snapshot: /** @type {EXPECTED_ANY} */ ({
+				managedPaths: [],
+				immutablePaths: []
+			}),
+			maxAge: 1000 * 60
+		});
+
+		await strategy._cleanupUnusedFiles(
+			new Set(["written"]),
+			new Set(["retained"])
+		);
+
+		const files = fs.readdirSync(tempPath).sort();
+		expect(files).toEqual([
+			"nested.pack",
+			"orphan-new.pack",
+			"retained.pack",
+			"subdir",
+			"written.pack"
+		]);
+	});
+
+	it("walks each retained file only once across stores", async () => {
+		const gracefulFs = require("graceful-fs");
+
+		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
+
+		gracefulFs.mkdirSync(tempPath, { recursive: true });
+		gracefulFs.writeFileSync(
+			path.join(tempPath, "retained.pack"),
+			buildFileWithPointers(["nested"])
+		);
+		gracefulFs.writeFileSync(
+			path.join(tempPath, "nested.pack"),
+			buildFileWithPointers([])
+		);
+
+		/** @type {Map<string, number>} */
+		const readCounts = new Map();
+		/** @type {EXPECTED_ANY} */
+		const fs = Object.create(gracefulFs);
+		fs.open = (
+			/** @type {string} */ file,
+			/** @type {string} */ flags,
+			/** @type {EXPECTED_ANY} */ callback
+		) => {
+			readCounts.set(file, (readCounts.get(file) || 0) + 1);
+			gracefulFs.open(file, flags, callback);
+		};
+
+		/** @type {EXPECTED_ANY} */
+		const logger = {
+			time: () => {},
+			timeEnd: () => {},
+			log: () => {},
+			debug: () => {},
+			warn: () => {},
+			error: () => {},
+			getChildLogger: () => logger
+		};
+		const strategy = new PackFileCacheStrategy({
+			compiler: /** @type {EXPECTED_ANY} */ ({
+				options: { output: { hashFunction: "md4" } }
+			}),
+			fs,
+			context: tempPath,
+			cacheLocation: tempPath,
+			version: "test",
+			logger,
+			snapshot: /** @type {EXPECTED_ANY} */ ({
+				managedPaths: [],
+				immutablePaths: []
+			}),
+			maxAge: 1000 * 60
+		});
+
+		const retainedPath = path.join(tempPath, "retained.pack");
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(readCounts.get(retainedPath)).toBe(1);
+		// second store: both walked files come from the memo, no re-read
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(readCounts.get(retainedPath)).toBe(1);
+		expect(readCounts.get(path.join(tempPath, "nested.pack"))).toBe(1);
+		// a rewritten file is dropped from the memo and walked again when retained
+		await strategy._cleanupUnusedFiles(new Set(["retained"]), new Set());
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(readCounts.get(retainedPath)).toBe(2);
+		// entries of files that are no longer alive are pruned
+		strategy._referencedFilesCache.set("ghost", []);
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(strategy._referencedFilesCache.has("ghost")).toBe(false);
+		expect(strategy._referencedFilesCache.has("retained")).toBe(true);
+	});
+});

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -130,7 +130,10 @@ describe("PackFileCacheStrategy cleanup", () => {
 			/** @type {string} */ flags,
 			/** @type {EXPECTED_ANY} */ callback
 		) => {
-			readCounts.set(file, (readCounts.get(file) || 0) + 1);
+			// the strategy joins paths with "/"; normalize so lookups built with
+			// path.join match on Windows too
+			const key = path.normalize(file);
+			readCounts.set(key, (readCounts.get(key) || 0) + 1);
 			gracefulFs.open(file, flags, callback);
 		};
 

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -230,9 +230,91 @@ describe("PackFileCacheStrategy cleanup", () => {
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
 		expect(readCounts.get(retainedPath)).toBe(2);
 		// entries of files that are no longer alive are pruned
-		strategy._referencedFilesCache.set("ghost", []);
+		strategy._referencedFilesCache.set("ghost", {
+			mtimeMs: 0,
+			referenced: []
+		});
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
 		expect(strategy._referencedFilesCache.has("ghost")).toBe(false);
 		expect(strategy._referencedFilesCache.has("retained")).toBe(true);
+	});
+
+	it("re-reads a retained file rewritten in place by a concurrent process", async () => {
+		const fs = require("graceful-fs");
+
+		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		fs.writeFileSync(
+			path.join(tempPath, "retained.pack"),
+			buildFileWithPointers(["nested-a"])
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "nested-a.pack"),
+			buildFileWithPointers([])
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "nested-b.pack"),
+			buildFileWithPointers([])
+		);
+		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		for (const file of ["retained.pack", "nested-a.pack", "nested-b.pack"]) {
+			fs.utimesSync(path.join(tempPath, file), oldTime, oldTime);
+		}
+
+		/** @type {EXPECTED_ANY} */
+		const logger = {
+			time: () => {},
+			timeEnd: () => {},
+			log: () => {},
+			debug: () => {},
+			warn: () => {},
+			error: () => {},
+			getChildLogger: () => logger
+		};
+		const strategy = new PackFileCacheStrategy({
+			compiler: /** @type {EXPECTED_ANY} */ ({
+				options: { output: { hashFunction: "md4" } }
+			}),
+			fs,
+			context: tempPath,
+			cacheLocation: tempPath,
+			version: "test",
+			logger,
+			snapshot: /** @type {EXPECTED_ANY} */ ({
+				managedPaths: [],
+				immutablePaths: []
+			}),
+			maxAge: 1000 * 60
+		});
+
+		// first store memoizes retained -> nested-a
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(fs.readdirSync(tempPath).sort()).toEqual([
+			"nested-a.pack",
+			"retained.pack"
+		]);
+
+		// a concurrent process rewrites retained.pack to reference nested-b
+		fs.writeFileSync(
+			path.join(tempPath, "retained.pack"),
+			buildFileWithPointers(["nested-b"])
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "nested-b.pack"),
+			buildFileWithPointers([])
+		);
+		// old but newer than the memoized mtime, so the memo must be refreshed
+		const newerOldTime = new Date(Date.now() - 60 * 60 * 1000);
+		for (const file of ["retained.pack", "nested-b.pack"]) {
+			fs.utimesSync(path.join(tempPath, file), newerOldTime, newerOldTime);
+		}
+
+		// a stale memo would keep nested-a alive and delete nested-b
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
+		expect(fs.readdirSync(tempPath).sort()).toEqual([
+			"nested-b.pack",
+			"retained.pack"
+		]);
 	});
 });

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -106,6 +106,61 @@ describe("PackFileCacheStrategy cleanup", () => {
 		]);
 	});
 
+	it("aborts the whole cleanup and deletes nothing when a retained file is unreadable", async () => {
+		const fs = require("graceful-fs");
+
+		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		// walking this retained file fails: the live set would be incomplete
+		fs.writeFileSync(path.join(tempPath, "corrupt.pack"), "not a pack file");
+		// stale orphan that a successful cleanup would delete
+		fs.writeFileSync(path.join(tempPath, "orphan-old.pack"), "orphan");
+		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		for (const file of ["corrupt.pack", "orphan-old.pack"]) {
+			fs.utimesSync(path.join(tempPath, file), oldTime, oldTime);
+		}
+
+		/** @type {string[]} */
+		const warnings = [];
+		/** @type {EXPECTED_ANY} */
+		const logger = {
+			time: () => {},
+			timeEnd: () => {},
+			log: () => {},
+			debug: () => {},
+			warn: (/** @type {string} */ message) => warnings.push(message),
+			error: () => {},
+			getChildLogger: () => logger
+		};
+		const strategy = new PackFileCacheStrategy({
+			compiler: /** @type {EXPECTED_ANY} */ ({
+				options: { output: { hashFunction: "md4" } }
+			}),
+			fs,
+			context: tempPath,
+			cacheLocation: tempPath,
+			version: "test",
+			logger,
+			snapshot: /** @type {EXPECTED_ANY} */ ({
+				managedPaths: [],
+				immutablePaths: []
+			}),
+			maxAge: 1000 * 60
+		});
+
+		await strategy._cleanupUnusedFiles(new Set(), new Set(["corrupt"]));
+
+		// nothing was deleted, not even the stale orphan
+		expect(fs.readdirSync(tempPath).sort()).toEqual([
+			"corrupt.pack",
+			"orphan-old.pack"
+		]);
+		expect(warnings).toEqual([
+			expect.stringMatching(/Cleanup of unused cache files failed/)
+		]);
+	});
+
 	it("walks each retained file only once across stores", async () => {
 		const gracefulFs = require("graceful-fs");
 

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -333,6 +333,50 @@ export default 40 + file;
 		expect(execute()).toBe(43);
 	}, 60000);
 
+	it("should delete old unused packs", async () => {
+		// ported from #14661: entry churn with a tiny maxAge orphans whole packs
+		const data = {
+			"a.js": "export default 1;",
+			"b.js": "export default 2;",
+			"c.js": "export default 3;",
+			"d.js": "export default 4;",
+			"e.js": "export default 5;"
+		};
+		await updateSrc(data);
+		const backdateCache = async () => {
+			const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+			for (const file of await readdir(cachePath)) {
+				await utimes(path.join(cachePath, file), oldTime, oldTime);
+			}
+		};
+		const c = (/** @type {string} */ items) => {
+			/** @type {Record<string, string>} */
+			const entry = {};
+			for (const item of items) entry[item] = `./src/${item}.js`;
+			return compile({ entry, cache: { ...config.cache, maxAge: 5000 } });
+		};
+		await c("ab");
+		// content pack and index
+		await expect(readdir(cachePath)).resolves.toHaveLength(2);
+		await c("c");
+		// new content pack, old one still within the grace period, index and index.old
+		await expect(readdir(cachePath)).resolves.toHaveLength(4);
+		// item expiry needs real elapsed time; the grace period is aged via utimes
+		await backdateCache();
+		await new Promise((resolve) => {
+			setTimeout(resolve, 6000);
+		});
+		await c("cde");
+		const remaining = await readdir(cachePath);
+		// unreferenced files beyond the grace period are gone: the pack holding
+		// only the expired a/b items and the old index backup
+		expect(remaining).not.toContain("0.pack");
+		expect(remaining).not.toContain("index.pack.old");
+		// the old-but-still-referenced pack (c stayed cached in it) survives
+		expect(remaining).toContain("1.pack");
+		expect(remaining).toContain("index.pack");
+	}, 60000);
+
 	it("should keep recently modified unreferenced cache files", async () => {
 		await updateSrc({
 			"index.js": "export default 42;"

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -375,6 +375,13 @@ export default 40 + file;
 		// the old-but-still-referenced pack (c stayed cached in it) survives
 		expect(remaining).toContain("1.pack");
 		expect(remaining).toContain("index.pack");
+		// once c stops being used it expires, and its pack gets deleted too
+		await backdateCache();
+		await new Promise((resolve) => {
+			setTimeout(resolve, 6000);
+		});
+		await c("de");
+		expect(await readdir(cachePath)).not.toContain("1.pack");
 	}, 60000);
 
 	it("should keep recently modified unreferenced cache files", async () => {

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -308,6 +308,46 @@ import 'lodash';
 		await expect(getCacheFileTimes()).resolves.toEqual(firstCacheFileTimes);
 	}, 20000);
 
+	it("should delete no longer referenced cache files after storing", async () => {
+		await updateSrc({
+			"index.js": `import file from "./file.js";
+export default 40 + file;
+`,
+			"file.js": "export default 2;"
+		});
+		await compile();
+		// plant an orphan file and age every cache file beyond the cleanup grace period
+		const orphan = "0123456789abcdef0123456789abcdef.pack";
+		await writeFile(path.join(cachePath, orphan), "orphan");
+		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		for (const file of await readdir(cachePath)) {
+			await utimes(path.join(cachePath, file), oldTime, oldTime);
+		}
+		await updateSrc({
+			"file.js": "export default 3;"
+		});
+		await compile();
+		expect(await readdir(cachePath)).not.toContain(orphan);
+		// every file the new index references must have survived the cleanup
+		await compile();
+		expect(execute()).toBe(43);
+	}, 60000);
+
+	it("should keep recently modified unreferenced cache files", async () => {
+		await updateSrc({
+			"index.js": "export default 42;"
+		});
+		await compile();
+		// fresh orphan: within the cleanup grace period, so it must survive
+		const orphan = "0123456789abcdef0123456789abcdef.pack";
+		await writeFile(path.join(cachePath, orphan), "orphan");
+		await updateSrc({
+			"index.js": "export default 43;"
+		});
+		await compile();
+		expect(await readdir(cachePath)).toContain(orphan);
+	}, 60000);
+
 	it("should not invalidate cache files if timestamps changed with dynamic import()", async () => {
 		const configAdditions = {
 			entry: "./src/main.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #13291. The filesystem cache directory grows without bound because files orphaned by cache invalidations (version/config changes, compression changes, stale `index.pack.old`) are never removed — up to 27 GB reported on CI. After a successful store, the strategy now deletes files that are no longer reachable from the stored index: it collects written and retained file names during serialization (decoding retained lazy pointers, the part that blocked #14661), walks retained files on disk for nested references (header + pointer ranges only, memoized across stores), and unlinks unreferenced files older than a 30-minute grace period so concurrent builds sharing the directory are never disturbed. Any walk error aborts the whole cleanup (never delete with an incomplete live set), and the cleanup runs in the idle store phase, off the build's critical path (~100 µs per deleted file, one-time; build times unchanged in benchmarks).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — integration cases in `test/PersistentCaching.test.js` (orphan deleted, fresh files kept, cache restores fully afterwards), direct strategy tests in `test/PackFileCacheStrategyCleanup.test.js` (nested retained walk, grace period, memoization/invalidation), and walker unit tests in `test/FileMiddleware.unittest.js` (pointer parsing, compression variants, truncated/corrupt files); all verified via mutation testing to fail when the fix is removed.

**Does this PR introduce a breaking change?**

No — only files unreachable from the just-stored cache index are deleted, so no valid cache is ever invalidated; filesystems without `unlink` skip the cleanup entirely. Known limitation: compressed packs > 2 GB abort the cleanup with a warning (uncompressed packs are read by byte range and have no such limit).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was developed with the assistance of Claude Code (Anthropic): investigation of the issue and prior PRs (#13875, #14661), implementation, tests, benchmarks, and mutation-testing verification were done by the AI under my direction and review; I validated the approach and results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistent cache on disk and concurrent shared cache dirs; mistakes could delete still-needed packs, though abort-on-error and the grace period mitigate that.
> 
> **Overview**
> Fixes unbounded growth of the filesystem cache directory by **deleting pack files that are no longer reachable** from the index after a successful store.
> 
> **`PackFileCacheStrategy`** now runs post-store cleanup when the filesystem supports `unlink`: it builds a **live file set** from the new index, files written in that store, and **retained** lazy segments (plus a BFS walk of nested references via **`getReferencedFilenames`**). Anything else in the cache dir that is a **regular file** and older than a **30-minute grace period** is unlinked. Walk/parse failures **abort the whole cleanup** (warning only, no partial deletes); failed stores clear the reference memo.
> 
> **`FileMiddleware`** records **`writtenFiles`** / **`retainedFiles`** during serialization (including names from reused lazy pointer buffers) and exports **`getReferencedFilenames`** to read pointer targets from pack headers without full deserialization (byte-range reads for uncompressed packs; full decompress for `.gz`/`.br`/`.zst`, with corrupt-file guards).
> 
> Integration and strategy tests cover orphans, grace period, nested retention, memoization, concurrent in-place rewrites, and entry-churn pack expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c310c1a6e9ad20215cfc64263da095afeb344a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->