### PR TITLE
perf: walk the ast on node offsets in getPathInAst

### DIFF
--- a/.changeset/500-get-path-in-ast-perf.md
+++ b/.changeset/500-get-path-in-ast-perf.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up concatenated module renaming by walking the ast on node offsets.

--- a/lib/util/concatenate.js
+++ b/lib/util/concatenate.js
@@ -12,6 +12,8 @@ const Template = require("../Template");
 /** @typedef {import("../javascript/JavascriptModulesPlugin").Reference} Reference */
 /** @typedef {import("../javascript/JavascriptModulesPlugin").Variable} Variable */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
+/** @typedef {Node & { start?: number, end?: number }} PositionedNode */
+/** @typedef {Exclude<keyof Node, "range" | "loc" | "leadingComments" | "trailingComments">} ChildKey */
 /** @typedef {Set<string>} UsedNames */
 
 const DEFAULT_EXPORT = "__WEBPACK_DEFAULT_EXPORT__";
@@ -41,7 +43,115 @@ const getAllReferences = (variable) => {
 };
 
 /**
- * Returns result.
+ * Tests whether a node covers the searched range. `start`/`end` are read before
+ * `range`, because webpack's parser serves `range` from a lazy getter that
+ * allocates an array and transitions the node's shape on first access — reading
+ * it while walking would pay that for most nodes of the ast.
+ * @param {PositionedNode} node node
+ * @param {number} start start of the searched range
+ * @param {number} end end of the searched range
+ * @returns {boolean} whether the node covers the range
+ */
+const coversRange = (node, start, end) => {
+	const nodeStart = node.start;
+	if (typeof nodeStart === "number") {
+		return nodeStart <= start && /** @type {number} */ (node.end) >= end;
+	}
+	const range = node.range;
+	return range !== undefined && range[0] <= start && range[1] >= end;
+};
+
+/**
+ * Returns the single sibling covering the searched range.
+ * @param {Node[]} items sibling nodes
+ * @param {number} start start of the searched range
+ * @param {number} end end of the searched range
+ * @returns {Node | undefined} covering sibling
+ */
+const findCoveringItem = (items, start, end) => {
+	// sibling ranges are ordered and disjoint; binary search the container
+	let low = 0;
+	let high = items.length - 1;
+	while (low <= high) {
+		const middle = (low + high) >> 1;
+		const item = /** @type {PositionedNode} */ (items[middle]);
+		/** @type {number | undefined} */
+		let itemStart;
+		/** @type {number | undefined} */
+		let itemEnd;
+		if (item) {
+			itemStart = item.start;
+			if (typeof itemStart === "number") {
+				itemEnd = item.end;
+			} else {
+				const range = item.range;
+				if (range === undefined) {
+					itemStart = undefined;
+				} else {
+					itemStart = range[0];
+					itemEnd = range[1];
+				}
+			}
+		}
+		if (itemStart === undefined) {
+			// holes or range-less nodes: scan the remaining window linearly
+			for (let i = low; i <= high; i++) {
+				const candidate = items[i];
+				if (candidate && coversRange(candidate, start, end)) return candidate;
+			}
+			return undefined;
+		}
+		if (itemStart > start) {
+			high = middle - 1;
+		} else if (start >= /** @type {number} */ (itemEnd)) {
+			low = middle + 1;
+		} else {
+			return /** @type {number} */ (itemEnd) >= end ? item : undefined;
+		}
+	}
+	return undefined;
+};
+
+/**
+ * Collects the ancestors of `node` below `parent`, innermost first.
+ * Keeps scanning after a covering child turns out not to contain `node`:
+ * a shorthand `{ a }` holds two distinct identifiers with the same range.
+ * @param {Node} parent node to search in
+ * @param {number} start start of the searched range
+ * @param {number} end end of the searched range
+ * @param {Node} node node to find
+ * @param {Node[]} path collected ancestors
+ * @returns {boolean} whether the node was found
+ */
+const collectPathInNode = (parent, start, end, node, path) => {
+	for (const key in parent) {
+		// sit in front of the child keys on every node and never hold one, so
+		// skipping them by name is what keeps the per-level scan short
+		if (key === "type" || key === "start" || key === "end") continue;
+		const value = parent[/** @type {ChildKey} */ (key)];
+		if (value === null || typeof value !== "object") continue;
+		/** @type {Node | undefined} */
+		let child;
+		if (Array.isArray(value)) {
+			// `range` is a number pair on parsers that own the property
+			if (key === "range") continue;
+			child = findCoveringItem(value, start, end);
+		} else if (coversRange(value, start, end)) {
+			child = value;
+		}
+		if (
+			child !== undefined &&
+			(child === node || collectPathInNode(child, start, end, node, path))
+		) {
+			path.push(child);
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
+ * Returns the ancestors of `node` up to (but excluding) `ast`, innermost first.
  * @param {Node | Node[]} ast ast
  * @param {Node} node node
  * @returns {undefined | Node[]} result
@@ -51,69 +161,25 @@ const getPathInAst = (ast, node) => {
 		return [];
 	}
 
-	const nr = /** @type {Range} */ (node.range);
-
-	/**
-	 * Returns result.
-	 * @param {Node} n node
-	 * @returns {Node[] | undefined} result
-	 */
-	const enterNode = (n) => {
-		if (!n) return;
-		const r = n.range;
-		if (r && r[0] <= nr[0] && r[1] >= nr[1]) {
-			const path = getPathInAst(n, node);
-			if (path) {
-				path.push(n);
-				return path;
-			}
-		}
-	};
+	const nodeRange = /** @type {Range} */ (node.range);
+	const start = nodeRange[0];
+	const end = nodeRange[1];
+	/** @type {Node[]} */
+	const path = [];
 
 	if (Array.isArray(ast)) {
-		// sibling ranges are ordered and disjoint; binary search the container
-		let lo = 0;
-		let hi = ast.length - 1;
-		while (lo <= hi) {
-			const mid = (lo + hi) >> 1;
-			const item = ast[mid];
-			const r = item && item.range;
-			if (!r) {
-				// holes or range-less nodes: scan the remaining window linearly
-				for (let i = lo; i <= hi; i++) {
-					const enterResult = enterNode(ast[i]);
-					if (enterResult !== undefined) return enterResult;
-				}
-				return;
-			}
-			if (r[0] > nr[0]) {
-				hi = mid - 1;
-			} else if (nr[0] >= r[1]) {
-				lo = mid + 1;
-			} else {
-				return r[1] >= nr[1] ? enterNode(item) : undefined;
-			}
+		const item = findCoveringItem(ast, start, end);
+		if (item === undefined) return undefined;
+		if (item !== node && !collectPathInNode(item, start, end, node, path)) {
+			return undefined;
 		}
-	} else if (ast && typeof ast === "object") {
-		const keys =
-			/** @type {(keyof Node)[]} */
-			(Object.keys(ast));
-		for (let i = 0; i < keys.length; i++) {
-			// We are making the faster check in `enterNode` using `n.range`
-			const value =
-				ast[
-					/** @type {Exclude<keyof Node, "range" | "loc" | "leadingComments" | "trailingComments">} */
-					(keys[i])
-				];
-			if (Array.isArray(value)) {
-				const pathResult = getPathInAst(value, node);
-				if (pathResult !== undefined) return pathResult;
-			} else if (value && typeof value === "object") {
-				const enterResult = enterNode(value);
-				if (enterResult !== undefined) return enterResult;
-			}
-		}
+		path.push(item);
+		return path;
 	}
+
+	if (!ast || typeof ast !== "object") return undefined;
+
+	return collectPathInNode(ast, start, end, node, path) ? path : undefined;
 };
 
 /** @type {Map<string, string[]>} */

--- a/test/getPathInAst.unittest.js
+++ b/test/getPathInAst.unittest.js
@@ -1,0 +1,176 @@
+"use strict";
+
+const JavascriptParser = require("../lib/javascript/JavascriptParser");
+const { getPathInAst } = require("../lib/util/concatenate");
+
+/** @typedef {import("estree").Node} Node */
+/** @typedef {import("estree").Program} Program */
+
+/**
+ * @param {string} source source code
+ * @returns {Program} parsed ast
+ */
+const parse = (source) =>
+	JavascriptParser._parse(source, { sourceType: "module", ranges: true }).ast;
+
+/**
+ * @param {Node} node node to search in
+ * @param {(node: Node) => boolean} test predicate
+ * @returns {Node} first matching node
+ */
+const findNode = (node, test) => {
+	if (test(node)) return node;
+	for (const key of Object.keys(node)) {
+		const value = /** @type {EXPECTED_ANY} */ (node)[key];
+		for (const child of Array.isArray(value) ? value : [value]) {
+			if (
+				child &&
+				typeof child === "object" &&
+				typeof child.type === "string"
+			) {
+				const found = findNode(child, test);
+				if (found) return found;
+			}
+		}
+	}
+	return /** @type {EXPECTED_ANY} */ (undefined);
+};
+
+/**
+ * @param {Node[] | undefined} path path
+ * @returns {string[]} node types
+ */
+const types = (path) => /** @type {Node[]} */ (path).map((node) => node.type);
+
+describe("getPathInAst", () => {
+	it("should return an empty path for the ast itself", () => {
+		const ast = parse("const value = 1;");
+		expect(getPathInAst(ast, ast)).toEqual([]);
+	});
+
+	it("should return the ancestors innermost first", () => {
+		const ast = parse("const value = { nested: [42] };");
+		const literal = findNode(ast, (node) => node.type === "Literal");
+		expect(types(getPathInAst(ast, literal))).toEqual([
+			"Literal",
+			"ArrayExpression",
+			"Property",
+			"ObjectExpression",
+			"VariableDeclarator",
+			"VariableDeclaration"
+		]);
+	});
+
+	it("should accept a node array as the ast", () => {
+		const ast = parse("const first = 1;\nconst second = 2;");
+		const declarator = findNode(
+			ast.body[1],
+			(node) => node.type === "VariableDeclarator"
+		);
+		expect(types(getPathInAst(ast.body, declarator))).toEqual([
+			"VariableDeclarator",
+			"VariableDeclaration"
+		]);
+	});
+
+	it("should tell the key and the value of a shorthand property apart", () => {
+		// both identifiers share one range, so the value is only reachable by
+		// continuing the scan past the key
+		const ast = parse("const a = 1;\nconst o = { a };");
+		const property = /** @type {EXPECTED_ANY} */ (
+			findNode(ast, (node) => node.type === "Property")
+		);
+		const keyPath = /** @type {Node[]} */ (getPathInAst(ast, property.key));
+		const valuePath = /** @type {Node[]} */ (getPathInAst(ast, property.value));
+		expect(property.key).not.toBe(property.value);
+		expect(keyPath[0]).toBe(property.key);
+		expect(keyPath[1]).toBe(property);
+		expect(valuePath[0]).toBe(property.value);
+		expect(valuePath[1]).toBe(property);
+	});
+
+	it("should skip holes in a node array", () => {
+		const ast = parse("const list = [];\nconst [, second] = list;");
+		const identifier = findNode(
+			ast.body[1],
+			(node) => node.type === "Identifier" && node.name === "second"
+		);
+		expect(types(getPathInAst(ast, identifier))).toEqual([
+			"Identifier",
+			"ArrayPattern",
+			"VariableDeclarator",
+			"VariableDeclaration"
+		]);
+	});
+
+	it("should support nodes that only expose range", () => {
+		const identifier = { type: "Identifier", name: "a", range: [10, 11] };
+		const statement = {
+			type: "ExpressionStatement",
+			expression: identifier,
+			range: [10, 12]
+		};
+		const program = {
+			type: "Program",
+			body: [statement],
+			range: [0, 12]
+		};
+		const ast = /** @type {EXPECTED_ANY} */ (program);
+		expect(getPathInAst(ast, /** @type {EXPECTED_ANY} */ (identifier))).toEqual(
+			[identifier, statement]
+		);
+	});
+
+	it("should scan past siblings without position info", () => {
+		const identifier = { type: "Identifier", name: "a", range: [4, 5] };
+		const program = /** @type {EXPECTED_ANY} */ ({
+			type: "Program",
+			body: [{ type: "EmptyStatement" }, identifier],
+			range: [0, 6]
+		});
+		expect(
+			getPathInAst(program, /** @type {EXPECTED_ANY} */ (identifier))
+		).toEqual([identifier]);
+		expect(
+			getPathInAst(
+				program,
+				/** @type {EXPECTED_ANY} */ ({ type: "Identifier", range: [9, 10] })
+			)
+		).toBeUndefined();
+	});
+
+	it("should ignore an own range property", () => {
+		const ast = parse("const value = 1;");
+		const literal = findNode(ast, (node) => node.type === "Literal");
+		for (const node of /** @type {{ start: number, end: number, range?: [number, number] }[]} */ (
+			/** @type {unknown} */ ([ast, ...ast.body])
+		)) {
+			node.range = [node.start, node.end];
+		}
+		expect(types(getPathInAst(ast, literal))).toEqual([
+			"Literal",
+			"VariableDeclarator",
+			"VariableDeclaration"
+		]);
+	});
+
+	it("should return undefined for a node outside the ast", () => {
+		const ast = parse("const value = 1;");
+		const other = findNode(
+			parse("other;"),
+			(node) => node.type === "Identifier"
+		);
+		expect(getPathInAst(ast, other)).toBeUndefined();
+		expect(getPathInAst(ast.body, other)).toBeUndefined();
+	});
+
+	it("should return undefined when the ast is not a node", () => {
+		const identifier = findNode(
+			parse("value;"),
+			(node) => node.type === "Identifier"
+		);
+		expect(
+			getPathInAst(/** @type {EXPECTED_ANY} */ ("not a node"), identifier)
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`getPathInAst` runs for every identifier of every variable renamed while concatenating modules, and it read `node.range` on each visited node — but webpack's parser serves `range` from a lazy getter that allocates an array and transitions the node's hidden class on first access. It also scanned `type`/`start`/`end`, which sit in front of every node's real children, as child candidates. Reading the numeric offsets instead, skipping those keys, and dropping the closure allocated per recursion level makes it ~2.2x faster over webpack/acorn/terser sources and ~3.1x on shorthand-heavy code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — `test/getPathInAst.unittest.js`, which also covers the branches a real build cannot reach (asts that only expose `range`, holes in a node array, a node array as the root).

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No, the returned paths are unchanged.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes. Claude Code was used to profile `getPathInAst`, draft the rewrite and the unit test, and check equivalence by comparing every path returned by the old and the new implementation across ~520k lookups over real-world sources; the result was reviewed before submitting.

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal algorithm refactor with unit tests and no intended API/output change; only affects concatenation rename hot path performance.
> 
> **Overview**
> **Speeds up concatenated-module renaming** by rewriting `getPathInAst` in `lib/util/concatenate.js`, which runs for every identifier renamed during scope/module concatenation.
> 
> The new implementation prefers numeric **`start`/`end`** over touching **`node.range`** on each visited node, avoiding webpack parser’s lazy `range` getter (allocation + shape transition). It **skips non-child keys** (`type`, `start`, `end`), uses **binary search** for ordered sibling arrays via `findCoveringItem`, and collects ancestors with **`collectPathInNode`** instead of recursive closures. It still handles **shorthand properties** (key/value share a range), **array holes**, and AST roots that are node arrays.
> 
> Adds **`test/getPathInAst.unittest.js`** for these behaviors and a **patch changeset** noting the perf win.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8e6719a274f9250560f6e887f962e4a2f93b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->