### PR TITLE
fix: allow MultiCompiler to run again after dependency validation failure

### DIFF
--- a/.changeset/107-multi-compiler-stuck-running.md
+++ b/.changeset/107-multi-compiler-stuck-running.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Allow MultiCompiler to run again after a dependency validation failure.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -650,33 +650,33 @@ module.exports = class MultiCompiler {
 			handler(new ConcurrentCompilationError());
 			return;
 		}
-		this.running = true;
-
-		if (this.validateDependencies(handler)) {
-			const watchings = this._runGraph(
-				(compiler, idx, callback, isBlocked, setChanged, setInvalid) => {
-					const watching = compiler.watch(
-						Array.isArray(watchOptions) ? watchOptions[idx] : watchOptions,
-						callback
-					);
-					if (watching) {
-						watching._onInvalid = setInvalid;
-						watching._onChange = setChanged;
-						watching._isBlocked = isBlocked;
-					}
-					return watching;
-				},
-				(compiler, watching, _callback) => {
-					if (compiler.watching !== watching) return;
-					if (!watching.running) watching.invalidate();
-				},
-				handler
-			);
-			this.watching = new MultiWatching(watchings, this);
+		// Only mark as running after validation, so a retry reports the real error
+		if (!this.validateDependencies(handler)) {
+			this.watching = new MultiWatching([], this);
 			return this.watching;
 		}
+		this.running = true;
 
-		this.watching = new MultiWatching([], this);
+		const watchings = this._runGraph(
+			(compiler, idx, callback, isBlocked, setChanged, setInvalid) => {
+				const watching = compiler.watch(
+					Array.isArray(watchOptions) ? watchOptions[idx] : watchOptions,
+					callback
+				);
+				if (watching) {
+					watching._onInvalid = setInvalid;
+					watching._onChange = setChanged;
+					watching._isBlocked = isBlocked;
+				}
+				return watching;
+			},
+			(compiler, watching, _callback) => {
+				if (compiler.watching !== watching) return;
+				if (!watching.running) watching.invalidate();
+			},
+			handler
+		);
+		this.watching = new MultiWatching(watchings, this);
 		return this.watching;
 	}
 
@@ -690,21 +690,21 @@ module.exports = class MultiCompiler {
 			callback(new ConcurrentCompilationError());
 			return;
 		}
+		// Only mark as running after validation, so a retry reports the real error
+		if (!this.validateDependencies(callback)) return;
 		this.running = true;
 
-		if (this.validateDependencies(callback)) {
-			this._runGraph(
-				() => {},
-				(compiler, setupResult, callback) => compiler.run(callback),
-				(err, stats) => {
-					this.running = false;
+		this._runGraph(
+			() => {},
+			(compiler, setupResult, callback) => compiler.run(callback),
+			(err, stats) => {
+				this.running = false;
 
-					if (callback !== undefined) {
-						return callback(err, stats);
-					}
+				if (callback !== undefined) {
+					return callback(err, stats);
 				}
-			);
-		}
+			}
+		);
 	}
 
 	purgeInputFileSystem() {

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -368,6 +368,46 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should not stay running after dependency validation fails", (done) => {
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ ([
+					{
+						name: "a",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./a.js",
+						dependencies: ["missing"]
+					},
+					{
+						name: "b",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./b.js"
+					}
+				])
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		compiler.run((err) => {
+			expect(/** @type {Error} */ (err).message).toMatch(
+				/Compiler dependency `missing` not found/
+			);
+			// A retry must report the real error again, not a ConcurrentCompilationError
+			compiler.run((err2) => {
+				expect(/** @type {Error} */ (err2).message).toMatch(
+					/Compiler dependency `missing` not found/
+				);
+				compiler.watch({}, (err3) => {
+					expect(/** @type {Error} */ (err3).message).toMatch(
+						/Compiler dependency `missing` not found/
+					);
+					compiler.close(done);
+				});
+			});
+		});
+	});
+
 	it("should expose `watching` when dependency validation fails", (done) => {
 		const compiler = /** @type {import("../").MultiCompiler} */ (
 			webpack(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

When `MultiCompiler` dependency validation fails (unknown dependency name or a cycle), `running` stays `true` forever, so every retry reports a misleading `ConcurrentCompilationError` instead of the real validation error. This marks the compiler as running only after validation passes.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, in `test/MultiCompiler.test.js` (retrying `run()` and `watch()` after a validation failure reports the validation error again).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with AI assistance (Claude Code), directed and reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change in MultiCompiler run/watch with a focused regression test; no auth, data, or API breaking changes.
> 
> **Overview**
> Fixes **`MultiCompiler`** getting stuck in a “running” state when child **`dependencies`** fail validation (missing compiler name or circular deps). Previously **`running`** was set **before** **`validateDependencies`**, so a failed **`run()`** or **`watch()`** never cleared the flag and later calls surfaced **`ConcurrentCompilationError`** instead of the real validation error.
> 
> **`run()`** and **`watch()`** now set **`running = true`** only after validation passes. On **`watch()`** failure, behavior is unchanged: the handler still receives the validation error and a **`MultiWatching`** with an empty watcher list is returned for **`close()`** compatibility.
> 
> Adds a test that repeated **`run()`** / **`watch()`** after a bad dependency config still reports the dependency error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6198867e9860e9ce5b289321d2064860071422d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->