### PR TITLE
perf(javascript): cut parser allocations and own acorn's construction path

### DIFF
--- a/.changeset/160-js-parser-acorn-exactness.md
+++ b/.changeset/160-js-parser-acorn-exactness.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reject `**` on an arrow operand and keep LS/PS in cooked template values.

--- a/.changeset/160-js-parser-acorn-exactness.md
+++ b/.changeset/160-js-parser-acorn-exactness.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Reject `**` on an arrow operand and keep LS/PS in cooked template values.
+Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse.

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -58,6 +58,7 @@ const JavascriptModule = require("./JavascriptModule");
 const JavascriptParser = require("./JavascriptParser");
 const analyzeScope = require("./ScopeAnalyzer");
 const { renderAwaitedEntries } = require("./StartupHelpers");
+const { releaseParserCaches } = require("./syntax");
 
 /**
  * @import {
@@ -471,6 +472,10 @@ class JavascriptModulesPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		// the parser's shared string caches only pay off while modules parse —
+		// drop them when the build ends so an idle process retains no parser state
+		compiler.hooks.done.tap(PLUGIN_NAME, releaseParserCaches);
+		compiler.hooks.failed.tap(PLUGIN_NAME, releaseParserCaches);
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1855,13 +1855,17 @@ const createDestructuringErrors = () => {
 /** @type {Map<string, WordLookups>} */
 const wordLookupsCache = new Map();
 
+// Sentinel for the released cache state; `ensureParserCaches` runs in the
+// parser constructor, so the hot paths never observe the nulls behind it.
+const NO_CACHE = /** @type {EXPECTED_ANY} */ (null);
+
 // Direct-mapped identifier cache for `readWord1`: one slot per hash, verified
 // by char compare, overwritten on collision. Shared across parses — hits are
 // content-checked, so a stale entry is merely a miss. Only words short enough
 // to be flat V8 strings (never slices retaining their whole source) are stored.
 const WORD_CACHE_MASK = 0x1fff;
 /** @type {(string | null)[]} */
-const WORD_CACHE = Array.from({ length: WORD_CACHE_MASK + 1 }, () => null);
+let WORD_CACHE = NO_CACHE;
 const WORD_CACHE_MAX_LEN = 12;
 
 // Classification memo parallel to `WORD_CACHE`, same slot: every cache write
@@ -1871,8 +1875,9 @@ const WORD_CACHE_MAX_LEN = 12;
 // by the cache's own slot adds no extra string references — the memo can
 // never retain a word the cache itself dropped.
 /** @type {(TokenType | null)[]} */
-const WORD_TYPES = Array.from({ length: WORD_CACHE_MASK + 1 }, () => null);
-const WORD_TYPE_OWNERS = new Int32Array(WORD_CACHE_MASK + 1);
+let WORD_TYPES = NO_CACHE;
+/** @type {Int32Array} */
+let WORD_TYPE_OWNERS = NO_CACHE;
 let nextWordLookupsId = 1;
 
 // Direct-mapped cache for short non-word slices, WORD_CACHE's regime applied
@@ -1883,8 +1888,38 @@ let nextWordLookupsId = 1;
 // lengths V8 stores flat (never slices retaining the source).
 const SLICE_CACHE_MASK = 0x1fff;
 /** @type {(string | null)[]} */
-const SLICE_CACHE = Array.from({ length: SLICE_CACHE_MASK + 1 }, () => null);
+let SLICE_CACHE = NO_CACHE;
 const SLICE_CACHE_MAX_LEN = 12;
+
+/**
+ * Allocates the shared tokenizer caches; runs in the parser constructor so
+ * they exist exactly while something is parsing.
+ * @returns {void}
+ */
+const ensureParserCaches = () => {
+	if (WORD_CACHE !== null) return;
+	WORD_CACHE = Array.from({ length: WORD_CACHE_MASK + 1 }, () => null);
+	WORD_TYPES = Array.from({ length: WORD_CACHE_MASK + 1 }, () => null);
+	WORD_TYPE_OWNERS = new Int32Array(WORD_CACHE_MASK + 1);
+	SLICE_CACHE = Array.from({ length: SLICE_CACHE_MASK + 1 }, () => null);
+};
+
+/**
+ * Drops every shared parser cache — the string/type caches above plus the
+ * word-lookup, operator, regexp-flag and construction-shape memos — so an
+ * idle process retains no parser state. The next parse rebuilds them.
+ * @returns {void}
+ */
+const releaseParserCaches = () => {
+	WORD_CACHE = NO_CACHE;
+	WORD_TYPES = NO_CACHE;
+	WORD_TYPE_OWNERS = NO_CACHE;
+	SLICE_CACHE = NO_CACHE;
+	wordLookupsCache.clear();
+	OP_CACHE.clear();
+	VALID_REGEXP_FLAGS.clear();
+	fastConstructionShapes.clear();
+};
 
 /**
  * Cached `input.slice(start, end)` for spans of 2-12 chars (callers gate the
@@ -2233,6 +2268,7 @@ class WebpackParser extends BaseParser {
 	 * @param {number=} startPos start position
 	 */
 	constructor(options, input, startPos) {
+		ensureParserCaches();
 		// fast construction for the gated hot-path shape: skip acorn's per-parse
 		// getOptions/wordsRegexp work. A derived constructor may return an object
 		// without calling super(); a plugin subclass's constructor body then runs
@@ -9730,3 +9766,4 @@ module.exports.collectCjsRequireSpecifiers = collectCjsRequireSpecifiers;
 module.exports.hasOctalEscape = hasOctalEscape;
 module.exports.isIdentifierChar = isIdentifierChar;
 module.exports.positionAt = positionAt;
+module.exports.releaseParserCaches = releaseParserCaches;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1863,7 +1863,7 @@ const NO_CACHE = /** @type {EXPECTED_ANY} */ (null);
 // by char compare, overwritten on collision. Shared across parses — hits are
 // content-checked, so a stale entry is merely a miss. Only words short enough
 // to be flat V8 strings (never slices retaining their whole source) are stored.
-const WORD_CACHE_MASK = 0x1fff;
+const WORD_CACHE_MASK = 0xfff;
 /** @type {(string | null)[]} */
 let WORD_CACHE = NO_CACHE;
 const WORD_CACHE_MAX_LEN = 12;
@@ -1886,7 +1886,7 @@ let nextWordLookupsId = 1;
 // too, so serving them from one shared string cuts both allocation churn and
 // retained AST strings. Same rules as WORD_CACHE: content-checked hits, only
 // lengths V8 stores flat (never slices retaining the source).
-const SLICE_CACHE_MASK = 0x1fff;
+const SLICE_CACHE_MASK = 0xfff;
 /** @type {(string | null)[]} */
 let SLICE_CACHE = NO_CACHE;
 const SLICE_CACHE_MAX_LEN = 12;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -89,7 +89,8 @@ const stringToBigInt = (str) => BigInt(str.replace(/_/g, ""));
  * } from "acorn"
  */
 /** @typedef {import("acorn").ImportSpecifier | import("acorn").ImportDefaultSpecifier | import("acorn").ImportNamespaceSpecifier} AnyImportSpecifier */
-/** @typedef {TokenType & { beforeExpr: boolean, isAssign?: boolean, prefix?: boolean, postfix?: boolean, binop: number | null, updateContext: ((prevType: TokenType) => void) | null }} TokenTypeInternal acorn's internal TokenType fields, absent from its public types */
+/** @typedef {TokenType & { beforeExpr: boolean, isAssign?: boolean, prefix?: boolean, postfix?: boolean, startsExpr?: boolean, isLoop?: boolean, binop: number | null, updateContext: ((prevType: TokenType) => void) | null }} TokenTypeInternal acorn's internal TokenType fields, absent from its public types */
+/** @typedef {import("estree").SourceLocation} SourceLocation */
 /** @typedef {[number, number]} Range */
 /** @typedef {"defer" | "source"} ImportPhase */
 /** @typedef {import("estree").Comment & { start: number, end: number }} CollectedComment comment as JavascriptParser exposes it */
@@ -890,6 +891,348 @@ class FunctionNode {
 }
 
 /**
+ * Single-shape `ImportDeclaration`; `phase` (`import defer/source`) stays a
+ * post-construction addition since phase imports are rare.
+ */
+class ImportDeclarationNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {AnyImportSpecifier[]} specifiers import specifiers
+	 * @param {Expression} source module source string literal
+	 * @param {ImportAttribute[]} attributes import attributes (`with { ... }`)
+	 */
+	constructor(start, end, specifiers, source, attributes) {
+		this.type = "ImportDeclaration";
+		this.start = start;
+		this.end = end;
+		this.specifiers = specifiers;
+		this.source = source;
+		this.attributes = attributes;
+	}
+}
+
+/**
+ * Single-shape `ImportSpecifier`.
+ */
+class ImportSpecifierNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} imported imported name (identifier or string literal)
+	 * @param {Node} local local binding identifier
+	 */
+	constructor(start, end, imported, local) {
+		this.type = "ImportSpecifier";
+		this.start = start;
+		this.end = end;
+		this.imported = imported;
+		this.local = local;
+	}
+}
+
+/**
+ * Single-shape `ImportDefaultSpecifier`/`ImportNamespaceSpecifier` —
+ * identical field sets, so both node types share one hidden class.
+ */
+class ImportSimpleSpecifierNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {"ImportDefaultSpecifier" | "ImportNamespaceSpecifier"} type node type
+	 * @param {Node} local local binding identifier
+	 */
+	constructor(start, end, type, local) {
+		this.type = type;
+		this.start = start;
+		this.end = end;
+		this.local = local;
+	}
+}
+
+/**
+ * Single-shape `ImportAttribute`.
+ */
+class ImportAttributeNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} key attribute key (identifier or string literal)
+	 * @param {Node} value attribute value string literal
+	 */
+	constructor(start, end, key, value) {
+		this.type = "ImportAttribute";
+		this.start = start;
+		this.end = end;
+		this.key = key;
+		this.value = value;
+	}
+}
+
+/**
+ * Single-shape `ExportNamedDeclaration`.
+ */
+class ExportNamedDeclarationNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node | null} declaration exported declaration statement
+	 * @param {Node[]} specifiers export specifiers
+	 * @param {Expression | null} source re-export source string literal
+	 * @param {ImportAttribute[]} attributes import attributes (`with { ... }`)
+	 */
+	constructor(start, end, declaration, specifiers, source, attributes) {
+		this.type = "ExportNamedDeclaration";
+		this.start = start;
+		this.end = end;
+		this.declaration = declaration;
+		this.specifiers = specifiers;
+		this.source = source;
+		this.attributes = attributes;
+	}
+}
+
+/**
+ * Single-shape `ExportDefaultDeclaration`.
+ */
+class ExportDefaultDeclarationNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} declaration default-exported declaration or expression
+	 */
+	constructor(start, end, declaration) {
+		this.type = "ExportDefaultDeclaration";
+		this.start = start;
+		this.end = end;
+		this.declaration = declaration;
+	}
+}
+
+/**
+ * Single-shape `ExportAllDeclaration`.
+ */
+class ExportAllDeclarationNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node | null} exported `export * as name` export name
+	 * @param {Expression} source re-export source string literal
+	 * @param {ImportAttribute[]} attributes import attributes (`with { ... }`)
+	 */
+	constructor(start, end, exported, source, attributes) {
+		this.type = "ExportAllDeclaration";
+		this.start = start;
+		this.end = end;
+		this.exported = exported;
+		this.source = source;
+		this.attributes = attributes;
+	}
+}
+
+/**
+ * Single-shape `ExportSpecifier`.
+ */
+class ExportSpecifierNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} local local name (identifier or string literal)
+	 * @param {Node} exported exported name (identifier or string literal)
+	 */
+	constructor(start, end, local, exported) {
+		this.type = "ExportSpecifier";
+		this.start = start;
+		this.end = end;
+		this.local = local;
+		this.exported = exported;
+	}
+}
+
+/**
+ * Single-shape `AssignmentPattern` (also the shape retyped
+ * `AssignmentExpression`s collapse to, minus their deleted `operator`).
+ */
+class AssignmentPatternNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} left binding target
+	 * @param {Expression} right default value
+	 */
+	constructor(start, end, left, right) {
+		this.type = "AssignmentPattern";
+		this.start = start;
+		this.end = end;
+		this.left = left;
+		this.right = right;
+	}
+}
+
+/**
+ * Single-shape `DoWhileStatement`.
+ */
+class DoWhileStatementNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} body loop body
+	 * @param {Expression} test loop condition
+	 */
+	constructor(start, end, body, test) {
+		this.type = "DoWhileStatement";
+		this.start = start;
+		this.end = end;
+		this.body = body;
+		this.test = test;
+	}
+}
+
+/**
+ * Single-shape `WithStatement`.
+ */
+class WithStatementNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Expression} object scope object expression
+	 * @param {Node} body statement body
+	 */
+	constructor(start, end, object, body) {
+		this.type = "WithStatement";
+		this.start = start;
+		this.end = end;
+		this.object = object;
+		this.body = body;
+	}
+}
+
+/**
+ * Single-shape `LabeledStatement`; `body` leads `label`, matching acorn's
+ * write order.
+ */
+class LabeledStatementNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node} body labeled statement
+	 * @param {Identifier} label label identifier
+	 */
+	constructor(start, end, body, label) {
+		this.type = "LabeledStatement";
+		this.start = start;
+		this.end = end;
+		this.body = body;
+		this.label = label;
+	}
+}
+
+/**
+ * Single-shape `EmptyStatement`.
+ */
+class EmptyStatementNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 */
+	constructor(start, end) {
+		this.type = "EmptyStatement";
+		this.start = start;
+		this.end = end;
+	}
+}
+
+/**
+ * Single-shape `DebuggerStatement`.
+ */
+class DebuggerStatementNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 */
+	constructor(start, end) {
+		this.type = "DebuggerStatement";
+		this.start = start;
+		this.end = end;
+	}
+}
+
+/**
+ * Single-shape `AwaitExpression`.
+ */
+class AwaitExpressionNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Expression} argument awaited expression
+	 */
+	constructor(start, end, argument) {
+		this.type = "AwaitExpression";
+		this.start = start;
+		this.end = end;
+		this.argument = argument;
+	}
+}
+
+/**
+ * Single-shape `YieldExpression`; `delegate` leads, matching acorn's write
+ * order.
+ */
+class YieldExpressionNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {boolean} delegate whether this is `yield*`
+	 * @param {Expression | null} argument yielded expression
+	 */
+	constructor(start, end, delegate, argument) {
+		this.type = "YieldExpression";
+		this.start = start;
+		this.end = end;
+		this.delegate = delegate;
+		this.argument = argument;
+	}
+}
+
+/**
+ * Single-shape `PrivateIdentifier` (`IdentifierNode`'s fields, distinct
+ * type).
+ */
+class PrivateIdentifierNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {string} name private name without the `#`
+	 */
+	constructor(start, end, name) {
+		this.type = "PrivateIdentifier";
+		this.start = start;
+		this.end = end;
+		this.name = name;
+	}
+}
+
+/**
+ * Single-shape `Program`; `sourceType` trails `body`, matching acorn's
+ * write order.
+ */
+class ProgramNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node[]} body top-level statements
+	 * @param {string} sourceType effective source type
+	 */
+	constructor(start, end, body, sourceType) {
+		this.type = "Program";
+		this.start = start;
+		this.end = end;
+		this.body = body;
+		this.sourceType = sourceType;
+	}
+}
+
+/**
  * Single-shape `SpreadElement`/`RestElement` — identical field sets, so both
  * node types share one hidden class.
  */
@@ -916,6 +1259,35 @@ const SWITCH_LABEL = { kind: "switch" };
 // acorn's module-level `empty`.
 /** @type {Expression[]} */
 const EMPTY_NEW_ARGS = [];
+
+// Shared zero-length specifiers array for `import "x"`, mirroring acorn's
+// module-level `empty$1`.
+/** @type {AnyImportSpecifier[]} */
+const EMPTY_IMPORT_SPECIFIERS = [];
+
+// Mirror of acorn's module-level `loneSurrogate` (not exported), for the owned
+// `parseModuleExportName`'s string-name check.
+const LONE_SURROGATE_REGEXP =
+	/(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+
+/**
+ * Character-level mirror of acorn's `keywordRelationalOperator` (`in` /
+ * `instanceof`) over a source span, so lookahead probes need no identifier
+ * slice.
+ * @param {string} input source text
+ * @param {number} start span start offset
+ * @param {number} end span end offset
+ * @returns {boolean} whether the span spells `in` or `instanceof`
+ */
+const isRelationalKeyword = (input, start, end) => {
+	const len = end - start;
+	if (len === 2) {
+		return (
+			input.charCodeAt(start) === 105 && input.charCodeAt(start + 1) === 110
+		);
+	}
+	return len === 10 && input.startsWith("instanceof", start);
+};
 
 /**
  * Mirror of acorn's module-level `isLocalVariableAccess`.
@@ -979,6 +1351,24 @@ for (const NodeClass of [
 	PropertyNode,
 	RestSpreadNode,
 	FunctionNode,
+	ProgramNode,
+	AwaitExpressionNode,
+	YieldExpressionNode,
+	PrivateIdentifierNode,
+	AssignmentPatternNode,
+	DoWhileStatementNode,
+	WithStatementNode,
+	LabeledStatementNode,
+	EmptyStatementNode,
+	DebuggerStatementNode,
+	ImportDeclarationNode,
+	ImportSpecifierNode,
+	ImportSimpleSpecifierNode,
+	ImportAttributeNode,
+	ExportNamedDeclarationNode,
+	ExportDefaultDeclarationNode,
+	ExportAllDeclarationNode,
+	ExportSpecifierNode,
 	ForStatementNode,
 	ForInStatementNode,
 	ForOfStatementNode,
@@ -1098,6 +1488,7 @@ class Scope {
  * value: unknown,
  * start: number,
  * startLoc?: Position,
+ * lastTokEndLoc?: Position | null,
  * containsEsc: boolean,
  * exprAllowed: boolean,
  * options: Options,
@@ -1117,7 +1508,7 @@ class Scope {
  * parseLiteral: (value: unknown) => Node,
  * awaitIdentPos: number,
  * lastTokStart: number,
- * lastTokStartLoc?: Position,
+ * lastTokStartLoc?: Position | null,
  * yieldPos: number,
  * awaitPos: number,
  * parseExpression: (forInit?: boolean | string, refDestructuringErrors?: DestructuringErrorsShim | null) => Expression,
@@ -1146,6 +1537,7 @@ class Scope {
  * semicolon: () => void,
  * exitScope: () => void,
  * parseStatement: (context: string | null, topLevel?: boolean, exports?: unknown) => Node,
+ * parseTopLevel: (node: Node) => Node,
  * parseBindingAtom: () => Node,
  * parseVarStatement: (node: Node, kind: string, allowMissingInitializer?: boolean) => Node,
  * parseVar: (node: Node, isFor: boolean, kind: string, allowMissingInitializer?: boolean) => Node,
@@ -1173,6 +1565,8 @@ class Scope {
  * _acquireScratch: () => EXPECTED_ANY[],
  * _releaseScratch: (scratch: EXPECTED_ANY[], count: number) => EXPECTED_ANY[],
  * parseRestBinding: () => Node,
+ * parseMaybeDefault: (startPos: number, startLoc?: Position, left?: Node) => Node,
+ * checkPatternExport: (exports: unknown, pattern: Node) => void,
  * parseBindingListItem: (param: Node) => Node,
  * parseAssignableListItem: (allowModifiers?: boolean) => Node,
  * parseParenItem: (item: Expression | Node) => Expression,
@@ -1231,6 +1625,13 @@ class Scope {
  * context: TokContextShim[],
  * pos: number,
  * input: string,
+ * sourceFile: string | null | undefined,
+ * curLine: number,
+ * lineStart: number,
+ * endLoc?: Position,
+ * regexpState: unknown,
+ * curPosition: () => Position | undefined,
+ * initialContext: () => TokContextShim[],
  * scopeStack: Scope[],
  * _scopePool: Scope[],
  * _setPool: Set<string>[],
@@ -1263,6 +1664,24 @@ class Scope {
  * parseImport: (node: Node) => Node,
  * parseExport: (node: Node, exports: unknown) => Node,
  * parseImportSpecifiers: () => AnyImportSpecifier[],
+ * _parseImportSpecifiersBase: () => AnyImportSpecifier[],
+ * parseImportSpecifier: () => Node,
+ * parseImportDefaultSpecifier: () => Node,
+ * parseImportNamespaceSpecifier: () => Node,
+ * parseModuleExportName: () => Node,
+ * parseExportAllDeclaration: (node: Node, exports: unknown) => Node,
+ * parseExportDefaultDeclaration: () => Node,
+ * parseExportDeclaration: (node: Node) => Node,
+ * parseExportSpecifier: (exports: unknown) => Node,
+ * parseExportSpecifiers: (exports: unknown) => Node[],
+ * checkExport: (exports: unknown, name: string | Node, pos: number) => void,
+ * checkLocalExport: (id: Identifier) => void,
+ * parseWithClause: () => ImportAttribute[],
+ * checkVariableExport: (exports: unknown, declarations: Node[]) => void,
+ * shouldParseExportStatement: () => boolean,
+ * expectContextual: (name: string) => void,
+ * parseClass: (node: Node, isStatement: string | boolean) => Node,
+ * _moduleDeclFastPath: boolean,
  * parseImportAttribute: () => ImportAttribute,
  * parseExprImport: (forNew: boolean) => Expression,
  * parseImportMeta: (node: Node) => Expression,
@@ -1305,6 +1724,11 @@ class Scope {
  * _funcStmtOwn: boolean,
  * _parseFunctionAt: (start: number, statement: number, allowExpressionBody: boolean, isAsync: boolean, forInit?: boolean | string) => Expression,
  * isLet: (context?: string | null) => boolean,
+ * isAsyncFunction: () => boolean,
+ * isUsingKeyword: (isAwaitUsing: boolean, isFor?: boolean) => boolean,
+ * fullCharCodeAt: (pos: number) => number,
+ * _scanGap: (pos: number) => number,
+ * _scanGapNewline: boolean,
  * parseVarId: (decl: Node, kind: string) => void,
  * _varIdOwn: boolean,
  * isSimpleAssignTarget: (expr: Expression) => boolean,
@@ -1322,6 +1746,10 @@ class Scope {
  * parseForIn: (node: Node, init: Node) => Node,
  * parseForAfterInit: (node: Node, init: Node, awaitAt: number) => Node,
  * parseWhileStatement: (node: Node) => Node,
+ * parseDoStatement: (node: Node) => Node,
+ * parseWithStatement: (node: Node) => Node,
+ * parseEmptyStatement: (node: Node) => Node,
+ * parseDebuggerStatement: (node: Node) => Node,
  * parseSwitchStatement: (node: Node) => Node,
  * parseThrowStatement: (node: Node) => Node,
  * parseTryStatement: (node: Node) => Node,
@@ -1626,6 +2054,174 @@ const getWordLookups = (parser) => {
 };
 
 /**
+ * Per-option-shape data for the fast construction path: everything acorn's
+ * constructor derives from options alone.
+ * @typedef {object} FastConstructionShape
+ * @property {Options} options normalized options template — never handed to an instance, see `cloneNormalizedOptions`
+ * @property {RegExp} keywords acorn's interned keywords regexp
+ * @property {RegExp} reservedWords acorn's interned reserved-words regexp
+ * @property {RegExp} reservedWordsStrict acorn's interned strict reserved-words regexp
+ * @property {RegExp} reservedWordsStrictBind acorn's interned strict-bind reserved-words regexp
+ * @property {WordLookups} wordLookups word lookups for this keyword set
+ * @property {number} ecmaVersion normalized numeric ecmaVersion
+ * @property {boolean} inModule whether sourceType is module
+ * @property {boolean} baseStrict strictness before the directive probe (module or explicit strict)
+ * @property {boolean} allowHashBang normalized allowHashBang
+ * @property {string} validRegexpFlags regexp flag whitelist for the ecmaVersion
+ */
+
+// One record per option shape passing the fast-construction gate; webpack
+// parses with one or two shapes, so this is effectively a one-time build.
+/** @type {Map<string, FastConstructionShape>} */
+const fastConstructionShapes = new Map();
+
+/**
+ * Fresh per-instance copy of a shape's normalized options: `_tryModuleFallback`
+ * writes `sourceType`/`allowReturnOutsideFunction` into `this.options`
+ * mid-parse, so a shared template would leak one parse's downgrade into every
+ * later parse. Sequential stores in `defaultOptions` key order land on the
+ * hidden class acorn's `getOptions` builds, keeping `this.options` reads
+ * monomorphic across fast- and slow-constructed parsers.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/options.js
+ * @param {Options} template normalized options template of the shape
+ * @returns {Options} per-instance options object
+ */
+const cloneNormalizedOptions = (template) => {
+	const from = /** @type {Record<string, unknown>} */ (
+		/** @type {unknown} */ (template)
+	);
+	/** @type {Record<string, unknown>} */
+	const options = {};
+	options.ecmaVersion = from.ecmaVersion;
+	options.sourceType = from.sourceType;
+	options.strict = from.strict;
+	options.onInsertedSemicolon = from.onInsertedSemicolon;
+	options.onTrailingComma = from.onTrailingComma;
+	options.allowReserved = from.allowReserved;
+	options.allowReturnOutsideFunction = from.allowReturnOutsideFunction;
+	options.allowImportExportEverywhere = from.allowImportExportEverywhere;
+	options.allowAwaitOutsideFunction = from.allowAwaitOutsideFunction;
+	options.allowSuperOutsideMethod = from.allowSuperOutsideMethod;
+	options.allowHashBang = from.allowHashBang;
+	options.checkPrivateFields = from.checkPrivateFields;
+	options.locations = from.locations;
+	options.startLocation = from.startLocation;
+	options.onToken = from.onToken;
+	options.onComment = from.onComment;
+	options.ranges = from.ranges;
+	options.program = from.program;
+	options.sourceFile = from.sourceFile;
+	options.directSourceFile = from.directSourceFile;
+	options.preserveParens = from.preserveParens;
+	return /** @type {Options} */ (/** @type {unknown} */ (options));
+};
+
+/**
+ * Builds a shape via one sacrificial base construction: acorn's `getOptions`
+ * and `wordsRegexp` run once here, and the captured regexps are the interned
+ * instances acorn's module-level cache would serve every equal construction —
+ * so `getWordLookups`' identity memo keeps matching for slow-path parsers too.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/state.js
+ * @param {Options} options raw options that passed the fast-construction gate
+ * @returns {FastConstructionShape} shape record
+ */
+const buildFastConstructionShape = (options) => {
+	// canonicalized copy of the gate-variable options; acorn reads `strict` only
+	// as `=== true` and the allow* flags only by truthiness, so booleans match
+	/** @type {Options} */
+	const raw = {
+		ecmaVersion: /** @type {Options["ecmaVersion"]} */ (options.ecmaVersion),
+		sourceType: options.sourceType,
+		strict: options.strict === true,
+		allowReturnOutsideFunction: Boolean(options.allowReturnOutsideFunction),
+		allowImportExportEverywhere: Boolean(options.allowImportExportEverywhere),
+		allowAwaitOutsideFunction: Boolean(options.allowAwaitOutsideFunction),
+		allowSuperOutsideMethod: Boolean(options.allowSuperOutsideMethod)
+	};
+	// null/undefined must stay absent so getOptions applies its own default
+	if (options.allowHashBang !== null && options.allowHashBang !== undefined) {
+		raw.allowHashBang = Boolean(options.allowHashBang);
+	}
+	const ProbeParser =
+		/** @type {new (options: Options, input: string) => unknown} */ (
+			/** @type {unknown} */ (BaseParser)
+		);
+	const probe = /** @type {ParserInternals} */ (new ProbeParser(raw, ""));
+	const normalized = probe.options;
+	const ecmaVersion = /** @type {number} */ (normalized.ecmaVersion);
+	return {
+		options: normalized,
+		keywords: probe.keywords,
+		reservedWords: probe.reservedWords,
+		reservedWordsStrict: probe.reservedWordsStrict,
+		reservedWordsStrictBind: probe.reservedWordsStrictBind,
+		wordLookups: getWordLookups(probe),
+		ecmaVersion,
+		inModule: normalized.sourceType === "module",
+		baseStrict:
+			normalized.sourceType === "module" || normalized.strict === true,
+		allowHashBang: normalized.allowHashBang === true,
+		validRegexpFlags: getValidRegexpFlags(ecmaVersion)
+	};
+};
+
+/**
+ * Gate for the fast construction path: the exact webpack hot-path option
+ * shape, with every option whose normalization is not replicated absent or
+ * default. Returns the cached per-shape record, or null for the slow path.
+ * @param {Options & { lazyNodes?: boolean }} options raw options
+ * @param {string} input source code
+ * @param {number | undefined} startPos start position
+ * @returns {FastConstructionShape | null} shape record, or null for the slow path
+ */
+const getFastConstructionShape = (options, input, startPos) => {
+	if (
+		startPos !== undefined ||
+		options.lazyNodes !== true ||
+		typeof input !== "string" ||
+		options.ecmaVersion === null ||
+		options.ecmaVersion === undefined ||
+		(options.sourceType !== "module" && options.sourceType !== "script") ||
+		(options.allowReserved !== null && options.allowReserved !== undefined) ||
+		options.onInsertedSemicolon ||
+		options.onTrailingComma ||
+		options.locations ||
+		options.startLocation ||
+		options.onToken ||
+		options.onComment ||
+		options.ranges ||
+		options.program ||
+		options.sourceFile ||
+		options.directSourceFile ||
+		options.preserveParens ||
+		// getOptions copies an explicitly-present key even when undefined, so
+		// presence with any value but true must take the slow path
+		(options.checkPrivateFields !== true && "checkPrivateFields" in options)
+	) {
+		return null;
+	}
+	const key = `${options.ecmaVersion}|${options.sourceType}|${
+		options.strict === true ? "s" : ""
+	}${options.allowReturnOutsideFunction ? "r" : ""}${
+		options.allowImportExportEverywhere ? "e" : ""
+	}${options.allowAwaitOutsideFunction ? "a" : ""}${
+		options.allowSuperOutsideMethod ? "m" : ""
+	}${
+		options.allowHashBang === null || options.allowHashBang === undefined
+			? ""
+			: options.allowHashBang
+				? "|h"
+				: "|n"
+	}`;
+	let shape = fastConstructionShapes.get(key);
+	if (shape === undefined) {
+		shape = buildFastConstructionShape(options);
+		fastConstructionShapes.set(key, shape);
+	}
+	return shape;
+};
+
+/**
  * webpack's parser: acorn plus lazy `range` (no `loc` at all), Set-based scopes,
  * tokenizer fast paths, import attributes and import phases (with acorn's
  * `!forNew` guard, unlike the former `acorn-import-phases` package).
@@ -1637,6 +2233,166 @@ class WebpackParser extends BaseParser {
 	 * @param {number=} startPos start position
 	 */
 	constructor(options, input, startPos) {
+		// fast construction for the gated hot-path shape: skip acorn's per-parse
+		// getOptions/wordsRegexp work. A derived constructor may return an object
+		// without calling super(); a plugin subclass's constructor body then runs
+		// on the returned object exactly as it would after its super() call.
+		const shape = getFastConstructionShape(options, input, startPos);
+		if (shape !== null) {
+			// write order below is load-bearing: acorn's constructor fields first,
+			// in dist order (a chained `a = b = v` creates b before a), then the
+			// WebpackParser fields in slow-constructor order — so fast- and
+			// slow-built instances walk one hidden-class transition chain
+			// acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/state.js
+			const self = /** @type {ParserInternals} */ (
+				/** @type {unknown} */ (Object.create(new.target.prototype))
+			);
+			self.options = cloneNormalizedOptions(shape.options);
+			self.sourceFile = null;
+			self.keywords = shape.keywords;
+			self.reservedWords = shape.reservedWords;
+			self.reservedWordsStrict = shape.reservedWordsStrict;
+			self.reservedWordsStrictBind = shape.reservedWordsStrictBind;
+			self.input = input;
+			self.containsEsc = false;
+			self.pos = 0;
+			self.curLine = 1;
+			self.lineStart = 0;
+			self.type = tokTypes.eof;
+			self.value = null;
+			self.end = 0;
+			self.start = 0;
+			// locations are off, so this yields undefined — still called so a
+			// plugin override of curPosition keeps taking effect
+			const curPos = self.curPosition();
+			self.endLoc = curPos;
+			self.startLoc = curPos;
+			self.lastTokStartLoc = null;
+			self.lastTokEndLoc = null;
+			self.lastTokEnd = 0;
+			self.lastTokStart = 0;
+			self.context = self.initialContext();
+			self.exprAllowed = true;
+			self.inModule = shape.inModule;
+			// acorn's short-circuit order: the directive probe runs only for
+			// sloppy scripts, and before the hashbang skip below moves `pos`
+			self.strict = shape.baseStrict || self.strictDirective(self.pos);
+			self.potentialArrowAt = -1;
+			self.potentialArrowInForAwait = false;
+			self.awaitIdentPos = 0;
+			self.awaitPos = 0;
+			self.yieldPos = 0;
+			self.labels = [];
+			self.undefinedExports = Object.create(null);
+			// hashbang at acorn's position; _lazyComments does not exist yet, so
+			// the owned skipLineComment delegates and the comment is rebuilt below
+			const hashbang = shape.allowHashBang && input.startsWith("#!");
+			if (hashbang) self.skipLineComment(2);
+			self.scopeStack = [];
+			// sourceType is gated to module/script, never commonjs's SCOPE_FUNCTION
+			self.enterScope(SCOPE_TOP);
+			self.regexpState = null;
+			self.privateNameStack = [];
+			// WebpackParser fields, mirroring the slow constructor below with the
+			// gate-guaranteed constants (lazy, no locations/onComment) folded in
+			self._wordLookups = shape.wordLookups;
+			// acorn only calls `.test()` on reservedWordsStrictBind (in
+			// checkLValSimple); swap its regexp for the Set-backed check
+			/** @type {{ reservedWordsStrictBind: { test: (name: string) => boolean } }} */ (
+				/** @type {unknown} */ (self)
+			).reservedWordsStrictBind = shape.wordLookups.reservedBindTest;
+			self._ecmaVersion = shape.ecmaVersion;
+			self._noLocations = true;
+			self._lazy = true;
+			self._lazyComments =
+				/** @type {Options & { lazyComments?: CollectedComment[] }} */ (
+					options
+				).lazyComments;
+			// the comment the acorn-position hashbang skip could not record yet
+			if (self._lazyComments !== undefined && hashbang) {
+				self._lazyComments.push(new LazyComment(false, 2, 0, self.pos, input));
+			}
+			self._importPhase = null;
+			self._importPhasesEnabled =
+				/** @type {Options & { importPhases?: boolean }} */ (options)
+					.importPhases === true;
+			self._moduleFallback =
+				/** @type {Options & { moduleFallback?: boolean }} */ (options)
+					.moduleFallback === true;
+			self._moduleSyntaxSeen = false;
+			self._subscriptFastPath = shape.ecmaVersion >= 11;
+			const proto = WebpackParser.prototype;
+			// lazy is gate-guaranteed, so the slow path's `lazy ||` short-circuits
+			// fold to constants; the method-identity gates still run so a plugin
+			// subclass constructed through here keeps its overrides respected
+			self._tokenFastPath = true;
+			self._fullTokenFastPath = shape.ecmaVersion >= 12;
+			self._inlineFinish = self.finishToken === proto.finishToken;
+			self._newlineBefore = 2;
+			self._deStack = [];
+			self._deDepth = 0;
+			self._propHashFastPath = self.checkPropClash === base.checkPropClash;
+			self._propHashStack = [];
+			self._propHashDepth = 0;
+			self._arrStack = [];
+			self._arrDepth = 0;
+			self._scopePool = [];
+			self._setPool = [];
+			self._labelsStack = [];
+			self._labelsDepth = 0;
+			self._scanGapNewline = false;
+			self._validRegexpFlags = shape.validRegexpFlags;
+			self._varIdOwn = self.parseVarId === base.parseVarId;
+			self._stmtFastPath =
+				self._varIdOwn &&
+				self.parseVarStatement === proto.parseVarStatement &&
+				self.parseVar === proto.parseVar &&
+				self.parseIfStatement === proto.parseIfStatement &&
+				self.parseReturnStatement === proto.parseReturnStatement &&
+				self.parseExpressionStatement === proto.parseExpressionStatement;
+			self._lastArrow = null;
+			self._arrowFastPath =
+				self.parseArrowExpression === proto.parseArrowExpression;
+			self._funcFastPath =
+				shape.ecmaVersion >= 9 &&
+				self.initFunction === base.initFunction &&
+				self.isSimpleParamList === base.isSimpleParamList;
+			self._funcStmtOwn =
+				self._funcFastPath &&
+				self.parseFunctionStatement === base.parseFunctionStatement &&
+				self.parseFunction === proto.parseFunction;
+			self._stmt2FastPath =
+				shape.ecmaVersion >= 9 &&
+				self._varIdOwn &&
+				self.parseForStatement === base.parseForStatement &&
+				self.parseFor === base.parseFor &&
+				self.parseForIn === base.parseForIn &&
+				self.parseForAfterInit === base.parseForAfterInit &&
+				self.parseVar === proto.parseVar &&
+				self.parseWhileStatement === base.parseWhileStatement &&
+				self.parseSwitchStatement === base.parseSwitchStatement &&
+				self.parseThrowStatement === base.parseThrowStatement &&
+				self.parseTryStatement === base.parseTryStatement &&
+				self.parseBreakContinueStatement === base.parseBreakContinueStatement &&
+				self.parseDoStatement === base.parseDoStatement &&
+				self.parseWithStatement === base.parseWithStatement &&
+				self.parseEmptyStatement === base.parseEmptyStatement &&
+				self.parseDebuggerStatement === base.parseDebuggerStatement;
+			self._exprFastPath =
+				self.parseMaybeConditional === proto.parseMaybeConditional &&
+				self.parseExprOps === proto.parseExprOps &&
+				self.parseExprOp === proto.parseExprOp &&
+				self.parseMaybeUnary === proto.parseMaybeUnary &&
+				self.parseExprSubscripts === proto.parseExprSubscripts &&
+				self.parseSubscripts === proto.parseSubscripts &&
+				self.parseSubscript === proto.parseSubscript &&
+				self.parseExprAtom === proto.parseExprAtom &&
+				self.checkExpressionErrors === proto.checkExpressionErrors &&
+				self.isContextual === base.isContextual;
+			self._moduleDeclFastPath = shape.ecmaVersion >= 16;
+			// eslint-disable-next-line no-constructor-return -- the explicit object return is the mechanism that skips acorn's constructor
+			return /** @type {WebpackParser} */ (/** @type {unknown} */ (self));
+		}
 		const lazy = options.lazyNodes === true;
 		// JavascriptParser._parse pre-disables acorn's tracking, so the
 		// defensive copy only runs for direct callers
@@ -1776,6 +2532,8 @@ class WebpackParser extends BaseParser {
 		/** @type {{ kind?: string | null, name?: string, statementStart?: number }[][]} */
 		this._labelsStack = [];
 		this._labelsDepth = 0;
+		// whether the last _scanGap saw a line terminator
+		this._scanGapNewline = false;
 		// `readRegexp`'s flag whitelist depends only on the ecmaVersion
 		this._validRegexpFlags = getValidRegexpFlags(this._ecmaVersion);
 		// _parseVarInto inlines acorn's parseVarId, so an override of it turns
@@ -1832,7 +2590,11 @@ class WebpackParser extends BaseParser {
 			internals.parseThrowStatement === base.parseThrowStatement &&
 			internals.parseTryStatement === base.parseTryStatement &&
 			internals.parseBreakContinueStatement ===
-				base.parseBreakContinueStatement;
+				base.parseBreakContinueStatement &&
+			internals.parseDoStatement === base.parseDoStatement &&
+			internals.parseWithStatement === base.parseWithStatement &&
+			internals.parseEmptyStatement === base.parseEmptyStatement &&
+			internals.parseDebuggerStatement === base.parseDebuggerStatement;
 		// `parseMaybeAssign`'s trivial-atom fast path returns the atom without
 		// descending the seven-layer expression chain, so every layer it skips
 		// must be the owned one
@@ -1848,6 +2610,9 @@ class WebpackParser extends BaseParser {
 			this.parseExprAtom === proto.parseExprAtom &&
 			this.checkExpressionErrors === proto.checkExpressionErrors &&
 			internals.isContextual === base.isContextual;
+		// the owned import/export declarations bake in ecmaVersion ≥ 16 (import
+		// attributes; with it string export names ≥ 13 and `export * as` ≥ 11)
+		this._moduleDeclFastPath = lazy && this._ecmaVersion >= 16;
 	}
 
 	/**
@@ -2217,6 +2982,186 @@ class WebpackParser extends BaseParser {
 			return false;
 		}
 		return !this.exprAllowed;
+	}
+
+	/**
+	 * Allocation-free mirror of acorn's `skipWhiteSpace` regexp: advances over
+	 * whitespace and comments from `pos` without touching tokenizer state,
+	 * flagging line terminators (including inside block comments) in
+	 * `_scanGapNewline`. An unterminated block comment stops the scan, exactly
+	 * like the regexp.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/whitespace.js
+	 * @param {number} pos scan start offset
+	 * @returns {number} offset of the first char past the gap
+	 * @this {ParserInternals}
+	 */
+	_scanGap(pos) {
+		const input = this.input;
+		const len = input.length;
+		let newline = false;
+		while (pos < len) {
+			const ch = input.charCodeAt(pos);
+			if (ch === 32 || ch === 9 || ch === 11 || ch === 12 || ch === 160) {
+				pos++;
+			} else if (ch === 10 || ch === 13 || ch === 0x2028 || ch === 0x2029) {
+				newline = true;
+				pos++;
+			} else if (ch === 47) {
+				const next = input.charCodeAt(pos + 1);
+				if (next === 47) {
+					pos += 2;
+					while (pos < len) {
+						const commentCh = input.charCodeAt(pos);
+						if (
+							commentCh === 10 ||
+							commentCh === 13 ||
+							commentCh === 0x2028 ||
+							commentCh === 0x2029
+						) {
+							break;
+						}
+						pos++;
+					}
+				} else if (next === 42) {
+					const end = input.indexOf("*/", pos + 2);
+					if (end === -1) break;
+					if (!newline) {
+						for (let i = pos + 2; i < end; i++) {
+							const commentCh = input.charCodeAt(i);
+							if (
+								commentCh === 10 ||
+								commentCh === 13 ||
+								commentCh === 0x2028 ||
+								commentCh === 0x2029
+							) {
+								newline = true;
+								break;
+							}
+						}
+					}
+					pos = end + 2;
+				} else {
+					break;
+				}
+			} else if (
+				ch >= 5760 &&
+				nonASCIIwhitespace.test(String.fromCharCode(ch))
+			) {
+				pos++;
+			} else {
+				break;
+			}
+		}
+		this._scanGapNewline = newline;
+		return pos;
+	}
+
+	/**
+	 * Owned `isLet`: acorn's lookahead runs `skipWhiteSpace.exec` (a match
+	 * array plus matched-substring allocation) and slices the trailing
+	 * identifier; the scan helper and charCode compares do neither.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {string | null=} context statement context
+	 * @returns {boolean} whether `let` heads a lexical declaration here
+	 * @this {ParserInternals}
+	 */
+	isLet(context) {
+		if (this._ecmaVersion < 6 || !this.isContextual("let")) return false;
+		let next = this._scanGap(this.pos);
+		let nextCh = this.fullCharCodeAt(next);
+		// `let [` is an explicit negative lookahead for ExpressionStatement
+		if (nextCh === 91 || nextCh === 92) return true; // '[', '\'
+		if (context) return false;
+		if (nextCh === 123) return true; // '{'
+		if (isIdentifierStart(nextCh)) {
+			const start = next;
+			do {
+				next += nextCh <= 0xffff ? 1 : 2;
+			} while (isIdentifierChar((nextCh = this.fullCharCodeAt(next))));
+			if (nextCh === 92) return true;
+			if (!isRelationalKeyword(this.input, start, next)) return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Owned `isAsyncFunction` (`async [no LineTerminator here] function`),
+	 * allocation-free like `isLet`.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {boolean} whether `async` heads an async function here
+	 * @this {ParserInternals}
+	 */
+	isAsyncFunction() {
+		if (this._ecmaVersion < 8 || !this.isContextual("async")) return false;
+		const input = this.input;
+		const next = this._scanGap(this.pos);
+		if (this._scanGapNewline || !input.startsWith("function", next)) {
+			return false;
+		}
+		if (next + 8 === input.length) return true;
+		const after = this.fullCharCodeAt(next + 8);
+		return !(isIdentifierChar(after) || after === 92);
+	}
+
+	/**
+	 * Owned `isUsingKeyword` (backing `isUsing`/`isAwaitUsing`, which acorn
+	 * dispatches here), allocation-free like `isLet`.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {boolean} isAwaitUsing whether checking `await using`
+	 * @param {boolean=} isFor whether in a `for` head
+	 * @returns {boolean} whether a `using` declaration starts here
+	 * @this {ParserInternals}
+	 */
+	isUsingKeyword(isAwaitUsing, isFor) {
+		if (
+			this._ecmaVersion < 17 ||
+			!this.isContextual(isAwaitUsing ? "await" : "using")
+		) {
+			return false;
+		}
+		const input = this.input;
+		let next = this._scanGap(this.pos);
+		if (this._scanGapNewline) return false;
+		if (isAwaitUsing) {
+			const usingEndPos = next + 5;
+			let after;
+			if (
+				!input.startsWith("using", next) ||
+				usingEndPos === input.length ||
+				isIdentifierChar((after = this.fullCharCodeAt(usingEndPos))) ||
+				after === 92
+			) {
+				return false;
+			}
+			next = this._scanGap(usingEndPos);
+			if (this._scanGapNewline) return false;
+		}
+		let ch = this.fullCharCodeAt(next);
+		if (!isIdentifierStart(ch) && ch !== 92) return false;
+		const idStart = next;
+		do {
+			next += ch <= 0xffff ? 1 : 2;
+		} while (isIdentifierChar((ch = this.fullCharCodeAt(next))));
+		if (ch === 92) return true;
+		if (isRelationalKeyword(input, idStart, next)) return false;
+		if (
+			isFor &&
+			!isAwaitUsing &&
+			next - idStart === 2 &&
+			input.charCodeAt(idStart) === 111 &&
+			input.charCodeAt(idStart + 1) === 102
+		) {
+			// `for (using of …)`: only an initializer keeps it a declaration
+			next = this._scanGap(next);
+			if (
+				input.charCodeAt(next) !== 61 ||
+				(ch = input.charCodeAt(next + 1)) === 61 ||
+				ch === 62
+			) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -3559,6 +4504,9 @@ class WebpackParser extends BaseParser {
 	 */
 	checkUnreserved(ref) {
 		const { start, end, name } = ref;
+		// a string-literal module export name lands here (`export { "x" }`);
+		// acorn no-ops on it — no keyword or reserved set contains a non-string
+		if (typeof name !== "string") return;
 		// every reserved word and special name below is short lowercase ASCII, so
 		// most identifiers exit on this shape gate before any string compare
 		// (`yield`/`await`/`arguments` all pass it: lengths 5/5/9 ≤ reservedMaxLen,
@@ -3916,17 +4864,30 @@ class WebpackParser extends BaseParser {
 	 * @this {ParserInternals}
 	 */
 	parseIdent(liberal) {
-		if (this.type !== tokTypes.name || !this._lazy) {
+		if (!this._lazy) return base.parseIdent.call(this, liberal);
+		/** @type {string} */
+		let name;
+		const type = this.type;
+		if (type === tokTypes.name) {
+			name = /** @type {string} */ (this.value);
+		} else if (type.keyword) {
+			// keyword as identifier (`obj.class`, `{ default: x }`)
+			name = type.keyword;
+			// acorn #575: class/function pushed a context this use never pops,
+			// except after `.` where updateContext already ignored the keyword
+			if (
+				(name === "class" || name === "function") &&
+				(this.lastTokEnd !== this.lastTokStart + 1 ||
+					this.input.charCodeAt(this.lastTokStart) !== 46)
+			) {
+				this.context.pop();
+			}
+			this.type = tokTypes.name;
+		} else {
 			return base.parseIdent.call(this, liberal);
 		}
 		const node = /** @type {Identifier} */ (
-			/** @type {unknown} */ (
-				new IdentifierNode(
-					this.start,
-					this.end,
-					/** @type {string} */ (this.value)
-				)
-			)
+			/** @type {unknown} */ (new IdentifierNode(this.start, this.end, name))
 		);
 		this.next(Boolean(liberal));
 		if (!liberal) {
@@ -4163,6 +5124,85 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
+	 * Owned instance `parse`: acorn wraps the top-level parse in
+	 * `catchStackOverflow`, allocating a closure per parse; inline the try/catch
+	 * instead (same overflow-message translation). A `program` continuation and
+	 * non-lazy mode delegate to acorn.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/state.js
+	 * @returns {import("acorn").Program} program node
+	 * @this {ParserInternals}
+	 */
+	parse() {
+		if (!this._lazy || this.options.program) {
+			return base.parse.call(this);
+		}
+		const node = this.startNode();
+		this.nextToken();
+		try {
+			return /** @type {import("acorn").Program} */ (
+				/** @type {unknown} */ (this.parseTopLevel(node))
+			);
+		} catch (err) {
+			// acorn's catchStackOverflow: translate an engine stack-overflow error
+			if (
+				err instanceof Error &&
+				(/\bstack\b.*\b(exceeded|overflow)\b/i.test(err.message) ||
+					/\btoo much recursion\b/i.test(err.message))
+			) {
+				this.raise(this.start, "Not enough stack space to parse input");
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * Owned `parseTopLevel`, an exact-semantics copy of acorn 8's: the body
+	 * accumulates in a scratch array and the finished program lands on
+	 * `ProgramNode`'s single shape. Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started program node (discarded, as in the owned statement parsers)
+	 * @returns {Node} program node
+	 * @this {ParserInternals}
+	 */
+	parseTopLevel(node) {
+		// a `program` continuation node must be appended to and returned as-is,
+		// which only acorn's copy does (base parse() reaches here via dispatch)
+		if (!this._lazy || this.options.program) {
+			return base.parseTopLevel.call(this, node);
+		}
+		/** @type {Record<string, boolean>} */
+		const exports = Object.create(null);
+		const scratch = this._acquireScratch();
+		let count = 0;
+		while (this.type !== tokTypes.eof) {
+			scratch[count++] = this.parseStatement(null, true, exports);
+		}
+		const body = this._releaseScratch(scratch, count);
+		if (this.inModule) {
+			for (const name of Object.keys(this.undefinedExports)) {
+				this.raiseRecoverable(
+					this.undefinedExports[name].start,
+					`Export '${name}' is not defined`
+				);
+			}
+		}
+		this.adaptDirectivePrologue(body);
+		this.next();
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ProgramNode(
+					node.start,
+					this.lastTokEnd,
+					body,
+					this.options.sourceType === "commonjs"
+						? "script"
+						: /** @type {string} */ (this.options.sourceType)
+				)
+			)
+		);
+	}
+
+	/**
 	 * Owned `parseStatement` for the hot statement heads: acorn starts a node
 	 * before dispatching, but the owned statement parsers build their own
 	 * single-shape nodes, so that started node was one discarded allocation per
@@ -4252,13 +5292,103 @@ class WebpackParser extends BaseParser {
 					return base.parseStatement.call(this, context, topLevel, exports);
 				}
 				return this._parseWhileStatementAt(this.start);
-			case tokTypes._debugger:
-			case tokTypes._do:
-			case tokTypes._class:
-			case tokTypes._with:
-			case tokTypes.semi:
+			case tokTypes.semi: {
+				if (!this._stmt2FastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				const start = this.start;
+				this.next();
+				return /** @type {Node} */ (
+					/** @type {unknown} */ (
+						new EmptyStatementNode(start, this.lastTokEnd)
+					)
+				);
+			}
+			case tokTypes._debugger: {
+				if (!this._stmt2FastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				const start = this.start;
+				this.next();
+				this.semicolon();
+				return /** @type {Node} */ (
+					/** @type {unknown} */ (
+						new DebuggerStatementNode(start, this.lastTokEnd)
+					)
+				);
+			}
+			case tokTypes._do: {
+				if (!this._stmt2FastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				const start = this.start;
+				this.next();
+				this.labels.push(LOOP_LABEL);
+				const body = this.parseStatement("do");
+				this.labels.pop();
+				this.expect(tokTypes._while);
+				const test = this.parseParenExpression();
+				// fast-path gate guarantees ES6+, where the semicolon is optional
+				this.eat(tokTypes.semi);
+				return /** @type {Node} */ (
+					/** @type {unknown} */ (
+						new DoWhileStatementNode(start, this.lastTokEnd, body, test)
+					)
+				);
+			}
+			case tokTypes._with: {
+				if (!this._stmt2FastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				if (this.strict) this.raise(this.start, "'with' in strict mode");
+				const start = this.start;
+				this.next();
+				const object = this.parseParenExpression();
+				const body = this.parseStatement("with");
+				return /** @type {Node} */ (
+					/** @type {unknown} */ (
+						new WithStatementNode(start, this.lastTokEnd, object, body)
+					)
+				);
+			}
 			case tokTypes._export:
-			case tokTypes._import:
+			case tokTypes._import: {
+				if (!this._moduleDeclFastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				// import( / import. head is an expression statement, peeked without
+				// acorn's skipWhiteSpace.exec allocation (gate guarantees ES11+)
+				if (startType === tokTypes._import) {
+					const next = this._scanGap(this.pos);
+					const nextCh = this.input.charCodeAt(next);
+					if (nextCh === 40 || nextCh === 46) {
+						const start = this.start;
+						return this._parseExpressionStatementAt(
+							start,
+							this.parseExpression()
+						);
+					}
+				}
+				if (!this.options.allowImportExportEverywhere) {
+					if (!topLevel) {
+						this.raise(
+							this.start,
+							"'import' and 'export' may only appear at the top level"
+						);
+					}
+					if (!this.inModule) {
+						this.raise(
+							this.start,
+							"'import' and 'export' may appear only with 'sourceType: module'"
+						);
+					}
+				}
+				const node = this.startNode();
+				return startType === tokTypes._import
+					? this.parseImport(node)
+					: this.parseExport(node, exports);
+			}
+			case tokTypes._class:
 				return base.parseStatement.call(this, context, topLevel, exports);
 			default: {
 				if (startType === tokTypes.name) {
@@ -5065,6 +6195,65 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
+	 * Owned `parseLabeledStatement`, an exact-semantics copy of acorn 8's
+	 * landing on `LabeledStatementNode`'s single shape (the passed started node
+	 * supplies only its start offset). Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started statement node
+	 * @param {string} maybeName label name
+	 * @param {Identifier} expr parsed label identifier
+	 * @param {string | null} context statement context
+	 * @returns {Node} labeled statement
+	 * @this {ParserInternals}
+	 */
+	parseLabeledStatement(node, maybeName, expr, context) {
+		if (!this._lazy) {
+			return base.parseLabeledStatement.call(
+				this,
+				node,
+				maybeName,
+				expr,
+				context
+			);
+		}
+		const labels = this.labels;
+		for (let i = 0; i < labels.length; i++) {
+			if (labels[i].name === maybeName) {
+				this.raise(expr.start, `Label '${maybeName}' is already declared`);
+			}
+		}
+		const kind = /** @type {TokenTypeInternal} */ (this.type).isLoop
+			? "loop"
+			: this.type === tokTypes._switch
+				? "switch"
+				: null;
+		for (let i = labels.length - 1; i >= 0; i--) {
+			const label = labels[i];
+			if (label.statementStart === node.start) {
+				// update information about previous labels on this node
+				label.statementStart = this.start;
+				label.kind = kind;
+			} else {
+				break;
+			}
+		}
+		labels.push({ name: maybeName, kind, statementStart: this.start });
+		const body = this.parseStatement(
+			context
+				? !context.includes("label")
+					? `${context}label`
+					: context
+				: "label"
+		);
+		labels.pop();
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new LabeledStatementNode(node.start, this.lastTokEnd, body, expr)
+			)
+		);
+	}
+
+	/**
 	 * Owned `parseSpread` landing on `RestSpreadNode`'s single shape.
 	 * Non-lazy mode delegates.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
@@ -5397,6 +6586,225 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
+	 * Owned `toAssignable`, an exact-semantics copy of acorn 8's: retyped nodes
+	 * land on shapes designed for them (`ObjectNode`, `RestSpreadNode`); the
+	 * `AssignmentExpression` case keeps acorn's `delete` for the output key
+	 * set, at the cost of dictionary mode on that one node. Non-lazy mode
+	 * delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @param {Node} node expression to convert in place
+	 * @param {boolean=} isBinding whether converting a binding pattern
+	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to flush
+	 * @returns {Node} the converted node
+	 * @this {ParserInternals}
+	 */
+	toAssignable(node, isBinding, refDestructuringErrors) {
+		if (!this._lazy) {
+			return base.toAssignable.call(
+				this,
+				node,
+				isBinding,
+				refDestructuringErrors
+			);
+		}
+		if (this._ecmaVersion >= 6 && node) {
+			const target =
+				/** @type {Node & { name?: string, properties?: Node[], elements?: (Node | null)[], argument?: Node, value?: Node, key?: Node, kind?: string, operator?: string, left?: Node, expression?: Node }} */ (
+					node
+				);
+			switch (node.type) {
+				case "Identifier":
+					if (this.inAsync && target.name === "await") {
+						this.raise(
+							node.start,
+							"Cannot use 'await' as identifier inside an async function"
+						);
+					}
+					break;
+				case "ObjectPattern":
+				case "ArrayPattern":
+				case "AssignmentPattern":
+				case "RestElement":
+					break;
+				case "ObjectExpression": {
+					node.type = "ObjectPattern";
+					if (refDestructuringErrors) {
+						this.checkPatternErrors(refDestructuringErrors, true);
+					}
+					const properties = /** @type {Node[]} */ (target.properties);
+					for (let i = 0; i < properties.length; i++) {
+						const prop =
+							/** @type {Node & { argument?: Node }} */
+							(properties[i]);
+						this.toAssignable(prop, isBinding);
+						// a rest property's target must not be a nested pattern
+						const restArgument = /** @type {Node | undefined} */ (
+							prop.argument
+						);
+						if (
+							prop.type === "RestElement" &&
+							restArgument !== undefined &&
+							(restArgument.type === "ArrayPattern" ||
+								restArgument.type === "ObjectPattern")
+						) {
+							this.raise(
+								/** @type {Node} */ (prop.argument).start,
+								"Unexpected token"
+							);
+						}
+					}
+					break;
+				}
+				case "Property":
+					// AssignmentProperty has type === "Property"
+					if (target.kind !== "init") {
+						this.raise(
+							/** @type {Node} */ (target.key).start,
+							"Object pattern can't contain getter or setter"
+						);
+					}
+					this.toAssignable(/** @type {Node} */ (target.value), isBinding);
+					break;
+				case "ArrayExpression":
+					node.type = "ArrayPattern";
+					if (refDestructuringErrors) {
+						this.checkPatternErrors(refDestructuringErrors, true);
+					}
+					this.toAssignableList(
+						/** @type {Node[]} */ (target.elements),
+						Boolean(isBinding)
+					);
+					break;
+				case "SpreadElement":
+					node.type = "RestElement";
+					this.toAssignable(/** @type {Node} */ (target.argument), isBinding);
+					if (
+						/** @type {Node} */ (target.argument).type === "AssignmentPattern"
+					) {
+						this.raise(
+							/** @type {Node} */ (target.argument).start,
+							"Rest elements cannot have a default value"
+						);
+					}
+					break;
+				case "AssignmentExpression":
+					if (target.operator !== "=") {
+						this.raise(
+							/** @type {Node} */ (target.left).end,
+							"Only '=' operator can be used for specifying default value."
+						);
+					}
+					node.type = "AssignmentPattern";
+					delete target.operator;
+					this.toAssignable(/** @type {Node} */ (target.left), isBinding);
+					break;
+				case "ParenthesizedExpression":
+					this.toAssignable(
+						/** @type {Node} */ (target.expression),
+						isBinding,
+						refDestructuringErrors
+					);
+					break;
+				case "ChainExpression":
+					this.raiseRecoverable(
+						node.start,
+						"Optional chaining cannot appear in left-hand side"
+					);
+					break;
+				case "MemberExpression":
+					if (!isBinding) break;
+				// falls through
+				default:
+					this.raise(node.start, "Assigning to rvalue");
+			}
+		} else if (refDestructuringErrors) {
+			this.checkPatternErrors(refDestructuringErrors, true);
+		}
+		return node;
+	}
+
+	/**
+	 * Owned `toAssignableList`, acorn's verbatim. Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @param {Node[]} exprList expressions to convert in place
+	 * @param {boolean} isBinding whether converting binding patterns
+	 * @returns {Node[]} the converted list
+	 * @this {ParserInternals}
+	 */
+	toAssignableList(exprList, isBinding) {
+		if (!this._lazy) {
+			return base.toAssignableList.call(this, exprList, isBinding);
+		}
+		const end = exprList.length;
+		for (let i = 0; i < end; i++) {
+			const element = exprList[i];
+			if (element) this.toAssignable(element, isBinding);
+		}
+		if (end) {
+			const last = /** @type {Node & { argument?: Node }} */ (
+				exprList[end - 1]
+			);
+			if (
+				this._ecmaVersion === 6 &&
+				isBinding &&
+				last &&
+				last.type === "RestElement" &&
+				/** @type {Node} */ (last.argument).type !== "Identifier"
+			) {
+				this.unexpected(/** @type {Node} */ (last.argument).start);
+			}
+		}
+		return exprList;
+	}
+
+	/**
+	 * Owned `parseMaybeDefault` landing on `AssignmentPatternNode`'s single
+	 * shape. Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @param {number} startPos pattern start offset
+	 * @param {Position=} startLoc pattern start position
+	 * @param {Node=} left already-parsed binding target
+	 * @returns {Node} binding target, possibly wrapped in a default pattern
+	 * @this {ParserInternals}
+	 */
+	parseMaybeDefault(startPos, startLoc, left) {
+		if (!this._lazy) {
+			return base.parseMaybeDefault.call(this, startPos, startLoc, left);
+		}
+		left = left || this.parseBindingAtom();
+		if (this._ecmaVersion < 6 || !this.eat(tokTypes.eq)) return left;
+		const right = this.parseMaybeAssign();
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new AssignmentPatternNode(startPos, this.lastTokEnd, left, right)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseRestBinding` landing on `RestSpreadNode`'s single shape.
+	 * Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @returns {Node} rest element
+	 * @this {ParserInternals}
+	 */
+	parseRestBinding() {
+		if (!this._lazy) return base.parseRestBinding.call(this);
+		const start = this.start;
+		this.next();
+		// a rest element inside a function parameter must be an identifier in ES6
+		if (this._ecmaVersion === 6 && this.type !== tokTypes.name) {
+			this.unexpected();
+		}
+		const argument = this.parseBindingAtom();
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new RestSpreadNode(start, this.lastTokEnd, "RestElement", argument)
+			)
+		);
+	}
+
+	/**
 	 * Owned `parseBindingAtom`: acorn's exact dispatch minus the per-call
 	 * normalized-options read. Non-lazy mode and pre-ES6 delegate.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
@@ -5712,7 +7120,12 @@ class WebpackParser extends BaseParser {
 				/** @type {Options & { onTrailingComma?: (pos: number, loc?: Position) => void }} */
 				(this.options).onTrailingComma;
 			if (onTrailingComma) {
-				onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+				onTrailingComma(
+					this.lastTokStart,
+					/** @type {Position | undefined} */ (
+						this.lastTokStartLoc === null ? undefined : this.lastTokStartLoc
+					)
+				);
 			}
 			if (!notNext) this.next();
 			return true;
@@ -7075,36 +8488,564 @@ class WebpackParser extends BaseParser {
 	// ----- import phases (`import defer/source`, `import.defer/source()`) -----
 
 	/**
+	 * Owned `parseImportAttribute` landing on `ImportAttributeNode`'s single
+	 * shape; serves both `with { ... }` and the legacy `assert { ... }` clause.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
-	 * @param {Node & { phase?: ImportPhase }} node import declaration node
-	 * @returns {Node} finished node
+	 * @returns {ImportAttribute} import attribute
+	 * @this {ParserInternals}
+	 */
+	parseImportAttribute() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseImportAttribute.call(this);
+		}
+		const start = this.start;
+		const key =
+			this.type === tokTypes.string
+				? /** @type {Node} */ (/** @type {unknown} */ (this.parseExprAtom()))
+				: /** @type {Node} */ (
+						/** @type {unknown} */ (
+							this.parseIdent(this.options.allowReserved !== "never")
+						)
+					);
+		this.expect(tokTypes.colon);
+		if (this.type !== tokTypes.string) {
+			this.unexpected();
+		}
+		const value = /** @type {Node} */ (
+			/** @type {unknown} */ (this.parseExprAtom())
+		);
+		return /** @type {ImportAttribute} */ (
+			/** @type {unknown} */ (
+				new ImportAttributeNode(start, this.lastTokEnd, key, value)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseModuleExportName`; the gate's ecmaVersion bound covers
+	 * acorn's ≥ 13 probe for string export names.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Node} identifier or string-literal export name
+	 * @this {ParserInternals}
+	 */
+	parseModuleExportName() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseModuleExportName.call(this);
+		}
+		if (this.type === tokTypes.string) {
+			const stringLiteral = /** @type {Node & { value: string }} */ (
+				this.parseLiteral(this.value)
+			);
+			if (LONE_SURROGATE_REGEXP.test(stringLiteral.value)) {
+				this.raise(
+					stringLiteral.start,
+					"An export name cannot include a lone surrogate."
+				);
+			}
+			return stringLiteral;
+		}
+		return /** @type {Node} */ (/** @type {unknown} */ (this.parseIdent(true)));
+	}
+
+	/**
+	 * Owned `parseImport`, an exact-semantics copy of acorn 8's landing on
+	 * `ImportDeclarationNode`'s single shape (the started node is discarded);
+	 * `phase` is attached post-hoc, matching the former delegate-and-patch flow.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node & { phase?: ImportPhase }} node started statement node from `parseStatement`
+	 * @returns {Node} import declaration
 	 * @this {ParserInternals}
 	 */
 	parseImport(node) {
 		this._moduleSyntaxSeen = true;
 		this._importPhase = null;
-		const result = base.parseImport.call(this, node);
-		if (this._importPhase) node.phase = this._importPhase;
+		if (!this._moduleDeclFastPath) {
+			const result = base.parseImport.call(this, node);
+			if (this._importPhase) node.phase = this._importPhase;
+			return result;
+		}
+		this.next();
+		/** @type {AnyImportSpecifier[]} */
+		let specifiers;
+		/** @type {Expression} */
+		let source;
+		// import '...'
+		if (this.type === tokTypes.string) {
+			specifiers = EMPTY_IMPORT_SPECIFIERS;
+			source = this.parseExprAtom();
+		} else {
+			specifiers = this.parseImportSpecifiers();
+			this.expectContextual("from");
+			source =
+				this.type === tokTypes.string
+					? this.parseExprAtom()
+					: this.unexpected();
+		}
+		const attributes = this.parseWithClause();
+		this.semicolon();
+		const result =
+			/** @type {Node & { phase?: ImportPhase }} */
+			(
+				/** @type {unknown} */
+				(
+					new ImportDeclarationNode(
+						node.start,
+						this.lastTokEnd,
+						specifiers,
+						source,
+						attributes
+					)
+				)
+			);
+		if (this._importPhase) result.phase = this._importPhase;
 		return result;
 	}
 
 	/**
-	 * Owned `parseExport` only to flag module syntax for the auto-fallback guard;
-	 * parsing itself delegates to acorn.
+	 * Owned `parseImportSpecifier` landing on `ImportSpecifierNode`'s single
+	 * shape.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
-	 * @param {Node} node started export node
-	 * @param {unknown} exports export-name tracking object
+	 * @returns {Node} import specifier
+	 * @this {ParserInternals}
+	 */
+	parseImportSpecifier() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseImportSpecifier.call(this);
+		}
+		const start = this.start;
+		const imported = this.parseModuleExportName();
+		/** @type {Node} */
+		let local;
+		if (this.eatContextual("as")) {
+			local = /** @type {Node} */ (/** @type {unknown} */ (this.parseIdent()));
+		} else {
+			this.checkUnreserved(/** @type {Identifier} */ (imported));
+			local = imported;
+		}
+		this.checkLValSimple(local, BIND_LEXICAL);
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ImportSpecifierNode(start, this.lastTokEnd, imported, local)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseImportDefaultSpecifier` landing on
+	 * `ImportSimpleSpecifierNode`'s single shape.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Node} default import specifier
+	 * @this {ParserInternals}
+	 */
+	parseImportDefaultSpecifier() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseImportDefaultSpecifier.call(this);
+		}
+		// import defaultObj, { x, y as z } from '...'
+		const start = this.start;
+		const local = /** @type {Node} */ (
+			/** @type {unknown} */ (this.parseIdent())
+		);
+		this.checkLValSimple(local, BIND_LEXICAL);
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ImportSimpleSpecifierNode(
+					start,
+					this.lastTokEnd,
+					"ImportDefaultSpecifier",
+					local
+				)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseImportNamespaceSpecifier` landing on
+	 * `ImportSimpleSpecifierNode`'s single shape.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Node} namespace import specifier
+	 * @this {ParserInternals}
+	 */
+	parseImportNamespaceSpecifier() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseImportNamespaceSpecifier.call(this);
+		}
+		const start = this.start;
+		this.next();
+		this.expectContextual("as");
+		const local = /** @type {Node} */ (
+			/** @type {unknown} */ (this.parseIdent())
+		);
+		this.checkLValSimple(local, BIND_LEXICAL);
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ImportSimpleSpecifierNode(
+					start,
+					this.lastTokEnd,
+					"ImportNamespaceSpecifier",
+					local
+				)
+			)
+		);
+	}
+
+	/**
+	 * Acorn's `parseImportSpecifiers` list body over a pooled scratch array;
+	 * the phase detection wrapping it lives in `parseImportSpecifiers`.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {AnyImportSpecifier[]} import specifiers
+	 * @this {ParserInternals}
+	 */
+	_parseImportSpecifiersBase() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseImportSpecifiers.call(this);
+		}
+		const scratch = this._acquireScratch();
+		let count = 0;
+		let first = true;
+		if (this.type === tokTypes.name) {
+			scratch[count++] = this.parseImportDefaultSpecifier();
+			if (!this.eat(tokTypes.comma)) {
+				return this._releaseScratch(scratch, count);
+			}
+		}
+		if (this.type === tokTypes.star) {
+			scratch[count++] = this.parseImportNamespaceSpecifier();
+			return this._releaseScratch(scratch, count);
+		}
+		this.expect(tokTypes.braceL);
+		while (!this.eat(tokTypes.braceR)) {
+			if (!first) {
+				this.expect(tokTypes.comma);
+				if (this.afterTrailingComma(tokTypes.braceR)) break;
+			} else {
+				first = false;
+			}
+			scratch[count++] = this.parseImportSpecifier();
+		}
+		return this._releaseScratch(scratch, count);
+	}
+
+	/**
+	 * Owned `parseExport`, an exact-semantics copy of acorn 8's landing on the
+	 * single-shape export declaration nodes (the started node is discarded).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started export node from `parseStatement`
+	 * @param {unknown} exports export-name tracking record
 	 * @returns {Node} export declaration
 	 * @this {ParserInternals}
 	 */
 	parseExport(node, exports) {
 		this._moduleSyntaxSeen = true;
-		return base.parseExport.call(this, node, exports);
+		if (!this._moduleDeclFastPath) {
+			return base.parseExport.call(this, node, exports);
+		}
+		this.next();
+		// export * from '...'
+		if (this.eat(tokTypes.star)) {
+			return this.parseExportAllDeclaration(node, exports);
+		}
+		if (this.eat(tokTypes._default)) {
+			// export default ...
+			this.checkExport(exports, "default", this.lastTokStart);
+			const declaration = this.parseExportDefaultDeclaration();
+			return /** @type {Node} */ (
+				/** @type {unknown} */ (
+					new ExportDefaultDeclarationNode(
+						node.start,
+						this.lastTokEnd,
+						declaration
+					)
+				)
+			);
+		}
+		/** @type {Node | null} */
+		let declaration;
+		/** @type {Node[]} */
+		let specifiers;
+		/** @type {Expression | null} */
+		let source;
+		/** @type {ImportAttribute[]} */
+		let attributes;
+		// export var|const|let|function|class ...
+		if (this.shouldParseExportStatement()) {
+			declaration = this.parseExportDeclaration(node);
+			if (declaration.type === "VariableDeclaration") {
+				this.checkVariableExport(
+					exports,
+					/** @type {Node & { declarations: Node[] }} */ (declaration)
+						.declarations
+				);
+			} else {
+				const id = /** @type {Node & { id: Identifier }} */ (declaration).id;
+				this.checkExport(exports, id, id.start);
+			}
+			specifiers = [];
+			source = null;
+			attributes = [];
+		} else {
+			// export { x, y as z } [from '...']
+			declaration = null;
+			specifiers = this.parseExportSpecifiers(exports);
+			if (this.eatContextual("from")) {
+				if (this.type !== tokTypes.string) this.unexpected();
+				source = this.parseExprAtom();
+				attributes = this.parseWithClause();
+			} else {
+				for (let i = 0; i < specifiers.length; i++) {
+					// check for keywords used as local names
+					const local = /** @type {Node & { local: Node }} */ (specifiers[i])
+						.local;
+					this.checkUnreserved(/** @type {Identifier} */ (local));
+					// check if export is defined
+					this.checkLocalExport(/** @type {Identifier} */ (local));
+					if (local.type === "Literal") {
+						this.raise(
+							local.start,
+							"A string literal cannot be used as an exported binding without `from`."
+						);
+					}
+				}
+				source = null;
+				attributes = [];
+			}
+			this.semicolon();
+		}
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ExportNamedDeclarationNode(
+					node.start,
+					this.lastTokEnd,
+					declaration,
+					specifiers,
+					source,
+					attributes
+				)
+			)
+		);
 	}
 
 	/**
-	 * Owned `parseAwait` only to flag top-level await (module-only) for the
-	 * auto-fallback guard; await inside a function is not module syntax.
+	 * Owned `parseExportAllDeclaration` landing on `ExportAllDeclarationNode`'s
+	 * single shape; the gate's ecmaVersion bound covers acorn's ≥ 11 probe.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started export node from `parseExport`
+	 * @param {unknown} exports export-name tracking record
+	 * @returns {Node} export-all declaration
+	 * @this {ParserInternals}
+	 */
+	parseExportAllDeclaration(node, exports) {
+		if (!this._moduleDeclFastPath) {
+			return base.parseExportAllDeclaration.call(this, node, exports);
+		}
+		/** @type {Node | null} */
+		let exported;
+		if (this.eatContextual("as")) {
+			exported = this.parseModuleExportName();
+			this.checkExport(exports, exported, this.lastTokStart);
+		} else {
+			exported = null;
+		}
+		this.expectContextual("from");
+		if (this.type !== tokTypes.string) this.unexpected();
+		const source = this.parseExprAtom();
+		const attributes = this.parseWithClause();
+		this.semicolon();
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ExportAllDeclarationNode(
+					node.start,
+					this.lastTokEnd,
+					exported,
+					source,
+					attributes
+				)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseExportDefaultDeclaration`, acorn's exact body: no node of its
+	 * own, kept owned so the export family delegates as one unit.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Node} default-exported declaration or expression
+	 * @this {ParserInternals}
+	 */
+	parseExportDefaultDeclaration() {
+		if (!this._moduleDeclFastPath) {
+			return base.parseExportDefaultDeclaration.call(this);
+		}
+		let isAsync = false;
+		if (
+			this.type === tokTypes._function ||
+			(isAsync = this.isAsyncFunction())
+		) {
+			const functionNode = this.startNode();
+			this.next();
+			if (isAsync) this.next();
+			return /** @type {Node} */ (
+				/** @type {unknown} */ (
+					this.parseFunction(
+						functionNode,
+						FUNC_STATEMENT | FUNC_NULLABLE_ID,
+						false,
+						isAsync
+					)
+				)
+			);
+		}
+		if (this.type === tokTypes._class) {
+			const classNode = this.startNode();
+			return this.parseClass(classNode, "nullableID");
+		}
+		const declaration = /** @type {Node} */ (
+			/** @type {unknown} */ (this.parseMaybeAssign())
+		);
+		this.semicolon();
+		return declaration;
+	}
+
+	/**
+	 * Mirror of acorn's `checkExport` with `hasOwn` spelled for Node ≥ 10
+	 * (mode-independent, so no gate, like `checkUnreserved`).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {unknown} exports export-name tracking record
+	 * @param {string | Node} name exported name, or the node carrying it
+	 * @param {number} pos source offset for the duplicate-export error
+	 * @this {ParserInternals}
+	 */
+	checkExport(exports, name, pos) {
+		if (!exports) return;
+		const record = /** @type {Record<string, boolean>} */ (exports);
+		const key =
+			typeof name === "string"
+				? name
+				: /** @type {string} */ (
+						name.type === "Identifier"
+							? /** @type {Identifier} */ (name).name
+							: /** @type {Node & { value?: unknown }} */ (name).value
+					);
+		if (Object.prototype.hasOwnProperty.call(record, key)) {
+			this.raiseRecoverable(pos, `Duplicate export '${key}'`);
+		}
+		record[key] = true;
+	}
+
+	/**
+	 * Mirror of acorn's `checkPatternExport` (mode-independent, so no gate).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {unknown} exports export-name tracking record
+	 * @param {Node} pat exported binding pattern
+	 * @this {ParserInternals}
+	 */
+	checkPatternExport(exports, pat) {
+		const type = pat.type;
+		if (type === "Identifier") {
+			this.checkExport(exports, pat, pat.start);
+		} else if (type === "ObjectPattern") {
+			for (const prop of /** @type {Node & { properties: Node[] }} */ (pat)
+				.properties) {
+				this.checkPatternExport(exports, prop);
+			}
+		} else if (type === "ArrayPattern") {
+			for (const element of /** @type {Node & { elements: (Node | null)[] }} */ (
+				pat
+			).elements) {
+				if (element) this.checkPatternExport(exports, element);
+			}
+		} else if (type === "Property") {
+			this.checkPatternExport(
+				exports,
+				/** @type {Node & { value: Node }} */ (pat).value
+			);
+		} else if (type === "AssignmentPattern") {
+			this.checkPatternExport(
+				exports,
+				/** @type {Node & { left: Node }} */ (pat).left
+			);
+		} else if (type === "RestElement") {
+			this.checkPatternExport(
+				exports,
+				/** @type {Node & { argument: Node }} */ (pat).argument
+			);
+		}
+	}
+
+	/**
+	 * Mirror of acorn's `checkVariableExport` (mode-independent, so no gate).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {unknown} exports export-name tracking record
+	 * @param {Node[]} declarations exported declarators
+	 * @this {ParserInternals}
+	 */
+	checkVariableExport(exports, declarations) {
+		if (!exports) return;
+		for (const declaration of declarations) {
+			this.checkPatternExport(
+				exports,
+				/** @type {Node & { id: Node }} */ (declaration).id
+			);
+		}
+	}
+
+	/**
+	 * Owned `parseExportSpecifier` landing on `ExportSpecifierNode`'s single
+	 * shape.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {unknown} exports export-name tracking record
+	 * @returns {Node} export specifier
+	 * @this {ParserInternals}
+	 */
+	parseExportSpecifier(exports) {
+		if (!this._moduleDeclFastPath) {
+			return base.parseExportSpecifier.call(this, exports);
+		}
+		const start = this.start;
+		const local = this.parseModuleExportName();
+		const exported = this.eatContextual("as")
+			? this.parseModuleExportName()
+			: local;
+		this.checkExport(exports, exported, exported.start);
+		return /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ExportSpecifierNode(start, this.lastTokEnd, local, exported)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseExportSpecifiers`, acorn's exact loop over a pooled scratch
+	 * array.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {unknown} exports export-name tracking record
+	 * @returns {Node[]} export specifiers
+	 * @this {ParserInternals}
+	 */
+	parseExportSpecifiers(exports) {
+		if (!this._moduleDeclFastPath) {
+			return base.parseExportSpecifiers.call(this, exports);
+		}
+		const scratch = this._acquireScratch();
+		let count = 0;
+		let first = true;
+		// export { x, y as z } [from '...']
+		this.expect(tokTypes.braceL);
+		while (!this.eat(tokTypes.braceR)) {
+			if (!first) {
+				this.expect(tokTypes.comma);
+				if (this.afterTrailingComma(tokTypes.braceR)) break;
+			} else {
+				first = false;
+			}
+			scratch[count++] = this.parseExportSpecifier(exports);
+		}
+		return this._releaseScratch(scratch, count);
+	}
+
+	/**
+	 * Owned `parseAwait`: flags top-level await (module-only) for the
+	 * auto-fallback guard, then lands on `AwaitExpressionNode`'s single shape.
+	 * Non-lazy mode delegates.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-loop init context flag
 	 * @returns {Expression} await expression
@@ -7114,7 +9055,80 @@ class WebpackParser extends BaseParser {
 		if (this.inModule && this.currentVarScope().flags & SCOPE_TOP) {
 			this._moduleSyntaxSeen = true;
 		}
-		return base.parseAwait.call(this, forInit);
+		if (!this._lazy) return base.parseAwait.call(this, forInit);
+		if (!this.awaitPos) this.awaitPos = this.start;
+		const start = this.start;
+		this.next();
+		const argument = this.parseMaybeUnary(null, true, false, forInit);
+		return /** @type {Expression} */ (
+			/** @type {unknown} */ (
+				new AwaitExpressionNode(start, this.lastTokEnd, argument)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parseYield` landing on `YieldExpressionNode`'s single shape.
+	 * Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {boolean | string=} forInit for-loop init context flag
+	 * @returns {Expression} yield expression
+	 * @this {ParserInternals}
+	 */
+	parseYield(forInit) {
+		if (!this._lazy) return base.parseYield.call(this, forInit);
+		if (!this.yieldPos) this.yieldPos = this.start;
+		const start = this.start;
+		this.next();
+		let delegate = false;
+		/** @type {Expression | null} */
+		let argument = null;
+		if (!(
+			this.type === tokTypes.semi ||
+			this.canInsertSemicolon() ||
+			(this.type !== tokTypes.star &&
+				!(/** @type {TokenTypeInternal} */ (this.type).startsExpr))
+		)) {
+			delegate = this.eat(tokTypes.star);
+			argument = this.parseMaybeAssign(forInit);
+		}
+		return /** @type {Expression} */ (
+			/** @type {unknown} */ (
+				new YieldExpressionNode(start, this.lastTokEnd, delegate, argument)
+			)
+		);
+	}
+
+	/**
+	 * Owned `parsePrivateIdent` landing on `PrivateIdentifierNode`'s single
+	 * shape. Non-lazy mode delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @returns {Node} private identifier node
+	 * @this {ParserInternals}
+	 */
+	parsePrivateIdent() {
+		if (!this._lazy) return base.parsePrivateIdent.call(this);
+		if (this.type !== tokTypes.privateId) this.unexpected();
+		const node = new PrivateIdentifierNode(
+			this.start,
+			this.end,
+			/** @type {string} */ (this.value)
+		);
+		this.next();
+		// for validating existence when the enclosing class closes
+		if (this.options.checkPrivateFields) {
+			if (this.privateNameStack.length === 0) {
+				this.raise(
+					node.start,
+					`Private field '#${node.name}' must be declared in an enclosing class`
+				);
+			} else {
+				/** @type {{ used: unknown[] }} */ (
+					this.privateNameStack[this.privateNameStack.length - 1]
+				).used.push(node);
+			}
+		}
+		return /** @type {Node} */ (/** @type {unknown} */ (node));
 	}
 
 	/**
@@ -7124,7 +9138,7 @@ class WebpackParser extends BaseParser {
 	 */
 	parseImportSpecifiers() {
 		if (!this._importPhasesEnabled) {
-			return base.parseImportSpecifiers.call(this);
+			return this._parseImportSpecifiersBase();
 		}
 
 		/** @type {ImportPhase | null} */
@@ -7133,7 +9147,7 @@ class WebpackParser extends BaseParser {
 			: this.isContextual("source")
 				? "source"
 				: null;
-		if (!phase) return base.parseImportSpecifiers.call(this);
+		if (!phase) return this._parseImportSpecifiersBase();
 
 		const phaseId = this.parseIdent();
 		if (this.isContextual("from") || this.type === tokTypes.comma) {
@@ -7158,7 +9172,7 @@ class WebpackParser extends BaseParser {
 				if (this.type !== tokTypes.star && this.type !== tokTypes.braceL) {
 					this.unexpected();
 				}
-				nodes.push(...base.parseImportSpecifiers.call(this));
+				nodes.push(...this._parseImportSpecifiersBase());
 			}
 			return nodes;
 		}
@@ -7179,7 +9193,7 @@ class WebpackParser extends BaseParser {
 			);
 		}
 
-		const specifiers = base.parseImportSpecifiers.call(this);
+		const specifiers = this._parseImportSpecifiersBase();
 
 		if (
 			phase === "source" &&

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1126,7 +1126,7 @@ class Scope {
  * _gapHasNewline: () => boolean,
  * parseExprList: (close: TokenType, allowTrailingComma: boolean, allowEmpty: boolean, refDestructuringErrors?: DestructuringErrorsShim | null) => Expression[],
  * parsePrivateIdent: () => Node,
- * parseTemplate: (opts: { isTagged: boolean }) => Node,
+ * parseTemplate: (opts?: { isTagged?: boolean }) => Node,
  * shouldParseAsyncArrow: () => boolean,
  * parseSubscriptAsyncArrow: (startPos: number, startLoc: Position | undefined, exprList: Expression[], forInit: boolean | string) => Expression,
  * checkPatternErrors: (refDestructuringErrors: DestructuringErrorsShim, isAssign: boolean) => void,
@@ -1232,6 +1232,11 @@ class Scope {
  * pos: number,
  * input: string,
  * scopeStack: Scope[],
+ * _scopePool: Scope[],
+ * _setPool: Set<string>[],
+ * _takeSet: () => Set<string>,
+ * _labelsStack: { kind?: string | null, name?: string, statementStart?: number }[][],
+ * _labelsDepth: number,
  * currentScope: () => Scope,
  * currentThisScope: () => Scope,
  * currentVarScope: () => Scope,
@@ -1300,6 +1305,9 @@ class Scope {
  * _funcStmtOwn: boolean,
  * _parseFunctionAt: (start: number, statement: number, allowExpressionBody: boolean, isAsync: boolean, forInit?: boolean | string) => Expression,
  * isLet: (context?: string | null) => boolean,
+ * parseVarId: (decl: Node, kind: string) => void,
+ * _varIdOwn: boolean,
+ * isSimpleAssignTarget: (expr: Expression) => boolean,
  * parseLabeledStatement: (node: Node, maybeName: string, expr: Identifier, context: string | null) => Node,
  * _parseVarInto: (declarations: Node[], isFor: boolean, kind: string, allowMissingInitializer?: boolean) => number,
  * _parseVarStatementAt: (start: number, kind: string, allowMissingInitializer?: boolean) => Node,
@@ -1438,6 +1446,42 @@ const WORD_CACHE_MAX_LEN = 12;
 const WORD_TYPES = Array.from({ length: WORD_CACHE_MASK + 1 }, () => null);
 const WORD_TYPE_OWNERS = new Int32Array(WORD_CACHE_MASK + 1);
 let nextWordLookupsId = 1;
+
+// Direct-mapped cache for short non-word slices, WORD_CACHE's regime applied
+// to literal text: number raws repeat heavily (a typical large input has ~10x
+// more number literals than distinct raws) and short string values/raws repeat
+// too, so serving them from one shared string cuts both allocation churn and
+// retained AST strings. Same rules as WORD_CACHE: content-checked hits, only
+// lengths V8 stores flat (never slices retaining the source).
+const SLICE_CACHE_MASK = 0x1fff;
+/** @type {(string | null)[]} */
+const SLICE_CACHE = Array.from({ length: SLICE_CACHE_MASK + 1 }, () => null);
+const SLICE_CACHE_MAX_LEN = 12;
+
+/**
+ * Cached `input.slice(start, end)` for spans of 2-12 chars (callers gate the
+ * length; 1-char slices come from V8's single-character table already).
+ * @param {string} input source text
+ * @param {number} start span start offset
+ * @param {number} end span end offset
+ * @returns {string} the span's text, shared across equal occurrences
+ */
+const getShortSlice = (input, start, end) => {
+	let hash = 0;
+	for (let i = start; i < end; i++) {
+		hash = (Math.imul(hash, 33) + input.charCodeAt(i)) | 0;
+	}
+	const slot = hash & SLICE_CACHE_MASK;
+	const cached = SLICE_CACHE[slot];
+	if (
+		cached !== null &&
+		cached.length === end - start &&
+		input.startsWith(cached, start)
+	) {
+		return cached;
+	}
+	return (SLICE_CACHE[slot] = input.slice(start, end));
+};
 
 /**
  * Keyword-or-name classification: pure in (word, keywords), so it can be
@@ -1721,12 +1765,27 @@ class WebpackParser extends BaseParser {
 		/** @type {unknown[][]} */
 		this._arrStack = [];
 		this._arrDepth = 0;
+		// LIFO pool of exited Scope records reused by enterScope; a raise leaves
+		// stale entries behind, which the next parse's resets make harmless
+		/** @type {Scope[]} */
+		this._scopePool = [];
+		// pool of emptied name Sets harvested by exitScope for declareName
+		/** @type {Set<string>[]} */
+		this._setPool = [];
+		// per-depth pool of function-body label arrays (see parseFunctionBody)
+		/** @type {{ kind?: string | null, name?: string, statementStart?: number }[][]} */
+		this._labelsStack = [];
+		this._labelsDepth = 0;
 		// `readRegexp`'s flag whitelist depends only on the ecmaVersion
 		this._validRegexpFlags = getValidRegexpFlags(this._ecmaVersion);
+		// _parseVarInto inlines acorn's parseVarId, so an override of it turns
+		// every owned var-declaration path off
+		this._varIdOwn = self.parseVarId === base.parseVarId;
 		// the owned parseStatement inlines these methods, so a parser plugin
 		// overriding any of them turns the statement fast path off
 		this._stmtFastPath =
 			lazy &&
+			this._varIdOwn &&
 			this.parseVarStatement === proto.parseVarStatement &&
 			this.parseVar === proto.parseVar &&
 			this.parseIfStatement === proto.parseIfStatement &&
@@ -1762,6 +1821,7 @@ class WebpackParser extends BaseParser {
 		this._stmt2FastPath =
 			lazy &&
 			this._ecmaVersion >= 9 &&
+			this._varIdOwn &&
 			internals.parseForStatement === base.parseForStatement &&
 			internals.parseFor === base.parseFor &&
 			internals.parseForIn === base.parseForIn &&
@@ -1858,7 +1918,7 @@ class WebpackParser extends BaseParser {
 	 * this folds whitespace and comment skipping and the ASCII token dispatch
 	 * into one function so nothing re-enters acorn's per-step option checks.
 	 * Template/`preserveSpace` contexts and other modes use acorn's tokenizer.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @returns {void}
 	 * @this {ParserInternals}
 	 */
@@ -2036,7 +2096,7 @@ class WebpackParser extends BaseParser {
 	 * dead `endLoc` write on every token and reaches `updateContext` through an
 	 * extra method call. Skip the probe and inline acorn's `updateContext` body —
 	 * this runs once per token. Other modes use acorn's.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @param {TokenType} type token type
 	 * @param {unknown=} value token value
 	 * @returns {void}
@@ -2116,7 +2176,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `braceIsBlock`, acorn's verbatim except the line-terminator probe:
 	 * acorn slices the inter-token gap and runs a regexp; `_gapHasNewline`
 	 * answers from the tokenizer's newline flag (scanning only when unknown).
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokencontext.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokencontext.js
 	 * @param {TokenType} prevType type of the previous token
 	 * @returns {boolean} whether a `{` opens a block in this context
 	 * @this {ParserInternals}
@@ -2190,7 +2250,7 @@ class WebpackParser extends BaseParser {
 	 * `lastTokStartLoc` and probes `options.onToken` on every token, both dead in
 	 * `_tokenFastPath` mode (locations off, no token stream), leaving only the
 	 * two offset writes and the keyword-escape guard. Other modes use acorn's.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @param {boolean=} ignoreEscapeSequenceInKeyword whether an escape in a keyword is allowed here
 	 * @returns {void}
 	 * @this {ParserInternals}
@@ -2218,7 +2278,7 @@ class WebpackParser extends BaseParser {
 	 * every operator token, allocating a fresh 2-4 char string per `=>`, `===`,
 	 * `&&` etc. Serve those from `OP_CACHE` instead; single-char operators keep
 	 * the direct slice, which V8 serves from its single-character table.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @param {TokenType} type token type
 	 * @param {number} size operator length
 	 * @returns {void}
@@ -2252,7 +2312,7 @@ class WebpackParser extends BaseParser {
 	 * `scanPunctuation`) — no method chain, no slice, no `OP_CACHE` probe. The
 	 * HTML-comment forms (`<!--`, `-->`) inline acorn's line-comment handling;
 	 * `#` and unknown chars use the owned cold reader.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @param {number} code current char code
 	 * @returns {void}
 	 * @this {ParserInternals}
@@ -2553,7 +2613,7 @@ class WebpackParser extends BaseParser {
 	 * which dominate real code — reuse one string instead of slicing a fresh
 	 * one per occurrence; sharing also keeps their cached string hashes warm
 	 * for the keyword/scope Map lookups downstream.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {string} the word
 	 */
@@ -2611,7 +2671,7 @@ class WebpackParser extends BaseParser {
 	 * Hex/unicode/octal escapes (`\x`, `\u`, `\0`-`\9`) restart the owned cold
 	 * reader, which owns their readers and strict-mode errors; old ecmaVersions
 	 * (LS/PS terminate strings there) and location tracking use acorn's own.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} quote quote char code
 	 * @returns {void}
@@ -2693,7 +2753,13 @@ class WebpackParser extends BaseParser {
 		}
 		this.pos = pos + 1;
 		if (chunkStart === start) {
-			return this.finishToken(tokTypes.string, input.slice(start, pos));
+			const len = pos - start;
+			return this.finishToken(
+				tokTypes.string,
+				len >= 2 && len <= SLICE_CACHE_MAX_LEN
+					? getShortSlice(input, start, pos)
+					: input.slice(start, pos)
+			);
 		}
 		this.finishToken(tokTypes.string, out + input.slice(chunkStart, pos));
 	}
@@ -2703,7 +2769,7 @@ class WebpackParser extends BaseParser {
 	 * digits so the float is exact) are accumulated numerically — no slice,
 	 * no parseFloat, no separator handling. Everything else (dots, exponents,
 	 * bigints, separators, octal forms) restarts the owned cold reader.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {boolean} startsWithDot whether the number started with a dot
 	 * @returns {void}
@@ -2787,7 +2853,15 @@ class WebpackParser extends BaseParser {
 			return this._readNumberCold(startsWithDot);
 		}
 		this.pos = pos;
-		this.finishToken(tokTypes.num, Number.parseFloat(input.slice(start, pos)));
+		// the cached slice also pre-warms the slot parseLiteral's raw reuses
+		this.finishToken(
+			tokTypes.num,
+			Number.parseFloat(
+				pos - start <= SLICE_CACHE_MAX_LEN
+					? getShortSlice(input, start, pos)
+					: input.slice(start, pos)
+			)
+		);
 	}
 
 	/**
@@ -2795,7 +2869,7 @@ class WebpackParser extends BaseParser {
 	 * `this.input.slice(start)` — a fresh sliced string per (sloppy-mode)
 	 * function body. Sticky regexes at the offset scan the same grammar with no
 	 * slice. Same directive-prologue semantics, including the ASI tail checks.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/parseutil.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
 	 * @param {number} start offset of the function body's first statement
 	 * @returns {boolean} true when a 'use strict' directive leads the prologue
 	 * @this {ParserInternals & { input: string, options: { ecmaVersion: number } }}
@@ -2843,7 +2917,7 @@ class WebpackParser extends BaseParser {
 	 * cooked value is one slice (LF/LS/PS cook to themselves). Escapes and CR
 	 * normalization restart the owned cold reader (its exact errors); location
 	 * tracking uses acorn's own.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {void}
 	 */
@@ -2883,7 +2957,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Fast path for the common run of plain ASCII whitespace; comments and
 	 * unicode whitespace use the owned cold reader, location tracking acorn's.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals & { pos: number }}
 	 * @returns {void}
 	 */
@@ -2915,7 +2989,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `readInt`: reads `radix`-base digits (optionally exactly `len` of
 	 * them), honoring ES2021 `_` separators.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} radix numeric radix
 	 * @param {number=} len fixed digit count (for escapes), else read greedily
@@ -2981,7 +3055,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * acorn `readRadixNumber`: `0x`/`0o`/`0b` integer or bigint literals.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} radix numeric radix (2/8/16)
 	 * @returns {void}
@@ -3008,7 +3082,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `readNumber`: decimal/float/legacy-octal/bigint literals (the fast
 	 * path handles only plain integers and simple fractions).
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {boolean} startsWithDot whether the literal started with `.`
 	 * @returns {void}
@@ -3050,7 +3124,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * acorn `readCodePoint`: a `\u{...}` or `\uXXXX` escape.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {number} the escaped code point
 	 */
@@ -3074,7 +3148,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * acorn `readHexChar`: exactly `len` hex digits.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} len number of hex digits
 	 * @returns {number} the parsed code
@@ -3091,7 +3165,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `readString`: the escape-bearing string reader (the fast path cooks
 	 * only the common single-char escapes inline).
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} quote quote char code
 	 * @returns {void}
@@ -3130,7 +3204,7 @@ class WebpackParser extends BaseParser {
 	 * acorn `readTmplToken`: the escape/CR-normalizing template reader. Invalid
 	 * escapes throw acorn's sentinel via `invalidStringToken`, which acorn's own
 	 * `tryReadTemplateToken` (not overridden here) catches to re-read raw.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {void}
 	 */
@@ -3166,8 +3240,15 @@ class WebpackParser extends BaseParser {
 			} else if (isNewLine(ch)) {
 				out += input.slice(chunkStart, this.pos);
 				++this.pos;
-				if (ch === 13 && input.charCodeAt(this.pos) === 10) ++this.pos;
-				out += "\n";
+				// only CR(LF) cooks to "\n"; LS/PS cook to themselves
+				if (ch === 13) {
+					if (input.charCodeAt(this.pos) === 10) ++this.pos;
+					out += "\n";
+				} else if (ch === 10) {
+					out += "\n";
+				} else {
+					out += String.fromCharCode(ch);
+				}
 				chunkStart = this.pos;
 			} else {
 				++this.pos;
@@ -3177,7 +3258,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * acorn `readEscapedChar`: cooks one backslash escape in a string/template.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {boolean} inTemplate whether the escape is in a template literal
 	 * @returns {string} the cooked replacement (may be `""`)
@@ -3253,7 +3334,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `readWord1`: the escape-/astral-aware identifier reader (the fast
 	 * path handles pure-ASCII words).
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {string} the (possibly escape-cooked) word
 	 */
@@ -3296,7 +3377,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `skipSpace` (location-free): unicode whitespace and comments. Only
 	 * reached from the lazy fast paths, which keep no line bookkeeping.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {void}
 	 */
@@ -3346,7 +3427,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * acorn `readToken_numberSign` plus `getTokenFromCode`'s default: a private
 	 * identifier (`#x`) or an unexpected-character error.
-	 * https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} code current char code
 	 * @returns {void}
@@ -3370,7 +3451,7 @@ class WebpackParser extends BaseParser {
 	 * token type can be memoized per `WORD_CACHE` slot (classification is pure in
 	 * the word and the per-option keyword set) — a cache hit serves the type by
 	 * identity compare instead of a keywords Map probe.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {void}
 	 */
@@ -3472,7 +3553,7 @@ class WebpackParser extends BaseParser {
 	 * single `reservedKinds` lookup — one hash probe instead of two, and the
 	 * common plain identifier misses it and returns. Branches and error
 	 * messages match acorn exactly.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {Identifier} ref identifier node
 	 * @this {ParserInternals}
 	 */
@@ -3540,7 +3621,7 @@ class WebpackParser extends BaseParser {
 	 * strict-bind probe inlined: the constructor-installed Set stand-in is one
 	 * `has` behind a length gate instead of a closure call per checked name.
 	 * A runtime-replaced `reservedWordsStrictBind` falls back to `.test()`.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr assignment/binding target
 	 * @param {number=} bindingType acorn BIND_* binding type
 	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
@@ -3622,7 +3703,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `checkLValPattern`, acorn's verbatim, so declarator/assignment
 	 * targets stay on owned code down to `checkLValSimple`/`declareName`.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr binding pattern
 	 * @param {number=} bindingType acorn BIND_* binding type
 	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
@@ -3654,7 +3735,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * Owned `checkLValInnerPattern`, acorn's verbatim.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr pattern element
 	 * @param {number=} bindingType acorn BIND_* binding type
 	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
@@ -3696,7 +3777,7 @@ class WebpackParser extends BaseParser {
 	 * inter-token gap and runs a regexp on it for every ASI decision (hundreds
 	 * of thousands per file). Scan the gap for a line terminator instead — no
 	 * slice, no regexp.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/parseutil.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
 	 * @returns {boolean} whether a semicolon may be inserted here
 	 * @this {ParserInternals}
 	 */
@@ -3715,7 +3796,7 @@ class WebpackParser extends BaseParser {
 	 * Replaces acorn's `skipLineComment` when comments are collected lazily:
 	 * the same scan, but no text slice and no position objects. Acorn calls
 	 * this for `//`, hashbangs and HTML-style comments (varying `startSkip`).
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @param {number} startSkip length of the comment opener
 	 * @returns {void}
@@ -3742,7 +3823,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Replaces acorn's `skipBlockComment` when comments are collected lazily.
 	 * Locations are always off in lazy mode, so line breaks need no handling.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals}
 	 * @returns {void}
 	 */
@@ -3763,7 +3844,7 @@ class WebpackParser extends BaseParser {
 	// ----- lazy range -----
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/node.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/node.js
 	 * @returns {Node} new node
 	 * @this {ParserInternals}
 	 */
@@ -3773,7 +3854,7 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/node.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/node.js
 	 * @param {number} pos start offset
 	 * @param {Position=} loc start position when acorn tracks locations
 	 * @returns {Node} new node
@@ -3788,7 +3869,7 @@ class WebpackParser extends BaseParser {
 	 * Lazy-mode `finishNode`: acorn's `locations`/`ranges` writes are dead when
 	 * `range` is served lazily and `loc` not at all, so skip them and the `finishNodeAt`
 	 * indirection. Runs once per node.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/node.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/node.js
 	 * @param {Node} node node to finish
 	 * @param {string} type node type
 	 * @returns {Node} the finished node
@@ -3804,7 +3885,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Mirror of acorn's `copyNode`, which bypasses `startNodeAt` via
 	 * `new Node(...)` and would otherwise produce non-lazy nodes.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/node.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/node.js
 	 * @param {Node} node node to copy
 	 * @returns {Node} copied node
 	 * @this {ParserInternals}
@@ -3829,7 +3910,7 @@ class WebpackParser extends BaseParser {
 	 * `IdentifierNode` directly, skipping acorn's `parseIdentNode`/`startNode`/
 	 * `finishNode` chain and its keyword branches. Keyword-as-identifier
 	 * (`obj.class`) and non-lazy mode delegate to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean=} liberal whether reserved words are allowed
 	 * @returns {Identifier} identifier node
 	 * @this {ParserInternals}
@@ -3862,7 +3943,7 @@ class WebpackParser extends BaseParser {
 	 * async-arrow-head probe reordered cheapest-first (all operands are pure)
 	 * and the arrow exit probe served by `_lastArrow` identity instead of the
 	 * megamorphic `.type` load. Delegates when either fast path is off.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {Expression} baseExpr subscript base
 	 * @param {number} startPos expression start offset
 	 * @param {Position | undefined} startLoc expression start position
@@ -3937,7 +4018,7 @@ class WebpackParser extends BaseParser {
 	 * reachable during it), landing on `MemberExpressionNode`/
 	 * `CallExpressionNode`'s single shapes. Pre-optional-chaining ecmaVersions
 	 * and non-lazy mode delegate to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {Expression} baseExpr subscript base
 	 * @param {number} startPos expression start offset
 	 * @param {Position | undefined} startLoc expression start position
@@ -4089,7 +4170,7 @@ class WebpackParser extends BaseParser {
 	 * blocks and plain expression statements) without it; everything rarer, the
 	 * `name`-token ambiguities (`let`/`async`/`using`/`await` heads) and
 	 * plugin-overridden parsers delegate to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {string | null} context statement context
 	 * @param {boolean=} topLevel whether parsing top-level statements
 	 * @param {unknown=} exports export tracking object
@@ -4225,7 +4306,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseVarStatement`: the passed started node is filled by
 	 * `parseVar` as acorn expects, then the finished statement lands on
 	 * `VariableDeclarationNode`'s single shape. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started statement node from `parseStatement`
 	 * @param {string} kind declaration kind
 	 * @param {boolean=} allowMissingInitializer whether `const x;` is allowed
@@ -4233,7 +4314,7 @@ class WebpackParser extends BaseParser {
 	 * @this {ParserInternals}
 	 */
 	parseVarStatement(node, kind, allowMissingInitializer) {
-		if (!this._lazy) {
+		if (!this._lazy || !this._varIdOwn) {
 			return base.parseVarStatement.call(
 				this,
 				node,
@@ -4247,7 +4328,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Statement-position `var`/`let`/`const` without a started node: the
 	 * declaration lands directly on `VariableDeclarationNode`'s single shape.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {string} kind declaration kind
 	 * @param {boolean=} allowMissingInitializer whether `const x;` is allowed
@@ -4277,7 +4358,7 @@ class WebpackParser extends BaseParser {
 	 * declarator fully-formed on `VariableDeclaratorNode`'s single shape. The
 	 * passed node keeps receiving `declarations`/`kind` because
 	 * `parseForStatement` finishes it itself. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node declaration node to fill
 	 * @param {boolean} isFor whether parsing a `for` head
 	 * @param {string} kind declaration kind
@@ -4286,7 +4367,7 @@ class WebpackParser extends BaseParser {
 	 * @this {ParserInternals}
 	 */
 	parseVar(node, isFor, kind, allowMissingInitializer) {
-		if (!this._lazy) {
+		if (!this._lazy || !this._varIdOwn) {
 			return base.parseVar.call(
 				this,
 				node,
@@ -4318,7 +4399,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * The declarator loop of the owned `parseVar`, shared with the owned
 	 * `parseStatement`'s node-free statement path.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node[]} declarations scratch array for the declarators
 	 * @param {boolean} isFor whether parsing a `for` head
 	 * @param {string} kind declaration kind
@@ -4386,7 +4467,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseExpressionStatement`: the statement lands on
 	 * `ExpressionStatementNode`'s single shape (the passed started node is
 	 * discarded, matching acorn's observable output). Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started statement node from `parseStatement`
 	 * @param {Expression} expr the parsed expression
 	 * @returns {Node} expression statement
@@ -4401,7 +4482,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * `parseExpressionStatement` without a started node.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {Expression} expr the parsed expression
 	 * @returns {Node} expression statement
@@ -4419,7 +4500,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseBlock`, an exact-semantics copy of acorn 8's landing on
 	 * `BlockStatementNode`'s single shape. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {boolean=} createNewLexicalScope whether the block opens a scope
 	 * @param {Node=} node started statement node, when called from `parseStatement`
 	 * @param {boolean=} exitStrict whether to restore sloppy mode at the end
@@ -4461,7 +4542,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseIfStatement` landing on `IfStatementNode`'s single shape.
 	 * Non-lazy mode delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started statement node from `parseStatement`
 	 * @returns {Node} if statement
 	 * @this {ParserInternals}
@@ -4473,7 +4554,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * `parseIfStatement` without a started node.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} if statement
 	 * @this {ParserInternals}
@@ -4496,7 +4577,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseReturnStatement` landing on `ReturnStatementNode`'s single
 	 * shape. Non-lazy mode delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started statement node from `parseStatement`
 	 * @returns {Node} return statement
 	 * @this {ParserInternals}
@@ -4536,7 +4617,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * `parseReturnStatement` without a started node.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} return statement
 	 * @this {ParserInternals}
@@ -4563,7 +4644,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseBreakContinueStatement` without a started node, landing on
 	 * `BreakContinueNode`'s single shape.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {string} keyword `break` or `continue`
 	 * @returns {Node} break or continue statement
@@ -4614,7 +4695,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseForStatement` without a started node (fast-path gate guarantees
 	 * `ecmaVersion >= 9`, folding acorn's version probes).
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} for/for-in/for-of statement
 	 * @this {ParserInternals}
@@ -4724,7 +4805,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * `parseForAfterInit` without a started node.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {Node} init parsed variable declaration
 	 * @param {number} awaitAt offset of a consumed `await`, or -1
@@ -4763,7 +4844,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseFor` without a started node, landing on `ForStatementNode`'s
 	 * single shape.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {Node | null} init init clause
 	 * @returns {Node} for statement
@@ -4789,7 +4870,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseForIn` without a started node, landing on `ForInStatementNode`/
 	 * `ForOfStatementNode`'s single shapes.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @param {boolean} isAwait whether this is `for await`
 	 * @param {Node} init loop target
@@ -4842,7 +4923,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseSwitchStatement` without a started node, landing on
 	 * `SwitchStatementNode`'s single shape with pre-shaped `SwitchCaseNode`s.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} switch statement
 	 * @this {ParserInternals}
@@ -4899,7 +4980,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseThrowStatement` without a started node; the illegal-newline probe
 	 * runs on the tokenizer's newline flag instead of acorn's gap slice+regexp.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} throw statement
 	 * @this {ParserInternals}
@@ -4921,7 +5002,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseTryStatement` without a started node, landing on
 	 * `TryStatementNode`/`CatchClauseNode`'s single shapes.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} try statement
 	 * @this {ParserInternals}
@@ -4965,7 +5046,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseWhileStatement` without a started node, landing on
 	 * `WhileStatementNode`'s single shape.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start statement start offset
 	 * @returns {Node} while statement
 	 * @this {ParserInternals}
@@ -4986,7 +5067,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseSpread` landing on `RestSpreadNode`'s single shape.
 	 * Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Node} spread element
 	 * @this {ParserInternals}
@@ -5008,7 +5089,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseMaybeConditional` landing on
 	 * `ConditionalExpressionNode`'s single shape. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Expression} expression node
@@ -5107,7 +5188,7 @@ class WebpackParser extends BaseParser {
 	 * `FunctionNode`'s pre-declared shape (the passed started node is discarded,
 	 * matching acorn's observable output; `initFunction`'s writes are the
 	 * constructor defaults). Non-lazy mode and plugin overrides delegate.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started node from the caller
 	 * @param {number} statement FUNC_* statement bit flags
 	 * @param {boolean=} allowExpressionBody whether an expression body is allowed
@@ -5139,7 +5220,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * `parseFunction` without a started node (fast-path gate guarantees
 	 * `ecmaVersion >= 9`, folding acorn's version probes).
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {number} start function start offset
 	 * @param {number} statement FUNC_* statement bit flags
 	 * @param {boolean} allowExpressionBody whether an expression body is allowed
@@ -5211,7 +5292,7 @@ class WebpackParser extends BaseParser {
 	 * `isSimpleParamList` inlined and computed once (acorn walks the params
 	 * twice) — the fast-path gate pins it to acorn's own implementation.
 	 * Non-lazy mode and plugin overrides delegate.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node function node being filled
 	 * @param {boolean} isArrowFunction whether this is an arrow function
 	 * @param {boolean} isMethod whether this is an object/class method
@@ -5260,7 +5341,14 @@ class WebpackParser extends BaseParser {
 				}
 			}
 			const oldLabels = this.labels;
-			this.labels = [];
+			// pooled per nesting depth like _arrStack: one array per function body
+			// otherwise, and labels are pushed, so stale entries must be dropped
+			const labelsStack = this._labelsStack;
+			const labelsDepth = this._labelsDepth++;
+			let labels = labelsStack[labelsDepth];
+			if (labels === undefined) labelsStack[labelsDepth] = labels = [];
+			else labels.length = 0;
+			this.labels = labels;
 			if (useStrict) this.strict = true;
 			this.checkParams(
 				node,
@@ -5278,15 +5366,40 @@ class WebpackParser extends BaseParser {
 			this.adaptDirectivePrologue(
 				/** @type {Node & { body: Node[] }} */ (target.body).body
 			);
+			this._labelsDepth--;
 			this.labels = oldLabels;
 		}
 		this.exitScope();
 	}
 
 	/**
+	 * Owned `checkParams`: acorn allocates a dictionary-mode
+	 * `Object.create(null)` clash record for every function body, but most
+	 * functions cannot clash at all — no record is needed with duplicates
+	 * allowed, for zero params, or for one plain-identifier param.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node function node whose params are checked
+	 * @param {boolean} allowDuplicates whether duplicate param names are legal
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	checkParams(node, allowDuplicates) {
+		const params = /** @type {Node & { params: Node[] }} */ (node).params;
+		const nameHash =
+			allowDuplicates ||
+			params.length === 0 ||
+			(params.length === 1 && params[0].type === "Identifier")
+				? null
+				: /** @type {Record<string, boolean>} */ (Object.create(null));
+		for (let i = 0; i < params.length; i++) {
+			this.checkLValInnerPattern(params[i], BIND_VAR, nameHash);
+		}
+	}
+
+	/**
 	 * Owned `parseBindingAtom`: acorn's exact dispatch minus the per-call
 	 * normalized-options read. Non-lazy mode and pre-ES6 delegate.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @returns {Node} binding atom (identifier or pattern)
 	 * @this {ParserInternals}
 	 */
@@ -5310,7 +5423,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseExprSubscripts`, an exact copy of acorn 8's with the arrow
 	 * probe served by `_lastArrow` identity. Delegates when the fast path is off.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @returns {Expression} expression node
@@ -5329,7 +5442,12 @@ class WebpackParser extends BaseParser {
 		const expr = this.parseExprAtom(refDestructuringErrors, forInit);
 		if (
 			expr === this._lastArrow &&
-			this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")"
+			// acorn compares the last token's text against ")"; a ")" token always
+			// spans exactly one char, so two offset probes replace the gap slice
+			!(
+				this.lastTokEnd - this.lastTokStart === 1 &&
+				this.input.charCodeAt(this.lastTokStart) === 41
+			)
 		) {
 			return expr;
 		}
@@ -5357,7 +5475,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseExprList`, an exact-semantics copy of acorn 8's built in a
 	 * scratch array and materialized exactly sized. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {TokenType} close closing token type
 	 * @param {boolean} allowTrailingComma whether a trailing comma is allowed
 	 * @param {boolean} allowEmpty whether holes are allowed
@@ -5408,7 +5526,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseBindingList`, an exact-semantics copy of acorn 8's built in a
 	 * scratch array and materialized exactly sized. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/lval.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {TokenType} close closing token type
 	 * @param {boolean} allowEmpty whether holes are allowed
 	 * @param {boolean} allowTrailingComma whether a trailing comma is allowed
@@ -5460,7 +5578,7 @@ class WebpackParser extends BaseParser {
 	 * acorn 8's with the per-paren `DestructuringErrors` record pooled and the
 	 * expression list built in a scratch array. Non-lazy mode delegates (the
 	 * copy assumes ES6+, which `_lazy` guarantees via `ecmaVersion: "latest"`).
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean} canBeArrow whether this may be an arrow head
 	 * @param {boolean | string} forInit for-init context flag
 	 * @returns {Expression} expression node
@@ -5582,7 +5700,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `afterTrailingComma`, acorn's verbatim (mode-independent), so the
 	 * owned list parsers do not bounce through the dist for each element.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/parseutil.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
 	 * @param {TokenType} tokType closing token type
 	 * @param {boolean=} notNext whether to leave the closing token unconsumed
 	 * @returns {boolean} true when the list ended on a trailing comma
@@ -5605,7 +5723,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `checkExpressionErrors`, acorn's verbatim (mode-independent): it
 	 * runs several times per expression from the owned spine.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/parseutil.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors record to inspect
 	 * @param {boolean=} andThrow whether to throw on error
 	 * @returns {boolean} whether an error position was set
@@ -5632,7 +5750,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseExpression`: acorn wraps every call in `catchStackOverflow`,
 	 * allocating a fresh closure per expression; inline the try/catch instead
 	 * (same overflow-message translation, no closure). Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Expression} expression node
@@ -5679,7 +5797,7 @@ class WebpackParser extends BaseParser {
 	 * lands on `NewExpressionNode`'s single shape (zero-argument calls share
 	 * one empty array like acorn's `empty`); the rare `new.target` path keeps
 	 * the generic node. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @returns {Expression} new expression or meta property
 	 * @this {ParserInternals}
 	 */
@@ -5738,7 +5856,7 @@ class WebpackParser extends BaseParser {
 		}
 		/** @type {Expression[]} */
 		const args = this.eat(tokTypes.parenL)
-			? this.parseExprList(tokTypes.parenR, true, false)
+			? this.parseExprList(tokTypes.parenR, this._ecmaVersion >= 8, false)
 			: EMPTY_NEW_ARGS;
 		return /** @type {Expression} */ (
 			/** @type {unknown} */ (
@@ -5751,7 +5869,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseTemplateElement` landing on `TemplateElementNode`'s single
 	 * shape; matches acorn's CRLF normalization and invalid-escape handling.
 	 * Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {{ isTagged: boolean }} opts whether the template is tagged
 	 * @returns {Node} template element
 	 * @this {ParserInternals}
@@ -5802,7 +5920,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseTemplate` landing on `TemplateLiteralNode`'s single shape.
 	 * Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {{ isTagged?: boolean }=} opts whether the template is tagged
 	 * @returns {Node} template literal
 	 * @this {ParserInternals}
@@ -5853,7 +5971,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseMaybeUnary`, an exact-semantics copy of acorn 8's: prefix
 	 * unary/update and postfix update nodes are built fully-formed on
 	 * `UnaryNode`'s shared single shape. Non-lazy mode delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {DestructuringErrorsShim | null} refDestructuringErrors destructuring errors to fill
 	 * @param {boolean} sawUnary whether a unary operator was already consumed
 	 * @param {boolean} incDec whether the caller was an update operator
@@ -5949,18 +6067,26 @@ class WebpackParser extends BaseParser {
 			}
 		}
 
-		if (!incDec && this.eat(tokTypes.starstar)) {
-			if (sawUnary) {
-				this.unexpected(this.lastTokStart);
-			} else {
-				return this.buildBinary(
-					startPos,
-					startLoc,
-					expr,
-					this.parseMaybeUnary(null, false, false, forInit),
-					"**",
-					false
-				);
+		if (!incDec && this.type === tokTypes.starstar) {
+			// acorn 8.18: `**` must not take a naked arrow function as its left
+			// operand; leaving the token unconsumed makes the caller raise there
+			const isArrowAtStart = this._arrowFastPath
+				? expr === this._lastArrow && expr.start === startPos
+				: expr.type === "ArrowFunctionExpression" && expr.start === startPos;
+			if (!isArrowAtStart) {
+				this.next();
+				if (sawUnary) {
+					this.unexpected(this.lastTokStart);
+				} else {
+					return this.buildBinary(
+						startPos,
+						startLoc,
+						expr,
+						this.parseMaybeUnary(null, false, false, forInit),
+						"**",
+						false
+					);
+				}
 			}
 		}
 		return expr;
@@ -6022,7 +6148,7 @@ class WebpackParser extends BaseParser {
 	 * operator is captured before `next()` and the `AssignmentExpression` is
 	 * built fully-formed on `AssignmentNode`'s single shape after the
 	 * right-hand parse. Yield and non-lazy mode delegate to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @param {((this: unknown, left: Expression, startPos: number, startLoc?: Position) => Expression)=} afterLeftParse hook applied to the parsed left side
@@ -6123,7 +6249,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseExprOps`, an exact copy of acorn 8's, so the hot expression
 	 * spine (`parseMaybeAssign` → here → `parseMaybeUnary`) stays monomorphic
 	 * on owned code. Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Expression} expression node
@@ -6155,7 +6281,7 @@ class WebpackParser extends BaseParser {
 	 * same-precedence continuation turned from tail recursion into a loop —
 	 * `a + b + c + d` runs one frame instead of one per operator. Non-lazy mode
 	 * delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {Expression} left left operand
 	 * @param {number} leftStartPos expression start offset
 	 * @param {Position | undefined} leftStartLoc expression start position
@@ -6232,7 +6358,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `buildBinary` (acorn calls it only from `parseExprOp`): binary and
 	 * logical nodes are built fully-formed on `BinaryNode`'s single shape.
 	 * Non-lazy mode delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {number} startPos expression start offset
 	 * @param {Position | undefined} startLoc expression start position
 	 * @param {Expression} left left operand
@@ -6280,7 +6406,7 @@ class WebpackParser extends BaseParser {
 	 * async-function/async-arrow detection), number/string literals, keyword
 	 * literals (`true`/`false`/`null` — on the same `LiteralNode` shape as the
 	 * rest) and `this`. Everything else, and non-lazy mode, delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @param {boolean | string=} forInit for-init context flag
 	 * @param {boolean=} forNew whether parsed as a `new` callee
@@ -6395,6 +6521,59 @@ class WebpackParser extends BaseParser {
 				)
 			);
 		}
+		// the remaining hot atoms only dispatch to methods owned above, so the
+		// bounce through acorn's own switch is skipped (acorn's exact bodies)
+		if (type === tokTypes.parenL) {
+			const canBeArrow = this.potentialArrowAt === this.start;
+			const start = this.start;
+			const expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+			if (refDestructuringErrors) {
+				if (
+					refDestructuringErrors.parenthesizedAssign < 0 &&
+					!this.isSimpleAssignTarget(expr)
+				) {
+					refDestructuringErrors.parenthesizedAssign = start;
+				}
+				if (refDestructuringErrors.parenthesizedBind < 0) {
+					refDestructuringErrors.parenthesizedBind = start;
+				}
+			}
+			return expr;
+		}
+		if (type === tokTypes.braceL) {
+			this.overrideContext(CTX_B_EXPR);
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.parseObj(false, refDestructuringErrors))
+			);
+		}
+		if (type === tokTypes._function) {
+			if (this._funcStmtOwn) {
+				const start = this.start;
+				this.next();
+				return this._parseFunctionAt(start, 0, false, false, undefined);
+			}
+			const node = this.startNode();
+			this.next();
+			return this.parseFunction(node, 0);
+		}
+		if (type === tokTypes._new) return this.parseNew();
+		if (type === tokTypes.backQuote) {
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.parseTemplate())
+			);
+		}
+		if (type === tokTypes.regexp) {
+			const value =
+				/** @type {{ pattern: string, flags: string, value: RegExp | null }} */ (
+					this.value
+				);
+			const node =
+				/** @type {Expression & { regex?: { pattern: string, flags: string } }} */ (
+					/** @type {unknown} */ (this.parseLiteral(value.value))
+				);
+			node.regex = { pattern: value.pattern, flags: value.flags };
+			return node;
+		}
 		return base.parseExprAtom.call(
 			this,
 			refDestructuringErrors,
@@ -6407,7 +6586,7 @@ class WebpackParser extends BaseParser {
 	 * Owned `parseObj`, an exact-semantics copy of acorn 8's landing on
 	 * `ObjectNode`'s single shape (the ES5 trailing-comma gate is dropped —
 	 * the fast path requires ES11+). Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean} isPattern whether parsing a binding pattern
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Node} object expression or pattern
@@ -6474,7 +6653,7 @@ class WebpackParser extends BaseParser {
 	 * `PropertyNode`, which acorn's shared `parsePropertyName`/
 	 * `parsePropertyValue` then fill in place (ES9+ semantics assumed via the
 	 * ES11 fast-path gate). Non-lazy mode delegates.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean} isPattern whether parsing a binding pattern
 	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
 	 * @returns {Node} property, spread element or rest element
@@ -6568,7 +6747,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseLiteral`: builds the finished `LiteralNode` directly; the
 	 * `bigint` branch matches acorn's. Non-lazy mode delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {unknown} value literal value
 	 * @returns {Node} literal node
 	 * @this {ParserInternals}
@@ -6577,7 +6756,11 @@ class WebpackParser extends BaseParser {
 		if (!this._lazy) return base.parseLiteral.call(this, value);
 		const start = this.start;
 		const end = this.end;
-		const raw = this.input.slice(start, end);
+		const len = end - start;
+		const raw =
+			len >= 2 && len <= SLICE_CACHE_MAX_LEN
+				? getShortSlice(this.input, start, end)
+				: this.input.slice(start, end);
 		const node = new LiteralNode(start, end, value, raw);
 		if (raw.charCodeAt(raw.length - 1) === 110) {
 			// acorn falls back to normalizing `raw` when `BigInt` is missing;
@@ -6594,7 +6777,7 @@ class WebpackParser extends BaseParser {
 	 * then builds the value with a second `new RegExp`. This override scans
 	 * like acorn, keeps acorn's flag validation (for its exact messages) and
 	 * lets one `new RegExp` be both the V8-backed validation and the value.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/tokenize.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
 	 * @this {ParserInternals & { regexpState: unknown }}
 	 * @returns {void}
 	 */
@@ -6667,7 +6850,7 @@ class WebpackParser extends BaseParser {
 	 * that validation costs several percent of parse time. Raise from V8's
 	 * verdict instead — invalid patterns still fail the module build, only
 	 * exotic engine-specific message texts may differ.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/regexp.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/regexp.js
 	 * @param {{ start: number, source: string, flags: string }} state acorn regexp validation state
 	 * @this {ParserInternals}
 	 */
@@ -6683,17 +6866,69 @@ class WebpackParser extends BaseParser {
 	// ----- scope tracking (Set-based, replaces acorn's array + indexOf) -----
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/scope.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
 	 * @param {number} flags scope flags
 	 * @this {ParserInternals}
 	 */
 	enterScope(flags) {
+		// the top-level scope enters from acorn's base constructor, before the
+		// subclass constructor body created the pool
+		const pool = this._scopePool;
+		const cached = pool === undefined ? undefined : pool.pop();
+		if (cached !== undefined) {
+			cached.flags = flags;
+			this.scopeStack.push(cached);
+			return;
+		}
 		this.scopeStack.push(new Scope(flags));
 	}
 
 	/**
+	 * Owned `exitScope`: recycles the popped scope — nothing in acorn or the
+	 * overrides above holds a scope past its exit (every reader walks the live
+	 * `scopeStack`), so the pool caps allocations at the deepest nesting.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
+	 * @this {ParserInternals}
+	 */
+	exitScope() {
+		const scope = /** @type {Scope} */ (this.scopeStack.pop());
+		// harvest the name sets emptied (an idle pooled scope must not retain
+		// names) so declareName reuses the wrappers
+		const setPool = this._setPool;
+		const varSet = scope.var;
+		if (varSet !== undefined) {
+			varSet.clear();
+			setPool.push(varSet);
+			scope.var = undefined;
+		}
+		const lexicalSet = scope.lexical;
+		if (lexicalSet !== undefined) {
+			lexicalSet.clear();
+			setPool.push(lexicalSet);
+			scope.lexical = undefined;
+		}
+		const functionsSet = scope.functions;
+		if (functionsSet !== undefined) {
+			functionsSet.clear();
+			setPool.push(functionsSet);
+			scope.functions = undefined;
+		}
+		scope.firstLexical = undefined;
+		this._scopePool.push(scope);
+	}
+
+	/**
+	 * @returns {Set<string>} empty name set, pooled by `exitScope`
+	 * @this {ParserInternals}
+	 */
+	_takeSet() {
+		const cached = this._setPool.pop();
+		return cached === undefined ? new Set() : cached;
+	}
+
+	/**
 	 * Set-backed replacement for acorn's `declareName` on Set-backed scopes.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/scope.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
 	 * @param {string} name declared name
 	 * @param {number} bindingType acorn BIND_* binding type
 	 * @param {number} pos source offset for redeclaration errors
@@ -6709,7 +6944,7 @@ class WebpackParser extends BaseParser {
 				(scope.var !== undefined && scope.var.has(name));
 			if (scope.lexical === undefined) {
 				scope.firstLexical = name;
-				scope.lexical = new Set();
+				scope.lexical = this._takeSet();
 			}
 			scope.lexical.add(name);
 			if (this.inModule && scope.flags & SCOPE_TOP) {
@@ -6719,7 +6954,7 @@ class WebpackParser extends BaseParser {
 			const scope = this.currentScope();
 			if (scope.lexical === undefined) {
 				scope.firstLexical = name;
-				scope.lexical = new Set();
+				scope.lexical = this._takeSet();
 			}
 			scope.lexical.add(name);
 		} else if (bindingType === /* BIND_FUNCTION */ 3) {
@@ -6728,7 +6963,7 @@ class WebpackParser extends BaseParser {
 				? scope.lexical !== undefined && scope.lexical.has(name)
 				: (scope.lexical !== undefined && scope.lexical.has(name)) ||
 					(scope.var !== undefined && scope.var.has(name));
-			(scope.functions || (scope.functions = new Set())).add(name);
+			(scope.functions || (scope.functions = this._takeSet())).add(name);
 		} else {
 			for (let i = this.scopeStack.length - 1; i >= 0; --i) {
 				const scope = this.scopeStack[i];
@@ -6747,7 +6982,7 @@ class WebpackParser extends BaseParser {
 					redeclared = true;
 					break;
 				}
-				(scope.var || (scope.var = new Set())).add(name);
+				(scope.var || (scope.var = this._takeSet())).add(name);
 				if (this.inModule && scope.flags & SCOPE_TOP) {
 					delete this.undefinedExports[name];
 				}
@@ -6764,7 +6999,7 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * Set-backed replacement for acorn's `checkLocalExport` on Set-backed scopes.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/scope.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
 	 * @param {Identifier} id exported identifier
 	 * @this {ParserInternals}
 	 */
@@ -6840,7 +7075,7 @@ class WebpackParser extends BaseParser {
 	// ----- import phases (`import defer/source`, `import.defer/source()`) -----
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node & { phase?: ImportPhase }} node import declaration node
 	 * @returns {Node} finished node
 	 * @this {ParserInternals}
@@ -6856,7 +7091,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseExport` only to flag module syntax for the auto-fallback guard;
 	 * parsing itself delegates to acorn.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @param {Node} node started export node
 	 * @param {unknown} exports export-name tracking object
 	 * @returns {Node} export declaration
@@ -6870,7 +7105,7 @@ class WebpackParser extends BaseParser {
 	/**
 	 * Owned `parseAwait` only to flag top-level await (module-only) for the
 	 * auto-fallback guard; await inside a function is not module syntax.
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean | string=} forInit for-loop init context flag
 	 * @returns {Expression} await expression
 	 * @this {ParserInternals}
@@ -6883,7 +7118,7 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/statement.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
 	 * @returns {AnyImportSpecifier[]} import specifiers
 	 * @this {ParserInternals}
 	 */
@@ -6960,7 +7195,7 @@ class WebpackParser extends BaseParser {
 	}
 
 	/**
-	 * acorn source: https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
 	 * @param {boolean} forNew whether parsed as the operand of `new`
 	 * @returns {Expression} expression node
 	 * @this {ParserInternals}

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -1445,6 +1445,46 @@ describe("JavascriptParser", () => {
 			).toThrow(/Unsyntactic break/);
 		});
 
+		it("appends to a `program` continuation node like acorn", () => {
+			const first = parse("a;");
+			const second = /** @type {EXPECTED_ANY} */ (
+				WebpackParser.parse(
+					"b;",
+					/** @type {import("acorn").Options} */ (
+						/** @type {unknown} */ ({
+							ecmaVersion: 2022,
+							lazyNodes: true,
+							program: first
+						})
+					)
+				)
+			);
+			expect(second).toBe(first);
+			expect(second.body).toHaveLength(2);
+		});
+
+		it("reports acorn's error for string names bound without `from`", () => {
+			/**
+			 * @param {string} source module source code
+			 * @returns {() => void} thunk parsing the source as a module
+			 */
+			const parseModule = (source) => () =>
+				WebpackParser.parse(
+					source,
+					/** @type {import("acorn").Options} */ (
+						/** @type {unknown} */ ({
+							ecmaVersion: "latest",
+							sourceType: "module",
+							lazyNodes: true
+						})
+					)
+				);
+			expect(parseModule('export { "x" };')).toThrow(
+				/A string literal cannot be used as an exported binding without `from`/
+			);
+			expect(parseModule('import { "x" } from "y";')).toThrow(/Binding rvalue/);
+		});
+
 		it("serves comment ranges lazily with a stable memo and writable slot", () => {
 			/** @type {EXPECTED_ANY[]} */
 			const comments = [];

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -1333,6 +1333,118 @@ describe("JavascriptParser", () => {
 			expect(ast.body[0].expression.right.type).toBe("ArrowFunctionExpression");
 		});
 
+		it("rejects `**` with a bare arrow left operand like acorn 8.18", () => {
+			expect(() => parse("x = () => {} ** 2")).toThrow(/Unexpected token/);
+			const ok = parse("x = (() => {}) ** 2").body[0].expression.right;
+			expect(ok.type).toBe("BinaryExpression");
+			expect(ok.operator).toBe("**");
+			expect(() => parse("x = -2 ** 2")).toThrow(/Unexpected token/);
+			// the type-based fallback probe (plugin overriding parseArrowExpression)
+			const Extended = WebpackParser.extend(
+				/** @type {EXPECTED_ANY} */ (
+					(/** @type {EXPECTED_ANY} */ P) =>
+						class extends P {
+							/**
+							 * @param {...EXPECTED_ANY} args acorn args
+							 * @returns {EXPECTED_ANY} arrow node
+							 */
+							parseArrowExpression(...args) {
+								return super.parseArrowExpression(...args);
+							}
+						}
+				)
+			);
+			expect(() => Extended.parse("x = () => {} ** 2", parseOptions)).toThrow(
+				/Unexpected token/
+			);
+		});
+
+		it("preserves LS/PS in cooked template chunks read by the cold reader", () => {
+			// the escape forces the cold reader; LS must survive while CR/LF cook
+			const value = parse("`a\\tb\u2028c\rd\ne`").body[0].expression.quasis[0]
+				.value;
+			expect(value.cooked).toBe("a\tb\u2028c\nd\ne");
+			expect(value.raw).toBe("a\\tb\u2028c\nd\ne");
+		});
+
+		it("serves repeated short literal raws from one cached string", () => {
+			const [first, second] = parse("x = 123456; y = 123456;").body;
+			expect(first.expression.right.raw).toBe("123456");
+			// identity: strings compare by value, so sharing is unobservable
+			// beyond the allocation it saves — pinned here to keep the cache wired
+			expect(second.expression.right.raw).toBe(first.expression.right.raw);
+			const long = parse("z = 'quite a long string literal';").body[0];
+			expect(long.expression.right.value).toBe("quite a long string literal");
+			const fraction = parse("w = 123456789.0123456;").body[0];
+			expect(fraction.expression.right.value).toBe(123456789.0123456);
+			expect(fraction.expression.right.raw).toBe("123456789.0123456");
+		});
+
+		it("still detects parameter clashes without the per-body clash record", () => {
+			// strict mode: multi-param duplicate must throw, 0/1-param must not
+			expect(() => parse("'use strict'; function f(a, a) {}")).toThrow(
+				/Argument name clash/
+			);
+			expect(() => parse("'use strict'; function f(a) {}")).not.toThrow();
+			// one destructuring param carries two names — the record path
+			expect(() => parse("function f({ a: x, b: x }) {}")).toThrow(
+				/Argument name clash/
+			);
+		});
+
+		it("delegates var declarations when a plugin overrides parseVarId", () => {
+			let calls = 0;
+			const Extended = WebpackParser.extend(
+				/** @type {EXPECTED_ANY} */ (
+					(/** @type {EXPECTED_ANY} */ P) =>
+						class extends P {
+							/**
+							 * @param {...EXPECTED_ANY} args acorn args
+							 * @returns {EXPECTED_ANY} declarator id
+							 */
+							parseVarId(...args) {
+								calls++;
+								return super.parseVarId(...args);
+							}
+						}
+				)
+			);
+			const ast = /** @type {EXPECTED_ANY} */ (
+				Extended.parse("var a = 1; for (let b = 0; b < 1; b++);", parseOptions)
+			);
+			expect(calls).toBe(2);
+			expect(ast.body[0].declarations[0].id.name).toBe("a");
+		});
+
+		it("keeps scope bindings isolated across pooled sibling scopes", () => {
+			// a pooled scope must not leak names or the simple-catch marker
+			expect(() =>
+				parse("{ let a; } { let a; } try {} catch (e) { var e; }")
+			).not.toThrow();
+			// block-level function declarations exercise the functions-set harvest
+			expect(() =>
+				parse("{ function g() {} } { let g; function h() {} }")
+			).not.toThrow();
+			expect(() => parse("{ let a; } { let b; let b; }")).toThrow(
+				/already been declared/
+			);
+			expect(() => parse("try {} catch (a) {} { let x; var x; }")).toThrow(
+				/already been declared/
+			);
+		});
+
+		it("keeps labels isolated across pooled function bodies", () => {
+			expect(() =>
+				parse(
+					"function f() { lab: for (;;) break lab; } function g() { lab: for (;;) break lab; }"
+				)
+			).not.toThrow();
+			// a stale pooled label must not make this break resolvable
+			expect(() =>
+				parse("function f() { lab: ; } function g() { break lab; }")
+			).toThrow(/Unsyntactic break/);
+		});
+
 		it("serves comment ranges lazily with a stable memo and writable slot", () => {
 			/** @type {EXPECTED_ANY[]} */
 			const comments = [];

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2102,4 +2102,41 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			/Private field '#missing' must be declared in an enclosing class/
 		);
 	});
+
+	describe("releaseParserCaches", () => {
+		const {
+			WebpackParser,
+			releaseParserCaches
+		} = require("../lib/javascript/syntax");
+
+		const options = {
+			ecmaVersion: "latest",
+			sourceType: "module",
+			lazyNodes: true,
+			locations: false,
+			ranges: false
+		};
+		const code =
+			"const value = 123; export function repeatedName(repeatedParameter) { return repeatedParameter + value + 0.5; }";
+
+		it("parses identically after the caches are released", () => {
+			const before = JSON.stringify(WebpackParser.parse(code, options));
+			releaseParserCaches();
+			const after = JSON.stringify(WebpackParser.parse(code, options));
+			expect(after).toBe(before);
+		});
+
+		it("is idempotent and keeps the tokenizer working", () => {
+			releaseParserCaches();
+			releaseParserCaches();
+			let count = 0;
+			for (const token of WebpackParser.tokenizer(code, {
+				ecmaVersion: "latest",
+				sourceType: "module"
+			})) {
+				if (token) count++;
+			}
+			expect(count).toBeGreaterThan(10);
+		});
+	});
 });

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2126,6 +2126,32 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			expect(after).toBe(before);
 		});
 
+		it("is registered on the compiler's done and failed hooks", () => {
+			const { AsyncSeriesHook, SyncHook } = require("tapable");
+			const JavascriptModulesPlugin = require("../lib/javascript/JavascriptModulesPlugin");
+
+			// tap targets mirror lib/Compiler.js hook types
+			const compiler = {
+				hooks: {
+					done: new AsyncSeriesHook(["stats"]),
+					failed: new SyncHook(["error"]),
+					compilation: new SyncHook(["compilation", "params"])
+				}
+			};
+			new JavascriptModulesPlugin().apply(
+				/** @type {EXPECTED_ANY} */ (compiler)
+			);
+			// the plugin taps the exported function itself, so identity proves
+			// the release really runs on both lifecycle ends
+			expect(compiler.hooks.done.taps.map((tap) => tap.fn)).toContain(
+				releaseParserCaches
+			);
+			expect(compiler.hooks.failed.taps.map((tap) => tap.fn)).toContain(
+				releaseParserCaches
+			);
+			compiler.hooks.failed.call(new Error("test"));
+		});
+
 		it("is idempotent and keeps the tokenizer working", () => {
 			releaseParserCaches();
 			releaseParserCaches();

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -1894,7 +1894,6 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			 */
 			checkParams(node, allowDuplicates) {
 				calls++;
-				// @ts-expect-error acorn internal
 				return super.checkParams(node, allowDuplicates);
 			}
 		}

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2109,13 +2109,15 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			releaseParserCaches
 		} = require("../lib/javascript/syntax");
 
-		const options = {
-			ecmaVersion: "latest",
-			sourceType: "module",
-			lazyNodes: true,
-			locations: false,
-			ranges: false
-		};
+		const options = /** @type {import("acorn").Options} */ (
+			/** @type {unknown} */ ({
+				ecmaVersion: "latest",
+				sourceType: "module",
+				lazyNodes: true,
+				locations: false,
+				ranges: false
+			})
+		);
 		const code =
 			"const value = 123; export function repeatedName(repeatedParameter) { return repeatedParameter + value + 0.5; }";
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

First of a 3-PR stack optimizing webpack's JavaScript parser (the acorn subclass in `lib/javascript/syntax.js`): direct-mapped word/slice/operator caches, scope/set/label pooling, and an acorn-mirroring fast construction path plus owned `parseTopLevel`/module-declaration parsing, so hot paths avoid acorn's allocation-heavy generic code. Also fixes four divergences from acorn found while verifying (`**`-arrow precedence guard, LS/PS template cooking, string export names, `options.program` reuse). Verified by differential testing against acorn as oracle: JSON-identical ASTs and identical error messages over 9 library corpora and 508 feature-probe runs.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — regression tests in `test/JavascriptParser.unittest.js` and `test/WebpackParser.unittest.js` (including a fast/slow construction shape-parity tripwire and plugin-fallback gate tests).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was developed with Claude (AI assistant) under human direction: it performed the analysis, implementation, differential verification against acorn, and measurements; the requester reviewed and directed the work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo1cHj5Asx24LuVcz2CqT6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript parsing compatibility for exponentiation arrows, template literals, string export names, parameter names, module bindings, and continued program parsing.
  * Improved handling of pooled scopes, labels, and variable declarations.
  * Ensured parser resources are released after successful or failed builds while preserving continued tokenization.

* **Tests**
  * Added regression coverage for parsing edge cases, scope and label isolation, resource management, repeated releases, and tokenizer reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->