### PR TITLE
ci(bun): restore the worker idle memory limit and end a Bun worker from itself

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,10 +335,9 @@ jobs:
       # OOMs the runner on the full suite and Bun's child_process workers hang, but
       # threads work once jest-worker loads the Bun preload per thread. Apply that
       # patch here (Bun only) rather than via a repo-wide postinstall. The
-      # jest-runner patch tolerates Bun's transient memoryUsage failures.
-      # test:base:bun also drops --workerIdleMemoryLimit: restarting a worker
-      # thread on it segfaults Bun, and the runner's heaps sit at the 512MB the
-      # other runtimes use, so it fired constantly.
+      # jest-runner patch tolerates Bun's transient memoryUsage failures. The
+      # jest-worker patch also has a Bun worker end itself rather than be
+      # terminated from the parent, which segfaults Bun on an idle-memory restart.
       - if: matrix.runtime == 'bun'
         run: |
           git apply test/patches/jest-worker+30.4.1.patch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,7 +337,9 @@ jobs:
       # patch here (Bun only) rather than via a repo-wide postinstall. The
       # jest-runner patch tolerates Bun's transient memoryUsage failures. The
       # jest-worker patch also has a Bun worker end itself rather than be
-      # terminated from the parent, which segfaults Bun on an idle-memory restart.
+      # terminated from the parent, which segfaults Bun on an idle-memory restart
+      # — and exit once it has, since ending only drops its message listener and
+      # a worker still holding a handle would never be replaced.
       - if: matrix.runtime == 'bun'
         run: |
           git apply test/patches/jest-worker+30.4.1.patch

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "test:deno": "yarn test:base:deno --reporters default --reporters \"<rootDir>/test/runtimeCrashReporter.js\" --testMatch \"<rootDir>/test/*.{basictest,longtest,test,unittest}.js\" --testPathIgnorePatterns \"/node_modules/\" \"(ProfilingPlugin[.]unittest|SyntaxBrowserEquivalence|WebpackDevServer)\"",
     "test:base:deno": "deno --allow-read --allow-env --allow-sys --allow-ffi --allow-write --allow-run --allow-net --import-map=test/deno-import-map.json --v8-flags='--max-old-space-size=4096' ./node_modules/jest-cli/bin/jest.js --workerIdleMemoryLimit=512MB --logHeapUsage",
     "test:bun": "yarn test:base:bun --reporters default --reporters \"<rootDir>/test/runtimeCrashReporter.js\" --testMatch \"<rootDir>/test/*.{basictest,longtest,test,unittest}.js\" --testPathIgnorePatterns \"/node_modules/\" \"(ProfilingPlugin[.]unittest|SyntaxBrowserEquivalence|WebpackDevServer)\"",
-    "test:base:bun": "bun --bun --smol --preload ./test/bun-preload.js ./node_modules/jest-cli/bin/jest.js --workerThreads --logHeapUsage",
+    "test:base:bun": "bun --bun --smol --preload ./test/bun-preload.js ./node_modules/jest-cli/bin/jest.js --workerThreads --workerIdleMemoryLimit=512MB --logHeapUsage",
     "test:update-snapshots": "yarn test:base -u",
     "test:size": "node --max-old-space-size=4096 ./test/CodeSizeTestCases.size.js",
     "report:cover": "nyc report --reporter=lcov  --reporter=text -t coverage",

--- a/test/patches/jest-worker+30.4.1.patch
+++ b/test/patches/jest-worker+30.4.1.patch
@@ -1,7 +1,8 @@
 diff --git a/node_modules/jest-worker/build/index.js b/node_modules/jest-worker/build/index.js
+index a2fb689..e333058 100644
 --- a/node_modules/jest-worker/build/index.js
 +++ b/node_modules/jest-worker/build/index.js
-@@ -1345,7 +1345,13 @@
+@@ -1345,7 +1345,13 @@ class ExperimentalWorker extends _WorkerAbstract.default {
        }
        if (limit && this._childIdleMemoryUsage && this._childIdleMemoryUsage > limit) {
          this.state = _types.WorkerStates.RESTARTING;
@@ -17,7 +18,7 @@ diff --git a/node_modules/jest-worker/build/index.js b/node_modules/jest-worker/
      }
    }
 diff --git a/node_modules/jest-worker/build/threadChild.js b/node_modules/jest-worker/build/threadChild.js
-index e757511..4be460e 100644
+index e757511..55ec9be 100644
 --- a/node_modules/jest-worker/build/threadChild.js
 +++ b/node_modules/jest-worker/build/threadChild.js
 @@ -6,6 +6,13 @@
@@ -34,3 +35,16 @@ index e757511..4be460e 100644
  /******/ (() => { // webpackBootstrap
  /******/ 	"use strict";
  /******/ 	var __webpack_modules__ = ({
+@@ -309,6 +316,12 @@ function end() {
+ function exitProcess() {
+   // Clean up open handles so the worker ideally exits gracefully
+   _nodeWorker_threads().parentPort.removeListener('message', messageListener);
++  // webpack: on Bun the parent asks the worker to end rather than terminating
++  // it, so the thread has to leave for real — a handle it still holds would
++  // otherwise keep it alive and the pool would never replace it.
++  if (process.versions.bun) {
++    process.exit(0);
++  }
+ }
+ function execMethod(method, args) {
+   const main = require(file);

--- a/test/patches/jest-worker+30.4.1.patch
+++ b/test/patches/jest-worker+30.4.1.patch
@@ -1,3 +1,21 @@
+diff --git a/node_modules/jest-worker/build/index.js b/node_modules/jest-worker/build/index.js
+--- a/node_modules/jest-worker/build/index.js
++++ b/node_modules/jest-worker/build/index.js
+@@ -1345,7 +1345,13 @@
+       }
+       if (limit && this._childIdleMemoryUsage && this._childIdleMemoryUsage > limit) {
+         this.state = _types.WorkerStates.RESTARTING;
+-        this._worker.terminate();
++        // webpack: Bun segfaults when a worker thread is terminated from the
++        // parent, so ask the worker to end itself. No-op off Bun.
++        if (process.versions.bun) {
++          this._worker.postMessage([_types.CHILD_MESSAGE_END, false]);
++        } else {
++          this._worker.terminate();
++        }
+       }
+     }
+   }
 diff --git a/node_modules/jest-worker/build/threadChild.js b/node_modules/jest-worker/build/threadChild.js
 index e757511..4be460e 100644
 --- a/node_modules/jest-worker/build/threadChild.js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

#21629 stopped the Bun job's segfault by dropping `--workerIdleMemoryLimit` from `test:base:bun`, which was the wrong fix: the flag is what bounds the worker heaps, and without it the full suite OOM-kills the runner. This restores the flag and fixes the actual cause — `jest-worker`'s idle-memory restart calls `this._worker.terminate()` from the parent, and Bun 1.3.14 segfaults in thread teardown (a different wild address each run, with `workers_terminated` short of `workers_spawned`). The patch has the worker end itself instead, which is a no-op off Bun.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

ci

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — the change is the Bun CI job's own configuration and its `test/patches/jest-worker+30.4.1.patch`; the Bun job is the test.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to diagnose the segfault down to the `terminate()` call, write the patch hunk and the workflow comment, and rebase the branch. Every claim was checked against a local Bun run before being written down; the memory half can only be judged by CI, since this sandbox walls at ~15.1–15.5 GB on the full Bun suite in every configuration including unmodified `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2hnP1RFcrUEtWeCLsFpsd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-runner stability under Bun by enforcing a 512 MB worker memory limit.
  * Prevented worker crashes when memory limits trigger restarts.
  * Added safer Bun worker shutdown behavior and startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->