### PR TITLE
fix: recover MultiCompiler watch after fatal child error without leaking watchings

### DIFF
--- a/.changeset/108-multi-compiler-watch-error-recovery.md
+++ b/.changeset/108-multi-compiler-watch-error-recovery.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Recover MultiCompiler watch mode after a fatal child error and stop leaking watchings.

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -510,7 +510,28 @@ module.exports = class MultiCompiler {
 		}
 		let errored = false;
 		let running = 0;
+		let duringSetup = true;
+		/** @type {Error | null} */
+		let setupError = null;
 		const parallelism = /** @type {number} */ (this._options.parallelism);
+		/**
+		 * Closes all node watchings.
+		 * @param {() => void} onClosed called when every watching is closed
+		 * @returns {void}
+		 */
+		const closeWatchings = (onClosed) => {
+			asyncLib.each(
+				nodes,
+				(node, callback) => {
+					if (node.compiler.watching) {
+						node.compiler.watching.close(callback);
+					} else {
+						callback();
+					}
+				},
+				onClosed
+			);
+		};
 		/**
 		 * Processes the provided node.
 		 * @param {Node} node node
@@ -522,17 +543,13 @@ module.exports = class MultiCompiler {
 			if (errored) return;
 			if (err) {
 				errored = true;
-				return asyncLib.each(
-					nodes,
-					(node, callback) => {
-						if (node.compiler.watching) {
-							node.compiler.watching.close(callback);
-						} else {
-							callback();
-						}
-					},
-					() => callback(err)
-				);
+				// During setup later watchings do not exist yet — defer the close
+				// sweep until the setup loop created them all, or they would leak
+				if (duringSetup) {
+					setupError = err;
+					return;
+				}
+				return closeWatchings(() => callback(err));
 			}
 			node.result = stats;
 			running--;
@@ -652,7 +669,14 @@ module.exports = class MultiCompiler {
 				}
 			}
 		};
-		processQueueWorker();
+		duringSetup = false;
+		if (setupError) {
+			// The setup loop finished, every watching exists now — safe to sweep
+			const err = setupError;
+			closeWatchings(() => callback(err));
+		} else {
+			processQueueWorker();
+		}
 		return setupResults;
 	}
 
@@ -691,7 +715,11 @@ module.exports = class MultiCompiler {
 				if (compiler.watching !== watching) return;
 				if (!watching.running) watching.invalidate();
 			},
-			handler
+			(err, stats) => {
+				// A fatal error tears the whole graph down — allow watching again
+				if (err) this.running = false;
+				handler(err, stats);
+			}
 		);
 		this.watching = new MultiWatching(watchings, this);
 		return this.watching;

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -465,6 +465,42 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should allow watching again after a fatal error in a child compiler", (done) => {
+		const compiler = createMultiCompiler();
+		compiler.compilers[1].hooks.watchRun.tapAsync(
+			"MultiCompiler test",
+			(_compiler, callback) => {
+				callback(new Error("fatal child error"));
+			}
+		);
+		compiler.watch({}, (err) => {
+			expect(/** @type {Error} */ (err).message).toBe("fatal child error");
+			expect(compiler.running).toBe(false);
+			// A retry must report the real error again, not a ConcurrentCompilationError
+			compiler.watch({}, (err2) => {
+				expect(/** @type {Error} */ (err2).message).toBe("fatal child error");
+				compiler.close(done);
+			});
+		});
+	});
+
+	it("should close every child watching when the watch setup fails synchronously", (done) => {
+		const compiler = createMultiCompiler();
+		// A child already watching makes its setup fail synchronously
+		compiler.compilers[0].watch({}, () => {});
+		compiler.watch({}, (err) => {
+			expect(/** @type {Error} */ (err).message).toMatch(
+				/You ran Webpack twice/
+			);
+			// No child watching may leak, including ones created after the error
+			for (const child of compiler.compilers) {
+				expect(child.watching).toBeUndefined();
+			}
+			expect(compiler.running).toBe(false);
+			compiler.close(done);
+		});
+	});
+
 	it("should expose `watching` when dependency validation fails", (done) => {
 		const compiler = /** @type {import("../").MultiCompiler} */ (
 			webpack(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

When a child compiler fails fatally in watch mode, `MultiCompiler` closes the watchings and reports the error but leaves `running` stuck on `true`, so every later `watch()` reports a misleading `ConcurrentCompilationError`; additionally, when the failure happens synchronously while the watch setup loop is still creating the remaining child watchings, those are created after the close sweep and leak forever. This resets `running` on a fatal watch error and defers the close sweep until setup created every watching.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, in `test/MultiCompiler.test.js` (retrying watch after an async fatal child error, and no leaked child watchings after a synchronous setup failure).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with AI assistance (Claude Code), directed and reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MultiCompiler watch error teardown and lifecycle flags; behavior is narrow and covered by new tests, but affects concurrent watch entry and resource cleanup.
> 
> **Overview**
> Fixes **MultiCompiler** watch teardown when a child compiler fails fatally: **`running` is cleared** on a fatal watch error so a follow-up `watch()` surfaces the real failure instead of **`ConcurrentCompilationError`**, and **`_runGraph` defers closing child watchings** until the synchronous setup loop has created every watching so later children are not left leaking.
> 
> Error handling now routes through a shared **`closeWatchings`** helper; setup-time failures are stored and swept only after setup finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4bf2afbb5cab43fd2dea0ef465a0a9e258d8c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->