### PR TITLE
chore(ci): single comment

### DIFF
--- a/.github/scripts/pr-report-comment.mjs
+++ b/.github/scripts/pr-report-comment.mjs
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path from "path";
+
+// Every producer writes into this one comment; `find-comment` locates it by the marker.
+const MARKER = "<!-- webpack-ci-report -->";
+const HEADING = "### 🤖 webpack CI report";
+// Sections render in this order, whichever workflow produces them first.
+const SECTION_ORDER = ["package-preview", "types-coverage"];
+const SECTION_SEPARATOR = "\n\n---\n\n";
+// GitHub rejects comment bodies over 65536 characters; leave headroom because it
+// counts differently than `String#length` for astral characters.
+const MAX_BODY_LENGTH = 65000;
+const TRUNCATION_NOTICE =
+	"\n\n_Report truncated to fit GitHub's comment size limit._";
+
+/**
+ * @param {string} section section id
+ * @returns {string} opening delimiter of the section
+ */
+function startDelimiter(section) {
+	return `<!-- section:${section} -->`;
+}
+
+/**
+ * @param {string} section section id
+ * @returns {string} closing delimiter of the section
+ */
+function endDelimiter(section) {
+	return `<!-- /section:${section} -->`;
+}
+
+/**
+ * @param {string} body existing comment body
+ * @returns {Map<string, string>} section id to its markdown
+ */
+function parseSections(body) {
+	/** @type {Map<string, string>} */
+	const sections = new Map();
+	const regexp =
+		/<!-- section:([\w-]+) -->\n([\s\S]*?)\n<!-- \/section:\1 -->/g;
+	let match;
+
+	while ((match = regexp.exec(body)) !== null) {
+		sections.set(match[1], match[2]);
+	}
+
+	return sections;
+}
+
+/**
+ * @param {Map<string, string>} sections section id to its markdown
+ * @returns {string} full comment body
+ */
+function renderBody(sections) {
+	const known = SECTION_ORDER.filter((section) => sections.has(section));
+	const unknown = [...sections.keys()].filter(
+		(section) => !SECTION_ORDER.includes(section)
+	);
+	const rendered = [...known, ...unknown]
+		.map(
+			(section) =>
+				`${startDelimiter(section)}\n${sections.get(section)}\n${endDelimiter(section)}`
+		)
+		.join(SECTION_SEPARATOR);
+	const body = `${MARKER}\n${HEADING}\n\n${rendered}`;
+
+	return body.length > MAX_BODY_LENGTH
+		? body.slice(0, MAX_BODY_LENGTH - TRUNCATION_NOTICE.length) +
+				TRUNCATION_NOTICE
+		: body;
+}
+
+const sectionsPath = process.env.SECTIONS_PATH;
+const outputPath = process.env.OUTPUT_PATH;
+
+// GitHub serves comment bodies with CRLF line endings, the delimiters use LF.
+const existingBody = (process.env.EXISTING_BODY || "").replace(/\r\n/g, "\n");
+// Sections without a downloaded artifact keep whatever the comment already shows.
+const sections = parseSections(existingBody);
+const collected = fs
+	.readdirSync(sectionsPath)
+	.filter((entry) => entry.endsWith(".md"));
+
+for (const entry of collected) {
+	const section = path.basename(entry, ".md");
+	const sectionBody = fs
+		.readFileSync(path.join(sectionsPath, entry), "utf8")
+		.trim();
+
+	if (sectionBody) {
+		sections.set(section, sectionBody);
+	} else {
+		sections.delete(section);
+	}
+}
+
+const body = renderBody(sections);
+
+fs.writeFileSync(outputPath, body);

--- a/.github/scripts/publish-to-pkg-pr-new.mjs
+++ b/.github/scripts/publish-to-pkg-pr-new.mjs
@@ -1,23 +1,22 @@
 /* eslint-disable no-console */
-/* eslint-disable camelcase */
 
 import fs from "fs";
 
-/**
- * @param {{ github: EXPECTED_ANY, context: EXPECTED_ANY }} params params
- */
-export async function run({ github, context }) {
-	const output = JSON.parse(fs.readFileSync("output.json", "utf8"));
+const output = JSON.parse(fs.readFileSync("output.json", "utf8"));
+const outputPath = process.env.OUTPUT_PATH;
+const sha = process.env.COMMIT_SHA;
 
-	const sha =
-		context.eventName === "pull_request"
-			? context.payload.pull_request.head.sha
-			: context.sha;
+if (!outputPath || !sha) {
+	throw new Error("OUTPUT_PATH and COMMIT_SHA must both be provided");
+}
 
-	const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`;
+const commitUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/commit/${sha}`;
+const packages = output.packages.map((p) => p.url).join(" ");
 
-	const botCommentIdentifier = "<!-- posted by pkg.pr.new -->";
-	const body = `${botCommentIdentifier}
+fs.writeFileSync(
+	outputPath,
+	`#### 📦 Package preview
+
 This PR is packaged and the instant preview is available (${commitUrl}).
 
 Install it locally:
@@ -25,105 +24,29 @@ Install it locally:
 - npm
 
 \`\`\`shell
-npm i -D webpack@${output.packages.map((p) => p.url).join(" ")}
+npm i -D webpack@${packages}
 \`\`\`
 
 - yarn
 
 \`\`\`shell
-yarn add -D webpack@${output.packages.map((p) => p.url).join(" ")}
+yarn add -D webpack@${packages}
 \`\`\`
 
 - pnpm
 
 \`\`\`shell
-pnpm add -D webpack@${output.packages.map((p) => p.url).join(" ")}
+pnpm add -D webpack@${packages}
 \`\`\`
-`;
+`
+);
 
-	/**
-	 * @param {number=} issueNumber PR number
-	 * @returns {Promise<EXPECTED_ANY[]>} comments
-	 */
-	async function findBotComment(issueNumber) {
-		if (!issueNumber) return null;
-		const comments = await github.rest.issues.listComments({
-			owner: context.repo.owner,
-			repo: context.repo.repo,
-			issue_number: issueNumber
-		});
-		return comments.data.find(
-			(comment) =>
-				// Prevent unintentional overwriting
-				comment.user &&
-				comment.user.login === "github-actions[bot]" &&
-				comment.body.includes(botCommentIdentifier)
-		);
-	}
-
-	/**
-	 * @param {number=} issueNumber issue number
-	 * @returns {Promise<void>}
-	 */
-	async function createOrUpdateComment(issueNumber) {
-		if (!issueNumber) {
-			console.log("No issue number provided. Cannot post or update comment.");
-			return;
-		}
-
-		const existingComment = await findBotComment(issueNumber);
-
-		if (existingComment) {
-			await github.rest.issues.updateComment({
-				owner: context.repo.owner,
-				repo: context.repo.repo,
-				comment_id: existingComment.id,
-				body
-			});
-		} else {
-			await github.rest.issues.createComment({
-				issue_number: issueNumber,
-				owner: context.repo.owner,
-				repo: context.repo.repo,
-				body
-			});
-		}
-	}
-
-	/**
-	 * @returns {void}
-	 */
-	function logPublishInfo() {
-		console.log(`\n${"=".repeat(50)}`);
-		console.log("Publish Information");
-		console.log("=".repeat(50));
-		console.log("\nPublished Packages:");
-		console.log(output.packages);
-		console.log("\nTemplates:");
-		console.log(output.templates);
-		console.log(`\nCommit URL: ${commitUrl}`);
-		console.log(`\n${"=".repeat(50)}`);
-	}
-
-	if (context.eventName === "pull_request") {
-		if (context.issue.number) {
-			await createOrUpdateComment(context.issue.number);
-		}
-	} else if (context.eventName === "push") {
-		const { data: prs } =
-			await github.rest.repos.listPullRequestsAssociatedWithCommit({
-				owner: context.repo.owner,
-				repo: context.repo.repo,
-				commit_sha: sha
-			});
-
-		if (prs.length > 0) {
-			await createOrUpdateComment(prs[0].number);
-		} else {
-			console.log(
-				"No open pull request found for this push. Logging publish information to console:"
-			);
-			logPublishInfo();
-		}
-	}
-}
+console.log(`\n${"=".repeat(50)}`);
+console.log("Publish Information");
+console.log("=".repeat(50));
+console.log("\nPublished Packages:");
+console.log(output.packages);
+console.log("\nTemplates:");
+console.log(output.templates);
+console.log(`\nCommit URL: ${commitUrl}`);
+console.log(`\n${"=".repeat(50)}`);

--- a/.github/scripts/types-coverage-comment.mjs
+++ b/.github/scripts/types-coverage-comment.mjs
@@ -1,0 +1,105 @@
+/* eslint-disable no-console */
+
+import fs from "fs";
+
+// Keeps the section small enough that every producer fits in the shared comment.
+const MAX_LISTED_FILES = 50;
+
+/**
+ * @typedef {object} FileCoverage
+ * @property {string} path repository relative path
+ * @property {number} found number of statements
+ * @property {number} hit number of precisely typed statements
+ */
+
+/**
+ * @param {string} lcov contents of an lcov report
+ * @returns {FileCoverage[]} coverage per file
+ */
+function parseLcov(lcov) {
+	/** @type {FileCoverage[]} */
+	const files = [];
+	/** @type {FileCoverage | undefined} */
+	let current;
+
+	for (const line of lcov.split(/\r?\n/)) {
+		if (line.startsWith("SF:")) {
+			current = { path: line.slice(3), found: 0, hit: 0 };
+		} else if (!current) {
+			continue;
+		} else if (line.startsWith("LF:")) {
+			current.found = Number(line.slice(3));
+		} else if (line.startsWith("LH:")) {
+			current.hit = Number(line.slice(3));
+		} else if (line === "end_of_record") {
+			files.push(current);
+			current = undefined;
+		}
+	}
+
+	return files;
+}
+
+/**
+ * @param {number} hit number of precisely typed statements
+ * @param {number} found number of statements
+ * @returns {string} percentage with two decimals
+ */
+function percentage(hit, found) {
+	return found === 0 ? "100.00%" : `${((hit / found) * 100).toFixed(2)}%`;
+}
+
+const lcovPath = process.env.LCOV_PATH || "coverage/lcov.info";
+const outputPath = process.env.OUTPUT_PATH;
+
+if (!outputPath) {
+	throw new Error("OUTPUT_PATH must be provided");
+}
+
+const files = parseLcov(fs.readFileSync(lcovPath, "utf8"));
+const found = files.reduce((total, file) => total + file.found, 0);
+const hit = files.reduce((total, file) => total + file.hit, 0);
+const untyped = files
+	.filter((file) => file.hit < file.found)
+	.sort((a, b) => b.found - b.hit - (a.found - a.hit));
+
+const lines = [
+	"#### 🧩 Types coverage",
+	"",
+	`**${percentage(hit, found)}** of \`${found.toLocaleString("en-US")}\` statements are precisely typed.`
+];
+
+if (untyped.length > 0) {
+	const repository = process.env.GITHUB_REPOSITORY;
+	const sha = process.env.COMMIT_SHA || process.env.GITHUB_SHA;
+	const listed = untyped.slice(0, MAX_LISTED_FILES);
+
+	lines.push(
+		"",
+		"<details>",
+		`<summary>${untyped.length} files with untyped statements</summary>`,
+		"",
+		"| File | Coverage | Untyped |",
+		"| :--- | ---: | ---: |",
+		...listed.map((file) => {
+			const name =
+				repository && sha
+					? `[${file.path}](https://github.com/${repository}/blob/${sha}/${file.path})`
+					: file.path;
+
+			return `| ${name} | ${percentage(file.hit, file.found)} | ${file.found - file.hit} |`;
+		})
+	);
+
+	if (untyped.length > listed.length) {
+		lines.push("", `_… and ${untyped.length - listed.length} more files._`);
+	}
+
+	lines.push("", "</details>");
+}
+
+fs.writeFileSync(outputPath, `${lines.join("\n")}\n`);
+
+console.log(
+	`Types coverage: ${percentage(hit, found)} (${found - hit} untyped of ${found}) across ${files.length} files.`
+);

--- a/.github/workflows/publish-to-pkg-pr-new.yml
+++ b/.github/workflows/publish-to-pkg-pr-new.yml
@@ -8,8 +8,7 @@ on:
     tags: ["!**"]
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   publish:
@@ -19,9 +18,6 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository)
     name: Publish to pkg.pr.new
     runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.publish.outputs.sha }}
-      urls: ${{ steps.publish.outputs.urls }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: corepack enable
@@ -32,10 +28,15 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile
       - run: npx pkg-pr-new publish --compact --json output.json --comment=off
-      - name: Add metadata to output
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Build the package preview report
+        run: node .github/scripts/publish-to-pkg-pr-new.mjs
+        env:
+          OUTPUT_PATH: ${{ runner.temp }}/package-preview.md
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # Picked up by `update-shared-comment.yml`, the sole writer of the comment.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { run } = await import('${{ github.workspace }}/.github/scripts/publish-to-pkg-pr-new.mjs');
-            await run({ github, context });
+          name: pr-report-package-preview
+          path: ${{ runner.temp }}/package-preview.md
+          retention-days: 1

--- a/.github/workflows/publish-to-pkg-pr-new.yml
+++ b/.github/workflows/publish-to-pkg-pr-new.yml
@@ -12,10 +12,7 @@ permissions:
 
 jobs:
   publish:
-    if: |
-      github.repository == 'webpack/webpack' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'webpack/webpack'
     name: Publish to pkg.pr.new
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           yarn validate:changeset
 
   types-coverage:
-    if: github.repository == 'webpack/webpack' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository == 'webpack/webpack' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,7 @@ jobs:
     if: github.repository == 'webpack/webpack' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -87,15 +86,19 @@ jobs:
       - name: Collect types coverage
         run: yarn types:cover:report
 
-      - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
-        id: findPr
+      - name: Build the types coverage report
+        run: node .github/scripts/types-coverage-comment.mjs
+        env:
+          LCOV_PATH: ./coverage/lcov.info
+          OUTPUT_PATH: ${{ runner.temp }}/types-coverage.md
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - uses: Nef10/lcov-reporter-action@797ec1c1e78e3a9a7890c1a104d58b9e05fcef76 # v0.3.0
+      # Picked up by `update-shared-comment.yml`, the sole writer of the comment.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          pr-number: ${{ steps.findPr.outputs.number }}
-          lcov-file: ./coverage/lcov.info
-          title: Types Coverage
-          delete-old-comments: true
+          name: pr-report-types-coverage
+          path: ${{ runner.temp }}/types-coverage.md
+          retention-days: 1
 
   validate-legacy-node:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-shared-comment.yml
+++ b/.github/workflows/update-shared-comment.yml
@@ -11,12 +11,20 @@ permissions:
   contents: read
 
 concurrency:
-  # One writer per pull request; the newest report supersedes whatever it cancels.
-  group: update-shared-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+  # One writer per pull request, queued rather than cancelled: each run carries the
+  # other workflow's section over from the comment it reads, so cancelling a pending
+  # write would drop that section. Fork pull requests have no `pull_requests` entry.
+  group: update-shared-comment-${{ github.event.workflow_run.pull_requests[0].number || format('{0}@{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) }}
+  cancel-in-progress: false
 
 jobs:
   update:
+    # Only a green pull request run carries a report; pushes, failures and cancelled
+    # runs have nothing to say.
+    if: |
+      github.repository == 'webpack/webpack' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -26,7 +34,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Each artifact holds a single `<section>.md`, so they merge into one directory.
+      # Downloading fails when a producing job was skipped instead of run, which
+      # leaves nothing to post; `hashFiles` below turns that into a no-op.
       - name: Download the report sections
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pr-report-*
@@ -44,7 +55,7 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             if (run.pull_requests.length > 0) return run.pull_requests[0].number;
-            // A push to `main` reports on the pull request that was merged.
+            // `pull_requests` is empty for a fork; the head commit still resolves.
             const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               ...context.repo,
               commit_sha: run.head_sha

--- a/.github/workflows/update-shared-comment.yml
+++ b/.github/workflows/update-shared-comment.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download the report sections
-        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pr-report-*
@@ -66,7 +65,7 @@ jobs:
               return;
             }
 
-            core.setOutput('number', match.number);
+            core.setOutput('result', match.number);
 
       - name: Find the shared comment
         id: find

--- a/.github/workflows/update-shared-comment.yml
+++ b/.github/workflows/update-shared-comment.yml
@@ -1,7 +1,5 @@
 name: Update shared comment
 
-# Sole writer of the sticky CI report comment. Producing workflows only upload
-# their section as an artifact, so none of them needs write access to the PR.
 on:
   workflow_run:
     workflows: [Github Actions, Publish to pkg.pr.new]
@@ -11,16 +9,11 @@ permissions:
   contents: read
 
 concurrency:
-  # One writer per pull request, queued rather than cancelled: each run carries the
-  # other workflow's section over from the comment it reads, so cancelling a pending
-  # write would drop that section. Fork pull requests have no `pull_requests` entry.
-  group: update-shared-comment-${{ github.event.workflow_run.pull_requests[0].number || format('{0}@{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) }}
+  group: update-shared-comment-${{ format('{0}@{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) }}
   cancel-in-progress: false
 
 jobs:
   update:
-    # Only a green pull request run carries a report; pushes, failures and cancelled
-    # runs have nothing to say.
     if: |
       github.repository == 'webpack/webpack' &&
       github.event.workflow_run.event == 'pull_request' &&
@@ -33,9 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Each artifact holds a single `<section>.md`, so they merge into one directory.
-      # Downloading fails when a producing job was skipped instead of run, which
-      # leaves nothing to post; `hashFiles` below turns that into a no-op.
       - name: Download the report sections
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -46,21 +36,37 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve the pull request
+      - name: Resolve Pull Request Number
         id: pr
-        if: hashFiles('sections/*.md') != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          result-encoding: string
           script: |
             const run = context.payload.workflow_run;
-            if (run.pull_requests.length > 0) return run.pull_requests[0].number;
-            // `pull_requests` is empty for a fork; the head commit still resolves.
-            const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              ...context.repo,
-              commit_sha: run.head_sha
-            });
-            return data.length > 0 ? data[0].number : "";
+
+            // 1. For same-repo Pull Requests the run is already linked to its PR(s).
+            if (run.pull_requests && run.pull_requests.length) {
+              core.setOutput('number', run.pull_requests[0].number);
+              return;
+            }
+
+            // 2. For forks that list is empty, so find the open Pull Request who has the
+            // correct branch information
+            const match = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 1,
+            }).then(r => r.data[0]);
+
+            if (!match) {
+              core.info(`No open pull request found for HEAD ${run.head_sha}`);
+              return;
+            }
+
+            core.setOutput('number', match.number);
 
       - name: Find the shared comment
         id: find

--- a/.github/workflows/update-shared-comment.yml
+++ b/.github/workflows/update-shared-comment.yml
@@ -1,0 +1,78 @@
+name: Update shared comment
+
+# Sole writer of the sticky CI report comment. Producing workflows only upload
+# their section as an artifact, so none of them needs write access to the PR.
+on:
+  workflow_run:
+    workflows: [Github Actions, Publish to pkg.pr.new]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  # One writer per pull request; the newest report supersedes whatever it cancels.
+  group: update-shared-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Each artifact holds a single `<section>.md`, so they merge into one directory.
+      - name: Download the report sections
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pr-report-*
+          merge-multiple: true
+          path: sections
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the pull request
+        id: pr
+        if: hashFiles('sections/*.md') != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const run = context.payload.workflow_run;
+            if (run.pull_requests.length > 0) return run.pull_requests[0].number;
+            // A push to `main` reports on the pull request that was merged.
+            const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              ...context.repo,
+              commit_sha: run.head_sha
+            });
+            return data.length > 0 ? data[0].number : "";
+
+      - name: Find the shared comment
+        id: find
+        if: steps.pr.outputs.result != ''
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        with:
+          issue-number: ${{ steps.pr.outputs.result }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- webpack-ci-report -->
+
+      - name: Assemble the comment
+        if: steps.pr.outputs.result != ''
+        run: node .github/scripts/pr-report-comment.mjs
+        env:
+          SECTIONS_PATH: sections
+          EXISTING_BODY: ${{ steps.find.outputs.comment-body }}
+          OUTPUT_PATH: ${{ runner.temp }}/pr-report-comment.md
+
+      - name: Create or update the shared comment
+        if: steps.pr.outputs.result != ''
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ steps.pr.outputs.result }}
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          body-path: ${{ runner.temp }}/pr-report-comment.md
+          edit-mode: replace


### PR DESCRIPTION
Changes our CI to (for GitHub Actions comments) to use a single, continuously updating comment (+ one that works on fork PRs).

To reduce notification-spam from robots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New `workflow_run` orchestration and PR-number resolution are easy to get wrong; same-repo paths set output `number` while later steps gate on `result`, which may block the shared comment unless fixed. No runtime/webpack behavior changes.
> 
> **Overview**
> CI bot output on pull requests moves from **separate comments** (pkg.pr.new, lcov reporter, etc.) to **one** `### 🤖 webpack CI report` comment that gets updated in place, which should cut notification noise.
> 
> **Package preview** and **types coverage** jobs now only build markdown sections and upload `pr-report-*` artifacts; `publish-to-pkg-pr-new.mjs` no longer talks to the GitHub API and pkg.pr.new runs with `--comment=off`. A new **`update-shared-comment`** workflow runs after `Github Actions` or `Publish to pkg.pr.new` succeed, merges section files with any existing comment body via `pr-report-comment.mjs` (ordered sections, size truncation), and creates/updates the shared comment. Types coverage is rendered in-repo from LCOV instead of **Nef10/lcov-reporter-action**.
> 
> Workflow permissions are tightened (mostly `contents: read`; comment writes live on the updater job). Fork PRs are in scope again for publish/types-coverage, with PR lookup via `workflow_run` plus a fork branch query when `pull_requests` is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e57b5e4f667c4d29d49311828ac1a47dd4720a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->