### PR TITLE
fix(css): terminate a string or url() the tokenizer closed at EOF

### DIFF
--- a/.changeset/040-css-terminate-eof-tokens.md
+++ b/.changeset/040-css-terminate-eof-tokens.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Terminate a CSS string or `url()` the tokenizer closed at EOF when printing it.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -5564,6 +5564,25 @@ const _minifyIdentEscapes = (text) => {
 };
 
 /**
+ * Whether a token the tokenizer ran to EOF still lacks its terminator. §4.3.5
+ * and §4.3.6 end such a token at EOF, so its content is everything up to there —
+ * but the printer writes the enclosing `}` after it, which the token would take
+ * into its content unless the terminator is written back.
+ * @param {string} raw the token's source text
+ * @param {number} terminator the code point that closes it
+ * @returns {boolean} true when the terminator is absent or itself escaped
+ */
+const _isUnterminated = (raw, terminator) => {
+	const n = raw.length;
+	if (n < 2 || raw.charCodeAt(n - 1) !== terminator) return true;
+	let backslashes = 0;
+	for (let i = n - 2; i > 0 && raw.charCodeAt(i) === CC_REVERSE_SOLIDUS; i--) {
+		backslashes++;
+	}
+	return backslashes % 2 === 1;
+};
+
+/**
  * Normalize a string token's quotes, following cssnano's `postcss-normalize-string`:
  * prefer `"`, switch to whichever quote needs fewer escapes, and unescape a quote
  * the chosen wrapper no longer escapes. A string already holding a literal quote
@@ -6450,7 +6469,9 @@ const printer = (path, writer) => {
 			if (!minify) return `${name}(${inner})`;
 			// An+B in a selector: `2n+1` is what `odd` names, and shorter written so.
 			if (!path.inValue() && NTH_PSEUDO_FUNCTIONS.has(name.toLowerCase())) {
-				return `${name}(${inner.replace(/\s+/g, "") === "2n+1" ? "odd" : inner})`;
+				return `${name}(${
+					inner.replace(/\s+/g, "") === "2n+1" ? "odd" : inner
+				})`;
 			}
 			// Function names match ASCII case-insensitively; lowercase once for the
 			// three transforms below.
@@ -6528,12 +6549,12 @@ const printer = (path, writer) => {
 		}
 		case T_URL: {
 			const raw = path.source();
+			// Closed at EOF: write the `)` back so the url stops where it stopped for
+			// the tokenizer rather than swallowing what the printer emits next.
+			if (_isUnterminated(raw, CC_RIGHT_PARENTHESIS)) return `${raw})`;
 			// The tokenizer already trimmed the url-token's content, so the padding in
-			// `url(  a.png  )` carries nothing. Only a `)`-terminated token is rewritten
-			// — one closed at EOF would gain a `)` it never had.
-			if (!minify || raw.charCodeAt(raw.length - 1) !== CC_RIGHT_PARENTHESIS) {
-				return raw;
-			}
+			// `url(  a.png  )` carries nothing.
+			if (!minify) return raw;
 			const open = raw.indexOf("(");
 			// Padding only exists when the content is whitespace-bounded; checking
 			// that costs two char reads, reading the content costs a slice.
@@ -6548,7 +6569,11 @@ const printer = (path, writer) => {
 		case T_STRING: {
 			const raw = path.source();
 			// A custom property hands its string back as written, quotes included.
-			return minify && !_inCustomProperty ? _minifyString(raw) : raw;
+			const text = minify && !_inCustomProperty ? _minifyString(raw) : raw;
+			// Closed at EOF: write the quote back, for the same reason as `url()`.
+			return _isUnterminated(text, text.charCodeAt(0))
+				? `${text}${text[0]}`
+				: text;
 		}
 		case T_IDENT: {
 			const raw = path.source();

--- a/test/SyntaxBrowserEquivalence.unittest.js
+++ b/test/SyntaxBrowserEquivalence.unittest.js
@@ -111,10 +111,6 @@ const buildCorpora = () => {
 // matches this set exactly, so an entry outlives its defect by exactly one run.
 const FILED_CSS_DEFECTS = new Map([
 	[
-		"test/configCases/css/minimize-strings/unterminated.css",
-		"a string closed at EOF takes the printer's `}` into its content"
-	],
-	[
 		"test/configCases/css/minimize-strings/style.css",
 		"a string closed at EOF stops swallowing the rules after it"
 	],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

CSS Syntax §4.3.5 and §4.3.6 end a string and a `url()` at EOF, so the token's content stops there and the enclosing block is closed too. The printer re-emitted such a token exactly as written and then wrote the enclosing `}`, which the still-open token took into its content — `.a{content:"abc` printed as `.a{content:"abc}`, and `.a{background:url(foo` as `.a{background:url(foo}`. Writing the terminator back makes the token end where it ended for the tokenizer. A terminator that is itself escaped (`"x\"`) does not close the token, so the check counts trailing backslashes instead of reading the last character. Refs #21608.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — the browser equivalence suite already covered this as a filed defect, so the regression test is `test/configCases/css/minimize-strings/unterminated.css` coming back out of `FILED_CSS_DEFECTS` in `test/SyntaxBrowserEquivalence.unittest.js`. That assertion is exact in both directions, so it fails if the defect returns and also fails if the entry is left behind after a fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The path only runs for a string or `url()` left unterminated at end of file; well-formed input is byte-identical.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used. Claude Code reduced the filed defect to a minimal reproduction, located the two print sites, wrote the fix and checked well-formed strings and `url()`s are unchanged. It also established that the three remaining EOF-adjacent fixtures are bad-string/bad-url recovery rather than the same cause, so they are deliberately left filed. All changes were reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fix for malformed EOF-terminated tokens in the CSS printer; well-formed CSS is unchanged per tests and PR notes.
> 
> **Overview**
> Fixes CSS printing when a **string** or **`url()`** token ends at EOF: the printer now re-emits the missing closing quote or `)` so the token does not absorb the next output (e.g. a following `}`).
> 
> Adds `_isUnterminated` to detect tokens that lack a real terminator (including when the last character is an escaped quote/paren). **`T_URL`** and **`T_STRING`** printing use it before minification logic; **`url()`** minification no longer skips EOF-closed tokens solely because they lack a trailing `)`.
> 
> Removes the `unterminated.css` entry from **`FILED_CSS_DEFECTS`** in the browser equivalence suite now that this case is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8b03a3f8ecb9f2f828a3b91d9aa20bc0df97dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->