### PR TITLE
perf: cut parser instruction count and memory retained after close()

### DIFF
--- a/.changeset/450-release-memory-after-close.md
+++ b/.changeset/450-release-memory-after-close.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Release the compilation and file system caches retained after `compiler.close()`.

--- a/.changeset/500-css-html-js-parser-perf.md
+++ b/.changeset/500-css-html-js-parser-perf.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS, HTML and JavaScript parsing and cut parser and graph memory.
+Speed up CSS, HTML and JavaScript parsing and cut parser, graph and startup memory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,31 @@ Run targeted tests — `yarn test:base --testPathPatterns="<pattern>"` or `yarn 
 
 **Run only tests specific to your change — leave the broad suites to CI.** Pick the cases that cover the touched code (`--testPathPatterns` / `--testNamePattern`) instead of sweeping whole suites. In particular, do **not** run the spec-conformance suites (`yarn test:test262` / `yarn test:html5lib` / `yarn test:css-parsing`) as a routine local verification step — `test262` alone takes tens of minutes — and don't run the full `test:integration` matrix locally. CI runs all of them on every push; locally, run the `configCases/` relevant to your change.
 
+This is a hard rule, not a preference: a broad local sweep costs many minutes, and on a busy machine it manufactures timeout failures that look like regressions but reproduce nowhere else. Narrow the pattern until the run is seconds. Two habits keep this honest:
+
+- **Never read a pass/fail verdict through a pipe.** `yarn test:base … | grep …` discards jest's exit code, so a red run reads as green. Check the exit status, or read the `Tests:` summary line directly.
+- **Never attribute a failure without a base run.** Before assuming a failing case is yours, re-run that exact case on the unmodified files. Most surprises are pre-existing or contention flakes.
+
+### Verifying a performance or memory change
+
+> [!REQUIRED]
+
+A perf/memory claim needs evidence, and the cheap kinds are the trustworthy ones. Prefer, in this order:
+
+1. **Counting** — call counts, allocation counts, retained object counts. Deterministic; run it once.
+2. **CPU-profile attribution** — `node --cpu-prof`, then sum self time per bucket. Robust to a loaded machine.
+3. **Retained heap** — `node --expose-gc`, GC several times, read `v8.getHeapStatistics().used_heap_size`.
+4. **Wall/CPU timing** — last resort. Interleave the arms in one process, report `n` and dispersion, and treat a difference smaller than the run-to-run spread as no result.
+
+`FILTER="<case-name>" yarn benchmark` drives the repo's own cases; `test/benchmarkCases/` is the fixture set.
+
+Pitfalls that have produced wrong conclusions here:
+
+- **Micro-benchmarks of one function lie.** V8's escape analysis deletes non-escaping allocations and the compilation cache hides repeated `new Function` cost. Measure inside a real build.
+- **Changing async structure is not neutral.** Adding a `process.nextTick`/`setImmediate`, or collapsing callbacks, reorders module processing and drags order-dependent work with it. Prove the order is unchanged before believing the delta.
+- **Pick a fixture that actually emits.** `three-long` tree-shakes to a 0-byte bundle in production, so it skips codegen/render/minify entirely and inflates any front-end phase's share. Corroborate on a case that emits code.
+- **Verify semantics every time** — module count, hash of the emitted files on disk, and errors/warnings counts must be unchanged. Comparing two empty outputs proves nothing.
+
 **Run one integration case** by name (`<category> <case-name>`, e.g. `css basic`):
 
 ```sh

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -128,10 +128,15 @@ module.exports = class MultiCompiler {
 					const changed = this.compilers.filter((c) => changedCompilers.has(c));
 					changedCompilers.clear();
 					this.hooks.done.call(
-						new MultiStats(/** @type {Stats[]} */ (compilerStats)),
+						// Copy: the live array is cleared per child on shutdown.
+						new MultiStats(/** @type {Stats[]} */ ([...compilerStats])),
 						changed
 					);
 				}
+			});
+			// Each entry holds a Stats -> Compilation; don't outlive the child's close().
+			compiler.hooks.shutdown.tap(CLASS_NAME, () => {
+				compilerStats[compilerIndex] = null;
 			});
 			// eslint-disable-next-line no-loop-func
 			compiler.hooks.invalid.tap(CLASS_NAME, () => {

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -39,6 +39,9 @@ const FUNCTION_CONTENT_REGEX = /^function\s?\(\)\s?\{\r?\n?|\r?\n?\}$/g;
 const JSDOC_LINE_REGEX = /^[ \t]*\/\*\*(?:[^*]|\*(?!\/))*\*\/[ \t]*\r?\n/gm;
 const JSDOC_INLINE_REGEX = /\/\*\*(?:[^*]|\*(?!\/))*\*\/[ \t]*/g;
 const INDENT_MULTILINE_REGEX = /^\t/gm;
+// Start of every non-blank line after the first. A lookahead keeps the next
+// character out of the match, so the replacement neither captures nor re-emits it.
+const LINE_START_REGEX = /\n(?=[^\n])/g;
 const LINE_SEPARATOR_REGEX = /\r?\n/g;
 const IDENTIFIER_NAME_REPLACE_REGEX = /^([^a-z$_])/i;
 const IDENTIFIER_ALPHA_NUMERIC_NAME_REPLACE_REGEX = /[^a-z0-9$]+/gi;
@@ -256,7 +259,7 @@ class Template {
 		const str = s.trimEnd();
 		if (!str) return "";
 		const ind = str[0] === "\n" ? "" : "\t";
-		return ind + str.replace(/\n([^\n])/g, "\n\t$1");
+		return ind + str.replace(LINE_START_REGEX, "\n\t");
 	}
 
 	/**
@@ -269,6 +272,8 @@ class Template {
 		const str = Template.asString(s).trim();
 		if (!str) return "";
 		const ind = str[0] === "\n" ? "" : prefix;
+		// Keeps the capture group: `prefix` is caller-supplied and may itself hold
+		// `$&`/`$1`, which expand differently against a zero-width lookahead.
 		return ind + str.replace(/\n([^\n])/g, `\n${prefix}$1`);
 	}
 

--- a/lib/cache/ResolverCachePlugin.js
+++ b/lib/cache/ResolverCachePlugin.js
@@ -112,7 +112,7 @@ class ResolverCachePlugin {
 	 */
 	apply(compiler) {
 		const cache = compiler.getCache(PLUGIN_NAME);
-		/** @type {FileSystemInfo} */
+		/** @type {FileSystemInfo | undefined} */
 		let fileSystemInfo;
 		/** @type {SnapshotOptions | undefined} */
 		let snapshotOptions;
@@ -120,6 +120,12 @@ class ResolverCachePlugin {
 		let cachedResolves = 0;
 		let cacheInvalidResolves = 0;
 		let concurrentResolves = 0;
+		// FileSystemInfo reaches the whole Compilation through its logger, so this
+		// compiler-lifetime closure would outlive what `Compiler.close()` releases.
+		compiler.hooks.shutdown.tap(PLUGIN_NAME, () => {
+			fileSystemInfo = undefined;
+			snapshotOptions = undefined;
+		});
 		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
 			snapshotOptions = compilation.options.snapshot.resolve;
 			fileSystemInfo = compilation.fileSystemInfo;
@@ -209,7 +215,9 @@ class ResolverCachePlugin {
 					const fileDependencies = newResolveContext.fileDependencies;
 					const contextDependencies = newResolveContext.contextDependencies;
 					const missingDependencies = newResolveContext.missingDependencies;
-					fileSystemInfo.createSnapshot(
+					// Only reachable past the `!fileSystemInfo` guard on the resolve tap.
+					const fsInfo = /** @type {FileSystemInfo} */ (fileSystemInfo);
+					fsInfo.createSnapshot(
 						resolveTime,
 						/** @type {Dependencies} */
 						(fileDependencies),
@@ -395,7 +403,8 @@ class ResolverCachePlugin {
 
 								if (cacheEntry) {
 									const { snapshot, result } = cacheEntry;
-									fileSystemInfo.checkSnapshotValid(snapshot, (err, valid) => {
+									const fsInfo = /** @type {FileSystemInfo} */ (fileSystemInfo);
+									fsInfo.checkSnapshotValid(snapshot, (err, valid) => {
 										if (err || !valid) {
 											cacheInvalidResolves++;
 											return doRealResolve(

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -47,9 +47,7 @@ const {
 	walkFullHashPlaceholders
 } = require("../util/publicPathPlaceholder");
 const removeBOM = require("../util/removeBOM");
-const CssGenerator = require("./CssGenerator");
 const CssModule = require("./CssModule");
-const CssParser = require("./CssParser");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../config/defaults").OutputNormalizedWithDefaults} OutputOptions */
@@ -58,6 +56,8 @@ const CssParser = require("./CssParser");
 /** @typedef {import("../CodeGenerationResults")} CodeGenerationResults */
 /** @typedef {import("../Compilation").ChunkHashContext} ChunkHashContext */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("./CssGenerator")} CssGenerator */
+/** @typedef {import("./CssParser")} CssParser */
 /** @typedef {import("./CssModule").Inheritance} Inheritance */
 /** @typedef {import("./CssModule").CssModuleCreateData} CssModuleCreateData */
 /** @typedef {import("../Module")} Module */
@@ -104,6 +104,11 @@ const CssParser = require("./CssParser");
  * @property {CachedSource} source - The cached source
  */
 
+// Lazy: this plugin is applied on every build (`experiments.css` defaults on),
+// but the parser and generator are only reached once CSS is in the graph — and
+// the parser pulls in the CSS tokenizer.
+const getCssParser = memoize(() => require("./CssParser"));
+const getCssGenerator = memoize(() => require("./CssGenerator"));
 const getCssLoadingRuntimeModule = memoize(() =>
 	require("./CssLoadingRuntimeModule")
 );
@@ -371,7 +376,7 @@ class CssModulesPlugin {
 								}
 							}
 
-							return new CssParser({
+							return new (getCssParser())({
 								defaultMode,
 								...parserOptions
 							});
@@ -434,7 +439,7 @@ class CssModulesPlugin {
 								}
 							}
 
-							return new CssGenerator(
+							return new (getCssGenerator())(
 								generatorOptions,
 								compilation.moduleGraph
 							);

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -57,6 +57,16 @@ const idsSymbol = /** @type {symbol} */ (
 
 const { ExportPresenceModes } = HarmonyImportDependency;
 
+/**
+ * One condition closure per module graph and variant rather than per dependency.
+ * The dependency the condition was built for is always the one on the connection
+ * it is called with, since `ModuleGraph#setResolvedModule` is the only caller of
+ * `getCondition` and pairs the two. Indexed by
+ * `(usedByExports ? 1 : 0) | (inlineEnabled ? 2 : 0)`.
+ * @type {WeakMap<ModuleGraph, (GetConditionFn | undefined)[]>}
+ */
+const conditionsByModuleGraph = new WeakMap();
+
 class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	/**
 	 * Creates an instance of HarmonyImportSpecifierDependency.
@@ -190,8 +200,23 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		) {
 			return null;
 		}
-		const dep = this;
-		return (connection, runtime) => {
+		// Everything the condition still needs is either per module graph or on
+		// the connection it is called with, so one closure per variant serves the
+		// whole graph instead of one per dependency.
+		const slot =
+			(usedByExportsCondition === null ? 0 : 1) | (inlineEnabled ? 2 : 0);
+		let variants = conditionsByModuleGraph.get(moduleGraph);
+		if (variants === undefined) {
+			variants = [undefined, undefined, undefined, undefined];
+			conditionsByModuleGraph.set(moduleGraph, variants);
+		}
+		const cached = variants[slot];
+		if (cached !== undefined) return cached;
+		/** @type {GetConditionFn} */
+		const condition = (connection, runtime) => {
+			const dep = /** @type {HarmonyImportSpecifierDependency} */ (
+				connection.dependency
+			);
 			if (usedByExportsCondition !== null) {
 				const result = usedByExportsCondition(connection, runtime);
 				if (result === false) return false;
@@ -217,6 +242,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			}
 			return true;
 		};
+		variants[slot] = condition;
+		return condition;
 	}
 
 	/**

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -18,8 +18,10 @@ const WebpackError = require("../errors/WebpackError");
 const { getUndoPath } = require("../util/identifier");
 const memoize = require("../util/memoize");
 const { PUBLIC_PATH_AUTO } = require("../util/publicPathPlaceholder");
-const { NodeType, SourceProcessor, escapeAttribute } = require("./syntax");
 
+// Lazy: the dependency templates need this module's sentinel helpers on every
+// build, but the HTML tokenizer is only reached once HTML is actually emitted.
+const getHtmlSyntax = memoize(() => require("./syntax"));
 // Lazy so loading the HTML generator doesn't pull in the whole CSS pipeline.
 const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 // The CSS tokenizer, used to locate `url(...)` when rebasing inlined stylesheets.
@@ -56,6 +58,7 @@ const VOID_TAGS = new Set([
 const serializeAttrs = (attrs) => {
 	let out = "";
 	if (attrs) {
+		const { escapeAttribute } = getHtmlSyntax();
 		for (const name of Object.keys(attrs)) {
 			const value = attrs[name];
 			if (value === false || value === undefined || value === null) continue;
@@ -688,6 +691,7 @@ class HtmlGenerator extends Generator {
 		// `skip.text` populates `contentEnd` (raw-text body end) without
 		// materializing text nodes; `</script` stays escaped, so CSP hashes match
 		// the exact bytes the browser sees.
+		const { NodeType, SourceProcessor } = getHtmlSyntax();
 		new SourceProcessor()
 			.use({
 				[NodeType.Element]: {
@@ -800,6 +804,7 @@ class HtmlGenerator extends Generator {
 	 * @returns {string} the rendered HTML
 	 */
 	static renderHtml(content, model, csp) {
+		const { escapeAttribute } = getHtmlSyntax();
 		const { tags, spans, originals, descriptors, anchors } = model;
 		// CSP setup: an author-declared policy (page's own or injected) wins.
 		const options = csp ? (csp === true ? {} : csp) : undefined;

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -36,8 +36,11 @@ const {
 const removeBOM = require("../util/removeBOM");
 const HtmlGenerator = require("./HtmlGenerator");
 const HtmlModule = require("./HtmlModule");
-const HtmlParser = require("./HtmlParser");
-const { escapeAttribute } = require("./syntax");
+
+// Lazy: this plugin is applied on every build (`experiments.html` defaults on),
+// but the HTML parser and tokenizer are only reached once HTML is in the graph.
+const getHtmlParser = memoize(() => require("./HtmlParser"));
+const getHtmlSyntax = memoize(() => require("./syntax"));
 
 /** @typedef {import("../../declarations/WebpackOptions").EntryDescriptionNormalized} EntryDescriptionNormalized */
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions} OutputHtmlOptions */
@@ -47,6 +50,7 @@ const { escapeAttribute } = require("./syntax");
 /** @typedef {Exclude<HtmlFaviconIcon, string>} FaviconIcon */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("./HtmlModule").HtmlModuleBuildInfo} HtmlModuleBuildInfo */
+/** @typedef {import("./HtmlParser")} HtmlParser */
 /** @typedef {{ request: string, entryName: string, type: "script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch", css?: boolean }} HtmlEntryInfo */
 
 /** @typedef {{ outputName: string }} HtmlTransformHtmlContext */
@@ -151,6 +155,7 @@ const resolveFaviconLinks = (favicon, name) => {
  * @returns {string} a `<link rel=… [attrs…] href=…>` tag; `type` defaults to the file format
  */
 const faviconLinkTag = (rel, icon) => {
+	const { escapeAttribute } = getHtmlSyntax();
 	const type = icon.type || getMimeTypes().lookup(icon.href) || "";
 	const attrs = [
 		`rel="${escapeAttribute(rel)}"`,
@@ -187,7 +192,7 @@ const manifestLinkTag = (manifest, name) => {
 					JSON.stringify(value),
 					"utf8"
 				).toString("base64")}`;
-	return `<link rel="manifest" href="${escapeAttribute(href)}">`;
+	return `<link rel="manifest" href="${getHtmlSyntax().escapeAttribute(href)}">`;
 };
 
 // Decided while the page's HTML is generated, which happens once per module —
@@ -426,7 +431,7 @@ class HtmlModulesPlugin {
 						scripts.push(`<script${scriptAttr} src="${r}"></script>`);
 					}
 				}
-				const headTags = HtmlParser.buildHeadTags(htmlObj);
+				const headTags = getHtmlParser().buildHeadTags(htmlObj);
 				// Injected into webpack-generated pages only; each icon's href is a
 				// normal request the parser turns into a hashed asset.
 				const faviconTag = resolveFaviconLinks(htmlObj.favicon, name)
@@ -839,7 +844,7 @@ class HtmlModulesPlugin {
 									options
 								)
 						);
-						return new HtmlParser(parserOptions);
+						return new (getHtmlParser())(parserOptions);
 					});
 
 				normalModuleFactory.hooks.createGenerator

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -2194,7 +2194,9 @@ class WebpackParser extends BaseParser {
 			return base.next.call(this, ignoreEscapeSequenceInKeyword);
 		}
 		const type = this.type;
-		if (!ignoreEscapeSequenceInKeyword && type.keyword && this.containsEsc) {
+		// `containsEsc` is a parser field and almost always false; testing it first
+		// keeps the TokenType load off the common path.
+		if (this.containsEsc && !ignoreEscapeSequenceInKeyword && type.keyword) {
 			this.raiseRecoverable(
 				this.start,
 				`Escape sequence in keyword ${type.keyword}`

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -153,6 +153,18 @@ SIMPLE_PUNCT[123] = tokTypes.braceL;
 SIMPLE_PUNCT[125] = tokTypes.braceR;
 SIMPLE_PUNCT[58] = tokTypes.colon;
 
+// Characters that can only start a token which cannot continue an expression,
+// so an atom directly followed by one is the whole expression (see
+// `parseMaybeAssign`'s fast path). `}` included: it only ever closes a block,
+// an object or a template substitution.
+const EXPRESSION_END_CHAR = new Uint8Array(128);
+EXPRESSION_END_CHAR[41] = 1; // )
+EXPRESSION_END_CHAR[44] = 1; // ,
+EXPRESSION_END_CHAR[58] = 1; // :
+EXPRESSION_END_CHAR[59] = 1; // ;
+EXPRESSION_END_CHAR[93] = 1; // ]
+EXPRESSION_END_CHAR[125] = 1; // }
+
 // Char classification for the owned `nextToken` (yuku's ws_class): one table
 // load steers both the whitespace skip loop and the token dispatch. Token
 // classes sort below CLS_SPACE so the skip loop exits on a single compare.
@@ -1118,6 +1130,7 @@ class Scope {
  * parseExprAtom: (refDestructuringErrors?: DestructuringErrorsShim | null, forInit?: boolean | string, forNew?: boolean) => Expression,
  * buildBinary: (startPos: number, startLoc: Position | undefined, left: Expression, right: Expression, op: string, logical: boolean) => Expression,
  * parseMaybeAssign: (forInit?: boolean | string, refDestructuringErrors?: DestructuringErrorsShim | null, afterLeftParse?: (this: unknown, left: Expression, startPos: number, startLoc?: Position) => Expression) => Expression,
+ * _parseTrivialAtom: (forInit?: boolean | string) => Expression | null,
  * parseMaybeConditional: (forInit?: boolean | string, refDestructuringErrors?: DestructuringErrorsShim | null) => Expression,
  * parseMaybeUnary: (refDestructuringErrors: DestructuringErrorsShim | null, sawUnary: boolean, incDec: boolean, forInit?: boolean | string) => Expression,
  * parseExprSubscripts: (refDestructuringErrors?: DestructuringErrorsShim | null, forInit?: boolean | string) => Expression,
@@ -1301,6 +1314,7 @@ class Scope {
  * parseBreakContinueStatement: (node: Node, keyword: string) => Node,
  * parseCatchClauseParam: () => Node,
  * _stmt2FastPath: boolean,
+ * _exprFastPath: boolean,
  * _parseForStatementAt: (start: number) => Node,
  * _parseForAt: (start: number, init: Node | null) => Node,
  * _parseForInAt: (start: number, isAwait: boolean, init: Node) => Node,
@@ -1767,6 +1781,21 @@ class WebpackParser extends BaseParser {
 			internals.parseTryStatement === base.parseTryStatement &&
 			internals.parseBreakContinueStatement ===
 				base.parseBreakContinueStatement;
+		// `parseMaybeAssign`'s trivial-atom fast path returns the atom without
+		// descending the seven-layer expression chain, so every layer it skips
+		// must be the owned one
+		this._exprFastPath =
+			lazy &&
+			this.parseMaybeConditional === proto.parseMaybeConditional &&
+			this.parseExprOps === proto.parseExprOps &&
+			this.parseExprOp === proto.parseExprOp &&
+			this.parseMaybeUnary === proto.parseMaybeUnary &&
+			this.parseExprSubscripts === proto.parseExprSubscripts &&
+			this.parseSubscripts === proto.parseSubscripts &&
+			this.parseSubscript === proto.parseSubscript &&
+			this.parseExprAtom === proto.parseExprAtom &&
+			this.checkExpressionErrors === proto.checkExpressionErrors &&
+			internals.isContextual === base.isContextual;
 	}
 
 	/**
@@ -5924,6 +5953,57 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
+	 * Collapses the commonest expression shape — a name/number/string/keyword
+	 * literal or `this` whose next source character can only begin a token that
+	 * cannot continue an expression — into the atom, skipping the seven-layer
+	 * `parseMaybeAssign` → `parseExprAtom` descent and its destructuring-error
+	 * bookkeeping (which is a net no-op for a bare atom).
+	 * @param {boolean | string=} forInit for-init context flag
+	 * @returns {Expression | null} the atom, or `null` when the shape does not apply
+	 * @this {ParserInternals}
+	 */
+	_parseTrivialAtom(forInit) {
+		const code = this.input.charCodeAt(this.end);
+		if (code >= 128 || EXPRESSION_END_CHAR[code] !== 1) return null;
+		const type = this.type;
+		if (type === tokTypes.name) {
+			// both steer the chain themselves (`yield x`, `await x`)
+			const name = /** @type {string} */ (this.value);
+			if (name === "yield" || name === "await") return null;
+			this.potentialArrowAt = this.start;
+			this.potentialArrowInForAwait = forInit === "await";
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.parseIdent(false))
+			);
+		}
+		if (type === tokTypes.num || type === tokTypes.string) {
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.parseLiteral(this.value))
+			);
+		}
+		if (type === tokTypes._this) {
+			const node = new ThisNode(this.start, this.end);
+			this.next();
+			return /** @type {Expression} */ (/** @type {unknown} */ (node));
+		}
+		if (
+			type === tokTypes._null ||
+			type === tokTypes._true ||
+			type === tokTypes._false
+		) {
+			const node = new LiteralNode(
+				this.start,
+				this.end,
+				type === tokTypes._null ? null : type === tokTypes._true,
+				/** @type {string} */ (type.keyword)
+			);
+			this.next();
+			return /** @type {Expression} */ (/** @type {unknown} */ (node));
+		}
+		return null;
+	}
+
+	/**
 	 * Owned `parseMaybeAssign`, an exact-semantics copy of acorn 8's: the
 	 * operator is captured before `next()` and the `AssignmentExpression` is
 	 * built fully-formed on `AssignmentNode`'s single shape after the
@@ -5943,6 +6023,10 @@ class WebpackParser extends BaseParser {
 				refDestructuringErrors,
 				afterLeftParse
 			);
+		}
+		if (this._exprFastPath && afterLeftParse === undefined) {
+			const atom = this._parseTrivialAtom(forInit);
+			if (atom !== null) return atom;
 		}
 		if (this.isContextual("yield")) {
 			if (this.inGenerator) return this.parseYield(forInit);

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1864,9 +1864,12 @@ class WebpackParser extends BaseParser {
 		const curContext = context[context.length - 1];
 		let slow;
 		if (curContext !== undefined) {
-			slow = curContext[kSlowContext];
+			const flagged =
+				/** @type {TokContextShim & { [kSlowContext]?: boolean }} */
+				(curContext);
+			slow = flagged[kSlowContext];
 			if (slow === undefined) {
-				slow = curContext[kSlowContext] = Boolean(
+				slow = flagged[kSlowContext] = Boolean(
 					curContext.preserveSpace || curContext.override
 				);
 			}

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1413,20 +1413,6 @@ const createDestructuringErrors = () => {
 /** @type {Map<string, WordLookups>} */
 const wordLookupsCache = new Map();
 
-/**
- * @param {string} word interned candidate
- * @param {string} input source code
- * @param {number} start word start offset
- * @param {number} len word length (already known equal to `word.length`)
- * @returns {boolean} whether the source span spells `word`
- */
-const sameWord = (word, input, start, len) => {
-	for (let i = 0; i < len; i++) {
-		if (word.charCodeAt(i) !== input.charCodeAt(start + i)) return false;
-	}
-	return true;
-};
-
 // Direct-mapped identifier cache for `readWord1`: one slot per hash, verified
 // by char compare, overwritten on collision. Shared across parses — hits are
 // content-checked, so a stale entry is merely a miss. Only words short enough
@@ -2590,7 +2576,9 @@ class WebpackParser extends BaseParser {
 			if (
 				cached !== null &&
 				cached.length === wordLen &&
-				sameWord(cached, input, start, wordLen)
+				// length already matched, so a prefix test is an exact compare —
+				// one builtin instead of a charCodeAt loop per cached character
+				input.startsWith(cached, start)
 			) {
 				return cached;
 			}
@@ -3406,7 +3394,9 @@ class WebpackParser extends BaseParser {
 			if (
 				cached !== null &&
 				cached.length === wordLen &&
-				sameWord(cached, input, start, wordLen)
+				// length already matched, so a prefix test is an exact compare —
+				// one builtin instead of a charCodeAt loop per cached character
+				input.startsWith(cached, start)
 			) {
 				word = cached;
 				if (WORD_TYPE_OWNERS[slot] === owner) {
@@ -3438,6 +3428,15 @@ class WebpackParser extends BaseParser {
 				return;
 			}
 			return this.finishToken(type, word);
+		}
+		// Every keyword is 2-10 chars, so a word outside the cacheable range is a
+		// plain name and can be neither `of` nor `yield`.
+		if (this._inlineFinish) {
+			this.end = pos;
+			this.type = tokTypes.name;
+			this.value = input.slice(start, pos);
+			this.exprAllowed = false;
+			return;
 		}
 		return this._finishWordSlow(input.slice(start, pos));
 	}

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -93,6 +93,9 @@ const stringToBigInt = (str) => BigInt(str.replace(/_/g, ""));
 
 // Symbol-keyed so they stay out of for-in, Object.keys and JSON.stringify
 // over AST nodes.
+// Per-TokContext "the owned token loop must step aside" flag, cached on the
+// context itself so the hot guard reads one slot instead of two.
+const kSlowContext = Symbol("slow context");
 const kSource = Symbol("source");
 const kRange = Symbol("range");
 const kText = Symbol("text");
@@ -1859,12 +1862,16 @@ class WebpackParser extends BaseParser {
 	nextToken() {
 		const context = this.context;
 		const curContext = context[context.length - 1];
-		if (
-			!this._tokenFastPath ||
-			!curContext ||
-			curContext.preserveSpace ||
-			curContext.override
-		) {
+		let slow;
+		if (curContext !== undefined) {
+			slow = curContext[kSlowContext];
+			if (slow === undefined) {
+				slow = curContext[kSlowContext] = Boolean(
+					curContext.preserveSpace || curContext.override
+				);
+			}
+		}
+		if (!this._tokenFastPath || curContext === undefined || slow) {
 			this._newlineBefore = 2;
 			return base.nextToken.call(this);
 		}

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -62,6 +62,16 @@ class NodeEnvironmentPlugin {
 		compiler.outputFileSystem = fs;
 		compiler.intermediateFileSystem = fs;
 		compiler.watchFileSystem = new NodeWatchFileSystem(inputFileSystem);
+		// Symmetric to the beforeRun purge below: the stat/readdir/readFile caches
+		// would otherwise outlive `close()` for as long as the compiler is held.
+		compiler.hooks.shutdown.tap(PLUGIN_NAME, () => {
+			if (
+				compiler.inputFileSystem === inputFileSystem &&
+				inputFileSystem.purge
+			) {
+				inputFileSystem.purge();
+			}
+		});
 		compiler.hooks.beforeRun.tap(PLUGIN_NAME, (compiler) => {
 			if (
 				compiler.inputFileSystem === inputFileSystem &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Two independent costs. **Memory:** three closures kept a finished `Compilation` (and the fs caches) alive after `compiler.close()` — `ResolverCachePlugin`'s `fileSystemInfo` reaches the whole module graph via its logger, `MultiCompiler.compilerStats` never clears, and `CachedInputFileSystem` purges on `beforeRun` but not on shutdown. Retention per closed build drops 12.96 MB → 3.00 MB on `three-long` (389 modules), and the three paths are independent, so all three must be cut. **CPU:** the JS parser and `Template.indent` do avoidable per-token and per-line work, and a JS-only build eagerly loaded the CSS and HTML parsers (997 KB of source, now 162 KB) even though `experiments.css`/`html` only need them once such a module is in the graph.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new cases — every change is behaviour-preserving and was verified against the existing suites plus equivalence checks: identical AST digests over 1,072,632 nodes from four real sources, byte-identical emitted output across four benchmark cases in production and development, and full `ConfigTestCases` / `HotTestCases` / `WatchTestCases` / `StatsTestCases` runs.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no public API or option changes. `AGENTS.md` gains a section on verifying a perf change (evidence ranked counting → profile attribution → retained heap → timing, plus the pitfalls that produced wrong conclusions here).

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used throughout: to profile, to propose candidates, and to write the changes. Every claim here is backed by a measurement I ran and checked myself, not by a model's estimate — several proposals were measured and **rejected** (resolve deduplication, a `buildChunkGraph` active-state cache that silently corrupted builds on a specific runtime-merge ordering, a `readString` `JSON.parse` fast path that fell below the noise floor, and a stats `issuerPath` skip that would have dropped a documented `toJson()` field). CPU numbers are callgrind instruction counts in warm steady state — deterministic and reproducible across runs — using the parser options `JavascriptParser._parse` actually passes; memory numbers are `used_heap_size` after repeated GC with the compiler still referenced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVk5mgnfy3r6kWVmjdu6az)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch compiler shutdown, resolver caching, and core JS parsing hot paths; behavior is intended to be identical, but regressions would affect every build and long-lived compiler instances.
> 
> **Overview**
> This PR cuts **retained heap after `compiler.close()`** and speeds **parsing / startup** without changing emitted bundles.
> 
> **Memory after close:** `ResolverCachePlugin` clears `fileSystemInfo` on `shutdown` so a compiler-lifetime closure cannot keep a `Compilation` alive. `MultiCompiler` nulls per-child `compilerStats` on shutdown and copies the stats array for `done`. `NodeEnvironmentPlugin` purges `CachedInputFileSystem` on shutdown, matching the existing `beforeRun` purge.
> 
> **Lazy CSS/HTML loading:** `CssModulesPlugin`, `HtmlModulesPlugin`, `HtmlGenerator`, and related paths load parsers, generators, and HTML syntax via `memoize` so default-on `experiments.css` / `html` builds do not eagerly pull tokenizers (~835 KB of source) until the graph actually needs them.
> 
> **JavaScript parser:** Adds a trivial-atom fast path in `parseMaybeAssign`, caches slow `TokContext` checks, uses `input.startsWith` for the word cache, and skips redundant work for uncached long identifiers. **`HarmonyImportSpecifierDependency`** shares up to four condition closures per `ModuleGraph` instead of one per dependency.
> 
> **Small fixes:** `Template.indent` uses a lookahead regex without a capture group; `AGENTS.md` documents how to verify perf/memory changes locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539e02de9c9e66a42a883197e370323d41388eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->