### PR TITLE
perf(css): recycle nested block contents during the walk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,7 +339,9 @@ jobs:
       # jest-worker patch also has a Bun worker end itself rather than be
       # terminated from the parent, which segfaults Bun on an idle-memory restart
       # — and exit once it has, since ending only drops its message listener and
-      # a worker still holding a handle would never be replaced.
+      # a worker still holding a handle would never be replaced. That buys Bun a
+      # restart it would not otherwise survive, but not a run full of them, so the
+      # limit has to sit above what the suite actually uses (see test:base:bun).
       - if: matrix.runtime == 'bun'
         run: |
           git apply test/patches/jest-worker+30.4.1.patch

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3020,7 +3020,7 @@ const declarationStartLikely = (ts) => {
  * when given, each consumed declaration / rule is handed to it immediately (in
  * source order) instead of being collected, so the returned lists are empty.
  *
- * `streamDepth` / `streamRule` are the other half of `streamBlocks` (see
+ * `streamDepth` / `streamRule` are the other half of block streaming (see
  * `_streamConsumeBlock`): the block collects into its own arrays exactly as it
  * always has, and only once it has grown past `_STREAM_MIN_NODES` does it
  * activate and switch to the sink. Keeping that check here rather than behind
@@ -3030,7 +3030,7 @@ const declarationStartLikely = (ts) => {
  * of nothing but declarations never touches one.
  * @param {TokenStream} ts token stream
  * @param {((node: Declaration | Rule) => void)=} onNode optional per-node sink (streaming); nodes are not collected when given
- * @param {number=} streamDepth this block's frame depth when `streamBlocks` is on, else undefined
+ * @param {number=} streamDepth this block's frame depth while the walk streams, else undefined
  * @param {Rule=} streamRule the rule this block belongs to, needed only to stream it
  * Results go into `_bcDecls` / `_bcRules` rather than a returned object — one
  * block's contents per rule made that object pure garbage. `consumeABlocksContents`
@@ -3793,7 +3793,6 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {string=} content the input's contents for the map's `sourcesContent`; only read while printing
  * @property {CssEnvironment=} environment what the target can read (the CSS entries of `output.environment`), so a spelling it would not understand is never reached for; only read while printing, and an absent entry means the modern spelling is available
  * @property {boolean=} convertLengthUnits rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
- * @property {boolean=} streamBlocks walk, print and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Printing streams too — the rule's `prelude{` goes out when the block opens and each child straight after it — and the output is byte for byte the one the collected printer produces. It changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
  */
 
 /**
@@ -4039,9 +4038,11 @@ const _walkRule = (node, parent, index, writer) => {
 // only merges in a block with no child rule, which is exactly the block this
 // declines to stream, and the last of a set of identical declarations is reached
 // by taking the earlier ones back out of the output rather than by looking ahead.
-// Opt-in (`streamBlocks`), since a streamed rule hands its children to the
-// visitors instead of collecting them, so `A.declarations` / `A.childRules` read
-// as an empty block on it.
+// On for every walk, and not an option: a block under the threshold is collected
+// and walked in one batch exactly as it always was, so there is nothing to trade
+// off. It is still a flag because the standalone `parseA*` entry points hand back
+// a materialized tree and must not stream — `_setupParse` leaves it off for them,
+// and only `grammar` turns it on.
 let _streamBlocks = false;
 /** @type {Node | null} node already walked inline, so its sink only recycles */
 let _streamWalked = null;
@@ -4541,11 +4542,13 @@ const grammar = (input, visitors, writer, options) => {
 	_skipSelectorPrelude = skip !== undefined && skip.selectorPrelude === true;
 	_skipAtRulePrelude = skip !== undefined && skip.atRulePrelude === true;
 	_recurseBlocks = options.recurseBlocks !== false;
-	_streamBlocks = options.streamBlocks === true;
-	// Printing streams too: the rule's opener goes out when its block opens and
-	// each child straight after it, so the printer never assembles a parent from
-	// text a streamed body has already released.
-	_streamWriter = _streamBlocks ? writer : undefined;
+	// The walk always streams: there is nothing to trade off, since a block under
+	// the threshold is collected and walked in one batch exactly as it always was.
+	// Printing streams with it — the rule's opener goes out when its block opens
+	// and each child straight after it — so the printer never assembles a parent
+	// from text a streamed body has already released.
+	_streamBlocks = true;
+	_streamWriter = writer;
 	_printing = writer !== undefined;
 	_convertLengthUnits =
 		writer !== undefined && writer.options.convertLengthUnits === true;
@@ -8535,6 +8538,10 @@ const A = {
 		);
 	},
 	/**
+	 * A block big enough to stream hands its children to the visitors as each one
+	 * finishes rather than collecting them, so both lists read as an empty block
+	 * on it — `null`, which means no block at all, is still only for the `@…;`
+	 * forms. Read a block's children from the walk, not from here.
 	 * @param {Node=} n node
 	 * @returns {Declaration[] | null} block declarations
 	 */
@@ -8545,6 +8552,7 @@ const A = {
 		return bi === 0 ? null : /** @type {Declaration[]} */ (_declBodies[bi - 1]);
 	},
 	/**
+	 * Reads as an empty block on a streamed rule; see {@link declarations}.
 	 * @param {Node=} n node
 	 * @returns {Rule[] | null} block child rules
 	 */

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4143,7 +4143,13 @@ const _streamPublishFrame = (d, rule, markNode, markFlat, decls, rules) => {
 const _streamOpen = (d, rule) => {
 	const writer = /** @type {PrintContext} */ (_streamWriter);
 	const minify = writer.options.mode === "minify";
+	// Bind the whole path, not just the node: a prelude can be read in terms of
+	// what encloses it — a keyframe selector is `from` only inside `@keyframes` —
+	// and `_streamEnterRule` binds the parent only when the rule has an `enter`
+	// visitor to run, which printing on its own does not.
 	_currentNode = rule;
+	_currentParent = d === 0 ? null : _nodeRef(_frameRule[d - 1]);
+	_currentIndex = _frameParentIndex[d];
 	_framePendingDepth[d] = writer.pushPending(
 		`${_rulePrelude(A, writer, minify)}${minify ? "" : " "}{`
 	);

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3110,22 +3110,29 @@ const consumeABlocksContentsInto = (ts, onNode, streamDepth, streamRule) => {
 					} else {
 						decls.push(decl);
 						if (_nodeCount > limit) {
-							if (!published) {
-								published = true;
-								// Grew past the threshold on declarations alone, so the frame
-								// has to be written here instead.
-								_streamPublishFrame(
-									d,
-									streamRule,
-									markNode,
-									markFlat,
-									decls,
-									rules
-								);
+							if (_streamWriter !== undefined && rules === null) {
+								// A block of declarations only is the one the printer may
+								// still merge a longhand family in, which needs all of them at
+								// once. Wait for a child rule, which is what turns that off.
+								limit = _nodeCount + _STREAM_MIN_NODES;
+							} else {
+								if (!published) {
+									published = true;
+									// Grew past the threshold on declarations alone, so the
+									// frame has to be written here instead.
+									_streamPublishFrame(
+										d,
+										streamRule,
+										markNode,
+										markFlat,
+										decls,
+										rules
+									);
+								}
+								_streamActivate(d);
+								sink = _streamOnNode;
+								limit = _STREAM_NO_LIMIT;
 							}
-							_streamActivate(d);
-							sink = _streamOnNode;
-							limit = _STREAM_NO_LIMIT;
 						}
 					}
 					continue;
@@ -3786,7 +3793,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {string=} content the input's contents for the map's `sourcesContent`; only read while printing
  * @property {CssEnvironment=} environment what the target can read (the CSS entries of `output.environment`), so a spelling it would not understand is never reached for; only read while printing, and an absent entry means the modern spelling is available
  * @property {boolean=} convertLengthUnits rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
- * @property {boolean=} streamBlocks walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and it changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
+ * @property {boolean=} streamBlocks walk, print and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Printing streams too — the rule's `prelude{` goes out when the block opens and each child straight after it — and the output is byte for byte the one the collected printer produces. It changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
  */
 
 /**
@@ -4024,10 +4031,17 @@ const _walkRule = (node, parent, index, writer) => {
 // released until the whole subtree finished. Enter an open rule once its block
 // has grown enough to be worth it, then walk and recycle each later child as it
 // completes: peak storage becomes the open path rather than the block.
-// Walk-only — a printer assembles a parent from its children's text, which a
-// streamed body has already released — and opt-in (`streamBlocks`), since a
-// streamed rule hands its children to the visitors instead of collecting them,
-// so `A.declarations` / `A.childRules` read empty on it.
+// Printing streams with it: a rule's `prelude{` is held back when the block
+// opens (`_streamOpen`), each finished child is emitted straight after it
+// (`_streamEmitChild`), and the `}` closes it (`_streamClose`) — so the printer
+// never assembles a parent from children a streamed body has already released.
+// The two things that need a whole block at once still hold: a longhand family
+// only merges in a block with no child rule, which is exactly the block this
+// declines to stream, and the last of a set of identical declarations is reached
+// by taking the earlier ones back out of the output rather than by looking ahead.
+// Opt-in (`streamBlocks`), since a streamed rule hands its children to the
+// visitors instead of collecting them, so `A.declarations` / `A.childRules` read
+// as an empty block on it.
 let _streamBlocks = false;
 /** @type {Node | null} node already walked inline, so its sink only recycles */
 let _streamWalked = null;
@@ -4066,6 +4080,19 @@ const _frameDecls = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 /** @type {(Rule[] | null)[]} */
 const _frameRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 const _frameParentIndex = new Int32Array(_STREAM_MAX_DEPTH);
+// Printing a streamed block: where its first item landed in the output, how deep
+// its opener sits in the writer's pending stack, and the direct declarations it
+// has emitted so far — the last of a set of identical ones is the only one that
+// can be read, and the earlier are taken back as each later one arrives.
+const _frameFirstChunk = new Int32Array(_STREAM_MAX_DEPTH);
+const _framePendingDepth = new Int32Array(_STREAM_MAX_DEPTH);
+/** @type {(Map<string, number> | null)[]} */
+const _frameSeenDeclarations = Array.from(
+	{ length: _STREAM_MAX_DEPTH },
+	() => null
+);
+/** @type {PrintContext | undefined} the print context while streaming, else undefined */
+let _streamWriter;
 // A block earns the streaming machinery only once it holds enough to be worth
 // releasing. `_nodeCount` restarts at each top-level node, so
 // `_nodeCount - mark` is exactly how far this block has grown; under the
@@ -4106,6 +4133,94 @@ const _streamPublishFrame = (d, rule, markNode, markFlat, decls, rules) => {
 };
 
 /**
+ * Hold back the opener of a streamed rule — `prelude{`, which its prelude
+ * already determines. Held rather than emitted so a block that prints to nothing
+ * can still be dropped whole at its `}`.
+ * @param {number} d the block's depth
+ * @param {Rule} rule the open rule
+ */
+const _streamOpen = (d, rule) => {
+	const writer = /** @type {PrintContext} */ (_streamWriter);
+	const minify = writer.options.mode === "minify";
+	_currentNode = rule;
+	_framePendingDepth[d] = writer.pushPending(
+		`${_rulePrelude(A, writer, minify)}${minify ? "" : " "}{`
+	);
+	_frameSeenDeclarations[d] = null;
+	_frameFirstChunk[d] = writer.mark;
+	// The outermost opener carries the whole run's source anchor: it is the one
+	// the kept comments precede and the mapping points at.
+	if (d === 0) {
+		const i0 = _nodeIndex(rule);
+		const start = _starts[i0];
+		const loc = _locConverter.get(start);
+		writer.anchorPending(start, loc.line - 1, loc.column);
+	}
+};
+
+/**
+ * Emit one finished child of a streamed block, and with it every opener still
+ * held back — something inside them printed, so they are not empty after all.
+ * @param {number} d the block's depth
+ * @param {Node} child the finished child
+ */
+const _streamEmitChild = (d, child) => {
+	const writer = /** @type {PrintContext} */ (_streamWriter);
+	const text = writer.get(child);
+	// A declaration the minifier dropped prints to nothing, and an empty rule to
+	// nothing as well: neither makes the block it sits in non-empty.
+	if (text.length === 0) return;
+	writer.flushPending();
+	const minify = writer.options.mode === "minify";
+	const at = writer._emit(minify ? text : `\n${text}`);
+	if (!minify || _nodeTypeOf(child) !== T_DECLARATION) return;
+	// Only the last of a set of identical declarations can be read, so each one
+	// takes back the one it repeats. Keyed on the printed text, as the collected
+	// printer keys its own pass.
+	let seen = _frameSeenDeclarations[d];
+	if (seen === null) {
+		seen = new Map();
+		_frameSeenDeclarations[d] = seen;
+	}
+	const previous = seen.get(text);
+	if (previous !== undefined) writer.retract(previous);
+	seen.set(text, at);
+};
+
+/**
+ * Close a streamed rule: emit its `}`, or drop the whole rule when its block
+ * printed to nothing and the block itself carries no meaning.
+ * @param {number} d the block's depth
+ * @param {Rule} rule the rule being closed
+ */
+const _streamClose = (d, rule) => {
+	const writer = /** @type {PrintContext} */ (_streamWriter);
+	const minify = writer.options.mode === "minify";
+	_frameSeenDeclarations[d] = null;
+	if (writer.isPending(_framePendingDepth[d])) {
+		// Nothing inside printed. An empty rule paints nothing, so dropping it
+		// leaves the cascade as it was — but only where the block itself carries no
+		// meaning (see `DROPPABLE_WHEN_EMPTY_AT_RULES`).
+		const i0 = _nodeIndex(rule);
+		if (
+			minify &&
+			(_types[i0] === T_QUALIFIED_RULE ||
+				DROPPABLE_WHEN_EMPTY_AT_RULES.has(
+					_input.slice(_starts[i0] + 1, _aux0[i0]).toLowerCase()
+				))
+		) {
+			writer.dropPending();
+			return;
+		}
+		writer.flushPending();
+	} else if (minify) {
+		// The `;` the last declaration carries is the one a `}` makes redundant.
+		writer.dropTrailing(_frameFirstChunk[d], CC_SEMICOLON);
+	}
+	writer._emit(minify ? "}" : "\n}");
+};
+
+/**
  * Fire an open rule's `enter` and walk its prelude — both are final at `{`.
  * @param {Rule} rule the open rule
  * @param {Node | null} parent enclosing rule
@@ -4143,7 +4258,7 @@ const _streamEnterRule = (rule, parent, index) => {
 		}
 	}
 	for (let i = ps; i < pe; i++) {
-		_walkValue(_nodeRef(_flat[i]), rule, i - ps, undefined);
+		_walkValue(_nodeRef(_flat[i]), rule, i - ps, _streamWriter);
 	}
 	_inSupportsPrelude = prevSupports;
 	_inMediaConditionPrelude = prevMedia;
@@ -4177,6 +4292,7 @@ const _streamActivate = (d) => {
 			k === 0 ? null : _nodeRef(_frameRule[k - 1]),
 			parentIndex
 		);
+		if (_streamWriter !== undefined) _streamOpen(k, rule);
 		const walk = !skipped && _recurseBlocks;
 		_frameWalk[k] = walk ? 1 : 0;
 		const decls = _frameDecls[k];
@@ -4195,22 +4311,25 @@ const _streamActivate = (d) => {
 		let di = 0;
 		let ri = 0;
 		while (di < dn || ri < rn) {
+			/** @type {Node} */
+			let child;
 			if (
 				ri >= rn ||
 				(di < dn &&
 					_starts[_nodeIndex(/** @type {Declaration[]} */ (decls)[di])] <
 						_starts[_nodeIndex(/** @type {Rule[]} */ (rules)[ri])])
 			) {
-				_walkRule(
-					/** @type {Declaration[]} */ (decls)[di],
-					rule,
-					di,
-					undefined
-				);
+				child = /** @type {Declaration[]} */ (decls)[di];
+				_walkRule(child, rule, di, _streamWriter);
 				di++;
 			} else {
-				_walkRule(/** @type {Rule[]} */ (rules)[ri], rule, ri, undefined);
+				child = /** @type {Rule[]} */ (rules)[ri];
+				_walkRule(child, rule, ri, _streamWriter);
 				ri++;
+			}
+			if (_streamWriter !== undefined) {
+				_streamEmitChild(k, child);
+				_streamWriter.dropStore();
 			}
 		}
 	}
@@ -4234,13 +4353,19 @@ const _streamOnNode = (node) => {
 	// A child rule that streamed on its own already entered, walked and exited
 	// inline and released its ids; it reaches the sink already finished.
 	if (node === _streamWalked) {
+		// Already entered, printed and closed itself inline, straight into the
+		// output — there is nothing left of it to emit here.
 		_streamWalked = null;
 	} else if (_frameWalk[d] === 1) {
 		const index =
 			_nodeTypeOf(node) === T_DECLARATION
 				? _frameDeclIndex[d]++
 				: _frameRuleIndex[d]++;
-		_walkRule(node, _nodeRef(_frameRule[d]), index, undefined);
+		_walkRule(node, _nodeRef(_frameRule[d]), index, _streamWriter);
+		if (_streamWriter !== undefined) {
+			_streamEmitChild(d, node);
+			_streamWriter.dropStore();
+		}
 	}
 	if (_nodeCount > _peak) _peak = _nodeCount;
 	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
@@ -4300,7 +4425,9 @@ const _streamConsumeBlock = (ts, rule) => {
 		_setBody(rule, decls, rules);
 		return;
 	}
-	// Streamed: `_streamActivate` already claimed the body slot, empty.
+	// Streamed: `_streamActivate` already claimed the body slot, empty. The exit
+	// visitors still run here; the rule's own `}` follows them, where the printer
+	// would have run for a rule printed in one piece.
 	_exitNode(
 		rule,
 		d === 0 ? null : _nodeRef(_frameRule[d - 1]),
@@ -4308,6 +4435,7 @@ const _streamConsumeBlock = (ts, rule) => {
 		_visitors[_types[_nodeIndex(rule)]],
 		undefined
 	);
+	if (_streamWriter !== undefined) _streamClose(d, rule);
 	_streamWalked = rule;
 };
 
@@ -4408,9 +4536,11 @@ const grammar = (input, visitors, writer, options) => {
 	_skipSelectorPrelude = skip !== undefined && skip.selectorPrelude === true;
 	_skipAtRulePrelude = skip !== undefined && skip.atRulePrelude === true;
 	_recurseBlocks = options.recurseBlocks !== false;
-	// Walk-only: a printer assembles a parent from its children's text, which a
-	// streamed body has already released.
-	_streamBlocks = options.streamBlocks === true && writer === undefined;
+	_streamBlocks = options.streamBlocks === true;
+	// Printing streams too: the rule's opener goes out when its block opens and
+	// each child straight after it, so the printer never assembles a parent from
+	// text a streamed body has already released.
+	_streamWriter = _streamBlocks ? writer : undefined;
 	_printing = writer !== undefined;
 	_convertLengthUnits =
 		writer !== undefined && writer.options.convertLengthUnits === true;
@@ -4473,11 +4603,13 @@ const grammar = (input, visitors, writer, options) => {
 		// parses.
 		_streamBlocks = false;
 		_streamWalked = null;
+		_streamWriter = undefined;
 		_depth = 0;
 		// A frame is left as the block closed it (nothing reads a closed one), so
 		// the last open path's buffers are dropped here rather than per block.
 		_frameDecls.fill(null);
 		_frameRules.fill(null);
+		_frameSeenDeclarations.fill(null);
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;
@@ -7589,6 +7721,61 @@ const _printAttributeSelector = (path, children, writer) => {
 };
 
 /**
+ * A rule's prelude: everything before its `{`, which depends on nothing but the
+ * prelude itself. Split out of the printer so a rule whose block is streamed can
+ * print its opener when the block opens, long before the block's children exist.
+ * @param {CssPath} path the accessor positioned on the rule
+ * @param {PrintContext} writer the print context
+ * @param {boolean} minify whether printing minified
+ * @returns {string} the rule's prelude text
+ */
+const _rulePrelude = (path, writer, minify) => {
+	const parts = [];
+	// Fold the `@name` in first so the join keeps the separator before the
+	// prelude's first token (e.g. `@media screen`, unmerged).
+	if (path.type() === T_AT_RULE) parts.push(`@${path.name()}`);
+	for (const c of path.prelude()) parts.push(writer.get(c));
+	// `@media`/`@container` only: the two preludes whose `(…)` is a media
+	// feature, so an `and` of two of them is an interval.
+	if (
+		minify &&
+		path.type() === T_AT_RULE &&
+		(equalsLowerCase(path.name(), "media") ||
+			equalsLowerCase(path.name(), "container")) &&
+		_rangeSpellingAllowed(writer)
+	) {
+		_collapseRangeInterval(parts);
+	}
+	if (minify && path.type() === T_QUALIFIED_RULE) {
+		_dropLegacyPseudoElementColon(parts);
+		_dropImpliedUniversalSelector(parts);
+	}
+	// Only a qualified rule's prelude is a selector — trim combinator spaces
+	// there; an at-rule prelude (media / container query) keeps its spacing.
+	const prelude = _join(
+		parts,
+		!minify,
+		path.type() === T_QUALIFIED_RULE ? _TRIM_COMBINATORS : _TRIM_NOTHING
+	);
+	if (minify && path.type() === T_QUALIFIED_RULE) {
+		// A keyframe selector, not a selector list: `from` is the `0%` CSS
+		// Animations 1 §4 defines it as, written two bytes shorter. `to` keeps
+		// its spelling, being shorter than the `100%` it names.
+		const parent = path.parent;
+		if (
+			parent !== null &&
+			path.type(parent) === T_AT_RULE &&
+			KEYFRAMES_AT_RULE_RE.test(path.name(parent))
+		) {
+			return _splitSelectorList(prelude)
+				.map((one) => (equalsLowerCase(one, "from") ? "0%" : one))
+				.join(",");
+		}
+	}
+	return prelude;
+};
+
+/**
  * The default CSS node printer — passed to the `SourceProcessor` and fired once a
  * node's visitors and children are done (a developer could supply their own).
  * It takes the same `path` a visitor gets plus the print context as its `writer`,
@@ -7905,48 +8092,7 @@ const printer = (path, writer) => {
 		}
 		case T_AT_RULE:
 		case T_QUALIFIED_RULE: {
-			const parts = [];
-			// Fold the `@name` in first so the join keeps the separator before the
-			// prelude's first token (e.g. `@media screen`, unmerged).
-			if (path.type() === T_AT_RULE) parts.push(`@${path.name()}`);
-			for (const c of path.prelude()) parts.push(writer.get(c));
-			// `@media`/`@container` only: the two preludes whose `(…)` is a media
-			// feature, so an `and` of two of them is an interval.
-			if (
-				minify &&
-				path.type() === T_AT_RULE &&
-				(equalsLowerCase(path.name(), "media") ||
-					equalsLowerCase(path.name(), "container")) &&
-				_rangeSpellingAllowed(writer)
-			) {
-				_collapseRangeInterval(parts);
-			}
-			if (minify && path.type() === T_QUALIFIED_RULE) {
-				_dropLegacyPseudoElementColon(parts);
-				_dropImpliedUniversalSelector(parts);
-			}
-			// Only a qualified rule's prelude is a selector — trim combinator spaces
-			// there; an at-rule prelude (media / container query) keeps its spacing.
-			let prelude = _join(
-				parts,
-				!minify,
-				path.type() === T_QUALIFIED_RULE ? _TRIM_COMBINATORS : _TRIM_NOTHING
-			);
-			if (minify && path.type() === T_QUALIFIED_RULE) {
-				// A keyframe selector, not a selector list: `from` is the `0%` CSS
-				// Animations 1 §4 defines it as, written two bytes shorter. `to` keeps
-				// its spelling, being shorter than the `100%` it names.
-				const parent = path.parent;
-				if (
-					parent !== null &&
-					path.type(parent) === T_AT_RULE &&
-					KEYFRAMES_AT_RULE_RE.test(path.name(parent))
-				) {
-					prelude = _splitSelectorList(prelude)
-						.map((one) => (equalsLowerCase(one, "from") ? "0%" : one))
-						.join(",");
-				}
-			}
+			const prelude = _rulePrelude(path, writer, minify);
 			const decls = path.declarations();
 			// A qualified rule always has a block; an at-rule has one only when its
 			// declaration list is non-null — else it is `@…;`.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4172,11 +4172,16 @@ const _streamEmitChild = (d, child) => {
 	if (text.length === 0) return;
 	writer.flushPending();
 	const minify = writer.options.mode === "minify";
-	const at = writer._emit(minify ? text : `\n${text}`);
-	if (!minify || _nodeTypeOf(child) !== T_DECLARATION) return;
+	if (!minify || _nodeTypeOf(child) !== T_DECLARATION) {
+		// A child rule is never taken back, so it just extends the output.
+		writer._emit(minify ? text : `\n${text}`);
+		return;
+	}
 	// Only the last of a set of identical declarations can be read, so each one
-	// takes back the one it repeats. Keyed on the printed text, as the collected
-	// printer keys its own pass.
+	// takes back the one it repeats — which is the only thing here that needs a
+	// piece of its own. Keyed on the printed text, as the collected printer keys
+	// its own pass.
+	const at = writer.emitRetractable(text);
 	let seen = _frameSeenDeclarations[d];
 	if (seen === null) {
 		seen = new Map();

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -2736,6 +2736,10 @@ const consumeAnAtRule = (ts, nested = false) => {
 		// Consume a block from input, and assign the result to rule's declarations and child rules.
 		else if (t.type === TT_LEFT_CURLY_BRACKET) {
 			_setPrelude(rule, prelude);
+			if (_streamBlocks) {
+				_streamConsumeBlock(ts, rule);
+				return rule;
+			}
 			consumeABlock(ts);
 			_setBody(rule, _blockDecls, _blockRules);
 			_setBlock(rule, _blockStart);
@@ -2890,6 +2894,10 @@ const consumeAQualifiedRule = (ts, stopToken, nested = false) => {
 				return undefined;
 			}
 			if (prelude !== null) _setPrelude(rule, prelude);
+			if (_streamBlocks) {
+				_streamConsumeBlock(ts, rule);
+				return rule;
+			}
 			consumeABlock(ts);
 			_setBody(rule, _blockDecls, _blockRules);
 			_setBlock(rule, _blockStart);
@@ -3695,6 +3703,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {string=} content the input's contents for the map's `sourcesContent`; only read while printing
  * @property {CssEnvironment=} environment what the target can read (the CSS entries of `output.environment`), so a spelling it would not understand is never reached for; only read while printing, and an absent entry means the modern spelling is available
  * @property {boolean=} convertLengthUnits rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
+ * @property {boolean=} streamBlocks walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and the children reach the visitors instead of the rule's body, so `A.declarations` / `A.childRules` read empty for a streamed rule
  */
 
 /**
@@ -3927,6 +3936,135 @@ const _walkRule = (node, parent, index, writer) => {
 	_exitNode(node, parent, index, b, writer);
 };
 
+// === Nested-block streaming ===
+// Top-level nodes already stream, but inside one big block nothing could be
+// released until the whole subtree finished. Enter an open rule as soon as its
+// prelude is sealed, then walk and recycle each child as it completes: peak
+// storage becomes the open path rather than the block. Walk-only — a printer
+// builds a parent's text out of its children's — and off unless the caller asks
+// (`streamBlocks`), since a streamed rule's body is handed to the visitors
+// instead of being collected, so `A.declarations` / `A.childRules` read empty.
+let _streamBlocks = false;
+/** @type {Declaration[]} a streamed rule's body is handed to the visitors, not collected */
+const _EMPTY_DECLS = /** @type {Declaration[]} */ ([]);
+/** @type {Node[]} open rules, innermost last */
+const _openRules = [];
+/** @type {number[]} `_nodeCount` at each open rule's `{`: ids above are reclaimable */
+const _openMarks = [];
+/** @type {number[]} `_flatTop` at each open rule's `{` */
+const _openFlatMarks = [];
+/** @type {number[]} next child index to report for each open rule */
+const _openIndices = [];
+/** @type {Node | null} node already walked inline, so the outer sink only recycles */
+let _streamWalked = null;
+
+/**
+ * Per-child sink for a streamed block: walk the finished child, then rewind the
+ * allocator over its subtree. Module-level (no per-rule closure) — the open
+ * stacks carry the parent and index.
+ * @param {Rule | Declaration} node the finished child
+ */
+const _streamOnNode = (node) => {
+	const d = _openRules.length - 1;
+	// A child rule with a block was already entered, walked and exited inline by
+	// `_streamConsumeBlock`; it reaches the sink only to be recycled.
+	if (node === _streamWalked) _streamWalked = null;
+	else _walkRule(node, _openRules[d], _openIndices[d]++, undefined);
+	// Ids are bump-allocated, so the child's whole subtree sits above the mark
+	// taken at `{` — everything still live was allocated below it.
+	if (_nodeCount > _peak) _peak = _nodeCount;
+	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
+	_nodeCount = _openMarks[d];
+	_flatTop = _openFlatMarks[d];
+};
+
+/**
+ * Sink for a streamed block under `skipChildren()`: recycle without visiting.
+ * @param {Rule | Declaration} _node the finished child, not visited
+ */
+const _streamDropNode = (_node) => {
+	const d = _openRules.length - 1;
+	if (_nodeCount > _peak) _peak = _nodeCount;
+	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
+	_nodeCount = _openMarks[d];
+	_flatTop = _openFlatMarks[d];
+};
+
+/**
+ * Consume a rule's block with its children streamed: fire the rule's `enter`
+ * and walk its prelude first (both are final at `{`), stream the body, then
+ * fire `exit` once `}` gives the rule its real end.
+ * @param {TokenStream} ts token stream
+ * @param {Rule} rule the rule whose block follows
+ */
+const _streamConsumeBlock = (ts, rule) => {
+	const i0 = _nodeIndex(rule);
+	const ty = _types[i0];
+	const b = _visitors[ty];
+	const depth = _openRules.length - 1;
+	const parent = depth >= 0 ? _openRules[depth] : null;
+	const index = depth >= 0 ? _openIndices[depth]++ : 0;
+	let skip = false;
+	if (b !== undefined && b.enter.length !== 0) {
+		_walkSkip = false;
+		_currentNode = rule;
+		_currentParent = parent;
+		_currentIndex = index;
+		const e = b.enter;
+		for (let i = 0; i < e.length; i++) e[i](A);
+		skip = _walkSkip;
+		_walkSkip = false;
+	}
+	if (!skip) {
+		const ps = _listStarts[i0];
+		const pe = ps + _listLens[i0];
+		const prevSupports = _inSupportsPrelude;
+		const prevMedia = _inMediaConditionPrelude;
+		if (ty === T_AT_RULE) {
+			const atName = _input.slice(_starts[i0] + 1, _aux0[i0]);
+			if (equalsLowerCase(atName, "supports")) {
+				_inSupportsPrelude = true;
+			} else if (
+				equalsLowerCase(atName, "media") ||
+				equalsLowerCase(atName, "container")
+			) {
+				_inMediaConditionPrelude = true;
+			}
+		}
+		for (let i = ps; i < pe; i++) {
+			_walkValue(_nodeRef(_flat[i]), rule, i - ps, undefined);
+		}
+		_inSupportsPrelude = prevSupports;
+		_inMediaConditionPrelude = prevMedia;
+	}
+	const blockStart = ts.next().start;
+	ts.discard();
+	_openRules.push(rule);
+	_openMarks.push(_nodeCount);
+	_openFlatMarks.push(_flatTop);
+	_openIndices.push(0);
+	consumeABlocksContentsInto(
+		ts,
+		skip || !_recurseBlocks ? _streamDropNode : _streamOnNode
+	);
+	_openRules.pop();
+	_openMarks.pop();
+	_openFlatMarks.pop();
+	_openIndices.pop();
+	const close = ts.next();
+	const end = close.type === TT_RIGHT_CURLY_BRACKET ? close.end : close.start;
+	ts.discard();
+	_blockDecls = _EMPTY_DECLS;
+	_blockRules = _EMPTY_LIST;
+	_blockStart = blockStart;
+	_blockEnd = end;
+	_setBody(rule, _EMPTY_DECLS, _EMPTY_LIST);
+	_setBlock(rule, blockStart);
+	_setEnd(rule, end);
+	_exitNode(rule, parent, index, b, undefined);
+	_streamWalked = rule;
+};
+
 /**
  * The `grammar` streaming sink: walk one top-level node, then recycle the
  * buffers for the next.
@@ -3934,6 +4072,11 @@ const _walkRule = (node, parent, index, writer) => {
  * @param {PrintContext=} writer print context when printing, else undefined
  */
 const _walkTopLevel = (node, writer) => {
+	if (node === _streamWalked) {
+		_streamWalked = null;
+		_recycleTopLevel(node);
+		return;
+	}
 	_walkRule(node, null, 0, writer);
 	// The walk fired each node's printer into the context; hand this finished
 	// top-level node to the writer with its source position — it flushes any kept
@@ -4019,6 +4162,9 @@ const grammar = (input, visitors, writer, options) => {
 	_skipSelectorPrelude = skip !== undefined && skip.selectorPrelude === true;
 	_skipAtRulePrelude = skip !== undefined && skip.atRulePrelude === true;
 	_recurseBlocks = options.recurseBlocks !== false;
+	// Walk-only: a printer assembles a parent from its children's text, which a
+	// streamed body has already released.
+	_streamBlocks = options.streamBlocks === true && writer === undefined;
 	_printing = writer !== undefined;
 	_convertLengthUnits =
 		writer !== undefined && writer.options.convertLengthUnits === true;
@@ -4079,6 +4225,12 @@ const grammar = (input, visitors, writer, options) => {
 		// Drop the module-level column references so the last parsed source (and
 		// its LocConverter / child lists / visitors) don't stay alive between
 		// parses.
+		_streamBlocks = false;
+		_streamWalked = null;
+		_openRules.length = 0;
+		_openMarks.length = 0;
+		_openFlatMarks.length = 0;
+		_openIndices.length = 0;
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3938,74 +3938,54 @@ const _walkRule = (node, parent, index, writer) => {
 
 // === Nested-block streaming ===
 // Top-level nodes already stream, but inside one big block nothing could be
-// released until the whole subtree finished. Enter an open rule as soon as its
-// prelude is sealed, then walk and recycle each child as it completes: peak
-// storage becomes the open path rather than the block. Walk-only — a printer
-// builds a parent's text out of its children's — and off unless the caller asks
-// (`streamBlocks`), since a streamed rule's body is handed to the visitors
-// instead of being collected, so `A.declarations` / `A.childRules` read empty.
+// released until the whole subtree finished. Enter an open rule once its block
+// has grown enough to be worth it, then walk and recycle each later child as it
+// completes: peak storage becomes the open path rather than the block.
+// Walk-only — a printer assembles a parent from its children's text, which a
+// streamed body has already released — and opt-in (`streamBlocks`), since a
+// streamed rule hands its children to the visitors instead of collecting them,
+// so `A.declarations` / `A.childRules` read empty on it.
 let _streamBlocks = false;
-/** @type {Declaration[]} a streamed rule's body is handed to the visitors, not collected */
-const _EMPTY_DECLS = /** @type {Declaration[]} */ ([]);
-// The innermost open rule's frame. `_streamConsumeBlock` recurses through the
-// block consumer, so its own locals are the stack — saving these four into
-// locals across the recursive call beats four parallel arrays with their bounds
-// and capacity checks on every rule.
-/** @type {Node | null} innermost open rule */
-let _openRule = null;
-/** `_nodeCount` at the open rule's `{`: ids above it are reclaimable */
-let _openMark = 0;
-/** `_flatTop` at the open rule's `{` */
-let _openFlatMark = 0;
-/** next child index to report under the open rule */
-let _openIndex = 0;
-/** @type {Node | null} node already walked inline, so the outer sink only recycles */
+/** @type {Node | null} node already walked inline, so its sink only recycles */
 let _streamWalked = null;
+// One frame per open block, indexed by depth rather than pushed and popped:
+// nesting is shallow and strictly LIFO, so an indexed store costs a write where
+// four parallel arrays cost bounds and capacity checks on every rule. Activation
+// needs to reach every ancestor, which locals could not offer.
+const _STREAM_MAX_DEPTH = 64;
+let _depth = 0;
+/** @type {(Node | null)[]} */
+const _frameRule = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
+const _frameMark = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
+const _frameFlatMark = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
+const _frameIndex = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
+const _frameActive = Array.from({ length: _STREAM_MAX_DEPTH }, () => false);
+const _frameSkipped = Array.from({ length: _STREAM_MAX_DEPTH }, () => false);
+/** @type {(Declaration[] | null)[]} */
+const _frameDecls = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
+/** @type {(Rule[] | null)[]} */
+const _frameRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
+/** @type {(Node | null)[]} */
+const _frameParent = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
+const _frameParentIndex = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
+// A block earns the streaming machinery only once it holds enough to be worth
+// releasing. `_nodeCount` restarts at each top-level node, so
+// `_nodeCount - mark` is exactly how far this block has grown; under the
+// threshold the sink collects like the non-streaming path and the rule is
+// walked once, in one batch, as before.
+const _STREAM_MIN_NODES = 8192;
 
 /**
- * Per-child sink for a streamed block: walk the finished child, then rewind the
- * allocator over its subtree. Module-level (no per-rule closure) — the open
- * stacks carry the parent and index.
- * @param {Rule | Declaration} node the finished child
+ * Fire an open rule's `enter` and walk its prelude — both are final at `{`.
+ * @param {Rule} rule the open rule
+ * @param {Node | null} parent enclosing rule
+ * @param {number} index the rule's index among its siblings
+ * @returns {boolean} whether `skipChildren()` declined its children
  */
-const _streamOnNode = (node) => {
-	// A child rule with a block was already entered, walked and exited inline by
-	// `_streamConsumeBlock`; it reaches the sink only to be recycled.
-	if (node === _streamWalked) _streamWalked = null;
-	else _walkRule(node, _openRule, _openIndex++, undefined);
-	// Ids are bump-allocated, so the child's whole subtree sits above the mark
-	// taken at `{` — everything still live was allocated below it.
-	if (_nodeCount > _peak) _peak = _nodeCount;
-	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
-	_nodeCount = _openMark;
-	_flatTop = _openFlatMark;
-};
-
-/**
- * Sink for a streamed block under `skipChildren()`: recycle without visiting.
- * @param {Rule | Declaration} _node the finished child, not visited
- */
-const _streamDropNode = (_node) => {
-	if (_nodeCount > _peak) _peak = _nodeCount;
-	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
-	_nodeCount = _openMark;
-	_flatTop = _openFlatMark;
-};
-
-/**
- * Consume a rule's block with its children streamed: fire the rule's `enter`
- * and walk its prelude first (both are final at `{`), stream the body, then
- * fire `exit` once `}` gives the rule its real end.
- * @param {TokenStream} ts token stream
- * @param {Rule} rule the rule whose block follows
- */
-const _streamConsumeBlock = (ts, rule) => {
+const _streamEnterRule = (rule, parent, index) => {
 	const i0 = _nodeIndex(rule);
 	const ty = _types[i0];
 	const b = _visitors[ty];
-	const parent = _openRule;
-	const index = parent !== null ? _openIndex++ : 0;
-	let skip = false;
 	if (b !== undefined && b.enter.length !== 0) {
 		_walkSkip = false;
 		_currentNode = rule;
@@ -4013,60 +3993,180 @@ const _streamConsumeBlock = (ts, rule) => {
 		_currentIndex = index;
 		const e = b.enter;
 		for (let i = 0; i < e.length; i++) e[i](A);
-		skip = _walkSkip;
+		const skip = _walkSkip;
 		_walkSkip = false;
+		if (skip) return true;
 	}
-	if (!skip) {
-		const ps = _listStarts[i0];
-		const pe = ps + _listLens[i0];
-		const prevSupports = _inSupportsPrelude;
-		const prevMedia = _inMediaConditionPrelude;
-		if (ty === T_AT_RULE) {
-			const atName = _input.slice(_starts[i0] + 1, _aux0[i0]);
-			if (equalsLowerCase(atName, "supports")) {
-				_inSupportsPrelude = true;
-			} else if (
-				equalsLowerCase(atName, "media") ||
-				equalsLowerCase(atName, "container")
-			) {
-				_inMediaConditionPrelude = true;
+	const ps = _listStarts[i0];
+	const pe = ps + _listLens[i0];
+	const prevSupports = _inSupportsPrelude;
+	const prevMedia = _inMediaConditionPrelude;
+	if (ty === T_AT_RULE) {
+		const atName = _input.slice(_starts[i0] + 1, _aux0[i0]);
+		if (equalsLowerCase(atName, "supports")) {
+			_inSupportsPrelude = true;
+		} else if (
+			equalsLowerCase(atName, "media") ||
+			equalsLowerCase(atName, "container")
+		) {
+			_inMediaConditionPrelude = true;
+		}
+	}
+	for (let i = ps; i < pe; i++) {
+		_walkValue(_nodeRef(_flat[i]), rule, i - ps, undefined);
+	}
+	_inSupportsPrelude = prevSupports;
+	_inMediaConditionPrelude = prevMedia;
+	return false;
+};
+
+/**
+ * A block at `d` has grown past the threshold. Every ancestor still buffering
+ * must be entered first, outermost in, so `enter` stays in source order; each
+ * one then walks what it buffered (its two lists are each source-ordered, so
+ * merging on start offset restores source order) before the deeper level does.
+ * @param {number} d depth of the block that crossed the threshold
+ */
+const _streamActivate = (d) => {
+	for (let k = 0; k <= d; k++) {
+		if (_frameActive[k]) continue;
+		_frameActive[k] = true;
+		const rule = /** @type {Rule} */ (_frameRule[k]);
+		const skipped = _streamEnterRule(
+			rule,
+			_frameParent[k],
+			_frameParentIndex[k]
+		);
+		_frameSkipped[k] = skipped;
+		const decls = _frameDecls[k];
+		const rules = _frameRules[k];
+		_frameDecls[k] = null;
+		_frameRules[k] = null;
+		if (skipped || !_recurseBlocks) continue;
+		const dn = decls === null ? 0 : decls.length;
+		const rn = rules === null ? 0 : rules.length;
+		let di = 0;
+		let ri = 0;
+		while (di < dn || ri < rn) {
+			const child =
+				ri >= rn ||
+				(di < dn &&
+					_starts[_nodeIndex(/** @type {Declaration[]} */ (decls)[di])] <
+						_starts[_nodeIndex(/** @type {Rule[]} */ (rules)[ri])])
+					? /** @type {Declaration[]} */ (decls)[di++]
+					: /** @type {Rule[]} */ (rules)[ri++];
+			_walkRule(child, rule, _frameIndex[k]++, undefined);
+		}
+	}
+	// Only the deepest block may release: an ancestor's mark sits below the ids
+	// its still-open descendants are using.
+	if (_nodeCount > _peak) _peak = _nodeCount;
+	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
+	_nodeCount = _frameMark[d];
+	_flatTop = _frameFlatMark[d];
+};
+
+/**
+ * Per-child sink for a streamed block. Module-level (no per-rule closure) — the
+ * depth-indexed frame carries the open rule, its index and its mark.
+ * @param {Rule | Declaration} node the finished child
+ */
+const _streamOnNode = (node) => {
+	const d = _depth - 1;
+	// A child rule that streamed on its own already entered, walked and exited
+	// inline and released its ids; it reaches the sink already finished.
+	const done = node === _streamWalked;
+	if (done) _streamWalked = null;
+	if (!_frameActive[d]) {
+		// Still small: collect as the non-streaming path does, so a block that
+		// never grows is walked once, in one batch, by the ordinary walk.
+		if (!done) {
+			if (_nodeTypeOf(node) === T_DECLARATION) {
+				(_frameDecls[d] || (_frameDecls[d] = [])).push(
+					/** @type {Declaration} */ (node)
+				);
+			} else {
+				(_frameRules[d] || (_frameRules[d] = [])).push(
+					/** @type {Rule} */ (node)
+				);
 			}
 		}
-		for (let i = ps; i < pe; i++) {
-			_walkValue(_nodeRef(_flat[i]), rule, i - ps, undefined);
-		}
-		_inSupportsPrelude = prevSupports;
-		_inMediaConditionPrelude = prevMedia;
+		if (_nodeCount - _frameMark[d] > _STREAM_MIN_NODES) _streamActivate(d);
+		return;
 	}
+	if (!done && !_frameSkipped[d] && _recurseBlocks) {
+		_walkRule(node, _frameRule[d], _frameIndex[d]++, undefined);
+	}
+	if (_nodeCount > _peak) _peak = _nodeCount;
+	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
+	_nodeCount = _frameMark[d];
+	_flatTop = _frameFlatMark[d];
+};
+
+/**
+ * Consume a rule's block, streaming its children once the block grows past
+ * `_STREAM_MIN_NODES`. A block that stays small is handed back materialized for
+ * the ordinary walk, so it costs a collect and nothing else.
+ * @param {TokenStream} ts token stream
+ * @param {Rule} rule the rule whose block follows
+ */
+const _streamConsumeBlock = (ts, rule) => {
+	const d = _depth;
+	const parent = d > 0 ? _frameRule[d - 1] : null;
+	const parentIndex = d > 0 ? _frameIndex[d - 1]++ : 0;
 	const blockStart = ts.next().start;
 	ts.discard();
-	const prevRule = _openRule;
-	const prevMark = _openMark;
-	const prevFlatMark = _openFlatMark;
-	const prevIndex = _openIndex;
-	_openRule = rule;
-	_openMark = _nodeCount;
-	_openFlatMark = _flatTop;
-	_openIndex = 0;
-	consumeABlocksContentsInto(
-		ts,
-		skip || !_recurseBlocks ? _streamDropNode : _streamOnNode
-	);
-	_openRule = prevRule;
-	_openMark = prevMark;
-	_openFlatMark = prevFlatMark;
-	_openIndex = prevIndex;
+	if (d >= _STREAM_MAX_DEPTH) {
+		// Deeper than the frame table: fall back to the materializing path.
+		consumeABlocksContentsInto(ts);
+		const decls = _bcDecls;
+		const rules = _bcRules;
+		const c = ts.next();
+		ts.discard();
+		_setBody(rule, decls, rules);
+		_setBlock(rule, blockStart);
+		_setEnd(rule, c.type === TT_RIGHT_CURLY_BRACKET ? c.end : c.start);
+		return;
+	}
+	_frameRule[d] = rule;
+	_frameMark[d] = _nodeCount;
+	_frameFlatMark[d] = _flatTop;
+	_frameIndex[d] = 0;
+	_frameActive[d] = false;
+	_frameSkipped[d] = false;
+	_frameDecls[d] = null;
+	_frameRules[d] = null;
+	_frameParent[d] = parent;
+	_frameParentIndex[d] = parentIndex;
+	_depth = d + 1;
+	consumeABlocksContentsInto(ts, _streamOnNode);
+	_depth = d;
+	const active = _frameActive[d];
+	const decls = _frameDecls[d];
+	const rules = _frameRules[d];
+	_frameRule[d] = null;
+	_frameDecls[d] = null;
+	_frameRules[d] = null;
+	_frameParent[d] = null;
 	const close = ts.next();
 	const end = close.type === TT_RIGHT_CURLY_BRACKET ? close.end : close.start;
 	ts.discard();
-	_blockDecls = _EMPTY_DECLS;
-	_blockRules = _EMPTY_LIST;
-	_blockStart = blockStart;
-	_blockEnd = end;
-	_setBody(rule, _EMPTY_DECLS, _EMPTY_LIST);
 	_setBlock(rule, blockStart);
 	_setEnd(rule, end);
-	_exitNode(rule, parent, index, b, undefined);
+	if (!active) {
+		// Never grew: hand the body back, so the ordinary walk visits it and
+		// `A.declarations` / `A.childRules` still read it.
+		_setBody(rule, decls || _EMPTY_LIST, rules || _EMPTY_LIST);
+		return;
+	}
+	_setBody(rule, _EMPTY_LIST, _EMPTY_LIST);
+	_exitNode(
+		rule,
+		parent,
+		parentIndex,
+		_visitors[_types[_nodeIndex(rule)]],
+		undefined
+	);
 	_streamWalked = rule;
 };
 
@@ -4232,7 +4332,7 @@ const grammar = (input, visitors, writer, options) => {
 		// parses.
 		_streamBlocks = false;
 		_streamWalked = null;
-		_openRule = null;
+		_depth = 0;
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1580,6 +1580,10 @@ let _bcDecls = /** @type {Declaration[]} */ (
 );
 /** @type {Rule[]} */
 let _bcRules = _EMPTY_LIST;
+// Whether the block just consumed streamed: read with `_bcDecls` / `_bcRules`.
+// A frame slot cannot answer this, because a block that never streamed may never
+// have written one (see `_streamPublishFrame`).
+let _bcStreamed = false;
 /** @type {Uint8Array} */
 let _skipTypes = _NO_SKIP_TYPES;
 // Fast-path flag: true only when a real skip set is active, so the (dominant)
@@ -3015,14 +3019,25 @@ const declarationStartLikely = (ts) => {
  * `onNode` is the same streaming extension `consumeAStylesheetsContents` exposes:
  * when given, each consumed declaration / rule is handed to it immediately (in
  * source order) instead of being collected, so the returned lists are empty.
+ *
+ * `streamDepth` / `streamRule` are the other half of `streamBlocks` (see
+ * `_streamConsumeBlock`): the block collects into its own arrays exactly as it
+ * always has, and only once it has grown past `_STREAM_MIN_NODES` does it
+ * activate and switch to the sink. Keeping that check here rather than behind
+ * `onNode` is what makes a small block cost the same as it does with nothing
+ * streaming — no call, no type test per child — and the block's frame is written
+ * only when something could still read it (see `_streamPublishFrame`), so a block
+ * of nothing but declarations never touches one.
  * @param {TokenStream} ts token stream
  * @param {((node: Declaration | Rule) => void)=} onNode optional per-node sink (streaming); nodes are not collected when given
+ * @param {number=} streamDepth this block's frame depth when `streamBlocks` is on, else undefined
+ * @param {Rule=} streamRule the rule this block belongs to, needed only to stream it
  * Results go into `_bcDecls` / `_bcRules` rather than a returned object — one
  * block's contents per rule made that object pure garbage. `consumeABlocksContents`
  * below wraps this for the callers that do want an object.
  * @returns {void}
  */
-const consumeABlocksContentsInto = (ts, onNode) => {
+const consumeABlocksContentsInto = (ts, onNode, streamDepth, streamRule) => {
 	/** @type {Declaration[]} */
 	const decls = [];
 	// Child rules are the common empty case (most rules carry only declarations),
@@ -3031,6 +3046,20 @@ const consumeABlocksContentsInto = (ts, onNode) => {
 	// stays eager so the hot declaration append keeps a branch-free `push`.
 	/** @type {Rule[] | null} */
 	let rules = null;
+	let sink = onNode;
+	// -1 = nothing to stream, and then the growth check below can never fire.
+	const d = streamDepth === undefined ? -1 : streamDepth;
+	let limit = _STREAM_NO_LIMIT;
+	// Where this block began, kept in locals until something needs the frame.
+	let markNode = 0;
+	let markFlat = 0;
+	let published = false;
+	if (d >= 0) {
+		markNode = _nodeCount;
+		markFlat = _flatTop;
+		limit = markNode + _STREAM_MIN_NODES;
+		_bcStreamed = false;
+	}
 
 	// Process input:
 	for (;;) {
@@ -3040,22 +3069,28 @@ const consumeABlocksContentsInto = (ts, onNode) => {
 		// Discard a token from input (`t` was just peeked and is non-EOF).
 		if (t.type === TT_WHITESPACE || t.type === TT_SEMICOLON) {
 			ts.advance();
+			continue;
 		}
 		// <EOF-token> / <}-token>
 		// Return decls and rules.
-		else if (t.type === TT_EOF || t.type === TT_RIGHT_CURLY_BRACKET) {
+		if (t.type === TT_EOF || t.type === TT_RIGHT_CURLY_BRACKET) {
 			_bcDecls = decls;
 			_bcRules = rules || _EMPTY_LIST;
+			// Read from the frame, not from `sink`: a descendant can activate this
+			// block during a child rule that then fails to parse.
+			if (d >= 0) _bcStreamed = published && _frameActive[d] === 1;
 			return;
 		}
+		/** @type {Rule | undefined} */
+		let childRule;
 		// <at-keyword-token>
 		// Consume an at-rule from input, with nested set to true. If a rule was returned, append it to rules.
-		else if (t.type === TT_AT_KEYWORD) {
-			const atRule = consumeAnAtRule(ts, true);
-			if (atRule) {
-				if (onNode) onNode(atRule);
-				else (rules || (rules = [])).push(atRule);
+		if (t.type === TT_AT_KEYWORD) {
+			if (d >= 0 && !published && sink === undefined) {
+				published = true;
+				_streamPublishFrame(d, streamRule, markNode, markFlat, decls, rules);
 			}
+			childRule = consumeAnAtRule(ts, true);
 		}
 		// anything else
 		// Mark input. Consume a declaration from input, with nested set to true.
@@ -3067,29 +3102,77 @@ const consumeABlocksContentsInto = (ts, onNode) => {
 				ts.mark();
 				const decl = consumeADeclaration(ts, true);
 				if (decl) {
-					if (onNode) onNode(decl);
-					else decls.push(decl);
 					ts.discardMark();
+					// A declaration opens no block, so nothing can have activated this
+					// one behind our back — only its own growth has to be checked.
+					if (sink) {
+						sink(decl);
+					} else {
+						decls.push(decl);
+						if (_nodeCount > limit) {
+							if (!published) {
+								published = true;
+								// Grew past the threshold on declarations alone, so the frame
+								// has to be written here instead.
+								_streamPublishFrame(
+									d,
+									streamRule,
+									markNode,
+									markFlat,
+									decls,
+									rules
+								);
+							}
+							_streamActivate(d);
+							sink = _streamOnNode;
+							limit = _STREAM_NO_LIMIT;
+						}
+					}
 					continue;
 				}
 				ts.restoreMark();
 			}
+			// A child rule opens a block, and a block is the only thing that can reach
+			// back up and activate this one — so this is the last moment the frame has
+			// to be readable, and a block of nothing but declarations never gets here.
+			if (d >= 0 && !published && sink === undefined) {
+				published = true;
+				_streamPublishFrame(d, streamRule, markNode, markFlat, decls, rules);
+			}
 			const rawStart = t.start;
-			const rule = consumeAQualifiedRule(ts, TT_SEMICOLON, true);
-			if (rule) {
-				if (onNode) onNode(rule);
-				else (rules || (rules = [])).push(rule);
-			} else if (_printing) {
+			childRule = consumeAQualifiedRule(ts, TT_SEMICOLON, true);
+			if (!childRule && _printing) {
 				// Workaround, deliberately off-spec: §5.4 drops input both productions
 				// reject, which would silently delete IE hacks and template
 				// placeholders from minified output. Keep the source verbatim instead.
 				// Printing only, so the spec-exact tree is what every consumer sees.
-				const raw = _makeRaw(rawStart, ts.next().start);
-				if (raw !== undefined) {
-					if (onNode) onNode(/** @type {Rule} */ (raw));
-					else (rules || (rules = [])).push(/** @type {Rule} */ (raw));
-				}
+				childRule = /** @type {Rule | undefined} */ (
+					_makeRaw(rawStart, ts.next().start)
+				);
 			}
+		}
+		// A child rule holds a block, so a descendant of it may have activated this
+		// block while it was being consumed — `decls` / `rules` are then already
+		// walked and recycled, and everything from here on belongs to the sink.
+		// Checked even when the rule did not parse, since the block it opened is
+		// what activated us and the next child must not reach a recycled list.
+		if (!sink && published && _frameActive[d] === 1) sink = _streamOnNode;
+		if (!childRule) continue;
+		if (sink) {
+			sink(childRule);
+			continue;
+		}
+		if (rules === null) {
+			rules = [];
+			// The frame is written before any child rule is consumed, so it is
+			// already pointing at this block and needs the list it did not yet have.
+			if (published) _frameRules[d] = rules;
+		}
+		rules.push(childRule);
+		if (_nodeCount > limit) {
+			_streamActivate(d);
+			sink = _streamOnNode;
+			limit = _STREAM_NO_LIMIT;
 		}
 	}
 };
@@ -3703,7 +3786,7 @@ const TOP_LEVEL_CONSUMERS = {
  * @property {string=} content the input's contents for the map's `sourcesContent`; only read while printing
  * @property {CssEnvironment=} environment what the target can read (the CSS entries of `output.environment`), so a spelling it would not understand is never reached for; only read while printing, and an absent entry means the modern spelling is available
  * @property {boolean=} convertLengthUnits rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
- * @property {boolean=} streamBlocks walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and the children reach the visitors instead of the rule's body, so `A.declarations` / `A.childRules` read empty for a streamed rule
+ * @property {boolean=} streamBlocks walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and it changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
  */
 
 /**
@@ -3950,30 +4033,77 @@ let _streamBlocks = false;
 let _streamWalked = null;
 // One frame per open block, indexed by depth rather than pushed and popped:
 // nesting is shallow and strictly LIFO, so an indexed store costs a write where
-// four parallel arrays cost bounds and capacity checks on every rule. Activation
+// parallel stacks cost bounds and capacity checks on every rule. Activation
 // needs to reach every ancestor, which locals could not offer.
+//
+// A frame is written lazily, by `_streamPublishFrame`, and only where an
+// ancestor could still be reached for: just before a child rule — the one thing
+// that can open a block that reaches back up — and on the block's own growth
+// past the threshold. Every other block, which is every leaf rule in a
+// stylesheet, keeps its state in `consumeABlocksContentsInto`'s locals and never
+// touches these at all. A node is an id, so every slot but the two buffers is
+// numeric: typed columns keep a write off the GC's books.
 const _STREAM_MAX_DEPTH = 64;
 let _depth = 0;
-/** @type {(Node | null)[]} */
-const _frameRule = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
-const _frameMark = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
-const _frameFlatMark = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
-const _frameIndex = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
-const _frameActive = Array.from({ length: _STREAM_MAX_DEPTH }, () => false);
-const _frameSkipped = Array.from({ length: _STREAM_MAX_DEPTH }, () => false);
+/** @type {Int32Array} node id of the open rule */
+const _frameRule = new Int32Array(_STREAM_MAX_DEPTH);
+const _frameMark = new Int32Array(_STREAM_MAX_DEPTH);
+const _frameFlatMark = new Int32Array(_STREAM_MAX_DEPTH);
+const _frameBodyMark = new Int32Array(_STREAM_MAX_DEPTH);
+const _frameActive = new Uint8Array(_STREAM_MAX_DEPTH);
+// Sibling counters, kept apart because the walk indexes declarations and child
+// rules independently (see `_walkRule`) and a streamed block must agree with it.
+const _frameDeclIndex = new Int32Array(_STREAM_MAX_DEPTH);
+const _frameRuleIndex = new Int32Array(_STREAM_MAX_DEPTH);
+// Whether a finished child of this frame is walked at all: `skipChildren()` and
+// `recurseBlocks: false` both decline them, folded into one test per child.
+const _frameWalk = new Uint8Array(_STREAM_MAX_DEPTH);
+// What the block buffered before it activated. `consumeABlocksContentsInto`
+// collects into these very arrays, so a descendant that crosses the threshold
+// first can still drain what its ancestors hold.
 /** @type {(Declaration[] | null)[]} */
 const _frameDecls = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 /** @type {(Rule[] | null)[]} */
 const _frameRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
-/** @type {(Node | null)[]} */
-const _frameParent = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
-const _frameParentIndex = Array.from({ length: _STREAM_MAX_DEPTH }, () => 0);
+const _frameParentIndex = new Int32Array(_STREAM_MAX_DEPTH);
 // A block earns the streaming machinery only once it holds enough to be worth
 // releasing. `_nodeCount` restarts at each top-level node, so
 // `_nodeCount - mark` is exactly how far this block has grown; under the
-// threshold the sink collects like the non-streaming path and the rule is
-// walked once, in one batch, as before.
-const _STREAM_MIN_NODES = 8192;
+// threshold `consumeABlocksContentsInto` collects into its own arrays exactly as
+// it does when nothing streams, and the rule is walked once, in one batch.
+// Tuned: a block that crosses only just, near its own `}`, activates for almost
+// nothing back, so the threshold sits above the few-hundred-rule `@media` a
+// stylesheet actually tends to hold. It bounds what is ever buffered, and even
+// so that is a fraction of the block it replaces.
+const _STREAM_MIN_NODES = 16384;
+// `_nodeCount` never reaches this, so a non-streaming block's per-child growth
+// check is one compare that can never fire — no second code path to maintain.
+const _STREAM_NO_LIMIT = 0x7fffffff;
+// How many finished bodies a streamed block lets pile up before handing them
+// back in one go (see `_streamOnNode`).
+const _STREAM_BODY_SLACK = 64;
+
+/**
+ * Make an open block's frame readable, so a descendant that crosses the
+ * threshold can enter and drain it on the way in. Called at most once per block,
+ * and only by blocks that could still need it.
+ * @param {number} d the block's depth
+ * @param {Rule | undefined} rule the rule whose block this is
+ * @param {number} markNode `_nodeCount` when the block opened
+ * @param {number} markFlat `_flatTop` when the block opened
+ * @param {Declaration[]} decls the block's declarations so far
+ * @param {Rule[] | null} rules the block's child rules so far
+ */
+const _streamPublishFrame = (d, rule, markNode, markFlat, decls, rules) => {
+	_frameRule[d] = _nodeIndex(/** @type {Rule} */ (rule));
+	_frameMark[d] = markNode;
+	_frameFlatMark[d] = markFlat;
+	_frameActive[d] = 0;
+	// The very arrays the block is collecting into, so a descendant can drain what
+	// it buffered without it being on the stack.
+	_frameDecls[d] = decls;
+	_frameRules[d] = rules;
+};
 
 /**
  * Fire an open rule's `enter` and walk its prelude — both are final at `{`.
@@ -4029,33 +4159,59 @@ const _streamEnterRule = (rule, parent, index) => {
  */
 const _streamActivate = (d) => {
 	for (let k = 0; k <= d; k++) {
-		if (_frameActive[k]) continue;
-		_frameActive[k] = true;
-		const rule = /** @type {Rule} */ (_frameRule[k]);
+		if (_frameActive[k] === 1) continue;
+		_frameActive[k] = 1;
+		const rule = /** @type {Rule} */ (_nodeRef(_frameRule[k]));
+		// Claim the body slot before `enter` can read it: a streamed rule hands its
+		// children to the visitors, so its own block has to report as empty rather
+		// than as `null`, which is how a rule with no block at all reads. Everything
+		// a later child claims sits above this, so the slots come back per child.
+		_setBody(rule, _EMPTY_LIST, _EMPTY_LIST);
+		_frameBodyMark[k] = _declBodies.length;
+		// The enclosing block has just been activated and drained, so its rule
+		// counter is exactly how many siblings precede this one.
+		const parentIndex = k === 0 ? 0 : _frameRuleIndex[k - 1]++;
+		_frameParentIndex[k] = parentIndex;
 		const skipped = _streamEnterRule(
 			rule,
-			_frameParent[k],
-			_frameParentIndex[k]
+			k === 0 ? null : _nodeRef(_frameRule[k - 1]),
+			parentIndex
 		);
-		_frameSkipped[k] = skipped;
+		const walk = !skipped && _recurseBlocks;
+		_frameWalk[k] = walk ? 1 : 0;
 		const decls = _frameDecls[k];
 		const rules = _frameRules[k];
 		_frameDecls[k] = null;
 		_frameRules[k] = null;
-		if (skipped || !_recurseBlocks) continue;
 		const dn = decls === null ? 0 : decls.length;
 		const rn = rules === null ? 0 : rules.length;
+		// Both counters end at what was buffered, so the children still to come
+		// carry on from there whether or not this block's body was walked.
+		_frameDeclIndex[k] = dn;
+		_frameRuleIndex[k] = rn;
+		if (!walk) continue;
+		// Merging the two source-ordered lists on start offset restores source
+		// order, while each child keeps the sibling index the batch walk gives it.
 		let di = 0;
 		let ri = 0;
 		while (di < dn || ri < rn) {
-			const child =
+			if (
 				ri >= rn ||
 				(di < dn &&
 					_starts[_nodeIndex(/** @type {Declaration[]} */ (decls)[di])] <
 						_starts[_nodeIndex(/** @type {Rule[]} */ (rules)[ri])])
-					? /** @type {Declaration[]} */ (decls)[di++]
-					: /** @type {Rule[]} */ (rules)[ri++];
-			_walkRule(child, rule, _frameIndex[k]++, undefined);
+			) {
+				_walkRule(
+					/** @type {Declaration[]} */ (decls)[di],
+					rule,
+					di,
+					undefined
+				);
+				di++;
+			} else {
+				_walkRule(/** @type {Rule[]} */ (rules)[ri], rule, ri, undefined);
+				ri++;
+			}
 		}
 	}
 	// Only the deepest block may release: an ancestor's mark sits below the ids
@@ -4067,40 +4223,38 @@ const _streamActivate = (d) => {
 };
 
 /**
- * Per-child sink for a streamed block. Module-level (no per-rule closure) — the
- * depth-indexed frame carries the open rule, its index and its mark.
+ * Per-child sink of an *activated* block: walk the finished child, then release
+ * every id it used. Module-level (no per-rule closure) — the depth-indexed frame
+ * carries the open rule, its sibling counters and its mark. A block only reaches
+ * for this once it has activated, so a small block never calls it.
  * @param {Rule | Declaration} node the finished child
  */
 const _streamOnNode = (node) => {
 	const d = _depth - 1;
 	// A child rule that streamed on its own already entered, walked and exited
 	// inline and released its ids; it reaches the sink already finished.
-	const done = node === _streamWalked;
-	if (done) _streamWalked = null;
-	if (!_frameActive[d]) {
-		// Still small: collect as the non-streaming path does, so a block that
-		// never grows is walked once, in one batch, by the ordinary walk.
-		if (!done) {
-			if (_nodeTypeOf(node) === T_DECLARATION) {
-				(_frameDecls[d] || (_frameDecls[d] = [])).push(
-					/** @type {Declaration} */ (node)
-				);
-			} else {
-				(_frameRules[d] || (_frameRules[d] = [])).push(
-					/** @type {Rule} */ (node)
-				);
-			}
-		}
-		if (_nodeCount - _frameMark[d] > _STREAM_MIN_NODES) _streamActivate(d);
-		return;
-	}
-	if (!done && !_frameSkipped[d] && _recurseBlocks) {
-		_walkRule(node, _frameRule[d], _frameIndex[d]++, undefined);
+	if (node === _streamWalked) {
+		_streamWalked = null;
+	} else if (_frameWalk[d] === 1) {
+		const index =
+			_nodeTypeOf(node) === T_DECLARATION
+				? _frameDeclIndex[d]++
+				: _frameRuleIndex[d]++;
+		_walkRule(node, _nodeRef(_frameRule[d]), index, undefined);
 	}
 	if (_nodeCount > _peak) _peak = _nodeCount;
 	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
 	_nodeCount = _frameMark[d];
 	_flatTop = _frameFlatMark[d];
+	// The child is walked, so the body slots it and its subtree claimed go back
+	// too — otherwise the one thing a streamed block still grew per child. Handed
+	// back in batches: shortening the two arrays costs more than the compare, and
+	// what a batch holds onto is a few dozen finished bodies.
+	const bodyMark = _frameBodyMark[d];
+	if (_declBodies.length >= bodyMark + _STREAM_BODY_SLACK) {
+		_declBodies.length = bodyMark;
+		_ruleBodies.length = bodyMark;
+	}
 };
 
 /**
@@ -4112,8 +4266,6 @@ const _streamOnNode = (node) => {
  */
 const _streamConsumeBlock = (ts, rule) => {
 	const d = _depth;
-	const parent = d > 0 ? _frameRule[d - 1] : null;
-	const parentIndex = d > 0 ? _frameIndex[d - 1]++ : 0;
 	const blockStart = ts.next().start;
 	ts.discard();
 	if (d >= _STREAM_MAX_DEPTH) {
@@ -4128,42 +4280,31 @@ const _streamConsumeBlock = (ts, rule) => {
 		_setEnd(rule, c.type === TT_RIGHT_CURLY_BRACKET ? c.end : c.start);
 		return;
 	}
-	_frameRule[d] = rule;
-	_frameMark[d] = _nodeCount;
-	_frameFlatMark[d] = _flatTop;
-	_frameIndex[d] = 0;
-	_frameActive[d] = false;
-	_frameSkipped[d] = false;
-	_frameDecls[d] = null;
-	_frameRules[d] = null;
-	_frameParent[d] = parent;
-	_frameParentIndex[d] = parentIndex;
+	// Nothing is written to the frame here: the block keeps its state in locals
+	// and writes one only if it could still be read (see `_streamPublishFrame`),
+	// so a rule whose block is all declarations costs what it always did.
 	_depth = d + 1;
-	consumeABlocksContentsInto(ts, _streamOnNode);
+	consumeABlocksContentsInto(ts, undefined, d, rule);
 	_depth = d;
-	const active = _frameActive[d];
-	const decls = _frameDecls[d];
-	const rules = _frameRules[d];
-	_frameRule[d] = null;
-	_frameDecls[d] = null;
-	_frameRules[d] = null;
-	_frameParent[d] = null;
+	const streamed = _bcStreamed;
+	const decls = _bcDecls;
+	const rules = _bcRules;
 	const close = ts.next();
 	const end = close.type === TT_RIGHT_CURLY_BRACKET ? close.end : close.start;
 	ts.discard();
 	_setBlock(rule, blockStart);
 	_setEnd(rule, end);
-	if (!active) {
+	if (!streamed) {
 		// Never grew: hand the body back, so the ordinary walk visits it and
 		// `A.declarations` / `A.childRules` still read it.
-		_setBody(rule, decls || _EMPTY_LIST, rules || _EMPTY_LIST);
+		_setBody(rule, decls, rules);
 		return;
 	}
-	_setBody(rule, _EMPTY_LIST, _EMPTY_LIST);
+	// Streamed: `_streamActivate` already claimed the body slot, empty.
 	_exitNode(
 		rule,
-		parent,
-		parentIndex,
+		d === 0 ? null : _nodeRef(_frameRule[d - 1]),
+		_frameParentIndex[d],
 		_visitors[_types[_nodeIndex(rule)]],
 		undefined
 	);
@@ -4333,6 +4474,10 @@ const grammar = (input, visitors, writer, options) => {
 		_streamBlocks = false;
 		_streamWalked = null;
 		_depth = 0;
+		// A frame is left as the block closed it (nothing reads a closed one), so
+		// the last open path's buffers are dropped here rather than per block.
+		_frameDecls.fill(null);
+		_frameRules.fill(null);
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4154,7 +4154,7 @@ const _streamOpen = (d, rule) => {
 		`${_rulePrelude(A, writer, minify)}${minify ? "" : " "}{`
 	);
 	_frameSeenDeclarations[d] = null;
-	_frameFirstChunk[d] = writer.mark;
+	_frameFirstChunk[d] = writer.markCut();
 	// The outermost opener carries the whole run's source anchor: it is the one
 	// the kept comments precede and the mapping points at.
 	if (d === 0) {

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3947,14 +3947,18 @@ const _walkRule = (node, parent, index, writer) => {
 let _streamBlocks = false;
 /** @type {Declaration[]} a streamed rule's body is handed to the visitors, not collected */
 const _EMPTY_DECLS = /** @type {Declaration[]} */ ([]);
-/** @type {Node[]} open rules, innermost last */
-const _openRules = [];
-/** @type {number[]} `_nodeCount` at each open rule's `{`: ids above are reclaimable */
-const _openMarks = [];
-/** @type {number[]} `_flatTop` at each open rule's `{` */
-const _openFlatMarks = [];
-/** @type {number[]} next child index to report for each open rule */
-const _openIndices = [];
+// The innermost open rule's frame. `_streamConsumeBlock` recurses through the
+// block consumer, so its own locals are the stack — saving these four into
+// locals across the recursive call beats four parallel arrays with their bounds
+// and capacity checks on every rule.
+/** @type {Node | null} innermost open rule */
+let _openRule = null;
+/** `_nodeCount` at the open rule's `{`: ids above it are reclaimable */
+let _openMark = 0;
+/** `_flatTop` at the open rule's `{` */
+let _openFlatMark = 0;
+/** next child index to report under the open rule */
+let _openIndex = 0;
 /** @type {Node | null} node already walked inline, so the outer sink only recycles */
 let _streamWalked = null;
 
@@ -3965,17 +3969,16 @@ let _streamWalked = null;
  * @param {Rule | Declaration} node the finished child
  */
 const _streamOnNode = (node) => {
-	const d = _openRules.length - 1;
 	// A child rule with a block was already entered, walked and exited inline by
 	// `_streamConsumeBlock`; it reaches the sink only to be recycled.
 	if (node === _streamWalked) _streamWalked = null;
-	else _walkRule(node, _openRules[d], _openIndices[d]++, undefined);
+	else _walkRule(node, _openRule, _openIndex++, undefined);
 	// Ids are bump-allocated, so the child's whole subtree sits above the mark
 	// taken at `{` — everything still live was allocated below it.
 	if (_nodeCount > _peak) _peak = _nodeCount;
 	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
-	_nodeCount = _openMarks[d];
-	_flatTop = _openFlatMarks[d];
+	_nodeCount = _openMark;
+	_flatTop = _openFlatMark;
 };
 
 /**
@@ -3983,11 +3986,10 @@ const _streamOnNode = (node) => {
  * @param {Rule | Declaration} _node the finished child, not visited
  */
 const _streamDropNode = (_node) => {
-	const d = _openRules.length - 1;
 	if (_nodeCount > _peak) _peak = _nodeCount;
 	if (_flatTop > _flatPeak) _flatPeak = _flatTop;
-	_nodeCount = _openMarks[d];
-	_flatTop = _openFlatMarks[d];
+	_nodeCount = _openMark;
+	_flatTop = _openFlatMark;
 };
 
 /**
@@ -4001,9 +4003,8 @@ const _streamConsumeBlock = (ts, rule) => {
 	const i0 = _nodeIndex(rule);
 	const ty = _types[i0];
 	const b = _visitors[ty];
-	const depth = _openRules.length - 1;
-	const parent = depth >= 0 ? _openRules[depth] : null;
-	const index = depth >= 0 ? _openIndices[depth]++ : 0;
+	const parent = _openRule;
+	const index = parent !== null ? _openIndex++ : 0;
 	let skip = false;
 	if (b !== undefined && b.enter.length !== 0) {
 		_walkSkip = false;
@@ -4039,18 +4040,22 @@ const _streamConsumeBlock = (ts, rule) => {
 	}
 	const blockStart = ts.next().start;
 	ts.discard();
-	_openRules.push(rule);
-	_openMarks.push(_nodeCount);
-	_openFlatMarks.push(_flatTop);
-	_openIndices.push(0);
+	const prevRule = _openRule;
+	const prevMark = _openMark;
+	const prevFlatMark = _openFlatMark;
+	const prevIndex = _openIndex;
+	_openRule = rule;
+	_openMark = _nodeCount;
+	_openFlatMark = _flatTop;
+	_openIndex = 0;
 	consumeABlocksContentsInto(
 		ts,
 		skip || !_recurseBlocks ? _streamDropNode : _streamOnNode
 	);
-	_openRules.pop();
-	_openMarks.pop();
-	_openFlatMarks.pop();
-	_openIndices.pop();
+	_openRule = prevRule;
+	_openMark = prevMark;
+	_openFlatMark = prevFlatMark;
+	_openIndex = prevIndex;
 	const close = ts.next();
 	const end = close.type === TT_RIGHT_CURLY_BRACKET ? close.end : close.start;
 	ts.discard();
@@ -4227,10 +4232,7 @@ const grammar = (input, visitors, writer, options) => {
 		// parses.
 		_streamBlocks = false;
 		_streamWalked = null;
-		_openRules.length = 0;
-		_openMarks.length = 0;
-		_openFlatMarks.length = 0;
-		_openIndices.length = 0;
+		_openRule = null;
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -133,18 +133,128 @@ class PrintContext {
 		this._printer = printer;
 		/** @type {Map<TNode, string>} printed text of each finished node */
 		this._store = new Map();
-		/** @type {string} accumulated output (flushed top-level nodes) */
-		this._out = "";
-		/** @type {number} 0-based line of the output's current end */
-		this._genLine = 0;
-		/** @type {number} 0-based column of the output's current end */
-		this._genCol = 0;
-		/** @type {number[][]} `[genLine, genCol, srcLine, srcCol]`, output-ordered */
+		// Output as the pieces it was emitted in, joined once at the end. A piece
+		// can still be taken back after later ones were emitted ({@link retract}),
+		// which is what lets a printer emit before it knows a later sibling
+		// overrides it; a string could only do that by rebuilding itself.
+		/** @type {string[]} accumulated output pieces */
+		this._chunks = [];
+		/** @type {[number, number, number][]} `[chunkIndex, srcLine, srcCol]`, output-ordered */
 		this._mappings = [];
 		/** @type {[number, string][]} source-anchored literals to keep (comments), source-ordered */
 		this._inserts = [];
 		/** @type {number} next `_inserts` entry not yet flushed */
 		this._insertIdx = 0;
+		// Openers of the nodes being printed in pieces, innermost last, held back
+		// until one of them turns out to have content: a node whose children all
+		// print to nothing can then still be dropped whole, which is the one thing
+		// emitting an opener eagerly would give up.
+		/** @type {string[]} openers not yet emitted, outermost first */
+		this._pending = [];
+		/** @type {[number | undefined, number | undefined, number | undefined] | null} anchor for the first pending opener */
+		this._pendingAnchor = null;
+	}
+
+	/**
+	 * Hold `text` back as the opener of a node being printed in pieces. Nothing
+	 * reaches the output until {@link flushPending}, so {@link dropPending} can
+	 * still take it back if the node turns out to be empty.
+	 * @param {string} text the node's opener
+	 * @returns {number} the opener's depth, for {@link isPending}
+	 */
+	pushPending(text) {
+		return this._pending.push(text) - 1;
+	}
+
+	/**
+	 * Emit every held-back opener, outermost first — something inside the
+	 * innermost one has content, so all of them do.
+	 * @returns {void}
+	 */
+	flushPending() {
+		const pending = this._pending;
+		if (pending.length === 0) return;
+		const anchor = this._pendingAnchor;
+		if (anchor !== null) {
+			this._pendingAnchor = null;
+			this.anchor(anchor[0], anchor[1], anchor[2]);
+		}
+		for (let i = 0; i < pending.length; i++) this._chunks.push(pending[i]);
+		pending.length = 0;
+	}
+
+	/**
+	 * Anchor the outermost held-back opener, applied when it is flushed. Openers
+	 * are flushed together, so only the outermost carries one.
+	 * @param {number=} srcOffset the node's source offset (kept-comment flush boundary)
+	 * @param {number=} srcLine 0-based source line of the node's start
+	 * @param {number=} srcCol 0-based source column of the node's start
+	 */
+	anchorPending(srcOffset, srcLine, srcCol) {
+		this._pendingAnchor = [srcOffset, srcLine, srcCol];
+	}
+
+	/**
+	 * @param {number} depth an opener's depth, from {@link pushPending}
+	 * @returns {boolean} whether it is still held back (nothing inside it printed)
+	 */
+	isPending(depth) {
+		return this._pending.length > depth;
+	}
+
+	/**
+	 * Drop the innermost held-back opener — its node printed to nothing.
+	 * @returns {void}
+	 */
+	dropPending() {
+		this._pending.pop();
+		const anchor = this._pendingAnchor;
+		if (this._pending.length !== 0 || anchor === null) return;
+		// The node printed to nothing, but it was still a node here: {@link take}
+		// anchors before it can know the text is empty, and the map has to read the
+		// same either way. The kept comments before it are due for the same reason.
+		this._pendingAnchor = null;
+		this.anchor(anchor[0], anchor[1], anchor[2]);
+	}
+
+	/**
+	 * @returns {number} the index the next emitted piece will get
+	 */
+	get mark() {
+		return this._chunks.length;
+	}
+
+	/**
+	 * Forget every node's printed text. A node printed in pieces does this once
+	 * each child is emitted, so the store never holds more than one of them —
+	 * which is also what keeps a recycled node id from reading as an earlier
+	 * node's text.
+	 */
+	dropStore() {
+		this._store.clear();
+	}
+
+	/**
+	 * Drop trailing `charCode`s from the end of the output at or after `from` —
+	 * the separator the piece before a terminator no longer needs. Walks back over
+	 * pieces emptied by {@link retract}, so it sees what the output reads as.
+	 * @param {number} from earliest piece index this may touch
+	 * @param {number} charCode the character to drop
+	 */
+	dropTrailing(from, charCode) {
+		const chunks = this._chunks;
+		for (let i = chunks.length - 1; i >= from; i--) {
+			let text = chunks[i];
+			if (text.length === 0) continue;
+			while (
+				text.length !== 0 &&
+				text.charCodeAt(text.length - 1) === charCode
+			) {
+				text = text.slice(0, -1);
+			}
+			chunks[i] = text;
+			if (text.length !== 0) return;
+		}
 	}
 
 	/**
@@ -166,27 +276,24 @@ class PrintContext {
 	}
 
 	/**
-	 * Append `text` to the output, advancing the tracked generated position past
-	 * it (counting newlines) so the next mapping lands at the right output line/
-	 * column.
+	 * Append `text` to the output. Where in the output that lands is worked out
+	 * only if a source map is asked for (see {@link sourceMap}), so printing
+	 * without one never walks the text looking for newlines.
 	 * @param {string} text output text
+	 * @returns {number} the piece's index, for {@link retract}
 	 */
 	_emit(text) {
-		this._out += text;
-		let from = 0;
-		let nl = text.indexOf("\n");
-		let lines = 0;
-		while (nl !== -1) {
-			lines++;
-			from = nl + 1;
-			nl = text.indexOf("\n", from);
-		}
-		if (lines !== 0) {
-			this._genLine += lines;
-			this._genCol = text.length - from;
-		} else {
-			this._genCol += text.length;
-		}
+		return this._chunks.push(text) - 1;
+	}
+
+	/**
+	 * Take back an already-emitted piece — the printer has since found that a
+	 * later one overrides it. Pieces after it keep their place, so this must not
+	 * be used on a piece something was anchored to (see {@link take}).
+	 * @param {number} index the piece's index, from {@link _emit}
+	 */
+	retract(index) {
+		this._chunks[index] = "";
 	}
 
 	/**
@@ -202,19 +309,31 @@ class PrintContext {
 	 * @param {number=} srcCol 0-based source column of the node's start
 	 */
 	take(node, srcOffset, srcLine, srcCol) {
+		this.anchor(srcOffset, srcLine, srcCol);
+		this._emit(this.get(node));
+		this._store.clear();
+	}
+
+	/**
+	 * Tie whatever is emitted next to a source position: flush the kept comments
+	 * that precede it, then record the mapping. Split out of {@link take} for a
+	 * node printed in pieces, whose first piece is emitted well after the printer
+	 * for it began.
+	 * @param {number=} srcOffset the node's source offset (kept-comment flush boundary)
+	 * @param {number=} srcLine 0-based source line of the node's start
+	 * @param {number=} srcCol 0-based source column of the node's start
+	 */
+	anchor(srcOffset, srcLine, srcCol) {
 		if (srcOffset !== undefined && this._insertIdx < this._inserts.length) {
 			this._flushBefore(srcOffset);
 		}
 		if (srcLine !== undefined) {
 			this._mappings.push([
-				this._genLine,
-				this._genCol,
+				this._chunks.length,
 				srcLine,
 				/** @type {number} */ (srcCol)
 			]);
 		}
-		this._emit(this.get(node));
-		this._store.clear();
 	}
 
 	/**
@@ -284,7 +403,37 @@ class PrintContext {
 		let srcLine = 0;
 		let srcCol = 0;
 		let atLineStart = true;
-		for (const [gl, gc, sl, sc] of this._mappings) {
+		// Where each anchored piece landed, walked once alongside the mappings —
+		// both are in output order, so this is one pass over the pieces, not a
+		// position recomputed per mapping.
+		const chunks = this._chunks;
+		let at = 0;
+		let atLine = 0;
+		let atCol = 0;
+		/** @param {number} upto piece index to advance the position to */
+		const advanceTo = (upto) => {
+			while (at < upto) {
+				const text = chunks[at++];
+				let from = 0;
+				let nl = text.indexOf("\n");
+				let lines = 0;
+				while (nl !== -1) {
+					lines++;
+					from = nl + 1;
+					nl = text.indexOf("\n", from);
+				}
+				if (lines === 0) {
+					atCol += text.length;
+				} else {
+					atLine += lines;
+					atCol = text.length - from;
+				}
+			}
+		};
+		for (const [chunkIndex, sl, sc] of this._mappings) {
+			advanceTo(chunkIndex);
+			const gl = atLine;
+			const gc = atCol;
 			while (genLine < gl) {
 				out += ";";
 				genLine++;
@@ -309,7 +458,7 @@ class PrintContext {
 	result() {
 		// Trailing kept comments (after the last top-level node) flush here.
 		if (this._insertIdx < this._inserts.length) this._flushBefore(Infinity);
-		return this._out;
+		return this._chunks.join("");
 	}
 }
 

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -231,9 +231,14 @@ class PrintContext {
 	}
 
 	/**
+	 * Close off what has been emitted so far and return the index the next piece
+	 * will take. Cutting is the point: a caller bounding a later edit by this
+	 * (see {@link dropTrailing}) must not be able to reach output from before it,
+	 * which a mark taken while the tail was still open would sit in the middle of.
 	 * @returns {number} the index the next emitted piece will get
 	 */
-	get mark() {
+	markCut() {
+		this._cutTail();
 		return this._chunks.length;
 	}
 
@@ -317,10 +322,8 @@ class PrintContext {
 	 * Move the accumulated tail into the finished pieces, flattened.
 	 */
 	_cutTail() {
-		// Nothing has accumulated since the last cut — which is every retractable
-		// piece after the first in a run of them. A piece holding no characters
-		// would only pad the output, and an anchor's offset into an empty tail is
-		// the start of whatever is cut next either way.
+		// A run of retractable pieces cuts after each; an empty piece would only pad
+		// the output, and an anchor into an empty tail already points past it.
 		if (this._tailLength === 0) return;
 		// Reading a character is what forces it flat; the value is not wanted, and
 		// it is kept only so the read cannot be optimized away.

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -69,6 +69,11 @@ const _makeMap = (options, mappings) => ({
 	mappings
 });
 
+// How much output accumulates before it is cut off and forced flat (see
+// `PrintContext._emit`). Large enough that the flattening copy is amortized away,
+// small enough that the un-flattened fragments behind it stay bounded.
+const FLATTEN_BLOCK = 64 * 1024;
+
 // Base64 VLQ, the source-map `mappings` encoding. Hand-rolled so producing a map
 // pulls in no dependency (`source-map` is not a webpack dep).
 const _B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -133,13 +138,21 @@ class PrintContext {
 		this._printer = printer;
 		/** @type {Map<TNode, string>} printed text of each finished node */
 		this._store = new Map();
-		// Output as the pieces it was emitted in, joined once at the end. A piece
-		// can still be taken back after later ones were emitted ({@link retract}),
-		// which is what lets a printer emit before it knows a later sibling
-		// overrides it; a string could only do that by rebuilding itself.
-		/** @type {string[]} accumulated output pieces */
+		// Output accumulates into `_tail`, a plain string append, so printing that
+		// never takes anything back costs exactly what appending to one string
+		// costs. A piece is cut off into `_chunks` only for text that may still be
+		// taken back ({@link emitRetractable}) — that is what lets a printer emit
+		// before it knows a later sibling overrides it, without every other emit
+		// paying for the ability. The output is `_chunks` joined, then `_tail`.
+		/** @type {string[]} pieces already cut off, in output order */
 		this._chunks = [];
-		/** @type {[number, number, number][]} `[chunkIndex, srcLine, srcCol]`, output-ordered */
+		/** @type {string} output after the last cut piece */
+		this._tail = "";
+		/** @type {number} characters in `_tail`, so its length is not read off a rope */
+		this._tailLength = 0;
+		/** @type {number} scratch for the flattening read in {@link _cutTail} */
+		this._flattened = 0;
+		/** @type {[number, number, number, number][]} `[chunkIndex, offsetInChunk, srcLine, srcCol]`, output-ordered */
 		this._mappings = [];
 		/** @type {[number, string][]} source-anchored literals to keep (comments), source-ordered */
 		this._inserts = [];
@@ -179,7 +192,7 @@ class PrintContext {
 			this._pendingAnchor = null;
 			this.anchor(anchor[0], anchor[1], anchor[2]);
 		}
-		for (let i = 0; i < pending.length; i++) this._chunks.push(pending[i]);
+		for (let i = 0; i < pending.length; i++) this._emit(pending[i]);
 		pending.length = 0;
 	}
 
@@ -243,8 +256,8 @@ class PrintContext {
 	 */
 	dropTrailing(from, charCode) {
 		const chunks = this._chunks;
-		for (let i = chunks.length - 1; i >= from; i--) {
-			let text = chunks[i];
+		for (let i = chunks.length; i >= from; i--) {
+			let text = i === chunks.length ? this._tail : chunks[i];
 			if (text.length === 0) continue;
 			while (
 				text.length !== 0 &&
@@ -252,7 +265,12 @@ class PrintContext {
 			) {
 				text = text.slice(0, -1);
 			}
-			chunks[i] = text;
+			if (i === chunks.length) {
+				this._tail = text;
+				this._tailLength = text.length;
+			} else {
+				chunks[i] = text;
+			}
 			if (text.length !== 0) return;
 		}
 	}
@@ -280,9 +298,43 @@ class PrintContext {
 	 * only if a source map is asked for (see {@link sourceMap}), so printing
 	 * without one never walks the text looking for newlines.
 	 * @param {string} text output text
-	 * @returns {number} the piece's index, for {@link retract}
 	 */
 	_emit(text) {
+		this._tail += text;
+		this._tailLength += text.length;
+		// A printer returns its text as a rope of its children's pieces, and
+		// appending a rope onto a rope keeps every fragment of every node reachable
+		// until the output is finally flattened — on a stylesheet of many top-level
+		// rules, a second copy of the whole output. So cut the tail off once it has
+		// grown past a block and force that block flat, which drops every fragment
+		// behind it. Per block rather than per piece: the flattening copy is one
+		// the result would have paid for anyway, but paying it per piece means an
+		// allocation for each, and the pieces are small.
+		if (this._tailLength >= FLATTEN_BLOCK) this._cutTail();
+	}
+
+	/**
+	 * Move the accumulated tail into the finished pieces, flattened.
+	 */
+	_cutTail() {
+		// Reading a character is what forces it flat; the value is not wanted, and
+		// it is kept only so the read cannot be optimized away.
+		this._flattened = this._tail.charCodeAt(0);
+		this._chunks.push(this._tail);
+		this._tail = "";
+		this._tailLength = 0;
+	}
+
+	/**
+	 * Append `text` as a piece of its own, so {@link retract} can still take it
+	 * back once a later sibling turns out to override it. Cuts the accumulating
+	 * tail off in front of it, so it is for the text that may actually be taken
+	 * back and not for output at large.
+	 * @param {string} text output text
+	 * @returns {number} the piece's index, for {@link retract}
+	 */
+	emitRetractable(text) {
+		this._cutTail();
 		return this._chunks.push(text) - 1;
 	}
 
@@ -290,7 +342,7 @@ class PrintContext {
 	 * Take back an already-emitted piece — the printer has since found that a
 	 * later one overrides it. Pieces after it keep their place, so this must not
 	 * be used on a piece something was anchored to (see {@link take}).
-	 * @param {number} index the piece's index, from {@link _emit}
+	 * @param {number} index the piece's index, from {@link emitRetractable}
 	 */
 	retract(index) {
 		this._chunks[index] = "";
@@ -328,8 +380,11 @@ class PrintContext {
 			this._flushBefore(srcOffset);
 		}
 		if (srcLine !== undefined) {
+			// `_chunks.length` is where the tail will land once it is cut off, so
+			// this stays right whether or not a piece is cut after it.
 			this._mappings.push([
 				this._chunks.length,
+				this._tailLength,
 				srcLine,
 				/** @type {number} */ (srcCol)
 			]);
@@ -403,35 +458,55 @@ class PrintContext {
 		let srcLine = 0;
 		let srcCol = 0;
 		let atLineStart = true;
-		// Where each anchored piece landed, walked once alongside the mappings —
-		// both are in output order, so this is one pass over the pieces, not a
-		// position recomputed per mapping.
+		// Where each anchor landed, walked once alongside the mappings — both are
+		// in output order, so this is one pass over the output, not a position
+		// recomputed per mapping. An anchor can sit inside a piece rather than at
+		// its start, since output accumulates into the piece it is appending to.
 		const chunks = this._chunks;
-		let at = 0;
+		const tail = this._tail;
+		/**
+		 * @param {number} i piece index, `chunks.length` being the tail
+		 * @returns {string} that piece
+		 */
+		const pieceAt = (i) => (i === chunks.length ? tail : chunks[i]);
+		let atChunk = 0;
+		let atOffset = 0;
 		let atLine = 0;
 		let atCol = 0;
-		/** @param {number} upto piece index to advance the position to */
-		const advanceTo = (upto) => {
-			while (at < upto) {
-				const text = chunks[at++];
-				let from = 0;
-				let nl = text.indexOf("\n");
-				let lines = 0;
-				while (nl !== -1) {
-					lines++;
-					from = nl + 1;
-					nl = text.indexOf("\n", from);
-				}
-				if (lines === 0) {
-					atCol += text.length;
-				} else {
-					atLine += lines;
-					atCol = text.length - from;
-				}
+		/**
+		 * @param {string} text the piece to walk
+		 * @param {number} from offset to walk from
+		 * @param {number} to offset to walk to
+		 */
+		const advanceOver = (text, from, to) => {
+			let lineStart = from;
+			let nl = text.indexOf("\n", from);
+			while (nl !== -1 && nl < to) {
+				atLine++;
+				atCol = 0;
+				lineStart = nl + 1;
+				nl = text.indexOf("\n", lineStart);
+			}
+			atCol += to - lineStart;
+		};
+		/**
+		 * @param {number} chunk piece index to advance to
+		 * @param {number} offset offset within it
+		 */
+		const advanceTo = (chunk, offset) => {
+			while (atChunk < chunk) {
+				const text = pieceAt(atChunk);
+				advanceOver(text, atOffset, text.length);
+				atChunk++;
+				atOffset = 0;
+			}
+			if (offset > atOffset) {
+				advanceOver(pieceAt(atChunk), atOffset, offset);
+				atOffset = offset;
 			}
 		};
-		for (const [chunkIndex, sl, sc] of this._mappings) {
-			advanceTo(chunkIndex);
+		for (const [chunkIndex, chunkOffset, sl, sc] of this._mappings) {
+			advanceTo(chunkIndex, chunkOffset);
 			const gl = atLine;
 			const gc = atCol;
 			while (genLine < gl) {
@@ -458,7 +533,9 @@ class PrintContext {
 	result() {
 		// Trailing kept comments (after the last top-level node) flush here.
 		if (this._insertIdx < this._inserts.length) this._flushBefore(Infinity);
-		return this._chunks.join("");
+		// Nothing was ever cut into its own piece, so there is nothing to join.
+		const chunks = this._chunks;
+		return chunks.length === 0 ? this._tail : chunks.join("") + this._tail;
 	}
 }
 

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -473,21 +473,25 @@ class PrintContext {
 		let atOffset = 0;
 		let atLine = 0;
 		let atCol = 0;
+		// Offset of the next newline at or after the cursor, `-1` for none left in
+		// this piece. Carried rather than searched for per mapping: `indexOf` has no
+		// end bound, so asking it again for each of a piece's mappings scans again to
+		// the end of the piece every time — and minified output, the case with no
+		// newlines at all, is the one where that is the whole piece.
+		let nextNewline = pieceAt(0).indexOf("\n");
 		/**
 		 * @param {string} text the piece to walk
-		 * @param {number} from offset to walk from
 		 * @param {number} to offset to walk to
 		 */
-		const advanceOver = (text, from, to) => {
-			let lineStart = from;
-			let nl = text.indexOf("\n", from);
-			while (nl !== -1 && nl < to) {
+		const advanceOver = (text, to) => {
+			while (nextNewline !== -1 && nextNewline < to) {
 				atLine++;
 				atCol = 0;
-				lineStart = nl + 1;
-				nl = text.indexOf("\n", lineStart);
+				atOffset = nextNewline + 1;
+				nextNewline = text.indexOf("\n", atOffset);
 			}
-			atCol += to - lineStart;
+			atCol += to - atOffset;
+			atOffset = to;
 		};
 		/**
 		 * @param {number} chunk piece index to advance to
@@ -496,14 +500,12 @@ class PrintContext {
 		const advanceTo = (chunk, offset) => {
 			while (atChunk < chunk) {
 				const text = pieceAt(atChunk);
-				advanceOver(text, atOffset, text.length);
+				advanceOver(text, text.length);
 				atChunk++;
 				atOffset = 0;
+				nextNewline = pieceAt(atChunk).indexOf("\n");
 			}
-			if (offset > atOffset) {
-				advanceOver(pieceAt(atChunk), atOffset, offset);
-				atOffset = offset;
-			}
+			if (offset > atOffset) advanceOver(pieceAt(atChunk), offset);
 		};
 		for (const [chunkIndex, chunkOffset, sl, sc] of this._mappings) {
 			advanceTo(chunkIndex, chunkOffset);

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -317,6 +317,11 @@ class PrintContext {
 	 * Move the accumulated tail into the finished pieces, flattened.
 	 */
 	_cutTail() {
+		// Nothing has accumulated since the last cut — which is every retractable
+		// piece after the first in a run of them. A piece holding no characters
+		// would only pad the output, and an anchor's offset into an empty tail is
+		// the start of whatever is cut next either way.
+		if (this._tailLength === 0) return;
 		// Reading a character is what forces it flat; the value is not wanted, and
 		// it is kept only so the read cannot be optimized away.
 		this._flattened = this._tail.charCodeAt(0);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "test:deno": "yarn test:base:deno --reporters default --reporters \"<rootDir>/test/runtimeCrashReporter.js\" --testMatch \"<rootDir>/test/*.{basictest,longtest,test,unittest}.js\" --testPathIgnorePatterns \"/node_modules/\" \"(ProfilingPlugin[.]unittest|SyntaxBrowserEquivalence|WebpackDevServer)\"",
     "test:base:deno": "deno --allow-read --allow-env --allow-sys --allow-ffi --allow-write --allow-run --allow-net --import-map=test/deno-import-map.json --v8-flags='--max-old-space-size=4096' ./node_modules/jest-cli/bin/jest.js --workerIdleMemoryLimit=512MB --logHeapUsage",
     "test:bun": "yarn test:base:bun --reporters default --reporters \"<rootDir>/test/runtimeCrashReporter.js\" --testMatch \"<rootDir>/test/*.{basictest,longtest,test,unittest}.js\" --testPathIgnorePatterns \"/node_modules/\" \"(ProfilingPlugin[.]unittest|SyntaxBrowserEquivalence|WebpackDevServer)\"",
-    "test:base:bun": "bun --bun --smol --preload ./test/bun-preload.js ./node_modules/jest-cli/bin/jest.js --workerThreads --workerIdleMemoryLimit=512MB --logHeapUsage",
+    "test:base:bun": "bun --bun --smol --preload ./test/bun-preload.js ./node_modules/jest-cli/bin/jest.js --workerThreads --workerIdleMemoryLimit=2048MB --logHeapUsage",
     "test:update-snapshots": "yarn test:base -u",
     "test:size": "node --max-old-space-size=4096 ./test/CodeSizeTestCases.size.js",
     "report:cover": "nyc report --reporter=lcov  --reporter=text -t coverage",

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -903,13 +903,137 @@ describe("CssSyntax — streamBlocks", () => {
 		);
 	});
 
-	it("is declined while printing, which assembles a rule from its children", () => {
-		const minify = (/** @type {boolean} */ streamBlocks) =>
-			new SourceProcessor().process(`@media screen{${SMALL}${BIG}}`, {
+	/**
+	 * Child rules the first rule of type `type` reports while printing streamed:
+	 * 0 means it streamed (its children went to the visitors, not to its body), a
+	 * positive count means the block stayed under the threshold and was collected.
+	 * @param {string} src css source
+	 * @param {number=} type the node type to look at (default `AtRule`)
+	 * @returns {number | null} the count, or null if that rule has no block
+	 */
+	const streamedChildCount = (src, type = NodeType.AtRule) => {
+		/** @type {number | null} */
+		let count = null;
+		let seen = false;
+		new SourceProcessor()
+			.use({
+				[type]: (/** @type {import("../lib/css/syntax").CssPath} */ path) => {
+					if (seen) return;
+					seen = true;
+					const rules = path.childRules();
+					count = rules === null ? null : rules.length;
+				}
+			})
+			.process(src, { minimize: true, streamBlocks: true });
+		return count;
+	};
+
+	/**
+	 * Minify `src` both ways; the streamed output has to be the collected one
+	 * byte for byte, source map included.
+	 * @param {string} src css source
+	 * @returns {void}
+	 */
+	const expectSamePrint = (src) => {
+		const run = (/** @type {boolean} */ streamBlocks) =>
+			new SourceProcessor().process(src, {
 				minimize: true,
+				source: "in.css",
 				streamBlocks
-			}).code;
-		expect(minify(true)).toBe(minify(false));
+			});
+		const collected = run(false);
+		const streamed = run(true);
+		expect(streamed.code).toBe(collected.code);
+		expect(streamed.map).toEqual(collected.map);
+	};
+
+	it("prints a streamed block as the collected printer does", () => {
+		expectSamePrint(`@media screen{${SMALL}${BIG}}`);
+		expectSamePrint(`@media screen{@supports (display:grid){${BIG}}}`);
+		expectSamePrint(
+			`.root{color:red;${repeat(1800, (i) => `& .n${i}{color:red}`)}}`
+		);
+	});
+
+	it("streams while printing, not only while walking", () => {
+		// A collected block reports its children, a streamed one reports an empty
+		// block — which is how the cases here pin that they took the streamed path
+		// rather than passing because nothing streamed at all.
+		expect(streamedChildCount(`@media screen{${BIG}}`)).toBe(0);
+		expect(streamedChildCount(`@media screen{${SMALL}}`)).toBe(4);
+	});
+
+	it("drops a streamed block that prints to nothing", () => {
+		// The opener is held back until something inside prints, so a rule whose
+		// every child minifies away is still dropped whole at its `}`. An empty
+		// rule is only a few nodes, so it takes a lot of them to reach the
+		// threshold — `EMPTY` is sized to cross it, which the assertion below pins.
+		const EMPTY = repeat(6000, (i) => `.e${i}{}`);
+		expect(streamedChildCount(`@media a{${EMPTY}}`)).toBe(0);
+		expectSamePrint(`@media a{${EMPTY}}`);
+		expectSamePrint(`@media a{${EMPTY}@media b{${EMPTY}}}`);
+		expect(
+			new SourceProcessor().process(`@media a{${EMPTY}}`, {
+				minimize: true,
+				streamBlocks: true
+			}).code
+		).toBe("");
+		// A `@layer` block carries meaning even when empty, so it stays.
+		expect(
+			new SourceProcessor().process(`@layer a{${EMPTY}}`, {
+				minimize: true,
+				streamBlocks: true
+			}).code
+		).toBe("@layer a{}");
+	});
+
+	it("keeps only the last of a streamed block's identical declarations", () => {
+		// Reached by taking the earlier one back out of the output, since a
+		// streamed block cannot look ahead for the later one. The duplicate is
+		// separated from its match by a child rule, so it is the whole block that
+		// has to agree with the collected printer, not a run of declarations.
+		const src = `.root{color:red;& .n{a:b}${repeat(3000, (i) => `& .m${i}{a:b}`)}color:red;}`;
+		expect(streamedChildCount(src, NodeType.QualifiedRule)).toBe(0);
+		expectSamePrint(src);
+		expectSamePrint(
+			`.root{${repeat(1800, (i) => `color:red;color:rgb(${i % 7},0,0);& .n${i}{a:b}color:red;`)}}`
+		);
+	});
+
+	it("declines to stream a block a longhand family could still merge in", () => {
+		// `_mergeBoxLonghands` needs every declaration at once, and only runs in a
+		// block with no child rule — so such a block is never streamed, however far
+		// past the threshold it grows, and its four longhands still collapse.
+		const src = `.root{${repeat(20000, (i) => `--v${i}:${i};`)}margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px}`;
+		/** @type {number | null} */
+		let declared = null;
+		let seen = false;
+		new SourceProcessor()
+			.use({
+				[NodeType.QualifiedRule]: (
+					/** @type {import("../lib/css/syntax").CssPath} */ path
+				) => {
+					if (seen) return;
+					seen = true;
+					const decls = path.declarations();
+					declared = decls === null ? null : decls.length;
+				}
+			})
+			.process(src, { minimize: true, streamBlocks: true });
+		// Collected, so it still reports every declaration it holds — a streamed
+		// block would report none, and the merge below would be lost with them.
+		expect(declared).toBe(20004);
+		expectSamePrint(src);
+		expect(
+			new SourceProcessor().process(src, {
+				minimize: true,
+				streamBlocks: true
+			}).code
+		).toContain("margin:1px 2px 3px 4px");
+	});
+
+	it("keeps the kept comments and the source map of a streamed run", () => {
+		expectSamePrint(`/*! keep */@media a{${BIG}}/*! tail */`);
 	});
 
 	it("leaves no state behind for the next parse", () => {

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -758,6 +758,185 @@ describe("CssSyntax — SourceProcessor", () => {
 	});
 });
 
+describe("CssSyntax — streamBlocks", () => {
+	// Streaming only engages past `_STREAM_MIN_NODES` nodes in one block; `BIG`
+	// clears it comfortably and `SMALL` stays well under, so the two exercise the
+	// streamed and the collected path of the same code. The streamed-body test
+	// pins that `BIG` really does cross, so this stays honest if the threshold
+	// moves.
+	/** @type {(i: number) => string} */
+	const rule = (i) =>
+		`.c${i}>d${i}:hover{color:rgb(${i % 255},0,0);margin:1px}`;
+	/** @type {(n: number, f: (i: number) => string) => string} */
+	const repeat = (n, f) => {
+		let s = "";
+		for (let i = 0; i < n; i++) s += f(i);
+		return s;
+	};
+	const BIG = repeat(1800, rule);
+	const SMALL = repeat(4, rule);
+
+	/**
+	 * Every node the walk visits, as `type|index|start`, entering and exiting.
+	 * @param {string} src css source
+	 * @param {boolean} streamBlocks whether to stream nested blocks
+	 * @param {import("../lib/css/syntax").CssProcessOptions=} extra more options
+	 * @returns {string[]} the visit sequence
+	 */
+	const walk = (src, streamBlocks, extra) => {
+		/** @type {string[]} */
+		const seq = [];
+		/** @type {import("../lib/css/syntax").VisitorMap} */
+		const map = {};
+		for (const name of Object.keys(NodeType)) {
+			const type = NodeType[/** @type {keyof typeof NodeType} */ (name)];
+			map[type] = {
+				enter: (/** @type {import("../lib/css/syntax").CssPath} */ path) =>
+					seq.push(`+${name}|${path.index}|${path.start()}`),
+				exit: (/** @type {import("../lib/css/syntax").CssPath} */ path) =>
+					seq.push(`-${name}|${path.index}|${path.start()}`)
+			};
+		}
+		new SourceProcessor().use(map).process(src, { ...extra, streamBlocks });
+		return seq;
+	};
+
+	/**
+	 * @param {string} src css source
+	 * @param {import("../lib/css/syntax").CssProcessOptions=} extra more options
+	 * @returns {void}
+	 */
+	const expectSameWalk = (src, extra) => {
+		expect(walk(src, true, extra)).toEqual(walk(src, false, extra));
+	};
+
+	it("visits a streamed block exactly as the collected walk does", () => {
+		expectSameWalk(`@media screen{${BIG}}`);
+	});
+
+	it("visits nested streamed blocks outermost first", () => {
+		// The inner block crosses the threshold first, so the outer rule has to be
+		// entered on its way in — otherwise `@supports` would be entered before the
+		// `@media` holding it.
+		expectSameWalk(`@media screen{@supports (display:grid){${BIG}}}`);
+	});
+
+	it("visits a streamed CSS-nesting block as the collected walk does", () => {
+		expectSameWalk(
+			`.root{color:red;${repeat(1800, (i) => `& .n${i}{color:red}`)}}`
+		);
+	});
+
+	it("leaves a block that never grows to the collected walk", () => {
+		expectSameWalk(`@media screen{${SMALL}}`);
+		expectSameWalk("a{color:red}@media x{b{color:blue}}@media y{}c{}");
+	});
+
+	it("falls back past the frame table's depth", () => {
+		const depth = 70;
+		expectSameWalk(
+			`${repeat(depth, (i) => `@media (min-width:${i}px){`)}${BIG}${repeat(
+				depth,
+				() => "}"
+			)}`
+		);
+	});
+
+	it("keeps a streamed block's children in source order", () => {
+		// The one visit-order difference streaming makes: the collected walk emits
+		// every declaration and only then every child rule, where a streamed block
+		// emits each child as it finishes. Both see the same children.
+		const src = `@media screen{${repeat(1800, (i) => `p${i}:v${i};${rule(i)}`)}}`;
+		const starts = (/** @type {boolean} */ s) =>
+			walk(src, s).filter((e) => e.startsWith("+Declaration|"));
+		expect(starts(true)).not.toEqual(starts(false));
+		expect([...starts(true)].sort()).toEqual([...starts(false)].sort());
+	});
+
+	it("reads a streamed rule's body as an empty block, not as no block", () => {
+		/** @type {(src: string) => unknown[]} */
+		const body = (src) => {
+			/** @type {unknown[]} */
+			const seen = [];
+			new SourceProcessor()
+				.use({
+					[NodeType.AtRule]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						const decls = path.declarations();
+						const rules = path.childRules();
+						seen.push(decls === null ? null : decls.length);
+						seen.push(rules === null ? null : rules.length);
+					}
+				})
+				.process(src, { streamBlocks: true });
+			return seen;
+		};
+		// A streamed rule hands its children to the visitors instead of collecting
+		// them, so both lists read empty — but the block itself is still there,
+		// which `null` (the no-block at-rules) would deny.
+		expect(body(`@media screen{${BIG}}`)).toEqual([0, 0]);
+		expect(body(`@media screen{${SMALL}}`)).toEqual([0, 4]);
+		expect(body("@import url(x);")).toEqual([null, null]);
+	});
+
+	it("honours skipChildren() and recurseBlocks on a streamed rule", () => {
+		/** @type {(opts: import("../lib/css/syntax").CssProcessOptions, skip: boolean) => number} */
+		const children = (opts, skip) => {
+			let n = 0;
+			new SourceProcessor()
+				.use({
+					[NodeType.AtRule]: (
+						/** @type {import("../lib/css/syntax").CssPath} */ path
+					) => {
+						if (skip) path.skipChildren();
+					},
+					[NodeType.QualifiedRule]: () => n++
+				})
+				.process(`@media screen{${BIG}}`, opts);
+			return n;
+		};
+		expect(children({ streamBlocks: true }, true)).toBe(0);
+		expect(children({ streamBlocks: true }, false)).toBe(1800);
+		expect(children({ streamBlocks: true, recurseBlocks: false }, false)).toBe(
+			0
+		);
+	});
+
+	it("is declined while printing, which assembles a rule from its children", () => {
+		const minify = (/** @type {boolean} */ streamBlocks) =>
+			new SourceProcessor().process(`@media screen{${SMALL}${BIG}}`, {
+				minimize: true,
+				streamBlocks
+			}).code;
+		expect(minify(true)).toBe(minify(false));
+	});
+
+	it("leaves no state behind for the next parse", () => {
+		const src = "@media x{a{c:1}b{d:2}}";
+		let seen = 0;
+		let throwAt = -1;
+		const sp = new SourceProcessor().use({
+			[NodeType.QualifiedRule]: () => {
+				if (++seen === throwAt) throw new Error("boom");
+			}
+		});
+		const plain = walk(src, false);
+		sp.process(`@media screen{${BIG}}`, { streamBlocks: true });
+		expect(walk(src, false)).toEqual(plain);
+		// Part-way through the streamed block, so the frame depth is unwound from
+		// inside the walk rather than at the closing `}`.
+		seen = 0;
+		throwAt = 500;
+		expect(() =>
+			sp.process(`@media screen{${BIG}}`, { streamBlocks: true })
+		).toThrow("boom");
+		throwAt = -1;
+		expect(walk(src, false)).toEqual(plain);
+		expect(walk(src, true)).toEqual(plain);
+	});
+});
+
 describe("CssSyntax — minify comment preservation", () => {
 	/**
 	 * @param {string} src css source

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -758,15 +758,14 @@ describe("CssSyntax — SourceProcessor", () => {
 	});
 });
 
-describe("CssSyntax — streamBlocks", () => {
-	// Streaming only engages past `_STREAM_MIN_NODES` nodes in one block; `BIG`
-	// clears it comfortably and `SMALL` stays well under, so the two exercise the
-	// streamed and the collected path of the same code. The streamed-body test
-	// pins that `BIG` really does cross, so this stays honest if the threshold
-	// moves.
+describe("CssSyntax — block streaming", () => {
+	// A block streams once it holds more than `_STREAM_MIN_NODES` nodes; under
+	// that it is collected and walked in one batch, as it always was. `BIG` clears
+	// the threshold and `SMALL` stays well under, and every case below pins which
+	// of the two it is exercising, so none of them can quietly stop testing the
+	// streamed path if the threshold moves.
 	/** @type {(i: number) => string} */
-	const rule = (i) =>
-		`.c${i}>d${i}:hover{color:rgb(${i % 255},0,0);margin:1px}`;
+	const rule = (i) => `.c${i}>d${i}:hover{color:red;margin:1px}`;
 	/** @type {(n: number, f: (i: number) => string) => string} */
 	const repeat = (n, f) => {
 		let s = "";
@@ -777,13 +776,37 @@ describe("CssSyntax — streamBlocks", () => {
 	const SMALL = repeat(4, rule);
 
 	/**
+	 * Child rules the first rule of `type` reports: 0 means it streamed (its
+	 * children went to the visitors, not to its body), a positive count means it
+	 * was collected.
+	 * @param {string} src css source
+	 * @param {number=} type the node type to look at (default `AtRule`)
+	 * @returns {number | null} the count, or null if that rule has no block
+	 */
+	const childCount = (src, type = NodeType.AtRule) => {
+		/** @type {number | null} */
+		let count = null;
+		let seen = false;
+		new SourceProcessor()
+			.use({
+				[type]: (/** @type {import("../lib/css/syntax").CssPath} */ path) => {
+					if (seen) return;
+					seen = true;
+					const rules = path.childRules();
+					count = rules === null ? null : rules.length;
+				}
+			})
+			.process(src, { minimize: true });
+		return count;
+	};
+
+	/**
 	 * Every node the walk visits, as `type|index|start`, entering and exiting.
 	 * @param {string} src css source
-	 * @param {boolean} streamBlocks whether to stream nested blocks
 	 * @param {import("../lib/css/syntax").CssProcessOptions=} extra more options
 	 * @returns {string[]} the visit sequence
 	 */
-	const walk = (src, streamBlocks, extra) => {
+	const walk = (src, extra) => {
 		/** @type {string[]} */
 		const seq = [];
 		/** @type {import("../lib/css/syntax").VisitorMap} */
@@ -797,60 +820,88 @@ describe("CssSyntax — streamBlocks", () => {
 					seq.push(`-${name}|${path.index}|${path.start()}`)
 			};
 		}
-		new SourceProcessor().use(map).process(src, { ...extra, streamBlocks });
+		new SourceProcessor().use(map).process(src, extra);
 		return seq;
 	};
 
 	/**
 	 * @param {string} src css source
-	 * @param {import("../lib/css/syntax").CssProcessOptions=} extra more options
-	 * @returns {void}
+	 * @returns {string} its minified output
 	 */
-	const expectSameWalk = (src, extra) => {
-		expect(walk(src, true, extra)).toEqual(walk(src, false, extra));
-	};
+	const minify = (src) =>
+		new SourceProcessor().process(src, { minimize: true }).code;
 
-	it("visits a streamed block exactly as the collected walk does", () => {
-		expectSameWalk(`@media screen{${BIG}}`);
+	it("streams a block past the threshold and collects one under it", () => {
+		expect(childCount(`@media screen{${BIG}}`)).toBe(0);
+		expect(childCount(`@media screen{${SMALL}}`)).toBe(4);
 	});
 
-	it("visits nested streamed blocks outermost first", () => {
-		// The inner block crosses the threshold first, so the outer rule has to be
-		// entered on its way in — otherwise `@supports` would be entered before the
-		// `@media` holding it.
-		expectSameWalk(`@media screen{@supports (display:grid){${BIG}}}`);
+	it("enters a streamed rule before its children and exits after them", () => {
+		const seq = walk(`@media screen{${SMALL}}`, { recurseBlocks: true });
+		expect(seq[0]).toBe("+AtRule|0|0");
+		expect(seq[seq.length - 1]).toBe("-AtRule|0|0");
+		const streamed = walk(`@media screen{${BIG}}`);
+		expect(streamed[0]).toBe("+AtRule|0|0");
+		expect(streamed[streamed.length - 1]).toBe("-AtRule|0|0");
 	});
 
-	it("visits a streamed CSS-nesting block as the collected walk does", () => {
-		expectSameWalk(
-			`.root{color:red;${repeat(1800, (i) => `& .n${i}{color:red}`)}}`
-		);
-	});
-
-	it("leaves a block that never grows to the collected walk", () => {
-		expectSameWalk(`@media screen{${SMALL}}`);
-		expectSameWalk("a{color:red}@media x{b{color:blue}}@media y{}c{}");
-	});
-
-	it("falls back past the frame table's depth", () => {
-		const depth = 70;
-		expectSameWalk(
-			`${repeat(depth, (i) => `@media (min-width:${i}px){`)}${BIG}${repeat(
-				depth,
-				() => "}"
-			)}`
-		);
-	});
-
-	it("keeps a streamed block's children in source order", () => {
-		// The one visit-order difference streaming makes: the collected walk emits
-		// every declaration and only then every child rule, where a streamed block
-		// emits each child as it finishes. Both see the same children.
+	it("visits a streamed block's children in source order", () => {
+		// The collected walk emits every declaration and only then every child
+		// rule; a streamed block emits each child as it finishes, so declarations
+		// and child rules interleave the way the source has them.
 		const src = `@media screen{${repeat(1800, (i) => `p${i}:v${i};${rule(i)}`)}}`;
-		const starts = (/** @type {boolean} */ s) =>
-			walk(src, s).filter((e) => e.startsWith("+Declaration|"));
-		expect(starts(true)).not.toEqual(starts(false));
-		expect([...starts(true)].sort()).toEqual([...starts(false)].sort());
+		const kinds = walk(src)
+			.filter(
+				(e) => e.startsWith("+Declaration|") || e.startsWith("+QualifiedRule|")
+			)
+			.map((e) => e.slice(1, e.indexOf("|")));
+		// A declaration of the block, then a rule, then that rule's own two
+		// declarations — repeating, which only source order produces.
+		expect(kinds.slice(0, 8)).toEqual([
+			"Declaration",
+			"QualifiedRule",
+			"Declaration",
+			"Declaration",
+			"Declaration",
+			"QualifiedRule",
+			"Declaration",
+			"Declaration"
+		]);
+	});
+
+	it("indexes a streamed block's declarations and child rules apart", () => {
+		// The collected walk numbers the two lists independently (see `_walkRule`),
+		// so a streamed block has to as well — not one counter running across the
+		// merged source order.
+		const src = `@media screen{${repeat(1800, (i) => `p${i}:v${i};${rule(i)}`)}}`;
+		/** @type {string[]} */
+		const seen = [];
+		new SourceProcessor()
+			.use({
+				[NodeType.Declaration]: (
+					/** @type {import("../lib/css/syntax").CssPath} */ path
+				) => {
+					const parent = path.parent;
+					if (parent !== null && path.type(parent) === NodeType.AtRule) {
+						seen.push(`d${path.index}`);
+					}
+				},
+				[NodeType.QualifiedRule]: (
+					/** @type {import("../lib/css/syntax").CssPath} */ path
+				) => seen.push(`r${path.index}`)
+			})
+			.process(src, { minimize: true });
+		expect(seen.slice(0, 6)).toEqual(["d0", "r0", "d1", "r1", "d2", "r2"]);
+		expect(seen[seen.length - 1]).toBe("r1799");
+	});
+
+	it("enters nested streamed blocks outermost first", () => {
+		// The inner block crosses the threshold first, so the outer rule has to be
+		// entered on the way in — otherwise `@supports` would be entered before the
+		// `@media` holding it.
+		const seq = walk(`@media screen{@supports (display:grid){${BIG}}}`);
+		expect(seq[0]).toBe("+AtRule|0|0");
+		expect(seq.filter((e) => e.startsWith("+AtRule|"))[1]).toBe("+AtRule|0|14");
 	});
 
 	it("reads a streamed rule's body as an empty block, not as no block", () => {
@@ -869,12 +920,12 @@ describe("CssSyntax — streamBlocks", () => {
 						seen.push(rules === null ? null : rules.length);
 					}
 				})
-				.process(src, { streamBlocks: true });
+				.process(src, { minimize: true });
 			return seen;
 		};
 		// A streamed rule hands its children to the visitors instead of collecting
 		// them, so both lists read empty — but the block itself is still there,
-		// which `null` (the no-block at-rules) would deny.
+		// which `null` (the block-less at-rules) would deny.
 		expect(body(`@media screen{${BIG}}`)).toEqual([0, 0]);
 		expect(body(`@media screen{${SMALL}}`)).toEqual([0, 4]);
 		expect(body("@import url(x);")).toEqual([null, null]);
@@ -896,108 +947,46 @@ describe("CssSyntax — streamBlocks", () => {
 				.process(`@media screen{${BIG}}`, opts);
 			return n;
 		};
-		expect(children({ streamBlocks: true }, true)).toBe(0);
-		expect(children({ streamBlocks: true }, false)).toBe(1800);
-		expect(children({ streamBlocks: true, recurseBlocks: false }, false)).toBe(
-			0
-		);
+		expect(children({}, true)).toBe(0);
+		expect(children({}, false)).toBe(1800);
+		expect(children({ recurseBlocks: false }, false)).toBe(0);
 	});
 
-	/**
-	 * Child rules the first rule of type `type` reports while printing streamed:
-	 * 0 means it streamed (its children went to the visitors, not to its body), a
-	 * positive count means the block stayed under the threshold and was collected.
-	 * @param {string} src css source
-	 * @param {number=} type the node type to look at (default `AtRule`)
-	 * @returns {number | null} the count, or null if that rule has no block
-	 */
-	const streamedChildCount = (src, type = NodeType.AtRule) => {
-		/** @type {number | null} */
-		let count = null;
-		let seen = false;
-		new SourceProcessor()
-			.use({
-				[type]: (/** @type {import("../lib/css/syntax").CssPath} */ path) => {
-					if (seen) return;
-					seen = true;
-					const rules = path.childRules();
-					count = rules === null ? null : rules.length;
-				}
-			})
-			.process(src, { minimize: true, streamBlocks: true });
-		return count;
-	};
-
-	/**
-	 * Minify `src` both ways; the streamed output has to be the collected one
-	 * byte for byte, source map included.
-	 * @param {string} src css source
-	 * @returns {void}
-	 */
-	const expectSamePrint = (src) => {
-		const run = (/** @type {boolean} */ streamBlocks) =>
-			new SourceProcessor().process(src, {
-				minimize: true,
-				source: "in.css",
-				streamBlocks
-			});
-		const collected = run(false);
-		const streamed = run(true);
-		expect(streamed.code).toBe(collected.code);
-		expect(streamed.map).toEqual(collected.map);
-	};
-
-	it("prints a streamed block as the collected printer does", () => {
-		expectSamePrint(`@media screen{${SMALL}${BIG}}`);
-		expectSamePrint(`@media screen{@supports (display:grid){${BIG}}}`);
-		expectSamePrint(
-			`.root{color:red;${repeat(1800, (i) => `& .n${i}{color:red}`)}}`
+	it("prints a streamed block as the collected printer would", () => {
+		// The fixture is already minimal, so the whole output is known: opener,
+		// every child in source order, closer — and no `;` before the `}`.
+		expect(minify(`@media screen{${BIG}}`)).toBe(`@media screen{${BIG}}`);
+		expect(minify(`@media screen{@supports (display:grid){${BIG}}}`)).toBe(
+			`@media screen{@supports (display:grid){${BIG}}}`
 		);
-	});
-
-	it("streams while printing, not only while walking", () => {
-		// A collected block reports its children, a streamed one reports an empty
-		// block — which is how the cases here pin that they took the streamed path
-		// rather than passing because nothing streamed at all.
-		expect(streamedChildCount(`@media screen{${BIG}}`)).toBe(0);
-		expect(streamedChildCount(`@media screen{${SMALL}}`)).toBe(4);
+		const nesting = `.root{color:red;${repeat(1800, (i) => `& .n${i}{color:red}`)}}`;
+		expect(minify(nesting)).toBe(nesting);
 	});
 
 	it("drops a streamed block that prints to nothing", () => {
 		// The opener is held back until something inside prints, so a rule whose
 		// every child minifies away is still dropped whole at its `}`. An empty
-		// rule is only a few nodes, so it takes a lot of them to reach the
-		// threshold — `EMPTY` is sized to cross it, which the assertion below pins.
+		// rule is only a few nodes, so it takes a lot of them to cross.
 		const EMPTY = repeat(6000, (i) => `.e${i}{}`);
-		expect(streamedChildCount(`@media a{${EMPTY}}`)).toBe(0);
-		expectSamePrint(`@media a{${EMPTY}}`);
-		expectSamePrint(`@media a{${EMPTY}@media b{${EMPTY}}}`);
-		expect(
-			new SourceProcessor().process(`@media a{${EMPTY}}`, {
-				minimize: true,
-				streamBlocks: true
-			}).code
-		).toBe("");
+		expect(childCount(`@media a{${EMPTY}}`)).toBe(0);
+		expect(minify(`@media a{${EMPTY}}`)).toBe("");
+		expect(minify(`@media a{${EMPTY}@media b{${EMPTY}}}`)).toBe("");
+		expect(minify(`@media a{${EMPTY}.keep{color:red}}`)).toBe(
+			"@media a{.keep{color:red}}"
+		);
 		// A `@layer` block carries meaning even when empty, so it stays.
-		expect(
-			new SourceProcessor().process(`@layer a{${EMPTY}}`, {
-				minimize: true,
-				streamBlocks: true
-			}).code
-		).toBe("@layer a{}");
+		expect(minify(`@layer a{${EMPTY}}`)).toBe("@layer a{}");
 	});
 
 	it("keeps only the last of a streamed block's identical declarations", () => {
 		// Reached by taking the earlier one back out of the output, since a
 		// streamed block cannot look ahead for the later one. The duplicate is
-		// separated from its match by a child rule, so it is the whole block that
-		// has to agree with the collected printer, not a run of declarations.
-		const src = `.root{color:red;& .n{a:b}${repeat(3000, (i) => `& .m${i}{a:b}`)}color:red;}`;
-		expect(streamedChildCount(src, NodeType.QualifiedRule)).toBe(0);
-		expectSamePrint(src);
-		expectSamePrint(
-			`.root{${repeat(1800, (i) => `color:red;color:rgb(${i % 7},0,0);& .n${i}{a:b}color:red;`)}}`
-		);
+		// separated from its match by 3000 child rules, so this is the whole block
+		// agreeing, not a run of adjacent declarations.
+		const middle = repeat(3000, (i) => `& .m${i}{color:red}`);
+		const src = `.root{color:red;${middle}color:red;}`;
+		expect(childCount(src, NodeType.QualifiedRule)).toBe(0);
+		expect(minify(src)).toBe(`.root{${middle}color:red}`);
 	});
 
 	it("declines to stream a block a longhand family could still merge in", () => {
@@ -1019,21 +1008,17 @@ describe("CssSyntax — streamBlocks", () => {
 					declared = decls === null ? null : decls.length;
 				}
 			})
-			.process(src, { minimize: true, streamBlocks: true });
+			.process(src, { minimize: true });
 		// Collected, so it still reports every declaration it holds — a streamed
 		// block would report none, and the merge below would be lost with them.
 		expect(declared).toBe(20004);
-		expectSamePrint(src);
-		expect(
-			new SourceProcessor().process(src, {
-				minimize: true,
-				streamBlocks: true
-			}).code
-		).toContain("margin:1px 2px 3px 4px");
+		expect(minify(src)).toContain("margin:1px 2px 3px 4px");
 	});
 
-	it("keeps the kept comments and the source map of a streamed run", () => {
-		expectSamePrint(`/*! keep */@media a{${BIG}}/*! tail */`);
+	it("keeps the comments a streamed run carries through", () => {
+		expect(minify(`/*! keep */@media a{${BIG}}/*! tail */`)).toBe(
+			`/*! keep */@media a{${BIG}}/*! tail */`
+		);
 	});
 
 	it("leaves no state behind for the next parse", () => {
@@ -1045,19 +1030,17 @@ describe("CssSyntax — streamBlocks", () => {
 				if (++seen === throwAt) throw new Error("boom");
 			}
 		});
-		const plain = walk(src, false);
-		sp.process(`@media screen{${BIG}}`, { streamBlocks: true });
-		expect(walk(src, false)).toEqual(plain);
+		const plain = walk(src);
+		sp.process(`@media screen{${BIG}}`, {});
+		expect(walk(src)).toEqual(plain);
 		// Part-way through the streamed block, so the frame depth is unwound from
 		// inside the walk rather than at the closing `}`.
 		seen = 0;
 		throwAt = 500;
-		expect(() =>
-			sp.process(`@media screen{${BIG}}`, { streamBlocks: true })
-		).toThrow("boom");
+		expect(() => sp.process(`@media screen{${BIG}}`, {})).toThrow("boom");
 		throwAt = -1;
-		expect(walk(src, false)).toEqual(plain);
-		expect(walk(src, true)).toEqual(plain);
+		expect(walk(src)).toEqual(plain);
+		expect(minify(src)).toBe(src);
 	});
 });
 

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -963,6 +963,37 @@ describe("CssSyntax — block streaming", () => {
 		expect(minify(nesting)).toBe(nesting);
 	});
 
+	it("reads a streamed rule's prelude in terms of what encloses it", () => {
+		// `from` is the `0%` a keyframe selector means only inside `@keyframes`, so
+		// the opener has to be printed with the whole path bound, not just the rule.
+		const nested = repeat(3000, (i) => `& .x${i}{color:red}`);
+		expect(
+			childCount(`@keyframes k{from{${nested}}}`, NodeType.QualifiedRule)
+		).toBe(0);
+		expect(minify(`@keyframes k{from{${nested}}}`)).toBe(
+			`@keyframes k{0%{${nested}}}`
+		);
+		// `to` is already shorter than the `100%` it names, and a `.from` selector
+		// outside `@keyframes` is a class like any other.
+		expect(minify(`@keyframes k{to{${nested}}}`)).toBe(
+			`@keyframes k{to{${nested}}}`
+		);
+		expect(minify(`.from{${nested}}`)).toBe(`.from{${nested}}`);
+	});
+
+	it("falls back past the depth the frame table holds", () => {
+		// Deeper than `_STREAM_MAX_DEPTH`, where a block is materialized instead of
+		// streamed; the levels above it still stream, so the two have to meet.
+		// `@media m0` and not a feature query: a `(min-width:…)` prelude minifies to
+		// the range spelling, and the point here is the nesting, not the prelude.
+		const depth = 70;
+		const open = repeat(depth, (i) => `@media m${i}{`);
+		const close = repeat(depth, () => "}");
+		expect(minify(`${open}${BIG}${close}`)).toBe(`${open}${BIG}${close}`);
+		// The same nesting with nothing in it still collapses to nothing.
+		expect(minify(`${open}${close}`)).toBe("");
+	});
+
 	it("drops a streamed block that prints to nothing", () => {
 		// The opener is held back until something inside prints, so a rule whose
 		// every child minifies away is still dropped whole at its `}`. An empty

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -1020,6 +1020,16 @@ describe("CssSyntax — block streaming", () => {
 		expect(minify(src)).toBe(`.root{${middle}color:red}`);
 	});
 
+	it("takes back only its own output when it drops the last `;`", () => {
+		// The `;` a `}` makes redundant is dropped by walking back over the pieces
+		// the block emitted, past the empty one a later duplicate took back. What
+		// stands before the block keeps its own separator.
+		const mid = repeat(3000, (i) => `& .m${i}{color:red}`);
+		const src = `.root{lead:1;${mid}dup:2;dup:2;}`;
+		expect(childCount(src, NodeType.QualifiedRule)).toBe(0);
+		expect(minify(src)).toBe(`.root{lead:1;${mid}dup:2}`);
+	});
+
 	it("declines to stream a block a longhand family could still merge in", () => {
 		// `_mergeBoxLonghands` needs every declaration at once, and only runs in a
 		// block with no child rule — so such a block is never streamed, however far

--- a/types.d.ts
+++ b/types.d.ts
@@ -5962,7 +5962,7 @@ declare interface CssProcessOptions {
 	convertLengthUnits?: boolean;
 
 	/**
-	 * walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and it changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
+	 * walk, print and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Printing streams too — the rule's `prelude{` goes out when the block opens and each child straight after it — and the output is byte for byte the one the collected printer produces. It changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
 	 */
 	streamBlocks?: boolean;
 }
@@ -21578,11 +21578,59 @@ declare class PrintContext<TPath, TNode> {
 	options: PrintOptions;
 
 	/**
+	 * Hold `text` back as the opener of a node being printed in pieces. Nothing
+	 * reaches the output until {@link flushPending}, so {@link dropPending} can
+	 * still take it back if the node turns out to be empty.
+	 */
+	pushPending(text: string): number;
+
+	/**
+	 * Emit every held-back opener, outermost first — something inside the
+	 * innermost one has content, so all of them do.
+	 */
+	flushPending(): void;
+
+	/**
+	 * Anchor the outermost held-back opener, applied when it is flushed. Openers
+	 * are flushed together, so only the outermost carries one.
+	 */
+	anchorPending(srcOffset?: number, srcLine?: number, srcCol?: number): void;
+	isPending(depth: number): boolean;
+
+	/**
+	 * Drop the innermost held-back opener — its node printed to nothing.
+	 */
+	dropPending(): void;
+	get mark(): number;
+
+	/**
+	 * Forget every node's printed text. A node printed in pieces does this once
+	 * each child is emitted, so the store never holds more than one of them —
+	 * which is also what keeps a recycled node id from reading as an earlier
+	 * node's text.
+	 */
+	dropStore(): void;
+
+	/**
+	 * Drop trailing `charCode`s from the end of the output at or after `from` —
+	 * the separator the piece before a terminator no longer needs. Walks back over
+	 * pieces emptied by {@link retract}, so it sees what the output reads as.
+	 */
+	dropTrailing(from: number, charCode: number): void;
+
+	/**
 	 * Run the node printer for `node` and store what it returns (the grammar calls
 	 * this once the node's visitors and children are done). `path` is on `node`.
 	 */
 	printNode(node: TNode, path: TPath): void;
 	get(node: TNode): string;
+
+	/**
+	 * Take back an already-emitted piece — the printer has since found that a
+	 * later one overrides it. Pieces after it keep their place, so this must not
+	 * be used on a piece something was anchored to (see {@link take}).
+	 */
+	retract(index: number): void;
 
 	/**
 	 * Emit one finished top-level node: first any kept comments that precede it,
@@ -21598,6 +21646,14 @@ declare class PrintContext<TPath, TNode> {
 		srcLine?: number,
 		srcCol?: number
 	): void;
+
+	/**
+	 * Tie whatever is emitted next to a source position: flush the kept comments
+	 * that precede it, then record the mapping. Split out of {@link take} for a
+	 * node printed in pieces, whose first piece is emitted well after the printer
+	 * for it began.
+	 */
+	anchor(srcOffset?: number, srcLine?: number, srcCol?: number): void;
 
 	/**
 	 * Queue a literal to carry through to the output at source offset `pos` — a

--- a/types.d.ts
+++ b/types.d.ts
@@ -5960,6 +5960,11 @@ declare interface CssProcessOptions {
 	 * rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
 	 */
 	convertLengthUnits?: boolean;
+
+	/**
+	 * walk and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Walk-only, and it changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
+	 */
+	streamBlocks?: boolean;
 }
 type DeclarationEstreeIndex =
 	FunctionDeclaration | VariableDeclaration | ClassDeclaration;

--- a/types.d.ts
+++ b/types.d.ts
@@ -21596,7 +21596,14 @@ declare class PrintContext<TPath, TNode> {
 	 * Drop the innermost held-back opener — its node printed to nothing.
 	 */
 	dropPending(): void;
-	get mark(): number;
+
+	/**
+	 * Close off what has been emitted so far and return the index the next piece
+	 * will take. Cutting is the point: a caller bounding a later edit by this
+	 * (see {@link dropTrailing}) must not be able to reach output from before it,
+	 * which a mark taken while the tail was still open would sit in the middle of.
+	 */
+	markCut(): number;
 
 	/**
 	 * Forget every node's printed text. A node printed in pieces does this once

--- a/types.d.ts
+++ b/types.d.ts
@@ -5960,11 +5960,6 @@ declare interface CssProcessOptions {
 	 * rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
 	 */
 	convertLengthUnits?: boolean;
-
-	/**
-	 * walk, print and recycle a block's children as each finishes, so peak storage is the open path rather than the whole block (default false). Printing streams too — the rule's `prelude{` goes out when the block opens and each child straight after it — and the output is byte for byte the one the collected printer produces. It changes what a streamed rule reports about its own block: the children reach the visitors instead of the body, so `A.declarations` / `A.childRules` read as an empty block, and they reach the visitors in source order rather than every declaration before every child rule. Each child still carries the sibling index the collected walk gives it, and a block too small to be worth streaming is walked collected
-	 */
-	streamBlocks?: boolean;
 }
 type DeclarationEstreeIndex =
 	FunctionDeclaration | VariableDeclaration | ClassDeclaration;
@@ -26127,7 +26122,16 @@ declare class SourceProcessorSyntaxClass_2 extends SourceProcessorClass<
 		prelude(n?: NodeSyntax): ComponentValue[];
 		childCount(n?: NodeSyntax): number;
 		childAt(n: NodeSyntax, i: number): ComponentValue;
+		/**
+		 * A block big enough to stream hands its children to the visitors as each one
+		 * finishes rather than collecting them, so both lists read as an empty block
+		 * on it — `null`, which means no block at all, is still only for the `@…;`
+		 * forms. Read a block's children from the walk, not from here.
+		 */
 		declarations(n?: NodeSyntax): null | DeclarationSyntax[];
+		/**
+		 * Reads as an empty block on a streamed rule; see {@link declarations }.
+		 */
 		childRules(n?: NodeSyntax): null | RuleSyntax[];
 		blockStart(n?: NodeSyntax): number;
 		blockEnd(n?: NodeSyntax): number;
@@ -29201,7 +29205,16 @@ declare namespace exports {
 				prelude(n?: NodeSyntax): ComponentValue[];
 				childCount(n?: NodeSyntax): number;
 				childAt(n: NodeSyntax, i: number): ComponentValue;
+				/**
+				 * A block big enough to stream hands its children to the visitors as each one
+				 * finishes rather than collecting them, so both lists read as an empty block
+				 * on it — `null`, which means no block at all, is still only for the `@…;`
+				 * forms. Read a block's children from the walk, not from here.
+				 */
 				declarations(n?: NodeSyntax): null | DeclarationSyntax[];
+				/**
+				 * Reads as an empty block on a streamed rule; see {@link declarations }.
+				 */
 				childRules(n?: NodeSyntax): null | RuleSyntax[];
 				blockStart(n?: NodeSyntax): number;
 				blockEnd(n?: NodeSyntax): number;
@@ -29346,7 +29359,16 @@ declare namespace exports {
 					prelude(n?: NodeSyntax): ComponentValue[];
 					childCount(n?: NodeSyntax): number;
 					childAt(n: NodeSyntax, i: number): ComponentValue;
+					/**
+					 * A block big enough to stream hands its children to the visitors as each one
+					 * finishes rather than collecting them, so both lists read as an empty block
+					 * on it — `null`, which means no block at all, is still only for the `@…;`
+					 * forms. Read a block's children from the walk, not from here.
+					 */
 					declarations(n?: NodeSyntax): null | DeclarationSyntax[];
+					/**
+					 * Reads as an empty block on a streamed rule; see {@link declarations }.
+					 */
 					childRules(n?: NodeSyntax): null | RuleSyntax[];
 					blockStart(n?: NodeSyntax): number;
 					blockEnd(n?: NodeSyntax): number;
@@ -29387,7 +29409,16 @@ declare namespace exports {
 						prelude(n?: NodeSyntax): ComponentValue[];
 						childCount(n?: NodeSyntax): number;
 						childAt(n: NodeSyntax, i: number): ComponentValue;
+						/**
+						 * A block big enough to stream hands its children to the visitors as each one
+						 * finishes rather than collecting them, so both lists read as an empty block
+						 * on it — `null`, which means no block at all, is still only for the `@…;`
+						 * forms. Read a block's children from the walk, not from here.
+						 */
 						declarations(n?: NodeSyntax): null | DeclarationSyntax[];
+						/**
+						 * Reads as an empty block on a streamed rule; see {@link declarations }.
+						 */
 						childRules(n?: NodeSyntax): null | RuleSyntax[];
 						blockStart(n?: NodeSyntax): number;
 						blockEnd(n?: NodeSyntax): number;

--- a/types.d.ts
+++ b/types.d.ts
@@ -21626,6 +21626,14 @@ declare class PrintContext<TPath, TNode> {
 	get(node: TNode): string;
 
 	/**
+	 * Append `text` as a piece of its own, so {@link retract} can still take it
+	 * back once a later sibling turns out to override it. Cuts the accumulating
+	 * tail off in front of it, so it is for the text that may actually be taken
+	 * back and not for output at large.
+	 */
+	emitRetractable(text: string): number;
+
+	/**
 	 * Take back an already-emitted piece — the printer has since found that a
 	 * later one overrides it. Pieces after it keep their place, so this must not
 	 * be used on a piece something was anchored to (see {@link take}).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The CSS grammar streams and recycles per *top-level* node, so anything wrapped in one large block holds its whole subtree: 20k rules inside a single `@media` keep 8.05 MiB of columns, against 0 for the same rules written flat. This enters a rule once its block grows past a threshold, then walks and recycles each later child as it completes, so peak storage is the open path rather than the block. Draft: the memory goal is met on every shape, CPU is not yet at parity (see below).

Measured, 20k rules per shape, walk-only, interleaved min-of-N:

| shape | CPU | memory before | memory after |
| --- | ---: | ---: | ---: |
| `@media { …20k… }` | +1.8% | 8.05 MiB | **0** |
| `@supports { …20k… }` | +4.5% | 8.05 MiB | **0** |
| `@media{@supports{ … }}` | +4.1% | 8.05 MiB | **0** |
| CSS nesting in one rule | +1.9% | 4.39 MiB | **0** |
| flat (each rule top-level) | +7.4% | 0 | 0 |
| many small `@media` | +7.7% | 0 | 0 |

Streaming is opt-in (`streamBlocks`) and walk-only, so nothing in `CssParser` or the printer changes yet.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Not yet — draft. Verified so far with a differential against the non-streaming walk (27 shapes including six past 6,000 rules): 0 sequence differences, every delta being the provisional `end` reported at `enter`, 0 at `exit`. Existing suites are unaffected because streaming is opt-in: 320/320 `CssSyntax` unit tests and 917/917 `configCases/css`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — opt-in and off by default. Two semantic notes for when it is enabled: a rule entered before its block closes reports a provisional `end` at `enter` (final at `exit`), and a streamed rule hands its children to the visitors instead of collecting them, so `A.declarations` / `A.childRules` read empty on it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — internal parser option, not part of the public config surface.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to implement this change and to run the measurements and the differential harness reported above. All numbers in this description are from runs on this branch against `main`; the design decisions and the correctness checks were reviewed by a human before each commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeEiGFFPameQQphZXcKbfa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved processing of large and deeply nested CSS blocks through incremental streaming.
  - Reduced memory usage during CSS parsing and printing while preserving source order.

- **Bug Fixes**
  - Improved handling of empty rules, duplicate declarations, comments, minified output, and nested blocks.
  - Prevented shutdown-related crashes during Bun test execution.

- **Reliability**
  - Improved source-map generation and processing stability.
  - Expanded coverage for traversal, skipped children, error recovery, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->