### PR TITLE
perf(html): load the html generator only for builds with html modules

### DIFF
--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -9,11 +9,14 @@ const {
 	CSS_TYPE,
 	JAVASCRIPT_TYPE
 } = require("../ModuleSourceTypeConstants");
-const HtmlGenerator = require("../html/HtmlGenerator");
 const ResourceHintPlugin = require("../prefetch/ResourceHintPlugin");
 const ResourceHintRuntimeModule = require("../prefetch/ResourceHintRuntimeModule");
 const makeSerializable = require("../util/makeSerializable");
+const memoize = require("../util/memoize");
 const ModuleDependency = require("./ModuleDependency");
+
+// only the template needs it, and that runs only for a real html module
+const getHtmlGenerator = memoize(() => require("../html/HtmlGenerator"));
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Chunk")} Chunk */
@@ -638,7 +641,7 @@ const resolveResourceHint = (desc, ctx) => {
 		if (!has) continue;
 		tags.push(
 			buildLinkTag(rel, {
-				href: HtmlGenerator.makeChunkUrlSentinel(chunk, kind),
+				href: getHtmlGenerator().makeChunkUrlSentinel(chunk, kind),
 				as,
 				type: desc.type,
 				crossorigin,
@@ -649,7 +652,7 @@ const resolveResourceHint = (desc, ctx) => {
 					(rel === "preload" || rel === "modulepreload") &&
 					desc.integrity !== false &&
 					ctx.integrityOn
-						? ` integrity="${HtmlGenerator.makeChunkIntegritySentinel(chunk, kind)}"`
+						? ` integrity="${getHtmlGenerator().makeChunkIntegritySentinel(chunk, kind)}"`
 						: undefined,
 				media: desc.media,
 				fetchpriority: desc.fetchPriority
@@ -682,7 +685,7 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 			source.replace(
 				dep.range[0],
 				dep.range[1] - 1,
-				HtmlGenerator.makeHtmlPageUrlSentinel(dep.entryName)
+				getHtmlGenerator().makeHtmlPageUrlSentinel(dep.entryName)
 			);
 			return;
 		}
@@ -717,7 +720,7 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 		// `integrity` options, so sentinels are emitted whenever any page wants SRI
 		// and each page then resolves or strips them on emit.
 		const htmlOption = compilation.outputOptions.html;
-		const integrityOn = HtmlGenerator.hasIntegritySentinels(compilation);
+		const integrityOn = getHtmlGenerator().hasIntegritySentinels(compilation);
 		const inject =
 			typeof htmlOption === "object" ? htmlOption.inject : undefined;
 
@@ -743,7 +746,7 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 				}
 				source.insert(
 					dep.tagNameEnd,
-					` integrity="${HtmlGenerator.makeChunkIntegritySentinel(
+					` integrity="${getHtmlGenerator().makeChunkIntegritySentinel(
 						chunk,
 						contentHashType
 					)}"`
@@ -760,7 +763,7 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 			source.replace(
 				dep.range[0],
 				dep.range[1] - 1,
-				HtmlGenerator.makeChunkUrlSentinel(entryChunk, contentHashType)
+				getHtmlGenerator().makeChunkUrlSentinel(entryChunk, contentHashType)
 			);
 			// `preload` is integrity-eligible per the SRI spec, so mirror
 			// `crossorigin`/`integrity` onto it (SRI requires CORS). `prefetch` is a
@@ -819,7 +822,7 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 			isChunkInlined(entryChunk, entryContentHashType);
 
 		if (entryInlined) {
-			const inlineSentinel = HtmlGenerator.makeChunkInlineSentinel(
+			const inlineSentinel = getHtmlGenerator().makeChunkInlineSentinel(
 				entryChunk,
 				entryContentHashType
 			);
@@ -840,7 +843,10 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 			source.replace(
 				dep.range[0],
 				dep.range[1] - 1,
-				HtmlGenerator.makeChunkUrlSentinel(entryChunk, entryContentHashType)
+				getHtmlGenerator().makeChunkUrlSentinel(
+					entryChunk,
+					entryContentHashType
+				)
 			);
 		}
 
@@ -869,14 +875,17 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 			 */
 			const buildSibling = (chunk, kind) => {
 				if (isChunkInlined(chunk, kind)) {
-					const sentinel = HtmlGenerator.makeChunkInlineSentinel(chunk, kind);
+					const sentinel = getHtmlGenerator().makeChunkInlineSentinel(
+						chunk,
+						kind
+					);
 					return kind === "css"
 						? `<style>${sentinel}</style>`
 						: `<script${scriptTypeAttr}>${sentinel}</script>`;
 				}
-				const url = HtmlGenerator.makeChunkUrlSentinel(chunk, kind);
+				const url = getHtmlGenerator().makeChunkUrlSentinel(chunk, kind);
 				const integrityAttr = integrityOn
-					? ` integrity="${HtmlGenerator.makeChunkIntegritySentinel(chunk, kind)}"`
+					? ` integrity="${getHtmlGenerator().makeChunkIntegritySentinel(chunk, kind)}"`
 					: "";
 				if (kind === "css") {
 					// A CSS chunk is always loaded via `<link rel="stylesheet">`.
@@ -1115,13 +1124,13 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 						) {
 							continue;
 						}
-						const href = HtmlGenerator.makeChunkUrlSentinel(
+						const href = getHtmlGenerator().makeChunkUrlSentinel(
 							chunk,
 							"javascript"
 						);
 						const integrityAttr =
 							integrityOn && !prefetchMode
-								? ` integrity="${HtmlGenerator.makeChunkIntegritySentinel(
+								? ` integrity="${getHtmlGenerator().makeChunkIntegritySentinel(
 										chunk,
 										"javascript"
 									)}"`
@@ -1230,7 +1239,9 @@ HtmlEntryDependency.Template = class HtmlEntryDependencyTemplate extends (
 				const typeAttr = md.typeAttribute;
 				const mediaAttr = md.mediaAttribute;
 				const fetchPriority = md.fetchPriority;
-				const href = HtmlGenerator.makeAssetUrlSentinel(module.identifier());
+				const href = getHtmlGenerator().makeAssetUrlSentinel(
+					module.identifier()
+				);
 				const attrs =
 					`${asAttr ? ` as="${escapeAttr(asAttr)}"` : ""}` +
 					`${typeAttr ? ` type="${escapeAttr(typeAttr)}"` : ""}` +

--- a/lib/dependencies/HtmlInlineScriptDependency.js
+++ b/lib/dependencies/HtmlInlineScriptDependency.js
@@ -4,9 +4,12 @@
 
 "use strict";
 
-const HtmlGenerator = require("../html/HtmlGenerator");
 const makeSerializable = require("../util/makeSerializable");
+const memoize = require("../util/memoize");
 const ModuleDependency = require("./ModuleDependency");
+
+// only the template needs it, and that runs only for a real html module
+const getHtmlGenerator = memoize(() => require("../html/HtmlGenerator"));
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Chunk")} Chunk */
@@ -106,7 +109,7 @@ HtmlInlineScriptDependency.Template = class HtmlInlineScriptDependencyTemplate e
 		if (entrypoint) {
 			const chunk = /** @type {Chunk} */ (entrypoint.getEntrypointChunk());
 			// Defer chunk-URL substitution to renderManifest — chunk hashes aren't ready yet.
-			url = HtmlGenerator.makeChunkUrlSentinel(chunk, "javascript");
+			url = getHtmlGenerator().makeChunkUrlSentinel(chunk, "javascript");
 		}
 
 		// Insert ` src="…"` right after `<script` so the inline body is

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -37,7 +37,6 @@ const {
 	PUBLIC_PATH_AUTO: autoPlaceholder
 } = require("../util/publicPathPlaceholder");
 const removeBOM = require("../util/removeBOM");
-const HtmlGenerator = require("./HtmlGenerator");
 const HtmlModule = require("./HtmlModule");
 
 const getMimeTypes = memoize(() => require("../util/mimeTypes"));
@@ -47,6 +46,9 @@ const getHtmlSyntax = memoize(() => require("./syntax"));
 // Lazy: this plugin is applied on every build (`experiments.html` defaults on),
 // but the HTML parser and tokenizer are only reached once HTML is in the graph.
 const getHtmlParser = lazyModule(() => require("./HtmlParser"));
+
+// html generation only happens once a build actually has an html module
+const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 
 /** @typedef {import("../../declarations/WebpackOptions").EntryDescriptionNormalized} EntryDescriptionNormalized */
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions} OutputHtmlOptions */
@@ -599,7 +601,7 @@ class HtmlModulesPlugin {
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				if (anyIntegrity) {
-					HtmlGenerator.enableIntegritySentinels(compilation);
+					getHtmlGenerator().enableIntegritySentinels(compilation);
 				}
 				if (implicitlyEnabled) {
 					implicitTypeLoaderFallback(
@@ -656,17 +658,17 @@ class HtmlModulesPlugin {
 							// that doesn't drops them again here.
 							if (resolved.includes("__WEBPACK_HTML_INTEGRITY__")) {
 								resolved = isIntegrityEnabled(integrity)
-									? HtmlGenerator.resolveChunkIntegritySentinels(
+									? getHtmlGenerator().resolveChunkIntegritySentinels(
 											resolved,
 											compilation,
 											/** @type {import("./HtmlGenerator").HtmlIntegrity} */ (
 												integrity
 											)
 										)
-									: HtmlGenerator.stripChunkIntegritySentinels(resolved);
+									: getHtmlGenerator().stripChunkIntegritySentinels(resolved);
 							}
 							if (resolved.includes("__WEBPACK_HTML_INLINE__")) {
-								resolved = HtmlGenerator.resolveChunkInlineSentinels(
+								resolved = getHtmlGenerator().resolveChunkInlineSentinels(
 									resolved,
 									compilation,
 									name,
@@ -685,15 +687,15 @@ class HtmlModulesPlugin {
 							});
 							const transformTags = hooks.transformTags.taps.length > 0;
 							if (injected.length > 0 || transformTags || csp) {
-								const model = HtmlGenerator.collectHtml(resolved);
-								HtmlGenerator.addInjectedTags(model, injected);
+								const model = getHtmlGenerator().collectHtml(resolved);
+								getHtmlGenerator().addInjectedTags(model, injected);
 								if (transformTags) {
 									await hooks.transformTags.promise(model.tags, {
 										outputName: name,
 										html: resolved
 									});
 								}
-								resolved = HtmlGenerator.renderHtml(resolved, model, csp);
+								resolved = getHtmlGenerator().renderHtml(resolved, model, csp);
 							}
 							// Final, fully-resolved HTML — let plugins transform it (minify,
 							// inject a CSP meta, rewrite tags) before it is written.
@@ -868,7 +870,10 @@ class HtmlModulesPlugin {
 									options
 								)
 						);
-						return new HtmlGenerator(generatorOptions, compilation.moduleGraph);
+						return new (getHtmlGenerator())(
+							generatorOptions,
+							compilation.moduleGraph
+						);
 					});
 
 				NormalModule.getCompilationHooks(compilation).processResult.tap(
@@ -948,9 +953,9 @@ class HtmlModulesPlugin {
 						// Asset URL sentinels (from `HtmlEntryDependency` resource-hint
 						// tags) resolve here too — deferred from template.apply so it
 						// doesn't race with asset-module codegen.
-						const resolvedContent = HtmlGenerator.resolveAssetUrlSentinels(
-							HtmlGenerator.embedInlineChunkHashes(
-								HtmlGenerator.resolveChunkUrlSentinels(
+						const resolvedContent = getHtmlGenerator().resolveAssetUrlSentinels(
+							getHtmlGenerator().embedInlineChunkHashes(
+								getHtmlGenerator().resolveChunkUrlSentinels(
 									/** @type {string} */ (placeholderSource.source()),
 									compilation
 								),
@@ -1091,10 +1096,11 @@ class HtmlModulesPlugin {
 							// Resolve linked-page (`type: "html"`) sentinels to each page's
 							// emitted filename before the undo path, so the href is relative to
 							// this page.
-							const finalContent = HtmlGenerator.resolveHtmlPageUrlSentinels(
-								resolvedContent,
-								computePageFilenameByEntry
-							)
+							const finalContent = getHtmlGenerator()
+								.resolveHtmlPageUrlSentinels(
+									resolvedContent,
+									computePageFilenameByEntry
+								)
 								.split(autoPlaceholder)
 								.join(undoPath);
 							const finalSource = new RawSource(finalContent);
@@ -1164,20 +1170,26 @@ class HtmlModulesPlugin {
 					// Strip integrity and inline sentinels (not resolve): a JS chunk
 					// can't hold real SRI hashes for its own not-yet-final bytes, and
 					// inline content belongs only in the final .html, never in JS bundles.
-					const resolved = HtmlGenerator.stripChunkIntegritySentinels(
-						HtmlGenerator.resolveAssetUrlSentinels(
-							HtmlGenerator.resolveHtmlPageUrlSentinels(
-								HtmlGenerator.resolveChunkUrlSentinels(raw, compilation),
-								computePageFilenameByEntry
-							),
-							compilation
+					const resolved = getHtmlGenerator()
+						.stripChunkIntegritySentinels(
+							getHtmlGenerator()
+								.resolveAssetUrlSentinels(
+									getHtmlGenerator().resolveHtmlPageUrlSentinels(
+										getHtmlGenerator().resolveChunkUrlSentinels(
+											raw,
+											compilation
+										),
+										computePageFilenameByEntry
+									),
+									compilation
+								)
+								.split(autoPlaceholder)
+								.join("")
 						)
-							.split(autoPlaceholder)
-							.join("")
-					).replace(
-						/__WEBPACK_HTML_INLINE__[0-9a-f]+__[a-z]+(?:__[0-9a-f]+)?__END__/g,
-						""
-					);
+						.replace(
+							/__WEBPACK_HTML_INLINE__[0-9a-f]+__[a-z]+(?:__[0-9a-f]+)?__END__/g,
+							""
+						);
 					if (resolved === raw) return source;
 					const chunkId = String(renderContext.chunk.id);
 					const prior = sentinelResolvedSourceCache.get(chunkId);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -600,9 +600,6 @@ class HtmlModulesPlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
-				if (anyIntegrity) {
-					getHtmlGenerator().enableIntegritySentinels(compilation);
-				}
 				if (implicitlyEnabled) {
 					implicitTypeLoaderFallback(
 						normalModuleFactory,
@@ -618,7 +615,13 @@ class HtmlModulesPlugin {
 				// module in the graph. Tracking only records; entries are still
 				// added (and awaited) in `finishMake`.
 				const trackHtmlModule = (/** @type {import("../Module")} */ module) => {
-					if (module.type === HTML_MODULE_TYPE) htmlModules.add(module);
+					if (module.type !== HTML_MODULE_TYPE) return;
+					// enabled here, not on the compilation hook: an integrity build
+					// with no html module must not load the generator
+					if (anyIntegrity) {
+						getHtmlGenerator().enableIntegritySentinels(compilation);
+					}
+					htmlModules.add(module);
 				};
 				compilation.hooks.succeedModule.tap(PLUGIN_NAME, trackHtmlModule);
 				compilation.hooks.stillValidModule.tap(PLUGIN_NAME, trackHtmlModule);

--- a/lib/prefetch/ResourceHintPlugin.js
+++ b/lib/prefetch/ResourceHintPlugin.js
@@ -11,6 +11,7 @@ const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
 const URLDependency = require("../dependencies/URLDependency");
 const lazyModule = require("../util/lazyModule");
+const memoize = require("../util/memoize");
 const { guessAsAttribute } = require("./parseResourceHintOptions");
 const parseResourceHintOptions = require("./parseResourceHintOptions");
 
@@ -96,6 +97,11 @@ const getResourceHintRuntimeModule = lazyModule(() =>
 );
 const getStartupAssetHintRuntimeModule = lazyModule(() =>
 	require("./StartupAssetHintRuntimeModule")
+);
+// only reached once a build has an html module, so a js-only build never
+// pays for the html generator this drags in
+const getHtmlEntryDependency = memoize(() =>
+	require("../dependencies/HtmlEntryDependency")
 );
 
 const PLUGIN_NAME = "ResourceHintPlugin";
@@ -354,14 +360,13 @@ const collectEntrypointHints = (compilation, entryName, hints) => {
 	// `stats.entrypoints[name].resourceHints` see `"js"`.
 	let hostType = /** @type {"html" | "js"} */ ("js");
 
-	const HtmlEntryDependency = require("../dependencies/HtmlEntryDependency");
-
 	outer: for (const module of compilation.modules) {
 		if (!module.getSourceTypes || !module.getSourceTypes().has("html")) {
 			continue;
 		}
 		const presDeps = module.presentationalDependencies;
 		if (!presDeps) continue;
+		const HtmlEntryDependency = getHtmlEntryDependency();
 		for (const dep of presDeps) {
 			if (
 				dep instanceof HtmlEntryDependency &&
@@ -499,8 +504,6 @@ class ResourceHintPlugin {
 	apply(compiler) {
 		const hints = this._hints;
 
-		const HtmlEntryDependency = require("../dependencies/HtmlEntryDependency");
-
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
 			// Lazy-computed on first access — walk every HTML module's
 			// `HtmlEntryDependency`s, resolve each named entry, and collect
@@ -527,6 +530,7 @@ class ResourceHintPlugin {
 					// they don't affect module resolution, only rendering.
 					const presDeps = module.presentationalDependencies;
 					if (!presDeps) continue;
+					const HtmlEntryDependency = getHtmlEntryDependency();
 					for (const dep of presDeps) {
 						if (
 							!(dep instanceof HtmlEntryDependency) ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`experiments.html` defaults to `"auto"`, so `HtmlModulesPlugin` installs on every build and dragged `HtmlGenerator` in through three module-scope requires; `ResourceHintPlugin` also required `HtmlEntryDependency` unconditionally, once in `apply()`. Every use is template or hook code that only runs once a build actually has an html module, so they now go through `memoize`. Measured on a plain js build, 3 interleaved runs against `main` (spread ≤2 KB): 375 vs 376 lib modules loaded, 4394 vs 4459 KB of lib source, and 24360 vs 24753 KB retained heap — **−393 KB on every build that has no html** — with module count, error/warning counts and emitted asset byte-identical.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new tests — behaviour is unchanged; covered by the existing `configCases/html/**` and prefetch/preload/resource-hint cases (548 tests, 32 snapshots) in both `ConfigTestCases` and `ConfigCacheTestCases`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to profile where build memory goes, to find the eager require chains with a `Module._load` counter, to apply the deferrals, and to run the affected config cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_012YyGDY3xjM7qazsDC34U57)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved startup efficiency by loading HTML processing components only when needed.
  * Reduced unnecessary work during builds while preserving existing HTML generation and resource hint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->