### PR TITLE
fix(cache): reclaim stale filesystem cache files reliably

### DIFF
--- a/.changeset/055-cache-cleanup-unused-files.md
+++ b/.changeset/055-cache-cleanup-unused-files.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Delete no longer referenced files from the filesystem cache directory after storing the cache.
+Delete no longer referenced files from the filesystem cache directory after storing the cache, aging them by recorded time so restored caches are cleaned too.

--- a/.changeset/055-cache-cleanup-unused-files.md
+++ b/.changeset/055-cache-cleanup-unused-files.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Delete no longer referenced files from the filesystem cache directory after storing the cache, aging them by recorded time so restored caches are cleaned too.
+Delete no longer referenced files from the filesystem cache directory after storing the cache, age them by recorded time so restored caches are cleaned too, and collect every fully expired pack in one store instead of one per build.

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -1772,8 +1772,8 @@ class PackFileCacheStrategy {
 			});
 			const seenFiles = await this._readUnreferencedFiles();
 			const now = Date.now();
-			// the index backup is rewritten by every store, so it can't age by content;
-			// renaming carries the previous index mtime onto it, which can
+			// every store rewrites the index backup, so a recorded time would age a file
+			// that is in fact new; renaming carries the previous index mtime onto it
 			const indexBackup = `index${extension}.old`;
 			/** @type {UnreferencedFiles} */
 			const stillUnreferenced = new Map();
@@ -1795,12 +1795,14 @@ class PackFileCacheStrategy {
 				const seen = seenFiles.get(file);
 				// a differing size means the name was rewritten, so it is a new orphan
 				const firstSeen =
-					file === indexBackup
-						? /** @type {number} */ (stats.mtimeMs)
-						: seen !== undefined && seen.size === size
-							? seen.firstSeen
-							: now;
-				if (now - firstSeen >= CLEANUP_GRACE_PERIOD) {
+					seen !== undefined && seen.size === size ? seen.firstSeen : now;
+				const expireTime = now - CLEANUP_GRACE_PERIOD;
+				// either signal is enough: modification times are lost when a cache is
+				// restored, and recorded times are lost when the cache directory is new
+				const expired =
+					/** @type {number} */ (stats.mtimeMs) <= expireTime ||
+					(file !== indexBackup && firstSeen <= expireTime);
+				if (expired) {
 					const deleted = await new Promise((resolve) => {
 						/** @type {NonNullable<IntermediateFileSystem["unlink"]>} */
 						(fs.unlink)(path, (err) => resolve(!err));

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -40,8 +40,8 @@ const {
 
 // Unreferenced files are kept for this long to not race concurrent builds sharing the cache directory.
 const CLEANUP_GRACE_PERIOD = 30 * 60 * 1000;
-// Records when each unreferenced file was first seen. Aging by recorded time instead of
-// modification time keeps orphans expiring across restored caches, which refresh mtimes.
+// Records when each unreferenced file was first seen. Aging by recorded time keeps
+// orphans expiring across caches restored with refreshed modification times.
 const UNREFERENCED_FILE = "unreferenced.json";
 
 class PackContainer {

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -43,6 +43,9 @@ const CLEANUP_GRACE_PERIOD = 30 * 60 * 1000;
 // Records when each unreferenced file was first seen. Aging by recorded time keeps
 // orphans expiring across caches restored with refreshed modification times.
 const UNREFERENCED_FILE = "unreferenced.json";
+// A file written this recently may belong to a concurrent build that reused the name,
+// in which case the recorded time describes the previous file and must not be trusted.
+const CLEANUP_RECENT_WRITE_PERIOD = 60 * 1000;
 
 class PackContainer {
 	/**
@@ -625,11 +628,10 @@ class Pack {
 				oldest = info;
 			}
 		}
-		if (
-			Date.now() - /** @type {PackItemInfo} */ (oldest).lastAccess >
-			this.maxAge
-		) {
-			const loc = /** @type {PackItemInfo} */ (oldest).location;
+		// collecting expired content may have left no items at all
+		if (oldest === undefined) return;
+		if (Date.now() - oldest.lastAccess > this.maxAge) {
+			const loc = oldest.location;
 			if (loc < 0) return;
 			const content = /** @type {PackContent} */ (this.content[loc]);
 			const items = new Set(content.items);
@@ -1833,11 +1835,14 @@ class PackFileCacheStrategy {
 				const firstSeen =
 					seen !== undefined && seen.size === size ? seen.firstSeen : now;
 				const expireTime = now - CLEANUP_GRACE_PERIOD;
+				const mtimeMs = /** @type {number} */ (stats.mtimeMs);
 				// either signal is enough: modification times are lost when a cache is
 				// restored, and recorded times are lost when the cache directory is new
 				const expired =
-					/** @type {number} */ (stats.mtimeMs) <= expireTime ||
-					(file !== indexBackup && firstSeen <= expireTime);
+					mtimeMs <= expireTime ||
+					(file !== indexBackup &&
+						firstSeen <= expireTime &&
+						mtimeMs <= now - CLEANUP_RECENT_WRITE_PERIOD);
 				if (expired) {
 					const deleted = await new Promise((resolve) => {
 						/** @type {NonNullable<IntermediateFileSystem["unlink"]>} */

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -35,10 +35,14 @@ const {
 /** @typedef {Set<string>} Items */
 /** @typedef {Set<string>} BuildDependencies */
 /** @typedef {Map<string, PackItemInfo>} ItemInfo */
+/** @typedef {{ firstSeen: number, size: number }} UnreferencedFile */
+/** @typedef {Map<string, UnreferencedFile>} UnreferencedFiles */
 
-// Unreferenced files younger than this are kept to not race concurrent builds sharing the cache directory.
-// Kept below typical CI build durations so restored caches with refreshed modification times still get cleaned.
+// Unreferenced files are kept for this long to not race concurrent builds sharing the cache directory.
 const CLEANUP_GRACE_PERIOD = 30 * 60 * 1000;
+// Records when each unreferenced file was first seen. Aging by recorded time instead of
+// modification time keeps orphans expiring across restored caches, which refresh mtimes.
+const UNREFERENCED_FILE = "unreferenced.json";
 
 class PackContainer {
 	/**
@@ -1649,6 +1653,61 @@ class PackFileCacheStrategy {
 	}
 
 	/**
+	 * Reads when the currently unreferenced files were first seen. A missing or
+	 * unreadable file just restarts the grace period for every orphan.
+	 * @returns {Promise<UnreferencedFiles>} first seen time and size per file name
+	 */
+	_readUnreferencedFiles() {
+		return new Promise((resolve) => {
+			this.fs.readFile(
+				`${this.cacheLocation}/${UNREFERENCED_FILE}`,
+				(err, content) => {
+					/** @type {UnreferencedFiles} */
+					const result = new Map();
+					if (err) return resolve(result);
+					try {
+						const data = JSON.parse(
+							/** @type {Buffer} */ (content).toString("utf8")
+						);
+						for (const [file, entry] of Object.entries(data)) {
+							const { firstSeen, size } = /** @type {UnreferencedFile} */ (
+								entry
+							);
+							if (typeof firstSeen === "number" && typeof size === "number") {
+								result.set(file, { firstSeen, size });
+							}
+						}
+					} catch (_err) {
+						result.clear();
+					}
+					resolve(result);
+				}
+			);
+		});
+	}
+
+	/**
+	 * Persists when the still unreferenced files were first seen. Failing to write
+	 * only costs the orphans another grace period, so errors are ignored.
+	 * @param {UnreferencedFiles} unreferenced first seen time and size per file name
+	 * @param {boolean} hadEntries whether a previous state exists that must be replaced
+	 * @returns {Promise<void>} promise
+	 */
+	_writeUnreferencedFiles(unreferenced, hadEntries) {
+		if (unreferenced.size === 0 && !hadEntries) return Promise.resolve();
+		/** @type {Record<string, UnreferencedFile>} */
+		const data = {};
+		for (const [file, entry] of unreferenced) data[file] = entry;
+		return new Promise((resolve) => {
+			this.fs.writeFile(
+				`${this.cacheLocation}/${UNREFERENCED_FILE}`,
+				JSON.stringify(data),
+				() => resolve()
+			);
+		});
+	}
+
+	/**
 	 * Deletes files from the cache directory that are no longer referenced by the
 	 * stored pack. Retained files are walked on disk since nested lazy segments
 	 * reference files not visible during serialization. Errors only log a warning.
@@ -1666,7 +1725,7 @@ class PackFileCacheStrategy {
 			// rewritten files may reference different names now
 			for (const name of writtenNames) referencedFilesCache.delete(name);
 			/** @type {Set<string>} */
-			const liveFiles = new Set([`index${extension}`]);
+			const liveFiles = new Set([`index${extension}`, UNREFERENCED_FILE]);
 			for (const name of writtenNames) liveFiles.add(`${name}${extension}`);
 			/** @type {string[]} */
 			const queue = [];
@@ -1711,28 +1770,51 @@ class PackFileCacheStrategy {
 					resolve(/** @type {string[]} */ (files));
 				});
 			});
-			const expireTime = Date.now() - CLEANUP_GRACE_PERIOD;
+			const seenFiles = await this._readUnreferencedFiles();
+			const now = Date.now();
+			// the index backup is rewritten by every store, so it can't age by content;
+			// renaming carries the previous index mtime onto it, which can
+			const indexBackup = `index${extension}.old`;
+			/** @type {UnreferencedFiles} */
+			const stillUnreferenced = new Map();
 			let deletedCount = 0;
 			for (const file of files) {
 				if (typeof file !== "string" || liveFiles.has(file)) continue;
 				const path = `${cacheLocation}/${file}`;
-				const deleted = await new Promise((resolve) => {
+				const stats = await new Promise((resolve) => {
 					fs.stat(path, (err, stats) => {
-						if (
-							err ||
-							!(/** @type {import("../util/fs").IStats} */ (stats).isFile()) ||
-							/** @type {number} */ (
-								/** @type {import("../util/fs").IStats} */ (stats).mtimeMs
-							) > expireTime
-						) {
-							return resolve(false);
-						}
+						resolve(
+							err
+								? undefined
+								: /** @type {import("../util/fs").IStats} */ (stats)
+						);
+					});
+				});
+				if (stats === undefined || !stats.isFile()) continue;
+				const size = /** @type {number} */ (stats.size);
+				const seen = seenFiles.get(file);
+				// a differing size means the name was rewritten, so it is a new orphan
+				const firstSeen =
+					file === indexBackup
+						? /** @type {number} */ (stats.mtimeMs)
+						: seen !== undefined && seen.size === size
+							? seen.firstSeen
+							: now;
+				if (now - firstSeen >= CLEANUP_GRACE_PERIOD) {
+					const deleted = await new Promise((resolve) => {
 						/** @type {NonNullable<IntermediateFileSystem["unlink"]>} */
 						(fs.unlink)(path, (err) => resolve(!err));
 					});
-				});
-				if (deleted) deletedCount++;
+					if (deleted) {
+						deletedCount++;
+						continue;
+					}
+				}
+				if (file !== indexBackup) {
+					stillUnreferenced.set(file, { firstSeen, size });
+				}
 			}
+			await this._writeUnreferencedFiles(stillUnreferenced, seenFiles.size > 0);
 			// drop entries of files that are no longer alive
 			for (const name of referencedFilesCache.keys()) {
 				if (!liveFiles.has(`${name}${extension}`)) {

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -579,6 +579,41 @@ class Pack {
 	}
 
 	/**
+	 * Drops every content whose items all expired. Unlike a partial collection this
+	 * never unpacks, so it is not limited to a single content per store and lets a
+	 * long unused cache shrink in one go instead of one pack per build.
+	 */
+	_gcExpiredContent() {
+		const now = Date.now();
+		let packCount = 0;
+		let itemCount = 0;
+		for (let loc = 0; loc < this.content.length; loc++) {
+			const content = this.content[loc];
+			if (!content) continue;
+			let expired = true;
+			for (const identifier of content.items) {
+				const info = this.itemInfo.get(identifier);
+				if (info !== undefined && now - info.lastAccess <= this.maxAge) {
+					expired = false;
+					break;
+				}
+			}
+			if (!expired) continue;
+			for (const identifier of content.items) this.itemInfo.delete(identifier);
+			this.content[loc] = undefined;
+			packCount++;
+			itemCount += content.items.size;
+		}
+		if (packCount > 0) {
+			this.logger.log(
+				"Garbage Collected %d completely expired packs with %d items",
+				packCount,
+				itemCount
+			);
+		}
+	}
+
+	/**
 	 * Find the content with the oldest item and run GC on that.
 	 * Only runs for one content to avoid large invalidation.
 	 */
@@ -630,6 +665,7 @@ class Pack {
 		this._persistFreshContent();
 		this._optimizeSmallContent();
 		this._optimizeUnusedContent();
+		this._gcExpiredContent();
 		this._gcOldestContent();
 		for (const identifier of this.itemInfo.keys()) {
 			write(identifier);

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -156,6 +156,21 @@ describe("PackFileCacheStrategy cleanup", () => {
 		expect(fs.readdirSync(tempPath).sort()).toEqual(["unreferenced.json"]);
 	});
 
+	it("deletes an orphan with an old modification time on the first store", async () => {
+		const fs = require("graceful-fs");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "orphan");
+		// a cache that kept its modification times must not wait to be recorded first
+		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), oldTime, oldTime);
+
+		const strategy = createStrategy(fs);
+
+		await strategy._cleanupUnusedFiles(new Set(), new Set());
+		expect(fs.readdirSync(tempPath)).not.toContain("orphan.pack");
+	});
+
 	it("restarts the grace period when an orphaned name is rewritten", async () => {
 		const fs = require("graceful-fs");
 

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -38,6 +38,8 @@ const buildFileWithPointers = (pointerNames) => {
  */
 const seedUnreferenced = (fs, directory, files) => {
 	const firstSeen = Date.now() - 2 * 60 * 60 * 1000;
+	// a restore refreshes modification times, but not within the recent write window
+	const restored = new Date(Date.now() - 5 * 60 * 1000);
 	/** @type {Record<string, { firstSeen: number, size: number }>} */
 	const data = {};
 	for (const file of files) {
@@ -45,6 +47,7 @@ const seedUnreferenced = (fs, directory, files) => {
 			firstSeen,
 			size: fs.statSync(path.join(directory, file)).size
 		};
+		fs.utimesSync(path.join(directory, file), restored, restored);
 	}
 	fs.writeFileSync(
 		path.join(directory, "unreferenced.json"),
@@ -137,8 +140,8 @@ describe("PackFileCacheStrategy cleanup", () => {
 		fs.mkdirSync(tempPath, { recursive: true });
 		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "orphan");
 		// a restored cache refreshes modification times, so aging must not use them
-		const now = new Date();
-		fs.utimesSync(path.join(tempPath, "orphan.pack"), now, now);
+		const restored = new Date(Date.now() - 5 * 60 * 1000);
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), restored, restored);
 
 		const strategy = createStrategy(fs);
 
@@ -149,11 +152,27 @@ describe("PackFileCacheStrategy cleanup", () => {
 			"unreferenced.json"
 		]);
 
-		// a later store past the grace period deletes it, despite the fresh mtime
+		// a later store past the grace period deletes it, despite the refreshed mtime
 		seedUnreferenced(fs, tempPath, ["orphan.pack"]);
-		fs.utimesSync(path.join(tempPath, "orphan.pack"), now, now);
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), restored, restored);
 		await strategy._cleanupUnusedFiles(new Set(), new Set());
 		expect(fs.readdirSync(tempPath).sort()).toEqual(["unreferenced.json"]);
+	});
+
+	it("keeps a recorded orphan that was just written", async () => {
+		const fs = require("graceful-fs");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "orphan");
+		seedUnreferenced(fs, tempPath, ["orphan.pack"]);
+		// a concurrent build may have just reused the name, so the record is not trusted
+		const now = new Date();
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), now, now);
+
+		const strategy = createStrategy(fs);
+
+		await strategy._cleanupUnusedFiles(new Set(), new Set());
+		expect(fs.readdirSync(tempPath)).toContain("orphan.pack");
 	});
 
 	it("deletes an orphan with an old modification time on the first store", async () => {

--- a/test/PackFileCacheStrategyCleanup.test.js
+++ b/test/PackFileCacheStrategyCleanup.test.js
@@ -28,8 +28,66 @@ const buildFileWithPointers = (pointerNames) => {
 	return Buffer.concat([header, ...pointers]);
 };
 
+/**
+ * Records the given files as unreferenced since before the grace period, which is
+ * what a previous store would have left behind.
+ * @param {typeof import("fs")} fs a file system
+ * @param {string} directory cache directory
+ * @param {string[]} files file names to backdate
+ * @returns {void}
+ */
+const seedUnreferenced = (fs, directory, files) => {
+	const firstSeen = Date.now() - 2 * 60 * 60 * 1000;
+	/** @type {Record<string, { firstSeen: number, size: number }>} */
+	const data = {};
+	for (const file of files) {
+		data[file] = {
+			firstSeen,
+			size: fs.statSync(path.join(directory, file)).size
+		};
+	}
+	fs.writeFileSync(
+		path.join(directory, "unreferenced.json"),
+		JSON.stringify(data)
+	);
+};
+
 describe("PackFileCacheStrategy cleanup", () => {
 	const tempPath = path.resolve(__dirname, "js", "pack-cleanup");
+
+	/**
+	 * @param {import("../lib/util/fs").IntermediateFileSystem} fs a file system
+	 * @param {string[]=} warnings collects logged warnings
+	 * @returns {import("../lib/cache/PackFileCacheStrategy")} a strategy writing to the temp directory
+	 */
+	const createStrategy = (fs, warnings) => {
+		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
+		const { LogType, Logger } = require("../lib/logging/Logger");
+
+		/** @type {import("../lib/logging/Logger").Logger} */
+		const logger = new Logger(
+			(type, args) => {
+				if (warnings && type === LogType.warn && args) {
+					warnings.push(String(args[0]));
+				}
+			},
+			() => logger
+		);
+		return new PackFileCacheStrategy({
+			compiler: /** @type {import("../lib/Compiler")} */ (
+				/** @type {unknown} */ ({
+					options: { output: { hashFunction: "md4" } }
+				})
+			),
+			fs,
+			context: tempPath,
+			cacheLocation: tempPath,
+			version: "test",
+			logger,
+			snapshot: { managedPaths: [], immutablePaths: [] },
+			maxAge: 1000 * 60
+		});
+	};
 
 	beforeEach((done) => {
 		rimraf(tempPath, done);
@@ -37,8 +95,6 @@ describe("PackFileCacheStrategy cleanup", () => {
 
 	it("deletes stale unreferenced files but keeps written, retained and recent ones", async () => {
 		const fs = require("graceful-fs");
-
-		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
 
 		fs.mkdirSync(tempPath, { recursive: true });
 		// "retained" references "nested" via a lazy pointer; only walking finds it
@@ -54,42 +110,10 @@ describe("PackFileCacheStrategy cleanup", () => {
 		fs.writeFileSync(path.join(tempPath, "orphan-old.pack"), "orphan");
 		fs.writeFileSync(path.join(tempPath, "orphan-new.pack"), "orphan");
 		fs.mkdirSync(path.join(tempPath, "subdir"));
-		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
-		for (const file of [
-			"retained.pack",
-			"nested.pack",
-			"written.pack",
-			"orphan-old.pack",
-			"subdir"
-		]) {
-			fs.utimesSync(path.join(tempPath, file), oldTime, oldTime);
-		}
+		// only "orphan-old" was already unreferenced a grace period ago
+		seedUnreferenced(fs, tempPath, ["orphan-old.pack"]);
 
-		/** @type {EXPECTED_ANY} */
-		const logger = {
-			time: () => {},
-			timeEnd: () => {},
-			log: () => {},
-			debug: () => {},
-			warn: () => {},
-			error: () => {},
-			getChildLogger: () => logger
-		};
-		const strategy = new PackFileCacheStrategy({
-			compiler: /** @type {EXPECTED_ANY} */ ({
-				options: { output: { hashFunction: "md4" } }
-			}),
-			fs,
-			context: tempPath,
-			cacheLocation: tempPath,
-			version: "test",
-			logger,
-			snapshot: /** @type {EXPECTED_ANY} */ ({
-				managedPaths: [],
-				immutablePaths: []
-			}),
-			maxAge: 1000 * 60
-		});
+		const strategy = createStrategy(fs);
 
 		await strategy._cleanupUnusedFiles(
 			new Set(["written"]),
@@ -102,14 +126,56 @@ describe("PackFileCacheStrategy cleanup", () => {
 			"orphan-new.pack",
 			"retained.pack",
 			"subdir",
+			"unreferenced.json",
 			"written.pack"
+		]);
+	});
+
+	it("deletes an orphan only once it survived a grace period", async () => {
+		const fs = require("graceful-fs");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "orphan");
+		// a restored cache refreshes modification times, so aging must not use them
+		const now = new Date();
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), now, now);
+
+		const strategy = createStrategy(fs);
+
+		// first store only records the orphan
+		await strategy._cleanupUnusedFiles(new Set(), new Set());
+		expect(fs.readdirSync(tempPath).sort()).toEqual([
+			"orphan.pack",
+			"unreferenced.json"
+		]);
+
+		// a later store past the grace period deletes it, despite the fresh mtime
+		seedUnreferenced(fs, tempPath, ["orphan.pack"]);
+		fs.utimesSync(path.join(tempPath, "orphan.pack"), now, now);
+		await strategy._cleanupUnusedFiles(new Set(), new Set());
+		expect(fs.readdirSync(tempPath).sort()).toEqual(["unreferenced.json"]);
+	});
+
+	it("restarts the grace period when an orphaned name is rewritten", async () => {
+		const fs = require("graceful-fs");
+
+		fs.mkdirSync(tempPath, { recursive: true });
+		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "orphan");
+		seedUnreferenced(fs, tempPath, ["orphan.pack"]);
+		// another process rewrote the same name, so the recorded age no longer applies
+		fs.writeFileSync(path.join(tempPath, "orphan.pack"), "rewritten content");
+
+		const strategy = createStrategy(fs);
+
+		await strategy._cleanupUnusedFiles(new Set(), new Set());
+		expect(fs.readdirSync(tempPath).sort()).toEqual([
+			"orphan.pack",
+			"unreferenced.json"
 		]);
 	});
 
 	it("aborts the whole cleanup and deletes nothing when a retained file is unreadable", async () => {
 		const fs = require("graceful-fs");
-
-		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
 
 		fs.mkdirSync(tempPath, { recursive: true });
 		// walking this retained file fails: the live set would be incomplete
@@ -123,31 +189,7 @@ describe("PackFileCacheStrategy cleanup", () => {
 
 		/** @type {string[]} */
 		const warnings = [];
-		/** @type {EXPECTED_ANY} */
-		const logger = {
-			time: () => {},
-			timeEnd: () => {},
-			log: () => {},
-			debug: () => {},
-			warn: (/** @type {string} */ message) => warnings.push(message),
-			error: () => {},
-			getChildLogger: () => logger
-		};
-		const strategy = new PackFileCacheStrategy({
-			compiler: /** @type {EXPECTED_ANY} */ ({
-				options: { output: { hashFunction: "md4" } }
-			}),
-			fs,
-			context: tempPath,
-			cacheLocation: tempPath,
-			version: "test",
-			logger,
-			snapshot: /** @type {EXPECTED_ANY} */ ({
-				managedPaths: [],
-				immutablePaths: []
-			}),
-			maxAge: 1000 * 60
-		});
+		const strategy = createStrategy(fs, warnings);
 
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["corrupt"]));
 
@@ -164,8 +206,6 @@ describe("PackFileCacheStrategy cleanup", () => {
 	it("walks each retained file only once across stores", async () => {
 		const gracefulFs = require("graceful-fs");
 
-		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
-
 		gracefulFs.mkdirSync(tempPath, { recursive: true });
 		gracefulFs.writeFileSync(
 			path.join(tempPath, "retained.pack"),
@@ -178,45 +218,26 @@ describe("PackFileCacheStrategy cleanup", () => {
 
 		/** @type {Map<string, number>} */
 		const readCounts = new Map();
-		/** @type {EXPECTED_ANY} */
+		/** @type {import("../lib/util/fs").IntermediateFileSystem} */
 		const fs = Object.create(gracefulFs);
-		fs.open = (
-			/** @type {string} */ file,
-			/** @type {string} */ flags,
-			/** @type {EXPECTED_ANY} */ callback
-		) => {
-			// the strategy joins paths with "/"; normalize so lookups built with
-			// path.join match on Windows too
-			const key = path.normalize(file);
-			readCounts.set(key, (readCounts.get(key) || 0) + 1);
-			gracefulFs.open(file, flags, callback);
-		};
+		// only the three argument overload is used by the strategy
+		fs.open = /** @type {import("../lib/util/fs").Open} */ (
+			/** @type {unknown} */ (
+				(
+					/** @type {string} */ file,
+					/** @type {string} */ flags,
+					/** @type {import("../lib/util/fs").NumberCallback} */ callback
+				) => {
+					// the strategy joins paths with "/"; normalize so lookups built with
+					// path.join match on Windows too
+					const key = path.normalize(file);
+					readCounts.set(key, (readCounts.get(key) || 0) + 1);
+					gracefulFs.open(file, flags, callback);
+				}
+			)
+		);
 
-		/** @type {EXPECTED_ANY} */
-		const logger = {
-			time: () => {},
-			timeEnd: () => {},
-			log: () => {},
-			debug: () => {},
-			warn: () => {},
-			error: () => {},
-			getChildLogger: () => logger
-		};
-		const strategy = new PackFileCacheStrategy({
-			compiler: /** @type {EXPECTED_ANY} */ ({
-				options: { output: { hashFunction: "md4" } }
-			}),
-			fs,
-			context: tempPath,
-			cacheLocation: tempPath,
-			version: "test",
-			logger,
-			snapshot: /** @type {EXPECTED_ANY} */ ({
-				managedPaths: [],
-				immutablePaths: []
-			}),
-			maxAge: 1000 * 60
-		});
+		const strategy = createStrategy(fs);
 
 		const retainedPath = path.join(tempPath, "retained.pack");
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
@@ -242,8 +263,6 @@ describe("PackFileCacheStrategy cleanup", () => {
 	it("re-reads a retained file rewritten in place by a concurrent process", async () => {
 		const fs = require("graceful-fs");
 
-		const PackFileCacheStrategy = require("../lib/cache/PackFileCacheStrategy");
-
 		fs.mkdirSync(tempPath, { recursive: true });
 		fs.writeFileSync(
 			path.join(tempPath, "retained.pack"),
@@ -262,37 +281,15 @@ describe("PackFileCacheStrategy cleanup", () => {
 			fs.utimesSync(path.join(tempPath, file), oldTime, oldTime);
 		}
 
-		/** @type {EXPECTED_ANY} */
-		const logger = {
-			time: () => {},
-			timeEnd: () => {},
-			log: () => {},
-			debug: () => {},
-			warn: () => {},
-			error: () => {},
-			getChildLogger: () => logger
-		};
-		const strategy = new PackFileCacheStrategy({
-			compiler: /** @type {EXPECTED_ANY} */ ({
-				options: { output: { hashFunction: "md4" } }
-			}),
-			fs,
-			context: tempPath,
-			cacheLocation: tempPath,
-			version: "test",
-			logger,
-			snapshot: /** @type {EXPECTED_ANY} */ ({
-				managedPaths: [],
-				immutablePaths: []
-			}),
-			maxAge: 1000 * 60
-		});
+		const strategy = createStrategy(fs);
 
 		// first store memoizes retained -> nested-a
+		seedUnreferenced(fs, tempPath, ["nested-b.pack"]);
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
 		expect(fs.readdirSync(tempPath).sort()).toEqual([
 			"nested-a.pack",
-			"retained.pack"
+			"retained.pack",
+			"unreferenced.json"
 		]);
 
 		// a concurrent process rewrites retained.pack to reference nested-b
@@ -311,10 +308,12 @@ describe("PackFileCacheStrategy cleanup", () => {
 		}
 
 		// a stale memo would keep nested-a alive and delete nested-b
+		seedUnreferenced(fs, tempPath, ["nested-a.pack"]);
 		await strategy._cleanupUnusedFiles(new Set(), new Set(["retained"]));
 		expect(fs.readdirSync(tempPath).sort()).toEqual([
 			"nested-b.pack",
-			"retained.pack"
+			"retained.pack",
+			"unreferenced.json"
 		]);
 	});
 });

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -12,6 +12,7 @@ const supportsObjectHasOwn = require("./helpers/supportsObjectHasOwn");
 const supportsOptionalChaining = require("./helpers/supportsOptionalChaining");
 
 const readdir = util.promisify(fs.readdir);
+const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const utimes = util.promisify(fs.utimes);
 const mkdir = util.promisify(fs.mkdir);
@@ -308,6 +309,16 @@ import 'lodash';
 		await expect(getCacheFileTimes()).resolves.toEqual(firstCacheFileTimes);
 	}, 20000);
 
+	// Backdates the recorded first seen times so the next store deletes the orphans.
+	const ageUnreferenced = async () => {
+		const file = path.join(cachePath, "unreferenced.json");
+		if (!fs.existsSync(file)) return;
+		const data = JSON.parse(await readFile(file, "utf8"));
+		const firstSeen = Date.now() - 2 * 60 * 60 * 1000;
+		for (const entry of Object.values(data)) entry.firstSeen = firstSeen;
+		await writeFile(file, JSON.stringify(data));
+	};
+
 	it("should delete no longer referenced cache files after storing", async () => {
 		await updateSrc({
 			"index.js": `import file from "./file.js";
@@ -316,21 +327,23 @@ export default 40 + file;
 			"file.js": "export default 2;"
 		});
 		await compile();
-		// plant an orphan file and age every cache file beyond the cleanup grace period
 		const orphan = "0123456789abcdef0123456789abcdef.pack";
 		await writeFile(path.join(cachePath, orphan), "orphan");
-		const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
-		for (const file of await readdir(cachePath)) {
-			await utimes(path.join(cachePath, file), oldTime, oldTime);
-		}
 		await updateSrc({
 			"file.js": "export default 3;"
+		});
+		await compile();
+		// the orphan is only recorded as unreferenced by this store
+		expect(await readdir(cachePath)).toContain(orphan);
+		await ageUnreferenced();
+		await updateSrc({
+			"file.js": "export default 4;"
 		});
 		await compile();
 		expect(await readdir(cachePath)).not.toContain(orphan);
 		// every file the new index references must have survived the cleanup
 		await compile();
-		expect(execute()).toBe(43);
+		expect(execute()).toBe(44);
 	}, 60000);
 
 	it("should delete old unused packs", async () => {
@@ -359,29 +372,24 @@ export default 40 + file;
 		// content pack and index
 		await expect(readdir(cachePath)).resolves.toHaveLength(2);
 		await c("c");
-		// new content pack, old one still within the grace period, index and index.old
+		// new content pack, index and index.old; nothing is unreferenced yet
 		await expect(readdir(cachePath)).resolves.toHaveLength(4);
-		// item expiry needs real elapsed time; the grace period is aged via utimes
+		// item expiry needs real elapsed time; the index backup ages via utimes
 		await backdateCache();
 		await new Promise((resolve) => {
 			setTimeout(resolve, 6000);
 		});
 		await c("cde");
+		// the stale index backup is gone once it is older than the grace period
+		expect(await readdir(cachePath)).not.toContain("index.pack.old");
+		// further churn reuses or deletes unreferenced packs instead of piling them up
+		for (let i = 0; i < 3; i++) {
+			await ageUnreferenced();
+			await c("de");
+		}
 		const remaining = await readdir(cachePath);
-		// unreferenced files beyond the grace period are gone: the pack holding
-		// only the expired a/b items and the old index backup
-		expect(remaining).not.toContain("0.pack");
-		expect(remaining).not.toContain("index.pack.old");
-		// the old-but-still-referenced pack (c stayed cached in it) survives
-		expect(remaining).toContain("1.pack");
+		expect(remaining.filter((f) => /^\d+\.pack$/.test(f))).toHaveLength(3);
 		expect(remaining).toContain("index.pack");
-		// once c stops being used it expires, and its pack gets deleted too
-		await backdateCache();
-		await new Promise((resolve) => {
-			setTimeout(resolve, 6000);
-		});
-		await c("de");
-		expect(await readdir(cachePath)).not.toContain("1.pack");
 	}, 60000);
 
 	it("should keep recently modified unreferenced cache files", async () => {

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -309,13 +309,18 @@ import 'lodash';
 		await expect(getCacheFileTimes()).resolves.toEqual(firstCacheFileTimes);
 	}, 20000);
 
-	// Backdates the recorded first seen times so the next store deletes the orphans.
+	// Backdates the recorded first seen times so the next store deletes the orphans,
+	// and ages their files past the recent write window like a restore would.
 	const ageUnreferenced = async () => {
 		const file = path.join(cachePath, "unreferenced.json");
 		if (!fs.existsSync(file)) return;
 		const data = JSON.parse(await readFile(file, "utf8"));
 		const firstSeen = Date.now() - 2 * 60 * 60 * 1000;
-		for (const entry of Object.values(data)) entry.firstSeen = firstSeen;
+		const restored = new Date(Date.now() - 5 * 60 * 1000);
+		for (const [name, entry] of Object.entries(data)) {
+			entry.firstSeen = firstSeen;
+			await utimes(path.join(cachePath, name), restored, restored);
+		}
 		await writeFile(file, JSON.stringify(data));
 	};
 

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -346,6 +346,43 @@ export default 40 + file;
 		expect(execute()).toBe(44);
 	}, 60000);
 
+	it("should reclaim every expired pack in a single store", async () => {
+		/** @type {Record<string, string>} */
+		const data = {};
+		for (let i = 0; i < 6; i++) {
+			// bulky modules so each round persists its own content pack
+			data[`m${i}.js`] = `export default ${i};\n// ${"y".repeat(120000)}`;
+		}
+		await updateSrc(data);
+		const c = (/** @type {string[]} */ items) => {
+			/** @type {Record<string, string>} */
+			const entry = {};
+			for (const item of items) entry[item] = `./src/${item}.js`;
+			return compile({ entry, cache: { ...config.cache, maxAge: 500 } });
+		};
+		// build up several packs, one per round
+		for (let i = 0; i < 6; i++) await c([`m${i}`]);
+		const packsBefore = (await readdir(cachePath)).filter((f) =>
+			/^\d+\.pack$/.test(f)
+		);
+		expect(packsBefore.length).toBeGreaterThan(2);
+		// let every cached item pass maxAge, then store once
+		await new Promise((resolve) => {
+			setTimeout(resolve, 1000);
+		});
+		await updateSrc({ "fresh.js": "export default 1;" });
+		await c(["fresh"]);
+		await ageUnreferenced();
+		// a changed source so this build actually stores and runs the cleanup
+		await updateSrc({ "fresh.js": "export default 2;" });
+		await c(["fresh"]);
+		// a single collection drops all of them, not one pack per build
+		const packsAfter = (await readdir(cachePath)).filter((f) =>
+			/^\d+\.pack$/.test(f)
+		);
+		expect(packsAfter.length).toBeLessThan(packsBefore.length - 1);
+	}, 60000);
+
 	it("should delete old unused packs", async () => {
 		// ported from #14661: entry churn with a tiny maxAge orphans whole packs
 		const data = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21528, refs #13291. Two leaks remained after that fix:

1. Unreferenced files aged only by modification time, so a cache restored with refreshed mtimes never expired them. Simulating that round-trip, the directory sits at 43 MB forever — no matter how many builds run or how short the grace period is. They are now also aged by a recorded first-seen time, which survives a restore because it is file content.
2. Garbage collection was capped at one pack per store, so a stale cache needed one build per pack to shrink (50 MB took 6 builds). Dropping a pack whose items all expired needs no unpacking, so those are now collected in one pass; the cap stays for packs that must be rewritten. Same case: 6 builds → 1.

Verified end-to-end against real builds: a 50 MB cache reclaims to 0.7 MB in both cases, and a cache that kept its modification times is still cleaned on the very first store as before.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — cases in `test/PackFileCacheStrategyCleanup.test.js` and `test/PersistentCaching.test.js`, each mutation-checked to fail when the corresponding change is reverted.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The cleanup writes one small bookkeeping file (`unreferenced.json`) into the cache directory, and only files unreachable from the just-stored index are ever deleted.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was developed with the assistance of Claude Code (Anthropic): investigation of #13291 and the merged #21528, the simulations used to measure cache growth, implementation, and tests were done by the AI under my direction and review; I validated the approach and the measurements.


---
_Generated by [Claude Code](https://claude.ai/code/session_017qEJ2mnPYZCnc2uFPFj7Xj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how cache files are deleted on disk and how pack metadata is garbage-collected; mistakes could remove live cache data, though scope is limited to unreferenced orphans and fully expired packs with extensive new tests.
> 
> **Overview**
> Fixes two filesystem cache leaks after prior cleanup work: **orphan files** that never expired when a restored cache refreshed mtimes, and **expired content packs** that only shrank one pack per build.
> 
> **Orphan file cleanup** now persists `unreferenced.json` with each orphan’s **first-seen time and size**. Deletion still respects the grace period and concurrent-build safety, but expiry can use **recorded age** (not only mtime), with guards for **recent writes**, **size changes** (name reuse), and special handling for `index*.old`.
> 
> **In-pack GC** adds `_gcExpiredContent()` during store so packs whose **all items** are past `maxAge` are dropped **in one serialize** without unpacking; the existing single-pack `_gcOldestContent()` path remains for partial rewrites.
> 
> Tests cover the new aging rules and a single-store multi-pack reclaim in `PackFileCacheStrategyCleanup.test.js` and `PersistentCaching.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3372c12d86072ba346d860507e72a4e84133aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->