### PR TITLE
test(css): read the equivalence probe's style with no transition in flight

### DIFF
--- a/test/SyntaxBrowserEquivalence.unittest.js
+++ b/test/SyntaxBrowserEquivalence.unittest.js
@@ -129,10 +129,6 @@ const FILED_CSS_DEFECTS = new Map([
 	[
 		"test/configCases/css/minimize-lightningcss-values/style.css",
 		"attr()'s empty fallback comma is dropped"
-	],
-	[
-		"test/configCases/css/css-modules/at-rule-value.module.css",
-		"a rule under `@media small` computes a different color"
 	]
 ]);
 
@@ -327,6 +323,9 @@ const installHelpers = () => {
 	const computed = (declaration) => {
 		probe.style.cssText = "";
 		probe.style.cssText = declaration;
+		// A declaration carrying `transition-*` animates the shared probe away from
+		// the previous rule's value, and the computed style would be read in flight.
+		for (const animation of probe.getAnimations()) animation.cancel();
 		const style = getComputedStyle(probe);
 		/** @type {string[]} */
 		const out = [];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`SyntaxBrowserEquivalence` applies every declaration to one shared probe element. A declaration carrying `transition-*` therefore starts a CSS transition from whatever the previous rule left on the probe, and `getComputedStyle` reads the interpolated value instead of the one the declaration sets — for `color: limegreen; transition-duration: 1s` it returned `rgb(0, 0, 0)` on one side and `rgb(0, 128, 0)` on the other, neither of them `limegreen`. The walk order is deterministic, so this looked like a stable printer defect and `at-rule-value.module.css` was filed as one; the printed CSS and the resulting CSSOM are in fact identical on both sides. Cancelling any running animations before the read fixes it, and that fixture comes back out of `FILED_CSS_DEFECTS`. Refs #21608.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

The change is to a test. It was verified in both directions: with the fix and the entry removed the suite passes, and with the entry removed but the fix reverted it fails and reports the fixture again — so the assertion still pins the behaviour.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — no `lib/` code changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used. Claude Code diagnosed the divergence by logging the helper's input and output (identical input, differing computed colour), reproduced the mid-transition read in isolation in headless Chromium, and confirmed the fix in both directions. All changes were reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the browser equivalence harness; no production or minifier code paths are modified.
> 
> **Overview**
> Fixes a **false failure** in `SyntaxBrowserEquivalence` where the shared DOM probe kept a **CSS transition running** from the previous rule, so `getComputedStyle` saw **mid-animation** values instead of the declaration under test.
> 
> Before each computed-style read, the helper now **cancels active animations** on the probe. **`at-rule-value.module.css`** is removed from `FILED_CSS_DEFECTS` because the raw vs minified CSS was already equivalent; the mismatch was test harness noise, not a printer bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbb4747e372ff75ccad662cbe439a28f6c004bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->