### PR TITLE
test: cover rebuilding an entry that lives under the context

### DIFF
--- a/test/watchCases/resolve/entry-subdirectory-context/0/src/index.js
+++ b/test/watchCases/resolve/entry-subdirectory-context/0/src/index.js
@@ -1,0 +1,5 @@
+const value = 1;
+
+it("should rebuild an entry that lives below the context", () => {
+	expect(value).toBe(WATCH_STEP === "0" ? 1 : 2);
+});

--- a/test/watchCases/resolve/entry-subdirectory-context/1/src/index.js
+++ b/test/watchCases/resolve/entry-subdirectory-context/1/src/index.js
@@ -1,0 +1,5 @@
+const value = 2;
+
+it("should rebuild an entry that lives below the context", () => {
+	expect(value).toBe(WATCH_STEP === "0" ? 1 : 2);
+});

--- a/test/watchCases/resolve/entry-subdirectory-context/loader.js
+++ b/test/watchCases/resolve/entry-subdirectory-context/loader.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/**
+ * @param {string} source source
+ * @returns {string} source
+ */
+module.exports = (source) => source;

--- a/test/watchCases/resolve/entry-subdirectory-context/test.config.js
+++ b/test/watchCases/resolve/entry-subdirectory-context/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	findBundle: () => "./bundle.js"
+};

--- a/test/watchCases/resolve/entry-subdirectory-context/webpack.config.js
+++ b/test/watchCases/resolve/entry-subdirectory-context/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	// entry lives below the context; re-factorizing must resolve the request
+	// against the context, not against the entry module's own directory
+	entry: "./src/index.js",
+	output: {
+		filename: "bundle.js"
+	},
+	module: {
+		rules: [
+			{
+				// a loader makes the entry re-runnable through the factory pipeline
+				test: /index\.js$/,
+				use: path.resolve(__dirname, "loader.js")
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Add one failed test case for https://github.com/webpack/webpack/pull/21556.

I hit this while test incremental rebuild locally: the first build was fine, and then editing the entry made every following rebuild fail with

```
ModuleNotFoundError: Module not found: Error: Can't resolve './src/index.js' in '<context>/src'
```

because the rebuild re-resolved the entry request from the entry module's directory and probed `<context>/src/src/index.js`.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->
Partial

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a watch integration test fixture; no library or build logic is modified.
> 
> **Overview**
> Adds a **watchCases** regression test for incremental rebuilds when the entry path is **below** the compilation context (e.g. `./src/index.js`).
> 
> The scenario uses a loader on the entry so it goes through the module factory again on rebuild, and two watch steps (`0/` and `1/`) that change `src/index.js` and assert `WATCH_STEP`-dependent behavior. The config comments spell out the expected fix: on re-factorization, the entry request must be resolved from the **context**, not from the entry module’s directory (which would incorrectly probe `src/src/index.js`).
> 
> This is **test-only** coverage tied to PR #21556; no webpack runtime changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0670d0762b74519d97e68a4310183c3115b0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->