### PR TITLE
fix(minimize): skip CSS or HTML a configured minimizer already covers

### DIFF
--- a/.changeset/155-native-css-html-safe-minify.md
+++ b/.changeset/155-native-css-html-safe-minify.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Safely minify native CSS (with source maps) and HTML output when `optimization.minimize` is enabled.
+Safely minify CSS (with source maps) and HTML assets when `optimization.minimize` is enabled, unless a minimizer is already configured for them.

--- a/cspell.json
+++ b/cspell.json
@@ -358,6 +358,7 @@
     "unexception",
     "uniquename",
     "unlazy",
+    "unminified",
     "unoptimized",
     "unreviewed",
     "unshifted",

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -2410,34 +2410,40 @@ const applyOptimizationDefaults = (
 				// worker-safe by resolving their parser with `require("webpack/…")` in
 				// the worker, so all three share the same pool. `test` is widened to let
 				// CSS / HTML assets reach the dispatcher.
+				// Step aside for a minimizer the user already configured for these
+				// types: whichever of the two ran first would mark the asset
+				// `minimized` and silently disable the other, so webpack only claims
+				// what nothing else does. Their asset matchers are read directly rather
+				// than resolved per asset — a coarse check, but it keeps the outcome
+				// independent of tap order and of the plugin version in use.
+				const claimedByOtherMinimizer = require("./getClaimedAssetTypes")(
+					compiler
+				);
+
 				const { css, html } = compiler.options.experiments;
-				if (css && html) {
-					new TerserPlugin({
-						test: /\.(?:[cm]?js|css|html)(\?.*)?$/i,
-						minify: [
-							TerserPlugin.terserMinify,
-							require("../css/cssMinify"),
-							require("../html/htmlMinify")
-						],
-						minimizerOptions: [terserOptions, {}, {}]
-					}).apply(/** @type {EXPECTED_ANY} */ (compiler));
-				} else if (css) {
-					new TerserPlugin({
-						test: /\.(?:[cm]?js|css)(\?.*)?$/i,
-						minify: [TerserPlugin.terserMinify, require("../css/cssMinify")],
-						minimizerOptions: [terserOptions, {}]
-					}).apply(/** @type {EXPECTED_ANY} */ (compiler));
-				} else if (html) {
-					new TerserPlugin({
-						test: /\.(?:[cm]?js|html)(\?.*)?$/i,
-						minify: [TerserPlugin.terserMinify, require("../html/htmlMinify")],
-						minimizerOptions: [terserOptions, {}]
-					}).apply(/** @type {EXPECTED_ANY} */ (compiler));
-				} else {
+				const minifyCss = Boolean(css) && !claimedByOtherMinimizer.css;
+				const minifyHtml = Boolean(html) && !claimedByOtherMinimizer.html;
+				if (!minifyCss && !minifyHtml) {
 					new TerserPlugin({ terserOptions }).apply(
 						/** @type {EXPECTED_ANY} */ (compiler)
 					);
+					return;
 				}
+				/** @type {(typeof TerserPlugin.terserMinify | typeof import("../css/cssMinify") | typeof import("../html/htmlMinify"))[]} */
+				const minify = [TerserPlugin.terserMinify];
+				/** @type {EXPECTED_OBJECT[]} */
+				const minimizerOptions = [terserOptions];
+				if (minifyCss) minify.push(require("../css/cssMinify"));
+				if (minifyHtml) minify.push(require("../html/htmlMinify"));
+				for (let i = 1; i < minify.length; i++) minimizerOptions.push({});
+				new TerserPlugin({
+					test: new RegExp(
+						`\\.(?:[cm]?js${minifyCss ? "|css" : ""}${minifyHtml ? "|html" : ""})(\\?.*)?$`,
+						"i"
+					),
+					minify,
+					minimizerOptions
+				}).apply(/** @type {EXPECTED_ANY} */ (compiler));
 			}
 		}
 	]);

--- a/lib/config/getClaimedAssetTypes.js
+++ b/lib/config/getClaimedAssetTypes.js
@@ -26,8 +26,15 @@ const claims = (candidate, file) => {
 	// every file — reading those as minimizers would disable minification.
 	const { options } = /** @type {{ options?: MinimizerOptions }} */ (candidate);
 	if (!options || !options.minimizer) return false;
-	const { test, include, exclude } = options;
-	return matchObject({ test, include, exclude }, file);
+	// `test`/`include` say which types it handles, `exclude` only narrows the
+	// files within them — honouring that narrowing would make a minimizer scoped
+	// to a subdirectory claim nothing, and webpack would then race it on the very
+	// files it was configured for.
+	const { test, include } = options;
+	return (
+		(test !== undefined && matchObject({ test }, file)) ||
+		(include !== undefined && matchObject({ include }, file))
+	);
 };
 
 /**
@@ -35,8 +42,8 @@ const claims = (candidate, file) => {
  * default minimizer can leave those alone instead of racing the user's plugin
  * for them (the loser is skipped via `minimized` asset info, so without this
  * whichever tapped first would win). Deliberately coarse: it reads a plugin's
- * matcher rather than resolving it per emitted asset, so a minimizer scoped to a
- * subset still claims the whole type.
+ * matcher rather than resolving it per emitted asset, so a minimizer restricted
+ * to some of a type's files still claims the whole type.
  * @param {Compiler} compiler the compiler
  * @returns {{ css: boolean, html: boolean }} types another minimizer handles
  */

--- a/lib/config/getClaimedAssetTypes.js
+++ b/lib/config/getClaimedAssetTypes.js
@@ -9,6 +9,7 @@ const { matchObject } = require("../ModuleFilenameHelpers");
 
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../ModuleFilenameHelpers").MatchObject} MatchObject */
+/** @typedef {MatchObject & { minimizer?: EXPECTED_OBJECT }} MinimizerOptions */
 
 /**
  * @param {unknown} candidate a configured plugin or minimizer entry
@@ -18,16 +19,14 @@ const { matchObject } = require("../ModuleFilenameHelpers");
 const claims = (candidate, file) => {
 	// Every minimizer in the `minimizer-webpack-plugin` family (itself,
 	// `css-minimizer-webpack-plugin`, `html-minimizer-webpack-plugin`, …) keeps
-	// its asset matcher on `options` in the shape `matchObject` reads. Anything
-	// else — a plugin function, a plugin without options — is not a minimizer.
-	const { options } = /** @type {{ options?: MatchObject }} */ (candidate);
-	if (!options) return false;
+	// the minify implementation on `options.minimizer` and its asset matcher
+	// alongside it in the shape `matchObject` reads. The matcher alone is not
+	// enough to recognize one: `BannerPlugin` and `SourceMapDevToolPlugin` carry
+	// the same three keys, and `LoaderOptionsPlugin` defaults `test` to match
+	// every file — reading those as minimizers would disable minification.
+	const { options } = /** @type {{ options?: MinimizerOptions }} */ (candidate);
+	if (!options || !options.minimizer) return false;
 	const { test, include, exclude } = options;
-	// A matcher-less `options` is some other kind of plugin; passing it to
-	// `matchObject` would match every file and claim everything.
-	if (test === undefined && include === undefined && exclude === undefined) {
-		return false;
-	}
 	return matchObject({ test, include, exclude }, file);
 };
 

--- a/lib/config/getClaimedAssetTypes.js
+++ b/lib/config/getClaimedAssetTypes.js
@@ -1,0 +1,59 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author sheo13666q @sheo13666q
+*/
+
+"use strict";
+
+const { matchObject } = require("../ModuleFilenameHelpers");
+
+/** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../ModuleFilenameHelpers").MatchObject} MatchObject */
+
+/**
+ * @param {unknown} candidate a configured plugin or minimizer entry
+ * @param {string} file probe filename
+ * @returns {boolean} whether the candidate minimizes that file
+ */
+const claims = (candidate, file) => {
+	// Every minimizer in the `minimizer-webpack-plugin` family (itself,
+	// `css-minimizer-webpack-plugin`, `html-minimizer-webpack-plugin`, …) keeps
+	// its asset matcher on `options` in the shape `matchObject` reads. Anything
+	// else — a plugin function, a plugin without options — is not a minimizer.
+	const { options } = /** @type {{ options?: MatchObject }} */ (candidate);
+	if (!options) return false;
+	const { test, include, exclude } = options;
+	// A matcher-less `options` is some other kind of plugin; passing it to
+	// `matchObject` would match every file and claim everything.
+	if (test === undefined && include === undefined && exclude === undefined) {
+		return false;
+	}
+	return matchObject({ test, include, exclude }, file);
+};
+
+/**
+ * Which asset types the user's own configuration already minimizes, so webpack's
+ * default minimizer can leave those alone instead of racing the user's plugin
+ * for them (the loser is skipped via `minimized` asset info, so without this
+ * whichever tapped first would win). Deliberately coarse: it reads a plugin's
+ * matcher rather than resolving it per emitted asset, so a minimizer scoped to a
+ * subset still claims the whole type.
+ * @param {Compiler} compiler the compiler
+ * @returns {{ css: boolean, html: boolean }} types another minimizer handles
+ */
+module.exports = (compiler) => {
+	const { optimization, plugins } = compiler.options;
+	let css = false;
+	let html = false;
+	// Both lists are normalized arrays with falsy entries already filtered out,
+	// and `minimizer` was filled in by the defaults before any plugin applies.
+	const minimizer =
+		/** @type {NonNullable<typeof optimization.minimizer>} */
+		(optimization.minimizer);
+	for (const candidate of [...minimizer, ...plugins]) {
+		if (!css) css = claims(candidate, "file.css");
+		if (!html) html = claims(candidate, "file.html");
+		if (css && html) break;
+	}
+	return { css, html };
+};

--- a/lib/css/cssMinify.js
+++ b/lib/css/cssMinify.js
@@ -24,11 +24,12 @@
  * @returns {{ code: string, map: SourceMap }} the minified CSS and its input->output source map
  */
 const cssMinify = (input, sourceMap, minimizerOptions = {}) => {
-	// eslint-disable-next-line import/no-extraneous-dependencies -- webpack self-require, re-resolved inside the worker
-	const webpack = require(/** @type {string} */ ("webpack"));
+	const webpack = /** @type {typeof import("../index")} */ (
+		// eslint-disable-next-line import/no-extraneous-dependencies -- webpack self-require, re-resolved inside the worker
+		require(/** @type {string} */ ("webpack"))
+	);
 
-	const { SourceProcessor } = /** @type {typeof import("../index")} */ (webpack)
-		.css.syntax;
+	const { SourceProcessor } = webpack.css.syntax;
 	const [[file, code]] = Object.entries(input);
 	// `process` parses once, and with `minimize` the same walk also prints the
 	// safely minified serialization — no second parse — and always returns

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1270,7 +1270,12 @@ const NodeType = {
 	Stylesheet: 26,
 	// Comments are never tree nodes; this type exists only so a `NodeType.Comment`
 	// visitor can be registered (fired during tokenization — see `grammar`).
-	Comment: 27
+	Comment: 27,
+	// NOT A SPEC NODE — a workaround. §5.4 discards input a block's contents
+	// rejects; this keeps the source so minifying can't lose what the
+	// unminified asset shows. Only built while printing; a walk-only parse
+	// never sees one.
+	Raw: 28
 };
 const {
 	Ident: T_IDENT,
@@ -1299,7 +1304,8 @@ const {
 	AtRule: T_AT_RULE,
 	QualifiedRule: T_QUALIFIED_RULE,
 	Stylesheet: T_STYLESHEET,
-	Comment: T_COMMENT
+	Comment: T_COMMENT,
+	Raw: T_RAW
 } = NodeType;
 
 /**
@@ -1674,6 +1680,16 @@ const _makeUrl = (start, end, cs, ce) => {
 };
 /** @type {(start: number) => Node} */
 const _makeStylesheet = (start) => _makeContainer(T_STYLESHEET, start, start);
+// Workaround node (see `NodeType.Raw`), trimmed of the whitespace the block's
+// own separators already cover; an all-whitespace span yields no node.
+/** @type {(start: number, end: number) => Node | undefined} */
+const _makeRaw = (start, end) => {
+	let from = start;
+	let to = end;
+	while (from < to && _isWhiteSpace(_input.charCodeAt(to - 1))) to--;
+	while (from < to && _isWhiteSpace(_input.charCodeAt(from))) from++;
+	return from === to ? undefined : _makeLeaf(T_RAW, from, to);
+};
 // name / nameStart are derived from start + nameEnd; only nameEnd is stored.
 /** @type {(r: Node, nameStart: number, nameEnd: number) => void} */
 const _setName = (r, ns, ne) => {
@@ -1756,6 +1772,9 @@ const _setupParse = (input, lc) => {
 	_skipActive = false;
 	_skipSelectorPrelude = false;
 	_skipAtRulePrelude = false;
+	// Only `grammar` re-enables it (after this call); the standalone `parseA*`
+	// entry points never print, so they must not inherit a previous parse's flag.
+	_printing = false;
 };
 
 /**
@@ -2941,10 +2960,21 @@ const consumeABlocksContents = (ts, onNode) => {
 				}
 				ts.restoreMark();
 			}
+			const rawStart = t.start;
 			const rule = consumeAQualifiedRule(ts, TT_SEMICOLON, true);
 			if (rule) {
 				if (onNode) onNode(rule);
 				else (rules || (rules = [])).push(rule);
+			} else if (_printing) {
+				// Workaround, deliberately off-spec: §5.4 drops input both productions
+				// reject, which would silently delete IE hacks and template
+				// placeholders from minified output. Keep the source verbatim instead.
+				// Printing only, so the spec-exact tree is what every consumer sees.
+				const raw = _makeRaw(rawStart, ts.next().start);
+				if (raw !== undefined) {
+					if (onNode) onNode(/** @type {Rule} */ (raw));
+					else (rules || (rules = [])).push(/** @type {Rule} */ (raw));
+				}
 			}
 		}
 	}
@@ -3562,6 +3592,9 @@ const TOP_LEVEL_CONSUMERS = {
 /** @type {CompiledVisitorMap} */
 let _visitors = /** @type {CompiledVisitorMap} */ (/** @type {unknown} */ ([]));
 let _recurseBlocks = true;
+// Printing needs a faithful serialization, so it keeps dropped input as `T_RAW`
+// nodes; a walk-only parse leaves this false and allocates none.
+let _printing = false;
 /** @type {CompiledVisitorBucket | undefined} */
 let _commentBucket;
 
@@ -3755,15 +3788,21 @@ const _KEEP_COMMENT_RE = /@(?:license|preserve)/i;
 /**
  * A comment worth carrying through minification, matching terser's default set:
  * a `/*!` banner (fast char-code check, no allocation) or a `@license` /
- * `@preserve` annotated comment.
+ * `@preserve` annotated comment. `/*#` covers the `sourceMappingURL` /
+ * `sourceURL` pragmas, which are a link to drop, not a comment.
  * @param {string} src source text
  * @param {number} start comment start offset (at `/`)
  * @param {number} end comment end offset (past the closing `/`)
  * @returns {boolean} whether the comment survives minification
  */
-const _isKeptComment = (src, start, end) =>
-	src.charCodeAt(start + 2) === CC_EXCLAMATION ||
-	_KEEP_COMMENT_RE.test(src.slice(start, end));
+const _isKeptComment = (src, start, end) => {
+	const marker = src.charCodeAt(start + 2);
+	return (
+		marker === CC_EXCLAMATION ||
+		marker === CC_NUMBER_SIGN ||
+		_KEEP_COMMENT_RE.test(src.slice(start, end))
+	);
+};
 
 /**
  * The CSS `SourceProcessor` grammar: consume top-level rules one at a time
@@ -3790,6 +3829,7 @@ const grammar = (input, visitors, writer, options) => {
 	_skipSelectorPrelude = skip !== undefined && skip.selectorPrelude === true;
 	_skipAtRulePrelude = skip !== undefined && skip.atRulePrelude === true;
 	_recurseBlocks = options.recurseBlocks !== false;
+	_printing = writer !== undefined;
 	_visitors = visitors;
 	_commentBucket = visitors[T_COMMENT];
 
@@ -4395,6 +4435,11 @@ const printer = (path, writer) => {
 			}
 			return `${prelude}${soft}{${body}${nl}}`;
 		}
+		case T_RAW:
+			// Off-spec passthrough (see `NodeType.Raw`). It sits in a declaration
+			// list, so it carries the `;` separating it from the next item (stripped
+			// again before a `}`).
+			return `${path.source()};`;
 		case T_HASH: {
 			const raw = path.source();
 			// A hash is a hex color only in a value (`color:#abc`), an id in a selector

--- a/lib/html/htmlMinify.js
+++ b/lib/html/htmlMinify.js
@@ -25,11 +25,12 @@
  * @returns {{ code: string }} the minified HTML
  */
 const htmlMinify = (input, sourceMap, minimizerOptions = {}) => {
-	// eslint-disable-next-line import/no-extraneous-dependencies -- webpack self-require, re-resolved inside the worker
-	const webpack = require(/** @type {string} */ ("webpack"));
+	const webpack = /** @type {typeof import("../index")} */ (
+		// eslint-disable-next-line import/no-extraneous-dependencies -- webpack self-require, re-resolved inside the worker
+		require(/** @type {string} */ ("webpack"))
+	);
 
-	const { SourceProcessor } = /** @type {typeof import("../index")} */ (webpack)
-		.html.syntax;
+	const { SourceProcessor } = webpack.html.syntax;
 	const [[, code]] = Object.entries(input);
 	// `process` parses once, and with `minimize` its walk also prints the safely
 	// minified serialization — no second parse. It returns `{ code, map }`, but the

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8381,6 +8381,17 @@ const _LITERAL_TEXT_PARENTS = new Set([
 const _LEADING_NEWLINE_ELEMENTS = new Set(["pre", "textarea", "listing"]);
 
 /**
+ * Whether the text ends inside an unterminated character reference, so the next
+ * sibling's first characters could complete it (`a &am` + `p;`).
+ * @param {string} s source text
+ * @returns {boolean} true when a character reference is still open at the end
+ */
+const _hasOpenReference = (s) => {
+	const last = s.lastIndexOf("&");
+	return last !== -1 && !/[^\dA-Za-z#]/.test(s.slice(last + 1));
+};
+
+/**
  * Escape a text node's decoded data for re-serialization: only `&`, `<`, `>`,
  * the three that could otherwise start markup. Unlike the exported `escapeText`
  * (which also numerically encodes newlines and U+00A0 for single-line `data:`
@@ -8474,14 +8485,17 @@ const printer = (path, writer) => {
 			// Off-spec workaround: §13.3 escapes `<`/`>` in text, which would rewrite
 			// `<%= x %>` to `&lt;%= x %&gt;` in HTML webpack only passes through. Text
 			// that decoded to itself re-tokenizes to itself, so emit its source bytes.
-			// The guards are what keep that equivalence: a length mismatch means the
-			// node was merged or foster-parented and its range no longer describes
-			// `data`, and a trailing `<` could fuse with the next sibling once a
-			// comment between them is dropped.
+			// The guards are what keep that equivalence: every character reference is
+			// at least two characters longer than what it decodes to, so equal lengths
+			// mean nothing decoded — an unequal one means the node was merged or
+			// foster-parented and its range no longer describes `data`. The tail is
+			// checked separately because it is the only place concatenation can change
+			// tokenization: a `<`, or a `&` still open on a reference, would fuse with
+			// the next sibling once a comment between them is dropped.
 			if (
 				raw.length === data.length &&
-				!raw.includes("&") &&
-				raw.charCodeAt(raw.length - 1) !== 60
+				raw.charCodeAt(raw.length - 1) !== 60 &&
+				!_hasOpenReference(raw)
 			) {
 				return raw;
 			}

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8395,13 +8395,18 @@ const _escapeTextContent = (s) => {
 
 /**
  * Whether a comment must survive minification: downlevel conditional comments
- * (`<!--[if …]>` / `<![endif]-->`) drive IE branching and server-side includes
- * (`<!--#…-->`) are directives — both behavior-bearing. Every other comment is
- * inert, so dropping it preserves meaning.
+ * (`<!--[if …]>` / `<![endif]-->`) drive IE branching, server-side includes
+ * (`<!--#…-->`) are directives, and a `<?…?>` bogus comment is a server-side
+ * template tag — all behavior-bearing. Every other comment is inert, so
+ * dropping it preserves meaning.
  * @param {string} data comment data (between `<!--` and `-->`)
+ * @param {string} source the comment's source text, including its delimiters
  * @returns {boolean} true to keep the comment
  */
-const _keepComment = (data) => {
+const _keepComment = (data, source) => {
+	// `<?php … ?>` / `<%… %>` reach the tree as bogus comments (§13.2.5.42) but
+	// are server-side directives, so they outrank the inert-comment rule.
+	if (source.charCodeAt(1) === 63) return true;
 	const s = data.trimStart();
 	return s.startsWith("[if") || s.startsWith("[endif") || s.startsWith("#");
 };
@@ -8462,15 +8467,32 @@ const printer = (path, writer) => {
 			// Literal-text elements (`script` / `style` / …) keep their body raw;
 			// every other text node is escaped (the WHATWG text split).
 			const parent = path.parentOf();
-			return parent !== 0 && _LITERAL_TEXT_PARENTS.has(path.tagName(parent))
-				? data
-				: _escapeTextContent(data);
+			if (parent !== 0 && _LITERAL_TEXT_PARENTS.has(path.tagName(parent))) {
+				return data;
+			}
+			const raw = path.source();
+			// Off-spec workaround: §13.3 escapes `<`/`>` in text, which would rewrite
+			// `<%= x %>` to `&lt;%= x %&gt;` in HTML webpack only passes through. Text
+			// that decoded to itself re-tokenizes to itself, so emit its source bytes.
+			// The guards are what keep that equivalence: a length mismatch means the
+			// node was merged or foster-parented and its range no longer describes
+			// `data`, and a trailing `<` could fuse with the next sibling once a
+			// comment between them is dropped.
+			if (
+				raw.length === data.length &&
+				!raw.includes("&") &&
+				raw.charCodeAt(raw.length - 1) !== 60
+			) {
+				return raw;
+			}
+			return _escapeTextContent(data);
 		}
 		case NodeType.Doctype:
 			// A leaf with no children; its source is tight, so keep it verbatim.
 			return path.source();
 		case NodeType.Comment:
-			return writer.options.mode === "minify" && !_keepComment(path.data())
+			return writer.options.mode === "minify" &&
+				!_keepComment(path.data(), path.source())
 				? ""
 				: path.source();
 		default: {

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -873,6 +873,58 @@ describe("CssSyntax — minify token-boundary safety", () => {
 	});
 });
 
+describe("CssSyntax — minify keeps input the grammar rejects", () => {
+	/**
+	 * @param {string} src css source
+	 * @returns {string} the minified serialization
+	 */
+	const min = (src) =>
+		new SourceProcessor().process(src, { minimize: true }).code;
+
+	it("keeps the sourceMappingURL pragma", () => {
+		// A `/*#` pragma is a link, not a comment — dropping it breaks the map of
+		// an already-built stylesheet webpack only passes through.
+		expect(min("/*# sourceMappingURL=a.css.map */\n.v{color:red}")).toBe(
+			"/*# sourceMappingURL=a.css.map */.v{color:red}"
+		);
+		expect(min("/* inert */.v{color:red}")).toBe(".v{color:red}");
+	});
+
+	it("keeps a declaration neither production accepts", () => {
+		// The IE star hack is not a declaration and not a qualified rule, so §5.4
+		// discards it; minifying must still emit what the source had.
+		expect(min("a{*zoom:1;_height:1px;color:red}")).toBe(
+			"a{*zoom:1;_height:1px;color:red}"
+		);
+		expect(min("a{color:red;*zoom:1}")).toBe("a{color:red;*zoom:1}");
+		expect(min("@media screen{a{*zoom:1;color:red}}")).toBe(
+			"@media screen{a{*zoom:1;color:red}}"
+		);
+	});
+
+	it("keeps rejected input in a block's contents", () => {
+		expect(min("a{foo bar;color:red}")).toBe("a{foo bar;color:red}");
+		// A `{}` block in a value routes the whole declaration to the qualified-rule
+		// production; its contents are rejected there but must survive.
+		expect(min("a{color:{{x}}}")).toBe("a{color:{{x}}}");
+	});
+
+	it("trims to the rejected input itself", () => {
+		// Surrounding whitespace belongs to the block's own separators, and a span
+		// holding only whitespace carries nothing at all.
+		expect(min("a{   *zoom:1   ;color:red}")).toBe("a{*zoom:1;color:red}");
+		expect(min("a{;;;color:red}")).toBe("a{color:red}");
+	});
+
+	it("never materializes rejected input for a walk-only parse", () => {
+		// `Raw` exists only for the printer — a plain parse still drops the input,
+		// so consumers never see a node type they don't know.
+		const rule = parseAStylesheet("a{*zoom:1;color:red}").rules[0];
+		expect(rule.declarations).toHaveLength(1);
+		expect(rule.childRules).toHaveLength(0);
+	});
+});
+
 describe("CssSyntax — nesting and error recovery", () => {
 	/**
 	 * @param {string} src css source

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4675,3 +4675,42 @@ describe("tokenize — fused state transitions", () => {
 		]);
 	});
 });
+
+describe("htmlMinify — assets webpack only passes through", () => {
+	const htmlMinify = require("../lib/html/htmlMinify");
+
+	/**
+	 * @param {string} src html source
+	 * @returns {string} the minified serialization
+	 */
+	const min = (src) => htmlMinify({ "page.html": src }).code;
+
+	it("keeps server-side template tags", () => {
+		// `<?php … ?>` is a bogus comment per §13.2.5.42, so the inert-comment rule
+		// would delete the whole directive from a copied template.
+		expect(min("<?php echo $t; ?>\n<html><body><p>a</p></body></html>")).toBe(
+			"<?php echo $t; ?><html><body><p>a</p></body></html>"
+		);
+		expect(min("<html><body><!-- inert --><p>a</p></body></html>")).toBe(
+			"<html><body><p>a</p></body></html>"
+		);
+	});
+
+	it("keeps text-level template placeholders unescaped", () => {
+		// Escaping these to `&lt;%= t %&gt;` breaks the server-side render.
+		expect(min("<div>   <%= t %>   </div>")).toBe("<div>   <%= t %>   </div>");
+		expect(min("<div>{{ t }}</div>")).toBe("<div>{{ t }}</div>");
+	});
+
+	it("still escapes text that would re-parse as markup", () => {
+		// `a &lt;b&gt;c` decodes to `a <b>c`; emitting that raw would build a real
+		// `<b>` element, so the escaped form has to survive.
+		expect(min("<p>a &lt;b&gt;c</p>")).toBe("<p>a &lt;b&gt;c</p>");
+		expect(min("<p>a&amp;b</p>")).toBe("<p>a&amp;b</p>");
+		// Foster-parented text merges into one node whose range no longer covers
+		// its data — the source slice would drop the `c`.
+		expect(min("<table>a<tr><td>b</td></tr>c</table>")).toBe(
+			"ac<table><tr><td>b</td></tr></table>"
+		);
+	});
+});

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4718,6 +4718,25 @@ describe("htmlMinify — assets webpack only passes through", () => {
 		expect(min("<p>a<<!--c--></p>")).toBe("<p>a&lt;</p>");
 	});
 
+	it("keeps template expressions containing ampersands", () => {
+		// `&&` is everywhere in EJS/PHP conditionals; escaping it to `&amp;&amp;`
+		// breaks the server-side render just as escaping `<` does.
+		expect(min("<div><%= a && b %></div>")).toBe("<div><%= a && b %></div>");
+		expect(min("<div><% if (a && b) { %>x<% } %></div>")).toBe(
+			"<div><% if (a && b) { %>x<% } %></div>"
+		);
+		expect(min("<p>a & b</p>")).toBe("<p>a & b</p>");
+		expect(min("<p>a &foo; b</p>")).toBe("<p>a &foo; b</p>");
+	});
+
+	it("escapes a character reference left open at the end", () => {
+		// The next sibling could complete it (`a &am` + `p;`) once a comment
+		// between them is dropped, so only a closed tail passes through.
+		expect(min("<p>a &</p>")).toBe("<p>a &amp;</p>");
+		expect(min("<p>a &am</p>")).toBe("<p>a &amp;am</p>");
+		expect(min("<p>a &am<!--c-->p;</p>")).toBe("<p>a &amp;amp;</p>");
+	});
+
 	it("keeps the body of literal-text elements raw", () => {
 		// `script` / `style` bodies are not markup, so `<` must not be escaped —
 		// `a &lt; b` would change what the script does.

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4712,5 +4712,20 @@ describe("htmlMinify — assets webpack only passes through", () => {
 		expect(min("<table>a<tr><td>b</td></tr>c</table>")).toBe(
 			"ac<table><tr><td>b</td></tr></table>"
 		);
+		// A trailing `<` has to stay escaped: dropping a comment after it would
+		// let it fuse with the next sibling into a tag.
+		expect(min("<p>a<</p>")).toBe("<p>a&lt;</p>");
+		expect(min("<p>a<<!--c--></p>")).toBe("<p>a&lt;</p>");
+	});
+
+	it("keeps the body of literal-text elements raw", () => {
+		// `script` / `style` bodies are not markup, so `<` must not be escaped —
+		// `a &lt; b` would change what the script does.
+		expect(min("<script>if (a < b) { x(); }</script>")).toBe(
+			"<script>if (a < b) { x(); }</script>"
+		);
+		expect(min("<style>.a { color: red }</style>")).toBe(
+			"<style>.a { color: red }</style>"
+		);
 	});
 });

--- a/test/configCases/css/minimize-experiments-auto/index.js
+++ b/test/configCases/css/minimize-experiments-auto/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should minify auto-enabled CSS assets", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-experiments-auto/infrastructure-log.js
+++ b/test/configCases/css/minimize-experiments-auto/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.css$/
+];

--- a/test/configCases/css/minimize-experiments-auto/style.css
+++ b/test/configCases/css/minimize-experiments-auto/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-experiments-auto/test.config.js
+++ b/test/configCases/css/minimize-experiments-auto/test.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// The branch under test: no `experiments.css` and no rule for `.css` resolve to `"auto"`.
+		expect(read("experiments.txt")).toBe(JSON.stringify("auto"));
+
+		// Rendered by webpack itself.
+		expect(read("bundle0.css")).toBe(".native{color:red}");
+
+		// Emitted by another plugin and unclaimed, so the built-in minifier takes
+		// it too — a copied stylesheet still gets minimized.
+		expect(read("copied.css")).toBe(".copied{color:red}");
+
+		// Already marked `minimized`, so a minimizer the user configured has
+		// handled it — webpack must leave it exactly as it was.
+		expect(read("already.css")).toBe(".already {\n\tcolor : red ;\n}\n");
+	}
+};

--- a/test/configCases/css/minimize-experiments-auto/webpack.config.js
+++ b/test/configCases/css/minimize-experiments-auto/webpack.config.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const { sources } = require("../../../../");
+
+// Stands in for the plugins that emit CSS webpack never rendered itself
+// (copy-webpack-plugin, mini-css-extract-plugin, …). `already.css` arrives
+// flagged `minimized`, the way every minimizer built on
+// `minimizer-webpack-plugin` marks what it has handled.
+class EmitOtherCssAssetsPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"EmitOtherCssAssetsPlugin",
+			(compilation) => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "EmitOtherCssAssetsPlugin",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+					},
+					() => {
+						// Record what the `"auto"` resolution settled on so the test can
+						// assert which `lib/config/defaults.js` branch ran.
+						compilation.emitAsset(
+							"experiments.txt",
+							new sources.RawSource(
+								JSON.stringify(compiler.options.experiments.css)
+							)
+						);
+						compilation.emitAsset(
+							"copied.css",
+							new sources.RawSource(".copied {\n\tcolor : red ;\n}\n")
+						);
+						compilation.emitAsset(
+							"already.css",
+							new sources.RawSource(".already {\n\tcolor : red ;\n}\n"),
+							{ minimized: true }
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` expands to webpack's own default minimizer, so this drives the
+		// real `lib/config/defaults.js` wiring rather than a hand-built one.
+		minimizer: ["..."]
+	},
+	plugins: [new EmitOtherCssAssetsPlugin()]
+};

--- a/test/configCases/css/minimize-experiments-true/index.js
+++ b/test/configCases/css/minimize-experiments-true/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should minify explicitly enabled CSS assets", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-experiments-true/infrastructure-log.js
+++ b/test/configCases/css/minimize-experiments-true/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.css$/
+];

--- a/test/configCases/css/minimize-experiments-true/style.css
+++ b/test/configCases/css/minimize-experiments-true/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-experiments-true/test.config.js
+++ b/test/configCases/css/minimize-experiments-true/test.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// The branch under test: `experiments.css: true` is the explicit opt-in.
+		expect(read("experiments.txt")).toBe(JSON.stringify(true));
+
+		// Rendered by webpack itself.
+		expect(read("bundle0.css")).toBe(".native{color:red}");
+
+		// Emitted by another plugin and unclaimed, so the built-in minifier takes
+		// it too — a copied stylesheet still gets minimized.
+		expect(read("copied.css")).toBe(".copied{color:red}");
+
+		// Already marked `minimized`, so a minimizer the user configured has
+		// handled it — webpack must leave it exactly as it was.
+		expect(read("already.css")).toBe(".already {\n\tcolor : red ;\n}\n");
+	}
+};

--- a/test/configCases/css/minimize-experiments-true/webpack.config.js
+++ b/test/configCases/css/minimize-experiments-true/webpack.config.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const { sources } = require("../../../../");
+
+// Stands in for the plugins that emit CSS webpack never rendered itself
+// (copy-webpack-plugin, mini-css-extract-plugin, …). `already.css` arrives
+// flagged `minimized`, the way every minimizer built on
+// `minimizer-webpack-plugin` marks what it has handled.
+class EmitOtherCssAssetsPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"EmitOtherCssAssetsPlugin",
+			(compilation) => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "EmitOtherCssAssetsPlugin",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+					},
+					() => {
+						// Record what the `"auto"` resolution settled on so the test can
+						// assert which `lib/config/defaults.js` branch ran.
+						compilation.emitAsset(
+							"experiments.txt",
+							new sources.RawSource(
+								JSON.stringify(compiler.options.experiments.css)
+							)
+						);
+						compilation.emitAsset(
+							"copied.css",
+							new sources.RawSource(".copied {\n\tcolor : red ;\n}\n")
+						);
+						compilation.emitAsset(
+							"already.css",
+							new sources.RawSource(".already {\n\tcolor : red ;\n}\n"),
+							{ minimized: true }
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` expands to webpack's own default minimizer, so this drives the
+		// real `lib/config/defaults.js` wiring rather than a hand-built one.
+		minimizer: ["..."]
+	},
+	plugins: [new EmitOtherCssAssetsPlugin()],
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/minimize-minimizer-detection/index.js
+++ b/test/configCases/css/minimize-minimizer-detection/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+import "./page.html";
+
+it("should ignore configured entries that are not asset minimizers", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunks are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-minimizer-detection/page.html
+++ b/test/configCases/css/minimize-minimizer-detection/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/css/minimize-minimizer-detection/style.css
+++ b/test/configCases/css/minimize-minimizer-detection/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-minimizer-detection/test.config.js
+++ b/test/configCases/css/minimize-minimizer-detection/test.config.js
@@ -14,8 +14,9 @@ module.exports = {
 			fs.readFileSync(path.join(options.output.path, name), "utf8");
 
 		// Nothing in the configuration claims either type, so webpack minifies
-		// both itself.
-		expect(read("main.css")).toBe(".native{color:red}");
+		// both itself (the banner is `BannerPlugin`'s, and its presence shows that
+		// plugin was not mistaken for a CSS minimizer).
+		expect(read("main.css")).toBe("/*! banner */.native{color:red}");
 		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
 	}
 };

--- a/test/configCases/css/minimize-minimizer-detection/test.config.js
+++ b/test/configCases/css/minimize-minimizer-detection/test.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// Nothing in the configuration claims either type, so webpack minifies
+		// both itself.
+		expect(read("main.css")).toBe(".native{color:red}");
+		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
+	}
+};

--- a/test/configCases/css/minimize-minimizer-detection/webpack.config.js
+++ b/test/configCases/css/minimize-minimizer-detection/webpack.config.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+// A plugin carrying an `options` object that is not an asset matcher — reading
+// it as one would match every file and claim every type.
+class PluginWithUnrelatedOptions {
+	constructor() {
+		this.options = { filename: "[name].css" };
+	}
+
+	apply() {}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// None of these claim CSS or HTML: the default JS minimizer's matcher only
+		// covers `.js`, the `exclude` cancels the `.html` matcher for the probe
+		// name, and a plugin function has no options at all.
+		minimizer: [
+			"...",
+			new MinimizerPlugin({ test: /\.[cm]?js(\?.*)?$/i }),
+			new MinimizerPlugin({ test: /\.html$/i, exclude: /file/ }),
+			(compiler) => {
+				compiler.hooks.done.tap("NoopMinimizer", () => {});
+			}
+		]
+	},
+	plugins: [
+		new PluginWithUnrelatedOptions(),
+		// An `include`-only matcher that resolves to a different type.
+		{
+			options: { include: /\.svg$/i },
+			apply() {}
+		},
+		{
+			apply() {}
+		}
+	],
+	experiments: {
+		css: true,
+		html: true
+	}
+};

--- a/test/configCases/css/minimize-minimizer-detection/webpack.config.js
+++ b/test/configCases/css/minimize-minimizer-detection/webpack.config.js
@@ -30,13 +30,12 @@ module.exports = {
 	},
 	optimization: {
 		minimize: true,
-		// None of these claim CSS or HTML: the default JS minimizer's matcher only
-		// covers `.js`, the `exclude` cancels the `.html` matcher for the probe
-		// name, and a plugin function has no options at all.
+		// None of these claim CSS or HTML: two real minimizers whose matchers cover
+		// other types, and a plugin function with no options at all.
 		minimizer: [
 			"...",
 			new MinimizerPlugin({ test: /\.[cm]?js(\?.*)?$/i }),
-			new MinimizerPlugin({ test: /\.html$/i, exclude: /file/ }),
+			new MinimizerPlugin({ test: /\.json$/i, include: /\.txt$/i }),
 			(compiler) => {
 				compiler.hooks.done.tap("NoopMinimizer", () => {});
 			}

--- a/test/configCases/css/minimize-minimizer-detection/webpack.config.js
+++ b/test/configCases/css/minimize-minimizer-detection/webpack.config.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const MinimizerPlugin = require("minimizer-webpack-plugin");
+const { BannerPlugin, LoaderOptionsPlugin } = require("../../../../");
 
 // A plugin carrying an `options` object that is not an asset matcher — reading
 // it as one would match every file and claim every type.
@@ -42,6 +43,11 @@ module.exports = {
 		]
 	},
 	plugins: [
+		// Real plugins that carry `test`/`include`/`exclude` without being
+		// minimizers: `LoaderOptionsPlugin` defaults `test` to match every file,
+		// and a `BannerPlugin` scoped to CSS matches the probe name.
+		new LoaderOptionsPlugin({}),
+		new BannerPlugin({ banner: "banner", test: /\.css$/i }),
 		new PluginWithUnrelatedOptions(),
 		// An `include`-only matcher that resolves to a different type.
 		{

--- a/test/configCases/css/minimize-minimizer-in-plugins/index.js
+++ b/test/configCases/css/minimize-minimizer-in-plugins/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+import "./page.html";
+
+it("should detect a minimizer added to plugins, per asset type", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunks are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-minimizer-in-plugins/page.html
+++ b/test/configCases/css/minimize-minimizer-in-plugins/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/css/minimize-minimizer-in-plugins/style.css
+++ b/test/configCases/css/minimize-minimizer-in-plugins/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-minimizer-in-plugins/test.config.js
+++ b/test/configCases/css/minimize-minimizer-in-plugins/test.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// CSS is claimed, so it reaches the configured minimizer unminified.
+		const css = read("main.css");
+
+		expect(css.startsWith("/*user*/")).toBe(true);
+		expect(css).toContain("\n");
+
+		// HTML is claimed by nothing, so webpack still minifies it.
+		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
+	}
+};

--- a/test/configCases/css/minimize-minimizer-in-plugins/webpack.config.js
+++ b/test/configCases/css/minimize-minimizer-in-plugins/webpack.config.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		minimizer: ["..."]
+	},
+	// A minimizer belongs in `optimization.minimizer`, but it works from
+	// `plugins` too and is often put there. It claims CSS only, so HTML is still
+	// webpack's to minify.
+	plugins: [
+		new MinimizerPlugin({
+			test: /\.css$/i,
+			minify: (input) => ({ code: `/*user*/${Object.values(input)[0]}` }),
+			minimizerOptions: {}
+		})
+	],
+	experiments: {
+		css: true,
+		html: true
+	}
+};

--- a/test/configCases/css/minimize-minimizer-include-only/index.js
+++ b/test/configCases/css/minimize-minimizer-include-only/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+import "./page.html";
+
+it("should let a minimizer claim a type through include alone", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunks are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-minimizer-include-only/page.html
+++ b/test/configCases/css/minimize-minimizer-include-only/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/css/minimize-minimizer-include-only/style.css
+++ b/test/configCases/css/minimize-minimizer-include-only/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-minimizer-include-only/test.config.js
+++ b/test/configCases/css/minimize-minimizer-include-only/test.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// CSS is claimed through `include`, so webpack leaves it entirely to the
+		// configured minimizer — here one that does nothing, which is what
+		// claiming a whole type on a coarse match costs.
+		expect(read("main.css")).toContain("\n");
+
+		// HTML is claimed by nothing, so webpack still minifies it.
+		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
+	}
+};

--- a/test/configCases/css/minimize-minimizer-include-only/webpack.config.js
+++ b/test/configCases/css/minimize-minimizer-include-only/webpack.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+// A custom minimizer that declares the type it handles with `include` instead of
+// `test` — webpack must still recognize it and leave CSS alone.
+class IncludeOnlyCssMinimizer {
+	constructor() {
+		this.options = {
+			include: /\.css$/i,
+			minimizer: { implementation: () => {} }
+		};
+	}
+
+	apply() {}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		minimizer: ["...", new IncludeOnlyCssMinimizer()]
+	},
+	experiments: {
+		css: true,
+		html: true
+	}
+};

--- a/test/configCases/css/minimize-user-minimizer-both-types/index.js
+++ b/test/configCases/css/minimize-user-minimizer-both-types/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+import "./page.html";
+
+it("should leave both types to one minimizer that covers them", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunks are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-user-minimizer-both-types/page.html
+++ b/test/configCases/css/minimize-user-minimizer-both-types/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/css/minimize-user-minimizer-both-types/style.css
+++ b/test/configCases/css/minimize-user-minimizer-both-types/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-user-minimizer-both-types/test.config.js
+++ b/test/configCases/css/minimize-user-minimizer-both-types/test.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// Both reach the configured minimizer unminified — the marker is there and
+		// the source line breaks survive, so neither built-in minifier ran.
+		const css = read("main.css");
+		const html = read("page.html");
+
+		expect(css.startsWith("/*u*/")).toBe(true);
+		expect(css).toContain("\n");
+		expect(html.startsWith("<!--u-->")).toBe(true);
+		expect(html).toContain("\n  <body>");
+	}
+};

--- a/test/configCases/css/minimize-user-minimizer-both-types/webpack.config.js
+++ b/test/configCases/css/minimize-user-minimizer-both-types/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// One instance covering both types — the shape a project already using
+		// `minimizer-webpack-plugin` for CSS and HTML has. Webpack adds neither of
+		// its built-in minifiers.
+		minimizer: [
+			"...",
+			new MinimizerPlugin({
+				test: /\.(css|html)$/i,
+				minify: (input) => {
+					const [[name, code]] = Object.entries(input);
+
+					return {
+						code: `${name.endsWith(".css") ? "/*u*/" : "<!--u-->"}${code}`
+					};
+				},
+				minimizerOptions: {}
+			})
+		]
+	},
+	// Nothing to claim, but it follows the minimizer that already claimed both
+	// types — the scan must stop rather than keep probing.
+	plugins: [
+		{
+			apply() {}
+		}
+	],
+	experiments: {
+		css: true,
+		html: true
+	}
+};

--- a/test/configCases/css/minimize-user-minimizer/index.js
+++ b/test/configCases/css/minimize-user-minimizer/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should leave CSS to the minimizer the user configured", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-user-minimizer/infrastructure-log.js
+++ b/test/configCases/css/minimize-user-minimizer/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.css$/
+];

--- a/test/configCases/css/minimize-user-minimizer/style.css
+++ b/test/configCases/css/minimize-user-minimizer/style.css
@@ -1,0 +1,3 @@
+.native {
+	color : red ;
+}

--- a/test/configCases/css/minimize-user-minimizer/test.config.js
+++ b/test/configCases/css/minimize-user-minimizer/test.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// Both webpack's own stylesheet and the copied one reach the configured
+		// minimizer unminified: the marker is there and the source line breaks
+		// survive, so webpack's built-in CSS minifier never ran.
+		const own = read("bundle0.css");
+		const copied = read("copied.css");
+
+		expect(own.startsWith("/*user*/")).toBe(true);
+		expect(own).toContain("\n");
+		expect(copied).toBe("/*user*/.copied {\n\tcolor : red ;\n}\n");
+	}
+};

--- a/test/configCases/css/minimize-user-minimizer/webpack.config.js
+++ b/test/configCases/css/minimize-user-minimizer/webpack.config.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+const { sources } = require("../../../../");
+
+class EmitCopiedCssPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("EmitCopiedCssPlugin", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "EmitCopiedCssPlugin",
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(
+						"copied.css",
+						new sources.RawSource(".copied {\n\tcolor : red ;\n}\n")
+					);
+				}
+			);
+		});
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` is webpack's own default minimizer; the entry after it already
+		// claims `.css`, so webpack must not attach its built-in CSS minifier.
+		minimizer: [
+			"...",
+			new MinimizerPlugin({
+				test: /\.css$/i,
+				minify: (input) => ({ code: `/*user*/${Object.values(input)[0]}` }),
+				minimizerOptions: {}
+			})
+		]
+	},
+	plugins: [new EmitCopiedCssPlugin()],
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/minimize/style.css
+++ b/test/configCases/css/minimize/style.css
@@ -36,6 +36,14 @@
 	x : 1 ;
 }
 
+/* Input the CSS grammar rejects (an IE star hack) is still carried through
+   verbatim — minifying must never drop what the unminified asset keeps. */
+.hacks {
+	*zoom : 1 ;
+	_height : 1px ;
+	color : red ;
+}
+
 :not( .f ) .g {
 	content : "; } , keep {" ;
 }

--- a/test/configCases/css/minimize/test.config.js
+++ b/test/configCases/css/minimize/test.config.js
@@ -57,6 +57,9 @@ module.exports = {
 		// An id selector that looks like a hex color is NOT shortened (ids are
 		// case-sensitive and not colors).
 		expect(css).toContain("#ABCDEF{x:1}");
+		// Input the grammar rejects (`*zoom: 1`) is carried through verbatim
+		// instead of being dropped, so minifying loses nothing the source had.
+		expect(css).toContain(".hacks{*zoom : 1;_height:1px;color:red}");
 		// Whitespace around a top-level combinator (`.c > .d`) is trimmed, but the
 		// descendant combinator (the space in `:not(.f) .g`) is meaningful and kept.
 		expect(css).toContain(".c>.d,.e{");

--- a/test/configCases/html/minimize-experiments-auto/index.js
+++ b/test/configCases/html/minimize-experiments-auto/index.js
@@ -1,0 +1,7 @@
+import "./page.html";
+
+it("should minify auto-enabled HTML assets", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk (and its `.html`) is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-experiments-auto/infrastructure-log.js
+++ b/test/configCases/html/minimize-experiments-auto/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.html$/
+];

--- a/test/configCases/html/minimize-experiments-auto/page.html
+++ b/test/configCases/html/minimize-experiments-auto/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/html/minimize-experiments-auto/test.config.js
+++ b/test/configCases/html/minimize-experiments-auto/test.config.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// The branch under test: no `experiments.html` and no rule for `.html` resolve to `"auto"`.
+		expect(read("experiments.txt")).toBe(JSON.stringify("auto"));
+
+		// Rendered by webpack itself.
+		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
+
+		// Emitted by another plugin and unclaimed, so the built-in minifier takes
+		// it too: the inert comment goes, and the `<%= title %>` placeholder
+		// survives because text nodes serialize from their source bytes.
+		const copied = read("copied.html");
+
+		expect(copied).not.toContain("drop me");
+		expect(copied).toContain("<div><%= title %></div>");
+
+		// Already marked `minimized`, so a minimizer the user configured has
+		// handled it — webpack must leave it exactly as it was.
+		expect(read("already.html")).toBe(
+			"<!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+		);
+	}
+};

--- a/test/configCases/html/minimize-experiments-auto/webpack.config.js
+++ b/test/configCases/html/minimize-experiments-auto/webpack.config.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const { sources } = require("../../../../");
+
+// Stands in for the plugins that emit HTML webpack never rendered itself
+// (copy-webpack-plugin, html-webpack-plugin, …). `already.html` arrives flagged
+// `minimized`, the way every minimizer built on `minimizer-webpack-plugin`
+// marks what it has handled.
+class EmitOtherHtmlAssetsPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"EmitOtherHtmlAssetsPlugin",
+			(compilation) => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "EmitOtherHtmlAssetsPlugin",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+					},
+					() => {
+						// Record what the `"auto"` resolution settled on so the test can
+						// assert which `lib/config/defaults.js` branch ran.
+						compilation.emitAsset(
+							"experiments.txt",
+							new sources.RawSource(
+								JSON.stringify(compiler.options.experiments.html)
+							)
+						);
+						compilation.emitAsset(
+							"copied.html",
+							new sources.RawSource(
+								"<!DOCTYPE html>\n<html><body>\n<!-- drop me -->\n<div><%= title %></div>\n</body></html>\n"
+							)
+						);
+						compilation.emitAsset(
+							"already.html",
+							new sources.RawSource(
+								"<!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+							),
+							{ minimized: true }
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` expands to webpack's own default minimizer, so this drives the
+		// real `lib/config/defaults.js` wiring rather than a hand-built one.
+		minimizer: ["..."]
+	},
+	plugins: [new EmitOtherHtmlAssetsPlugin()]
+};

--- a/test/configCases/html/minimize-experiments-true/index.js
+++ b/test/configCases/html/minimize-experiments-true/index.js
@@ -1,0 +1,7 @@
+import "./page.html";
+
+it("should minify explicitly enabled HTML assets", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk (and its `.html`) is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-experiments-true/infrastructure-log.js
+++ b/test/configCases/html/minimize-experiments-true/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.html$/
+];

--- a/test/configCases/html/minimize-experiments-true/page.html
+++ b/test/configCases/html/minimize-experiments-true/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/html/minimize-experiments-true/test.config.js
+++ b/test/configCases/html/minimize-experiments-true/test.config.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// The branch under test: `experiments.html: true` is the explicit opt-in.
+		expect(read("experiments.txt")).toBe(JSON.stringify(true));
+
+		// Rendered by webpack itself.
+		expect(read("page.html")).toContain('<!DOCTYPE html><html lang="en">');
+
+		// Emitted by another plugin and unclaimed, so the built-in minifier takes
+		// it too: the inert comment goes, and the `<%= title %>` placeholder
+		// survives because text nodes serialize from their source bytes.
+		const copied = read("copied.html");
+
+		expect(copied).not.toContain("drop me");
+		expect(copied).toContain("<div><%= title %></div>");
+
+		// Already marked `minimized`, so a minimizer the user configured has
+		// handled it — webpack must leave it exactly as it was.
+		expect(read("already.html")).toBe(
+			"<!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+		);
+	}
+};

--- a/test/configCases/html/minimize-experiments-true/webpack.config.js
+++ b/test/configCases/html/minimize-experiments-true/webpack.config.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { sources } = require("../../../../");
+
+// Stands in for the plugins that emit HTML webpack never rendered itself
+// (copy-webpack-plugin, html-webpack-plugin, …). `already.html` arrives flagged
+// `minimized`, the way every minimizer built on `minimizer-webpack-plugin`
+// marks what it has handled.
+class EmitOtherHtmlAssetsPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"EmitOtherHtmlAssetsPlugin",
+			(compilation) => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "EmitOtherHtmlAssetsPlugin",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+					},
+					() => {
+						// Record what the `"auto"` resolution settled on so the test can
+						// assert which `lib/config/defaults.js` branch ran.
+						compilation.emitAsset(
+							"experiments.txt",
+							new sources.RawSource(
+								JSON.stringify(compiler.options.experiments.html)
+							)
+						);
+						compilation.emitAsset(
+							"copied.html",
+							new sources.RawSource(
+								"<!DOCTYPE html>\n<html><body>\n<!-- drop me -->\n<div><%= title %></div>\n</body></html>\n"
+							)
+						);
+						compilation.emitAsset(
+							"already.html",
+							new sources.RawSource(
+								"<!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+							),
+							{ minimized: true }
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` expands to webpack's own default minimizer, so this drives the
+		// real `lib/config/defaults.js` wiring rather than a hand-built one.
+		minimizer: ["..."]
+	},
+	plugins: [new EmitOtherHtmlAssetsPlugin()],
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/minimize-user-minimizer/index.js
+++ b/test/configCases/html/minimize-user-minimizer/index.js
@@ -1,0 +1,7 @@
+import "./page.html";
+
+it("should leave HTML to the minimizer the user configured", () => {
+	// The assertions on the emitted files live in test.config.js (afterExecute),
+	// this keeps a runnable entry so the chunk (and its `.html`) is produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-user-minimizer/infrastructure-log.js
+++ b/test/configCases/html/minimize-user-minimizer/infrastructure-log.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The copied asset comes from a plugin rather than the module graph, so the
+// minimizer's cache entry for it is always written after the pack was built —
+// the same pattern as `configCases/process-assets/html-plugin`.
+module.exports = [
+	/^Pack got invalid because of write to: TerserWebpackPlugin\|copied\.html$/
+];

--- a/test/configCases/html/minimize-user-minimizer/page.html
+++ b/test/configCases/html/minimize-user-minimizer/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>native</p>
+  </body>
+</html>

--- a/test/configCases/html/minimize-user-minimizer/test.config.js
+++ b/test/configCases/html/minimize-user-minimizer/test.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// `output.filename` is `[name].js`, so the test entry bundle is `main.js`.
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const read = (name) =>
+			fs.readFileSync(path.join(options.output.path, name), "utf8");
+
+		// Both pages reach the configured minimizer unminified: the marker is
+		// there, the copied file is byte-identical behind it, and webpack's own
+		// page still has its source line breaks — the built-in never ran.
+		const own = read("page.html");
+
+		expect(own.startsWith("<!--user-->")).toBe(true);
+		expect(own).toContain("\n");
+		expect(read("copied.html")).toBe(
+			"<!--user--><!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+		);
+	}
+};

--- a/test/configCases/html/minimize-user-minimizer/webpack.config.js
+++ b/test/configCases/html/minimize-user-minimizer/webpack.config.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+const { sources } = require("../../../../");
+
+class EmitCopiedHtmlPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"EmitCopiedHtmlPlugin",
+			(compilation) => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "EmitCopiedHtmlPlugin",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+					},
+					() => {
+						compilation.emitAsset(
+							"copied.html",
+							new sources.RawSource(
+								"<!DOCTYPE html>\n<html><body>\n<!-- keep me -->\n</body></html>\n"
+							)
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` is webpack's own default minimizer; the entry after it already
+		// claims `.html`, so webpack must not attach its built-in HTML minifier.
+		minimizer: [
+			"...",
+			new MinimizerPlugin({
+				test: /\.html$/i,
+				minify: (input) => ({ code: `<!--user-->${Object.values(input)[0]}` }),
+				minimizerOptions: {}
+			})
+		]
+	},
+	plugins: [new EmitCopiedHtmlPlugin()],
+	experiments: {
+		html: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -28980,6 +28980,7 @@ declare namespace exports {
 				export let QualifiedRule: number;
 				export let Stylesheet: number;
 				export let Comment: number;
+				export let Raw: number;
 			}
 			export let TT_AT_KEYWORD: 16;
 			export let TT_BAD_STRING_TOKEN: 4;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The built-in CSS/HTML minifiers added in #21491 tap the same `processAssets` stage as a user's own minimizer, and whichever ran first marked the asset `minimized` so the other silently did nothing — with `"..."` expanding ahead of the entries after it, webpack usually won and disabled the minimizer the user asked for (`["...", new CssMinimizerPlugin()]` produced 53 B where cssnano alone produced 25 B). The default now reads the asset matcher off every configured minimizer and plugin and claims only the types nothing else does, per type; deciding this at config time rather than by tap order keeps the result identical on every version of `minimizer-webpack-plugin`. Assets webpack only passes through are still minified, so this also stops `<?php … ?>`, `<%= x %>` and `/*# sourceMappingURL */` being dropped from copied files. Refs #21491.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — nine `test/configCases/{css,html}/minimize-*` cases (both `experiments` values, a minimizer in `optimization.minimizer` or in `plugins`, one covering both types, and entries that must not be mistaken for minimizers), plus `test/CssSyntax.unittest.js` and `test/HtmlSyntax.unittest.js` for the serializer changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — #21491 has not been released, so this only changes behaviour introduced within the same unreleased range.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Worth a line in the `optimization.minimizer` docs: webpack's built-in CSS/HTML minification steps aside for a minimizer already configured for that type, and the check is per type and coarse (a minimizer scoped with `include`/`exclude` still claims the whole type).

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used throughout: to reproduce the interaction against real `copy-webpack-plugin` / `css-minimizer-webpack-plugin` / `html-webpack-plugin` builds, to weigh the alternatives (an asset-info provenance marker and a later `processAssets` stage were both prototyped and rejected), and to write the implementation and tests. Every claim in this description was verified by running the builds and the test suites; all output was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3SPJcsf32H9s2wjjbgTje)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default production minification and CSS/HTML serialization; behavior changes are intentional but affect all builds using native CSS/HTML minify alongside custom minimizers.
> 
> **Overview**
> Fixes a race where webpack’s built-in CSS/HTML minifiers and a user’s `minimizer-webpack-plugin` (e.g. `CssMinimizerPlugin` after `"..."`) both ran on the same assets—whoever ran first set `minimized` and the other was skipped. **`getClaimedAssetTypes`** scans `optimization.minimizer` and `plugins` for real minimizers (`options.minimizer` plus `test`/`include` on probe names) and the default **Terser** setup only attaches native **cssMinify** / **htmlMinify** for types nothing else claims.
> 
> **CSS/HTML serializers** are tightened for assets webpack only passes through: CSS keeps grammar-rejected input via printing-only **`Raw`** nodes, preserves `/*# sourceMappingURL */`, and HTML keeps `<?…?>` directives, template text when safe, and stricter comment rules. Many **configCases** and unit tests cover claiming, experiments auto/true, and false-positive detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223c971a61d1ca3ad849188e0c259f0fbc6b8526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->