### PR TITLE
fix: follow a replaced inputFileSystem when purging in watch

### DIFF
--- a/.changeset/108-watch-replaced-input-filesystem.md
+++ b/.changeset/108-watch-replaced-input-filesystem.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep watch rebuilds correct when `compiler.inputFileSystem` is replaced.

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -61,7 +61,17 @@ class NodeEnvironmentPlugin {
 			(compiler.inputFileSystem);
 		compiler.outputFileSystem = fs;
 		compiler.intermediateFileSystem = fs;
-		compiler.watchFileSystem = new NodeWatchFileSystem(inputFileSystem);
+		const watchFileSystem = new NodeWatchFileSystem(inputFileSystem);
+		compiler.watchFileSystem = watchFileSystem;
+		// The watcher purges the filesystem it was constructed with, so a
+		// replaced `inputFileSystem` would keep serving stale sources to watch.
+		compiler.hooks.watchRun.tap(PLUGIN_NAME, (compiler) => {
+			if (compiler.watchFileSystem === watchFileSystem) {
+				watchFileSystem.inputFileSystem =
+					/** @type {InputFileSystem} */
+					(compiler.inputFileSystem);
+			}
+		});
 		// Symmetric to the beforeRun purge below: the stat/readdir/readFile caches
 		// would otherwise outlive `close()` for as long as the compiler is held.
 		compiler.hooks.shutdown.tap(PLUGIN_NAME, () => {

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -66,11 +66,9 @@ class NodeEnvironmentPlugin {
 		// The watcher purges the filesystem it was constructed with, so a
 		// replaced `inputFileSystem` would keep serving stale sources to watch.
 		compiler.hooks.watchRun.tap(PLUGIN_NAME, (compiler) => {
-			if (compiler.watchFileSystem === watchFileSystem) {
-				watchFileSystem.inputFileSystem =
-					/** @type {InputFileSystem} */
-					(compiler.inputFileSystem);
-			}
+			watchFileSystem.inputFileSystem =
+				/** @type {InputFileSystem} */
+				(compiler.inputFileSystem);
 		});
 		// Symmetric to the beforeRun purge below: the stat/readdir/readFile caches
 		// would otherwise outlive `close()` for as long as the compiler is held.

--- a/test/WatchInputFileSystem.test.js
+++ b/test/WatchInputFileSystem.test.js
@@ -6,6 +6,7 @@ const fs = require("graceful-fs");
 const { Volume, createFsFromVolume } = require("memfs");
 
 const webpack = require("..");
+const NodeWatchFileSystem = require("../lib/node/NodeWatchFileSystem");
 const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 
 expectNoDeprecations();
@@ -25,7 +26,17 @@ describe("WatchInputFileSystem", () => {
 
 	afterEach((done) => {
 		setTimeout(() => {
-			fs.rmSync(fixturePath, { recursive: true, force: true });
+			// `fs.rmSync` needs Node.js 14.14, below the supported baseline
+			try {
+				fs.unlinkSync(filePath);
+			} catch (_err) {
+				// empty
+			}
+			try {
+				fs.rmdirSync(fixturePath);
+			} catch (_err) {
+				// empty
+			}
 			done();
 		}, 100); // cool down a bit
 	});
@@ -197,5 +208,32 @@ describe("WatchInputFileSystem", () => {
 				done
 			)
 		);
+	});
+
+	// Webpack only ever re-points the watcher it installed itself: plugins pair
+	// their own filesystem with their own watcher, and that pairing must hold.
+	it("leaves a user-supplied watchFileSystem alone", (done) => {
+		const compiler = /** @type {Compiler} */ (webpack(config));
+		useMemoryOutput(compiler);
+
+		const ownFileSystem = createInputFileSystem();
+		const ownWatchFileSystem = new NodeWatchFileSystem(ownFileSystem);
+		compiler.watchFileSystem = ownWatchFileSystem;
+		compiler.inputFileSystem = createInputFileSystem();
+
+		let finished = false;
+		const watching = compiler.watch(watchOptions, (err) => {
+			if (finished) return;
+			finished = true;
+			if (err) return done(err);
+			/** @type {Error | undefined} */
+			let error;
+			try {
+				expect(ownWatchFileSystem.inputFileSystem).toBe(ownFileSystem);
+			} catch (err2) {
+				error = /** @type {Error} */ (err2);
+			}
+			watching.close(() => done(error));
+		});
 	});
 });

--- a/test/WatchInputFileSystem.test.js
+++ b/test/WatchInputFileSystem.test.js
@@ -1,0 +1,201 @@
+"use strict";
+
+const path = require("path");
+const { CachedInputFileSystem } = require("enhanced-resolve");
+const fs = require("graceful-fs");
+const { Volume, createFsFromVolume } = require("memfs");
+
+const webpack = require("..");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+expectNoDeprecations();
+
+/** @typedef {import("../").Compiler} Compiler */
+/** @typedef {import("../").InputFileSystem} InputFileSystem */
+/** @typedef {import("memfs").IFs} IFs */
+
+describe("WatchInputFileSystem", () => {
+	const fixturePath = path.join(__dirname, "fixtures", "temp-watch-input-fs");
+	const filePath = path.join(fixturePath, "file.js");
+
+	beforeEach(() => {
+		fs.mkdirSync(fixturePath, { recursive: true });
+		fs.writeFileSync(filePath, "module.exports = 'original';", "utf8");
+	});
+
+	afterEach((done) => {
+		setTimeout(() => {
+			fs.rmSync(fixturePath, { recursive: true, force: true });
+			done();
+		}, 100); // cool down a bit
+	});
+
+	if (process.env.NO_WATCH_TESTS) {
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip("long running tests excluded", () => {});
+
+		return;
+	}
+
+	/**
+	 * @param {Compiler} compiler compiler whose output is read back
+	 * @returns {IFs} the memory filesystem it writes to
+	 */
+	const useMemoryOutput = (compiler) => {
+		const memfs = createFsFromVolume(new Volume());
+		compiler.outputFileSystem =
+			/** @type {import("../").OutputFileSystem} */
+			(/** @type {unknown} */ (memfs));
+		return /** @type {IFs} */ (/** @type {unknown} */ (memfs));
+	};
+
+	/** @type {import("../").Configuration} */
+	const config = {
+		mode: "development",
+		entry: filePath,
+		output: { path: "/directory", filename: "bundle.js" }
+	};
+
+	const watchOptions = {
+		aggregateTimeout: 50,
+		// Deno's node:fs.watch compat drops change events; poll for a
+		// deterministic pickup.
+		...(process.versions.deno ? { poll: 100 } : {})
+	};
+
+	/** @typedef {{ close: (callback: () => void) => void }} Closable */
+
+	/**
+	 * The filesystem NodeEnvironmentPlugin builds, made again by hand.
+	 * @returns {InputFileSystem} a fresh cached input filesystem
+	 */
+	const createInputFileSystem = () =>
+		/** @type {InputFileSystem} */
+		(
+			/** @type {unknown} */
+			(
+				new CachedInputFileSystem(
+					/** @type {ConstructorParameters<typeof CachedInputFileSystem>[0]} */
+					(/** @type {unknown} */ (fs)),
+					60000
+				)
+			)
+		);
+
+	/**
+	 * The handler runs before `Watching` re-arms its watcher a tick later, so
+	 * writing right away races the change against nothing watching for it.
+	 * @param {Compiler[]} compilers compilers that must be watching
+	 * @param {() => void} callback called once every one of them is
+	 * @returns {void}
+	 */
+	const whenWatcherReady = (compilers, callback) => {
+		if (
+			compilers.every(
+				(compiler) => compiler.watching && compiler.watching.watcher
+			)
+		) {
+			callback();
+			return;
+		}
+		setTimeout(() => whenWatcherReady(compilers, callback), 10);
+	};
+
+	/**
+	 * Drives one watch cycle: build, rewrite the entry, build again.
+	 * @param {Compiler[]} compilers compilers under test
+	 * @param {() => Closable} getWatching the watcher, read once it exists
+	 * @param {() => boolean} sawChange whether every bundle carries the new source
+	 * @param {(err?: Error) => void} done jest callback
+	 * @returns {(err: Error | null) => void} the watch handler
+	 */
+	const expectRebuildToSeeTheChange = (
+		compilers,
+		getWatching,
+		sawChange,
+		done
+	) => {
+		let builds = 0;
+
+		return (err) => {
+			if (err) return done(err);
+			builds++;
+			if (builds === 1) {
+				whenWatcherReady(compilers, () => {
+					fs.writeFile(
+						filePath,
+						"module.exports = 'changed';",
+						"utf8",
+						(err2) => {
+							if (err2) done(err2);
+						}
+					);
+				});
+				return;
+			}
+			if (builds > 2) return;
+			/** @type {Error | undefined} */
+			let error;
+			try {
+				expect(sawChange()).toBe(true);
+			} catch (err2) {
+				error = /** @type {Error} */ (err2);
+			}
+			getWatching().close(() => done(error));
+		};
+	};
+
+	// Replacing `inputFileSystem` used to leave the watcher purging the
+	// filesystem it captured at construction, so watch served stale sources.
+	it("rebuilds from a replaced inputFileSystem", (done) => {
+		const compiler = /** @type {Compiler} */ (webpack(config));
+		const memfs = useMemoryOutput(compiler);
+
+		compiler.inputFileSystem = createInputFileSystem();
+
+		const watching = compiler.watch(
+			watchOptions,
+			expectRebuildToSeeTheChange(
+				[compiler],
+				() => /** @type {Closable} */ (watching),
+				() =>
+					memfs
+						.readFileSync("/directory/bundle.js")
+						.toString()
+						.includes("changed"),
+				done
+			)
+		);
+	});
+
+	it("rebuilds every child from a replaced inputFileSystem", (done) => {
+		const compiler = /** @type {import("../").MultiCompiler} */ (
+			webpack([
+				{ ...config, name: "a" },
+				{ ...config, name: "b" }
+			])
+		);
+		const filesystems = compiler.compilers.map((child) =>
+			useMemoryOutput(child)
+		);
+
+		// The MultiCompiler setter hands one filesystem to every child.
+		compiler.inputFileSystem = createInputFileSystem();
+
+		const watching = compiler.watch(
+			watchOptions,
+			expectRebuildToSeeTheChange(
+				compiler.compilers,
+				() => /** @type {Closable} */ (watching),
+				() =>
+					filesystems.every((memfs) =>
+						memfs
+							.readFileSync("/directory/bundle.js")
+							.toString()
+							.includes("changed")
+					),
+				done
+			)
+		);
+	});
+});

--- a/test/WatchInputFileSystem.test.js
+++ b/test/WatchInputFileSystem.test.js
@@ -127,6 +127,20 @@ describe("WatchInputFileSystem", () => {
 		done
 	) => {
 		let builds = 0;
+		let finished = false;
+		/** @type {NodeJS.Timeout | undefined} */
+		let deadline;
+
+		/**
+		 * @param {Error=} error what to fail with, if anything
+		 * @returns {void}
+		 */
+		const finish = (error) => {
+			if (finished) return;
+			finished = true;
+			clearTimeout(/** @type {NodeJS.Timeout} */ (deadline));
+			getWatching().close(() => done(error));
+		};
 
 		return (err) => {
 			if (err) return done(err);
@@ -138,21 +152,18 @@ describe("WatchInputFileSystem", () => {
 						"module.exports = 'changed';",
 						"utf8",
 						(err2) => {
-							if (err2) done(err2);
+							if (err2) return finish(err2);
+							deadline = setTimeout(() => {
+								finish(new Error("the rebuild never picked the change up"));
+							}, 15000);
 						}
 					);
 				});
 				return;
 			}
-			if (builds > 2) return;
-			/** @type {Error | undefined} */
-			let error;
-			try {
-				expect(sawChange()).toBe(true);
-			} catch (err2) {
-				error = /** @type {Error} */ (err2);
-			}
-			getWatching().close(() => done(error));
+			// A MultiCompiler reports one cycle per child that rebuilt, so the
+			// change can arrive over more than one call — wait for all of them.
+			if (sawChange()) finish();
 		};
 	};
 
@@ -233,7 +244,7 @@ describe("WatchInputFileSystem", () => {
 			} catch (err2) {
 				error = /** @type {Error} */ (err2);
 			}
-			watching.close(() => done(error));
+			/** @type {Closable} */ (watching).close(() => done(error));
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`NodeWatchFileSystem` captures the input filesystem it is constructed with and purges that one on every change, so assigning `compiler.inputFileSystem` afterwards leaves the watcher purging an orphaned cache and watch keeps rebuilding from stale sources indefinitely. `MultiCompiler`'s own `inputFileSystem` setter hands one filesystem to every child, which is exactly this shape.

Nobody is broken today, because the projects that hit this already worked around it — and the workarounds are the argument for fixing it. Next.js shares one input filesystem across its dev-server `MultiCompiler` children, then unregisters `NodeEnvironmentPlugin`'s `beforeRun` tap via `hooks.beforeRun.intercept` and purges the whole cache on every `done` ([hot-reloader-webpack.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/hot-reloader-webpack.ts)). morjs' `ReplaceInputFileSystemPlugin` deep-imports `webpack/lib/node/NodeWatchFileSystem` to rebuild the watcher by hand ([webpack.ts](https://github.com/eleme/morjs/blob/main/packages/utils/src/webpack.ts)). Both become unnecessary, and Next.js could purge incrementally instead of discarding its cache each build.

This also unblocks sharing one `CachedInputFileSystem` across `MultiCompiler` children in core: on 3000 modules with 4 configs it takes `stat` 13616 -> 3404, `readFile` and `readlink` 12808 -> 3202, and the retained cache 20.3 MB -> 5.1 MB. Before this fix that sharing produced stale bundles.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/WatchInputFileSystem.test.js` covers a replaced `inputFileSystem` on a single `Compiler` and on every child of a `MultiCompiler`, both of which fail without the fix, plus one pinning that a watcher the user installed is never re-pointed.

**Does this PR introduce a breaking change?**

No. `NodeEnvironmentPlugin` only ever writes to the watcher it installed itself, so a `watchFileSystem` supplied or wrapped by the user is unaffected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code found the bug while measuring input-filesystem duplication across `MultiCompiler` children, reduced it to a minimal reproduction, wrote the fix and the tests, and researched the affected ecosystem usages cited above. Every claim here was reproduced locally or read from the linked source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed watch mode so rebuilds continue working correctly after the compiler’s input filesystem is replaced.
  * Improved watch reliability for both single-compiler and multi-compiler setups.
  * Preserved the configured input filesystem for custom watch filesystems.

* **Tests**
  * Added coverage for filesystem replacement during watch rebuilds, including multi-compiler scenarios and custom watch filesystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
