### PR TITLE
fix: resolve a symlink whose target is absolute

### DIFF
--- a/.changeset/043-symlink-absolute-target.md
+++ b/.changeset/043-symlink-absolute-target.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve a symlink whose target is absolute to that target instead of joining it onto the link's directory.

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -709,7 +709,10 @@ const lstatReadlinkAbsolute = (fs, p, callback) => {
 			}
 			if (err) return callback(err);
 			const value = /** @type {string} */ (target).toString();
-			callback(null, join(fs, dirname(fs, p), value));
+			callback(
+				null,
+				isAbsolute(value) ? value : join(fs, dirname(fs, p), value)
+			);
 		});
 	};
 	const doStat = () => {

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -721,6 +721,25 @@ ${details(snapshot)}`)
 				done();
 			});
 		});
+
+		// #21636: an absolute target was joined onto the link's parent directory,
+		// so the snapshot pointed at a path that does not exist.
+		it("should invalidate the snapshot when a symlink with an absolute target changes", (done) => {
+			const fs = createFs();
+			const fsInfo = createFsInfo(fs);
+			fsInfo.createSnapshot(
+				Date.now() + 10000,
+				[],
+				["/path/context/sub"],
+				[],
+				{ hash: true },
+				(err, snapshot) => {
+					if (err) return done(err);
+					fs.writeFileSync("/path/folder/context/file.txt", "Changed");
+					expectSnapshotState(fs, snapshot, false, done);
+				}
+			);
+		});
 	});
 
 	describe("unsupported directory entries", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`lstatReadlinkAbsolute` joins every `readlink` result onto the link's parent directory, and `path.join("/repo/sub", "/repo/node_modules")` is `/repo/sub/repo/node_modules`. A symlink with an absolute target was therefore snapshotted under a path that does not exist, so `FileSystemInfo` stopped noticing changes behind the link, and the empty entry read back for that path can reach `hash.update(undefined)` and abort the build with `TypeError: Cannot read properties of undefined (reading 'length')`. An absolute target now resolves to itself. Fixes #21636.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, a case in `test/FileSystemInfo.unittest.js` that expects a snapshot to go invalid once a file behind an absolute-target symlink changes.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core filesystem symlink handling used by `FileSystemInfo` caching and invalidation; behavior change is narrow (absolute targets only) and covered by a regression test.
> 
> **Overview**
> **Symlink resolution** in `lstatReadlinkAbsolute` no longer always joins `readlink` results onto the link’s parent directory. When the target is already absolute, it is returned unchanged; relative targets still resolve relative to the link’s directory.
> 
> That wrong join could produce a non-existent path (e.g. `join("/repo/sub", "/repo/node_modules")`), so **filesystem snapshots** tracked the wrong location, missed changes behind the link, and in hash mode could hit `hash.update(undefined)` and crash the build.
> 
> A **unit test** asserts that a context snapshot including an absolute-target symlink (as in `createFs`) becomes invalid after the real target file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f717847100c52eadab4006d08d65f8fd73c0295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->