### PR TITLE
feat: extend analyzable ESM output to async WebAssembly and hinted refs

### DIFF
--- a/.changeset/analyzable-async-wasm.md
+++ b/.changeset/analyzable-async-wasm.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Emit analyzable `new URL()` references for async WebAssembly under `output.module`.

--- a/.changeset/analyzable-async-wasm.md
+++ b/.changeset/analyzable-async-wasm.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Emit analyzable `new URL()` references for async WebAssembly under `output.module`.

--- a/.changeset/analyzable-esm-output.md
+++ b/.changeset/analyzable-esm-output.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Emit analyzable `new URL()` refs for async WebAssembly and keep them for prefetch/preload-hinted `new URL()`/`new Worker()` refs.

--- a/.changeset/analyzable-url-prefetch-preload.md
+++ b/.changeset/analyzable-url-prefetch-preload.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep analyzable ESM output for `new URL()` refs carrying a prefetch/preload hint.

--- a/.changeset/analyzable-url-prefetch-preload.md
+++ b/.changeset/analyzable-url-prefetch-preload.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep analyzable ESM output for `new URL()` refs carrying a prefetch/preload hint.
+Keep analyzable ESM output for hinted `new URL()` refs and fix the dropped asset wrapper under an eval devtool.

--- a/.changeset/analyzable-url-prefetch-preload.md
+++ b/.changeset/analyzable-url-prefetch-preload.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Keep analyzable ESM output for hinted `new URL()` refs and fix the dropped asset wrapper under an eval devtool.

--- a/.changeset/analyzable-worker-resource-hint.md
+++ b/.changeset/analyzable-worker-resource-hint.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep analyzable ESM output for `new Worker()` refs carrying a prefetch/preload hint.

--- a/.changeset/analyzable-worker-resource-hint.md
+++ b/.changeset/analyzable-worker-resource-hint.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Keep analyzable ESM output for `new Worker()` refs carrying a prefetch/preload hint.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1468,7 +1468,6 @@ class RuntimeTemplate {
 		if (
 			exportsType === "namespace" &&
 			mangleableNamespace &&
-			this.compilation &&
 			this.compilation.options.optimization.mangleExports
 		) {
 			const materialized = this._materializedNamespaceObject({

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1575,10 +1575,10 @@ class RuntimeTemplate {
 			message,
 			chunkName: block.chunkName
 		});
-		// `fetchPriority` is not supported for ESM module output — a native `import()`
-		// can't carry the hint, and the ESM chunk-loading runtime ignores the priority
-		// argument too. So it never blocks the analyzable form; the hint is simply not
-		// applied there (documented limitation). Non-module output is unaffected below.
+		// `fetchPriority` is unsupported for ESM output (a native `import()` can't carry it,
+		// and the ESM chunk loader ignores the argument), so it never blocks the analyzable form.
+		// TODO recheck: browsers honor `fetchpriority` on `modulepreload` only when parser-inserted
+		// (see `output.resourceHints.fetchPriority`); support this here once runtime-injected works.
 		const fetchPriority = chunkGroup.options.fetchPriority;
 		if (chunks.length === 1) {
 			const analyzable = this._analyzableChunkImport(

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -49,6 +49,7 @@ const getModuleHotAcceptDependency = memoize(() =>
 	require("./dependencies/ModuleHotAcceptDependency")
 );
 const getAPIPlugin = memoize(() => require("./APIPlugin"));
+const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 
 // Module-federation module types whose chunks load through the federation runtime.
 /** @type {Set<string>} */
@@ -316,6 +317,24 @@ class RuntimeTemplate {
 	 */
 	importMetaUrl(specifier) {
 		return `new URL(${specifier}, ${this.outputOptions.importMetaName}.url)`;
+	}
+
+	/**
+	 * Whether async wasm binaries are referenced by a fully baked
+	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
+	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
+	 * @returns {boolean} true when the literal form is emitted
+	 */
+	supportsAnalyzableWasm() {
+		return (
+			this.supportsAnalyzableEsmUrl() &&
+			// `[fullhash]` is only known after code generation.
+			!getTemplatedPathPlugin()
+				.getPresentKinds(
+					/** @type {string} */ (this.outputOptions.webassemblyModuleFilename)
+				)
+				.has("fullhash")
+		);
 	}
 
 	supportTemplateLiteral() {
@@ -1824,6 +1843,33 @@ class RuntimeTemplate {
 			return toJsStringLiteral(publicPath + filename);
 		}
 		return null;
+	}
+
+	/**
+	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
+	 * module. Only called when `supportsAnalyzableWasm()` holds.
+	 * @param {Module} module the async wasm module
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {RuntimeSpec} runtime the runtime
+	 * @param {RuntimeRequirements} runtimeRequirements runtime requirements
+	 * @returns {string} expression evaluating to the binary's URL
+	 */
+	_getAnalyzableWasmUrl(module, chunkGraph, runtime, runtimeRequirements) {
+		const { compilation } = this;
+		const filename = compilation.getPath(
+			/** @type {string} */ (this.outputOptions.webassemblyModuleFilename),
+			{ module, runtime, chunkGraph }
+		);
+		const undo = this._getModuleUndoPath(module, chunkGraph);
+		let specifier;
+		if (undo === null) {
+			// Chunks of different depths hold the module, so no single literal works.
+			runtimeRequirements.add(RuntimeGlobals.publicPath);
+			specifier = `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
+		} else {
+			specifier = toJsStringLiteral(undo + filename);
+		}
+		return this.importMetaUrl(specifier);
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1860,6 +1860,7 @@ class RuntimeTemplate {
 			{ module, runtime, chunkGraph }
 		);
 		const undo = this._getModuleUndoPath(module, chunkGraph);
+		/** @type {string} */
 		let specifier;
 		if (undo === null) {
 			// Chunks of different depths hold the module, so no single literal works.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1575,19 +1575,19 @@ class RuntimeTemplate {
 			message,
 			chunkName: block.chunkName
 		});
-		// A `fetchPriority` hint rides on the runtime `ensureChunk(id, priority)` call;
-		// the analyzable literal `import()` can't carry it, so keep the runtime form.
+		// `fetchPriority` is not supported for ESM module output — a native `import()`
+		// can't carry the hint, and the ESM chunk-loading runtime ignores the priority
+		// argument too. So it never blocks the analyzable form; the hint is simply not
+		// applied there (documented limitation). Non-module output is unaffected below.
 		const fetchPriority = chunkGroup.options.fetchPriority;
 		if (chunks.length === 1) {
-			const analyzable = fetchPriority
-				? null
-				: this._analyzableChunkImport(
-						chunks[0],
-						comment,
-						runtimeRequirements,
-						originModule,
-						chunkGraph
-					);
+			const analyzable = this._analyzableChunkImport(
+				chunks[0],
+				comment,
+				runtimeRequirements,
+				originModule,
+				chunkGraph
+			);
 			if (analyzable !== null) {
 				return analyzable;
 			}
@@ -1602,10 +1602,6 @@ class RuntimeTemplate {
 				fetchPriority ? `, ${JSON.stringify(fetchPriority)}` : ""
 			})`;
 		} else if (chunks.length > 0) {
-			if (fetchPriority) {
-				runtimeRequirements.add(RuntimeGlobals.hasFetchPriority);
-			}
-
 			let needEnsureChunk = false;
 			/**
 			 * Analyzable `import()` for a solely-owned JS chunk, else runtime ensureChunk.
@@ -1613,15 +1609,13 @@ class RuntimeTemplate {
 			 * @returns {string} require chunk id code
 			 */
 			const requireChunkId = (chunk) => {
-				const analyzable = fetchPriority
-					? null
-					: this._analyzableChunkImport(
-							chunk,
-							"",
-							runtimeRequirements,
-							originModule,
-							chunkGraph
-						);
+				const analyzable = this._analyzableChunkImport(
+					chunk,
+					"",
+					runtimeRequirements,
+					originModule,
+					chunkGraph
+				);
 				if (analyzable !== null) return analyzable;
 				needEnsureChunk = true;
 				return `${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)}${
@@ -1631,6 +1625,10 @@ class RuntimeTemplate {
 			const items = chunks.map(requireChunkId);
 			if (needEnsureChunk) {
 				runtimeRequirements.add(RuntimeGlobals.ensureChunk);
+				// Only needed when an `ensureChunk(id, priority)` call is actually emitted.
+				if (fetchPriority) {
+					runtimeRequirements.add(RuntimeGlobals.hasFetchPriority);
+				}
 			}
 			return `Promise.all(${comment.trim()}[${items.join(", ")}])`;
 		}

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -766,11 +766,14 @@ class AssetGenerator extends Generator {
 	getTypes(module) {
 		const connections = this._moduleGraph.getIncomingConnections(module);
 
-		// Only ESM output can drop a bare `new URL()` to an analyzable asset-url; without
+		// Only analyzable ESM output can drop a bare `new URL()` to an asset-url; without
 		// it every JS consumer needs the wrapper, so skip the per-connection dependency
-		// probe entirely and keep the pre-existing cheap path.
+		// probe entirely and keep the pre-existing cheap path. Must match the condition
+		// `URLDependency` uses to emit the literal, or the wrapper is dropped while the
+		// call site still requires the module (e.g. under an `eval` devtool).
 		const isModule = Boolean(
-			this._compilation && this._compilation.outputOptions.module
+			this._compilation &&
+			this._compilation.runtimeTemplate.supportsAnalyzableEsm()
 		);
 
 		// Collapse the incoming origin types into flags instead of a Set of prefixes:
@@ -794,15 +797,15 @@ class AssetGenerator extends Generator {
 			if (originType === ASSET_MODULE_TYPE_WEBMANIFEST) {
 				hasUrl = true;
 			} else if (typePrefixEquals(originType, JAVASCRIPT_TYPE)) {
-				// Only a bare `new URL()` becomes the analyzable literal; relative and
-				// prefetch/preload refs keep the runtime form and still need the wrapper.
+				// Only a bare `new URL()` becomes the analyzable literal; a relative ref
+				// keeps the runtime form and still needs the wrapper. Prefetch/preload
+				// refs don't: their `<link>` is emitted at chunk startup, which resolves
+				// the href from the asset filename when there is no wrapper.
 				const dependency = isModule && connection.dependency;
 				if (
 					dependency &&
 					dependency.type === "new URL()" &&
-					!(/** @type {URLDependency} */ (dependency).relative) &&
-					!(/** @type {URLDependency} */ (dependency).prefetch) &&
-					!(/** @type {URLDependency} */ (dependency).preload)
+					!(/** @type {URLDependency} */ (dependency).relative)
 				) {
 					hasUrlJs = true;
 				} else {

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -226,16 +226,21 @@ URLDependency.Template = class URLDependencyTemplate extends (
 
 		// For ESM module output, emit the analyzable `new URL("./asset", import.meta.url)`
 		// form (literal specifier, no runtime helpers) so other bundlers and webpack itself
-		// can statically follow the asset. `url: "relative"` and prefetch/preload hints
-		// (which need the runtime asset reference) keep the runtime form.
-		if (
-			!dep.relative &&
-			!dep.prefetch &&
-			!dep.preload &&
-			runtimeTemplate.supportsAnalyzableEsm()
-		) {
+		// can statically follow the asset. `url: "relative"` keeps the runtime form.
+		// A prefetch/preload hint doesn't force it: the `<link>` is emitted separately at
+		// chunk startup (`StartupAssetHintRuntimeModule`), independent of the call site.
+		if (!dep.relative && runtimeTemplate.supportsAnalyzableEsm()) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {
+				if (dep.prefetch || dep.preload) {
+					runtimeRequirements.add(RuntimeGlobals.startupAssetHints);
+					if (dep.prefetch) {
+						runtimeRequirements.add(RuntimeGlobals.prefetchAsset);
+					}
+					if (dep.preload) {
+						runtimeRequirements.add(RuntimeGlobals.preloadAsset);
+					}
+				}
 				source.replace(
 					dep.range[0],
 					dep.range[1] - 1,

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -135,19 +135,34 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 
 		// For ESM module output emit the analyzable `new URL("./worker.<name>.js",
 		// import.meta.url)` form (literal specifier, no runtime helpers) so other bundlers
-		// and webpack itself can statically follow the worker. Resource-hint workers keep
-		// the runtime form because the hint needs the runtime chunk reference.
-		const analyzableSpecifier =
-			!dep.options.resourceHint && runtimeTemplate.supportsAnalyzableEsm()
-				? runtimeTemplate._getAnalyzableChunkSpecifier(
-						dep.options.publicPath,
-						chunk,
-						templateContext.module,
-						chunkGraph
-					)
-				: null;
+		// and webpack itself can statically follow the worker. A resource hint doesn't
+		// block it: the `<link>` is emitted at chunk startup instead of wrapping the href,
+		// which would turn the specifier into a non-analyzable expression.
+		const analyzableSpecifier = runtimeTemplate.supportsAnalyzableEsm()
+			? runtimeTemplate._getAnalyzableChunkSpecifier(
+					dep.options.publicPath,
+					chunk,
+					templateContext.module,
+					chunkGraph
+				)
+			: null;
 
 		if (analyzableSpecifier !== null) {
+			const startupHint = dep.options.resourceHint;
+			if (startupHint && (startupHint.preload || startupHint.prefetch)) {
+				// Declared here, not in the runtime module: requirements added during
+				// `generate()` are too late for the corresponding modules to be created.
+				runtimeRequirements.add(RuntimeGlobals.startupAssetHints);
+				runtimeRequirements.add(
+					startupHint.preload
+						? RuntimeGlobals.preloadAsset
+						: RuntimeGlobals.prefetchAsset
+				);
+				runtimeRequirements.add(RuntimeGlobals.getChunkScriptFilename);
+				if (!dep.options.publicPath) {
+					runtimeRequirements.add(RuntimeGlobals.publicPath);
+				}
+			}
 			const urlArgs = `/* worker import */ ${analyzableSpecifier}, ${runtimeTemplate.outputOptions.importMetaName}.url`;
 			source.replace(
 				dep.range[0],

--- a/lib/prefetch/StartupAssetHintRuntimeModule.js
+++ b/lib/prefetch/StartupAssetHintRuntimeModule.js
@@ -10,6 +10,7 @@ const Template = require("../Template");
 const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
 const URLDependency = require("../dependencies/URLDependency");
+const WorkerDependency = require("../dependencies/WorkerDependency");
 const ResourceHintRuntimeModule = require("./ResourceHintRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
@@ -123,8 +124,6 @@ class StartupAssetHintRuntimeModule extends RuntimeModule {
 		// `new Worker(new URL("./worker.js", import.meta.url))` form can't wrap its own
 		// href (that would stop the specifier being a literal), so the `<link>` is fired
 		// here instead. Keyed by chunk, not by asset module, hence the separate pass.
-		const WorkerDependency = require("../dependencies/WorkerDependency");
-
 		/** @type {Set<string | number>} */
 		const seenWorkerChunks = new Set();
 		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {

--- a/lib/prefetch/StartupAssetHintRuntimeModule.js
+++ b/lib/prefetch/StartupAssetHintRuntimeModule.js
@@ -118,6 +118,49 @@ class StartupAssetHintRuntimeModule extends RuntimeModule {
 			}
 		}
 		const lines = [];
+
+		// Worker chunks referenced from this chunk with a resource hint. The analyzable
+		// `new Worker(new URL("./worker.js", import.meta.url))` form can't wrap its own
+		// href (that would stop the specifier being a literal), so the `<link>` is fired
+		// here instead. Keyed by chunk, not by asset module, hence the separate pass.
+		const WorkerDependency = require("../dependencies/WorkerDependency");
+
+		/** @type {Set<string | number>} */
+		const seenWorkerChunks = new Set();
+		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
+			for (const block of module.blocks) {
+				for (const dep of block.dependencies) {
+					if (!(dep instanceof WorkerDependency)) continue;
+					const hint = dep.options.resourceHint;
+					if (!hint || (!hint.preload && !hint.prefetch)) continue;
+					const group = chunkGraph.getBlockChunkGroup(block);
+					if (!group) continue;
+					const workerChunk =
+						/** @type {import("../Entrypoint")} */
+						(group).getEntrypointChunk();
+					if (workerChunk.id === null || seenWorkerChunks.has(workerChunk.id)) {
+						continue;
+					}
+					seenWorkerChunks.add(workerChunk.id);
+					const base = dep.options.publicPath
+						? JSON.stringify(dep.options.publicPath)
+						: RuntimeGlobals.publicPath;
+					const fn = hint.preload
+						? RuntimeGlobals.preloadAsset
+						: RuntimeGlobals.prefetchAsset;
+					const href = `${base} + ${RuntimeGlobals.getChunkScriptFilename}(${JSON.stringify(workerChunk.id)})`;
+					lines.push(
+						`${fn}(${href}, ${JSON.stringify(hint.as || "script")}, ${
+							hint.type ? JSON.stringify(hint.type) : "undefined"
+						}, ${hint.media ? JSON.stringify(hint.media) : "undefined"}, ${
+							hint.fetchPriority
+								? JSON.stringify(hint.fetchPriority)
+								: "undefined"
+						});`
+					);
+				}
+			}
+		}
 		for (const entry of perAsset.values()) {
 			const fn = entry.preload
 				? RuntimeGlobals.preloadAsset

--- a/lib/prefetch/StartupAssetHintRuntimeModule.js
+++ b/lib/prefetch/StartupAssetHintRuntimeModule.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+const { ASSET_URL_TYPE } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
@@ -11,10 +12,15 @@ const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
 const URLDependency = require("../dependencies/URLDependency");
 const WorkerDependency = require("../dependencies/WorkerDependency");
+const {
+	PUBLIC_PATH_AUTO,
+	PUBLIC_PATH_FULL_HASH
+} = require("../util/publicPathPlaceholder");
 const ResourceHintRuntimeModule = require("./ResourceHintRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../CodeGenerationResults")} CodeGenerationResults */
 /** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
@@ -183,12 +189,38 @@ class StartupAssetHintRuntimeModule extends RuntimeModule {
 					weak: false
 				});
 			} else {
-				const buildInfo =
-					/** @type {{ filename?: string }} */
-					(entry.assetModule.buildInfo);
-				if (!buildInfo || !buildInfo.filename) continue;
-				runtimeRequirements.add(RuntimeGlobals.publicPath);
-				hrefExpr = `${RuntimeGlobals.publicPath} + ${JSON.stringify(buildInfo.filename)}`;
+				// A generator `publicPath` (e.g. a CDN override) makes the asset's own
+				// url differ from `output.publicPath` + filename, so prefer it. It is
+				// only a usable literal once placeholder-free — `"auto"` and `[fullhash]`
+				// are resolved after this runs and fall back to the runtime form.
+				const codeGenerationResults =
+					/** @type {CodeGenerationResults} */
+					(compilation.codeGenerationResults);
+				const urlData = codeGenerationResults.has(
+					entry.assetModule,
+					chunk.runtime
+				)
+					? codeGenerationResults.getData(
+							entry.assetModule,
+							chunk.runtime,
+							"url"
+						)
+					: undefined;
+				const resolved = urlData && urlData[ASSET_URL_TYPE];
+				if (
+					typeof resolved === "string" &&
+					!resolved.includes(PUBLIC_PATH_AUTO) &&
+					!resolved.includes(PUBLIC_PATH_FULL_HASH)
+				) {
+					hrefExpr = JSON.stringify(resolved);
+				} else {
+					const buildInfo =
+						/** @type {{ filename?: string }} */
+						(entry.assetModule.buildInfo);
+					if (!buildInfo || !buildInfo.filename) continue;
+					runtimeRequirements.add(RuntimeGlobals.publicPath);
+					hrefExpr = `${RuntimeGlobals.publicPath} + ${JSON.stringify(buildInfo.filename)}`;
+				}
 			}
 			const as =
 				entry.as || ResourceHintRuntimeModule.guessAsAttribute(entry.request);

--- a/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
@@ -56,22 +56,26 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		// Opt-out fallback to non-streaming when the server serves wasm with a wrong MIME type.
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.compileWasm;
-		const wasmModuleSrcPath = compilation.getPath(
-			JSON.stringify(outputOptions.webassemblyModuleFilename),
-			{
-				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
-				hashWithLength: (length) =>
-					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
-				module: {
-					id: '" + wasmModuleId + "',
-					hash: '" + wasmModuleHash + "',
-					hashWithLength(length) {
-						return `" + wasmModuleHash.slice(0, ${length}) + "`;
+		// Analyzable output bakes the binary's URL into the call site instead.
+		const analyzable = runtimeTemplate.supportsAnalyzableWasm();
+		const wasmModuleSrcPath = analyzable
+			? "wasmModuleUrl"
+			: compilation.getPath(
+					JSON.stringify(outputOptions.webassemblyModuleFilename),
+					{
+						hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
+						hashWithLength: (length) =>
+							`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+						module: {
+							id: '" + wasmModuleId + "',
+							hash: '" + wasmModuleHash + "',
+							hashWithLength(length) {
+								return `" + wasmModuleHash.slice(0, ${length}) + "`;
+							}
+						},
+						runtime: chunk.runtime
 					}
-				},
-				runtime: chunk.runtime
-			}
-		);
+				);
 
 		const loader = this.generateLoadBinaryCode(wasmModuleSrcPath);
 
@@ -138,7 +142,7 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		};
 
 		return `${fn} = ${runtimeTemplate.basicFunction(
-			"wasmModuleId, wasmModuleHash",
+			analyzable ? "wasmModuleUrl" : "wasmModuleId, wasmModuleHash",
 			this.supportsStreaming
 				? getStreaming()
 				: [

--- a/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
@@ -57,22 +57,26 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		// Opt-in fallback to non-streaming when the server serves wasm with a wrong MIME type.
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.instantiateWasm;
-		const wasmModuleSrcPath = compilation.getPath(
-			JSON.stringify(outputOptions.webassemblyModuleFilename),
-			{
-				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
-				hashWithLength: (length) =>
-					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
-				module: {
-					id: '" + wasmModuleId + "',
-					hash: '" + wasmModuleHash + "',
-					hashWithLength(length) {
-						return `" + wasmModuleHash.slice(0, ${length}) + "`;
+		// Analyzable output bakes the binary's URL into the call site instead.
+		const analyzable = runtimeTemplate.supportsAnalyzableWasm();
+		const wasmModuleSrcPath = analyzable
+			? "wasmModuleUrl"
+			: compilation.getPath(
+					JSON.stringify(outputOptions.webassemblyModuleFilename),
+					{
+						hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
+						hashWithLength: (length) =>
+							`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+						module: {
+							id: '" + wasmModuleId + "',
+							hash: '" + wasmModuleHash + "',
+							hashWithLength(length) {
+								return `" + wasmModuleHash.slice(0, ${length}) + "`;
+							}
+						},
+						runtime: chunk.runtime
 					}
-				},
-				runtime: chunk.runtime
-			}
-		);
+				);
 
 		const loader = this.generateLoadBinaryCode(wasmModuleSrcPath);
 		const fallback = [
@@ -149,7 +153,9 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		};
 
 		return `${fn} = ${runtimeTemplate.basicFunction(
-			"exports, wasmModuleId, wasmModuleHash, importsObj",
+			analyzable
+				? "exports, wasmModuleUrl, importsObj"
+				: "exports, wasmModuleId, wasmModuleHash, importsObj",
 			this.supportsStreaming
 				? getStreaming()
 				: [

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -72,8 +72,19 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 			return this._generateSourcePhase(module, generateContext);
 		}
 
+		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm()
+			? runtimeTemplate._getAnalyzableWasmUrl(
+					module,
+					chunkGraph,
+					runtime,
+					runtimeRequirements
+				)
+			: null;
+
 		runtimeRequirements.add(RuntimeGlobals.module);
-		runtimeRequirements.add(RuntimeGlobals.moduleId);
+		if (analyzableUrl === null) {
+			runtimeRequirements.add(RuntimeGlobals.moduleId);
+		}
 		runtimeRequirements.add(RuntimeGlobals.exports);
 		runtimeRequirements.add(RuntimeGlobals.instantiateWasm);
 		/** @type {InitFragment<GenerateContext>[]} */
@@ -173,11 +184,15 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 					])
 				: undefined;
 
-		const instantiateCall = `${RuntimeGlobals.instantiateWasm}(${module.exportsArgument}, ${
-			module.moduleArgument
-		}.id, ${JSON.stringify(
-			chunkGraph.getRenderedModuleHash(module, runtime)
-		)}${importsObj ? `, ${importsObj})` : ")"}`;
+		const locator =
+			analyzableUrl === null
+				? `${module.moduleArgument}.id, ${JSON.stringify(
+						chunkGraph.getRenderedModuleHash(module, runtime)
+					)}`
+				: analyzableUrl;
+		const instantiateCall = `${RuntimeGlobals.instantiateWasm}(${
+			module.exportsArgument
+		}, ${locator}${importsObj ? `, ${importsObj})` : ")"}`;
 
 		if (promises.length > 0) {
 			runtimeRequirements.add(RuntimeGlobals.asyncModule);
@@ -225,8 +240,19 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 		const { chunkGraph, runtimeTemplate, runtimeRequirements, runtime } =
 			generateContext;
 
+		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm()
+			? runtimeTemplate._getAnalyzableWasmUrl(
+					module,
+					chunkGraph,
+					runtime,
+					runtimeRequirements
+				)
+			: null;
+
 		runtimeRequirements.add(RuntimeGlobals.module);
-		runtimeRequirements.add(RuntimeGlobals.moduleId);
+		if (analyzableUrl === null) {
+			runtimeRequirements.add(RuntimeGlobals.moduleId);
+		}
 		runtimeRequirements.add(RuntimeGlobals.exports);
 		runtimeRequirements.add(RuntimeGlobals.compileWasm);
 		runtimeRequirements.add(RuntimeGlobals.asyncModule);
@@ -234,8 +260,12 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 
 		// Source phase: export default WebAssembly.Module (via compileWasm)
 		const compileCall = `${RuntimeGlobals.compileWasm}(${
-			module.moduleArgument
-		}.id, ${JSON.stringify(chunkGraph.getRenderedModuleHash(module, runtime))})`;
+			analyzableUrl === null
+				? `${module.moduleArgument}.id, ${JSON.stringify(
+						chunkGraph.getRenderedModuleHash(module, runtime)
+					)}`
+				: analyzableUrl
+		})`;
 
 		// Use async module wrapper to handle the Promise from compileWasm
 		return new RawSource(

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -69,6 +69,12 @@ class FetchCompileAsyncWasmPlugin {
 			 */
 			const generateAnalyzableLoadBinaryCode = (path) =>
 				`fetch(${compilation.runtimeTemplate.importMetaUrl(path)})`;
+			/**
+			 * The call site already passes a complete `URL`, so no base is applied here.
+			 * @param {string} path the wasm binary's URL expression
+			 * @returns {string} code to load the wasm file
+			 */
+			const generateBakedLoadBinaryCode = (path) => `fetch(${path})`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.instantiateWasm)
@@ -82,6 +88,7 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
+					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
 					if (!analyzable) set.add(RuntimeGlobals.publicPath);
@@ -93,9 +100,11 @@ class FetchCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmLoadingRuntimeModule({
-							generateLoadBinaryCode: analyzable
-								? generateAnalyzableLoadBinaryCode
-								: generateLoadBinaryCode,
+							generateLoadBinaryCode: baked
+								? generateBakedLoadBinaryCode
+								: analyzable
+									? generateAnalyzableLoadBinaryCode
+									: generateLoadBinaryCode,
 							supportsStreaming: true
 						})
 					);
@@ -113,6 +122,7 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
+					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
 					if (!analyzable) set.add(RuntimeGlobals.publicPath);
@@ -124,9 +134,11 @@ class FetchCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmCompileRuntimeModule({
-							generateLoadBinaryCode: analyzable
-								? generateAnalyzableLoadBinaryCode
-								: generateLoadBinaryCode,
+							generateLoadBinaryCode: baked
+								? generateBakedLoadBinaryCode
+								: analyzable
+									? generateAnalyzableLoadBinaryCode
+									: generateLoadBinaryCode,
 							supportsStreaming: true
 						})
 					);

--- a/test/configCases/analyzable/dynamic-import-fetch-priority/index.js
+++ b/test/configCases/analyzable/dynamic-import-fetch-priority/index.js
@@ -3,18 +3,20 @@ import path from "path";
 
 // Reference the chunk statically so it is emitted, but don't execute the load —
 // the assertion only inspects the generated source.
-const load = () =>
-	import(/* webpackFetchPriority: "high" */ "./dynamic.js");
+const load = () => import(/* webpackFetchPriority: "high" */ "./dynamic.js");
 
-it("should keep the runtime ensureChunk form when a fetchPriority hint is set", () => {
+it("should still emit the analyzable form when a fetchPriority hint is set", () => {
 	expect(typeof load).toBe("function");
 
 	const bundle = fs.readFileSync(
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// The analyzable literal `import()` can't carry the fetchPriority hint, so the
-	// runtime `ensureChunk(id, "high")` form is kept instead of `.ei(...)`.
-	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.ei(`);
+	// `fetchPriority` is not supported for ESM module output: a native `import()`
+	// can't carry the hint, and the ESM chunk-loading runtime ignores the priority
+	// argument too. So the hint must not degrade the output — the analyzable literal
+	// is still emitted and no priority-aware runtime is pulled in.
+	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
+	expect(bundle).not.toContain(`${'"hi'}${'gh"'}`);
 });

--- a/test/configCases/asset-modules/url-module-eval-devtool/file.png
+++ b/test/configCases/asset-modules/url-module-eval-devtool/file.png
@@ -1,0 +1,1 @@
+PNG-EVAL

--- a/test/configCases/asset-modules/url-module-eval-devtool/index.js
+++ b/test/configCases/asset-modules/url-module-eval-devtool/index.js
@@ -1,0 +1,6 @@
+it("should resolve new URL() under an eval devtool", () => {
+	// Without the asset's JS wrapper this throws "Cannot find module './file.png'".
+	const url = new URL("./file.png", import.meta.url);
+
+	expect(url.href).toBe("https://example.com/public/file.png");
+});

--- a/test/configCases/asset-modules/url-module-eval-devtool/test.config.js
+++ b/test/configCases/asset-modules/url-module-eval-devtool/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	}
+};

--- a/test/configCases/asset-modules/url-module-eval-devtool/webpack.config.js
+++ b/test/configCases/asset-modules/url-module-eval-devtool/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// An `eval` devtool disables the analyzable literal (`import.meta` is a syntax error
+// inside `eval`), so the `new URL()` call site keeps the runtime form and the asset's
+// JS wrapper must be kept with it. Regression test: the wrapper-drop decision used to
+// look only at `output.module` and dropped it here, leaving the call site requiring a
+// module that no longer existed.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	devtool: "eval",
+	output: {
+		filename: "[name].mjs",
+		module: true,
+		chunkFormat: "module",
+		publicPath: "https://example.com/public/",
+		assetModuleFilename: "[name][ext]"
+	},
+	experiments: {
+		outputModule: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.png$/,
+				type: "asset/resource"
+			}
+		]
+	}
+};

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/cdn.svg
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/cdn.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"/>

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/index.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/index.js
@@ -19,6 +19,17 @@ it("should still inject the <link> for a hinted new URL()", () => {
 	expect(preloaded.as).toBe("font");
 });
 
+it("should build the <link> href from a generator publicPath", () => {
+	// The startup hint must use the asset's own url, not `output.publicPath` +
+	// filename, or the preload points at a different origin than the call site.
+	const preloaded = findLink((l) => l.href.endsWith("/cdn.svg"));
+	expect(preloaded).toBeDefined();
+	expect(preloaded.href).toBe("https://cdn.example.com/cdn.svg");
+
+	const icon = new URL(/* webpackPreload: true */ "./cdn.svg", import.meta.url);
+	expect(icon.href).toBe("https://cdn.example.com/cdn.svg");
+});
+
 it("should resolve the hinted URLs correctly", () => {
 	const image = new URL(/* webpackPrefetch: true */ "./image.png", import.meta.url);
 	const font = new URL(/* webpackPreload: true */ "./font.woff2", import.meta.url);

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/index.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/index.js
@@ -1,0 +1,48 @@
+import fs from "fs";
+import path from "path";
+
+const findLink = (predicate) =>
+	document.head._children.find(
+		(el) => el._type === "link" && predicate(el)
+	);
+
+it("should still inject the <link> for a hinted new URL()", () => {
+	// The hint is fired by the chunk's startup runtime, not by the call site, so it
+	// must exist before any user code runs — even though the call site is a literal.
+	const prefetched = findLink((l) => l.href.endsWith("/image.png"));
+	expect(prefetched).toBeDefined();
+	expect(prefetched.rel).toBe("prefetch");
+
+	const preloaded = findLink((l) => l.href.endsWith("/font.woff2"));
+	expect(preloaded).toBeDefined();
+	expect(preloaded.rel).toBe("preload");
+	expect(preloaded.as).toBe("font");
+});
+
+it("should resolve the hinted URLs correctly", () => {
+	const image = new URL(/* webpackPrefetch: true */ "./image.png", import.meta.url);
+	const font = new URL(/* webpackPreload: true */ "./font.woff2", import.meta.url);
+
+	expect(image.href).toBe("https://example.com/public/image.png");
+	expect(font.href).toBe("https://example.com/public/font.woff2");
+});
+
+it("should emit the analyzable literal for hinted new URL() refs", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "main.mjs"),
+		"utf8"
+	);
+	// Needles are built at runtime so they are not source string literals here.
+	const marker = `/* asset ${"import"} */`;
+
+	// The hint's magic comment is preserved before the substituted literal.
+	expect(bundle).toContain(
+		`${marker} "https://example.com/public/image.png", import.meta.url)`
+	);
+	expect(bundle).toContain(
+		`${marker} "https://example.com/public/font.woff2", import.meta.url)`
+	);
+	// The asset's JS wrapper is dropped — nothing requires the asset module.
+	expect(bundle).not.toContain(`${"__webpack_require__"}(/*! ./image.png`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}(/*! ./font.woff2`);
+});

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/test.config.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	}
+};

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/test.filter.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// The `node-commonjs` externals below build `require` from `node:module`, which
+// only exists from Node 12.2.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/webpack.config.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+// A `webpackPrefetch` / `webpackPreload` hint must not force the runtime form: the
+// `<link>` is emitted at chunk startup, independent of the `new URL(...)` call site,
+// so the call site can still be the analyzable literal.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].mjs",
+		module: true,
+		chunkFormat: "module",
+		publicPath: "https://example.com/public/",
+		assetModuleFilename: "[name][ext]"
+	},
+	experiments: {
+		outputModule: true
+	},
+	// `target: "web"` for the `<link>` injection; the assertions still read the
+	// emitted bundle, so keep the node builtins external.
+	externals: { fs: "node-commonjs fs", path: "node-commonjs path" },
+	module: {
+		rules: [
+			{
+				test: /\.(png|woff2)$/,
+				type: "asset/resource"
+			}
+		]
+	}
+};

--- a/test/configCases/asset-modules/url-prefetch-preload-analyzable/webpack.config.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-analyzable/webpack.config.js
@@ -27,6 +27,11 @@ module.exports = {
 			{
 				test: /\.(png|woff2)$/,
 				type: "asset/resource"
+			},
+			{
+				test: /\.svg$/,
+				type: "asset/resource",
+				generator: { publicPath: "https://cdn.example.com/" }
 			}
 		]
 	}

--- a/test/configCases/asset-modules/url-prefetch-preload-css-auto/index.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-css-auto/index.js
@@ -1,0 +1,19 @@
+"use strict";
+
+import "./style.css";
+
+const findLink = (predicate) =>
+	document.head._children.find((el) => el._type === "link" && predicate(el));
+
+it("should inject hints for CSS-only assets under an auto public path", () => {
+	// No JS consumer, so the asset has no wrapper to read the url from and the
+	// href is rebuilt from the runtime public path plus the emitted filename.
+	const png = findLink((l) => l.href.endsWith("image.png"));
+	expect(png).toBeDefined();
+	expect(png.rel).toBe("prefetch");
+
+	const woff = findLink((l) => l.href.endsWith("font.woff2"));
+	expect(woff).toBeDefined();
+	expect(woff.rel).toBe("preload");
+	expect(woff.as).toBe("font");
+});

--- a/test/configCases/asset-modules/url-prefetch-preload-css-auto/style.css
+++ b/test/configCases/asset-modules/url-prefetch-preload-css-auto/style.css
@@ -1,0 +1,8 @@
+.bg {
+	background-image: url(./image.png);
+}
+
+@font-face {
+	font-family: "MyFont";
+	src: url(./font.woff2) format("woff2");
+}

--- a/test/configCases/asset-modules/url-prefetch-preload-css-auto/webpack.config.js
+++ b/test/configCases/asset-modules/url-prefetch-preload-css-auto/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+// Same CSS-only hinted assets as `url-prefetch-preload-css`, but under
+// `publicPath: "auto"`. The asset's own url is still a placeholder at this point,
+// so the startup hint falls back to the runtime `__webpack_require__.p` form.
+
+const rules = [
+	{ test: /\.(png|webp|jpg)$/, prefetch: true },
+	{ test: /\.woff2$/, preload: true }
+];
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	experiments: {
+		css: true
+	},
+	output: {
+		assetModuleFilename: "[name][ext]",
+		publicPath: "auto"
+	},
+	module: {
+		parser: {
+			javascript: { urlHints: rules },
+			css: { urlHints: rules }
+		},
+		rules: [
+			{
+				test: /\.(png|woff2)$/,
+				type: "asset/resource"
+			}
+		]
+	}
+};

--- a/test/configCases/html/initial-chunk-modulepreload-fetchpriority/index.js
+++ b/test/configCases/html/initial-chunk-modulepreload-fetchpriority/index.js
@@ -1,0 +1,1 @@
+console.log("app");

--- a/test/configCases/html/initial-chunk-modulepreload-fetchpriority/page.html
+++ b/test/configCases/html/initial-chunk-modulepreload-fetchpriority/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>ESM modulepreload fetchpriority</title>
+</head>
+<body>
+<script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/test/configCases/html/initial-chunk-modulepreload-fetchpriority/test.config.js
+++ b/test/configCases/html/initial-chunk-modulepreload-fetchpriority/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/initial-chunk-modulepreload-fetchpriority/test.js
+++ b/test/configCases/html/initial-chunk-modulepreload-fetchpriority/test.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+const page = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+const head = page.slice(0, page.indexOf("</head>"));
+
+it("should emit fetchpriority on auto initial-graph modulepreload hints", () => {
+	// Parser-inserted hints are the one place a `fetchpriority` on a
+	// `<link rel="modulepreload">` is honored — browsers ignore the attribute on
+	// links injected at runtime, so webpack only emits it here.
+	const tag = head.match(/<link rel="modulepreload"[^>]*>/)[0];
+
+	expect(tag).toContain('href="runtime.mjs"');
+	expect(tag).toContain('fetchpriority="high"');
+});

--- a/test/configCases/html/initial-chunk-modulepreload-fetchpriority/webpack.config.js
+++ b/test/configCases/html/initial-chunk-modulepreload-fetchpriority/webpack.config.js
@@ -1,0 +1,53 @@
+"use strict";
+
+// `fetchpriority` on the auto initial-graph hints, set through the `resourceHints`
+// function form (map each default hint to a fresh descriptor — returning the default
+// object itself reuses its prebuilt tag). Worth covering because these hints land in
+// the extracted HTML: the preload scanner sees them, so the attribute is honored,
+// whereas browsers ignore it on a runtime-injected `modulepreload` link.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	entry: { page: "./page.html" },
+	output: {
+		filename: "[name].mjs",
+		chunkFilename: "[name].chunk.mjs",
+		module: true,
+		resourceHints: ({ defaultHints }) =>
+			defaultHints.map((h) => ({
+				rel: h.rel,
+				chunk: h.chunk,
+				fetchPriority: "high"
+			}))
+	},
+	optimization: { chunkIds: "named", runtimeChunk: "single" },
+	experiments: { html: true, outputModule: true },
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/wasm/analyzable-esm/deep.js
+++ b/test/configCases/wasm/analyzable-esm/deep.js
@@ -1,0 +1,5 @@
+import { getNumber } from "./wasm.wat";
+
+export function run() {
+	return getNumber() + getNumber();
+}

--- a/test/configCases/wasm/analyzable-esm/flat.js
+++ b/test/configCases/wasm/analyzable-esm/flat.js
@@ -1,0 +1,5 @@
+import { getNumber } from "./wasm.wat";
+
+export function run() {
+	return getNumber();
+}

--- a/test/configCases/wasm/analyzable-esm/index.js
+++ b/test/configCases/wasm/analyzable-esm/index.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+
+it("should instantiate wasm from chunks at both depths", async () => {
+	const [flat, deep] = await Promise.all([
+		import(/* webpackChunkName: "flat" */ "./flat"),
+		import(/* webpackChunkName: "deep" */ "./deep")
+	]);
+
+	expect(flat.run()).toBe(42);
+	expect(deep.run()).toBe(84);
+});
+
+it("should reference the wasm binary in the expected form", () => {
+	const source = fs.readFileSync(
+		path.join(__STATS__.children[0].outputPath, __WASM_CHUNK__),
+		"utf8"
+	);
+
+	expect(source).toContain(__WASM_REF__);
+});

--- a/test/configCases/wasm/analyzable-esm/wasm.wat
+++ b/test/configCases/wasm/analyzable-esm/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-esm/webpack.config.js
+++ b/test/configCases/wasm/analyzable-esm/webpack.config.js
@@ -1,0 +1,70 @@
+"use strict";
+
+// Async wasm under `output.module`: the binary URL is baked into the module call site
+// (`__webpack_require__.v(exports, new URL("./x.wasm", import.meta.url))`) so it can be
+// followed statically, instead of being assembled by the generic runtime helper.
+
+const webpack = require("../../../../");
+
+const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
+
+/**
+ * @param {string} chunkFile emitted file of the `flat` chunk
+ * @param {string} wasmRef expected wasm reference in that chunk
+ * @returns {import("../../../../").WebpackPluginInstance} define plugin
+ */
+const expectations = (chunkFile, wasmRef) =>
+	new webpack.DefinePlugin({
+		__WASM_CHUNK__: JSON.stringify(chunkFile),
+		__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef)
+	});
+
+/**
+ * @param {Partial<import("../../../../").Configuration>} config config
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (config) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	...config,
+	output: {
+		module: true,
+		webassemblyModuleFilename: "[id].[hash].wasm",
+		...config.output
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base({
+		// Every chunk holding the wasm module sits at the same depth, so a plain
+		// relative literal works.
+		output: { chunkFilename: "a-chunks/[name].mjs" },
+		plugins: [expectations("a-chunks/flat.mjs", 'new URL("../')]
+	}),
+	base({
+		// The wasm module is duplicated into chunks of different depths, so no single
+		// literal works and the public path expression is used instead.
+		output: {
+			chunkFilename: (pathData) =>
+				pathData.chunk.name === "deep" ? "b-deep/[name].mjs" : "b-[name].mjs"
+		},
+		plugins: [
+			expectations("b-flat.mjs", `new URL(${"__webpack_require__"}.p + "`)
+		]
+	}),
+	base({
+		// A non-`auto` public path keeps the runtime form: the node backends ignore
+		// `output.publicPath`, so it can't be baked into a shared literal.
+		output: { chunkFilename: "c-[name].mjs", publicPath: "./" },
+		plugins: [expectations("c-flat.mjs", "module.id, ")]
+	})
+];

--- a/test/configCases/wasm/analyzable-esm/webpack.config.js
+++ b/test/configCases/wasm/analyzable-esm/webpack.config.js
@@ -66,5 +66,15 @@ module.exports = [
 		// `output.publicPath`, so it can't be baked into a shared literal.
 		output: { chunkFilename: "c-[name].mjs", publicPath: "./" },
 		plugins: [expectations("c-flat.mjs", "module.id, ")]
+	}),
+	base({
+		// Truncated `[hash:<n>]` on the runtime form: the helper slices the hash it is
+		// handed rather than reading a baked literal.
+		output: {
+			chunkFilename: "d-[name].mjs",
+			publicPath: "./",
+			webassemblyModuleFilename: "[id].[hash:6].wasm"
+		},
+		plugins: [expectations("d-flat.mjs", "module.id, ")]
 	})
 ];

--- a/test/configCases/wasm/module-hash-length-source/index.js
+++ b/test/configCases/wasm/module-hash-length-source/index.js
@@ -1,0 +1,8 @@
+it("should slice the module hash for a source-phase import", () =>
+	import.source("./wasm.wat").then((wasmModule) => {
+		expect(wasmModule instanceof WebAssembly.Module).toBe(true);
+
+		return WebAssembly.instantiate(wasmModule).then((instance) => {
+			expect(instance.exports.add(10, 32)).toBe(42);
+		});
+	}));

--- a/test/configCases/wasm/module-hash-length-source/wasm.wat
+++ b/test/configCases/wasm/module-hash-length-source/wasm.wat
@@ -1,0 +1,6 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1))))

--- a/test/configCases/wasm/module-hash-length-source/webpack.config.js
+++ b/test/configCases/wasm/module-hash-length-source/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// Source-phase wasm with an explicit *module*-hash length (`[hash:6]`). A non-`auto`
+// public path keeps the runtime form, so the compile runtime module slices the hash
+// it is handed rather than reading a baked literal.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "async-node",
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	output: {
+		module: true,
+		publicPath: "./",
+		chunkFilename: "chunks/[name].async.mjs",
+		webassemblyModuleFilename: "[id].[hash:6].module.async.wasm"
+	},
+	experiments: {
+		outputModule: true,
+		asyncWebAssembly: true,
+		sourceImport: true
+	}
+};

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/index.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/index.js
@@ -18,6 +18,23 @@ it("should emit the analyzable worker form even with a resource hint", () => {
 	expect(bundle).not.toContain(`${marker} ${"__webpack_require__"}.`);
 });
 
+it("should skip workers and blocks without a hint", async () => {
+	// Exercises the startup-hint pass's skip paths: a block dependency that is not a
+	// worker, a worker carrying no hint, and a second reference to an already-seen
+	// worker chunk. Only the hinted chunk may produce a `<link>`.
+	// eslint-disable-next-line no-new
+	new Worker(new URL("./plain.worker.js", import.meta.url));
+	// eslint-disable-next-line no-new
+	new Worker(
+		new URL(/* webpackPreload: true */ "./preload.worker.js", import.meta.url)
+	);
+	expect((await import("./lazy.js")).default).toBe(42);
+
+	const links = document.head._children.filter((el) => el._type === "link");
+	expect(links.filter((l) => String(l.href).includes("plain_worker_js"))).toHaveLength(0);
+	expect(links.filter((l) => String(l.href).includes("preload_worker_js"))).toHaveLength(1);
+});
+
 it("should still inject the <link> for a hinted worker", () => {
 	// Fired by the chunk's startup runtime, so it exists before this body runs.
 	const link = document.head._children.find(

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/index.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/index.js
@@ -1,0 +1,32 @@
+import fs from "fs";
+import path from "path";
+
+it("should emit the analyzable worker form even with a resource hint", () => {
+	// eslint-disable-next-line no-new
+	new Worker(
+		new URL(/* webpackPreload: true */ "./preload.worker.js", import.meta.url)
+	);
+
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "main.mjs"),
+		"utf8"
+	);
+	const marker = `/* worker ${"import"} */`;
+
+	// The specifier stays a literal — the hint no longer wraps it.
+	expect(bundle).toContain(`${marker} "./preload_worker_js.mjs"`);
+	expect(bundle).not.toContain(`${marker} ${"__webpack_require__"}.`);
+});
+
+it("should still inject the <link> for a hinted worker", () => {
+	// Fired by the chunk's startup runtime, so it exists before this body runs.
+	const link = document.head._children.find(
+		(el) =>
+			el._type === "link" &&
+			el.rel === "preload" &&
+			String(el.href).includes("preload_worker_js")
+	);
+
+	expect(link).toBeDefined();
+	expect(link.as).toBe("script");
+});

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/lazy.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/plain.worker.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/plain.worker.js
@@ -1,0 +1,1 @@
+self.onmessage = () => {};

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/preload.worker.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/preload.worker.js
@@ -1,0 +1,4 @@
+// trivial worker source
+self.onmessage = (event) => {
+	self.postMessage(`echo: ${event.data}`);
+};

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/test.config.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	}
+};

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/test.filter.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/worker-prefetch-preload-analyzable/webpack.config.js
+++ b/test/configCases/worker/worker-prefetch-preload-analyzable/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// A resource hint must not stop `new Worker(new URL(...))` being analyzable — the
+// worker reference is itself a statically-followable construct. The hint is fired at
+// chunk startup instead of wrapping the href (which would stop the specifier being a
+// literal). `devtool: false` so the analyzable form is actually emitted.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].mjs",
+		chunkFilename: "[name].mjs",
+		module: true,
+		chunkFormat: "module",
+		workerChunkLoading: "import"
+	},
+	experiments: {
+		outputModule: true
+	},
+	externals: { fs: "node-commonjs fs", path: "node-commonjs path" },
+	performance: { hints: false }
+};

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -22,7 +22,7 @@ public-path-override:
 fetch-priority:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 6 modules
+  runtime modules X KiB 4 modules
   cacheable modules X bytes
     ./index-fetch-priority.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]

--- a/test/statsCases/analyzable-esm-fallbacks/index-fetch-priority.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-fetch-priority.js
@@ -1,3 +1,4 @@
-// `webpackFetchPriority` rides on the runtime `ensureChunk(id, priority)` call.
+// `webpackFetchPriority` is unsupported for ESM output, so it must not degrade the
+// output — the analyzable form is still emitted.
 export const load = () =>
 	import(/* webpackFetchPriority: "high" */ "./async").then((m) => m.value);

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -14,7 +14,9 @@ const HELPER = "__webpack_require__.ei";
 const CASES = {
 	analyzable: { file: "main.mjs", expect: "analyzable" },
 	"public-path-override": { file: "main.mjs", expect: "fallback" },
-	"fetch-priority": { file: "main.mjs", expect: "fallback" },
+	// `fetchPriority` is unsupported for ESM output, so it must not degrade the
+	// output — the analyzable form is still emitted (documented limitation).
+	"fetch-priority": { file: "main.mjs", expect: "analyzable" },
 	"content-hash": { file: "main.mjs", expect: "fallback" },
 	"templated-public-path": { file: "main.mjs", expect: "fallback" },
 	"bare-public-path": { file: "main.mjs", expect: "fallback" },

--- a/types.d.ts
+++ b/types.d.ts
@@ -24477,6 +24477,13 @@ declare abstract class RuntimeTemplate {
 	 * global — the form other bundlers and webpack itself can statically follow.
 	 */
 	importMetaUrl(specifier: string): string;
+
+	/**
+	 * Whether async wasm binaries are referenced by a fully baked
+	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
+	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
+	 */
+	supportsAnalyzableWasm(): boolean;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Under `output.module` webpack emits `new URL("./asset", import.meta.url)` so other tools can statically follow asset references, but three cases still fell back to the runtime form. Async WebAssembly always went through `__webpack_require__.v(exports, module.id, "<hash>")`, and a `webpackPrefetch`/`webpackPreload` hint on a `new URL()` or `new Worker()` ref degraded the call site even though the `<link>` is emitted separately at chunk startup. Also fixes the asset wrapper being dropped under an `eval` devtool while the call site still required it.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/wasm/analyzable-esm/`, `test/configCases/asset-modules/url-prefetch-preload-analyzable/`, `test/configCases/asset-modules/url-module-eval-devtool/`, `test/configCases/worker/worker-prefetch-preload-analyzable/` and `test/configCases/prefetch-preload/startup-asset-hints-worker-analyzable/`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Output only changes under `output.module`, and every case that cannot be made analyzable (non-`auto` `output.publicPath`, a `[fullhash]` filename template, a module duplicated into chunks at differing output depths) keeps the existing runtime form.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The `output.module` docs could note that async WebAssembly is now statically analyzable, along with the conditions that fall back to the runtime form.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to explore the existing analyzable-output paths, draft the implementation and tests, and run the test suites. Every change was reviewed and the behaviour verified against real builds and the test suite before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011gLkJyyoJtX2BVpZNPndbb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ESM code generation, wasm load runtime signatures, and prefetch/preload startup behavior; changes are gated to analyzable ESM conditions with explicit fallbacks and broad new config-case coverage.
> 
> **Overview**
> Under **`output.module`**, webpack can emit static `new URL(..., import.meta.url)` (and related forms) so other tools can follow references. This PR **widens** that behavior and **stops resource hints from downgrading** call sites to runtime helpers.
> 
> **Async WebAssembly** can now pass a baked **`new URL("./<file>.wasm", import.meta.url)`** (or `publicPath + filename` when chunk depth differs) into `instantiateWasm` / `compileWasm` when `supportsAnalyzableWasm()` holds—i.e. analyzable ESM URL support and no `[fullhash]` in `webassemblyModuleFilename`. Otherwise the existing id/hash runtime path remains.
> 
> **`webpackPrefetch` / `webpackPreload`** on **`new URL()`** assets and **`new Worker(new URL(...))`** no longer force the non-analyzable runtime href wrapper. Hints are injected at **chunk startup** via **`StartupAssetHintRuntimeModule`** (including worker chunks and CSS-only assets, with generator `publicPath` / `auto` fallbacks). Call sites keep literal specifiers; asset JS wrappers can still be dropped when only bare `new URL()` consumers exist.
> 
> **`webpackFetchPriority`** on dynamic `import()` no longer blocks the analyzable **`.ei`** chunk loader for ESM output (priority is effectively unsupported there).
> 
> **`AssetGenerator`** aligns wrapper dropping with **`supportsAnalyzableEsm()`** (not just `output.module`), fixing **`eval` devtool** cases where the literal form is impossible but the wrapper was still removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 503465aaed40952508be5315576cf45c83d62a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->