### PR TITLE
fix: compute common MultiCompiler outputPath by path segments

### DIFF
--- a/.changeset/105-multi-compiler-output-path.md
+++ b/.changeset/105-multi-compiler-output-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Compute the common MultiCompiler `outputPath` by whole path segments.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -195,10 +195,22 @@ module.exports = class MultiCompiler {
 	}
 
 	get outputPath() {
+		// Match whole path segments: "/dist-app" must not count as inside "/dist"
+		/**
+		 * @param {string} parent candidate ancestor path
+		 * @param {string} path path to test
+		 * @returns {boolean} true when path is parent or inside it
+		 */
+		const isSubPath = (parent, path) => {
+			if (path === parent) return true;
+			if (!path.startsWith(parent)) return false;
+			const next = path.charCodeAt(parent.length);
+			return next === 47 || next === 92 || /[/\\]$/.test(parent);
+		};
 		let commonPath = this.compilers[0].outputPath;
 		for (const compiler of this.compilers) {
 			while (
-				compiler.outputPath.indexOf(commonPath) !== 0 &&
+				!isSubPath(commonPath, compiler.outputPath) &&
 				/[/\\]/.test(commonPath)
 			) {
 				commonPath = commonPath.replace(/[/\\][^/\\]*$/, "");

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -244,6 +244,63 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should compute the common outputPath by path segments", (done) => {
+		/**
+		 * @param {string} pathA output path for a
+		 * @param {string} pathB output path for b
+		 * @returns {import("../").MultiCompiler} compiler
+		 */
+		const createWithOutputPaths = (pathA, pathB) =>
+			/** @type {import("../").MultiCompiler} */ (
+				webpack(
+					/** @type {import("../").MultiConfiguration} */ ([
+						{
+							name: "a",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./a.js",
+							output: { path: pathA }
+						},
+						{
+							name: "b",
+							context: path.join(__dirname, "fixtures"),
+							entry: "./b.js",
+							output: { path: pathB }
+						}
+					])
+				)
+			);
+		const base = path.join(__dirname, "js", "output-path");
+		// A sibling directory sharing a name prefix is not a common ancestor.
+		const prefixed = createWithOutputPaths(
+			path.join(base, "dist"),
+			path.join(base, "dist-modern")
+		);
+		expect(prefixed.outputPath).toBe(base);
+		const nested = createWithOutputPaths(
+			path.join(base, "dist", "a"),
+			path.join(base, "dist", "b")
+		);
+		expect(nested.outputPath).toBe(path.join(base, "dist"));
+		const same = createWithOutputPaths(
+			path.join(base, "dist"),
+			path.join(base, "dist")
+		);
+		expect(same.outputPath).toBe(path.join(base, "dist"));
+		// Root ancestor: keeps the trailing-separator parent working.
+		const root = createWithOutputPaths("/", "/foo");
+		expect(root.outputPath).toBe("/");
+		prefixed.close((err) => {
+			if (err) return done(err);
+			nested.close((err2) => {
+				if (err2) return done(err2);
+				same.close((err3) => {
+					if (err3) return done(err3);
+					root.close(done);
+				});
+			});
+		});
+	});
+
 	it("should watch again correctly after first compilation", (done) => {
 		const compiler = createMultiCompiler();
 		compiler.run((err, _stats) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`MultiCompiler`'s `outputPath` computes the common path with a plain string prefix check, so a sibling directory sharing a name prefix (e.g. `/proj/dist` and `/proj/dist-modern`) is reported as `/proj/dist`, which is not a common ancestor — breaking consumers like webpack-dev-middleware that resolve served assets from it. This matches whole path segments instead.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, in `test/MultiCompiler.test.js` (prefix-sibling, nested, identical and root output paths).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with AI assistance (Claude Code), directed and reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bugfix to MultiCompiler path resolution with targeted tests; behavior change only affects incorrect prefix matches, which fixes dev-middleware-style consumers.
> 
> **Overview**
> Fixes **`MultiCompiler.outputPath`** so it no longer treats string-prefix matches as a shared ancestor (e.g. `…/dist` vs `…/dist-modern` incorrectly collapsing to `…/dist`). The getter now uses an **`isSubPath`** helper that requires a path separator (or trailing separator on the parent) after the parent segment, while keeping the existing walk-up logic and root (`/`) behavior.
> 
> Adds **`test/MultiCompiler.test.js`** coverage for prefix siblings, nested outputs, identical paths, and root ancestor cases, plus a patch **changeset** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236e5de5767d08a5ae022f2247f3f24f29620655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->