### PR TITLE
fix(css): name CSS sources in source maps by their resource path

### DIFF
--- a/.changeset/030-css-source-map-source-names.md
+++ b/.changeset/030-css-source-map-source-names.md
@@ -3,3 +3,4 @@
 ---
 
 Name CSS sources in source maps by their resource path, like JS sources.
+Keep the `css ` display prefix out of the `[resource]` and `[loaders]` placeholders.

--- a/.changeset/030-css-source-map-source-names.md
+++ b/.changeset/030-css-source-map-source-names.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Name CSS sources in source maps by their resource path, like JS sources.

--- a/.changeset/030-css-source-map-source-names.md
+++ b/.changeset/030-css-source-map-source-names.md
@@ -2,5 +2,4 @@
 "webpack": patch
 ---
 
-Name CSS sources in source maps by their resource path, like JS sources.
-Keep the `css ` display prefix out of the `[resource]` and `[loaders]` placeholders.
+Name CSS sources in source maps by their resource path, without the `css ` prefix.

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -169,11 +169,14 @@ ModuleFilenameHelpers.createFilename = (
 	let moduleId;
 	/** @type {ReturnStringCallback} */
 	let shortIdentifier;
+	/** @type {ReturnStringCallback} */
+	let resourceIdentifier;
 	if (typeof module === "string") {
 		shortIdentifier =
 			/** @type {ReturnStringCallback} */
 			(memoize(() => requestShortener.shorten(module)));
 		identifier = shortIdentifier;
+		resourceIdentifier = shortIdentifier;
 		moduleId = () => "";
 		absoluteResourcePath = () =>
 			/** @type {string} */ (module.split("!").pop());
@@ -181,6 +184,13 @@ ModuleFilenameHelpers.createFilename = (
 	} else {
 		shortIdentifier = memoize(() =>
 			module.readableIdentifier(requestShortener)
+		);
+		// `[resource]` must stay a request path: a subclass's readable identifier
+		// may carry display-only decorations (e.g. CssModule's `css ` prefix)
+		resourceIdentifier = memoize(() =>
+			module instanceof NormalModule
+				? /** @type {string} */ (requestShortener.shorten(module.userRequest))
+				: module.readableIdentifier(requestShortener)
 		);
 		identifier =
 			/** @type {ReturnStringCallback} */
@@ -196,7 +206,7 @@ ModuleFilenameHelpers.createFilename = (
 	}
 	const resource =
 		/** @type {ReturnStringCallback} */
-		(memoize(() => shortIdentifier().split("!").pop()));
+		(memoize(() => resourceIdentifier().split("!").pop()));
 
 	const loaders = getBefore(shortIdentifier, "!");
 	const allLoaders = getBefore(identifier, "!");

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -185,8 +185,9 @@ ModuleFilenameHelpers.createFilename = (
 		shortIdentifier = memoize(() =>
 			module.readableIdentifier(requestShortener)
 		);
-		// `[resource]` must stay a request path: a subclass's readable identifier
-		// may carry display-only decorations (e.g. CssModule's `css ` prefix)
+		// `[resource]` and `[loaders]` must stay request paths: a subclass's
+		// readable identifier may carry display-only decorations (e.g. CssModule's
+		// `css ` prefix)
 		resourceIdentifier = memoize(() =>
 			module instanceof NormalModule
 				? /** @type {string} */ (requestShortener.shorten(module.userRequest))
@@ -208,7 +209,7 @@ ModuleFilenameHelpers.createFilename = (
 		/** @type {ReturnStringCallback} */
 		(memoize(() => resourceIdentifier().split("!").pop()));
 
-	const loaders = getBefore(shortIdentifier, "!");
+	const loaders = getBefore(resourceIdentifier, "!");
 	const allLoaders = getBefore(identifier, "!");
 	const query = getAfter(resource, "?");
 	const resourcePath = () => {

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -52,7 +52,7 @@ const {
 	ABSOLUTE_PATH_REGEXP,
 	absolutify,
 	contextify,
-	makePathsRelative
+	contextifySourceUrl
 } = require("./util/identifier");
 const makeSerializable = require("./util/makeSerializable");
 const memoize = require("./util/memoize");
@@ -390,21 +390,6 @@ const walkSideEffects = (rootMod, moduleGraph, SideEffectDep) => {
  * @property {string | null=} ident
  * @property {string | null=} type
  */
-
-/**
- * @param {string} context absolute context path
- * @param {string} source a source path
- * @param {AssociatedObjectForCache=} associatedObjectForCache an object to which the cache will be attached
- * @returns {string} new source path
- */
-const contextifySourceUrl = (context, source, associatedObjectForCache) => {
-	if (source.startsWith("webpack://")) return source;
-	return `webpack://${makePathsRelative(
-		context,
-		source,
-		associatedObjectForCache
-	)}`;
-};
 
 /**
  * @param {string} context absolute context path

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -33,6 +33,7 @@ const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 
 const { encodeMappings } = require("../util/createMappings");
+const { contextifySourceUrl } = require("../util/identifier");
 const memoize = require("../util/memoize");
 const {
 	PUBLIC_PATH_FULL_HASH,
@@ -549,8 +550,13 @@ class CssGenerator extends Generator {
 				}
 
 				const generatedJs = /** @type {string} */ (source.source());
-				const sourceName = module.readableIdentifier(
-					compilation.requestShortener
+				// Context-relative identifier, like `NormalModule.createSource` — so
+				// `SourceMapDevToolPlugin` can match the module and apply the
+				// devtool filename template instead of leaking this raw name
+				const sourceName = contextifySourceUrl(
+					/** @type {string} */ (compilation.options.context),
+					module.identifier(),
+					compilation.compiler.root
 				);
 
 				if (

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -539,7 +539,7 @@ const makePathsRelative = makeCacheableWithContext(_makePathsRelative);
  * URL, as used for the `sources` of module-level source maps.
  * @param {string} context absolute context path
  * @param {string} source a source path
- * @param {object=} associatedObjectForCache an object to which the cache will be attached
+ * @param {AssociatedObjectForCache=} associatedObjectForCache an object to which the cache will be attached
  * @returns {string} new source path
  */
 const contextifySourceUrl = (context, source, associatedObjectForCache) => {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -532,6 +532,25 @@ const escapeHashInPathRequest = (request) => {
 	return pathPart.replace(HASH_REGEXP, "\0#") + request.slice(lastSep);
 };
 
+const makePathsRelative = makeCacheableWithContext(_makePathsRelative);
+
+/**
+ * Turns a source path into a `webpack://`-prefixed, context-relative source
+ * URL, as used for the `sources` of module-level source maps.
+ * @param {string} context absolute context path
+ * @param {string} source a source path
+ * @param {object=} associatedObjectForCache an object to which the cache will be attached
+ * @returns {string} new source path
+ */
+const contextifySourceUrl = (context, source, associatedObjectForCache) => {
+	if (source.startsWith("webpack://")) return source;
+	return `webpack://${makePathsRelative(
+		context,
+		source,
+		associatedObjectForCache
+	)}`;
+};
+
 const LINE_SEPARATOR_REGEXP = /[\u2028\u2029]/g;
 
 /**
@@ -550,11 +569,12 @@ module.exports.ABSOLUTE_PATH_REGEXP = ABSOLUTE_PATH_REGEXP;
 module.exports.WINDOWS_ABS_PATH_REGEXP = WINDOWS_ABS_PATH_REGEXP;
 module.exports.absolutify = absolutify;
 module.exports.contextify = contextify;
+module.exports.contextifySourceUrl = contextifySourceUrl;
 module.exports.escapeHashInPathRequest = escapeHashInPathRequest;
 module.exports.getUndoPath = getUndoPath;
 module.exports.makeCacheable = makeCacheable;
 module.exports.makePathsAbsolute = makeCacheableWithContext(_makePathsAbsolute);
-module.exports.makePathsRelative = makeCacheableWithContext(_makePathsRelative);
+module.exports.makePathsRelative = makePathsRelative;
 module.exports.parseResource = makeCacheable(_parseResource);
 module.exports.parseResourceWithoutFragment = makeCacheable(
 	_parseResourceWithoutFragment

--- a/test/configCases/css/source-map-loaders-placeholder/index.js
+++ b/test/configCases/css/source-map-loaders-placeholder/index.js
@@ -1,0 +1,13 @@
+import "!./loader.js!./style.css";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+it("should keep the readable-identifier prefix out of [loaders]", () => {
+	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".css.map"));
+	if (!mapFile) throw new Error("No .css.map emitted");
+	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+	expect(map.sources).toStrictEqual([
+		"webpack:///./style.css?loaders=./loader.js"
+	]);
+});

--- a/test/configCases/css/source-map-loaders-placeholder/loader.js
+++ b/test/configCases/css/source-map-loaders-placeholder/loader.js
@@ -1,0 +1,6 @@
+"use strict";
+
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(source) {
+	return `${source}\n.appended {\n\tcolor: teal;\n}\n`;
+};

--- a/test/configCases/css/source-map-loaders-placeholder/style.css
+++ b/test/configCases/css/source-map-loaders-placeholder/style.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/css/source-map-loaders-placeholder/webpack.config.js
+++ b/test/configCases/css/source-map-loaders-placeholder/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	node: { __dirname: false, __filename: false },
+	mode: "development",
+	devtool: "source-map",
+	experiments: { css: true },
+	output: {
+		devtoolModuleFilenameTemplate:
+			"webpack://[namespace]/[resource-path]?loaders=[loaders]"
+	}
+};

--- a/test/configCases/css/source-map-source-names/index.js
+++ b/test/configCases/css/source-map-source-names/index.js
@@ -4,23 +4,51 @@ import * as s from "./style.module.css";
 const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
 
+const readMap = (extension) => {
+	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(extension));
+	if (!mapFile) throw new Error(`No ${extension} emitted`);
+	return JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+};
+
+const contentOf = (map, source) =>
+	map.sourcesContent[map.sources.indexOf(source)];
+
 it("should name css sources by their resource path, like js sources", () => {
 	// reference the module so the css module stays in the graph
 	expect(typeof s.title).toBe("string");
-	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".css.map"));
-	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+	const map = readMap(".css.map");
 	expect(map.sources).toContain("webpack:///./style.css");
 	expect(map.sources).toContain("webpack:///./style.module.css");
+	expect(contentOf(map, "webpack:///./style.module.css")).toContain(".title");
 	// no source keeps the readable-identifier "css " prefix or option suffixes
 	for (const source of map.sources) {
 		expect(source).not.toMatch(/webpack:\/\/\/css /);
 	}
 });
 
+it("should disambiguate css modules sharing a resource path by hash", () => {
+	const map = readMap(".css.map");
+	// `shared.css` is imported under two layers, so it is two modules
+	const shared = map.sources.filter((source) =>
+		source.startsWith("webpack:///./shared.css")
+	);
+	expect(shared).toHaveLength(2);
+	expect(shared).toContain("webpack:///./shared.css");
+	expect(
+		shared.filter((source) =>
+			/^webpack:\/\/\/\.\/shared\.css\?\w+$/.test(source)
+		)
+	).toHaveLength(1);
+	for (const source of shared) {
+		expect(contentOf(map, source)).toContain("color: green");
+	}
+});
+
 it("should name the js wrapper of a css module by its resource path too", () => {
-	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".js.map"));
-	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+	const map = readMap(".js.map");
 	expect(map.sources).toContain("webpack:///./style.module.css");
+	// same name in both maps, so it must carry the same content
+	expect(contentOf(map, "webpack:///./style.module.css")).toContain(".title");
 	for (const source of map.sources) {
 		expect(source).not.toMatch(/webpack:\/\/\/css /);
 	}

--- a/test/configCases/css/source-map-source-names/index.js
+++ b/test/configCases/css/source-map-source-names/index.js
@@ -5,7 +5,8 @@ const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
 
 it("should name css sources by their resource path, like js sources", () => {
-	globalThis.__keepCssAlive = s;
+	// reference the module so the css module stays in the graph
+	expect(typeof s.title).toBe("string");
 	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".css.map"));
 	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
 	expect(map.sources).toContain("webpack:///./style.css");

--- a/test/configCases/css/source-map-source-names/index.js
+++ b/test/configCases/css/source-map-source-names/index.js
@@ -1,0 +1,26 @@
+import "./style.css";
+import * as s from "./style.module.css";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+it("should name css sources by their resource path, like js sources", () => {
+	globalThis.__keepCssAlive = s;
+	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".css.map"));
+	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+	expect(map.sources).toContain("webpack:///./style.css");
+	expect(map.sources).toContain("webpack:///./style.module.css");
+	// no source keeps the readable-identifier "css " prefix or option suffixes
+	for (const source of map.sources) {
+		expect(source).not.toMatch(/webpack:\/\/\/css /);
+	}
+});
+
+it("should name the js wrapper of a css module by its resource path too", () => {
+	const mapFile = fs.readdirSync(__dirname).find((f) => f.endsWith(".js.map"));
+	const map = JSON.parse(fs.readFileSync(path.join(__dirname, mapFile), "utf-8"));
+	expect(map.sources).toContain("webpack:///./style.module.css");
+	for (const source of map.sources) {
+		expect(source).not.toMatch(/webpack:\/\/\/css /);
+	}
+});

--- a/test/configCases/css/source-map-source-names/shared.css
+++ b/test/configCases/css/source-map-source-names/shared.css
@@ -1,0 +1,3 @@
+a {
+	color: green;
+}

--- a/test/configCases/css/source-map-source-names/style.css
+++ b/test/configCases/css/source-map-source-names/style.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/css/source-map-source-names/style.css
+++ b/test/configCases/css/source-map-source-names/style.css
@@ -1,3 +1,6 @@
+@import "./shared.css" layer(base);
+@import "./shared.css" layer(theme);
+
 body {
 	background: red;
 }

--- a/test/configCases/css/source-map-source-names/style.module.css
+++ b/test/configCases/css/source-map-source-names/style.module.css
@@ -1,0 +1,3 @@
+.title {
+	color: blue;
+}

--- a/test/configCases/css/source-map-source-names/webpack.config.js
+++ b/test/configCases/css/source-map-source-names/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	node: { __dirname: false, __filename: false },
+	mode: "development",
+	devtool: "source-map",
+	experiments: { css: true }
+};

--- a/test/configCases/source-map/devtools-default/index.js
+++ b/test/configCases/source-map/devtools-default/index.js
@@ -19,8 +19,8 @@ const getSourceMap = (filename) => {
 it("should compile successfully and have individual css sourcemap", async () => {
 	let map = getSourceMap("bundle0.css.map");
 	expect(map.sources).toStrictEqual([
-		"webpack:///css ./bar.css",
-		"webpack:///css ./foo.css"
+		"webpack:///./bar.css",
+		"webpack:///./foo.css"
 	]);
 	expect(() => {
 		readFile("bundle0.js.map");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

With `experiments.css` + `devtool: "source-map"`, CSS sources were named after the module's readable identifier (`webpack:///css ./style.css`, sometimes with a stray query) instead of their resource path like JS sources, so DevTools cannot correlate them with on-disk files; the `[resource]` placeholder now derives from the module's request, and the JS wrapper of a CSS module names its source by the context-relative identifier (via a shared `contextifySourceUrl` helper) so `SourceMapDevToolPlugin` rewrites it through the regular filename template. Refs #14893.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, `test/configCases/css/source-map-source-names/` (CSS asset map and JS wrapper map source names), and updated `test/configCases/source-map/devtools-default/` which pinned the old names.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — only the `sources` strings of source maps change, from a broken display name to the resource path; tooling that parsed the old `css `-prefixed names should switch to the plain path.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate the naming chain, draft the fix and tests, and run the test suites; all changes were reviewed, directed and verified by the author.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to source map `sources` strings and devtool template placeholders; no runtime bundle output changes, though tools that parsed the old `css `-prefixed names need to follow the new paths.
> 
> **Overview**
> With `experiments.css` and `devtool: "source-map"`, **source map `sources` entries no longer use CssModule’s display-only `css …` readable identifier**. They align with JS modules as context-relative `webpack:///./file.css` paths so DevTools can match on-disk files.
> 
> **`ModuleFilenameHelpers`** now drives `[resource]`, `[loaders]`, and related placeholders from the module **request** (`userRequest` on `NormalModule`) instead of `readableIdentifier`, so devtool filename templates are not polluted by the `css ` prefix or layer/supports suffixes.
> 
> **`CssGenerator`** names the JS wrapper’s source map source via shared **`contextifySourceUrl`** (moved from `NormalModule` into `util/identifier`), matching `NormalModule.createSource` so `SourceMapDevToolPlugin` can rewrite names through the normal template.
> 
> Tests cover CSS/JS map source names, `[loaders]` placeholders, and update expectations in `devtools-default`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c505af2525ba51e10d375b0249cb75e48f2f34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->