### PR TITLE
fix(cjs): disconnect unused side-effect-free reexport requires

### DIFF
--- a/.changeset/040-drop-unused-cjs-requires.md
+++ b/.changeset/040-drop-unused-cjs-requires.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Drop unused side-effect-free CommonJS require() calls.
+Drop unused side-effect-free CommonJS require() calls and reexports.

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -22,6 +22,7 @@ const processExportInfo = require("./processExportInfo");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
+/** @typedef {import("../Dependency").GetConditionFn} GetConditionFn */
 /** @typedef {import("../Dependency").RawReferencedExports} RawReferencedExports */
 /** @typedef {import("../Dependency").ReferencedExports} ReferencedExports */
 /** @typedef {import("../Dependency").TRANSITIVE} TRANSITIVE */
@@ -31,6 +32,7 @@ const processExportInfo = require("./processExportInfo");
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
+/** @typedef {import("../ModuleGraphConnection")} ModuleGraphConnection */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./CommonJsDependencyHelpers").CommonJSDependencyBaseKeywords} CommonJSDependencyBaseKeywords */
@@ -100,6 +102,31 @@ class CommonJsExportRequireDependency extends ModuleDependency {
 	 */
 	canConcatenate(concatenateCommonJsModules) {
 		return concatenateCommonJsModules;
+	}
+
+	/**
+	 * Returns function to determine if the connection is active.
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @returns {null | false | GetConditionFn} function to determine if the connection is active
+	 */
+	getCondition(moduleGraph) {
+		// Conservative: keep `module.exports = require(...)` (names empty) active even
+		// when the parent is evaluation-only and the target is side-effect-free.
+		if (this.resultUsed || this.names.length === 0) return null;
+		const names = this.names;
+		const getter = this.getter;
+		return (connection, runtime) => {
+			const parentModule = moduleGraph.getParentModule(this);
+			if (!parentModule) return true;
+			const used = moduleGraph
+				.getExportsInfo(parentModule)
+				.getUsedName(names, runtime);
+			if (used !== false) return true;
+			if (getter) return false;
+			const refModule = connection.resolvedModule;
+			if (!refModule) return true;
+			return refModule.getSideEffectsConnectionState(moduleGraph);
+		};
 	}
 
 	/**
@@ -459,6 +486,16 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 			moduleGraph.getExportsInfo(module).getUsedName(dep.names, runtime)
 		);
 
+		const connection = /** @type {ModuleGraphConnection | undefined} */ (
+			moduleGraph.getConnection(dep)
+		);
+		// Inactive unused reexport: no module id; drop to a no-op.
+		// Missing connection (e.g. IgnorePlugin) must keep the require so it throws.
+		if (!used && connection && !connection.isTargetActive(runtime)) {
+			source.replace(dep.range[0], dep.range[1] - 1, "/* unused reexport */ 0");
+			return;
+		}
+
 		const [type, base] = handleDependencyBase(
 			dep.base,
 			module,
@@ -535,14 +572,12 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 				// barrel files (e.g. webpack's own `lib/index.js`).
 				const valueRange = /** @type {Range} */ (dep.valueRange);
 				if (!used) {
-					// A lazy getter never runs `require` until accessed, so an unused
-					// one can be dropped entirely; an eager value must keep side effects.
+					// Active unused eager reexport: keep side effects. Unused getters
+					// are inactive and already replaced with `0` above.
 					source.replace(
 						dep.range[0],
 						dep.range[1] - 1,
-						dep.getter
-							? "/* unused reexport */ 0"
-							: `/* unused reexport */ ${requireExpr}`
+						`/* unused reexport */ ${requireExpr}`
 					);
 					return;
 				}

--- a/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-cyclic-unused-export-require/index.js
@@ -1,13 +1,11 @@
 import { A } from "./a.cjs";
 import { B } from "./b.cjs";
 
-// `fromA`/`fromB` stay unused, so each require references no export while both
-// modules are still required and evaluated. Walking them has to be recorded
-// separately from any usage flag, or this cycle never reaches a fixpoint and
-// the compilation hangs.
-it("terminates on cyclic evaluation-only requires between side-effect-free modules", () => {
+// Unused cyclic reexports between side-effect-free modules must deactivate
+// without hanging, while used exports stay.
+it("terminates on cyclic unused reexports between side-effect-free modules", () => {
 	expect(A).toBe(1);
 	expect(B).toBe(2);
 	const src = String(__webpack_modules__["./a.cjs"]);
-	expect(src).toMatch(/unused reexport/);
+	expect(src).toMatch(/\/\* unused reexport \*\/ 0/);
 });

--- a/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/index.js
+++ b/test/configCases/cjs-tree-shaking/side-effect-free-unused-export-require/index.js
@@ -2,11 +2,11 @@ import { NodeSDK } from "./sdk-node.cjs";
 
 export const sdk = new NodeSDK();
 
-// `tracing` is never imported, so the `require("./utility.cjs")` behind it
-// references no export while the module is still required and evaluated.
-it("keeps a self-referenced export behind an unused cjs re-export", () => {
+// `tracing` is never imported; the side-effect-free reexport target is dropped.
+it("drops a side-effect-free module behind an unused cjs re-export", () => {
 	expect(sdk).toBeInstanceOf(NodeSDK);
-	const src = String(__webpack_modules__["./utility.cjs"]);
-	expect(src).toMatch(/exports\.DEFAULT_LIMIT = 128;/);
-	expect(src).toMatch(/__webpack_unused_export__ = function getLimit/);
+	expect("./utility.cjs" in __webpack_modules__).toBe(false);
+	expect(String(__webpack_modules__["./sdk-node.cjs"])).toMatch(
+		/\/\* unused reexport \*\/ 0/
+	);
 });

--- a/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/effect.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/effect.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+global.__cjs_unused_eager_effect_ran = true;
+module.exports = "effect";

--- a/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/index.js
@@ -1,0 +1,8 @@
+import { used } from "./lib.cjs";
+
+it("keeps evaluating a side-effectful module behind an unused eager reexport", () => {
+	expect(used).toBe("used");
+	expect("./effect.cjs" in __webpack_modules__).toBe(true);
+	expect(global.__cjs_unused_eager_effect_ran).toBe(true);
+	delete global.__cjs_unused_eager_effect_ran;
+});

--- a/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/lib.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/lib.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.unused = require("./effect.cjs");
+exports.used = "used";

--- a/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/unused-eager-reexport-keeps-effect/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/heavy.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/heavy.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+global.__cjs_unused_getter_heavy_ran = true;
+module.exports = "heavy";

--- a/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/index.js
@@ -1,0 +1,7 @@
+import { used } from "./lib.cjs";
+
+it("drops a module behind an unused getter reexport even with side effects", () => {
+	expect(used).toBe("used");
+	expect("./heavy.cjs" in __webpack_modules__).toBe(false);
+	expect(global.__cjs_unused_getter_heavy_ran).toBe(undefined);
+});

--- a/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/lib.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/lib.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "lazy", {
+	enumerable: true,
+	get: () => require("./heavy.cjs")
+});
+exports.used = "used";

--- a/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/unused-getter-reexport-drop/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/index.js
@@ -1,0 +1,10 @@
+import { used } from "./lib.cjs";
+
+it("drops an unused SEF reexport when concatenateModules is enabled", () => {
+	expect(used).toBe("used");
+	expect("./sef.cjs" in __webpack_modules__).toBe(false);
+	const src = Object.keys(__webpack_modules__)
+		.map((id) => String(__webpack_modules__[id]))
+		.join("\n");
+	expect(src).toMatch(/\/\* unused reexport \*\/ 0/);
+});

--- a/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/lib.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/lib.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.unused = require("./sef.cjs");
+exports.used = "used";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/sef.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/sef.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.marker = "SEF_CONCAT_MARKER";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-concatenated-drop/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "sef.cjs"),
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: true
+	}
+};

--- a/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/index.js
@@ -1,0 +1,9 @@
+import { used } from "./lib.cjs";
+
+it("drops unused nested, defineProperty-value, and ids reexports of a SEF module", () => {
+	expect(used).toBe("used");
+	expect("./sef.cjs" in __webpack_modules__).toBe(false);
+	const src = String(__webpack_modules__["./lib.cjs"]);
+	expect(src).not.toMatch(/SEF_MARKER/);
+	expect((src.match(/\/\* unused reexport \*\/ 0/g) || []).length).toBe(3);
+});

--- a/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/lib.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/lib.cjs
@@ -1,0 +1,10 @@
+"use strict";
+
+exports.ns = {};
+exports.ns.x = require("./sef.cjs");
+Object.defineProperty(exports, "viaValue", {
+	enumerable: true,
+	value: require("./sef.cjs")
+});
+exports.viaIds = require("./sef.cjs").y;
+exports.used = "used";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/sef.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/sef.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.y = 1;
+exports.marker = "SEF_MARKER";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-forms-drop/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "sef.cjs"),
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/index.js
@@ -1,0 +1,11 @@
+import { used } from "./lib.cjs";
+
+it("drops an unused reexport when the target package declares sideEffects: false", () => {
+	expect(used).toBe("used");
+	const src = String(__webpack_modules__["./lib.cjs"]);
+	expect(src).toMatch(/\/\* unused reexport \*\/ 0/);
+	expect(src).not.toMatch(/SEF_PKG_MARKER/);
+	expect(
+		Object.keys(__webpack_modules__).some((id) => /sef-pkg/.test(id))
+	).toBe(false);
+});

--- a/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/lib.cjs
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/lib.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.unused = require("sef-pkg");
+exports.used = "used";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/node_modules/sef-pkg/index.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/node_modules/sef-pkg/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.marker = "SEF_PKG_MARKER";

--- a/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/node_modules/sef-pkg/package.json
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/node_modules/sef-pkg/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "sef-pkg",
+	"main": "index.js",
+	"sideEffects": false
+}

--- a/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/unused-reexport-package-sideEffects-drop/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};

--- a/test/configCases/ignore/unused-getter-reexport/folder-b/ignored-module.js
+++ b/test/configCases/ignore/unused-getter-reexport/folder-b/ignored-module.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/configCases/ignore/unused-getter-reexport/folder-b/lib.cjs
+++ b/test/configCases/ignore/unused-getter-reexport/folder-b/lib.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "lazy", {
+	enumerable: true,
+	get: () => require("./ignored-module")
+});
+exports.used = "used";

--- a/test/configCases/ignore/unused-getter-reexport/index.js
+++ b/test/configCases/ignore/unused-getter-reexport/index.js
@@ -1,0 +1,8 @@
+it("keeps a missing-module throw for an unused ignored getter reexport", () => {
+	expect(() => {
+		require("./folder-b/lib.cjs");
+	}).toThrow(/Cannot find module/);
+	const src = String(__webpack_modules__["./folder-b/lib.cjs"]);
+	expect(src).toMatch(/webpackMissingModule/);
+	expect(src).not.toMatch(/\/\* unused reexport \*\/ 0/);
+});

--- a/test/configCases/ignore/unused-getter-reexport/webpack.config.js
+++ b/test/configCases/ignore/unused-getter-reexport/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const IgnorePlugin = require("../../../../").IgnorePlugin;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	entry: "./index.js",
+	plugins: [
+		new IgnorePlugin({
+			resourceRegExp: /ignored-module/,
+			contextRegExp: /folder-b/
+		})
+	],
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		mangleExports: false,
+		usedExports: true,
+		sideEffects: true,
+		concatenateModules: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Unused named CJS reexports (`exports.x = require(...)` / unused getters) kept the target module in the graph even when side-effect-free; deactivate those edges like evaluation-only requires, while keeping whole-module assigns and missing targets (e.g. IgnorePlugin) alive.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/cjs-tree-shaking/unused-*`, updated `side-effect-free-*-unused-export-require`, and `test/configCases/ignore/unused-getter-reexport`.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI assisted implementation of `getCondition` on `CommonJsExportRequireDependency`, regression fixtures, and review of edge cases (IgnorePlugin / missing connection).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CommonJS tree-shaking to remove unused re-exports from side-effect-free modules.
  * Preserved required execution for unused re-exports that may have side effects.
  * Added support for safely handling unused nested, getter-based, and package-based re-export patterns.
* **Bug Fixes**
  * Prevented cyclic unused re-exports from causing processing issues.
* **Tests**
  * Added coverage for multiple CommonJS re-export forms, side-effect behavior, module concatenation, and ignored modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->