### PR TITLE
test: cover the circular re-export bail-out in concatenated modules

### DIFF
--- a/test/configCases/concatenate-modules/circular-namespace-reexport/a.js
+++ b/test/configCases/concatenate-modules/circular-namespace-reexport/a.js
@@ -1,0 +1,7 @@
+export * as ns from "./b";
+
+// the side effect keeps SideEffectsFlagPlugin from collapsing the re-export
+// chain, so the cycle is still there at code generation time
+global.__a = true;
+
+export const a = 1;

--- a/test/configCases/concatenate-modules/circular-namespace-reexport/b.js
+++ b/test/configCases/concatenate-modules/circular-namespace-reexport/b.js
@@ -1,0 +1,6 @@
+export * as ns from "./a";
+
+// see ./a.js
+global.__b = true;
+
+export const b = 2;

--- a/test/configCases/concatenate-modules/circular-namespace-reexport/index.js
+++ b/test/configCases/concatenate-modules/circular-namespace-reexport/index.js
@@ -1,0 +1,22 @@
+import { ns } from "./a";
+
+it("should concatenate both sides of the namespace re-export cycle", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./a.js",
+		"./b.js",
+		"./index.js"
+	]);
+});
+
+it("should resolve a namespace re-export chain up to the cycle", () => {
+	expect(ns.b).toBe(2);
+	expect(ns.ns.a).toBe(1);
+});
+
+it("should bail out when the namespace re-export chain closes the cycle", () => {
+	// `ns.ns.ns` walks a.ns -> b.ns -> a.ns, so the binding is rendered as a
+	// self-calling function instead of a name; reading it throws
+	expect(() => ns.ns.ns).toThrow();
+});

--- a/test/configCases/concatenate-modules/circular-namespace-reexport/webpack.config.js
+++ b/test/configCases/concatenate-modules/circular-namespace-reexport/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: true,
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`getFinalBinding` renders a repeated export info as `/* circular reexport */ Object(function x() { x() }())`, but no test reached that branch. Named re-export cycles can't reach it (`ModuleConcatenationPlugin` bails with "Reexports in this module do not have a static target"), so the new case builds an `export * as ns` cycle, whose namespace target ends `ExportInfo.getTarget` early while `getFinalBinding` keeps walking the remaining ids.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/concatenate-modules/circular-namespace-reexport/` (the PR is test-only).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to work out which module shape reaches the branch and to draft the fixture; I reviewed the case and verified the emitted bundle really contains the circular binding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and assertions; no runtime or bundler logic changes.
> 
> **Overview**
> Adds a **test-only** config case under `test/configCases/concatenate-modules/circular-namespace-reexport/` that exercises module concatenation when two modules form an `export * as ns` cycle (`a.js` ↔ `b.js`), with side effects so the re-export chain is not collapsed before codegen.
> 
> The fixture asserts all three modules still concatenate into one scope, that bindings along the namespace chain resolve (`ns.b`, `ns.ns.a`), and that following the cycle (`ns.ns.ns`) hits the existing `getFinalBinding` circular bail-out and throws when the binding is emitted as the self-calling placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f34477cb8cee7f1ba7fef9eeeedd5ec60154e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->