### PR TITLE
fix(minify): keep CSS/HTML minification meaning-preserving in edge cases

### DIFF
--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1783,6 +1783,8 @@ const _setupParse = (input, lc) => {
 	// Only `grammar` re-enables it (after this call); the standalone `parseA*`
 	// entry points never print, so they must not inherit a previous parse's flag.
 	_printing = false;
+	// A visitor throw mid-value can leave the flag set; never carry it over.
+	_inValue = false;
 };
 
 /**
@@ -4166,6 +4168,20 @@ const _normalizeNumericToken = (text) =>
 	_normalizeNumber(text.slice(0, _numberEnd(text))) +
 	text.slice(_numberEnd(text));
 
+// Value functions whose hash arguments are colors. A hash in any other function
+// (`-moz-element(#id)`, `url()`-like references) is a case-sensitive reference.
+const _COLOR_HASH_FUNCTIONS = new Set([
+	"linear-gradient",
+	"radial-gradient",
+	"conic-gradient",
+	"repeating-linear-gradient",
+	"repeating-radial-gradient",
+	"repeating-conic-gradient",
+	"color-mix",
+	"cross-fade",
+	"image"
+]);
+
 const _HEX = "0123456789abcdef";
 
 /**
@@ -4307,15 +4323,23 @@ const _minifyColorFunction = (name, inner) => {
 	/** @type {number[]} */
 	const channels = [];
 	let alpha = 1;
+	let percentChannelCount = 0;
 	for (let i = 0; i < args.length; i++) {
 		const s = args[i];
 		if (!/^[+-]?(?:\d+\.?\d*|\.\d+)%?$/.test(s)) return null;
 		const pct = s.endsWith("%");
 		const v = Number.parseFloat(pct ? s.slice(0, -1) : s);
 		if (Number.isNaN(v)) return null;
-		if (i === 3) alpha = pct ? v / 100 : v;
-		else channels.push(_clamp255(pct ? (v * 255) / 100 : v));
+		if (i === 3) {
+			alpha = pct ? v / 100 : v;
+		} else {
+			if (pct) percentChannelCount++;
+			channels.push(_clamp255(pct ? (v * 255) / 100 : v));
+		}
 	}
+	// Mixed number/percentage channels are invalid CSS (ignored by browsers);
+	// rewriting would activate a dead declaration.
+	if (percentChannelCount !== 0 && percentChannelCount !== 3) return null;
 	// Fully transparent *black* only — `transparent` is `rgba(0,0,0,0)`, so a
 	// non-black transparent (e.g. `rgba(255,0,0,0)`) is a different value.
 	if (
@@ -4358,7 +4382,9 @@ const printer = (path, writer) => {
 		case T_PERCENTAGE:
 		case T_DIMENSION: {
 			const raw = path.source();
-			return minify ? _normalizeNumericToken(raw) : raw;
+			// Only declaration values: a prelude number is An+B (`2n+1`) or similar,
+			// where stripping a `+` breaks the selector.
+			return minify && path.inValue() ? _normalizeNumericToken(raw) : raw;
 		}
 		case T_FUNCTION: {
 			const name = path.name();
@@ -4385,9 +4411,11 @@ const printer = (path, writer) => {
 			const children = path.children();
 			let value = "";
 			if (children.length !== 0) {
-				if (name.startsWith("--")) {
+				if (name.startsWith("--") || name.toLowerCase() === "unicode-range") {
 					// Custom-property value: verbatim (its internal whitespace matters), so
 					// concatenate the children's raw source rather than their printed text.
+					// unicode-range too: its `U+…` tokenizes as numbers, which numeric
+					// normalization would corrupt.
 					value = children.map((c) => path.source(c)).join("");
 				} else {
 					// Value hashes were already shortened by the hash printer (they print
@@ -4455,6 +4483,15 @@ const printer = (path, writer) => {
 			// (`#Abc{}`, `:not(#Abc)`) — ids are case-sensitive, so shorten only the
 			// former. Works at any value depth (e.g. inside a gradient).
 			if (!minify || !path.inValue()) return raw;
+			// Inside a function, only known color functions take color hashes.
+			const parent = path.parent;
+			if (
+				parent !== null &&
+				path.type(parent) === T_FUNCTION &&
+				!_COLOR_HASH_FUNCTIONS.has(path.name(parent).toLowerCase())
+			) {
+				return raw;
+			}
 			const short = _minifyHash(raw);
 			return short === null ? raw : short;
 		}

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8403,8 +8403,20 @@ const _LITERAL_TEXT_PARENTS = new Set([
 	"iframe",
 	"noembed",
 	"noframes",
-	"noscript",
 	"plaintext"
+]);
+
+// The only elements this printer may leave transparent when they lack a source
+// tag: the parser re-implies them identically on re-parse. Any other tag-less
+// element (adoption-agency clone, reconstructed formatting element, renamed
+// token) must be materialized or the DOM changes.
+const _TRANSPARENT_IMPLIED_ELEMENTS = new Set([
+	"html",
+	"head",
+	"body",
+	"colgroup",
+	"tbody",
+	"tr"
 ]);
 
 // Elements the parser strips one leading newline from: when the serialized body
@@ -8436,6 +8448,29 @@ const _escapeTextContent = (s) => {
 };
 
 /**
+ * Rebuild an opening tag from the node's name and attributes, for elements with
+ * no matching source tag (adoption-agency clones, reconstructed formatting
+ * elements, renamed tokens like `<image>`). Attribute values are raw
+ * (undecoded), so they re-parse to the original decoded values.
+ * @param {HtmlPath} path the accessor positioned on the element
+ * @returns {string} serialized opening tag
+ */
+const _synthesizeOpenTag = (path) => {
+	let out = `<${path.tagName()}`;
+	for (const attribute of path.attributes()) {
+		const name =
+			attribute.serializedName !== undefined
+				? attribute.serializedName
+				: attribute.name;
+		out +=
+			attribute.value === ""
+				? ` ${name}`
+				: ` ${name}="${attribute.value.replace(/"/g, "&quot;")}"`;
+	}
+	return `${out}>`;
+};
+
+/**
  * Whether a comment must survive minification: downlevel conditional comments
  * (`<!--[if …]>` / `<![endif]-->`) drive IE branching, server-side includes
  * (`<!--#…-->`) are directives, and a `<?…?>` bogus comment is a server-side
@@ -8450,7 +8485,14 @@ const _keepComment = (data, source) => {
 	// are server-side directives, so they outrank the inert-comment rule.
 	if (source.charCodeAt(1) === 63) return true;
 	const s = data.trimStart();
-	return s.startsWith("[if") || s.startsWith("[endif") || s.startsWith("#");
+	// `<![` covers the downlevel-revealed forms: `<!--<![endif]-->` closers and
+	// standalone `<![if …]>` openers.
+	return (
+		s.startsWith("[if") ||
+		s.startsWith("[endif") ||
+		s.startsWith("<![") ||
+		s.startsWith("#")
+	);
 };
 
 /**
@@ -8474,8 +8516,11 @@ const printer = (path, writer) => {
 	switch (path.type()) {
 		case NodeType.Element: {
 			const open = path.openTag();
-			// Void / self-closing elements have no children and no end tag.
-			if (path.selfClosing()) return open;
+			// Void / self-closing elements have no children and no end tag; a
+			// tag-less one (`<image>` → img, `</br>` → br) is rebuilt, not dropped.
+			if (path.selfClosing()) {
+				return open !== "" ? open : _synthesizeOpenTag(path);
+			}
 			// `<template>` holds its children in a content fragment, not the child
 			// chain; every other element reconstructs from its children in order.
 			const tc = path.templateContent();
@@ -8495,13 +8540,28 @@ const printer = (path, writer) => {
 					inner = `\n${inner}`;
 				}
 			}
-			// A parser-inserted element (auto `html`/`head`/`body`/`tbody`, …) has no
-			// source tag; it stays transparent — emit only its children — so the
-			// output keeps the source's element shape instead of materializing it.
-			if (open === "") return inner;
-			// A source self-closing tag (`<rect/>` in foreign content) with no
-			// children needs no end tag; only `>`-closed elements get one.
-			const close = inner === "" && open.endsWith("/>") ? "" : path.closeTag();
+			const name = path.tagName();
+			if (open === "") {
+				// A parser-implied structural element stays transparent — the parser
+				// re-implies it — but only when attribute-less (repeated `<html>` /
+				// `<body>` tags merge attributes onto the implied element).
+				if (
+					path.attributeCount() === 0 &&
+					_TRANSPARENT_IMPLIED_ELEMENTS.has(name)
+				) {
+					return inner;
+				}
+				// Anything else tag-less (adoption-agency clone, reconstructed
+				// formatting element) must materialize or its formatting is lost.
+				return `${_synthesizeOpenTag(path) + inner}</${name}>`;
+			}
+			// Everything after `<plaintext>` is text; an emitted end tag would
+			// re-parse as literal text. A source self-closing tag (`<rect/>` in
+			// foreign content) with no children needs no end tag either.
+			const close =
+				name === "plaintext" || (inner === "" && open.endsWith("/>"))
+					? ""
+					: path.closeTag();
 			return open + inner + close;
 		}
 		case NodeType.Text: {

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -925,6 +925,81 @@ describe("CssSyntax — minify keeps input the grammar rejects", () => {
 	});
 });
 
+describe("CssSyntax — minify value-safety edge cases", () => {
+	/**
+	 * @param {string} src css source
+	 * @returns {string} the minified serialization
+	 */
+	const min = (src) =>
+		new SourceProcessor().process(src, { minimize: true }).code;
+
+	it("keeps An+B selector arguments verbatim (no sign stripping)", () => {
+		expect(min("a:nth-child(2n+1){b:c}")).toBe("a:nth-child(2n+1){b:c}");
+		expect(min("a:nth-last-child(-n+3){b:c}")).toBe(
+			"a:nth-last-child(-n+3){b:c}"
+		);
+		expect(min("a:nth-of-type(2n-1){b:c}")).toBe("a:nth-of-type(2n-1){b:c}");
+		expect(min("a:nth-child(+3){b:c}")).toBe("a:nth-child(+3){b:c}");
+		expect(min("a:nth-child(even){b:c}")).toBe("a:nth-child(even){b:c}");
+	});
+
+	it("still normalizes numbers in declaration values", () => {
+		expect(min("a{margin:+1.50px}")).toBe("a{margin:1.5px}");
+		expect(min("a{margin:0.50px 1.0px 0}")).toBe("a{margin:.5px 1px 0}");
+	});
+
+	it("keeps unicode-range values verbatim", () => {
+		expect(min("@font-face{unicode-range:U+0025-00FF}")).toBe(
+			"@font-face{unicode-range:U+0025-00FF}"
+		);
+		expect(min("@font-face{unicode-range:u+4??}")).toBe(
+			"@font-face{unicode-range:u+4??}"
+		);
+		expect(min("@font-face{unicode-range:U+26}")).toBe(
+			"@font-face{unicode-range:U+26}"
+		);
+		expect(min("@font-face{unicode-range:U+0-7F,U+80-FF}")).toBe(
+			"@font-face{unicode-range:U+0-7F,U+80-FF}"
+		);
+	});
+
+	it("does not turn an invalid mixed-channel rgb() into a valid color", () => {
+		expect(min("a{color:rgb(50%,100,30)}")).toBe("a{color:rgb(50%,100,30)}");
+		expect(min("a{color:rgb(50%,100%,30)}")).toBe("a{color:rgb(50%,100%,30)}");
+	});
+
+	it("still minifies all-number and all-percentage rgb()", () => {
+		expect(min("a{color:rgb(255,0,0)}")).toBe("a{color:red}");
+		expect(min("a{color:rgb(100%,0%,0%)}")).toBe("a{color:red}");
+	});
+
+	it("keeps a hash inside a non-color function verbatim (id reference)", () => {
+		expect(min("a{background:-moz-element(#Abc)}")).toBe(
+			"a{background:-moz-element(#Abc)}"
+		);
+	});
+
+	it("still minifies top-level and gradient hashes as colors", () => {
+		expect(min("a{color:#ABCDEF}")).toBe("a{color:#abcdef}");
+		expect(min("a{b:linear-gradient(#AABBCC,#FF0000)}")).toBe(
+			"a{b:linear-gradient(#abc,red)}"
+		);
+	});
+
+	it("does not leak the value context into the next parse after a visitor throw", () => {
+		const processor = new SourceProcessor().use({
+			[NodeType.Ident]: (
+				/** @type {import("../lib/css/syntax").CssPath} */ path
+			) => {
+				if (path.inValue()) throw new Error("boom");
+			}
+		});
+		expect(() => processor.process("a{color:red}")).toThrow("boom");
+		// A leaked in-value flag would treat the selector hash as a color here.
+		expect(min("#Face{color:red}")).toBe("#Face{color:red}");
+	});
+});
+
 describe("CssSyntax — nesting and error recovery", () => {
 	/**
 	 * @param {string} src css source

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4831,3 +4831,102 @@ describe("htmlMinify — assets webpack only passes through", () => {
 		);
 	});
 });
+
+describe("SourceProcessor — minify serialization edge cases", () => {
+	const { SourceProcessor } = require("../lib/html/syntax");
+
+	/**
+	 * @param {string} source html source
+	 * @returns {string} minified serialization
+	 */
+	const minify = (source) =>
+		new SourceProcessor().process(source, { minimize: true }).code;
+
+	describe("cloned / reconstructed formatting elements", () => {
+		it("keeps the reconstructed <b> around text after an implied </p>", () => {
+			expect(minify("<p><b>a<p>b")).toBe("<p><b>a</b></p><p><b>b</b></p>");
+		});
+
+		it("keeps the adoption-agency clone of <b> inside <p>", () => {
+			expect(minify("<b><p>x</b>y</p>")).toBe("<b></b><p><b>x</b>y</p>");
+		});
+
+		it("keeps cloned attributes on the reconstructed element", () => {
+			expect(minify('<b x="1"><p>x</b>y</p>')).toBe(
+				'<b x="1"></b><p><b x="1">x</b>y</p>'
+			);
+		});
+
+		it("keeps the reconstructed <b> in a full document round-trip", () => {
+			expect(
+				minify(
+					"<!DOCTYPE html><html><head></head><body><p><b>a<p>b</body></html>"
+				)
+			).toBe(
+				"<!DOCTYPE html><html><head></head><body><p><b>a</b></p><p><b>b</b></p></body></html>"
+			);
+		});
+
+		it("escapes a quote-holding cloned attribute value safely", () => {
+			expect(minify("<b a='x\"y'><p>t</b>")).toBe(
+				'<b a=\'x"y\'></b><p><b a="x&quot;y">t</b></p>'
+			);
+		});
+
+		it("rebuilds renamed void tokens instead of dropping them", () => {
+			expect(minify('<image src="a&amp;b">')).toBe('<img src="a&amp;b">');
+			expect(minify("a</br>b")).toBe("a<br>b");
+		});
+
+		it("materializes an implied <body> once attributes merge onto it", () => {
+			expect(minify('<div>a</div><body class="x">')).toBe(
+				'<body class="x"><div>a</div></body>'
+			);
+		});
+
+		it("still omits parser-inserted html/head/body and table sections", () => {
+			expect(minify("<p>x")).toBe("<p>x</p>");
+			expect(minify("<table><tr><td>x</td></tr></table>")).toBe(
+				"<table><tr><td>x</td></tr></table>"
+			);
+			expect(minify("<table><td>x")).toBe("<table><td>x</td></table>");
+		});
+	});
+
+	describe("<noscript> content", () => {
+		it("re-escapes decoded text inside <noscript>", () => {
+			expect(minify("<body><noscript>a &lt;b&gt; c</noscript>")).toBe(
+				"<body><noscript>a &lt;b&gt; c</noscript></body>"
+			);
+		});
+
+		it("round-trips elements nested inside <noscript>", () => {
+			expect(minify('<noscript><link href="x"></noscript>')).toBe(
+				'<noscript><link href="x"></noscript>'
+			);
+		});
+	});
+
+	describe("comments", () => {
+		it("keeps both halves of a downlevel-revealed conditional block", () => {
+			expect(minify('<!--[if !IE]><!--><link href="x"><!--<![endif]-->')).toBe(
+				'<!--[if !IE]><!--><link href="x"><!--<![endif]-->'
+			);
+			expect(minify("<!--[if IE]><p>ie only</p><![endif]-->")).toBe(
+				"<!--[if IE]><p>ie only</p><![endif]-->"
+			);
+		});
+
+		it("keeps server-side include directives", () => {
+			expect(minify('<!--#include virtual="a.html" -->')).toBe(
+				'<!--#include virtual="a.html" -->'
+			);
+		});
+	});
+
+	describe("<plaintext>", () => {
+		it("never emits a </plaintext> end tag", () => {
+			expect(minify("<plaintext>foo")).toBe("<plaintext>foo");
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes meaning-changing edge cases in the native CSS/HTML minifier introduced by #21491 (unreleased): An+B selectors (`:nth-child(2n+1)`) and `unicode-range` values were corrupted, invalid mixed-channel `rgb()` became valid, case-sensitive id hashes in non-color functions were lowercased, a value-context flag leaked across parses, adoption-agency/reconstructed formatting elements lost their tags, `<noscript>` children were emitted unescaped, downlevel-revealed conditional-comment closers were dropped, and `<plaintext>` gained an end tag.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — unit tests in `test/CssSyntax.unittest.js` and `test/HtmlSyntax.unittest.js` (each written first and confirmed failing); css-parsing, html5lib and the `css minimize` / `html minimize` integration cases stay green.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) found the bugs by reviewing recent commits, wrote the fixes and tests under my direction, and I reviewed the behavior decisions (e.g. keeping IE conditional comments intact).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core minify printers for CSS and HTML where incorrect transforms change selectors, colors, or DOM structure; changes are narrowly scoped with extensive regression tests.
> 
> **Overview**
> Fixes **meaning-changing edge cases** in the native CSS/HTML minifier so round-trips preserve computed style and DOM semantics.
> 
> **CSS minify** now limits numeric normalization and hash color shortening to **declaration values** (`path.inValue()`), leaves **`unicode-range`** and custom properties verbatim, refuses to rewrite **invalid mixed-channel `rgb()`**, only treats hashes as colors inside known **gradient/color functions**, and **resets `_inValue`** on each parse so a visitor throw cannot leak value context into the next run.
> 
> **HTML minify** **materializes** tag-less adoption-agency clones, reconstructed formatting elements, and renamed void tokens via **`_synthesizeOpenTag`**, while still omitting only **attribute-less** parser-implied structural tags; **`noscript`** is no longer raw-text (children re-escape), **downlevel-revealed** conditional comments (`<![`) are kept, and **`plaintext`** never gets a closing tag.
> 
> Unit tests in `test/CssSyntax.unittest.js` and `test/HtmlSyntax.unittest.js` cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05300c3a42e860803e1e7c00a5174c04daf54e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->