### PR TITLE
test(hash-length): give each output-filename config a unique name

### DIFF
--- a/test/configCases/hash-length/output-filename/webpack.config.js
+++ b/test/configCases/hash-length/output-filename/webpack.config.js
@@ -169,7 +169,7 @@ module.exports = [
 		}
 	},
 	{
-		name: "contenthash in webpack",
+		name: "contenthash in web",
 		entry: "./no-async",
 		output: {
 			filename: "bundle14.[contenthash].js",
@@ -183,7 +183,7 @@ module.exports = [
 		}
 	},
 	{
-		name: "contenthash in async-node with length",
+		name: "contenthash in web with length",
 		entry: "./no-async",
 		output: {
 			filename: "bundle15.[contenthash:7].js",
@@ -197,7 +197,7 @@ module.exports = [
 		}
 	},
 	{
-		name: "contenthash in webpack",
+		name: "contenthash in webworker",
 		entry: "./no-async",
 		output: {
 			filename: "bundle16.[contenthash].js",
@@ -211,7 +211,7 @@ module.exports = [
 		}
 	},
 	{
-		name: "contenthash in async-node with length",
+		name: "contenthash in webworker with length",
 		entry: "./no-async",
 		output: {
 			filename: "bundle17.[contenthash:7].js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Five of the eighteen configs in `test/configCases/hash-length/output-filename/webpack.config.js` shared two names across three different targets — `contenthash in webpack` covered both the `web` and `webworker` builds, and `contenthash in async-node with length` covered the `async-node`, `web` and `webworker` ones. Anything keyed on the config name then attributes rows to the wrong build, which is how the `Code Size` report came to list `jsonp chunk loading` under a row labelled `async-node`. Each config is now named after the target it actually builds.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new tests — this only renames existing cases; `ConfigTestCases` and `ConfigCacheTestCases` cover them and both pass (70 tests).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to spot the duplicate names while investigating a mislabelled `Code Size` row on #21652, to apply the rename, and to run the affected config cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_012YyGDY3xjM7qazsDC34U57)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test case names to clearly identify web and webworker targets.
  * Confirmed hash configuration and expected output filename lengths remain unchanged.
  * No user-facing behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->