### PR TITLE
fix: respect strictThisContextOnImports in require().fn calls

### DIFF
--- a/.changeset/045-strict-this-context-on-require.md
+++ b/.changeset/045-strict-this-context-on-require.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Respect `strictThisContextOnImports` for `require()` member calls.

--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -29,8 +29,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("../util/chainedImports").IdRanges} IdRanges */
 /** @typedef {import("./HarmonyImportGuard").DependencyGuard} DependencyGuard */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean]>} ObjectSerializerContext */
 
 const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
@@ -56,6 +56,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this.idRanges = idRanges;
 		/** @type {boolean} */
 		this.call = false;
+		/** @type {boolean} */
+		this.namespaceObjectAsContext = false;
 		/** @type {undefined | boolean} */
 		this.asiSafe = undefined;
 		/** @type {DependencyGuard[] | undefined} */
@@ -106,6 +108,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		if (
 			this.call &&
 			(!importedModule ||
+				// the namespace object of a required ESM module is the call receiver
+				this.namespaceObjectAsContext ||
 				importedModule.getExportsType(moduleGraph, false) !== "namespace")
 		) {
 			return [{ name: this.names.slice(0, -1), canInline: false }];
@@ -124,7 +128,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 			.write(this.call)
 			.write(this.asiSafe)
 			.write(this.branchGuards)
-			.write(this._canConcatenate);
+			.write(this._canConcatenate)
+			.write(this.namespaceObjectAsContext);
 		super.serialize(context);
 	}
 
@@ -144,7 +149,9 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this.branchGuards = c4.read();
 		const c5 = c4.rest;
 		this._canConcatenate = c5.read();
-		super.deserialize(c5.rest);
+		const c6 = c5.rest;
+		this.namespaceObjectAsContext = c6.read();
+		super.deserialize(c6.rest);
 	}
 
 	get type() {

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -698,6 +698,9 @@ class CommonJsImportsParserPlugin {
 					/** @type {Range[]} */ memberRanges
 				);
 				dep.call = true;
+				dep.namespaceObjectAsContext = Boolean(
+					options.strictThisContextOnImports
+				);
 				dep.asiSafe = !parser.isAsiPosition(
 					/** @type {Range} */ (expr.range)[0]
 				);

--- a/test/configCases/cjs-tree-shaking/strict-this-context-on-require/index.js
+++ b/test/configCases/cjs-tree-shaking/strict-this-context-on-require/index.js
@@ -1,0 +1,9 @@
+it("should keep the namespace object as this for require(esm).fn()", () => {
+	expect(require("./module").that().value).toBe(42);
+	expect(require("./module").usedExports).toBe(true);
+});
+
+it("should still tree-shake member access that is not a call", () => {
+	expect(require("./plain").value).toBe(7);
+	expect(require("./plain").usedExports).toEqual(["usedExports", "value"]);
+});

--- a/test/configCases/cjs-tree-shaking/strict-this-context-on-require/module.js
+++ b/test/configCases/cjs-tree-shaking/strict-this-context-on-require/module.js
@@ -1,0 +1,7 @@
+export function that() {
+	return this;
+}
+
+export const value = 42;
+
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/test/configCases/cjs-tree-shaking/strict-this-context-on-require/plain.js
+++ b/test/configCases/cjs-tree-shaking/strict-this-context-on-require/plain.js
@@ -1,0 +1,5 @@
+export const value = 7;
+
+export const unused = 8;
+
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/test/configCases/cjs-tree-shaking/strict-this-context-on-require/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/strict-this-context-on-require/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	module: {
+		parser: {
+			javascript: {
+				strictThisContextOnImports: true
+			}
+		}
+	},
+	optimization: {
+		minimize: false,
+		usedExports: true,
+		concatenateModules: false
+	}
+};


### PR DESCRIPTION

**Summary**

With `strictThisContextOnImports` enabled, `require("./esm").fn()` keeps the namespace object as the call receiver so `fn` can reach any export through `this`, but the referenced-exports rule skipped namespace modules and let those siblings be tree-shaken away.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — `test/configCases/cjs-tree-shaking/strict-this-context-on-require/`, covering both the method call and a plain member access that must still shake.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No — it only keeps more exports alive, and only under the opt-in `strictThisContextOnImports` parser option.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes — Claude Code was used to analyse the `CommonJsFullRequireDependency` call rule and to prepare this PR description and changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in parser option only; changes referenced-export metadata for `require().call()` patterns and may retain slightly more exports when enabled, with no default behavior change.
> 
> **Overview**
> With **`strictThisContextOnImports`**, `require("./esm").method()` should bind **`this`** to the ESM namespace object (same idea as `import().method()`). The **`CommonJsFullRequireDependency`** call path did not pass that flag into referenced-exports analysis, so namespace ESM modules were treated like a direct export reference and sibling exports could be tree-shaken even when the method reads them via **`this`**.
> 
> This PR adds **`namespaceObjectAsContext`** on **`CommonJsFullRequireDependency`**, sets it from **`strictThisContextOnImports`** in **`CommonJsImportsParserPlugin`** for `require(...).member()` calls, and extends serialize/deserialize. **`getReferencedExports`** now uses the call-receiver rule (parent member chain) when that flag is set, so exports reachable through **`this`** stay alive under the opt-in parser option.
> 
> Non-call member access (e.g. **`require("./plain").value`**) is unchanged and still tree-shakes unused exports. Config-case tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c0c6a3bd5c61c1661eb81d1e6d2c31a0fd1f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->