### PR TITLE
fix: reconcile finishMake html entries on incremental rebuilds

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3267,11 +3267,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						/** @type {"dependencies" | "includeDependencies"} */ (target)
 					];
 				// only deps added inside the make-hook window (config entry plugins,
-				// re-run every make) may be dropped; finishMake-driven deps (html
-				// pages, sharing includes) persist until their originator re-runs.
-				// KNOWN LIMITATION: an originator that rebuilt and dropped one of its
-				// entries leaves it stale — removal needs the originator linkage only
-				// the adding plugin has
+				// re-run every make) may be dropped here; finishMake-driven entries
+				// reconcile after finishMake (_incrementalReconcileFinishMakeEntries)
+				// and sharing includes persist
 				const kept = deps.filter(
 					(d) => !configEntryDependencies.has(d) || touchedEntries.has(d)
 				);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1415,6 +1415,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this._incrementalMakeBuilt = false;
 		// true while Compiler runs the make hook; used for entry provenance
 		this._inMakeHookWindow = false;
+		// same for the finishMake hook (html-driven entries)
+		this._inFinishMakeWindow = false;
 		// set by a seal that snapshotted the base sets and started the journal
 		this._incrementalReady = false;
 		// re-factorization resolved to a new module — the orphaned old one is pruned
@@ -1846,7 +1848,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					if (currentProfile !== undefined) {
 						currentProfile.markBuildingEnd();
 					}
-					this.hooks.stillValidModule.call(module);
+					// the incremental scan already announced every persisted module
+					if (!this._incrementalRebuild) {
+						this.hooks.stillValidModule.call(module);
+					}
 					return callback();
 				}
 
@@ -3025,6 +3030,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					(this._incrementalTouchedEntries).add(existing);
 					if (this._inMakeHookWindow) {
 						this.compiler._configEntryDependencies.add(existing);
+					} else if (this._inFinishMakeWindow && target === "dependencies") {
+						this.compiler._finishMakeEntryDependencies.add(existing);
 					}
 					// fire the entry hooks like a fresh make would, with the connected
 					// dependency so plugins resolving it via getModule see the module;
@@ -3046,6 +3053,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		}
 		if (this.compiler.watchMode && this._inMakeHookWindow) {
 			this.compiler._configEntryDependencies.add(entry);
+		} else if (
+			this.compiler.watchMode &&
+			this._inFinishMakeWindow &&
+			target === "dependencies"
+		) {
+			this.compiler._finishMakeEntryDependencies.add(entry);
 		}
 		if (entryData === undefined) {
 			entryData = {
@@ -3173,6 +3186,52 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	}
 
 	/**
+	 * Drops persisted finishMake-window entry deps (html script/style entries)
+	 * this compilation's finishMake did not re-add — their html page rebuilt
+	 * without them or disappeared. Runs after the finishMake hook, once every
+	 * originator had its chance to re-add.
+	 * @returns {void}
+	 */
+	_incrementalReconcileFinishMakeEntries() {
+		if (!this._incrementalRebuild) return;
+		const touchedEntries =
+			/** @type {Set<Dependency>} */
+			(this._incrementalTouchedEntries);
+		const finishMakeEntryDependencies =
+			this.compiler._finishMakeEntryDependencies;
+		let entriesDropped = false;
+		/** @type {(entryData: EntryData) => void} */
+		const reconcileEntryData = (entryData) => {
+			const deps = entryData.dependencies;
+			const kept = deps.filter(
+				(d) => !finishMakeEntryDependencies.has(d) || touchedEntries.has(d)
+			);
+			if (kept.length !== deps.length) {
+				entriesDropped = true;
+				deps.length = 0;
+				for (const d of kept) deps.push(d);
+			}
+		};
+		reconcileEntryData(this.globalEntry);
+		for (const [name, entryData] of this.entries) {
+			reconcileEntryData(entryData);
+			if (
+				entryData.dependencies.length === 0 &&
+				entryData.includeDependencies.length === 0
+			) {
+				this.entries.delete(name);
+			}
+		}
+		if (entriesDropped) {
+			// removed roots change reachability and chunk structure — also undo
+			// the make-time fast-seal decision, taken before finishMake ran
+			this._pruneUnreachableModules();
+			this._incrementalMakeBuilt = true;
+			this._incrementalNoStructuralChange = false;
+		}
+	}
+
+	/**
 	 * Incremental make (incremental rebuilds): against the persisted module
 	 * graph, detect modules whose inputs changed and rebuild only those. New
 	 * dependencies discovered during rebuild are factorized and built through the
@@ -3277,6 +3336,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 								if (err2) return cb(err2);
 								if (valid) {
 									this._lazyBarrelController.classify(module);
+									this.hooks.stillValidModule.call(module);
 								} else {
 									changed.push(module);
 								}
@@ -3288,6 +3348,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					// unchanged barrels are never processed here — classify so a newly
 					// imported deferred re-export can still un-lazy
 					this._lazyBarrelController.classify(module);
+					this.hooks.stillValidModule.call(module);
 					cb();
 				});
 			},

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -375,6 +375,11 @@ class Compiler {
 		// runs and must persist
 		/** @type {WeakSet<import("./Dependency")>} */
 		this._configEntryDependencies = new WeakSet();
+		// entry deps (not includes) added inside the finishMake window (html
+		// script/style entries); re-added every make since persisted modules
+		// announce via stillValidModule, so they reconcile after finishMake
+		/** @type {WeakSet<import("./Dependency")>} */
+		this._finishMakeEntryDependencies = new WeakSet();
 		/** @type {NormalModuleFactory | undefined} */
 		this._lastNormalModuleFactory = undefined;
 
@@ -1457,9 +1462,13 @@ ${other}`);
 				if (err) return callback(err);
 
 				logger.time("finish make hook");
+				compilation._inFinishMakeWindow = true;
 				this.hooks.finishMake.callAsync(compilation, (err) => {
+					compilation._inFinishMakeWindow = false;
 					logger.timeEnd("finish make hook");
 					if (err) return callback(err);
+
+					compilation._incrementalReconcileFinishMakeEntries();
 
 					process.nextTick(() => {
 						logger.time("finish compilation");

--- a/test/watchCases/incremental/html-entry-removed/0/index.js
+++ b/test/watchCases/incremental/html-entry-removed/0/index.js
@@ -1,0 +1,8 @@
+import "./page.html";
+
+it("should drop entries the html page stopped referencing", () => {
+	const htmlEntryAssets = STATS_JSON.assets.filter((a) =>
+		/^__html_/.test(a.name)
+	);
+	expect(htmlEntryAssets.length).toBe(WATCH_STEP === "0" ? 2 : 1);
+});

--- a/test/watchCases/incremental/html-entry-removed/0/page.html
+++ b/test/watchCases/incremental/html-entry-removed/0/page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="./scripta.js"></script>
+<script src="./scriptb.js"></script>
+</head>
+<body>
+<p>page</p>
+</body>
+</html>

--- a/test/watchCases/incremental/html-entry-removed/0/scripta.js
+++ b/test/watchCases/incremental/html-entry-removed/0/scripta.js
@@ -1,0 +1,1 @@
+globalThis.__scriptA = 1;

--- a/test/watchCases/incremental/html-entry-removed/0/scriptb.js
+++ b/test/watchCases/incremental/html-entry-removed/0/scriptb.js
@@ -1,0 +1,1 @@
+globalThis.__scriptB = 1;

--- a/test/watchCases/incremental/html-entry-removed/1/page.html
+++ b/test/watchCases/incremental/html-entry-removed/1/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="./scripta.js"></script>
+</head>
+<body>
+<p>page</p>
+</body>
+</html>

--- a/test/watchCases/incremental/html-entry-removed/webpack.config.js
+++ b/test/watchCases/incremental/html-entry-removed/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	node: {
+		__dirname: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		}
+	},
+	experiments: {
+		html: true
+	},
+	optimization: {
+		chunkIds: "named"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Persisted `finishMake`-driven entries (html script/style entries) were never dropped on incremental watch rebuilds when their page stopped referencing them — the known limitation noted in #21556. The incremental scan now announces persisted modules via `stillValidModule` so `HtmlModulesPlugin` re-adds its entries every make, and a post-`finishMake` reconciliation drops the ones no longer re-added. Refs #21556.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, `test/watchCases/incremental/html-entry-removed` (red without the fix).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was developed with AI assistance (Claude Code): investigation, implementation and tests were AI-generated under human direction and review, following the webpack AI policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches incremental make/seal and entry graph reconciliation in the compiler core; behavior is scoped to incremental watch rebuilds with a targeted watch test.
> 
> **Overview**
> Fixes stale **HTML script/style entry points** on incremental watch rebuilds when a page stops referencing a script (known limitation in #21556).
> 
> **finishMake-window tracking:** Entries added during `finishMake` (not config `make` entries) are recorded in `_finishMakeEntryDependencies`. After `finishMake`, `_incrementalReconcileFinishMakeEntries()` removes deps that were not re-touched this compilation, prunes empty named entries, and forces a fuller seal when roots change.
> 
> **Re-announce persisted modules:** The incremental scan now fires `stillValidModule` for unchanged persisted modules so HTML plugins can re-add their entries each make; the normal `needBuild` skip path avoids double-firing that hook on incremental rebuilds.
> 
> Make-time entry reconciliation is limited to **config/make-window** deps; finishMake-driven deps are handled only after `finishMake`.
> 
> Adds watch case `html-entry-removed` (two HTML assets → one after removing a script from the page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000f83cb8707955f2f14e9f6ae3726455cc3d9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->