### PR TITLE
perf(javascript): stop executing acorn code on the lazy parse path

### DIFF
--- a/.changeset/160-js-parser-acorn-exactness.md
+++ b/.changeset/160-js-parser-acorn-exactness.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse.
+Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse; serialize parse-error locations.

--- a/.changeset/160-js-parser-acorn-exactness.md
+++ b/.changeset/160-js-parser-acorn-exactness.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse; serialize parse-error locations.
+Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse; serialize parse-error locations; trim walker allocations.

--- a/.changeset/160-js-parser-acorn-exactness.md
+++ b/.changeset/160-js-parser-acorn-exactness.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse; serialize parse-error locations; trim walker allocations.
+Match acorn on `**` arrows, LS/PS cooking, string export names, `program` reuse.

--- a/.changeset/170-js-parser-lazy-path-walker.md
+++ b/.changeset/170-js-parser-lazy-path-walker.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Parse without acorn, serialize parse-error locations, trim walker allocations.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -867,7 +867,7 @@ class JavascriptParser extends Parser {
 			const callee = expr.callee;
 			if (callee.type !== "Identifier") return;
 			if (callee.name !== "RegExp") {
-				return this.callHooksForName(
+				return this._callHooksForName1(
 					this.hooks.evaluateNewExpression,
 					callee.name,
 					expr
@@ -1484,7 +1484,7 @@ class JavascriptParser extends Parser {
 			if (expr.operator === "typeof") {
 				switch (expr.argument.type) {
 					case "Identifier": {
-						const res = this.callHooksForName(
+						const res = this._callHooksForName1(
 							this.hooks.evaluateTypeof,
 							expr.argument.name,
 							expr
@@ -1493,7 +1493,7 @@ class JavascriptParser extends Parser {
 						break;
 					}
 					case "MetaProperty": {
-						const res = this.callHooksForName(
+						const res = this._callHooksForName1(
 							this.hooks.evaluateTypeof,
 							/** @type {string} */
 							(getRootName(expr.argument)),
@@ -1699,7 +1699,7 @@ class JavascriptParser extends Parser {
 		this.hooks.evaluate.for("MetaProperty").tap(CLASS_NAME, (expr) => {
 			const metaProperty = /** @type {MetaProperty} */ (expr);
 
-			return this.callHooksForName(
+			return this._callHooksForName1(
 				this.hooks.evaluateIdentifier,
 				/** @type {string} */
 				(getRootName(metaProperty)),
@@ -1733,7 +1733,7 @@ class JavascriptParser extends Parser {
 					return hook.call(expr, param);
 				}
 			} else if (expr.callee.type === "Identifier") {
-				return this.callHooksForName(
+				return this._callHooksForName1(
 					this.hooks.evaluateCallExpression,
 					expr.callee.name,
 					expr
@@ -2504,13 +2504,14 @@ class JavascriptParser extends Parser {
 	 * @param {BlockStatement | StaticBlock} statement block statement
 	 */
 	walkBlockStatement(statement) {
-		this.inBlockScope(() => {
-			const body = statement.body;
-			const prev = this.prevStatement;
-			this.blockPreWalkStatements(body);
-			this.prevStatement = prev;
-			this.walkStatements(body);
-		}, true);
+		const oldScope = this._enterBlockScope();
+		const body = statement.body;
+		const prev = this.prevStatement;
+		this.blockPreWalkStatements(body);
+		this.prevStatement = prev;
+		this.walkStatements(body);
+
+		this._exitBlockScope(oldScope, true);
 	}
 
 	/**
@@ -2562,18 +2563,27 @@ class JavascriptParser extends Parser {
 		if (result === undefined) {
 			const guard = this.hooks.collectGuards.call(statement.test);
 			this.walkExpression(statement.test);
-			this.walkGuardedBranch(guard ? guard.consequent : undefined, () =>
-				this.walkNestedStatement(statement.consequent)
-			);
+			// allocate the branch closure only when a guard frame needs pushing
+			if (guard && guard.consequent) {
+				this.walkGuardedBranch(guard.consequent, () =>
+					this.walkNestedStatement(statement.consequent)
+				);
+			} else {
+				this.walkNestedStatement(statement.consequent);
+			}
 
 			const consequentTerminated = this.scope.terminated;
 			this.scope.terminated = undefined;
 
 			if (statement.alternate) {
 				const alternate = statement.alternate;
-				this.walkGuardedBranch(guard ? guard.alternate : undefined, () =>
-					this.walkNestedStatement(alternate)
-				);
+				if (guard && guard.alternate) {
+					this.walkGuardedBranch(guard.alternate, () =>
+						this.walkNestedStatement(alternate)
+					);
+				} else {
+					this.walkNestedStatement(alternate);
+				}
 			}
 
 			const alternateTerminated = this.scope.terminated;
@@ -2607,9 +2617,10 @@ class JavascriptParser extends Parser {
 			const result = hook.call(statement);
 			if (result === true) return;
 		}
-		this.inBlockScope(() => {
-			this.walkNestedStatement(statement.body);
-		});
+		const oldScope = this._enterBlockScope();
+		this.walkNestedStatement(statement.body);
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2631,10 +2642,11 @@ class JavascriptParser extends Parser {
 				statement
 			);
 		}
-		this.inBlockScope(() => {
-			this.walkExpression(statement.object);
-			this.walkNestedStatement(statement.body);
-		});
+		const oldScope = this._enterBlockScope();
+		this.walkExpression(statement.object);
+		this.walkNestedStatement(statement.body);
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2747,10 +2759,11 @@ class JavascriptParser extends Parser {
 	 * @param {WhileStatement} statement while statement
 	 */
 	walkWhileStatement(statement) {
-		this.inBlockScope(() => {
-			this.walkExpression(statement.test);
-			this.walkNestedStatement(statement.body);
-		});
+		const oldScope = this._enterBlockScope();
+		this.walkExpression(statement.test);
+		this.walkNestedStatement(statement.body);
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2766,10 +2779,11 @@ class JavascriptParser extends Parser {
 	 * @param {DoWhileStatement} statement do while statement
 	 */
 	walkDoWhileStatement(statement) {
-		this.inBlockScope(() => {
-			this.walkNestedStatement(statement.body);
-			this.walkExpression(statement.test);
-		});
+		const oldScope = this._enterBlockScope();
+		this.walkNestedStatement(statement.body);
+		this.walkExpression(statement.test);
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2788,35 +2802,36 @@ class JavascriptParser extends Parser {
 	 * @param {ForStatement} statement for statement
 	 */
 	walkForStatement(statement) {
-		this.inBlockScope(() => {
-			if (statement.init) {
-				if (statement.init.type === "VariableDeclaration") {
-					this.blockPreWalkVariableDeclaration(statement.init);
-					this.prevStatement = undefined;
-					this.walkStatement(statement.init);
-				} else {
-					this.walkExpression(statement.init);
-				}
-			}
-			if (statement.test) {
-				this.walkExpression(statement.test);
-			}
-			if (statement.update) {
-				this.walkExpression(statement.update);
-			}
-
-			const body = statement.body;
-
-			if (body.type === "BlockStatement") {
-				// no need to add additional scope
-				const prev = this.prevStatement;
-				this.blockPreWalkStatements(body.body);
-				this.prevStatement = prev;
-				this.walkStatements(body.body);
+		const oldScope = this._enterBlockScope();
+		if (statement.init) {
+			if (statement.init.type === "VariableDeclaration") {
+				this.blockPreWalkVariableDeclaration(statement.init);
+				this.prevStatement = undefined;
+				this.walkStatement(statement.init);
 			} else {
-				this.walkNestedStatement(body);
+				this.walkExpression(statement.init);
 			}
-		});
+		}
+		if (statement.test) {
+			this.walkExpression(statement.test);
+		}
+		if (statement.update) {
+			this.walkExpression(statement.update);
+		}
+
+		const body = statement.body;
+
+		if (body.type === "BlockStatement") {
+			// no need to add additional scope
+			const prev = this.prevStatement;
+			this.blockPreWalkStatements(body.body);
+			this.prevStatement = prev;
+			this.walkStatements(body.body);
+		} else {
+			this.walkNestedStatement(body);
+		}
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2835,28 +2850,29 @@ class JavascriptParser extends Parser {
 	 * @param {ForInStatement} statement for statement
 	 */
 	walkForInStatement(statement) {
-		this.inBlockScope(() => {
-			if (statement.left.type === "VariableDeclaration") {
-				this.blockPreWalkVariableDeclaration(statement.left);
-				this.walkVariableDeclaration(statement.left);
-			} else {
-				this.walkPattern(statement.left);
-			}
+		const oldScope = this._enterBlockScope();
+		if (statement.left.type === "VariableDeclaration") {
+			this.blockPreWalkVariableDeclaration(statement.left);
+			this.walkVariableDeclaration(statement.left);
+		} else {
+			this.walkPattern(statement.left);
+		}
 
-			this.walkExpression(statement.right);
+		this.walkExpression(statement.right);
 
-			const body = statement.body;
+		const body = statement.body;
 
-			if (body.type === "BlockStatement") {
-				// no need to add additional scope
-				const prev = this.prevStatement;
-				this.blockPreWalkStatements(body.body);
-				this.prevStatement = prev;
-				this.walkStatements(body.body);
-			} else {
-				this.walkNestedStatement(body);
-			}
-		});
+		if (body.type === "BlockStatement") {
+			// no need to add additional scope
+			const prev = this.prevStatement;
+			this.blockPreWalkStatements(body.body);
+			this.prevStatement = prev;
+			this.walkStatements(body.body);
+		} else {
+			this.walkNestedStatement(body);
+		}
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2878,28 +2894,29 @@ class JavascriptParser extends Parser {
 	 * @param {ForOfStatement} statement for statement
 	 */
 	walkForOfStatement(statement) {
-		this.inBlockScope(() => {
-			if (statement.left.type === "VariableDeclaration") {
-				this.blockPreWalkVariableDeclaration(statement.left);
-				this.walkVariableDeclaration(statement.left);
-			} else {
-				this.walkPattern(statement.left);
-			}
+		const oldScope = this._enterBlockScope();
+		if (statement.left.type === "VariableDeclaration") {
+			this.blockPreWalkVariableDeclaration(statement.left);
+			this.walkVariableDeclaration(statement.left);
+		} else {
+			this.walkPattern(statement.left);
+		}
 
-			this.walkExpression(statement.right);
+		this.walkExpression(statement.right);
 
-			const body = statement.body;
+		const body = statement.body;
 
-			if (body.type === "BlockStatement") {
-				// no need to add additional scope
-				const prev = this.prevStatement;
-				this.blockPreWalkStatements(body.body);
-				this.prevStatement = prev;
-				this.walkStatements(body.body);
-			} else {
-				this.walkNestedStatement(body);
-			}
-		});
+		if (body.type === "BlockStatement") {
+			// no need to add additional scope
+			const prev = this.prevStatement;
+			this.blockPreWalkStatements(body.body);
+			this.prevStatement = prev;
+			this.walkStatements(body.body);
+		} else {
+			this.walkNestedStatement(body);
+		}
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -2925,19 +2942,20 @@ class JavascriptParser extends Parser {
 		if (this._strictInModuleOutput) {
 			this._checkStrictModeParams(statement.params);
 		}
-		this.inFunctionScope(true, statement.params, () => {
-			for (const param of statement.params) {
-				this.walkPattern(param);
-			}
+		const oldScope = this._enterFunctionScope(true, statement.params);
+		for (const param of statement.params) {
+			this.walkPattern(param);
+		}
 
-			this.detectMode(statement.body.body);
+		this.detectMode(statement.body.body);
 
-			const prev = this.prevStatement;
+		const prev = this.prevStatement;
 
-			this.preWalkStatement(statement.body);
-			this.prevStatement = prev;
-			this.walkStatement(statement.body);
-		});
+		this.preWalkStatement(statement.body);
+		this.prevStatement = prev;
+		this.walkStatement(statement.body);
+
+		this.scope = oldScope;
 		this.scope.topLevelScope = wasTopLevel;
 	}
 
@@ -3303,7 +3321,9 @@ class JavascriptParser extends Parser {
 		/** @type {OnIdent | undefined} */
 		let onIdent;
 		const checkStrictBindings = this._strictInModuleOutput;
-		for (const declarator of statement.declarations) {
+		const declarations = statement.declarations;
+		for (let i = 0, len = declarations.length; i < len; i++) {
+			const declarator = declarations[i];
 			if (declarator.type !== "VariableDeclarator") continue;
 			this.preWalkVariableDeclarator(declarator);
 			if (this.hooks.preDeclarator.call(declarator, statement)) continue;
@@ -3312,7 +3332,7 @@ class JavascriptParser extends Parser {
 				if (checkStrictBindings) this._checkStrictModeBinding(id.name, id);
 				// fast path: plain `const x =` skips the enterPattern dispatch and
 				// the per-declaration onIdent closure (only patterns need it)
-				if (!this.callHooksForName(this.hooks.pattern, id.name, id)) {
+				if (!this._callHooksForName1(this.hooks.pattern, id.name, id)) {
 					this._defineVariableForDeclaration(id.name, id, hookMap);
 				}
 			} else {
@@ -3452,7 +3472,9 @@ class JavascriptParser extends Parser {
 	 * @param {VariableDeclaration} statement variable declaration
 	 */
 	walkVariableDeclaration(statement) {
-		for (const declarator of statement.declarations) {
+		const declarations = statement.declarations;
+		for (let i = 0, len = declarations.length; i < len; i++) {
+			const declarator = declarations[i];
 			switch (declarator.type) {
 				case "VariableDeclarator": {
 					const renameIdentifier =
@@ -3523,40 +3545,41 @@ class JavascriptParser extends Parser {
 	 * @param {SwitchCase[]} switchCases switch statement
 	 */
 	walkSwitchCases(switchCases) {
-		this.inBlockScope(() => {
-			const len = switchCases.length;
+		const oldScope = this._enterBlockScope();
+		const len = switchCases.length;
 
-			// we need to pre walk all statements first since we can have invalid code
-			// import A from "module";
-			// switch(1) {
-			//    case 1:
-			//      console.log(A); // should fail at runtime
-			//    case 2:
-			//      const A = 1;
-			// }
-			for (let index = 0; index < len; index++) {
-				const switchCase = switchCases[index];
+		// we need to pre walk all statements first since we can have invalid code
+		// import A from "module";
+		// switch(1) {
+		//    case 1:
+		//      console.log(A); // should fail at runtime
+		//    case 2:
+		//      const A = 1;
+		// }
+		for (let index = 0; index < len; index++) {
+			const switchCase = switchCases[index];
 
-				if (switchCase.consequent.length > 0) {
-					const prev = this.prevStatement;
-					this.blockPreWalkStatements(switchCase.consequent);
-					this.prevStatement = prev;
-				}
+			if (switchCase.consequent.length > 0) {
+				const prev = this.prevStatement;
+				this.blockPreWalkStatements(switchCase.consequent);
+				this.prevStatement = prev;
+			}
+		}
+
+		for (let index = 0; index < len; index++) {
+			const switchCase = switchCases[index];
+
+			if (switchCase.test) {
+				this.walkExpression(switchCase.test);
 			}
 
-			for (let index = 0; index < len; index++) {
-				const switchCase = switchCases[index];
-
-				if (switchCase.test) {
-					this.walkExpression(switchCase.test);
-				}
-
-				if (switchCase.consequent.length > 0) {
-					this.walkStatements(switchCase.consequent);
-					this.scope.terminated = undefined;
-				}
+			if (switchCase.consequent.length > 0) {
+				this.walkStatements(switchCase.consequent);
+				this.scope.terminated = undefined;
 			}
-		});
+		}
+
+		this._exitBlockScope(oldScope, false);
 	}
 
 	/**
@@ -3572,22 +3595,23 @@ class JavascriptParser extends Parser {
 	 * @param {CatchClause} catchClause catch clause
 	 */
 	walkCatchClause(catchClause) {
-		this.inBlockScope(() => {
-			// Error binding is optional in catch clause since ECMAScript 2019
-			if (catchClause.param !== null) {
-				this.enterPattern(catchClause.param, (ident, identifier) => {
-					if (this._strictInModuleOutput) {
-						this._checkStrictModeBinding(ident, identifier);
-					}
-					this.defineVariable(ident);
-				});
-				this.walkPattern(catchClause.param);
-			}
-			const prev = this.prevStatement;
-			this.blockPreWalkStatement(catchClause.body);
-			this.prevStatement = prev;
-			this.walkStatement(catchClause.body);
-		}, true);
+		const oldScope = this._enterBlockScope();
+		// Error binding is optional in catch clause since ECMAScript 2019
+		if (catchClause.param !== null) {
+			this.enterPattern(catchClause.param, (ident, identifier) => {
+				if (this._strictInModuleOutput) {
+					this._checkStrictModeBinding(ident, identifier);
+				}
+				this.defineVariable(ident);
+			});
+			this.walkPattern(catchClause.param);
+		}
+		const prev = this.prevStatement;
+		this.blockPreWalkStatement(catchClause.body);
+		this.prevStatement = prev;
+		this.walkStatement(catchClause.body);
+
+		this._exitBlockScope(oldScope, true);
 	}
 
 	/**
@@ -3885,19 +3909,20 @@ class JavascriptParser extends Parser {
 				this._checkStrictModeBinding(expression.id.name, expression.id);
 			}
 		}
-		this.inFunctionScope(true, scopeParams, () => {
-			for (const param of expression.params) {
-				this.walkPattern(param);
-			}
+		const oldScope = this._enterFunctionScope(true, scopeParams);
+		for (const param of expression.params) {
+			this.walkPattern(param);
+		}
 
-			this.detectMode(expression.body.body);
+		this.detectMode(expression.body.body);
 
-			const prev = this.prevStatement;
+		const prev = this.prevStatement;
 
-			this.preWalkStatement(expression.body);
-			this.prevStatement = prev;
-			this.walkStatement(expression.body);
-		});
+		this.preWalkStatement(expression.body);
+		this.prevStatement = prev;
+		this.walkStatement(expression.body);
+
+		this.scope = oldScope;
 		this.scope.topLevelScope = wasTopLevel;
 	}
 
@@ -3911,20 +3936,21 @@ class JavascriptParser extends Parser {
 		if (this._strictInModuleOutput) {
 			this._checkStrictModeParams(expression.params);
 		}
-		this.inFunctionScope(false, expression.params, () => {
-			for (const param of expression.params) {
-				this.walkPattern(param);
-			}
-			if (expression.body.type === "BlockStatement") {
-				this.detectMode(expression.body.body);
-				const prev = this.prevStatement;
-				this.preWalkStatement(expression.body);
-				this.prevStatement = prev;
-				this.walkStatement(expression.body);
-			} else {
-				this.walkExpression(expression.body);
-			}
-		});
+		const oldScope = this._enterFunctionScope(false, expression.params);
+		for (const param of expression.params) {
+			this.walkPattern(param);
+		}
+		if (expression.body.type === "BlockStatement") {
+			this.detectMode(expression.body.body);
+			const prev = this.prevStatement;
+			this.preWalkStatement(expression.body);
+			this.prevStatement = prev;
+			this.walkStatement(expression.body);
+		} else {
+			this.walkExpression(expression.body);
+		}
+
+		this.scope = oldScope;
 		this.scope.topLevelScope = wasTopLevel;
 	}
 
@@ -4185,7 +4211,7 @@ class JavascriptParser extends Parser {
 			const renameIdentifier = this.getRenameIdentifier(expression.right);
 			if (
 				renameIdentifier &&
-				this.callHooksForInfo(
+				this._callHooksForInfo1(
 					this.hooks.canRename,
 					renameIdentifier,
 					expression.right
@@ -4193,7 +4219,7 @@ class JavascriptParser extends Parser {
 			) {
 				// renaming "a = b;"
 				if (
-					!this.callHooksForInfo(
+					!this._callHooksForInfo1(
 						this.hooks.rename,
 						renameIdentifier,
 						expression.right
@@ -4209,18 +4235,23 @@ class JavascriptParser extends Parser {
 				return;
 			}
 			this.walkExpression(expression.right);
-			this.enterPattern(expression.left, (name, _decl) => {
-				if (!this.callHooksForName(this.hooks.assign, name, expression)) {
-					this.walkExpression(
-						/** @type {MemberExpression} */
-						(expression.left)
-					);
-				}
-			});
+			// inlined enterPattern → enterIdentifier for the Identifier left side:
+			// same hook sequence without the per-assignment closure
+			const leftName = expression.left.name;
+			if (
+				!this._callHooksForName1(
+					this.hooks.pattern,
+					leftName,
+					expression.left
+				) &&
+				!this._callHooksForName1(this.hooks.assign, leftName, expression)
+			) {
+				this.walkExpression(expression.left);
+			}
 		} else if (expression.left.type.endsWith("Pattern")) {
 			this.walkExpression(expression.right);
 			this.enterPattern(expression.left, (name, _decl) => {
-				if (!this.callHooksForName(this.hooks.assign, name, expression)) {
+				if (!this._callHooksForName1(this.hooks.assign, name, expression)) {
 					this.defineVariable(name);
 				}
 			});
@@ -4261,15 +4292,24 @@ class JavascriptParser extends Parser {
 		if (result === undefined) {
 			const guard = this.hooks.collectGuards.call(expression.test);
 			this.walkExpression(expression.test);
-			this.walkGuardedBranch(guard ? guard.consequent : undefined, () =>
-				this.walkExpression(expression.consequent)
-			);
+			// allocate the branch closure only when a guard frame needs pushing
+			if (guard && guard.consequent) {
+				this.walkGuardedBranch(guard.consequent, () =>
+					this.walkExpression(expression.consequent)
+				);
+			} else {
+				this.walkExpression(expression.consequent);
+			}
 
 			if (expression.alternate) {
 				const alternate = expression.alternate;
-				this.walkGuardedBranch(guard ? guard.alternate : undefined, () =>
-					this.walkExpression(alternate)
-				);
+				if (guard && guard.alternate) {
+					this.walkGuardedBranch(guard.alternate, () =>
+						this.walkExpression(alternate)
+					);
+				} else {
+					this.walkExpression(alternate);
+				}
 			}
 		} else if (result) {
 			this.walkExpression(expression.consequent);
@@ -4375,13 +4415,13 @@ class JavascriptParser extends Parser {
 			const renameIdentifier = this.getRenameIdentifier(argOrThis);
 			if (
 				renameIdentifier &&
-				this.callHooksForInfo(
+				this._callHooksForInfo1(
 					this.hooks.canRename,
 					renameIdentifier,
 					/** @type {Expression} */
 					(argOrThis)
 				) &&
-				!this.callHooksForInfo(
+				!this._callHooksForInfo1(
 					this.hooks.rename,
 					renameIdentifier,
 					/** @type {Expression} */
@@ -4422,26 +4462,27 @@ class JavascriptParser extends Parser {
 			scopeParams.push(functionExpression.id.name);
 		}
 
-		this.inFunctionScope(true, scopeParams, () => {
-			if (renameThis && !arrow) {
-				this.setVariable("this", renameThis);
-			}
-			for (let i = 0; i < varInfoForArgs.length; i++) {
-				const varInfo = varInfoForArgs[i];
-				if (!varInfo) continue;
-				if (!params[i] || params[i].type !== "Identifier") continue;
-				this.setVariable(/** @type {Identifier} */ (params[i]).name, varInfo);
-			}
-			if (functionExpression.body.type === "BlockStatement") {
-				this.detectMode(functionExpression.body.body);
-				const prev = this.prevStatement;
-				this.preWalkStatement(functionExpression.body);
-				this.prevStatement = prev;
-				this.walkStatement(functionExpression.body);
-			} else {
-				this.walkExpression(functionExpression.body);
-			}
-		});
+		const oldScope = this._enterFunctionScope(true, scopeParams);
+		if (renameThis && !arrow) {
+			this.setVariable("this", renameThis);
+		}
+		for (let i = 0; i < varInfoForArgs.length; i++) {
+			const varInfo = varInfoForArgs[i];
+			if (!varInfo) continue;
+			if (!params[i] || params[i].type !== "Identifier") continue;
+			this.setVariable(/** @type {Identifier} */ (params[i]).name, varInfo);
+		}
+		if (functionExpression.body.type === "BlockStatement") {
+			this.detectMode(functionExpression.body.body);
+			const prev = this.prevStatement;
+			this.preWalkStatement(functionExpression.body);
+			this.prevStatement = prev;
+			this.walkStatement(functionExpression.body);
+		} else {
+			this.walkExpression(functionExpression.body);
+		}
+
+		this.scope = oldScope;
 		this.scope.topLevelScope = wasTopLevel;
 	}
 
@@ -4568,7 +4609,7 @@ class JavascriptParser extends Parser {
 					callee.getMemberRanges ? callee.getMemberRanges() : []
 				);
 				if (result1 === true) return;
-				const result2 = this.callHooksForInfo(
+				const result2 = this._callHooksForInfo1(
 					this.hooks.call,
 					/** @type {NonNullable<BasicEvaluatedExpression["identifier"]>} */
 					(callee.identifier),
@@ -4604,7 +4645,7 @@ class JavascriptParser extends Parser {
 		if (exprInfo) {
 			switch (exprInfo.type) {
 				case "expression": {
-					const result1 = this.callHooksForInfo(
+					const result1 = this._callHooksForInfo1(
 						this.hooks.expression,
 						exprInfo.name,
 						expression
@@ -4684,7 +4725,7 @@ class JavascriptParser extends Parser {
 			const property = members[members.length - 1];
 			name = name.slice(0, -property.length - 1);
 			members.pop();
-			const result = this.callHooksForInfo(
+			const result = this._callHooksForInfo1(
 				this.hooks.expression,
 				name,
 				expression.object
@@ -4708,7 +4749,7 @@ class JavascriptParser extends Parser {
 	 * @param {ThisExpression} expression this expression
 	 */
 	walkThisExpression(expression) {
-		this.callHooksForName(this.hooks.expression, "this", expression);
+		this._callHooksForName1(this.hooks.expression, "this", expression);
 	}
 
 	/**
@@ -4716,7 +4757,7 @@ class JavascriptParser extends Parser {
 	 * @param {Identifier} expression identifier
 	 */
 	walkIdentifier(expression) {
-		this.callHooksForName(this.hooks.expression, expression.name, expression);
+		this._callHooksForName1(this.hooks.expression, expression.name, expression);
 	}
 
 	/**
@@ -4904,6 +4945,69 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
+	 * Single-argument twin of `callHooksForName` (must stay in sync with
+	 * `_callHooksForInfo`): every internal dispatch passes exactly one hook
+	 * argument, so this skips the rest-array collection and spread call the
+	 * generic path pays per identifier.
+	 * @template T
+	 * @template R
+	 * @param {HookMap<SyncBailHook<T, R>>} hookMap hooks that should be called
+	 * @param {string} name key in map
+	 * @param {AsArray<T>[0]} arg the single hook argument
+	 * @returns {R | undefined} result of hook
+	 */
+	_callHooksForName1(hookMap, name, arg) {
+		return this._callHooksForInfo1(hookMap, this.getVariableInfo(name), arg);
+	}
+
+	/**
+	 * Single-argument twin of `callHooksForInfo` (must stay in sync with
+	 * `_callHooksForInfo`), for the hot dispatch sites that pass one argument
+	 * and no fallback/defined callbacks.
+	 * @template T
+	 * @template R
+	 * @param {HookMap<SyncBailHook<T, R>>} hookMap hooks that should be called
+	 * @param {ExportedVariableInfo} info variable info
+	 * @param {AsArray<T>[0]} arg the single hook argument
+	 * @returns {R | undefined} result of hook
+	 */
+	_callHooksForInfo1(hookMap, info, arg) {
+		/** @type {string} */
+		let name;
+		if (typeof info === "string") {
+			name = info;
+		} else {
+			if (!(info instanceof VariableInfo)) {
+				return;
+			}
+			let tagInfo = info.tagInfo;
+			while (tagInfo !== undefined) {
+				const hook =
+					/** @type {SyncBailHook<[AsArray<T>[0]], R> | undefined} */
+					(hookMap.get(tagInfo.tag));
+				if (hook !== undefined) {
+					this.currentTagData = tagInfo.data;
+					const result = hook.call(arg);
+					this.currentTagData = undefined;
+					if (result !== undefined) return result;
+				}
+				tagInfo = tagInfo.next;
+			}
+			if (!info.isFree() && !info.isTagged()) {
+				return;
+			}
+			name = /** @type {string} */ (info.name);
+		}
+		const hook =
+			/** @type {SyncBailHook<[AsArray<T>[0]], R> | undefined} */
+			(hookMap.get(name));
+		if (hook !== undefined) {
+			const result = hook.call(arg);
+			if (result !== undefined) return result;
+		}
+	}
+
+	/**
 	 * Processes the provided param.
 	 * @deprecated
 	 * @param {(string | Pattern | Property)[]} params scope params
@@ -4971,26 +5075,8 @@ class JavascriptParser extends Parser {
 	 * @returns {void}
 	 */
 	inFunctionScope(hasThis, params, fn) {
-		const oldScope = this.scope;
-		this.scope = {
-			topLevelScope: oldScope.topLevelScope,
-			inTry: false,
-			inShorthand: false,
-			inTaggedTemplateTag: false,
-			isStrict: oldScope.isStrict,
-			isAsmJs: oldScope.isAsmJs,
-			terminated: undefined,
-			definitions: oldScope.definitions.createChild()
-		};
-
-		if (hasThis) {
-			this.undefineVariable("this");
-		}
-
-		this.enterPatterns(params, this._defineVariable);
-
+		const oldScope = this._enterFunctionScope(hasThis, params);
 		fn();
-
 		this.scope = oldScope;
 	}
 
@@ -5001,6 +5087,18 @@ class JavascriptParser extends Parser {
 	 * @returns {void}
 	 */
 	inBlockScope(fn, inExecutedPath = false) {
+		const oldScope = this._enterBlockScope();
+		fn();
+		this._exitBlockScope(oldScope, inExecutedPath);
+	}
+
+	/**
+	 * Enters a fresh block scope: the closure-free core of `inBlockScope`, used
+	 * directly by the internal walkers so each block does not allocate a
+	 * closure and context. Pass the returned scope to `_exitBlockScope`.
+	 * @returns {ScopeInfo} the previous scope
+	 */
+	_enterBlockScope() {
 		const oldScope = this.scope;
 		this.scope = {
 			topLevelScope: oldScope.topLevelScope,
@@ -5012,16 +5110,48 @@ class JavascriptParser extends Parser {
 			terminated: oldScope.terminated,
 			definitions: oldScope.definitions.createChild()
 		};
+		return oldScope;
+	}
 
-		fn();
-
+	/**
+	 * Leaves a block scope entered with `_enterBlockScope`.
+	 * @param {ScopeInfo} oldScope scope returned by `_enterBlockScope`
+	 * @param {boolean} inExecutedPath whether termination propagates to the outer scope
+	 * @returns {void}
+	 */
+	_exitBlockScope(oldScope, inExecutedPath) {
 		const terminated = this.scope.terminated;
-
 		if (inExecutedPath && terminated) {
 			oldScope.terminated = terminated;
 		}
-
 		this.scope = oldScope;
+	}
+
+	/**
+	 * Enters a fresh function scope: the closure-free core of `inFunctionScope`,
+	 * used directly by the internal walkers. Restore `this.scope` to the
+	 * returned scope when leaving.
+	 * @param {boolean} hasThis true, when this is defined
+	 * @param {(Pattern | string)[]} params scope params
+	 * @returns {ScopeInfo} the previous scope
+	 */
+	_enterFunctionScope(hasThis, params) {
+		const oldScope = this.scope;
+		this.scope = {
+			topLevelScope: oldScope.topLevelScope,
+			inTry: false,
+			inShorthand: false,
+			inTaggedTemplateTag: false,
+			isStrict: oldScope.isStrict,
+			isAsmJs: oldScope.isAsmJs,
+			terminated: undefined,
+			definitions: oldScope.definitions.createChild()
+		};
+		if (hasThis) {
+			this.undefineVariable("this");
+		}
+		this.enterPatterns(params, this._defineVariable);
+		return oldScope;
 	}
 
 	/**
@@ -5103,7 +5233,7 @@ class JavascriptParser extends Parser {
 	 * @param {OnIdent} onIdent callback
 	 */
 	enterIdentifier(pattern, onIdent) {
-		if (!this.callHooksForName(this.hooks.pattern, pattern.name, pattern)) {
+		if (!this._callHooksForName1(this.hooks.pattern, pattern.name, pattern)) {
 			onIdent(pattern.name, pattern);
 		}
 	}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -3548,14 +3548,8 @@ class JavascriptParser extends Parser {
 		const oldScope = this._enterBlockScope();
 		const len = switchCases.length;
 
-		// we need to pre walk all statements first since we can have invalid code
-		// import A from "module";
-		// switch(1) {
-		//    case 1:
-		//      console.log(A); // should fail at runtime
-		//    case 2:
-		//      const A = 1;
-		// }
+		// pre-walk every case first: a `const` declared in a later case is already
+		// in scope for an earlier case that reads it (and fails at runtime)
 		for (let index = 0; index < len; index++) {
 			const switchCase = switchCases[index];
 

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-// cspell:ignore yuku binop prec Prec
+// cspell:ignore yuku binop prec Prec iget iset sget sset
 
 const { Parser: BaseParser, tokTypes } = require("acorn");
 
@@ -119,9 +119,12 @@ const SCOPE_ASYNC = 4;
 const SCOPE_GENERATOR = 8;
 const SCOPE_ARROW = 16;
 const SCOPE_SIMPLE_CATCH = 32;
-// SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK
+const SCOPE_SUPER = 64;
+const SCOPE_DIRECT_SUPER = 128;
+const SCOPE_CLASS_STATIC_BLOCK = 256;
+const SCOPE_CLASS_FIELD_INIT = 512;
 const SCOPE_SWITCH = 1024;
-const SCOPE_VAR = 0b100000011;
+const SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
 // acorn's parseFunction statement bit flags
 const FUNC_STATEMENT = 1;
 const FUNC_HANGING_STATEMENT = 2;
@@ -891,6 +894,112 @@ class FunctionNode {
 }
 
 /**
+ * Pre-shaped `ClassDeclaration`/`ClassExpression`: acorn fills class nodes
+ * through shared subroutines (`parseClassId`/`parseClassSuper`), so like
+ * `FunctionNode` the fields are declared up-front in acorn's write order —
+ * one hidden class for both node types, no transitions.
+ */
+class ClassNode {
+	/**
+	 * @param {number} start start offset
+	 */
+	constructor(start) {
+		this.type = "";
+		this.start = start;
+		this.end = 0;
+		/** @type {Identifier | null} */
+		this.id = null;
+		/** @type {Expression | null} */
+		this.superClass = null;
+		/** @type {Node | null} */
+		this.body = null;
+	}
+}
+
+/**
+ * Single-shape `ClassBody`.
+ */
+class ClassBodyNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 * @param {Node[]} body class elements
+	 */
+	constructor(start, end, body) {
+		this.type = "ClassBody";
+		this.start = start;
+		this.end = end;
+		this.body = body;
+	}
+}
+
+/**
+ * Pre-shaped `MethodDefinition`, filled in acorn's write order (`static`,
+ * `computed`, `key`, `kind`, `value`) and finished via `finishNode`. Also the
+ * scratch an ambiguous class element parses its name into before the
+ * method/field split (see `parseClassElement`) — it carries the superset of
+ * both shapes' fields, so no write transitions it.
+ */
+class MethodDefinitionNode {
+	/**
+	 * @param {number} start start offset
+	 */
+	constructor(start) {
+		this.type = "";
+		this.start = start;
+		this.end = 0;
+		this.static = false;
+		this.computed = false;
+		/** @type {Node | null} */
+		this.key = null;
+		this.kind = "";
+		/** @type {Node | null} */
+		this.value = null;
+	}
+}
+
+/**
+ * Pre-shaped `PropertyDefinition` — `kind`-less, matching acorn's key set, so
+ * it cannot share `MethodDefinitionNode`'s shape: `value` lands in
+ * `parseClassField`, `finishNode` sets `type` and `end`.
+ */
+class PropertyDefinitionNode {
+	/**
+	 * @param {number} start start offset
+	 * @param {boolean} isStatic whether the field is static
+	 * @param {boolean} computed whether the key is computed
+	 * @param {Node} key field key
+	 */
+	constructor(start, isStatic, computed, key) {
+		this.type = "";
+		this.start = start;
+		this.end = 0;
+		this.static = isStatic;
+		this.computed = computed;
+		this.key = key;
+		/** @type {Node | null} */
+		this.value = null;
+	}
+}
+
+/**
+ * Pre-shaped `StaticBlock` (no `static` slot — acorn never writes one):
+ * `parseClassStaticBlock` fills `body`, `finishNode` sets `type` and `end`.
+ */
+class StaticBlockNode {
+	/**
+	 * @param {number} start start offset
+	 */
+	constructor(start) {
+		this.type = "";
+		this.start = start;
+		this.end = 0;
+		/** @type {Node[] | null} */
+		this.body = null;
+	}
+}
+
+/**
  * Single-shape `ImportDeclaration`; `phase` (`import defer/source`) stays a
  * post-construction addition since phase imports are rare.
  */
@@ -1290,6 +1399,66 @@ const isRelationalKeyword = (input, start, end) => {
 };
 
 /**
+ * Mirror of acorn's module-level `checkKeyName`.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+ * @param {Node & { computed?: boolean, key?: Node | null }} node class element
+ * @param {string} name checked name
+ * @returns {boolean} whether the element's non-computed key spells `name`
+ */
+const checkKeyName = (node, name) => {
+	const computed = node.computed;
+	const key = /** @type {Node & { name?: string, value?: unknown }} */ (
+		node.key
+	);
+	return (
+		!computed &&
+		((key.type === "Identifier" && key.name === name) ||
+			(key.type === "Literal" && key.value === name))
+	);
+};
+
+/**
+ * Mirror of acorn's module-level `isPrivateNameConflicted`.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+ * @param {Record<string, string>} privateNameMap declared private names of the enclosing class body
+ * @param {Node & { kind?: string, static?: boolean, key?: Node & { name: string } }} element class element with a `PrivateIdentifier` key
+ * @returns {boolean} whether the name conflicts with an earlier declaration
+ */
+const isPrivateNameConflicted = (privateNameMap, element) => {
+	const name = /** @type {Node & { name: string }} */ (element.key).name;
+	const curr = privateNameMap[name];
+	let next = "true";
+	if (
+		element.type === "MethodDefinition" &&
+		(element.kind === "get" || element.kind === "set")
+	) {
+		next = (element.static ? "s" : "i") + element.kind;
+	}
+	// `class { get #a(){}; static set #a(_){} }` is also a conflict
+	if (
+		(curr === "iget" && next === "iset") ||
+		(curr === "iset" && next === "iget") ||
+		(curr === "sget" && next === "sset") ||
+		(curr === "sset" && next === "sget")
+	) {
+		privateNameMap[name] = "true";
+		return false;
+	} else if (!curr) {
+		privateNameMap[name] = next;
+		return false;
+	}
+	return true;
+};
+
+/**
+ * Acorn's per-class private-name record: `declared` maps each private name to
+ * "true" or an accessor tag (`iget`/`iset`/`sget`/`sset`); `used` collects the
+ * `PrivateIdentifier` nodes `parsePrivateIdent` saw, resolved against
+ * `declared` when the class body closes (`exitClassBody`).
+ * @typedef {{ declared: Record<string, string>, used: (Node & { name: string })[] }} PrivateNameStackEntry
+ */
+
+/**
  * Mirror of acorn's module-level `isLocalVariableAccess`.
  * @param {Node} node checked node
  * @returns {boolean} whether the node reads a local variable
@@ -1369,6 +1538,11 @@ for (const NodeClass of [
 	ExportDefaultDeclarationNode,
 	ExportAllDeclarationNode,
 	ExportSpecifierNode,
+	ClassNode,
+	ClassBodyNode,
+	MethodDefinitionNode,
+	PropertyDefinitionNode,
+	StaticBlockNode,
 	ForStatementNode,
 	ForInStatementNode,
 	ForOfStatementNode,
@@ -1533,7 +1707,20 @@ class Scope {
  * parseExprSubscripts: (refDestructuringErrors?: DestructuringErrorsShim | null, forInit?: boolean | string) => Expression,
  * parseAwait: (forInit?: boolean | string) => Expression,
  * canAwait: boolean,
- * privateNameStack: unknown[],
+ * privateNameStack: PrivateNameStackEntry[],
+ * parseGetterSetter: (prop: Node) => void,
+ * parseMethod: (isGenerator: boolean, isAsync?: boolean, allowDirectSuper?: boolean) => Expression,
+ * parseClassElement: (constructorAllowsSuper: boolean) => Node | null,
+ * isClassElementNameStart: () => boolean,
+ * parseClassElementName: (element: Node) => void,
+ * parseClassMethod: (method: Node, isGenerator: boolean, isAsync: boolean, allowsDirectSuper: boolean) => Node,
+ * parseClassField: (field: Node) => Node,
+ * parseClassStaticBlock: (node: Node) => Node,
+ * parseClassId: (node: Node, isStatement: boolean | string) => void,
+ * parseClassSuper: (node: Node) => void,
+ * enterClassBody: () => Record<string, string>,
+ * exitClassBody: () => void,
+ * _classFastPath: boolean,
  * semicolon: () => void,
  * exitScope: () => void,
  * parseStatement: (context: string | null, topLevel?: boolean, exports?: unknown) => Node,
@@ -1590,8 +1777,8 @@ class Scope {
  * parseFunction: (node: Node, statement: number, allowExpressionBody?: boolean, isAsync?: boolean, forInit?: boolean | string) => Expression,
  * parseArrowExpression: (node: Node, params: Node[], isAsync: boolean, forInit?: boolean | string) => Expression,
  * _subscriptFastPath: boolean,
- * checkLValSimple: (expr: Node, bindingType?: number, checkClashes?: Record<string, boolean> | null) => void,
- * checkLValInnerPattern: (expr: Node, bindingType?: number, checkClashes?: Record<string, boolean> | null) => void,
+ * checkLValSimple: (expr: Node, bindingType?: number, checkClashes?: Record<string, boolean> | false | null) => void,
+ * checkLValInnerPattern: (expr: Node, bindingType?: number, checkClashes?: Record<string, boolean> | false | null) => void,
  * declareName: (name: string, bindingType: number, pos: number) => void,
  * startNode: () => Node,
  * startNodeAt: (pos: number, loc?: Position) => Node,
@@ -2367,7 +2554,7 @@ class WebpackParser extends BaseParser {
 			self._newlineBefore = 2;
 			self._deStack = [];
 			self._deDepth = 0;
-			self._propHashFastPath = self.checkPropClash === base.checkPropClash;
+			self._propHashFastPath = self.checkPropClash === proto.checkPropClash;
 			self._propHashStack = [];
 			self._propHashDepth = 0;
 			self._arrStack = [];
@@ -2426,6 +2613,10 @@ class WebpackParser extends BaseParser {
 				self.checkExpressionErrors === proto.checkExpressionErrors &&
 				self.isContextual === base.isContextual;
 			self._moduleDeclFastPath = shape.ecmaVersion >= 16;
+			self._classFastPath =
+				shape.ecmaVersion >= 13 &&
+				self.parseClassElementName === proto.parseClassElementName &&
+				self.parsePropertyName === proto.parsePropertyName;
 			// eslint-disable-next-line no-constructor-return -- the explicit object return is the mechanism that skips acorn's constructor
 			return /** @type {WebpackParser} */ (/** @type {unknown} */ (self));
 		}
@@ -2542,12 +2733,13 @@ class WebpackParser extends BaseParser {
 		/** @type {DestructuringErrorsShim[]} */
 		this._deStack = [];
 		this._deDepth = 0;
-		// LIFO pool for `parseObj`'s prop-clash records: acorn's ES6+
-		// `checkPropClash` only ever touches `.proto`, so one record per nesting
-		// depth suffices; an overriding subclass gets the fresh `{}` acorn expects
+		// LIFO pool for `parseObj`'s prop-clash records: the ES9+ `checkPropClash`
+		// (base's and the owned copy alike) only ever touches `.proto`, so one
+		// record per nesting depth suffices; an overriding subclass gets the
+		// fresh `{}` acorn expects
 		this._propHashFastPath =
 			/** @type {ParserInternals} */ (/** @type {unknown} */ (this))
-				.checkPropClash === base.checkPropClash;
+				.checkPropClash === WebpackParser.prototype.checkPropClash;
 		/** @type {{ proto: boolean }[]} */
 		this._propHashStack = [];
 		this._propHashDepth = 0;
@@ -2649,6 +2841,15 @@ class WebpackParser extends BaseParser {
 		// the owned import/export declarations bake in ecmaVersion ≥ 16 (import
 		// attributes; with it string export names ≥ 13 and `export * as` ≥ 11)
 		this._moduleDeclFastPath = lazy && this._ecmaVersion >= 16;
+		// the owned parseClassElement bakes in ES13 semantics (static blocks,
+		// fields) and rebuilds field elements on `PropertyDefinitionNode`, which
+		// would drop fields an overriding name parser adds — such overrides (and
+		// pre-ES13 versions) gate the whole class family back to acorn
+		this._classFastPath =
+			lazy &&
+			this._ecmaVersion >= 13 &&
+			this.parseClassElementName === proto.parseClassElementName &&
+			this.parsePropertyName === proto.parsePropertyName;
 	}
 
 	/**
@@ -4608,7 +4809,7 @@ class WebpackParser extends BaseParser {
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr assignment/binding target
 	 * @param {number=} bindingType acorn BIND_* binding type
-	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
+	 * @param {Record<string, boolean> | false | null=} checkClashes param-name clash record
 	 * @returns {void}
 	 * @this {ParserInternals}
 	 */
@@ -4690,7 +4891,7 @@ class WebpackParser extends BaseParser {
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr binding pattern
 	 * @param {number=} bindingType acorn BIND_* binding type
-	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
+	 * @param {Record<string, boolean> | false | null=} checkClashes param-name clash record
 	 * @returns {void}
 	 * @this {ParserInternals}
 	 */
@@ -4722,7 +4923,7 @@ class WebpackParser extends BaseParser {
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
 	 * @param {Node} expr pattern element
 	 * @param {number=} bindingType acorn BIND_* binding type
-	 * @param {Record<string, boolean> | null=} checkClashes param-name clash record
+	 * @param {Record<string, boolean> | false | null=} checkClashes param-name clash record
 	 * @returns {void}
 	 * @this {ParserInternals}
 	 */
@@ -5424,8 +5625,13 @@ class WebpackParser extends BaseParser {
 					? this.parseImport(node)
 					: this.parseExport(node, exports);
 			}
-			case tokTypes._class:
-				return base.parseStatement.call(this, context, topLevel, exports);
+			case tokTypes._class: {
+				if (!this._classFastPath) {
+					return base.parseStatement.call(this, context, topLevel, exports);
+				}
+				if (context) this.unexpected();
+				return this.parseClass(this.startNode(), true);
+			}
 			default: {
 				if (startType === tokTypes.name) {
 					const value = this.value;
@@ -8191,6 +8397,747 @@ class WebpackParser extends BaseParser {
 			containsEsc
 		);
 		return this.finishNode(prop, "Property");
+	}
+
+	// ----- class bodies (declarations/expressions, methods, fields) -----
+
+	/**
+	 * Owned `parseClass`, an exact-semantics copy of acorn 8's landing on
+	 * `ClassNode`/`ClassBodyNode`'s pre-declared shapes (the passed started
+	 * node is discarded — every acorn call site consumes the return value).
+	 * Delegates when the class fast path is off.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started node from the caller
+	 * @param {boolean | string} isStatement statement flag (`true`, `false` or `"nullableID"`)
+	 * @returns {Node} class declaration or expression
+	 * @this {ParserInternals}
+	 */
+	parseClass(node, isStatement) {
+		if (!this._classFastPath) {
+			return base.parseClass.call(this, node, isStatement);
+		}
+		const classNode =
+			/** @type {Node & { id: Identifier | null, superClass: Expression | null, body: Node | null }} */ (
+				/** @type {unknown} */ (new ClassNode(node.start))
+			);
+		this.next();
+		// ecma-262 14.6: a class definition is always strict mode code
+		const oldStrict = this.strict;
+		this.strict = true;
+		this.parseClassId(classNode, isStatement);
+		this.parseClassSuper(classNode);
+		const privateNameMap = this.enterClassBody();
+		const bodyStart = this.start;
+		let hadConstructor = false;
+		const scratch = this._acquireScratch();
+		let count = 0;
+		this.expect(tokTypes.braceL);
+		while (this.type !== tokTypes.braceR) {
+			const element =
+				/** @type {(Node & { kind?: string, static?: boolean, key?: Node & { name: string } }) | null} */ (
+					this.parseClassElement(classNode.superClass !== null)
+				);
+			if (element) {
+				scratch[count++] = element;
+				if (
+					element.type === "MethodDefinition" &&
+					element.kind === "constructor"
+				) {
+					if (hadConstructor) {
+						this.raiseRecoverable(
+							element.start,
+							"Duplicate constructor in the same class"
+						);
+					}
+					hadConstructor = true;
+				} else if (
+					element.key &&
+					element.key.type === "PrivateIdentifier" &&
+					isPrivateNameConflicted(privateNameMap, element)
+				) {
+					this.raiseRecoverable(
+						element.key.start,
+						`Identifier '#${element.key.name}' has already been declared`
+					);
+				}
+			}
+		}
+		this.strict = oldStrict;
+		this.next();
+		classNode.body = /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new ClassBodyNode(
+					bodyStart,
+					this.lastTokEnd,
+					this._releaseScratch(scratch, count)
+				)
+			)
+		);
+		this.exitClassBody();
+		return this.finishNode(
+			/** @type {Node} */ (/** @type {unknown} */ (classNode)),
+			isStatement ? "ClassDeclaration" : "ClassExpression"
+		);
+	}
+
+	/**
+	 * Owned `parseClassElement`, an exact-semantics copy of acorn 8's with the
+	 * ES13 probes folded (the gate guarantees static blocks and fields exist):
+	 * an ambiguous element parses its name into a `MethodDefinitionNode`, which
+	 * either is the method node or donates `static`/`computed`/`key` to a
+	 * `PropertyDefinitionNode` once the token after the name settles the split.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {boolean} constructorAllowsSuper whether a constructor may call `super()`
+	 * @returns {Node | null} class element (`null` for a lone `;`)
+	 * @this {ParserInternals}
+	 */
+	parseClassElement(constructorAllowsSuper) {
+		if (!this._classFastPath) {
+			return base.parseClassElement.call(this, constructorAllowsSuper);
+		}
+		if (this.eat(tokTypes.semi)) return null;
+		const start = this.start;
+		let keyName = "";
+		let isGenerator = false;
+		let isAsync = false;
+		let kind = "method";
+		let isStatic = false;
+		if (this.eatContextual("static")) {
+			// static initialization block
+			if (this.eat(tokTypes.braceL)) {
+				const block = /** @type {Node} */ (
+					/** @type {unknown} */ (new StaticBlockNode(start))
+				);
+				this.parseClassStaticBlock(block);
+				return block;
+			}
+			if (this.isClassElementNameStart() || this.type === tokTypes.star) {
+				isStatic = true;
+			} else {
+				keyName = "static";
+			}
+		}
+		if (!keyName && this.eatContextual("async")) {
+			if (
+				(this.isClassElementNameStart() || this.type === tokTypes.star) &&
+				!this.canInsertSemicolon()
+			) {
+				isAsync = true;
+			} else {
+				keyName = "async";
+			}
+		}
+		if (!keyName && this.eat(tokTypes.star)) {
+			isGenerator = true;
+		}
+		if (!keyName && !isAsync && !isGenerator) {
+			const lastValue = this.value;
+			if (this.eatContextual("get") || this.eatContextual("set")) {
+				if (this.isClassElementNameStart()) {
+					kind = /** @type {string} */ (lastValue);
+				} else {
+					keyName = /** @type {string} */ (lastValue);
+				}
+			}
+		}
+		const element =
+			/** @type {Node & { static: boolean, computed: boolean, key: Node | null, kind: string, value: Node | null }} */ (
+				/** @type {unknown} */ (new MethodDefinitionNode(start))
+			);
+		element.static = isStatic;
+		if (keyName) {
+			// `async`/`get`/`set`/`static` was the element name, not a modifier
+			element.computed = false;
+			element.key = /** @type {Node} */ (
+				/** @type {unknown} */ (
+					new IdentifierNode(this.lastTokStart, this.lastTokEnd, keyName)
+				)
+			);
+		} else {
+			this.parseClassElementName(element);
+		}
+		if (
+			this.type === tokTypes.parenL ||
+			kind !== "method" ||
+			isGenerator ||
+			isAsync
+		) {
+			const isConstructor =
+				!element.static && checkKeyName(element, "constructor");
+			const allowsDirectSuper = isConstructor && constructorAllowsSuper;
+			// acorn keeps this check out of parseClassMethod for backward compat
+			if (isConstructor && kind !== "method") {
+				this.raise(
+					/** @type {Node} */ (element.key).start,
+					"Constructor can't have get/set modifier"
+				);
+			}
+			element.kind = isConstructor ? "constructor" : kind;
+			this.parseClassMethod(element, isGenerator, isAsync, allowsDirectSuper);
+			return element;
+		}
+		// field: rebuild on PropertyDefinition's own `kind`-less shape
+		const field = /** @type {Node} */ (
+			/** @type {unknown} */ (
+				new PropertyDefinitionNode(
+					start,
+					element.static,
+					element.computed,
+					/** @type {Node} */ (element.key)
+				)
+			)
+		);
+		this.parseClassField(field);
+		return field;
+	}
+
+	/**
+	 * Owned `parseClassElementName`, an exact-semantics copy of acorn 8's.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} element class element receiving `computed`/`key`
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parseClassElementName(element) {
+		if (!this._classFastPath) {
+			return base.parseClassElementName.call(this, element);
+		}
+		const target =
+			/** @type {Node & { computed: boolean, key: Node | null }} */ (element);
+		if (this.type === tokTypes.privateId) {
+			if (this.value === "constructor") {
+				this.raise(
+					this.start,
+					"Classes can't have an element named '#constructor'"
+				);
+			}
+			target.computed = false;
+			target.key = this.parsePrivateIdent();
+		} else {
+			this.parsePropertyName(element);
+		}
+	}
+
+	/**
+	 * Owned `parseClassMethod`, an exact-semantics copy of acorn 8's; the value
+	 * lands via `parseMethod` on `FunctionNode`'s shape.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} method class element holding the parsed key and kind
+	 * @param {boolean} isGenerator whether the method is a generator
+	 * @param {boolean} isAsync whether the method is async
+	 * @param {boolean} allowsDirectSuper whether `super()` is allowed inside
+	 * @returns {Node} finished method definition
+	 * @this {ParserInternals}
+	 */
+	parseClassMethod(method, isGenerator, isAsync, allowsDirectSuper) {
+		if (!this._classFastPath) {
+			return base.parseClassMethod.call(
+				this,
+				method,
+				isGenerator,
+				isAsync,
+				allowsDirectSuper
+			);
+		}
+		const target =
+			/** @type {Node & { static: boolean, kind: string, key: Node, value: Node | null }} */ (
+				method
+			);
+		const key = target.key;
+		if (target.kind === "constructor") {
+			if (isGenerator) {
+				this.raise(key.start, "Constructor can't be a generator");
+			}
+			if (isAsync) {
+				this.raise(key.start, "Constructor can't be an async method");
+			}
+		} else if (target.static && checkKeyName(target, "prototype")) {
+			this.raise(
+				key.start,
+				"Classes may not have a static property named prototype"
+			);
+		}
+		const value = /** @type {Node & { params: Node[] }} */ (
+			/** @type {unknown} */ (
+				target.value = /** @type {Node} */ (
+					/** @type {unknown} */ (
+						this.parseMethod(isGenerator, isAsync, allowsDirectSuper)
+					)
+				)
+			)
+		);
+		if (target.kind === "get" && value.params.length !== 0) {
+			this.raiseRecoverable(value.start, "getter should have no params");
+		}
+		if (target.kind === "set" && value.params.length !== 1) {
+			this.raiseRecoverable(
+				value.start,
+				"setter should have exactly one param"
+			);
+		}
+		if (target.kind === "set" && value.params[0].type === "RestElement") {
+			this.raiseRecoverable(
+				value.params[0].start,
+				"Setter cannot use rest params"
+			);
+		}
+		return this.finishNode(method, "MethodDefinition");
+	}
+
+	/**
+	 * Owned `parseClassField`, an exact-semantics copy of acorn 8's.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} field class element holding the parsed key
+	 * @returns {Node} finished property definition
+	 * @this {ParserInternals}
+	 */
+	parseClassField(field) {
+		if (!this._classFastPath) {
+			return base.parseClassField.call(this, field);
+		}
+		const target =
+			/** @type {Node & { static: boolean, key: Node, value: Node | null }} */ (
+				field
+			);
+		if (checkKeyName(target, "constructor")) {
+			this.raise(
+				target.key.start,
+				"Classes can't have a field named 'constructor'"
+			);
+		} else if (target.static && checkKeyName(target, "prototype")) {
+			this.raise(
+				target.key.start,
+				"Classes can't have a static field named 'prototype'"
+			);
+		}
+		if (this.eat(tokTypes.eq)) {
+			// a dedicated scope so `arguments` in the initializer raises
+			this.enterScope(SCOPE_CLASS_FIELD_INIT | SCOPE_SUPER);
+			target.value = /** @type {Node} */ (
+				/** @type {unknown} */ (this.parseMaybeAssign())
+			);
+			this.exitScope();
+		} else {
+			target.value = null;
+		}
+		this.semicolon();
+		return this.finishNode(field, "PropertyDefinition");
+	}
+
+	/**
+	 * Owned `parseClassStaticBlock`, an exact-semantics copy of acorn 8's.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node static-block element (`{` already consumed)
+	 * @returns {Node} finished static block
+	 * @this {ParserInternals}
+	 */
+	parseClassStaticBlock(node) {
+		if (!this._classFastPath) {
+			return base.parseClassStaticBlock.call(this, node);
+		}
+		const target = /** @type {Node & { body: Node[] }} */ (node);
+		target.body = [];
+		const oldLabels = this.labels;
+		this.labels = [];
+		this.enterScope(SCOPE_CLASS_STATIC_BLOCK | SCOPE_SUPER);
+		while (this.type !== tokTypes.braceR) {
+			const statement = this.parseStatement(null);
+			target.body.push(statement);
+		}
+		this.next();
+		this.exitScope();
+		this.labels = oldLabels;
+		return this.finishNode(node, "StaticBlock");
+	}
+
+	/**
+	 * Owned `parseClassId`, an exact-semantics copy of acorn 8's.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node class node receiving `id`
+	 * @param {boolean | string} isStatement statement flag (`true`, `false` or `"nullableID"`)
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parseClassId(node, isStatement) {
+		if (!this._classFastPath) {
+			return base.parseClassId.call(this, node, isStatement);
+		}
+		const target = /** @type {Node & { id: Identifier | null }} */ (node);
+		if (this.type === tokTypes.name) {
+			target.id = this.parseIdent();
+			if (isStatement) this.checkLValSimple(target.id, BIND_LEXICAL, false);
+		} else {
+			if (isStatement === true) this.unexpected();
+			target.id = null;
+		}
+	}
+
+	/**
+	 * Owned `parseClassSuper`, an exact-semantics copy of acorn 8's.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node class node receiving `superClass`
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parseClassSuper(node) {
+		if (!this._classFastPath) {
+			return base.parseClassSuper.call(this, node);
+		}
+		/** @type {Node & { superClass: Expression | null }} */ (node).superClass =
+			this.eat(tokTypes._extends)
+				? this.parseExprSubscripts(null, false)
+				: null;
+	}
+
+	/**
+	 * Owned `enterClassBody`, an exact-semantics copy of acorn 8's: pushes the
+	 * private-name record `parsePrivateIdent` and `exitClassBody` read.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Record<string, string>} the body's declared-private-names map
+	 * @this {ParserInternals}
+	 */
+	enterClassBody() {
+		if (!this._classFastPath) return base.enterClassBody.call(this);
+		/** @type {PrivateNameStackEntry} */
+		const element = { declared: Object.create(null), used: [] };
+		this.privateNameStack.push(element);
+		return element.declared;
+	}
+
+	/**
+	 * Owned `exitClassBody`, an exact-semantics copy of acorn 8's: private
+	 * names used but not declared bubble to the enclosing class body, or raise
+	 * at the outermost one (only with `options.checkPrivateFields`).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	exitClassBody() {
+		if (!this._classFastPath) return base.exitClassBody.call(this);
+		const entry = /** @type {PrivateNameStackEntry} */ (
+			this.privateNameStack.pop()
+		);
+		const declared = entry.declared;
+		const used = entry.used;
+		if (!this.options.checkPrivateFields) return;
+		const len = this.privateNameStack.length;
+		const parent = len === 0 ? null : this.privateNameStack[len - 1];
+		for (let i = 0; i < used.length; ++i) {
+			const id = used[i];
+			if (!Object.prototype.hasOwnProperty.call(declared, id.name)) {
+				if (parent) {
+					parent.used.push(id);
+				} else {
+					this.raiseRecoverable(
+						id.start,
+						`Private field '#${id.name}' must be declared in an enclosing class`
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Owned `parseMethod`, an exact-semantics copy of acorn 8's with the
+	 * started node replaced by the pre-shaped `FunctionNode` (`initFunction`'s
+	 * writes are its constructor defaults — the fast-path gate pins it) and
+	 * acorn's `functionFlags` inlined. ES9+ probes folded by the gate.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {boolean} isGenerator whether the method is a generator
+	 * @param {boolean=} isAsync whether the method is async
+	 * @param {boolean=} allowDirectSuper whether `super()` is allowed in the body
+	 * @returns {Expression} method function expression
+	 * @this {ParserInternals}
+	 */
+	parseMethod(isGenerator, isAsync, allowDirectSuper) {
+		if (!this._funcFastPath) {
+			return base.parseMethod.call(
+				this,
+				isGenerator,
+				isAsync,
+				allowDirectSuper
+			);
+		}
+		const node =
+			/** @type {Node & { generator: boolean, async: boolean, params: Node[] | null }} */ (
+				/** @type {unknown} */ (new FunctionNode(this.start))
+			);
+		const oldYieldPos = this.yieldPos;
+		const oldAwaitPos = this.awaitPos;
+		const oldAwaitIdentPos = this.awaitIdentPos;
+		node.generator = isGenerator;
+		node.async = Boolean(isAsync);
+		this.yieldPos = 0;
+		this.awaitPos = 0;
+		this.awaitIdentPos = 0;
+		this.enterScope(
+			SCOPE_FUNCTION |
+				(isAsync ? SCOPE_ASYNC : 0) |
+				(node.generator ? SCOPE_GENERATOR : 0) |
+				SCOPE_SUPER |
+				(allowDirectSuper ? SCOPE_DIRECT_SUPER : 0)
+		);
+		this.expect(tokTypes.parenL);
+		// fast-path gate guarantees ES9+, so trailing commas are allowed
+		node.params = this.parseBindingList(tokTypes.parenR, false, true);
+		this.checkYieldAwaitInDefaultParams();
+		this.parseFunctionBody(
+			/** @type {Node} */ (/** @type {unknown} */ (node)),
+			false,
+			true,
+			false
+		);
+		this.yieldPos = oldYieldPos;
+		this.awaitPos = oldAwaitPos;
+		this.awaitIdentPos = oldAwaitIdentPos;
+		return /** @type {Expression} */ (
+			/** @type {unknown} */ (this.finishNode(node, "FunctionExpression"))
+		);
+	}
+
+	/**
+	 * Owned `parsePropertyName`, an exact-semantics copy of acorn 8's ES6+ path
+	 * (the fast-path gate folds the version probe).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} prop node receiving `computed`/`key`
+	 * @returns {Node} the parsed key
+	 * @this {ParserInternals}
+	 */
+	parsePropertyName(prop) {
+		if (!this._subscriptFastPath) {
+			return base.parsePropertyName.call(this, prop);
+		}
+		const target =
+			/** @type {Node & { computed: boolean, key: Node | null }} */ (prop);
+		if (this.eat(tokTypes.bracketL)) {
+			target.computed = true;
+			target.key = /** @type {Node} */ (
+				/** @type {unknown} */ (this.parseMaybeAssign())
+			);
+			this.expect(tokTypes.bracketR);
+			return target.key;
+		}
+		target.computed = false;
+		return (target.key =
+			this.type === tokTypes.num || this.type === tokTypes.string
+				? /** @type {Node} */ (/** @type {unknown} */ (this.parseExprAtom()))
+				: /** @type {Node} */ (
+						/** @type {unknown} */ (
+							this.parseIdent(this.options.allowReserved !== "never")
+						)
+					));
+	}
+
+	/**
+	 * Owned `parsePropertyValue`, an exact-semantics copy of acorn 8's with the
+	 * version probes folded (gate is ES11+) and the shorthand branch's
+	 * `copyNode(prop.key)` replaced by a direct `IdentifierNode` build: on a
+	 * lazy identifier `copyNode` copies exactly `type`/`start`/`end`/`name`
+	 * (symbol slots skip for-in), which is precisely that constructor.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} prop property node being filled
+	 * @param {boolean} isPattern whether parsing a binding pattern
+	 * @param {boolean} isGenerator whether a `*` modifier was seen
+	 * @param {boolean} isAsync whether an `async` modifier was seen
+	 * @param {number | undefined} startPos property start offset (set when a pattern is possible)
+	 * @param {Position | undefined} startLoc property start position
+	 * @param {DestructuringErrorsShim | null | undefined} refDestructuringErrors destructuring errors to fill
+	 * @param {boolean} containsEsc whether the key contained an escape
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parsePropertyValue(
+		prop,
+		isPattern,
+		isGenerator,
+		isAsync,
+		startPos,
+		startLoc,
+		refDestructuringErrors,
+		containsEsc
+	) {
+		if (!this._subscriptFastPath) {
+			return base.parsePropertyValue.call(
+				this,
+				prop,
+				isPattern,
+				isGenerator,
+				isAsync,
+				startPos,
+				startLoc,
+				refDestructuringErrors,
+				containsEsc
+			);
+		}
+		const target =
+			/** @type {Node & { computed: boolean, key: Node, value: Node | null, kind: string, method: boolean, shorthand: boolean }} */ (
+				prop
+			);
+		if ((isGenerator || isAsync) && this.type === tokTypes.colon) {
+			this.unexpected();
+		}
+		// the parsed key's plain name, read once for the get/set and shorthand arms
+		const plainKeyName =
+			!target.computed && target.key.type === "Identifier"
+				? /** @type {Identifier} */ (target.key).name
+				: null;
+		if (this.eat(tokTypes.colon)) {
+			target.value = isPattern
+				? this.parseMaybeDefault(this.start, this.startLoc)
+				: /** @type {Node} */ (
+						/** @type {unknown} */ (
+							this.parseMaybeAssign(false, refDestructuringErrors)
+						)
+					);
+			target.kind = "init";
+		} else if (this.type === tokTypes.parenL) {
+			if (isPattern) this.unexpected();
+			target.method = true;
+			target.value = /** @type {Node} */ (
+				/** @type {unknown} */ (this.parseMethod(isGenerator, isAsync))
+			);
+			target.kind = "init";
+		} else if (
+			!isPattern &&
+			!containsEsc &&
+			(plainKeyName === "get" || plainKeyName === "set") &&
+			this.type !== tokTypes.comma &&
+			this.type !== tokTypes.braceR &&
+			this.type !== tokTypes.eq
+		) {
+			if (isGenerator || isAsync) this.unexpected();
+			this.parseGetterSetter(prop);
+		} else if (plainKeyName !== null) {
+			if (isGenerator || isAsync) this.unexpected();
+			const key = /** @type {Identifier} */ (target.key);
+			this.checkUnreserved(key);
+			if (key.name === "await" && !this.awaitIdentPos) {
+				// acorn assigns startPos raw; it is undefined only where acorn's is
+				this.awaitIdentPos = /** @type {number} */ (startPos);
+			}
+			if (isPattern) {
+				target.value = this.parseMaybeDefault(
+					/** @type {number} */ (startPos),
+					startLoc,
+					/** @type {Node} */ (
+						/** @type {unknown} */ (
+							new IdentifierNode(key.start, key.end, key.name)
+						)
+					)
+				);
+			} else if (this.type === tokTypes.eq && refDestructuringErrors) {
+				if (refDestructuringErrors.shorthandAssign < 0) {
+					refDestructuringErrors.shorthandAssign = this.start;
+				}
+				target.value = this.parseMaybeDefault(
+					/** @type {number} */ (startPos),
+					startLoc,
+					/** @type {Node} */ (
+						/** @type {unknown} */ (
+							new IdentifierNode(key.start, key.end, key.name)
+						)
+					)
+				);
+			} else {
+				target.value = /** @type {Node} */ (
+					/** @type {unknown} */ (
+						new IdentifierNode(key.start, key.end, key.name)
+					)
+				);
+			}
+			target.kind = "init";
+			target.shorthand = true;
+		} else {
+			this.unexpected();
+		}
+	}
+
+	/**
+	 * Owned `isAsyncProp`, an exact-semantics copy of acorn 8's with the ES9
+	 * `star` probe folded and the gap regexp replaced by the memoized
+	 * `_gapHasNewline` (same span, same four terminator chars, no slice).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} prop property whose parsed key might be the `async` modifier
+	 * @returns {boolean} whether the key is an `async` method modifier
+	 * @this {ParserInternals}
+	 */
+	isAsyncProp(prop) {
+		if (!this._subscriptFastPath) {
+			return base.isAsyncProp.call(this, prop);
+		}
+		const target = /** @type {Node & { computed: boolean, key: Node }} */ (
+			prop
+		);
+		return (
+			!target.computed &&
+			target.key.type === "Identifier" &&
+			/** @type {Identifier} */ (target.key).name === "async" &&
+			(this.type === tokTypes.name ||
+				this.type === tokTypes.num ||
+				this.type === tokTypes.string ||
+				this.type === tokTypes.bracketL ||
+				Boolean(this.type.keyword) ||
+				this.type === tokTypes.star) &&
+			!this._gapHasNewline()
+		);
+	}
+
+	/**
+	 * Owned `checkPropClash`, an exact-semantics copy of acorn 8's ES9+ path
+	 * (only `__proto__` can clash) — it touches nothing but `propHash.proto`,
+	 * preserving the pooled-record contract of the owned `parseObj`.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} prop parsed property
+	 * @param {Record<string, unknown>} propHash per-object clash record
+	 * @param {DestructuringErrorsShim | null=} refDestructuringErrors destructuring errors to fill
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	checkPropClash(prop, propHash, refDestructuringErrors) {
+		if (!this._subscriptFastPath) {
+			return base.checkPropClash.call(
+				this,
+				prop,
+				propHash,
+				refDestructuringErrors
+			);
+		}
+		const target =
+			/** @type {Node & { computed?: boolean, method?: boolean, shorthand?: boolean, key?: Node, kind?: string }} */ (
+				prop
+			);
+		if (target.type === "SpreadElement") return;
+		if (target.computed || target.method || target.shorthand) return;
+		const key = /** @type {Node & { name?: string, value?: unknown }} */ (
+			target.key
+		);
+		/** @type {string} */
+		let name;
+		switch (key.type) {
+			case "Identifier":
+				name = /** @type {string} */ (key.name);
+				break;
+			case "Literal":
+				name = String(key.value);
+				break;
+			default:
+				return;
+		}
+		if (name === "__proto__" && target.kind === "init") {
+			if (propHash.proto) {
+				if (refDestructuringErrors) {
+					if (refDestructuringErrors.doubleProto < 0) {
+						refDestructuringErrors.doubleProto = key.start;
+					}
+				} else {
+					this.raiseRecoverable(
+						key.start,
+						"Redefinition of __proto__ property"
+					);
+				}
+			}
+			propHash.proto = true;
+		}
 	}
 
 	/**

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -17,7 +17,7 @@ const tokContexts =
 		(/** @type {unknown} */ (require("acorn"))).tokContexts
 	);
 
-/** @typedef {{ token: string, isExpr: boolean, preserveSpace?: boolean, override?: unknown }} TokContextShim acorn TokContext fields read by the owned tokenizer */
+/** @typedef {{ token: string, isExpr: boolean, preserveSpace?: boolean, generator?: boolean, override?: unknown }} TokContextShim acorn TokContext fields read by the owned tokenizer */
 
 // acorn's token contexts used by the inlined finishToken context updates
 const CTX_B_STAT = /** @type {TokContextShim} */ (tokContexts.b_stat);
@@ -112,6 +112,7 @@ const LEGACY_ASSERT_ATTRIBUTES = Symbol("assert");
 const BIND_NONE = 0;
 const BIND_VAR = 1;
 const BIND_LEXICAL = 2;
+const BIND_SIMPLE_CATCH = 4;
 const BIND_OUTSIDE = 5;
 const SCOPE_TOP = 1;
 const SCOPE_FUNCTION = 2;
@@ -1364,6 +1365,71 @@ class RestSpreadNode {
 const LOOP_LABEL = { kind: "loop" };
 const SWITCH_LABEL = { kind: "switch" };
 
+// Mirror of acorn's module-level `INVALID_TEMPLATE_ESCAPE_ERROR` sentinel,
+// thrown by the owned `invalidStringToken` and caught by the owned
+// `tryReadTemplateToken` (identity-matched, so the pair must stay owned).
+const INVALID_TEMPLATE_ESCAPE_ERROR = {};
+
+/**
+ * Mirror of acorn's `Position` (line/column pair with its `offset` helper),
+ * served by the owned `raise`/`curPosition`.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/locutil.js
+ */
+class ParserPosition {
+	/**
+	 * @param {number} line 1-based line
+	 * @param {number} col 0-based column
+	 */
+	constructor(line, col) {
+		this.line = line;
+		this.column = col;
+	}
+
+	/**
+	 * @param {number} n column offset to add
+	 * @returns {ParserPosition} shifted position
+	 */
+	offset(n) {
+		return new ParserPosition(this.line, this.column + n);
+	}
+}
+
+/**
+ * Mirror of acorn's module-level `nextLineBreak`.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/whitespace.js
+ * @param {string} code source text
+ * @param {number} from scan start offset
+ * @param {number} end scan end offset
+ * @returns {number} offset after the next line break, or -1
+ */
+const nextLineBreak = (code, from, end) => {
+	for (let i = from; i < end; i++) {
+		const next = code.charCodeAt(i);
+		if (isNewLine(next)) {
+			return i < end - 1 && next === 13 && code.charCodeAt(i + 1) === 10
+				? i + 2
+				: i + 1;
+		}
+	}
+	return -1;
+};
+
+/**
+ * Mirror of acorn's module-level `getLineInfo`.
+ * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/locutil.js
+ * @param {string} input source text
+ * @param {number} offset target offset
+ * @returns {ParserPosition} the offset's line/column
+ */
+const getLineInfo = (input, offset) => {
+	for (let line = 1, cur = 0; ;) {
+		const nextBreak = nextLineBreak(input, cur, offset);
+		if (nextBreak < 0) return new ParserPosition(line, offset - cur);
+		++line;
+		cur = nextBreak;
+	}
+};
+
 // Shared zero-length arguments array for `new X` without parens, mirroring
 // acorn's module-level `empty`.
 /** @type {Expression[]} */
@@ -1756,7 +1822,7 @@ class Scope {
  * checkPatternExport: (exports: unknown, pattern: Node) => void,
  * parseBindingListItem: (param: Node) => Node,
  * parseAssignableListItem: (allowModifiers?: boolean) => Node,
- * parseParenItem: (item: Expression | Node) => Expression,
+ * parseParenItem: (item: Node) => Node,
  * shouldParseArrow: (exprList: Expression[]) => boolean,
  * parseParenArrowList: (startPos: number, startLoc: Position | undefined, exprList: Expression[], forInit?: boolean | string) => Expression,
  * finishNodeAt: (node: Node, type: string, pos: number, loc?: Position) => Node,
@@ -1819,6 +1885,14 @@ class Scope {
  * regexpState: unknown,
  * curPosition: () => Position | undefined,
  * initialContext: () => TokContextShim[],
+ * curContext: () => TokContextShim,
+ * tryReadTemplateToken: () => void,
+ * readInvalidTemplateToken: () => void,
+ * inTemplateElement: boolean,
+ * inFunction: boolean,
+ * allowSuper: boolean,
+ * allowDirectSuper: boolean,
+ * allowUsing: boolean,
  * scopeStack: Scope[],
  * _scopePool: Scope[],
  * _setPool: Set<string>[],
@@ -1904,6 +1978,7 @@ class Scope {
  * isSimpleParamList: (params: Node[]) => boolean,
  * checkParams: (node: Node, allowDuplicates: boolean) => void,
  * adaptDirectivePrologue: (statements: Node[]) => void,
+ * isDirectiveCandidate: (statement: Node) => boolean,
  * toAssignableList: (exprList: Node[], isBinding: boolean) => Node[],
  * parseBindingList: (close: TokenType, allowEmpty: boolean, allowTrailingComma: boolean, allowModifiers?: boolean) => Node[],
  * strictDirective: (start: number) => boolean,
@@ -2507,10 +2582,10 @@ class WebpackParser extends BaseParser {
 			self.yieldPos = 0;
 			self.labels = [];
 			self.undefinedExports = Object.create(null);
-			// hashbang at acorn's position; _lazyComments does not exist yet, so
-			// the owned skipLineComment delegates and the comment is rebuilt below
+			// the hashbang skip is deferred below `_lazyComments` (it only moves
+			// `pos`, which nothing before the first token reads), so the owned
+			// skipLineComment records the comment directly instead of via acorn
 			const hashbang = shape.allowHashBang && input.startsWith("#!");
-			if (hashbang) self.skipLineComment(2);
 			self.scopeStack = [];
 			// sourceType is gated to module/script, never commonjs's SCOPE_FUNCTION
 			self.enterScope(SCOPE_TOP);
@@ -2531,10 +2606,7 @@ class WebpackParser extends BaseParser {
 				/** @type {Options & { lazyComments?: CollectedComment[] }} */ (
 					options
 				).lazyComments;
-			// the comment the acorn-position hashbang skip could not record yet
-			if (self._lazyComments !== undefined && hashbang) {
-				self._lazyComments.push(new LazyComment(false, 2, 0, self.pos, input));
-			}
+			if (hashbang) self.skipLineComment(2);
 			self._importPhase = null;
 			self._importPhasesEnabled =
 				/** @type {Options & { importPhases?: boolean }} */ (options)
@@ -2611,7 +2683,7 @@ class WebpackParser extends BaseParser {
 				self.parseSubscript === proto.parseSubscript &&
 				self.parseExprAtom === proto.parseExprAtom &&
 				self.checkExpressionErrors === proto.checkExpressionErrors &&
-				self.isContextual === base.isContextual;
+				self.isContextual === proto.isContextual;
 			self._moduleDeclFastPath = shape.ecmaVersion >= 16;
 			self._classFastPath =
 				shape.ecmaVersion >= 13 &&
@@ -2698,7 +2770,7 @@ class WebpackParser extends BaseParser {
 				this.skipSpace === proto.skipSpace &&
 				this.getTokenFromCode === proto.getTokenFromCode &&
 				this.finishOp === proto.finishOp &&
-				self.readToken === base.readToken &&
+				self.readToken === proto.readToken &&
 				self.updateContext === base.updateContext &&
 				self.readToken_dot === base.readToken_dot &&
 				self.readToken_eq_excl === base.readToken_eq_excl);
@@ -2837,7 +2909,7 @@ class WebpackParser extends BaseParser {
 			this.parseSubscript === proto.parseSubscript &&
 			this.parseExprAtom === proto.parseExprAtom &&
 			this.checkExpressionErrors === proto.checkExpressionErrors &&
-			internals.isContextual === base.isContextual;
+			this.isContextual === proto.isContextual;
 		// the owned import/export declarations bake in ecmaVersion ≥ 16 (import
 		// attributes; with it string export names ≥ 13 and `export * as` ≥ 11)
 		this._moduleDeclFastPath = lazy && this._ecmaVersion >= 16;
@@ -2910,6 +2982,826 @@ class WebpackParser extends BaseParser {
 		return scratch.slice(0, count);
 	}
 
+	// ----- owned acorn utility layer (exact copies; with these the lazy path
+	// no longer executes any acorn code — what remains of the dependency is the
+	// class relationship, the token/context tables and the cold delegations) -----
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {TokenType} type expected token type
+	 * @returns {boolean} whether the token was consumed
+	 * @this {ParserInternals}
+	 */
+	eat(type) {
+		if (this.type === type) {
+			this.next();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {TokenType} type expected token type
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	expect(type) {
+		if (!this.eat(type)) this.unexpected();
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	semicolon() {
+		if (!this.eat(tokTypes.semi) && !this.insertSemicolon()) this.unexpected();
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @returns {boolean | undefined} true when a semicolon was inserted
+	 * @this {ParserInternals}
+	 */
+	insertSemicolon() {
+		if (this.canInsertSemicolon()) {
+			const onInsertedSemicolon =
+				/** @type {Options & { onInsertedSemicolon?: (pos: number, loc?: Position | null) => void }} */ (
+					this.options
+				).onInsertedSemicolon;
+			if (onInsertedSemicolon) {
+				onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+			}
+			return true;
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {string} name contextual keyword
+	 * @returns {boolean} whether the current token is that contextual name
+	 * @this {ParserInternals}
+	 */
+	isContextual(name) {
+		return (
+			this.type === tokTypes.name && this.value === name && !this.containsEsc
+		);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {string} name contextual keyword
+	 * @returns {boolean} whether the token was consumed
+	 * @this {ParserInternals}
+	 */
+	eatContextual(name) {
+		if (!this.isContextual(name)) return false;
+		this.next();
+		return true;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {string} name contextual keyword
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	expectContextual(name) {
+		if (!this.eatContextual(name)) this.unexpected();
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {DestructuringErrorsShim | null | undefined} refDestructuringErrors record to flush
+	 * @param {boolean} isAssign whether flushing for an assignment target
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	checkPatternErrors(refDestructuringErrors, isAssign) {
+		if (!refDestructuringErrors) return;
+		if (refDestructuringErrors.trailingComma > -1) {
+			this.raiseRecoverable(
+				refDestructuringErrors.trailingComma,
+				"Comma is not permitted after the rest element"
+			);
+		}
+		const parens = isAssign
+			? refDestructuringErrors.parenthesizedAssign
+			: refDestructuringErrors.parenthesizedBind;
+		if (parens > -1) {
+			this.raiseRecoverable(
+				parens,
+				isAssign ? "Assigning to rvalue" : "Parenthesized pattern"
+			);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	checkYieldAwaitInDefaultParams() {
+		if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+			this.raise(this.yieldPos, "Yield expression cannot be a default value");
+		}
+		if (this.awaitPos) {
+			this.raise(this.awaitPos, "Await expression cannot be a default value");
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
+	 * @param {Expression} expr checked expression
+	 * @returns {boolean} whether the expression is a simple assignment target
+	 * @this {ParserInternals}
+	 */
+	isSimpleAssignTarget(expr) {
+		if (expr.type === "ParenthesizedExpression") {
+			return this.isSimpleAssignTarget(
+				/** @type {Expression} */ (
+					/** @type {Expression & { expression?: Expression }} */ (expr)
+						.expression
+				)
+			);
+		}
+		return expr.type === "Identifier" || expr.type === "MemberExpression";
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Expression} parenthesized expression
+	 * @this {ParserInternals}
+	 */
+	parseParenExpression() {
+		this.expect(tokTypes.parenL);
+		const val = this.parseExpression();
+		this.expect(tokTypes.parenR);
+		return val;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {boolean=} isFor whether in a `for` head
+	 * @returns {boolean} whether a `using` declaration starts here
+	 * @this {ParserInternals}
+	 */
+	isUsing(isFor) {
+		return this.isUsingKeyword(false, isFor);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {boolean=} isFor whether in a `for` head
+	 * @returns {boolean} whether an `await using` declaration starts here
+	 * @this {ParserInternals}
+	 */
+	isAwaitUsing(isFor) {
+		return this.isUsingKeyword(true, isFor);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {boolean} whether an exported declaration statement follows
+	 * @this {ParserInternals}
+	 */
+	shouldParseExportStatement() {
+		const keyword = this.type.keyword;
+		return (
+			keyword === "var" ||
+			keyword === "const" ||
+			keyword === "class" ||
+			keyword === "function" ||
+			this.isLet() ||
+			this.isAsyncFunction()
+		);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node started export node (unused, matching acorn)
+	 * @returns {Node} exported declaration statement
+	 * @this {ParserInternals}
+	 */
+	parseExportDeclaration(node) {
+		return this.parseStatement(null);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} prop property whose key named the accessor kind
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parseGetterSetter(prop) {
+		const target =
+			/** @type {Node & { key: Node & { name: string }, value: Node & { params: Node[] }, kind: string }} */ (
+				prop
+			);
+		const kind = target.key.name;
+		this.parsePropertyName(prop);
+		target.value = /** @type {Node & { params: Node[] }} */ (
+			/** @type {unknown} */ (this.parseMethod(false))
+		);
+		target.kind = kind;
+		const paramCount = target.kind === "get" ? 0 : 1;
+		if (target.value.params.length !== paramCount) {
+			const start = target.value.start;
+			if (target.kind === "get") {
+				this.raiseRecoverable(start, "getter should have no params");
+			} else {
+				this.raiseRecoverable(start, "setter should have exactly one param");
+			}
+		} else if (
+			target.kind === "set" &&
+			target.value.params[0].type === "RestElement"
+		) {
+			this.raiseRecoverable(
+				target.value.params[0].start,
+				"Setter cannot use rest params"
+			);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} node function node receiving `params`
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	parseFunctionParams(node) {
+		this.expect(tokTypes.parenL);
+		/** @type {Node & { params: Node[] }} */ (node).params =
+			this.parseBindingList(tokTypes.parenR, false, this._ecmaVersion >= 8);
+		this.checkYieldAwaitInDefaultParams();
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @returns {boolean} whether an async arrow follows (consumes the arrow)
+	 * @this {ParserInternals}
+	 */
+	shouldParseAsyncArrow() {
+		return !this.canInsertSemicolon() && this.eat(tokTypes.arrow);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {number} startPos arrow start offset
+	 * @param {Position | undefined} startLoc arrow start position
+	 * @param {Expression[]} exprList parsed parameter expressions
+	 * @param {boolean | string=} forInit for-init context flag
+	 * @returns {Expression} async arrow function expression
+	 * @this {ParserInternals}
+	 */
+	parseSubscriptAsyncArrow(startPos, startLoc, exprList, forInit) {
+		return this.parseArrowExpression(
+			this.startNodeAt(startPos, startLoc),
+			/** @type {Node[]} */ (/** @type {unknown} */ (exprList)),
+			true,
+			forInit
+		);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Expression[]} exprList parsed parameter expressions (unused, matching acorn)
+	 * @returns {boolean} whether an arrow body may follow
+	 * @this {ParserInternals}
+	 */
+	shouldParseArrow(exprList) {
+		return !this.canInsertSemicolon();
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {number} startPos arrow start offset
+	 * @param {Position | undefined} startLoc arrow start position
+	 * @param {Expression[]} exprList parsed parameter expressions
+	 * @param {boolean | string=} forInit for-init context flag
+	 * @returns {Expression} arrow function expression
+	 * @this {ParserInternals}
+	 */
+	parseParenArrowList(startPos, startLoc, exprList, forInit) {
+		return this.parseArrowExpression(
+			this.startNodeAt(startPos, startLoc),
+			/** @type {Node[]} */ (/** @type {unknown} */ (exprList)),
+			false,
+			forInit
+		);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/expression.js
+	 * @param {Node} item parsed paren item
+	 * @returns {Node} the item unchanged
+	 * @this {ParserInternals}
+	 */
+	parseParenItem(item) {
+		return item;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @param {boolean=} allowModifiers unused by acorn's own grammar
+	 * @returns {Node} binding element, possibly with a default
+	 * @this {ParserInternals}
+	 */
+	parseAssignableListItem(allowModifiers) {
+		const element = this.parseMaybeDefault(this.start, this.startLoc);
+		this.parseBindingListItem(element);
+		return element;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/lval.js
+	 * @param {Node} param binding element
+	 * @returns {Node} the element unchanged
+	 * @this {ParserInternals}
+	 */
+	parseBindingListItem(param) {
+		return param;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node[]} statements directive-prologue candidates
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	adaptDirectivePrologue(statements) {
+		for (
+			let i = 0;
+			i < statements.length && this.isDirectiveCandidate(statements[i]);
+			++i
+		) {
+			const statement =
+				/** @type {Node & { directive?: string, expression: Node & { raw: string } }} */ (
+					statements[i]
+				);
+			statement.directive = statement.expression.raw.slice(1, -1);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @param {Node} statement checked statement
+	 * @returns {boolean} whether the statement can be a directive
+	 * @this {ParserInternals}
+	 */
+	isDirectiveCandidate(statement) {
+		const target =
+			/** @type {Node & { expression?: Node & { value?: unknown } }} */ (
+				statement
+			);
+		const quote = this.input.charCodeAt(statement.start);
+		return (
+			this._ecmaVersion >= 5 &&
+			statement.type === "ExpressionStatement" &&
+			/** @type {Node} */ (target.expression).type === "Literal" &&
+			typeof (
+				/** @type {Node & { value?: unknown }} */ (target.expression).value
+			) === "string" &&
+			// reject parenthesized strings
+			(quote === 34 || quote === 39)
+		);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {Node} catch parameter (scope entered as a side effect)
+	 * @this {ParserInternals}
+	 */
+	parseCatchClauseParam() {
+		const param = this.parseBindingAtom();
+		const simple = param.type === "Identifier";
+		this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0);
+		this.checkLValPattern(param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL);
+		this.expect(tokTypes.parenR);
+		return param;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/statement.js
+	 * @returns {boolean} whether a class element name starts at the current token
+	 * @this {ParserInternals}
+	 */
+	isClassElementNameStart() {
+		const type = this.type;
+		return Boolean(
+			type === tokTypes.name ||
+			type === tokTypes.privateId ||
+			type === tokTypes.num ||
+			type === tokTypes.string ||
+			type === tokTypes.bracketL ||
+			type.keyword
+		);
+	}
+
+	/**
+	 * Lazy-mode `finishNodeAt` (explicit end offset); non-lazy delegates.
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/node.js
+	 * @param {Node} node node to finish
+	 * @param {string} type node type
+	 * @param {number} pos end offset
+	 * @param {Position=} loc end position when acorn tracks locations
+	 * @returns {Node} the finished node
+	 * @this {ParserInternals}
+	 */
+	finishNodeAt(node, type, pos, loc) {
+		if (!this._lazy) return base.finishNodeAt.call(this, node, type, pos, loc);
+		node.type = type;
+		node.end = pos;
+		return node;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @param {number} pos code unit offset
+	 * @returns {number} full code point at the offset
+	 * @this {ParserInternals}
+	 */
+	fullCharCodeAt(pos) {
+		const code = this.input.charCodeAt(pos);
+		if (code <= 0xd7ff || code >= 0xdc00) return code;
+		const next = this.input.charCodeAt(pos + 1);
+		return next <= 0xdbff || next >= 0xe000
+			? code
+			: (code << 10) + next - 0x35fdc00;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @returns {number} full code point at the current position
+	 * @this {ParserInternals}
+	 */
+	fullCharCodeAtPos() {
+		return this.fullCharCodeAt(this.pos);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @param {number} code current char code
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	readToken(code) {
+		// identifiers may start with an escape, so '\' dispatches to readWord too
+		if (isIdentifierStart(code, this._ecmaVersion >= 6) || code === 92) {
+			return this.readWord();
+		}
+		return this.getTokenFromCode(code);
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokencontext.js
+	 * @returns {TokContextShim} the current token context
+	 * @this {ParserInternals}
+	 */
+	curContext() {
+		return this.context[this.context.length - 1];
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokencontext.js
+	 * @param {unknown} tokenCtx token context to force
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	overrideContext(tokenCtx) {
+		if (this.curContext() !== tokenCtx) {
+			this.context[this.context.length - 1] = /** @type {TokContextShim} */ (
+				tokenCtx
+			);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokencontext.js
+	 * @returns {boolean} whether the enclosing function context is a generator
+	 * @this {ParserInternals}
+	 */
+	inGeneratorContext() {
+		for (let i = this.context.length - 1; i >= 1; i--) {
+			const context = this.context[i];
+			if (context.token === "function") {
+				return /** @type {boolean} */ (context.generator);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokencontext.js
+	 * @returns {TokContextShim[]} initial token-context stack
+	 * @this {ParserInternals}
+	 */
+	initialContext() {
+		return [CTX_B_STAT];
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
+	 * @returns {Scope} innermost scope
+	 * @this {ParserInternals}
+	 */
+	currentScope() {
+		return this.scopeStack[this.scopeStack.length - 1];
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
+	 * @returns {Scope} innermost var-hoisting scope
+	 * @this {ParserInternals}
+	 */
+	currentVarScope() {
+		for (let i = this.scopeStack.length - 1; ; i--) {
+			const scope = this.scopeStack[i];
+			if (
+				scope.flags &
+				(SCOPE_VAR | SCOPE_CLASS_FIELD_INIT | SCOPE_CLASS_STATIC_BLOCK)
+			) {
+				return scope;
+			}
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
+	 * @returns {Scope} innermost scope that binds `this`
+	 * @this {ParserInternals}
+	 */
+	currentThisScope() {
+		for (let i = this.scopeStack.length - 1; ; i--) {
+			const scope = this.scopeStack[i];
+			if (
+				scope.flags &
+					(SCOPE_VAR | SCOPE_CLASS_FIELD_INIT | SCOPE_CLASS_STATIC_BLOCK) &&
+				!(scope.flags & SCOPE_ARROW)
+			) {
+				return scope;
+			}
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/scope.js
+	 * @param {Scope} scope checked scope
+	 * @returns {boolean | number} whether function declarations bind like vars there
+	 * @this {ParserInternals}
+	 */
+	treatFunctionsAsVarInScope(scope) {
+		return Boolean(
+			scope.flags & SCOPE_FUNCTION ||
+			(!this.inModule && scope.flags & SCOPE_TOP)
+		);
+	}
+
+	/**
+	 * @returns {boolean} whether the current position is inside a function body
+	 * @this {ParserInternals}
+	 */
+	get inFunction() {
+		return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
+	}
+
+	/**
+	 * @returns {boolean} whether the enclosing function is a generator
+	 * @this {ParserInternals}
+	 */
+	get inGenerator() {
+		return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0;
+	}
+
+	/**
+	 * @returns {boolean} whether the enclosing function is async
+	 * @this {ParserInternals}
+	 */
+	get inAsync() {
+		return (this.currentVarScope().flags & SCOPE_ASYNC) > 0;
+	}
+
+	/**
+	 * @returns {boolean} whether `await` is usable at the current position
+	 * @this {ParserInternals}
+	 */
+	get canAwait() {
+		for (let i = this.scopeStack.length - 1; i >= 0; i--) {
+			const flags = this.scopeStack[i].flags;
+			if (flags & (SCOPE_CLASS_STATIC_BLOCK | SCOPE_CLASS_FIELD_INIT)) {
+				return false;
+			}
+			if (flags & SCOPE_FUNCTION) return (flags & SCOPE_ASYNC) > 0;
+		}
+		return (
+			(this.inModule && this._ecmaVersion >= 13) ||
+			this.options.allowAwaitOutsideFunction === true
+		);
+	}
+
+	/**
+	 * @returns {boolean} whether a `return` statement is allowed here
+	 * @this {ParserInternals}
+	 */
+	get allowReturn() {
+		if (this.inFunction) return true;
+		return Boolean(
+			this.options.allowReturnOutsideFunction &&
+			this.currentVarScope().flags & SCOPE_TOP
+		);
+	}
+
+	/**
+	 * @returns {boolean} whether `super.x` is allowed here
+	 * @this {ParserInternals}
+	 */
+	get allowSuper() {
+		return (
+			(this.currentThisScope().flags & SCOPE_SUPER) > 0 ||
+			this.options.allowSuperOutsideMethod === true
+		);
+	}
+
+	/**
+	 * @returns {boolean} whether `super()` is allowed here
+	 * @this {ParserInternals}
+	 */
+	get allowDirectSuper() {
+		return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
+	}
+
+	/**
+	 * @returns {boolean | number} whether function declarations bind like vars here
+	 * @this {ParserInternals}
+	 */
+	get treatFunctionsAsVar() {
+		return this.treatFunctionsAsVarInScope(this.currentScope());
+	}
+
+	/**
+	 * @returns {boolean} whether `new.target` is allowed here
+	 * @this {ParserInternals}
+	 */
+	get allowNewDotTarget() {
+		for (let i = this.scopeStack.length - 1; i >= 0; i--) {
+			const flags = this.scopeStack[i].flags;
+			if (
+				flags & (SCOPE_CLASS_STATIC_BLOCK | SCOPE_CLASS_FIELD_INIT) ||
+				(flags & SCOPE_FUNCTION && !(flags & SCOPE_ARROW))
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @returns {boolean} whether a `using` declaration is allowed here
+	 * @this {ParserInternals}
+	 */
+	get allowUsing() {
+		const flags = this.currentScope().flags;
+		if (flags & SCOPE_SWITCH) return false;
+		if (!this.inModule && flags & SCOPE_TOP) return false;
+		return true;
+	}
+
+	/**
+	 * @returns {boolean} whether the current position is in a static block
+	 * @this {ParserInternals}
+	 */
+	get inClassStaticBlock() {
+		return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK) > 0;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/location.js
+	 * @param {number} pos error offset
+	 * @param {string} message error message
+	 * @returns {never} always throws
+	 * @this {ParserInternals}
+	 */
+	raise(pos, message) {
+		const loc = getLineInfo(this.input, pos);
+		message += ` (${loc.line}:${loc.column})`;
+		if (this.sourceFile) message += ` in ${this.sourceFile}`;
+		const err =
+			/** @type {SyntaxError & { pos: number, loc: ParserPosition, raisedAt: number }} */ (
+				new SyntaxError(message)
+			);
+		err.pos = pos;
+		err.loc = loc;
+		err.raisedAt = this.pos;
+		throw err;
+	}
+
+	/**
+	 * Same body as `raise`, mirroring acorn's aliasing (a plugin overriding one
+	 * must not implicitly change the other).
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/location.js
+	 * @param {number} pos error offset
+	 * @param {string} message error message
+	 * @returns {never} always throws
+	 * @this {ParserInternals}
+	 */
+	raiseRecoverable(pos, message) {
+		const loc = getLineInfo(this.input, pos);
+		message += ` (${loc.line}:${loc.column})`;
+		if (this.sourceFile) message += ` in ${this.sourceFile}`;
+		const err =
+			/** @type {SyntaxError & { pos: number, loc: ParserPosition, raisedAt: number }} */ (
+				new SyntaxError(message)
+			);
+		err.pos = pos;
+		err.loc = loc;
+		err.raisedAt = this.pos;
+		throw err;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/location.js
+	 * @returns {Position | undefined} current position when locations are tracked
+	 * @this {ParserInternals}
+	 */
+	curPosition() {
+		if (this.options.locations) {
+			return /** @type {Position} */ (
+				/** @type {unknown} */ (
+					new ParserPosition(this.curLine, this.pos - this.lineStart)
+				)
+			);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @param {number} position error offset
+	 * @param {string} message error message
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	invalidStringToken(position, message) {
+		if (this.inTemplateElement && this._ecmaVersion >= 9) {
+			throw INVALID_TEMPLATE_ESCAPE_ERROR;
+		} else {
+			this.raise(position, message);
+		}
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	tryReadTemplateToken() {
+		this.inTemplateElement = true;
+		try {
+			this.readTmplToken();
+		} catch (err) {
+			if (err === INVALID_TEMPLATE_ESCAPE_ERROR) {
+				this.readInvalidTemplateToken();
+			} else {
+				throw err;
+			}
+		}
+		this.inTemplateElement = false;
+	}
+
+	/**
+	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/tokenize.js
+	 * @returns {void}
+	 * @this {ParserInternals}
+	 */
+	readInvalidTemplateToken() {
+		const input = this.input;
+		for (; this.pos < input.length; this.pos++) {
+			switch (input[this.pos]) {
+				case "\\":
+					++this.pos;
+					break;
+				case "$":
+					if (input[this.pos + 1] !== "{") break;
+				// falls through
+				case "`":
+					return this.finishToken(
+						tokTypes.invalidTemplate,
+						input.slice(this.start, this.pos)
+					);
+				case "\r":
+					if (input[this.pos + 1] === "\n") ++this.pos;
+				// falls through
+				case "\n":
+				case "\u2028":
+				case "\u2029":
+					++this.curLine;
+					this.lineStart = this.pos + 1;
+					break;
+			}
+		}
+		this.raise(this.start, "Unterminated template");
+	}
+
 	// ----- tokenizer fast paths -----
 
 	/**
@@ -2939,8 +3831,25 @@ class WebpackParser extends BaseParser {
 				);
 			}
 		}
-		if (!this._tokenFastPath || curContext === undefined || slow) {
+		if (!this._tokenFastPath || curContext === undefined) {
 			this._newlineBefore = 2;
+			return base.nextToken.call(this);
+		}
+		if (slow) {
+			this._newlineBefore = 2;
+			// template contexts: acorn's nextToken minus the dead location
+			// bookkeeping — no space skipping, EOF probe, then the context's
+			// own reader (`tryReadTemplateToken`, dispatched virtually)
+			const override = curContext.override;
+			if (override !== undefined && curContext.preserveSpace) {
+				this.start = this.pos;
+				if (this.pos >= this.input.length) {
+					return this.finishToken(tokTypes.eof);
+				}
+				return /** @type {(parser: ParserInternals) => void} */ (override)(
+					this
+				);
+			}
 			return base.nextToken.call(this);
 		}
 		const input = this.input;
@@ -4988,7 +5897,12 @@ class WebpackParser extends BaseParser {
 	 */
 	skipLineComment(startSkip) {
 		const comments = this._lazyComments;
-		if (comments === undefined) {
+		if (
+			comments === undefined &&
+			(this._noLocations !== true ||
+				/** @type {Options & { onComment?: unknown }} */ (this.options)
+					.onComment)
+		) {
 			return base.skipLineComment.call(this, startSkip);
 		}
 		const input = this.input;
@@ -5002,7 +5916,11 @@ class WebpackParser extends BaseParser {
 			pos++;
 		}
 		this.pos = pos;
-		comments.push(new LazyComment(false, start + startSkip, start, pos, input));
+		if (comments !== undefined) {
+			comments.push(
+				new LazyComment(false, start + startSkip, start, pos, input)
+			);
+		}
 	}
 
 	/**
@@ -5014,16 +5932,23 @@ class WebpackParser extends BaseParser {
 	 */
 	skipBlockComment() {
 		const comments = this._lazyComments;
-		if (comments === undefined) {
+		if (
+			comments === undefined &&
+			(this._noLocations !== true ||
+				/** @type {Options & { onComment?: unknown }} */ (this.options)
+					.onComment)
+		) {
 			return base.skipBlockComment.call(this);
 		}
 		const start = this.pos;
 		const end = this.input.indexOf("*/", (this.pos += 2));
 		if (end === -1) this.raise(this.pos - 2, "Unterminated comment");
 		this.pos = end + 2;
-		comments.push(
-			new LazyComment(true, start + 2, start, this.pos, this.input)
-		);
+		if (comments !== undefined) {
+			comments.push(
+				new LazyComment(true, start + 2, start, this.pos, this.input)
+			);
+		}
 	}
 
 	// ----- lazy range -----
@@ -5642,14 +6567,38 @@ class WebpackParser extends BaseParser {
 							return this._parseVarStatementAt(this.start, "let");
 						}
 						// `let` as a plain identifier: expression/label tail below
-					} else if (
-						value === "async" ||
-						value === "using" ||
-						value === "await"
-					) {
-						// async functions and using declarations keep acorn's
-						// lookahead-heavy classification
-						return base.parseStatement.call(this, context, topLevel, exports);
+					} else if (value === "async") {
+						if (!this._funcStmtOwn) {
+							return base.parseStatement.call(this, context, topLevel, exports);
+						}
+						// `async function` statement head, acorn's dispatch with the
+						// started node folded away
+						if (this.isAsyncFunction()) {
+							// a truthy context raises, so the statement bit stands alone
+							if (context) this.unexpected();
+							const start = this.start;
+							this.next();
+							this.next();
+							return this._parseFunctionAt(
+								start,
+								FUNC_STATEMENT,
+								false,
+								true,
+								undefined
+							);
+						}
+						// plain `async` identifier: expression/label tail below
+					} else if (value === "using" || value === "await") {
+						const usingKind = this.isAwaitUsing(false)
+							? "await using"
+							: this.isUsing(false)
+								? "using"
+								: null;
+						if (usingKind !== null) {
+							// using declarations keep acorn's dispatch (rare)
+							return base.parseStatement.call(this, context, topLevel, exports);
+						}
+						// plain identifier or top-level await: expression/label tail below
 					}
 				}
 				// unambiguous expression statement, with acorn's label tail
@@ -7283,7 +8232,9 @@ class WebpackParser extends BaseParser {
 				scratch[count++] = this.parseMaybeAssign(
 					false,
 					refDestructuringErrors,
-					this.parseParenItem
+					/** @type {(this: unknown, left: Expression, startPos: number, startLoc?: Position) => Expression} */ (
+						/** @type {unknown} */ (this.parseParenItem)
+					)
 				);
 			}
 		}
@@ -8215,6 +9166,38 @@ class WebpackParser extends BaseParser {
 		if (type === tokTypes.backQuote) {
 			return /** @type {Expression} */ (
 				/** @type {unknown} */ (this.parseTemplate())
+			);
+		}
+		if (type === tokTypes._class) {
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.parseClass(this.startNode(), false))
+			);
+		}
+		if (type === tokTypes._import && this._ecmaVersion >= 11) {
+			return this.parseExprImport(forNew === true);
+		}
+		if (type === tokTypes._super) {
+			if (!this.allowSuper) {
+				this.raise(this.start, "'super' keyword outside a method");
+			}
+			const node = this.startNode();
+			this.next();
+			if (this.type === tokTypes.parenL && !this.allowDirectSuper) {
+				this.raise(
+					node.start,
+					"super() call outside constructor of a subclass"
+				);
+			}
+			// `super` may only start super[expr], super.name or super(args)
+			if (
+				this.type !== tokTypes.dot &&
+				this.type !== tokTypes.bracketL &&
+				this.type !== tokTypes.parenL
+			) {
+				this.unexpected();
+			}
+			return /** @type {Expression} */ (
+				/** @type {unknown} */ (this.finishNode(node, "Super"))
 			);
 		}
 		if (type === tokTypes.regexp) {

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -11690,6 +11690,7 @@ const collectCjsRequireSpecifiers = (source) => {
 };
 
 module.exports.LEGACY_ASSERT_ATTRIBUTES = LEGACY_ASSERT_ATTRIBUTES;
+module.exports.ParserPosition = ParserPosition;
 module.exports.WebpackParser = WebpackParser;
 module.exports.buildLineStarts = buildLineStarts;
 module.exports.collectCjsRequireSpecifiers = collectCjsRequireSpecifiers;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1365,9 +1365,8 @@ class RestSpreadNode {
 const LOOP_LABEL = { kind: "loop" };
 const SWITCH_LABEL = { kind: "switch" };
 
-// Mirror of acorn's module-level `INVALID_TEMPLATE_ESCAPE_ERROR` sentinel,
-// thrown by the owned `invalidStringToken` and caught by the owned
-// `tryReadTemplateToken` (identity-matched, so the pair must stay owned).
+// Mirror of acorn's `INVALID_TEMPLATE_ESCAPE_ERROR`: thrown by the owned
+// `invalidStringToken`, caught by identity in the owned `tryReadTemplateToken`.
 const INVALID_TEMPLATE_ESCAPE_ERROR = {};
 
 /**
@@ -2582,9 +2581,8 @@ class WebpackParser extends BaseParser {
 			self.yieldPos = 0;
 			self.labels = [];
 			self.undefinedExports = Object.create(null);
-			// the hashbang skip is deferred below `_lazyComments` (it only moves
-			// `pos`, which nothing before the first token reads), so the owned
-			// skipLineComment records the comment directly instead of via acorn
+			// the hashbang skip waits for `_lazyComments` (it only moves `pos`), so
+			// the owned skipLineComment records the comment itself, not via acorn
 			const hashbang = shape.allowHashBang && input.startsWith("#!");
 			self.scopeStack = [];
 			// sourceType is gated to module/script, never commonjs's SCOPE_FUNCTION
@@ -2805,10 +2803,8 @@ class WebpackParser extends BaseParser {
 		/** @type {DestructuringErrorsShim[]} */
 		this._deStack = [];
 		this._deDepth = 0;
-		// LIFO pool for `parseObj`'s prop-clash records: the ES9+ `checkPropClash`
-		// (base's and the owned copy alike) only ever touches `.proto`, so one
-		// record per nesting depth suffices; an overriding subclass gets the
-		// fresh `{}` acorn expects
+		// LIFO pool of `parseObj` prop-clash records: ES9+ `checkPropClash` only
+		// touches `.proto`, so one per depth; a subclass override gets a fresh `{}`
 		this._propHashFastPath =
 			/** @type {ParserInternals} */ (/** @type {unknown} */ (this))
 				.checkPropClash === WebpackParser.prototype.checkPropClash;
@@ -2913,10 +2909,8 @@ class WebpackParser extends BaseParser {
 		// the owned import/export declarations bake in ecmaVersion ≥ 16 (import
 		// attributes; with it string export names ≥ 13 and `export * as` ≥ 11)
 		this._moduleDeclFastPath = lazy && this._ecmaVersion >= 16;
-		// the owned parseClassElement bakes in ES13 semantics (static blocks,
-		// fields) and rebuilds field elements on `PropertyDefinitionNode`, which
-		// would drop fields an overriding name parser adds — such overrides (and
-		// pre-ES13 versions) gate the whole class family back to acorn
+		// the owned parseClassElement bakes in ES13 and rebuilds field nodes, which
+		// would drop what a name-parser override adds: those (and pre-ES13) use acorn
 		this._classFastPath =
 			lazy &&
 			this._ecmaVersion >= 13 &&
@@ -2982,9 +2976,8 @@ class WebpackParser extends BaseParser {
 		return scratch.slice(0, count);
 	}
 
-	// ----- owned acorn utility layer (exact copies; with these the lazy path
-	// no longer executes any acorn code — what remains of the dependency is the
-	// class relationship, the token/context tables and the cold delegations) -----
+	// ----- owned acorn utility layer: exact copies, so the lazy path runs no acorn
+	// code; what remains is the class relationship, tables and cold delegations -----
 
 	/**
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/parseutil.js
@@ -3837,9 +3830,8 @@ class WebpackParser extends BaseParser {
 		}
 		if (slow) {
 			this._newlineBefore = 2;
-			// template contexts: acorn's nextToken minus the dead location
-			// bookkeeping — no space skipping, EOF probe, then the context's
-			// own reader (`tryReadTemplateToken`, dispatched virtually)
+			// template contexts: acorn's nextToken minus its dead location bookkeeping
+			// (no space skipping, EOF probe, then the context's own virtual reader)
 			const override = curContext.override;
 			if (override !== undefined && curContext.preserveSpace) {
 				this.start = this.pos;
@@ -3855,10 +3847,8 @@ class WebpackParser extends BaseParser {
 		const input = this.input;
 		const len = input.length;
 		let pos = this.pos;
-		// line terminators are flagged while skipping (yuku's
-		// `line_terminator_before`), so ASI checks need no gap re-scan. A
-		// delegated path (acorn's html-comment handling) may have consumed part
-		// of the gap before re-entering — start at "unknown" then.
+		// line terminators are flagged while skipping, so ASI needs no gap re-scan;
+		// a delegated path (acorn html comments) may eat part of it, so 2 = unknown
 		/** @type {0 | 1 | 2} */
 		let newline = pos === this.lastTokEnd ? 0 : 2;
 		// one CHAR_CLASS load classifies each char for both the skip loop and
@@ -4023,8 +4013,7 @@ class WebpackParser extends BaseParser {
 		this.value = value;
 		const internal = /** @type {TokenTypeInternal} */ (type);
 		// acorn's updateContext, inlined: keyword-after-dot forbids an expression,
-		// else the token type's own context hook runs, else `exprAllowed` follows
-		// the type's `beforeExpr` (the branch that makes `/` after a value divide)
+		// else the type's context hook, else `beforeExpr` (`/` after a value divides)
 		if (type === tokTypes.name) {
 			// name.updateContext, inlined for the commonest token: only `of` /
 			// `yield` (outside a `.` access, ES6+) can re-allow an expression
@@ -4036,8 +4025,7 @@ class WebpackParser extends BaseParser {
 		} else {
 			const update = internal.updateContext;
 			if (update === null) {
-				// no context hook (most punctuation, operators, literals and
-				// keywords): acorn's keyword-after-dot probe, else `beforeExpr` —
+				// no context hook (most tokens): keyword-after-dot, else `beforeExpr`;
 				// checked first so this majority skips the per-type compares below
 				this.exprAllowed =
 					prevType === tokTypes.dot && internal.keyword !== undefined
@@ -4325,9 +4313,8 @@ class WebpackParser extends BaseParser {
 			const ch = input.charCodeAt(i);
 			// LF, CR, LS, PS — acorn's `lineBreak` alternation
 			if (ch === 10 || ch === 13 || ch === 0x2028 || ch === 0x2029) {
-				// memoize: the gap is fixed until the next token is read, and
-				// `nextToken` rewrites the flag — ASI probes often repeat per token
-				// (e.g. name atoms behind a /*#__PURE__*/ comment)
+				// memoize: the gap is fixed until `nextToken` rewrites the flag, and
+				// ASI probes repeat per token (e.g. names behind a /*#__PURE__*/ comment)
 				this._newlineBefore = 1;
 				return true;
 			}
@@ -8498,10 +8485,8 @@ class WebpackParser extends BaseParser {
 			};
 		} else {
 			const cooked = /** @type {string} */ (this.value);
-			// Every escape cooks strictly shorter and CRLF shortens, while a lone CR
-			// cooks to the LF the raw normalization would produce — so an
-			// equal-length cooked string IS the normalized raw. That covers every
-			// fast-path chunk (no backslash, no CR): raw and cooked share one string.
+			// every escape and CRLF cook shorter and a lone CR cooks to the LF raw
+			// normalization yields: an equal-length cooked string IS the normalized raw
 			value = {
 				raw:
 					cooked.length === this.end - this.start
@@ -9236,10 +9221,8 @@ class WebpackParser extends BaseParser {
 		}
 		const start = this.start;
 		let first = true;
-		// acorn's ES6+ `checkPropClash` only ever reads/writes `.proto`, so the
-		// record is pooled by nesting depth (like `_deStack`); a subclass override
-		// might write arbitrary keys and gets a fresh `{}` instead. Depth resets
-		// implicitly since a raise aborts the whole parse.
+		// `checkPropClash` only touches `.proto`, so records pool by depth like
+		// `_deStack` (a raise aborts the parse: no unwind); overrides get a fresh `{}`
 		const pooled = this._propHashFastPath;
 		/** @type {Record<string, unknown>} */
 		let propHash;

--- a/lib/util/registerExternalSerializer.js
+++ b/lib/util/registerExternalSerializer.js
@@ -17,6 +17,7 @@ const {
 	ReplaceSource,
 	SourceMapSource
 } = require("webpack-sources");
+const ParserPosition = require("../javascript/syntax").ParserPosition;
 const { register } = require("./serialization");
 
 /** @import { RealDependencyLocation, SourcePosition } from "../Dependency" */
@@ -274,6 +275,36 @@ register(
 		/**
 		 * Serializes this instance into the provided serializer context.
 		 * @param {Position} pos the position to be serialized
+		 * @param {import("../serialization/ObjectMiddleware").ObjectSerializerContext<number[]>} context context
+		 * @returns {void}
+		 */
+		serialize(pos, { write }) {
+			write(pos.line);
+			write(pos.column);
+		}
+
+		/**
+		 * Restores this instance from the provided deserializer context.
+		 * @param {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<number[]>} context context
+		 * @returns {SourcePosition} position
+		 */
+		deserialize({ read }) {
+			return {
+				line: read(),
+				column: read()
+			};
+		}
+	})()
+);
+
+register(
+	ParserPosition,
+	CURRENT_MODULE,
+	"webpack/ParserPosition",
+	new (class ParserPositionSerializer {
+		/**
+		 * Serializes this instance into the provided serializer context.
+		 * @param {ParserPosition} pos the position to be serialized
 		 * @param {import("../serialization/ObjectMiddleware").ObjectSerializerContext<number[]>} context context
 		 * @returns {void}
 		 */

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -833,6 +833,43 @@ describe("JavascriptParser", () => {
 		});
 	});
 
+	describe("inBlockScope", () => {
+		it("should isolate definitions and propagate termination only on executed paths", () => {
+			const parser = new JavascriptParser();
+			expect.assertions(8);
+
+			parser.hooks.program.tap("JavascriptParserTest", () => {
+				const outerScope = parser.scope;
+				outerScope.inShorthand = true;
+				parser.inBlockScope(() => {
+					expect(parser.scope).not.toBe(outerScope);
+					expect(parser.scope.inShorthand).toBe(false);
+					parser.defineVariable("inner");
+					expect(parser.scope.definitions.has("inner")).toBe(true);
+					parser.scope.terminated = 1;
+				});
+				expect(parser.scope).toBe(outerScope);
+				expect(outerScope.definitions.has("inner")).toBe(false);
+				expect(outerScope.terminated).toBeUndefined();
+
+				parser.inBlockScope(() => {
+					parser.scope.terminated = 2;
+				}, true);
+				expect(parser.scope).toBe(outerScope);
+				expect(outerScope.terminated).toBe(2);
+				outerScope.inShorthand = false;
+				outerScope.terminated = undefined;
+			});
+
+			parser.parse(
+				"",
+				/** @type {import("../lib/Parser").ParserState} */ (
+					/** @type {unknown} */ ({})
+				)
+			);
+		});
+	});
+
 	describe("parse calculated string", () => {
 		describe("should work", () => {
 			const cases = {

--- a/test/StackedMap.unittest.js
+++ b/test/StackedMap.unittest.js
@@ -157,4 +157,128 @@ describe("StackedMap", () => {
 		parent.set("late", 42);
 		expect(child.get("late")).toBe(42);
 	});
+
+	describe("stale views (parent used again while child references live on)", () => {
+		it("should keep answering own and inherited keys from a stale child", () => {
+			const root = new StackedMap();
+			root.set("r", 9);
+			const a = root.createChild();
+			a.set("k", 1);
+			// switching back to the root abandons `a`
+			root.set("r2", 10);
+			expect(a.get("k")).toBe(1);
+			expect(a.get("r")).toBe(9);
+			expect(a.has("k")).toBe(true);
+			expect(root.get("k")).toBeUndefined();
+		});
+
+		it("should expose later live-chain writes to stale views", () => {
+			const root = new StackedMap();
+			const a = root.createChild();
+			a.set("k", 1);
+			root.set("late", 42);
+			expect(a.get("late")).toBe(42);
+			expect(a.has("late")).toBe(true);
+		});
+
+		it("should keep sibling branch writes invisible to stale views", () => {
+			const root = new StackedMap();
+			root.set("r", 9);
+			const a = root.createChild();
+			a.set("k", 1);
+			const b = a.createChild();
+			b.set("k", 2);
+			// creating a sibling of `b` abandons it
+			const d = a.createChild();
+			d.set("r", 7);
+			d.set("k", 3);
+			expect(b.get("k")).toBe(2);
+			expect(b.get("r")).toBe(9);
+			expect(b.has("r")).toBe(true);
+			expect(d.get("r")).toBe(7);
+			// returning to `a` abandons `d` too; both stale views stay intact
+			expect(a.get("r")).toBe(9);
+			expect(a.get("k")).toBe(1);
+			expect(d.get("r")).toBe(7);
+			expect(d.get("k")).toBe(3);
+			expect(b.get("k")).toBe(2);
+		});
+
+		it("should answer through a deep stale chain", () => {
+			const root = new StackedMap();
+			root.set("x", "root");
+			const a = root.createChild();
+			a.set("a", 1);
+			const b = a.createChild();
+			b.set("b", 2);
+			const c = b.createChild();
+			c.set("c", 3);
+			c.delete("x");
+			root.set("y", "afterwards");
+			expect(c.get("c")).toBe(3);
+			expect(c.get("b")).toBe(2);
+			expect(c.get("a")).toBe(1);
+			expect(c.get("x")).toBeUndefined();
+			expect(c.has("x")).toBe(false);
+			expect(c.get("y")).toBe("afterwards");
+			expect(b.get("x")).toBe("root");
+			expect(b.get("c")).toBeUndefined();
+		});
+
+		it("should accept writes and deletes on stale views", () => {
+			const root = new StackedMap();
+			root.set("r", 9);
+			const a = root.createChild();
+			a.set("k", 1);
+			root.set("r2", 10);
+			a.set("z", 5);
+			a.delete("r");
+			expect(a.get("z")).toBe(5);
+			expect(a.get("r")).toBeUndefined();
+			expect(a.has("r")).toBe(false);
+			expect(a.get("k")).toBe(1);
+			expect(root.get("r")).toBe(9);
+			expect(root.get("z")).toBeUndefined();
+		});
+
+		it("should preserve explicit undefined in stale views", () => {
+			const root = new StackedMap();
+			const a = root.createChild();
+			a.set("u", undefined);
+			root.set("other", 1);
+			expect(a.get("u")).toBeUndefined();
+			expect(a.has("u")).toBe(true);
+		});
+
+		it("should enumerate stale views", () => {
+			const root = new StackedMap();
+			root.set("r", 9);
+			const a = root.createChild();
+			a.set("k", 1);
+			a.delete("r");
+			const b = root.createChild();
+			b.set("other", 2);
+			expect(a.asArray().sort()).toEqual(["k"]);
+			expect(a.asPairArray().sort((x, y) => (x[0] < y[0] ? -1 : 1))).toEqual([
+				["k", 1]
+			]);
+			expect(a.size).toBe(1);
+			expect(b.asArray().sort()).toEqual(["other", "r"]);
+		});
+
+		it("should support children of stale views", () => {
+			const root = new StackedMap();
+			root.set("r", 9);
+			const a = root.createChild();
+			a.set("k", 1);
+			root.set("r2", 10);
+			const child = a.createChild();
+			expect(child.get("k")).toBe(1);
+			expect(child.get("r")).toBe(9);
+			child.set("k", 2);
+			expect(child.get("k")).toBe(2);
+			expect(a.get("k")).toBe(1);
+			expect(child.asArray().sort()).toEqual(["k", "r", "r2"]);
+		});
+	});
 });

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2103,6 +2103,85 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 		);
 	});
 
+	it("executes no acorn prototype code on the lazy path", () => {
+		// tripwire for the acorn-free direction: every method and accessor on
+		// acorn's prototype is counted while a feature-rich module parses lazily
+		const acorn = require("acorn");
+
+		const source = [
+			"#!/usr/bin/env node",
+			"import def, { a as b } from 'm'; import * as ns from 'n';",
+			"export const answer = 42; export default class Widget extends ns.Base {",
+			"\tstatic #count = 0; #label; static { Widget.#count = 0; }",
+			// eslint-disable-next-line no-template-curly-in-string
+			"\tconstructor() { super(); this.#label = `w${Widget.#count++}`; }",
+			"\tget label() { return this.#label; } async *walk([x = 1, ...rest] = []) {",
+			"\t\tlab: for (const item of rest) { if (item ?? x) { yield (await item) ** 2; continue lab; } }",
+			"\t}",
+			"}",
+			"export { answer as 'the answer' } ;",
+			"async function main() { const res = await ns.open?.(); do main(res); while (false); }",
+			"let { p, q: [r = /re?g/gu] = [] } = ns, s = 0b101 + 1_000n;",
+			"debugger;",
+			"await ns.ready;"
+		].join("\n");
+		const options = /** @type {import("acorn").Options} */ (
+			/** @type {unknown} */ ({
+				ecmaVersion: "latest",
+				sourceType: "module",
+				lazyNodes: true,
+				lazyComments: [],
+				allowHashBang: true,
+				allowReturnOutsideFunction: false
+			})
+		);
+		// warm the construction-shape cache before instrumenting
+		WebpackParser.parse(source, options);
+		const proto = /** @type {EXPECTED_ANY} */ (acorn.Parser.prototype);
+		/** @type {string[]} */
+		const hits = [];
+		/** @type {[string, PropertyDescriptor][]} */
+		const originals = [];
+		for (const name of Object.getOwnPropertyNames(proto)) {
+			if (name === "constructor") continue;
+			const descriptor =
+				/** @type {PropertyDescriptor} */
+				(Object.getOwnPropertyDescriptor(proto, name));
+			originals.push([name, descriptor]);
+			if (typeof descriptor.value === "function") {
+				const original = descriptor.value;
+				Object.defineProperty(proto, name, {
+					...descriptor,
+					/**
+					 * @param {...EXPECTED_ANY} args original arguments
+					 * @returns {EXPECTED_ANY} original result
+					 */
+					value(...args) {
+						hits.push(name);
+						return original.apply(this, args);
+					}
+				});
+			} else if (descriptor.get) {
+				const original = descriptor.get;
+				Object.defineProperty(proto, name, {
+					...descriptor,
+					get() {
+						hits.push(`get ${name}`);
+						return original.call(this);
+					}
+				});
+			}
+		}
+		try {
+			WebpackParser.parse(source, options);
+		} finally {
+			for (const [name, descriptor] of originals) {
+				Object.defineProperty(proto, name, descriptor);
+			}
+		}
+		expect(hits).toEqual([]);
+	});
+
 	it("builds fast- and slow-constructed parsers with one field layout", () => {
 		// tripwire for acorn upgrades: the fast construction path replicates
 		// acorn's constructor, so its own-key order and its normalized options

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2103,9 +2103,86 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 		);
 	});
 
+	it("builds fast- and slow-constructed parsers with one field layout", () => {
+		// tripwire for acorn upgrades: the fast construction path replicates
+		// acorn's constructor, so its own-key order and its normalized options
+		// keys must match a super()-built instance and acorn's defaultOptions
+		const acorn = require("acorn");
+
+		const fast = /** @type {EXPECTED_ANY} */ (
+			new WebpackParser(lazyOptions, "let x = 1;")
+		);
+		const slowOptions = /** @type {import("acorn").Options} */ (
+			/** @type {unknown} */ (
+				// present-but-undefined checkPrivateFields fails the fast gate
+				{
+					.../** @type {EXPECTED_ANY} */ (lazyOptions),
+					checkPrivateFields: undefined
+				}
+			)
+		);
+		const slow = /** @type {EXPECTED_ANY} */ (
+			new WebpackParser(slowOptions, "let x = 1;")
+		);
+		expect(Object.keys(fast)).toEqual(Object.keys(slow));
+		expect(Object.keys(fast.options)).toEqual(
+			Object.keys(acorn.defaultOptions)
+		);
+		expect(JSON.stringify(WebpackParser.parse("let x = 1;", lazyOptions))).toBe(
+			JSON.stringify(WebpackParser.parse("let x = 1;", slowOptions))
+		);
+	});
+
+	it("keeps the class fast path off for plugins overriding element names", () => {
+		let calls = 0;
+		class Plugin extends WebpackParser {
+			/**
+			 * @param {import("acorn").Node} element class element node
+			 * @returns {void}
+			 */
+			parseClassElementName(element) {
+				calls++;
+				return super.parseClassElementName(element);
+			}
+		}
+		const code =
+			"class A extends B { constructor() { super(); } static #p = 1; get g() { return A.#p; } static {} }";
+		const ast = Plugin.parse(code, lazyOptions);
+		expect(calls).toBeGreaterThan(0);
+		expect(JSON.stringify(ast)).toBe(
+			JSON.stringify(WebpackParser.parse(code, lazyOptions))
+		);
+	});
+
+	it("keeps dynamic dispatch working through the owned module declarations", () => {
+		let calls = 0;
+		class Plugin extends WebpackParser {
+			/**
+			 * @returns {import("acorn").Node} import specifier
+			 */
+			parseImportSpecifier() {
+				calls++;
+				return super.parseImportSpecifier();
+			}
+		}
+		const moduleOptions = /** @type {import("acorn").Options} */ (
+			/** @type {unknown} */ ({
+				ecmaVersion: "latest",
+				sourceType: "module",
+				lazyNodes: true
+			})
+		);
+		const code = "import { a, b as c } from 'm'; export { c as d };";
+		const ast = /** @type {EXPECTED_ANY} */ (Plugin.parse(code, moduleOptions));
+		expect(calls).toBe(2);
+		expect(JSON.stringify(ast)).toBe(
+			JSON.stringify(WebpackParser.parse(code, moduleOptions))
+		);
+	});
+
 	describe("releaseParserCaches", () => {
 		const {
-			WebpackParser,
+			WebpackParser: CacheParser,
 			releaseParserCaches
 		} = require("../lib/javascript/syntax");
 
@@ -2122,9 +2199,9 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			"const value = 123; export function repeatedName(repeatedParameter) { return repeatedParameter + value + 0.5; }";
 
 		it("parses identically after the caches are released", () => {
-			const before = JSON.stringify(WebpackParser.parse(code, options));
+			const before = JSON.stringify(CacheParser.parse(code, options));
 			releaseParserCaches();
-			const after = JSON.stringify(WebpackParser.parse(code, options));
+			const after = JSON.stringify(CacheParser.parse(code, options));
 			expect(after).toBe(before);
 		});
 
@@ -2158,7 +2235,7 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			releaseParserCaches();
 			releaseParserCaches();
 			let count = 0;
-			for (const token of WebpackParser.tokenizer(code, {
+			for (const token of CacheParser.tokenizer(code, {
 				ecmaVersion: "latest",
 				sourceType: "module"
 			})) {

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2183,9 +2183,8 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 	});
 
 	it("builds fast- and slow-constructed parsers with one field layout", () => {
-		// tripwire for acorn upgrades: the fast construction path replicates
-		// acorn's constructor, so its own-key order and its normalized options
-		// keys must match a super()-built instance and acorn's defaultOptions
+		// tripwire for acorn upgrades: the fast construction path replicates acorn's
+		// constructor, so its key order and option keys must match a super()-built one
 		const acorn = require("acorn");
 
 		const fast = /** @type {EXPECTED_ANY} */ (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Second PR of the stack (depends on #21666; review shows only its own 3 commits). Owns class-body/method/property parsing and the remaining acorn utility layer (contextual checks, scope walkers, error raising, template machinery), so webpack's lazy parse path executes zero acorn prototype code — an instrumentation census over the corpus went from 5.26M acorn prototype calls to 0, guarded by a tripwire test. Also registers a persistent-cache serializer for the parser's own `ParserPosition` so modules carrying a `ModuleParseError` stay serializable (mirrors the existing acorn `Position` serializer).

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — extended `test/WebpackParser.unittest.js` (acorn-prototype tripwire, class-family plugin gates) and `test/JavascriptParser.unittest.js`; the serializer fix is covered by the `ConfigCacheTestCases` `parsing/context` case.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was developed with Claude (AI assistant) under human direction: it performed the analysis, implementation, differential verification against acorn, and measurements; the requester reviewed and directed the work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo1cHj5Asx24LuVcz2CqT6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved JavaScript parsing efficiency by reducing overhead and memory allocations during common parsing operations.
  * Added faster parsing paths for supported JavaScript modules.

* **Bug Fixes**
  * Improved serialization and restoration of parse-error locations.
  * Preserved parser behavior when cached state is released.
  * Ensured stale map views correctly handle inherited values, updates, writes, deletes, and enumeration.

* **Tests**
  * Expanded coverage for parsing performance, dynamic dispatch, cache handling, scope behavior, and stale map views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->