### PR TITLE
fix: resolve an absolute symlink target and skip an unreadable context entry

### DIFF
--- a/.changeset/043-symlink-absolute-target.md
+++ b/.changeset/043-symlink-absolute-target.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Resolve a symlink with an absolute target to that target and stop hashing an unreadable context entry.
+Resolve absolute symlink targets and skip hashing an unreadable context entry.

--- a/.changeset/043-symlink-absolute-target.md
+++ b/.changeset/043-symlink-absolute-target.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Resolve a symlink with an absolute target to that target and stop hashing an unreadable context entry.

--- a/.changeset/043-symlink-absolute-target.md
+++ b/.changeset/043-symlink-absolute-target.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Resolve absolute symlink targets and skip hashing an unreadable context entry.
+Resolve absolute symlink targets and treat an unreadable context as missing.

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1442,7 +1442,7 @@ class FileSystemInfo {
 		this._contextTimestamps = new StackedCacheMap();
 		/** @type {Map<string, ContextHash>} */
 		this._contextHashes = new Map();
-		/** @type {Map<string, ContextTimestampAndHash>} */
+		/** @type {Map<string, ContextTimestampAndHash | null>} */
 		this._contextTshs = new Map();
 		/** @type {Map<string, string>} */
 		this._managedItems = new Map();
@@ -1864,7 +1864,10 @@ class FileSystemInfo {
 		if (cache !== undefined) {
 			const resolved = getResolvedTimestamp(cache);
 			if (resolved !== undefined) return callback(null, resolved);
-			return this._resolveContextTsh(cache, callback);
+			return this._resolveContextTsh(
+				/** @type {ContextTimestampAndHash} */ (cache),
+				callback
+			);
 		}
 		this.contextTshQueue.add(path, (err, _entry) => {
 			if (err) return callback(err);
@@ -2902,7 +2905,10 @@ class FileSystemInfo {
 								}
 							};
 							if (cache !== undefined) {
-								this._resolveContextTsh(cache, callback);
+								this._resolveContextTsh(
+									/** @type {ContextTimestampAndHash} */ (cache),
+									callback
+								);
 							} else {
 								this.getContextTsh(path, callback);
 							}
@@ -4332,12 +4338,17 @@ class FileSystemInfo {
 		/**
 		 * Processes the provided timestamp.
 		 * @param {ContextTimestamp} timestamp timestamp
-		 * @param {ContextHash} hash hash
+		 * @param {ContextHash | null} hash hash
 		 */
 		const finalize = (timestamp, hash) => {
-			const result =
-				/** @type {ContextTimestampAndHash} */
-				(timestamp === "ignore" ? hash : { ...timestamp, ...hash });
+			/** @type {ContextTimestampAndHash | null} */
+			let result = null;
+			// Merging two `null` reads yields `{}`, which reads as "exists, no hash" (#21636)
+			if (hash !== null) {
+				result =
+					/** @type {ContextTimestampAndHash} */
+					(timestamp === "ignore" ? hash : { ...timestamp, ...hash });
+			}
 			this._contextTshs.set(path, result);
 			callback(null, result);
 		};
@@ -4478,8 +4489,7 @@ class FileSystemInfo {
 				this._getUnresolvedContextTsh(target, (err, entry) => {
 					if (err) return callback(err);
 					if (entry) {
-						// A target in neither cache reduces to `{}`, which has no hash (#21636)
-						if (entry.hash !== undefined) hashes.push(entry.hash);
+						hashes.push(entry.hash);
 						if (entry.timestampHash) tsHashes.push(entry.timestampHash);
 						if (entry.safeTime) {
 							safeTime = Math.max(safeTime, entry.safeTime);

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -4478,7 +4478,8 @@ class FileSystemInfo {
 				this._getUnresolvedContextTsh(target, (err, entry) => {
 					if (err) return callback(err);
 					if (entry) {
-						hashes.push(entry.hash);
+						// A target in neither cache reduces to `{}`, which has no hash (#21636)
+						if (entry.hash !== undefined) hashes.push(entry.hash);
 						if (entry.timestampHash) tsHashes.push(entry.timestampHash);
 						if (entry.safeTime) {
 							safeTime = Math.max(safeTime, entry.safeTime);

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1442,7 +1442,7 @@ class FileSystemInfo {
 		this._contextTimestamps = new StackedCacheMap();
 		/** @type {Map<string, ContextHash>} */
 		this._contextHashes = new Map();
-		/** @type {Map<string, ContextTimestampAndHash | null>} */
+		/** @type {Map<string, ContextTimestampAndHash>} */
 		this._contextTshs = new Map();
 		/** @type {Map<string, string>} */
 		this._managedItems = new Map();
@@ -1864,10 +1864,7 @@ class FileSystemInfo {
 		if (cache !== undefined) {
 			const resolved = getResolvedTimestamp(cache);
 			if (resolved !== undefined) return callback(null, resolved);
-			return this._resolveContextTsh(
-				/** @type {ContextTimestampAndHash} */ (cache),
-				callback
-			);
+			return this._resolveContextTsh(cache, callback);
 		}
 		this.contextTshQueue.add(path, (err, _entry) => {
 			if (err) return callback(err);
@@ -2905,10 +2902,7 @@ class FileSystemInfo {
 								}
 							};
 							if (cache !== undefined) {
-								this._resolveContextTsh(
-									/** @type {ContextTimestampAndHash} */ (cache),
-									callback
-								);
+								this._resolveContextTsh(cache, callback);
 							} else {
 								this.getContextTsh(path, callback);
 							}
@@ -4341,14 +4335,14 @@ class FileSystemInfo {
 		 * @param {ContextHash | null} hash hash
 		 */
 		const finalize = (timestamp, hash) => {
-			/** @type {ContextTimestampAndHash | null} */
-			let result = null;
 			// Merging two `null` reads yields `{}`, which reads as "exists, no hash" (#21636)
-			if (hash !== null) {
-				result =
-					/** @type {ContextTimestampAndHash} */
-					(timestamp === "ignore" ? hash : { ...timestamp, ...hash });
-			}
+			const result =
+				/** @type {ContextTimestampAndHash} */
+				(
+					hash === null || timestamp === "ignore"
+						? hash
+						: { ...timestamp, ...hash }
+				);
 			this._contextTshs.set(path, result);
 			callback(null, result);
 		};

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -709,7 +709,11 @@ const lstatReadlinkAbsolute = (fs, p, callback) => {
 			}
 			if (err) return callback(err);
 			const value = /** @type {string} */ (target).toString();
-			callback(null, join(fs, dirname(fs, p), value));
+			// An absolute target must not be joined onto the link's directory (#21636)
+			callback(
+				null,
+				isAbsolute(value) ? value : join(fs, dirname(fs, p), value)
+			);
 		});
 	};
 	const doStat = () => {

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -721,6 +721,48 @@ ${details(snapshot)}`)
 				done();
 			});
 		});
+
+		// #21636: an absolute target was joined onto the link's parent directory
+		// (`join("/path/context/sub", "/path/folder/context")`), so the snapshot
+		// tracked a path that does not exist and never went invalid.
+		it("should invalidate a snapshot when a file behind an absolute symlink target changes", (done) => {
+			const fs = createFs();
+			const fsInfo = createFsInfo(fs);
+			fsInfo.createSnapshot(
+				Date.now() + 10000,
+				[],
+				["/path/context/sub"],
+				[],
+				{ hash: true },
+				(err, snapshot) => {
+					if (err) return done(err);
+					fs.writeFileSync("/path/folder/context/file.txt", "Changed");
+					expectSnapshotState(fs, snapshot, false, done);
+				}
+			);
+		});
+
+		// #21636: a symlink target that is in the timestamp and the hash cache as
+		// `null` merges to `{}`, whose missing hash used to reach
+		// `hash.update(undefined)` and abort the build with a `TypeError`.
+		it("should not crash on a symlink whose target directory is missing", (done) => {
+			const fs = createFs();
+			fs.symlinkSync("/path/missing", "/path/context/sub/dangling", "dir");
+			const fsInfo = createFsInfo(fs);
+			fsInfo.getContextTimestamp("/path/missing", (err) => {
+				if (err) return done(err);
+				fsInfo.getContextHash("/path/missing", (err) => {
+					if (err) return done(err);
+					fsInfo.getContextTsh("/path/context/sub", (err, tsh) => {
+						if (err) return done(err);
+						expect(typeof (/** @type {{ hash: string }} */ (tsh).hash)).toBe(
+							"string"
+						);
+						done();
+					});
+				});
+			});
+		});
 	});
 
 	describe("unsupported directory entries", () => {

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -741,8 +741,8 @@ ${details(snapshot)}`)
 			);
 		});
 
-		// #21636: a target cached as `null` twice merges to `{}`, whose missing
-		// hash used to reach `hash.update(undefined)` and abort the build.
+		// #21636: a target read as `null` for both timestamp and hash merged to
+		// `{}`, whose missing hash reached `hash.update(undefined)`.
 		it("should not crash on a symlink whose target directory is missing", (done) => {
 			const fs = createFs();
 			fs.symlinkSync("/path/missing", "/path/context/sub/dangling", "dir");
@@ -758,6 +758,32 @@ ${details(snapshot)}`)
 						);
 						done();
 					});
+				});
+			});
+		});
+
+		// #21636: the same `{}` is truthy, so a missing directory was snapshotted
+		// as existing and creating it no longer counted as a change.
+		it("should invalidate a snapshot when a missing directory is created", (done) => {
+			const fs = createFs();
+			const fsInfo = createFsInfo(fs);
+			fsInfo.getContextTimestamp("/path/missing", (err) => {
+				if (err) return done(err);
+				fsInfo.getContextHash("/path/missing", (err) => {
+					if (err) return done(err);
+					fsInfo.createSnapshot(
+						Date.now() + 10000,
+						[],
+						["/path/missing"],
+						[],
+						{ timestamp: true, hash: true },
+						(err, snapshot) => {
+							if (err) return done(err);
+							fs.mkdirSync("/path/missing", { recursive: true });
+							fs.writeFileSync("/path/missing/file.txt", "Hello World");
+							expectSnapshotState(fs, snapshot, false, done);
+						}
+					);
 				});
 			});
 		});

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -722,9 +722,8 @@ ${details(snapshot)}`)
 			});
 		});
 
-		// #21636: an absolute target was joined onto the link's parent directory
-		// (`join("/path/context/sub", "/path/folder/context")`), so the snapshot
-		// tracked a path that does not exist and never went invalid.
+		// #21636: joining an absolute target onto the link's directory produced a
+		// path that does not exist, so the snapshot never went invalid.
 		it("should invalidate a snapshot when a file behind an absolute symlink target changes", (done) => {
 			const fs = createFs();
 			const fsInfo = createFsInfo(fs);
@@ -742,9 +741,8 @@ ${details(snapshot)}`)
 			);
 		});
 
-		// #21636: a symlink target that is in the timestamp and the hash cache as
-		// `null` merges to `{}`, whose missing hash used to reach
-		// `hash.update(undefined)` and abort the build with a `TypeError`.
+		// #21636: a target cached as `null` twice merges to `{}`, whose missing
+		// hash used to reach `hash.update(undefined)` and abort the build.
 		it("should not crash on a symlink whose target directory is missing", (done) => {
 			const fs = createFs();
 			fs.symlinkSync("/path/missing", "/path/context/sub/dangling", "dir");


### PR DESCRIPTION
**Summary**

Two defects behind #21636. `lstatReadlinkAbsolute` joined every `readlink` result onto the link's parent directory, so a symlink with an absolute target was snapshotted under a path that does not exist (`join("/repo/sub", "/repo/node_modules")` is `/repo/sub/repo/node_modules`); an absolute target now resolves to itself. Separately, a context that is unreadable is read back as `null` for both its timestamp and its hash, and merging those two in `_readContextTimestampAndHash` produced `{}` — an entry claiming the context exists while carrying no hash. That crashed the tsh walk on `hash.update(undefined)`, and, because `{}` is truthy, let a snapshot of a missing directory stay valid after that directory was created; such a read now yields `null`, the value the timestamp-only and hash-only reads already use. Closes #21636. The path fix is the same one-liner as #21637 (credit to @lazerg), which this supersedes.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — three cases in `test/FileSystemInfo.unittest.js`: a snapshot that must go invalid when a file behind an absolute-target symlink changes, a context walk over a symlink whose target directory is missing, and a snapshot that must go invalid once a missing directory is created.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — Claude Code was used to reproduce both defects, review #21637 against the issue, and write the fixes and regression tests; each test was checked to fail against unmodified `main` and pass with the change.
