### PR TITLE
refactor(graph): add ModuleGraph primitives for incremental rebuilds

### DIFF
--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -171,6 +171,15 @@ class ModuleGraph {
 		 */
 		this._cacheStage = undefined;
 
+		// incremental rebuilds: when set, move/copyOutgoingModuleConnections record
+		// their seal-time graph mutations (concatenation) here so they can be reversed,
+		// keeping this durable graph reusable across rebuilds
+		/**
+		 * @type {{ oldModule?: Module, newModule: Module, movedOut?: ModuleGraphConnection[] | undefined, movedIn?: ModuleGraphConnection[] | undefined, copied?: ModuleGraphConnection[] }[] | undefined}
+		 * @private
+		 */
+		this._mutationJournal = undefined;
+
 		/**
 		 * @type {WeakMap<Dependency, DependencySourceOrder>}
 		 * @private
@@ -396,6 +405,59 @@ class ModuleGraph {
 	}
 
 	/**
+	 * Removes every outgoing connection of `module` whose dependency is in
+	 * `staleDependencies`, including inactive ones left by `updateModule`
+	 * re-targeting (which the dependency-keyed `removeConnection` misses). Needed
+	 * when a module is rebuilt against a persisted graph so stale connections don't
+	 * linger in the old target's incoming set and crash seal-time plugins.
+	 * @param {Module} module the rebuilt origin module
+	 * @param {Set<Dependency>} staleDependencies dependencies replaced by the rebuild
+	 * @returns {void}
+	 */
+	_removeStaleOutgoingConnections(module, staleDependencies) {
+		const mgm = this._getModuleGraphModule(module);
+		const outgoing = mgm.outgoingConnections;
+		if (outgoing === undefined) return;
+		for (const connection of outgoing) {
+			if (
+				!staleDependencies.has(
+					/** @type {Dependency} */ (connection.dependency)
+				)
+			) {
+				continue;
+			}
+			outgoing.delete(connection);
+			if (connection.module !== null) {
+				this._getModuleGraphModule(
+					connection.module
+				).incomingConnections.delete(connection);
+			}
+		}
+	}
+
+	/**
+	 * Assigns `module`'s pending outgoing connections into the dependency map by
+	 * origin. `getConnection` normally does this lazily keyed by a dependency's
+	 * PARENT module; an incremental barrel un-lazy wires a re-export target from
+	 * the importer's walk, so the export dep's parent differs from its origin
+	 * barrel and the lazy flush never reaches it. Flush by origin to fix that.
+	 * @param {Module} module the origin module
+	 * @returns {void}
+	 */
+	_flushUnassignedConnections(module) {
+		const mgm = this._getModuleGraphModule(module);
+		const pending = mgm._unassignedConnections;
+		if (pending === undefined || pending.length === 0) return;
+		for (const connection of pending) {
+			this._dependencyMap.set(
+				/** @type {Dependency} */ (connection.dependency),
+				connection
+			);
+		}
+		pending.length = 0;
+	}
+
+	/**
 	 * Adds the provided dependency to the module graph.
 	 * @param {Dependency} dependency the referencing dependency
 	 * @param {string} explanation an explanation
@@ -438,6 +500,35 @@ class ModuleGraph {
 	}
 
 	/**
+	 * Removes a module from the graph entirely, detaching its connections. Used to
+	 * drop stale runtime modules on an incremental rebuild so the persisted graph
+	 * doesn't accumulate them.
+	 * @param {Module} module the module to remove
+	 * @returns {void}
+	 */
+	_removeModule(module) {
+		const mgm = this._moduleMap.get(module);
+		if (mgm === undefined) return;
+		if (mgm.outgoingConnections !== undefined) {
+			for (const connection of mgm.outgoingConnections) {
+				if (connection.module && connection.module !== module) {
+					const other = this._moduleMap.get(connection.module);
+					if (other !== undefined) other.incomingConnections.delete(connection);
+				}
+			}
+		}
+		for (const connection of mgm.incomingConnections) {
+			if (connection.originModule && connection.originModule !== module) {
+				const other = this._moduleMap.get(connection.originModule);
+				if (other !== undefined && other.outgoingConnections !== undefined) {
+					other.outgoingConnections.delete(connection);
+				}
+			}
+		}
+		this._moduleMap.delete(module);
+	}
+
+	/**
 	 * Removes all module attributes.
 	 * @returns {void}
 	 */
@@ -461,6 +552,11 @@ class ModuleGraph {
 		if (oldModule === newModule) return;
 		const oldMgm = this._getModuleGraphModule(oldModule);
 		const newMgm = this._getModuleGraphModule(newModule);
+		const journal = this._mutationJournal;
+		/** @type {ModuleGraphConnection[] | undefined} */
+		const movedOut = journal ? [] : undefined;
+		/** @type {ModuleGraphConnection[] | undefined} */
+		const movedIn = journal ? [] : undefined;
 		// Outgoing connections
 		const oldConnections = oldMgm.outgoingConnections;
 		if (oldConnections !== undefined) {
@@ -473,6 +569,7 @@ class ModuleGraph {
 					connection.originModule = newModule;
 					newConnections.add(connection);
 					oldConnections.delete(connection);
+					if (movedOut) movedOut.push(connection);
 				}
 			}
 		}
@@ -484,8 +581,69 @@ class ModuleGraph {
 				connection.module = newModule;
 				newConnections2.add(connection);
 				oldConnections2.delete(connection);
+				if (movedIn) movedIn.push(connection);
 			}
 		}
+		if (journal) journal.push({ oldModule, newModule, movedOut, movedIn });
+	}
+
+	/**
+	 * Start recording connection moves so they can later be reversed for incremental rebuilds.
+	 * @returns {void}
+	 */
+	_startMutationJournal() {
+		this._mutationJournal = [];
+	}
+
+	/**
+	 * Reverse all recorded connection moves, restoring the graph to its pre-seal
+	 * (end-of-make) state, then stop recording (incremental rebuilds).
+	 * @returns {void}
+	 */
+	_restoreFromMutationJournal() {
+		const journal = this._mutationJournal;
+		if (journal === undefined) return;
+		for (let i = journal.length - 1; i >= 0; i--) {
+			const { oldModule, newModule, movedOut, movedIn, copied } = journal[i];
+			const newMgm = this._getModuleGraphModule(newModule);
+			// copyOutgoingModuleConnections clones connections onto newModule and the
+			// external targets; undo by deleting the clones (there is no oldModule)
+			if (copied !== undefined) {
+				for (const connection of copied) {
+					if (newMgm.outgoingConnections !== undefined) {
+						newMgm.outgoingConnections.delete(connection);
+					}
+					if (connection.module !== null && connection.module !== undefined) {
+						this._getModuleGraphModule(
+							connection.module
+						).incomingConnections.delete(connection);
+					}
+				}
+				continue;
+			}
+			const oldModuleT = /** @type {Module} */ (oldModule);
+			const oldMgm = this._getModuleGraphModule(oldModuleT);
+			if (movedOut !== undefined) {
+				if (oldMgm.outgoingConnections === undefined) {
+					oldMgm.outgoingConnections = new SortableSet();
+				}
+				for (const connection of movedOut) {
+					connection.originModule = oldModuleT;
+					oldMgm.outgoingConnections.add(connection);
+					if (newMgm.outgoingConnections !== undefined) {
+						newMgm.outgoingConnections.delete(connection);
+					}
+				}
+			}
+			if (movedIn !== undefined) {
+				for (const connection of movedIn) {
+					connection.module = oldModuleT;
+					oldMgm.incomingConnections.add(connection);
+					newMgm.incomingConnections.delete(connection);
+				}
+			}
+		}
+		this._mutationJournal = undefined;
 	}
 
 	/**
@@ -499,6 +657,9 @@ class ModuleGraph {
 		if (oldModule === newModule) return;
 		const oldMgm = this._getModuleGraphModule(oldModule);
 		const newMgm = this._getModuleGraphModule(newModule);
+		const journal = this._mutationJournal;
+		/** @type {ModuleGraphConnection[] | undefined} */
+		const copied = journal ? [] : undefined;
 		// Outgoing connections
 		const oldConnections = oldMgm.outgoingConnections;
 		if (oldConnections !== undefined) {
@@ -515,8 +676,12 @@ class ModuleGraph {
 						const otherMgm = this._getModuleGraphModule(newConnection.module);
 						otherMgm.incomingConnections.add(newConnection);
 					}
+					if (copied) copied.push(newConnection);
 				}
 			}
+		}
+		if (journal && copied !== undefined && copied.length > 0) {
+			journal.push({ newModule, copied });
 		}
 	}
 
@@ -1044,9 +1209,7 @@ class ModuleGraph {
 				const moduleGraph = moduleGraphForModuleMap.get(module);
 				if (!moduleGraph) {
 					throw new Error(
-						`${
-							deprecateMessage
-						}There was no ModuleGraph assigned to the Module for backward-compat (Use the new API)`
+						`${deprecateMessage}There was no ModuleGraph assigned to the Module for backward-compat (Use the new API)`
 					);
 				}
 				return moduleGraph;

--- a/test/ModuleGraph.unittest.js
+++ b/test/ModuleGraph.unittest.js
@@ -1,0 +1,158 @@
+"use strict";
+
+const Dependency = require("../lib/Dependency");
+const Module = require("../lib/Module");
+const ModuleGraph = require("../lib/ModuleGraph");
+
+/**
+ * @returns {Module} module
+ */
+const createModule = () => new Module("javascript/auto", null, null);
+
+describe("ModuleGraph", () => {
+	describe("_removeStaleOutgoingConnections", () => {
+		it("removes only connections of the stale dependencies from both sides", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const targetA = createModule();
+			const targetB = createModule();
+			const staleDependency = new Dependency();
+			const freshDependency = new Dependency();
+			moduleGraph.setResolvedModule(origin, staleDependency, targetA);
+			moduleGraph.setResolvedModule(origin, freshDependency, targetB);
+
+			moduleGraph._removeStaleOutgoingConnections(
+				origin,
+				new Set([staleDependency])
+			);
+
+			const outgoing = [...moduleGraph.getOutgoingConnections(origin)];
+			expect(outgoing).toHaveLength(1);
+			expect(outgoing[0].module).toBe(targetB);
+			expect([...moduleGraph.getIncomingConnections(targetA)]).toHaveLength(0);
+			expect([...moduleGraph.getIncomingConnections(targetB)]).toHaveLength(1);
+		});
+	});
+
+	describe("_flushUnassignedConnections", () => {
+		it("makes connections resolvable by dependency without a parent module", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const target = createModule();
+			const dependency = new Dependency();
+			moduleGraph.setResolvedModule(origin, dependency, target);
+
+			// without a parent module the lazy flush in getConnection cannot run
+			moduleGraph._flushUnassignedConnections(origin);
+
+			const connection =
+				/** @type {import("../lib/ModuleGraphConnection")} */
+				(moduleGraph.getConnection(dependency));
+			expect(connection).toBeDefined();
+			expect(connection.module).toBe(target);
+		});
+
+		it("without the flush the connection is not found", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const target = createModule();
+			const dependency = new Dependency();
+			moduleGraph.setResolvedModule(origin, dependency, target);
+
+			expect(moduleGraph.getConnection(dependency)).toBeUndefined();
+		});
+	});
+
+	describe("_removeModule", () => {
+		it("detaches incoming and outgoing connections of the removed module", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const removed = createModule();
+			const target = createModule();
+			moduleGraph.setResolvedModule(origin, new Dependency(), removed);
+			moduleGraph.setResolvedModule(removed, new Dependency(), target);
+
+			moduleGraph._removeModule(removed);
+
+			expect([...moduleGraph.getOutgoingConnections(origin)]).toHaveLength(0);
+			expect([...moduleGraph.getIncomingConnections(target)]).toHaveLength(0);
+		});
+	});
+
+	describe("mutation journal", () => {
+		it("reverses moved connections back to the original module", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const replacement = createModule();
+			const incomingSource = createModule();
+			const target = createModule();
+			moduleGraph.setResolvedModule(origin, new Dependency(), target);
+			moduleGraph.setResolvedModule(incomingSource, new Dependency(), origin);
+
+			moduleGraph._startMutationJournal();
+			moduleGraph.moveModuleConnections(origin, replacement, () => true);
+
+			expect([...moduleGraph.getOutgoingConnections(replacement)]).toHaveLength(
+				1
+			);
+			expect([...moduleGraph.getIncomingConnections(replacement)]).toHaveLength(
+				1
+			);
+
+			moduleGraph._restoreFromMutationJournal();
+
+			const outgoing = [...moduleGraph.getOutgoingConnections(origin)];
+			expect(outgoing).toHaveLength(1);
+			expect(outgoing[0].originModule).toBe(origin);
+			expect(outgoing[0].module).toBe(target);
+			const incoming = [...moduleGraph.getIncomingConnections(origin)];
+			expect(incoming).toHaveLength(1);
+			expect(incoming[0].module).toBe(origin);
+			expect([...moduleGraph.getOutgoingConnections(replacement)]).toHaveLength(
+				0
+			);
+			expect([...moduleGraph.getIncomingConnections(replacement)]).toHaveLength(
+				0
+			);
+		});
+
+		it("removes copied connections from the copy target and its modules", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const replacement = createModule();
+			const target = createModule();
+			moduleGraph.setResolvedModule(origin, new Dependency(), target);
+
+			moduleGraph._startMutationJournal();
+			moduleGraph.copyOutgoingModuleConnections(
+				origin,
+				replacement,
+				() => true
+			);
+
+			expect([...moduleGraph.getOutgoingConnections(replacement)]).toHaveLength(
+				1
+			);
+			expect([...moduleGraph.getIncomingConnections(target)]).toHaveLength(2);
+
+			moduleGraph._restoreFromMutationJournal();
+
+			expect([...moduleGraph.getOutgoingConnections(replacement)]).toHaveLength(
+				0
+			);
+			expect([...moduleGraph.getIncomingConnections(target)]).toHaveLength(1);
+			expect([...moduleGraph.getOutgoingConnections(origin)]).toHaveLength(1);
+		});
+
+		it("does nothing when no journal was started", () => {
+			const moduleGraph = new ModuleGraph();
+			const origin = createModule();
+			const target = createModule();
+			moduleGraph.setResolvedModule(origin, new Dependency(), target);
+
+			moduleGraph._restoreFromMutationJournal();
+
+			expect([...moduleGraph.getOutgoingConnections(origin)]).toHaveLength(1);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Adds internal `ModuleGraph` primitives (stale-connection removal, module removal with connection detachment, by-origin flush of unassigned connections, and a mutation journal that records and reverses seal-time connection moves) as groundwork for reusing the module graph across watch rebuilds (incremental rebuilds). No behavior change; first PR of a series extracted from [`perf/incremental-rebuild`](https://github.com/bjohansebas/webpack/tree/perf/incremental-rebuild).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, `test/ModuleGraph.unittest.js` covers all five new methods.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to extract this change from my working branch, adapt it onto current `main`, and draft the unit tests; I reviewed and validated everything locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core module-graph connection invariants and seal-time move/copy paths, but new APIs are private and unused until follow-up PRs; risk is mainly regression if journal recording diverges from actual mutations.
> 
> **Overview**
> Adds **private** `ModuleGraph` APIs so a module graph can be cleaned up and rolled back between watch rebuilds, without changing current compilation behavior until later PRs wire them in.
> 
> New helpers cover **rebuild hygiene**: `_removeStaleOutgoingConnections` drops outgoing edges for replaced dependencies (including inactive ones from `updateModule`), `_flushUnassignedConnections` registers pending connections in the dependency map by origin (barrel re-export case), and `_removeModule` removes a module and detaches its edges.
> 
> **Mutation journal**: `_startMutationJournal` / `_restoreFromMutationJournal` record seal-time changes from existing `moveModuleConnections` and `copyOutgoingModuleConnections` and undo them in reverse order so concatenation-style mutations do not stick on a reused graph.
> 
> Adds `test/ModuleGraph.unittest.js` for these methods; only a trivial string-formatting tweak elsewhere in `ModuleGraph.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5efa3426d76872b455e702c47a591971a24c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->