### PR TITLE
feat(esm): bake templated public paths and hashed wasm names into analyzable output

### DIFF
--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output to HMR, and to names built from hashes or functions.
+Widen analyzable ESM output to HMR, hashed and function chunk names, and wasm.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output to HMR, and to hashed chunk, function and wasm names.
+Widen analyzable ESM output to HMR, and to names built from hashes or functions.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Widen analyzable ESM output to HMR, hashed and function chunk names, and wasm.
+Widen analyzable ESM output to HMR, and to hashed chunk, function and wasm names.

--- a/.changeset/022-analyzable-public-path-and-wasm-names.md
+++ b/.changeset/022-analyzable-public-path-and-wasm-names.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Bake templated public paths and hashed wasm names into analyzable output.

--- a/.changeset/022-analyzable-public-path-and-wasm-names.md
+++ b/.changeset/022-analyzable-public-path-and-wasm-names.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake templated public paths and hashed wasm names into analyzable output.
+Bake templated public paths, hashed wasm names and concatenated origins into analyzable output.

--- a/.changeset/022-wasm-full-hash-digest-filename.md
+++ b/.changeset/022-wasm-full-hash-digest-filename.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Fix a wasm binary name built from a re-encoded `[fullhash:<digest>]`.

--- a/.changeset/022-wasm-full-hash-digest-filename.md
+++ b/.changeset/022-wasm-full-hash-digest-filename.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix a wasm binary name built from a re-encoded `[fullhash:<digest>]`.

--- a/.changeset/023-analyzable-substitution-source-maps.md
+++ b/.changeset/023-analyzable-substitution-source-maps.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep source maps aligned when an analyzable specifier is filled in.

--- a/.changeset/023-analyzable-substitution-source-maps.md
+++ b/.changeset/023-analyzable-substitution-source-maps.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Keep source maps aligned when an analyzable specifier is filled in.

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -26,28 +26,92 @@ const {
 } = require("./javascript/JavascriptParserHelpers");
 const ChunkNameRuntimeModule = require("./runtime/ChunkNameRuntimeModule");
 const GetFullHashRuntimeModule = require("./runtime/GetFullHashRuntimeModule");
+const { forEachRuntime } = require("./util/runtime");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
 /** @typedef {import("./Module").BuildInfo} BuildInfo */
 /** @typedef {import("./javascript/JavascriptModule").JavascriptModuleBuildInfo} JavascriptModuleBuildInfo */
 /** @typedef {import("./Compilation")} Compilation */
+/** @typedef {import("./ChunkGraph")} ChunkGraph */
+/** @typedef {import("./Module")} Module */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("./javascript/JavascriptParser").Range} Range */
 
-// Compilations where a module reassigns `__webpack_public_path__` at runtime.
-// A baked analyzable specifier can't reflect that, so those forms fall back.
-// Also recorded per module in `buildInfo`, because a module restored from the
-// persistent cache is never re-parsed and would otherwise lose the flag.
-/** @type {WeakSet<Compilation>} */
-const runtimePublicPathOverride = new WeakSet();
+// Modules that reassign `__webpack_public_path__` at runtime, by compilation. A baked
+// analyzable specifier can't reflect that, so those forms fall back. Also recorded per
+// module in `buildInfo`, because a module restored from the persistent cache is never
+// re-parsed and would otherwise lose the flag.
+/** @type {WeakMap<Compilation, Set<Module>>} */
+const runtimePublicPathOverride = new WeakMap();
 
 /**
  * @param {Compilation} compilation compilation
- * @returns {boolean} true when a module reassigns `__webpack_public_path__` at runtime
+ * @param {Module} module the module doing the reassigning
+ * @returns {void}
+ */
+const addRuntimePublicPathOverride = (compilation, module) => {
+	const modules = runtimePublicPathOverride.get(compilation);
+	if (modules === undefined) {
+		runtimePublicPathOverride.set(compilation, new Set([module]));
+	} else {
+		modules.add(module);
+	}
+};
+
+/**
+ * @param {Compilation} compilation compilation
+ * @returns {boolean} true when any module reassigns `__webpack_public_path__` at runtime
  */
 const usesRuntimePublicPathOverride = (compilation) =>
 	runtimePublicPathOverride.has(compilation);
+
+// `__webpack_require__.p` belongs to a runtime, so a reassignment only reaches the
+// runtimes the reassigning module is instantiated in. Computed once the chunk graph
+// can answer that, which is any time code is being generated.
+/** @type {WeakMap<Compilation, Set<string>>} */
+const overriddenRuntimes = new WeakMap();
+
+/**
+ * Whether the public path is reassigned in any runtime `module` belongs to. Falls back
+ * to the whole compilation when there is no chunk graph to place the module in.
+ * @param {Compilation} compilation compilation
+ * @param {ChunkGraph=} chunkGraph the chunk graph
+ * @param {Module=} module the module a reference is emitted into
+ * @returns {boolean} true when a reassignment can reach this module's runtimes
+ */
+const runtimeUsesPublicPathOverride = (compilation, chunkGraph, module) => {
+	const modules = runtimePublicPathOverride.get(compilation);
+	if (modules === undefined) return false;
+	if (chunkGraph === undefined || module === undefined) return true;
+	let runtimes = overriddenRuntimes.get(compilation);
+	if (runtimes === undefined) {
+		/** @type {Set<string>} */
+		const collected = new Set();
+		for (const overriding of modules) {
+			for (const runtime of chunkGraph.getModuleRuntimes(overriding)) {
+				forEachRuntime(runtime, (key) => {
+					collected.add(/** @type {string} */ (key));
+				});
+			}
+		}
+		runtimes = collected;
+		overriddenRuntimes.set(compilation, collected);
+	}
+	const overridden = runtimes;
+	if (overridden.size === 0) return false;
+	/** @type {Set<string>} */
+	const own = new Set();
+	for (const runtime of chunkGraph.getModuleRuntimes(module)) {
+		forEachRuntime(runtime, (key) => {
+			own.add(/** @type {string} */ (key));
+		});
+	}
+	for (const key of own) {
+		if (overridden.has(key)) return true;
+	}
+	return false;
+};
 
 /**
  * Returns the replacement definitions used for webpack API identifiers.
@@ -187,7 +251,7 @@ class APIPlugin {
 						/** @type {JavascriptModuleBuildInfo | undefined} */
 						(module.buildInfo);
 					if (buildInfo && buildInfo.usingPublicPathOverride) {
-						runtimePublicPathOverride.add(compilation);
+						addRuntimePublicPathOverride(compilation, module);
 					}
 				});
 
@@ -312,7 +376,7 @@ class APIPlugin {
 							parser.hooks.assign.for(key).tap(PLUGIN_NAME, () => {
 								/** @type {JavascriptModuleBuildInfo} */
 								(parser.state.module.buildInfo).usingPublicPathOverride = true;
-								runtimePublicPathOverride.add(compilation);
+								addRuntimePublicPathOverride(compilation, parser.state.module);
 							});
 						}
 						if (info.type) {
@@ -434,4 +498,5 @@ class APIPlugin {
 }
 
 module.exports = APIPlugin;
+module.exports.runtimeUsesPublicPathOverride = runtimeUsesPublicPathOverride;
 module.exports.usesRuntimePublicPathOverride = usesRuntimePublicPathOverride;

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -26,7 +26,12 @@ const {
 } = require("./javascript/JavascriptParserHelpers");
 const ChunkNameRuntimeModule = require("./runtime/ChunkNameRuntimeModule");
 const GetFullHashRuntimeModule = require("./runtime/GetFullHashRuntimeModule");
+const memoize = require("./util/memoize");
 const { forEachRuntime } = require("./util/runtime");
+
+const getConcatenatedModule = memoize(() =>
+	require("./optimize/ConcatenatedModule")
+);
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
@@ -88,8 +93,13 @@ const runtimeUsesPublicPathOverride = (compilation, chunkGraph, module) => {
 	if (runtimes === undefined) {
 		/** @type {Set<string>} */
 		const collected = new Set();
+		const ConcatenatedModule = getConcatenatedModule();
 		for (const overriding of modules) {
-			for (const runtime of chunkGraph.getModuleRuntimes(overriding)) {
+			// Concatenation may have absorbed the reassigning module, and the chunk graph
+			// places only the `ConcatenatedModule` that replaced it.
+			for (const runtime of chunkGraph.getModuleRuntimes(
+				ConcatenatedModule.getChunkGraphModule(compilation, overriding)
+			)) {
 				forEachRuntime(runtime, (key) => {
 					collected.add(/** @type {string} */ (key));
 				});

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -6,7 +6,10 @@
 "use strict";
 
 const RuntimeGlobals = require("./RuntimeGlobals");
-const { getPresentKinds } = require("./TemplatedPathPlugin");
+const {
+	getPresentKinds,
+	usesFullHashDigest
+} = require("./TemplatedPathPlugin");
 const CssModulesPlugin = require("./css/CssModulesPlugin");
 const RuntimeRequirementsDependency = require("./dependencies/RuntimeRequirementsDependency");
 const JavascriptModulesPlugin = require("./javascript/JavascriptModulesPlugin");
@@ -236,18 +239,6 @@ const usesFullHash = (template) => {
 	return kinds.has("fullhash") || kinds.has("hash");
 };
 
-// `[fullhash:<digest>]`/`[hash:<digest>]` — a non-numeric first arg is a digest (a
-// numeric one is just a length). The re-encoded full hash must be inlined post-hash
-// rather than read from the runtime `getFullHash()` expression.
-const FULLHASH_DIGEST_REGEXP = /\[(?:fullhash|hash):(?!\d+\])\w/;
-
-/**
- * @param {string} template path template
- * @returns {boolean} true when it references `[fullhash:<digest>]`/`[hash:<digest>]`
- */
-const usesFullHashWithDigest = (template) =>
-	FULLHASH_DIGEST_REGEXP.test(template);
-
 const PLUGIN_NAME = "RuntimePlugin";
 
 class RuntimePlugin {
@@ -443,7 +434,7 @@ class RuntimePlugin {
 					const hmr = set.has(RuntimeGlobals.hmrDownloadUpdateHandlers);
 					const fullHashDigest =
 						typeof compilation.outputOptions.chunkFilename === "string" &&
-						usesFullHashWithDigest(compilation.outputOptions.chunkFilename);
+						usesFullHashDigest(compilation.outputOptions.chunkFilename);
 					compilation.addLazyRuntimeModule(
 						chunk,
 						getGetChunkFilenameRuntimeModule,
@@ -487,7 +478,7 @@ class RuntimePlugin {
 					const hmr = set.has(RuntimeGlobals.hmrDownloadUpdateHandlers);
 					const fullHashDigest =
 						typeof compilation.outputOptions.cssChunkFilename === "string" &&
-						usesFullHashWithDigest(compilation.outputOptions.cssChunkFilename);
+						usesFullHashDigest(compilation.outputOptions.cssChunkFilename);
 					compilation.addLazyRuntimeModule(
 						chunk,
 						getGetChunkFilenameRuntimeModule,
@@ -522,7 +513,7 @@ class RuntimePlugin {
 					const fullHashDigest =
 						typeof compilation.outputOptions.hotUpdateChunkFilename ===
 							"string" &&
-						usesFullHashWithDigest(
+						usesFullHashDigest(
 							compilation.outputOptions.hotUpdateChunkFilename
 						);
 					compilation.addLazyRuntimeModule(

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -367,12 +367,28 @@ class RuntimeTemplate {
 		return (
 			this.supportsAnalyzableEsm() &&
 			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
-			// `[fullhash]` is only known after code generation.
-			!getTemplatedPathPlugin()
-				.getPresentKinds(
-					/** @type {string} */ (this.outputOptions.webassemblyModuleFilename)
-				)
-				.has("fullhash")
+			this._canBakeWasmFullHash()
+		);
+	}
+
+	/**
+	 * Whether the compilation hash in `output.webassemblyModuleFilename` is one the
+	 * deferred pass can fill in. It is unknown during code generation, so a stand-in is
+	 * emitted and replaced once it exists — which rewrites the chunk after its own
+	 * content hash was taken, so `RealContentHashPlugin` has to be there to repair it.
+	 * @returns {boolean} true when a `[fullhash]` in it is no obstacle
+	 */
+	_canBakeWasmFullHash() {
+		const filename =
+			/** @type {string} */
+			(this.outputOptions.webassemblyModuleFilename);
+		if (!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash")) {
+			return true;
+		}
+		const plugin = getAnalyzableChunkHashPlugin();
+		return (
+			plugin.canDeferFullHash(filename) &&
+			plugin.canDeferSpecifier(this.compilation)
 		);
 	}
 
@@ -1945,7 +1961,14 @@ class RuntimeTemplate {
 		const { compilation } = this;
 		const filename = compilation.getPath(
 			/** @type {string} */ (this.outputOptions.webassemblyModuleFilename),
-			{ module, runtime, chunkGraph }
+			{
+				module,
+				runtime,
+				chunkGraph,
+				// The module's own hash and id are settled here; the compilation's is not,
+				// so it is left as a stand-in for the deferred pass to fill in.
+				...getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
+			}
 		);
 		// Only a chunk that fetches may carry the public path into the literal: `readFile`
 		// takes a `file:` URL alone, and those loaders address the binary relative to the

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1927,9 +1927,8 @@ class RuntimeTemplate {
 					: prefix + filename
 			);
 		if (overridePublicPath) {
-			return overridePublicPath.includes("[")
-				? null
-				: specifier(overridePublicPath);
+			const prefix = this._resolvePublicPathPrefix(overridePublicPath);
+			return prefix === null ? null : specifier(prefix);
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
@@ -1942,10 +1941,34 @@ class RuntimeTemplate {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
-		if (typeof publicPath === "string" && !publicPath.includes("[")) {
-			return specifier(publicPath);
+		if (typeof publicPath === "string") {
+			const prefix = this._resolvePublicPathPrefix(publicPath);
+			if (prefix !== null) return specifier(prefix);
 		}
 		return null;
+	}
+
+	/**
+	 * What a public path puts in front of a filename, as a literal. A templated one is
+	 * resolved as far as code generation can — the compilation hash it may carry is
+	 * left as a stand-in for the deferred pass, exactly as `PublicPathRuntimeModule`
+	 * resolves the same string once that hash exists.
+	 * @param {string} publicPath the configured public path
+	 * @returns {string | null} the prefix, or `null` when it cannot be known here
+	 */
+	_resolvePublicPathPrefix(publicPath) {
+		if (!publicPath.includes("[")) return publicPath;
+		const plugin = getAnalyzableChunkHashPlugin();
+		if (
+			!plugin.canDeferFullHash(publicPath) ||
+			!plugin.canDeferSpecifier(this.compilation)
+		) {
+			return null;
+		}
+		return this.compilation.getPath(
+			publicPath,
+			plugin.DEFERRED_FULL_HASH_PATH_DATA
+		);
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -315,9 +315,25 @@ class RuntimeTemplate {
 		return this.outputOptions.environment.modulePreload;
 	}
 
+	/**
+	 * Analyzable output — a reference a foreign bundler can follow without running
+	 * webpack's runtime — comes in two forms, and what rules them out differs:
+	 *
+	 * - a literal `import("./chunk.js")`, gated by `supportsAnalyzableImport`
+	 * - a literal `new URL(<file>, import.meta.url)`, gated by `supportsAnalyzableEsm`
+	 *
+	 * Either way a name that is not settled during code generation may still be baked,
+	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
+	 *
+	 * What still forces the runtime form, and is not covered by any of the three:
+	 * a module federation module in the chunk, a chunk reachable at more than one
+	 * output depth under an `auto` public path, and a chunk with no id.
+	 * @returns {boolean} true when a `new URL(…, import.meta.url)` literal may be emitted
+	 */
 	supportsAnalyzableEsm() {
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error, so the literal `new URL(…, import.meta.url)` form can't be used.
+		// A literal `import()` survives it, which is why the import form does not check.
 		const { devtool } = this.compilation.options;
 		return (
 			this.isModule() &&
@@ -326,6 +342,58 @@ class RuntimeTemplate {
 			// A runtime `__webpack_public_path__` override can't be reflected in a
 			// baked literal, so keep the runtime form that reads `__webpack_require__.p`.
 			!APIPlugin.usesRuntimePublicPathOverride(this.compilation)
+		);
+	}
+
+	/**
+	 * Whether a chunk reference emitted into `originModule` may be a literal
+	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
+	 * @param {Module=} originModule the module the `import()` is emitted into
+	 * @param {ChunkGraph=} chunkGraph the chunk graph
+	 * @returns {boolean} true when the literal form may be emitted
+	 */
+	supportsAnalyzableImport(originModule, chunkGraph) {
+		const { outputOptions } = this;
+		if (
+			!outputOptions.module ||
+			outputOptions.chunkFormat !== "module" ||
+			// Only a native `import()` is a specifier a foreign bundler reads.
+			outputOptions.importFunctionName !== "import" ||
+			!originModule ||
+			!chunkGraph
+		) {
+			return false;
+		}
+		// A runtime `__webpack_public_path__` override can't reach a baked literal.
+		if (APIPlugin.usesRuntimePublicPathOverride(this.compilation)) return false;
+		// A worker loading its own chunks some other way keeps that runtime; one on
+		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
+		for (const originChunk of chunkGraph.getModuleChunksIterable(
+			originModule
+		)) {
+			const entryOptions = originChunk.getEntryOptions();
+			if (!entryOptions || !entryOptions.worker) continue;
+			// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
+			if (entryOptions.chunkLoading !== "import") return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Whether a name that code generation cannot settle may be reserved as a stand-in
+	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
+	 * content hash was taken, and `RealContentHashPlugin` is what brings the two back
+	 * in line — without it the name would go stale.
+	 * @param {string=} template a name whose compilation hash is left as a stand-in
+	 * inside it; omit when the whole name is re-resolved later instead, which puts no
+	 * stand-in of its own into the output and so accepts any hash spelling
+	 * @returns {boolean} true when deferring is safe
+	 */
+	canDeferAnalyzableName(template) {
+		if (!this.compilation.options.optimization.realContentHash) return false;
+		return (
+			template === undefined ||
+			getAnalyzableChunkHashPlugin().canDeferFullHash(template)
 		);
 	}
 
@@ -364,31 +432,16 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the literal form is emitted
 	 */
 	supportsAnalyzableWasm() {
-		return (
-			this.supportsAnalyzableEsm() &&
-			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
-			this._canBakeWasmFullHash()
-		);
-	}
-
-	/**
-	 * Whether the compilation hash in `output.webassemblyModuleFilename` is one the
-	 * deferred pass can fill in. It is unknown during code generation, so a stand-in is
-	 * emitted and replaced once it exists — which rewrites the chunk after its own
-	 * content hash was taken, so `RealContentHashPlugin` has to be there to repair it.
-	 * @returns {boolean} true when a `[fullhash]` in it is no obstacle
-	 */
-	_canBakeWasmFullHash() {
 		const filename =
 			/** @type {string} */
 			(this.outputOptions.webassemblyModuleFilename);
-		if (!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash")) {
-			return true;
-		}
-		const plugin = getAnalyzableChunkHashPlugin();
 		return (
-			plugin.canDeferFullHash(filename) &&
-			plugin.canDeferSpecifier(this.compilation)
+			this.supportsAnalyzableEsm() &&
+			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
+			// The compilation hash is settled after code generation, so a name carrying
+			// one is baked only where the deferred pass can fill it in.
+			(!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") ||
+				this.canDeferAnalyzableName(filename))
 		);
 	}
 
@@ -1745,32 +1798,13 @@ class RuntimeTemplate {
 		originModule,
 		chunkGraph
 	) {
-		const { outputOptions } = this;
 		// `blockPromise` has already dropped any chunk without an id.
 		if (
-			!outputOptions.module ||
-			outputOptions.chunkFormat !== "module" ||
-			outputOptions.importFunctionName !== "import" ||
 			!originModule ||
-			!chunkGraph
+			!chunkGraph ||
+			!this.supportsAnalyzableImport(originModule, chunkGraph)
 		) {
 			return null;
-		}
-		// A runtime `__webpack_public_path__` override can't reach a baked literal.
-		if (APIPlugin.usesRuntimePublicPathOverride(this.compilation)) {
-			return null;
-		}
-		// A worker loading its own chunks some other way keeps that runtime; one on
-		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
-		for (const originChunk of chunkGraph.getModuleChunksIterable(
-			originModule
-		)) {
-			const entryOptions = originChunk.getEntryOptions();
-			if (!entryOptions || !entryOptions.worker) continue;
-			// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
-			if (entryOptions.chunkLoading !== "import") {
-				return null;
-			}
 		}
 		// Prefetch/preload children are injected by the runtime `.f` handlers, which `.ei`
 		// runs too — but they attach to `.f`, so it has to exist.
@@ -1898,9 +1932,9 @@ class RuntimeTemplate {
 		if (
 			deferred &&
 			// An id names the chunk in the stand-in, and one nothing could resolve would
-			// reach the bundle verbatim.
-			(chunk.id === null ||
-				!getAnalyzableChunkHashPlugin().canDeferSpecifier(compilation))
+			// reach the bundle verbatim. The whole name is re-resolved later rather than
+			// carrying a stand-in of its own, so any hash spelling is fine here.
+			(chunk.id === null || !this.canDeferAnalyzableName())
 		) {
 			return null;
 		}
@@ -1958,16 +1992,10 @@ class RuntimeTemplate {
 	 */
 	_resolvePublicPathPrefix(publicPath) {
 		if (!publicPath.includes("[")) return publicPath;
-		const plugin = getAnalyzableChunkHashPlugin();
-		if (
-			!plugin.canDeferFullHash(publicPath) ||
-			!plugin.canDeferSpecifier(this.compilation)
-		) {
-			return null;
-		}
+		if (!this.canDeferAnalyzableName(publicPath)) return null;
 		return this.compilation.getPath(
 			publicPath,
-			plugin.DEFERRED_FULL_HASH_PATH_DATA
+			getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
 		);
 	}
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -348,19 +348,17 @@ class RuntimeTemplate {
 	/**
 	 * Whether a chunk reference emitted into `originModule` may be a literal
 	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
-	 * @param {Module=} originModule the module the `import()` is emitted into
-	 * @param {ChunkGraph=} chunkGraph the chunk graph
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Module} originModule the module the `import()` is emitted into
 	 * @returns {boolean} true when the literal form may be emitted
 	 */
-	supportsAnalyzableImport(originModule, chunkGraph) {
+	supportsAnalyzableImport(chunkGraph, originModule) {
 		const { outputOptions } = this;
 		if (
 			!outputOptions.module ||
 			outputOptions.chunkFormat !== "module" ||
 			// Only a native `import()` is a specifier a foreign bundler reads.
-			outputOptions.importFunctionName !== "import" ||
-			!originModule ||
-			!chunkGraph
+			outputOptions.importFunctionName !== "import"
 		) {
 			return false;
 		}
@@ -1813,8 +1811,9 @@ class RuntimeTemplate {
 	 * @param {Chunk} chunk the chunk to load
 	 * @param {string} comment leading comment (chunk name / message)
 	 * @param {RuntimeRequirements} runtimeRequirements runtime requirements
-	 * @param {Module=} originModule the module the `import()` is emitted into
-	 * @param {ChunkGraph=} chunkGraph the chunk graph
+	 * @param {Module | undefined} originModule the module the `import()` is emitted
+	 * into, if the block names one
+	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @returns {string | null} the import expression, or `null`
 	 */
 	_analyzableChunkImport(
@@ -1824,11 +1823,12 @@ class RuntimeTemplate {
 		originModule,
 		chunkGraph
 	) {
-		// `blockPromise` has already dropped any chunk without an id.
+		// `blockPromise` has already dropped any chunk without an id. It leaves the
+		// origin out for a block that names none — `require.ensure`, an AMD `require`,
+		// a lazy-once context, a container entry — and nothing can be relative to it.
 		if (
 			!originModule ||
-			!chunkGraph ||
-			!this.supportsAnalyzableImport(originModule, chunkGraph)
+			!this.supportsAnalyzableImport(chunkGraph, originModule)
 		) {
 			return null;
 		}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -46,6 +46,9 @@ const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 const getAnalyzableChunkHashPlugin = memoize(() =>
 	require("./esm/AnalyzableChunkHashPlugin")
 );
+const getConcatenatedModule = memoize(() =>
+	require("./optimize/ConcatenatedModule")
+);
 
 // Module-federation module types whose chunks load through the federation runtime.
 /** @type {Set<string>} */
@@ -351,9 +354,23 @@ class RuntimeTemplate {
 			!APIPlugin.runtimeUsesPublicPathOverride(
 				this.compilation,
 				chunkGraph,
-				module
+				this._chunkGraphModule(module)
 			)
 		);
+	}
+
+	/**
+	 * Resolves a module to the one the chunk graph holds. Dependency templates run
+	 * against the module that wrote the reference, which concatenation may have
+	 * absorbed — and an absorbed module is in no chunk and no runtime, so every
+	 * chunk-graph question about it answers about nothing.
+	 * @param {Module=} module the module a reference is emitted into
+	 * @returns {Module | undefined} the module the chunk graph holds
+	 */
+	_chunkGraphModule(module) {
+		return module === undefined
+			? undefined
+			: getConcatenatedModule().getChunkGraphModule(this.compilation, module);
 	}
 
 	/**
@@ -373,13 +390,16 @@ class RuntimeTemplate {
 		) {
 			return false;
 		}
+		const placedModule = /** @type {Module} */ (
+			this._chunkGraphModule(originModule)
+		);
 		// A runtime `__webpack_public_path__` override can't reach a baked literal, but
 		// `.p` belongs to a runtime, so only this module's own runtimes matter.
 		if (
 			APIPlugin.runtimeUsesPublicPathOverride(
 				this.compilation,
 				chunkGraph,
-				originModule
+				placedModule
 			)
 		) {
 			return false;
@@ -387,7 +407,7 @@ class RuntimeTemplate {
 		// A worker loading its own chunks some other way keeps that runtime; one on
 		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
 		for (const originChunk of chunkGraph.getModuleChunksIterable(
-			originModule
+			placedModule
 		)) {
 			const entryOptions = originChunk.getEntryOptions();
 			if (!entryOptions || !entryOptions.worker) continue;
@@ -1923,7 +1943,9 @@ class RuntimeTemplate {
 		/** @type {string | null} */
 		let result = null;
 		let found = false;
-		for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
+		for (const chunk of chunkGraph.getModuleChunksIterable(
+			/** @type {Module} */ (this._chunkGraphModule(module))
+		)) {
 			const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
 				chunk,
 				outputOptions

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -382,19 +382,45 @@ class RuntimeTemplate {
 	/**
 	 * Whether a name that code generation cannot settle may be reserved as a stand-in
 	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
-	 * content hash was taken, and `RealContentHashPlugin` is what brings the two back
-	 * in line — without it the name would go stale.
+	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
+	 * back in line, or no emitted javascript may be named by its content in the first
+	 * place — with a name like `[name].js` there is nothing to go stale.
 	 * @param {string=} template a name whose compilation hash is left as a stand-in
 	 * inside it; omit when the whole name is re-resolved later instead, which puts no
 	 * stand-in of its own into the output and so accepts any hash spelling
 	 * @returns {boolean} true when deferring is safe
 	 */
 	canDeferAnalyzableName(template) {
-		if (!this.compilation.options.optimization.realContentHash) return false;
+		if (
+			!this.compilation.options.optimization.realContentHash &&
+			!this._namesJavascriptWithoutContent()
+		) {
+			return false;
+		}
 		return (
 			template === undefined ||
 			getAnalyzableChunkHashPlugin().canDeferFullHash(template)
 		);
+	}
+
+	/**
+	 * Whether no javascript asset takes its name from its own content, which is what
+	 * rewriting one after hashing would invalidate. A function template could name a
+	 * chunk anything, so it counts as one that does.
+	 * @returns {boolean} true when no emitted javascript is named by its content
+	 */
+	_namesJavascriptWithoutContent() {
+		const { filename, chunkFilename, workerChunkFilename } = this.outputOptions;
+		for (const template of [filename, chunkFilename, workerChunkFilename]) {
+			if (template === undefined) continue;
+			if (typeof template !== "string") return false;
+			if (
+				getTemplatedPathPlugin().getPresentKinds(template).has("contenthash")
+			) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -328,9 +328,11 @@ class RuntimeTemplate {
 	 * What still forces the runtime form, and is not covered by any of the three:
 	 * a module federation module in the chunk, a chunk reachable at more than one
 	 * output depth under an `auto` public path, and a chunk with no id.
+	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
+	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when a `new URL(…, import.meta.url)` literal may be emitted
 	 */
-	supportsAnalyzableEsm() {
+	supportsAnalyzableEsm(chunkGraph, module) {
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error, so the literal `new URL(…, import.meta.url)` form can't be used.
 		// A literal `import()` survives it, which is why the import form does not check.
@@ -339,9 +341,18 @@ class RuntimeTemplate {
 			this.isModule() &&
 			this.supportsEcmaScriptModuleSyntax() &&
 			!(typeof devtool === "string" && devtool.includes("eval")) &&
-			// A runtime `__webpack_public_path__` override can't be reflected in a
-			// baked literal, so keep the runtime form that reads `__webpack_require__.p`.
-			!APIPlugin.usesRuntimePublicPathOverride(this.compilation)
+			// Build-time execution keeps the runtime form — `import.meta` does not parse
+			// in its vm script wrapper. `getTypes` has no chunk graph and does not care:
+			// `AssetModulesPlugin` emulates the wrapper there.
+			!(chunkGraph && chunkGraph.buildTimeExecution) &&
+			// A runtime `__webpack_public_path__` override can't be reflected in a baked
+			// literal, so keep the runtime form that reads `__webpack_require__.p` — but
+			// only where the reassignment reaches, since `.p` belongs to a runtime.
+			!APIPlugin.runtimeUsesPublicPathOverride(
+				this.compilation,
+				chunkGraph,
+				module
+			)
 		);
 	}
 
@@ -362,8 +373,17 @@ class RuntimeTemplate {
 		) {
 			return false;
 		}
-		// A runtime `__webpack_public_path__` override can't reach a baked literal.
-		if (APIPlugin.usesRuntimePublicPathOverride(this.compilation)) return false;
+		// A runtime `__webpack_public_path__` override can't reach a baked literal, but
+		// `.p` belongs to a runtime, so only this module's own runtimes matter.
+		if (
+			APIPlugin.runtimeUsesPublicPathOverride(
+				this.compilation,
+				chunkGraph,
+				originModule
+			)
+		) {
+			return false;
+		}
 		// A worker loading its own chunks some other way keeps that runtime; one on
 		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
 		for (const originChunk of chunkGraph.getModuleChunksIterable(
@@ -429,11 +449,14 @@ class RuntimeTemplate {
 	 * relative URL equivalent to the runtime `__webpack_require__.p + path` form.
 	 * Callers that can bake the public path into a static literal specifier should
 	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
+	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
+	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when the analyzable chunk-relative URL applies
 	 */
-	supportsAnalyzableEsmUrl() {
+	supportsAnalyzableEsmUrl(chunkGraph, module) {
 		return (
-			this.supportsAnalyzableEsm() && this.outputOptions.publicPath === "auto"
+			this.supportsAnalyzableEsm(chunkGraph, module) &&
+			this.outputOptions.publicPath === "auto"
 		);
 	}
 
@@ -453,14 +476,16 @@ class RuntimeTemplate {
 	 * Whether async wasm binaries are referenced by a fully baked
 	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
 	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
+	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
+	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when the literal form is emitted
 	 */
-	supportsAnalyzableWasm() {
+	supportsAnalyzableWasm(chunkGraph, module) {
 		const filename =
 			/** @type {string} */
 			(this.outputOptions.webassemblyModuleFilename);
 		return (
-			this.supportsAnalyzableEsm() &&
+			this.supportsAnalyzableEsm(chunkGraph, module) &&
 			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
 			// The compilation hash is settled after code generation, so a name carrying
 			// one is baked only where the deferred pass can fill it in.

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -75,6 +75,18 @@ const getPresentKinds = (path) => {
 	return kinds;
 };
 
+// `[fullhash:<digest>]`/`[hash:<digest>]` — a non-numeric first argument is a digest
+// (a numeric one is just a length). A digest re-encodes the hash rather than reading
+// it, so no stand-in or runtime expression can take its place: the settled value has
+// to be inlined instead.
+const FULL_HASH_DIGEST_REGEXP = /\[(?:fullhash|hash):(?!\d+\])\w/;
+
+/**
+ * @param {string} template path template
+ * @returns {boolean} true when it references `[fullhash:<digest>]`/`[hash:<digest>]`
+ */
+const usesFullHashDigest = (template) => FULL_HASH_DIGEST_REGEXP.test(template);
+
 const PARENT_SEGMENTS_REGEXP = /^(?:\.\.\/)+/;
 
 /**
@@ -832,3 +844,4 @@ module.exports.interpolate = interpolate;
 module.exports.reEncodeDigest = reEncodeDigest;
 module.exports.toContainedPath = toContainedPath;
 module.exports.toTemplateSourceFileName = toTemplateSourceFileName;
+module.exports.usesFullHashDigest = usesFullHashDigest;

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -229,12 +229,9 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		// can statically follow the asset. `url: "relative"` keeps the runtime form.
 		// A prefetch/preload hint doesn't force it: the `<link>` is emitted separately at
 		// chunk startup (`StartupAssetHintRuntimeModule`), independent of the call site.
-		// Build-time execution keeps the runtime form — `import.meta` does not
-		// parse in its vm script wrapper.
 		if (
 			!dep.relative &&
-			!chunkGraph.buildTimeExecution &&
-			runtimeTemplate.supportsAnalyzableEsm()
+			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, templateContext.module)
 		) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -138,7 +138,10 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 		// and webpack itself can statically follow the worker. A resource hint doesn't
 		// block it: the `<link>` is emitted at chunk startup instead of wrapping the href,
 		// which would turn the specifier into a non-analyzable expression.
-		const analyzableSpecifier = runtimeTemplate.supportsAnalyzableEsm()
+		const analyzableSpecifier = runtimeTemplate.supportsAnalyzableEsm(
+			chunkGraph,
+			templateContext.module
+		)
 			? runtimeTemplate._getAnalyzableChunkSpecifier(
 					dep.options.publicPath,
 					chunk,

--- a/lib/dependencies/WorkletDependency.js
+++ b/lib/dependencies/WorkletDependency.js
@@ -143,7 +143,8 @@ WorkletDependency.Template = class WorkletDependencyTemplate extends (
 		// and webpack itself can statically follow the worklet. The worklet chunk links its
 		// splits via native `import`, so only the entry chunk is referenced.
 		const analyzableSpecifier =
-			runtimeTemplate.supportsAnalyzableEsm() && entryChunk.id !== null
+			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, module) &&
+			entryChunk.id !== null
 				? runtimeTemplate._getAnalyzableChunkSpecifier(
 						dep.options.publicPath,
 						entryChunk,

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { RawSource } = require("webpack-sources");
+const { ReplaceSource } = require("webpack-sources");
 const Compilation = require("../Compilation");
 const memoize = require("../util/memoize");
 
@@ -98,8 +98,9 @@ const appliedTo = new WeakSet();
 /**
  * Fills in the names reserved during code generation, once the hashes they are built
  * from exist: a chunk's own filename, and the compilation hash inside any other
- * emitted asset's. Runs before `RealContentHashPlugin`, which repairs each rewritten
- * chunk's own name.
+ * emitted asset's. Replaces in place so the asset keeps its mappings, and runs before
+ * anything reads it — `RealContentHashPlugin` still repairs each rewritten chunk's own
+ * name later.
  */
 class AnalyzableChunkHashPlugin {
 	/**
@@ -114,12 +115,31 @@ class AnalyzableChunkHashPlugin {
 			compilation.hooks.processAssets.tap(
 				{
 					name: PLUGIN_NAME,
-					stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH - 1
+					// Before source maps are written and before a minifier runs: both read
+					// the asset, and a stand-in is a different length than what replaces it.
+					// Every hash it reads is already settled — `createHash` runs ahead of
+					// every `processAssets` stage — and `RealContentHashPlugin` still repairs
+					// the names afterwards.
+					stage: Compilation.PROCESS_ASSETS_STAGE_DERIVED
 				},
 				() => {
 					const { outputOptions } = compilation;
+					const fullHash = compilation.hash;
 					/** @type {Map<string, Chunk> | undefined} */
 					let chunksById;
+					/**
+					 * @param {string} value text that may carry compilation-hash stand-ins
+					 * @returns {string} the text with each of them filled in
+					 */
+					const fillFullHash = (value) => {
+						if (fullHash === undefined) return value;
+						FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
+						return value.replace(FULL_HASH_TOKEN_REGEXP, (_match, length) =>
+							length === undefined
+								? fullHash
+								: fullHash.slice(0, Number(length))
+						);
+					};
 					/**
 					 * @param {string} payload the encoded half of a stand-in
 					 * @returns {string | null} the specifier, or `null` if unresolvable
@@ -152,12 +172,14 @@ class AnalyzableChunkHashPlugin {
 								}
 							);
 						// A bare specifier is a package name, so make it explicitly relative
-						// the way the chunk loader does.
-						return /^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(specifier)
-							? specifier
-							: `./${specifier}`;
+						// the way the chunk loader does. A templated public path left its own
+						// stand-in in the prefix, so finish that here rather than scanning again.
+						return fillFullHash(
+							/^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(specifier)
+								? specifier
+								: `./${specifier}`
+						);
 					};
-					const fullHash = compilation.hash;
 					for (const name of Object.keys(compilation.assets)) {
 						const content = compilation.assets[name].source();
 						if (typeof content !== "string") continue;
@@ -167,27 +189,40 @@ class AnalyzableChunkHashPlugin {
 						const hasFullHashToken =
 							fullHash !== undefined && FULL_HASH_TOKEN_REGEXP.test(content);
 						if (!hasChunkToken && !hasFullHashToken) continue;
-						let updated = content;
+						// Replaced in place rather than rebuilt from a string: a stand-in and
+						// the name filling it in are different lengths, so everything after it
+						// shifts and the asset's existing mappings have to move with it.
+						const replaced = new ReplaceSource(compilation.assets[name]);
+						/**
+						 * @param {RegExp} source what to look for
+						 * @param {(match: string, group: string) => string | null} fill what to put there
+						 * @returns {void}
+						 */
+						const replaceAll = (source, fill) => {
+							// Its own instance: `fill` may run the shared one over what it
+							// returns, and a `replace` there would rewind this scan.
+							const regexp = new RegExp(source.source, source.flags);
+							/** @type {RegExpExecArray | null} */
+							let match;
+							while ((match = regexp.exec(content)) !== null) {
+								const value = fill(match[0], match[1]);
+								if (value === null) continue;
+								replaced.replace(
+									match.index,
+									match.index + match[0].length - 1,
+									value
+								);
+							}
+						};
 						if (hasChunkToken) {
-							TOKEN_REGEXP.lastIndex = 0;
-							updated = updated.replace(TOKEN_REGEXP, (match, payload) => {
-								const specifier = resolve(payload);
-								return specifier === null ? match : specifier;
-							});
+							replaceAll(TOKEN_REGEXP, (_match, payload) => resolve(payload));
 						}
-						// After the chunk pass, never before it: a templated public path puts
-						// its stand-in inside the specifier that pass just wrote.
-						if (fullHash !== undefined) {
-							FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
-							updated = updated.replace(
-								FULL_HASH_TOKEN_REGEXP,
-								(_match, length) =>
-									length === undefined
-										? fullHash
-										: fullHash.slice(0, Number(length))
+						if (hasFullHashToken) {
+							replaceAll(FULL_HASH_TOKEN_REGEXP, (match) =>
+								fillFullHash(match)
 							);
 						}
-						compilation.updateAsset(name, new RawSource(updated));
+						compilation.updateAsset(name, replaced);
 					}
 				}
 			);

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -90,16 +90,6 @@ const readSpecifier = (payload) => {
 	return [prefix, chunkId];
 };
 
-/**
- * Whether a specifier may be deferred at all. Substituting rewrites a chunk after its
- * own content hash was taken, and `RealContentHashPlugin` is what brings the two back
- * in line — without it the name would go stale.
- * @param {Compilation} compilation the compilation
- * @returns {boolean} true when deferring is safe
- */
-const canDeferSpecifier = (compilation) =>
-	Boolean(compilation.options.optimization.realContentHash);
-
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
 
 // More than one plugin reserves stand-ins, and each has to bring the pass that fills
@@ -210,5 +200,4 @@ class AnalyzableChunkHashPlugin {
 module.exports = AnalyzableChunkHashPlugin;
 module.exports.DEFERRED_FULL_HASH_PATH_DATA = DEFERRED_FULL_HASH_PATH_DATA;
 module.exports.canDeferFullHash = canDeferFullHash;
-module.exports.canDeferSpecifier = canDeferSpecifier;
 module.exports.reserveSpecifier = reserveSpecifier;

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -22,6 +22,37 @@ const getJavascriptModulesPlugin = memoize(() =>
 // restored from the persistent cache is never generated again.
 const TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
 
+// Stands in for the compilation hash inside an otherwise resolved filename, with the
+// requested length when the placeholder asked for one.
+const FULL_HASH_TOKEN_REGEXP = /@@webpackFullHash(?:-(\d+))?@@/g;
+
+/**
+ * @param {number=} length how many characters the placeholder asked for
+ * @returns {string} the stand-in to emit
+ */
+const reserveFullHash = (length) =>
+	`@@webpackFullHash${length === undefined ? "" : `-${length}`}@@`;
+
+// `[fullhash:<digest>]` re-encodes the hash rather than reading it, which a stand-in
+// cannot survive — a non-numeric first argument is a digest, a numeric one a length.
+const FULL_HASH_DIGEST_REGEXP = /\[(?:fullhash|hash):(?!\d+\])\w/;
+
+/**
+ * Whether a filename's compilation-hash placeholders can be filled in by the deferred
+ * pass at all.
+ * @param {string} template path template
+ * @returns {boolean} true when every `[fullhash]` in it is a plain read
+ */
+const canDeferFullHash = (template) => !FULL_HASH_DIGEST_REGEXP.test(template);
+
+// `getPath` data that leaves every compilation-hash placeholder as a stand-in while the
+// rest of the name resolves — a module's own hash and id are settled during code
+// generation, the compilation's is not. Shared: it closes over nothing.
+const DEFERRED_FULL_HASH_PATH_DATA = {
+	hash: reserveFullHash(),
+	hashWithLength: reserveFullHash
+};
+
 /**
  * @param {string} prefix what goes in front of the chunk's filename
  * @param {ChunkId} chunkId id of the chunk being addressed
@@ -71,18 +102,26 @@ const canDeferSpecifier = (compilation) =>
 
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
 
+// More than one plugin reserves stand-ins, and each has to bring the pass that fills
+// them in — but only the first application of it.
+/** @type {WeakSet<Compiler>} */
+const appliedTo = new WeakSet();
+
 /**
- * Fills in the specifiers reserved during code generation, once the hashes their
- * filenames are built from exist. Runs before `RealContentHashPlugin`, which repairs
- * each rewritten chunk's own name.
+ * Fills in the names reserved during code generation, once the hashes they are built
+ * from exist: a chunk's own filename, and the compilation hash inside any other
+ * emitted asset's. Runs before `RealContentHashPlugin`, which repairs each rewritten
+ * chunk's own name.
  */
 class AnalyzableChunkHashPlugin {
 	/**
-	 * Apply the plugin.
+	 * Apply the plugin. Applying it more than once to a compiler is a no-op.
 	 * @param {Compiler} compiler the compiler
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		if (appliedTo.has(compiler)) return;
+		appliedTo.add(compiler);
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
 			compilation.hooks.processAssets.tap(
 				{
@@ -130,21 +169,35 @@ class AnalyzableChunkHashPlugin {
 							? specifier
 							: `./${specifier}`;
 					};
+					const fullHash = compilation.hash;
 					for (const name of Object.keys(compilation.assets)) {
 						const content = compilation.assets[name].source();
 						if (typeof content !== "string") continue;
 						TOKEN_REGEXP.lastIndex = 0;
-						if (!TOKEN_REGEXP.test(content)) continue;
-						TOKEN_REGEXP.lastIndex = 0;
-						compilation.updateAsset(
-							name,
-							new RawSource(
-								content.replace(TOKEN_REGEXP, (match, payload) => {
-									const specifier = resolve(payload);
-									return specifier === null ? match : specifier;
-								})
-							)
-						);
+						FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
+						const hasChunkToken = TOKEN_REGEXP.test(content);
+						const hasFullHashToken =
+							fullHash !== undefined && FULL_HASH_TOKEN_REGEXP.test(content);
+						if (!hasChunkToken && !hasFullHashToken) continue;
+						let updated = content;
+						if (hasChunkToken) {
+							TOKEN_REGEXP.lastIndex = 0;
+							updated = updated.replace(TOKEN_REGEXP, (match, payload) => {
+								const specifier = resolve(payload);
+								return specifier === null ? match : specifier;
+							});
+						}
+						if (hasFullHashToken) {
+							FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
+							updated = updated.replace(
+								FULL_HASH_TOKEN_REGEXP,
+								(_match, length) =>
+									length === undefined
+										? fullHash
+										: fullHash.slice(0, Number(length))
+							);
+						}
+						compilation.updateAsset(name, new RawSource(updated));
 					}
 				}
 			);
@@ -153,5 +206,7 @@ class AnalyzableChunkHashPlugin {
 }
 
 module.exports = AnalyzableChunkHashPlugin;
+module.exports.DEFERRED_FULL_HASH_PATH_DATA = DEFERRED_FULL_HASH_PATH_DATA;
+module.exports.canDeferFullHash = canDeferFullHash;
 module.exports.canDeferSpecifier = canDeferSpecifier;
 module.exports.reserveSpecifier = reserveSpecifier;

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -16,6 +16,7 @@ const memoize = require("../util/memoize");
 const getJavascriptModulesPlugin = memoize(() =>
 	require("../javascript/JavascriptModulesPlugin")
 );
+const getTemplatedPathPlugin = memoize(() => require("../TemplatedPathPlugin"));
 
 // Looks like a relative specifier, so the code around it needs no special case, and
 // carries what it resolves to rather than an index into per-build state — a module
@@ -33,17 +34,14 @@ const FULL_HASH_TOKEN_REGEXP = /@@webpackFullHash(?:-(\d+))?@@/g;
 const reserveFullHash = (length) =>
 	`@@webpackFullHash${length === undefined ? "" : `-${length}`}@@`;
 
-// `[fullhash:<digest>]` re-encodes the hash rather than reading it, which a stand-in
-// cannot survive — a non-numeric first argument is a digest, a numeric one a length.
-const FULL_HASH_DIGEST_REGEXP = /\[(?:fullhash|hash):(?!\d+\])\w/;
-
 /**
  * Whether a filename's compilation-hash placeholders can be filled in by the deferred
- * pass at all.
+ * pass at all — a re-encoded digest cannot be spelled by a stand-in.
  * @param {string} template path template
  * @returns {boolean} true when every `[fullhash]` in it is a plain read
  */
-const canDeferFullHash = (template) => !FULL_HASH_DIGEST_REGEXP.test(template);
+const canDeferFullHash = (template) =>
+	!getTemplatedPathPlugin().usesFullHashDigest(template);
 
 // `getPath` data that leaves every compilation-hash placeholder as a stand-in while the
 // rest of the name resolves — a module's own hash and id are settled during code

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -187,7 +187,9 @@ class AnalyzableChunkHashPlugin {
 								return specifier === null ? match : specifier;
 							});
 						}
-						if (hasFullHashToken) {
+						// After the chunk pass, never before it: a templated public path puts
+						// its stand-in inside the specifier that pass just wrote.
+						if (fullHash !== undefined) {
 							FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
 							updated = updated.replace(
 								FULL_HASH_TOKEN_REGEXP,

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -8,20 +8,13 @@
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
-const { getPresentKinds } = require("../TemplatedPathPlugin");
+const { usesFullHashDigest } = require("../TemplatedPathPlugin");
+const { needsRuntimeFullHash } = require("../wasm/wasmModuleFilename");
 const AsyncWasmCompileRuntimeModule = require("../wasm-async/AsyncWasmCompileRuntimeModule");
 const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
-
-/**
- * The wasm runtime inlines `[fullhash]` as a runtime `getFullHash()` call, so
- * that runtime module must be requested (`[hash]` is the per-module hash here).
- * @param {string} filename `output.webassemblyModuleFilename`
- * @returns {boolean} whether it references the compilation `[fullhash]`
- */
-const usesFullHash = (filename) => getPresentKinds(filename).has("fullhash");
 
 /**
  * Defines the read file compile async wasm plugin options type used by this module.
@@ -143,13 +136,22 @@ class ReadFileCompileAsyncWasmPlugin {
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmLoadingRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode,
 							supportsStreaming: false
 						})
@@ -171,13 +173,22 @@ class ReadFileCompileAsyncWasmPlugin {
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmCompileRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode,
 							supportsStreaming: false
 						})

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -140,7 +140,9 @@ class ReadFileCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
+					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
+						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
@@ -166,7 +168,9 @@ class ReadFileCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
+					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
+						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);

--- a/lib/node/ReadFileCompileWasmPlugin.js
+++ b/lib/node/ReadFileCompileWasmPlugin.js
@@ -8,19 +8,12 @@
 const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
-const { getPresentKinds } = require("../TemplatedPathPlugin");
+const { usesFullHashDigest } = require("../TemplatedPathPlugin");
+const { needsRuntimeFullHash } = require("../wasm/wasmModuleFilename");
 const WasmChunkLoadingRuntimeModule = require("../wasm-sync/WasmChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
-
-/**
- * The wasm runtime inlines `[fullhash]` as a runtime `getFullHash()` call, so
- * that runtime module must be requested (`[hash]` is the per-module hash here).
- * @param {string} filename `output.webassemblyModuleFilename`
- * @returns {boolean} whether it references the compilation `[fullhash]`
- */
-const usesFullHash = (filename) => getPresentKinds(filename).has("fullhash");
 
 /**
  * Defines the read file compile wasm plugin options type used by this module.
@@ -131,13 +124,22 @@ class ReadFileCompileWasmPlugin {
 					}
 					set.add(RuntimeGlobals.moduleCache);
 					if (
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new WasmChunkLoadingRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode,
 							supportsStreaming: false,
 							mangleImports: this.options.mangleImports,

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -3303,4 +3303,32 @@ ConcatenatedModule.getCompilationHooks = createHooksRegistry(
 
 makeSerializable(ConcatenatedModule, "webpack/lib/optimize/ConcatenatedModule");
 
+/** @type {WeakMap<Compilation, WeakMap<Module, ConcatenatedModule>>} */
+const absorbedBy = new WeakMap();
+
+/**
+ * The module the chunk graph holds for `module`: concatenation replaces every module
+ * it absorbs with one `ConcatenatedModule`, so an absorbed module is itself in no
+ * chunk and no runtime, and asking the chunk graph about it answers about nothing.
+ * @param {Compilation} compilation the compilation
+ * @param {Module} module a module, possibly absorbed by concatenation
+ * @returns {Module} the module the chunk graph holds, or `module` itself
+ */
+ConcatenatedModule.getChunkGraphModule = (compilation, module) => {
+	let map = absorbedBy.get(compilation);
+	if (map === undefined) {
+		map = new WeakMap();
+		for (const candidate of compilation.modules) {
+			if (candidate instanceof ConcatenatedModule) {
+				for (const inner of candidate._modules) {
+					map.set(inner, candidate);
+				}
+			}
+		}
+		absorbedBy.set(compilation, map);
+	}
+	const outer = map.get(module);
+	return outer === undefined ? module : outer;
+};
+
 module.exports = ConcatenatedModule;

--- a/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
+const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compilation")} Compilation */
@@ -22,6 +23,7 @@ const Template = require("../Template");
  * @property {GenerateBeforeLoadBinaryCode=} generateBeforeLoadBinaryCode
  * @property {GenerateBeforeCompileStreaming=} generateBeforeCompileStreaming
  * @property {boolean} supportsStreaming
+ * @property {boolean=} fullHashDigest the binary's name inlines a re-encoded compilation hash
  */
 
 class AsyncWasmCompileRuntimeModule extends RuntimeModule {
@@ -32,9 +34,16 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		generateLoadBinaryCode,
 		generateBeforeLoadBinaryCode,
 		generateBeforeCompileStreaming,
-		supportsStreaming
+		supportsStreaming,
+		fullHashDigest
 	}) {
 		super("wasm compile", RuntimeModule.STAGE_NORMAL);
+		// A re-encoded digest is inlined from the settled hash, so this has to render
+		// again once there is one.
+		if (fullHashDigest) {
+			/** @type {boolean} */
+			this.fullHash = true;
+		}
 		/** @type {GenerateLoadBinaryCode} */
 		this.generateLoadBinaryCode = generateLoadBinaryCode;
 		/** @type {GenerateBeforeLoadBinaryCode | undefined} */
@@ -63,9 +72,7 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 			: compilation.getPath(
 					JSON.stringify(outputOptions.webassemblyModuleFilename),
 					{
-						hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
-						hashWithLength: (length) =>
-							`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+						...fullHashPathData(compilation),
 						module: {
 							id: '" + wasmModuleId + "',
 							hash: '" + wasmModuleHash + "',

--- a/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
+const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compilation")} Compilation */
@@ -22,6 +23,7 @@ const Template = require("../Template");
  * @property {GenerateBeforeLoadBinaryCode=} generateBeforeLoadBinaryCode
  * @property {GenerateBeforeInstantiateStreaming=} generateBeforeInstantiateStreaming
  * @property {boolean} supportsStreaming
+ * @property {boolean=} fullHashDigest the binary's name inlines a re-encoded compilation hash
  */
 
 class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
@@ -32,9 +34,16 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		generateLoadBinaryCode,
 		generateBeforeLoadBinaryCode,
 		generateBeforeInstantiateStreaming,
-		supportsStreaming
+		supportsStreaming,
+		fullHashDigest
 	}) {
 		super("wasm loading", RuntimeModule.STAGE_NORMAL);
+		// A re-encoded digest is inlined from the settled hash, so this has to render
+		// again once there is one.
+		if (fullHashDigest) {
+			/** @type {boolean} */
+			this.fullHash = true;
+		}
 		/** @type {GenerateLoadBinaryCode} */
 		this.generateLoadBinaryCode = generateLoadBinaryCode;
 		/** @type {generateBeforeLoadBinaryCode | undefined} */
@@ -64,9 +73,7 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 			: compilation.getPath(
 					JSON.stringify(outputOptions.webassemblyModuleFilename),
 					{
-						hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
-						hashWithLength: (length) =>
-							`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+						...fullHashPathData(compilation),
 						module: {
 							id: '" + wasmModuleId + "',
 							hash: '" + wasmModuleHash + "',

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -72,7 +72,10 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 			return this._generateSourcePhase(module, generateContext);
 		}
 
-		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm()
+		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm(
+			chunkGraph,
+			module
+		)
 			? runtimeTemplate._getAnalyzableWasmUrl(
 					module,
 					chunkGraph,
@@ -240,7 +243,10 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 		const { chunkGraph, runtimeTemplate, runtimeRequirements, runtime } =
 			generateContext;
 
-		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm()
+		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm(
+			chunkGraph,
+			module
+		)
 			? runtimeTemplate._getAnalyzableWasmUrl(
 					module,
 					chunkGraph,

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -10,6 +10,7 @@ const Generator = require("../Generator");
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
 const { tryRunOrWebpackError } = require("../errors/HookWebpackError");
+const AnalyzableChunkHashPlugin = require("../esm/AnalyzableChunkHashPlugin");
 const { compareModulesByFullName } = require("../util/comparators");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const lazyModule = require("../util/lazyModule");
@@ -78,6 +79,10 @@ class AsyncWebAssemblyModulesPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		// A binary's name may carry the compilation hash, which the analyzable call site
+		// leaves as a stand-in — so whatever the chunk loading is, the pass that fills it
+		// in has to be there. Applying it twice is a no-op.
+		new AnalyzableChunkHashPlugin().apply(compiler);
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {

--- a/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
+++ b/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
@@ -8,6 +8,7 @@
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const { usesFullHashDigest } = require("../TemplatedPathPlugin");
 const AsyncWasmCompileRuntimeModule = require("../wasm-async/AsyncWasmCompileRuntimeModule");
 const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRuntimeModule");
 
@@ -110,6 +111,11 @@ class UniversalCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmLoadingRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateBeforeLoadBinaryCode,
 							generateLoadBinaryCode,
 							generateBeforeInstantiateStreaming: generateBeforeStreaming,
@@ -133,6 +139,11 @@ class UniversalCompileAsyncWasmPlugin {
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmCompileRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateBeforeLoadBinaryCode,
 							generateLoadBinaryCode,
 							generateBeforeCompileStreaming: generateBeforeStreaming,

--- a/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
+++ b/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
@@ -8,6 +8,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 const { compareModulesByIdentifier } = require("../util/comparators");
+const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 const WebAssemblyUtils = require("./WebAssemblyUtils");
 
 /** @typedef {import("@webassemblyjs/ast").Signature} Signature */
@@ -225,6 +226,7 @@ const generateImportObject = (
  * @property {boolean=} supportsStreaming
  * @property {boolean=} mangleImports
  * @property {ReadOnlyRuntimeRequirements} runtimeRequirements
+ * @property {boolean=} fullHashDigest the binary's name inlines a re-encoded compilation hash
  */
 
 class WasmChunkLoadingRuntimeModule extends RuntimeModule {
@@ -235,9 +237,16 @@ class WasmChunkLoadingRuntimeModule extends RuntimeModule {
 		generateLoadBinaryCode,
 		supportsStreaming,
 		mangleImports,
-		runtimeRequirements
+		runtimeRequirements,
+		fullHashDigest
 	}) {
 		super("wasm chunk loading", RuntimeModule.STAGE_ATTACH);
+		// A re-encoded digest is inlined from the settled hash, so this has to render
+		// again once there is one.
+		if (fullHashDigest) {
+			/** @type {boolean} */
+			this.fullHash = true;
+		}
 		this.generateLoadBinaryCode = generateLoadBinaryCode;
 		/** @type {boolean | undefined} */
 		this.supportsStreaming = supportsStreaming;
@@ -291,9 +300,7 @@ class WasmChunkLoadingRuntimeModule extends RuntimeModule {
 		const wasmModuleSrcPath = compilation.getPath(
 			JSON.stringify(outputOptions.webassemblyModuleFilename),
 			{
-				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
-				hashWithLength: (length) =>
-					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+				...fullHashPathData(compilation),
 				module: {
 					id: '" + wasmModuleId + "',
 					hash: `" + ${JSON.stringify(

--- a/lib/wasm/wasmModuleFilename.js
+++ b/lib/wasm/wasmModuleFilename.js
@@ -1,0 +1,54 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author sheo13666q @sheo13666q
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const {
+	getPresentKinds,
+	reEncodeDigest,
+	usesFullHashDigest
+} = require("../TemplatedPathPlugin");
+
+/** @typedef {import("../Compilation")} Compilation */
+
+/**
+ * Whether the runtime needs `getFullHash` to build a binary's name. A `[hash]` next to
+ * a module resolves to that module's hash, not the compilation's, so only the explicit
+ * `[fullhash]` spelling asks for it — and a digest is inlined rather than read.
+ * @param {string} filename `output.webassemblyModuleFilename`
+ * @returns {boolean} true when the runtime reads the compilation hash
+ */
+const needsRuntimeFullHash = (filename) =>
+	getPresentKinds(filename).has("fullhash") && !usesFullHashDigest(filename);
+
+/**
+ * The compilation-hash half of the `getPath` data for interpolating
+ * `output.webassemblyModuleFilename` into runtime code.
+ * @param {Compilation} compilation the compilation
+ * @returns {{ hash: string, hashWithLength: (length: number) => string, hashWithDigest: (digest: string, length?: number) => string }} the fields
+ */
+const fullHashPathData = (compilation) => ({
+	hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
+	hashWithLength: (length) =>
+		`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+	// A digest re-encodes the hash, which the runtime expression above cannot carry, so
+	// the settled value is inlined instead — byte-identical to the emitted filename.
+	hashWithDigest: (digest, length) => {
+		const { fullHash, outputOptions } = compilation;
+		// Pre-hash pass: a stand-in, replaced on the post-hash re-render that
+		// `needsInlinedFullHash` asks for. Matches `GetFullHashRuntimeModule`.
+		if (!fullHash) return length ? "x".repeat(length) : "x";
+		const hash = reEncodeDigest(
+			fullHash,
+			outputOptions.hashDigest || "hex",
+			digest
+		);
+		return length ? hash.slice(0, length) : hash;
+	}
+});
+
+module.exports.fullHashPathData = fullHashPathData;
+module.exports.needsRuntimeFullHash = needsRuntimeFullHash;

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -7,20 +7,13 @@
 
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
-const { getPresentKinds } = require("../TemplatedPathPlugin");
+const { usesFullHashDigest } = require("../TemplatedPathPlugin");
+const { needsRuntimeFullHash } = require("../wasm/wasmModuleFilename");
 const AsyncWasmCompileRuntimeModule = require("../wasm-async/AsyncWasmCompileRuntimeModule");
 const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
-
-/**
- * The wasm runtime inlines `[fullhash]` as a runtime `getFullHash()` call, so
- * that runtime module must be requested (`[hash]` is the per-module hash here).
- * @param {string} filename `output.webassemblyModuleFilename`
- * @returns {boolean} whether it references the compilation `[fullhash]`
- */
-const usesFullHash = (filename) => getPresentKinds(filename).has("fullhash");
 
 const PLUGIN_NAME = "FetchCompileAsyncWasmPlugin";
 
@@ -97,13 +90,22 @@ class FetchCompileAsyncWasmPlugin {
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!baked &&
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmLoadingRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode: baked
 								? generateBakedLoadBinaryCode
 								: analyzable
@@ -135,13 +137,22 @@ class FetchCompileAsyncWasmPlugin {
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!baked &&
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new AsyncWasmCompileRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode: baked
 								? generateBakedLoadBinaryCode
 								: analyzable

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -94,7 +94,9 @@ class FetchCompileAsyncWasmPlugin {
 					// A baked URL carries the public path already, or asks for the global itself
 					// when the module sits at several depths.
 					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
+						!baked &&
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
@@ -130,7 +132,9 @@ class FetchCompileAsyncWasmPlugin {
 					// A baked URL carries the public path already, or asks for the global itself
 					// when the module sits at several depths.
 					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
+						!baked &&
 						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
 					) {
 						set.add(RuntimeGlobals.getFullHash);

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -7,19 +7,12 @@
 
 const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
-const { getPresentKinds } = require("../TemplatedPathPlugin");
+const { usesFullHashDigest } = require("../TemplatedPathPlugin");
+const { needsRuntimeFullHash } = require("../wasm/wasmModuleFilename");
 const WasmChunkLoadingRuntimeModule = require("../wasm-sync/WasmChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
-
-/**
- * The wasm runtime inlines `[fullhash]` as a runtime `getFullHash()` call, so
- * that runtime module must be requested (`[hash]` is the per-module hash here).
- * @param {string} filename `output.webassemblyModuleFilename`
- * @returns {boolean} whether it references the compilation `[fullhash]`
- */
-const usesFullHash = (filename) => getPresentKinds(filename).has("fullhash");
 
 /**
  * Options that influence how synchronous WebAssembly modules are emitted for
@@ -102,13 +95,22 @@ class FetchCompileWasmPlugin {
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
 					if (!analyzable) set.add(RuntimeGlobals.publicPath);
 					if (
-						usesFullHash(compilation.outputOptions.webassemblyModuleFilename)
+						needsRuntimeFullHash(
+							/** @type {string} */ (
+								compilation.outputOptions.webassemblyModuleFilename
+							)
+						)
 					) {
 						set.add(RuntimeGlobals.getFullHash);
 					}
 					compilation.addRuntimeModule(
 						chunk,
 						new WasmChunkLoadingRuntimeModule({
+							fullHashDigest: usesFullHashDigest(
+								/** @type {string} */ (
+									compilation.outputOptions.webassemblyModuleFilename
+								)
+							),
 							generateLoadBinaryCode: analyzable
 								? generateAnalyzableLoadBinaryCode
 								: generateLoadBinaryCode,

--- a/test/configCases/analyzable/block-without-origin/index.js
+++ b/test/configCases/analyzable/block-without-origin/index.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should load a require.ensure block", (done) => {
+	require.ensure(
+		["./lazy"],
+		() => {
+			expect(require("./lazy")).toBe("lazy");
+			done();
+		},
+		"ensured"
+	);
+});
+
+it("should keep the runtime form where the block names no origin", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+	const ensureChunkCall = `${"__webpack_require__"}.e(`;
+
+	expect(bundle).toContain(ensureChunkCall);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.ei(`);
+});

--- a/test/configCases/analyzable/block-without-origin/lazy.js
+++ b/test/configCases/analyzable/block-without-origin/lazy.js
@@ -1,0 +1,1 @@
+module.exports = "lazy";

--- a/test/configCases/analyzable/block-without-origin/test.filter.js
+++ b/test/configCases/analyzable/block-without-origin/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// `require.ensure` in ESM output emits `import { createRequire } from "module"`,
+// which older Node versions can't link in the vm ESM runner.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/block-without-origin/webpack.config.js
+++ b/test/configCases/analyzable/block-without-origin/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// `require.ensure` names no origin module for its block, so there is nothing a baked
+// specifier could be relative to and the runtime form stays.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		publicPath: "auto",
+		chunkFilename: "[name].mjs"
+	}
+};

--- a/test/configCases/analyzable/concatenated-origin/helper.js
+++ b/test/configCases/analyzable/concatenated-origin/helper.js
@@ -1,0 +1,1 @@
+export const double = (n) => n * 2;

--- a/test/configCases/analyzable/concatenated-origin/index.js
+++ b/test/configCases/analyzable/concatenated-origin/index.js
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+
+const read = (name) =>
+	fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+const analyzableImport = `${"__webpack_require__"}.ei(`;
+
+it("should bake a literal when concatenation absorbed the consuming module", () => {
+	const code = read("plain.mjs");
+
+	// The chunk graph places the `ConcatenatedModule`, not `plain.js` inside it, so the
+	// output depth this literal is relative to has to be read off the former.
+	expect(code).toContain(analyzableImport);
+	expect(code).toMatch(
+		/import\((?:\/\*[^*]*\*\/\s*)?"\.\/plain-lazy_js\.mjs"\)/
+	);
+	expect(fs.existsSync(path.join(__STATS__.outputPath, "plain-lazy_js.mjs"))).toBe(
+		true
+	);
+});
+
+it("should keep the runtime form when the absorbed module reassigns the public path", () => {
+	expect(read("overriding.mjs")).not.toContain(analyzableImport);
+});
+
+it("should load a chunk through the baked specifier", async () => {
+	const { value } = await import("./plain-lazy");
+
+	expect(value).toBe("plain-lazy");
+});

--- a/test/configCases/analyzable/concatenated-origin/overriding-lazy.js
+++ b/test/configCases/analyzable/concatenated-origin/overriding-lazy.js
@@ -1,0 +1,1 @@
+export const value = "overriding-lazy";

--- a/test/configCases/analyzable/concatenated-origin/overriding.js
+++ b/test/configCases/analyzable/concatenated-origin/overriding.js
@@ -1,0 +1,8 @@
+import { double } from "./helper";
+
+// Reassigns the public path, so nothing in this entry's runtime can bake a literal —
+// even though concatenation absorbs the module that reassigns it.
+__webpack_public_path__ = "/from-runtime/";
+
+export const load = () => import("./overriding-lazy");
+export const n = double(21);

--- a/test/configCases/analyzable/concatenated-origin/plain-lazy.js
+++ b/test/configCases/analyzable/concatenated-origin/plain-lazy.js
@@ -1,0 +1,1 @@
+export const value = "plain-lazy";

--- a/test/configCases/analyzable/concatenated-origin/plain.js
+++ b/test/configCases/analyzable/concatenated-origin/plain.js
@@ -1,0 +1,4 @@
+import { double } from "./helper";
+
+export const load = () => import("./plain-lazy");
+export const n = double(21);

--- a/test/configCases/analyzable/concatenated-origin/webpack.config.js
+++ b/test/configCases/analyzable/concatenated-origin/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+// Concatenation replaces the module that wrote the reference, so the chunk graph no
+// longer places that module — but the analyzable form still depends on where it lands.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: {
+		bundle0: "./index.js",
+		overriding: "./overriding.js",
+		plain: "./plain.js"
+	},
+	experiments: { outputModule: true },
+	optimization: {
+		chunkIds: "named",
+		runtimeChunk: false,
+		concatenateModules: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		publicPath: "auto",
+		chunkFilename: "[name].mjs"
+	}
+};

--- a/test/configCases/analyzable/deferred-before-minify/dynamic.js
+++ b/test/configCases/analyzable/deferred-before-minify/dynamic.js
@@ -1,0 +1,4 @@
+export const value = "dynamic";
+
+export const describe = (count) =>
+	`${value} chunk carrying ${count} identifiers that a minifier will rename`;

--- a/test/configCases/analyzable/deferred-before-minify/index.js
+++ b/test/configCases/analyzable/deferred-before-minify/index.js
@@ -1,0 +1,75 @@
+import fs from "fs";
+import path from "path";
+
+const BASE64 =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Generated column of every mapping, per generated line — the only field of a
+ * segment this needs, decoded here so the case pulls in no bundled dependency.
+ * @param {string} mappings the map's `mappings` field
+ * @returns {number[][]} generated columns, indexed by zero-based generated line
+ */
+const generatedColumns = (mappings) =>
+	mappings.split(";").map((line) => {
+		const columns = [];
+		let column = 0;
+
+		for (const segment of line.split(",")) {
+			if (segment === "") continue;
+
+			let value = 0;
+			let shift = 0;
+			let index = 0;
+			let digit;
+
+			do {
+				digit = BASE64.indexOf(segment[index++]);
+				value += (digit & 31) << shift;
+				shift += 5;
+			} while (digit & 32);
+
+			column += value & 1 ? -(value >> 1) : value >> 1;
+			columns.push(column);
+		}
+
+		return columns;
+	});
+
+it("should load the chunk through the baked specifier", async () => {
+	const { value, describe } = await import(
+		/* webpackChunkName: "dynamic" */ "./dynamic"
+	);
+
+	expect(value).toBe("dynamic");
+	expect(describe(2)).toContain("minifier");
+});
+
+it("should keep every mapping inside the line it names after minification", () => {
+	const dir = __STATS__.outputPath;
+	const code = fs.readFileSync(path.join(dir, "bundle0.mjs"), "utf8");
+	const map = JSON.parse(
+		fs.readFileSync(path.join(dir, "bundle0.mjs.map"), "utf8")
+	);
+	// A source checked out with CRLF ends each line with a `\r` the mappings do not
+	// name — drop it so the line lengths are the same on every platform.
+	const lines = code.split("\n").map((text) => text.replace(/\r$/, ""));
+	const specifier = /"(\.\/dynamic\.[0-9a-f]+\.mjs)"/.exec(code);
+
+	expect(specifier).not.toBe(null);
+	expect(fs.existsSync(path.join(dir, specifier[1].slice(2)))).toBe(true);
+
+	// A map written before the stand-in was replaced describes text longer than what
+	// was emitted, so the mappings past the specifier run off the end of their line.
+	const columns = generatedColumns(map.mappings);
+
+	expect(columns.length).toBeLessThanOrEqual(lines.length);
+	for (const [line, inLine] of columns.entries()) {
+		for (const column of inLine) {
+			expect([line, column]).toEqual([
+				line,
+				Math.min(column, lines[line].length)
+			]);
+		}
+	}
+});

--- a/test/configCases/analyzable/deferred-before-minify/roundTrip.js
+++ b/test/configCases/analyzable/deferred-before-minify/roundTrip.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Marker: RoundTripConfigCases re-bundles this case's output and asserts the
+// minified, hash-named `import("./dynamic.<hash>.mjs")` survives the round trip.
+module.exports = true;

--- a/test/configCases/analyzable/deferred-before-minify/webpack.config.js
+++ b/test/configCases/analyzable/deferred-before-minify/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// Terser and the source-map writer both read the asset, so a stand-in must already
+// be gone: it is a different length than the name that replaces it.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: "source-map",
+	experiments: { outputModule: true },
+	optimization: {
+		chunkIds: "named",
+		minimize: true,
+		splitChunks: false,
+		realContentHash: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module",
+		publicPath: "auto",
+		chunkFilename: "[name].[contenthash].mjs"
+	}
+};

--- a/test/configCases/analyzable/deferred-before-source-maps/dynamic.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/dynamic.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/test/configCases/analyzable/deferred-before-source-maps/index.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/index.js
@@ -1,28 +1,70 @@
 import fs from "fs";
 import path from "path";
 
+const BASE64 =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Generated columns of the mappings on one line, which is the only field of a
+ * segment this needs — decoded here so the case pulls in no bundled dependency.
+ * @param {string} mappings the map's `mappings` field
+ * @param {number} line one-based generated line
+ * @returns {number[]} generated column of each mapping on that line
+ */
+const generatedColumns = (mappings, line) => {
+	const columns = [];
+	let column = 0;
+
+	for (const segment of mappings.split(";")[line - 1].split(",")) {
+		if (segment === "") continue;
+
+		let value = 0;
+		let shift = 0;
+		let index = 0;
+		let digit;
+
+		do {
+			digit = BASE64.indexOf(segment[index++]);
+			value += (digit & 31) << shift;
+			shift += 5;
+		} while (digit & 32);
+
+		column += value & 1 ? -(value >> 1) : value >> 1;
+		columns.push(column);
+	}
+
+	return columns;
+};
+
 it("should load the chunk through the baked specifier", async () => {
 	const { value } = await import(/* webpackChunkName: "dynamic" */ "./dynamic");
 
 	expect(value).toBe("dynamic");
 });
 
-it("should describe the substituted bundle in the source map", () => {
+it("should keep the mappings past the specifier on the columns they name", () => {
 	const dir = __STATS__.outputPath;
 	const code = fs.readFileSync(path.join(dir, "bundle0.mjs"), "utf8");
 	const map = JSON.parse(
 		fs.readFileSync(path.join(dir, "bundle0.mjs.map"), "utf8")
 	);
-	const specifier = code.match(
-		/import\((?:\/\*[^*]*\*\/\s*)?"(\.\/dynamic\.[0-9a-f]+\.mjs)"\)/
+	// A source checked out with CRLF puts a `\r` after the statement, which the
+	// mappings do not name — drop it so the last column is the same on every platform.
+	const lines = code.split("\n").map((text) => text.replace(/\r$/, ""));
+	const line = lines.findIndex((text) =>
+		/"\.\/dynamic\.[0-9a-f]+\.mjs"/.test(text)
 	);
 
-	// The name reached the bundle and the file it names reached disk.
-	expect(specifier).not.toBe(null);
+	expect(line).not.toBe(-1);
+	const specifier = /"(\.\/dynamic\.[0-9a-f]+\.mjs)"/.exec(lines[line]);
+
 	expect(fs.existsSync(path.join(dir, specifier[1].slice(2)))).toBe(true);
-	// A map generated before substitution would describe a longer file.
-	expect(map.mappings.length).toBeGreaterThan(0);
-	expect(code.split("\n").length).toBeGreaterThanOrEqual(
-		map.mappings.split(";").length - 1
-	);
+
+	const columns = generatedColumns(map.mappings, line + 1);
+
+	// The statement's last mapping names its last character. A map written against
+	// the stand-in names a column short by what the two names differ in length by.
+	expect(columns.length).toBeGreaterThan(1);
+	expect(columns[columns.length - 1]).toBe(lines[line].length - 1);
+	expect(columns[columns.length - 1]).toBeGreaterThan(lines[line].indexOf(specifier[1]));
 });

--- a/test/configCases/analyzable/deferred-before-source-maps/index.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/index.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+it("should load the chunk through the baked specifier", async () => {
+	const { value } = await import(/* webpackChunkName: "dynamic" */ "./dynamic");
+
+	expect(value).toBe("dynamic");
+});
+
+it("should describe the substituted bundle in the source map", () => {
+	const dir = __STATS__.outputPath;
+	const code = fs.readFileSync(path.join(dir, "bundle0.mjs"), "utf8");
+	const map = JSON.parse(
+		fs.readFileSync(path.join(dir, "bundle0.mjs.map"), "utf8")
+	);
+	const specifier = code.match(
+		/import\((?:\/\*[^*]*\*\/\s*)?"(\.\/dynamic\.[0-9a-f]+\.mjs)"\)/
+	);
+
+	// The name reached the bundle and the file it names reached disk.
+	expect(specifier).not.toBe(null);
+	expect(fs.existsSync(path.join(dir, specifier[1].slice(2)))).toBe(true);
+	// A map generated before substitution would describe a longer file.
+	expect(map.mappings.length).toBeGreaterThan(0);
+	expect(code.split("\n").length).toBeGreaterThanOrEqual(
+		map.mappings.split(";").length - 1
+	);
+});

--- a/test/configCases/analyzable/deferred-before-source-maps/webpack.config.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/webpack.config.js
@@ -1,0 +1,58 @@
+"use strict";
+
+// A stand-in is a different length than the name that replaces it, so everything
+// after it moves. Whatever reads an asset — the source-map writer, a minifier — has
+// to see the final text, not the stand-in.
+
+const Compilation = require("../../../../lib/Compilation");
+
+const MARKERS = ["@@webpackAnalyzableChunk", "@@webpackFullHash"];
+
+/** Fails the build if a stand-in is still there when source maps are written. */
+class AssertSubstitutedBeforeDevTooling {
+	/**
+	 * @param {import("../../../../").Compiler} compiler the compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("AssertSubstituted", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "AssertSubstituted",
+					stage: Compilation.PROCESS_ASSETS_STAGE_DEV_TOOLING
+				},
+				(assets) => {
+					for (const name of Object.keys(assets)) {
+						const source = assets[name].source();
+						if (typeof source !== "string") continue;
+						for (const marker of MARKERS) {
+							if (source.includes(marker)) {
+								compilation.errors.push(
+									new Error(
+										`${name} still carries a ${marker} stand-in when source maps are written`
+									)
+								);
+							}
+						}
+					}
+				}
+			);
+		});
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: "source-map",
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", realContentHash: true },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		publicPath: "auto",
+		chunkFilename: "[name].[contenthash].mjs"
+	},
+	plugins: [new AssertSubstitutedBeforeDevTooling()]
+};

--- a/test/configCases/analyzable/public-path-override-scope/index.js
+++ b/test/configCases/analyzable/public-path-override-scope/index.js
@@ -1,0 +1,15 @@
+import fs from "fs";
+import path from "path";
+
+const read = (name) =>
+	fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+const analyzableImport = `${"__webpack_require__"}.ei(`;
+
+it("should keep the runtime form in the entry that reassigns the public path", () => {
+	expect(read("overriding.mjs")).not.toContain(analyzableImport);
+});
+
+it("should still bake in an entry that does not", () => {
+	expect(read("plain.mjs")).toContain(analyzableImport);
+	expect(read("plain.mjs")).toMatch(/import\((?:\/\*[^*]*\*\/\s*)?"\.\/plain-lazy_js\.mjs"\)/);
+});

--- a/test/configCases/analyzable/public-path-override-scope/overriding-lazy.js
+++ b/test/configCases/analyzable/public-path-override-scope/overriding-lazy.js
@@ -1,0 +1,1 @@
+export const value = "overriding";

--- a/test/configCases/analyzable/public-path-override-scope/overriding.js
+++ b/test/configCases/analyzable/public-path-override-scope/overriding.js
@@ -1,0 +1,4 @@
+// Reassigns the public path, so nothing in this entry's runtime can bake a literal.
+__webpack_public_path__ = "/from-runtime/";
+
+export const load = () => import("./overriding-lazy");

--- a/test/configCases/analyzable/public-path-override-scope/plain-lazy.js
+++ b/test/configCases/analyzable/public-path-override-scope/plain-lazy.js
@@ -1,0 +1,1 @@
+export const value = "plain";

--- a/test/configCases/analyzable/public-path-override-scope/plain.js
+++ b/test/configCases/analyzable/public-path-override-scope/plain.js
@@ -1,0 +1,1 @@
+export const load = () => import("./plain-lazy");

--- a/test/configCases/analyzable/public-path-override-scope/webpack.config.js
+++ b/test/configCases/analyzable/public-path-override-scope/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// `__webpack_require__.p` belongs to a runtime, so an entry that reassigns it says
+// nothing about an entry that does not.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: {
+		bundle0: "./index.js",
+		overriding: "./overriding.js",
+		plain: "./plain.js"
+	},
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", runtimeChunk: false },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		publicPath: "auto",
+		chunkFilename: "[name].mjs"
+	}
+};

--- a/test/configCases/analyzable/templated-public-path/dynamic.js
+++ b/test/configCases/analyzable/templated-public-path/dynamic.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/test/configCases/analyzable/templated-public-path/index.js
+++ b/test/configCases/analyzable/templated-public-path/index.js
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced so the chunk exists, never executed — the harness cannot fetch an
+// absolute CDN url.
+const load = () => import(/* webpackChunkName: "dynamic" */ "./dynamic.js");
+
+const stats = __STATS__.children[__INDEX__];
+const bundle = () =>
+	fs.readFileSync(path.join(stats.outputPath, `bundle${__INDEX__}.mjs`), "utf8");
+// Built here so an assertion never matches this file's own source.
+const ensureChunkCall = `${"__webpack_require__"}.e(`;
+
+it("should keep the chunk referenced", () => {
+	expect(typeof load).toBe("function");
+});
+
+if (__BAKED__) {
+	it("should bake the public path's compilation hash into the specifier", () => {
+		const specifier = bundle().match(
+			/import\((?:\/\*[^*]*\*\/\s*)?"(https:\/\/cdn\.example\.com\/[^"]+)"\)/
+		);
+
+		expect(specifier).not.toBe(null);
+		const url = specifier[1];
+		const [, hash, file] = url.split("https://cdn.example.com/")[1].match(
+			/^([^/]+)\/(.+)$/
+		);
+
+		expect(hash).toBe(
+			__SLICE__ ? stats.hash.slice(0, __SLICE__) : stats.hash
+		);
+		// The name in the specifier is the one that reached disk.
+		expect(fs.existsSync(path.join(stats.outputPath, file))).toBe(true);
+	});
+
+	it("should not fall back to the runtime chunk loader", () => {
+		expect(bundle()).toContain(`${"__webpack_require__"}.ei(`);
+		expect(bundle()).not.toContain(ensureChunkCall);
+	});
+} else {
+	it("should keep the runtime form when the public path cannot be filled in", () => {
+		expect(bundle()).not.toMatch(/import\((?:\/\*[^*]*\*\/\s*)?"https:/);
+		expect(bundle()).toContain(ensureChunkCall);
+	});
+}

--- a/test/configCases/analyzable/templated-public-path/webpack.config.js
+++ b/test/configCases/analyzable/templated-public-path/webpack.config.js
@@ -50,7 +50,10 @@ module.exports = [
 	// A digest re-encodes the hash rather than reading it, which a stand-in cannot
 	// survive, so the whole specifier stays on the runtime form.
 	base(3, "digest", "[fullhash:base64]", false),
-	// Substituting rewrites the chunk after its own content hash was taken, and
-	// `RealContentHashPlugin` is what brings the two back in line.
-	base(4, "no-repair", "[fullhash]", false, "", false)
+	// No javascript here is named by its content, so rewriting one invalidates
+	// nothing and there is no repair to need.
+	base(4, "no-repair-hash-free", "[fullhash]", true, "", false),
+	// This one is: substituting rewrites the chunk after its own content hash was
+	// taken, and `RealContentHashPlugin` is what brings the two back in line.
+	base(5, "no-repair-hashed", "[fullhash]", false, ".[contenthash]", false)
 ];

--- a/test/configCases/analyzable/templated-public-path/webpack.config.js
+++ b/test/configCases/analyzable/templated-public-path/webpack.config.js
@@ -1,0 +1,56 @@
+"use strict";
+
+// A public path carrying `[fullhash]` is settled no earlier than the hash it reads,
+// so the specifier reserves a stand-in the deferred pass fills in.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {string} hashPart the `[fullhash]` form under test
+ * @param {boolean} baked whether the specifier is expected to be a literal
+ * @param {string=} chunkSuffix what follows the chunk's name in its filename
+ * @param {boolean=} realContentHash whether the deferred pass may run at all
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (
+	index,
+	name,
+	hashPart,
+	baked,
+	chunkSuffix = "",
+	realContentHash = true
+) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", realContentHash },
+	output: {
+		module: true,
+		publicPath: `https://cdn.example.com/${hashPart}/`,
+		chunkFilename: `${name}-[name]${chunkSuffix}.mjs`
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__BAKED__: JSON.stringify(baked),
+			__SLICE__: JSON.stringify(hashPart.includes(":8") ? 8 : 0)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "plain", "[fullhash]", true),
+	base(1, "sliced", "[fullhash:8]", true),
+	// Both halves of the name are deferred: the public path's hash and the chunk's own.
+	base(2, "hashed-chunk", "[fullhash]", true, ".[contenthash]"),
+	// A digest re-encodes the hash rather than reading it, which a stand-in cannot
+	// survive, so the whole specifier stays on the runtime form.
+	base(3, "digest", "[fullhash:base64]", false),
+	// Substituting rewrites the chunk after its own content hash was taken, and
+	// `RealContentHashPlugin` is what brings the two back in line.
+	base(4, "no-repair", "[fullhash]", false, "", false)
+];

--- a/test/configCases/analyzable/templated-worker-public-path/index.js
+++ b/test/configCases/analyzable/templated-worker-public-path/index.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced so the worker chunk exists, never started — the harness cannot fetch an
+// absolute CDN url.
+const spawn = () =>
+	new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+
+it("should bake a worker's own templated public path", () => {
+	expect(typeof spawn).toBe("function");
+
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+	const specifier = bundle.match(
+		/\/\* worker import \*\/ "(https:\/\/cdn\.example\.com\/[^"]+)"/
+	);
+
+	expect(specifier).not.toBe(null);
+	const [, hash, file] = specifier[1]
+		.split("https://cdn.example.com/")[1]
+		.match(/^([^/]+)\/(.+)$/);
+
+	expect(hash).toBe(__STATS__.hash);
+	// The name in the specifier is the one that reached disk.
+	expect(fs.existsSync(path.join(__STATS__.outputPath, file))).toBe(true);
+});

--- a/test/configCases/analyzable/templated-worker-public-path/test.config.js
+++ b/test/configCases/analyzable/templated-worker-public-path/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		scope.URL = URL;
+	}
+};

--- a/test/configCases/analyzable/templated-worker-public-path/test.filter.js
+++ b/test/configCases/analyzable/templated-worker-public-path/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/analyzable/templated-worker-public-path/webpack.config.js
+++ b/test/configCases/analyzable/templated-worker-public-path/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// `output.workerPublicPath` wins over the global one for a worker's chunks, and
+// carries the same `[fullhash]` — resolved the same way.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node14",
+	mode: "development",
+	devtool: false,
+	optimization: { chunkIds: "named", realContentHash: true },
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		publicPath: "auto",
+		workerPublicPath: "https://cdn.example.com/[fullhash]/",
+		workerChunkFilename: "[name].mjs"
+	}
+};

--- a/test/configCases/analyzable/templated-worker-public-path/worker.js
+++ b/test/configCases/analyzable/templated-worker-public-path/worker.js
@@ -1,0 +1,5 @@
+import { parentPort } from "worker_threads";
+
+parentPort.on("message", msg => {
+	parentPort.postMessage(`data: ${msg.toUpperCase()}, thanks`);
+});

--- a/test/configCases/wasm/analyzable-fullhash-filename/index.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/index.js
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+// Always referenced so the chunk under test exists; only called where the emitted
+// name is one the runtime can actually find.
+export const load = () => import("./module");
+
+const outputPath = __STATS__.children[__INDEX__].outputPath;
+const chunk = () =>
+	fs.readFileSync(path.join(outputPath, __WASM_CHUNK__), "utf8");
+// Built here so an assertion never matches this file's own source.
+const byIdAndHash = `${"__webpack_require__"}.v(exports, module.id, "`;
+
+if (__RUNS__) {
+	it("should load an async WebAssembly module named with the compilation hash", async () => {
+		const { run } = await load();
+		expect(run()).toBe(84);
+	});
+}
+
+if (__BAKED__) {
+	it("should bake the binary's name, compilation hash and all", () => {
+		const urls = chunk().match(/new URL\("[^"]+\.module\.wasm"/g);
+
+		expect(urls).toHaveLength(2);
+		for (const match of urls) {
+			const specifier = match.slice('new URL("'.length, -1);
+			// Relative to the chunk, which sits one directory down.
+			expect(specifier.slice(0, 3)).toBe("../");
+			expect(fs.existsSync(path.join(outputPath, specifier.slice(3)))).toBe(
+				true
+			);
+		}
+	});
+
+	it("should hand the loader a url rather than an id to name the binary from", () => {
+		expect(chunk()).not.toContain(byIdAndHash);
+	});
+} else {
+	it("should keep the runtime form when the name cannot be filled in", () => {
+		expect(chunk()).not.toMatch(/new URL\("[^"]+\.module\.wasm"/);
+		expect(chunk()).toContain(byIdAndHash);
+	});
+}

--- a/test/configCases/wasm/analyzable-fullhash-filename/index.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/index.js
@@ -6,8 +6,13 @@ import path from "path";
 export const load = () => import("./module");
 
 const outputPath = __STATS__.children[__INDEX__].outputPath;
-const chunk = () =>
-	fs.readFileSync(path.join(outputPath, __WASM_CHUNK__), "utf8");
+// Found rather than named: the chunk's filename may carry a content hash.
+const chunk = () => {
+	const dir = path.join(outputPath, __CHUNK_DIR__);
+	const file = fs.readdirSync(dir).find((name) => name.startsWith("module_js"));
+
+	return fs.readFileSync(path.join(dir, file), "utf8");
+};
 // Built here so an assertion never matches this file's own source.
 const byIdAndHash = `${"__webpack_require__"}.v(exports, module.id, "`;
 

--- a/test/configCases/wasm/analyzable-fullhash-filename/module.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/module.js
@@ -1,0 +1,6 @@
+import { getNumber } from "./wasm.wat?1";
+import { getNumber as getNumber2 } from "./wasm.wat?2";
+
+export function run() {
+	return getNumber() + getNumber2();
+}

--- a/test/configCases/wasm/analyzable-fullhash-filename/test.config.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	moduleScope(scope) {
+		scope.fs = fs;
+		scope.path = path;
+	}
+};

--- a/test/configCases/wasm/analyzable-fullhash-filename/wasm.wat
+++ b/test/configCases/wasm/analyzable-fullhash-filename/wasm.wat
@@ -1,0 +1,9 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))

--- a/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
@@ -11,10 +11,19 @@ const webpack = require("../../../../");
  * @param {string} hashPart the `[fullhash]` form under test
  * @param {boolean} baked whether the binary's url is expected to be a literal
  * @param {boolean} runs whether the binary can be loaded back
+ * @param {string=} chunkSuffix what follows the chunk's name in its filename
  * @param {boolean=} realContentHash whether the deferred pass may run at all
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, name, hashPart, baked, runs, realContentHash = true) => ({
+const base = (
+	index,
+	name,
+	hashPart,
+	baked,
+	runs,
+	chunkSuffix = "",
+	realContentHash = true
+) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -28,14 +37,14 @@ const base = (index, name, hashPart, baked, runs, realContentHash = true) => ({
 	output: {
 		module: true,
 		wasmLoading: "async-node",
-		chunkFilename: `${name}-chunks/[name].mjs`,
+		chunkFilename: `${name}-chunks/[name]${chunkSuffix}.mjs`,
 		webassemblyModuleFilename: `${name}.${hashPart}.[hash].module.wasm`,
 		publicPath: "auto"
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
-			__WASM_CHUNK__: JSON.stringify(`${name}-chunks/module_js.mjs`),
+			__CHUNK_DIR__: JSON.stringify(`${name}-chunks`),
 			__BAKED__: JSON.stringify(baked),
 			__RUNS__: JSON.stringify(runs)
 		})
@@ -52,6 +61,7 @@ module.exports = [
 	// only the fall back itself is asserted here.
 	base(2, "digest", "[fullhash:base64]", false, false),
 	// Substituting rewrites the chunk after its own content hash was taken, and
-	// `RealContentHashPlugin` is what brings the two back in line.
-	base(3, "no-repair", "[fullhash]", false, true, false)
+	// `RealContentHashPlugin` is what brings the two back in line. Without a content
+	// hash in the name there would be nothing to bring back in line, so it carries one.
+	base(3, "no-repair", "[fullhash]", false, true, ".[contenthash]", false)
 ];

--- a/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
@@ -1,0 +1,57 @@
+"use strict";
+
+// `[fullhash]` in a wasm filename is settled only after code generation, so the
+// analyzable call site reserves a stand-in that the deferred pass fills in.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {string} hashPart the `[fullhash]` form under test
+ * @param {boolean} baked whether the binary's url is expected to be a literal
+ * @param {boolean} runs whether the binary can be loaded back
+ * @param {boolean=} realContentHash whether the deferred pass may run at all
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, hashPart, baked, runs, realContentHash = true) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false, realContentHash },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "async-node",
+		chunkFilename: `${name}-chunks/[name].mjs`,
+		webassemblyModuleFilename: `${name}.${hashPart}.[hash].module.wasm`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__WASM_CHUNK__: JSON.stringify(`${name}-chunks/module_js.mjs`),
+			__BAKED__: JSON.stringify(baked),
+			__RUNS__: JSON.stringify(runs)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "plain", "[fullhash]", true, true),
+	base(1, "sliced", "[fullhash:8]", true, true),
+	// A digest re-encodes the hash rather than reading it, which a stand-in cannot
+	// survive, so the name stays on the runtime form. That form drops the hash
+	// entirely (a bug of its own, and the reason this one is not loaded back), so
+	// only the fall back itself is asserted here.
+	base(2, "digest", "[fullhash:base64]", false, false),
+	// Substituting rewrites the chunk after its own content hash was taken, and
+	// `RealContentHashPlugin` is what brings the two back in line.
+	base(3, "no-repair", "[fullhash]", false, true, false)
+];

--- a/test/configCases/wasm/full-hash-digest-filename/index.js
+++ b/test/configCases/wasm/full-hash-digest-filename/index.js
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+
+const outputPath = __STATS__.children[__INDEX__].outputPath;
+const bundle = () =>
+	fs.readFileSync(path.join(outputPath, `bundle${__INDEX__}.mjs`), "utf8");
+
+it("should load a wasm binary whose name carries the compilation hash", async () => {
+	const { run } = await import("./module");
+
+	expect(run()).toBe(84);
+});
+
+it("should assemble the name the binary was emitted under", () => {
+	const emitted = fs
+		.readdirSync(outputPath)
+		.filter((name) => name.startsWith(__PREFIX__));
+
+	expect(emitted).toHaveLength(2);
+	// Everything before the per-module hash is fixed for the whole build.
+	const prefix = emitted[0].slice(0, emitted[0].lastIndexOf(".", emitted[0].length - 13));
+	const getFullHash = `${"__webpack_require__"}.h()`;
+
+	if (__INLINED__) {
+		// A re-encoded digest cannot be read back at runtime, so it is already there.
+		expect(bundle()).toContain(`"${prefix}.`);
+		expect(bundle()).not.toContain(getFullHash);
+	} else {
+		expect(bundle()).toContain(getFullHash);
+	}
+});

--- a/test/configCases/wasm/full-hash-digest-filename/module.js
+++ b/test/configCases/wasm/full-hash-digest-filename/module.js
@@ -1,0 +1,6 @@
+import { getNumber } from "./wasm.wat?1";
+import { getNumber as getNumber2 } from "./wasm.wat?2";
+
+export function run() {
+	return getNumber() + getNumber2();
+}

--- a/test/configCases/wasm/full-hash-digest-filename/wasm.wat
+++ b/test/configCases/wasm/full-hash-digest-filename/wasm.wat
@@ -1,0 +1,9 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))

--- a/test/configCases/wasm/full-hash-digest-filename/webpack.config.js
+++ b/test/configCases/wasm/full-hash-digest-filename/webpack.config.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// A `[fullhash:<digest>]` in a wasm binary's name re-encodes the compilation hash, so
+// the runtime cannot read it back from `getFullHash()` — the settled value is inlined
+// into the loader instead.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {string} hashPart the `[fullhash]` form under test
+ * @param {boolean} inlined whether the compilation hash is inlined into the loader
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, hashPart, inlined) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "async-node",
+		chunkFilename: `${name}-chunks/[name].mjs`,
+		webassemblyModuleFilename: `${name}.${hashPart}.[hash].module.wasm`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__PREFIX__: JSON.stringify(`${name}.`),
+			__INLINED__: JSON.stringify(inlined)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "digest", "[fullhash:base64safe]", true),
+	base(1, "digest-sliced", "[fullhash:base64safe:8]", true),
+	// A plain read still goes through the runtime helper.
+	base(2, "plain", "[fullhash]", false)
+];

--- a/test/configCases/wasm/full-hash-digest-filename/webpack.config.js
+++ b/test/configCases/wasm/full-hash-digest-filename/webpack.config.js
@@ -27,7 +27,7 @@ const base = (index, name, hashPart, inlined) => ({
 	output: {
 		module: true,
 		wasmLoading: "async-node",
-		chunkFilename: `${name}-chunks/[name].mjs`,
+		chunkFilename: `${name}-chunks/[name].[contenthash].mjs`,
 		webassemblyModuleFilename: `${name}.${hashPart}.[hash].module.wasm`,
 		publicPath: "auto"
 	},
@@ -44,6 +44,8 @@ const base = (index, name, hashPart, inlined) => ({
 module.exports = [
 	base(0, "digest", "[fullhash:base64safe]", true),
 	base(1, "digest-sliced", "[fullhash:base64safe:8]", true),
-	// A plain read still goes through the runtime helper.
+	// A plain read still goes through the runtime helper. Every config here names its
+	// javascript by content, which keeps the analyzable form from baking the name and
+	// leaves the runtime interpolation this case is about in place.
 	base(2, "plain", "[fullhash]", false)
 ];

--- a/test/configCases/wasm/full-hash-digest-source-phase/index.js
+++ b/test/configCases/wasm/full-hash-digest-source-phase/index.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should load a source-phase binary named by a re-encoded compilation hash", async () => {
+	const { run } = await import("./module");
+
+	expect(run()).toBe(84);
+});
+
+it("should inline the hash rather than read it back at runtime", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.js"),
+		"utf8"
+	);
+
+	expect(bundle).toContain(".compile.wasm");
+	expect(bundle).not.toContain(`${"__webpack_require__"}.h()`);
+});

--- a/test/configCases/wasm/full-hash-digest-source-phase/module.js
+++ b/test/configCases/wasm/full-hash-digest-source-phase/module.js
@@ -1,0 +1,9 @@
+import source wasmModule1 from "./wasm.wat?1";
+import source wasmModule2 from "./wasm.wat?2";
+
+const wasm1 = new WebAssembly.Instance(wasmModule1);
+const wasm2 = new WebAssembly.Instance(wasmModule2);
+
+export function run() {
+	return wasm1.exports.getNumber() + wasm2.exports.getNumber();
+}

--- a/test/configCases/wasm/full-hash-digest-source-phase/wasm.wat
+++ b/test/configCases/wasm/full-hash-digest-source-phase/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/full-hash-digest-source-phase/webpack.config.js
+++ b/test/configCases/wasm/full-hash-digest-source-phase/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+// A source-phase import names its binary through `compileWasm` rather than through the
+// instantiating loader, so that runtime module has to inline the re-encoded hash too.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	output: {
+		webassemblyModuleFilename: "[id].[fullhash:base64safe].compile.wasm"
+	},
+	experiments: { asyncWebAssembly: true, sourceImport: true }
+};

--- a/test/configCases/wasm/full-hash-digest-sync/index.js
+++ b/test/configCases/wasm/full-hash-digest-sync/index.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should load a sync binary named by a re-encoded compilation hash", async () => {
+	const { run } = await import("./module");
+
+	expect(run()).toBe(84);
+});
+
+it("should inline the hash rather than read it back at runtime", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.js"),
+		"utf8"
+	);
+
+	expect(bundle).toContain(".sync.wasm");
+	expect(bundle).not.toContain(`${"__webpack_require__"}.h()`);
+});

--- a/test/configCases/wasm/full-hash-digest-sync/module.js
+++ b/test/configCases/wasm/full-hash-digest-sync/module.js
@@ -1,0 +1,6 @@
+import { getNumber } from "./wasm.wat?1";
+import { getNumber as getNumber2 } from "./wasm.wat?2";
+
+export function run() {
+	return getNumber() + getNumber2();
+}

--- a/test/configCases/wasm/full-hash-digest-sync/wasm.wat
+++ b/test/configCases/wasm/full-hash-digest-sync/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/full-hash-digest-sync/webpack.config.js
+++ b/test/configCases/wasm/full-hash-digest-sync/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+// A sync binary is named by the chunk loader rather than by an async loader, so that
+// runtime module has to inline the re-encoded hash too.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/sync" }]
+	},
+	output: {
+		webassemblyModuleFilename: "[id].[fullhash:base64safe].sync.wasm"
+	},
+	experiments: { syncWebAssembly: true }
+};

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -59,6 +59,15 @@ hmr:
     ./async.js X bytes [built] [code generated]
   hmr (webpack x.x.x) compiled successfully in X ms
 
+templated-public-path:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 4 modules
+  cacheable modules X bytes
+    ./index.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  templated-public-path (webpack x.x.x) compiled successfully in X ms
+
 public-path-override:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
@@ -75,14 +84,5 @@ content-hash:
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
-  content-hash (webpack x.x.x) compiled successfully in X ms
-
-templated-public-path:
-  asset main.mjs X KiB [emitted] [javascript module] (name: main)
-  asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 7 modules
-  cacheable modules X bytes
-    ./index.js X bytes [built] [code generated]
-    ./async.js X bytes [built] [code generated]
-  templated-public-path (webpack x.x.x) compiled successfully in X ms"
+  content-hash (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -15,7 +15,9 @@ const CASES = {
 	// output — the analyzable form is still emitted (documented limitation).
 	"fetch-priority": { file: "main.mjs", expect: "analyzable" },
 	"content-hash": { file: "main.mjs", expect: "fallback" },
-	"templated-public-path": { file: "main.mjs", expect: "fallback" },
+	// The public path's hash is filled in by the deferred pass, and no name here is
+	// built from content, so there is none for the rewrite to invalidate.
+	"templated-public-path": { file: "main.mjs", expect: "analyzable" },
 	"bare-public-path": { file: "main.mjs", expect: "analyzable" },
 	"shared-chunk": { file: "a.mjs", expect: "analyzable" },
 	prefetch: { file: "main.mjs", expect: "analyzable" },

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -49,15 +49,17 @@ module.exports = [
 	// Also analyzable: the hot require wraps `.ei` the same way it wraps `.e`, so an
 	// update still blocks on an in-flight chunk load.
 	base("hmr", { plugins: [new webpack.HotModuleReplacementPlugin()] }),
-	// Every case below must fall back with no `.ei` emitted.
-	base("public-path-override", { entry: "./index-public-path-override" }),
-	// The two hashed names below are deferrable in themselves; what stops them here is
-	// `optimization.realContentHash`, off by default in development — without it the
-	// rewritten chunk's own content hash would go stale.
-	base("content-hash", {
-		output: { chunkFilename: "[name].[contenthash].mjs" }
-	}),
+	// Also analyzable: the public path's hash is filled in by the deferred pass, and
+	// nothing here is named by its content, so rewriting a chunk invalidates no name.
 	base("templated-public-path", {
 		output: { publicPath: "/assets/[fullhash]/" }
+	}),
+	// Every case below must fall back with no `.ei` emitted.
+	base("public-path-override", { entry: "./index-public-path-override" }),
+	// Deferrable in itself; what stops it here is that the chunk is named by its own
+	// content while `optimization.realContentHash` is off, as it is by default in
+	// development — so the name it would be rewritten under has nothing to repair it.
+	base("content-hash", {
+		output: { chunkFilename: "[name].[contenthash].mjs" }
 	})
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -51,6 +51,9 @@ module.exports = [
 	base("hmr", { plugins: [new webpack.HotModuleReplacementPlugin()] }),
 	// Every case below must fall back with no `.ei` emitted.
 	base("public-path-override", { entry: "./index-public-path-override" }),
+	// The two hashed names below are deferrable in themselves; what stops them here is
+	// `optimization.realContentHash`, off by default in development — without it the
+	// rewritten chunk's own content hash would go stale.
 	base("content-hash", {
 		output: { chunkFilename: "[name].[contenthash].mjs" }
 	}),

--- a/test/statsCases/output-module/__snapshots__/StatsTest.snap
+++ b/test/statsCases/output-module/__snapshots__/StatsTest.snap
@@ -3,7 +3,7 @@
 exports[`StatsTestCases output-module should print correct stats for output-module 1`] = `
 "asset main.mjs X KiB [emitted] [javascript module] (name: main)
 asset 936.mjs X bytes [emitted] [javascript module]
-runtime modules X KiB 5 modules
+runtime modules X KiB 3 modules
 orphan modules X bytes [orphan] 1 module
 cacheable modules X bytes
   ./index.js + 1 modules X bytes [built] [code generated]

--- a/types.d.ts
+++ b/types.d.ts
@@ -24691,7 +24691,36 @@ declare abstract class RuntimeTemplate {
 	supportsDynamicImport(): boolean;
 	supportsEcmaScriptModuleSyntax(): boolean;
 	supportsModulePreload(): boolean;
+
+	/**
+	 * Analyzable output — a reference a foreign bundler can follow without running
+	 * webpack's runtime — comes in two forms, and what rules them out differs:
+	 * - a literal `import("./chunk.js")`, gated by `supportsAnalyzableImport`
+	 * - a literal `new URL(<file>, import.meta.url)`, gated by `supportsAnalyzableEsm`
+	 * Either way a name that is not settled during code generation may still be baked,
+	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
+	 * What still forces the runtime form, and is not covered by any of the three:
+	 * a module federation module in the chunk, a chunk reachable at more than one
+	 * output depth under an `auto` public path, and a chunk with no id.
+	 */
 	supportsAnalyzableEsm(): boolean;
+
+	/**
+	 * Whether a chunk reference emitted into `originModule` may be a literal
+	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
+	 */
+	supportsAnalyzableImport(
+		originModule?: Module,
+		chunkGraph?: ChunkGraph
+	): boolean;
+
+	/**
+	 * Whether a name that code generation cannot settle may be reserved as a stand-in
+	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
+	 * content hash was taken, and `RealContentHashPlugin` is what brings the two back
+	 * in line — without it the name would go stale.
+	 */
+	canDeferAnalyzableName(template?: string): boolean;
 
 	/**
 	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm

--- a/types.d.ts
+++ b/types.d.ts
@@ -24703,22 +24703,23 @@ declare abstract class RuntimeTemplate {
 	 * a module federation module in the chunk, a chunk reachable at more than one
 	 * output depth under an `auto` public path, and a chunk with no id.
 	 */
-	supportsAnalyzableEsm(): boolean;
+	supportsAnalyzableEsm(chunkGraph?: ChunkGraph, module?: Module): boolean;
 
 	/**
 	 * Whether a chunk reference emitted into `originModule` may be a literal
 	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
 	 */
 	supportsAnalyzableImport(
-		originModule?: Module,
-		chunkGraph?: ChunkGraph
+		chunkGraph: ChunkGraph,
+		originModule: Module
 	): boolean;
 
 	/**
 	 * Whether a name that code generation cannot settle may be reserved as a stand-in
 	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
-	 * content hash was taken, and `RealContentHashPlugin` is what brings the two back
-	 * in line — without it the name would go stale.
+	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
+	 * back in line, or no emitted javascript may be named by its content in the first
+	 * place — with a name like `[name].js` there is nothing to go stale.
 	 */
 	canDeferAnalyzableName(template?: string): boolean;
 
@@ -24731,7 +24732,7 @@ declare abstract class RuntimeTemplate {
 	 * Callers that can bake the public path into a static literal specifier should
 	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
 	 */
-	supportsAnalyzableEsmUrl(): boolean;
+	supportsAnalyzableEsmUrl(chunkGraph?: ChunkGraph, module?: Module): boolean;
 
 	/**
 	 * Builds the analyzable `new URL(specifier, import.meta.url)` expression the ESM
@@ -24746,7 +24747,7 @@ declare abstract class RuntimeTemplate {
 	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
 	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
 	 */
-	supportsAnalyzableWasm(): boolean;
+	supportsAnalyzableWasm(chunkGraph?: ChunkGraph, module?: Module): boolean;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Three shapes that used to fall back to the runtime chunk loader are now baked into a literal a foreign bundler can follow: a `[fullhash]` in `output.webassemblyModuleFilename`, a templated `output.publicPath` / `output.workerPublicPath`, and a build where some *other* entry reassigns `__webpack_public_path__` (that switch was compilation-wide, but `__webpack_require__.p` belongs to a runtime). Deferring a name no longer requires `optimization.realContentHash` when no emitted javascript is named by its content — with `[name].js` there is nothing to go stale — so those names bake in a plain development build too.

Two bugs found on the way are fixed here as well. A `[fullhash:<digest>]` wasm name lost its hash segment entirely at runtime, so the loader fetched a path no emitted file had and every wasm module in such a build failed to load; it reproduces identically on `main`. And the deferred substitution ran at `PROCESS_ASSETS_STAGE_OPTIMIZE_HASH - 1`, after source maps are written and after a minifier runs — a stand-in and the name replacing it are different lengths, so mappings after it shifted (measured at 16 columns on a minified line, where the whole bundle is one line). Refs #17121

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. New: `configCases/analyzable/{templated-public-path,templated-worker-public-path,deferred-before-source-maps,public-path-override-scope,block-without-origin}` and `configCases/wasm/{analyzable-fullhash-filename,full-hash-digest-filename}`. Updated: `statsCases/analyzable-esm-fallbacks`. Each case was confirmed to fail without its change.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

That `output.publicPath`, `output.workerPublicPath` and `output.webassemblyModuleFilename` may now carry `[fullhash]` in an analyzable ESM build. Two limitations are worth stating: a `[fullhash:<digest>]` cannot be baked (a stand-in cannot survive re-encoding), and a hashed *chunk* name still needs `optimization.realContentHash`, because the referencing chunk's hash would have to depend on the referenced chunk's.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — written with Claude Code. It traced the fallback paths, implemented the changes and wrote the test cases, and produced the evidence cited above: before/after builds compared against the emitted assets, a source-map alignment measurement, and branch-reachability probes run over the full test suite to tell a dead guard from an untested one. I reviewed every change and every measurement before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011gLkJyyoJtX2BVpZNPndbb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analyzable module imports, workers, worklets, and WebAssembly URLs.
  * Added support for templated public paths and hashed WebAssembly filenames, including truncated and digest-based hashes.
  * Preserved runtime loading when public paths are overridden or output cannot be safely analyzed.

* **Bug Fixes**
  * Improved source-map alignment when deferred URLs are resolved.
  * Ensured generated chunk and WebAssembly filenames use consistent hash handling.

* **Tests**
  * Added coverage for public-path overrides, workers, dynamic imports, source maps, and WebAssembly loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->