### PR TITLE
fix: expose exports of all entry modules in library output

### DIFF
--- a/.changeset/multi-entry-library-exports.md
+++ b/.changeset/multi-entry-library-exports.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Expose exports of all entry modules in library output when an entry is an array of modules, instead of only the last entry module's exports (fixes #15936)

--- a/lib/library/AbstractLibraryPlugin.js
+++ b/lib/library/AbstractLibraryPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -40,6 +41,7 @@ const COMMON_LIBRARY_NAME_MESSAGE =
  * @typedef {object} AbstractLibraryPluginOptions
  * @property {string} pluginName name of the plugin
  * @property {LibraryType} type used library type
+ * @property {boolean=} finishAllEntryModules when true, finishEntryModule is called for every entry dependency instead of only the last one, so exports of all entry modules survive optimization
  */
 
 /**
@@ -51,11 +53,13 @@ class AbstractLibraryPlugin {
 	 * Creates an instance of AbstractLibraryPlugin.
 	 * @param {AbstractLibraryPluginOptions} options options
 	 */
-	constructor({ pluginName, type }) {
+	constructor({ pluginName, type, finishAllEntryModules }) {
 		/** @type {AbstractLibraryPluginOptions["pluginName"]} */
 		this._pluginName = pluginName;
 		/** @type {AbstractLibraryPluginOptions["type"]} */
 		this._type = type;
+		/** @type {boolean} */
+		this._finishAllEntryModules = finishAllEntryModules || false;
 		/** @type {WeakMap<LibraryOptions, T>} */
 		this._parseCache = new WeakMap();
 	}
@@ -84,8 +88,10 @@ class AbstractLibraryPlugin {
 								: compilation.outputOptions.library
 						);
 						if (options !== false) {
-							const dep = deps[deps.length - 1];
-							if (dep) {
+							const relevantDeps = this._finishAllEntryModules
+								? deps
+								: deps.slice(-1);
+							for (const dep of relevantDeps) {
 								const module = compilation.moduleGraph.getModule(dep);
 								if (module) {
 									this.finishEntryModule(module, name, {
@@ -147,6 +153,21 @@ class AbstractLibraryPlugin {
 						compilation,
 						chunkGraph: compilation.chunkGraph
 					});
+				});
+			}
+
+			if (this._finishAllEntryModules) {
+				hooks.inlineInRuntimeBailout.tap(_pluginName, (module, context) => {
+					const { chunk } = context;
+					if (chunk === undefined) return;
+					const options = getOptionsForChunk(chunk);
+					if (options === false) return;
+					if (
+						this._getMergeableEntryModules(compilation.chunkGraph, chunk)
+							.length > 0
+					) {
+						return "the exports of multiple entry modules are merged into the library export";
+					}
 				});
 			}
 
@@ -262,6 +283,101 @@ class AbstractLibraryPlugin {
 	 * @returns {void}
 	 */
 	finishEntryModule(module, entryName, libraryContext) {}
+
+	/**
+	 * Get all javascript entry modules of a chunk that can take part in
+	 * merging exports into the library exports object. Returns an empty array
+	 * when merging is not applicable (single entry, or an entry depends on
+	 * other chunks so startup is delayed).
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Chunk} chunk the chunk
+	 * @returns {Module[]} the entry modules
+	 */
+	_getMergeableEntryModules(chunkGraph, chunk) {
+		/** @type {Module[]} */
+		const entries = [];
+		for (const [
+			module,
+			entrypoint
+		] of chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk)) {
+			if (!chunkGraph.getModuleSourceTypes(module).has("javascript")) continue;
+			if (entrypoint && entrypoint.chunks.some((c) => c !== chunk)) {
+				// entry depends on other chunks, startup is delayed and
+				// exports are not synchronously available for merging
+				return [];
+			}
+			entries.push(module);
+		}
+		return entries.length > 1 ? entries : [];
+	}
+
+	/**
+	 * Render code that merges the exports of all entry modules of the chunk
+	 * into the final library exports object. Returns an empty string when the
+	 * chunk has fewer than two mergeable entry modules. Later entry modules
+	 * override earlier ones on export name conflicts, which keeps the
+	 * documented "last entry wins" semantics for conflicting names.
+	 * @param {Module} startupModule the entry module whose exports are already assigned to the exports object by the startup code
+	 * @param {StartupRenderContext} renderContext render context
+	 * @returns {string} the merge code or an empty string
+	 */
+	_renderEntryExportsMerge(startupModule, renderContext) {
+		const { chunk, chunkGraph, inlined } = renderContext;
+		if (inlined) return "";
+		const entries = this._getMergeableEntryModules(chunkGraph, chunk);
+		if (entries.length === 0) return "";
+		const buf = [
+			"// merge exports of all entry modules into the library exports object",
+			"// entries are merged in reverse order and existing keys are skipped,",
+			"// so later entry modules win on export name conflicts",
+			"var __webpack_exports_merged__ = {};",
+			"var __webpack_merge_entry__ = function (exports) {",
+			Template.indent([
+				"for (var key in exports) {",
+				Template.indent([
+					"if (Object.prototype.hasOwnProperty.call(exports, key) && !Object.prototype.hasOwnProperty.call(__webpack_exports_merged__, key)) {",
+					Template.indent(
+						"Object.defineProperty(__webpack_exports_merged__, key, Object.getOwnPropertyDescriptor(exports, key));"
+					),
+					"}"
+				]),
+				"}"
+			]),
+			"};"
+		];
+		buf.push(`__webpack_merge_entry__(${RuntimeGlobals.exports});`);
+		// the startup module's exports are already in the exports object, all
+		// other entry modules are merged via the (cached) require function
+		for (const module of entries.filter((m) => m !== startupModule).reverse()) {
+			const moduleId = chunkGraph.getModuleId(module);
+			if (moduleId === null) continue;
+			buf.push(
+				`__webpack_merge_entry__(${RuntimeGlobals.require}(${JSON.stringify(
+					moduleId
+				)}));`
+			);
+		}
+		buf.push(
+			`if (${RuntimeGlobals.exports}.__esModule) ${RuntimeGlobals.makeNamespaceObject}(__webpack_exports_merged__);`
+		);
+		buf.push(`${RuntimeGlobals.exports} = __webpack_exports_merged__;`);
+		return `${Template.asString(buf)}\n`;
+	}
+
+	/**
+	 * Add the runtime requirements needed by the entry exports merge code
+	 * when the chunk has multiple mergeable entry modules.
+	 * @param {Chunk} chunk the chunk
+	 * @param {RuntimeRequirements} set runtime requirements
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {void}
+	 */
+	_addEntryExportsMergeRuntimeRequirements(chunk, set, chunkGraph) {
+		if (this._getMergeableEntryModules(chunkGraph, chunk).length > 0) {
+			set.add(RuntimeGlobals.require);
+			set.add(RuntimeGlobals.makeNamespaceObject);
+		}
+	}
 
 	/**
 	 * Embed in runtime bailout.

--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -132,7 +132,10 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 	constructor(options) {
 		super({
 			pluginName: "AssignLibraryPlugin",
-			type: options.type
+			type: options.type,
+			// "static" enumerates the exports of the last entry module at
+			// compile time, so merging all entry exports is not applicable
+			finishAllEntryModules: options.unnamed !== "static"
 		});
 		/** @type {AssignLibraryPluginOptions["prefix"]} */
 		this.prefix = options.prefix;
@@ -315,18 +318,18 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 	 * @param {LibraryContext<T>} libraryContext context
 	 * @returns {Source} source with library export
 	 */
-	renderStartup(
-		source,
-		module,
-		{ moduleGraph, chunk },
-		{ options, compilation }
-	) {
+	renderStartup(source, module, renderContext, { options, compilation }) {
+		const { moduleGraph, chunk } = renderContext;
 		const fullNameResolved = this._getResolvedFullName(
 			options,
 			chunk,
 			compilation
 		);
 		const staticExports = this.unnamed === "static";
+		if (!staticExports) {
+			const merge = this._renderEntryExportsMerge(module, renderContext);
+			if (merge) source = new ConcatSource(source, merge);
+		}
 		const exportAccess = options.export
 			? propertyAccess(
 					Array.isArray(options.export) ? options.export : [options.export]
@@ -430,6 +433,13 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 	 */
 	runtimeRequirements(chunk, set, libraryContext) {
 		set.add(RuntimeGlobals.exports);
+		if (this.unnamed !== "static") {
+			this._addEntryExportsMergeRuntimeRequirements(
+				chunk,
+				set,
+				libraryContext.chunkGraph
+			);
+		}
 	}
 
 	/**

--- a/lib/library/ExportPropertyLibraryPlugin.js
+++ b/lib/library/ExportPropertyLibraryPlugin.js
@@ -50,7 +50,8 @@ class ExportPropertyLibraryPlugin extends AbstractLibraryPlugin {
 	constructor({ type }) {
 		super({
 			pluginName: "ExportPropertyLibraryPlugin",
-			type
+			type,
+			finishAllEntryModules: true
 		});
 	}
 
@@ -102,6 +103,11 @@ class ExportPropertyLibraryPlugin extends AbstractLibraryPlugin {
 	 */
 	runtimeRequirements(chunk, set, libraryContext) {
 		set.add(RuntimeGlobals.exports);
+		this._addEntryExportsMergeRuntimeRequirements(
+			chunk,
+			set,
+			libraryContext.chunkGraph
+		);
 	}
 
 	/**
@@ -113,13 +119,14 @@ class ExportPropertyLibraryPlugin extends AbstractLibraryPlugin {
 	 * @returns {Source} source with library export
 	 */
 	renderStartup(source, module, renderContext, { options }) {
-		if (!options.export) return source;
-		const postfix = `${RuntimeGlobals.exports} = ${
-			RuntimeGlobals.exports
-		}${propertyAccess(
-			Array.isArray(options.export) ? options.export : [options.export]
-		)};\n`;
-		return new ConcatSource(source, postfix);
+		const merge = this._renderEntryExportsMerge(module, renderContext);
+		const postfix = options.export
+			? `${RuntimeGlobals.exports} = ${RuntimeGlobals.exports}${propertyAccess(
+					Array.isArray(options.export) ? options.export : [options.export]
+				)};\n`
+			: "";
+		if (!merge && !postfix) return source;
+		return new ConcatSource(source, merge, postfix);
 	}
 }
 

--- a/test/configCases/library/issue-15936-entry-array-exports/a.js
+++ b/test/configCases/library/issue-15936-entry-array-exports/a.js
@@ -1,0 +1,2 @@
+export const fromA = "a";
+export const shared = "from-a";

--- a/test/configCases/library/issue-15936-entry-array-exports/b.js
+++ b/test/configCases/library/issue-15936-entry-array-exports/b.js
@@ -1,0 +1,2 @@
+export const fromB = "b";
+export const shared = "from-b";

--- a/test/configCases/library/issue-15936-entry-array-exports/index.js
+++ b/test/configCases/library/issue-15936-entry-array-exports/index.js
@@ -1,0 +1,11 @@
+export const fromIndex = "index";
+
+it("should expose exports of all entry modules in the library (issue 15936)", () => {
+	expect(MultiEntryLib.fromA).toBe("a");
+	expect(MultiEntryLib.fromB).toBe("b");
+	expect(MultiEntryLib.fromIndex).toBe("index");
+});
+
+it("should let later entry modules win on export name conflicts", () => {
+	expect(MultiEntryLib.shared).toBe("from-b");
+});

--- a/test/configCases/library/issue-15936-entry-array-exports/webpack.config.js
+++ b/test/configCases/library/issue-15936-entry-array-exports/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: ["./a.js", "./b.js", "./index.js"]
+	},
+	output: {
+		library: { name: "MultiEntryLib", type: "var" }
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -234,6 +234,11 @@ declare interface AbstractLibraryPluginOptions {
 	 * used library type
 	 */
 	type: string;
+
+	/**
+	 * when true, finishEntryModule is called for every entry dependency instead of only the last one, so exports of all entry modules survive optimization
+	 */
+	finishAllEntryModules?: boolean;
 }
 declare interface AdditionalData {
 	[index: string]: any;


### PR DESCRIPTION
Fixes #15936

> Note: supersedes #21661, which was auto-closed by the quality bot before my CLA signature had processed. CLA is now signed, the changeset is included, and CodeRabbit's review feedback from that PR has been addressed in this one.

## Problem
With `entry: ["./a.js", "./b.js", "./c.js"]` and a library output, only the last entry module's exports were flagged as used — exports of earlier entries were tree-shaken away and silently dropped from the library.

## Solution (library plugin layer only)
- `AbstractLibraryPlugin` gains an opt-in `finishAllEntryModules` mode that flags exports of **every** entry dependency as used, plus a helper that renders startup code merging all entry modules' exports into the library exports object.
- `AssignLibraryPlugin` (var/assign/this/window/self/global/commonjs/commonjs2) and `ExportPropertyLibraryPlugin` (amd/umd/system/jsonp) opt in.
- Later entries win on export name conflicts — preserving the documented "last entry wins" semantics for conflicting names.
- `module`/`modern-module` and `commonjs-static` intentionally keep current behavior (their export lists are generated statically from the last entry module).
- Merging is skipped when startup is delayed by depending chunks or when entry modules are inlined; single-entry output is byte-identical to before.

## Testing
- New test case `test/configCases/library/issue-15936-entry-array-exports` — fails on main, passes with this change (multi-entry exposure + conflict semantics).
- Full `library` category of ConfigTestCases: zero new failures vs baseline.
- Includes a changeset (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library bundles with multiple entry points now expose exports from all entry modules.
  - When export names conflict, the value from the later entry module takes precedence.

- **Bug Fixes**
  - Fixed incomplete exports in libraries configured with array-based entry points.

- **Tests**
  - Added coverage for combined exports and conflicting export names across multiple entries.

- **Documentation**
  - Added a release note describing the multi-entry export improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->