### PR TITLE
fix: keep a nested bundle's runtime tables out of the chunk's scope

### DIFF
--- a/.changeset/110-nested-webpack-runtime-tables.md
+++ b/.changeset/110-nested-webpack-runtime-tables.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep a nested bundle's runtime tables separate when bundling webpack output.

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -34,6 +34,7 @@ const { last, someInIterable } = require("../util/IterableHelpers");
 const StringXor = require("../util/StringXor");
 const { compareModulesByFullName } = require("../util/comparators");
 const {
+	CHUNK_RUNTIME_DECLARATIONS,
 	RESERVED_NAMES,
 	addScopeSymbols,
 	findNewName,
@@ -1758,6 +1759,21 @@ class JavascriptModulesPlugin {
 							"// This entry module doesn't tell about it's top-level declarations so it can't be inlined"
 						);
 						result.allowInlineStartup = false;
+					}
+					if (result.allowInlineStartup) {
+						const topLevelDeclarations =
+							(data && data.get("topLevelDeclarations")) ||
+							(entryModule.buildInfo &&
+								entryModule.buildInfo.topLevelDeclarations);
+						for (const name of CHUNK_RUNTIME_DECLARATIONS) {
+							if (/** @type {Set<string>} */ (topLevelDeclarations).has(name)) {
+								buf2.push(
+									`// This entry module declares '${name}' on top-level, which the runtime also declares, so it can't be inlined`
+								);
+								result.allowInlineStartup = false;
+								break;
+							}
+						}
 					}
 					if (result.allowInlineStartup) {
 						const bailout = hooks.inlineInRuntimeBailout.call(

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1761,10 +1761,12 @@ class JavascriptModulesPlugin {
 						result.allowInlineStartup = false;
 					}
 					if (result.allowInlineStartup) {
+						// the bail-out above already established that one of the two
+						// sources carries them
 						const topLevelDeclarations =
 							(data && data.get("topLevelDeclarations")) ||
-							(entryModule.buildInfo &&
-								entryModule.buildInfo.topLevelDeclarations);
+							/** @type {BuildInfo} */ (entryModule.buildInfo)
+								.topLevelDeclarations;
 						for (const name of CHUNK_RUNTIME_DECLARATIONS) {
 							if (/** @type {Set<string>} */ (topLevelDeclarations).has(name)) {
 								buf2.push(

--- a/lib/util/concatenate.js
+++ b/lib/util/concatenate.js
@@ -276,11 +276,21 @@ const addScopeSymbols = (s, nameSet, scopeSet1, scopeSet2) => {
 	}
 };
 
+// Declared by the chunk bootstrap in the scope module code is hoisted into.
+// Hit when a webpack bundle is bundled again, since its output declares exactly
+// these: the `const` one then fails to parse, the `var` one silently clobbers
+// the module table. CompatibilityPlugin renames the other two runtime names.
+const CHUNK_RUNTIME_DECLARATIONS = new Set([
+	"__webpack_modules__",
+	"__webpack_module_cache__"
+]);
+
 const RESERVED_NAMES = new Set(
 	[
 		// internal names (should always be renamed)
 		DEFAULT_EXPORT,
 		NAMESPACE_OBJECT_EXPORT,
+		...CHUNK_RUNTIME_DECLARATIONS,
 
 		// keywords
 		"abstract,arguments,async,await,boolean,break,byte,case,catch,char,class,const,continue",
@@ -343,6 +353,7 @@ const getUsedNamesInScopeInfo = (usedNamesInScopeInfo, module, id) => {
 };
 
 module.exports = {
+	CHUNK_RUNTIME_DECLARATIONS,
 	DEFAULT_EXPORT,
 	NAMESPACE_OBJECT_EXPORT,
 	RESERVED_NAMES,

--- a/test/configCases/module/consume-webpack-runtime-tables/index.js
+++ b/test/configCases/module/consume-webpack-runtime-tables/index.js
@@ -1,0 +1,10 @@
+import value, { moduleIds } from "./lib.js";
+
+it("should keep a nested bundle's runtime tables separate from the chunk's own", async () => {
+	// the nested table must still hold its module, not the chunk's empty one
+	expect(moduleIds).toEqual(["940"]);
+	expect(value).toBe(42);
+	// a dynamic import forces the chunk to have its own runtime tables
+	const lazy = await import("./lazy.js");
+	expect(lazy.default).toBe(7);
+});

--- a/test/configCases/module/consume-webpack-runtime-tables/lazy.js
+++ b/test/configCases/module/consume-webpack-runtime-tables/lazy.js
@@ -1,0 +1,1 @@
+export default 7;

--- a/test/configCases/module/consume-webpack-runtime-tables/lib.js
+++ b/test/configCases/module/consume-webpack-runtime-tables/lib.js
@@ -1,0 +1,20 @@
+// Shaped like another webpack bundle's ESM output: the chunk bootstrap declares
+// these same names, so without renaming both land in one scope — `const` fails
+// to parse and `var` silently clobbers the table.
+var __webpack_modules__ = ({
+	940: ((module, exports) => {
+		exports.value = 42;
+	})
+});
+const __webpack_module_cache__ = {};
+function __webpack_require__(moduleId) {
+	const cachedModule = __webpack_module_cache__[moduleId];
+	if (cachedModule !== undefined) return cachedModule.exports;
+	const module = (__webpack_module_cache__[moduleId] = { exports: {} });
+	__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+	return module.exports;
+}
+__webpack_require__.m = __webpack_modules__;
+
+export const moduleIds = Object.keys(__webpack_modules__);
+export default __webpack_require__(940).value;

--- a/test/configCases/module/consume-webpack-runtime-tables/webpack.config.js
+++ b/test/configCases/module/consume-webpack-runtime-tables/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		name: "concatenated",
+		target: "node",
+		optimization: { concatenateModules: true },
+		experiments: { outputModule: true },
+		output: { module: true, chunkFormat: "module" }
+	},
+	{
+		name: "not-concatenated",
+		target: "node",
+		optimization: { concatenateModules: false },
+		experiments: { outputModule: true },
+		output: { module: true, chunkFormat: "module" }
+	}
+];

--- a/test/configCases/module/dynamic-import-specifier-output/a.js
+++ b/test/configCases/module/dynamic-import-specifier-output/a.js
@@ -1,0 +1,2 @@
+import { shared } from "./shared.js";
+export default 1 + shared();

--- a/test/configCases/module/dynamic-import-specifier-output/b.js
+++ b/test/configCases/module/dynamic-import-specifier-output/b.js
@@ -1,0 +1,2 @@
+import { shared } from "./shared.js";
+export default 2 + shared();

--- a/test/configCases/module/dynamic-import-specifier-output/index.js
+++ b/test/configCases/module/dynamic-import-specifier-output/index.js
@@ -1,0 +1,13 @@
+import { shared } from "./shared.js";
+
+it("should emit literal relative specifiers, not public path concatenation", async () => {
+	const a = await import("./a.js");
+	expect(a.default + shared()).toBe(21);
+
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const source = fs.readFileSync(path.join(__dirname, "bundle0.mjs"), "utf-8");
+	// statically analysable: the specifier is a literal, not built at runtime
+	expect(source).toMatch(/import\(\s*(?:\/\*[^*]*\*\/\s*)?"\.\//);
+	expect(source).not.toMatch(/__webpack_require__\.p\s*\+/);
+});

--- a/test/configCases/module/dynamic-import-specifier-output/shared.js
+++ b/test/configCases/module/dynamic-import-specifier-output/shared.js
@@ -1,0 +1,1 @@
+export const shared = () => 10;

--- a/test/configCases/module/dynamic-import-specifier-output/test.config.js
+++ b/test/configCases/module/dynamic-import-specifier-output/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return [`bundle${i}.mjs`];
+	}
+};

--- a/test/configCases/module/dynamic-import-specifier-output/test.filter.js
+++ b/test/configCases/module/dynamic-import-specifier-output/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// Reading the emitted bundle uses `__non_webpack_require__`, which webpack
+// serves in ESM output through `createRequire` — added in Node 12.
+module.exports = function filter() {
+	const major = Number(process.versions.node.split(".")[0]);
+	return major >= 12;
+};

--- a/test/configCases/module/dynamic-import-specifier-output/webpack.config.js
+++ b/test/configCases/module/dynamic-import-specifier-output/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	target: "node",
+	// splitChunks gives the chunks a dependency of their own, so the runtime
+	// chunk-loading path is exercised as well as the import sites
+	optimization: { splitChunks: { chunks: "all", minSize: 0 } },
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "bundle0.mjs",
+		chunkFilename: "[name].chunk.mjs",
+		publicPath: "auto"
+	}
+};

--- a/test/configCases/module/dynamic-import-specifier/a.js
+++ b/test/configCases/module/dynamic-import-specifier/a.js
@@ -1,0 +1,2 @@
+import { shared } from "./shared.js";
+export default 1 + shared();

--- a/test/configCases/module/dynamic-import-specifier/b.js
+++ b/test/configCases/module/dynamic-import-specifier/b.js
@@ -1,0 +1,2 @@
+import { shared } from "./shared.js";
+export default 2 + shared();

--- a/test/configCases/module/dynamic-import-specifier/index.js
+++ b/test/configCases/module/dynamic-import-specifier/index.js
@@ -1,0 +1,9 @@
+import { shared } from "./shared.js";
+
+// Chunks are addressed by a literal relative specifier, so ESM resolves them
+// against the emitting bundle's own URL — no public path is involved.
+it("should load chunks through relative specifiers on every target", async () => {
+	const a = await import("./a.js");
+	const b = await import("./b.js");
+	expect(a.default + b.default + shared()).toBe(33);
+});

--- a/test/configCases/module/dynamic-import-specifier/shared.js
+++ b/test/configCases/module/dynamic-import-specifier/shared.js
@@ -1,0 +1,1 @@
+export const shared = () => 10;

--- a/test/configCases/module/dynamic-import-specifier/test.config.js
+++ b/test/configCases/module/dynamic-import-specifier/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return [`bundle${i}.mjs`];
+	}
+};

--- a/test/configCases/module/dynamic-import-specifier/webpack.config.js
+++ b/test/configCases/module/dynamic-import-specifier/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration[]} */
+module.exports = ["node", "web"].map((target, index) => ({
+	name: target,
+	target,
+	// splitChunks gives the chunks a dependency of their own, so the runtime
+	// chunk-loading path is exercised as well as the import sites
+	optimization: { splitChunks: { chunks: "all", minSize: 0 } },
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: `bundle${index}.mjs`,
+		chunkFilename: `[name].${index}.chunk.mjs`,
+		publicPath: "auto"
+	}
+}));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Bundling webpack output again puts the nested bundle's top-level `__webpack_modules__` and `__webpack_module_cache__` in the same scope as the consuming chunk's bootstrap: the `const` one then fails to parse, and the `var` one is a legal redeclaration that silently clobbers the module table, so the bundle loads and throws later. `CompatibilityPlugin` already renames `__webpack_require__` and `__webpack_exports__` for exactly this reason; this reserves the other two names when concatenating and stops inlining an entry module that declares one. Refs #17121 ("consuming build output at build time").

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/module/consume-webpack-runtime-tables` under both `concatenateModules: true` and `false` (confirmed failing on both before the change), and `module/dynamic-import-specifier`/`-output`, which pin dynamic imports to literal relative specifiers rather than public-path concatenation on the node and web targets.

**Does this PR introduce a breaking change?**

No. An entry module that declares one of these two names loses inline startup, which only affects modules using webpack's own runtime names.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code was used to reproduce and isolate the collision, implement the fix and write the tests; I reviewed the diff and verified the suites before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_016mxFzPn7Fko3AgbmjkDazQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chunk bootstrap and module-concatenation naming; impact is limited to modules that declare webpack runtime globals at top level, with targeted regression tests.
> 
> **Overview**
> Fixes **re-bundling webpack output** where nested bundles’ top-level `__webpack_modules__` and `__webpack_module_cache__` could share a scope with the outer chunk bootstrap—leading to parse errors or a silent clobber of the module table.
> 
> **`CHUNK_RUNTIME_DECLARATIONS`** is introduced and folded into **`RESERVED_NAMES`** in `concatenate.js` so scope merging/renaming treats those identifiers like other internal webpack names. **`JavascriptModulesPlugin`** also **bails out of entry inline startup** when an entry’s top-level declarations include either name.
> 
> Adds **`consume-webpack-runtime-tables`** (concatenated and non-concatenated) plus **`dynamic-import-specifier`** / **`dynamic-import-specifier-output`** config cases for related ESM chunk-loading behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d642132e89603ce9d20f299c900a39c97bb368c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->