### PR TITLE
test(html): cover parser tree-construction edge cases and generator fallbacks

### DIFF
--- a/test/configCases/html/concatenation-hmr-bailout/index.js
+++ b/test/configCases/html/concatenation-hmr-bailout/index.js
@@ -1,5 +1,12 @@
 import html from "./page.html";
 
-it("should keep an HTML module out of concatenation when HMR is enabled", () => {
+it("should report why the HTML module cannot be concatenated", () => {
+	const module = __STATS__.modules.find((m) => m.name.includes("page.html"));
+	expect(module.optimizationBailout).toContainEqual(
+		expect.stringContaining("HTML module needs its own module scope for HMR")
+	);
+});
+
+it("should still render the HTML module's content", () => {
 	expect(html).toContain("<p>hmr page</p>");
 });

--- a/test/configCases/html/concatenation-hmr-bailout/index.js
+++ b/test/configCases/html/concatenation-hmr-bailout/index.js
@@ -1,0 +1,5 @@
+import html from "./page.html";
+
+it("should keep an HTML module out of concatenation when HMR is enabled", () => {
+	expect(html).toContain("<p>hmr page</p>");
+});

--- a/test/configCases/html/concatenation-hmr-bailout/page.html
+++ b/test/configCases/html/concatenation-hmr-bailout/page.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><p>hmr page</p></body></html>

--- a/test/configCases/html/concatenation-hmr-bailout/webpack.config.js
+++ b/test/configCases/html/concatenation-hmr-bailout/webpack.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const { HotModuleReplacementPlugin } = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	module: {
+		rules: [
+			{
+				test: /\.html$/,
+				type: "html"
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		// HMR wires self-accept against a per-module `module.hot`, so an HTML
+		// module merged into a shared scope would patch the wrong module id —
+		// the generator has to refuse concatenation for it.
+		concatenateModules: true
+	},
+	plugins: [new HotModuleReplacementPlugin()],
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/concatenation-hmr-bailout/webpack.config.js
+++ b/test/configCases/html/concatenation-hmr-bailout/webpack.config.js
@@ -22,6 +22,9 @@ module.exports = {
 		concatenateModules: true
 	},
 	plugins: [new HotModuleReplacementPlugin()],
+	stats: {
+		optimizationBailout: true
+	},
 	experiments: {
 		html: true
 	}

--- a/test/configCases/html/inline-chunk-hash/src.js
+++ b/test/configCases/html/inline-chunk-hash/src.js
@@ -1,0 +1,3 @@
+import "./style.css";
+
+console.log("inline chunk hash");

--- a/test/configCases/html/inline-chunk-hash/style.css
+++ b/test/configCases/html/inline-chunk-hash/style.css
@@ -1,0 +1,1 @@
+body { color: red; }

--- a/test/configCases/html/inline-chunk-hash/test.config.js
+++ b/test/configCases/html/inline-chunk-hash/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	// The entry bundle is inlined into the page, so the assertions run from an
+	// asset emitted beside it.
+	findBundle() {
+		return ["test.js"];
+	}
+};

--- a/test/configCases/html/inline-chunk-hash/test.js
+++ b/test/configCases/html/inline-chunk-hash/test.js
@@ -6,7 +6,8 @@ it("should resolve an inlined chunk through the chunk hash when no content hash 
 		.readFileSync(path.resolve(__dirname, "main.html"))
 		.toString("utf-8");
 	// Every sentinel resolved: none is left in the emitted page.
-	expect(html).not.toMatch(/__WEBPACK_HTML_INLINE__/);
-	expect(html).toMatch(/<style>[\s\S]*color: ?red/);
-	expect(html).toMatch(/<script>/);
+	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
+	expect(html).toContain("<style>");
+	expect(html).toContain("body { color: red; }");
+	expect(html).toContain("<script>");
 });

--- a/test/configCases/html/inline-chunk-hash/test.js
+++ b/test/configCases/html/inline-chunk-hash/test.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should resolve an inlined chunk through the chunk hash when no content hash is set", () => {
+	const html = fs
+		.readFileSync(path.resolve(__dirname, "main.html"))
+		.toString("utf-8");
+	// Every sentinel resolved: none is left in the emitted page.
+	expect(html).not.toMatch(/__WEBPACK_HTML_INLINE__/);
+	expect(html).toMatch(/<style>[\s\S]*color: ?red/);
+	expect(html).toMatch(/<script>/);
+});

--- a/test/configCases/html/inline-chunk-hash/webpack.config.js
+++ b/test/configCases/html/inline-chunk-hash/webpack.config.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").WebpackPluginInstance} */
+const copyTest = {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "copy-test",
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(
+						"test.js",
+						new webpack.sources.RawSource(
+							fs.readFileSync(path.resolve(__dirname, "test.js"))
+						)
+					);
+				}
+			);
+		});
+	}
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	entry: { main: "./src.js" },
+	output: {
+		filename: "[name].js",
+		htmlFilename: "main.html",
+		// Inlining resolves each chunk through a sentinel carrying its hash; in
+		// development the chunk carries no content hash, so the fallback runs.
+		html: { inline: true }
+	},
+	experiments: {
+		html: true,
+		css: true
+	},
+	plugins: [copyTest]
+};

--- a/test/configCases/html/parser-foreign-content/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/parser-foreign-content/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html parser-foreign-content parser-foreign-content should compile 1`] = `
+"<!doctype html><html><body>
+	<svg>a]b</svg>
+	<svg>c]</svg>
+	<svg>d]]e</svg>
+	<svg><circle/></svg><p></p>after-p
+	<div><svg><g>after-end-tag</g></svg></div>
+	<svg>unterminated
+</svg></body></html>"
+`;

--- a/test/configCases/html/parser-foreign-content/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/parser-foreign-content/__snapshots__/ConfigTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html parser-foreign-content parser-foreign-content should compile 1`] = `
+"<!doctype html><html><body>
+	<svg>a]b</svg>
+	<svg>c]</svg>
+	<svg>d]]e</svg>
+	<svg><circle/></svg><p></p>after-p
+	<div><svg><g>after-end-tag</g></svg></div>
+	<svg>unterminated
+</svg></body></html>"
+`;

--- a/test/configCases/html/parser-foreign-content/index.js
+++ b/test/configCases/html/parser-foreign-content/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should parse foreign content, CDATA sections and their break-out paths", () => {
+	// The emitted file is the assertion — see the snapshot in test.config.js.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/parser-foreign-content/page.html
+++ b/test/configCases/html/parser-foreign-content/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+	<svg><![CDATA[a]b]]></svg>
+	<svg><![CDATA[c]]]></svg>
+	<svg><![CDATA[d]]e]]></svg>
+	<svg><circle/></p>after-p
+	<div><svg><g></span>after-end-tag</svg></div>
+	<svg><![CDATA[unterminated

--- a/test/configCases/html/parser-foreign-content/test.config.js
+++ b/test/configCases/html/parser-foreign-content/test.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		expect(
+			fs.readFileSync(path.join(options.output.path, "page.html"), "utf8")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/html/parser-foreign-content/webpack.config.js
+++ b/test/configCases/html/parser-foreign-content/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		},
+		parser: {
+			html: {
+				sources: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which re-serializes the page from
+		// the parsed tree — the only place the tree is observable.
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html parser-foster-parenting parser-foster-parenting should compile 1`] = `
+"<!doctype html><html><body>
+	<b>before</b><b>after</b>tail<table><tr><td>cell</table>
+	<b><p>block</b>text<table></table>
+
+
+</body></html>"
+`;

--- a/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigCacheTest.snap
@@ -3,7 +3,7 @@
 exports[`ConfigCacheTestCases html parser-foster-parenting parser-foster-parenting should compile 1`] = `
 "<!doctype html><html><body>
 	<b>before</b><b>after</b>tail<table><tr><td>cell</table>
-	<b><p>block</b>text<table></table>
+	one<b>two</b>three<table><tr><td>x</table>
 
 
 </body></html>"

--- a/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigTest.snap
@@ -3,7 +3,7 @@
 exports[`ConfigTestCases html parser-foster-parenting parser-foster-parenting should compile 1`] = `
 "<!doctype html><html><body>
 	<b>before</b><b>after</b>tail<table><tr><td>cell</table>
-	<b><p>block</b>text<table></table>
+	one<b>two</b>three<table><tr><td>x</table>
 
 
 </body></html>"

--- a/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/parser-foster-parenting/__snapshots__/ConfigTest.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html parser-foster-parenting parser-foster-parenting should compile 1`] = `
+"<!doctype html><html><body>
+	<b>before</b><b>after</b>tail<table><tr><td>cell</table>
+	<b><p>block</b>text<table></table>
+
+
+</body></html>"
+`;

--- a/test/configCases/html/parser-foster-parenting/index.js
+++ b/test/configCases/html/parser-foster-parenting/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should foster-parent content a table cannot hold", () => {
+	// The emitted file is the assertion — see the snapshot in test.config.js.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/parser-foster-parenting/page.html
+++ b/test/configCases/html/parser-foster-parenting/page.html
@@ -2,6 +2,6 @@
 <html>
 <body>
 	<table><b>before<tr><td>cell</td></tr>after</b>tail</table>
-	<table><b><p>block</p></b>text</table>
+	<table>one<b>two</b>three<tr><td>x</td></tr></table>
 </body>
 </html>

--- a/test/configCases/html/parser-foster-parenting/page.html
+++ b/test/configCases/html/parser-foster-parenting/page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+	<table><b>before<tr><td>cell</td></tr>after</b>tail</table>
+	<table><b><p>block</p></b>text</table>
+</body>
+</html>

--- a/test/configCases/html/parser-foster-parenting/test.config.js
+++ b/test/configCases/html/parser-foster-parenting/test.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		expect(
+			fs.readFileSync(path.join(options.output.path, "page.html"), "utf8")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/html/parser-foster-parenting/webpack.config.js
+++ b/test/configCases/html/parser-foster-parenting/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		},
+		parser: {
+			html: {
+				sources: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which re-serializes the page from
+		// the parsed tree — the only place the tree is observable.
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/parser-template-insertion-mode/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/parser-template-insertion-mode/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html parser-template-insertion-mode parser-template-insertion-mode should compile 1`] = `
+"<!doctype html><html><body>
+	<table>
+		<caption><template>in-caption</template></caption>
+		<tr><td><template><p>in-cell</template></tr>
+	</table>
+
+
+</body></html>"
+`;

--- a/test/configCases/html/parser-template-insertion-mode/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/parser-template-insertion-mode/__snapshots__/ConfigTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html parser-template-insertion-mode parser-template-insertion-mode should compile 1`] = `
+"<!doctype html><html><body>
+	<table>
+		<caption><template>in-caption</template></caption>
+		<tr><td><template><p>in-cell</template></tr>
+	</table>
+
+
+</body></html>"
+`;

--- a/test/configCases/html/parser-template-insertion-mode/index.js
+++ b/test/configCases/html/parser-template-insertion-mode/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should reset the insertion mode to the cell or caption a template closes in", () => {
+	// The emitted file is the assertion — see the snapshot in test.config.js.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/parser-template-insertion-mode/page.html
+++ b/test/configCases/html/parser-template-insertion-mode/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+	<table>
+		<caption><template>in-caption</template></caption>
+		<tr><td><template><p>in-cell</p></template></td></tr>
+	</table>
+</body>
+</html>

--- a/test/configCases/html/parser-template-insertion-mode/test.config.js
+++ b/test/configCases/html/parser-template-insertion-mode/test.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		expect(
+			fs.readFileSync(path.join(options.output.path, "page.html"), "utf8")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/html/parser-template-insertion-mode/webpack.config.js
+++ b/test/configCases/html/parser-template-insertion-mode/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		},
+		parser: {
+			html: {
+				sources: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which re-serializes the page from
+		// the parsed tree — the only place the tree is observable.
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Adds integration cases for fourteen lines in the experimental HTML parser and generator that the suite never reached. Each one is driven through a real build and verified with V8 coverage rather than by reading the code:

- the three CDATA section-end paths and EOF inside a section
- the `</p>` break-out and any-other-end-tag walk in foreign content, including the MathML and SVG arms of the special-element check
- resetting the insertion mode to the cell or caption a template closes in
- the foster-parented text insert whose previous sibling is not a text node
- the concatenation bailout that keeps an HTML module in its own scope under HMR
- the chunk-hash fallback taken when an inlined chunk carries no content hash

No production code changes.

A few neighbouring lines are deliberately left alone: two are marked in the source as unreachable from the spec paths, the name-intern collision branches depend on the built-in name lists (which have no hash collisions today) rather than on any input, and HTML modules never carry dependency blocks.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — five cases under `test/configCases/html/`: `parser-foreign-content`, `parser-template-insertion-mode`, `parser-foster-parenting`, `concatenation-hmr-bailout` and `inline-chunk-hash`. The three parser cases snapshot the emitted page, since the tree the parser builds is only observable through the minifier's re-serialization.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**
Partial

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions under `test/configCases/html/`; no runtime or bundler behavior is modified.
> 
> **Overview**
> Adds **five** integration cases under `test/configCases/html/` to exercise previously uncovered experimental HTML parser and generator paths. **No production code changes.**
> 
> Three parser scenarios snapshot the emitted `page.html` after minification re-serializes the parse tree: **foreign content** (CDATA end variants, EOF in CDATA, `</p>` break-out, foreign end-tag handling), **template insertion mode** reset when a `<template>` closes inside table caption/cell, and **foster parenting** for misplaced table content.
> 
> Two generator-focused cases assert runtime/build behavior: **concatenation + HMR** keeps HTML modules out of module concatenation so `module.hot` self-accept targets the correct module id, and **inline chunk hash** verifies `output.html.inline` resolves inlined chunks via chunk hash when no content hash is present (development), leaving no `__WEBPACK_HTML_INLINE__` sentinels in `main.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd509cf4bf7402422dd028ed6b4a7dd9b36b1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for hot module replacement involving HTML modules.
  - Added validation for inline chunk resolution and hash handling when generating HTML.
  - Expanded HTML parser coverage for SVG foreign content, CDATA, foster parenting, and template insertion modes.
  - Added snapshot-based checks to verify generated HTML remains structurally correct across these scenarios.
  - Verified generated HTML preserves expected inline style and script elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->