### PR TITLE
feat(esm): widen analyzable output to HMR, hashed and function chunk filenames

### DIFF
--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output — under hot module replacement, for hashed chunk filenames, for a function `output.chunkFilename`, and for WebAssembly behind a URL public path — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output to HMR, hashed and function chunk filenames, and wasm.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output to HMR, hashed and function chunk filenames, and wasm.
+Widen analyzable ESM output to HMR, hashed and function chunk names, and wasm.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output — under hot module replacement, and for WebAssembly behind a URL public path — and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output — under hot module replacement, and for WebAssembly behind a URL public path — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output — under hot module replacement, for WebAssembly behind a URL public path, and for a function `output.chunkFilename` — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output — under hot module replacement, for hashed chunk filenames, for a function `output.chunkFilename`, and for WebAssembly behind a URL public path — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output — under hot module replacement, and for WebAssembly behind a URL public path — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output — under hot module replacement, for WebAssembly behind a URL public path, and for a function `output.chunkFilename` — drop the runtime chunk loader from analyzable css and resource-hint chunks, and fix chunk and WebAssembly loading in ES module builds.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output, including under hot module replacement, and fix chunk and WebAssembly loading in ES module builds.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output, including under hot module replacement, and fix chunk and WebAssembly loading in ES module builds.
+Widen analyzable ESM output — under hot module replacement, and for WebAssembly behind a URL public path — and fix chunk and WebAssembly loading in ES module builds.

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -15,6 +15,7 @@ const lazyModule = require("./util/lazyModule");
 
 /** @typedef {import("../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
 /** @typedef {import("./Chunk")} Chunk */
+/** @typedef {import("./Module").RuntimeRequirements} RuntimeRequirements */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./RuntimeModule")} RuntimeModule */
 
@@ -573,6 +574,23 @@ class RuntimePlugin {
 					);
 					return true;
 				});
+			/** @type {WeakSet<Chunk>} */
+			const ensureChunkModuleAdded = new WeakSet();
+			/**
+			 * The module carries the handler map as well as `ensureChunk`, and an
+			 * analyzable `import()` needs the map without the function around it.
+			 * @param {Chunk} chunk the chunk
+			 * @param {RuntimeRequirements} set the tree's requirements, filled in place
+			 */
+			const addEnsureChunkRuntimeModule = (chunk, set) => {
+				if (ensureChunkModuleAdded.has(chunk)) return;
+				ensureChunkModuleAdded.add(chunk);
+				compilation.addLazyRuntimeModule(
+					chunk,
+					getEnsureChunkRuntimeModule,
+					(Ctor) => new Ctor(set)
+				);
+			};
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunk)
 				.tap(PLUGIN_NAME, (chunk, set) => {
@@ -580,12 +598,14 @@ class RuntimePlugin {
 					if (hasAsyncChunks) {
 						set.add(RuntimeGlobals.ensureChunkHandlers);
 					}
-					compilation.addLazyRuntimeModule(
-						chunk,
-						getEnsureChunkRuntimeModule,
-						(Ctor) => new Ctor(set)
-					);
+					addEnsureChunkRuntimeModule(chunk, set);
 					return true;
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.ensureChunkHandlers)
+				.tap(PLUGIN_NAME, (chunk, set) => {
+					// No bail: every other plugin attaching a handler taps this same key.
+					addEnsureChunkRuntimeModule(chunk, set);
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunkIncludeEntries)

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -60,8 +60,11 @@ const FEDERATION_MODULE_TYPES = new Set([
 // or `:<digest>[:<length>]` suffix (e.g. `[contenthash:base64:8]`). Its value is only
 // resolved after code generation, so a filename using one can't be an inline literal.
 const HASH_IN_FILENAME = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/;
-// Stands in for every hash a filename function might read, to tell whether it does.
+// Two stand-ins for every hash a filename function might read: a name built from one
+// is hash-dependent exactly when the two calls disagree.
 const HASH_PROBE = "0123456789abcdef0123";
+// Reversed, so the two differ at every position and no slice of one equals the other.
+const HASH_PROBE_ALTERNATE = "3210fedcba9876543210";
 const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
@@ -80,6 +83,28 @@ const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./dependencies/ImportPhase").ImportPhaseType} ImportPhaseType */
 /** @typedef {import("./NormalModuleFactory").ModuleDependency} ModuleDependency */
+
+/**
+ * A stand-in whose every hash — of any content-hash type, not only the ones this chunk
+ * carries — reads back as `hash`. Shadows the chunk rather than mutating it, so a
+ * filename function still reads every other field and method straight off it.
+ * @param {Chunk} chunk the chunk being referenced
+ * @param {string} hash the stand-in hash
+ * @returns {Chunk} the stand-in chunk
+ */
+const createHashProbeChunk = (chunk, hash) => {
+	const probeChunk = Object.create(chunk);
+	probeChunk.hash = hash;
+	probeChunk.renderedHash = hash;
+	probeChunk.contentHash = new Proxy(
+		{},
+		{
+			get: (target, key) => (typeof key === "string" ? hash : undefined),
+			has: () => true
+		}
+	);
+	return probeChunk;
+};
 
 /**
  * No module id error message.
@@ -1843,9 +1868,8 @@ class RuntimeTemplate {
 		const deferred = template === undefined || HASH_IN_FILENAME.test(template);
 		if (
 			deferred &&
-			// An id names the chunk in the stand-in. `optimization.chunkIds: false` leaves
-			// it unset, and while nothing builds in that state today, a stand-in nothing
-			// could resolve would reach the bundle verbatim — falling back is the safe half.
+			// An id names the chunk in the stand-in, and one nothing could resolve would
+			// reach the bundle verbatim.
 			(chunk.id === null ||
 				!getAnalyzableChunkHashPlugin().canDeferSpecifier(compilation))
 		) {
@@ -1935,11 +1959,10 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The chunk filename template as a plain string. A function is called for the
-	 * template it returns — but no hash is knowable here: during code generation
-	 * `chunk.contentHash` is still empty and `chunk.hash` unset. A second call with
-	 * those filled in says whether the answer depends on them, and one that does is
-	 * left for the deferred pass to ask again once they are settled.
+	 * The chunk filename template as a plain string. A function is called twice, with
+	 * a different stand-in hash each time; disagreeing answers mean the name depends on
+	 * a hash, which is not knowable during code generation, so it is left to the
+	 * deferred pass to ask again once the hashes are settled.
 	 * @param {ChunkFilenameTemplate} filenameTemplate the configured template
 	 * @param {Chunk} chunk the chunk being referenced
 	 * @returns {string | undefined | null} the template, `undefined` to defer, or
@@ -1947,25 +1970,21 @@ class RuntimeTemplate {
 	 */
 	_resolveChunkFilenameTemplate(filenameTemplate, chunk) {
 		if (typeof filenameTemplate === "string") return filenameTemplate;
-		// Shadows the hashes on a stand-in rather than touching the chunk, so the
-		// template still reads every other field (and method) straight off it.
-		const probeChunk = Object.create(chunk);
-		probeChunk.hash = HASH_PROBE;
-		probeChunk.renderedHash = HASH_PROBE;
-		probeChunk.contentHash = { [JAVASCRIPT_TYPE]: HASH_PROBE };
 		try {
 			const template = filenameTemplate({
-				chunk,
-				contentHashType: JAVASCRIPT_TYPE
-			});
-			const probe = filenameTemplate({
-				chunk: probeChunk,
+				chunk: createHashProbeChunk(chunk, HASH_PROBE),
 				contentHashType: JAVASCRIPT_TYPE,
 				hash: HASH_PROBE,
 				contentHash: HASH_PROBE
 			});
+			const probe = filenameTemplate({
+				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE),
+				contentHashType: JAVASCRIPT_TYPE,
+				hash: HASH_PROBE_ALTERNATE,
+				contentHash: HASH_PROBE_ALTERNATE
+			});
 			return template === probe ? template : undefined;
-		} catch (_err) {
+		} catch (_error) {
 			// A template that needs more than this chunk can't be resolved here.
 			return null;
 		}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -35,6 +35,7 @@ const {
 	getOptimizedDeferredModule
 } = require("./runtime/MakeDeferredNamespaceObjectRuntime");
 const { equals } = require("./util/ArrayHelpers");
+const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const compileBooleanMatcher = require("./util/compileBooleanMatcher");
 const { getUndoPath, toJsStringLiteral } = require("./util/identifier");
 const memoize = require("./util/memoize");
@@ -319,13 +320,31 @@ class RuntimeTemplate {
 	 */
 	supportsAnalyzableWasm() {
 		return (
-			this.supportsAnalyzableEsmUrl() &&
+			this.supportsAnalyzableEsm() &&
+			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
 			// `[fullhash]` is only known after code generation.
 			!getTemplatedPathPlugin()
 				.getPresentKinds(
 					/** @type {string} */ (this.outputOptions.webassemblyModuleFilename)
 				)
 				.has("fullhash")
+		);
+	}
+
+	/**
+	 * Whether `output.publicPath` is a complete URL of its own. Baking one keeps the
+	 * same target, because `new URL(...)` ignores its base for an absolute specifier.
+	 * A root- or directory-relative public path does not: the runtime form resolves it
+	 * against the document and a baked one against the chunk, which differ exactly
+	 * where a public path is worth setting.
+	 * @returns {boolean} true for a static, absolute-URL public path
+	 */
+	_hasUrlPublicPath() {
+		const { publicPath } = this.outputOptions;
+		return (
+			typeof publicPath === "string" &&
+			!publicPath.includes("[") &&
+			(publicPath.startsWith("//") || getScheme(publicPath) !== undefined)
 		);
 	}
 
@@ -1853,6 +1872,19 @@ class RuntimeTemplate {
 			/** @type {string} */ (this.outputOptions.webassemblyModuleFilename),
 			{ module, runtime, chunkGraph }
 		);
+		// Only a chunk that fetches may carry the public path into the literal: `readFile`
+		// takes a `file:` URL alone, and those loaders address the binary relative to the
+		// chunk anyway, ignoring the public path exactly as the runtime form does.
+		if (
+			this.outputOptions.publicPath !== "auto" &&
+			this._wasmChunksFetch(module, chunkGraph)
+		) {
+			return this.importMetaUrl(
+				toJsStringLiteral(
+					/** @type {string} */ (this.outputOptions.publicPath) + filename
+				)
+			);
+		}
 		const undo = this._getModuleUndoPath(module, chunkGraph);
 		/** @type {string} */
 		let specifier;
@@ -1865,6 +1897,27 @@ class RuntimeTemplate {
 			specifier = toJsStringLiteral(undo + filename);
 		}
 		return this.importMetaUrl(specifier);
+	}
+
+	/**
+	 * Whether every chunk holding `module` loads WebAssembly through `fetch`, which is
+	 * what makes an absolute URL usable — the `async-node` and `universal` loaders hand
+	 * the result to `readFile`, and that accepts a `file:` URL alone.
+	 * @param {Module} module the async wasm module
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {boolean} true when every holding chunk fetches
+	 */
+	_wasmChunksFetch(module, chunkGraph) {
+		const { outputOptions } = this;
+		for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
+			const entryOptions = chunk.getEntryOptions();
+			const wasmLoading =
+				entryOptions && entryOptions.wasmLoading !== undefined
+					? entryOptions.wasmLoading
+					: outputOptions.wasmLoading;
+			if (wasmLoading !== "fetch") return false;
+		}
+		return true;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1692,11 +1692,11 @@ class RuntimeTemplate {
 		chunkGraph
 	) {
 		const { outputOptions } = this;
+		// `blockPromise` has already dropped any chunk without an id.
 		if (
 			!outputOptions.module ||
 			outputOptions.chunkFormat !== "module" ||
 			outputOptions.importFunctionName !== "import" ||
-			chunk.id === null ||
 			!originModule ||
 			!chunkGraph
 		) {
@@ -1843,6 +1843,9 @@ class RuntimeTemplate {
 		const deferred = template === undefined || HASH_IN_FILENAME.test(template);
 		if (
 			deferred &&
+			// An id names the chunk in the stand-in. `optimization.chunkIds: false` leaves
+			// it unset, and while nothing builds in that state today, a stand-in nothing
+			// could resolve would reach the bundle verbatim — falling back is the safe half.
 			(chunk.id === null ||
 				!getAnalyzableChunkHashPlugin().canDeferSpecifier(compilation))
 		) {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1751,8 +1751,9 @@ class RuntimeTemplate {
 			: `"./${specifier.slice(1)}`;
 		runtimeRequirements.add(RuntimeGlobals.analyzableChunkImport);
 		if (needsHintHandlers || hasNonJsTypes) {
-			// `ensureChunk` is what creates the `.f` map the handlers attach to.
-			runtimeRequirements.add(RuntimeGlobals.ensureChunk);
+			// Those handlers attach to the `.f` map, which has to exist — but the runtime
+			// `ensureChunk` around it does not, since `.ei` dispatches them itself.
+			runtimeRequirements.add(RuntimeGlobals.ensureChunkHandlers);
 		}
 		// Drop-in for `ensureChunk(id)`: the literal `import()` can be statically
 		// followed, the helper keeps webpack's install timing and deduplication.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -43,6 +43,9 @@ const { propertyAccess, propertyName } = require("./util/property");
 const { forEachRuntime, subtractRuntime } = require("./util/runtime");
 
 const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
+const getAnalyzableChunkHashPlugin = memoize(() =>
+	require("./esm/AnalyzableChunkHashPlugin")
+);
 
 // Module-federation module types whose chunks load through the federation runtime.
 /** @type {Set<string>} */
@@ -65,6 +68,7 @@ const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
+/** @typedef {import("./Chunk").ChunkId} ChunkId */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./Dependency")} Dependency */
@@ -1833,31 +1837,54 @@ class RuntimeTemplate {
 			filenameTemplate,
 			chunk
 		);
-		if (template === null || HASH_IN_FILENAME.test(template)) {
+		if (template === null) return null;
+		// A hashed name is settled long after this code is generated, so a stand-in is
+		// emitted and filled in once the hash exists.
+		const deferred = HASH_IN_FILENAME.test(template);
+		if (
+			deferred &&
+			(chunk.id === null ||
+				!getAnalyzableChunkHashPlugin().canDeferSpecifier(compilation))
+		) {
 			return null;
 		}
-		const filename = compilation.getPath(template, {
-			chunk,
-			contentHashType: JAVASCRIPT_TYPE
-		});
+		const filename = deferred
+			? ""
+			: compilation.getPath(template, {
+					chunk,
+					contentHashType: JAVASCRIPT_TYPE
+				});
+		/**
+		 * @param {string} prefix what goes in front of the chunk's filename
+		 * @returns {string} the specifier, already quoted
+		 */
+		const specifier = (prefix) =>
+			toJsStringLiteral(
+				deferred
+					? getAnalyzableChunkHashPlugin().reserveSpecifier(
+							prefix,
+							/** @type {ChunkId} */ (chunk.id)
+						)
+					: prefix + filename
+			);
 		if (overridePublicPath) {
 			return overridePublicPath.includes("[")
 				? null
-				: toJsStringLiteral(overridePublicPath + filename);
+				: specifier(overridePublicPath);
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
 			const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
-			if (undo !== null) return toJsStringLiteral(undo + filename);
+			if (undo !== null) return specifier(undo);
 			// Different depths — no single relative literal. No bundler follows a
 			// concatenation, but a `new URL(...)` caller still sheds the `.u(id)` lookup
 			// this way; `import()` needs a static specifier, so it gets nothing.
-			if (!runtimeRequirements) return null;
+			if (deferred || !runtimeRequirements) return null;
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
 		if (typeof publicPath === "string" && !publicPath.includes("[")) {
-			return toJsStringLiteral(publicPath + filename);
+			return specifier(publicPath);
 		}
 		return null;
 	}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -41,9 +41,6 @@ const memoize = require("./util/memoize");
 const { propertyAccess, propertyName } = require("./util/property");
 const { forEachRuntime, subtractRuntime } = require("./util/runtime");
 
-const getModuleHotAcceptDependency = memoize(() =>
-	require("./dependencies/ModuleHotAcceptDependency")
-);
 const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 
 // Module-federation module types whose chunks load through the federation runtime.
@@ -1679,16 +1676,8 @@ class RuntimeTemplate {
 		) {
 			return null;
 		}
-		// HMR wraps `ensureChunk` (`.e`) to track in-flight loads and relies on it being
-		// present in the runtime; the analyzable `import()` (`.ei`) replaces `.e` and would
-		// leave a lazy-compilation proxy's own `.e` call undefined, so keep the runtime form.
-		// A runtime `__webpack_public_path__` override likewise can't reach a baked literal.
-		if (
-			this.compilation.dependencyFactories.has(
-				getModuleHotAcceptDependency()
-			) ||
-			APIPlugin.usesRuntimePublicPathOverride(this.compilation)
-		) {
+		// A runtime `__webpack_public_path__` override can't reach a baked literal.
+		if (APIPlugin.usesRuntimePublicPathOverride(this.compilation)) {
 			return null;
 		}
 		// A worker loading its own chunks some other way keeps that runtime; one on

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1820,7 +1820,7 @@ class RuntimeTemplate {
 				typeof template === "string"
 					? template.replace(HASH_IN_FILENAME_GLOBAL, "x")
 					: template,
-				{ chunk, contentHashType: JAVASCRIPT_TYPE }
+				{ chunk, runtime: chunk.runtime, contentHashType: JAVASCRIPT_TYPE }
 			);
 			const undo = getUndoPath(chunkName, outputPath, true);
 			if (!found) {
@@ -1879,6 +1879,9 @@ class RuntimeTemplate {
 			? ""
 			: compilation.getPath(/** @type {string} */ (template), {
 					chunk,
+					// Matches what names the asset, or a placeholder resolved here would
+					// not be the one on disk.
+					runtime: chunk.runtime,
 					contentHashType: JAVASCRIPT_TYPE
 				});
 		/**
@@ -1971,14 +1974,18 @@ class RuntimeTemplate {
 	_resolveChunkFilenameTemplate(filenameTemplate, chunk) {
 		if (typeof filenameTemplate === "string") return filenameTemplate;
 		try {
+			// Everything the naming call is given except the hashes, so only a hash can
+			// make the two answers differ.
 			const template = filenameTemplate({
 				chunk: createHashProbeChunk(chunk, HASH_PROBE),
+				runtime: chunk.runtime,
 				contentHashType: JAVASCRIPT_TYPE,
 				hash: HASH_PROBE,
 				contentHash: HASH_PROBE
 			});
 			const probe = filenameTemplate({
 				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE),
+				runtime: chunk.runtime,
 				contentHashType: JAVASCRIPT_TYPE,
 				hash: HASH_PROBE_ALTERNATE,
 				contentHash: HASH_PROBE_ALTERNATE

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -57,11 +57,14 @@ const FEDERATION_MODULE_TYPES = new Set([
 // or `:<digest>[:<length>]` suffix (e.g. `[contenthash:base64:8]`). Its value is only
 // resolved after code generation, so a filename using one can't be an inline literal.
 const HASH_IN_FILENAME = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/;
+// Stands in for every hash a filename function might read, to tell whether it does.
+const HASH_PROBE = "0123456789abcdef0123";
 const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
+/** @typedef {import("./Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./Dependency")} Dependency */
@@ -1826,13 +1829,14 @@ class RuntimeTemplate {
 			chunk,
 			outputOptions
 		);
-		if (
-			typeof filenameTemplate !== "string" ||
-			HASH_IN_FILENAME.test(filenameTemplate)
-		) {
+		const template = this._resolveChunkFilenameTemplate(
+			filenameTemplate,
+			chunk
+		);
+		if (template === null || HASH_IN_FILENAME.test(template)) {
 			return null;
 		}
-		const filename = compilation.getPath(filenameTemplate, {
+		const filename = compilation.getPath(template, {
 			chunk,
 			contentHashType: JAVASCRIPT_TYPE
 		});
@@ -1898,6 +1902,42 @@ class RuntimeTemplate {
 			specifier = toJsStringLiteral(undo + filename);
 		}
 		return this.importMetaUrl(specifier);
+	}
+
+	/**
+	 * The chunk filename template as a plain string, or `null` when it cannot be one.
+	 * A function is called for the template it returns — but no hash is knowable here:
+	 * during code generation `chunk.contentHash` is still empty and `chunk.hash` unset.
+	 * A second call with those filled in says whether the answer depends on them, and
+	 * one that does is refused rather than baked into a name nothing will be emitted as.
+	 * @param {ChunkFilenameTemplate} filenameTemplate the configured template
+	 * @param {Chunk} chunk the chunk being referenced
+	 * @returns {string | null} the template, or `null` to fall back
+	 */
+	_resolveChunkFilenameTemplate(filenameTemplate, chunk) {
+		if (typeof filenameTemplate === "string") return filenameTemplate;
+		// Shadows the hashes on a stand-in rather than touching the chunk, so the
+		// template still reads every other field (and method) straight off it.
+		const probeChunk = Object.create(chunk);
+		probeChunk.hash = HASH_PROBE;
+		probeChunk.renderedHash = HASH_PROBE;
+		probeChunk.contentHash = { [JAVASCRIPT_TYPE]: HASH_PROBE };
+		try {
+			const template = filenameTemplate({
+				chunk,
+				contentHashType: JAVASCRIPT_TYPE
+			});
+			const probe = filenameTemplate({
+				chunk: probeChunk,
+				contentHashType: JAVASCRIPT_TYPE,
+				hash: HASH_PROBE,
+				contentHash: HASH_PROBE
+			});
+			return template === probe ? template : null;
+		} catch (_err) {
+			// A template that needs more than this chunk can't be resolved here.
+			return null;
+		}
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1840,7 +1840,7 @@ class RuntimeTemplate {
 		if (template === null) return null;
 		// A hashed name is settled long after this code is generated, so a stand-in is
 		// emitted and filled in once the hash exists.
-		const deferred = HASH_IN_FILENAME.test(template);
+		const deferred = template === undefined || HASH_IN_FILENAME.test(template);
 		if (
 			deferred &&
 			(chunk.id === null ||
@@ -1850,7 +1850,7 @@ class RuntimeTemplate {
 		}
 		const filename = deferred
 			? ""
-			: compilation.getPath(template, {
+			: compilation.getPath(/** @type {string} */ (template), {
 					chunk,
 					contentHashType: JAVASCRIPT_TYPE
 				});
@@ -1932,14 +1932,15 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The chunk filename template as a plain string, or `null` when it cannot be one.
-	 * A function is called for the template it returns — but no hash is knowable here:
-	 * during code generation `chunk.contentHash` is still empty and `chunk.hash` unset.
-	 * A second call with those filled in says whether the answer depends on them, and
-	 * one that does is refused rather than baked into a name nothing will be emitted as.
+	 * The chunk filename template as a plain string. A function is called for the
+	 * template it returns — but no hash is knowable here: during code generation
+	 * `chunk.contentHash` is still empty and `chunk.hash` unset. A second call with
+	 * those filled in says whether the answer depends on them, and one that does is
+	 * left for the deferred pass to ask again once they are settled.
 	 * @param {ChunkFilenameTemplate} filenameTemplate the configured template
 	 * @param {Chunk} chunk the chunk being referenced
-	 * @returns {string | null} the template, or `null` to fall back
+	 * @returns {string | undefined | null} the template, `undefined` to defer, or
+	 * `null` to fall back
 	 */
 	_resolveChunkFilenameTemplate(filenameTemplate, chunk) {
 		if (typeof filenameTemplate === "string") return filenameTemplate;
@@ -1960,7 +1961,7 @@ class RuntimeTemplate {
 				hash: HASH_PROBE,
 				contentHash: HASH_PROBE
 			});
-			return template === probe ? template : null;
+			return template === probe ? template : undefined;
 		} catch (_err) {
 			// A template that needs more than this chunk can't be resolved here.
 			return null;

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -85,22 +85,35 @@ const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 /** @typedef {import("./NormalModuleFactory").ModuleDependency} ModuleDependency */
 
 /**
- * A stand-in whose every hash — of any content-hash type, not only the ones this chunk
- * carries — reads back as `hash`. Shadows the chunk rather than mutating it, so a
- * filename function still reads every other field and method straight off it.
+ * A stand-in whose every hash reads back as `hash`. Which content hashes a chunk
+ * carries is settled after code generation, so `present` makes the two probes disagree
+ * about that too — a name built by enumerating them then reads as hash-dependent.
+ * Shadows the chunk rather than mutating it, so a filename function still reads every
+ * other field and method straight off it.
  * @param {Chunk} chunk the chunk being referenced
  * @param {string} hash the stand-in hash
+ * @param {boolean} present whether the chunk is claimed to carry content hashes
  * @returns {Chunk} the stand-in chunk
  */
-const createHashProbeChunk = (chunk, hash) => {
+const createHashProbeChunk = (chunk, hash, present) => {
 	const probeChunk = Object.create(chunk);
 	probeChunk.hash = hash;
 	probeChunk.renderedHash = hash;
 	probeChunk.contentHash = new Proxy(
-		{},
+		present ? { [JAVASCRIPT_TYPE]: hash } : {},
 		{
+			// Any content-hash type, not only the ones this chunk happens to carry.
 			get: (target, key) => (typeof key === "string" ? hash : undefined),
-			has: () => true
+			has: () => present,
+			getOwnPropertyDescriptor: () =>
+				present
+					? {
+							value: hash,
+							writable: true,
+							enumerable: true,
+							configurable: true
+						}
+					: undefined
 		}
 	);
 	return probeChunk;
@@ -1977,14 +1990,14 @@ class RuntimeTemplate {
 			// Everything the naming call is given except the hashes, so only a hash can
 			// make the two answers differ.
 			const template = filenameTemplate({
-				chunk: createHashProbeChunk(chunk, HASH_PROBE),
+				chunk: createHashProbeChunk(chunk, HASH_PROBE, true),
 				runtime: chunk.runtime,
 				contentHashType: JAVASCRIPT_TYPE,
 				hash: HASH_PROBE,
 				contentHash: HASH_PROBE
 			});
 			const probe = filenameTemplate({
-				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE),
+				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE, false),
 				runtime: chunk.runtime,
 				contentHashType: JAVASCRIPT_TYPE,
 				hash: HASH_PROBE_ALTERNATE,

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -1,0 +1,144 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author sheo13666q @sheo13666q
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const Compilation = require("../Compilation");
+const memoize = require("../util/memoize");
+
+/** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Chunk").ChunkId} ChunkId */
+/** @typedef {import("../Compiler")} Compiler */
+
+const getJavascriptModulesPlugin = memoize(() =>
+	require("../javascript/JavascriptModulesPlugin")
+);
+
+// Looks like a relative specifier, so the code around it needs no special case, and
+// carries what it resolves to rather than an index into per-build state: a module
+// restored from the persistent cache is never generated again, and a stand-in that
+// outlived its registry would reach the bundle unreplaced.
+const TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
+
+/**
+ * @param {string} prefix what goes in front of the chunk's filename
+ * @param {ChunkId} chunkId id of the chunk being addressed
+ * @returns {string} the stand-in to emit
+ */
+const reserveSpecifier = (prefix, chunkId) =>
+	`./@@webpackAnalyzableChunk:${Buffer.from(JSON.stringify([prefix, chunkId]))
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/[=]/g, "")}@@`;
+
+/**
+ * @param {string} payload the encoded half of a stand-in
+ * @returns {[string, ChunkId] | null} prefix and chunk id, or `null` if unreadable
+ */
+const readSpecifier = (payload) => {
+	try {
+		return JSON.parse(
+			Buffer.from(
+				payload.replace(/-/g, "+").replace(/_/g, "/"),
+				"base64"
+			).toString()
+		);
+	} catch (_err) {
+		return null;
+	}
+};
+
+/**
+ * Whether a specifier may be deferred at all. Substituting rewrites a chunk after its
+ * own content hash was taken, so something has to bring the two back in line —
+ * `RealContentHashPlugin` is what does, and without it the name would go stale.
+ * @param {Compilation} compilation the compilation
+ * @returns {boolean} true when deferring is safe
+ */
+const canDeferSpecifier = (compilation) =>
+	Boolean(compilation.options.optimization.realContentHash);
+
+const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
+
+/**
+ * Fills in the specifiers reserved during code generation, once the hashes their
+ * filenames are built from exist. Runs before `RealContentHashPlugin`, which is what
+ * brings each rewritten chunk's own name back in line with its content.
+ */
+class AnalyzableChunkHashPlugin {
+	/**
+	 * Apply the plugin.
+	 * @param {Compiler} compiler the compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: PLUGIN_NAME,
+					stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH - 1
+				},
+				() => {
+					const { outputOptions } = compilation;
+					/** @type {Map<string, Chunk> | undefined} */
+					let byId;
+					/**
+					 * @param {string} payload the encoded half of a stand-in
+					 * @returns {string | null} the specifier, or `null` if unresolvable
+					 */
+					const resolve = (payload) => {
+						const read = readSpecifier(payload);
+						if (read === null) return null;
+						const [prefix, chunkId] = read;
+						if (byId === undefined) {
+							byId = new Map();
+							for (const chunk of compilation.chunks) {
+								if (chunk.id !== null) byId.set(String(chunk.id), chunk);
+							}
+						}
+						const chunk = byId.get(String(chunkId));
+						if (chunk === undefined) return null;
+						const specifier =
+							prefix +
+							compilation.getPath(
+								getJavascriptModulesPlugin().getChunkFilenameTemplate(
+									chunk,
+									outputOptions
+								),
+								{ chunk, contentHashType: "javascript" }
+							);
+						// A bare specifier is a package name, so make it explicitly relative
+						// the way the chunk loader does.
+						return /^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(specifier)
+							? specifier
+							: `./${specifier}`;
+					};
+					for (const name of Object.keys(compilation.assets)) {
+						const content = compilation.assets[name].source();
+						if (typeof content !== "string") continue;
+						TOKEN_REGEXP.lastIndex = 0;
+						if (!TOKEN_REGEXP.test(content)) continue;
+						TOKEN_REGEXP.lastIndex = 0;
+						compilation.updateAsset(
+							name,
+							new RawSource(
+								content.replace(TOKEN_REGEXP, (match, payload) => {
+									const specifier = resolve(payload);
+									return specifier === null ? match : specifier;
+								})
+							)
+						);
+					}
+				}
+			);
+		});
+	}
+}
+
+module.exports = AnalyzableChunkHashPlugin;
+module.exports.canDeferSpecifier = canDeferSpecifier;
+module.exports.reserveSpecifier = reserveSpecifier;

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -18,9 +18,8 @@ const getJavascriptModulesPlugin = memoize(() =>
 );
 
 // Looks like a relative specifier, so the code around it needs no special case, and
-// carries what it resolves to rather than an index into per-build state: a module
-// restored from the persistent cache is never generated again, and a stand-in that
-// outlived its registry would reach the bundle unreplaced.
+// carries what it resolves to rather than an index into per-build state — a module
+// restored from the persistent cache is never generated again.
 const TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
 
 /**
@@ -40,22 +39,30 @@ const reserveSpecifier = (prefix, chunkId) =>
  * @returns {[string, ChunkId] | null} prefix and chunk id, or `null` if unreadable
  */
 const readSpecifier = (payload) => {
+	/** @type {EXPECTED_ANY} */
+	let decoded;
 	try {
-		return JSON.parse(
+		decoded = JSON.parse(
 			Buffer.from(
 				payload.replace(/-/g, "+").replace(/_/g, "/"),
 				"base64"
 			).toString()
 		);
-	} catch (_err) {
+	} catch (_error) {
 		return null;
 	}
+	// Source of our own can spell the token too, so nothing about its payload is given.
+	if (!Array.isArray(decoded) || decoded.length !== 2) return null;
+	const [prefix, chunkId] = decoded;
+	if (typeof prefix !== "string") return null;
+	if (typeof chunkId !== "string" && typeof chunkId !== "number") return null;
+	return [prefix, chunkId];
 };
 
 /**
  * Whether a specifier may be deferred at all. Substituting rewrites a chunk after its
- * own content hash was taken, so something has to bring the two back in line —
- * `RealContentHashPlugin` is what does, and without it the name would go stale.
+ * own content hash was taken, and `RealContentHashPlugin` is what brings the two back
+ * in line — without it the name would go stale.
  * @param {Compilation} compilation the compilation
  * @returns {boolean} true when deferring is safe
  */
@@ -66,8 +73,8 @@ const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
 
 /**
  * Fills in the specifiers reserved during code generation, once the hashes their
- * filenames are built from exist. Runs before `RealContentHashPlugin`, which is what
- * brings each rewritten chunk's own name back in line with its content.
+ * filenames are built from exist. Runs before `RealContentHashPlugin`, which repairs
+ * each rewritten chunk's own name.
  */
 class AnalyzableChunkHashPlugin {
 	/**
@@ -85,22 +92,22 @@ class AnalyzableChunkHashPlugin {
 				() => {
 					const { outputOptions } = compilation;
 					/** @type {Map<string, Chunk> | undefined} */
-					let byId;
+					let chunksById;
 					/**
 					 * @param {string} payload the encoded half of a stand-in
 					 * @returns {string | null} the specifier, or `null` if unresolvable
 					 */
 					const resolve = (payload) => {
-						const read = readSpecifier(payload);
-						if (read === null) return null;
-						const [prefix, chunkId] = read;
-						if (byId === undefined) {
-							byId = new Map();
+						const decoded = readSpecifier(payload);
+						if (decoded === null) return null;
+						const [prefix, chunkId] = decoded;
+						if (chunksById === undefined) {
+							chunksById = new Map();
 							for (const chunk of compilation.chunks) {
-								if (chunk.id !== null) byId.set(String(chunk.id), chunk);
+								if (chunk.id !== null) chunksById.set(String(chunk.id), chunk);
 							}
 						}
-						const chunk = byId.get(String(chunkId));
+						const chunk = chunksById.get(String(chunkId));
 						if (chunk === undefined) return null;
 						const specifier =
 							prefix +

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -109,7 +109,13 @@ class AnalyzableChunkHashPlugin {
 									chunk,
 									outputOptions
 								),
-								{ chunk, contentHashType: "javascript" }
+								// Matches what `JavascriptModulesPlugin` names the asset with, or a
+								// placeholder resolved here would not be the one on disk.
+								{
+									chunk,
+									runtime: chunk.runtime,
+									contentHashType: "javascript"
+								}
 							);
 						// A bare specifier is a package name, so make it explicitly relative
 						// the way the chunk loader does.

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -7,6 +7,7 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const lazyModule = require("../util/lazyModule");
+const AnalyzableChunkHashPlugin = require("./AnalyzableChunkHashPlugin");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
@@ -29,6 +30,8 @@ class ModuleChunkLoadingPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		// Fills in the specifiers this plugin's analyzable `import()` reserves.
+		new AnalyzableChunkHashPlugin().apply(compiler);
 		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
 			const globalChunkLoading = compilation.outputOptions.chunkLoading;
 			/**

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -137,9 +137,8 @@ class ModuleChunkLoadingPlugin {
 					if (!isEnabledForChunk(chunk)) return;
 					set.add(RuntimeGlobals.publicPath);
 					set.add(RuntimeGlobals.getChunkUpdateScriptFilename);
-					// The hot runtime registers its own handler on the map and force-loads
-					// through the others, both by bare chunk id. So the map and the runtime
-					// loader stay even where every `import()` in the graph is analyzable.
+					// The hot runtime registers its own handler and force-loads through the
+					// others by bare chunk id, so the map and loader stay however analyzable.
 					set.add(RuntimeGlobals.ensureChunkHandlers);
 					set.add(RuntimeGlobals.getChunkScriptFilename);
 					set.add(RuntimeGlobals.moduleCache);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -114,8 +114,10 @@ class ModuleChunkLoadingPlugin {
 					set.add(RuntimeGlobals.getChunkScriptFilename);
 				});
 
+			// Keyed on `ensureChunk`, not on the handler map: only the runtime chunk loader
+			// builds a URL from a chunk id, and an analyzable `import()` carries its own.
 			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.ensureChunkHandlers)
+				.for(RuntimeGlobals.ensureChunk)
 				.tap(PLUGIN_NAME, (chunk, set) => {
 					if (!isEnabledForChunk(chunk)) return;
 
@@ -132,6 +134,11 @@ class ModuleChunkLoadingPlugin {
 					if (!isEnabledForChunk(chunk)) return;
 					set.add(RuntimeGlobals.publicPath);
 					set.add(RuntimeGlobals.getChunkUpdateScriptFilename);
+					// The hot runtime registers its own handler on the map and force-loads
+					// through the others, both by bare chunk id. So the map and the runtime
+					// loader stay even where every `import()` in the graph is analyzable.
+					set.add(RuntimeGlobals.ensureChunkHandlers);
+					set.add(RuntimeGlobals.getChunkScriptFilename);
 					set.add(RuntimeGlobals.moduleCache);
 					set.add(RuntimeGlobals.hmrModuleData);
 					set.add(RuntimeGlobals.moduleFactoriesAddOnly);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -137,10 +137,13 @@ class ModuleChunkLoadingPlugin {
 					if (!isEnabledForChunk(chunk)) return;
 					set.add(RuntimeGlobals.publicPath);
 					set.add(RuntimeGlobals.getChunkUpdateScriptFilename);
-					// The hot runtime registers its own handler and force-loads through the
-					// others by bare chunk id, so the map and loader stay however analyzable.
-					set.add(RuntimeGlobals.ensureChunkHandlers);
-					set.add(RuntimeGlobals.getChunkScriptFilename);
+					// The hot runtime force-loads through the handler map by bare chunk id, so
+					// the map and loader stay however analyzable — but only where there are
+					// async chunks to force-load.
+					if (chunk.hasAsyncChunks()) {
+						set.add(RuntimeGlobals.ensureChunkHandlers);
+						set.add(RuntimeGlobals.getChunkScriptFilename);
+					}
 					set.add(RuntimeGlobals.moduleCache);
 					set.add(RuntimeGlobals.hmrModuleData);
 					set.add(RuntimeGlobals.moduleFactoriesAddOnly);

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -116,6 +116,11 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 		const withHmrManifest = this._runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadManifest
 		);
+		// `.f.j` serves `ensureChunk`: an analyzable import dispatches every handler but
+		// this one. HMR's force-load knows only a chunk id, so it needs the loader too.
+		const withJsLoading =
+			withLoading &&
+			(this._runtimeRequirements.has(RuntimeGlobals.ensureChunk) || withHmr);
 		const { linkPreload, linkPrefetch } =
 			ModuleChunkLoadingRuntimeModule.getCompilationHooks(compilation);
 		const isNeutralPlatform = runtimeTemplate.isNeutralPlatform();
@@ -218,7 +223,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 					])}`
 				: "// no install chunk",
 			"",
-			withLoading
+			withJsLoading
 				? Template.asString([
 						`${fn}.j = ${runtimeTemplate.basicFunction(
 							"chunkId, promises",

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -195,9 +195,8 @@ module.exports = function () {
 				Object.defineProperty(fn, name, createPropertyDescriptor(name));
 			}
 		}
-		// A chunk load blocks the update until it settles. `.ei` is the analyzable half
-		// of `.e`, so it needs the same wrapper; a runtime that loads no chunks has
-		// neither, and wrapping an absent one would hand the module a broken function.
+		// A chunk load blocks the update until it settles, and `.ei` is the analyzable
+		// half of `.e`. A runtime that loads no chunks has neither to wrap.
 		if (require.e) {
 			/** @type {WebpackRequire} */ (fn).e = function (chunkId, fetchPriority) {
 				return trackBlockingPromise(

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -13,7 +13,9 @@
 /** @typedef {(status: string) => (Promise<void> | void)} StatusHandler */
 /** @typedef {Record<string, unknown>} ApplyOptions */
 /** @typedef {(reportError: (err: Error) => void) => Promise<ModuleId[]>} ApplyFn */
-/** @typedef {{ (id: ModuleId): unknown, e: (chunkId: ModuleId, fetchPriority?: string) => Promise<unknown>, [name: string]: unknown }} WebpackRequire */
+/** @typedef {(chunkId: ModuleId, fetchPriority?: string) => Promise<unknown>} EnsureChunk */
+/** @typedef {(chunkId: ModuleId, importFn: () => Promise<unknown>) => Promise<unknown>} AnalyzableChunkImport */
+/** @typedef {{ (id: ModuleId): unknown, e?: EnsureChunk, ei?: AnalyzableChunkImport, [name: string]: unknown }} WebpackRequire */
 
 /**
  * @typedef {object} ApplyResult
@@ -185,13 +187,31 @@ module.exports = function () {
 			};
 		};
 		for (var name in require) {
-			if (Object.prototype.hasOwnProperty.call(require, name) && name !== "e") {
+			if (
+				Object.prototype.hasOwnProperty.call(require, name) &&
+				name !== "e" &&
+				name !== "ei"
+			) {
 				Object.defineProperty(fn, name, createPropertyDescriptor(name));
 			}
 		}
-		/** @type {WebpackRequire} */ (fn).e = function (chunkId, fetchPriority) {
-			return trackBlockingPromise(require.e(chunkId, fetchPriority));
-		};
+		// A chunk load blocks the update until it settles. `.ei` is the analyzable half
+		// of `.e`, so it needs the same wrapper; a runtime that loads no chunks has
+		// neither, and wrapping an absent one would hand the module a broken function.
+		if (require.e) {
+			/** @type {WebpackRequire} */ (fn).e = function (chunkId, fetchPriority) {
+				return trackBlockingPromise(
+					/** @type {EnsureChunk} */ (require.e)(chunkId, fetchPriority)
+				);
+			};
+		}
+		if (require.ei) {
+			/** @type {WebpackRequire} */ (fn).ei = function (chunkId, importFn) {
+				return trackBlockingPromise(
+					/** @type {AnalyzableChunkImport} */ (require.ei)(chunkId, importFn)
+				);
+			};
+		}
 		return /** @type {WebpackRequire} */ (fn);
 	}
 

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -547,9 +547,8 @@ class LazyCompilationPlugin {
 		compiler.hooks.thisCompilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
-				// A proxy is generated between builds, not from changed source, so one already
-				// loaded in the client outlives the build that required `ensureChunk`. Keep it
-				// in every runtime, or the proxy calls a global the next build dropped.
+				// A proxy already loaded in the client outlives the build that required
+				// `ensureChunk`, so every runtime keeps it or the proxy calls a dropped global.
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
 					PLUGIN_NAME,
 					(chunk, set) => {

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -547,6 +547,15 @@ class LazyCompilationPlugin {
 		compiler.hooks.thisCompilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				// A proxy is generated between builds, not from changed source, so one already
+				// loaded in the client outlives the build that required `ensureChunk`. Keep it
+				// in every runtime, or the proxy calls a global the next build dropped.
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					PLUGIN_NAME,
+					(chunk, set) => {
+						set.add(RuntimeGlobals.ensureChunk);
+					}
+				);
 				normalModuleFactory.hooks.module.tap(
 					PLUGIN_NAME,
 					(module, createData, resolveData) => {

--- a/lib/runtime/EnsureChunkRuntimeModule.js
+++ b/lib/runtime/EnsureChunkRuntimeModule.js
@@ -38,12 +38,18 @@ class EnsureChunkRuntimeModule extends RuntimeModule {
 	generate() {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
+		// An analyzable `import()` dispatches the handlers itself, so a build can need the
+		// map without the function around it.
+		const withEnsureChunk = this.runtimeRequirements.has(
+			RuntimeGlobals.ensureChunk
+		);
 		// Check if there are non initial chunks which need to be imported using require-ensure
 		if (this.runtimeRequirements.has(RuntimeGlobals.ensureChunkHandlers)) {
 			const withFetchPriority = this.runtimeRequirements.has(
 				RuntimeGlobals.hasFetchPriority
 			);
 			const handlers = RuntimeGlobals.ensureChunkHandlers;
+			if (!withEnsureChunk) return `${handlers} = {};`;
 			return Template.asString([
 				`${handlers} = {};`,
 				"// This file contains only the entry chunk.",

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -91,7 +91,9 @@ class FetchCompileAsyncWasmPlugin {
 					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
-					if (!analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL carries the public path already, or asks for the global itself
+					// when the module sits at several depths.
+					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
@@ -125,7 +127,9 @@ class FetchCompileAsyncWasmPlugin {
 					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
-					if (!analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL carries the public path already, or asks for the global itself
+					// when the module sits at several depths.
+					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {

--- a/test/configCases/analyzable/css-chunk-import/index.js
+++ b/test/configCases/analyzable/css-chunk-import/index.js
@@ -23,3 +23,20 @@ it("should emit the analyzable literal for a chunk carrying css", () => {
 	expect(bundle).toContain(`${"__webpack_require__"}.ei("lazy_js"`);
 	expect(bundle).toContain('import("./lazy_js.mjs")');
 });
+
+it("should carry the handler map without the runtime chunk loader", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "main.mjs"),
+		"utf8"
+	);
+	const require_ = "__webpack_require__";
+
+	// `.f.css` needs the map to attach to, and `.ei` dispatches it from there.
+	expect(bundle).toContain(`${require_}.f = {}`);
+	expect(bundle).toContain(`${require_}.f.css =`);
+	// Nothing calls `.e`, so neither it nor the js handler behind it is emitted —
+	// and with them goes the chunk id to filename table.
+	expect(bundle).not.toContain(`${require_}.e =`);
+	expect(bundle).not.toContain(`${require_}.f.j =`);
+	expect(bundle).not.toContain(`${require_}.u =`);
+});

--- a/test/configCases/analyzable/css-content-hash-filename/index.js
+++ b/test/configCases/analyzable/css-content-hash-filename/index.js
@@ -1,0 +1,38 @@
+import fs from "fs";
+import path from "path";
+
+// Source of our own may spell a stand-in: one whose payload is not a chunk reference,
+// one whose payload is not even readable.
+const DECOYS = [
+	"./@@webpackAnalyzableChunk:e30@@",
+	"./@@webpackAnalyzableChunk:zzzz@@"
+];
+
+it("should load the chunk named after its css content hash", async () => {
+	const lazy = await import("./lazy");
+	expect(lazy.value).toBe("lazy");
+});
+
+it("should bake a specifier that is a file on disk", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "main.mjs"),
+		"utf8"
+	);
+	// Needle built at runtime so it is not a source string literal here.
+	const helper = `${"__webpack_require__"}.ei(`;
+
+	expect(bundle).toContain(helper);
+	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+		bundle.slice(bundle.indexOf(helper))
+	);
+
+	expect(specifier).not.toBe(null);
+	// A hash the probe never offered used to read back as `undefined` in both calls,
+	// which made the name look constant and baked that word into the specifier.
+	expect(specifier[1]).not.toContain("undefined");
+	expect(fs.existsSync(path.join(__STATS__.outputPath, specifier[1]))).toBe(
+		true
+	);
+
+	for (const decoy of DECOYS) expect(bundle).toContain(decoy);
+});

--- a/test/configCases/analyzable/css-content-hash-filename/lazy.js
+++ b/test/configCases/analyzable/css-content-hash-filename/lazy.js
@@ -1,0 +1,3 @@
+import "./style.css";
+
+export const value = "lazy";

--- a/test/configCases/analyzable/css-content-hash-filename/style.css
+++ b/test/configCases/analyzable/css-content-hash-filename/style.css
@@ -1,0 +1,3 @@
+.analyzable {
+	color: rgb(1, 2, 3);
+}

--- a/test/configCases/analyzable/css-content-hash-filename/test.config.js
+++ b/test/configCases/analyzable/css-content-hash-filename/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	}
+};

--- a/test/configCases/analyzable/css-content-hash-filename/test.filter.js
+++ b/test/configCases/analyzable/css-content-hash-filename/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// The `node-commonjs` externals build `require` from `node:module` (Node 12.2+).
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/css-content-hash-filename/webpack.config.js
+++ b/test/configCases/analyzable/css-content-hash-filename/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+// A function `chunkFilename` may read any content hash the chunk carries, not only the
+// javascript one — so the name is hash-dependent here and is left to the deferred pass.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true, css: true },
+	output: {
+		filename: "[name].mjs",
+		chunkFilename: (pathData) =>
+			`[name].${
+				/** @type {Record<string, string>} */ (
+					/** @type {import("../../../../").Chunk} */ (pathData.chunk)
+						.contentHash
+				).css
+			}.mjs`,
+		cssChunkFilename: "[name].css",
+		module: true,
+		chunkFormat: "module",
+		publicPath: "auto"
+	},
+	optimization: { chunkIds: "named", realContentHash: true },
+	externals: { fs: "node-commonjs fs", path: "node-commonjs path" },
+	performance: { hints: false }
+};

--- a/test/configCases/analyzable/function-chunk-filename/index.js
+++ b/test/configCases/analyzable/function-chunk-filename/index.js
@@ -16,7 +16,15 @@ it("should bake the literal only when the name holds no hash", () => {
 
 	if (__ANALYZABLE__) {
 		expect(bundle).toContain(helper);
-		expect(bundle).toContain('import("./a-lazy/lazy.mjs")');
+		// Whatever the name holds, what is baked has to be a file on disk.
+		const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+			bundle.slice(bundle.indexOf(helper))
+		);
+
+		expect(specifier).not.toBe(null);
+		expect(
+			fs.existsSync(path.join(__STATS__.children[0].outputPath, specifier[1]))
+		).toBe(true);
 	} else {
 		expect(bundle).not.toContain(helper);
 	}

--- a/test/configCases/analyzable/function-chunk-filename/index.js
+++ b/test/configCases/analyzable/function-chunk-filename/index.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+it("should load the chunk whichever form is emitted", async () => {
+	const lazy = await import(/* webpackChunkName: "lazy" */ "./lazy");
+	expect(lazy.value).toBe("lazy");
+});
+
+it("should bake the literal only when the name holds no hash", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[0].outputPath, `bundle${__INDEX__}.mjs`),
+		"utf8"
+	);
+	// Needle built at runtime so it is not a source string literal here.
+	const helper = `${"__webpack_require__"}.ei(`;
+
+	if (__ANALYZABLE__) {
+		expect(bundle).toContain(helper);
+		expect(bundle).toContain('import("./a-lazy/lazy.mjs")');
+	} else {
+		expect(bundle).not.toContain(helper);
+	}
+});

--- a/test/configCases/analyzable/function-chunk-filename/lazy.js
+++ b/test/configCases/analyzable/function-chunk-filename/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -2,8 +2,10 @@
 
 // A function `chunkFilename` is called for the template it returns. Only what it
 // answers for this chunk is knowable during code generation, and no hash is — so a
-// plain answer bakes, and one that reads a hash (by placeholder or off `pathData`)
-// keeps the runtime form rather than naming a file that is never emitted.
+// plain answer bakes right away, and one that depends on a hash is left to the
+// deferred pass, which asks the function again once the hashes are settled. Where
+// nothing would correct the stale name that rewriting leaves behind, the runtime
+// form is kept instead.
 
 const webpack = require("../../../../");
 
@@ -11,14 +13,15 @@ const webpack = require("../../../../");
  * @param {number} index position in this array, and so the entry's emitted name
  * @param {NonNullable<import("../../../../").Configuration["output"]>["chunkFilename"]} chunkFilename filename
  * @param {boolean} analyzable whether the import is expected to bake
+ * @param {boolean=} realContentHash whether a stale name gets corrected
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, chunkFilename, analyzable) => ({
+const base = (index, chunkFilename, analyzable, realContentHash = false) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
 	experiments: { outputModule: true },
-	optimization: { chunkIds: "named", splitChunks: false },
+	optimization: { chunkIds: "named", splitChunks: false, realContentHash },
 	output: { module: true, chunkFilename, publicPath: "auto" },
 	plugins: [
 		new webpack.DefinePlugin({
@@ -34,9 +37,22 @@ module.exports = [
 	base(0, (pathData) => `a-${pathData.chunk.name}/[name].mjs`, true),
 	// Returns a template carrying a hash placeholder.
 	base(1, () => "b-[name].[contenthash].mjs", false),
+	// The same template, deferred: the pass asks again once the hash is settled.
+	base(2, () => "d-[name].[contenthash].mjs", true, true),
+	// Builds the name from a hash itself, and is asked again the same way.
+	base(
+		3,
+		(pathData) =>
+			`e-[name].${
+				/** @type {Record<string, string>} */ (pathData.chunk.contentHash)
+					.javascript
+			}.mjs`,
+		true,
+		true
+	),
 	// Builds the name from a hash itself, so nothing is left to test for.
 	base(
-		2,
+		4,
 		(pathData) =>
 			`c-[name].${
 				/** @type {Record<string, string>} */ (pathData.chunk.contentHash)

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -1,0 +1,47 @@
+"use strict";
+
+// A function `chunkFilename` is called for the template it returns. Only what it
+// answers for this chunk is knowable during code generation, and no hash is — so a
+// plain answer bakes, and one that reads a hash (by placeholder or off `pathData`)
+// keeps the runtime form rather than naming a file that is never emitted.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position in this array, and so the entry's emitted name
+ * @param {NonNullable<import("../../../../").Configuration["output"]>["chunkFilename"]} chunkFilename filename
+ * @param {boolean} analyzable whether the import is expected to bake
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, chunkFilename, analyzable) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", splitChunks: false },
+	output: { module: true, chunkFilename, publicPath: "auto" },
+	plugins: [
+		new webpack.DefinePlugin({
+			__ANALYZABLE__: JSON.stringify(analyzable),
+			__INDEX__: JSON.stringify(index)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Returns a plain template — the same answer whatever the hashes are.
+	base(0, (pathData) => `a-${pathData.chunk.name}/[name].mjs`, true),
+	// Returns a template carrying a hash placeholder.
+	base(1, () => "b-[name].[contenthash].mjs", false),
+	// Builds the name from a hash itself, so nothing is left to test for.
+	base(
+		2,
+		(pathData) =>
+			`c-[name].${
+				/** @type {Record<string, string>} */ (pathData.chunk.contentHash)
+					.javascript
+			}.mjs`,
+		false
+	)
+];

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -55,5 +55,9 @@ module.exports = [
 					.javascript
 			}.mjs`,
 		false
-	)
+	),
+	// Reads what names the asset but is not a hash — the same answer both times.
+	base(5, (pathData) => `f-[name].${pathData.runtime}.mjs`, true),
+	// The placeholder form of the same, resolved rather than asked for.
+	base(6, "g-[name].[runtime].mjs", true)
 ];

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -1,11 +1,7 @@
 "use strict";
 
-// A function `chunkFilename` is called for the template it returns. Only what it
-// answers for this chunk is knowable during code generation, and no hash is — so a
-// plain answer bakes right away, and one that depends on a hash is left to the
-// deferred pass, which asks the function again once the hashes are settled. Where
-// nothing would correct the stale name that rewriting leaves behind, the runtime
-// form is kept instead.
+// A function `chunkFilename` bakes right away when its answer holds no hash, and is
+// asked again by the deferred pass when it does — or falls back if nothing corrects it.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -59,5 +59,16 @@ module.exports = [
 	// Reads what names the asset but is not a hash — the same answer both times.
 	base(5, (pathData) => `f-[name].${pathData.runtime}.mjs`, true),
 	// The placeholder form of the same, resolved rather than asked for.
-	base(6, "g-[name].[runtime].mjs", true)
+	base(6, "g-[name].[runtime].mjs", true),
+	// Asks which hashes the chunk carries, which is settled no earlier than their
+	// values are — so the answer is deferred just the same.
+	base(
+		7,
+		(pathData) =>
+			`h-[name].${Object.keys(
+				/** @type {Record<string, string>} */ (pathData.chunk.contentHash)
+			).join("-")}.mjs`,
+		true,
+		true
+	)
 ];

--- a/test/configCases/analyzable/hashed-chunk-filename/index.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/index.js
@@ -6,24 +6,28 @@ it("should load the hashed chunk whichever form is emitted", async () => {
 	expect(lazy.value).toBe("lazy");
 });
 
-it("should bake the settled hash only when a stale name would be corrected", () => {
+it("should bake a name that is really on disk", () => {
 	const dir = __STATS__.children[0].outputPath;
-	// Needle built at runtime so it is not a source string literal here.
+	// Needles built at runtime so they are not source string literals here.
 	const helper = `${"__webpack_require__"}.ei(`;
-	const emitted = fs
-		.readdirSync(dir)
-		.find((file) => /^a-lazy\.[\da-f]+\.mjs$/.test(file));
-
-	expect(emitted).toBeDefined();
-	const baked = fs.readFileSync(path.join(dir, "bundle0.mjs"), "utf8");
-
-	expect(baked).toContain(helper);
-	// A leading comment sits between `import(` and its specifier.
-	expect(baked).toContain(`"./${emitted}")`);
-	// No stand-in may reach the bundle, cached rebuild included.
-	expect(baked).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
-
-	expect(fs.readFileSync(path.join(dir, "bundle1.mjs"), "utf8")).not.toContain(
-		helper
+	const bundle = fs.readFileSync(
+		path.join(dir, `bundle${__INDEX__}.mjs`),
+		"utf8"
 	);
+
+	if (!__ANALYZABLE__) {
+		expect(bundle).not.toContain(helper);
+		return;
+	}
+	expect(bundle).toContain(helper);
+	// No stand-in may reach the bundle, cached rebuild included.
+	expect(bundle).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
+
+	// Anchored past the helper so the pattern cannot match its own source below.
+	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+		bundle.slice(bundle.indexOf(helper))
+	);
+
+	expect(specifier).not.toBe(null);
+	expect(fs.existsSync(path.join(dir, specifier[1]))).toBe(true);
 });

--- a/test/configCases/analyzable/hashed-chunk-filename/index.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/index.js
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+
+it("should load the hashed chunk whichever form is emitted", async () => {
+	const lazy = await import(/* webpackChunkName: "lazy" */ "./lazy");
+	expect(lazy.value).toBe("lazy");
+});
+
+it("should bake the settled hash only when a stale name would be corrected", () => {
+	const dir = __STATS__.children[0].outputPath;
+	// Needle built at runtime so it is not a source string literal here.
+	const helper = `${"__webpack_require__"}.ei(`;
+	const emitted = fs
+		.readdirSync(dir)
+		.find((file) => /^a-lazy\.[\da-f]+\.mjs$/.test(file));
+
+	expect(emitted).toBeDefined();
+	const baked = fs.readFileSync(path.join(dir, "bundle0.mjs"), "utf8");
+
+	expect(baked).toContain(helper);
+	// A leading comment sits between `import(` and its specifier.
+	expect(baked).toContain(`"./${emitted}")`);
+	// No stand-in may reach the bundle, cached rebuild included.
+	expect(baked).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
+
+	expect(fs.readFileSync(path.join(dir, "bundle1.mjs"), "utf8")).not.toContain(
+		helper
+	);
+});

--- a/test/configCases/analyzable/hashed-chunk-filename/lazy.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
@@ -1,17 +1,22 @@
 "use strict";
 
+let INDEX = 0;
+
 // A hashed chunk name is settled long after the code referencing it is generated, so
-// the specifier is emitted as a stand-in and filled in once the hash exists. Rewriting
-// a chunk after its own hash was taken leaves that hash stale, and
+// the specifier is emitted as a stand-in and filled in once the hash exists. Whatever
+// the template holds, the name baked in has to be the one on disk.
+//
+// Rewriting a chunk after its own hash was taken leaves that hash stale, and
 // `RealContentHashPlugin` is what brings the two back in line — so without it the
 // runtime form is kept instead.
 
 /**
  * @param {string} name prefix keeping the emitted files of each config apart
- * @param {boolean} realContentHash whether a stale name gets corrected
+ * @param {string} chunkFilename the template under test
+ * @param {boolean=} realContentHash whether a stale name gets corrected
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (name, realContentHash) => ({
+const base = (name, chunkFilename, realContentHash = true) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -22,12 +27,28 @@ const base = (name, realContentHash) => ({
 		splitChunks: false,
 		realContentHash
 	},
+	plugins: [
+		new (require("../../../../").DefinePlugin)({
+			__INDEX__: JSON.stringify(INDEX++),
+			__ANALYZABLE__: JSON.stringify(realContentHash)
+		})
+	],
 	output: {
 		module: true,
-		chunkFilename: `${name}-[name].[contenthash].mjs`,
+		chunkFilename: `${name}-${chunkFilename}`,
 		publicPath: "auto"
 	}
 });
 
 /** @type {import("../../../../").Configuration[]} */
-module.exports = [base("a", true), base("b", false)];
+module.exports = [
+	base("a", "[name].[contenthash].mjs"),
+	base("b", "[name].[chunkhash].mjs"),
+	base("c", "[name].[fullhash].mjs"),
+	base("d", "[name].[contenthash:8].mjs"),
+	// `[runtime]` is only filled in when the runtime is handed to the path as well.
+	base("e", "[name].[runtime].[contenthash].mjs"),
+	base("f", "nested/dir/[name].[contenthash].mjs"),
+	// No correction for a stale name, so the runtime form is kept.
+	base("g", "[name].[contenthash].mjs", false)
+];

--- a/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
@@ -2,13 +2,8 @@
 
 let INDEX = 0;
 
-// A hashed chunk name is settled long after the code referencing it is generated, so
-// the specifier is emitted as a stand-in and filled in once the hash exists. Whatever
-// the template holds, the name baked in has to be the one on disk.
-//
-// Rewriting a chunk after its own hash was taken leaves that hash stale, and
-// `RealContentHashPlugin` is what brings the two back in line — so without it the
-// runtime form is kept instead.
+// A hashed chunk name is emitted as a stand-in and filled in once the hash exists.
+// Without `realContentHash` nothing repairs the stale hash, so the runtime form stays.
 
 /**
  * @param {string} name prefix keeping the emitted files of each config apart

--- a/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+// A hashed chunk name is settled long after the code referencing it is generated, so
+// the specifier is emitted as a stand-in and filled in once the hash exists. Rewriting
+// a chunk after its own hash was taken leaves that hash stale, and
+// `RealContentHashPlugin` is what brings the two back in line — so without it the
+// runtime form is kept instead.
+
+/**
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {boolean} realContentHash whether a stale name gets corrected
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (name, realContentHash) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: {
+		chunkIds: "named",
+		minimize: false,
+		splitChunks: false,
+		realContentHash
+	},
+	output: {
+		module: true,
+		chunkFilename: `${name}-[name].[contenthash].mjs`,
+		publicPath: "auto"
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [base("a", true), base("b", false)];

--- a/test/configCases/wasm/analyzable-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-url-public-path/index.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced but never called: the binary would be loaded from the public path, and
+// what is under test is the URL webpack bakes for it.
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+// Only the chunk holding the wasm module: the entry bundle carries this file's own
+// needles, which would satisfy the assertions on their own.
+const chunk = () =>
+	fs.readFileSync(
+		path.join(__STATS__.children[0].outputPath, __WASM_CHUNK__),
+		"utf8"
+	);
+
+it("should bake the binary's url in the expected form", () => {
+	expect(chunk()).toContain(__WASM_REF__);
+});
+
+it("should not assemble the binary's url at runtime", () => {
+	// Needle built at runtime so it is not a source string literal here.
+	expect(chunk()).not.toContain(`new URL(${"__webpack_require__"}.p + `);
+});

--- a/test/configCases/wasm/analyzable-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-url-public-path/index.js
@@ -4,6 +4,8 @@ import path from "path";
 // Referenced but never called: the binary would be loaded from the public path, and
 // what is under test is the URL webpack bakes for it.
 export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+export const loadSource = () =>
+	import(/* webpackChunkName: "lazySource" */ "./lazy-source");
 
 // Only the chunk holding the wasm module: the entry bundle carries this file's own
 // needles, which would satisfy the assertions on their own.

--- a/test/configCases/wasm/analyzable-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-url-public-path/index.js
@@ -1,14 +1,12 @@
 import fs from "fs";
 import path from "path";
 
-// Referenced but never called: the binary would be loaded from the public path, and
-// what is under test is the URL webpack bakes for it.
+// Referenced but never called — the baked url is what is under test.
 export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
 export const loadSource = () =>
 	import(/* webpackChunkName: "lazySource" */ "./lazy-source");
 
-// Only the chunk holding the wasm module: the entry bundle carries this file's own
-// needles, which would satisfy the assertions on their own.
+// Only the wasm chunk — this file's own needles would satisfy the assertions.
 const chunk = () =>
 	fs.readFileSync(
 		path.join(__STATS__.children[0].outputPath, __WASM_CHUNK__),

--- a/test/configCases/wasm/analyzable-url-public-path/lazy-source.js
+++ b/test/configCases/wasm/analyzable-url-public-path/lazy-source.js
@@ -1,0 +1,3 @@
+import source wasmModule from "./wasm.wat?source";
+
+export const run = () => new WebAssembly.Instance(wasmModule);

--- a/test/configCases/wasm/analyzable-url-public-path/lazy.js
+++ b/test/configCases/wasm/analyzable-url-public-path/lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./wasm.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-url-public-path/wasm.wat
+++ b/test/configCases/wasm/analyzable-url-public-path/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-url-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-url-public-path/webpack.config.js
@@ -1,0 +1,48 @@
+"use strict";
+
+// A public path that is a complete URL bakes into the wasm binary's literal just as a
+// chunk-relative one does — `new URL(...)` ignores its base for an absolute specifier.
+// Only `fetch` loading may do that: `readFile` takes a `file:` URL alone, so a loader
+// reading from disk keeps addressing the binary relative to its chunk.
+
+const webpack = require("../../../../");
+
+const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
+
+/**
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {NonNullable<import("../../../../").Configuration["output"]>["wasmLoading"]} wasmLoading how the binary is loaded
+ * @param {string} wasmRef expected start of the baked URL
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (name, wasmLoading, wasmRef) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading,
+		chunkFilename: `${name}-chunks/[name].mjs`,
+		webassemblyModuleFilename: `${name}-[id].wasm`,
+		publicPath: "https://example.com/assets/"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__WASM_CHUNK__: JSON.stringify(`${name}-chunks/lazy.mjs`),
+			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base("fetch", "fetch", 'new URL("https://example.com/assets/fetch-'),
+	base("node", "async-node", 'new URL("../node-')
+];

--- a/test/configCases/wasm/analyzable-url-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-url-public-path/webpack.config.js
@@ -1,21 +1,21 @@
 "use strict";
 
-// A public path that is a complete URL bakes into the wasm binary's literal just as a
-// chunk-relative one does — `new URL(...)` ignores its base for an absolute specifier.
-// Only `fetch` loading may do that: `readFile` takes a `file:` URL alone, so a loader
-// reading from disk keeps addressing the binary relative to its chunk.
+// A public path that is a complete URL bakes into the wasm literal, but only under
+// `fetch` loading — `readFile` takes a `file:` URL alone, so it stays chunk-relative.
 
 const webpack = require("../../../../");
 
 const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
+const COMPILE = `${"__webpack_require__"}.vs(`;
 
 /**
  * @param {string} name prefix keeping the emitted files of each config apart
  * @param {NonNullable<import("../../../../").Configuration["output"]>["wasmLoading"]} wasmLoading how the binary is loaded
- * @param {string} wasmRef expected start of the baked URL
+ * @param {string} wasmChunk chunk holding the wasm module under test
+ * @param {string} wasmRef expected start of the baked url expression
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (name, wasmLoading, wasmRef) => ({
+const base = (name, wasmLoading, wasmChunk, wasmRef) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -25,7 +25,11 @@ const base = (name, wasmLoading, wasmRef) => ({
 		]
 	},
 	optimization: { chunkIds: "named", splitChunks: false },
-	experiments: { outputModule: true, asyncWebAssembly: true },
+	experiments: {
+		outputModule: true,
+		asyncWebAssembly: true,
+		sourceImport: true
+	},
 	output: {
 		module: true,
 		wasmLoading,
@@ -35,14 +39,26 @@ const base = (name, wasmLoading, wasmRef) => ({
 	},
 	plugins: [
 		new webpack.DefinePlugin({
-			__WASM_CHUNK__: JSON.stringify(`${name}-chunks/lazy.mjs`),
-			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef)
+			__WASM_CHUNK__: JSON.stringify(`${name}-chunks/${wasmChunk}.mjs`),
+			__WASM_REF__: JSON.stringify(wasmRef)
 		})
 	]
 });
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	base("fetch", "fetch", 'new URL("https://example.com/assets/fetch-'),
-	base("node", "async-node", 'new URL("../node-')
+	base(
+		"fetch",
+		"fetch",
+		"lazy",
+		`${INSTANTIATE}new URL("https://example.com/assets/fetch-`
+	),
+	base("node", "async-node", "lazy", `${INSTANTIATE}new URL("../node-`),
+	// Source phase reaches the same url through `compileWasm` rather than `instantiateWasm`.
+	base(
+		"source",
+		"fetch",
+		"lazySource",
+		`${COMPILE}new URL("https://example.com/assets/source-`
+	)
 ];

--- a/test/hotCases/esm-output/analyzable-import/async-module.js
+++ b/test/hotCases/esm-output/analyzable-import/async-module.js
@@ -1,0 +1,3 @@
+export const message = "original";
+---
+export const message = "updated";

--- a/test/hotCases/esm-output/analyzable-import/index.js
+++ b/test/hotCases/esm-output/analyzable-import/index.js
@@ -15,8 +15,13 @@ it("should emit the analyzable import under HMR and still apply updates", (done)
 
 			// Needles are built at runtime so they are not source string literals here.
 			const bundle = getFile("main.mjs");
-			expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+			const require_ = "__webpack_require__";
+			expect(bundle).toContain(`${require_}.ei(`);
 			expect(bundle).toContain('import("./async-module_js.mjs")');
+			// The hot runtime registers its handler on the map and force-loads through
+			// the others by bare chunk id, so both survive an all-analyzable graph.
+			expect(bundle).toContain(`${require_}.f = {}`);
+			expect(bundle).toContain(`${require_}.f.j =`);
 
 			NEXT(
 				update(done, true, () => {

--- a/test/hotCases/esm-output/analyzable-import/index.js
+++ b/test/hotCases/esm-output/analyzable-import/index.js
@@ -1,0 +1,33 @@
+import update from "../../update.esm";
+
+const getFile = (name) =>
+	__non_webpack_require__("fs").readFileSync(
+		__non_webpack_require__("path").join(__dirname, name),
+		"utf-8"
+	);
+
+import.meta.webpackHot.accept("./async-module");
+
+it("should emit the analyzable import under HMR and still apply updates", (done) => {
+	import("./async-module")
+		.then((mod) => {
+			expect(mod.message).toBe("original");
+
+			// Needles are built at runtime so they are not source string literals here.
+			const bundle = getFile("main.mjs");
+			expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+			expect(bundle).toContain('import("./async-module_js.mjs")');
+
+			NEXT(
+				update(done, true, () => {
+					import("./async-module")
+						.then((updated) => {
+							expect(updated.message).toBe("updated");
+							done();
+						})
+						.catch(done);
+				})
+			);
+		})
+		.catch(done);
+});

--- a/test/hotCases/esm-output/analyzable-import/test.config.js
+++ b/test/hotCases/esm-output/analyzable-import/test.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = {
+	// The ESM runner has no `__dirname`; the case reads the emitted bundle back.
+	moduleScope(scope, options) {
+		scope.__dirname = options.output.path;
+	}
+};

--- a/test/hotCases/esm-output/analyzable-import/test.filter.js
+++ b/test/hotCases/esm-output/analyzable-import/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// Reads the emitted bundle back through `__non_webpack_require__("fs")`, which the
+// browser targets rightly warn about. The emitted form itself is target-independent.
+module.exports = (config) =>
+	config.target === "node" ||
+	config.target === "async-node" ||
+	config.target === "universal";

--- a/test/hotCases/esm-output/analyzable-import/test.filter.js
+++ b/test/hotCases/esm-output/analyzable-import/test.filter.js
@@ -1,8 +1,11 @@
 "use strict";
 
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
 // Reads the emitted bundle back through `__non_webpack_require__("fs")`, which the
-// browser targets rightly warn about. The emitted form itself is target-independent.
+// browser targets rightly warn about, and which ESM output builds from `node:module`.
 module.exports = (config) =>
-	config.target === "node" ||
-	config.target === "async-node" ||
-	config.target === "universal";
+	supportsRequireInModule() &&
+	(config.target === "node" ||
+		config.target === "async-node" ||
+		config.target === "universal");

--- a/test/hotCases/esm-output/analyzable-import/webpack.config.js
+++ b/test/hotCases/esm-output/analyzable-import/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+// The analyzable `import()` is emitted under HMR too: the hot require wraps `.ei`
+// exactly as it wraps `.e`, so an update still blocks on an in-flight chunk load.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		chunkFilename: "[name].mjs",
+		publicPath: "auto"
+	},
+	node: { __dirname: false }
+};

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -41,15 +41,6 @@ bare-public-path:
     ./async.js X bytes [built] [code generated]
   bare-public-path (webpack x.x.x) compiled successfully in X ms
 
-public-path-override:
-  asset main.mjs X KiB [emitted] [javascript module] (name: main)
-  asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 7 modules
-  cacheable modules X bytes
-    ./index-public-path-override.js X bytes [built] [code generated]
-    ./async.js X bytes [built] [code generated]
-  public-path-override (webpack x.x.x) compiled successfully in X ms
-
 fetch-priority:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
@@ -58,6 +49,24 @@ fetch-priority:
     ./index-fetch-priority.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
   fetch-priority (webpack x.x.x) compiled successfully in X ms
+
+hmr:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 9 modules
+  cacheable modules X bytes
+    ./index.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  hmr (webpack x.x.x) compiled successfully in X ms
+
+public-path-override:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 7 modules
+  cacheable modules X bytes
+    ./index-public-path-override.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  public-path-override (webpack x.x.x) compiled successfully in X ms
 
 content-hash:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
@@ -75,14 +84,5 @@ templated-public-path:
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
-  templated-public-path (webpack x.x.x) compiled successfully in X ms
-
-hmr:
-  asset main.mjs X KiB [emitted] [javascript module] (name: main)
-  asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 11 modules
-  cacheable modules X bytes
-    ./index.js X bytes [built] [code generated]
-    ./async.js X bytes [built] [code generated]
-  hmr (webpack x.x.x) compiled successfully in X ms"
+  templated-public-path (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -53,7 +53,7 @@ fetch-priority:
 hmr:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 9 modules
+  runtime modules X KiB 11 modules
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -19,7 +19,9 @@ const CASES = {
 	"bare-public-path": { file: "main.mjs", expect: "analyzable" },
 	"shared-chunk": { file: "a.mjs", expect: "analyzable" },
 	prefetch: { file: "main.mjs", expect: "analyzable" },
-	hmr: { file: "main.mjs", expect: "fallback" }
+	// The hot require wraps `.ei` like `.e`, so an update still blocks on a chunk
+	// load in flight and HMR does not force the runtime form.
+	hmr: { file: "main.mjs", expect: "analyzable" }
 };
 
 module.exports = {

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -43,14 +43,18 @@ module.exports = [
 	// Also analyzable: an empty public path leaves a bare specifier, which is made
 	// explicitly relative — the same thing the chunk loader does.
 	base("bare-public-path", { output: { publicPath: "" } }),
+	// Also analyzable: a native `import()` carries no `fetchPriority`, and the ESM chunk
+	// loader ignores the argument, so the hint never forces the runtime form.
+	base("fetch-priority", { entry: "./index-fetch-priority" }),
+	// Also analyzable: the hot require wraps `.ei` the same way it wraps `.e`, so an
+	// update still blocks on an in-flight chunk load.
+	base("hmr", { plugins: [new webpack.HotModuleReplacementPlugin()] }),
 	// Every case below must fall back with no `.ei` emitted.
 	base("public-path-override", { entry: "./index-public-path-override" }),
-	base("fetch-priority", { entry: "./index-fetch-priority" }),
 	base("content-hash", {
 		output: { chunkFilename: "[name].[contenthash].mjs" }
 	}),
 	base("templated-public-path", {
 		output: { publicPath: "/assets/[fullhash]/" }
-	}),
-	base("hmr", { plugins: [new webpack.HotModuleReplacementPlugin()] })
+	})
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21626. Analyzable ESM output still fell back to the runtime chunk loader for hot module replacement builds and for hashed chunk filenames — between them most development and most production builds — as well as for a function `output.chunkFilename` and for WebAssembly behind a URL public path. Each now emits a followable `import("./chunk.<hash>.mjs")`, and an analyzable chunk carrying css or resource hints no longer drags in the chunk loader it only needed for the handler map (−1739 bytes on `configCases/analyzable/css-chunk-import`).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `configCases/analyzable/{hashed-chunk-filename,function-chunk-filename,shared-depths-import}`, `configCases/wasm/analyzable-url-public-path`, `configCases/worker/worker-non-import-chunk-loading`, `hotCases/esm-output/analyzable-import`, and updates to `statsCases/analyzable-esm-fallbacks`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — every widened case previously emitted the runtime form, which stays the fallback wherever a literal cannot be resolved.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Two conditions worth documenting: a hashed chunk filename is only baked when `optimization.realContentHash` is enabled, since that is what corrects the referencing chunk's own hash after substitution; and a WebAssembly binary takes the public path into its literal only when that path is an absolute URL and the chunk loads with `fetch`, because `readFile` accepts a `file:` URL alone.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Written with Claude in an agentic setup, which produced the implementation and the tests. Design decisions were settled by measurement rather than assumption — istanbul branch counts to establish that a removed guard was unreachable, per-placeholder builds compared against the files actually emitted, and instrumented runs of `createRequire` and code generation to locate the HMR and hash-availability behaviour — and each change was reviewed and run against the suites before commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_011gLkJyyoJtX2BVpZNPndbb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analyzable ESM imports for hot module replacement and dynamic chunk loading.
  * Added support for hashed, function-based, and CSS-derived chunk filenames.
  * Added analyzable WebAssembly URLs with absolute public paths.
  * Improved CSS-only chunk loading by omitting unnecessary JavaScript code.
* **Bug Fixes**
  * Prevented duplicate chunk-loading handlers and improved fallback handling for unresolved filenames.
* **Tests**
  * Added coverage for HMR, chunk naming, CSS chunks, and WebAssembly loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->