### PR TITLE
fix(css): leave @namespace URIs alone

### DIFF
--- a/.changeset/041-css-namespace-uri.md
+++ b/.changeset/041-css-namespace-uri.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Leave a `@namespace` URI alone instead of resolving and rewriting it as an asset.

--- a/.github/workflows/code-size.yml
+++ b/.github/workflows/code-size.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Every push to `main` shares one group, so cancelling would leave the commits
+  # in a burst of merges with no uploaded report — and a pull request based on
+  # one of them with no baseline. Only a superseded pull request run is dropped.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -82,6 +85,9 @@ jobs:
           cat code-size-report.md >> "$GITHUB_STEP_SUMMARY"
         env:
           CODE_SIZE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          # The `main` commit the checked-out merge ref carries, so the report can
+          # tell whether the baseline it found is that same commit.
+          CODE_SIZE_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
 
       # On the pull request itself, not only in the job summary — a size change
       # nobody clicks through to see is a size change nobody sees. Updated in

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -2318,7 +2318,8 @@ class CssParser extends Parser {
 		const qualifiedRuleStateStack = [];
 
 		/**
-		 * Whether url() deps are emitted here (from `currentStructural`): false outside `options.url`, inside an `@import` prelude (the import target, unless url recovery is on) and inside a `@namespace` prelude (an opaque identifier, never fetched).
+		 * Whether url() deps are emitted here (from `currentStructural`): off in an `@import`
+		 * prelude (the import target, unless recovering) and in `@namespace` (an opaque identifier).
 		 * @returns {boolean} true when url() deps should be emitted
 		 */
 		const urlActive = () => {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -2318,13 +2318,14 @@ class CssParser extends Parser {
 		const qualifiedRuleStateStack = [];
 
 		/**
-		 * Whether url() deps are emitted here (from `currentStructural`): false outside `options.url` and inside an `@import` prelude (the import target, unless url recovery is on).
+		 * Whether url() deps are emitted here (from `currentStructural`): false outside `options.url`, inside an `@import` prelude (the import target, unless url recovery is on) and inside a `@namespace` prelude (an opaque identifier, never fetched).
 		 * @returns {boolean} true when url() deps should be emitted
 		 */
 		const urlActive = () => {
 			if (!this.options.url || !currentStructural) return false;
 			if (A.type(currentStructural) === NodeType.AtRule) {
 				// `currentAtRuleName` is cached on at-rule enter — no per-value slice.
+				if (currentAtRuleName === "@namespace") return false;
 				return currentAtRuleName !== "@import" || currentUrlRecovery;
 			}
 			return true;

--- a/test/CodeSizeReport.unittest.js
+++ b/test/CodeSizeReport.unittest.js
@@ -1,8 +1,9 @@
 "use strict";
 
-// The size report's row keys. `CodeSizeTestCases.size.js` runs a full build on
-// require, so the key assignment is unit-tested through its helper.
+// The size report's row keys and baseline check. `CodeSizeTestCases.size.js`
+// runs a full build on require, so both are unit-tested through their helpers.
 
+const codeSizeBaselineDrift = require("./helpers/codeSizeBaselineDrift");
 const codeSizeReportPrefixes = require("./helpers/codeSizeReportPrefixes");
 
 describe("codeSizeReportPrefixes", () => {
@@ -54,5 +55,29 @@ describe("codeSizeReportPrefixes", () => {
 		const names = ["a", "a", "a[1]", "a[1]", "a[1][3]", undefined, "5", "a"];
 		const prefixes = codeSizeReportPrefixes(names);
 		expect(new Set(prefixes).size).toBe(names.length);
+	});
+});
+
+describe("codeSizeBaselineDrift", () => {
+	const base = "e3f177ca7e9c645718d1dbe95bf3c6f60563f6e8";
+	const older = "a0b6a75e1c0d3f4a5b6c7d8e9f0a1b2c3d4e5f60";
+
+	it("says nothing when the baseline is the measured base", () => {
+		expect(codeSizeBaselineDrift(base, base)).toBeUndefined();
+	});
+
+	it("says nothing when either commit is unknown", () => {
+		// A `main` push has no base, and a baseline predating `meta.commit` has no
+		// commit — neither is drift, so neither warns.
+		expect(codeSizeBaselineDrift(base, undefined)).toBeUndefined();
+		expect(codeSizeBaselineDrift(undefined, base)).toBeUndefined();
+		expect(codeSizeBaselineDrift(undefined, undefined)).toBeUndefined();
+	});
+
+	it("names both commits when they differ", () => {
+		const note = codeSizeBaselineDrift(older, base);
+		expect(note).toContain("a0b6a75");
+		expect(note).toContain("e3f177c");
+		expect(note).toContain("[!WARNING]");
 	});
 });

--- a/test/CodeSizeTestCases.size.js
+++ b/test/CodeSizeTestCases.size.js
@@ -11,6 +11,7 @@ const path = require("path");
 const zlib = require("zlib");
 const webpack = require("..");
 const { DEFAULTS } = require("../lib/config/defaults");
+const codeSizeBaselineDrift = require("./helpers/codeSizeBaselineDrift");
 const codeSizeReportPrefixes = require("./helpers/codeSizeReportPrefixes");
 const prepareOptions = require("./helpers/prepareOptions");
 
@@ -41,7 +42,7 @@ const prepareOptions = require("./helpers/prepareOptions");
 /**
  * @typedef {object} Report
  * @property {number} version report format version
- * @property {{ commit?: string, node: string, cases: number, assets: number, withoutOutput: number }} meta run metadata
+ * @property {{ commit?: string, base?: string, node: string, cases: number, assets: number, withoutOutput: number }} meta run metadata
  * @property {Metrics} totals summed over every case
  * @property {Record<string, CaseResult>} cases result per `<category>/<case>`
  */
@@ -780,16 +781,21 @@ const formatMarkdown = (report, baseline, noBaselineReason) => {
 	];
 	const short = (/** @type {Report} */ report) =>
 		report.meta.commit ? `\`${report.meta.commit.slice(0, 7)}\`` : "unknown";
+	// A pull request is built from its merge ref, so name both halves of what
+	// was measured rather than the head alone.
+	const measured = report.meta.base
+		? `${short(report)} merged into \`${report.meta.base.slice(0, 7)}\``
+		: short(report);
+	const drift = codeSizeBaselineDrift(baseline.meta.commit, report.meta.base);
 
 	// How many moved and by how much, then the biggest movers — before any
 	// collapsed section, so the whole verdict is readable without unfolding one.
 	lines.push(
-		`Comparing ${short(report)} against ${short(
-			baseline
-		)}. Merging this PR will **${
+		`Comparing ${measured} against ${short(baseline)}. Merging this PR will **${
 			changes.length === 0 ? "not change" : "change"
 		}** the code webpack generates.`,
 		"",
+		...(drift ? [drift, ""] : []),
 		"| | Changed | New | Deleted | Unchanged | Raw change |",
 		"| :-- | --: | --: | --: | --: | --: |"
 	);
@@ -1041,6 +1047,7 @@ const run = async () => {
 		version: REPORT_VERSION,
 		meta: {
 			commit: process.env.CODE_SIZE_COMMIT || readCommit(),
+			base: process.env.CODE_SIZE_BASE_COMMIT || undefined,
 			node: process.version,
 			cases: cases.length,
 			assets,

--- a/test/configCases/css/namespace/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/namespace/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css namespace exported tests should emit the namespace URIs unchanged 1`] = `
+"/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+@namespace svg url('http://www.w3.org/2000/svg');
+@namespace vendor url(./ns.svg);
+
+body {
+	background: red;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/"
+`;

--- a/test/configCases/css/namespace/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/namespace/__snapshots__/ConfigCacheTest.snap
@@ -1,14 +1,38 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ConfigCacheTestCases css namespace exported tests should emit the namespace URIs unchanged 1`] = `
-"/*!***********************!*\\\\
+"/*!**************************!*\\\\
+  !*** css ./imported.css ***!
+  \\\\**************************/
+/* Same prefix as the importer, bound to a different URI: concatenation cannot
+   keep both, so this records what a merged sheet looks like today. */
+@namespace vendor url(./other-ns.svg);
+
+.imported {
+	color: green;
+}
+
+/*!***********************!*\\\\
   !*** css ./style.css ***!
   \\\\***********************/
+
 @namespace svg url('http://www.w3.org/2000/svg');
 @namespace vendor url(./ns.svg);
+@namespace url(http://www.w3.org/1999/xhtml);
+@namespace data url(data:text/plain,ns);
+@namespace empty url();
 
 body {
 	background: red;
+}
+
+/*!******************************!*\\\\
+  !*** css ./style.module.css ***!
+  \\\\******************************/
+@namespace scoped url(./ns.svg);
+
+._local {
+	color: blue;
 }
 
 

--- a/test/configCases/css/namespace/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/namespace/__snapshots__/ConfigTest.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css namespace exported tests should emit the namespace URIs unchanged 1`] = `
+"/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+@namespace svg url('http://www.w3.org/2000/svg');
+@namespace vendor url(./ns.svg);
+
+body {
+	background: red;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/"
+`;

--- a/test/configCases/css/namespace/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/namespace/__snapshots__/ConfigTest.snap
@@ -1,14 +1,38 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ConfigTestCases css namespace exported tests should emit the namespace URIs unchanged 1`] = `
-"/*!***********************!*\\\\
+"/*!**************************!*\\\\
+  !*** css ./imported.css ***!
+  \\\\**************************/
+/* Same prefix as the importer, bound to a different URI: concatenation cannot
+   keep both, so this records what a merged sheet looks like today. */
+@namespace vendor url(./other-ns.svg);
+
+.imported {
+	color: green;
+}
+
+/*!***********************!*\\\\
   !*** css ./style.css ***!
   \\\\***********************/
+
 @namespace svg url('http://www.w3.org/2000/svg');
 @namespace vendor url(./ns.svg);
+@namespace url(http://www.w3.org/1999/xhtml);
+@namespace data url(data:text/plain,ns);
+@namespace empty url();
 
 body {
 	background: red;
+}
+
+/*!******************************!*\\\\
+  !*** css ./style.module.css ***!
+  \\\\******************************/
+@namespace scoped url(./ns.svg);
+
+._local {
+	color: blue;
 }
 
 

--- a/test/configCases/css/namespace/__snapshots__/warnings.snap
+++ b/test/configCases/css/namespace/__snapshots__/warnings.snap
@@ -3,5 +3,6 @@
 exports[`warnings 1`] = `
 Array [
   "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
 ]
 `;

--- a/test/configCases/css/namespace/__snapshots__/warnings.snap
+++ b/test/configCases/css/namespace/__snapshots__/warnings.snap
@@ -4,5 +4,10 @@ exports[`warnings 1`] = `
 Array [
   "'@namespace' is not supported in bundled CSS",
   "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
+  "'@namespace' is not supported in bundled CSS",
 ]
 `;

--- a/test/configCases/css/namespace/imported.css
+++ b/test/configCases/css/namespace/imported.css
@@ -1,0 +1,7 @@
+/* Same prefix as the importer, bound to a different URI: concatenation cannot
+   keep both, so this records what a merged sheet looks like today. */
+@namespace vendor url(./other-ns.svg);
+
+.imported {
+	color: green;
+}

--- a/test/configCases/css/namespace/index.js
+++ b/test/configCases/css/namespace/index.js
@@ -1,4 +1,5 @@
 import "./style.css";
+import * as scoped from "./style.module.css";
 
 const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
@@ -7,6 +8,10 @@ it("should compile with warning", done => {
 	const style = getComputedStyle(document.body);
 	expect(style.getPropertyValue("background")).toBe(" red");
 	done();
+});
+
+it("should scope a module that also declares a namespace", () => {
+	expect(scoped.local).toBe("_local");
 });
 
 it("should emit the namespace URIs unchanged", () => {

--- a/test/configCases/css/namespace/index.js
+++ b/test/configCases/css/namespace/index.js
@@ -1,7 +1,21 @@
 import "./style.css";
 
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
 it("should compile with warning", done => {
 	const style = getComputedStyle(document.body);
 	expect(style.getPropertyValue("background")).toBe(" red");
 	done();
+});
+
+it("should emit the namespace URIs unchanged", () => {
+	expect(
+		fs.readFileSync(path.join(__dirname, "bundle0.css"), "utf-8")
+	).toMatchSnapshot();
+});
+
+it("should not emit an asset for a namespace URI", () => {
+	// A namespace URI is an opaque identifier, not a request for a file.
+	expect(fs.readdirSync(__dirname).filter(f => f.endsWith(".svg"))).toEqual([]);
 });

--- a/test/configCases/css/namespace/ns.svg
+++ b/test/configCases/css/namespace/ns.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/test/configCases/css/namespace/other-ns.svg
+++ b/test/configCases/css/namespace/other-ns.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/test/configCases/css/namespace/style.css
+++ b/test/configCases/css/namespace/style.css
@@ -1,4 +1,5 @@
 @namespace svg url('http://www.w3.org/2000/svg');
+@namespace vendor url(./ns.svg);
 
 body {
 	background: red;

--- a/test/configCases/css/namespace/style.css
+++ b/test/configCases/css/namespace/style.css
@@ -1,5 +1,10 @@
+@import "./imported.css";
+
 @namespace svg url('http://www.w3.org/2000/svg');
 @namespace vendor url(./ns.svg);
+@namespace url(http://www.w3.org/1999/xhtml);
+@namespace data url(data:text/plain,ns);
+@namespace empty url();
 
 body {
 	background: red;

--- a/test/configCases/css/namespace/style.module.css
+++ b/test/configCases/css/namespace/style.module.css
@@ -1,0 +1,5 @@
+@namespace scoped url(./ns.svg);
+
+.local {
+	color: blue;
+}

--- a/test/configCases/css/namespace/webpack.config.js
+++ b/test/configCases/css/namespace/webpack.config.js
@@ -3,6 +3,7 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	target: "web",
+	node: { __dirname: false, __filename: false },
 	mode: "development",
 	experiments: {
 		css: true

--- a/test/configCases/css/namespace/webpack.config.js
+++ b/test/configCases/css/namespace/webpack.config.js
@@ -5,6 +5,16 @@ module.exports = {
 	target: "web",
 	node: { __dirname: false, __filename: false },
 	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.module\.css$/,
+				type: "css/module",
+				/** @type {import("../../../../").GeneratorOptionsByModuleTypeKnown["css/module"]} */
+				generator: { localIdentName: "_[local]" }
+			}
+		]
+	},
 	experiments: {
 		css: true
 	}

--- a/test/helpers/codeSizeBaselineDrift.js
+++ b/test/helpers/codeSizeBaselineDrift.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * Why the baseline a size report compares against is not the `main` commit the
+ * run measured. A pull request is built from its merge ref, so the diff is only
+ * this pull request's when the baseline is that same commit; when it is an
+ * older one, whatever landed on `main` in between reads as the author's work.
+ * @param {string=} baselineCommit commit the baseline report was produced at
+ * @param {string=} measuredBase `main` commit the measured tree carries
+ * @returns {string | undefined} the note, or undefined when the two line up
+ */
+const codeSizeBaselineDrift = (baselineCommit, measuredBase) => {
+	if (!baselineCommit || !measuredBase || baselineCommit === measuredBase) {
+		return undefined;
+	}
+	return `> [!WARNING]\n> The baseline is \`${baselineCommit.slice(
+		0,
+		7
+	)}\`, not \`${measuredBase.slice(
+		0,
+		7
+	)}\` — the \`main\` commit this run was merged with. Everything that landed on \`main\` in between is counted below and is not this pull request's.`;
+};
+
+module.exports = codeSizeBaselineDrift;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The `@namespace` case in `CssParser` warns and `break`s without consuming its prelude, so the generic `url()` walker treated the namespace URI as an asset reference: `@namespace n url(./ns.svg)` emitted a hashed asset and rewrote the URI to it, an absolute `url(http://…)` created a phantom `external asset-url` module, and even `url('http://…')` lost its quotes — while the equivalent string form did none of that. A namespace URI is an opaque identifier, never fetched, so `urlActive()` now excludes `@namespace` the way it already excludes `@import`.

This does not make `@namespace` work across concatenated files (the existing "not supported in bundled CSS" warning still stands); it stops webpack from corrupting the URI on the way through.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/namespace/` is extended to drive the gate from every prelude shape: a no-prefix namespace, a `data:` URI, an empty `url()`, a relative `url()`, a CSS module that declares one alongside a scoped class, and an imported file whose prefix collides with the importer's. The emitted stylesheet is snapshotted in both `ConfigTestCases` and `ConfigCacheTestCases`, with an explicit assertion that no asset is emitted.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. A `@namespace` URI is now emitted as authored rather than resolved, which is the documented behaviour of every other engine; no build that produced correct CSS before changes output.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used. The defect was found by an empirical cross-bundler comparison of CSS/HTML handling (webpack, Rspack, esbuild, Lightning CSS, PostCSS, Vite, Parcel), then reproduced against webpack directly; the regression test was written and confirmed failing before the one-line parser change, and every claim above was verified by running the affected suites.


---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSS namespace URIs are now preserved exactly as written instead of being rewritten as asset references.
  * Namespace URIs no longer create unwanted emitted assets.
  * Behavior is supported consistently in regular stylesheets and CSS Modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->