### PR TITLE
feat(css): add __webpack_css_server_styles__ to read server-collected CSS

### DIFF
--- a/.changeset/018-css-server-styles.md
+++ b/.changeset/018-css-server-styles.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add the `__webpack_css_server_styles__` module variable to read the CSS collected while rendering without a DOM.

--- a/.changeset/018-css-server-styles.md
+++ b/.changeset/018-css-server-styles.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Add the `__webpack_css_server_styles__` module variable to read the CSS collected while rendering without a DOM.
+Add the `__webpack_css_server_styles__` module variable to read the CSS collected while rendering without a DOM, and keep that CSS in the order the styles were applied.

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -107,6 +107,12 @@ function getReplacements() {
 			type: "string",
 			assign: false
 		},
+		__webpack_css_server_styles__: {
+			expr: `${RuntimeGlobals.getCssServerStyles}()`,
+			req: [RuntimeGlobals.getCssServerStyles],
+			type: "string",
+			assign: false
+		},
 		__webpack_chunkname__: {
 			expr: RuntimeGlobals.chunkName,
 			req: [RuntimeGlobals.chunkName],

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -196,9 +196,16 @@ module.exports.getChunkScriptFilename = "__webpack_require__.u";
 module.exports.getChunkUpdateCssFilename = "__webpack_require__.hk";
 
 /**
- * the filename of the script part of the hot update chunk
+ * function returning the CSS collected while rendering without a DOM as a
+ * single string; empty when the styles went into the document instead
+ * Arguments: () => string
  */
 module.exports.getChunkUpdateScriptFilename = "__webpack_require__.hu";
+module.exports.getCssServerStyles = "__webpack_require__.cs";
+
+/**
+ * the filename of the script part of the hot update chunk
+ */
 
 /**
  * the webpack hash

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -196,16 +196,16 @@ module.exports.getChunkScriptFilename = "__webpack_require__.u";
 module.exports.getChunkUpdateCssFilename = "__webpack_require__.hk";
 
 /**
+ * the filename of the script part of the hot update chunk
+ */
+module.exports.getChunkUpdateScriptFilename = "__webpack_require__.hu";
+
+/**
  * function returning the CSS collected while rendering without a DOM as a
  * single string; empty when the styles went into the document instead
  * Arguments: () => string
  */
-module.exports.getChunkUpdateScriptFilename = "__webpack_require__.hu";
 module.exports.getCssServerStyles = "__webpack_require__.cs";
-
-/**
- * the filename of the script part of the hot update chunk
- */
 
 /**
  * the webpack hash

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -67,6 +67,7 @@ const GLOBALS_ON_REQUIRE = [
 	RuntimeGlobals.definePropertyGetters,
 	RuntimeGlobals.ensureChunk,
 	RuntimeGlobals.entryModuleId,
+	RuntimeGlobals.getCssServerStyles,
 	RuntimeGlobals.getFullHash,
 	RuntimeGlobals.global,
 	RuntimeGlobals.makeNamespaceObject,

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -7,6 +7,7 @@
 
 const RuntimeGlobals = require("./RuntimeGlobals");
 const { getPresentKinds } = require("./TemplatedPathPlugin");
+const CssServerStylesRuntimeModule = require("./css/CssServerStylesRuntimeModule");
 const RuntimeRequirementsDependency = require("./dependencies/RuntimeRequirementsDependency");
 const JavascriptModulesPlugin = require("./javascript/JavascriptModulesPlugin");
 const AsyncModuleGeneratorRuntimeModule = require("./runtime/AsyncModuleGeneratorRuntimeModule");
@@ -429,6 +430,20 @@ class RuntimePlugin {
 									compilation.outputOptions.hotUpdateChunkFilename
 								)
 						)
+					);
+					return true;
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.getCssServerStyles)
+				.tap(PLUGIN_NAME, (chunk, set) => {
+					// The registry lives on the global, reached via the polyfill when
+					// the target has no `globalThis`.
+					if (!compilation.outputOptions.environment.globalThis) {
+						set.add(RuntimeGlobals.global);
+					}
+					compilation.addRuntimeModule(
+						chunk,
+						new CssServerStylesRuntimeModule()
 					);
 					return true;
 				});

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -191,8 +191,10 @@ class RuntimeTemplate {
 
 	/**
 	 * Expression for the global registry that collects CSS server-side when there
-	 * is no DOM (SSR). An SSR host reads it from `globalThis`; it is keyed by the
-	 * style/chunk identifier and namespaced by `output.uniqueName`.
+	 * is no DOM (SSR). Read it with `__webpack_css_server_styles__`; it is keyed
+	 * by the style/chunk identifier and namespaced by `output.uniqueName`.
+	 * Targets without `globalThis` go through the `__webpack_require__.g`
+	 * polyfill, so consumers must also require `RuntimeGlobals.global`.
 	 * @returns {string} runtime expression evaluating to the registry object
 	 */
 	cssServerStyleRegistry() {
@@ -200,7 +202,10 @@ class RuntimeTemplate {
 		const key = JSON.stringify(
 			name ? `__webpack_css__${name}` : "__webpack_css__"
 		);
-		return `(${this.assignOr(`globalThis[${key}]`, "{}")})`;
+		const global = this.outputOptions.environment.globalThis
+			? "globalThis"
+			: RuntimeGlobals.global;
+		return `(${this.assignOr(`${global}[${key}]`, "{}")})`;
 	}
 
 	supportsConst() {

--- a/lib/css/CssInjectStyleRuntimeModule.js
+++ b/lib/css/CssInjectStyleRuntimeModule.js
@@ -63,7 +63,9 @@ class CssInjectStyleRuntimeModule extends RuntimeModule {
 			? [
 					"if (typeof document === 'undefined') {",
 					Template.indent([
-						`${runtimeTemplate.cssServerStyleRegistry()}[identifier] = css;`,
+						// "module-" keeps numeric module ids from enumerating in ascending
+						// order instead of the order the styles were applied in
+						`${runtimeTemplate.cssServerStyleRegistry()}["module-" + identifier] = css;`,
 						"return;"
 					]),
 					"}"
@@ -74,7 +76,7 @@ class CssInjectStyleRuntimeModule extends RuntimeModule {
 					"if (typeof document === 'undefined') {",
 					Template.indent([
 						`${cst} styles = ${runtimeTemplate.cssServerStyleRegistry()};`,
-						"for (var i = 0; i < identifiers.length; i++) delete styles[identifiers[i]];",
+						'for (var i = 0; i < identifiers.length; i++) delete styles["module-" + identifiers[i]];',
 						"return;"
 					]),
 					"}"

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -692,6 +692,13 @@ class CssModulesPlugin {
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
 
+					// The neutral platform's no-DOM branch stores styles on the global.
+					if (
+						compilation.runtimeTemplate.isNeutralPlatform() &&
+						!compilation.outputOptions.environment.globalThis
+					) {
+						set.add(RuntimeGlobals.global);
+					}
 					const CssLoadingRuntimeModule = getCssLoadingRuntimeModule();
 					compilation.addRuntimeModule(chunk, new CssLoadingRuntimeModule(set));
 				};
@@ -744,6 +751,13 @@ class CssModulesPlugin {
 					.tap(PLUGIN_NAME, (chunk, set) => {
 						// Same as above: namespace stub is enough.
 						set.add(RuntimeGlobals.requireScope);
+						// The neutral platform's no-DOM branch stores styles on the global.
+						if (
+							compilation.runtimeTemplate.isNeutralPlatform() &&
+							!compilation.outputOptions.environment.globalThis
+						) {
+							set.add(RuntimeGlobals.global);
+						}
 						const CssInjectStyleRuntimeModule =
 							getCssInjectStyleRuntimeModule();
 						compilation.addRuntimeModule(

--- a/lib/css/CssServerStylesRuntimeModule.js
+++ b/lib/css/CssServerStylesRuntimeModule.js
@@ -31,7 +31,8 @@ class CssServerStylesRuntimeModule extends RuntimeModule {
 				[
 					`${cst} registry = ${runtimeTemplate.cssServerStyleRegistry()};`,
 					'var css = "";',
-					// Insertion order matches the order the styles were applied in.
+					// keys are string-prefixed at the write site, so this yields
+					// insertion order rather than ascending numeric module id order
 					"for (var key in registry) css += registry[key];",
 					"return css;"
 				]

--- a/lib/css/CssServerStylesRuntimeModule.js
+++ b/lib/css/CssServerStylesRuntimeModule.js
@@ -1,0 +1,43 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+/** @typedef {import("../Compilation")} Compilation */
+
+class CssServerStylesRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("css server styles");
+	}
+
+	/**
+	 * Generates runtime code for this runtime module.
+	 * @returns {string | null} runtime code
+	 */
+	generate() {
+		const compilation = /** @type {Compilation} */ (this.compilation);
+		const { runtimeTemplate } = compilation;
+		const cst = runtimeTemplate.renderConst();
+
+		return Template.asString([
+			`${RuntimeGlobals.getCssServerStyles} = ${runtimeTemplate.basicFunction(
+				"",
+				[
+					`${cst} registry = ${runtimeTemplate.cssServerStyleRegistry()};`,
+					'var css = "";',
+					// Insertion order matches the order the styles were applied in.
+					"for (var key in registry) css += registry[key];",
+					"return css;"
+				]
+			)};`
+		]);
+	}
+}
+
+module.exports = CssServerStylesRuntimeModule;

--- a/module.d.ts
+++ b/module.d.ts
@@ -215,6 +215,7 @@ declare const __webpack_chunkname__: string;
 declare var __webpack_base_uri__: string;
 declare var __webpack_runtime_id__: string;
 declare const __webpack_hash__: string;
+declare const __webpack_css_server_styles__: string;
 declare const __webpack_modules__: Record<string | number, NodeJS.Module>;
 declare const __webpack_require__: (id: string | number) => unknown;
 declare var __webpack_chunk_load__: (chunkId: string | number) => Promise<void>;

--- a/test/configCases/css/css-server-styles-alone/index.js
+++ b/test/configCases/css/css-server-styles-alone/index.js
@@ -1,0 +1,4 @@
+// no CSS import: the module variable is the only thing pulling in runtime
+it("works when the collected styles are the only runtime consumer", () => {
+	expect(__webpack_css_server_styles__).toBe("");
+});

--- a/test/configCases/css/css-server-styles-alone/test.filter.js
+++ b/test/configCases/css/css-server-styles-alone/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/css/css-server-styles-alone/webpack.config.js
+++ b/test/configCases/css/css-server-styles-alone/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	experiments: {
+		css: true
+	},
+	output: {
+		uniqueName: "alone",
+		// without `globalThis` the registry pulls in the global polyfill, which
+		// would bring the require scope along and hide a missing one here
+		environment: {
+			globalThis: true
+		}
+	}
+};

--- a/test/configCases/css/css-server-styles-global-this/index.js
+++ b/test/configCases/css/css-server-styles-global-this/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+
+it("collects the styles on globalThis when the environment supports it", () => {
+	if (typeof document !== "undefined") return;
+
+	expect(__webpack_css_server_styles__).toContain("color: darkcyan");
+	expect(globalThis["__webpack_css__global-this"]).toBeTruthy();
+});

--- a/test/configCases/css/css-server-styles-global-this/style.css
+++ b/test/configCases/css/css-server-styles-global-this/style.css
@@ -1,0 +1,3 @@
+.badge {
+	color: darkcyan;
+}

--- a/test/configCases/css/css-server-styles-global-this/test.filter.js
+++ b/test/configCases/css/css-server-styles-global-this/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/css/css-server-styles-global-this/webpack.config.js
+++ b/test/configCases/css/css-server-styles-global-this/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css",
+				parser: {
+					exportType: "style"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	},
+	output: {
+		uniqueName: "global-this",
+		// the registry reaches `globalThis` directly instead of through the polyfill
+		environment: {
+			globalThis: true
+		}
+	}
+};

--- a/test/configCases/css/css-server-styles-order/first.css
+++ b/test/configCases/css/css-server-styles-order/first.css
@@ -1,0 +1,3 @@
+.box {
+	color: red;
+}

--- a/test/configCases/css/css-server-styles-order/index.js
+++ b/test/configCases/css/css-server-styles-order/index.js
@@ -1,0 +1,11 @@
+import "./first.css";
+import "./second.css";
+
+it("concatenates the styles in the order they were applied", () => {
+	if (typeof document !== "undefined") return;
+
+	const css = __webpack_css_server_styles__;
+
+	// last one applied wins the cascade, so it has to come last
+	expect(css.indexOf("color: red")).toBeLessThan(css.indexOf("color: green"));
+});

--- a/test/configCases/css/css-server-styles-order/second.css
+++ b/test/configCases/css/css-server-styles-order/second.css
@@ -1,0 +1,3 @@
+.box {
+	color: green;
+}

--- a/test/configCases/css/css-server-styles-order/webpack.config.js
+++ b/test/configCases/css/css-server-styles-order/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	// numeric module ids are what makes enumeration order observable
+	optimization: {
+		moduleIds: "deterministic"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css",
+				parser: {
+					exportType: "style"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	},
+	output: {
+		uniqueName: "order"
+	}
+};

--- a/test/configCases/css/css-server-styles-prerender/button.css
+++ b/test/configCases/css/css-server-styles-prerender/button.css
@@ -1,0 +1,4 @@
+.button {
+	background: rebeccapurple;
+	color: white;
+}

--- a/test/configCases/css/css-server-styles-prerender/button.js
+++ b/test/configCases/css/css-server-styles-prerender/button.js
@@ -1,0 +1,5 @@
+import "./button.css";
+
+export function renderButton(label) {
+	return `<button class="button">${label}</button>`;
+}

--- a/test/configCases/css/css-server-styles-prerender/index.js
+++ b/test/configCases/css/css-server-styles-prerender/index.js
@@ -1,0 +1,31 @@
+import "./layout.css";
+import { renderButton } from "./button";
+
+const hasDocument = typeof document !== "undefined";
+
+// Pre-render a page the way a static site generator would: build the markup,
+// then inline the styles the imported stylesheets produced.
+function prerender() {
+	return [
+		"<!doctype html>",
+		`<html><head><style>${__webpack_css_server_styles__}</style></head>`,
+		`<body><div class="page">${renderButton("Buy")}</div></body></html>`
+	].join("");
+}
+
+it("inlines the styles of every imported stylesheet into the markup", () => {
+	if (hasDocument) return;
+
+	const html = prerender();
+
+	expect(html).toContain('<div class="page">');
+	expect(html).toContain('<button class="button">Buy</button>');
+	expect(html).toContain("background: rebeccapurple");
+	expect(html).toContain("max-width: 40rem");
+});
+
+it("keeps the styles out of the markup when a DOM applied them", () => {
+	if (!hasDocument) return;
+
+	expect(prerender()).toContain("<style></style>");
+});

--- a/test/configCases/css/css-server-styles-prerender/layout.css
+++ b/test/configCases/css/css-server-styles-prerender/layout.css
@@ -1,0 +1,4 @@
+.page {
+	margin: 0 auto;
+	max-width: 40rem;
+}

--- a/test/configCases/css/css-server-styles-prerender/webpack.config.js
+++ b/test/configCases/css/css-server-styles-prerender/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css",
+				parser: {
+					exportType: "style"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	},
+	output: {
+		uniqueName: "prerender"
+	}
+};

--- a/test/configCases/css/css-server-styles/index.js
+++ b/test/configCases/css/css-server-styles/index.js
@@ -1,0 +1,16 @@
+import "./style.css";
+
+const hasDocument = typeof document !== "undefined";
+
+it("exposes the collected styles as a string", () => {
+	expect(typeof __webpack_css_server_styles__).toBe("string");
+});
+
+it("returns the styles collected while rendering without a DOM", () => {
+	if (hasDocument) {
+		// styles went into the document, so nothing was collected for the server
+		expect(__webpack_css_server_styles__).toBe("");
+	} else {
+		expect(__webpack_css_server_styles__).toContain("color: rebeccapurple");
+	}
+});

--- a/test/configCases/css/css-server-styles/style.css
+++ b/test/configCases/css/css-server-styles/style.css
@@ -1,0 +1,3 @@
+.title {
+	color: rebeccapurple;
+}

--- a/test/configCases/css/css-server-styles/webpack.config.js
+++ b/test/configCases/css/css-server-styles/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css",
+				parser: {
+					exportType: "style"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	},
+	output: {
+		uniqueName: "css-server-styles"
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -28751,8 +28751,8 @@ declare namespace exports {
 		export let getChunkCssFilename: "__webpack_require__.k";
 		export let getChunkScriptFilename: "__webpack_require__.u";
 		export let getChunkUpdateCssFilename: "__webpack_require__.hk";
-		export let getCssServerStyles: "__webpack_require__.cs";
 		export let getChunkUpdateScriptFilename: "__webpack_require__.hu";
+		export let getCssServerStyles: "__webpack_require__.cs";
 		export let getFullHash: "__webpack_require__.h";
 		export let getTrustedTypesPolicy: "__webpack_require__.tt";
 		export let getUpdateManifestFilename: "__webpack_require__.hmrF";

--- a/types.d.ts
+++ b/types.d.ts
@@ -24302,8 +24302,10 @@ declare abstract class RuntimeTemplate {
 
 	/**
 	 * Expression for the global registry that collects CSS server-side when there
-	 * is no DOM (SSR). An SSR host reads it from `globalThis`; it is keyed by the
-	 * style/chunk identifier and namespaced by `output.uniqueName`.
+	 * is no DOM (SSR). Read it with `__webpack_css_server_styles__`; it is keyed
+	 * by the style/chunk identifier and namespaced by `output.uniqueName`.
+	 * Targets without `globalThis` go through the `__webpack_require__.g`
+	 * polyfill, so consumers must also require `RuntimeGlobals.global`.
 	 */
 	cssServerStyleRegistry(): string;
 	supportsConst(): boolean;
@@ -28749,6 +28751,7 @@ declare namespace exports {
 		export let getChunkCssFilename: "__webpack_require__.k";
 		export let getChunkScriptFilename: "__webpack_require__.u";
 		export let getChunkUpdateCssFilename: "__webpack_require__.hk";
+		export let getCssServerStyles: "__webpack_require__.cs";
 		export let getChunkUpdateScriptFilename: "__webpack_require__.hu";
 		export let getFullHash: "__webpack_require__.h";
 		export let getTrustedTypesPolicy: "__webpack_require__.tt";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

When the neutral platform (`target: ["web", "node"]`) runs without a DOM, webpack already collects the styles it would have injected into a global registry — but reading them meant scanning `globalThis` for an internal key derived from `output.uniqueName` (webpack's own `export-type-style-universal` test does exactly that). This exposes the registry as a single string via `__webpack_css_server_styles__`, so the CSS can be inlined into generated HTML. The registry now also goes through the `__webpack_require__.g` polyfill on targets without `globalThis`, so it works on the supported node baseline.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/css-server-styles`, asserting the collected CSS is returned when there is no DOM and that it is empty when the styles went into the document instead.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The module variable is new, and the registry expression only changes on targets without `globalThis`, where it previously would have thrown.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

`__webpack_css_server_styles__` should be added to the module variables page, noting it is only populated on the neutral platform when rendering without a DOM.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to implement the runtime module and wiring, write the test case, and verify the behaviour against scratch builds (universal, browser-only, and a static page generator). All output was reviewed before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JQzhVFyccoCkLgnqaB82PX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive minor feature with new runtime/API surface; behavior changes are scoped to no-DOM universal CSS injection and registry key format for ordering.
> 
> **Overview**
> Adds **`__webpack_css_server_styles__`** as a public module variable that returns one concatenated string of CSS collected when universal (`web` + `node`) bundles run **without a DOM** (SSR/SSG). In the browser it stays **empty** because styles are injected into the document instead.
> 
> Wiring includes **`RuntimeGlobals.getCssServerStyles`** (`__webpack_require__.cs`), **`CssServerStylesRuntimeModule`**, and **`APIPlugin`** / TypeScript declarations. **`cssServerStyleRegistry()`** now uses **`globalThis`** when supported, otherwise **`__webpack_require__.g`**, with runtime requirements updated in **`CssModulesPlugin`** and **`RuntimePlugin`**.
> 
> **`CssInjectStyleRuntimeModule`** stores registry entries under **`"module-" + identifier`** so enumeration follows **application order**, not ascending numeric module ids; the getter walks the registry in that order. Config-case tests cover basic collection, ordering, prerender inlining, `globalThis`, and using the API without CSS imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a97898179dd504b75fe912e00ab525fce91e094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->