### PR TITLE
feat(css): add a hook to minify css embedded into a js bundle

### DIFF
--- a/.changeset/065-css-render-embedded-module-hook.md
+++ b/.changeset/065-css-render-embedded-module-hook.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add a `CssModulesPlugin` `renderEmbeddedModule` hook, so a sheet embedded into a JS bundle by `exportType` `style` or `text` can be minified — the asset minimizer never sees it.

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -32,6 +32,7 @@ const Template = require("../Template");
 const { getPresentKinds } = require("../TemplatedPathPlugin");
 const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
+const { tryRunOrWebpackError } = require("../errors/HookWebpackError");
 
 const { encodeMappings } = require("../util/createMappings");
 const {
@@ -898,15 +899,23 @@ class CssGenerator extends Generator {
 
 		const CssModulesPlugin = getCssModulesPlugin();
 		const hooks = CssModulesPlugin.getCompilationHooks(compilation);
-		return CssModulesPlugin.renderModule(
-			/** @type {CssModule} */ (module),
-			{
-				undoPath,
-				moduleSourceContent,
-				moduleFactoryCache: this._moduleFactoryCache,
-				runtimeTemplate: generateContext.runtimeTemplate
-			},
-			hooks
+		// `renderModule` only returns null for an empty `moduleSourceContent`, which
+		// is already ruled out above.
+		const rendered = /** @type {Source} */ (
+			CssModulesPlugin.renderModule(
+				/** @type {CssModule} */ (module),
+				{
+					undoPath,
+					moduleSourceContent,
+					moduleFactoryCache: this._moduleFactoryCache,
+					runtimeTemplate: generateContext.runtimeTemplate
+				},
+				hooks
+			)
+		);
+		return tryRunOrWebpackError(
+			() => hooks.renderEmbeddedModule.call(rendered, module),
+			"CssModulesPlugin.getCompilationHooks().renderEmbeddedModule"
 		);
 	}
 

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -228,6 +228,14 @@ const createCompilationHooks = () => ({
 		"renderContext"
 	]),
 	/**
+	 * Called with a module's rendered CSS when `exportType` `style` or `text`
+	 * embeds it into a JS bundle, which no `.css` asset carries and the asset
+	 * minimizer never sees. Placeholders are already substituted.
+	 * @type {SyncWaterfallHook<[Source, Module]>}
+	 * @since 5.110.0
+	 */
+	renderEmbeddedModule: new SyncWaterfallHook(["source", "module"]),
+	/**
 	 * @type {SyncHook<[Chunk, Hash, ChunkHashContext]>}
 	 * @since 5.94.0
 	 */

--- a/test/configCases/css/render-embedded-module-error/errors.js
+++ b/test/configCases/css/render-embedded-module-error/errors.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// `renderEmbeddedModule.call` is wrapped with `tryRunOrWebpackError`, so a throwing tap
+// fails the build with the original message rather than crashing the process,
+// and the error passed through `HookWebpackError` on its way — the CSS module's
+// `CodeGenerationError` wrapper keeps `message` and `stack` but not `details`,
+// so that is as far as the attribution is observable from here.
+module.exports = [
+	[
+		{
+			message: /boom/,
+			details: /^HookWebpackError: boom/
+		}
+	]
+];

--- a/test/configCases/css/render-embedded-module-error/index.js
+++ b/test/configCases/css/render-embedded-module-error/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/test/configCases/css/render-embedded-module-error/style.css
+++ b/test/configCases/css/render-embedded-module-error/style.css
@@ -1,0 +1,1 @@
+.a { color: red; }

--- a/test/configCases/css/render-embedded-module-error/test.config.js
+++ b/test/configCases/css/render-embedded-module-error/test.config.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// The css module fails code generation, so there is no runnable bundle.
+module.exports = {
+	noTests: true
+};

--- a/test/configCases/css/render-embedded-module-error/webpack.config.js
+++ b/test/configCases/css/render-embedded-module-error/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const { css } = require("../../../../");
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+
+// A throwing tap must surface as a HookWebpackError naming this hook, the way
+// a throw in `renderModulePackage` already does.
+const throwingTap = {
+	/**
+	 * @param {Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("ThrowingTap", (compilation) => {
+			css.CssModulesPlugin.getCompilationHooks(
+				compilation
+			).renderEmbeddedModule.tap("ThrowingTap", () => {
+				throw new Error("boom");
+			});
+		});
+	}
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	module: {
+		rules: [{ test: /\.css$/, type: "css", parser: { exportType: "style" } }]
+	},
+	plugins: [throwingTap],
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/render-embedded-module/embedded-style.css
+++ b/test/configCases/css/render-embedded-module/embedded-style.css
@@ -1,0 +1,5 @@
+.embedded-style {
+	background : url( ./image.png ) ;
+	color   :   #ff0000 ;
+	margin  :  0px 0px 0px 0px ;
+}

--- a/test/configCases/css/render-embedded-module/embedded-text.css
+++ b/test/configCases/css/render-embedded-module/embedded-text.css
@@ -1,0 +1,3 @@
+.embedded-text {
+	color   :   #00ff00 ;
+}

--- a/test/configCases/css/render-embedded-module/image.png
+++ b/test/configCases/css/render-embedded-module/image.png
@@ -1,0 +1,1 @@
+not-a-real-png

--- a/test/configCases/css/render-embedded-module/index.js
+++ b/test/configCases/css/render-embedded-module/index.js
@@ -1,0 +1,9 @@
+import "./embedded-style.css";
+import text from "./embedded-text.css";
+import "./plain.css";
+
+it("should hand the embedded css to the hook", () => {
+	// `text` exports the sheet as a string, so the hook's result is observable
+	// at runtime; the emitted files are asserted in test.config.js.
+	expect(text).toBe(".embedded-text{color:#0f0}");
+});

--- a/test/configCases/css/render-embedded-module/plain.css
+++ b/test/configCases/css/render-embedded-module/plain.css
@@ -1,0 +1,3 @@
+.plain {
+	color   :   #0000ff ;
+}

--- a/test/configCases/css/render-embedded-module/test.config.js
+++ b/test/configCases/css/render-embedded-module/test.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["./bundle0.js"];
+	},
+	afterExecute(options) {
+		const outputPath = /** @type {string} */ (options.output.path);
+		const read = (name) => fs.readFileSync(path.join(outputPath, name), "utf8");
+
+		// The hook runs after the dependency templates, so the asset url is already
+		// resolved by the time it sees the sheet.
+		const bundle = read("bundle0.js");
+		expect(bundle).toMatch(
+			/\.embedded-style\{background:url\(\w+\.png\);color:red;margin:0\}/
+		);
+		expect(bundle).not.toContain("#ff0000");
+
+		// A sheet that stays a `.css` asset never reaches the hook — the asset
+		// minimizer owns that one.
+		expect(read("bundle0.css")).toContain("color   :   #0000ff");
+	}
+};

--- a/test/configCases/css/render-embedded-module/webpack.config.js
+++ b/test/configCases/css/render-embedded-module/webpack.config.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const { css, sources } = require("../../../../");
+const { SourceProcessor } = require("../../../../lib/css/syntax");
+
+/** @typedef {import("../../../../").Compiler} Compiler */
+
+const minifyEmbedded = {
+	/**
+	 * @param {Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MinifyEmbedded", (compilation) => {
+			const hooks = css.CssModulesPlugin.getCompilationHooks(compilation);
+			hooks.renderEmbeddedModule.tap(
+				"MinifyEmbedded",
+				(source) =>
+					new sources.RawSource(
+						new SourceProcessor().process(source.source().toString(), {
+							minimize: true
+						}).code
+					)
+			);
+		});
+	}
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	output: {
+		pathinfo: false
+	},
+	module: {
+		rules: [
+			{
+				test: /embedded-style\.css$/,
+				type: "css",
+				parser: { exportType: "style" }
+			},
+			{
+				test: /embedded-text\.css$/,
+				type: "css",
+				parser: { exportType: "text" }
+			},
+			{ test: /plain\.css$/, type: "css" }
+		]
+	},
+	plugins: [minifyEmbedded],
+	experiments: {
+		css: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -5711,6 +5711,13 @@ declare class CssModulesPlugin {
 				Source
 			>;
 			/**
+			 * Called with a module's rendered CSS when `exportType` `style` or `text`
+			 * embeds it into a JS bundle, which no `.css` asset carries and the asset
+			 * minimizer never sees. Placeholders are already substituted.
+			 * @since 5.110.0
+			 */
+			renderEmbeddedModule: SyncWaterfallHook<[Source, Module], Source>;
+			/**
 			 * @since 5.94.0
 			 */
 			chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext]>;
@@ -5739,6 +5746,13 @@ declare class CssModulesPlugin {
 				[Source, Module, ChunkRenderContextCssModulesPlugin],
 				Source
 			>;
+			/**
+			 * Called with a module's rendered CSS when `exportType` `style` or `text`
+			 * embeds it into a JS bundle, which no `.css` asset carries and the asset
+			 * minimizer never sees. Placeholders are already substituted.
+			 * @since 5.110.0
+			 */
+			renderEmbeddedModule: SyncWaterfallHook<[Source, Module], Source>;
 			/**
 			 * @since 5.94.0
 			 */
@@ -5774,6 +5788,13 @@ declare class CssModulesPlugin {
 			[Source, Module, ChunkRenderContextCssModulesPlugin],
 			Source
 		>;
+		/**
+		 * Called with a module's rendered CSS when `exportType` `style` or `text`
+		 * embeds it into a JS bundle, which no `.css` asset carries and the asset
+		 * minimizer never sees. Placeholders are already substituted.
+		 * @since 5.110.0
+		 */
+		renderEmbeddedModule: SyncWaterfallHook<[Source, Module], Source>;
 		/**
 		 * @since 5.94.0
 		 */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`exportType` style or text embeds a sheet into the JS bundle as a string, so no `.css` asset carries it and the asset minimizer never sees it. Adds an `embeddedCss` hook on `CssModulesPlugin`, called after the dependency templates and placeholder substitutions run, so a tap sees the sheet in its final form.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/configCases/css/embedded-css-hook` drives a real build with a plugin that taps the hook with webpack's own CSS minifier, covering both `style` and `text` export types, an already-resolved `url()`, and confirming a plain `.css` asset never reaches the hook.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — no new configuration option, just a new compilation hook for plugin authors.

**Use of AI**

Yes — reviewed and tested manually against a real build, including a coverage check that caught and removed one unreachable branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive plugin hook on the CSS codegen path; default behavior is unchanged when nothing taps the hook, with tests for success and hook errors.
> 
> **Overview**
> Adds **`CssModulesPlugin.getCompilationHooks().renderEmbeddedModule`**, a `SyncWaterfallHook` that runs when CSS is inlined into the JS bundle via `exportType` **`style`** or **`text`** (after `renderModule` and placeholder substitution). Plugin authors can transform that CSS—e.g. minify it—because it never becomes a separate `.css` asset for the asset minimizer.
> 
> **`CssGenerator._renderCss`** now invokes the hook through **`tryRunOrWebpackError`**, matching **`renderModulePackage`** error attribution. Types and a minor changeset document the API (**since 5.110.0**).
> 
> Config-case tests cover minification for both export types, resolved `url()` in embedded CSS, plain `.css` assets skipping the hook, and build failure when a tap throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfc85c2a6af5961609f496c9aeb9fefb6bb8d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->