### PR TITLE
fix(html): apply an entry's html options over output.html

### DIFF
--- a/.changeset/060-html-entry-options.md
+++ b/.changeset/060-html-entry-options.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Support an object for an entry's `html` that overrides `output.html` per option.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1314,7 +1314,7 @@ export interface EntryDescription {
 	 */
 	filename?: EntryFilename;
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 	/**
@@ -3892,7 +3892,7 @@ export interface EntryDescriptionNormalized {
 	 */
 	filename?: Filename;
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 	/**

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1314,7 +1314,7 @@ export interface EntryDescription {
 	 */
 	filename?: EntryFilename;
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 	/**
@@ -3892,7 +3892,7 @@ export interface EntryDescriptionNormalized {
 	 */
 	filename?: Filename;
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 	/**

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -712,15 +712,12 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 				: "";
 
 		// Per-chunk SRI: emit an `integrity` sentinel resolved late (after the
-		// chunks' final bytes exist) by `resolveChunkIntegritySentinels`. On when
-		// `output.html.integrity` is `true`, a non-empty array, or a function.
+		// chunks' final bytes exist) by `resolveChunkIntegritySentinels`. Tags are
+		// generated per HTML module, but one module can back pages with different
+		// `integrity` options, so sentinels are emitted whenever any page wants SRI
+		// and each page then resolves or strips them on emit.
 		const htmlOption = compilation.outputOptions.html;
-		const integrity =
-			typeof htmlOption === "object" ? htmlOption.integrity : undefined;
-		const integrityOn =
-			integrity === true ||
-			typeof integrity === "function" ||
-			(Array.isArray(integrity) && integrity.length > 0);
+		const integrityOn = HtmlGenerator.hasIntegritySentinels(compilation);
 		const inject =
 			typeof htmlOption === "object" ? htmlOption.inject : undefined;
 

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -244,6 +244,11 @@ const HTML_PAGE_URL_SENTINEL_REGEXP =
 const ASSET_URL_SENTINEL_REGEXP =
 	/__WEBPACK_HTML_ASSET_URL__([0-9a-f]+)__END__/g;
 
+// Compilations whose HTML modules must emit SRI sentinels (see
+// `enableIntegritySentinels`).
+/** @type {WeakSet<Compilation>} */
+const integritySentinelCompilations = new WeakSet();
+
 // Matches the whole ` integrity="<sentinel>"` so the attribute can be dropped
 // entirely when the per-asset `integrity` function returns `false`.
 const INTEGRITY_SENTINEL_REGEXP =
@@ -461,6 +466,26 @@ class HtmlGenerator extends Generator {
 			if (filename) return `${PUBLIC_PATH_AUTO}${filename}`;
 			return "data:,";
 		});
+	}
+
+	/**
+	 * Turns SRI sentinel emission on for this compilation. Tags are generated
+	 * once per HTML module, but one module can back several pages with different
+	 * `integrity` options, so HtmlModulesPlugin flags the compilation when any
+	 * page wants SRI and each page resolves or strips the sentinels on emit.
+	 * @param {Compilation} compilation compilation
+	 * @returns {void}
+	 */
+	static enableIntegritySentinels(compilation) {
+		integritySentinelCompilations.add(compilation);
+	}
+
+	/**
+	 * @param {Compilation} compilation compilation
+	 * @returns {boolean} true when SRI sentinels must be emitted
+	 */
+	static hasIntegritySentinels(compilation) {
+		return integritySentinelCompilations.has(compilation);
 	}
 
 	/**

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -40,6 +40,7 @@ const HtmlParser = require("./HtmlParser");
 const { escapeAttribute } = require("./syntax");
 
 /** @typedef {import("../../declarations/WebpackOptions").EntryDescriptionNormalized} EntryDescriptionNormalized */
+/** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions} OutputHtmlOptions */
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions["favicon"]} FaviconOption */
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions["manifest"]} ManifestOption */
 /** @typedef {import("../../declarations/WebpackOptions").HtmlFaviconIcon} HtmlFaviconIcon */
@@ -189,6 +190,11 @@ const manifestLinkTag = (manifest, name) => {
 	return `<link rel="manifest" href="${escapeAttribute(href)}">`;
 };
 
+// Read once per compilation and applied to every emitted page, so an entry's
+// `html` object can't override them.
+/** @type {("csp" | "inline" | "integrity")[]} */
+const GLOBAL_ONLY_HTML_OPTIONS = ["csp", "inline", "integrity"];
+
 // `\.html`/`\.css` request matchers for the synthetic `output.html` wrapper.
 const HTML_REQUEST_RE = /\.html(\?|$)/i;
 const CSS_REQUEST_RE = /\.css(\?|$)/i;
@@ -299,25 +305,37 @@ class HtmlModulesPlugin {
 	apply(compiler) {
 		const { output } = compiler.options;
 		const htmlOption = output.html;
-		const scriptLoading =
-			(typeof htmlOption === "object" && htmlOption.scriptLoading) || "auto";
-		// ESM output emits `type="module"` (already deferred), so scriptLoading
-		// is ignored under output.module — warn on an explicit defer/blocking.
-		let scriptAttr = " defer";
-		if (output.module) {
-			scriptAttr = "";
-			if (scriptLoading === "defer" || scriptLoading === "blocking") {
-				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
-					compilation.warnings.push(
-						new WebpackError(
-							`output.html.scriptLoading: "${scriptLoading}" is ignored with output.module — ES module scripts are always deferred.`
-						)
-					);
-				});
+		const globalHtmlOptions =
+			typeof htmlOption === "object" ? htmlOption : undefined;
+		// Collected while entries are resolved (`entryOption`, before the first
+		// compilation) and reported on every compilation; a Set dedupes entries
+		// that hit the same problem.
+		/** @type {Set<string>} */
+		const optionWarnings = new Set();
+		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+			for (const message of optionWarnings) {
+				compilation.warnings.push(new WebpackError(message));
 			}
-		} else if (scriptLoading === "blocking") {
-			scriptAttr = "";
-		}
+		});
+
+		/**
+		 * Options for one page: an entry's `html` object overrides `output.html`
+		 * option by option, `true` inherits it as-is.
+		 * @param {EntryDescriptionNormalized["html"]} html the entry's `html` value
+		 * @param {string} name entry name
+		 * @returns {OutputHtmlOptions} resolved options
+		 */
+		const resolveHtmlOptions = (html, name) => {
+			if (typeof html !== "object") return globalHtmlOptions || {};
+			for (const option of GLOBAL_ONLY_HTML_OPTIONS) {
+				if (html[option] !== undefined) {
+					optionWarnings.add(
+						`entry "${name}" html.${option} is ignored — ${option} applies to every emitted page and can only be set on output.html.`
+					);
+				}
+			}
+			return globalHtmlOptions ? { ...globalHtmlOptions, ...html } : html;
+		};
 
 		// `output.html` (or an entry's `html`) wraps a non-HTML entry in a
 		// synthetic HTML module so the existing pipeline injects its JS/CSS
@@ -338,6 +356,27 @@ class HtmlModulesPlugin {
 				) {
 					return;
 				}
+				const htmlObj = resolveHtmlOptions(desc.html, name);
+				const scriptLoading = htmlObj.scriptLoading || "auto";
+				// ESM output emits `type="module"` (already deferred), so
+				// scriptLoading is ignored under output.module — warn on an
+				// explicit defer/blocking.
+				let scriptAttr = " defer";
+				if (output.module) {
+					scriptAttr = "";
+					if (scriptLoading === "defer" || scriptLoading === "blocking") {
+						const source =
+							typeof desc.html === "object" &&
+							desc.html.scriptLoading !== undefined
+								? `entry "${name}" html`
+								: "output.html";
+						optionWarnings.add(
+							`${source}.scriptLoading: "${scriptLoading}" is ignored with output.module — ES module scripts are always deferred.`
+						);
+					}
+				} else if (scriptLoading === "blocking") {
+					scriptAttr = "";
+				}
 				const entries = compiler.options.entry;
 				const requests =
 					typeof entries === "object" && entries[name]
@@ -352,27 +391,13 @@ class HtmlModulesPlugin {
 						scripts.push(`<script${scriptAttr} src="${r}"></script>`);
 					}
 				}
-				const htmlObj =
-					typeof html === "object"
-						? html
-						: typeof htmlOption === "object"
-							? htmlOption
-							: {};
 				const headTags = HtmlParser.buildHeadTags(htmlObj);
 				// Injected into webpack-generated pages only; each icon's href is a
 				// normal request the parser turns into a hashed asset.
-				const favicon =
-					typeof html === "object" && html.favicon !== undefined
-						? html.favicon
-						: false;
-				const faviconTag = resolveFaviconLinks(favicon, name)
+				const faviconTag = resolveFaviconLinks(htmlObj.favicon, name)
 					.map(([rel, icon]) => faviconLinkTag(rel, icon))
 					.join("");
-				const manifest =
-					typeof html === "object" && html.manifest !== undefined
-						? html.manifest
-						: false;
-				const manifestTag = manifestLinkTag(manifest, name);
+				const manifestTag = manifestLinkTag(htmlObj.manifest, name);
 				const inject = htmlObj.inject;
 				const scriptsInHead =
 					inject === "head" || (inject !== "body" && output.module);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -190,10 +190,21 @@ const manifestLinkTag = (manifest, name) => {
 	return `<link rel="manifest" href="${escapeAttribute(href)}">`;
 };
 
-// Read once per compilation and applied to every emitted page, so an entry's
-// `html` object can't override them.
-/** @type {("csp" | "inline" | "integrity")[]} */
-const GLOBAL_ONLY_HTML_OPTIONS = ["csp", "inline", "integrity"];
+// Decided while the page's HTML is generated, which happens once per module —
+// and one synthetic page module can back several entries — so an entry's `html`
+// object can't override it.
+/** @type {"inline"[]} */
+const GLOBAL_ONLY_HTML_OPTIONS = ["inline"];
+
+/**
+ * SRI is on when `integrity` names at least one algorithm.
+ * @param {OutputHtmlOptions["integrity"]} integrity integrity option
+ * @returns {boolean} true when integrity attributes must be emitted
+ */
+const isIntegrityEnabled = (integrity) =>
+	integrity === true ||
+	typeof integrity === "function" ||
+	(Array.isArray(integrity) && integrity.length > 0);
 
 // `\.html`/`\.css` request matchers for the synthetic `output.html` wrapper.
 const HTML_REQUEST_RE = /\.html(\?|$)/i;
@@ -318,6 +329,19 @@ class HtmlModulesPlugin {
 			}
 		});
 
+		// Resolved options per entry that owns a generated page, read back when the
+		// page is emitted (`csp`, `integrity`) — one synthetic page module can back
+		// several entries, so those can only be applied per emitted asset.
+		/** @type {Map<string, OutputHtmlOptions>} */
+		const htmlOptionsByEntry = new Map();
+		// SRI sentinels are emitted while the page's HTML is generated, before the
+		// owning entry is known, so any page asking for integrity turns them on for
+		// all of them; pages that don't want SRI drop them again on emit. Authored
+		// `.html` pages never reach the entry hook, hence the global seed.
+		let anyIntegrity = isIntegrityEnabled(
+			globalHtmlOptions && globalHtmlOptions.integrity
+		);
+
 		/**
 		 * Options for one page: an entry's `html` object overrides `output.html`
 		 * option by option, `true` inherits it as-is.
@@ -326,15 +350,24 @@ class HtmlModulesPlugin {
 		 * @returns {OutputHtmlOptions} resolved options
 		 */
 		const resolveHtmlOptions = (html, name) => {
-			if (typeof html !== "object") return globalHtmlOptions || {};
-			for (const option of GLOBAL_ONLY_HTML_OPTIONS) {
-				if (html[option] !== undefined) {
-					optionWarnings.add(
-						`entry "${name}" html.${option} is ignored — ${option} applies to every emitted page and can only be set on output.html.`
-					);
+			const options =
+				typeof html !== "object"
+					? globalHtmlOptions || {}
+					: globalHtmlOptions
+						? { ...globalHtmlOptions, ...html }
+						: html;
+			if (typeof html === "object") {
+				for (const option of GLOBAL_ONLY_HTML_OPTIONS) {
+					if (html[option] !== undefined) {
+						optionWarnings.add(
+							`entry "${name}" html.${option} is ignored — ${option} is resolved once per generated page and can only be set on output.html.`
+						);
+					}
 				}
 			}
-			return globalHtmlOptions ? { ...globalHtmlOptions, ...html } : html;
+			htmlOptionsByEntry.set(name, options);
+			if (isIntegrityEnabled(options.integrity)) anyIntegrity = true;
+			return options;
 		};
 
 		// `output.html` (or an entry's `html`) wraps a non-HTML entry in a
@@ -347,6 +380,9 @@ class HtmlModulesPlugin {
 		EntryOptionPlugin.getHooks(compiler).entry.tap(
 			PLUGIN_NAME,
 			(context, name, desc) => {
+				// Resolved for every entry, including the authored `.html` ones that
+				// need no wrapper below — their page reads back `csp`/`integrity` too.
+				const htmlObj = resolveHtmlOptions(desc.html, name);
 				const html = desc.html !== undefined ? desc.html : htmlOption;
 				const imports = desc.import;
 				if (
@@ -356,7 +392,6 @@ class HtmlModulesPlugin {
 				) {
 					return;
 				}
-				const htmlObj = resolveHtmlOptions(desc.html, name);
 				const scriptLoading = htmlObj.scriptLoading || "auto";
 				// ESM output emits `type="module"` (already deferred), so
 				// scriptLoading is ignored under output.module — warn on an
@@ -427,12 +462,13 @@ class HtmlModulesPlugin {
 		// `<link rel="modulepreload">` intact.
 		// Per-compilation state: the HTML modules seen during make (so
 		// `finishMake` creates their entries without scanning the whole module
-		// graph) and the stylesheet entry names (read in `afterChunks`).
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }>} */
+		// graph), the stylesheet entry names (read in `afterChunks`) and the html
+		// options of every emitted page, keyed by its asset name.
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetNames: Set<string> }} per-compilation state
+		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
@@ -440,7 +476,7 @@ class HtmlModulesPlugin {
 				state = {
 					htmlModules: new Set(),
 					stylesheetEntries: new Set(),
-					htmlAssetNames: new Set()
+					htmlAssetOptions: new Map()
 				};
 				compilationState.set(compilation, state);
 			}
@@ -540,15 +576,10 @@ class HtmlModulesPlugin {
 			);
 		});
 
-		const integrity =
-			typeof htmlOption === "object" ? htmlOption.integrity : undefined;
-		const integrityOn =
-			integrity === true ||
-			typeof integrity === "function" ||
-			(Array.isArray(integrity) && integrity.length > 0);
-		// `output.html.csp` injects a `<meta http-equiv="Content-Security-Policy">`
-		// once the page's inline content is final (in `processAssets` below).
-		const csp = typeof htmlOption === "object" ? htmlOption.csp : undefined;
+		// `csp` injects a `<meta http-equiv="Content-Security-Policy">` and
+		// `integrity` resolves the SRI sentinels — both once the page's inline
+		// content is final (in `processAssets` below), per page, so an entry's
+		// `html` can override them.
 		// `"auto"` marks implicit enablement (no user rule for HTML files) — see
 		// `applyExperimentsDefaults`. Only then loaders win over the built-in type
 		// (e.g. html-webpack-plugin's template loader in its child compiler).
@@ -557,6 +588,9 @@ class HtmlModulesPlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				if (anyIntegrity) {
+					HtmlGenerator.enableIntegritySentinels(compilation);
+				}
 				if (implicitlyEnabled) {
 					implicitTypeLoaderFallback(
 						normalModuleFactory,
@@ -584,7 +618,7 @@ class HtmlModulesPlugin {
 				// with CORS; without `output.crossOriginLoading` the browser
 				// silently ignores `integrity` on cross-origin loads. Warn once
 				// so a CDN deployment doesn't ship no-op integrity attributes.
-				if (integrityOn && !compilation.outputOptions.crossOriginLoading) {
+				if (anyIntegrity && !compilation.outputOptions.crossOriginLoading) {
 					compilation.warnings.push(
 						new WebpackError(
 							'output.html.integrity is set but output.crossOriginLoading is not. Browsers ignore Subresource Integrity on cross-origin requests made without CORS; set output.crossOriginLoading (e.g. "anonymous") if any asset is served from a different origin.'
@@ -597,26 +631,29 @@ class HtmlModulesPlugin {
 						stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH + 1
 					},
 					async (assets) => {
-						const { htmlAssetNames } = getState(compilation);
+						const { htmlAssetOptions } = getState(compilation);
 						const hooks = HtmlModulesPlugin.getCompilationHooks(compilation);
 						/** @type {Set<string>} */
 						const inlinedFiles = new Set();
 						for (const name of Object.keys(assets)) {
-							if (!htmlAssetNames.has(name)) continue;
+							const pageOptions = htmlAssetOptions.get(name);
+							if (pageOptions === undefined) continue;
 							const content = assets[name].source();
 							if (typeof content !== "string") continue;
+							const { csp, integrity } = pageOptions;
 							let resolved = content;
-							if (
-								integrityOn &&
-								resolved.includes("__WEBPACK_HTML_INTEGRITY__")
-							) {
-								resolved = HtmlGenerator.resolveChunkIntegritySentinels(
-									resolved,
-									compilation,
-									/** @type {import("./HtmlGenerator").HtmlIntegrity} */ (
-										integrity
-									)
-								);
+							// Sentinels are emitted whenever any page wants SRI, so a page
+							// that doesn't drops them again here.
+							if (resolved.includes("__WEBPACK_HTML_INTEGRITY__")) {
+								resolved = isIntegrityEnabled(integrity)
+									? HtmlGenerator.resolveChunkIntegritySentinels(
+											resolved,
+											compilation,
+											/** @type {import("./HtmlGenerator").HtmlIntegrity} */ (
+												integrity
+											)
+										)
+									: HtmlGenerator.stripChunkIntegritySentinels(resolved);
 							}
 							if (resolved.includes("__WEBPACK_HTML_INLINE__")) {
 								resolved = HtmlGenerator.resolveChunkInlineSentinels(
@@ -1058,8 +1095,14 @@ class HtmlModulesPlugin {
 											outputOptions
 										);
 
-							// Track HTML pages for the integrity sentinel pass (never JS chunks).
-							getState(compilation).htmlAssetNames.add(filename);
+							// Track HTML pages (never JS chunks) with the html options of the
+							// entry that owns them, read back by the emit passes below.
+							getState(compilation).htmlAssetOptions.set(
+								filename,
+								(chunk.name && htmlOptionsByEntry.get(chunk.name)) ||
+									globalHtmlOptions ||
+									{}
+							);
 
 							result.push({
 								render: () => finalSource,

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -909,7 +909,7 @@
           "$ref": "#/definitions/EntryFilename"
         },
         "html": {
-          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.",
+          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.",
           "anyOf": [
             {
               "type": "boolean"
@@ -975,7 +975,7 @@
           "$ref": "#/definitions/Filename"
         },
         "html": {
-          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.",
+          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.",
           "anyOf": [
             {
               "type": "boolean"

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -909,7 +909,7 @@
           "$ref": "#/definitions/EntryFilename"
         },
         "html": {
-          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.",
+          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.",
           "anyOf": [
             {
               "type": "boolean"
@@ -975,7 +975,7 @@
           "$ref": "#/definitions/Filename"
         },
         "html": {
-          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.",
+          "description": "Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.",
           "anyOf": [
             {
               "type": "boolean"

--- a/test/configCases/html/output-html-per-entry-csp-integrity/src/main.js
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/src/main.js
@@ -1,0 +1,1 @@
+console.log("per entry csp/integrity");

--- a/test/configCases/html/output-html-per-entry-csp-integrity/src/page.html
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/src/page.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><title>Authored</title></head><body><script src="./main.js"></script></body></html>

--- a/test/configCases/html/output-html-per-entry-csp-integrity/test.config.js
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/output-html-per-entry-csp-integrity/test.js
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/test.js
@@ -11,7 +11,7 @@ const cspContent = (html) => {
 };
 
 const integrityTags = (html) =>
-	(html.match(/<(?:script|link)\b[^>]*>/g) || [])
+	(html.match(/<(?:script|link)\b[^>]*>/gi) || [])
 		.map((tag) => ({
 			url: (tag.match(/(?:src|href)="([^"]+)"/) || [])[1],
 			integrity: (tag.match(/integrity="([^"]+)"/) || [])[1]

--- a/test/configCases/html/output-html-per-entry-csp-integrity/test.js
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/test.js
@@ -1,0 +1,64 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const read = (name) => fs.readFileSync(path.resolve(__dirname, name));
+const readHtml = (name) => read(name).toString("utf-8");
+
+const cspContent = (html) => {
+	const meta = html.match(/<meta http-equiv="Content-Security-Policy"[^>]*>/i);
+	return meta ? meta[0].match(/content="([^"]*)"/i)[1] : null;
+};
+
+const integrityTags = (html) =>
+	(html.match(/<(?:script|link)\b[^>]*>/g) || [])
+		.map((tag) => ({
+			url: (tag.match(/(?:src|href)="([^"]+)"/) || [])[1],
+			integrity: (tag.match(/integrity="([^"]+)"/) || [])[1]
+		}))
+		.filter((tag) => tag.integrity);
+
+const isRealSri = ({ url, integrity }) =>
+	integrity.split(" ").every((part) => {
+		const algorithm = part.slice(0, part.indexOf("-"));
+		return (
+			part ===
+			`${algorithm}-${crypto.createHash(algorithm).update(read(url)).digest("base64")}`
+		);
+	});
+
+it("a page without an override inherits csp and integrity", () => {
+	const html = readHtml("inherit.html");
+	expect(cspContent(html)).toContain("script-src 'self'");
+	const tags = integrityTags(html);
+	expect(tags).not.toHaveLength(0);
+	expect(tags.every(isRealSri)).toBe(true);
+});
+
+it("per-entry csp:false turns the CSP meta off for that page only", () => {
+	const html = readHtml("csp-off.html");
+	expect(cspContent(html)).toBeNull();
+	expect(integrityTags(html)).not.toHaveLength(0);
+});
+
+it("per-entry integrity:false drops SRI for that page only, leaving no sentinel", () => {
+	const html = readHtml("integrity-off.html");
+	expect(integrityTags(html)).toHaveLength(0);
+	expect(html).not.toContain("__WEBPACK_HTML_INTEGRITY__");
+	expect(html).not.toContain("integrity=");
+	expect(cspContent(html)).toContain("script-src 'self'");
+});
+
+it("per-entry csp object overrides the global policy for that page", () => {
+	const content = cspContent(readHtml("csp-policy.html"));
+	expect(content).toContain("img-src 'self'");
+	expect(cspContent(readHtml("inherit.html"))).not.toContain("img-src");
+});
+
+it("an authored page honors its entry's csp and integrity overrides", () => {
+	// an authored page is emitted under its source basename
+	const html = readHtml("page.html");
+	expect(cspContent(html)).toBeNull();
+	expect(integrityTags(html)).toHaveLength(0);
+	expect(html).not.toContain("__WEBPACK_HTML_INTEGRITY__");
+});

--- a/test/configCases/html/output-html-per-entry-csp-integrity/webpack.config.js
+++ b/test/configCases/html/output-html-per-entry-csp-integrity/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// `inline` decides the shape of a chunk's tag while the page's HTML is
-// generated — once per HTML module, which can back several entries — so it can
-// only be set on `output.html`; webpack warns instead of dropping it silently.
+// `csp` and `integrity` are resolved when a page is emitted, so an entry's
+// `html` object overrides `output.html` for its own page only.
 
 const fs = require("fs");
 const path = require("path");
@@ -32,10 +31,26 @@ const copyTest = {
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
+	target: "web",
 	entry: {
-		a: { import: "./src/a.js", html: { inline: true } }
+		inherit: "./src/main.js",
+		"csp-off": { import: "./src/main.js", html: { csp: false } },
+		"integrity-off": { import: "./src/main.js", html: { integrity: false } },
+		"csp-policy": {
+			import: "./src/main.js",
+			html: { csp: { policy: { "img-src": ["'self'"] } } }
+		},
+		// an authored page needs no wrapper, but its entry's options still apply
+		authored: {
+			import: "./src/page.html",
+			html: { csp: false, integrity: false }
+		}
 	},
-	output: { filename: "[name].js", html: true },
+	output: {
+		filename: "[name].js",
+		crossOriginLoading: "anonymous",
+		html: { csp: true, integrity: true }
+	},
 	experiments: { html: true },
 	plugins: [copyTest]
 };

--- a/test/configCases/html/output-html-per-entry-global-only-options/src/a.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/src/a.js
@@ -1,0 +1,1 @@
+console.log("global only options");

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.config.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.js
@@ -4,6 +4,8 @@ const path = require("path");
 const html = fs.readFileSync(path.resolve(__dirname, "a.html"), "utf-8");
 
 it("entry-level inline is not applied", () => {
-	expect(html).toMatch(/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script>/);
+	expect(html).toMatch(
+		/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script\s*>/i
+	);
 	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
 });

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.js
@@ -4,8 +4,6 @@ const path = require("path");
 const html = fs.readFileSync(path.resolve(__dirname, "a.html"), "utf-8");
 
 it("entry-level inline is not applied", () => {
-	expect(html).toMatch(
-		/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script\s*>/i
-	);
+	expect(html).toMatch(/<script[^>]* src="__html_[a-f0-9]+_0\.js">/i);
 	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
 });

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+const html = fs.readFileSync(path.resolve(__dirname, "a.html"), "utf-8");
+
+it("entry-level csp is not applied", () => {
+	expect(html).not.toContain("Content-Security-Policy");
+});
+
+it("entry-level integrity is not applied", () => {
+	expect(html).not.toContain("integrity=");
+});
+
+it("entry-level inline is not applied", () => {
+	expect(html).toMatch(
+		/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script>/
+	);
+});
+

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.js
@@ -3,17 +3,7 @@ const path = require("path");
 
 const html = fs.readFileSync(path.resolve(__dirname, "a.html"), "utf-8");
 
-it("entry-level csp is not applied", () => {
-	expect(html).not.toContain("Content-Security-Policy");
-});
-
-it("entry-level integrity is not applied", () => {
-	expect(html).not.toContain("integrity=");
-});
-
 it("entry-level inline is not applied", () => {
-	expect(html).toMatch(
-		/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script>/
-	);
+	expect(html).toMatch(/<script[^>]* src="__html_[a-f0-9]+_0\.js"><\/script>/);
+	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
 });
-

--- a/test/configCases/html/output-html-per-entry-global-only-options/warnings.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/warnings.js
@@ -1,9 +1,7 @@
 "use strict";
 
 module.exports = [
-	[/entry "a" html\.csp is ignored — csp applies to every emitted page/],
-	[/entry "a" html\.inline is ignored — inline applies to every emitted page/],
 	[
-		/entry "a" html\.integrity is ignored — integrity applies to every emitted page/
+		/entry "a" html\.inline is ignored — inline is resolved once per generated page/
 	]
 ];

--- a/test/configCases/html/output-html-per-entry-global-only-options/warnings.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/warnings.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = [
+	[/entry "a" html\.csp is ignored — csp applies to every emitted page/],
+	[/entry "a" html\.inline is ignored — inline applies to every emitted page/],
+	[
+		/entry "a" html\.integrity is ignored — integrity applies to every emitted page/
+	]
+];

--- a/test/configCases/html/output-html-per-entry-global-only-options/webpack.config.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/webpack.config.js
@@ -1,5 +1,9 @@
 "use strict";
 
+// `csp`, `inline` and `integrity` are resolved once for the whole compilation,
+// so an entry's `html` object can't override them — webpack warns instead of
+// silently dropping them.
+
 const fs = require("fs");
 const path = require("path");
 const webpack = require("../../../../");
@@ -29,26 +33,15 @@ const copyTest = {
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	entry: {
-		a: { import: "./src/a.js", html: { favicon: false } },
-		b: { import: "./src/b.js", html: { inject: "head" } },
-		c: { import: "./src/c.js", html: { favicon: "./src/icon.svg" } },
-		d: "./src/d.js",
-		e: { import: "./src/e.js", html: true },
-		f: {
-			import: "./src/f.js",
-			html: { title: "Page f", scriptLoading: "blocking" }
+		a: {
+			import: "./src/a.js",
+			html: { csp: true, inline: true, integrity: true }
 		}
 	},
 	output: {
 		filename: "[name].js",
-		html: {
-			favicon: true,
-			manifest: { name: "Global app" },
-			title: "Global title",
-			// eslint-disable-next-line unicorn/text-encoding-identifier-case
-			meta: { charset: "utf-8", description: "global description" },
-			inject: "body"
-		}
+		crossOriginLoading: "anonymous",
+		html: true
 	},
 	experiments: { html: true },
 	plugins: [copyTest]

--- a/test/configCases/html/output-html-per-entry-object/src/e.js
+++ b/test/configCases/html/output-html-per-entry-object/src/e.js
@@ -1,0 +1,1 @@
+console.log("entry e");

--- a/test/configCases/html/output-html-per-entry-object/src/f.js
+++ b/test/configCases/html/output-html-per-entry-object/src/f.js
@@ -1,0 +1,1 @@
+console.log("entry f");

--- a/test/configCases/html/output-html-per-entry-object/test.js
+++ b/test/configCases/html/output-html-per-entry-object/test.js
@@ -6,30 +6,58 @@ const readHtml = (name) =>
 
 const iconLink = (html) => html.match(/<link rel="icon"[^>]*>/i);
 const scriptRe = /<script[^>]* src="__html_[a-f0-9]+_0\.js"[^>]*>/;
+const deferScriptRe = /<script defer src="__html_[a-f0-9]+_0\.js"><\/script>/;
+const inHead = (html) => html.match(/<head>([\s\S]*?)<\/head>/i)[1];
+const inBody = (html) => html.match(/<body>([\s\S]*?)<\/body>/i)[1];
 
-it("per-entry html object with favicon:false overrides output.html", () => {
+it("entries without a per-entry html override inherit output.html", () => {
+	const html = readHtml("d.html");
+	expect(iconLink(html)).not.toBeNull();
+	expect(html).toContain('<link rel="manifest"');
+	expect(html).toContain("<title>Global title</title>");
+	expect(html).toContain('<meta charset="utf-8">');
+	expect(html).toContain('<meta name="description" content="global description">');
+	expect(inBody(html)).toMatch(deferScriptRe);
+});
+
+it("per-entry html object with favicon:false keeps the other output.html options", () => {
 	const html = readHtml("a.html");
 	expect(iconLink(html)).toBeNull();
+	expect(html).toContain('<link rel="manifest"');
+	expect(html).toContain("<title>Global title</title>");
+	expect(html).toContain('<meta charset="utf-8">');
 });
 
 it("per-entry html object with inject:'head' places scripts in <head>", () => {
 	const html = readHtml("b.html");
-	const head = html.match(/<head>([\s\S]*?)<\/head>/i)[1];
-	const body = html.match(/<body>([\s\S]*?)<\/body>/i)[1];
-	expect(head).toMatch(scriptRe);
-	expect(body).not.toMatch(scriptRe);
+	expect(inHead(html)).toMatch(scriptRe);
+	expect(inBody(html)).not.toMatch(scriptRe);
+	expect(iconLink(html)).not.toBeNull();
+	expect(html).toContain("<title>Global title</title>");
 });
 
-it("per-entry html object with favicon path emits a custom favicon link", () => {
+it("per-entry html object with favicon path overrides the inherited favicon", () => {
 	const html = readHtml("c.html");
 	const link = iconLink(html);
 	expect(link).not.toBeNull();
 	expect(link[0]).toContain('type="image/svg+xml"');
 	expect(link[0]).toMatch(/href="[^"]+\.svg"/);
+	expect(link[0]).not.toBe(iconLink(readHtml("d.html"))[0]);
 });
 
-it("entries without a per-entry html override inherit output.html", () => {
-	const html = readHtml("d.html");
-	const body = html.match(/<body>([\s\S]*?)<\/body>/i)[1];
-	expect(body).toMatch(scriptRe);
+it("per-entry html:true inherits every output.html option", () => {
+	const html = readHtml("e.html");
+	expect(iconLink(html)[0]).toBe(iconLink(readHtml("d.html"))[0]);
+	expect(html).toContain('<link rel="manifest"');
+	expect(html).toContain("<title>Global title</title>");
+	expect(inBody(html)).toMatch(deferScriptRe);
+});
+
+it("per-entry html object overrides title and scriptLoading", () => {
+	const html = readHtml("f.html");
+	expect(html).toContain("<title>Page f</title>");
+	expect(html).not.toContain("Global title");
+	expect(inBody(html)).toMatch(scriptRe);
+	expect(html).not.toContain("defer");
+	expect(iconLink(html)).not.toBeNull();
 });

--- a/test/configCases/html/output-html-per-entry-object/test.js
+++ b/test/configCases/html/output-html-per-entry-object/test.js
@@ -5,8 +5,9 @@ const readHtml = (name) =>
 	fs.readFileSync(path.resolve(__dirname, name), "utf-8");
 
 const iconLink = (html) => html.match(/<link rel="icon"[^>]*>/i);
-const scriptRe = /<script[^>]* src="__html_[a-f0-9]+_0\.js"[^>]*>/;
-const deferScriptRe = /<script defer src="__html_[a-f0-9]+_0\.js"><\/script>/;
+const scriptRe = /<script[^>]* src="__html_[a-f0-9]+_0\.js"[^>]*>/i;
+const deferScriptRe =
+	/<script defer src="__html_[a-f0-9]+_0\.js"><\/script\s*>/i;
 const inHead = (html) => html.match(/<head>([\s\S]*?)<\/head>/i)[1];
 const inBody = (html) => html.match(/<body>([\s\S]*?)<\/body>/i)[1];
 

--- a/test/configCases/html/output-html-per-entry-object/test.js
+++ b/test/configCases/html/output-html-per-entry-object/test.js
@@ -6,8 +6,7 @@ const readHtml = (name) =>
 
 const iconLink = (html) => html.match(/<link rel="icon"[^>]*>/i);
 const scriptRe = /<script[^>]* src="__html_[a-f0-9]+_0\.js"[^>]*>/i;
-const deferScriptRe =
-	/<script defer src="__html_[a-f0-9]+_0\.js"><\/script\s*>/i;
+const deferScriptRe = /<script defer src="__html_[a-f0-9]+_0\.js">/i;
 const inHead = (html) => html.match(/<head>([\s\S]*?)<\/head>/i)[1];
 const inBody = (html) => html.match(/<body>([\s\S]*?)<\/body>/i)[1];
 

--- a/test/configCases/html/output-html-script-loading/test.js
+++ b/test/configCases/html/output-html-script-loading/test.js
@@ -31,7 +31,7 @@ it("scriptLoading is ignored under output.module (still a module script)", () =>
 
 it("per-entry scriptLoading overrides output.html.scriptLoading", () => {
 	const html = read("entry-blocking.html");
-	expect(html).toMatch(/<script src="[^"]+"><\/script\s*>/i);
+	expect(html).toMatch(/<script src="[^"]+">/i);
 	expect(html).not.toContain("defer");
 });
 

--- a/test/configCases/html/output-html-script-loading/test.js
+++ b/test/configCases/html/output-html-script-loading/test.js
@@ -28,3 +28,15 @@ it("scriptLoading is ignored under output.module (still a module script)", () =>
 	expect(html).toMatch(/<script type="module" src="[^"]+">/);
 	expect(html).not.toContain("defer");
 });
+
+it("per-entry scriptLoading overrides output.html.scriptLoading", () => {
+	const html = read("entry-blocking.html");
+	expect(html).toMatch(/<script src="[^"]+"><\/script>/);
+	expect(html).not.toContain("defer");
+});
+
+it("per-entry scriptLoading is ignored under output.module", () => {
+	const html = read("module-entry-warning.html");
+	expect(html).toMatch(/<script type="module" src="[^"]+">/);
+	expect(html).not.toContain("defer");
+});

--- a/test/configCases/html/output-html-script-loading/test.js
+++ b/test/configCases/html/output-html-script-loading/test.js
@@ -31,7 +31,7 @@ it("scriptLoading is ignored under output.module (still a module script)", () =>
 
 it("per-entry scriptLoading overrides output.html.scriptLoading", () => {
 	const html = read("entry-blocking.html");
-	expect(html).toMatch(/<script src="[^"]+"><\/script>/);
+	expect(html).toMatch(/<script src="[^"]+"><\/script\s*>/i);
 	expect(html).not.toContain("defer");
 });
 

--- a/test/configCases/html/output-html-script-loading/warnings.js
+++ b/test/configCases/html/output-html-script-loading/warnings.js
@@ -1,5 +1,8 @@
 "use strict";
 
 module.exports = [
-	[/output\.html\.scriptLoading: "blocking" is ignored with output\.module/]
+	[/output\.html\.scriptLoading: "blocking" is ignored with output\.module/],
+	[
+		/entry "module-entry-warning" html\.scriptLoading: "defer" is ignored with output\.module/
+	]
 ];

--- a/test/configCases/html/output-html-script-loading/webpack.config.js
+++ b/test/configCases/html/output-html-script-loading/webpack.config.js
@@ -62,5 +62,29 @@ module.exports = [
 		output: { html: { scriptLoading: "blocking" } },
 		experiments: { html: true, outputModule: true },
 		plugins: [copyTest]
+	},
+	{
+		name: "entry-blocking",
+		entry: {
+			"entry-blocking": {
+				import: "./src/main.js",
+				html: { scriptLoading: "blocking" }
+			}
+		},
+		output: { filename: "[name].js", html: { scriptLoading: "defer" } },
+		experiments: { html: true },
+		plugins: [copyTest]
+	},
+	{
+		name: "module-entry-warning",
+		entry: {
+			"module-entry-warning": {
+				import: "./src/main.js",
+				html: { scriptLoading: "defer" }
+			}
+		},
+		output: { html: true },
+		experiments: { html: true, outputModule: true },
+		plugins: [copyTest]
 	}
 ];

--- a/types.d.ts
+++ b/types.d.ts
@@ -7049,7 +7049,7 @@ declare interface EntryDescription {
 	filename?: string | TemplatePathFn<PathDataChunk>;
 
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 
@@ -7119,7 +7119,7 @@ declare interface EntryDescriptionNormalized {
 	filename?: string | TemplatePathFn<PathDataChunk>;
 
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. Overrides `output.html` for this entry.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -7049,7 +7049,7 @@ declare interface EntryDescription {
 	filename?: string | TemplatePathFn<PathDataChunk>;
 
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 
@@ -7119,7 +7119,7 @@ declare interface EntryDescriptionNormalized {
 	filename?: string | TemplatePathFn<PathDataChunk>;
 
 	/**
-	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `csp`, `inline` and `integrity` apply to every emitted page and can only be set on `output.html`.
+	 * Generate an HTML file for this entrypoint with its JS and CSS output chunks injected. An object overrides `output.html` option by option for this entry; `inline` is resolved once per generated page and can only be set on `output.html`.
 	 */
 	html?: boolean | OutputHtmlOptions;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21447, which widened an entry's `html` to `boolean | OutputHtmlOptions` but left the implementation unchanged, so the object form did not behave as an override:

- An entry's object replaced `output.html` wholesale, so `html: { inject: "head" }` silently dropped the global `favicon`, `manifest`, `title`, `base` and `<meta charset>` for that page; `html: true` dropped `favicon`/`manifest` for the same reason. Options are now merged per option, entry wins.
- `scriptLoading`, `csp` and `integrity` were read once from `output.html` and ignored per entry. `scriptLoading` is now resolved per page; `csp` and `integrity` are resolved per emitted page, so an entry can turn them on, off, or use its own CSP policy — including on authored `.html` entries. One synthetic page module can back several entries, so SRI sentinels are emitted whenever any page wants them and each page then resolves or strips them; builds without `integrity` emit none and are byte-identical to before.
- `inline` stays `output.html`-only — it fixes the shape of a chunk's tag while the shared page module is generated, so there is nothing left to switch per page. Setting it on an entry now warns instead of being dropped silently.

Also adds the changeset that #21447 was merged without.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/html/output-html-per-entry-object` (rewritten so the assertions fail without the fix), new `test/configCases/html/output-html-per-entry-csp-integrity`, `test/configCases/html/output-html-per-entry-global-only-options`, and per-entry cases added to `test/configCases/html/output-html-script-loading`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Behavior only changes for the entry `html` object form, which never worked as documented; `html: true`/`false` and `output.html` are unaffected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

That an entry's `html` object overrides `output.html` per option (a falsy value switches an inherited option off) and that `inline` can only be set on `output.html`. The schema descriptions in this PR say both.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code was used to review #21447, reproduce each finding against real builds, write the fix and the test cases, and verify them (html `ConfigTestCases`/`ConfigCacheTestCases`, `StatsTestCases`, `Validation`, `Defaults`, `HotTestCasesWeb` and the full `yarn lint` gate). All output was reviewed by me before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLVg2s2V4kcKBp4t4PkQU1)_