### PR TITLE
feat: tree-shake unused properties in module.exports object literals

### DIFF
--- a/.changeset/025-cjs-object-literal-exports.md
+++ b/.changeset/025-cjs-object-literal-exports.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support tree-shaking module.exports object literals.

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -11,15 +11,19 @@ const formatLocation = require("../util/formatLocation");
 const { propertyAccess } = require("../util/property");
 const CommonJsExportRequireDependency = require("./CommonJsExportRequireDependency");
 const CommonJsExportsDependency = require("./CommonJsExportsDependency");
+const CommonJsObjectExportDependency = require("./CommonJsObjectExportDependency");
 const CommonJsSelfReferenceDependency = require("./CommonJsSelfReferenceDependency");
 const DynamicExports = require("./DynamicExports");
 const HarmonyExports = require("./HarmonyExports");
 const ModuleDecoratorDependency = require("./ModuleDecoratorDependency");
+const RuntimeRequirementsDependency = require("./RuntimeRequirementsDependency");
 
 /** @typedef {import("estree").AssignmentExpression} AssignmentExpression */
 /** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("estree").Expression} Expression */
 /** @typedef {import("estree").Node} Node */
+/** @typedef {import("estree").ObjectExpression} ObjectExpression */
+/** @typedef {import("estree").Property} Property */
 /** @typedef {import("estree").Super} Super */
 /** @typedef {import("estree").ThisExpression} ThisExpression */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
@@ -31,6 +35,7 @@ const ModuleDecoratorDependency = require("./ModuleDecoratorDependency");
 /** @typedef {import("../javascript/JavascriptParser").Members} Members */
 /** @typedef {import("../javascript/JavascriptParser").StatementPath} StatementPath */
 /** @typedef {import("./CommonJsDependencyHelpers").CommonJSDependencyBaseKeywords} CommonJSDependencyBaseKeywords */
+/** @typedef {import("./CommonJsObjectExportDependency").CommonJsObjectExportKind} CommonJsObjectExportKind */
 /** @typedef {import("../javascript/JavascriptModule").JavascriptModuleBuildMeta} JavascriptModuleBuildMeta */
 
 /**
@@ -413,7 +418,10 @@ class CommonJsExportsParserPlugin {
 
 				return true;
 			}
-			if (members.length === 0) return;
+			// `module.exports = { … }` — properties are the module's named exports.
+			if (members.length === 0) {
+				return handleObjectLiteralExport(expr, base);
+			}
 			enableStructuredExports();
 			const remainingMembers = members;
 			checkNamespace(
@@ -436,6 +444,116 @@ class CommonJsExportsParserPlugin {
 			).treatAsCommonJs = true;
 			keepAllExportsOnThisAccess(expr.right, base);
 			parser.walkExpression(expr.right);
+			return true;
+		};
+		/**
+		 * Handle top-level `module.exports = { … }` object-literal exports.
+		 * @param {AssignmentExpression} expr expression
+		 * @param {CommonJSDependencyBaseKeywords} base commonjs base keywords
+		 * @returns {boolean | undefined} true, when the expression was handled
+		 */
+		const handleObjectLiteralExport = (expr, base) => {
+			// Only `module.exports = { … }` replaces the whole exports object.
+			if (base !== "module.exports") return;
+			const isTopLevel =
+				/** @type {StatementPath} */ (parser.statementPath).length === 1 &&
+				parser.isStatementLevelExpression(expr);
+			if (!isTopLevel) return;
+			const right = expr.right;
+			if (right.type !== "ObjectExpression") return;
+
+			const bailoutObjectLiteral = () => {
+				bailout(
+					`module.exports = {…} cannot be statically analysed at ${formatLocation(
+						parser.getLocation(expr)
+					)}`
+				);
+				// LHS stays in source; factory still needs `module`.
+				parser.state.module.addPresentationalDependency(
+					new RuntimeRequirementsDependency([RuntimeGlobals.module])
+				);
+				parser.walkExpression(right);
+			};
+
+			const obj = /** @type {ObjectExpression} */ (right);
+			for (const prop of obj.properties) {
+				if (prop.type === "SpreadElement" || prop.computed) {
+					bailoutObjectLiteral();
+					return true;
+				}
+				const key = prop.key;
+				if (
+					key.type !== "Identifier" &&
+					!(key.type === "Literal" && typeof key.value === "string")
+				) {
+					bailoutObjectLiteral();
+					return true;
+				}
+			}
+
+			enableStructuredExports();
+			parser.state.module.addPresentationalDependency(
+				new RuntimeRequirementsDependency([RuntimeGlobals.module])
+			);
+			/** @type {JavascriptModuleBuildMeta} */ (
+				parser.state.module.buildMeta
+			).treatAsCommonJs = true;
+
+			for (const prop of obj.properties) {
+				const property = /** @type {Property} */ (prop);
+				const key = property.key;
+				const name =
+					key.type === "Identifier"
+						? key.name
+						: /** @type {string} */ (
+								/** @type {{ value: string }} */ (key).value
+							);
+
+				/** @type {CommonJsObjectExportKind} */
+				let kind;
+				/** @type {Range} */
+				let valueRange;
+				if (property.kind === "get") {
+					kind = "get";
+					valueRange = /** @type {Range} */ (property.value.range);
+				} else if (property.kind === "set") {
+					kind = "set";
+					valueRange = /** @type {Range} */ (property.value.range);
+				} else if (property.method) {
+					kind = "method";
+					valueRange = /** @type {Range} */ (property.value.range);
+				} else if (property.shorthand) {
+					kind = "shorthand";
+					valueRange = /** @type {Range} */ (property.range);
+				} else {
+					kind = "keyValue";
+					valueRange = /** @type {Range} */ (property.value.range);
+				}
+
+				if (name === "__esModule") {
+					checkNamespace(
+						true,
+						["__esModule"],
+						/** @type {Expression} */ (property.value)
+					);
+				}
+
+				const dep = new CommonJsObjectExportDependency(
+					/** @type {Range} */ (property.range),
+					/** @type {Range} */ (property.key.range),
+					valueRange,
+					name,
+					kind
+				);
+				dep.loc = parser.getLocation(property);
+				parser.state.module.addDependency(dep);
+
+				keepAllExportsOnThisAccess(
+					/** @type {Expression} */ (property.value),
+					base
+				);
+				parser.walkExpression(/** @type {Expression} */ (property.value));
+			}
 			return true;
 		};
 		parser.hooks.assignMemberChain

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -468,7 +468,11 @@ class CommonJsExportsParserPlugin {
 						parser.getLocation(expr)
 					)}`
 				);
-				// LHS stays in source; factory still needs `module`.
+				/** @type {JavascriptModuleBuildMeta} */ (
+					parser.state.module.buildMeta
+				).treatAsCommonJs = true;
+				// LHS stays as the text `module.exports` (moduleArgument is "module"
+				// unless a top-level `module` binding shadows it, which prevents this hook).
 				parser.state.module.addPresentationalDependency(
 					new RuntimeRequirementsDependency([RuntimeGlobals.module])
 				);
@@ -489,9 +493,17 @@ class CommonJsExportsParserPlugin {
 					bailoutObjectLiteral();
 					return true;
 				}
+				const name = key.type === "Identifier" ? key.name : String(key.value);
+				// `__proto__` sets [[Prototype]], not an own export.
+				if (name === "__proto__") {
+					bailoutObjectLiteral();
+					return true;
+				}
 			}
 
 			enableStructuredExports();
+			// LHS stays as the text `module.exports` (moduleArgument is "module"
+			// unless a top-level `module` binding shadows it, which prevents this hook).
 			parser.state.module.addPresentationalDependency(
 				new RuntimeRequirementsDependency([RuntimeGlobals.module])
 			);
@@ -506,8 +518,9 @@ class CommonJsExportsParserPlugin {
 					key.type === "Identifier"
 						? key.name
 						: /** @type {string} */ (
-								/** @type {{ value: string }} */ (key).value
+								/** @type {import("estree").Literal} */ (key).value
 							);
+				const value = /** @type {Expression} */ (property.value);
 
 				/** @type {CommonJsObjectExportKind} */
 				let kind;
@@ -515,27 +528,32 @@ class CommonJsExportsParserPlugin {
 				let valueRange;
 				if (property.kind === "get") {
 					kind = "get";
-					valueRange = /** @type {Range} */ (property.value.range);
+					valueRange = /** @type {Range} */ (value.range);
 				} else if (property.kind === "set") {
 					kind = "set";
-					valueRange = /** @type {Range} */ (property.value.range);
+					valueRange = /** @type {Range} */ (value.range);
 				} else if (property.method) {
-					kind = "method";
-					valueRange = /** @type {Range} */ (property.value.range);
+					valueRange = /** @type {Range} */ (value.range);
+					const fn = /** @type {import("estree").FunctionExpression} */ (value);
+					if (fn.async && fn.generator) {
+						kind = "asyncGeneratorMethod";
+					} else if (fn.async) {
+						kind = "asyncMethod";
+					} else if (fn.generator) {
+						kind = "generatorMethod";
+					} else {
+						kind = "method";
+					}
 				} else if (property.shorthand) {
 					kind = "shorthand";
 					valueRange = /** @type {Range} */ (property.range);
 				} else {
 					kind = "keyValue";
-					valueRange = /** @type {Range} */ (property.value.range);
+					valueRange = /** @type {Range} */ (value.range);
 				}
 
 				if (name === "__esModule") {
-					checkNamespace(
-						true,
-						["__esModule"],
-						/** @type {Expression} */ (property.value)
-					);
+					checkNamespace(true, ["__esModule"], value);
 				}
 
 				const dep = new CommonJsObjectExportDependency(
@@ -548,11 +566,8 @@ class CommonJsExportsParserPlugin {
 				dep.loc = parser.getLocation(property);
 				parser.state.module.addDependency(dep);
 
-				keepAllExportsOnThisAccess(
-					/** @type {Expression} */ (property.value),
-					base
-				);
-				parser.walkExpression(/** @type {Expression} */ (property.value));
+				keepAllExportsOnThisAccess(value, base);
+				parser.walkExpression(value);
 			}
 			return true;
 		};

--- a/lib/dependencies/CommonJsObjectExportDependency.js
+++ b/lib/dependencies/CommonJsObjectExportDependency.js
@@ -16,11 +16,21 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
-/** @typedef {"keyValue" | "shorthand" | "get" | "set" | "method"} CommonJsObjectExportKind */
+/** @typedef {"keyValue" | "shorthand" | "get" | "set" | "method" | "asyncMethod" | "generatorMethod" | "asyncGeneratorMethod"} CommonJsObjectExportKind */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectSerializerContext */
 
 const EMPTY_OBJECT = {};
+
+/** @type {ReadonlyMap<CommonJsObjectExportKind, string>} */
+const FUNCTION_PROPERTY_DROP_HEAD = new Map([
+	["get", "...void (function "],
+	["set", "...void (function "],
+	["method", "...void (function "],
+	["asyncMethod", "...void (async function "],
+	["generatorMethod", "...void (function* "],
+	["asyncGeneratorMethod", "...void (async function* "]
+]);
 
 class CommonJsObjectExportDependency extends NullDependency {
 	/**
@@ -56,7 +66,8 @@ class CommonJsObjectExportDependency extends NullDependency {
 			exports: [
 				{
 					name,
-					canMangle: !(name in EMPTY_OBJECT)
+					// Keep __esModule stable: the template never renames it.
+					canMangle: name !== "__esModule" && !(name in EMPTY_OBJECT)
 				}
 			],
 			dependencies: undefined
@@ -110,7 +121,7 @@ CommonJsObjectExportDependency.Template = class CommonJsObjectExportDependencyTe
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { module, moduleGraph, runtime }) {
+	apply(dependency, source, { module, moduleGraph, runtime, runtimeTemplate }) {
 		const dep = /** @type {CommonJsObjectExportDependency} */ (dependency);
 		// Interop marker must stay even when unused.
 		if (dep.name === "__esModule") return;
@@ -118,11 +129,17 @@ CommonJsObjectExportDependency.Template = class CommonJsObjectExportDependencyTe
 			moduleGraph.getExportsInfo(module).getUsedName(dep.name, runtime)
 		);
 		if (!used) {
+			// Object spread rewrite needs environment.spread.
+			if (!runtimeTemplate.supportsSpread()) return;
 			const range = /** @type {Range} */ (dep.range);
-			if (dep.kind === "get" || dep.kind === "set" || dep.kind === "method") {
+			if (FUNCTION_PROPERTY_DROP_HEAD.has(dep.kind)) {
 				// Keep the function body so nested dependency replaces stay valid.
 				const valueRange = /** @type {Range} */ (dep.valueRange);
-				source.replace(range[0], valueRange[0] - 1, "...void (function ");
+				source.replace(
+					range[0],
+					valueRange[0] - 1,
+					/** @type {string} */ (FUNCTION_PROPERTY_DROP_HEAD.get(dep.kind))
+				);
 				source.insert(valueRange[1], ")");
 				return;
 			}

--- a/lib/dependencies/CommonJsObjectExportDependency.js
+++ b/lib/dependencies/CommonJsObjectExportDependency.js
@@ -1,0 +1,154 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+const makeSerializable = require("../util/makeSerializable");
+const { propertyName } = require("../util/property");
+const NullDependency = require("./NullDependency");
+
+/** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
+/** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
+/** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
+/** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
+/** @typedef {import("../javascript/JavascriptParser").Range} Range */
+/** @typedef {"keyValue" | "shorthand" | "get" | "set" | "method"} CommonJsObjectExportKind */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectSerializerContext */
+
+const EMPTY_OBJECT = {};
+
+class CommonJsObjectExportDependency extends NullDependency {
+	/**
+	 * @param {Range} range property range
+	 * @param {Range} keyRange key range
+	 * @param {Range} valueRange value / function range
+	 * @param {ExportInfoName} name export name
+	 * @param {CommonJsObjectExportKind} kind property kind
+	 */
+	constructor(range, keyRange, valueRange, name, kind) {
+		super();
+		this.range = range;
+		this.keyRange = keyRange;
+		this.valueRange = valueRange;
+		/** @type {ExportInfoName} */
+		this.name = name;
+		/** @type {CommonJsObjectExportKind} */
+		this.kind = kind;
+	}
+
+	get type() {
+		return "cjs object exports";
+	}
+
+	/**
+	 * Returns the exported names
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @returns {ExportsSpec | undefined} export names
+	 */
+	getExports(moduleGraph) {
+		const name = this.name;
+		return {
+			exports: [
+				{
+					name,
+					canMangle: !(name in EMPTY_OBJECT)
+				}
+			],
+			dependencies: undefined
+		};
+	}
+
+	/**
+	 * Serializes this instance into the provided serializer context.
+	 * @param {ObjectSerializerContext} context context
+	 */
+	serialize(context) {
+		context
+			.write(this.range)
+			.write(this.keyRange)
+			.write(this.valueRange)
+			.write(this.name)
+			.write(this.kind);
+		super.serialize(context);
+	}
+
+	/**
+	 * Restores this instance from the provided deserializer context.
+	 * @param {ObjectDeserializerContext} context context
+	 */
+	deserialize(context) {
+		this.range = context.read();
+		const c1 = context.rest;
+		this.keyRange = c1.read();
+		const c2 = c1.rest;
+		this.valueRange = c2.read();
+		const c3 = c2.rest;
+		this.name = c3.read();
+		const c4 = c3.rest;
+		this.kind = c4.read();
+		super.deserialize(c4.rest);
+	}
+}
+
+makeSerializable(
+	CommonJsObjectExportDependency,
+	"webpack/lib/dependencies/CommonJsObjectExportDependency"
+);
+
+CommonJsObjectExportDependency.Template = class CommonJsObjectExportDependencyTemplate extends (
+	NullDependency.Template
+) {
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Dependency} dependency the dependency for which the template should be applied
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
+	 */
+	apply(dependency, source, { module, moduleGraph, runtime }) {
+		const dep = /** @type {CommonJsObjectExportDependency} */ (dependency);
+		// Interop marker must stay even when unused.
+		if (dep.name === "__esModule") return;
+		const used = /** @type {string | false} */ (
+			moduleGraph.getExportsInfo(module).getUsedName(dep.name, runtime)
+		);
+		if (!used) {
+			const range = /** @type {Range} */ (dep.range);
+			if (dep.kind === "get" || dep.kind === "set" || dep.kind === "method") {
+				// Keep the function body so nested dependency replaces stay valid.
+				const valueRange = /** @type {Range} */ (dep.valueRange);
+				source.replace(range[0], valueRange[0] - 1, "...void (function ");
+				source.insert(valueRange[1], ")");
+				return;
+			}
+			if (dep.kind === "shorthand") {
+				source.replace(range[0], range[1] - 1, `...void (${dep.name})`);
+				return;
+			}
+			// keyValue: keep the value's side effects in place.
+			const valueRange = /** @type {Range} */ (dep.valueRange);
+			source.replace(range[0], valueRange[0] - 1, "...void (");
+			source.replace(valueRange[1], range[1] - 1, ")");
+			return;
+		}
+		if (used === dep.name) return;
+		// Rename the key to the mangled export name.
+		const keyRange = /** @type {Range} */ (dep.keyRange);
+		if (dep.kind === "shorthand") {
+			source.replace(
+				keyRange[0],
+				keyRange[1] - 1,
+				`${propertyName(used)}: ${dep.name}`
+			);
+			return;
+		}
+		source.replace(keyRange[0], keyRange[1] - 1, propertyName(used));
+	}
+};
+
+module.exports = CommonJsObjectExportDependency;

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -23,6 +23,7 @@ const CommonJsExportsDependency = require("./CommonJsExportsDependency");
 const CommonJsExportsParserPlugin = require("./CommonJsExportsParserPlugin");
 const CommonJsFullRequireDependency = require("./CommonJsFullRequireDependency");
 const CommonJsImportsParserPlugin = require("./CommonJsImportsParserPlugin");
+const CommonJsObjectExportDependency = require("./CommonJsObjectExportDependency");
 const CommonJsRequireContextDependency = require("./CommonJsRequireContextDependency");
 const CommonJsRequireDependency = require("./CommonJsRequireDependency");
 const CommonJsSelfReferenceDependency = require("./CommonJsSelfReferenceDependency");
@@ -110,6 +111,11 @@ class CommonJsPlugin {
 				compilation.dependencyTemplates.set(
 					CommonJsExportsDependency,
 					new CommonJsExportsDependency.Template()
+				);
+
+				compilation.dependencyTemplates.set(
+					CommonJsObjectExportDependency,
+					new CommonJsObjectExportDependency.Template()
 				);
 
 				compilation.dependencyFactories.set(

--- a/lib/javascript/JavascriptGenerator.js
+++ b/lib/javascript/JavascriptGenerator.js
@@ -13,6 +13,7 @@ const { JAVASCRIPT_TYPES } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const CommonJsExportsDependency = require("../dependencies/CommonJsExportsDependency");
 const CommonJsFullRequireDependency = require("../dependencies/CommonJsFullRequireDependency");
+const CommonJsObjectExportDependency = require("../dependencies/CommonJsObjectExportDependency");
 const CommonJsRequireDependency = require("../dependencies/CommonJsRequireDependency");
 const CommonJsSelfReferenceDependency = require("../dependencies/CommonJsSelfReferenceDependency");
 const ContextDependency = require("../dependencies/ContextDependency");
@@ -112,6 +113,7 @@ const getCommonJsConcatenationBailoutReason = (module) => {
 	for (const dep of module.dependencies) {
 		if (
 			dep instanceof CommonJsExportsDependency ||
+			dep instanceof CommonJsObjectExportDependency ||
 			dep instanceof CommonJsSelfReferenceDependency
 		) {
 			// Any export shape is fine: hoisted modules restrict these below,
@@ -164,7 +166,10 @@ const getCommonJsConcatenationBailoutReason = (module) => {
  */
 const isCommonJsHoistable = (module) => {
 	for (const dep of module.dependencies) {
-		if (dep instanceof CommonJsExportsDependency) {
+		if (dep instanceof CommonJsObjectExportDependency) {
+			// `module.exports = {…}` keeps a real exports object (methods/`this`).
+			return false;
+		} else if (dep instanceof CommonJsExportsDependency) {
 			if (dep.base !== "exports" && dep.base !== "module.exports") return false;
 			if (dep.names.length === 0) return false;
 		} else if (dep instanceof CommonJsSelfReferenceDependency) {

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -51,6 +51,8 @@ module.exports = {
 		require("../dependencies/CommonJsExportsDependency"),
 	"dependencies/CommonJsFullRequireDependency": () =>
 		require("../dependencies/CommonJsFullRequireDependency"),
+	"dependencies/CommonJsObjectExportDependency": () =>
+		require("../dependencies/CommonJsObjectExportDependency"),
 	"dependencies/CommonJsRequireContextDependency": () =>
 		require("../dependencies/CommonJsRequireContextDependency"),
 	"dependencies/CommonJsRequireDependency": () =>

--- a/test/cases/cjs-tree-shaking/object-literal-accessors/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-accessors/index.js
@@ -1,0 +1,6 @@
+it("should remove unused getters and methods from module.exports = { … }", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used-value");
+	expect(m.usedGetter).toBe("used-getter");
+	expect(m.usedExports).toEqual(["used", "usedExports", "usedGetter"]);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-accessors/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal-accessors/lib.js
@@ -1,0 +1,13 @@
+module.exports = {
+	used: "used-value",
+	get usedGetter() {
+		return "used-getter";
+	},
+	get unusedGetter() {
+		return "unused-getter";
+	},
+	unusedMethod() {
+		return "unused-method";
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-accessors/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-accessors/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal-async-method/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-async-method/index.js
@@ -1,0 +1,5 @@
+it("should drop unused async and generator methods from module.exports = { … }", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.usedExports).toEqual(["used", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-async-method/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal-async-method/lib.js
@@ -1,0 +1,17 @@
+module.exports = {
+	used: "used",
+	async unusedAsync() {
+		await Promise.resolve(1);
+		return "unused-async";
+	},
+	*unusedGen() {
+		yield 1;
+		return "unused-gen";
+	},
+	async *unusedAsyncGen() {
+		await Promise.resolve();
+		yield 2;
+		return "unused-async-gen";
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-async-method/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-async-method/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/computed.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/computed.js
@@ -1,0 +1,6 @@
+const key = "dynamic";
+module.exports = {
+	used: "used",
+	[key]: "dynamic",
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/index.js
@@ -19,3 +19,10 @@ it("should bailout on indirect module.exports = object", () => {
 	expect(m.unused).toBe("unused");
 	expect(m.usedExports).toBe(null);
 });
+
+it("should bailout on __proto__ in module.exports object literal", () => {
+	const m = require("./proto");
+	expect(m.used).toBe("used");
+	expect(Object.getPrototypeOf(m)).toBe(null);
+	expect(m.usedExports).toBe(null);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/index.js
@@ -1,0 +1,21 @@
+it("should bailout on spread in module.exports object literal", () => {
+	const m = require("./spread");
+	expect(m.used).toBe("used");
+	expect(m.extra).toBe("extra");
+	// Bailout clears structured exports, so usage is unknown.
+	expect(m.usedExports).toBe(null);
+});
+
+it("should bailout on computed keys in module.exports object literal", () => {
+	const m = require("./computed");
+	expect(m.used).toBe("used");
+	expect(m.dynamic).toBe("dynamic");
+	expect(m.usedExports).toBe(null);
+});
+
+it("should bailout on indirect module.exports = object", () => {
+	const m = require("./indirect");
+	expect(m.used).toBe("used");
+	expect(m.unused).toBe("unused");
+	expect(m.usedExports).toBe(null);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/indirect.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/indirect.js
@@ -1,0 +1,6 @@
+const value = {
+	used: "used",
+	unused: "unused",
+	usedExports: __webpack_exports_info__.usedExports
+};
+module.exports = value;

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/proto.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/proto.js
@@ -1,0 +1,6 @@
+module.exports = {
+	used: "used",
+	__proto__: null,
+	unused: "unused",
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/spread.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/spread.js
@@ -1,0 +1,6 @@
+const extra = { extra: "extra" };
+module.exports = {
+	used: "used",
+	...extra,
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-bailout/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-bailout/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal-esmodule/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-esmodule/index.js
@@ -1,0 +1,6 @@
+it("should keep __esModule and drop unused properties", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used-value");
+	expect(m.__esModule).toBe(true);
+	expect(m.usedExports).toEqual(["__esModule", "used", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-esmodule/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal-esmodule/lib.js
@@ -1,0 +1,6 @@
+module.exports = {
+	__esModule: true,
+	used: "used-value",
+	unused: "unused-value",
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-esmodule/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-esmodule/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require/heavy.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require/heavy.js
@@ -1,0 +1,1 @@
+module.exports = "heavy";

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require/index.js
@@ -1,0 +1,5 @@
+it("should drop unused methods/getters that contain require without breaking codegen", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.usedExports).toEqual(["used", "usedExports"]);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require/lib.js
@@ -1,0 +1,13 @@
+module.exports = {
+	used: "used",
+	unusedMethod() {
+		return require("./heavy");
+	},
+	get unusedGetter() {
+		return require("./heavy");
+	},
+	set unusedSetter(_value) {
+		require("./heavy");
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal/index.js
@@ -1,0 +1,31 @@
+it("should tree-shake unused properties of module.exports = { … }", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used-value");
+	expect(m.usedShort).toBe("used-short");
+	expect(m.usedFn()).toBe("used-fn");
+	expect(m.usedExports).toEqual([
+		"used",
+		"usedExports",
+		"usedFn",
+		"usedShort"
+	]);
+});
+it("should keep side effects of unused data properties", () => {
+	const m = require("./side-effects");
+	expect(m.used).toBe("used");
+	expect(m.getCount()).toBe(1);
+});
+
+it("should keep the full object when the namespace is used as a value", () => {
+	const m = require("./lib-full");
+	expect(m).toEqual({
+		used: "used-value",
+		unused: "unused-value"
+	});
+});
+
+it("should keep sibling exports when an object method uses this", () => {
+	const m = require("./method-this");
+	expect(m.getValue()).toBe(10);
+	expect(m.usedExports).toBe(true);
+});

--- a/test/cases/cjs-tree-shaking/object-literal/lib-full.js
+++ b/test/cases/cjs-tree-shaking/object-literal/lib-full.js
@@ -1,0 +1,4 @@
+module.exports = {
+	used: "used-value",
+	unused: "unused-value"
+};

--- a/test/cases/cjs-tree-shaking/object-literal/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal/lib.js
@@ -1,0 +1,15 @@
+const usedShort = "used-short";
+const unusedShort = "unused-short";
+module.exports = {
+	used: "used-value",
+	unused: "unused-value",
+	usedShort,
+	unusedShort,
+	usedFn: function () {
+		return "used-fn";
+	},
+	unusedFn: function () {
+		return "unused-fn";
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal/method-this.js
+++ b/test/cases/cjs-tree-shaking/object-literal/method-this.js
@@ -1,0 +1,8 @@
+module.exports = {
+	value: 10,
+	unused: "drop-me",
+	getValue() {
+		return this.value;
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal/side-effects.js
+++ b/test/cases/cjs-tree-shaking/object-literal/side-effects.js
@@ -1,0 +1,8 @@
+let count = 0;
+module.exports = {
+	used: "used",
+	unused: (++count, "unused"),
+	getCount() {
+		return count;
+	}
+};

--- a/test/cases/cjs-tree-shaking/object-literal/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/mjs/non-mjs-cjs-import-default/index.js
+++ b/test/cases/mjs/non-mjs-cjs-import-default/index.js
@@ -32,24 +32,38 @@ it("should get correct values when importing named exports from a CommonJs modul
 			default: "default"
 		}
 	});
-	expect(star).toEqual({
-		data: "ok",
-		default: "default"
-	});
+	// Object-literal exports use default-with-named interop (same as mjs).
+	expect(star).toEqual(
+		nsObj({
+			default: {
+				data: "ok",
+				default: "default"
+			},
+			data: "ok"
+		})
+	);
 	expect({ star }).toEqual({
-		star: {
-			data: "ok",
-			default: "default"
-		}
+		star: nsObj({
+			default: {
+				data: "ok",
+				default: "default"
+			},
+			data: "ok"
+		})
 	});
 	expect(star.default).toEqual({
 		data: "ok",
 		default: "default"
 	});
-	expect(ns).toEqual({
-		data: "ok",
-		default: "default"
-	});
+	expect(ns).toEqual(
+		nsObj({
+			default: {
+				data: "ok",
+				default: "default"
+			},
+			data: "ok"
+		})
+	);
 	expect(def1).toEqual({
 		data: "ok",
 		default: "default"
@@ -62,10 +76,13 @@ it("should get correct values when importing named exports from a CommonJs modul
 	expect({ data2 }).toEqual({ data2: "ok" });
 	expect(reexport).toEqual(
 		nsObj({
-			ns: {
-				data: "ok",
-				default: "default"
-			},
+			ns: nsObj({
+				default: {
+					data: "ok",
+					default: "default"
+				},
+				data: "ok"
+			}),
 			default: {
 				data: "ok",
 				default: "default"

--- a/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/lib.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/lib.js
@@ -1,0 +1,5 @@
+const extra = { extra: "extra" };
+module.exports = {
+	used: "used",
+	...extra
+};

--- a/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/test.config.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/test.config.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.noTests = true;

--- a/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-bailout-module-library/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+/**
+ * @param {string} assetName emitted asset to assert on
+ * @returns {(this: import("../../../../").Compiler) => void} plugin
+ */
+const assertHasDefaultExport = (assetName) =>
+	function apply() {
+		this.hooks.compilation.tap("testcase", (compilation) => {
+			compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
+				const source = assets[assetName].source();
+				expect(source).toMatch(/\bexport\b/);
+			});
+		});
+	};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./lib.js",
+	target: "node14",
+	output: {
+		filename: "lib.mjs",
+		module: true,
+		library: { type: "module" }
+	},
+	optimization: {
+		minimize: false,
+		usedExports: true
+	},
+	experiments: { outputModule: true },
+	plugins: [assertHasDefaultExport("lib.mjs")]
+};

--- a/test/configCases/cjs-tree-shaking/object-literal-no-spread/index.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-no-spread/index.js
@@ -1,0 +1,5 @@
+it("should keep unused properties when object spread is unsupported", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.unused).toBe("unused-value");
+});

--- a/test/configCases/cjs-tree-shaking/object-literal-no-spread/lib.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-no-spread/lib.js
@@ -1,0 +1,4 @@
+module.exports = {
+	used: "used",
+	unused: "unused-value"
+};

--- a/test/configCases/cjs-tree-shaking/object-literal-no-spread/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-no-spread/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/**
+ * @param {string} assetName emitted asset to assert on
+ * @returns {(this: import("../../../../").Compiler) => void} plugin
+ */
+const assertNoObjectSpread = (assetName) =>
+	function apply() {
+		this.hooks.compilation.tap("testcase", (compilation) => {
+			compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
+				const source = assets[assetName].source();
+				expect(source).toContain("unused:");
+				expect(source).not.toMatch(/\.\.\.\s*void/);
+			});
+		});
+	};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	target: ["web", "es5"],
+	optimization: {
+		minimize: false,
+		usedExports: true,
+		concatenateModules: false
+	},
+	plugins: [assertNoObjectSpread("bundle0.js")]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Enable property-level tree-shaking for top-level `module.exports = { … }` object literals when `usedExports` is on. Unused data/shorthand props become `...void (…)`, unused get/set/method become `...void (function …)` (async/generator methods are left verbatim). `__proto__`, spread, and computed keys bail out. `__esModule` is never dropped.

This mainly improves export-graph / mangling, not raw bytes: dropped values stay wrapped in `void`, and `require()` inside an unused method can still pull the target module into the graph.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/cases/cjs-tree-shaking/object-literal/`, `object-literal-accessors/`, `object-literal-esmodule/`, `object-literal-bailout/` (incl. `__proto__`), `object-literal-nested-require/`, `object-literal-async-method/`, plus `test/configCases/cjs-tree-shaking/object-literal-no-spread/` and `object-literal-bailout-module-library/`.

**Does this PR introduce a breaking change?**

Yes — interop shape for CJS modules that use a static top-level `module.exports = { … }`. `enableStructuredExports()` moves them to `exportsType: "default"` / `defaultObject: "redirect"`, so `import * as ns` (and `library.type: "module"`) gets default-with-named namespace form instead of the previous opaque object. Closer to Node ESM↔CJS interop; changeset is `minor`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a (behavior is automatic under `usedExports`; interop change should be noted in the release notes via the changeset).

**Use of AI**

AI was used to implement the feature, address review feedback, write tests, and draft this PR description, with human review of the design and changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CJS→ESM namespace shape for static object-literal exports (documented breaking/minor) and touches core CommonJS parsing/codegen; behavior is gated on usedExports and well-tested but interop surprises are possible for existing consumers.
> 
> **Overview**
> Adds **property-level tree-shaking** for top-level **`module.exports = { … }`** when `optimization.usedExports` is enabled. The CommonJS exports parser now treats each static object property as a named export via **`CommonJsObjectExportDependency`**, instead of treating the whole assignment as an opaque export.
> 
> Unused properties are rewritten at codegen time (e.g. `...void (...)` for data/shorthand props, `...void (function …)` for getters/methods) while **preserving side effects** where needed. **`__esModule`** is never dropped. **Spread**, **computed keys**, **`__proto__`**, and **non–top-level** assignments **bail out** to the previous dynamic-export behavior.
> 
> Structured exports on these modules now use **default-with-named interop** (like ESM `export default { … }`), so **`import * as ns`** from such CJS modules exposes a **`default`** namespace entry—**interop expectations change** for static object-literal CJS exports. **`isCommonJsHoistable`** treats object-literal exports as non-hoistable (real exports object for methods/`this`).
> 
> Extensive **cjs-tree-shaking** tests cover accessors, async/generator methods, bailouts, nested `require`, ES5 targets without spread, and module library output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc69825a4d2ccb020e560774c9418669d60a4d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->