### PR TITLE
fix(css): name inlined CSS source map sources and honor hidden devtools

### DIFF
--- a/.changeset/030-css-inline-source-map-names.md
+++ b/.changeset/030-css-inline-source-map-names.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name sources of CSS maps inlined into JS by their resource path.
+Name sources of CSS maps inlined into JS and honor `hidden-source-map` there.

--- a/.changeset/030-css-inline-source-map-names.md
+++ b/.changeset/030-css-inline-source-map-names.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Name sources of CSS maps inlined into JS by their resource path.

--- a/.changeset/030-css-inline-source-map-names.md
+++ b/.changeset/030-css-inline-source-map-names.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name sources of CSS maps inlined into JS and honor `hidden-source-map` there.
+Fix names, hidden devtools and cache reuse for CSS maps inlined into JS.

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -21,6 +21,11 @@ const memoize = require("./util/memoize");
 
 const ModuleFilenameHelpers = module.exports;
 
+ModuleFilenameHelpers.DEFAULT_MODULE_FILENAME_TEMPLATE =
+	"webpack://[namespace]/[resourcePath]";
+ModuleFilenameHelpers.DEFAULT_FALLBACK_MODULE_FILENAME_TEMPLATE =
+	"webpack://[namespace]/[resourcePath]?[hash]";
+
 // TODO webpack 6: consider removing these
 ModuleFilenameHelpers.ALL_LOADERS_RESOURCE = "[all-loaders][resource]";
 ModuleFilenameHelpers.REGEXP_ALL_LOADERS_RESOURCE =

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -243,11 +243,12 @@ class SourceMapDevToolPlugin {
 					options.append || "\n//# source" + "MappingURL=[url]";
 		/** @type {DevtoolModuleFilenameTemplate} */
 		this.moduleFilenameTemplate =
-			options.moduleFilenameTemplate || "webpack://[namespace]/[resourcePath]";
+			options.moduleFilenameTemplate ||
+			ModuleFilenameHelpers.DEFAULT_MODULE_FILENAME_TEMPLATE;
 		/** @type {DevtoolFallbackModuleFilenameTemplate} */
 		this.fallbackModuleFilenameTemplate =
 			options.fallbackModuleFilenameTemplate ||
-			"webpack://[namespace]/[resourcePath]?[hash]";
+			ModuleFilenameHelpers.DEFAULT_FALLBACK_MODULE_FILENAME_TEMPLATE;
 		/** @type {DevtoolNamespace} */
 		this.namespace = options.namespace || "";
 		/** @type {SourceMapDevToolPluginOptions} */

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -749,11 +749,22 @@ class CssGenerator extends Generator {
 	updateHash(hash, { module, runtimeTemplate }) {
 		hash.update(/** @type {boolean} */ (this._esModule).toString());
 		hash.update(/** @type {boolean} */ (this._exportsOnly).toString());
-		// `hidden`/`nosources` change the inlined map without changing the module
-		// source, so the code generation cache has to be keyed on `devtool` too
-		if (runtimeTemplate) {
-			const devtool = runtimeTemplate.compilation.options.devtool;
-			hash.update(`|${typeof devtool === "string" ? devtool : ""}`);
+		// Only a module embedded in JS gets an inlined map, and it depends on
+		// `devtool` and the devtool filename options, none of which change the
+		// module source — key the codegen cache on them. Templates may be
+		// functions, hence `String`.
+		const exportType = /** @type {CssModule} */ (module).exportType || "link";
+		if (runtimeTemplate && exportType !== "link") {
+			const { compilation } = runtimeTemplate;
+			const devtool = compilation.options.devtool;
+			const outputOptions = compilation.outputOptions;
+			hash.update(
+				`|${typeof devtool === "string" ? devtool : ""}|${
+					outputOptions.devtoolNamespace || ""
+				}|${String(outputOptions.devtoolModuleFilenameTemplate || "")}|${String(
+					outputOptions.devtoolFallbackModuleFilenameTemplate || ""
+				)}`
+			);
 		}
 	}
 

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -47,6 +47,8 @@ const {
 // Avoids `type.split("/")[0]` allocation on the `getTypes` hot path.
 const CSS_TYPE_PREFIX = `${CSS_TYPE}/`;
 
+const URL_SCHEME_REGEXP = /^(?:data|https?):/;
+
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").CssModuleGeneratorOptions} CssModuleGeneratorOptions */
 /** @typedef {import("../Compilation").DependencyConstructor} DependencyConstructor */
@@ -922,8 +924,13 @@ class CssGenerator extends Generator {
 		const usedNames = new Set();
 		const sources = map.sources.map((source) => {
 			if (!source.startsWith("webpack://")) return source;
-			const module = compilation.findModule(absolutify(source.slice(10)));
-			if (!module) return source;
+			const absoluteSource = absolutify(source.slice(10));
+			// Sources a loader reported for files that are not modules (e.g. a less
+			// partial) are templated as a path, like `SourceMapDevToolPlugin` does
+			const module = compilation.findModule(absoluteSource) || absoluteSource;
+			if (typeof module === "string" && URL_SCHEME_REGEXP.test(module)) {
+				return module;
+			}
 			let name = ModuleFilenameHelpers.createFilename(
 				module,
 				options,

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -746,9 +746,15 @@ class CssGenerator extends Generator {
 	 * @param {Hash} hash hash that will be modified
 	 * @param {UpdateHashContext} updateHashContext context for updating hash
 	 */
-	updateHash(hash, { module }) {
+	updateHash(hash, { module, runtimeTemplate }) {
 		hash.update(/** @type {boolean} */ (this._esModule).toString());
 		hash.update(/** @type {boolean} */ (this._exportsOnly).toString());
+		// `hidden`/`nosources` change the inlined map without changing the module
+		// source, so the code generation cache has to be keyed on `devtool` too
+		if (runtimeTemplate) {
+			const devtool = runtimeTemplate.compilation.options.devtool;
+			hash.update(`|${typeof devtool === "string" ? devtool : ""}`);
+		}
 	}
 
 	/**

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -15,6 +15,7 @@ const {
 const { UsageState } = require("../ExportsInfo");
 const Generator = require("../Generator");
 const InitFragment = require("../InitFragment");
+const ModuleFilenameHelpers = require("../ModuleFilenameHelpers");
 const {
 	CSS_TEXT_TYPE,
 	CSS_TEXT_TYPES,
@@ -33,7 +34,10 @@ const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 
 const { encodeMappings } = require("../util/createMappings");
-const { contextifySourceUrl } = require("../util/identifier");
+const {
+	contextifySourceUrl,
+	makePathsAbsolute
+} = require("../util/identifier");
 const memoize = require("../util/memoize");
 const {
 	PUBLIC_PATH_FULL_HASH,
@@ -888,6 +892,66 @@ class CssGenerator extends Generator {
 	}
 
 	/**
+	 * Applies the devtool filename template to the sources of a map that is inlined
+	 * into the module's own output: `SourceMapDevToolPlugin` only rewrites maps of
+	 * emitted assets, so this one would keep raw module identifiers.
+	 * @param {RawSourceMap} map the map to rename the sources of
+	 * @param {GenerateContext} generateContext the generate context
+	 * @returns {RawSourceMap} the map with devtool source names
+	 */
+	_nameMapSources(map, generateContext) {
+		const { chunkGraph, runtimeTemplate } = generateContext;
+		const { compilation } = runtimeTemplate;
+		const outputOptions = compilation.outputOptions;
+		const absolutify = makePathsAbsolute.bindContextCache(
+			/** @type {string} */ (compilation.options.context),
+			compilation.compiler.root
+		);
+		const options = {
+			moduleFilenameTemplate:
+				outputOptions.devtoolModuleFilenameTemplate ||
+				ModuleFilenameHelpers.DEFAULT_MODULE_FILENAME_TEMPLATE,
+			namespace: outputOptions.devtoolNamespace || ""
+		};
+		const contextInfo = {
+			requestShortener: compilation.requestShortener,
+			chunkGraph,
+			hashFunction: outputOptions.hashFunction
+		};
+		/** @type {Set<string>} */
+		const usedNames = new Set();
+		const sources = map.sources.map((source) => {
+			if (!source.startsWith("webpack://")) return source;
+			const module = compilation.findModule(absolutify(source.slice(10)));
+			if (!module) return source;
+			let name = ModuleFilenameHelpers.createFilename(
+				module,
+				options,
+				contextInfo
+			);
+			// Same disambiguation as `SourceMapDevToolPlugin`: modules sharing a
+			// resource path (e.g. one file imported under two layers) collide
+			if (usedNames.has(name)) {
+				name = ModuleFilenameHelpers.createFilename(
+					module,
+					{
+						moduleFilenameTemplate:
+							outputOptions.devtoolFallbackModuleFilenameTemplate ||
+							ModuleFilenameHelpers.DEFAULT_FALLBACK_MODULE_FILENAME_TEMPLATE,
+						namespace: options.namespace
+					},
+					contextInfo
+				);
+				while (usedNames.has(name)) name += "*";
+			}
+			usedNames.add(name);
+			return name;
+		});
+
+		return { ...map, sources };
+	}
+
+	/**
 	 * Convert a CSS Source into a JS string literal, splicing `__webpack_require__.h()` for `[fullhash]` placeholders.
 	 * @param {Source} cssSource the CSS source
 	 * @param {import("../../declarations/WebpackOptions").DevTool | undefined} devtool the devtool option
@@ -898,10 +962,11 @@ class CssGenerator extends Generator {
 		const { source, map } = cssSource.sourceAndMap();
 		let content = /** @type {string} */ (source);
 		if (map) {
+			const namedMap = this._nameMapSources(map, generateContext);
 			const inlineMap =
 				typeof devtool === "string" && devtool.includes("nosources")
-					? { ...map, sourcesContent: undefined }
-					: map;
+					? { ...namedMap, sourcesContent: undefined }
+					: namedMap;
 			const base64Map = Buffer.from(JSON.stringify(inlineMap), "utf8").toString(
 				"base64"
 			);

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -961,7 +961,10 @@ class CssGenerator extends Generator {
 	_cssToJsLiteral(cssSource, devtool, generateContext) {
 		const { source, map } = cssSource.sourceAndMap();
 		let content = /** @type {string} */ (source);
-		if (map) {
+		// `hidden` keeps maps out of the output entirely, and this data URI would
+		// ship the sources inside the bundle
+		const hidden = typeof devtool === "string" && devtool.includes("hidden");
+		if (map && !hidden) {
 			const namedMap = this._nameMapSources(map, generateContext);
 			const inlineMap =
 				typeof devtool === "string" && devtool.includes("nosources")

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -310,3 +310,98 @@ describe("Compiler (filesystem caching)", () => {
 		);
 	});
 });
+
+describe("Compiler (filesystem caching, css devtool)", () => {
+	expectNoDeprecations();
+
+	const cachePath = path.join(
+		__dirname,
+		"fixtures",
+		"temp-css-devtool-cache-fixture"
+	);
+
+	beforeEach(() => {
+		rimraf.sync(cachePath);
+	});
+
+	afterEach(() => {
+		rimraf.sync(cachePath);
+	});
+
+	/**
+	 * @param {import("../declarations/WebpackOptions").DevTool} devtool devtool to build with
+	 * @returns {Promise<string>} the emitted bundle
+	 */
+	function build(devtool) {
+		const webpack = require("..");
+
+		return new Promise((resolve, reject) => {
+			const compiler = webpack({
+				context: path.join(__dirname, "fixtures", "css-devtool-cache"),
+				entry: "./index.js",
+				mode: "development",
+				devtool,
+				target: "web",
+				experiments: { css: true },
+				cache: { type: "filesystem", cacheDirectory: cachePath },
+				module: {
+					rules: [
+						{
+							test: /\.css$/,
+							type: "css/auto",
+							parser: { exportType: "text" }
+						}
+					]
+				},
+				output: { path: path.join(cachePath, "dist"), filename: "bundle.js" }
+			});
+
+			compiler.run((err, stats) => {
+				if (err) return reject(err);
+				if (/** @type {import("../types").Stats} */ (stats).hasErrors()) {
+					return reject(
+						new Error(
+							/** @type {import("../types").Stats} */ (stats).toString()
+						)
+					);
+				}
+				compiler.close(() => {
+					resolve(
+						fs
+							.readFileSync(path.join(cachePath, "dist", "bundle.js"))
+							.toString()
+					);
+				});
+			});
+		});
+	}
+
+	const INLINE_MAP_REGEXP = /sourceMappingURL=data:application\/json/;
+
+	it("should not reuse an inlined css map for a hidden devtool", async () => {
+		expect(await build("source-map")).toMatch(INLINE_MAP_REGEXP);
+		expect(await build("hidden-source-map")).not.toMatch(INLINE_MAP_REGEXP);
+	});
+
+	it("should not reuse a hidden result for a non-hidden devtool", async () => {
+		expect(await build("hidden-source-map")).not.toMatch(INLINE_MAP_REGEXP);
+		expect(await build("source-map")).toMatch(INLINE_MAP_REGEXP);
+	});
+
+	it("should not reuse sources of an inlined css map for nosources", async () => {
+		await build("source-map");
+
+		const bundle = await build("nosources-source-map");
+		const match =
+			/sourceMappingURL=data:application\/json;charset=utf-8;base64,([\w+/=]+)/.exec(
+				bundle
+			);
+		const map = JSON.parse(
+			Buffer.from(/** @type {RegExpExecArray} */ (match)[1], "base64").toString(
+				"utf8"
+			)
+		);
+
+		expect(map.sourcesContent).toBeUndefined();
+	});
+});

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -330,9 +330,10 @@ describe("Compiler (filesystem caching, css devtool)", () => {
 
 	/**
 	 * @param {import("../declarations/WebpackOptions").DevTool} devtool devtool to build with
+	 * @param {string=} devtoolModuleFilenameTemplate template to build with
 	 * @returns {Promise<string>} the emitted bundle
 	 */
-	function build(devtool) {
+	function build(devtool, devtoolModuleFilenameTemplate) {
 		const webpack = require("..");
 
 		return new Promise((resolve, reject) => {
@@ -353,7 +354,11 @@ describe("Compiler (filesystem caching, css devtool)", () => {
 						}
 					]
 				},
-				output: { path: path.join(cachePath, "dist"), filename: "bundle.js" }
+				output: {
+					path: path.join(cachePath, "dist"),
+					filename: "bundle.js",
+					devtoolModuleFilenameTemplate
+				}
 			});
 
 			compiler.run((err, stats) => {
@@ -386,6 +391,26 @@ describe("Compiler (filesystem caching, css devtool)", () => {
 	it("should not reuse a hidden result for a non-hidden devtool", async () => {
 		expect(await build("hidden-source-map")).not.toMatch(INLINE_MAP_REGEXP);
 		expect(await build("source-map")).toMatch(INLINE_MAP_REGEXP);
+	});
+
+	it("should not reuse inlined css map names for another template", async () => {
+		await build("source-map");
+
+		const bundle = await build(
+			"source-map",
+			"webpack://custom/[resource-path]"
+		);
+		const match =
+			/sourceMappingURL=data:application\/json;charset=utf-8;base64,([\w+/=]+)/.exec(
+				bundle
+			);
+		const map = JSON.parse(
+			Buffer.from(/** @type {RegExpExecArray} */ (match)[1], "base64").toString(
+				"utf8"
+			)
+		);
+
+		expect(map.sources).toContain("webpack://custom/./style.css");
 	});
 
 	it("should not reuse sources of an inlined css map for nosources", async () => {

--- a/test/configCases/css/source-map-hidden-payload/index.js
+++ b/test/configCases/css/source-map-hidden-payload/index.js
@@ -1,0 +1,25 @@
+import css from "./style.css";
+
+const fs = __nodeFs;
+const path = __nodePath;
+
+// Referencing the export keeps the value-returning `text` module in the bundle.
+if (typeof css !== "string") throw new Error("expected the css text export");
+
+const { outputPath } = __STATS__.children[__STATS_I__];
+const bundle = fs.readFileSync(
+	path.join(outputPath, `bundle${__STATS_I__}.js`),
+	"utf-8"
+);
+const hasInlineMap = /sourceMappingURL=data:application\/json/.test(bundle);
+
+if (__STATS_I__ === 2) {
+	it("should inline a map into the css payload for source-map", () => {
+		expect(hasInlineMap).toBe(true);
+	});
+} else {
+	// the inlined map would otherwise ship the sources inside the bundle
+	it("should not inline a map into the css payload for hidden devtools", () => {
+		expect(hasInlineMap).toBe(false);
+	});
+}

--- a/test/configCases/css/source-map-hidden-payload/style.css
+++ b/test/configCases/css/source-map-hidden-payload/style.css
@@ -1,0 +1,3 @@
+.hidden-payload-marker {
+	color: red;
+}

--- a/test/configCases/css/source-map-hidden-payload/test.config.js
+++ b/test/configCases/css/source-map-hidden-payload/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	moduleScope(scope) {
+		scope.__nodeFs = fs;
+		scope.__nodePath = path;
+	}
+};

--- a/test/configCases/css/source-map-hidden-payload/webpack.config.js
+++ b/test/configCases/css/source-map-hidden-payload/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * @param {string} name config name
+ * @param {import("../../../../").Configuration["devtool"]} devtool devtool under test
+ * @returns {import("../../../../").Configuration} webpack configuration
+ */
+const makeConfig = (name, devtool) => ({
+	name,
+	target: "web",
+	mode: "development",
+	devtool,
+	experiments: { css: true },
+	module: {
+		rules: [
+			{ test: /\.css$/, type: "css/auto", parser: { exportType: "text" } }
+		]
+	}
+});
+
+module.exports = [
+	makeConfig("hidden", "hidden-source-map"),
+	makeConfig("hidden-per-type", [{ type: "all", use: "hidden-source-map" }]),
+	makeConfig("source-map", "source-map")
+];

--- a/test/configCases/css/source-map-inline-names/index.js
+++ b/test/configCases/css/source-map-inline-names/index.js
@@ -27,6 +27,13 @@ const readInlineMaps = () => {
 	return maps;
 };
 
+// `Array.prototype.flat`/`flatMap` are not available on the oldest supported node
+const readInlineMapSources = () => {
+	const sources = [];
+	for (const map of readInlineMaps()) sources.push(...map.sources);
+	return sources;
+};
+
 it("should keep module identifier decorations out of inline css map sources", () => {
 	const maps = readInlineMaps();
 	expect(maps.length).toBeGreaterThan(0);
@@ -40,8 +47,15 @@ it("should keep module identifier decorations out of inline css map sources", ()
 
 if (__STATS_I__ === 2) {
 	it("should template sources a loader reported for non-modules", () => {
-		const sources = readInlineMaps().flatMap((map) => map.sources);
-		expect(sources).toContain("webpack:///./virtual-partial.css");
+		expect(readInlineMapSources()).toContain(
+			"webpack:///./virtual-partial.css"
+		);
+	});
+} else if (__STATS_I__ === 3) {
+	it("should keep absolute urls a loader reported as they are", () => {
+		expect(readInlineMapSources()).toContain(
+			"https://example.com/remote.css"
+		);
 	});
 } else if (__STATS_I__ === 0) {
 	it("should name inline css map sources like emitted asset maps do", () => {

--- a/test/configCases/css/source-map-inline-names/index.js
+++ b/test/configCases/css/source-map-inline-names/index.js
@@ -1,0 +1,59 @@
+import css from "./main.css";
+
+const fs = __nodeFs;
+const path = __nodePath;
+const NodeBuffer = __NodeBuffer;
+
+// Referencing the export keeps the value-returning `text` module in the bundle.
+if (typeof css !== "string") throw new Error("expected the css text export");
+
+const { outputPath } = __STATS__.children[__STATS_I__];
+
+const readInlineMaps = () => {
+	const bundle = fs.readFileSync(
+		path.join(outputPath, `bundle${__STATS_I__}.js`),
+		"utf-8"
+	);
+	const regexp =
+		/sourceMappingURL=data:application\/json;charset=utf-8;base64,([\w+/=]+)/g;
+	const maps = [];
+	let match = regexp.exec(bundle);
+	while (match) {
+		maps.push(
+			JSON.parse(NodeBuffer.from(match[1], "base64").toString("utf-8"))
+		);
+		match = regexp.exec(bundle);
+	}
+	return maps;
+};
+
+it("should keep module identifier decorations out of inline css map sources", () => {
+	const maps = readInlineMaps();
+	expect(maps.length).toBeGreaterThan(0);
+	for (const map of maps) {
+		for (const source of map.sources) {
+			expect(source).not.toMatch(/css\/(auto|module|global)\|/);
+			expect(source).not.toMatch(/\|text/);
+		}
+	}
+});
+
+if (__STATS_I__ === 0) {
+	it("should name inline css map sources like emitted asset maps do", () => {
+		const merged = readInlineMaps().find((map) => map.sources.length > 1);
+		expect(merged.sources).toContain("webpack:///./main.css");
+		expect(merged.sources).toContain("webpack:///./shared.css");
+		// `shared.css` is imported under two layers, so it is two modules
+		expect(
+			merged.sources.filter((source) =>
+				/^webpack:\/\/\/\.\/shared\.css\?\w+$/.test(source)
+			)
+		).toHaveLength(1);
+	});
+} else {
+	it("should apply output.devtoolModuleFilenameTemplate to inline css maps", () => {
+		const merged = readInlineMaps().find((map) => map.sources.length > 1);
+		expect(merged.sources).toContain("webpack://custom/./main.css");
+		expect(merged.sources).toContain("webpack://custom/./shared.css");
+	});
+}

--- a/test/configCases/css/source-map-inline-names/index.js
+++ b/test/configCases/css/source-map-inline-names/index.js
@@ -38,7 +38,12 @@ it("should keep module identifier decorations out of inline css map sources", ()
 	}
 });
 
-if (__STATS_I__ === 0) {
+if (__STATS_I__ === 2) {
+	it("should template sources a loader reported for non-modules", () => {
+		const sources = readInlineMaps().flatMap((map) => map.sources);
+		expect(sources).toContain("webpack:///./virtual-partial.css");
+	});
+} else if (__STATS_I__ === 0) {
 	it("should name inline css map sources like emitted asset maps do", () => {
 		const merged = readInlineMaps().find((map) => map.sources.length > 1);
 		expect(merged.sources).toContain("webpack:///./main.css");

--- a/test/configCases/css/source-map-inline-names/loader.js
+++ b/test/configCases/css/source-map-inline-names/loader.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(source) {
+	// Reports a source for a file that never becomes a module, like a less/sass
+	// partial does.
+	this.callback(null, source, {
+		version: 3,
+		sources: ["./virtual-partial.css"],
+		sourcesContent: [".virtual-rule {\n\tcolor: red;\n}\n"],
+		names: [],
+		mappings: "AAAA"
+	});
+};

--- a/test/configCases/css/source-map-inline-names/loader.js
+++ b/test/configCases/css/source-map-inline-names/loader.js
@@ -6,6 +6,7 @@ module.exports = function loader(source) {
 	// partial does.
 	this.callback(null, source, {
 		version: 3,
+		file: "",
 		sources: ["./virtual-partial.css"],
 		sourcesContent: [".virtual-rule {\n\tcolor: red;\n}\n"],
 		names: [],

--- a/test/configCases/css/source-map-inline-names/main.css
+++ b/test/configCases/css/source-map-inline-names/main.css
@@ -1,0 +1,6 @@
+@import "./shared.css" layer(base);
+@import "./shared.css" layer(theme);
+
+.main {
+	color: red;
+}

--- a/test/configCases/css/source-map-inline-names/remote-loader.js
+++ b/test/configCases/css/source-map-inline-names/remote-loader.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(source) {
+	// Reports an absolute URL source, like a loader pulling in a remote stylesheet.
+	this.callback(null, source, {
+		version: 3,
+		file: "",
+		sources: ["https://example.com/remote.css"],
+		sourcesContent: [".remote-rule {\n\tcolor: red;\n}\n"],
+		names: [],
+		mappings: "AAAA"
+	});
+};

--- a/test/configCases/css/source-map-inline-names/shared.css
+++ b/test/configCases/css/source-map-inline-names/shared.css
@@ -1,0 +1,3 @@
+.shared {
+	color: green;
+}

--- a/test/configCases/css/source-map-inline-names/test.config.js
+++ b/test/configCases/css/source-map-inline-names/test.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	moduleScope(scope) {
+		scope.__nodeFs = fs;
+		scope.__nodePath = path;
+		scope.__NodeBuffer = Buffer;
+	}
+};

--- a/test/configCases/css/source-map-inline-names/webpack.config.js
+++ b/test/configCases/css/source-map-inline-names/webpack.config.js
@@ -6,7 +6,7 @@ const path = require("path");
  * @param {string} name config name
  * @param {object} options options
  * @param {string=} options.devtoolModuleFilenameTemplate custom template under test
- * @param {boolean=} options.withLoader whether to run the css through a loader reporting its own map
+ * @param {string=} options.loader a loader reporting its own map, relative to this directory
  * @returns {import("../../../../").Configuration} webpack configuration
  */
 const makeConfig = (name, options = {}) => ({
@@ -21,8 +21,8 @@ const makeConfig = (name, options = {}) => ({
 				test: /\.css$/,
 				type: "css/auto",
 				parser: { exportType: "text" },
-				use: options.withLoader
-					? [path.resolve(__dirname, "loader.js")]
+				use: options.loader
+					? [path.resolve(__dirname, options.loader)]
 					: undefined
 			}
 		]
@@ -37,5 +37,6 @@ module.exports = [
 	makeConfig("custom-template", {
 		devtoolModuleFilenameTemplate: "webpack://custom/[resource-path]"
 	}),
-	makeConfig("loader-reported-sources", { withLoader: true })
+	makeConfig("loader-reported-sources", { loader: "loader.js" }),
+	makeConfig("loader-reported-urls", { loader: "remote-loader.js" })
 ];

--- a/test/configCases/css/source-map-inline-names/webpack.config.js
+++ b/test/configCases/css/source-map-inline-names/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * @param {string} name config name
+ * @param {string=} devtoolModuleFilenameTemplate custom template under test
+ * @returns {import("../../../../").Configuration} webpack configuration
+ */
+const makeConfig = (name, devtoolModuleFilenameTemplate) => ({
+	name,
+	target: "web",
+	mode: "development",
+	devtool: "source-map",
+	experiments: { css: true },
+	module: {
+		rules: [
+			{ test: /\.css$/, type: "css/auto", parser: { exportType: "text" } }
+		]
+	},
+	output: devtoolModuleFilenameTemplate ? { devtoolModuleFilenameTemplate } : {}
+});
+
+module.exports = [
+	makeConfig("default"),
+	makeConfig("custom-template", "webpack://custom/[resource-path]")
+];

--- a/test/configCases/css/source-map-inline-names/webpack.config.js
+++ b/test/configCases/css/source-map-inline-names/webpack.config.js
@@ -1,11 +1,15 @@
 "use strict";
 
+const path = require("path");
+
 /**
  * @param {string} name config name
- * @param {string=} devtoolModuleFilenameTemplate custom template under test
+ * @param {object} options options
+ * @param {string=} options.devtoolModuleFilenameTemplate custom template under test
+ * @param {boolean=} options.withLoader whether to run the css through a loader reporting its own map
  * @returns {import("../../../../").Configuration} webpack configuration
  */
-const makeConfig = (name, devtoolModuleFilenameTemplate) => ({
+const makeConfig = (name, options = {}) => ({
 	name,
 	target: "web",
 	mode: "development",
@@ -13,13 +17,25 @@ const makeConfig = (name, devtoolModuleFilenameTemplate) => ({
 	experiments: { css: true },
 	module: {
 		rules: [
-			{ test: /\.css$/, type: "css/auto", parser: { exportType: "text" } }
+			{
+				test: /\.css$/,
+				type: "css/auto",
+				parser: { exportType: "text" },
+				use: options.withLoader
+					? [path.resolve(__dirname, "loader.js")]
+					: undefined
+			}
 		]
 	},
-	output: devtoolModuleFilenameTemplate ? { devtoolModuleFilenameTemplate } : {}
+	output: options.devtoolModuleFilenameTemplate
+		? { devtoolModuleFilenameTemplate: options.devtoolModuleFilenameTemplate }
+		: {}
 });
 
 module.exports = [
 	makeConfig("default"),
-	makeConfig("custom-template", "webpack://custom/[resource-path]")
+	makeConfig("custom-template", {
+		devtoolModuleFilenameTemplate: "webpack://custom/[resource-path]"
+	}),
+	makeConfig("loader-reported-sources", { withLoader: true })
 ];

--- a/test/fixtures/css-devtool-cache/index.js
+++ b/test/fixtures/css-devtool-cache/index.js
@@ -1,0 +1,3 @@
+import css from "./style.css";
+
+if (typeof css !== "string") throw new Error("expected the css text export");

--- a/test/fixtures/css-devtool-cache/style.css
+++ b/test/fixtures/css-devtool-cache/style.css
@@ -1,0 +1,3 @@
+.rule {
+	color: red;
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -27947,6 +27947,8 @@ declare namespace exports {
 		) => null | Problem[];
 	}
 	export namespace ModuleFilenameHelpers {
+		export let DEFAULT_MODULE_FILENAME_TEMPLATE: string;
+		export let DEFAULT_FALLBACK_MODULE_FILENAME_TEMPLATE: string;
 		export let ALL_LOADERS_RESOURCE: string;
 		export let REGEXP_ALL_LOADERS_RESOURCE: RegExp;
 		export let LOADERS_RESOURCE: string;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

CSS inlined into JS (`parser.exportType: "text"` / `"css-style-sheet"`) appends its own `data:` source map to the payload, which `SourceMapDevToolPlugin` never sees, so two things were wrong there: the `sources` kept raw module identifiers (`webpack://css/auto|./style.css|text`) instead of the resource path emitted asset maps use, and `hidden-source-map` was ignored, embedding the map with full `sourcesContent` inside the bundle it is meant to keep sources out of. Follow-up to #21536, which fixed the two naming sites the plugin does reach. Refs #14893.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes: `test/configCases/css/source-map-inline-names/` covers the naming, a custom `output.devtoolModuleFilenameTemplate`, and the duplicate-resource-path fallback; `test/configCases/css/source-map-hidden-payload/` covers both `devtool` forms of `hidden-source-map` plus `source-map` as a control.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Note that `[contenthash]` moves for `exportType: text`/`css-style-sheet` builds with source maps, since the inlined map is part of the module's own output.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate the inlined-payload code path, compare the behaviour against other bundlers, draft the fix and tests, and run the suites; all changes were reviewed, directed and verified by the author.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkJNLKKRfpW2FTewLWo4UF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CSS-in-JS codegen, devtool/source-map output, and persistent cache keys; behavior fixes may change content hashes for affected builds but do not alter auth or runtime semantics.
> 
> **Overview**
> Fixes **CSS embedded in JS** (`exportType: "text"` / `"css-style-sheet"`) where webpack appends a `data:` source map on the CSS string inside the bundle—maps **`SourceMapDevToolPlugin` never processes**, so naming and `hidden` behavior were wrong.
> 
> **`CssGenerator`** now rewrites inline map `sources` via **`_nameMapSources`**, using the same **`ModuleFilenameHelpers.createFilename`** rules as emitted asset maps (custom `devtoolModuleFilenameTemplate`, fallback `?[hash]` for duplicate paths, loader-only paths, absolute `data:`/`https:` URLs unchanged). **`hidden-*` devtools** no longer append that inline map (avoiding `sourcesContent` in the bundle). **`nosources`** still strips `sourcesContent` on the inlined map.
> 
> Shared default templates live on **`ModuleFilenameHelpers`**; **`SourceMapDevToolPlugin`** uses them instead of duplicated strings.
> 
> **Filesystem codegen cache** for these modules now hashes **`devtool`** and devtool filename options in **`updateHash`**, so cached JS output is not reused across `source-map` vs `hidden-source-map`, different templates, or `nosources`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49c582bbdb37c9faf07c98ac1f3b649c977f6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->