### PR TITLE
chore(test): run suite-format unit and e2e benchmarks through the benchmark harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ The directory listings below are the canonical map of the repository. **Whenever
 **Tests** — see [TESTING_DOCS.md](TESTING_DOCS.md) for directory structure, naming, and how to run a single case.
 
 - `test/` — All test suites (`cases/`, `configCases/`, `watchCases/`, `hotCases/`, `statsCases/`, `typesCases/`, `test262-cases/`, `html5lib-tests/`, `css-parsing-tests/`, `benchmarkCases/`, `memoryLimitCases/`, etc.). `RoundTripConfigCases` re-bundles the output of `configCases` marked with a `roundTrip.js` file.
+- `test/benchmark/` — Suite-format benchmarks: `unit/` mirrors `lib/` for focused core benchmarks, `e2e/` holds full-build workloads, `helpers/` and `lib/` hold deterministic fixture generators and webpack lifecycle helpers; run by the benchmark harness (`FILTER="<suite>" yarn benchmark`).
 
 **Examples & changesets**
 

--- a/TESTING_DOCS.md
+++ b/TESTING_DOCS.md
@@ -21,6 +21,11 @@ This document explains the structure of the `test/` directory in the Webpack pro
 
 `exec` is reported per scenario, so a `development`/`production` pair shows what scope hoisting and minification are worth at runtime.
 
+### 2b. `benchmark/`
+
+- **Purpose**: Suite-format benchmarks: `unit/` for webpack internals (mirrors `lib/`), `e2e/` for full builds, `helpers/` and `lib/` for deterministic fixture generators and webpack lifecycle helpers.
+- **Usage**: Runs through the benchmark harness alongside `benchmarkCases/`: `FILTER="<suite>" yarn benchmark` (e.g. `FILTER="unit/util/semver"`).
+
 ### 3. `cases/`
 
 - **Purpose**: General test cases covering core functionalities.
@@ -141,6 +146,7 @@ yarn test
 | `test/watchCases/`        | `yarn test:base --testPathPatterns="WatchTestCases"`                                          |
 | `test/hotCases/`          | `yarn test:base --testPathPatterns="HotTestCases"`                                            |
 | `test/benchmarkCases/`    | `FILTER="<case-name>" yarn benchmark`                                                         |
+| `test/benchmark/`         | `FILTER="<suite name>" yarn benchmark`                                                        |
 | `test/test262-cases/`     | `yarn test:test262` (requires `git submodule update --init test/test262-cases` first)         |
 | `test/html5lib-tests/`    | `yarn test:html5lib` (requires `git submodule update --init test/html5lib-tests` first)       |
 | `test/css-parsing-tests/` | `yarn test:css-parsing` (requires `git submodule update --init test/css-parsing-tests` first) |

--- a/cspell.json
+++ b/cspell.json
@@ -115,6 +115,7 @@
     "Ewald",
     "exitance",
     "externref",
+    "fanout",
     "fetchpriority",
     "fontobject",
     "filebase",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig([
 		"!test/**/infrastructure-log.js",
 		"!test/helpers/*.*",
 		"!test/benchmarkCases/**/*.mjs",
+		"!test/benchmark/**/*.mjs",
+		"test/benchmark/**/generated/**",
 		"!test/harness/benchmark/**/*.mjs",
 		"!test/_helpers/**/*.mjs",
 		"!test/runner/*.js",
@@ -202,6 +204,7 @@ export default defineConfig([
 			"test/harness/benchmark/**/*.mjs",
 			"test/benchmarkCases/**/webpack.config.mjs",
 			"test/benchmarkCases/**/options.mjs",
+			"test/benchmark/**/*.mjs",
 			"test/benchmarkCases/**/index.bench.mjs"
 		],
 		languageOptions: {
@@ -209,6 +212,15 @@ export default defineConfig([
 		},
 		rules: {
 			"no-console": "off"
+		}
+	},
+	{
+		files: ["test/benchmark/**/*.mjs"],
+		rules: {
+			// Benchmarks run on current Node.js, not the package's engines range
+			"n/no-unsupported-features/es-builtins": "off",
+			"n/no-unsupported-features/es-syntax": "off",
+			"n/no-unsupported-features/node-builtins": "off"
 		}
 	},
 	{

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -30,8 +30,15 @@ import { simpleGit } from "simple-git";
  * @typedef {object} BenchmarkTask
  * @property {string} id task id (benchmark + scenario)
  * @property {string} benchmark benchmark name
- * @property {Scenario=} scenario scenario (omitted for `-unit` benchmarks)
+ * @property {Scenario=} scenario scenario (omitted for `-unit` and suite benchmarks)
+ * @property {string=} suiteFile absolute path of a suite-format `*.bench.mjs` file
  * @property {Baseline[]} baselines baselines measured in one task
+ */
+
+/**
+ * @typedef {object} DiscoveredBenchmark
+ * @property {string} name benchmark name
+ * @property {string=} suiteFile absolute path of a suite-format `*.bench.mjs` file
  */
 
 // One libuv thread → fs completions fire in submission order, making module
@@ -218,6 +225,8 @@ class BenchmarkRunner {
 		/** @type {string} */
 		this.casesPath = path.join(__dirname, "benchmarkCases");
 		/** @type {string} */
+		this.suitesPath = path.join(__dirname, "benchmark");
+		/** @type {string} */
 		this.baseOutputPath = path.join(__dirname, "js", "benchmark");
 		/** @type {BenchmarkWorker | undefined} */
 		this.workerPool = undefined;
@@ -285,9 +294,50 @@ class BenchmarkRunner {
 	}
 
 	/**
+	 * Discover suite-format benchmark files (`test/benchmark/{unit,e2e}`).
+	 * A suite's name is its path-derived id: `unit/<lib-path>` for unit suites,
+	 * `e2e/<case>` for e2e suites.
+	 * @param {RegExp | undefined} FILTER filter
+	 * @param {RegExp | undefined} NEGATIVE_FILTER negative filter
+	 * @returns {Promise<DiscoveredBenchmark[]>} suite benchmarks
+	 */
+	async discoverSuiteBenchmarks(FILTER, NEGATIVE_FILTER) {
+		/** @type {string[]} */
+		let files;
+
+		try {
+			files = /** @type {string[]} */ (
+				await fs.readdir(this.suitesPath, { recursive: true })
+			);
+		} catch (_err) {
+			return [];
+		}
+
+		/** @type {DiscoveredBenchmark[]} */
+		const suites = [];
+
+		for (const file of files) {
+			const normalized = file.split(path.sep).join("/");
+			if (!normalized.endsWith(".bench.mjs")) continue;
+			if (!/^(?:unit|e2e)\//.test(normalized)) continue;
+
+			const name = normalized.startsWith("e2e/")
+				? normalized.split("/").slice(0, 2).join("/")
+				: normalized.slice(0, -".bench.mjs".length);
+
+			if (FILTER && !FILTER.test(name)) continue;
+			if (NEGATIVE_FILTER && NEGATIVE_FILTER.test(name)) continue;
+
+			suites.push({ name, suiteFile: path.join(this.suitesPath, file) });
+		}
+
+		return suites.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	/**
 	 * Discover benchmark case directories, honoring FILTER / NEGATIVE_FILTER and
 	 * interleaving the long-running cases so shards stay balanced.
-	 * @returns {Promise<string[]>} benchmark names
+	 * @returns {Promise<DiscoveredBenchmark[]>} benchmark names
 	 */
 	async discoverBenchmarks() {
 		const FILTER =
@@ -328,16 +378,19 @@ class BenchmarkRunner {
 			}
 		}
 
-		return benchmarks;
+		return [
+			...benchmarks.map((name) => ({ name })),
+			...(await this.discoverSuiteBenchmarks(FILTER, NEGATIVE_FILTER))
+		];
 	}
 
 	/**
 	 * Build the benchmark tasks for this shard. Each non-unit benchmark expands
 	 * to one task per scenario (all baselines measured within the task); `-unit`
-	 * benchmarks have no scenarios and become a single task; `-runtime`
-	 * benchmarks skip the rebuild scenario, which emits the same output as the
-	 * initial build.
-	 * @param {string[]} benchmarks discovered benchmarks
+	 * and suite benchmarks have no scenarios and become a single task;
+	 * `-runtime` benchmarks skip the rebuild scenario, which emits the same
+	 * output as the initial build.
+	 * @param {DiscoveredBenchmark[]} benchmarks discovered benchmarks
 	 * @param {[number, number]} shard shard [part, count]
 	 * @param {Baseline[]} baselines baselines
 	 * @returns {BenchmarkTask[]} benchmark tasks
@@ -358,7 +411,12 @@ class BenchmarkRunner {
 		/** @type {BenchmarkTask[]} */
 		const benchmarkTasks = [];
 
-		for (const benchmark of shardBenchmarks) {
+		for (const { name: benchmark, suiteFile } of shardBenchmarks) {
+			if (suiteFile) {
+				benchmarkTasks.push({ id: benchmark, benchmark, suiteFile, baselines });
+				continue;
+			}
+
 			if (benchmark.includes("-unit")) {
 				benchmarkTasks.push({ id: benchmark, benchmark, baselines });
 				continue;
@@ -391,7 +449,10 @@ class BenchmarkRunner {
 		/** @type {Set<string>} */
 		const prepared = new Set();
 
-		for (const { benchmark } of benchmarkTasks) {
+		for (const { benchmark, suiteFile } of benchmarkTasks) {
+			// Suite benchmarks run their own `setup()` in the worker — a suite is
+			// never split across tasks, so no other worker depends on its fixtures.
+			if (suiteFile) continue;
 			if (prepared.has(benchmark)) continue;
 			prepared.add(benchmark);
 
@@ -442,7 +503,13 @@ class BenchmarkRunner {
 				console.log(
 					`Result: ${firstStats.text} is ${Math.round(
 						(secondStats.mean / firstStats.mean) * 100 - 100
-					)}% ${secondStats.maxConfidence < firstStats.minConfidence ? "slower than" : secondStats.minConfidence > firstStats.maxConfidence ? "faster than" : "the same as"} ${secondStats.text}`
+					)}% ${
+						secondStats.maxConfidence < firstStats.minConfidence
+							? "slower than"
+							: secondStats.minConfidence > firstStats.maxConfidence
+								? "faster than"
+								: "the same as"
+					} ${secondStats.text}`
 				);
 			}
 		}
@@ -474,7 +541,9 @@ class BenchmarkRunner {
 
 		if (failedTasks.length > 0) {
 			throw new Error(
-				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(", ")}`
+				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(
+					", "
+				)}`
 			);
 		}
 	}
@@ -553,7 +622,11 @@ class BenchmarkRunner {
 		this.workerPool = workerPool;
 
 		console.log(
-			`\nRunning ${benchmarkTasks.length} benchmark task(s) across ${numWorkers} worker(s) (cpu cap ${cpuWorkers}, memory cap ${memWorkers} @ ${totalGiB.toFixed(1)} GiB)\n`
+			`\nRunning ${
+				benchmarkTasks.length
+			} benchmark task(s) across ${numWorkers} worker(s) (cpu cap ${cpuWorkers}, memory cap ${memWorkers} @ ${totalGiB.toFixed(
+				1
+			)} GiB)\n`
 		);
 
 		try {

--- a/test/benchmark/e2e/asset-modules/index.bench.mjs
+++ b/test/benchmark/e2e/asset-modules/index.bench.mjs
@@ -1,0 +1,72 @@
+import path from "path";
+import { generateAssetProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const name = "e2e/asset-modules";
+
+/**
+ * @param {"asset" | "asset/bytes" | "asset/inline" | "asset/resource" | "asset/source"} type module type
+ * @param {number=} maxSize automatic inline threshold
+ * @returns {import("../../../..").Configuration} configuration
+ */
+const assetConfig = (type, maxSize) => ({
+	entry,
+	module: {
+		rules: [
+			{
+				test: /\.bin$/,
+				type,
+				...(maxSize === undefined
+					? {}
+					: { parser: { dataUrlCondition: { maxSize } } })
+			}
+		]
+	}
+});
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateAssetProject({
+			dir: generated,
+			count: 150,
+			size: (index) => (index % 2 === 0 ? 512 : 16_384)
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			case: "asset/resource",
+			entryFile: entry,
+			config: assetConfig("asset/resource")
+		}),
+		...createBuildScenarios({
+			case: "asset/inline",
+			entryFile: entry,
+			config: assetConfig("asset/inline")
+		}),
+		...createBuildScenarios({
+			case: "asset/source",
+			entryFile: entry,
+			config: assetConfig("asset/source")
+		}),
+		...createBuildScenarios({
+			case: "asset/bytes",
+			entryFile: entry,
+			config: assetConfig("asset/bytes")
+		}),
+		...createBuildScenarios({
+			case: "automatic-mixed",
+			entryFile: entry,
+			config: assetConfig("asset", 8192)
+		}),
+		...createBuildScenarios({
+			case: "automatic-resource",
+			entryFile: entry,
+			config: assetConfig("asset", 256)
+		})
+	]
+};

--- a/test/benchmark/e2e/code-splitting/index.bench.mjs
+++ b/test/benchmark/e2e/code-splitting/index.bench.mjs
@@ -1,0 +1,77 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const esmGenerated = path.join(caseDir, "generated", "esm");
+const esmEntry = path.join(esmGenerated, "module-0.js");
+const commonJsGenerated = path.join(caseDir, "generated", "commonjs");
+const commonJsEntry = path.join(commonJsGenerated, "module-0.js");
+const name = "e2e/code-splitting";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		// Every 7th edge is a dynamic import → dozens of async chunks, which
+		// exercises chunk graph building and splitChunks.
+		await Promise.all([
+			generateModuleTree({
+				dir: esmGenerated,
+				count: 200,
+				format: "esm",
+				dynamicEvery: 7
+			}),
+			generateModuleTree({
+				dir: commonJsGenerated,
+				count: 200,
+				format: "cjs",
+				dynamicEvery: 7
+			})
+		]);
+	},
+	benches: [
+		...createBuildScenarios({
+			case: "esm",
+			entryFile: esmEntry,
+			config: { entry: esmEntry }
+		}),
+		...createBuildScenarios({
+			case: "commonjs",
+			entryFile: commonJsEntry,
+			config: { entry: commonJsEntry }
+		}),
+		...createBuildScenarios({
+			case: "esm/split-chunks-all",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: {
+					splitChunks: { chunks: "all", minSize: 1000 }
+				}
+			}
+		}),
+		...createBuildScenarios({
+			case: "esm/split-chunks-max-size",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: {
+					splitChunks: {
+						chunks: "all",
+						minSize: 1000,
+						maxSize: 20_000
+					}
+				}
+			}
+		}),
+		...createBuildScenarios({
+			case: "esm/single-runtime-chunk",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: { runtimeChunk: "single" }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/css-modules/index.bench.mjs
+++ b/test/benchmark/e2e/css-modules/index.bench.mjs
@@ -1,0 +1,29 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { generateCssProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const name = "e2e/css-modules";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateCssProject({
+			dir: generated,
+			count: 40,
+			rulesPerFile: 30
+		});
+	},
+	benches: createBuildScenarios({
+		entryFile: entry,
+		config: {
+			entry,
+			target: "web",
+			experiments: { css: true }
+		}
+	})
+};

--- a/test/benchmark/e2e/filesystem-cache/index.bench.mjs
+++ b/test/benchmark/e2e/filesystem-cache/index.bench.mjs
@@ -1,0 +1,146 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { prepareConfig, runBuild } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/filesystem-cache";
+
+const createOutputPath = () =>
+	fs.mkdtemp(path.join(os.tmpdir(), "webpack-benchmark-"));
+
+/**
+ * @param {string} outputPath temporary output directory
+ * @param {string} benchName benchmark name
+ * @param {"development" | "production"} mode mode
+ * @param {false | "gzip" | "brotli"} compression cache compression
+ * @returns {{ write: import("../../../..").Configuration, read: import("../../../..").Configuration, cacheDirectory: string }} cache configurations
+ */
+const cacheConfigs = (outputPath, benchName, mode, compression) => {
+	const write = prepareConfig(outputPath, benchName, {
+		mode,
+		entry,
+		cache: {
+			type: "filesystem",
+			compression,
+			maxMemoryGenerations: 0,
+			idleTimeoutForInitialStore: 0
+		}
+	});
+	const fileCache =
+		/** @type {import("../../../..").FileCacheOptions} */ (write.cache);
+	return {
+		write,
+		read: {
+			...write,
+			cache: {
+				...fileCache,
+				readonly: true
+			}
+		},
+		cacheDirectory: /** @type {string} */ (fileCache.cacheDirectory)
+	};
+};
+
+/**
+ * @param {string} caseName benchmark case
+ * @param {"development" | "production"} mode mode
+ * @param {false | "gzip" | "brotli"} compression cache compression
+ * @returns {{ name: string, async: boolean, beforeAll: () => Promise<void>, fn: () => Promise<void>, afterAll: () => Promise<void> }} benchmark
+ */
+const warmCacheBench = (caseName, mode, compression) => {
+	const benchName = `${caseName}/${mode}-build`;
+	/** @type {ReturnType<typeof cacheConfigs> | undefined} */
+	let config;
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+			config = cacheConfigs(outputPath, benchName, mode, compression);
+			try {
+				await runBuild(config.write);
+			} catch (error) {
+				await fs.rm(outputPath, { recursive: true, force: true });
+				outputPath = undefined;
+				config = undefined;
+				throw error;
+			}
+		},
+		fn() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return runBuild(config.read);
+		},
+		async afterAll() {
+			config = undefined;
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+};
+
+const coldCacheBench = () => {
+	const benchName = "cold/development-build";
+	/** @type {ReturnType<typeof cacheConfigs> | undefined} */
+	let config;
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+			config = cacheConfigs(outputPath, benchName, "development", false);
+		},
+		beforeEach() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return fs.rm(config.cacheDirectory, {
+				recursive: true,
+				force: true
+			});
+		},
+		fn() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return runBuild(config.write);
+		},
+		async afterAll() {
+			config = undefined;
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+};
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 300,
+			format: "esm"
+		});
+	},
+	benches: [
+		warmCacheBench("warm", "development", false),
+		warmCacheBench("warm", "production", false),
+		warmCacheBench("warm-gzip", "development", "gzip"),
+		warmCacheBench("warm-brotli", "development", "brotli"),
+		coldCacheBench()
+	]
+};

--- a/test/benchmark/e2e/json-modules/index.bench.mjs
+++ b/test/benchmark/e2e/json-modules/index.bench.mjs
@@ -1,0 +1,48 @@
+import path from "path";
+import { generateJsonProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const selectedEntry = path.join(generated, "selected.js");
+const name = "e2e/json-modules";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateJsonProject({
+			dir: generated,
+			count: 60,
+			entriesPerFile: 200
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "deep-export-analysis",
+			entryFile: entry,
+			config: {
+				entry,
+				module: { parser: { json: { exportsDepth: Infinity } } }
+			}
+		}),
+		...createBuildScenarios({
+			case: "selected-exports",
+			entryFile: selectedEntry,
+			config: { entry: selectedEntry }
+		}),
+		...createBuildScenarios({
+			case: "without-json-parse",
+			entryFile: entry,
+			config: {
+				entry,
+				module: { generator: { json: { JSONParse: false } } }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/many-modules-commonjs/index.bench.mjs
+++ b/test/benchmark/e2e/many-modules-commonjs/index.bench.mjs
@@ -1,0 +1,39 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/many-modules-commonjs";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 250,
+			format: "cjs"
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "node",
+			entryFile: entry,
+			config: { entry, target: "node" }
+		}),
+		...createBuildScenarios({
+			case: "without-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { minimize: false }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/many-modules-esm/index.bench.mjs
+++ b/test/benchmark/e2e/many-modules-esm/index.bench.mjs
@@ -1,0 +1,58 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/many-modules-esm";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 250,
+			format: "esm"
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "with-module-concatenation",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: true }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-module-concatenation",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: false }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { minimize: false }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-concatenation-or-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: false, minimize: false }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/rebuild/index.bench.mjs
+++ b/test/benchmark/e2e/rebuild/index.bench.mjs
@@ -1,0 +1,48 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createWatchRebuildBench } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const dependency = path.join(generated, "module-1.js");
+const leaf = path.join(generated, "module-149.js");
+const name = "e2e/rebuild";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 150,
+			format: "esm"
+		});
+	},
+	benches: [
+		createWatchRebuildBench({
+			case: "entry-change",
+			entryFile: entry,
+			config: {
+				mode: "development",
+				entry
+			}
+		}),
+		createWatchRebuildBench({
+			case: "dependency-change",
+			entryFile: dependency,
+			config: {
+				mode: "development",
+				entry
+			}
+		}),
+		createWatchRebuildBench({
+			case: "leaf-change",
+			entryFile: leaf,
+			config: {
+				mode: "development",
+				entry
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/source-map/index.bench.mjs
+++ b/test/benchmark/e2e/source-map/index.bench.mjs
@@ -1,0 +1,40 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/source-map";
+
+/**
+ * @param {false | string} devtool devtool
+ * @returns {ReturnType<typeof createBuildScenarios>} benchmarks
+ */
+const sourceMapScenarios = (devtool) =>
+	createBuildScenarios({
+		case: devtool === false ? "none" : devtool,
+		entryFile: entry,
+		config: { entry, devtool }
+	});
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 150,
+			format: "esm"
+		});
+	},
+	benches: [
+		...sourceMapScenarios(false),
+		...sourceMapScenarios("eval"),
+		...sourceMapScenarios("eval-source-map"),
+		...sourceMapScenarios("eval-cheap-source-map"),
+		...sourceMapScenarios("cheap-module-source-map"),
+		...sourceMapScenarios("source-map"),
+		...sourceMapScenarios("hidden-nosources-source-map")
+	]
+};

--- a/test/benchmark/helpers/prng.mjs
+++ b/test/benchmark/helpers/prng.mjs
@@ -1,0 +1,39 @@
+/**
+ * Deterministic PRNG (mulberry32). Benchmarks must never use Math.random():
+ * fixture content has to be byte-identical on every run and machine.
+ * @param {number} seed 32-bit seed
+ * @returns {() => number} generator of floats in [0, 1)
+ */
+export function mulberry32(seed) {
+	let state = seed | 0;
+	return () => {
+		state = (state + 0x6d2b79f5) | 0;
+		let t = Math.imul(state ^ (state >>> 15), 1 | state);
+		t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/**
+ * @param {() => number} random generator from mulberry32
+ * @param {number} min inclusive lower bound
+ * @param {number} max exclusive upper bound
+ * @returns {number} integer in [min, max)
+ */
+export function randomInt(random, min, max) {
+	return min + Math.floor(random() * (max - min));
+}
+
+/**
+ * @param {number} seed 32-bit seed
+ * @param {number} size number of bytes
+ * @returns {Buffer} deterministic pseudo-random bytes
+ */
+export function deterministicBytes(seed, size) {
+	const random = mulberry32(seed);
+	const buffer = Buffer.allocUnsafe(size);
+	for (let i = 0; i < size; i++) {
+		buffer[i] = randomInt(random, 0, 256);
+	}
+	return buffer;
+}

--- a/test/benchmark/helpers/project.mjs
+++ b/test/benchmark/helpers/project.mjs
@@ -1,0 +1,229 @@
+import fs from "fs/promises";
+import path from "path";
+import { deterministicBytes } from "./prng.mjs";
+import { generateCssSource, generateJavaScriptSource } from "./sources.mjs";
+
+/**
+ * Deterministic on-disk project generators for e2e benchmarks. Output goes to
+ * `<caseDir>/generated` (gitignored via /test/`**`/generated/`**`) and is
+ * recreated from scratch on every run — content depends only on the arguments.
+ */
+
+/**
+ * @param {string} dir directory to recreate
+ * @returns {Promise<void>}
+ */
+async function recreate(dir) {
+	await fs.rm(dir, { recursive: true, force: true });
+	await fs.mkdir(dir, { recursive: true });
+}
+
+/**
+ * @typedef {object} ModuleTreeOptions
+ * @property {string} dir output directory
+ * @property {number} count number of modules
+ * @property {"esm" | "cjs"} format module format
+ * @property {number=} fanout imports per non-leaf module (default 4)
+ * @property {number=} dynamicEvery every n-th edge becomes a dynamic import (0 = none)
+ * @property {number=} paragraphs body size per module (default 2)
+ */
+
+/**
+ * Generate a module tree: module i imports its children by index
+ * (i * fanout + 1 … i * fanout + fanout), giving a balanced tree with
+ * deterministic shape and content. Entry is `<dir>/module-0.js`.
+ * @param {ModuleTreeOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateModuleTree(options) {
+	const {
+		dir,
+		count,
+		format,
+		fanout = 4,
+		dynamicEvery = 0,
+		paragraphs = 2
+	} = options;
+	await recreate(dir);
+	const esm = format === "esm";
+	for (let i = 0; i < count; i++) {
+		/** @type {string[]} */
+		const head = [];
+		/** @type {string[]} */
+		const body = [];
+		for (let child = i * fanout + 1, k = 0; k < fanout; k++, child++) {
+			if (child >= count) break;
+			const specifier = `./module-${child}.js`;
+			const isDynamic = dynamicEvery > 0 && child % dynamicEvery === 0;
+			if (isDynamic) {
+				body.push(
+					esm
+						? `export const lazy${k} = import(${JSON.stringify(specifier)});`
+						: `require.ensure([], () => { total += require(${JSON.stringify(specifier)}); });`
+				);
+			} else if (esm) {
+				head.push(`import child${k} from ${JSON.stringify(specifier)};`);
+				body.push(`total += child${k};`);
+			} else {
+				head.push(`const child${k} = require(${JSON.stringify(specifier)});`);
+				body.push(`total += child${k};`);
+			}
+		}
+		const source = [
+			...head,
+			"let total = 1;",
+			...body,
+			generateJavaScriptSource(paragraphs, esm),
+			esm ? "export default total;" : "module.exports = total;"
+		].join("\n");
+		await fs.writeFile(path.join(dir, `module-${i}.js`), source);
+	}
+	return path.join(dir, "module-0.js");
+}
+
+/**
+ * @typedef {object} CssProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of css/js module pairs
+ * @property {number=} rulesPerFile rules per css file (default 30)
+ */
+
+/**
+ * Generate plain/module CSS files with static and dynamic imports.
+ * @param {CssProjectOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateCssProject(options) {
+	const { dir, count, rulesPerFile = 30 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	for (let i = 0; i < count; i++) {
+		const isModule = i % 2 !== 0;
+		const isDynamic = i % 4 === 0;
+		const request = `./style-${i}${isModule ? ".module" : ""}.css`;
+		await fs.writeFile(
+			path.join(dir, request.slice(2)),
+			generateCssSource(rulesPerFile, isModule)
+		);
+		if (isDynamic) {
+			imports.push(
+				isModule
+					? `used += Object.keys(await import(${JSON.stringify(request)})).length;`
+					: `await import(${JSON.stringify(request)});`
+			);
+		} else if (isModule) {
+			imports.push(
+				`import * as style${i} from ${JSON.stringify(request)};`,
+				`used += Object.keys(style${i}).length;`
+			);
+		} else {
+			imports.push(`import ${JSON.stringify(request)};`);
+		}
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`let used = 0;\n${imports.join("\n")}\nexport default used;\n`
+	);
+	return entry;
+}
+
+/**
+ * @typedef {object} AssetProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of assets
+ * @property {number | ((index: number) => number)=} size bytes per asset (default 4096)
+ */
+
+/**
+ * Generate binary assets plus a JS entry importing all of them as URLs.
+ * @param {AssetProjectOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateAssetProject(options) {
+	const { dir, count, size = 4096 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	for (let i = 0; i < count; i++) {
+		const assetSize = typeof size === "function" ? size(i) : size;
+		await fs.writeFile(
+			path.join(dir, `asset-${i}.bin`),
+			deterministicBytes(i + 1, assetSize)
+		);
+		imports.push(
+			`import asset${i} from ${JSON.stringify(`./asset-${i}.bin`)};`,
+			`urls.push(asset${i});`
+		);
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`/** @type {string[]} */\nconst urls = [];\n${imports.join("\n")}\nexport default urls;\n`
+	);
+	return entry;
+}
+
+/**
+ * @typedef {object} JsonProject
+ * @property {string} entry entry importing every JSON export
+ * @property {string} selectedEntry entry importing one export per JSON file
+ */
+
+/**
+ * @typedef {object} JsonProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of JSON modules
+ * @property {number=} entriesPerFile keys per JSON file (default 200)
+ */
+
+/**
+ * Generate JSON modules with whole-object and selected-property imports.
+ * @param {JsonProjectOptions} options options
+ * @returns {Promise<JsonProject>} absolute paths of the entry modules
+ */
+export async function generateJsonProject(options) {
+	const { dir, count, entriesPerFile = 200 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	/** @type {string[]} */
+	const selectedImports = [];
+	for (let i = 0; i < count; i++) {
+		/** @type {Record<string, unknown>} */
+		const data = {};
+		for (let k = 0; k < entriesPerFile; k++) {
+			data[`key_${i}_${k}`] =
+				k % 3 === 0
+					? { nested: k, list: [k, `${k}`, k % 2 === 0] }
+					: k % 3 === 1
+						? `value ${i}-${k}`
+						: k * 1.5;
+		}
+		await fs.writeFile(
+			path.join(dir, `data-${i}.json`),
+			JSON.stringify(data, null, "\t")
+		);
+		const request = `./data-${i}.json`;
+		imports.push(
+			`import data${i} from ${JSON.stringify(request)}${i % 2 === 0 ? ' with { type: "json" }' : ""};`,
+			`total += Object.keys(data${i}).length;`
+		);
+		selectedImports.push(
+			`import selected${i} from ${JSON.stringify(request)}${i % 2 === 0 ? ' with { type: "json" }' : ""};`,
+			`selected += selected${i}.key_${i}_0.nested;`
+		);
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`let total = 0;\n${imports.join("\n")}\nexport default total;\n`
+	);
+	const selectedEntry = path.join(dir, "selected.js");
+	await fs.writeFile(
+		selectedEntry,
+		`let selected = 0;\n${selectedImports.join("\n")}\nexport default selected;\n`
+	);
+	return { entry, selectedEntry };
+}

--- a/test/benchmark/helpers/sources.mjs
+++ b/test/benchmark/helpers/sources.mjs
@@ -1,0 +1,161 @@
+import { mulberry32, randomInt } from "./prng.mjs";
+
+/**
+ * Deterministic source-text generators for parser/tokenizer benchmarks and
+ * generated e2e projects. All output depends only on the arguments.
+ */
+
+/**
+ * @param {number} index chunk index, varies the identifiers
+ * @returns {string} a paragraph of varied JavaScript
+ */
+function javaScriptParagraph(index) {
+	const i = index;
+	return `
+const value${i} = { a: ${i}, b: "str${i}", c: [${i}, ${i + 1}, ${i + 2}], d: null };
+let counter${i} = ${i};
+function helper${i}(arg, { opt = ${i}, ...rest } = {}) {
+	const mapped = arg.map((x) => x * opt + counter${i});
+	try {
+		for (const item of mapped) {
+			if (item % 2 === 0) counter${i} += item;
+			else counter${i} -= item | 0;
+		}
+	} catch (err) {
+		throw new Error(\`helper${i} failed: \${err.message}\`, { cause: err });
+	}
+	return { mapped, rest };
+}
+class Thing${i} {
+	#hidden = ${i};
+	static instances = 0;
+	constructor(name = "thing${i}") {
+		this.name = name;
+		Thing${i}.instances++;
+	}
+	get id() {
+		return \`\${this.name}-\${this.#hidden}\`;
+	}
+	async load() {
+		const result = await Promise.resolve(helper${i}([${i}, ${i * 2}, ${i * 3}]));
+		switch (result.mapped.length) {
+			case 0:
+				return null;
+			case 3:
+				return result.mapped;
+			default:
+				return result;
+		}
+	}
+}
+const arrow${i} = (a, b) => (a > b ? { ...value${i}, a } : [a ?? b, b?.toString()]);
+export const exported${i} = arrow${i}(counter${i}, ${i}) && new Thing${i}();
+`;
+}
+
+/**
+ * @param {number} paragraphs number of paragraphs (~1.2 KiB each)
+ * @param {boolean=} asModule include import/export syntax
+ * @returns {string} JavaScript source
+ */
+export function generateJavaScriptSource(paragraphs, asModule = true) {
+	const parts = [];
+	if (!asModule) {
+		parts.push('"use strict";\n');
+	}
+	for (let i = 0; i < paragraphs; i++) {
+		const paragraph = javaScriptParagraph(i);
+		parts.push(asModule ? paragraph : paragraph.replace(/^export /gm, ""));
+	}
+	return parts.join("\n// section separator\n");
+}
+
+const CSS_UNITS = ["px", "em", "rem", "%", "vh", "vw"];
+const CSS_PROPS = [
+	"margin",
+	"padding",
+	"width",
+	"height",
+	"top",
+	"left",
+	"font-size",
+	"line-height",
+	"border-radius",
+	"gap"
+];
+const CSS_COLORS = ["#f00", "#00ff00", "rgba(0, 0, 0, 0.5)", "currentColor"];
+
+/**
+ * @param {number} rules number of rules
+ * @param {boolean=} asModule generate CSS Modules flavored selectors (local classes)
+ * @returns {string} CSS source
+ */
+export function generateCssSource(rules, asModule = false) {
+	const random = mulberry32(rules * 31 + (asModule ? 1 : 0));
+	const parts = [":root { --main-color: #336699; --spacing: 8px; }\n"];
+	for (let i = 0; i < rules; i++) {
+		const cls = `item-${i}`;
+		const selector = asModule
+			? `.${cls}`
+			: i % 7 === 0
+				? `.${cls}:hover > .child, .${cls}::after`
+				: i % 5 === 0
+					? `#id-${i} .${cls}[data-state="on"]`
+					: `.${cls}`;
+		const declarations = [];
+		const count = 2 + (i % 4);
+		for (let d = 0; d < count; d++) {
+			const prop = CSS_PROPS[randomInt(random, 0, CSS_PROPS.length)];
+			const unit = CSS_UNITS[randomInt(random, 0, CSS_UNITS.length)];
+			declarations.push(`\t${prop}: ${randomInt(random, 0, 100)}${unit};`);
+		}
+		declarations.push(
+			`\tcolor: ${CSS_COLORS[i % CSS_COLORS.length]};`,
+			"\tbackground: url(\"data:image/gif;base64,R0lGODlhAQABAAAAACw=\") no-repeat;",
+			"\tmax-width: calc(100% - var(--spacing) * 2);"
+		);
+		parts.push(`${selector} {\n${declarations.join("\n")}\n}`);
+		if (i % 11 === 0) {
+			parts.push(
+				`@media (min-width: ${600 + i}px) {\n\t.${cls} { display: flex; }\n}`
+			);
+		}
+	}
+	return parts.join("\n\n");
+}
+
+/**
+ * @param {number} sections number of sections
+ * @returns {string} HTML document source
+ */
+export function generateHtmlSource(sections) {
+	const parts = [
+		"<!DOCTYPE html>",
+		"<html lang=\"en\">",
+		"<head>",
+		"<meta charset=\"utf-8\">",
+		"<title>Benchmark fixture</title>",
+		"<link rel=\"stylesheet\" href=\"./styles.css\">",
+		"</head>",
+		"<body>"
+	];
+	for (let i = 0; i < sections; i++) {
+		parts.push(
+			`<!-- section ${i} -->`,
+			`<section id="section-${i}" class="block b-${i % 13}" data-index="${i}">`,
+			`<h2>Section &amp; heading ${i}</h2>`,
+			`<p>Some <strong>rich</strong> <em>text</em> with an <a href="/page/${i}?a=1&amp;b=2">anchor</a>.</p>`,
+			"<ul>",
+			`<li>first ${i}</li><li>second ${i}</li><li>third ${i}</li>`,
+			"</ul>",
+			`<table><tr><td>${i}</td><td>${i * 2}</td></tr><tr><td colspan="2">${i * 3}</td></tr></table>`,
+			`<img src="./image-${i % 5}.png" alt="img ${i}" width="10" height="10">`,
+			i % 6 === 0
+				? `<template><div class="tpl">${i}</div></template>`
+				: `<div><br><input type="text" value="v${i}" disabled></div>`,
+			"</section>"
+		);
+	}
+	parts.push("<script>console.log(\"end\");</script>", "</body>", "</html>");
+	return parts.join("\n");
+}

--- a/test/benchmark/lib/webpack.mjs
+++ b/test/benchmark/lib/webpack.mjs
@@ -1,0 +1,332 @@
+import fs from "fs/promises";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+
+const require = createRequire(import.meta.url);
+
+/** @typedef {import("../../..")} Webpack */
+/** @typedef {import("../../..").Configuration} Configuration */
+/** @typedef {import("../../..").Stats} Stats */
+/** @typedef {import("../../..").Watching} Watching */
+/** @typedef {Configuration | (() => Configuration)} ConfigurationFactory */
+/** @typedef {() => unknown | Promise<unknown>} BenchFn */
+/** @typedef {() => void | Promise<void>} HookFn */
+
+/**
+ * @typedef {object} BenchmarkDefinition
+ * @property {string} name benchmark case
+ * @property {BenchFn} fn benchmarked function
+ * @property {boolean=} async whether the benchmark function is asynchronous
+ * @property {HookFn=} beforeEach hook before every round
+ * @property {HookFn=} afterEach hook after every round
+ * @property {HookFn=} beforeAll hook before the first execution
+ * @property {HookFn=} afterAll hook after the last execution
+ */
+
+/**
+ * @param {ConfigurationFactory} config configuration or factory
+ * @returns {Configuration} resolved configuration
+ */
+const resolveConfig = (config) =>
+	typeof config === "function" ? config() : config;
+
+/**
+ * @param {"build" | "rebuild"} operation benchmarked operation
+ * @param {ConfigurationFactory} config configuration or factory
+ * @param {string | undefined} caseName benchmark case
+ * @returns {string} benchmark case
+ */
+const createBenchmarkCase = (operation, config, caseName) => {
+	const mode = resolveConfig(config).mode;
+	if (mode === undefined) {
+		throw new Error("Benchmark configuration must specify `mode`");
+	}
+	return [caseName, `${mode}-${operation}`].filter(Boolean).join("/");
+};
+
+const createOutputPath = () =>
+	fs.mkdtemp(path.join(os.tmpdir(), "webpack-benchmark-"));
+
+/**
+ * The webpack of the current working tree. Non-comparative by design: no
+ * baseline revision is ever checked out or imported next to it.
+ * @returns {Webpack} webpack
+ */
+export function loadWebpack() {
+	return require("../../../lib/index.js");
+}
+
+/**
+ * Normalize an e2e case config with isolated output.
+ * @param {string} outputPath temporary output directory
+ * @param {string} benchName benchmark name within the case
+ * @param {Configuration} config partial configuration
+ * @returns {Configuration} built configuration
+ */
+export function prepareConfig(outputPath, benchName, config) {
+	/** @type {Configuration} */
+	const result = {
+		devtool: false,
+		performance: false,
+		...config,
+		name: benchName
+	};
+	result.output = {
+		...result.output,
+		path: outputPath
+	};
+	if (
+		result.cache &&
+		typeof result.cache === "object" &&
+		result.cache.type === "filesystem"
+	) {
+		result.cache.cacheDirectory = path.resolve(
+			/** @type {string} */ (result.output.path),
+			".cache"
+		);
+	}
+	return result;
+}
+
+/**
+ * Run a full build on a fresh compiler and force stats construction, matching
+ * what real builds pay for.
+ * @param {Configuration} config configuration
+ * @returns {Promise<void>}
+ */
+export function runBuild(config) {
+	const webpack = loadWebpack();
+	return new Promise(
+		/**
+		 * @param {(value: void) => void} resolve resolve
+		 * @param {(err?: Error) => void} reject reject
+		 */
+		(resolve, reject) => {
+			const compiler = webpack(config);
+			compiler.run((err, stats) => {
+				const statsError =
+					stats && (stats.hasWarnings() || stats.hasErrors())
+						? new Error(stats.toString())
+						: undefined;
+				compiler.close((closeErr) => {
+					const buildError = err || statsError || closeErr;
+					if (buildError) return reject(buildError);
+					if (stats) stats.toString();
+					resolve();
+				});
+			});
+		}
+	);
+}
+
+/**
+ * @typedef {object} BuildBenchOptions
+ * @property {string=} case benchmark case
+ * @property {ConfigurationFactory} config configuration or fresh config factory
+ */
+
+/**
+ * @param {BuildBenchOptions} options options
+ * @returns {BenchmarkDefinition} build benchmark
+ */
+export function createBuildBench(options) {
+	const { case: caseName, config } = options;
+	const benchName = createBenchmarkCase("build", config, caseName);
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+		},
+		fn() {
+			if (outputPath === undefined) {
+				throw new Error("Benchmark output directory is not initialized");
+			}
+			return runBuild(
+				prepareConfig(outputPath, benchName, resolveConfig(config))
+			);
+		},
+		async afterAll() {
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+}
+
+/**
+ * @typedef {object} WatchRebuildOptions
+ * @property {string=} case benchmark case
+ * @property {ConfigurationFactory} config partial configuration; entry must be a file path
+ * @property {string} entryFile absolute path of the file touched to trigger rebuilds
+ */
+
+/**
+ * Benchmark rebuilds while alternating between equal-length source changes.
+ * @param {WatchRebuildOptions} options options
+ * @returns {BenchmarkDefinition} a benchmark definition
+ */
+export function createWatchRebuildBench(options) {
+	const { case: caseName, config, entryFile } = options;
+	const benchName = createBenchmarkCase("rebuild", config, caseName);
+
+	/** @type {Watching | undefined} */
+	let watching;
+	/** @type {string | undefined} */
+	let outputPath;
+	/** @type {string} */
+	let originalContent = "";
+	/** @type {((err: Error | null, stats?: Stats) => void) | undefined} */
+	let next;
+	/** @type {Stats | undefined} */
+	let completedStats;
+	let iteration = 0;
+
+	/**
+	 * @returns {Promise<void>} resolves after the next successful build
+	 */
+	const nextBuild = () =>
+		new Promise(
+			/**
+			 * @param {(value: void) => void} resolve resolve
+			 * @param {(err?: Error | null) => void} reject reject
+			 */
+			(resolve, reject) => {
+				next = (err, stats) => {
+					next = undefined;
+					if (err || !stats) return reject(err);
+					resolve();
+				};
+			}
+		);
+
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			originalContent = await fs.readFile(entryFile, "utf8");
+			outputPath = await createOutputPath();
+			try {
+				const webpack = loadWebpack();
+				const watchConfig = prepareConfig(outputPath, benchName, {
+					...resolveConfig(config),
+					// Keep rebuilds warm but bounded, like a dev-server session.
+					cache: { type: "memory", maxGenerations: 1 }
+				});
+				const firstBuild = nextBuild();
+				const compiler = webpack(watchConfig);
+				compiler.hooks.afterDone.tap("BenchmarkWatchRebuild", () => {
+					if (next) next(null, completedStats);
+				});
+				watching = compiler.watch({}, (err, stats) => {
+					if (err || !stats) {
+						if (next) next(err, stats);
+						return;
+					}
+					if (stats.hasWarnings() || stats.hasErrors()) {
+						if (next) next(new Error(stats.toString()));
+						return;
+					}
+					stats.toString();
+					completedStats = stats;
+				});
+				await firstBuild;
+			} catch (err) {
+				const currentWatching = watching;
+				if (currentWatching) {
+					await new Promise((resolve) => {
+						currentWatching.close(() => resolve(undefined));
+					});
+				}
+				watching = undefined;
+				next = undefined;
+				const currentOutputPath = outputPath;
+				outputPath = undefined;
+				if (currentOutputPath !== undefined) {
+					await fs.rm(currentOutputPath, { recursive: true, force: true });
+				}
+				throw err;
+			}
+		},
+		async fn() {
+			const build = nextBuild();
+			iteration++;
+			await fs.writeFile(
+				entryFile,
+				`${originalContent};console.log(${iteration % 2});`
+			);
+			/** @type {Watching} */ (watching).invalidate();
+			await build;
+		},
+		async afterAll() {
+			try {
+				await new Promise(
+					/**
+					 * @param {(value: void) => void} resolve resolve
+					 * @param {(err?: Error | null) => void} reject reject
+					 */
+					(resolve, reject) => {
+						if (!watching) {
+							resolve();
+							return;
+						}
+						watching.close((closeErr) => {
+							if (closeErr) {
+								reject(closeErr);
+								return;
+							}
+							resolve();
+						});
+					}
+				);
+			} finally {
+				watching = undefined;
+				next = undefined;
+				completedStats = undefined;
+				try {
+					await fs.writeFile(entryFile, originalContent);
+				} finally {
+					if (outputPath !== undefined) {
+						const currentOutputPath = outputPath;
+						outputPath = undefined;
+						await fs.rm(currentOutputPath, { recursive: true, force: true });
+					}
+				}
+			}
+		}
+	};
+}
+
+/**
+ * @typedef {object} BuildScenarioOptions
+ * @property {string=} case benchmark case
+ * @property {string} entryFile entry file changed by the rebuild scenario
+ * @property {ConfigurationFactory} config shared configuration
+ */
+
+/**
+ * @param {BuildScenarioOptions} options options
+ * @returns {BenchmarkDefinition[]} development, production and rebuild benches
+ */
+export function createBuildScenarios(options) {
+	const { case: caseName, entryFile, config } = options;
+	return [
+		createBuildBench({
+			case: caseName,
+			config: () => ({ ...resolveConfig(config), mode: "development" }),
+		}),
+		createBuildBench({
+			case: caseName,
+			config: () => ({ ...resolveConfig(config), mode: "production" }),
+		}),
+		createWatchRebuildBench({
+			case: caseName,
+			entryFile,
+			config: () => ({ ...resolveConfig(config), mode: "development" }),
+		})
+	];
+}

--- a/test/benchmark/unit/css/syntax.bench.mjs
+++ b/test/benchmark/unit/css/syntax.bench.mjs
@@ -1,0 +1,49 @@
+import { createRequire } from "module";
+import { generateCssSource } from "../../helpers/sources.mjs";
+
+const require = createRequire(import.meta.url);
+
+const cssSyntax =
+	/** @type {import("../../../../lib/css/syntax")} */
+	(require("../../../../lib/css/syntax.js"));
+
+/** @type {string} */
+let cssSource = "";
+let sink = 0;
+
+export default {
+	name: "unit/css/syntax",
+	setup() {
+		// ~100 KiB of rules, media queries, urls and calc() expressions.
+		cssSource = generateCssSource(1100);
+	},
+	teardown() {
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "tokenize 100 KiB stylesheet",
+			fn() {
+				const out =
+					/** @type {import("../../../../lib/css/syntax").MutableToken} */ (
+						/** @type {unknown} */ ({})
+					);
+				let pos = 0;
+				let count = 0;
+				for (;;) {
+					const token = cssSyntax.readToken(cssSource, pos, out);
+					if (!token || token.type === cssSyntax.TT_EOF) break;
+					pos = token.end;
+					count++;
+				}
+				sink = count;
+			}
+		},
+		{
+			name: "parse 100 KiB stylesheet",
+			fn() {
+				sink = cssSyntax.parseAStylesheet(cssSource).rules.length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/html/syntax.bench.mjs
+++ b/test/benchmark/unit/html/syntax.bench.mjs
@@ -1,0 +1,59 @@
+import { createRequire } from "module";
+import { generateHtmlSource } from "../../helpers/sources.mjs";
+
+const require = createRequire(import.meta.url);
+
+const htmlSyntax =
+	/** @type {import("../../../../lib/html/syntax")} */
+	(require("../../../../lib/html/syntax.js"));
+
+/** @type {string} */
+let htmlSource = "";
+/** @type {string} */
+let fragmentSource = "";
+/** @type {unknown} */
+let sink;
+
+export default {
+	name: "unit/html/syntax",
+	setup() {
+		// ~150 KiB document: nested sections, tables, templates, entities.
+		htmlSource = generateHtmlSource(400);
+		fragmentSource = '<td class="cell">one <b>two</b> &amp; three</td>'.repeat(
+			2000
+		);
+	},
+	teardown() {
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "parse full document",
+			fn() {
+				sink = htmlSyntax.parseHtml(htmlSource);
+			}
+		},
+		{
+			name: "parse skipping text and comments",
+			fn() {
+				sink = htmlSyntax.parseHtml(htmlSource, 0, {
+					skip: { text: true, comments: true }
+				});
+			}
+		},
+		{
+			name: "parse table fragment",
+			fn() {
+				sink = htmlSyntax.parseHtml(fragmentSource, 0, {
+					fragmentContext: "tr"
+				});
+			}
+		},
+		{
+			name: "process document without visitors",
+			fn() {
+				sink = new htmlSyntax.SourceProcessor().use({}).process(htmlSource);
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/javascript/JavascriptParser.bench.mjs
+++ b/test/benchmark/unit/javascript/JavascriptParser.bench.mjs
@@ -1,0 +1,114 @@
+import { createRequire } from "module";
+import { generateJavaScriptSource } from "../../helpers/sources.mjs";
+
+const require = createRequire(import.meta.url);
+
+const JavascriptParser =
+	/** @type {typeof import("../../../../lib/javascript/JavascriptParser")} */
+	(require("../../../../lib/javascript/JavascriptParser.js"));
+
+/** @type {string} */
+let moduleSource = "";
+/** @type {string} */
+let scriptSource = "";
+/** @type {string} */
+let autoFallbackSource = "";
+let sink = 0;
+// webpack reuses parser instances across modules (cached per parser options),
+// so hook setup cost is excluded like in real builds.
+const parser = new JavascriptParser("auto");
+const scriptParser = new JavascriptParser("script");
+
+/**
+ * @param {string} source source code
+ * @param {"module" | "script"} sourceType source type
+ * @returns {import("../../../../lib/javascript/JavascriptParser").ParseResult} parse result
+ */
+const acornParse = (source, sourceType) =>
+	JavascriptParser._parse(
+		source,
+		/** @type {import("../../../../lib/javascript/JavascriptParser").InternalParseOptions} */ ({
+			sourceType,
+			comments: true,
+			ranges: true,
+			allowHashBang: true
+		})
+	);
+
+export default {
+	name: "unit/javascript/JavascriptParser",
+	setup() {
+		// ~100 KiB of varied syntax (classes, destructuring, async, template
+		// literals) — the per-module parse cost webpack pays on every build.
+		moduleSource = generateJavaScriptSource(80, true);
+		scriptSource = generateJavaScriptSource(80, false);
+		autoFallbackSource = `return 1;\n${scriptSource}`;
+	},
+	teardown() {
+		moduleSource = "";
+		scriptSource = "";
+		autoFallbackSource = "";
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "parse 100 KiB module",
+			fn() {
+				sink = acornParse(moduleSource, "module").comments.length;
+			}
+		},
+		{
+			name: "parse 100 KiB script",
+			fn() {
+				sink = acornParse(scriptSource, "script").comments.length;
+			}
+		},
+		{
+			name: "parse module without comments or ranges",
+			fn() {
+				sink = JavascriptParser._parse(moduleSource, {
+					sourceType: "module",
+					comments: false,
+					ranges: false,
+					allowHashBang: true
+				}).comments.length;
+			}
+		},
+		{
+			name: "parse auto script fallback",
+			fn() {
+				sink = JavascriptParser._parse(autoFallbackSource, {
+					sourceType: "auto",
+					comments: true,
+					ranges: true,
+					allowHashBang: true
+				}).comments.length;
+			}
+		},
+		{
+			name: "full parse and walk 100 KiB module",
+			fn() {
+				// Full pipeline: acorn parse + scope analysis + hook-driven walk.
+				const state = parser.parse(
+					moduleSource,
+					/** @type {import("../../../../lib/Parser").ParserState} */ (
+						/** @type {unknown} */ ({ source: moduleSource })
+					)
+				);
+				sink = /** @type {string} */ (state.source).length;
+			}
+		},
+		{
+			name: "full parse and walk 100 KiB script",
+			fn() {
+				const state = scriptParser.parse(
+					scriptSource,
+					/** @type {import("../../../../lib/Parser").ParserState} */ (
+						/** @type {unknown} */ ({ source: scriptSource })
+					)
+				);
+				sink = /** @type {string} */ (state.source).length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/json/JsonParser.bench.mjs
+++ b/test/benchmark/unit/json/JsonParser.bench.mjs
@@ -1,0 +1,106 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const JsonParser =
+	/** @type {typeof import("../../../../lib/json/JsonParser")} */
+	(require("../../../../lib/json/JsonParser.js"));
+
+const defaultParser = new JsonParser();
+const shallowParser = new JsonParser({
+	exportsDepth: 1,
+	namedExports: false
+});
+const customParser = new JsonParser({ parse: JSON.parse });
+
+let source = "";
+let sourceBuffer = Buffer.alloc(0);
+/** @type {import("../../../../lib/Parser").ParserState} */
+let state;
+let sink = 0;
+
+/**
+ * @returns {import("../../../../lib/Parser").ParserState} parser state
+ */
+const createState = () =>
+	/** @type {import("../../../../lib/Parser").ParserState} */ (
+		/** @type {unknown} */ ({
+			module: {
+				buildInfo: {},
+				buildMeta: {},
+				dependencies:
+					/** @type {import("../../../../lib/Dependency")[]} */ ([]),
+				/** @param {import("../../../../lib/Dependency")} dependency dependency */
+				addDependency(dependency) {
+					this.dependencies.push(dependency);
+				}
+			}
+		})
+	);
+
+export default {
+	name: "unit/json/JsonParser",
+	setup() {
+		source = JSON.stringify(
+			Object.fromEntries(
+				Array.from({ length: 5000 }, (_, i) => [
+					`key_${i}`,
+					{
+						id: i,
+						name: `module-${i}`,
+						values: [i, i + 1, i + 2],
+						nested: { enabled: i % 2 === 0 }
+					}
+				])
+			)
+		);
+		sourceBuffer = Buffer.from(source);
+	},
+	teardown() {
+		source = "";
+		sourceBuffer = Buffer.alloc(0);
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "parse 5000 JSON exports",
+			beforeEach() {
+				state = createState();
+			},
+			fn() {
+				defaultParser.parse(source, state);
+				sink = state.module.dependencies.length;
+			}
+		},
+		{
+			name: "parse JSON buffer",
+			beforeEach() {
+				state = createState();
+			},
+			fn() {
+				defaultParser.parse(sourceBuffer, state);
+				sink = state.module.dependencies.length;
+			}
+		},
+		{
+			name: "parse with shallow unnamed exports",
+			beforeEach() {
+				state = createState();
+			},
+			fn() {
+				shallowParser.parse(source, state);
+				sink = state.module.dependencies.length;
+			}
+		},
+		{
+			name: "parse with custom JSON parser",
+			beforeEach() {
+				state = createState();
+			},
+			fn() {
+				customParser.parse(source, state);
+				sink = state.module.dependencies.length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/loaders/LoaderRunner.bench.mjs
+++ b/test/benchmark/unit/loaders/LoaderRunner.bench.mjs
@@ -1,0 +1,88 @@
+import { createRequire } from "module";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const require = createRequire(import.meta.url);
+
+const { runLoaders } =
+	/** @type {typeof import("../../../../lib/loaders/LoaderRunner")} */
+	(require("../../../../lib/loaders/LoaderRunner.js"));
+
+const fixtures = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../fixtures/loader-runner"
+);
+const resource = path.join(fixtures, "resource.bin");
+const resourceBuffer = Buffer.from("benchmark resource");
+const identityLoader = path.join(fixtures, "identity-loader.js");
+const pitchingLoader = path.join(fixtures, "pitching-loader.js");
+const simpleLoader = path.join(fixtures, "simple-loader.js");
+
+/** @type {unknown} */
+let sink;
+
+/** @type {import("../../../../lib/loaders/LoaderRunner").ProcessOptions["processResource"]} */
+const processResource = (loaderContext, currentResource, callback) => {
+	loaderContext.addDependency(currentResource);
+	callback(null, resourceBuffer);
+};
+
+/**
+ * @param {string[]} loaders loader chain
+ * @param {number} count pipeline count
+ * @returns {Promise<void>}
+ */
+function runPipelines(loaders, count) {
+	return new Promise((resolve, reject) => {
+		let remaining = count;
+		/**
+		 * @param {Error | null} err loader error
+		 * @param {import("../../../../lib/loaders/LoaderRunner").RunLoaderResult} result loader result
+		 */
+		const onResult = (err, result) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			sink = result.result;
+			if (--remaining === 0) resolve();
+		};
+		for (let i = 0; i < count; i++) {
+			runLoaders(
+				{
+					resource: `${resource}?variant=${i % 10}#fragment`,
+					loaders,
+					processResource
+				},
+				onResult
+			);
+		}
+	});
+}
+
+export default {
+	name: "unit/loaders/LoaderRunner",
+	teardown() {
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "process 2000 resources without loaders",
+			fn() {
+				return runPipelines([], 2000);
+			}
+		},
+		{
+			name: "run 1000 three-loader pipelines",
+			fn() {
+				return runPipelines([identityLoader, simpleLoader, identityLoader], 1000);
+			}
+		},
+		{
+			name: "run 1000 pitching short circuits",
+			fn() {
+				return runPipelines([simpleLoader, pitchingLoader, simpleLoader], 1000);
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/rules/RuleSetCompiler.bench.mjs
+++ b/test/benchmark/unit/rules/RuleSetCompiler.bench.mjs
@@ -1,0 +1,118 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const BasicEffectRulePlugin =
+	/** @type {typeof import("../../../../lib/rules/BasicEffectRulePlugin")} */
+	(require("../../../../lib/rules/BasicEffectRulePlugin.js"));
+const BasicMatcherRulePlugin =
+	/** @type {typeof import("../../../../lib/rules/BasicMatcherRulePlugin")} */
+	(require("../../../../lib/rules/BasicMatcherRulePlugin.js"));
+const RuleSetCompiler =
+	/** @type {typeof import("../../../../lib/rules/RuleSetCompiler")} */
+	(require("../../../../lib/rules/RuleSetCompiler.js"));
+const UseEffectRulePlugin =
+	/** @type {typeof import("../../../../lib/rules/UseEffectRulePlugin")} */
+	(require("../../../../lib/rules/UseEffectRulePlugin.js"));
+
+// The subset of NormalModuleFactory's compiler wiring these rules exercise.
+const ruleSetCompiler = new RuleSetCompiler([
+	new BasicMatcherRulePlugin("test", "resource"),
+	new BasicMatcherRulePlugin("include", "resource"),
+	new BasicMatcherRulePlugin("exclude", "resource", true),
+	new BasicMatcherRulePlugin("resource"),
+	new BasicMatcherRulePlugin("resourceQuery"),
+	new BasicMatcherRulePlugin("issuer"),
+	new BasicEffectRulePlugin("type"),
+	new BasicEffectRulePlugin("sideEffects"),
+	new UseEffectRulePlugin()
+]);
+
+/**
+ * @returns {import("../../../../lib/rules/RuleSetCompiler").RuleSetRules} a realistic module.rules array
+ */
+function createRules() {
+	/** @type {import("../../../../lib/rules/RuleSetCompiler").RuleSetRules} */
+	const rules = [];
+	for (let i = 0; i < 20; i++) {
+		rules.push(
+			{
+				test: new RegExp(`\\.ext${i}\\.js$`),
+				exclude: /node_modules/,
+				use: [`loader-a-${i}`, { loader: `loader-b-${i}`, options: { i } }]
+			},
+			{
+				test: /\.css$/,
+				resourceQuery: new RegExp(`variant=${i}`),
+				oneOf: [
+					{ resourceQuery: /raw/, type: "asset/source" },
+					{ use: [`css-loader-${i}`] }
+				]
+			},
+			{
+				include: `/project/src/area-${i}`,
+				sideEffects: false,
+				use: [`side-effect-loader-${i}`]
+			}
+		);
+	}
+	return rules;
+}
+
+/** @type {import("../../../../lib/rules/RuleSetCompiler").RuleSet} */
+let ruleSet = ruleSetCompiler.compile([]);
+/** @type {{ resource: string, realResource: string, resourceQuery: string, resourceFragment: string, issuer: string, compiler: string, issuerLayer: string }[]} */
+let requests = [];
+let sink = 0;
+
+export default {
+	name: "unit/rules/RuleSetCompiler",
+	setup() {
+		ruleSet = ruleSetCompiler.compile([{ rules: createRules() }]);
+		requests = [];
+		for (let i = 0; i < 500; i++) {
+			const resource =
+				i % 3 === 0
+					? `/project/src/area-${i % 25}/file-${i}.ext${i % 20}.js`
+					: i % 3 === 1
+						? `/project/src/styles/style-${i}.css`
+						: `/project/node_modules/pkg-${i % 30}/index.js`;
+			requests.push({
+				resource,
+				realResource: resource,
+				resourceQuery: i % 4 === 0 ? `?variant=${i % 20}` : "",
+				resourceFragment: "",
+				issuer: `/project/src/index-${i % 5}.js`,
+				compiler: "",
+				issuerLayer: ""
+			});
+		}
+	},
+	teardown() {
+		requests = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "compile 60 rules",
+			fn() {
+				sink = ruleSetCompiler.compile([{ rules: createRules() }]).references
+					.size;
+			}
+		},
+		{
+			name: "exec 500 requests against 60 rules",
+			fn() {
+				let effects = 0;
+				for (const data of requests) {
+					effects += ruleSet.exec(
+						/** @type {import("../../../../lib/rules/RuleSetCompiler").EffectData} */ (
+							data
+						)
+					).length;
+				}
+				sink = effects;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/serialization/BinaryMiddleware.bench.mjs
+++ b/test/benchmark/unit/serialization/BinaryMiddleware.bench.mjs
@@ -1,0 +1,133 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const BinaryMiddleware =
+	/** @type {typeof import("../../../../lib/serialization/BinaryMiddleware")} */
+	(require("../../../../lib/serialization/BinaryMiddleware.js"));
+
+const middleware = new BinaryMiddleware();
+
+/** @type {import("../../../../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} */
+let numericData = [];
+/** @type {import("../../../../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} */
+let mixedData = [];
+/** @type {import("../../../../lib/serialization/BinaryMiddleware").SerializedType} */
+let numericSerialized = [];
+/** @type {import("../../../../lib/serialization/BinaryMiddleware").SerializedType} */
+let mixedSerialized = [];
+/** @type {Buffer[]} */
+let fragmentedSerialized = [];
+let sink = 0;
+
+/**
+ * @param {Buffer[]} buffers buffers
+ * @param {number} size chunk size
+ * @returns {Buffer[]} fixed-size chunks
+ */
+const fragment = (buffers, size) => {
+	const buffer = Buffer.concat(buffers);
+	const chunks = [];
+	for (let i = 0; i < buffer.length; i += size) {
+		chunks.push(buffer.subarray(i, i + size));
+	}
+	return chunks;
+};
+
+export default {
+	name: "unit/serialization/BinaryMiddleware",
+	setup() {
+		numericData = Array.from({ length: 60000 }, (_, i) => {
+			switch (i % 6) {
+				case 0:
+					return i % 11;
+				case 1:
+					return i * 1000;
+				case 2:
+					return i + 0.25;
+				case 3:
+					return i % 2 === 0;
+				case 4:
+					return null;
+				default:
+					return BigInt(i);
+			}
+		});
+		mixedData = Array.from({ length: 10000 }, (_, i) => {
+			switch (i % 4) {
+				case 0:
+					return `module-${i}/src/index.js`;
+				case 1:
+					return Buffer.alloc(64, i);
+				case 2:
+					return i;
+				default:
+					return i % 2 === 0;
+			}
+		});
+		numericSerialized =
+			/** @type {import("../../../../lib/serialization/BinaryMiddleware").SerializedType} */ (
+				middleware.serialize(numericData, {})
+			);
+		mixedSerialized =
+			/** @type {import("../../../../lib/serialization/BinaryMiddleware").SerializedType} */ (
+				middleware.serialize(mixedData, {})
+			);
+		fragmentedSerialized = fragment(
+			/** @type {Buffer[]} */ (numericSerialized),
+			64
+		);
+	},
+	teardown() {
+		numericData = [];
+		mixedData = [];
+		numericSerialized = [];
+		mixedSerialized = [];
+		fragmentedSerialized = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "serialize 60000 numeric values",
+			fn() {
+				sink =
+					/** @type {Buffer[]} */ (middleware.serialize(numericData, {}))
+						.length;
+			}
+		},
+		{
+			name: "deserialize 60000 numeric values",
+			fn() {
+				sink =
+					/** @type {import("../../../../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} */ (
+						middleware.deserialize(numericSerialized, {})
+					).length;
+			}
+		},
+		{
+			name: "deserialize numeric values from 64-byte chunks",
+			fn() {
+				sink =
+					/** @type {import("../../../../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} */ (
+						middleware.deserialize(fragmentedSerialized, {})
+					).length;
+			}
+		},
+		{
+			name: "serialize 10000 mixed values",
+			fn() {
+				sink =
+					/** @type {Buffer[]} */ (middleware.serialize(mixedData, {})).length;
+			}
+		},
+		{
+			name: "deserialize 10000 mixed values",
+			fn() {
+				sink =
+					/** @type {import("../../../../lib/serialization/BinaryMiddleware").PrimitiveSerializableType[]} */ (
+						middleware.deserialize(mixedSerialized, {})
+					).length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/AsyncQueue.bench.mjs
+++ b/test/benchmark/unit/util/AsyncQueue.bench.mjs
@@ -1,0 +1,74 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const AsyncQueue =
+	/** @type {typeof import("../../../../lib/util/AsyncQueue")} */
+	(require("../../../../lib/util/AsyncQueue.js"));
+
+/** @type {number[]} */
+let uniqueItems = [];
+/** @type {number[]} */
+let duplicateItems = [];
+let sink = 0;
+
+/** @type {import("../../../../lib/util/AsyncQueue").Processor<number, number>} */
+const processor = (item, callback) => callback(null, item);
+
+/**
+ * @param {number[]} items queue input
+ * @returns {Promise<number>} sum of processed results
+ */
+function processItems(items) {
+	return new Promise((resolve, reject) => {
+		const queue = new AsyncQueue({
+			name: "benchmark",
+			parallelism: 100,
+			processor
+		});
+		let remaining = items.length;
+		let total = 0;
+		/**
+		 * @param {Error | null | undefined} err queue error
+		 * @param {number | null | undefined} result queue result
+		 */
+		const onResult = (err, result) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			total += result || 0;
+			if (--remaining === 0) resolve(total);
+		};
+		for (const item of items) {
+			queue.add(item, onResult);
+		}
+	});
+}
+
+export default {
+	name: "unit/util/AsyncQueue",
+	setup() {
+		uniqueItems = Array.from({ length: 5000 }, (_, i) => i);
+		duplicateItems = Array.from({ length: 5000 }, (_, i) => i % 500);
+	},
+	teardown() {
+		uniqueItems = [];
+		duplicateItems = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "process 5000 unique items",
+			async fn() {
+				sink = await processItems(uniqueItems);
+			}
+		},
+		{
+			name: "deduplicate 5000 items to 500 keys",
+			async fn() {
+				sink = await processItems(duplicateItems);
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/SortableSet.bench.mjs
+++ b/test/benchmark/unit/util/SortableSet.bench.mjs
@@ -1,0 +1,60 @@
+import { createRequire } from "module";
+import { mulberry32 } from "../../helpers/prng.mjs";
+
+const require = createRequire(import.meta.url);
+
+const SortableSet =
+	/** @type {typeof import("../../../../lib/util/SortableSet")} */
+	(require("../../../../lib/util/SortableSet.js"));
+const { compareIds } =
+	/** @type {import("../../../../lib/util/comparators")} */
+	(require("../../../../lib/util/comparators.js"));
+
+/** @type {(string | number)[]} */
+let shuffledIds = [];
+/** @type {import("../../../../lib/util/SortableSet")<string | number>} */
+let set = new SortableSet();
+let sink = 0;
+
+export default {
+	name: "unit/util/SortableSet",
+	setup() {
+		// Deterministically shuffled mix of numeric and named ids, the shape
+		// chunk/module id sets have when sorted during codegen.
+		const random = mulberry32(42);
+		shuffledIds = [];
+		for (let i = 0; i < 10_000; i++) {
+			shuffledIds.push(i % 5 === 0 ? `module-${i}` : i);
+		}
+		for (let i = shuffledIds.length - 1; i > 0; i--) {
+			const j = Math.floor(random() * (i + 1));
+			const tmp = shuffledIds[i];
+			shuffledIds[i] = shuffledIds[j];
+			shuffledIds[j] = tmp;
+		}
+	},
+	teardown() {
+		shuffledIds = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "sortWith compareIds 10k entries",
+			beforeEach() {
+				// Fresh set per round: sortWith caches the last sort fn, so a
+				// reused set would measure the cached no-op instead of the sort.
+				set = new SortableSet(shuffledIds);
+			},
+			fn() {
+				set.sortWith(compareIds);
+				sink = set.size;
+			}
+		},
+		{
+			name: "construct from 10k entries",
+			fn() {
+				sink = new SortableSet(shuffledIds).size;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/cleverMerge.bench.mjs
+++ b/test/benchmark/unit/util/cleverMerge.bench.mjs
@@ -1,0 +1,89 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const cleverMergeModule =
+	/** @type {import("../../../../lib/util/cleverMerge")} */
+	(require("../../../../lib/util/cleverMerge.js"));
+
+/** @typedef {Record<string, unknown>} ConfigLike */
+
+/**
+ * @returns {ConfigLike} a webpack-config-shaped object
+ */
+function createFirst() {
+	return {
+		mode: "development",
+		devtool: "eval",
+		module: {
+			rules: [
+				{ test: /\.js$/, use: "babel-loader" },
+				{ test: /\.css$/, use: ["style-loader", "css-loader"] }
+			]
+		},
+		resolve: {
+			extensions: [".js", ".json"],
+			alias: { "@": "/src", lib: "/lib" },
+			byDependency: {
+				esm: { mainFields: ["module", "main"] },
+				commonjs: { mainFields: ["main"] }
+			}
+		},
+		optimization: { minimize: false, splitChunks: { chunks: "async" } }
+	};
+}
+
+/**
+ * @returns {ConfigLike} an override-shaped object
+ */
+function createSecond() {
+	return {
+		mode: "production",
+		module: {
+			rules: [{ test: /\.ts$/, use: "ts-loader" }]
+		},
+		resolve: {
+			extensions: [".ts", "..."],
+			alias: { "@": "/source" }
+		},
+		optimization: { minimize: true }
+	};
+}
+
+/** @type {ConfigLike} */
+let firstStable = {};
+/** @type {ConfigLike} */
+let secondStable = {};
+/** @type {unknown} */
+let sink;
+
+export default {
+	name: "unit/util/cleverMerge",
+	setup() {
+		firstStable = createFirst();
+		secondStable = createSecond();
+	},
+	teardown() {
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "cleverMerge 100 merges",
+			fn() {
+				// Uncached entry point — pays the full merge every call.
+				for (let i = 0; i < 100; i++) {
+					sink = cleverMergeModule.cleverMerge(firstStable, secondStable);
+				}
+			}
+		},
+		{
+			name: "cachedCleverMerge 1000 hits",
+			fn() {
+				// Same object pair → WeakMap hit, the per-module hot path.
+				for (let i = 0; i < 1000; i++) {
+					sink = cleverMergeModule.cachedCleverMerge(firstStable, secondStable);
+				}
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/comparators.bench.mjs
+++ b/test/benchmark/unit/util/comparators.bench.mjs
@@ -1,0 +1,65 @@
+import { createRequire } from "module";
+import { mulberry32 } from "../../helpers/prng.mjs";
+
+const require = createRequire(import.meta.url);
+
+const comparators =
+	/** @type {typeof import("../../../../lib/util/comparators")} */
+	(require("../../../../lib/util/comparators.js"));
+
+/** @type {string[]} */
+let strings = [];
+/** @type {(string | number)[]} */
+let ids = [];
+let sink = 0;
+
+/**
+ * @template T
+ * @param {T[]} items items to shuffle
+ * @param {number} seed random seed
+ * @returns {void}
+ */
+function shuffle(items, seed) {
+	const random = mulberry32(seed);
+	for (let i = items.length - 1; i > 0; i--) {
+		const j = Math.floor(random() * (i + 1));
+		const value = items[i];
+		items[i] = items[j];
+		items[j] = value;
+	}
+}
+
+export default {
+	name: "unit/util/comparators",
+	setup() {
+		strings = Array.from(
+			{ length: 10_000 },
+			(_, i) =>
+				`node_modules/package-${i % 200}/chunk-${i % 80}/module-${i}.js`
+		);
+		ids = Array.from({ length: 10_000 }, (_, i) =>
+			i % 5 === 0 ? `chunk-${i}` : i
+		);
+		shuffle(strings, 42);
+		shuffle(ids, 73);
+	},
+	teardown() {
+		strings = [];
+		ids = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "sort 10000 paths numerically",
+			fn() {
+				sink = [...strings].sort(comparators.compareStringsNumeric).length;
+			}
+		},
+		{
+			name: "sort 10000 mixed ids",
+			fn() {
+				sink = [...ids].sort(comparators.compareIds).length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/compileBooleanMatcher.bench.mjs
+++ b/test/benchmark/unit/util/compileBooleanMatcher.bench.mjs
@@ -1,0 +1,52 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const compileBooleanMatcher =
+	/** @type {import("../../../../lib/util/compileBooleanMatcher")} */
+	(require("../../../../lib/util/compileBooleanMatcher.js"));
+
+/** @type {Record<string, boolean>} */
+let chunkIdMap = {};
+/** @type {Record<string, boolean>} */
+let namedIdMap = {};
+/** @type {unknown} */
+let sink;
+
+export default {
+	name: "unit/util/compileBooleanMatcher",
+	setup() {
+		// The chunk-loading runtime compiles one matcher per chunk-having
+		// condition; maps look like {chunkId: hasCss} over the whole build.
+		chunkIdMap = {};
+		for (let i = 0; i < 2000; i++) {
+			chunkIdMap[`${i}`] = i % 3 !== 0;
+		}
+		namedIdMap = {};
+		for (let i = 0; i < 800; i++) {
+			namedIdMap[`vendors-node_modules_pkg-${i % 100}_index_js-${i}`] =
+				i % 4 !== 0;
+		}
+	},
+	teardown() {
+		chunkIdMap = {};
+		namedIdMap = {};
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "2000 numeric ids",
+			fn() {
+				const matcher = compileBooleanMatcher(chunkIdMap);
+				sink = typeof matcher === "function" ? matcher("chunkId") : matcher;
+			}
+		},
+		{
+			name: "800 named ids",
+			fn() {
+				const matcher = compileBooleanMatcher(namedIdMap);
+				sink = typeof matcher === "function" ? matcher("chunkId") : matcher;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/createHash.bench.mjs
+++ b/test/benchmark/unit/util/createHash.bench.mjs
@@ -1,0 +1,75 @@
+import { createRequire } from "module";
+import { deterministicBytes } from "../../helpers/prng.mjs";
+
+const require = createRequire(import.meta.url);
+
+const createHash =
+	/** @type {import("../../../../lib/util/createHash")} */
+	(require("../../../../lib/util/createHash.js"));
+
+/** @type {Buffer[]} */
+let chunks = [];
+/** @type {string[]} */
+let shortStrings = [];
+/** @type {string | Buffer} */
+let sink = "";
+
+/**
+ * @param {string} algorithm hash algorithm
+ * @returns {void}
+ */
+function hashChunks(algorithm) {
+	const hash = createHash(algorithm);
+	for (const chunk of chunks) hash.update(chunk);
+	sink = hash.digest("hex");
+}
+
+export default {
+	name: "unit/util/createHash",
+	setup() {
+		// 1 MiB in 4 KiB chunks — the shape of module source hashing.
+		chunks = Array.from({ length: 256 }, (_, i) =>
+			deterministicBytes(i + 1, 4096)
+		);
+		shortStrings = Array.from(
+			{ length: 2000 },
+			(_, i) => `webpack/lib/some/module-${i}.js|${i}|fallback`
+		);
+	},
+	teardown() {
+		chunks = [];
+		shortStrings = [];
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "md4 1 MiB in 4 KiB chunks",
+			fn() {
+				hashChunks("md4");
+			}
+		},
+		{
+			name: "xxhash64 1 MiB in 4 KiB chunks",
+			fn() {
+				hashChunks("xxhash64");
+			}
+		},
+		{
+			name: "sha256 1 MiB in 4 KiB chunks",
+			fn() {
+				hashChunks("sha256");
+			}
+		},
+		{
+			name: "xxhash64 2000 short strings",
+			fn() {
+				// One hash instance per string — the per-identifier hashing shape.
+				for (const str of shortStrings) {
+					const hash = createHash("xxhash64");
+					hash.update(str);
+					sink = hash.digest("hex");
+				}
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/createMappings.bench.mjs
+++ b/test/benchmark/unit/util/createMappings.bench.mjs
@@ -1,0 +1,67 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const createMappings =
+	/** @type {typeof import("../../../../lib/util/createMappings")} */
+	(require("../../../../lib/util/createMappings.js"));
+
+/** @type {import("../../../../lib/util/createMappings").LineMappings[]} */
+let lines = [];
+/** @type {number[]} */
+let values = [];
+let sink = "";
+
+export default {
+	name: "unit/util/createMappings",
+	setup() {
+		lines = Array.from({ length: 20_000 }, (_, i) => {
+			if (i % 11 === 0) return null;
+			const first = {
+				generatedColumn: 0,
+				sourceIndex: i % 40,
+				originalLine: i * 2,
+				originalColumn: i % 120,
+				nameIndex: i % 300
+			};
+			return i % 5 === 0
+				? [
+						first,
+						{
+							generatedColumn: 24,
+							sourceIndex: i % 40,
+							originalLine: i * 2,
+							originalColumn: (i % 120) + 12
+						}
+					]
+				: first;
+		});
+		values = Array.from(
+			{ length: 10_000 },
+			(_, i) => (i % 2 === 0 ? i * 7919 : i * -3571)
+		);
+	},
+	teardown() {
+		lines = [];
+		values = [];
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "encode 100000 VLQ values",
+			fn() {
+				for (let i = 0; i < 10; i++) {
+					for (const value of values) {
+						sink = createMappings.encodeVLQ(value);
+					}
+				}
+			}
+		},
+		{
+			name: "encode mappings for 20000 lines",
+			fn() {
+				sink = createMappings.encodeMappings(lines);
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/deterministicGrouping.bench.mjs
+++ b/test/benchmark/unit/util/deterministicGrouping.bench.mjs
@@ -1,0 +1,71 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const deterministicGrouping =
+	/** @type {typeof import("../../../../lib/util/deterministicGrouping")} */
+	(require("../../../../lib/util/deterministicGrouping.js"));
+
+/** @typedef {{ key: string, size: Record<string, number> }} GroupingItem */
+
+/** @type {GroupingItem[]} */
+let singleTypeItems = [];
+/** @type {GroupingItem[]} */
+let mixedTypeItems = [];
+let sink = 0;
+
+const getKey = (/** @type {GroupingItem} */ item) => item.key;
+const getSize = (/** @type {GroupingItem} */ item) => item.size;
+
+export default {
+	name: "unit/util/deterministicGrouping",
+	setup() {
+		singleTypeItems = [];
+		mixedTypeItems = [];
+		for (let i = 0; i < 4000; i++) {
+			const key = `node_modules/package-${i % 200}/dist/chunk-${String(
+				i
+			).padStart(5, "0")}-${((i * 2654435761) >>> 0).toString(16)}.js`;
+			const javascript = 1000 + ((i * 7919) % 30_000);
+			singleTypeItems.push({ key, size: { javascript } });
+			mixedTypeItems.push({
+				key,
+				size:
+					i % 5 === 0
+						? { javascript, css: 500 + ((i * 3571) % 12_000) }
+						: { javascript }
+			});
+		}
+	},
+	teardown() {
+		singleTypeItems = [];
+		mixedTypeItems = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "group 4000 JavaScript modules",
+			fn() {
+				sink = deterministicGrouping({
+					items: singleTypeItems,
+					minSize: { javascript: 20_000 },
+					maxSize: { javascript: 100_000 },
+					getKey,
+					getSize
+				}).length;
+			}
+		},
+		{
+			name: "group 4000 modules with mixed source types",
+			fn() {
+				sink = deterministicGrouping({
+					items: mixedTypeItems,
+					minSize: { javascript: 20_000, css: 10_000 },
+					maxSize: { javascript: 100_000, css: 60_000 },
+					getKey,
+					getSize
+				}).length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/findGraphRoots.bench.mjs
+++ b/test/benchmark/unit/util/findGraphRoots.bench.mjs
@@ -1,0 +1,48 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const findGraphRoots =
+	/** @type {import("../../../../lib/util/findGraphRoots")} */
+	(require("../../../../lib/util/findGraphRoots.js"));
+
+/** @typedef {{ id: number, deps: GraphNode[] }} GraphNode */
+
+/** @type {GraphNode[]} */
+let nodes = [];
+let sink = 0;
+
+export default {
+	name: "unit/util/findGraphRoots",
+	setup() {
+		// 5000-node graph with deterministic edges: forward jumps like a module
+		// graph plus back-edges every 17th node so cycle handling is exercised.
+		nodes = Array.from({ length: 5000 }, (_, id) => ({ id, deps: [] }));
+		for (const node of nodes) {
+			const { id } = node;
+			node.deps.push(
+				nodes[(id * 7 + 1) % nodes.length],
+				nodes[(id * 13 + 3) % nodes.length]
+			);
+			if (id % 17 === 0 && id > 0) {
+				node.deps.push(nodes[id - 1]);
+			}
+		}
+	},
+	teardown() {
+		nodes = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "5000 nodes with cycles",
+			fn() {
+				let count = 0;
+				for (const _root of findGraphRoots(nodes, (node) => node.deps)) {
+					count++;
+				}
+				sink = count;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/identifier.bench.mjs
+++ b/test/benchmark/unit/util/identifier.bench.mjs
@@ -1,0 +1,77 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const identifier =
+	/** @type {import("../../../../lib/util/identifier")} */
+	(require("../../../../lib/util/identifier.js"));
+
+const CONTEXT = "/home/user/project";
+
+/** @type {string[]} */
+let requests = [];
+/** @type {string} */
+let sink = "";
+/** @type {Record<string, unknown>} */
+let cacheObject = {};
+
+export default {
+	name: "unit/util/identifier",
+	setup() {
+		requests = [];
+		for (let i = 0; i < 400; i++) {
+			requests.push(
+				`/home/user/project/node_modules/pkg-${i % 40}/lib/deep/nested/file-${i}.js`,
+				`/home/user/project/src/components/feature-${i % 25}/Component${i}.js?query=${i}#fragment`,
+				`/home/user/project/node_modules/loader-${i % 7}/index.js!/home/user/project/src/entry-${i}.css`
+			);
+		}
+	},
+	teardown() {
+		requests = [];
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "makePathsRelative uncached 1200 requests",
+			fn() {
+				// No associated object → no cache, measures the raw conversion.
+				for (const request of requests) {
+					sink = identifier.makePathsRelative(CONTEXT, request);
+				}
+			}
+		},
+		{
+			name: "makePathsRelative cached 1200 requests",
+			beforeEach() {
+				// Fresh cache per round: measures one miss + reuse per distinct
+				// request instead of unbounded cross-round hits.
+				cacheObject = {};
+			},
+			fn() {
+				for (const request of requests) {
+					sink = identifier.makePathsRelative(CONTEXT, request, cacheObject);
+				}
+			}
+		},
+		{
+			name: "contextify 1200 requests",
+			fn() {
+				for (const request of requests) {
+					sink = identifier.contextify(CONTEXT, request);
+				}
+			}
+		},
+		{
+			name: "parseResource 1200 requests",
+			beforeEach() {
+				cacheObject = {};
+			},
+			fn() {
+				for (const request of requests) {
+					sink = identifier.parseResource(request, cacheObject).path;
+				}
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/numberHash.bench.mjs
+++ b/test/benchmark/unit/util/numberHash.bench.mjs
@@ -1,0 +1,45 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const numberHash =
+	/** @type {import("../../../../lib/util/numberHash")} */
+	(require("../../../../lib/util/numberHash.js"));
+
+/** @type {string[]} */
+let identifiers = [];
+let sink = 0;
+
+export default {
+	name: "unit/util/numberHash",
+	setup() {
+		// Module-identifier-shaped strings — what deterministic ids hash.
+		identifiers = Array.from(
+			{ length: 1000 },
+			(_, i) =>
+				`./node_modules/package-${i % 50}/dist/esm/internal/chunk-${i}.mjs`
+		);
+	},
+	teardown() {
+		identifiers = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "1000 identifiers, small range",
+			fn() {
+				let total = 0;
+				for (const id of identifiers) total += numberHash(id, 1000);
+				sink = total;
+			}
+		},
+		{
+			name: "1000 identifiers, large range",
+			fn() {
+				let total = 0;
+				for (const id of identifiers) total += numberHash(id, 2 ** 31);
+				sink = total;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/property.bench.mjs
+++ b/test/benchmark/unit/util/property.bench.mjs
@@ -1,0 +1,55 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const property =
+	/** @type {import("../../../../lib/util/property")} */
+	(require("../../../../lib/util/property.js"));
+
+/** @type {string[]} */
+let names = [];
+/** @type {string[][]} */
+let chains = [];
+/** @type {string} */
+let sink = "";
+
+export default {
+	name: "unit/util/property",
+	setup() {
+		names = [];
+		for (let i = 0; i < 200; i++) {
+			names.push(
+				`validName${i}`,
+				"default",
+				`with-dash-${i}`,
+				`${i}numeric`,
+				`has space ${i}`
+			);
+		}
+		chains = names.map((name, i) => [
+			"webpackExports",
+			name,
+			`nested${i % 10}`
+		]);
+	},
+	teardown() {
+		names = [];
+		chains = [];
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "propertyName 1000 names",
+			fn() {
+				// Runtime template generation quotes every export name this way.
+				for (const name of names) sink = property.propertyName(name);
+			}
+		},
+		{
+			name: "propertyAccess 1000 chains",
+			fn() {
+				for (const chain of chains) sink = property.propertyAccess(chain);
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/semver.bench.mjs
+++ b/test/benchmark/unit/util/semver.bench.mjs
@@ -1,0 +1,70 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const semver =
+	/** @type {import("../../../../lib/util/semver")} */
+	(require("../../../../lib/util/semver.js"));
+
+const RANGES = [
+	"^1.2.3",
+	"~2.4.0",
+	">=1.0.0 <2.0.0",
+	"1.2.3 - 2.3.4",
+	"^1.2.3 || ^2.0.0",
+	"2.x",
+	"*",
+	">=16.8.0 <17.0.0 || ^18.0.0"
+];
+
+const VERSIONS = ["1.2.3", "1.9.9", "2.0.0", "2.4.1", "16.14.0", "18.2.0"];
+
+/** @type {import("../../../../lib/util/semver").SemVerRange[]} */
+let parsedRanges = [];
+/** @type {unknown} */
+let sink;
+
+export default {
+	name: "unit/util/semver",
+	setup() {
+		parsedRanges = RANGES.map((range) => semver.parseRange(range));
+	},
+	teardown() {
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "parseRange 80 ranges",
+			fn() {
+				// Module Federation parses ranges for every shared module.
+				for (let i = 0; i < 10; i++) {
+					for (const range of RANGES) {
+						sink = semver.parseRange(range);
+					}
+				}
+			}
+		},
+		{
+			name: "satisfy 48 range/version pairs",
+			fn() {
+				let matches = 0;
+				for (const range of parsedRanges) {
+					for (const version of VERSIONS) {
+						if (semver.satisfy(range, version)) matches++;
+					}
+				}
+				sink = matches;
+			}
+		},
+		{
+			name: "rangeToString 80 ranges",
+			fn() {
+				for (let i = 0; i < 10; i++) {
+					for (const range of parsedRanges) {
+						sink = semver.rangeToString(range);
+					}
+				}
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/serialization.bench.mjs
+++ b/test/benchmark/unit/util/serialization.bench.mjs
@@ -1,0 +1,100 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const { buffersSerializer } =
+	/** @type {typeof import("../../../../lib/util/serialization")} */
+	(require("../../../../lib/util/serialization.js"));
+
+/** @type {Record<string, unknown>} */
+let flatData = {};
+/** @type {Record<string, unknown>} */
+let sharedGraph = {};
+/** @type {Buffer[]} */
+let flatSerialized = [];
+/** @type {Buffer[]} */
+let graphSerialized = [];
+let sink = 0;
+
+/**
+ * @param {unknown} value value
+ * @returns {Promise<Buffer[]>} serialized buffers
+ */
+const serialize = async (value) =>
+	/** @type {Buffer[]} */ (await buffersSerializer.serialize(value, {}));
+
+export default {
+	name: "unit/util/serialization",
+	async setup() {
+		flatData = Object.fromEntries(
+			Array.from({ length: 5000 }, (_, i) => [
+				`module-${i}`,
+				{
+					id: i,
+					resource: `/project/src/module-${i}.js`,
+					hash: `hash-${i}`,
+					dependencies: [`./dependency-${i % 100}`, `package-${i % 50}`]
+				}
+			])
+		);
+		const shared = {
+			buildMeta: { exportsType: "namespace", strictHarmonyModule: true },
+			flags: new Set(["cacheable", "built"])
+		};
+		const modules = Array.from({ length: 2000 }, (_, i) => ({
+			id: i,
+			resource: `/project/src/module-${i}.js`,
+			hash: Buffer.alloc(32, i),
+			shared,
+			dependencies: [i && i - 1, i > 1 && i - 2]
+		}));
+		sharedGraph = {
+			modules,
+			byId: new Map(modules.map((module) => [module.id, module])),
+			shared
+		};
+		flatSerialized = await serialize(flatData);
+		graphSerialized = await serialize(sharedGraph);
+	},
+	teardown() {
+		flatData = {};
+		sharedGraph = {};
+		flatSerialized = [];
+		graphSerialized = [];
+		if (sink === -1) console.log(sink);
+	},
+	benches: [
+		{
+			name: "serialize flat module metadata",
+			async fn() {
+				sink = (await serialize(flatData)).length;
+			}
+		},
+		{
+			name: "deserialize flat module metadata",
+			async fn() {
+				const value =
+					/** @type {Record<string, unknown>} */ (
+						await buffersSerializer.deserialize(flatSerialized, {})
+					);
+				sink = Object.keys(value).length;
+			}
+		},
+		{
+			name: "serialize shared module graph",
+			async fn() {
+				sink = (await serialize(sharedGraph)).length;
+			}
+		},
+		{
+			name: "deserialize shared module graph",
+			async fn() {
+				const value =
+					/** @type {{ modules: unknown[] }} */ (
+						await buffersSerializer.deserialize(graphSerialized, {})
+					);
+				sink = value.modules.length;
+			}
+		}
+	]
+};

--- a/test/benchmark/unit/util/smartGrouping.bench.mjs
+++ b/test/benchmark/unit/util/smartGrouping.bench.mjs
@@ -1,0 +1,70 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const smartGrouping =
+	/** @type {typeof import("../../../../lib/util/smartGrouping")} */
+	(require("../../../../lib/util/smartGrouping.js"));
+
+/** @typedef {{ id: number, type: string, packageName: string, cached: boolean }} StatsItem */
+/** @typedef {{ name: string, children: unknown[], size: number }} StatsGroup */
+
+/** @type {StatsItem[]} */
+let items = [];
+/** @type {unknown} */
+let sink;
+
+/** @type {import("../../../../lib/util/smartGrouping").GroupConfig<StatsItem, StatsGroup>[]} */
+const groupConfigs = [
+	{
+		getKeys: (item) => [item.type],
+		getOptions: () => ({ targetGroupCount: 4 }),
+		createGroup: (name, children, groupedItems) => ({
+			name: `type:${name}`,
+			children,
+			size: groupedItems.length
+		})
+	},
+	{
+		getKeys: (item) => [item.packageName],
+		getOptions: () => ({ groupChildren: false, targetGroupCount: 20 }),
+		createGroup: (name, children, groupedItems) => ({
+			name: `package:${name}`,
+			children,
+			size: groupedItems.length
+		})
+	},
+	{
+		getKeys: (item) => (item.cached ? ["cached"] : ["built"]),
+		createGroup: (name, children, groupedItems) => ({
+			name,
+			children,
+			size: groupedItems.length
+		})
+	}
+];
+
+export default {
+	name: "unit/util/smartGrouping",
+	setup() {
+		const types = ["javascript/auto", "javascript/esm", "css/auto", "asset"];
+		items = Array.from({ length: 5000 }, (_, id) => ({
+			id,
+			type: types[id % types.length],
+			packageName: `package-${id % 120}`,
+			cached: id % 3 !== 0
+		}));
+	},
+	teardown() {
+		items = [];
+		if (sink === "unreachable") console.log(sink);
+	},
+	benches: [
+		{
+			name: "group 5000 stats items",
+			fn() {
+				sink = smartGrouping(items, groupConfigs);
+			}
+		}
+	]
+};

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -28,6 +28,16 @@ import { Bench, hrtimeNow } from "tinybench";
 /** @typedef {import("../../BenchmarkTestCases.benchmark.mjs").Scenario} Scenario */
 /** @typedef {import("../../BenchmarkTestCases.benchmark.mjs").Baseline} Baseline */
 /** @typedef {import("../../BenchmarkTestCases.benchmark.mjs").BenchmarkTask} BenchmarkTask */
+/** @typedef {import("../../benchmark/lib/webpack.mjs").BenchmarkDefinition} SuiteBenchmarkDefinition */
+
+/**
+ * @typedef {object} Suite
+ * @property {string} name suite name, prefixed with "unit/" or "e2e/"
+ * @property {() => void | Promise<void>=} setup runs once before the suite's benchmarks
+ * @property {() => void | Promise<void>=} teardown runs once after the suite's benchmarks
+ * @property {number=} iterations measured rounds per benchmark
+ * @property {SuiteBenchmarkDefinition[]} benches benchmarks, executed in order
+ */
 
 /**
  * @typedef {object} ResultExtra
@@ -1241,9 +1251,58 @@ function attachResultCollector(bench, results) {
 }
 
 /**
+ * Register a suite-format benchmark file (`test/benchmark/{unit,e2e}`) onto
+ * `bench`. Suites measure the current lib only (no baselines, no scenarios);
+ * their benches carry their own hooks. Suite-level `setup` runs before the
+ * suite's first bench and `teardown` after its last — symmetrically in both
+ * the memory-mode prime pass and the measured pass, so re-running a pass
+ * always sees freshly set up fixtures.
+ * @param {Bench} bench bench
+ * @param {BenchmarkTask} task benchmark task
+ * @returns {Promise<void>}
+ */
+async function registerSuiteBenchmark(bench, task) {
+	const suiteFile = /** @type {string} */ (task.suiteFile);
+	/** @type {Suite} */
+	const suite = (await import(`${pathToFileURL(suiteFile)}`)).default;
+	const benches = suite.benches;
+	const state = { initialized: false };
+
+	for (const [index, definition] of benches.entries()) {
+		const isLast = index === benches.length - 1;
+		const taskName = `${suite.name}/${definition.name}`;
+
+		console.log(`Register: suite benchmark "${taskName}"`);
+
+		bench.add(taskName, definition.fn, {
+			// Forces async handling for benches whose fn returns a promise
+			// without being an async function (tinybench detects only the latter).
+			async: definition.async,
+			async beforeAll() {
+				if (!state.initialized) {
+					await suite.setup?.();
+					state.initialized = true;
+				}
+				await definition.beforeAll?.();
+			},
+			beforeEach: definition.beforeEach,
+			afterEach: definition.afterEach,
+			async afterAll() {
+				await definition.afterAll?.();
+				if (isLast) {
+					state.initialized = false;
+					await suite.teardown?.();
+				}
+			}
+		});
+	}
+}
+
+/**
  * Register one benchmark task's benches onto `bench`. `-unit` benchmarks
  * register their own tasks against the current lib, `-runtime` benchmarks
- * measure the compiled output; others add one build/watch bench per baseline.
+ * measure the compiled output, suite benchmarks load their suite file; others
+ * add one build/watch bench per baseline.
  * @param {Bench} bench bench
  * @param {BenchmarkTask} task benchmark task
  * @param {string} casesPath benchmark cases directory
@@ -1254,6 +1313,11 @@ async function registerBenchmark(bench, task, casesPath) {
 	const LAST_COMMIT = typeof process.env.LAST_COMMIT !== "undefined";
 	const testDirectory = path.join(casesPath, benchmark);
 	const isRuntime = benchmark.includes("-runtime");
+
+	if (task.suiteFile) {
+		await registerSuiteBenchmark(bench, task);
+		return;
+	}
 
 	if (benchmark.includes("-unit")) {
 		// Unit benchmarks register their own tasks against the current lib; they
@@ -1356,7 +1420,11 @@ export async function run({
 
 	return {
 		benchmark: task.benchmark,
-		scenario: task.scenario ? task.scenario.name : "unit",
+		scenario: task.scenario
+			? task.scenario.name
+			: task.suiteFile
+				? "suite"
+				: "unit",
 		results
 	};
 }

--- a/tsconfig.types.benchmark.json
+++ b/tsconfig.types.benchmark.json
@@ -5,9 +5,13 @@
     "moduleResolution": "bundler"
   },
   "include": [
+    "declarations.d.ts",
     "test/*.benchmark.mjs",
     "test/harness/benchmark/**/*.mjs",
     "test/benchmarkCases/**/webpack.config.mjs",
-    "test/benchmarkCases/**/options.mjs"
+    "test/benchmarkCases/**/options.mjs",
+    "test/benchmark/lib/**/*.mjs",
+    "test/benchmark/helpers/**/*.mjs",
+    "test/benchmark/**/*.bench.mjs"
   ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`test/benchmarkCases` only covers full builds, so regressions inside individual subsystems (parsers, serialization, rule matching, hashing) are invisible until they move a whole bundle. This adds a suite-format benchmark tree — `test/benchmark/unit` mirroring `lib/` and `test/benchmark/e2e` for full-build workloads, on deterministic fixture generators — and teaches the existing harness to discover and run it alongside `benchmarkCases`. Suites measure the current tree only (no HEAD/BASE comparison) and own their setup/teardown.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

chore

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

n/a — this PR is entirely test/benchmark infrastructure; no `lib/` code changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The existing `benchmarkCases` harness keeps working unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Nothing external; `AGENTS.md` and `TESTING_DOCS.md` are updated in this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code was used to help convert my local branch into a GitHub Stack.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only benchmark infrastructure with no `lib/` changes; existing `benchmarkCases` behavior is preserved, though CI benchmark jobs may run more workloads.
> 
> **Overview**
> Introduces a **suite-format** benchmark tree under `test/benchmark/`: **`unit/`** benches focused `lib/` areas (parsers, rules, serialization, util helpers) and **`e2e/`** full webpack builds (many modules, code splitting, filesystem cache, assets, CSS, JSON, source maps, watch rebuilds). Shared **`helpers/`** (mulberry32 PRNG, on-disk project generators) and **`lib/webpack.mjs`** (build, watch-rebuild, dev/prod scenario factories) keep fixtures deterministic and isolated.
> 
> The existing harness in **`BenchmarkTestCases.benchmark.mjs`** and **`benchmark.worker.mjs`** now **discovers** `test/benchmark/{unit,e2e}/**/*.bench.mjs`, creates one task per suite (honoring **`FILTER`**), skips orchestrator `options.setup()` for suites (they run **`setup()`** in the worker), and registers each suite’s **`benches`** with suite-level hooks. Suites measure the **current tree only**—no HEAD/BASE scenarios.
> 
> Docs and tooling are updated: **`AGENTS.md`**, **`TESTING_DOCS.md`**, ESLint ignores/rules for benchmark `.mjs`, **`cspell`**, and **`tsconfig.types.benchmark.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857eddd246cd205a0d0c51ab80bb941b7fe30119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->