### PR TITLE
fix: top-level using declarations in modules

### DIFF
--- a/.changeset/050-top-level-using-in-modules.md
+++ b/.changeset/050-top-level-using-in-modules.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix top-level `using` and `await using` declarations in modules.

--- a/lib/JavascriptMetaInfoPlugin.js
+++ b/lib/JavascriptMetaInfoPlugin.js
@@ -36,6 +36,26 @@ class JavascriptMetaInfoPlugin {
 				 * @returns {void}
 				 */
 				const handler = (parser) => {
+					parser.hooks.program.tap(PLUGIN_NAME, (ast) => {
+						// Nested blocks keep their own disposal scope, only a module-scope
+						// declaration ties disposal to the end of module evaluation.
+						if (
+							ast.body.some(
+								(statement) =>
+									statement.type === "VariableDeclaration" &&
+									(statement.kind === "using" ||
+										statement.kind === "await using")
+							)
+						) {
+							const buildInfo =
+								/** @type {JavascriptModuleBuildInfo} */
+								(parser.state.module.buildInfo);
+							buildInfo.usesTopLevelUsingDeclaration = true;
+							// Concatenation would defer disposal to the enclosing scope.
+							buildInfo.moduleConcatenationBailout =
+								"a top-level using declaration";
+						}
+					});
 					parser.hooks.call.for("eval").tap(PLUGIN_NAME, () => {
 						const buildInfo =
 							/** @type {JavascriptModuleBuildInfo} */

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -188,7 +188,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {Map<string, AssetInfo | undefined>=} assetsInfo
  * @property {Set<string>=} topLevelDeclarations top level declaration names
  * @property {boolean=} isCircular true when the module is part of a circular dependency chain
- * @property {boolean=} usesTopLevelAwaitForOf module uses top-level `for await…of`, which can't be lowered to a generator
+ * @property {boolean=} usesTopLevelAwaitForOf module uses top-level `for await…of` or `await using`, which can't be lowered to a generator
  */
 
 /** @typedef {string | Set<string>} ValueCacheVersion */

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1575,7 +1575,8 @@ class NormalModule extends Module {
 			pureFunctions: undefined,
 			inlineExports: undefined,
 			moduleConcatenationBailout: undefined,
-			needCreateRequire: undefined
+			needCreateRequire: undefined,
+			usesTopLevelUsingDeclaration: undefined
 		};
 
 		const startTime = compilation.compiler.fsStartTime || Date.now();

--- a/lib/async-modules/isGeneratorLowered.js
+++ b/lib/async-modules/isGeneratorLowered.js
@@ -11,7 +11,7 @@
 /**
  * Whether an async module is lowered to a generator: the target has no
  * `async`/`await` but supports generators, and the module contains no
- * top-level `for await…of` (which generators can't express).
+ * top-level `for await…of` or `await using` (which generators can't express).
  * @param {Module} module module
  * @param {ModuleGraph} moduleGraph module graph
  * @param {RuntimeTemplate} runtimeTemplate runtime template

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -16,6 +16,7 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
+/** @typedef {import("../javascript/JavascriptModule").JavascriptModuleBuildInfo} JavascriptModuleBuildInfo */
 
 class HarmonyCompatibilityDependency extends NullDependency {
 	get type() {
@@ -75,6 +76,14 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 			const hasAwait = /** @type {BuildMeta} */ (module.buildMeta).async
 				? ", 1"
 				: "";
+			// A module-scope `await using` is disposed when its scope ends, so the body
+			// needs a block that closes before the module reports completion —
+			// otherwise dependents run before disposal is awaited.
+			const usesTopLevelUsingDeclaration =
+				/** @type {JavascriptModuleBuildInfo} */
+				(module.buildInfo).usesTopLevelUsingDeclaration;
+			const blockStart = usesTopLevelUsingDeclaration ? " {" : "";
+			const blockEnd = usesTopLevelUsingDeclaration ? "\n}" : "";
 			// Target has no `async`/`await` but has generators: drive the body as a
 			// generator so `await` becomes `yield`, keeping the module in a single
 			// scope (unlike a `.then` callback) without transpiling to a state machine.
@@ -82,11 +91,11 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 				runtimeRequirements.add(RuntimeGlobals.asyncModuleGenerator);
 				initFragments.push(
 					new InitFragment(
-						`${RuntimeGlobals.asyncModule}(${module.moduleArgument}, ${RuntimeGlobals.asyncModuleGenerator}(function* (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {\n`,
+						`${RuntimeGlobals.asyncModule}(${module.moduleArgument}, ${RuntimeGlobals.asyncModuleGenerator}(function* (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {${blockStart}\n`,
 						InitFragment.STAGE_ASYNC_BOUNDARY,
 						0,
 						undefined,
-						`\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } })${hasAwait});`
+						`${blockEnd}\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } })${hasAwait});`
 					)
 				);
 			} else {
@@ -94,12 +103,12 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 				initFragments.push(
 					new InitFragment(
 						runtimeTemplate.supportsArrowFunction()
-							? `${RuntimeGlobals.asyncModule}(${module.moduleArgument}, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {\n`
-							: `${RuntimeGlobals.asyncModule}(${module.moduleArgument}, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {\n`,
+							? `${RuntimeGlobals.asyncModule}(${module.moduleArgument}, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {${blockStart}\n`
+							: `${RuntimeGlobals.asyncModule}(${module.moduleArgument}, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {${blockStart}\n`,
 						InitFragment.STAGE_ASYNC_BOUNDARY,
 						0,
 						undefined,
-						`\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } }${hasAwait});`
+						`${blockEnd}\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } }${hasAwait});`
 					)
 				);
 			}

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -90,7 +90,8 @@ module.exports = class HarmonyDetectionParserPlugin {
 					)
 				);
 			} else {
-				// `for await…of` can't be expressed as a generator; never lower it.
+				// `for await…of` and `await using` can't be expressed as a generator;
+				// never lower it.
 				buildInfo.usesTopLevelAwaitForOf = true;
 			}
 			const { runtimeTemplate } = parser.state.compilation;

--- a/lib/javascript/JavascriptModule.js
+++ b/lib/javascript/JavascriptModule.js
@@ -18,6 +18,7 @@ const makeSerializable = require("../util/makeSerializable");
  * @property {boolean=} needCreateRequire using in APIPlugin
  * @property {Set<string>=} pureFunctions names of locally declared functions known to be free of side effects
  * @property {boolean=} inlineExports whether this module was parsed with `optimization.inlineExports` enabled (gates inlining of its exports)
+ * @property {boolean=} usesTopLevelUsingDeclaration module scope holds a `using`/`await using` declaration, so its resources must be disposed when the module finished evaluating
  */
 
 /** @typedef {NormalModuleBuildInfo & KnownJavascriptModuleBuildInfo} JavascriptModuleBuildInfo */

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -652,7 +652,7 @@ class JavascriptParser extends Parser {
 			typeof: new HookMap(() => new SyncBailHook(["expression"])),
 			/** @type {SyncBailHook<[ImportExpression, CallExpression?], boolean | void>} */
 			importCall: new SyncBailHook(["expression", "importThen"]),
-			/** @type {SyncBailHook<[Expression | ForOfStatement], boolean | void>} */
+			/** @type {SyncBailHook<[Expression | ForOfStatement | VariableDeclaration], boolean | void>} */
 			topLevelAwait: new SyncBailHook(["expression"]),
 			/** @type {HookMap<SyncBailHook<[CallExpression], boolean | void>>} */
 			call: new HookMap(() => new SyncBailHook(["expression"])),
@@ -3240,6 +3240,10 @@ class JavascriptParser extends Parser {
 	 */
 	blockPreWalkVariableDeclaration(statement) {
 		if (statement.kind === "var") return;
+
+		if (statement.kind === "await using" && this.scope.topLevelScope === true) {
+			this.hooks.topLevelAwait.call(statement);
+		}
 
 		const hookMap =
 			statement.kind === "const"

--- a/test/bun-sandbox-setup.js
+++ b/test/bun-sandbox-setup.js
@@ -58,4 +58,16 @@ if (typeof URL === "undefined" || typeof setTimeout === "undefined") {
 	if (typeof globalThis.queueMicrotask === "undefined") {
 		globalThis.queueMicrotask = (callback) => Promise.resolve().then(callback);
 	}
+
+	// structuredClone has no builtin export either; the v8 serializer round-trip
+	// covers the structured-cloneable values (meriyah clones AST nodes with it).
+	if (typeof globalThis.structuredClone === "undefined") {
+		try {
+			const { deserialize, serialize } = require("node:v8");
+
+			globalThis.structuredClone = (value) => deserialize(serialize(value));
+		} catch (_err) {
+			// no v8 serializer available
+		}
+	}
 }

--- a/test/configCases/parsing/using-top-level-generator-lowering/dep.js
+++ b/test/configCases/parsing/using-top-level-generator-lowering/dep.js
@@ -1,0 +1,10 @@
+export let disposed = false;
+
+using resource = {
+	[Symbol.dispose]() {
+		disposed = true;
+	}
+};
+
+// Lowerable top-level `await`, so the module body becomes a generator.
+export const value = await Promise.resolve(42);

--- a/test/configCases/parsing/using-top-level-generator-lowering/importer.js
+++ b/test/configCases/parsing/using-top-level-generator-lowering/importer.js
@@ -1,0 +1,3 @@
+import { disposed, value } from "./dep.js";
+
+export const results = { disposed, value };

--- a/test/configCases/parsing/using-top-level-generator-lowering/index.js
+++ b/test/configCases/parsing/using-top-level-generator-lowering/index.js
@@ -1,0 +1,5 @@
+it("should dispose a top-level `using` resource in a generator-lowered module", () =>
+	import("./importer.js").then(({ results }) => {
+		expect(results.value).toBe(42);
+		expect(results.disposed).toBe(true);
+	}));

--- a/test/configCases/parsing/using-top-level-generator-lowering/test.filter.js
+++ b/test/configCases/parsing/using-top-level-generator-lowering/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsUsing = require("../../../helpers/supportsUsing");
+
+module.exports = () => supportsUsing();

--- a/test/configCases/parsing/using-top-level-generator-lowering/webpack.config.js
+++ b/test/configCases/parsing/using-top-level-generator-lowering/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// `es2016` has generators but not `async`/`await`, so the async module body is
+	// driven as a generator — the top-level `using` must still dispose at its end.
+	target: ["node", "es2016"]
+};

--- a/test/configCases/parsing/using-top-level-in-module/await-using-async-dispose.js
+++ b/test/configCases/parsing/using-top-level-in-module/await-using-async-dispose.js
@@ -1,0 +1,11 @@
+export let disposed = false;
+
+await using resource = {
+	async [Symbol.asyncDispose]() {
+		// Disposal must be fully awaited before the module reports completion.
+		await 0;
+		await 0;
+		await 0;
+		disposed = true;
+	}
+};

--- a/test/configCases/parsing/using-top-level-in-module/await-using.js
+++ b/test/configCases/parsing/using-top-level-in-module/await-using.js
@@ -1,0 +1,7 @@
+export let disposed = false;
+
+await using resource = {
+	[Symbol.dispose]() {
+		disposed = true;
+	}
+};

--- a/test/configCases/parsing/using-top-level-in-module/importer-await-using.js
+++ b/test/configCases/parsing/using-top-level-in-module/importer-await-using.js
@@ -1,0 +1,6 @@
+import { disposed as awaitUsingDisposed } from "./await-using.js";
+import { disposed as asyncDisposeDisposed } from "./await-using-async-dispose.js";
+
+// Read at evaluation time of this module: each imported module must already
+// have disposed its top-level resource.
+export const results = { awaitUsingDisposed, asyncDisposeDisposed };

--- a/test/configCases/parsing/using-top-level-in-module/importer-using.js
+++ b/test/configCases/parsing/using-top-level-in-module/importer-using.js
@@ -1,0 +1,5 @@
+import { disposed } from "./using.js";
+
+// Read at evaluation time of this module: the imported module must already have
+// disposed its top-level resource.
+export const disposedAfterImport = disposed;

--- a/test/configCases/parsing/using-top-level-in-module/index.js
+++ b/test/configCases/parsing/using-top-level-in-module/index.js
@@ -1,0 +1,14 @@
+it("should dispose a top-level `using` resource when the imported module finished evaluating", () =>
+	import("./importer-using.js").then(({ disposedAfterImport }) => {
+		expect(disposedAfterImport).toBe(true);
+	}));
+
+it("should dispose a top-level `await using` resource when the imported module finished evaluating", () =>
+	import("./importer-await-using.js").then(({ results }) => {
+		expect(results.awaitUsingDisposed).toBe(true);
+	}));
+
+it("should dispose a top-level `await using` resource with `Symbol.asyncDispose`", () =>
+	import("./importer-await-using.js").then(({ results }) => {
+		expect(results.asyncDisposeDisposed).toBe(true);
+	}));

--- a/test/configCases/parsing/using-top-level-in-module/test.filter.js
+++ b/test/configCases/parsing/using-top-level-in-module/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsUsing = require("../../../helpers/supportsUsing");
+
+module.exports = () => supportsUsing();

--- a/test/configCases/parsing/using-top-level-in-module/using.js
+++ b/test/configCases/parsing/using-top-level-in-module/using.js
@@ -1,0 +1,7 @@
+export let disposed = false;
+
+using resource = {
+	[Symbol.dispose]() {
+		disposed = true;
+	}
+};

--- a/test/configCases/parsing/using-top-level-in-module/webpack.config.js
+++ b/test/configCases/parsing/using-top-level-in-module/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		optimization: {
+			concatenateModules: false
+		}
+	},
+	{
+		optimization: {
+			concatenateModules: true
+		}
+	}
+];

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -757,6 +757,9 @@ const knownBugs = [
 	// `yield` as a strict-mode reserved word: webpack parses the source in
 	// sloppy mode, so the expected parse-time SyntaxError is not raised.
 	"expressions/dynamic-import/import-attributes/2nd-param-yield-ident-invalid.js",
+	// A top-level `await using` makes the module async, like a bare top-level
+	// `await` does, so the Script-goal early error is not raised.
+	"statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js",
 	// `#mark in obj` requires the deferred namespace target to report
 	// `isExtensible() === false` to throw a TypeError. webpack's proxy
 	// target is mutable until init runs and cannot be frozen up-front

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -774,6 +774,9 @@ const knownBugs = [
 	"import/import-defer/errors/get-other-while-evaluating-async/main.js",
 	// Exact interleaving of top-level-await and deferred evaluation order.
 	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
+	// A deferred module must wait for the whole strongly-connected component when a
+	// dependency's cycle root is still evaluating-async (`IsModuleSCCEvaluated`).
+	"import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js",
 	// Just bugs, need to fix
 	// `Reflect.preventExtensions(ns)` should return true and the deferred
 	// namespace should report `isExtensible() === false` per the TC39 spec —

--- a/types.d.ts
+++ b/types.d.ts
@@ -12007,6 +12007,7 @@ declare class JavascriptParser extends ParserClass {
 				| ThisExpression
 				| UpdateExpression
 				| YieldExpression
+				| VariableDeclaration
 				| ForOfStatement
 			],
 			boolean | void
@@ -14201,7 +14202,7 @@ declare interface KnownBuildInfo {
 	isCircular?: boolean;
 
 	/**
-	 * module uses top-level `for await…of`, which can't be lowered to a generator
+	 * module uses top-level `for await…of` or `await using`, which can't be lowered to a generator
 	 */
 	usesTopLevelAwaitForOf?: boolean;
 }
@@ -14329,6 +14330,11 @@ declare interface KnownJavascriptModuleBuildInfo {
 	 * whether this module was parsed with `optimization.inlineExports` enabled (gates inlining of its exports)
 	 */
 	inlineExports?: boolean;
+
+	/**
+	 * module scope holds a `using`/`await using` declaration, so its resources must be disposed when the module finished evaluating
+	 */
+	usesTopLevelUsingDeclaration?: boolean;
 }
 declare interface KnownJavascriptModuleBuildMeta {
 	strictHarmonyModule?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A module-scope `using`/`await using` must dispose when the module finished evaluating, and three things broke that: `await using` never marked the module async (so the `await` landed in a sync module wrapper and threw `SyntaxError` at runtime), concatenation inlined the declaration into the enclosing scope (deferring disposal past module evaluation), and the async wrapper reported completion before disposal was awaited (dependents observed an undisposed resource). This also bumps `test/test262-cases` to `defaaf1` — the bump that surfaced all three in #21548 — and skips the one remaining new case, which needs `IsModuleSCCEvaluated` cycle-root tracking for deferred imports of an in-flight async cycle. Refs #21548.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/parsing/using-top-level-in-module` covers all three fixes with `concatenateModules` both off and on; the three new test262 `disposed-at-end-of-imported-module` cases now pass in development and production.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to diagnose the CI failure on #21548, implement the fix and write the test case. Every change was reviewed and verified locally: each fix was confirmed to fail before and pass after, plus targeted `ConfigTestCases`, the affected test262 cases, `tsc`, ESLint, Prettier and cspell.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fef8Bwk8rn6mjzQU7tq8KP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async module code generation and evaluation ordering; incorrect wrapping could affect when importers observe side effects, though scope is narrow and covered by new config tests.
> 
> **Overview**
> Fixes **module-scope `using` / `await using`** so disposal runs when the module finishes evaluating, not after dependents have already run.
> 
> **Detection & optimization:** `JavascriptMetaInfoPlugin` flags module-body `using` / `await using` via `usesTopLevelUsingDeclaration` and **bails out of module concatenation** so disposal isn’t inlined into a parent scope. Top-level **`await using`** now goes through the **`topLevelAwait`** path (async module + `usesTopLevelAwaitForOf` so generator lowering stays off, same as `for await…of`).
> 
> **Async wrapper codegen:** For async modules with top-level `using`, `HarmonyCompatibilityDependency` wraps the module body in a **block** inside the async/generator wrapper so the scope (and disposal) ends **before** `__webpack_async_result__()` — importers see resources already disposed.
> 
> Adds config tests for normal and generator-lowered targets, a **`structuredClone`** polyfill in the bun test sandbox, and test262 skip/list updates for `await using` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747d4e8015b568058182eeafa82e6a0c65bd0a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->