### PR TITLE
feat: add aggregated shutdown hook to MultiCompiler

### DIFF
--- a/.changeset/055-multi-compiler-shutdown-hook.md
+++ b/.changeset/055-multi-compiler-shutdown-hook.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add aggregated `shutdown` hook to `MultiCompiler`.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -85,6 +85,8 @@ module.exports = class MultiCompiler {
 			run: new MultiHook(compilers.map((c) => c.hooks.run)),
 			/** @type {SyncHook<[]>} */
 			watchClose: new SyncHook([]),
+			/** @type {MultiHook<AsyncSeriesHook<[]>>} */
+			shutdown: new MultiHook(compilers.map((c) => c.hooks.shutdown)),
 			/** @type {MultiHook<AsyncSeriesHook<[Compiler]>>} */
 			watchRun: new MultiHook(compilers.map((c) => c.hooks.watchRun)),
 			/** @type {MultiHook<SyncBailHook<[string, string, EXPECTED_ANY[] | undefined], true | void>>} */

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -324,6 +324,22 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should trigger the aggregated 'shutdown' hook once per child compiler on close", (done) => {
+		const compiler = createMultiCompiler();
+		let shutdownCalled = 0;
+		compiler.hooks.shutdown.tapPromise("MultiCompiler test", async () => {
+			shutdownCalled++;
+		});
+		compiler.watch({}, (err, _stats) => {
+			if (err) return done(err);
+		});
+		compiler.close((err) => {
+			if (err) return done(err);
+			expect(shutdownCalled).toBe(2);
+			done();
+		});
+	});
+
 	it("should expose `watching` when dependency validation fails", (done) => {
 		const compiler = /** @type {import("../").MultiCompiler} */ (
 			webpack(

--- a/types.d.ts
+++ b/types.d.ts
@@ -17813,6 +17813,7 @@ declare class MultiCompiler {
 		invalid: MultiHook<SyncHook<[null | string, number]>>;
 		run: MultiHook<AsyncSeriesHook<[Compiler]>>;
 		watchClose: SyncHook<[]>;
+		shutdown: MultiHook<AsyncSeriesHook<[]>>;
 		watchRun: MultiHook<AsyncSeriesHook<[Compiler]>>;
 		infrastructureLog: MultiHook<
 			SyncBailHook<[string, string, undefined | any[]], true | void>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`MultiCompiler` has no aggregated `shutdown` hook, so consumers like webpack-dev-server's plugin mode must iterate `compiler.compilers` and tap each child's `shutdown` to run async teardown on `compiler.close()`. This adds `hooks.shutdown` as a `MultiHook` over the children's `shutdown` hooks, matching the existing `watchRun`/`run`/`invalid` aggregates.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes, in `test/MultiCompiler.test.js` (the aggregated hook fires once per child compiler on `close()`).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Document `multiCompiler.hooks.shutdown` in the MultiCompiler/Node API docs.

**Use of AI**

This PR was implemented with AI assistance (Claude Code), directed and reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public hook and types only; no change to existing close/shutdown behavior on child compilers.
> 
> **Overview**
> Adds **`multiCompiler.hooks.shutdown`** as a `MultiHook` over each child compiler’s `shutdown` hook, in line with existing aggregates like `run` and `watchRun`. Plugins and tools (e.g. webpack-dev-server in plugin mode) can register async teardown once on the multi compiler instead of looping `compiler.compilers`.
> 
> Type definitions are updated for the new hook, and a test asserts the aggregated hook runs once per child when `close()` is called after `watch()`. A minor changeset documents the API addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3936041455344002474a2e7e6420fd1b8dce10ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->