### PR TITLE
fix: drop unused pure values in module.exports object literals

### DIFF
--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -560,6 +560,11 @@ class CommonJsExportsParserPlugin {
 					valueRange = /** @type {Range} */ (value.range);
 				}
 
+				// scans the key/value gap, so `/*#__PURE__*/` is picked up here
+				const pure =
+					kind === "keyValue" &&
+					parser.isPure(value, /** @type {Range} */ (property.key.range)[1]);
+
 				if (name === "__esModule") {
 					checkNamespace(true, ["__esModule"], value);
 				}
@@ -569,7 +574,8 @@ class CommonJsExportsParserPlugin {
 					/** @type {Range} */ (property.key.range),
 					valueRange,
 					name,
-					kind
+					kind,
+					pure
 				);
 				dep.loc = parser.getLocation(property);
 				parser.state.module.addDependency(dep);

--- a/lib/dependencies/CommonJsObjectExportDependency.js
+++ b/lib/dependencies/CommonJsObjectExportDependency.js
@@ -17,8 +17,8 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {"keyValue" | "shorthand" | "get" | "set" | "method" | "asyncMethod" | "generatorMethod" | "asyncGeneratorMethod"} CommonJsObjectExportKind */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind, boolean]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, Range, Range, ExportInfoName, CommonJsObjectExportKind, boolean]>} ObjectSerializerContext */
 
 const EMPTY_OBJECT = {};
 
@@ -39,8 +39,9 @@ class CommonJsObjectExportDependency extends NullDependency {
 	 * @param {Range} valueRange value / function range
 	 * @param {ExportInfoName} name export name
 	 * @param {CommonJsObjectExportKind} kind property kind
+	 * @param {boolean} pure value is known to be side-effect free
 	 */
-	constructor(range, keyRange, valueRange, name, kind) {
+	constructor(range, keyRange, valueRange, name, kind, pure) {
 		super();
 		this.range = range;
 		this.keyRange = keyRange;
@@ -49,6 +50,8 @@ class CommonJsObjectExportDependency extends NullDependency {
 		this.name = name;
 		/** @type {CommonJsObjectExportKind} */
 		this.kind = kind;
+		/** @type {boolean} */
+		this.pure = pure;
 	}
 
 	get type() {
@@ -84,7 +87,8 @@ class CommonJsObjectExportDependency extends NullDependency {
 			.write(this.keyRange)
 			.write(this.valueRange)
 			.write(this.name)
-			.write(this.kind);
+			.write(this.kind)
+			.write(this.pure);
 		super.serialize(context);
 	}
 
@@ -102,7 +106,9 @@ class CommonJsObjectExportDependency extends NullDependency {
 		this.name = c3.read();
 		const c4 = c3.rest;
 		this.kind = c4.read();
-		super.deserialize(c4.rest);
+		const c5 = c4.rest;
+		this.pure = c5.read();
+		super.deserialize(c5.rest);
 	}
 }
 
@@ -149,6 +155,16 @@ CommonJsObjectExportDependency.Template = class CommonJsObjectExportDependencyTe
 			}
 			// keyValue: keep the value's side effects in place.
 			const valueRange = /** @type {Range} */ (dep.valueRange);
+			if (dep.pure) {
+				// spreading null adds nothing; the text stays so nested replaces hold
+				source.replace(
+					range[0],
+					valueRange[0] - 1,
+					"...(/* unused pure expression */ null && ("
+				);
+				source.replace(valueRange[1], range[1] - 1, "))");
+				return;
+			}
 			source.replace(range[0], valueRange[0] - 1, "...void (");
 			source.replace(valueRange[1], range[1] - 1, ")");
 			return;

--- a/test/cases/cjs-tree-shaking/object-literal/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal/index.js
@@ -29,3 +29,9 @@ it("should keep sibling exports when an object method uses this", () => {
 	expect(m.getValue()).toBe(10);
 	expect(m.usedExports).toBe(true);
 });
+
+it("should drop unused data properties with a side-effect-free value", () => {
+	const m = require("./pure");
+	expect(m.used).toBe("used");
+	expect(m.getCount()).toBe(0);
+});

--- a/test/cases/cjs-tree-shaking/object-literal/pure.js
+++ b/test/cases/cjs-tree-shaking/object-literal/pure.js
@@ -1,0 +1,22 @@
+let count = 0;
+
+function track(value) {
+	count++;
+	return value;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+function trackAnnotated(value) {
+	count++;
+	return value;
+}
+
+module.exports = {
+	used: "used",
+	unusedPure: /*#__PURE__*/ track("unused-pure"),
+	unusedAnnotated: trackAnnotated("unused-annotated"),
+	unusedLiteral: track,
+	getCount() {
+		return count;
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

An unused property of a `module.exports = { … }` object literal was rewritten to `...void (value)`, which still evaluates the value, and the rewrite also swallowed any `/*#__PURE__*/` annotation sitting between key and value — so even an explicitly annotated value could never be eliminated. This computes `parser.isPure()` for `keyValue` properties and emits `...(null && (value))` when the value is provably side-effect free, so `/*#__PURE__*/` and `/*#__NO_SIDE_EFFECTS__*/` values are dropped without relying on a minifier. Refs #21543.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/cases/cjs-tree-shaking/object-literal/pure.js` plus a new assertion in `test/cases/cjs-tree-shaking/object-literal/index.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to investigate how the CommonJS export dependency templates treat value side effects, to draft the `isPure` change and the test fixture, and to verify the emitted output; every change was reviewed by me, and the new test was confirmed to fail without the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CommonJS object-export codegen and serialization for a core tree-shaking path; behavior shift is intentional (fewer side effects) but could affect edge cases where unused exports were previously kept alive by evaluation.
> 
> **Overview**
> Unused **key/value** properties on `module.exports = { … }` were rewritten to `...void (value)`, which **still executed** the value expression. Annotations like `/*#__PURE__*/` between the key and value were also easy to miss in that path.
> 
> For unused exports, the parser now records whether the value is provably side-effect-free via `parser.isPure(value, afterKey)` (including comment annotations in the key/value gap). `CommonJsObjectExportDependency` carries a **`pure`** flag through serialize/deserialize. When dropping an unused pure property, the template emits `...(null && (value))` instead of `...void (value)`, matching the existing pure-expression pattern so annotated or statically pure values are not evaluated.
> 
> A new fixture **`pure.js`** asserts that unused pure/annotated properties do not increment a side-effect counter while used exports still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561789ea0125a8357fae3743a2d5e094409d7f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->