### PR TITLE
refactor(module): add internal parser/generator lifecycle for incremental rebuilds

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -1299,6 +1299,12 @@ class ExportInfo {
 		if (this.canMangleProvide === undefined) {
 			this.canMangleProvide = true;
 		}
+		// mirror setHasUseInfo: after a provide reset the owned nested info is
+		// undefined again, and FlagDependencyExports only upgrades from false/null
+		if (this.exportsInfoOwned) {
+			/** @type {ExportsInfo} */
+			(this.exportsInfo).setHasProvideInfo();
+		}
 	}
 
 	/**

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -333,6 +333,8 @@ class ExportsInfo {
 			exportInfo._resetUseInfo();
 		}
 		this._sideEffectsOnlyInfo._resetUseInfo();
+		// every InlinedUsedName was just cleared, so drop the fast-path flag
+		this._hasInlinedExports = false;
 		// mirror setHasUseInfo: follow the redirect target when present
 		if (this._redirectTo !== undefined) {
 			this._redirectTo._resetUsedExports();
@@ -1308,8 +1310,13 @@ class ExportInfo {
 		this.terminalBinding = false;
 		this.canMangleProvide = undefined;
 		this._inlinedValue = undefined;
-		this.exportsInfoOwned = false;
-		this.exportsInfo = undefined;
+		if (this.exportsInfoOwned) {
+			// reset the owned nested info in place so its use state survives
+			/** @type {ExportsInfo} */
+			(this.exportsInfo)._resetProvidedExports();
+		} else {
+			this.exportsInfo = undefined;
+		}
 		this._target = undefined;
 		// also drop the memoized max target so it cannot serve stale entries
 		this._maxTarget = undefined;

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -332,8 +332,13 @@ class ExportsInfo {
 		for (const exportInfo of this._exports.values()) {
 			exportInfo._resetUseInfo();
 		}
-		this._otherExportsInfo._resetUseInfo();
 		this._sideEffectsOnlyInfo._resetUseInfo();
+		// mirror setHasUseInfo: follow the redirect target when present
+		if (this._redirectTo !== undefined) {
+			this._redirectTo._resetUsedExports();
+		} else {
+			this._otherExportsInfo._resetUseInfo();
+		}
 	}
 
 	setHasUseInfo() {
@@ -1325,6 +1330,12 @@ class ExportInfo {
 		this.canMangleUse = undefined;
 		this._usedName = null;
 		this._inlineFlags &= PURE_PROVIDE_FLAG;
+		// mirror setHasUseInfo: recurse into an owned nested exportsInfo, where
+		// FlagDependencyUsage also writes usage
+		if (this.exportsInfoOwned) {
+			/** @type {ExportsInfo} */
+			(this.exportsInfo)._resetUsedExports();
+		}
 	}
 
 	setHasUseInfo() {

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -307,6 +307,35 @@ class ExportsInfo {
 		}
 	}
 
+	/**
+	 * Resets provide-side info so FlagDependencyExports can recompute it on an
+	 * incremental rebuild against the persisted module graph (which otherwise
+	 * keeps exports removed by the rebuild, since the plugin only merges).
+	 * @returns {void}
+	 */
+	_resetProvidedExports() {
+		for (const exportInfo of this._exports.values()) {
+			exportInfo._resetProvideInfo();
+		}
+		this._redirectTo = undefined;
+		this._otherExportsInfo._resetProvideInfo();
+	}
+
+	/**
+	 * Resets the use-side info to the undetermined state so FlagDependencyUsage
+	 * can re-trace usage on an incremental rebuild. The persisted graph keeps a
+	 * module marked "used", which stops the trace re-queuing it, so exports newly
+	 * used by a changed importer would never be flagged.
+	 * @returns {void}
+	 */
+	_resetUsedExports() {
+		for (const exportInfo of this._exports.values()) {
+			exportInfo._resetUseInfo();
+		}
+		this._otherExportsInfo._resetUseInfo();
+		this._sideEffectsOnlyInfo._resetUseInfo();
+	}
+
 	setHasUseInfo() {
 		for (const exportInfo of this._exports.values()) {
 			exportInfo.setHasUseInfo();
@@ -1263,6 +1292,39 @@ class ExportInfo {
 		if (this.canMangleProvide === undefined) {
 			this.canMangleProvide = true;
 		}
+	}
+
+	/**
+	 * Resets provide-side info to the undetermined state (use info untouched).
+	 * @returns {void}
+	 */
+	_resetProvideInfo() {
+		this.provided = undefined;
+		this.terminalBinding = false;
+		this.canMangleProvide = undefined;
+		this._inlinedValue = undefined;
+		this.exportsInfoOwned = false;
+		this.exportsInfo = undefined;
+		this._target = undefined;
+		// also drop the memoized max target so it cannot serve stale entries
+		this._maxTarget = undefined;
+		// clear the provide-side pure bit; FlagDependencyExports only ever sets it
+		// true, so an export that turned impure would otherwise stay marked pure
+		this._inlineFlags &= ~PURE_PROVIDE_FLAG;
+	}
+
+	/**
+	 * Resets the use-side info to the undetermined state (provide info untouched,
+	 * incl. the pure-provide bit) so FlagDependencyUsage can re-trace it.
+	 * @returns {void}
+	 */
+	_resetUseInfo() {
+		this._globalUsed = undefined;
+		this._usedInRuntime = undefined;
+		this._hasUseInRuntimeInfo = false;
+		this.canMangleUse = undefined;
+		this._usedName = null;
+		this._inlineFlags &= PURE_PROVIDE_FLAG;
 	}
 
 	setHasUseInfo() {

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -335,12 +335,9 @@ class ExportsInfo {
 		this._sideEffectsOnlyInfo._resetUseInfo();
 		// every InlinedUsedName was just cleared, so drop the fast-path flag
 		this._hasInlinedExports = false;
-		// mirror setHasUseInfo: follow the redirect target when present
-		if (this._redirectTo !== undefined) {
-			this._redirectTo._resetUsedExports();
-		} else {
-			this._otherExportsInfo._resetUseInfo();
-		}
+		// never follow _redirectTo: it points into another module's exports info
+		// (FlagDependencyExports targets), whose own reset/re-trace owns that state
+		this._otherExportsInfo._resetUseInfo();
 	}
 
 	setHasUseInfo() {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1251,6 +1251,21 @@ class Module extends DependenciesBlock {
 	}
 
 	/**
+	 * Re-acquire factory-derived helpers (parser/generator) for an incremental
+	 * rebuild so this compilation's plugin hooks apply. No-op unless overridden.
+	 * @param {NormalModuleFactory} normalModuleFactory the normal module factory
+	 * @returns {void}
+	 */
+	_restoreParserAndGenerator(normalModuleFactory) {}
+
+	/**
+	 * Releases the cached parser between incremental rebuilds so it doesn't keep
+	 * the previous compilation alive. No-op unless overridden.
+	 * @returns {void}
+	 */
+	_cleanupParserForCache() {}
+
+	/**
 	 * Gets the original source.
 	 * @returns {Source | null} the original source for the module before webpack transformation
 	 */

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1252,7 +1252,7 @@ class Module extends DependenciesBlock {
 
 	/**
 	 * Re-acquire factory-derived helpers (parser/generator) for an incremental
-	 * rebuild so this compilation's plugin hooks apply. No-op unless overridden.
+	 * rebuild so this compilation's plugin hooks apply.
 	 * @param {NormalModuleFactory} normalModuleFactory the normal module factory
 	 * @returns {void}
 	 */
@@ -1260,7 +1260,7 @@ class Module extends DependenciesBlock {
 
 	/**
 	 * Releases the cached parser between incremental rebuilds so it doesn't keep
-	 * the previous compilation alive. No-op unless overridden.
+	 * the previous compilation alive.
 	 * @returns {void}
 	 */
 	_cleanupParserForCache() {}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -817,7 +817,7 @@ class NormalModule extends Module {
 
 	/**
 	 * Releases the cached parser between incremental rebuilds so it doesn't keep
-	 * the previous compilation alive (parser options are kept for the restore).
+	 * the previous compilation alive.
 	 * @returns {void}
 	 */
 	_cleanupParserForCache() {

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -816,6 +816,29 @@ class NormalModule extends Module {
 	}
 
 	/**
+	 * Releases the cached parser between incremental rebuilds so it doesn't keep
+	 * the previous compilation alive (parser options are kept for the restore).
+	 * @returns {void}
+	 */
+	_cleanupParserForCache() {
+		this.parser = undefined;
+	}
+
+	/**
+	 * Re-acquire factory-derived helpers (parser/generator) for an incremental
+	 * rebuild so this compilation's plugin hooks apply.
+	 * @param {NormalModuleFactory} normalModuleFactory the normal module factory
+	 * @returns {void}
+	 */
+	_restoreParserAndGenerator(normalModuleFactory) {
+		this.parser = normalModuleFactory.getParser(this.type, this.parserOptions);
+		this.generator = normalModuleFactory.getGenerator(
+			this.type,
+			this.generatorOptions
+		);
+	}
+
+	/**
 	 * Module should be unsafe cached. Get data that's needed for that.
 	 * This data will be passed to restoreFromUnsafeCache later.
 	 * @returns {UnsafeCacheData} cached data

--- a/lib/util/AsyncQueue.js
+++ b/lib/util/AsyncQueue.js
@@ -226,9 +226,10 @@ class AsyncQueue {
 	 */
 	invalidate(item) {
 		const key = this._getKey(item);
-		const entry =
-			/** @type {AsyncQueueEntry<T, K, R>} */
-			(this._entries.get(key));
+		const entry = this._entries.get(key);
+		// nothing queued for this item in the current run (e.g. incremental rebuild
+		// against a persisted graph) — nothing to invalidate
+		if (entry === undefined) return;
 		this._entries.delete(key);
 		if (entry.state === QUEUED_STATE) {
 			this._queued.delete(entry);

--- a/test/AsyncQueue.unittest.js
+++ b/test/AsyncQueue.unittest.js
@@ -162,4 +162,10 @@ describe("AsyncQueue", () => {
 		// stop before the async beforeAdd hook completes
 		queue.stop();
 	});
+
+	it("should ignore invalidate for an item that was never added", () => {
+		const queue = createQueue();
+
+		expect(() => queue.invalidate(42)).not.toThrow();
+	});
 });

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -52,6 +52,17 @@ describe("ExportInfo", () => {
 			expect(info.canMangleUse).toBeUndefined();
 			expect(info.provided).toBe(true);
 		});
+
+		it("recurses into an owned nested exportsInfo", () => {
+			const info = new ExportInfo("foo");
+			const nested = info.createNestedExportsInfo();
+			const nestedExport = nested.getExportInfo("bar");
+			nestedExport.canMangleUse = false;
+
+			info._resetUseInfo();
+
+			expect(nested.getExportInfo("bar").canMangleUse).toBeUndefined();
+		});
 	});
 });
 
@@ -78,5 +89,17 @@ describe("ExportsInfo", () => {
 
 		expect(exportsInfo.getExportInfo("foo").canMangleUse).toBeUndefined();
 		expect(exportsInfo.getExportInfo("foo").provided).toBe(true);
+	});
+
+	it("_resetUsedExports follows the redirect target", () => {
+		const exportsInfo = new ExportsInfo();
+		const redirectTarget = new ExportsInfo();
+		exportsInfo.setRedirectNamedTo(redirectTarget);
+		const info = redirectTarget.getExportInfo("foo");
+		info.canMangleUse = false;
+
+		exportsInfo._resetUsedExports();
+
+		expect(redirectTarget.getExportInfo("foo").canMangleUse).toBeUndefined();
 	});
 });

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const ExportsInfo = require("../lib/ExportsInfo");
+
+const { ExportInfo } = ExportsInfo;
+
+describe("ExportInfo", () => {
+	describe("_resetProvideInfo", () => {
+		it("clears the pure-provide bit so a rebuilt impure export is not left marked pure", () => {
+			const info = new ExportInfo("foo");
+			info.pureProvide = true;
+			expect(info.pureProvide).toBe(true);
+
+			info._resetProvideInfo();
+
+			// FlagDependencyExports only ever sets pureProvide true, so without the
+			// reset an export that turned impure would incorrectly stay pure
+			expect(info.pureProvide).toBeUndefined();
+		});
+
+		it("resets provide-side fields to the undetermined state", () => {
+			const info = new ExportInfo("foo");
+			info.provided = true;
+			info.terminalBinding = true;
+			info.canMangleProvide = false;
+
+			info._resetProvideInfo();
+
+			expect(info.provided).toBeUndefined();
+			expect(info.terminalBinding).toBe(false);
+			expect(info.canMangleProvide).toBeUndefined();
+		});
+	});
+
+	describe("_resetUseInfo", () => {
+		it("preserves the pure-provide bit (provide info is untouched)", () => {
+			const info = new ExportInfo("foo");
+			info.pureProvide = true;
+
+			info._resetUseInfo();
+
+			expect(info.pureProvide).toBe(true);
+		});
+
+		it("resets use-side fields but keeps provide info", () => {
+			const info = new ExportInfo("foo");
+			info.provided = true;
+			info.canMangleUse = false;
+
+			info._resetUseInfo();
+
+			expect(info.canMangleUse).toBeUndefined();
+			expect(info.provided).toBe(true);
+		});
+	});
+});
+
+describe("ExportsInfo", () => {
+	it("_resetProvidedExports clears the pure-provide bit on every export", () => {
+		const exportsInfo = new ExportsInfo();
+		const info = exportsInfo.getExportInfo("foo");
+		info.pureProvide = true;
+		exportsInfo.otherExportsInfo.pureProvide = true;
+
+		exportsInfo._resetProvidedExports();
+
+		expect(exportsInfo.getExportInfo("foo").pureProvide).toBeUndefined();
+		expect(exportsInfo.otherExportsInfo.pureProvide).toBeUndefined();
+	});
+
+	it("_resetUsedExports resets use info on every export but keeps provide info", () => {
+		const exportsInfo = new ExportsInfo();
+		const info = exportsInfo.getExportInfo("foo");
+		info.provided = true;
+		info.canMangleUse = false;
+
+		exportsInfo._resetUsedExports();
+
+		expect(exportsInfo.getExportInfo("foo").canMangleUse).toBeUndefined();
+		expect(exportsInfo.getExportInfo("foo").provided).toBe(true);
+	});
+});

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -134,7 +134,7 @@ describe("ExportsInfo", () => {
 		expect(exportsInfo._hasInlinedExports).toBe(false);
 	});
 
-	it("_resetUsedExports follows the redirect target", () => {
+	it("_resetUsedExports does not wipe a redirect target owned by another module", () => {
 		const exportsInfo = new ExportsInfo();
 		const redirectTarget = new ExportsInfo();
 		exportsInfo.setRedirectNamedTo(redirectTarget);
@@ -143,6 +143,8 @@ describe("ExportsInfo", () => {
 
 		exportsInfo._resetUsedExports();
 
-		expect(redirectTarget.getExportInfo("foo").canMangleUse).toBeUndefined();
+		// the target belongs to target.module; wiping it would lose usage that
+		// module's own reset/re-trace is responsible for
+		expect(redirectTarget.getExportInfo("foo").canMangleUse).toBe(false);
 	});
 });

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -82,6 +82,22 @@ describe("ExportInfo", () => {
 			expect(nested.getExportInfo("bar").canMangleUse).toBeUndefined();
 		});
 	});
+
+	describe("setHasProvideInfo", () => {
+		it("recurses into an owned nested exportsInfo so a provide reset can be re-merged", () => {
+			const info = new ExportInfo("foo");
+			const nested = info.createNestedExportsInfo();
+			nested.getExportInfo("bar").provided = true;
+
+			info._resetProvideInfo();
+			info.setHasProvideInfo();
+
+			// FlagDependencyExports only upgrades provided from false/null, never
+			// from undefined, so the re-init must reach nested exports too
+			expect(nested.getExportInfo("bar").provided).toBe(false);
+			expect(nested.getExportInfo("bar").canMangleProvide).toBe(true);
+		});
+	});
 });
 
 describe("ExportsInfo", () => {

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -2,7 +2,7 @@
 
 const ExportsInfo = require("../lib/ExportsInfo");
 
-const { ExportInfo } = ExportsInfo;
+const { ExportInfo, UsageState } = ExportsInfo;
 
 describe("ExportInfo", () => {
 	describe("_resetProvideInfo", () => {
@@ -48,6 +48,32 @@ describe("ExportInfo", () => {
 			expect(info.terminalBinding).toBe(false);
 			expect(info.canMangleProvide).toBeUndefined();
 		});
+
+		it("clears the target map, the max-target memo and canInlineProvide", () => {
+			const info = new ExportInfo("foo");
+			info.setTarget({}, /** @type {EXPECTED_ANY} */ ({}), ["a"], 1);
+			// prime the memo so a stale entry would be observable
+			info._getMaxTarget();
+			info.canInlineProvide = true;
+
+			info._resetProvideInfo();
+
+			expect(info._target).toBeUndefined();
+			expect(info._maxTarget).toBeUndefined();
+			expect(info.canInlineProvide).toBeUndefined();
+		});
+
+		it("resets two levels of owned nested exports info in place", () => {
+			const info = new ExportInfo("foo");
+			const nested = info.createNestedExportsInfo();
+			const deep = nested.getExportInfo("bar").createNestedExportsInfo();
+			deep.getExportInfo("baz").provided = true;
+
+			info._resetProvideInfo();
+
+			expect(nested.getExportInfo("bar").getNestedExportsInfo()).toBe(deep);
+			expect(deep.getExportInfo("baz").provided).toBeUndefined();
+		});
 	});
 
 	describe("_resetUseInfo", () => {
@@ -80,6 +106,32 @@ describe("ExportInfo", () => {
 			info._resetUseInfo();
 
 			expect(nested.getExportInfo("bar").canMangleUse).toBeUndefined();
+		});
+
+		it("resets global and per-runtime usage state and the used name", () => {
+			const info = new ExportInfo("foo");
+			info.setHasUseInfo();
+			info.setUsed(UsageState.Used, undefined);
+			info.setUsed(UsageState.Used, "main");
+			info.setUsedName("a");
+
+			info._resetUseInfo();
+
+			expect(info._globalUsed).toBeUndefined();
+			expect(info._usedInRuntime).toBeUndefined();
+			expect(info._hasUseInRuntimeInfo).toBe(false);
+			expect(info._usedName).toBeNull();
+		});
+
+		it("recurses through two levels of owned nested exports info", () => {
+			const info = new ExportInfo("foo");
+			const nested = info.createNestedExportsInfo();
+			const deep = nested.getExportInfo("bar").createNestedExportsInfo();
+			deep.getExportInfo("baz").canMangleUse = false;
+
+			info._resetUseInfo();
+
+			expect(deep.getExportInfo("baz").canMangleUse).toBeUndefined();
 		});
 	});
 

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -51,10 +51,15 @@ describe("ExportInfo", () => {
 
 		it("clears the target map, the max-target memo and canInlineProvide", () => {
 			const info = new ExportInfo("foo");
-			info.setTarget({}, /** @type {EXPECTED_ANY} */ ({}), ["a"], 1);
+			info.setTarget(
+				/** @type {EXPECTED_ANY} */ ({}),
+				/** @type {EXPECTED_ANY} */ ({}),
+				["a"],
+				1
+			);
 			// prime the memo so a stale entry would be observable
 			info._getMaxTarget();
-			info.canInlineProvide = true;
+			info.canInlineProvide = /** @type {EXPECTED_ANY} */ (true);
 
 			info._resetProvideInfo();
 
@@ -117,10 +122,15 @@ describe("ExportInfo", () => {
 
 			info._resetUseInfo();
 
-			expect(info._globalUsed).toBeUndefined();
-			expect(info._usedInRuntime).toBeUndefined();
-			expect(info._hasUseInRuntimeInfo).toBe(false);
-			expect(info._usedName).toBeNull();
+			// no use info at all until the plugin re-initializes
+			expect(info.getUsed("main")).toBe(UsageState.NoInfo);
+			// after re-init the cleared state reads as unused in every runtime
+			info.setHasUseInfo();
+			expect(info.getUsed(undefined)).toBe(UsageState.Unused);
+			expect(info.getUsed("main")).toBe(UsageState.Unused);
+			// and a fresh use resolves to the export's own name, not the stale "a"
+			info.setUsed(UsageState.Used, "main");
+			expect(info.getUsedName(undefined, "main")).toBe("foo");
 		});
 
 		it("recurses through two levels of owned nested exports info", () => {

--- a/test/ExportsInfo.unittest.js
+++ b/test/ExportsInfo.unittest.js
@@ -18,6 +18,24 @@ describe("ExportInfo", () => {
 			expect(info.pureProvide).toBeUndefined();
 		});
 
+		it("keeps an owned nested exportsInfo and resets it in place", () => {
+			const info = new ExportInfo("foo");
+			const nested = info.createNestedExportsInfo();
+			const nestedExport = nested.getExportInfo("bar");
+			nestedExport.provided = true;
+			nestedExport.canMangleUse = false;
+
+			info._resetProvideInfo();
+
+			const kept =
+				/** @type {import("../lib/ExportsInfo")} */
+				(info.getNestedExportsInfo());
+			expect(kept).toBe(nested);
+			// provide side reset in place, use side untouched
+			expect(kept.getExportInfo("bar").provided).toBeUndefined();
+			expect(kept.getExportInfo("bar").canMangleUse).toBe(false);
+		});
+
 		it("resets provide-side fields to the undetermined state", () => {
 			const info = new ExportInfo("foo");
 			info.provided = true;
@@ -89,6 +107,15 @@ describe("ExportsInfo", () => {
 
 		expect(exportsInfo.getExportInfo("foo").canMangleUse).toBeUndefined();
 		expect(exportsInfo.getExportInfo("foo").provided).toBe(true);
+	});
+
+	it("_resetUsedExports drops the inlined-exports fast-path flag", () => {
+		const exportsInfo = new ExportsInfo();
+		exportsInfo.markInlinedExports();
+
+		exportsInfo._resetUsedExports();
+
+		expect(exportsInfo._hasInlinedExports).toBe(false);
 	});
 
 	it("_resetUsedExports follows the redirect target", () => {

--- a/test/NormalModule.unittest.js
+++ b/test/NormalModule.unittest.js
@@ -72,6 +72,31 @@ describe("NormalModule", () => {
 		});
 	});
 
+	describe("#_cleanupParserForCache and #_restoreParserAndGenerator", () => {
+		it("releases the parser and re-acquires parser and generator from the factory", () => {
+			const factoryParser = /** @type {Parser} */ (
+				/** @type {unknown} */ ({ parse() {} })
+			);
+			const factoryGenerator = /** @type {Generator} */ (
+				/** @type {unknown} */ ({ generate() {} })
+			);
+			const normalModuleFactory =
+				/** @type {import("../lib/NormalModuleFactory")} */ (
+					/** @type {unknown} */ ({
+						getParser: () => factoryParser,
+						getGenerator: () => factoryGenerator
+					})
+				);
+
+			normalModule._cleanupParserForCache();
+			expect(normalModule.parser).toBeUndefined();
+
+			normalModule._restoreParserAndGenerator(normalModuleFactory);
+			expect(normalModule.parser).toBe(factoryParser);
+			expect(normalModule.generator).toBe(factoryGenerator);
+		});
+	});
+
 	describe("#readableIdentifier", () => {
 		it("calls the given requestShortener with the user request", () => {
 			const spy = jest.fn();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Adds an internal parser/generator lifecycle to `Module`/`NormalModule` (`_cleanupParserForCache` releases the parser so it does not retain the previous compilation; `_restoreParserAndGenerator` re-acquires both from the factory so the new compilation's plugin hooks apply), and makes `AsyncQueue.invalidate` tolerate items absent from the current run. No behavior change; third PR of the incremental-rebuilds series (stacked on #21553, extracted from [`perf/incremental-rebuild`](https://github.com/bjohansebas/webpack/tree/perf/incremental-rebuild)).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, new cases in `test/NormalModule.unittest.js` and `test/AsyncQueue.unittest.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to extract this change from my working branch, adapt it onto current `main`, and draft the unit tests; I reviewed and validated everything locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal hooks and a defensive guard in AsyncQueue with no current call sites in this diff; behavior change is limited to invalidate on absent keys, which is explicitly tested.
> 
> **Overview**
> Prepares **incremental rebuilds** by introducing internal lifecycle hooks on `Module` / `NormalModule` for factory-derived **parser** and **generator** instances.
> 
> **`_cleanupParserForCache`** drops the cached parser so it does not retain the previous compilation. **`_restoreParserAndGenerator`** re-fetches parser and generator from `NormalModuleFactory` so the new compilation’s plugin hooks apply. Base `Module` defines no-op stubs; `NormalModule` implements them (parser-only cleanup vs full restore). This PR does not wire these hooks into compilation yet—they are scaffolding for the incremental-rebuild stack.
> 
> **`AsyncQueue.invalidate`** now returns immediately when there is no entry for the key (e.g. invalidating modules from a persisted graph that were not added in the current run), instead of assuming an entry exists.
> 
> Unit tests cover the `NormalModule` lifecycle and the no-op invalidate path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895ffe0f9ca7b8d07a86b0a231013df914d536de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->