### PR TITLE
fix(parser): report strict-mode-invalid binding names in ES module output

### DIFF
--- a/.changeset/100-strict-mode-binding-names.md
+++ b/.changeset/100-strict-mode-binding-names.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Report bindings named `eval`, `arguments` or reserved words in ES module output.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -4046,6 +4046,17 @@ class JavascriptParser extends Parser {
 					`"${name}" is not allowed as a parameter name`,
 					param
 				);
+			} else if (STRICT_MODE_RESERVED_WORDS.has(name)) {
+				this._reportStrictModeViolation(
+					`"${name}" is a reserved word in strict mode and is not allowed as a parameter name`,
+					param
+				);
+			} else if (name === "await") {
+				this._reportStrictModeViolation(
+					'"await" is not allowed as a parameter name',
+					param,
+					MODULE_GOAL_OUTPUT_REASON
+				);
 			}
 			if (seen === undefined) seen = new Set();
 			if (seen.has(name)) {
@@ -4307,6 +4318,10 @@ class JavascriptParser extends Parser {
 	 * @param {ClassExpression} expression the class expression
 	 */
 	walkClassExpression(expression) {
+		// only `await` reaches here, as for class declarations
+		if (this._strictInModuleOutput && expression.id) {
+			this._checkStrictModeBinding(expression.id.name, expression.id);
+		}
 		this.walkClass(expression);
 	}
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -4379,6 +4379,16 @@ class JavascriptParser extends Parser {
 		};
 		const { params, type } = functionExpression;
 		const arrow = type === "ArrowFunctionExpression";
+		// the walk skips walkFunctionExpression for a called function expression
+		if (this._strictInModuleOutput) {
+			this._checkStrictModeParams(params);
+			if (type === "FunctionExpression" && functionExpression.id) {
+				this._checkStrictModeBinding(
+					functionExpression.id.name,
+					functionExpression.id
+				);
+			}
+		}
 		const renameThis = currentThis ? getVarInfo(currentThis) : null;
 		const varInfoForArgs = options.map(getVarInfo);
 		const wasTopLevel = this.scope.topLevelScope;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -496,6 +496,25 @@ const EVALUATE_AST_CACHE_LIMIT = 4096;
 
 const CLASS_NAME = "JavascriptParser";
 
+// Reserved words in strict mode, so unusable as binding names there (12.7.2).
+const STRICT_MODE_RESERVED_WORDS = new Set([
+	"implements",
+	"interface",
+	"let",
+	"package",
+	"private",
+	"protected",
+	"public",
+	"static",
+	"yield"
+]);
+
+const STRICT_MODE_OUTPUT_REASON =
+	"The output is an ES module, which runs in strict mode.";
+// `await` is reserved by the module goal rather than by strict mode itself.
+const MODULE_GOAL_OUTPUT_REASON =
+	'The output is an ES module, where "await" is a reserved word.';
+
 class JavascriptParser extends Parser {
 	/**
 	 * Creates an instance of JavascriptParser.
@@ -2872,6 +2891,9 @@ class JavascriptParser extends Parser {
 	 */
 	preWalkFunctionDeclaration(statement) {
 		if (statement.id) {
+			if (this._strictInModuleOutput) {
+				this._checkStrictModeBinding(statement.id.name, statement.id);
+			}
 			this.defineVariable(statement.id.name);
 		}
 	}
@@ -3263,12 +3285,14 @@ class JavascriptParser extends Parser {
 	_preWalkVariableDeclaration(statement, hookMap) {
 		/** @type {OnIdent | undefined} */
 		let onIdent;
+		const checkStrictBindings = this._strictInModuleOutput;
 		for (const declarator of statement.declarations) {
 			if (declarator.type !== "VariableDeclarator") continue;
 			this.preWalkVariableDeclarator(declarator);
 			if (this.hooks.preDeclarator.call(declarator, statement)) continue;
 			const id = declarator.id;
 			if (id.type === "Identifier") {
+				if (checkStrictBindings) this._checkStrictModeBinding(id.name, id);
 				// fast path: plain `const x =` skips the enterPattern dispatch and
 				// the per-declaration onIdent closure (only patterns need it)
 				if (!this.callHooksForName(this.hooks.pattern, id.name, id)) {
@@ -3276,8 +3300,10 @@ class JavascriptParser extends Parser {
 				}
 			} else {
 				if (onIdent === undefined) {
-					onIdent = (name, ident) =>
+					onIdent = (name, ident) => {
+						if (checkStrictBindings) this._checkStrictModeBinding(name, ident);
 						this._defineVariableForDeclaration(name, ident, hookMap);
+					};
 				}
 				this.enterPattern(id, onIdent);
 			}
@@ -3447,6 +3473,11 @@ class JavascriptParser extends Parser {
 	 */
 	blockPreWalkClassDeclaration(statement) {
 		if (statement.id) {
+			// only `await` reaches here: acorn rejects the other names itself,
+			// since a class body is always strict even in a loose script
+			if (this._strictInModuleOutput) {
+				this._checkStrictModeBinding(statement.id.name, statement.id);
+			}
 			this.defineVariable(statement.id.name);
 		}
 	}
@@ -3527,7 +3558,10 @@ class JavascriptParser extends Parser {
 		this.inBlockScope(() => {
 			// Error binding is optional in catch clause since ECMAScript 2019
 			if (catchClause.param !== null) {
-				this.enterPattern(catchClause.param, (ident) => {
+				this.enterPattern(catchClause.param, (ident, identifier) => {
+					if (this._strictInModuleOutput) {
+						this._checkStrictModeBinding(ident, identifier);
+					}
 					this.defineVariable(ident);
 				});
 				this.walkPattern(catchClause.param);
@@ -3830,6 +3864,9 @@ class JavascriptParser extends Parser {
 
 		if (this._strictInModuleOutput) {
 			this._checkStrictModeParams(expression.params);
+			if (expression.id) {
+				this._checkStrictModeBinding(expression.id.name, expression.id);
+			}
 		}
 		this.inFunctionScope(true, scopeParams, () => {
 			for (const param of expression.params) {
@@ -3968,6 +4005,32 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
+	 * Reports a binding name a loose script allows but strict-mode ESM output
+	 * rejects — the whole bundle fails to parse, so this is never merely latent.
+	 * @param {string} name binding name
+	 * @param {Statement | Expression | Identifier} node node to report the violation at
+	 */
+	_checkStrictModeBinding(name, node) {
+		if (name === "eval" || name === "arguments") {
+			this._reportStrictModeViolation(
+				`"${name}" is not allowed as a binding name`,
+				node
+			);
+		} else if (STRICT_MODE_RESERVED_WORDS.has(name)) {
+			this._reportStrictModeViolation(
+				`"${name}" is a reserved word in strict mode and is not allowed as a binding name`,
+				node
+			);
+		} else if (name === "await") {
+			this._reportStrictModeViolation(
+				'"await" is not allowed as a binding name',
+				node,
+				MODULE_GOAL_OUTPUT_REASON
+			);
+		}
+	}
+
+	/**
 	 * Reports strict-mode-only errors in a function's parameter list: a duplicate
 	 * simple parameter, or a parameter named `eval` / `arguments`.
 	 * @param {(import("estree").Pattern)[]} params function parameters
@@ -4036,10 +4099,11 @@ class JavascriptParser extends Parser {
 	 * The location is computed here, on the rare violation path only.
 	 * @param {string} reason what is not allowed
 	 * @param {Statement | Expression | Identifier} node node to report the violation at
+	 * @param {string=} outputReason why the output rejects it, defaults to strict mode
 	 */
-	_reportStrictModeViolation(reason, node) {
+	_reportStrictModeViolation(reason, node, outputReason) {
 		const diagnostic = new WebpackError(
-			`${reason}. The output is an ES module, which runs in strict mode.`
+			`${reason}. ${outputReason === undefined ? STRICT_MODE_OUTPUT_REASON : outputReason}`
 		);
 		diagnostic.loc = this.getLocation(node);
 		if (this.options.strictModeViolations === "error") {

--- a/test/configCases/parsing/strict-mode-module-output-bindings/index.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/index.js
@@ -1,0 +1,1 @@
+import "./mod.js";

--- a/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
@@ -28,6 +28,18 @@ function awaitLocal() {
 }
 class await {}
 
+// Parameters are bindings too, including on arrow functions.
+function reservedParam(static) {
+	return static;
+}
+var arrowParam = (package) => package;
+function awaitParam(await) {
+	return await;
+}
+
+// A named class expression binds its name, same as a declaration.
+var namedClass = class await {};
+
 // Unaffected: reserved words are valid as property and method names.
 var properties = { static: 1, public: 2, await: 3 };
 var readsProperty = properties.static + properties.public;
@@ -44,6 +56,10 @@ module.exports = {
 	arguments,
 	awaitLocal,
 	await,
+	reservedParam,
+	arrowParam,
+	awaitParam,
+	namedClass,
 	readsProperty,
 	normalBinding
 };

--- a/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
@@ -40,6 +40,15 @@ function awaitParam(await) {
 // A named class expression binds its name, same as a declaration.
 var namedClass = class await {};
 
+// A called function expression is walked as an IIFE, not through
+// walkFunctionExpression.
+var iifeName = (function yield() {
+	return 1;
+})();
+var iifeParam = (function (static) {
+	return static;
+})(1);
+
 // Unaffected: reserved words are valid as property and method names.
 var properties = { static: 1, public: 2, await: 3 };
 var readsProperty = properties.static + properties.public;
@@ -60,6 +69,8 @@ module.exports = {
 	arrowParam,
 	awaitParam,
 	namedClass,
+	iifeName,
+	iifeParam,
 	readsProperty,
 	normalBinding
 };

--- a/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/mod.js
@@ -1,0 +1,49 @@
+// Sloppy CommonJS module: every binding below is legal in a loose script, so
+// acorn accepts it, but each one is a SyntaxError once the module is emitted
+// into strict-mode ESM output — the bundle would not parse at all.
+var eval = 1;
+function static() {}
+var namedExpression = function yield() {};
+var { package } = { package: 1 };
+var [private] = [1];
+var interface = 2;
+
+function reservedLocals() {
+	var protected = 1;
+	var public = 2;
+	return protected + public;
+}
+
+let arguments = 3;
+
+try {
+	null.x;
+} catch (implements) {}
+
+// `await` is not strict-mode-reserved, but it is reserved in module code, so
+// these break in ESM output for the same reason.
+function awaitLocal() {
+	var await = 4;
+	return await;
+}
+class await {}
+
+// Unaffected: reserved words are valid as property and method names.
+var properties = { static: 1, public: 2, await: 3 };
+var readsProperty = properties.static + properties.public;
+var normalBinding = 5;
+
+module.exports = {
+	eval,
+	static,
+	namedExpression,
+	package,
+	private,
+	interface,
+	reservedLocals,
+	arguments,
+	awaitLocal,
+	await,
+	readsProperty,
+	normalBinding
+};

--- a/test/configCases/parsing/strict-mode-module-output-bindings/test.config.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/test.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// The bundle intentionally keeps strict-mode-reserved bindings, so it must not run.
+module.exports.noTests = true;

--- a/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
@@ -36,5 +36,17 @@ module.exports = [
 		}
 	],
 	[{ message: /"await" is not allowed as a parameter name/ }],
-	[{ message: /"await" is not allowed as a binding name/ }]
+	[{ message: /"await" is not allowed as a binding name/ }],
+	[
+		{
+			message:
+				/"yield" is a reserved word in strict mode and is not allowed as a binding name/
+		}
+	],
+	[
+		{
+			message:
+				/"static" is a reserved word in strict mode and is not allowed as a parameter name/
+		}
+	]
 ];

--- a/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
@@ -1,0 +1,26 @@
+"use strict";
+
+module.exports = [
+	[
+		{
+			message: /"eval" is not allowed as a binding name/,
+			moduleName: /mod\.js/
+		}
+	],
+	[{ message: /"static" is a reserved word in strict mode/ }],
+	[{ message: /"yield" is a reserved word in strict mode/ }],
+	[{ message: /"package" is a reserved word in strict mode/ }],
+	[{ message: /"private" is a reserved word in strict mode/ }],
+	[{ message: /"interface" is a reserved word in strict mode/ }],
+	[{ message: /"protected" is a reserved word in strict mode/ }],
+	[{ message: /"public" is a reserved word in strict mode/ }],
+	[{ message: /"arguments" is not allowed as a binding name/ }],
+	[{ message: /"implements" is a reserved word in strict mode/ }],
+	[
+		{
+			message:
+				/"await" is not allowed as a binding name\. The output is an ES module, where "await" is a reserved word\./
+		}
+	],
+	[{ message: /"await" is not allowed as a binding name/ }]
+];

--- a/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/warnings.js
@@ -22,5 +22,19 @@ module.exports = [
 				/"await" is not allowed as a binding name\. The output is an ES module, where "await" is a reserved word\./
 		}
 	],
+	[{ message: /"await" is not allowed as a binding name/ }],
+	[
+		{
+			message:
+				/"static" is a reserved word in strict mode and is not allowed as a parameter name/
+		}
+	],
+	[
+		{
+			message:
+				/"package" is a reserved word in strict mode and is not allowed as a parameter name/
+		}
+	],
+	[{ message: /"await" is not allowed as a parameter name/ }],
 	[{ message: /"await" is not allowed as a binding name/ }]
 ];

--- a/test/configCases/parsing/strict-mode-module-output-bindings/webpack.config.js
+++ b/test/configCases/parsing/strict-mode-module-output-bindings/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	output: {
+		module: true,
+		chunkFormat: "module",
+		library: { type: "module" }
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/test/configCases/parsing/strict-mode-module-output-semantics-future-defaults/errors.js
+++ b/test/configCases/parsing/strict-mode-module-output-semantics-future-defaults/errors.js
@@ -18,5 +18,8 @@ module.exports = [
 	],
 	[{ message: /Assigning to the read-only global "NaN" is not allowed/ }],
 	[{ message: /Assigning to the read-only global "Infinity" is not allowed/ }],
-	[{ message: /Assigning to "eval" is not allowed/ }]
+	[{ message: /Assigning to "eval" is not allowed/ }],
+	// shadowing `arguments` suppresses the member checks, but the binding itself
+	// is a strict-mode SyntaxError
+	[{ message: /"arguments" is not allowed as a binding name/ }]
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

A loose script keeps binding names that strict mode rejects, so acorn accepts them, but emitting the module as ES module output makes the whole bundle fail to parse — previously with no diagnostic at all. This extends `strictModeViolations` to bindings named `eval`/`arguments`, the strict-mode reserved words, and `await` (reserved by the module goal, so it gets its own message), covering variable declarations, function/class declaration names, named function expressions and catch parameters. Refs #17121, and closes the gap left by #21387/#21434.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/parsing/strict-mode-module-output-bindings` (12 diagnostics across every binding form), plus an added expectation in `strict-mode-module-output-semantics-future-defaults`, where shadowing `arguments` is itself a strict-mode SyntaxError.

**Does this PR introduce a breaking change?**

No — reported as warnings by default, errors only under `experiments.futureDefaults`, and suppressible with `strictModeViolations: false`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Extend the `strictModeViolations` note with the binding-name diagnostics.

**Use of AI**

Yes. Claude Code was used to enumerate the strict-mode early errors from the spec, build fixtures proving each one breaks the emitted bundle, implement the checks and write the tests; I reviewed the diff and verified the runs before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_016mxFzPn7Fko3AgbmjkDazQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot parse paths in JavascriptParser for every binding form when ESM output is enabled; behavior is gated by strictModeViolations and only affects loose modules emitted as strict ESM.
> 
> **Overview**
> Extends **`strictModeViolations`** so loose source that would **fail to parse** once emitted as strict ES module output gets a **warning or error** instead of a silent broken bundle.
> 
> **`JavascriptParser`** now flags binding names that strict mode or module goal reject: **`eval`**, **`arguments`**, strict reserved words (`static`, `yield`, `package`, etc.), and **`await`** (with a distinct module-goal message). Checks run when `_strictInModuleOutput` is set—variable and destructuring declarations, function/class declaration names, parameters (including arrows), catch bindings, named function expressions, class expressions, and **IIFE** paths that bypass `walkFunctionExpression`. Parameter checking also covers reserved words and `await`, not only `eval`/`arguments`.
> 
> Diagnostics still honor **`strictModeViolations`** (warn vs error vs off). A new config-case asserts the expected warnings; **`strict-mode-module-output-semantics-future-defaults`** adds an expectation that shadowing **`arguments`** is reported as an invalid binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2caec488e5a4e9ba7b2e94247dddc42df8e54fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->