### PR TITLE
fix: bail out of concatenation when import.meta.main is used

### DIFF
--- a/.changeset/047-import-meta-main-concatenation.md
+++ b/.changeset/047-import-meta-main-concatenation.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Bail out of module concatenation when `import.meta.main` is read.

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -48,6 +48,7 @@ const WEBPACK_VERSION = Number.parseInt(
 /** @typedef {import("../Module").ValueCacheVersion} ValueCacheVersion */
 /** @typedef {import("../NormalModule").NormalModuleBuildInfo} NormalModuleBuildInfo */
 /** @typedef {import("../NormalModule")} NormalModule */
+/** @typedef {import("../javascript/JavascriptModule").JavascriptModuleBuildInfo} JavascriptModuleBuildInfo */
 /** @typedef {import("../javascript/JavascriptParser")} Parser */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../javascript/JavascriptParser").Members} Members */
@@ -412,6 +413,9 @@ class ImportMetaPlugin {
 									knownProps.push(`webpack: ${importMetaWebpackVersion()}`);
 								}
 								if (isImportMetaFieldEnabled(importMeta, "main")) {
+									/** @type {JavascriptModuleBuildInfo} */
+									(parser.state.module.buildInfo).moduleConcatenationBailout =
+										IMPORT_META_MAIN;
 									knownProps.push(
 										`main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument}`
 									);
@@ -492,6 +496,10 @@ class ImportMetaPlugin {
 										break;
 									case "main":
 										if (fieldEnabled) {
+											/** @type {JavascriptModuleBuildInfo} */
+											(
+												parser.state.module.buildInfo
+											).moduleConcatenationBailout = IMPORT_META_MAIN;
 											str += `main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument},`;
 											runtimeRequirements.push(
 												RuntimeGlobals.moduleCache,

--- a/test/configCases/parsing/import-meta-concatenation/index.js
+++ b/test/configCases/parsing/import-meta-concatenation/index.js
@@ -1,0 +1,7 @@
+import { main, url } from "./module.mjs";
+
+it("should handle a bare import.meta in a scope-hoisted strict harmony module", () => {
+	expect(typeof url).toBe("string");
+	expect(url.endsWith("module.mjs")).toBe(true);
+	expect(main).toBe(false);
+});

--- a/test/configCases/parsing/import-meta-concatenation/module.mjs
+++ b/test/configCases/parsing/import-meta-concatenation/module.mjs
@@ -1,0 +1,4 @@
+const meta = Object(import.meta);
+
+export const url = meta.url;
+export const main = meta.main;

--- a/test/configCases/parsing/import-meta-concatenation/webpack.config.js
+++ b/test/configCases/parsing/import-meta-concatenation/webpack.config.js
@@ -1,0 +1,6 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	target: "node"
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

A bare `import.meta` inside a strict harmony module bakes that module's factory argument name into the `main` field of the synthesized object, so the emitted code reads `__webpack_require__.c[__webpack_require__.s] === __webpack_module__`. Scope hoisting then removes the factory and the identifier is left unbound, which makes any production bundle containing such a module throw `ReferenceError: __webpack_module__ is not defined` while it evaluates. `APIPlugin` already registers a concatenation bailout for direct `__webpack_module__` references, so this registers one on the two paths that emit `main` as well.

Fixes #21617

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — `test/configCases/parsing/import-meta-concatenation/`, which fails with that ReferenceError before the change.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No. A module that reads `import.meta.main` through the synthesized object is no longer scope-hoisted, which is the same trade-off `__webpack_module__` already carries.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes — Claude Code was used to reproduce the report against `main`, compare the `ImportMetaPlugin` path with the equivalent one in `APIPlugin`, and draft the config case. I checked the emitted bundle in both states and reviewed the diff before opening this.

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser bailout in ImportMetaPlugin with regression test; same trade-off as existing __webpack_module__ concatenation skips.
> 
> **Overview**
> Fixes production **`ReferenceError: __webpack_module__ is not defined`** when ESM code reads **`import.meta.main`** via a bare **`import.meta`** (e.g. `Object(import.meta)`). Synthesizing the `main` property inlines the module factory argument name; module concatenation then drops that factory and leaves the identifier unbound.
> 
> **`ImportMetaPlugin`** now sets **`moduleConcatenationBailout`** to **`import.meta.main`** on both code paths that emit `main` in the synthesized object (full replacement and destructuring), matching the existing **`APIPlugin`** bailout for direct **`__webpack_module__`** use.
> 
> Adds config case **`import-meta-concatenation`** and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc26fc88c7a57218b27b207166e313cf3163c2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->