### PR TITLE
fix: clear a Watching's blocked flag when its build starts

### DIFF
--- a/.changeset/034-watching-blocked-flag.md
+++ b/.changeset/034-watching-blocked-flag.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Clear a `Watching`'s `blocked` flag when its build starts, so it reports only a child actually waiting for its MultiCompiler parent.

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -126,6 +126,8 @@ class Watching {
 	_go(fileTimeInfoEntries, contextTimeInfoEntries, changedFiles, removedFiles) {
 		this._initial = false;
 		if (this.startTime === null) this.startTime = Date.now();
+		// Whatever held this back let go — a build is starting.
+		this.blocked = false;
 		this.running = true;
 		if (this.watcher) {
 			this.pausedWatcher = this.watcher;

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -7,6 +7,9 @@ const { Volume, createFsFromVolume } = require("memfs");
 const webpack = require("..");
 const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
+// Not exported by name; it is the type `MultiCompiler.watching` carries.
+/** @typedef {NonNullable<import("../").MultiCompiler["watching"]>} MultiWatching */
+
 /**
  * @param {import("../").MultiCompilerOptions=} options options
  * @returns {import("../").MultiCompiler} compiler
@@ -764,13 +767,12 @@ describe("MultiCompiler", () => {
 		compiler.compilers[0].hooks.done.tap("test", () => {
 			// `a` is done but has not handed `b` over yet, so `b` is still waiting.
 			if (blockedWhileParentBuilds === undefined) {
-				blockedWhileParentBuilds = /** @type {import("../lib/Watching")} */ (
-					/** @type {import("../").MultiWatching} */ (compiler.watching)
-						.watchings[1]
-				).blocked;
+				blockedWhileParentBuilds = /** @type {MultiWatching} */ (
+					compiler.watching
+				).watchings[1].blocked;
 			}
 		});
-		const watching = /** @type {import("../").MultiWatching} */ (
+		const watching = /** @type {MultiWatching} */ (
 			compiler.watch({}, (err) => {
 				if (err) return done(err);
 				expect(blockedWhileParentBuilds).toBe(true);

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -729,6 +729,60 @@ describe("MultiCompiler", () => {
 		});
 	});
 
+	it("should report a child as blocked only while it waits for its parent", (done) => {
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack(
+				/** @type {import("../").MultiConfiguration} */ ([
+					{
+						name: "a",
+						mode: "development",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./a.js"
+					},
+					{
+						name: "b",
+						mode: "development",
+						context: path.join(__dirname, "fixtures"),
+						entry: "./b.js",
+						dependencies: ["a"]
+					}
+				])
+			)
+		);
+		compiler.outputFileSystem = /** @type {import("../").OutputFileSystem} */ (
+			/** @type {unknown} */ (createFsFromVolume(new Volume()))
+		);
+		compiler.watchFileSystem =
+			/** @type {import("../lib/util/fs").WatchFileSystem} */ ({
+				watch: (_a, _b, _c, _d, _e, _f, _g) =>
+					/** @type {import("../lib/util/fs").Watcher} */ (
+						/** @type {unknown} */ (undefined)
+					)
+			});
+		/** @type {boolean | undefined} */
+		let blockedWhileParentBuilds;
+		compiler.compilers[0].hooks.done.tap("test", () => {
+			// `a` is done but has not handed `b` over yet, so `b` is still waiting.
+			if (blockedWhileParentBuilds === undefined) {
+				blockedWhileParentBuilds = /** @type {import("../lib/Watching")} */ (
+					/** @type {import("../").MultiWatching} */ (compiler.watching)
+						.watchings[1]
+				).blocked;
+			}
+		});
+		const watching = /** @type {import("../").MultiWatching} */ (
+			compiler.watch({}, (err) => {
+				if (err) return done(err);
+				expect(blockedWhileParentBuilds).toBe(true);
+				// Both have built, so neither waits on anything any more.
+				for (const child of watching.watchings) {
+					expect(child.blocked).toBe(false);
+				}
+				compiler.close(done);
+			})
+		);
+	});
+
 	it("should respect parallelism when using invalidate", (done) => {
 		const compiler = /** @type {import("../").MultiCompiler} */ (
 			webpack(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`Watching.blocked` — a public field on `Watching` — is set the first time the MultiCompiler graph holds a child back and never cleared, so it reads `true` for a child that is idle or building. Measured on an `a -> b` watch: after the initial build `b.blocked` is already `true` with nothing to wait for, and while `a` rebuilds `a.blocked` is `true` too. Clearing it in `_go` (a build is starting, so whatever held this back let go) makes it report only a child actually waiting for its parent. The guard it feeds in `_done` re-asks `_isBlocked()` either way, so no decision changes: a mid-build invalidate still produces one `done` for a single compiler and two under a MultiCompiler, exactly as before.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `should report a child as blocked only while it waits for its parent` in `test/MultiCompiler.test.js`, which fails on `main` (`Expected: false, Received: true`).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code found the stale flag while probing MultiCompiler watch mode, measured its lifecycle in a real watch, wrote the fix and the regression test, and verified the build counts are unchanged; I reviewed everything before committing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch mode behavior for dependent builds.
  * Waiting states are now reported accurately while builds are in progress.
  * Waiting indicators are cleared when a new build begins, preventing stale status reporting.

* **Tests**
  * Added coverage for blocking and unblocking behavior in multi-compiler watch mode.
  * Verified dependent builds transition correctly after compilation completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->