### PR TITLE
fix: track usage through evaluated side-effect-free modules

### DIFF
--- a/.changeset/042-usage-of-evaluated-side-effect-free-modules.md
+++ b/.changeset/042-usage-of-evaluated-side-effect-free-modules.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Track exports usage of side-effect-free modules an active import() evaluates.

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -11,6 +11,7 @@ const ModuleGraphConnection = require("./ModuleGraphConnection");
 const { STAGE_DEFAULT } = require("./OptimizationStages");
 const ArrayQueue = require("./util/ArrayQueue");
 const TupleQueue = require("./util/TupleQueue");
+const TupleSet = require("./util/TupleSet");
 const { getEntryRuntime, mergeRuntimeOwned } = require("./util/runtime");
 
 /** @typedef {import("./Compiler")} Compiler */
@@ -80,20 +81,17 @@ class FlagDependencyUsagePlugin {
 					/** @type {TupleQueue<Module, RuntimeSpec>} */
 					const queue = new TupleQueue();
 
+					/** @type {TupleSet<Module, RuntimeSpec> | undefined} */
+					let walkedSideEffectFreeModules;
+
 					/**
 					 * Process referenced module.
 					 * @param {Module} module module to process
 					 * @param {ReferencedExports} usedExports list of used exports
 					 * @param {RuntimeSpec} runtime part of which runtime
-					 * @param {boolean} forceSideEffects always apply side effects
 					 * @returns {void}
 					 */
-					const processReferencedModule = (
-						module,
-						usedExports,
-						runtime,
-						forceSideEffects
-					) => {
+					const processReferencedModule = (module, usedExports, runtime) => {
 						const exportsInfo = moduleGraph.getExportsInfo(module);
 						if (usedExports === EXPORTS_OBJECT_REFERENCED_MANGLEABLE) {
 							// The whole namespace object escapes via a reference that codegen
@@ -211,20 +209,22 @@ class FlagDependencyUsagePlugin {
 									}
 								}
 							}
-						} else {
-							// for a module without side effects we stop tracking usage here when no export is used
-							// This module won't be evaluated in this case
-							// TODO webpack 6 remove this check
-							if (
-								!forceSideEffects &&
-								module.factoryMeta !== undefined &&
-								module.factoryMeta.sideEffectFree
-							) {
-								return;
+						} else if (
+							module.factoryMeta !== undefined &&
+							module.factoryMeta.sideEffectFree
+						) {
+							// Nothing is used and the module has no side effects, so it is
+							// not used for them either. An active connection still evaluates
+							// it, so keep walking it to count the references it makes itself.
+							if (walkedSideEffectFreeModules === undefined) {
+								walkedSideEffectFreeModules = new TupleSet();
 							}
-							if (exportsInfo.setUsedForSideEffectsOnly(runtime)) {
+							if (!walkedSideEffectFreeModules.has(module, runtime)) {
+								walkedSideEffectFreeModules.add(module, runtime);
 								queue.enqueue(module, runtime);
 							}
+						} else if (exportsInfo.setUsedForSideEffectsOnly(runtime)) {
+							queue.enqueue(module, runtime);
 						}
 					};
 
@@ -232,10 +232,9 @@ class FlagDependencyUsagePlugin {
 					 * Processes the provided module.
 					 * @param {DependenciesBlock} module the module
 					 * @param {RuntimeSpec} runtime part of which runtime
-					 * @param {boolean} forceSideEffects always apply side effects
 					 * @returns {void}
 					 */
-					const processModule = (module, runtime, forceSideEffects) => {
+					const processModule = (module, runtime) => {
 						/** @typedef {Map<string, string[] | ReferencedExport>} ExportMaps */
 						/** @type {Map<Module, ReferencedExports | ExportMaps>} */
 						const map = new Map();
@@ -258,8 +257,7 @@ class FlagDependencyUsagePlugin {
 										b,
 										this.global
 											? undefined
-											: b.groupOptions.entryOptions.runtime || undefined,
-										true
+											: b.groupOptions.entryOptions.runtime || undefined
 									);
 								} else {
 									queue.enqueue(b);
@@ -274,7 +272,7 @@ class FlagDependencyUsagePlugin {
 								if (activeState === false) continue;
 								const { module } = connection;
 								if (activeState === ModuleGraphConnection.TRANSITIVE_ONLY) {
-									processModule(module, runtime, false);
+									processModule(module, runtime);
 									continue;
 								}
 								const oldReferencedExports = map.get(module);
@@ -362,18 +360,12 @@ class FlagDependencyUsagePlugin {
 
 						for (const [module, referencedExports] of map) {
 							if (Array.isArray(referencedExports)) {
-								processReferencedModule(
-									module,
-									referencedExports,
-									runtime,
-									forceSideEffects
-								);
+								processReferencedModule(module, referencedExports, runtime);
 							} else {
 								processReferencedModule(
 									module,
 									[...referencedExports.values()],
-									runtime,
-									forceSideEffects
+									runtime
 								);
 							}
 						}
@@ -382,8 +374,7 @@ class FlagDependencyUsagePlugin {
 								processReferencedModule(
 									module,
 									EXPORTS_OBJECT_REFERENCED_MANGLEABLE,
-									runtime,
-									forceSideEffects
+									runtime
 								);
 							}
 						}
@@ -407,12 +398,7 @@ class FlagDependencyUsagePlugin {
 					const processEntryDependency = (dep, runtime) => {
 						const module = moduleGraph.getModule(dep);
 						if (module) {
-							processReferencedModule(
-								module,
-								NO_EXPORTS_REFERENCED,
-								runtime,
-								true
-							);
+							processReferencedModule(module, NO_EXPORTS_REFERENCED, runtime);
 						}
 					};
 					/** @type {RuntimeSpec} */
@@ -443,7 +429,7 @@ class FlagDependencyUsagePlugin {
 						const [module, runtime] = /** @type {[Module, RuntimeSpec]} */ (
 							queue.dequeue()
 						);
-						processModule(module, runtime, false);
+						processModule(module, runtime);
 					}
 					logger.timeEnd("trace exports usage in graph");
 				}

--- a/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/a.cjs
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/a.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.fromB = require("./b.cjs");
+exports.A = 1;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/b.cjs
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/b.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.fromA = require("./a.cjs");
+exports.B = 2;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/index.js
@@ -1,0 +1,13 @@
+import { A } from "./a.cjs";
+import { B } from "./b.cjs";
+
+// `fromA`/`fromB` stay unused, so each require references no export while both
+// modules are still required and evaluated. Walking them has to be recorded
+// separately from any usage flag, or this cycle never reaches a fixpoint and
+// the compilation hangs.
+it("terminates on cyclic evaluation-only requires between side-effect-free modules", () => {
+	expect(A).toBe(1);
+	expect(B).toBe(2);
+	const src = String(__webpack_modules__["./a.cjs"]);
+	expect(src).toMatch(/unused reexport/);
+});

--- a/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/webpack.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: [
+					path.resolve(__dirname, "a.cjs"),
+					path.resolve(__dirname, "b.cjs")
+				],
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/dep.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/dep.js
@@ -1,0 +1,2 @@
+exports.obj = { value: 42 };
+exports.other = 1;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/index.js
@@ -1,0 +1,11 @@
+// The unused `ns` parameter makes the import reference no export at all, while
+// the module is still loaded and evaluated. `lib.js` holds no self-reference, so
+// shaking away what it reads fails at evaluation instead of at build time.
+it("keeps exports that an evaluated side-effect-free cjs module reads", async () => {
+	await import("./lib.js").then((ns) => {});
+	expect(global.__cjsTransitiveValue).toBe(42);
+	const src = String(__webpack_modules__["./dep.js"]);
+	expect(src).toMatch(/exports\.obj = \{ value: 42 \};/);
+	expect(src).toMatch(/__webpack_unused_export__ = 1;/);
+	delete global.__cjsTransitiveValue;
+});

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/lib.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/lib.js
@@ -1,0 +1,6 @@
+// No self-reference: the only reads are of another module's exports.
+const dep = require("./dep.js");
+
+global.__cjsTransitiveValue = dep.obj.value;
+
+exports.y = dep.obj.value;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import-transitive/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "lib.js"),
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/index.js
@@ -1,0 +1,8 @@
+// The unused `ns` parameter makes the import reference no export at all, while
+// the module is still loaded and evaluated.
+it("keeps self-referenced exports of a side-effect-free cjs module", async () => {
+	await import("./lib.js").then((ns) => {});
+	const src = String(__webpack_modules__["./lib.js"]);
+	expect(src).toMatch(/exports\.a = 1;/);
+	expect(src).toMatch(/__webpack_unused_export__ = exports\.a \+ 1;/);
+});

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/lib.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/lib.js
@@ -1,0 +1,2 @@
+exports.a = 1;
+exports.b = exports.a + 1;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-dynamic-import/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "lib.js"),
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/index.js
@@ -1,0 +1,12 @@
+import { NodeSDK } from "./sdk-node.cjs";
+
+export const sdk = new NodeSDK();
+
+// `tracing` is never imported, so the `require("./utility.cjs")` behind it
+// references no export while the module is still required and evaluated.
+it("keeps a self-referenced export behind an unused cjs re-export", () => {
+	expect(sdk).toBeInstanceOf(NodeSDK);
+	const src = String(__webpack_modules__["./utility.cjs"]);
+	expect(src).toMatch(/exports\.DEFAULT_LIMIT = 128;/);
+	expect(src).toMatch(/__webpack_unused_export__ = function getLimit/);
+});

--- a/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/sdk-node.cjs
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/sdk-node.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.tracing = require("./utility.cjs");
+class NodeSDK {}
+exports.NodeSDK = NodeSDK;

--- a/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/utility.cjs
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/utility.cjs
@@ -1,0 +1,6 @@
+"use strict";
+
+exports.DEFAULT_LIMIT = 128;
+exports.getLimit = function getLimit() {
+	return exports.DEFAULT_LIMIT;
+};

--- a/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "utility.cjs"),
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};


### PR DESCRIPTION
**Summary**

Fixes https://github.com/webpack/webpack/issues/21619.

`FlagDependencyUsagePlugin` stopped tracking usage of a side-effect-free module when nothing referenced it, on the assumption that it would not be evaluated — but an active connection (`import()` with an unused result, or a `require()` landing in an unused CommonJS re-export) still evaluates it, so the walk ended there and the module's own references were never counted. That shook away exports the module reads back, failing the build with "Self-reference dependency has unused export name" or, with no self-reference involved, emitting a bundle that throws `TypeError` at runtime.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — three cases under `test/configCases/cjs-tree-shaking/`: `side-effect-free-dynamic-import`, `side-effect-free-dynamic-import-transitive` (silent runtime failure), and `side-effect-free-unused-export-require`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — Claude Code (Opus 5) was used to bisect the behaviour across releases, write the regression cases, and draft the patch. Every claim was verified by running builds and the affected test suites, and the final diff was reviewed line by line by me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core export-usage tracing in production optimization; behavior change is narrow but affects what gets shaken across many builds.
> 
> **Overview**
> Fixes incorrect **usedExports** analysis when a **side-effect-free** module is still **evaluated** (e.g. `import()` with an unused binding, or `require()` behind an unused CJS re-export) but no exports are referenced on that edge.
> 
> **`FlagDependencyUsagePlugin`** no longer bails out early for those modules. It removes the **`forceSideEffects`** plumbing and, when nothing is marked used and `factoryMeta.sideEffectFree` is set, **walks the module once per runtime** via a **`TupleSet`** so its own `require`/`import` references are traced without treating the module as side-effect-used. Cycles in evaluation-only requires are bounded so the walk can reach a fixpoint instead of hanging.
> 
> Adds **config-case regressions** under `test/configCases/cjs-tree-shaking/` (dynamic import, transitive deps, unused re-export require, cyclic side-effect-free requires) plus a **patch changeset**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ad0cb76375bd56b10b4753fc86193aacae47cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->