### PR TITLE
 fix(html): keep an end tag whose omission lets the adoption agency restructure the tree

### DIFF
--- a/.changeset/157-html-minify-text-fixes.md
+++ b/.changeset/157-html-minify-text-fixes.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix HTML minification losing a character after a CR line ending, dropping a body's leading whitespace when its tag is implied, and the parser case-folding the non-ASCII characters of an element or attribute name.
+Fix HTML minification losing a character after a CR line ending, dropping a body's leading whitespace when its tag is implied, omitting an end tag whose absence lets the parser's adoption agency restructure the tree, and the parser case-folding the non-ASCII characters of an element or attribute name.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7984,8 +7984,7 @@ const _canOmitEndTag = (path, name, node) => {
 		const parent = path.parentOf(node);
 		const parentIsHtml = parent !== 0 && path.namespace(parent) === NS_HTML;
 		// Left open inside a formatting element, this is the furthest block the
-		// adoption agency needs on the parent's end tag — it would clone the
-		// parent and move this under it, so §13.1.2.4's permission does not hold.
+		// adoption agency needs — the parent's end tag would then restructure both.
 		if (
 			parentIsHtml &&
 			SPECIAL.has(name) &&

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7981,9 +7981,20 @@ const _canOmitEndTag = (path, name, node) => {
 	const next = path.nextSibling(node);
 	if (next === 0) {
 		if (!OPTIONAL_END_TAG_AT_END.has(name)) return false;
-		if (name !== "p") return true;
 		const parent = path.parentOf(node);
-		if (parent === 0 || path.namespace(parent) !== NS_HTML) return false;
+		const parentIsHtml = parent !== 0 && path.namespace(parent) === NS_HTML;
+		// Left open inside a formatting element, this is the furthest block the
+		// adoption agency needs on the parent's end tag — it would clone the
+		// parent and move this under it, so §13.1.2.4's permission does not hold.
+		if (
+			parentIsHtml &&
+			SPECIAL.has(name) &&
+			FORMATTING.has(path.tagName(parent))
+		) {
+			return false;
+		}
+		if (name !== "p") return true;
+		if (!parentIsHtml) return false;
 		const parentName = path.tagName(parent);
 		// An autonomous custom element is spelled with a hyphen.
 		return !P_KEEPS_END_TAG_IN.has(parentName) && !parentName.includes("-");

--- a/test/configCases/html/minimize-end-tag-in-formatting/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/minimize-end-tag-in-formatting/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html minimize-end-tag-in-formatting minimize-end-tag-in-formatting should compile 1`] = `
+"<!doctype html><html><body>
+	<b><p>paragraph</p></b>tail
+	<em><li>item</li></em>rest
+	<div><p>kept anyway</div>
+	<b><span>not special</span></b>after
+
+
+</body></html>"
+`;

--- a/test/configCases/html/minimize-end-tag-in-formatting/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/minimize-end-tag-in-formatting/__snapshots__/ConfigTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html minimize-end-tag-in-formatting minimize-end-tag-in-formatting should compile 1`] = `
+"<!doctype html><html><body>
+	<b><p>paragraph</p></b>tail
+	<em><li>item</li></em>rest
+	<div><p>kept anyway</div>
+	<b><span>not special</span></b>after
+
+
+</body></html>"
+`;

--- a/test/configCases/html/minimize-end-tag-in-formatting/index.js
+++ b/test/configCases/html/minimize-end-tag-in-formatting/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should keep an end tag whose omission would let the adoption agency run", () => {
+	// The emitted file is the assertion — see the snapshot in test.config.js.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-end-tag-in-formatting/page.html
+++ b/test/configCases/html/minimize-end-tag-in-formatting/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+	<b><p>paragraph</p></b>tail
+	<em><li>item</li></em>rest
+	<div><p>kept anyway</p></div>
+	<b><span>not special</span></b>after
+</body>
+</html>

--- a/test/configCases/html/minimize-end-tag-in-formatting/test.config.js
+++ b/test/configCases/html/minimize-end-tag-in-formatting/test.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		expect(
+			fs.readFileSync(path.join(options.output.path, "page.html"), "utf8")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/html/minimize-end-tag-in-formatting/webpack.config.js
+++ b/test/configCases/html/minimize-end-tag-in-formatting/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		},
+		parser: {
+			html: {
+				sources: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

§13.1.2.4 lets a paragraph or list-item end tag be omitted when nothing follows it in its parent, and the minifier took that permission at face value. Inside a formatting element it does not hold: the element left open is exactly the furthest block the adoption agency looks for when the parent's end tag arrives, so the page re-parses to a different tree — `<b><p>x</p></b>` printed as `<b><p>x</b>` re-parses to `<b></b><p><b>x</b>`. An `em` wrapping an `li` breaks the same way. Found by the real-browser DOM equivalence check while adding parser coverage cases.

The end tag is now kept when the parent is an HTML formatting element and the element itself is special. A `div` or `ul` parent is unaffected, and no existing snapshot in the suite changed.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — test/configCases/html/minimize-end-tag-in-formatting, covering both broken shapes plus two controls that must keep omitting. The fixture is also picked up by the browser equivalence unit test, which failed on it before the fix (11 vs 13 elements) and passes after.

**Does this PR introduce a breaking change?**

No. Output only grows where it was previously wrong.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. I found the divergence through the browser equivalence check, then used AI to reduce it to a minimal reproduction, locate the rule in the printer, write the regression case and run the suites. I reviewed the change and verified the round-trip and the unaffected cases myself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML output minification to preserve required end tags in formatting elements.
  * Prevented serialized HTML from being restructured incorrectly by browser parsing behavior.

* **Tests**
  * Added coverage for end-tag minimization across paragraphs, list items, preserved blocks, and inline elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->