### PR TITLE
feat: report changed compilers on MultiCompiler done hook

### DIFF
--- a/.changeset/057-multi-compiler-done-changed-compilers.md
+++ b/.changeset/057-multi-compiler-done-changed-compilers.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Report which compilers changed on the MultiCompiler `done` hook.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -77,8 +77,8 @@ module.exports = class MultiCompiler {
 		}
 
 		this.hooks = Object.freeze({
-			/** @type {SyncHook<[MultiStats]>} */
-			done: new SyncHook(["stats"]),
+			/** @type {SyncHook<[MultiStats, Compiler[]]>} */
+			done: new SyncHook(["stats", "changedCompilers"]),
 			/** @type {MultiHook<SyncHook<[string | null, number]>>} */
 			invalid: new MultiHook(compilers.map((c) => c.hooks.invalid)),
 			/** @type {MultiHook<AsyncSeriesHook<[Compiler]>>} */
@@ -109,6 +109,8 @@ module.exports = class MultiCompiler {
 
 		/** @type {(Stats | null)[]} */
 		const compilerStats = this.compilers.map(() => null);
+		/** @type {Set<Compiler>} */
+		const changedCompilers = new Set();
 		let doneCompilers = 0;
 		for (let index = 0; index < this.compilers.length; index++) {
 			const compiler = this.compilers[index];
@@ -116,14 +118,18 @@ module.exports = class MultiCompiler {
 			let compilerDone = false;
 			// eslint-disable-next-line no-loop-func
 			compiler.hooks.done.tap(CLASS_NAME, (stats) => {
+				changedCompilers.add(compiler);
 				if (!compilerDone) {
 					compilerDone = true;
 					doneCompilers++;
 				}
 				compilerStats[compilerIndex] = stats;
 				if (doneCompilers === this.compilers.length) {
+					const changed = this.compilers.filter((c) => changedCompilers.has(c));
+					changedCompilers.clear();
 					this.hooks.done.call(
-						new MultiStats(/** @type {Stats[]} */ (compilerStats))
+						new MultiStats(/** @type {Stats[]} */ (compilerStats)),
+						changed
 					);
 				}
 			});

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -358,7 +358,7 @@ describe("MultiCompiler", () => {
 			if (phase === 0) {
 				phase = 1;
 				expect(changedNames).toEqual([["a", "b"]]);
-				/** @type {import("../lib/Watching")} */
+				/** @type {NonNullable<import("../").Compiler["watching"]>} */
 				(compiler.compilers[1].watching).invalidate();
 			} else if (phase === 1) {
 				phase = 2;

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -340,6 +340,34 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should report which compilers changed on the aggregated 'done' hook", (done) => {
+		const compiler = createMultiCompiler();
+		/** @type {string[][]} */
+		const changedNames = [];
+		compiler.hooks.done.tap(
+			"MultiCompiler test",
+			(_stats, changedCompilers) => {
+				changedNames.push(
+					changedCompilers.map((c) => /** @type {string} */ (c.name))
+				);
+			}
+		);
+		let phase = 0;
+		compiler.watch({}, (err) => {
+			if (err) return done(err);
+			if (phase === 0) {
+				phase = 1;
+				expect(changedNames).toEqual([["a", "b"]]);
+				/** @type {import("../lib/Watching")} */
+				(compiler.compilers[1].watching).invalidate();
+			} else if (phase === 1) {
+				phase = 2;
+				expect(changedNames).toEqual([["a", "b"], ["b"]]);
+				compiler.close(done);
+			}
+		});
+	});
+
 	it("should expose `watching` when dependency validation fails", (done) => {
 		const compiler = /** @type {import("../").MultiCompiler} */ (
 			webpack(

--- a/types.d.ts
+++ b/types.d.ts
@@ -17809,7 +17809,7 @@ declare class MultiCompiler {
 		options: MultiCompilerOptions
 	);
 	hooks: Readonly<{
-		done: SyncHook<[MultiStats]>;
+		done: SyncHook<[MultiStats, Compiler[]]>;
 		invalid: MultiHook<SyncHook<[null | string, number]>>;
 		run: MultiHook<AsyncSeriesHook<[Compiler]>>;
 		watchClose: SyncHook<[]>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The aggregated `done` hook of `MultiCompiler` always emits the full `MultiStats`, so consumers cannot tell which child compilers actually rebuilt in a cycle — webpack-dev-middleware for example is forced to keep a single all-or-nothing valid/invalid state and block requests for every bundle while any child rebuilds. This passes the compilers that rebuilt since the previous aggregated `done` as an additive second hook argument, exposing bookkeeping `MultiCompiler` already tracks internally.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes, in `test/MultiCompiler.test.js` (initial build reports all compilers, invalidating a single child reports only that one).

**Does this PR introduce a breaking change?**

No, the argument is additive; existing `done` taps are unaffected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Document the `changedCompilers` argument of `multiCompiler.hooks.done` in the Node API docs.

**Use of AI**

This PR was implemented with AI assistance (Claude Code), directed and reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive hook argument only; existing `done` listeners that ignore the second parameter should behave as before, with a small change to internal aggregation bookkeeping.
> 
> **Overview**
> **`multiCompiler.hooks.done`** now receives a second argument, **`changedCompilers`**: the child **`Compiler`** instances that finished a build since the previous aggregated `done` (still paired with the full **`MultiStats`**).
> 
> Tracking reuses the existing per-child `done` / `invalid` coordination: each child `done` adds that compiler to a set, and when all children have reported in, the hook fires with compilers in multi-compiler order before the set is cleared.
> 
> This is an **additive** Node API change (minor release per changeset); typings in **`types.d.ts`** are updated, and a watch test asserts an initial cycle lists all compilers while invalidating one child lists only that one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ce145fc3a5c832412c1fd291030bcd164dcd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->