### PR TITLE
fix(css): keep the token boundary a dropped comment stood for

### DIFF
--- a/.changeset/033-css-comment-parts-value-components.md
+++ b/.changeset/033-css-comment-parts-value-components.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep two value components a comment parts apart when minifying CSS.

--- a/.changeset/033-css-comment-parts-value-components.md
+++ b/.changeset/033-css-comment-parts-value-components.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep the tokens a comment parts apart when minifying CSS: a value's components, a custom property's value and a selector, where the separator stays a comment.
+Minify a dropped CSS comment to the token boundary it stood for.

--- a/.changeset/033-css-comment-parts-value-components.md
+++ b/.changeset/033-css-comment-parts-value-components.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep two value components a comment parts apart when minifying CSS.
+Keep the tokens a comment parts apart when minifying CSS: a value's components, a custom property's value and a selector, where the separator stays a comment.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -7384,10 +7384,12 @@ const printer = (path, writer) => {
 					// substitution would read. Verbatim, then: the source slice rather
 					// than the children joined, which would drop a comment standing
 					// between two of them and fuse the tokens it parts.
-					value = _input.slice(
-						path.start(children[0]),
-						path.end(children[children.length - 1])
-					);
+					const from = path.start(children[0]);
+					const to = path.end(children[children.length - 1]);
+					value = _input.slice(from, to);
+					// A kept comment in there rides along in the slice, so the copy the
+					// writer would re-emit before the next top-level node is dropped.
+					if (minify) writer.dropInserts(from, to);
 				} else if (property === "unicode-range") {
 					// `U+…` tokenizes as numbers, so the generic numeric normalization
 					// would corrupt it; each range is shortened as the urange it is.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -6093,6 +6093,36 @@ const _valueComponents = (path, children, writer) => {
 };
 
 /**
+ * A custom property's value as written — the tokens are the value, and the
+ * CSSOM hands this text back, so nothing in it is rewritten. A comment is the
+ * one exception: it is no tree node, so it survives as the gap it leaves
+ * between two children, and minifying prints that gap as the token boundary it
+ * stands for — the kept comments in it where they stood, otherwise a space, and
+ * nothing at all where the tokens either side already part.
+ * @param {CssPath} path the accessor positioned on the declaration
+ * @param {ComponentValue[]} children the value's children
+ * @param {PrintContext} writer the print context (holds the kept comments)
+ * @returns {string} the printed value
+ */
+const _customPropertyValue = (path, children, writer) => {
+	let out = "";
+	let previousEnd = -1;
+	for (const child of children) {
+		const source = path.source(child);
+		const start = path.start(child);
+		if (previousEnd !== -1 && start !== previousEnd) {
+			// Every other token is a child of its own, so the gap is comments only.
+			const kept = writer.takeInserts(previousEnd, start);
+			if (kept !== "") out += kept;
+			else if (_wouldFuseTokens(out, source)) out += " ";
+		}
+		out += source;
+		previousEnd = path.end(child);
+	}
+	return out;
+};
+
+/**
  * Split top-level components into the layers a comma parts. A comma is no
  * separator of its own, so it rides on the component it follows and a layer's
  * last component has to be cut back out of it.
@@ -7381,15 +7411,14 @@ const printer = (path, writer) => {
 					// A custom property's value is the text `getPropertyValue()` hands
 					// back, so rewriting it builds a different CSSOM from the same
 					// document — which `SyntaxBrowserEquivalence` forbids, whatever a
-					// substitution would read. Verbatim, then: the source slice rather
-					// than the children joined, which would drop a comment standing
-					// between two of them and fuse the tokens it parts.
-					const from = path.start(children[0]);
-					const to = path.end(children[children.length - 1]);
-					value = _input.slice(from, to);
-					// A kept comment in there rides along in the slice, so the copy the
-					// writer would re-emit before the next top-level node is dropped.
-					if (minify) writer.dropInserts(from, to);
+					// substitution would read. As written, then; only the comments in it
+					// minify, down to the boundary they stand for.
+					value = minify
+						? _customPropertyValue(path, children, writer)
+						: _input.slice(
+								path.start(children[0]),
+								path.end(children[children.length - 1])
+							);
 				} else if (property === "unicode-range") {
 					// `U+…` tokenizes as numbers, so the generic numeric normalization
 					// would corrupt it; each range is shortened as the urange it is.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4343,8 +4343,10 @@ const _join = (parts, beautify, trim = _TRIM_NOTHING) => {
 			pending = false;
 		} else if (out.length !== 0 && _wouldFuseTokens(out, f)) {
 			// Nothing separated these in source (a comment stood here, or a token was
-			// rewritten), yet joining them would read back as one token.
-			out += " ";
+			// rewritten), yet joining them would read back as one token. Whitespace
+			// is a descendant combinator in a selector, so there only an empty
+			// comment parts them without saying anything the source did not.
+			out += trim === _TRIM_COMBINATORS ? "/**/" : " ";
 		}
 		out += f;
 		last = f.charCodeAt(f.length - 1);
@@ -7379,8 +7381,13 @@ const printer = (path, writer) => {
 					// A custom property's value is the text `getPropertyValue()` hands
 					// back, so rewriting it builds a different CSSOM from the same
 					// document — which `SyntaxBrowserEquivalence` forbids, whatever a
-					// substitution would read. Verbatim, then.
-					value = children.map((c) => path.source(c)).join("");
+					// substitution would read. Verbatim, then: the source slice rather
+					// than the children joined, which would drop a comment standing
+					// between two of them and fuse the tokens it parts.
+					value = _input.slice(
+						path.start(children[0]),
+						path.end(children[children.length - 1])
+					);
 				} else if (property === "unicode-range") {
 					// `U+…` tokenizes as numbers, so the generic numeric normalization
 					// would corrupt it; each range is shortened as the urange it is.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -6093,33 +6093,86 @@ const _valueComponents = (path, children, writer) => {
 };
 
 /**
+ * What a comment-only gap in a custom property's value prints as: the kept
+ * comments in it where they stood, otherwise the boundary it stands for — a
+ * space where the tokens either side would fuse, and nothing where they part.
+ * @param {PrintContext} writer the print context (holds the kept comments)
+ * @param {number} start first source offset of the gap
+ * @param {number} end offset past its last
+ * @param {string} out the value printed so far
+ * @param {string} next the token about to follow it (empty at the end)
+ * @returns {string} the gap's text
+ */
+const _customPropertyGap = (writer, start, end, out, next) => {
+	const kept = writer.takeInserts(start, end);
+	if (kept !== "") return kept;
+	return next !== "" && _wouldFuseTokens(out, next) ? " " : "";
+};
+
+/**
  * A custom property's value as written — the tokens are the value, and the
  * CSSOM hands this text back, so nothing in it is rewritten. A comment is the
- * one exception: it is no tree node, so it survives as the gap it leaves
- * between two children, and minifying prints that gap as the token boundary it
- * stands for — the kept comments in it where they stood, otherwise a space, and
- * nothing at all where the tokens either side already part.
+ * one exception: it is no tree node, so it survives as a gap between two of
+ * them, which {@link _customPropertyGap} prints as the boundary it stood for.
  * @param {CssPath} path the accessor positioned on the declaration
- * @param {ComponentValue[]} children the value's children
+ * @param {ComponentValue[]} children the tokens to print
  * @param {PrintContext} writer the print context (holds the kept comments)
+ * @param {number} from source offset the tokens start at
+ * @param {number} to source offset they end at
  * @returns {string} the printed value
  */
-const _customPropertyValue = (path, children, writer) => {
+const _customPropertyValue = (path, children, writer, from, to) => {
 	let out = "";
-	let previousEnd = -1;
+	let at = from;
 	for (const child of children) {
-		const source = path.source(child);
+		const text = _customPropertyToken(path, child, writer);
 		const start = path.start(child);
-		if (previousEnd !== -1 && start !== previousEnd) {
-			// Every other token is a child of its own, so the gap is comments only.
-			const kept = writer.takeInserts(previousEnd, start);
-			if (kept !== "") out += kept;
-			else if (_wouldFuseTokens(out, source)) out += " ";
-		}
-		out += source;
-		previousEnd = path.end(child);
+		// Every other token is a child of its own, so a gap is comments only.
+		if (at !== start) out += _customPropertyGap(writer, at, start, out, text);
+		out += text;
+		at = path.end(child);
 	}
+	if (at !== to) out += _customPropertyGap(writer, at, to, out, "");
 	return out;
+};
+
+/**
+ * One token of a custom property's value, as written — recursing into a
+ * function or block so a comment nested in one minifies too. A source holding
+ * no `/*` holds no comment at any depth, so it is written back whole.
+ * @param {CssPath} path the accessor positioned on the declaration
+ * @param {ComponentValue} child the token to print
+ * @param {PrintContext} writer the print context (holds the kept comments)
+ * @returns {string} the printed token
+ */
+const _customPropertyToken = (path, child, writer) => {
+	const source = path.source(child);
+	const type = path.type(child);
+	if (
+		!source.includes("/*") ||
+		(type !== T_FUNCTION && type !== T_SIMPLE_BLOCK)
+	) {
+		return source;
+	}
+	const start = path.start(child);
+	const end = path.end(child);
+	let opened = path.nameEnd(child) + 1;
+	let closer = ")";
+	if (type === T_SIMPLE_BLOCK) {
+		const block = path.blockToken(child);
+		opened = start + 1;
+		closer = block === "[" ? "]" : block === "{" ? "}" : ")";
+	}
+	// Closed at EOF: there is no closer to write back, and it ends the value.
+	const closed = _input[end - 1] === closer;
+	const inner = _customPropertyValue(
+		path,
+		path.children(child),
+		writer,
+		opened,
+		closed ? end - 1 : end
+	);
+	return `${_input.slice(start, opened)}${inner}${closed ? closer : ""}`;
 };
 
 /**
@@ -7413,12 +7466,11 @@ const printer = (path, writer) => {
 					// document — which `SyntaxBrowserEquivalence` forbids, whatever a
 					// substitution would read. As written, then; only the comments in it
 					// minify, down to the boundary they stand for.
+					const from = path.start(children[0]);
+					const to = path.end(children[children.length - 1]);
 					value = minify
-						? _customPropertyValue(path, children, writer)
-						: _input.slice(
-								path.start(children[0]),
-								path.end(children[children.length - 1])
-							);
+						? _customPropertyValue(path, children, writer, from, to)
+						: _input.slice(from, to);
 				} else if (property === "unicode-range") {
 					// `U+…` tokenizes as numbers, so the generic numeric normalization
 					// would corrupt it; each range is shortened as the urange it is.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -6055,9 +6055,10 @@ const _SUBSTITUTION_RE = new RegExp(
 /**
  * Split a declaration value into its top-level components. Whitespace parts
  * them, and so does a `/` delim — it separates `border-radius`'s two boxes and
- * needs no whitespace of its own. Two children nothing parted stay one
- * component (a comment stood there), which is conservative: it only costs a
- * collapse.
+ * needs no whitespace of its own. A comment is no tree node, so the gap it
+ * leaves between two children parts them too: it ends both tokens, and a
+ * rewritten value joins its components with a space that has to stand where
+ * the comment did.
  * @param {CssPath} path the accessor positioned on the declaration
  * @param {ComponentValue[]} children the value's children
  * @param {PrintContext} writer the print context (children's printed text)
@@ -6067,9 +6068,16 @@ const _valueComponents = (path, children, writer) => {
 	/** @type {string[]} */
 	const components = [];
 	let current = "";
+	let previousEnd = -1;
 	for (const child of children) {
 		const type = path.type(child);
 		const text = writer.get(child);
+		const start = path.start(child);
+		if (current.length !== 0 && start !== previousEnd) {
+			components.push(current);
+			current = "";
+		}
+		previousEnd = path.end(child);
 		if (type === T_WHITESPACE || (type === T_DELIM && text === "/")) {
 			if (current.length !== 0) components.push(current);
 			current = "";

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -230,18 +230,31 @@ class PrintContext {
 	}
 
 	/**
-	 * Drop the queued inserts sitting in `[start, end)` — a printer that wrote
-	 * that source range out verbatim already carries them, in place.
+	 * Take the queued inserts sitting in `[start, end)` — a printer that writes
+	 * that source range out itself places them, so the writer must not flush
+	 * them ahead of the next top-level node as well.
 	 * @param {number} start first source offset of the range
 	 * @param {number} end offset past its last
+	 * @returns {string} their text, in source order
 	 */
-	dropInserts(start, end) {
+	takeInserts(start, end) {
 		const inserts = this._inserts;
-		for (let i = this._insertIdx; i < inserts.length; i++) {
-			const pos = inserts[i][0];
-			if (pos >= end) break;
-			if (pos >= start) inserts[i][1] = "";
+		// `_insertIdx` only moves on a flush, so walking from it would scan every
+		// insert the enclosing rule queued before this range again — quadratic over
+		// a rule's declarations. They arrive in source order, so binary search in.
+		let low = this._insertIdx;
+		let high = inserts.length;
+		while (low < high) {
+			const middle = (low + high) >> 1;
+			if (inserts[middle][0] < start) low = middle + 1;
+			else high = middle;
 		}
+		let out = "";
+		for (let i = low; i < inserts.length && inserts[i][0] < end; i++) {
+			out += inserts[i][1];
+			inserts[i][1] = "";
+		}
+		return out;
 	}
 
 	/**

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -230,6 +230,21 @@ class PrintContext {
 	}
 
 	/**
+	 * Drop the queued inserts sitting in `[start, end)` — a printer that wrote
+	 * that source range out verbatim already carries them, in place.
+	 * @param {number} start first source offset of the range
+	 * @param {number} end offset past its last
+	 */
+	dropInserts(start, end) {
+		const inserts = this._inserts;
+		for (let i = this._insertIdx; i < inserts.length; i++) {
+			const pos = inserts[i][0];
+			if (pos >= end) break;
+			if (pos >= start) inserts[i][1] = "";
+		}
+	}
+
+	/**
 	 * Emit every queued insert positioned before source offset `pos` (all of them
 	 * for `Infinity`), in source order, so kept comments keep their place relative
 	 * to the rules.
@@ -239,7 +254,7 @@ class PrintContext {
 		const inserts = this._inserts;
 		let i = this._insertIdx;
 		while (i < inserts.length && inserts[i][0] < pos) {
-			this._emit(inserts[i][1]);
+			if (inserts[i][1] !== "") this._emit(inserts[i][1]);
 			i++;
 		}
 		this._insertIdx = i;

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -879,6 +879,7 @@ describe("CssSyntax — minify token-boundary safety", () => {
 		expect(min("a{--x:foo(bar(a/*c*/b))}")).toBe("a{--x:foo(bar(a b))}");
 		expect(min("a{--x:[a/*c*/b]}")).toBe("a{--x:[a b]}");
 		expect(min("a{--x:{a:1/*c*/2}}")).toBe("a{--x:{a:1 2}}");
+		expect(min("a{--x:(a/*c*/b)}")).toBe("a{--x:(a b)}");
 		// Against the delimiters nothing fuses, so the comment simply goes.
 		expect(min("a{--x:foo(/*c*/a/*c*/)}")).toBe("a{--x:foo(a)}");
 		expect(min("a{--x:foo(1px/*c*/2px)/*c*/bar()}")).toBe(

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -856,6 +856,11 @@ describe("CssSyntax — minify token-boundary safety", () => {
 		expect(min("a{--x:1px 1px/**/1px 1px}")).toBe("a{--x:1px 1px/**/1px 1px}");
 		// Leading and trailing whitespace is not part of it.
 		expect(min("a{--x: 1px 2px }")).toBe("a{--x:1px 2px}");
+		// A kept comment rides along in the value, so it is not also re-emitted
+		// before the next top-level node.
+		expect(min("a{--x:1px/*!c*/2px}b{c:1}")).toBe("a{--x:1px/*!c*/2px}b{c:1}");
+		// Outside one it still moves ahead of the rule that follows it.
+		expect(min("a{c:red/*!c*/}b{c:1}")).toBe("a{c:red}/*!c*/b{c:1}");
 	});
 
 	it("separates rewritten numbers that would fuse", () => {

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -872,6 +872,26 @@ describe("CssSyntax — minify token-boundary safety", () => {
 		expect(min("a{c:red/*!c*/}b{c:1}")).toBe("a{c:red}/*!c*/b{c:1}");
 	});
 
+	it("minifies a comment nested in a custom property's value", () => {
+		// A function or block is no leaf, so the comments in one are the value's
+		// too — at any depth, and in a block of every shape.
+		expect(min("a{--x:foo(a/*c*/b)}")).toBe("a{--x:foo(a b)}");
+		expect(min("a{--x:foo(bar(a/*c*/b))}")).toBe("a{--x:foo(bar(a b))}");
+		expect(min("a{--x:[a/*c*/b]}")).toBe("a{--x:[a b]}");
+		expect(min("a{--x:{a:1/*c*/2}}")).toBe("a{--x:{a:1 2}}");
+		// Against the delimiters nothing fuses, so the comment simply goes.
+		expect(min("a{--x:foo(/*c*/a/*c*/)}")).toBe("a{--x:foo(a)}");
+		expect(min("a{--x:foo(1px/*c*/2px)/*c*/bar()}")).toBe(
+			"a{--x:foo(1px 2px)bar()}"
+		);
+		// Whitespace is a token of its own, so it is still written as it stands.
+		expect(min("a{--x:foo( /*c*/ a )}")).toBe("a{--x:foo(  a )}");
+		// A kept one is placed where it stood, at depth too.
+		expect(min("a{--x:foo(a/*!k*/b)}")).toBe("a{--x:foo(a/*!k*/b)}");
+		// A function closed at EOF has no `)` to write back.
+		expect(min("a{--x:foo(a/*c*/b")).toBe("a{--x:foo(a b}");
+	});
+
 	it("separates rewritten numbers that would fuse", () => {
 		// `1.0.5` is two numbers; normalized to `1` and `.5` they would join as the
 		// single number `1.5`.

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -837,6 +837,27 @@ describe("CssSyntax — minify token-boundary safety", () => {
 		);
 	});
 
+	it("parts a selector's tokens with a comment rather than whitespace", () => {
+		// Whitespace between two of a selector's tokens is a descendant combinator,
+		// so the separator a fusing junction needs there is an empty comment: `a b`
+		// would match what `a/**/b` (two adjacent type selectors) never does.
+		expect(min("a/**/b{c:1}")).toBe("a/**/b{c:1}");
+		expect(min("@scope (div/**/span){a{c:1}}")).toBe(
+			"@scope (div/**/span){a{c:1}}"
+		);
+		// A comment the source spelled out where nothing would fuse still goes.
+		expect(min("a/**/ b{c:1}")).toBe("a b{c:1}");
+	});
+
+	it("keeps a custom property's value as the source wrote it", () => {
+		// The value is the text `getPropertyValue()` hands back, so the comment
+		// stays: dropping it would fuse the two tokens it parts.
+		expect(min("a{--x:1px/**/2px}")).toBe("a{--x:1px/**/2px}");
+		expect(min("a{--x:1px 1px/**/1px 1px}")).toBe("a{--x:1px 1px/**/1px 1px}");
+		// Leading and trailing whitespace is not part of it.
+		expect(min("a{--x: 1px 2px }")).toBe("a{--x:1px 2px}");
+	});
+
 	it("separates rewritten numbers that would fuse", () => {
 		// `1.0.5` is two numbers; normalized to `1` and `.5` they would join as the
 		// single number `1.5`.

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -850,15 +850,24 @@ describe("CssSyntax — minify token-boundary safety", () => {
 	});
 
 	it("keeps a custom property's value as the source wrote it", () => {
-		// The value is the text `getPropertyValue()` hands back, so the comment
-		// stays: dropping it would fuse the two tokens it parts.
-		expect(min("a{--x:1px/**/2px}")).toBe("a{--x:1px/**/2px}");
-		expect(min("a{--x:1px 1px/**/1px 1px}")).toBe("a{--x:1px 1px/**/1px 1px}");
+		// The value is the text `getPropertyValue()` hands back, so it is not
+		// rewritten — but a dropped comment leaves the boundary it stood for, which
+		// is a space only where the tokens it parts would otherwise fuse.
+		expect(min("a{--x:1px/*c*/2px}")).toBe("a{--x:1px 2px}");
+		expect(min("a{--x:1px 1px/*c*/1px 1px}")).toBe("a{--x:1px 1px 1px 1px}");
+		expect(min("a{--x:1px /*c*/ 2px}")).toBe("a{--x:1px  2px}");
 		// Leading and trailing whitespace is not part of it.
 		expect(min("a{--x: 1px 2px }")).toBe("a{--x:1px 2px}");
-		// A kept comment rides along in the value, so it is not also re-emitted
-		// before the next top-level node.
+		// A `/*` inside a string is no comment.
+		expect(min('a{--x:"a/*c*/b"}')).toBe('a{--x:"a/*c*/b"}');
+		// A kept comment stays where it stood, so it is not also re-emitted before
+		// the next top-level node — and it parts the tokens itself.
 		expect(min("a{--x:1px/*!c*/2px}b{c:1}")).toBe("a{--x:1px/*!c*/2px}b{c:1}");
+		expect(min("a{--x:1px/*c*//*!k*/2px}")).toBe("a{--x:1px/*!k*/2px}");
+		// One rule's custom properties take their own, in the order they stand in.
+		expect(
+			min("/*!t*/a{--x:1px/*!k*/2px;--y:3px/*c*/4px;--z:5px/*!j*/6px}")
+		).toBe("/*!t*/a{--x:1px/*!k*/2px;--y:3px 4px;--z:5px/*!j*/6px}");
 		// Outside one it still moves ahead of the rule that follows it.
 		expect(min("a{c:red/*!c*/}b{c:1}")).toBe("a{c:red}/*!c*/b{c:1}");
 	});

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2314,6 +2314,26 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 	});
 
+	describe("a comment parting two components", () => {
+		// The comment ends both tokens, so a rewritten value has to keep them apart.
+		it.each([
+			["a{margin:1px 1px/*c*/1px 1px}", "a{margin:1px}"],
+			["a{margin:1px/*c*/2px 1px 2px}", "a{margin:1px 2px}"],
+			["a{box-shadow:1px 1px/*c*/2px 0 red}", "a{box-shadow:1px 1px 2px red}"],
+			[
+				"a{transition:opacity/*c*/1s ease-in 2s}",
+				"a{transition:opacity 1s 2s ease-in}"
+			],
+			["a{background-position:left/*c*/top}", "a{background-position:0%0%}"],
+			[
+				"a{grid-template-columns:1fr/*c*/1fr}",
+				"a{grid-template-columns:1fr 1fr}"
+			]
+		])("%s", (css, expected) => {
+			expect(minify(css)).toBe(expected);
+		});
+	});
+
 	describe("a value holding a substitution", () => {
 		// The engine keeps such a value as the token stream it was written as until
 		// the substitution resolves, so every rewrite inside one is declined.

--- a/test/configCases/css/minimize-selectors/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-selectors/__snapshots__/ConfigCacheTest.snap
@@ -70,5 +70,7 @@ Array [
   "/*! webpack: parted from the compound it is a descendant combinator */* .t71{color:red}",
   "/*! webpack: ...and on its own it is the selector */*{color:red}",
   "/*! webpack: a namespaced universal is not redundant */svg|*,*|*.t72{color:red}",
+  "/*! webpack: whitespace between two type selectors is a descendant combinator,
+   so the comment parting these stays as an empty one */a/**/b{color:red}",
 ]
 `;

--- a/test/configCases/css/minimize-selectors/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-selectors/__snapshots__/ConfigTest.snap
@@ -70,5 +70,7 @@ Array [
   "/*! webpack: parted from the compound it is a descendant combinator */* .t71{color:red}",
   "/*! webpack: ...and on its own it is the selector */*{color:red}",
   "/*! webpack: a namespaced universal is not redundant */svg|*,*|*.t72{color:red}",
+  "/*! webpack: whitespace between two type selectors is a descendant combinator,
+   so the comment parting these stays as an empty one */a/**/b{color:red}",
 ]
 `;

--- a/test/configCases/css/minimize-selectors/style.css
+++ b/test/configCases/css/minimize-selectors/style.css
@@ -167,3 +167,6 @@
 * { color: red }
 /*! webpack: a namespaced universal is not redundant */
 svg|*, *|*.t72 { color: red }
+/*! webpack: whitespace between two type selectors is a descendant combinator,
+   so the comment parting these stays as an empty one */
+a/*c*/b { color: red }

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
@@ -149,6 +149,7 @@ Array [
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
-  "/*! webpack: a custom property's value stays as written, comment included */.t140{--t140:1px 1px/*c*/1px 1px}",
+  "/*! webpack: a custom property's value stays as written, but a comment in it
+   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
@@ -150,6 +150,6 @@ Array [
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
   "/*! webpack: a custom property's value stays as written, but a comment in it
-   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}",
+   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}.t142{--t142:minmax(1px 2px, calc(3px 4px))}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
@@ -149,5 +149,6 @@ Array [
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
+  "/*! webpack: a custom property's value stays as written, comment included */.t140{--t140:1px 1px/*c*/1px 1px}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigCacheTest.snap
@@ -148,5 +148,6 @@ Array [
    5-digit hash would invalidate the shorthand and drop the width and style too */.t137{outline-width:3px;outline-style:dashed;outline-color:#12345}",
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
+  "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
@@ -149,6 +149,7 @@ Array [
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
-  "/*! webpack: a custom property's value stays as written, comment included */.t140{--t140:1px 1px/*c*/1px 1px}",
+  "/*! webpack: a custom property's value stays as written, but a comment in it
+   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
@@ -150,6 +150,6 @@ Array [
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
   "/*! webpack: a custom property's value stays as written, but a comment in it
-   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}",
+   minifies to the boundary it stands for */.t140{--t140:1px 1px 1px 1px}.t141{--t141:1px 1px/*!k*/1px 1px}.t142{--t142:minmax(1px 2px, calc(3px 4px))}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
@@ -149,5 +149,6 @@ Array [
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
   "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
+  "/*! webpack: a custom property's value stays as written, comment included */.t140{--t140:1px 1px/*c*/1px 1px}",
 ]
 `;

--- a/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-values/__snapshots__/ConfigTest.snap
@@ -148,5 +148,6 @@ Array [
    5-digit hash would invalidate the shorthand and drop the width and style too */.t137{outline-width:3px;outline-style:dashed;outline-color:#12345}",
   "/*! webpack: declined: \`list-style-type\` takes any identifier, so no other value
    in the family is unambiguous — an image included */.t133{list-style-type:square;list-style-position:inside;list-style-image:url(data:image/gif;base64,R0lGODlhAQABAAAAACw=)}",
+  "/*! webpack: a comment parts two components, so a rewrite keeps them apart */.t138{margin:1px}.t139{transition:opacity 1s 2s ease-in}",
 ]
 `;

--- a/test/configCases/css/minimize-values/style.css
+++ b/test/configCases/css/minimize-values/style.css
@@ -334,3 +334,4 @@
    minifies to the boundary it stands for */
 .t140 { --t140: 1px 1px/*c*/1px 1px }
 .t141 { --t141: 1px 1px/*!k*/1px 1px }
+.t142 { --t142: minmax(1px/*c*/2px, calc(3px/*c*/4px)) }

--- a/test/configCases/css/minimize-values/style.css
+++ b/test/configCases/css/minimize-values/style.css
@@ -327,3 +327,6 @@
 /*! webpack: declined: `list-style-type` takes any identifier, so no other value
    in the family is unambiguous — an image included */
 .t133 { list-style-type: square; list-style-position: inside; list-style-image: url("data:image/gif;base64,R0lGODlhAQABAAAAACw=") }
+/*! webpack: a comment parts two components, so a rewrite keeps them apart */
+.t138 { margin: 1px 1px/*c*/1px 1px }
+.t139 { transition: opacity/*c*/1s ease-in 2s }

--- a/test/configCases/css/minimize-values/style.css
+++ b/test/configCases/css/minimize-values/style.css
@@ -330,5 +330,7 @@
 /*! webpack: a comment parts two components, so a rewrite keeps them apart */
 .t138 { margin: 1px 1px/*c*/1px 1px }
 .t139 { transition: opacity/*c*/1s ease-in 2s }
-/*! webpack: a custom property's value stays as written, comment included */
+/*! webpack: a custom property's value stays as written, but a comment in it
+   minifies to the boundary it stands for */
 .t140 { --t140: 1px 1px/*c*/1px 1px }
+.t141 { --t141: 1px 1px/*!k*/1px 1px }

--- a/test/configCases/css/minimize-values/style.css
+++ b/test/configCases/css/minimize-values/style.css
@@ -330,3 +330,5 @@
 /*! webpack: a comment parts two components, so a rewrite keeps them apart */
 .t138 { margin: 1px 1px/*c*/1px 1px }
 .t139 { transition: opacity/*c*/1s ease-in 2s }
+/*! webpack: a custom property's value stays as written, comment included */
+.t140 { --t140: 1px 1px/*c*/1px 1px }

--- a/types.d.ts
+++ b/types.d.ts
@@ -21589,10 +21589,11 @@ declare class PrintContext<TPath, TNode> {
 	insert(pos: number, text: string): void;
 
 	/**
-	 * Drop the queued inserts sitting in `[start, end)` — a printer that wrote
-	 * that source range out verbatim already carries them, in place.
+	 * Take the queued inserts sitting in `[start, end)` — a printer that writes
+	 * that source range out itself places them, so the writer must not flush
+	 * them ahead of the next top-level node as well.
 	 */
-	dropInserts(start: number, end: number): void;
+	takeInserts(start: number, end: number): string;
 	sourceMap(options: SourceMapOptions): SourceMap;
 	result(): string;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -21587,6 +21587,12 @@ declare class PrintContext<TPath, TNode> {
 	 * starting after `pos` (or at the end, via {@link result}).
 	 */
 	insert(pos: number, text: string): void;
+
+	/**
+	 * Drop the queued inserts sitting in `[start, end)` — a printer that wrote
+	 * that source range out verbatim already carries them, in place.
+	 */
+	dropInserts(start: number, end: number): void;
 	sourceMap(options: SourceMapOptions): SourceMap;
 	result(): string;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Minifying CSS dropped a comment without keeping the token boundary it stood for, so valid input came out broken: `a{margin:1px 1px/*c*/1px 1px}` was emitted as `margin:1px 1px1px`, a single invalid token the engine drops. CSS Syntax §4.3.1/§4.3.2 consume and discard comments before each token, so a comment never sits inside one and the tokens either side stay separate. Three printer paths now respect that: a value's components (the gap between two children parts them), a custom property's value (printed as the source slice, comment included, which is the text `getPropertyValue()` hands back), and a selector, where the separator has to stay an empty comment — whitespace there is a descendant combinator, so `a/*c*/b` must not become `a b`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — three cases in `test/CssSyntax.unittest.js` plus corpus entries in `configCases/css/minimize-values` and `configCases/css/minimize-selectors`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code probed the value transforms against crafted inputs to find the defect, then wrote the fix, the tests and the changeset; I reviewed and verified everything before committing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CSS minify printing paths; behavior is correctness-focused and covered by new tests, but mistakes could still alter computed styles or selectors.
> 
> **Overview**
> Fixes CSS minify output that **fused tokens** after a comment was removed, producing invalid CSS (e.g. `1px 1px/*c*/1px` becoming `1px 1px1px`).
> 
> **Value rewriting** now treats a comment gap between value children as a component boundary (`_valueComponents` compares source offsets), so rewrites still join components with a separator where the comment stood.
> 
> **Custom properties** are emitted from the **source slice** of the value (matching `getPropertyValue()`), not by concatenating child prints; **`dropInserts`** on `SourceProcessor` clears duplicate queued comment inserts when that slice already includes a kept comment.
> 
> **Selectors** use an empty comment (`/**/`) instead of a space when `_join` must prevent fusion under combinator trimming, since whitespace would introduce a descendant combinator.
> 
> Unit and config-case tests cover selectors, custom properties, and comment-parted value components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdfea90559054e7f60b07b4dc1e8c62fe5a88756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSS minification to preserve comments when they separate selector or value components.
  - Prevented minification from accidentally changing selector meaning by merging tokens that require separation.
  - Preserved authored comments and spacing in custom-property values.
  - Improved handling of comments in shorthand values such as margins, shadows, transitions, positioning, and grid declarations.
- **API**
  - Added a public method for managing queued source inserts during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->