### PR TITLE
ci: unpin the test262 job from Node.js 26.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,8 +184,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          # Pinned; revert to "latest" once https://github.com/nodejs/node/issues/63715 is resolved
-          node-version: "26.2.0"
+          node-version: latest
           cache: yarn
 
       - run: yarn --frozen-lockfile


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The `test262` job was pinned to Node.js 26.2.0 in #21075 to work around a `vm` regression (https://github.com/nodejs/node/issues/63715), which is now fixed and released, so the job can track the latest Node.js release again like the other jobs.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

ci

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — the change only affects the CI workflow; the `test262` job itself is the verification.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to locate the pin, confirm the upstream Node.js issue is closed, and draft this PR description. The change itself was reviewed by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no runtime or library impact; slightly higher CI exposure to future Node releases via `latest`.
> 
> **Overview**
> The **`test262`** CI job in `.github/workflows/test.yml` no longer pins Node.js to **26.2.0** and again uses **`node-version: latest`**, matching the intent before the temporary workaround.
> 
> The pin and its comment (referencing the Node.js `vm` regression in nodejs/node#63715) are removed now that upstream is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af1a497437acf72754e00038f923076185f19a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->