### PR TITLE
fix(cjs): disconnect requires in unused object-literal methods

### DIFF
--- a/.changeset/025-cjs-object-literal-exports.md
+++ b/.changeset/025-cjs-object-literal-exports.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Support tree-shaking module.exports object literals.
+Tree-shake module.exports object literals and unused method requires.

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -11,12 +11,17 @@ const formatLocation = require("../util/formatLocation");
 const { propertyAccess } = require("../util/property");
 const CommonJsExportRequireDependency = require("./CommonJsExportRequireDependency");
 const CommonJsExportsDependency = require("./CommonJsExportsDependency");
+const CommonJsFullRequireDependency = require("./CommonJsFullRequireDependency");
 const CommonJsObjectExportDependency = require("./CommonJsObjectExportDependency");
+const CommonJsRequireDependency = require("./CommonJsRequireDependency");
 const CommonJsSelfReferenceDependency = require("./CommonJsSelfReferenceDependency");
 const DynamicExports = require("./DynamicExports");
 const HarmonyExports = require("./HarmonyExports");
 const ModuleDecoratorDependency = require("./ModuleDecoratorDependency");
 const RuntimeRequirementsDependency = require("./RuntimeRequirementsDependency");
+
+const FUNCTION_PROPERTY_DROP_HEAD =
+	CommonJsObjectExportDependency.FUNCTION_PROPERTY_DROP_HEAD;
 
 /** @typedef {import("estree").AssignmentExpression} AssignmentExpression */
 /** @typedef {import("estree").CallExpression} CallExpression */
@@ -581,7 +586,24 @@ class CommonJsExportsParserPlugin {
 				parser.state.module.addDependency(dep);
 
 				keepAllExportsOnThisAccess(value, base);
-				parser.walkExpression(value);
+				// Tag nested requires so unused get/set/method can disconnect them.
+				if (FUNCTION_PROPERTY_DROP_HEAD.has(kind)) {
+					const mod = parser.state.module;
+					const start = mod.dependencies.length;
+					parser.walkExpression(value);
+					const usedByExports = new Set([name]);
+					for (let i = start; i < mod.dependencies.length; i++) {
+						const nested = mod.dependencies[i];
+						if (
+							nested instanceof CommonJsRequireDependency ||
+							nested instanceof CommonJsFullRequireDependency
+						) {
+							nested.usedByExports = usedByExports;
+						}
+					}
+				} else {
+					parser.walkExpression(value);
+				}
 			}
 			return true;
 		};

--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -6,6 +6,9 @@
 "use strict";
 
 const Template = require("../Template");
+const {
+	getDependencyUsedByExportsCondition
+} = require("../optimize/InnerGraph");
 const { equals } = require("../util/ArrayHelpers");
 const { getTrimmedIdsAndRange } = require("../util/chainedImports");
 const makeSerializable = require("../util/makeSerializable");
@@ -26,11 +29,12 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
+/** @typedef {import("../optimize/InnerGraph").UsedByExports} UsedByExports */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("../util/chainedImports").IdRanges} IdRanges */
 /** @typedef {import("./HarmonyImportGuard").DependencyGuard} DependencyGuard */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[ExportInfoName[], IdRanges | undefined, boolean, undefined | boolean, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectSerializerContext */
 
 const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
@@ -62,6 +66,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this.asiSafe = undefined;
 		/** @type {DependencyGuard[] | undefined} */
 		this.branchGuards = undefined;
+		/** @type {UsedByExports | undefined} */
+		this.usedByExports = undefined;
 		/** @type {boolean} */
 		this._canConcatenate = false;
 	}
@@ -72,10 +78,25 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
 	 */
 	getCondition(moduleGraph) {
+		const usedByExportsCondition =
+			this.usedByExports !== undefined
+				? getDependencyUsedByExportsCondition(this, moduleGraph)
+				: null;
+		if (usedByExportsCondition === false) return false;
 		const guards = this.branchGuards;
-		if (guards === undefined) return null;
-		return (connection, runtime) =>
-			!getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime);
+		if (usedByExportsCondition === null && guards === undefined) return null;
+		return (connection, runtime) => {
+			if (
+				usedByExportsCondition !== null &&
+				usedByExportsCondition(connection, runtime) === false
+			) {
+				return false;
+			}
+			return !(
+				guards !== undefined &&
+				getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime)
+			);
+		};
 	}
 
 	/**
@@ -129,7 +150,8 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 			.write(this.asiSafe)
 			.write(this.branchGuards)
 			.write(this._canConcatenate)
-			.write(this.namespaceObjectAsContext);
+			.write(this.namespaceObjectAsContext)
+			.write(this.usedByExports);
 		super.serialize(context);
 	}
 
@@ -151,7 +173,9 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 		this._canConcatenate = c5.read();
 		const c6 = c5.rest;
 		this.namespaceObjectAsContext = c6.read();
-		super.deserialize(c6.rest);
+		const c7 = c6.rest;
+		this.usedByExports = c7.read();
+		super.deserialize(c7.rest);
 	}
 
 	get type() {

--- a/lib/dependencies/CommonJsObjectExportDependency.js
+++ b/lib/dependencies/CommonJsObjectExportDependency.js
@@ -185,3 +185,4 @@ CommonJsObjectExportDependency.Template = class CommonJsObjectExportDependencyTe
 };
 
 module.exports = CommonJsObjectExportDependency;
+module.exports.FUNCTION_PROPERTY_DROP_HEAD = FUNCTION_PROPERTY_DROP_HEAD;

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -7,6 +7,9 @@
 
 const Dependency = require("../Dependency");
 const RuntimeGlobals = require("../RuntimeGlobals");
+const {
+	getDependencyUsedByExportsCondition
+} = require("../optimize/InnerGraph");
 const makeSerializable = require("../util/makeSerializable");
 const memoize = require("../util/memoize");
 const {
@@ -24,10 +27,11 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
+/** @typedef {import("../optimize/InnerGraph").UsedByExports} UsedByExports */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./HarmonyImportGuard").DependencyGuard} DependencyGuard */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectSerializerContext */
 
 const getHarmonyImportGuard = memoize(() => require("./HarmonyImportGuard"));
 
@@ -78,6 +82,8 @@ class CommonJsRequireDependency extends ModuleDependency {
 		this.valueRange = valueRange;
 		/** @type {DependencyGuard[] | undefined} */
 		this.branchGuards = undefined;
+		/** @type {UsedByExports | undefined} */
+		this.usedByExports = undefined;
 		/** @type {boolean} */
 		this._canConcatenate = false;
 		// `new require(...)`; see the template for the return-value rule
@@ -110,10 +116,27 @@ class CommonJsRequireDependency extends ModuleDependency {
 	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
 	 */
 	getCondition(moduleGraph) {
+		const usedByExportsCondition =
+			this.usedByExports !== undefined
+				? getDependencyUsedByExportsCondition(this, moduleGraph)
+				: null;
+		if (usedByExportsCondition === false) return false;
 		const guards = this.branchGuards;
 		const evaluationOnly = this.isEvaluationOnly();
-		if (guards === undefined && !evaluationOnly) return null;
+		if (
+			usedByExportsCondition === null &&
+			guards === undefined &&
+			!evaluationOnly
+		) {
+			return null;
+		}
 		return (connection, runtime) => {
+			if (
+				usedByExportsCondition !== null &&
+				usedByExportsCondition(connection, runtime) === false
+			) {
+				return false;
+			}
 			if (
 				guards !== undefined &&
 				getHarmonyImportGuard().isDeadByGuards(guards, moduleGraph, runtime)
@@ -185,7 +208,8 @@ class CommonJsRequireDependency extends ModuleDependency {
 			.write(this.valueRange)
 			.write(this.branchGuards)
 			.write(this._canConcatenate)
-			.write(this.callNew);
+			.write(this.callNew)
+			.write(this.usedByExports);
 		super.serialize(context);
 	}
 
@@ -203,7 +227,9 @@ class CommonJsRequireDependency extends ModuleDependency {
 		this._canConcatenate = c3.read();
 		const c4 = c3.rest;
 		this.callNew = c4.read();
-		super.deserialize(c4.rest);
+		const c5 = c4.rest;
+		this.usedByExports = c5.read();
+		super.deserialize(c5.rest);
 	}
 }
 

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/heavy.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/heavy.js
@@ -1,0 +1,1 @@
+module.exports = "heavy";

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/index.js
@@ -1,0 +1,8 @@
+it("should keep a module still reached by an active require edge", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.usedExports).toEqual(["used", "usedExports"]);
+	// Live edge elsewhere keeps heavy even though unusedMethod's require is inactive.
+	expect(require("./heavy")).toBe("heavy");
+	expect(require.resolveWeak("./heavy")).not.toBe(null);
+});

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/lib.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/lib.js
@@ -1,0 +1,7 @@
+module.exports = {
+	used: "used",
+	unusedMethod() {
+		return require("./heavy");
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/test.filter.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require-kept/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function filter(config) {
+	// usedExports analysis only runs outside development mode.
+	return config.mode !== "development";
+};

--- a/test/cases/cjs-tree-shaking/object-literal-nested-require/index.js
+++ b/test/cases/cjs-tree-shaking/object-literal-nested-require/index.js
@@ -2,4 +2,6 @@ it("should drop unused methods/getters that contain require without breaking cod
 	const m = require("./lib");
 	expect(m.used).toBe("used");
 	expect(m.usedExports).toEqual(["used", "usedExports"]);
+	// Nested requires are disconnected when the owning export is unused.
+	expect(require.resolveWeak("./heavy")).toBe(null);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Unused get/set/method properties on `module.exports = { … }` were rewritten to `...void (function…)`, but nested `require()` edges stayed active and kept dead modules in the graph. Tag those requires with `usedByExports` (same condition as ESM) so the connection is inactive when the owning export is unused.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/cases/cjs-tree-shaking/object-literal-nested-require` (assert `require.resolveWeak("./heavy") === null`) and `object-literal-nested-require-kept` (live edge keeps the module).

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI assisted with implementing the `usedByExports` tagging on nested CJS requires, wiring `getCondition` on the require dependencies, and drafting tests/changeset text. I reviewed and pushed the commits.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tree-shaking for CommonJS object-literal exports.
  - Unused methods and their nested `require` dependencies are now removed more reliably.
  - Actively used exports continue to retain required modules and weak dependencies.

- **Tests**
  - Added coverage for retaining dependencies of used exports.
  - Added checks confirming unused nested dependencies are disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->