### PR TITLE
ci: report config case asset size changes on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,9 @@ jobs:
 
   basic:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -133,6 +136,87 @@ jobs:
       - run: yarn link webpack --frozen-lockfile
 
       - run: yarn test:basic --ci
+
+      # The suite above already built every config case — measure what it left
+      # in `test/js` instead of building a second time. Everything below reports
+      # only, so it must never decide whether this job passes.
+      - name: Measure the emitted assets
+        id: sizes
+        continue-on-error: true
+        run: |
+          node tooling/collect-asset-sizes.js --commit "${{ github.event.pull_request.head.sha || github.sha }}" --out "$RUNNER_TEMP/asset-sizes-head.json"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            cp "$RUNNER_TEMP/asset-sizes-head.json" "$RUNNER_TEMP/asset-sizes-baseline.json"
+          fi
+
+      # `main` publishes the baseline; a pull request restores the newest one
+      # rather than rebuilding it. Restoring is never paired with a save here, so
+      # a pull request can only ever read a baseline `main` produced.
+      - name: Publish the baseline asset sizes
+        if: github.event_name == 'push' && steps.sizes.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/asset-sizes-baseline.json
+          key: asset-sizes-${{ github.sha }}
+
+      - name: Restore the baseline asset sizes
+        id: baseline
+        if: github.event_name == 'pull_request' && steps.sizes.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/asset-sizes-baseline.json
+          key: asset-sizes-${{ github.sha }}
+          restore-keys: asset-sizes-
+
+      - name: Compare against the baseline
+        id: compare
+        if: steps.baseline.outputs.cache-matched-key != ''
+        continue-on-error: true
+        run: |
+          node tooling/compare-asset-sizes.js \
+            --base "$RUNNER_TEMP/asset-sizes-baseline.json" \
+            --head "$RUNNER_TEMP/asset-sizes-head.json" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --out "$RUNNER_TEMP/asset-sizes.md" \
+            --out-status "$RUNNER_TEMP/asset-sizes-status.json"
+          node tooling/compare-asset-sizes.js \
+            --base "$RUNNER_TEMP/asset-sizes-baseline.json" \
+            --head "$RUNNER_TEMP/asset-sizes-head.json" \
+            --limit 1000 >> "$GITHUB_STEP_SUMMARY"
+          node -e 'const s=require(`${process.env.RUNNER_TEMP}/asset-sizes-status.json`);console.log(`changed=${s.changed + s.added + s.removed}`)' >> "$GITHUB_OUTPUT"
+
+      # Forks keep the job summary: their token cannot write to the pull request.
+      - name: Comment the asset size report
+        if: steps.compare.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHANGED: ${{ steps.compare.outputs.changed }}
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- webpack-asset-sizes -->";
+            const body = fs.readFileSync(`${process.env.RUNNER_TEMP}/asset-sizes.md`, "utf8");
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number
+            });
+            const existing = comments.find((comment) => (comment.body || "").includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else if (process.env.CHANGED !== "0") {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
   unit:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ The directory listings below are the canonical map of the repository. **Whenever
   - `lib/wasm/`, `lib/wasm-async/`, `lib/wasm-sync/` — WebAssembly module support.
 - `hot/` — Runtime code shipped to browsers for HMR (browser-side, not Node tooling).
 - `bin/` — `webpack` CLI entry point.
-- `tooling/` — Repo-internal scripts: build/codegen (runtime/wasm generators, hash-debug tool) invoked by `yarn fix:special`, plus standalone analysis tools such as `compare-css-minifiers.js` / `compare-html-minifiers.js` (`yarn benchmark:css-minifiers`, `yarn benchmark:html-minifiers`), which install the packages they compare against into `node_modules/.cache/` on first run rather than into webpack's dependencies.
+- `tooling/` — Repo-internal scripts: build/codegen (runtime/wasm generators, hash-debug tool) invoked by `yarn fix:special`, plus standalone analysis tools such as `compare-css-minifiers.js` / `compare-html-minifiers.js` (`yarn benchmark:css-minifiers`, `yarn benchmark:html-minifiers`), which install the packages they compare against into `node_modules/.cache/` on first run rather than into webpack's dependencies. `collect-asset-sizes.js` / `compare-asset-sizes.js` size what the config cases emitted and diff two such reports — the CI job reads `test/js` after `yarn test:basic` instead of building a second time, so they measure whatever the suite last left there.
 - `assembly/` — WebAssembly source for the hash function.
 - `setup/` — One-time setup scripts.
 

--- a/tooling/collect-asset-sizes.js
+++ b/tooling/collect-asset-sizes.js
@@ -1,0 +1,147 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Haijie Xie @hai-x
+*/
+
+"use strict";
+
+// Record the size of every asset the config cases emitted, so two builds (base
+// and PR) can be diffed by `tooling/compare-asset-sizes.js`. Reads what the
+// suite left in `test/js` — run the suite first:
+//
+//   yarn test:base --testPathPatterns=ConfigTestCases.basictest --ci
+//   node tooling/collect-asset-sizes.js --out sizes.json
+//
+// Paths resolve against the working directory, not against this file: CI copies
+// the script out of the checkout to run it against a different commit.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+
+/**
+ * @typedef {object} AssetSizes
+ * @property {number} size raw byte size
+ * @property {number} gzip gzipped byte size
+ * @property {number} brotli brotli-compressed byte size
+ * @property {number} count assets folded into this entry
+ */
+
+/**
+ * @typedef {object} Report
+ * @property {string} suite test suite the assets came from
+ * @property {string} commit commit the assets were built from
+ * @property {Record<string, Record<string, AssetSizes>>} cases sizes per `<category>/<case>`, keyed by asset name
+ */
+
+// written by the harness next to the assets, not part of the compilation output
+const HARNESS_FILES = new Set(["stats.txt", "stats.json"]);
+// content hashes move on any change; match assets by shape instead of by name
+const HASH_REGEXP = /[\da-f]{8,}/gi;
+// The numbers are only ever read as a base/head difference, so the quality that
+// ships (11) buys nothing here — it costs ~50s per run against ~0.4s for 5.
+const BROTLI_QUALITY = 5;
+
+/**
+ * @param {string} dir directory to walk
+ * @param {string} prefix path prefix of `dir` relative to the walk root
+ * @param {string[]} result collected relative paths
+ * @returns {string[]} collected relative paths
+ */
+const walk = (dir, prefix, result) => {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) {
+			walk(path.join(dir, entry.name), relative, result);
+		} else if (entry.isFile() && !HARNESS_FILES.has(entry.name)) {
+			result.push(relative);
+		}
+	}
+	return result;
+};
+
+/**
+ * @param {string} dir directory to list
+ * @returns {string[]} sorted names of the contained directories
+ */
+const readDirectories = (dir) =>
+	fs
+		.readdirSync(dir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+
+/**
+ * @param {string} casesDir directory holding `<category>/<case>` output
+ * @returns {Record<string, Record<string, AssetSizes>>} sizes per case
+ */
+const collect = (casesDir) => {
+	/** @type {Record<string, Record<string, AssetSizes>>} */
+	const cases = {};
+	for (const category of readDirectories(casesDir)) {
+		for (const name of readDirectories(path.join(casesDir, category))) {
+			const caseDir = path.join(casesDir, category, name);
+			/** @type {Record<string, AssetSizes>} */
+			const assets = {};
+			for (const file of walk(caseDir, "", [])) {
+				const content = fs.readFileSync(path.join(caseDir, file));
+				const key = file.replace(HASH_REGEXP, "[hash]");
+				const sizes =
+					assets[key] ||
+					(assets[key] = { size: 0, gzip: 0, brotli: 0, count: 0 });
+				sizes.size += content.length;
+				sizes.gzip += zlib.gzipSync(content, { level: 9 }).length;
+				// eslint-disable-next-line n/no-unsupported-features/node-builtins
+				sizes.brotli += zlib.brotliCompressSync(content, {
+					params: {
+						[zlib.constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY,
+						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: content.length
+					}
+				}).length;
+				sizes.count++;
+			}
+			if (Object.keys(assets).length > 0) cases[`${category}/${name}`] = assets;
+		}
+	}
+	return cases;
+};
+
+/**
+ * @param {string[]} argv command line arguments
+ * @returns {Record<string, string>} parsed `--key value` pairs
+ */
+const parseArgs = (argv) => {
+	/** @type {Record<string, string>} */
+	const args = {};
+	for (let i = 0; i < argv.length; i += 2) {
+		const key = argv[i];
+		if (!key.startsWith("--")) throw new Error(`Unexpected argument ${key}`);
+		args[key.slice(2)] = argv[i + 1];
+	}
+	return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const suite = args.suite || "ConfigTestCases";
+const casesDir = path.resolve(args.dir || path.join("test", "js", suite));
+const out = path.resolve(args.out || "asset-sizes.json");
+
+if (!fs.existsSync(casesDir)) {
+	throw new Error(
+		`${casesDir} does not exist — run the ${suite} suite before collecting sizes`
+	);
+}
+
+const cases = collect(casesDir);
+/** @type {Report} */
+const report = { suite, commit: args.commit || "", cases };
+fs.mkdirSync(path.dirname(out), { recursive: true });
+fs.writeFileSync(out, JSON.stringify(report), "utf8");
+
+const assetCount = Object.values(cases).reduce(
+	(total, assets) => total + Object.keys(assets).length,
+	0
+);
+console.log(
+	`Collected ${assetCount} assets from ${Object.keys(cases).length} ${suite} cases into ${out}`
+);

--- a/tooling/compare-asset-sizes.js
+++ b/tooling/compare-asset-sizes.js
@@ -1,0 +1,263 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Haijie Xie @hai-x
+*/
+
+"use strict";
+
+// Diff two reports written by `tooling/collect-asset-sizes.js` and render the
+// result as markdown for a pull request comment.
+//
+//   node tooling/compare-asset-sizes.js --base base.json --head head.json --out comment.md
+//
+// Paths resolve against the working directory, not against this file: CI copies
+// the script out of the checkout to run it against a different commit.
+
+const fs = require("fs");
+const path = require("path");
+
+/** @typedef {import("./collect-asset-sizes").AssetSizes} AssetSizes */
+/** @typedef {import("./collect-asset-sizes").Report} Report */
+
+/**
+ * @typedef {object} Row
+ * @property {string} case case the asset belongs to
+ * @property {string} asset asset name
+ * @property {AssetSizes} base sizes on the base branch
+ * @property {AssetSizes} head sizes on this branch
+ */
+
+const MARKER = "<!-- webpack-asset-sizes -->";
+const EMPTY = { size: 0, gzip: 0, brotli: 0, count: 0 };
+
+/**
+ * @param {string} commit full commit hash
+ * @returns {string} abbreviated commit hash
+ */
+const shortCommit = (commit) => (commit ? commit.slice(0, 7) : "");
+
+/**
+ * @param {number} bytes byte count
+ * @returns {string} human readable size
+ */
+const formatBytes = (bytes) => {
+	if (Math.abs(bytes) < 1024) return `${bytes} B`;
+	if (Math.abs(bytes) < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+/**
+ * @param {number} bytes signed byte delta
+ * @returns {string} human readable delta
+ */
+const formatDelta = (bytes) =>
+	`${bytes > 0 ? "+" : bytes < 0 ? "-" : ""}${formatBytes(Math.abs(bytes))}`;
+
+/**
+ * @param {number} base base value
+ * @param {number} head head value
+ * @returns {number} percentage change from base to head
+ */
+const percent = (base, head) => {
+	if (base === head) return 0;
+	if (base === 0) return 100;
+	return ((head - base) / base) * 100;
+};
+
+/**
+ * @param {number} base base value
+ * @param {number} head head value
+ * @param {number} threshold percentage below which a change is not called out
+ * @returns {string} change cell with its indicator
+ */
+const formatChange = (base, head, threshold) => {
+	const delta = head - base;
+	const ratio = percent(base, head);
+	const indicator =
+		Math.abs(ratio) < threshold ? "⚫" : delta < 0 ? "🟢" : "🔴";
+	return `${indicator} ${formatDelta(delta)} (${ratio > 0 ? "+" : ""}${ratio.toFixed(1)}%)`;
+};
+
+/**
+ * @param {Record<string, AssetSizes>} totals accumulator keyed by nothing — mutated in place
+ * @param {string} key which total to add to
+ * @param {AssetSizes} sizes sizes to add
+ * @returns {void}
+ */
+const addTo = (totals, key, sizes) => {
+	const total = totals[key] || (totals[key] = { ...EMPTY });
+	total.size += sizes.size;
+	total.gzip += sizes.gzip;
+	total.brotli += sizes.brotli;
+	total.count += sizes.count;
+};
+
+/**
+ * @param {string[]} argv command line arguments
+ * @returns {Record<string, string>} parsed `--key value` pairs
+ */
+const parseArgs = (argv) => {
+	/** @type {Record<string, string>} */
+	const args = {};
+	for (let i = 0; i < argv.length; i += 2) {
+		const key = argv[i];
+		if (!key.startsWith("--")) throw new Error(`Unexpected argument ${key}`);
+		args[key.slice(2)] = argv[i + 1];
+	}
+	return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+/** @type {Report} */
+const baseReport = JSON.parse(fs.readFileSync(path.resolve(args.base), "utf8"));
+/** @type {Report} */
+const headReport = JSON.parse(fs.readFileSync(path.resolve(args.head), "utf8"));
+const limit = args.limit ? Number(args.limit) : 25;
+const threshold = args.threshold ? Number(args.threshold) : 1;
+
+/** @type {Row[]} */
+const changed = [];
+/** @type {Row[]} */
+const added = [];
+/** @type {Row[]} */
+const removed = [];
+/** @type {Record<string, AssetSizes>} */
+const totals = {};
+let comparedAssets = 0;
+
+for (const name of new Set([
+	...Object.keys(baseReport.cases),
+	...Object.keys(headReport.cases)
+]).values()) {
+	const baseAssets = baseReport.cases[name] || {};
+	const headAssets = headReport.cases[name] || {};
+	for (const asset of new Set([
+		...Object.keys(baseAssets),
+		...Object.keys(headAssets)
+	]).values()) {
+		const base = baseAssets[asset];
+		const head = headAssets[asset];
+		if (!base) {
+			added.push({ case: name, asset, base: EMPTY, head });
+			addTo(totals, "added", head);
+			continue;
+		}
+		if (!head) {
+			removed.push({ case: name, asset, base, head: EMPTY });
+			addTo(totals, "removed", base);
+			continue;
+		}
+		comparedAssets++;
+		addTo(totals, "base", base);
+		addTo(totals, "head", head);
+		if (base.size !== head.size || base.gzip !== head.gzip) {
+			changed.push({ case: name, asset, base, head });
+		}
+	}
+}
+
+changed.sort(
+	(a, b) =>
+		Math.abs(b.head.gzip - b.base.gzip) - Math.abs(a.head.gzip - a.base.gzip) ||
+		Math.abs(b.head.size - b.base.size) - Math.abs(a.head.size - a.base.size)
+);
+
+const smaller = changed.filter((row) => row.head.size < row.base.size).length;
+const larger = changed.length - smaller;
+const baseTotal = totals.base || { ...EMPTY };
+const headTotal = totals.head || { ...EMPTY };
+
+/** @type {string[]} */
+const lines = [
+	MARKER,
+	"## Config case asset sizes",
+	"",
+	`Compared \`${shortCommit(headReport.commit) || "this branch"}\` against base \`${shortCommit(baseReport.commit) || "main"}\` over ${comparedAssets} assets emitted by ${Object.keys(headReport.cases).length} \`test/configCases\` cases.`,
+	"",
+	`**${smaller} smaller · ${larger} larger · ${comparedAssets - changed.length} unchanged${added.length > 0 ? ` · ${added.length} added` : ""}${removed.length > 0 ? ` · ${removed.length} removed` : ""}**`,
+	""
+];
+
+if (changed.length === 0 && added.length === 0 && removed.length === 0) {
+	lines.push("No emitted asset changed size.", "");
+} else if (changed.length > 0) {
+	lines.push(
+		"| Case | Asset | Base | This PR | Change | Gzip |",
+		"|---|---|---:|---:|---|---|"
+	);
+	for (const row of changed.slice(0, limit)) {
+		lines.push(
+			`| \`${row.case}\` | \`${row.asset}\` | ${formatBytes(row.base.size)} | ${formatBytes(row.head.size)} | ${formatChange(row.base.size, row.head.size, threshold)} | ${formatChange(row.base.gzip, row.head.gzip, threshold)} |`
+		);
+	}
+	if (changed.length > limit) {
+		lines.push(
+			"",
+			`<sub>… and ${changed.length - limit} more changed assets — the full list is in the job summary.</sub>`
+		);
+	}
+	lines.push("");
+}
+
+/**
+ * @param {string} title section title
+ * @param {Row[]} rows rows to render
+ * @param {"base" | "head"} side which side holds the sizes
+ * @returns {void}
+ */
+const pushListSection = (title, rows, side) => {
+	if (rows.length === 0) return;
+	lines.push(`<details><summary>${title} (${rows.length})</summary>`, "");
+	lines.push("| Case | Asset | Size | Gzip |", "|---|---|---:|---:|");
+	for (const row of rows.slice(0, limit)) {
+		lines.push(
+			`| \`${row.case}\` | \`${row.asset}\` | ${formatBytes(row[side].size)} | ${formatBytes(row[side].gzip)} |`
+		);
+	}
+	if (rows.length > limit) {
+		lines.push("", `<sub>… and ${rows.length - limit} more.</sub>`);
+	}
+	lines.push("", "</details>", "");
+};
+
+pushListSection("Assets only in this PR", added, "head");
+pushListSection("Assets only on the base branch", removed, "base");
+
+lines.push(
+	"| Total over all cases | Base | This PR | Change |",
+	"|---|---:|---:|---|",
+	`| Raw | ${formatBytes(baseTotal.size)} | ${formatBytes(headTotal.size)} | ${formatChange(baseTotal.size, headTotal.size, threshold)} |`,
+	`| Gzip | ${formatBytes(baseTotal.gzip)} | ${formatBytes(headTotal.gzip)} | ${formatChange(baseTotal.gzip, headTotal.gzip, threshold)} |`,
+	`| Brotli | ${formatBytes(baseTotal.brotli)} | ${formatBytes(headTotal.brotli)} | ${formatChange(baseTotal.brotli, headTotal.brotli, threshold)} |`,
+	"",
+	"<sub>Brotli is measured at quality 5 — a relative signal, not the size a quality 11 build ships.</sub>",
+	""
+);
+
+if (args["run-url"]) {
+	lines.push(`[View the full report](${args["run-url"]})`, "");
+}
+
+lines.push(
+	`<sub>🟢 smaller · 🔴 larger · ⚫ change below ${threshold}% · assets with content hashes are matched by name shape · totals exclude added/removed assets</sub>`
+);
+
+// lets CI skip opening a comment on a pull request that changed nothing
+if (args["out-status"]) {
+	fs.writeFileSync(
+		path.resolve(args["out-status"]),
+		JSON.stringify({
+			changed: changed.length,
+			added: added.length,
+			removed: removed.length
+		}),
+		"utf8"
+	);
+}
+
+const markdown = `${lines.join("\n")}\n`;
+if (args.out) {
+	fs.writeFileSync(path.resolve(args.out), markdown, "utf8");
+} else {
+	console.log(markdown);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The `basic` job already builds every `test/configCases` case, but nothing reports how a change moves the bytes those builds emit. This measures what the suite leaves in `test/js` — no second build — and comments the base/head difference per asset, so a size regression or a tree-shaking win is visible on the pull request itself.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

ci

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No — this is CI reporting only; the two `tooling/` scripts were verified locally against a real `ConfigTestCases` run (5530 assets, 1488 cases) and against synthesized base reports covering the changed, added and removed paths.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes