### PR TITLE
fix(concatenation): keep wrapped module names and side effects intact

### DIFF
--- a/.changeset/010-concatenate-module-wrapping.md
+++ b/.changeset/010-concatenate-module-wrapping.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Wrap concatenated modules in lazy `__webpack_require__.cw` accessors and inline `require()`.
+Wrap concatenated modules in lazy `__webpack_require__.cw` accessors and inline `require()`, keeping a wrapped body's names and side effects intact.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -131,9 +131,6 @@ const getExternalModule = memoize(() => require("../ExternalModule"));
 const IDENTIFIER_SCAN_REGEXP = /[$A-Za-z_][\w$]*/g;
 const IDENTIFIER_SCAN_WHITESPACE = new Set([" ", "\t", "\n", "\r"]);
 
-/** @type {WeakMap<Source, Set<string>>} */
-const identifiersCache = new WeakMap();
-
 /**
  * Finds every identifier a generated source could resolve against the enclosing
  * concatenation scope. Property names are skipped; string and comment contents
@@ -142,8 +139,6 @@ const identifiersCache = new WeakMap();
  * @returns {ReadonlySet<string>} identifier names
  */
 const findIdentifiers = (source) => {
-	const cached = identifiersCache.get(source);
-	if (cached !== undefined) return cached;
 	const code = source.source().toString();
 	/** @type {Set<string>} */
 	const result = new Set();
@@ -158,7 +153,6 @@ const findIdentifiers = (source) => {
 		}
 		match = IDENTIFIER_SCAN_REGEXP.exec(code);
 	}
-	identifiersCache.set(source, result);
 	return result;
 };
 
@@ -810,10 +804,8 @@ const getFinalBinding = (
 				if (!usedName) {
 					return {
 						info,
-						rawName: getUnusedExportExpr(info),
-						// the wrapped form already evaluates to undefined; a member access
-						// on it would throw instead of staying inert
-						ids: info.wrapped ? [] : exportName.slice(1),
+						rawName: "/* unused export */ undefined",
+						ids: exportName.slice(1),
 						exportName
 					};
 				}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -128,6 +128,40 @@ const { InlinedUsedName } = require("./InlineExports");
 const getNormalModule = memoize(() => require("../NormalModule"));
 const getExternalModule = memoize(() => require("../ExternalModule"));
 
+const IDENTIFIER_SCAN_REGEXP = /[$A-Za-z_][\w$]*/g;
+const IDENTIFIER_SCAN_WHITESPACE = new Set([" ", "\t", "\n", "\r"]);
+
+/** @type {WeakMap<Source, Set<string>>} */
+const identifiersCache = new WeakMap();
+
+/**
+ * Finds every identifier a generated source could resolve against the enclosing
+ * concatenation scope. Property names are skipped; string and comment contents
+ * are not, which only over-reserves.
+ * @param {Source} source generated source
+ * @returns {ReadonlySet<string>} identifier names
+ */
+const findIdentifiers = (source) => {
+	const cached = identifiersCache.get(source);
+	if (cached !== undefined) return cached;
+	const code = source.source().toString();
+	/** @type {Set<string>} */
+	const result = new Set();
+	IDENTIFIER_SCAN_REGEXP.lastIndex = 0;
+	let match = IDENTIFIER_SCAN_REGEXP.exec(code);
+	while (match !== null) {
+		let i = match.index - 1;
+		while (i >= 0 && IDENTIFIER_SCAN_WHITESPACE.has(code[i])) i--;
+		// `a.b` can't bind to the outer scope, but the `b` of `...b` can
+		if (!(i >= 0 && code[i] === "." && code[i - 1] !== ".")) {
+			result.add(match[0]);
+		}
+		match = IDENTIFIER_SCAN_REGEXP.exec(code);
+	}
+	identifiersCache.set(source, result);
+	return result;
+};
+
 // fix eslint-scope to support class properties correctly
 // cspell:word Referencer
 const ReferencerClass = Referencer;
@@ -383,6 +417,18 @@ const getInteropExpr = (info, interopName) =>
 	info.wrapped ? `${interopName}()` : /** @type {string} */ (interopName);
 
 /**
+ * Expression for an export that is not used. A hoisted body runs at its own
+ * slot, but a wrapped one only runs when its accessor is called, so dropping
+ * the reference would drop the module's side effects with it.
+ * @param {ConcatenatedModuleInfo} info module info
+ * @returns {string} expression evaluating to undefined
+ */
+const getUnusedExportExpr = (info) =>
+	info.wrapped
+		? `/* unused export */ (${info.namespaceObjectName}, undefined)`
+		: "/* unused export */ undefined";
+
+/**
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {ModuleInfo} info module info
  * @param {ExportName} exportName exportName
@@ -436,7 +482,7 @@ const getFinalBinding = (
 		if (!usedName) {
 			return {
 				info,
-				rawName: "/* unused export */ undefined",
+				rawName: getUnusedExportExpr(info),
 				ids: [],
 				exportName
 			};
@@ -764,8 +810,10 @@ const getFinalBinding = (
 				if (!usedName) {
 					return {
 						info,
-						rawName: "/* unused export */ undefined",
-						ids: exportName.slice(1),
+						rawName: getUnusedExportExpr(info),
+						// the wrapped form already evaluates to undefined; a member access
+						// on it would throw instead of staying inert
+						ids: info.wrapped ? [] : exportName.slice(1),
 						exportName
 					};
 				}
@@ -1778,6 +1826,14 @@ class ConcatenatedModule extends Module {
 		for (const info of modulesWithInfo) {
 			if (info.type === "concatenated") {
 				if (info.wrapped) {
+					// The body is emitted verbatim and never renamed, so every identifier
+					// in it is claimed: its declarations must not shadow a name [3]
+					// generates, and its free globals must not be captured by one.
+					for (const name of findIdentifiers(
+						/** @type {Source} */ (info.internalSource)
+					)) {
+						allUsedNames.add(name);
+					}
 					// A wrapped body has no scope analysis, so its references are found
 					// textually. They still have to be resolved here: binding one is what
 					// flags the interop objects it needs, and [3] allocates their names.
@@ -2017,10 +2073,9 @@ class ConcatenatedModule extends Module {
 				case "concatenated": {
 					if (info.wrapped) {
 						// A wrapped module declares exactly one shared-scope name: the
-						// lazy wrapper accessor holding its body. The wrapped body is not
-						// scope-analyzed, so its locals are unknown here and can't be
-						// avoided by findNewName — the reserved `__webpack_` prefix is
-						// what keeps a local in that body from shadowing the accessor.
+						// lazy wrapper accessor holding its body. [2] claimed every
+						// identifier of that body, so findNewName avoids the ones that
+						// would shadow the accessor from inside it.
 						const namespaceFnName = findNewName(
 							"namespaceFn",
 							allUsedNames,
@@ -2963,9 +3018,10 @@ ${defineGetters}`
 		if (info.type === "concatenated") {
 			const m = info.module;
 			if (info.wrapped) {
-				// the wrapper isolates the body's top-level declarations, so no scope
-				// analysis or renaming is needed -- only a concatenation scope, to
-				// rewrite in-scope `require()` targets to accessor references
+				// the wrapper isolates the body's top-level declarations, so no
+				// renaming is needed -- only a concatenation scope, to rewrite in-scope
+				// `require()` targets to accessor references. [2] claims its identifiers
+				// textually in place of the scope analysis skipped here.
 				const concatenationScope = new ConcatenationScope(
 					modulesMap,
 					info,

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/alias-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/alias-target.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { tag: "alias-target" };

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/counter.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/counter.js
@@ -1,0 +1,10 @@
+"use strict";
+
+let calls = 0;
+
+module.exports = {
+	next() {
+		calls += 1;
+		return calls;
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/ctor.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/ctor.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function Thing() {
+	this.kind = "thing";
+};

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/dir/one.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/dir/one.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "one";

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/dir/two.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/dir/two.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "two";

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/esm-dep.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/esm-dep.js
@@ -1,0 +1,1 @@
+export const esmValue = "esm-dep";

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/index.js
@@ -1,0 +1,75 @@
+import { esmValue } from "./esm-dep.js";
+
+const { first, second } = require("./named-exports.js");
+const templateRequire = require(`./named-exports.js`);
+const contextName = "one";
+const contextRequire = require(`./dir/${contextName}.js`);
+const instance = new (require("./ctor.js"))();
+// `new require(x)` binds the argument list to `new`, so this is the exports
+// value itself -- the trailing `()` in `new require(x)()` would call it
+const constructedRequire = new require("./ctor.js");
+
+it("should read a destructured require()", () => {
+	expect(esmValue).toBe("esm-dep");
+	expect(first).toBe("first");
+	expect(second).toBe("second");
+});
+
+it("should read a require() written as a template literal", () => {
+	expect(templateRequire.first).toBe("first");
+});
+
+it("should pass the exports object as `this` to a member call", () => {
+	expect(require("./named-exports.js").readThis()).toBe("this=exports");
+});
+
+it("should keep a computed request resolving at runtime", () => {
+	expect(contextRequire).toBe("one");
+	// the context module stays out of the concatenation, so the two requires of
+	// ./named-exports.js must still share its instance
+	expect(templateRequire).toBe(require("./named-exports.js"));
+});
+
+it("should construct through a parenthesized require()", () => {
+	expect(instance.kind).toBe("thing");
+});
+
+it("should give `new require()` the Node.js return-value semantics", () => {
+	// a function exports value passes through the `new` return-value rule
+	expect(constructedRequire).toBe(require("./ctor.js"));
+	// so calling it is a plain call, with no `this` -- exactly as in Node.js
+	expect(() => new require("./ctor.js")()).toThrow(TypeError);
+});
+
+it("should share one instance across every require() of a module", () => {
+	const a = require("./counter.js");
+	const b = require("./counter.js");
+	expect(a).toBe(b);
+	expect(a.next()).toBe(1);
+	expect(b.next()).toBe(2);
+});
+
+it("should keep a whole-module and a member alias pointing at one instance", () => {
+	expect(require("./whole-alias.js")).toBe(require("./alias-target.js"));
+	expect(require("./member-alias.js").tag).toBe("alias-target");
+});
+
+it("should concatenate every module with a static request", () => {
+	const concatenated = new Set();
+	for (const m of __STATS__.modules) {
+		if (!m.modules) continue;
+		for (const inner of m.modules) concatenated.add(inner.name);
+	}
+	for (const name of [
+		"./alias-target.js",
+		"./counter.js",
+		"./ctor.js",
+		"./esm-dep.js",
+		"./index.js",
+		"./member-alias.js",
+		"./named-exports.js",
+		"./whole-alias.js"
+	]) {
+		expect(concatenated).toContain(name);
+	}
+});

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/member-alias.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/member-alias.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.tag = require("./alias-target.js").tag;

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/named-exports.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/named-exports.js
@@ -1,0 +1,7 @@
+"use strict";
+
+exports.first = "first";
+exports.second = "second";
+exports.readThis = function readThis() {
+	return this === module.exports ? "this=exports" : "this=other";
+};

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-shapes/whole-alias.js
+++ b/test/configCases/concatenate-modules/commonjs-require-shapes/whole-alias.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./alias-target.js");

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/alias.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/alias.js
@@ -1,0 +1,6 @@
+"use strict";
+
+exports.used = "used";
+// neither alias is ever read, but the require() behind it still has to run
+exports.unusedMember = require("./side.js").name;
+exports.unusedWhole = require("./whole.js");

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/esm-dep.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/esm-dep.js
@@ -1,0 +1,1 @@
+export const esmValue = "esm-dep";

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/index.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/index.js
@@ -1,0 +1,28 @@
+import { esmValue } from "./esm-dep.js";
+
+// evaluation-only: it must not mark alias.js's exports used
+require("./alias.js");
+
+it("should still evaluate a require() whose export alias is unused", () => {
+	expect(esmValue).toBe("esm-dep");
+	expect(require("./alias.js").used).toBe("used");
+	expect(global.__sideEffectOrder).toEqual(["side", "whole"]);
+});
+
+it("should evaluate such a module exactly once", () => {
+	expect(require("./alias.js").used).toBe("used");
+	expect(global.__sideEffectOrder).toEqual(["side", "whole"]);
+});
+
+it("should concatenate every module", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./alias.js",
+		"./esm-dep.js",
+		"./index.js",
+		"./side.js",
+		"./whole.js"
+	]);
+	delete global.__sideEffectOrder;
+});

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/side.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/side.js
@@ -1,0 +1,5 @@
+"use strict";
+
+(global.__sideEffectOrder || (global.__sideEffectOrder = [])).push("side");
+
+exports.name = "side";

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/whole.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-export-side-effects/whole.js
@@ -1,0 +1,5 @@
+"use strict";
+
+(global.__sideEffectOrder || (global.__sideEffectOrder = [])).push("whole");
+
+module.exports = { name: "whole" };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/esm-local.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/esm-local.js
@@ -1,0 +1,3 @@
+const sharedNameOfConcatenation = "esm local";
+
+export const esmValue = sharedNameOfConcatenation;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/index.js
@@ -1,0 +1,21 @@
+import { esmValue } from "./esm-local.js";
+
+global.sharedNameOfConcatenation = "real global";
+
+const readsGlobal = require("./reads-global.js");
+
+it("should not capture a wrapped body's free global with a top-level binding", () => {
+	expect(esmValue).toBe("esm local");
+	expect(readsGlobal.seen).toBe("real global");
+	delete global.sharedNameOfConcatenation;
+});
+
+it("should concatenate every module", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./esm-local.js",
+		"./index.js",
+		"./reads-global.js"
+	]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/reads-global.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/reads-global.js
@@ -1,0 +1,10 @@
+"use strict";
+
+// a free global: it must keep resolving to the global, not to the top-level
+// binding ./esm-local.js contributes to the same concatenation
+module.exports = {
+	seen:
+		typeof sharedNameOfConcatenation === "undefined"
+			? "undefined"
+			: sharedNameOfConcatenation
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-global-capture/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/dep.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/dep.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { value: "dep" };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/esm-dep.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/esm-dep.js
@@ -1,0 +1,1 @@
+export const esmValue = "esm-dep";

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/index.js
@@ -1,0 +1,27 @@
+import { esmValue } from "./esm-dep.js";
+
+const withVar = require("./shadows-with-var.js");
+const withFunction = require("./shadows-with-function.js");
+
+it("should not let a wrapped body's var shadow the accessor it calls", () => {
+	expect(esmValue).toBe("esm-dep");
+	expect(withVar.value).toBe("dep");
+	expect(withVar.local).toBe("local var");
+});
+
+it("should not let a wrapped body's function declaration shadow the accessor", () => {
+	expect(withFunction.value).toBe("dep");
+	expect(withFunction.local).toBe("local function");
+});
+
+it("should concatenate every module", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./dep.js",
+		"./esm-dep.js",
+		"./index.js",
+		"./shadows-with-function.js",
+		"./shadows-with-var.js"
+	]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/shadows-with-function.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/shadows-with-function.js
@@ -1,0 +1,10 @@
+"use strict";
+
+// a hoisted declaration shadows the accessor even above its own require()
+function dep_namespaceFn() {
+	return "local function";
+}
+
+const dep = require("./dep.js");
+
+module.exports = { value: dep.value, local: dep_namespaceFn() };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/shadows-with-var.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/shadows-with-var.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// same name the wrapper accessor for ./dep.js is derived from
+var dep_namespaceFn = "local var";
+
+const dep = require("./dep.js");
+
+module.exports = { value: dep.value, local: dep_namespaceFn };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-name-collision/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/cjs.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/cjs.js
@@ -1,0 +1,6 @@
+"use strict";
+
+(global.__reexportOrder || (global.__reexportOrder = [])).push("cjs");
+
+exports.read = "read";
+exports.neverRead = "never-read";

--- a/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/index.js
@@ -1,0 +1,20 @@
+import { read } from "./re.js";
+
+it("should resolve a used export through an ESM re-export of a wrapped module", () => {
+	expect(read).toBe("read");
+});
+
+it("should still evaluate the wrapped module behind an unused re-export", () => {
+	expect(global.__reexportOrder).toEqual(["cjs"]);
+});
+
+it("should concatenate every module", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./cjs.js",
+		"./index.js",
+		"./re.js"
+	]);
+	delete global.__reexportOrder;
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/re.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/re.js
@@ -1,0 +1,2 @@
+// the second binding is re-exported but nothing downstream reads it
+export { neverRead, read } from "./cjs.js";

--- a/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-unused-reexport/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
+++ b/test/configCases/defer-import/set-does-not-trigger-evaluation/index.js
@@ -1,5 +1,9 @@
 import defer * as ns from "./dep.js";
 
+// `import defer` leaves ./dep.js unevaluated, so this only clears a counter a
+// previous test file left behind where a worker shares globals (Bun)
+delete globalThis.evaluations;
+
 it("does not evaluate the deferred module on `import defer`", () => {
 	expect(globalThis.evaluations).toBe(undefined);
 });

--- a/test/configCases/inline-exports/module-declarations/index.js
+++ b/test/configCases/inline-exports/module-declarations/index.js
@@ -18,6 +18,9 @@ it("should inline constants from modules with import and re-export declarations"
 	expect(REMOVE_with_all_module_declarations).toBe(321);
 	// END
 	expect(globalThis.__inlineConstModuleDeclarationsSideEffect).toBe(3);
+	// the counter outlives this bundle where a worker shares globals between
+	// test files (Bun), so the next run of this case would start from 3
+	delete globalThis.__inlineConstModuleDeclarationsSideEffect;
 	const block = generated.match(/\/\/ START([\s\S]*)\/\/ END/)[1];
 	expect(
 		block.includes(`((/* inlined export .REMOVE_with_import */123)).toBe(123)`)

--- a/test/configCases/library/1-use-library/test.filter.js
+++ b/test/configCases/library/1-use-library/test.filter.js
@@ -1,0 +1,10 @@
+"use strict";
+
+// The amd-runtimeChunk variants pull the library through a `promise` external,
+// which is still settling when the harness deletes the `webpack*` chunk-loading
+// globals after execution. Node gives every test file a fresh global so the
+// reload succeeds; Bun shares one per worker thread, so the second suite to run
+// this case (ConfigTestCases vs ConfigCacheTestCases) loses the registration.
+module.exports = function filter() {
+	return !process.versions.bun;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Three correctness bugs in the wrapped-CommonJS concatenation added in #21519, found by compiling the same fixtures under `concatenateModules: false`, `{ commonjs: false }` and `{ commonjs: true }` and diffing the runtime behaviour. Refs #21519.

A wrapped body is emitted verbatim and never scope-analysed, so its identifiers never entered `allUsedNames`: a local declaration could shadow the wrapper accessor it calls (`var dep_namespaceFn = …` next to `require("./dep.js")` throws `dep_namespaceFn is not a function`, and the `function` form fails silently), and a free global could be captured by another member's top-level binding. `ConcatenatedModule` now claims those identifiers with a cached lexical scan, in place of the scope analysis that is deliberately skipped. Separately, an unused export of a wrapped module collapsed to `undefined`, dropping the accessor call and with it the module's side effects — a three-way require cycle evaluated `[a, b]` instead of `[a, b, c]`; it now renders as `(x_namespaceFn(), undefined)`.

The code asserted an invariant that was never implemented ("the reserved `__webpack_` prefix is what keeps a local in that body from shadowing the accessor" — `findNewName` produces `dep_namespaceFn`); those comments are corrected.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — four `test/configCases/concatenate-modules/` cases: `commonjs-wrapped-name-collision`, `commonjs-wrapped-global-capture`, `commonjs-unused-export-side-effects`, and `commonjs-require-shapes` (template-literal, destructured, `this`-binding, computed-request, alias and both `new` require forms). Each was verified to fail with the `lib/` change reverted.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — it only corrects output for modules wrapped by the opt-in `optimization.concatenateModules.commonjs` path.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code was used to build the differential harness that surfaced the three divergences, to write the fix and the test cases, and to verify each test fails without the fix. Every finding was reproduced in a real build and reviewed by me before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_014NxAwyKRtQpvuGkgqpu6Ev)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect production bundle codegen on the opt-in CommonJS concatenation path in `ConcatenatedModule.js`; incorrect identifier reservation or unused-export expressions could alter runtime behavior, though the added config cases target the reported failure modes.
> 
> **Overview**
> Fixes **three correctness bugs** in opt-in `optimization.concatenateModules.commonjs` wrapped-module output: verbatim CJS bodies were never scope-analyzed, so generated names could collide with body identifiers and unused exports could skip lazy accessor evaluation.
> 
> **Identifier reservation:** Adds `findIdentifiers` and, during the RESERVE phase, registers every identifier in a wrapped body in `allUsedNames` so `findNewName` does not pick names like `dep_namespaceFn` that locals or hoisted declarations inside the body would shadow.
> 
> **Unused wrapped exports:** Adds `getUnusedExportExpr` so unused exports on wrapped modules render as `(accessor(), undefined)` instead of bare `undefined`, preserving evaluation and side effects when nothing reads the export.
> 
> **Tests:** Four `concatenate-modules` config cases cover name collision, global capture, unused-export side effects, and `require()` shapes; smaller harness tweaks clear shared globals on Bun and skip a flaky library case there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2a86b1cbb6adc42eafa47f3bab366da23ae1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->