### PR TITLE
fix: avoid stray semicolon after a parenthesized sequence element

### DIFF
--- a/.changeset/020-fix-asi-parenthesized-sequence.md
+++ b/.changeset/020-fix-asi-parenthesized-sequence.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix stray semicolon emitted before an imported call following a parenthesized sequence element.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5625,8 +5625,10 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
-	 * First significant char code at or after `pos`, skipping whitespace and
-	 * comments, or -1 at end of source.
+	 * First significant char code at or after `pos`, skipping whitespace,
+	 * comments and grouping `)` (a parenthesized node's range excludes its
+	 * wrapping parens, so a `,`/`;` separator can sit behind them), or -1 at
+	 * end of source.
 	 * @param {string} source source text
 	 * @param {number} pos start offset
 	 * @returns {number} char code of the next token, or -1
@@ -5643,6 +5645,7 @@ class JavascriptParser extends Parser {
 				c === 13 ||
 				c === 11 ||
 				c === 12 ||
+				c === 41 /* ) */ ||
 				c === 0xa0 ||
 				c === 0xfeff ||
 				c === 0x2028 ||

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -385,6 +385,22 @@ describe("WebpackParser", () => {
 			}
 		});
 
+		it("should look past a parenthesized element's trailing `)` for the separator", () => {
+			// a parenthesized node's range excludes its wrapping parens, so the
+			// `,`/`;` separator sits behind one or more `)` — still non-ASI. `pos`
+			// is the end of the inner `a`, i.e. the first trailing `)`.
+			for (const [code, pos] of [
+				["(a),b", 2],
+				["((a)),b", 3],
+				["(a) ,b", 2],
+				["(a);b", 2]
+			]) {
+				const parser = new JavascriptParser("auto");
+				parser._source = /** @type {string} */ (code);
+				expect(parser._isAsiPosition(/** @type {number} */ (pos))).toBe(false);
+			}
+		});
+
 		it("should assume ASI when no source text is available", () => {
 			const parser = new JavascriptParser("auto");
 			parser.statementPath = [/** @type {EXPECTED_ANY} */ ({ range: [0, 1] })];

--- a/test/configCases/scope-hoisting/import-in-parenthesized-sequence/cjs.js
+++ b/test/configCases/scope-hoisting/import-in-parenthesized-sequence/cjs.js
@@ -1,0 +1,9 @@
+// CommonJS so it stays out of the concatenation scope and its exports are
+// referenced through the interop `(0, ns.export)` call wrapper.
+exports.check = function check(value) {
+	if (value === undefined) throw new Error("missing value");
+	return value;
+};
+exports.combine = function combine(a, b) {
+	return a + b;
+};

--- a/test/configCases/scope-hoisting/import-in-parenthesized-sequence/index.js
+++ b/test/configCases/scope-hoisting/import-in-parenthesized-sequence/index.js
@@ -1,0 +1,5 @@
+import { run } from "./module";
+
+it("should emit valid JS for an imported call after a parenthesized sequence element", () => {
+	expect(run({ a: 1, b: 2 })).toBe(3);
+});

--- a/test/configCases/scope-hoisting/import-in-parenthesized-sequence/module.js
+++ b/test/configCases/scope-hoisting/import-in-parenthesized-sequence/module.js
@@ -1,0 +1,11 @@
+import { check, combine } from "./cjs";
+
+// A statement-level sequence expression whose first element is a parenthesized
+// assignment: acorn excludes the wrapping parens from that element's range, so
+// the ASI check for the following imported call used to see `)` before the `,`
+// separator and splice in a stray `;`, producing `expr, ;expr` (invalid JS).
+export function run(source) {
+	let a, b, out;
+	({ a, b } = source), check(a), (out = combine(a, b));
+	return out;
+}

--- a/test/configCases/scope-hoisting/import-in-parenthesized-sequence/webpack.config.js
+++ b/test/configCases/scope-hoisting/import-in-parenthesized-sequence/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [new webpack.optimize.ModuleConcatenationPlugin()]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #21532. Since 5.109.0 (#21453), ASI positions are derived from the source text instead of acorn's `onInsertedSemicolon`. A parenthesized node's range excludes its wrapping parens, so for a statement-level sequence whose first element is parenthesized (e.g. `({a}=x), fn(), y`), the ASI scan started at that element's range end, hit the closing `)` before the `,` separator, and misclassified the following imported call as an ASI position — splicing a stray `;` after the comma and emitting invalid `expr, ;expr` (which then breaks Terser). The fix skips grouping `)` when scanning for the separator.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — a `test/configCases/scope-hoisting/import-in-parenthesized-sequence` regression case (fails with `SyntaxError: Unexpected token ';'` before the fix) and a focused `_isAsiPosition` unit test in `test/WebpackParser.unittest.js` covering the `)`-skip branch.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — investigation, the fix, and the tests were produced with Claude Code, then reviewed and verified locally (unit, ConfigTestCases, StatsTestCases suites all green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7AtLg1bSSAPGBCcskMAaU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parser ASI logic used during code generation; the change is narrow but affects emitted bundle syntax in edge cases.
> 
> **Overview**
> Fixes a **regression in source-text ASI detection** (since 5.109.0) where webpack could emit **invalid JavaScript** under **module concatenation / scope hoisting**.
> 
> When a statement-level **comma sequence** starts with a **parenthesized** expression (e.g. `({ a, b } = source), check(a), …`), acorn’s range ends **inside** the parens. `_isAsiPosition` scanned forward from that offset, saw `)` before the `,`, treated the next imported call as needing ASI, and inserted a stray `;` — yielding `expr, ;expr` and downstream minifier failures.
> 
> The change makes `_nextTokenCharCode` **skip grouping `)`** (like whitespace/comments) so the real `,` or `;` separator is found. Adds a **scope-hoisting config regression** with `ModuleConcatenationPlugin` and a **unit test** for `_isAsiPosition` on nested parens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c394adf3ca0a5b5a9a7c5aaa7f62fb0731e946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->