### PR TITLE
test: benchmark the runtime performance of emitted bundles

### DIFF
--- a/TESTING_DOCS.md
+++ b/TESTING_DOCS.md
@@ -13,6 +13,13 @@ This document explains the structure of the `test/` directory in the Webpack pro
 
 - **Purpose**: Contains test cases for benchmarking Webpack's performance.
 - **Usage**: Measures build times, memory usage, and optimization impact.
+- **Kinds of case** (picked from the directory name):
+  - _build_ (default, e.g. `many-modules-esm/`) — a `webpack.config.mjs` plus an entry; measures one build per scenario (`mode-development`, `mode-development-rebuild`, `mode-production`).
+  - `*-unit` (e.g. `js-parser-unit/`) — an `index.bench.mjs` exporting `default (bench) => {…}`; measures a piece of `lib/` directly, with no scenarios.
+  - `*-runtime` (e.g. `many-modules-interop-runtime/`) — measures **the emitted bundle**, not the build. The case is compiled once per scenario outside any measured region; the `exec` task then instantiates the output (runtime bootstrap plus every module factory that runs at import time) and calls the entry's exported `run` on it. The rebuild scenario is skipped, since it emits the same output.
+- **Writing a `*-runtime` case**: the entry must export `run(seed)`, do its work with that opaque seed, and return the result — otherwise the compiler folds the workload away and the bench measures nothing (both are checked and fail the run). The harness forces `target: "node"` and a `commonjs2` library so the output can be instantiated in-process; generate large fixtures from `options.mjs` (`setup()`), as the build cases do.
+
+`exec` is reported per scenario, so a `development`/`production` pair shows what scope hoisting and minification are worth at runtime.
 
 ### 3. `cases/`
 

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -334,7 +334,9 @@ class BenchmarkRunner {
 	/**
 	 * Build the benchmark tasks for this shard. Each non-unit benchmark expands
 	 * to one task per scenario (all baselines measured within the task); `-unit`
-	 * benchmarks have no scenarios and become a single task.
+	 * benchmarks have no scenarios and become a single task; `-runtime`
+	 * benchmarks skip the rebuild scenario, which emits the same output as the
+	 * initial build.
 	 * @param {string[]} benchmarks discovered benchmarks
 	 * @param {[number, number]} shard shard [part, count]
 	 * @param {Baseline[]} baselines baselines
@@ -362,7 +364,11 @@ class BenchmarkRunner {
 				continue;
 			}
 
-			for (const scenario of this.scenarios) {
+			const scenarios = benchmark.includes("-runtime")
+				? this.scenarios.filter((scenario) => !scenario.watch)
+				: this.scenarios;
+
+			for (const scenario of scenarios) {
 				benchmarkTasks.push({
 					id: `${benchmark}-${scenario.name}`,
 					benchmark,

--- a/test/benchmarkCases/many-modules-interop-runtime/index.js
+++ b/test/benchmarkCases/many-modules-interop-runtime/index.js
@@ -1,0 +1,1 @@
+export { run } from "./generated/module.js";

--- a/test/benchmarkCases/many-modules-interop-runtime/options.mjs
+++ b/test/benchmarkCases/many-modules-interop-runtime/options.mjs
@@ -1,0 +1,234 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+// Five modules per group — an ESM leaf, two CommonJS leaves, and one consumer
+// of each kind reaching across the other module system — so the bundle mixes
+// both systems at every level instead of only at the entry. 2042 modules total.
+const GROUP_COUNT = 400;
+const GROUPS_PER_BARREL = 10;
+// Memory mode measures allocations and the workload loop allocates nothing, so
+// instantiating the graph is the whole signal there; a couple of rounds suffice.
+const ROUNDS = memoryScaledCount(30, 2);
+const TABLE_SIZE = 8;
+
+/**
+ * @param {number} index group index
+ * @returns {string} generated module
+ */
+function generateEsm(index) {
+	return `const table = [];
+for (let i = 0; i < ${TABLE_SIZE}; i++) {
+	table.push((i * ${index} + 1) | 0);
+}
+
+export const value = table[3];
+
+export function scale(x) {
+	return (x + table[x & ${TABLE_SIZE - 1}]) | 0;
+}
+
+export default function identity(x) {
+	return (x + ${index}) | 0;
+}
+`;
+}
+
+/**
+ * @param {number} index group index
+ * @returns {string} generated module
+ */
+function generateCommonJs(index) {
+	return `const table = [];
+for (let i = 0; i < ${TABLE_SIZE}; i++) {
+	table.push((i * ${index} + 3) | 0);
+}
+
+exports.value = table[5];
+
+exports.scale = function scale(x) {
+	return (x + table[x & ${TABLE_SIZE - 1}]) | 0;
+};
+
+module.exports.identity = function identity(x) {
+	return (x + ${index}) | 0;
+};
+`;
+}
+
+/**
+ * `module.exports` assigned a function, the shape that makes an ESM default
+ * import go through the runtime's compat getter instead of a direct property
+ * read on the exports object.
+ * @param {number} index group index
+ * @returns {string} generated module
+ */
+function generateCommonJsCallable(index) {
+	return `module.exports = function callable(x) {
+	return (x + ${index}) | 0;
+};
+
+module.exports.extra = function extra(x) {
+	return (x * 2 + ${index}) | 0;
+};
+`;
+}
+
+/**
+ * CommonJS reading ESM: `require()` hands back a namespace object the runtime
+ * builds, `default` binding included.
+ * @param {number} index group index
+ * @returns {string} generated module
+ */
+function generateCommonJsConsumer(index) {
+	return `const esm = require("./esm-${index}.js");
+const commonjs = require("./commonjs-${index}.js");
+
+module.exports.call = function call(x) {
+	return (esm.default(x) + esm.scale(x) + commonjs.identity(x)) | 0;
+};
+`;
+}
+
+/**
+ * ESM reading CommonJS: the default import goes through the compat getter, the
+ * named one through webpack's analysis of the `exports` assignments. Export
+ * names carry the index so the barrels can `export *` without conflicts.
+ * @param {number} index group index
+ * @returns {string} generated module
+ */
+function generateEsmConsumer(index) {
+	return `import commonjsDefault from "./commonjs-${index}.js";
+import { scale } from "./commonjs-${index}.js";
+
+export const total${index} = commonjsDefault.value;
+
+export function mix${index}(x) {
+	return (commonjsDefault.identity(x) + scale(x)) | 0;
+}
+`;
+}
+
+/**
+ * @param {string[]} requests re-exported requests
+ * @returns {string} generated module
+ */
+function generateBarrel(requests) {
+	return requests
+		.map((request) => `export * from ${JSON.stringify(request)};\n`)
+		.join("");
+}
+
+/**
+ * Entry aggregator. Every round walks each group through all the ways the two
+ * module systems reach each other: default, namespace and named import of a
+ * CommonJS module, a callable one imported as default, a CommonJS module that
+ * consumed ESM, and an ESM module that consumed CommonJS — the last one behind
+ * a two-level barrel, read once as a named import and once off the namespace
+ * object.
+ * @param {number} groupCount count of groups
+ * @returns {string} generated module
+ */
+function generateAggregator(groupCount) {
+	const imports = ['import * as barrel from "./barrel.js";'];
+	const barrelNames = [];
+	const body = [];
+
+	for (let index = 0; index < groupCount; index++) {
+		imports.push(
+			`import commonjsDefault${index} from "./commonjs-${index}.js";
+import * as commonjsNamespace${index} from "./commonjs-${index}.js";
+import { scale as commonjsNamed${index} } from "./commonjs-${index}.js";
+import callable${index} from "./commonjs-callable-${index}.js";
+import consumer${index} from "./commonjs-consumer-${index}.js";`
+		);
+		barrelNames.push(`mix${index}`);
+		body.push(
+			`		total = commonjsDefault${index}.scale(total);
+		total = commonjsNamespace${index}.identity(total);
+		total = commonjsNamed${index}(total);
+		total = callable${index}(total);
+		total = callable${index}.extra(total);
+		total = consumer${index}.call(total);
+		total = mix${index}(total);
+		total = (total + barrel.total${index}) | 0;`
+		);
+	}
+
+	imports.push(`import { ${barrelNames.join(", ")} } from "./barrel.js";`);
+
+	return `${imports.join("\n")}
+
+export function run(seed) {
+	let total = seed | 0;
+
+	for (let round = 0; round < ${ROUNDS}; round++) {
+${body.join("\n")}
+	}
+
+	return total;
+}
+`;
+}
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await fs.mkdir(generated, { recursive: true });
+
+	/** @type {string[]} */
+	const barrels = [];
+
+	for (let start = 0; start < GROUP_COUNT; start += GROUPS_PER_BARREL) {
+		/** @type {string[]} */
+		const esmConsumers = [];
+
+		for (
+			let index = start;
+			index < Math.min(start + GROUPS_PER_BARREL, GROUP_COUNT);
+			index++
+		) {
+			await fs.writeFile(
+				resolve(generated, `./esm-${index}.js`),
+				generateEsm(index)
+			);
+			await fs.writeFile(
+				resolve(generated, `./commonjs-${index}.js`),
+				generateCommonJs(index)
+			);
+			await fs.writeFile(
+				resolve(generated, `./commonjs-callable-${index}.js`),
+				generateCommonJsCallable(index)
+			);
+			await fs.writeFile(
+				resolve(generated, `./commonjs-consumer-${index}.js`),
+				generateCommonJsConsumer(index)
+			);
+			await fs.writeFile(
+				resolve(generated, `./esm-consumer-${index}.js`),
+				generateEsmConsumer(index)
+			);
+			esmConsumers.push(`./esm-consumer-${index}.js`);
+		}
+
+		const barrel = `./barrel-${start / GROUPS_PER_BARREL}.js`;
+
+		await fs.writeFile(
+			resolve(generated, barrel),
+			generateBarrel(esmConsumers)
+		);
+		barrels.push(barrel);
+	}
+
+	await fs.writeFile(
+		resolve(generated, "./barrel.js"),
+		generateBarrel(barrels)
+	);
+	await fs.writeFile(
+		resolve(generated, "./module.js"),
+		generateAggregator(GROUP_COUNT)
+	);
+}

--- a/test/benchmarkCases/many-modules-interop-runtime/webpack.config.mjs
+++ b/test/benchmarkCases/many-modules-interop-runtime/webpack.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index"
+};

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -1,8 +1,10 @@
 import { writeFile } from "fs";
 import fs from "fs/promises";
 import { Session } from "inspector";
+import { createRequire } from "module";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
+import vm from "vm";
 import {
 	InstrumentHooks,
 	getCodspeedRunnerMode,
@@ -49,8 +51,16 @@ import { Bench, hrtimeNow } from "tinybench";
  * @property {typeof run} run run one benchmark task
  */
 
+/** @typedef {{ run: (seed: number) => unknown }} RuntimeBundleExports */
+/** @typedef {{ taskName: string, collectBy: string }} TaskNames */
+
 const GENERATE_PROFILE = typeof process.env.PROFILE !== "undefined";
 const codspeedRunnerMode = getCodspeedRunnerMode();
+
+// Emitted entry of a `-runtime` benchmark; fixed so the bench can locate it.
+const RUNTIME_BUNDLE_FILENAME = "bundle.js";
+// `run()` input. Opaque to the compiler, so the workload can't be constant-folded.
+const RUNTIME_SEED = 7;
 
 /** @type {string} */
 let baseOutputPath;
@@ -1037,6 +1047,120 @@ async function addWatchBench({ bench, taskName, collectBy, webpack, config }) {
 }
 
 /**
+ * Force the output shape a runtime bench needs: a single CommonJS bundle Node
+ * can instantiate, exposing the entry's exports on `module.exports`.
+ * @param {Configuration} config configuration
+ * @returns {Configuration} configuration
+ */
+function prepareRuntimeConfiguration(config) {
+	config.target = config.target || "node";
+	config.output = {
+		...config.output,
+		filename: RUNTIME_BUNDLE_FILENAME,
+		library: { type: "commonjs2" }
+	};
+	return config;
+}
+
+/**
+ * Compile the case and return a factory instantiating the emitted bundle.
+ * Building and V8-compiling the output happen here, outside every measured
+ * region, so the bench times only the generated code. The compiled function is
+ * reused across iterations — calling it re-runs the bundle body without
+ * re-parsing it, and each call gets a fresh `module`, so the bundle's module
+ * registry starts out empty.
+ * @param {Webpack} webpack webpack
+ * @param {Configuration} config configuration
+ * @returns {Promise<() => RuntimeBundleExports>} bundle instantiation
+ */
+async function compileRuntimeBundle(webpack, config) {
+	await runWebpack(webpack, config);
+
+	const outputPath = /** @type {string} */ (
+		/** @type {NonNullable<Configuration["output"]>} */ (config.output).path
+	);
+	const bundlePath = path.join(outputPath, RUNTIME_BUNDLE_FILENAME);
+	const source = await fs.readFile(bundlePath, "utf8");
+	const factory = vm.compileFunction(
+		source,
+		["module", "exports", "require", "__filename", "__dirname"],
+		{ filename: bundlePath }
+	);
+	// Bound to the emitted bundle so externals and node-target chunk loading
+	// resolve exactly as they would for a real consumer of the output.
+	const bundleRequire = createRequire(bundlePath);
+
+	return () => {
+		const bundleModule = { exports: {} };
+
+		factory(
+			bundleModule,
+			bundleModule.exports,
+			bundleRequire,
+			bundlePath,
+			outputPath
+		);
+
+		return /** @type {RuntimeBundleExports} */ (bundleModule.exports);
+	};
+}
+
+/**
+ * Register the runtime bench for one baseline. One measured region per
+ * iteration: instantiate the emitted bundle (runtime bootstrap plus every
+ * module factory that runs at import time), then call the entry's exported
+ * `run` on it, so both the boot and the steady-state cost of the generated
+ * code are counted.
+ * @param {object} params params
+ * @param {Bench} params.bench bench
+ * @param {(measure: string) => TaskNames} params.createNames task names factory
+ * @param {Webpack} params.webpack webpack
+ * @param {Configuration} params.config config
+ * @returns {Promise<void>}
+ */
+async function addRuntimeBench({ bench, createNames, webpack, config }) {
+	const instantiate = await compileRuntimeBundle(
+		webpack,
+		prepareRuntimeConfiguration(config)
+	);
+
+	// Probe once so a case exporting nothing measurable fails at registration
+	// instead of reporting a task that does no work.
+	if (typeof instantiate().run !== "function") {
+		throw new Error(
+			`The entry of runtime benchmark "${config.name}" must export a \`run\` function.`
+		);
+	}
+
+	const exec = createNames("exec");
+
+	// Holds what the measured region produced, so the work behind it stays
+	// observable; the `afterAll` assertion is what reads it back.
+	/** @type {unknown} */
+	let execResult;
+
+	bench.add(
+		exec.taskName,
+		() => {
+			execResult = instantiate().run(RUNTIME_SEED);
+		},
+		{
+			beforeAll() {
+				/** @type {Task} */
+				(this).collectBy = exec.collectBy;
+			},
+			afterAll() {
+				if (execResult === undefined) {
+					throw new Error(
+						`\`run()\` of runtime benchmark "${config.name}" returned nothing; return the workload result so it can't be optimized away`
+					);
+				}
+			}
+		}
+	);
+}
+
+/**
  * Create the CodSpeed-wrapped bench shared by one or many benchmarks.
  * @returns {Promise<Bench>} bench
  */
@@ -1118,8 +1242,8 @@ function attachResultCollector(bench, results) {
 
 /**
  * Register one benchmark task's benches onto `bench`. `-unit` benchmarks
- * register their own tasks against the current lib; others add one build/watch
- * bench per baseline.
+ * register their own tasks against the current lib, `-runtime` benchmarks
+ * measure the compiled output; others add one build/watch bench per baseline.
  * @param {Bench} bench bench
  * @param {BenchmarkTask} task benchmark task
  * @param {string} casesPath benchmark cases directory
@@ -1129,6 +1253,7 @@ async function registerBenchmark(bench, task, casesPath) {
 	const { benchmark, scenario, baselines } = task;
 	const LAST_COMMIT = typeof process.env.LAST_COMMIT !== "undefined";
 	const testDirectory = path.join(casesPath, benchmark);
+	const isRuntime = benchmark.includes("-runtime");
 
 	if (benchmark.includes("-unit")) {
 		// Unit benchmarks register their own tasks against the current lib; they
@@ -1169,13 +1294,30 @@ async function registerBenchmark(bench, task, casesPath) {
 		);
 
 		const stringifiedScenario = JSON.stringify(scenario);
-		const collectBy = `${benchmark}, scenario '${stringifiedScenario}'`;
-		const taskName = `benchmark "${benchmark}", scenario '${stringifiedScenario}'${LAST_COMMIT ? "" : ` ${baseline.name} (${baseline.rev})`}`;
+
+		/**
+		 * @param {string} measure measured region, empty for build benches
+		 * @returns {TaskNames} task names
+		 */
+		const createNames = (measure) => {
+			const suffix = measure ? `, measure '${measure}'` : "";
+
+			return {
+				collectBy: `${benchmark}, scenario '${stringifiedScenario}'${suffix}`,
+				taskName: `benchmark "${benchmark}", scenario '${stringifiedScenario}'${suffix}${LAST_COMMIT ? "" : ` ${baseline.name} (${baseline.rev})`}`
+			};
+		};
+
 		const fullTaskName = `benchmark "${benchmark}", scenario '${stringifiedScenario}' ${baseline.name} ${baseline.rev ? `(${baseline.rev})` : ""}`;
 
 		console.log(`Register: ${fullTaskName}`);
 
-		const params = { bench, taskName, collectBy, webpack, config };
+		if (isRuntime) {
+			await addRuntimeBench({ bench, createNames, webpack, config });
+			continue;
+		}
+
+		const params = { bench, ...createNames(""), webpack, config };
 
 		await (scenario.watch ? addWatchBench(params) : addBuildBench(params));
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The benchmarks measure webpack itself, but nothing measures the code webpack emits, so a codegen change that slows the output down — interop wrappers, export getters, a lost scope-hoisting opportunity — is invisible on CodSpeed. This adds a `-runtime` benchmark kind that compiles the case outside every measured region and then times only the output (instantiating the emitted bundle and calling its exported `run`), plus a first case, `many-modules-interop-runtime`: a 2042-module graph mixing CommonJS and ESM in both interop directions.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

n/a — the change is test infrastructure: `test/benchmarkCases/many-modules-interop-runtime/` plus the harness support in `test/harness/benchmark/benchmark.worker.mjs`. Task names of the existing build benchmarks are byte-identical, so their CodSpeed history stays comparable.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the new case kind, and how to write one, are documented in `TESTING_DOCS.md` in this PR.

**Use of AI**

Claude Code was used to draft the harness support, the generated fixture and the docs. I reviewed the result, and the benchmark runs, lint, type checks and inspection of the emitted bundles were done locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/benchmark harness and docs; production webpack behavior is unchanged. Existing build benchmark task naming stays comparable when the measure suffix is omitted.
> 
> **Overview**
> Adds a **`*-runtime`** benchmark kind so CodSpeed can measure **emitted bundle execution**, not only compile time. The harness compiles each case once outside the timed region, then registers an **`exec`** task that instantiates the CommonJS output (`vm.compileFunction` + fresh `module`) and calls the entry’s exported **`run(seed)`**, with checks that `run` exists and returns a value so the workload isn’t optimized away. Output is forced to **`node`** + **`commonjs2`** for in-process loading.
> 
> **Orchestration** skips the rebuild/watch scenario for `*-runtime` cases (same emitted output). **`TESTING_DOCS.md`** documents build vs unit vs runtime cases and how to author runtime fixtures via `options.mjs` `setup()`.
> 
> **First case: `many-modules-interop-runtime`** — `setup()` generates ~2042 modules mixing ESM and CommonJS interop (default/namespace/named imports, callable `module.exports`, cross-system consumers, barrels); `run(seed)` walks that graph each round so codegen changes to interop wrappers and export getters show up in **`development` vs `production`** `exec` numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc8d4166be56afc50815bef215a12f26d30cbb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->