### PR TITLE
fix: keep tree-shaken arrays as arrays in json module

### DIFF
--- a/.changeset/160-json-array-prototype-read.md
+++ b/.changeset/160-json-array-prototype-read.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep tree-shaken JSON arrays as arrays when a prototype property is read.

--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -44,6 +44,24 @@ const stringifySafe = (data) => {
 };
 
 /**
+ * Collapsing an array to an object of used indices is smaller, but the value
+ * stops being an array, so it is only safe while nothing but indices and
+ * `length` is read.
+ * @param {ExportsInfo} exportsInfo exports info of the array
+ * @param {RuntimeSpec} runtime the runtime
+ * @returns {boolean} true when the array may collapse into an object
+ */
+const canCollapseArrToObject = (exportsInfo, runtime) => {
+	for (const exportInfo of exportsInfo.ownedExports) {
+		if (exportInfo.getUsed(runtime) === UsageState.Unused) continue;
+		const name = exportInfo.name;
+		// non-index names resolve on the prototype, where array and object differ
+		if (name !== "length" && `${Number(name)}` !== name) return false;
+	}
+	return true;
+};
+
+/**
  * Creates an object for exports info.
  * @param {JsonObject | JsonArray} data Raw JSON data (always an object or array)
  * @param {ExportsInfo} exportsInfo exports info
@@ -100,7 +118,10 @@ const createObjectForExportsInfo = (data, exportsInfo, runtime) => {
 				8 -
 				(arrayLengthWhenUsed - reducedDataLength) * 2;
 		}
-		if (sizeObjectMinusArray < 0) {
+		if (
+			sizeObjectMinusArray < 0 &&
+			canCollapseArrToObject(exportsInfo, runtime)
+		) {
 			return Object.assign(
 				arrayLengthWhenUsed === undefined
 					? {}

--- a/test/cases/json/prototype-methods/index.js
+++ b/test/cases/json/prototype-methods/index.js
@@ -1,5 +1,6 @@
 import data1 from "./array.json?1";
 import data2 from "./array.json?2";
+import data4 from "./array.json?4";
 
 it("should allow to call prototype methods", () => {
 	expect(data1.map(d => d * 2)).toEqual([2, 2, 4, 6, 10]);
@@ -17,4 +18,13 @@ it("should allow to call prototype methods", () => {
 	} finally {
 		delete Object.prototype.smoosh;
 	}
+});
+
+it("should allow to read prototype properties", () => {
+	// plain member reads only: `Array.isArray(…)` would reference the whole
+	// value and hide the collapse to `{ length: 5 }`
+	expect(data4.length).toBe(5);
+	expect(data4.constructor).toBe(Array);
+	expect(require("./array.json?5").length).toBe(5);
+	expect(require("./array.json?5").constructor).toBe(Array);
 });


### PR DESCRIPTION
**Summary**

A tree-shaken JSON array could be emitted as a plain object when that was smaller, which made a prototype read such as `arr.constructor` resolve to `Object` instead of `Array`; the collapse is now only applied when nothing but indices and `length` is read.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — new assertions in `test/cases/json/prototype-methods/index.js` covering both the ESM and `require()` forms.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes — Claude Code was used to investigate the tree-shaking behaviour, build a differential repro against `origin/main`, and draft the fix and test. An earlier attempt that widened referenced exports was discarded after it regressed `configCases/json/tree-shaking-default`; the final change was verified against the json test cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to JSON module emission and an existing size optimization; behavior change only when non-index exports are used, with targeted tests.
> 
> **Overview**
> Fixes incorrect runtime behavior when webpack tree-shakes JSON arrays: the generator could still emit a plain object `{ length, …indices }` if that was smaller than a sparse array literal, so reads like `constructor` resolved via `Object` instead of `Array`.
> 
> **`JsonGenerator`** now adds `canCollapseArrToObject`, which only allows that collapse when every used export is a numeric index or `length`—any other property name (prototype reads tracked as exports) forces keeping a real array shape.
> 
> Tests in `prototype-methods/index.js` cover `length` and `constructor` for ESM and `require()` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c51d6ecd4e26726cd73b2d24bada846547bb55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->