### PR TITLE
docs(agents): require one branch per task and reporting leftover refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,19 @@ Do **not** use `claude/`, `claude-code/`, `bot/`, `ai/`, or any tool/agent ident
 
 If the task harness pre-created a branch with a different prefix, rename it before the first push: `git branch -m <new-name>`.
 
+### One ref per task — report the leftovers
+
+> [!REQUIRED]
+
+A task must leave **one** branch on `origin`: the one its PR is opened from. What accumulates here is never the PR head — GitHub deletes those on merge — but the refs no PR ever pointed at, which nothing can find afterwards: a squash merge leaves no ancestry, so a landed draft looks exactly like unmerged work.
+
+Three habits prevent that, and the fourth reports what they cannot:
+
+- **Rename before the _first_ push.** `git branch -m` runs before any `git push`, so a pre-created name never reaches `origin`.
+- **Do not rename a branch already pushed.** Its old name stays on `origin` as a ref someone must delete by hand, so pick the final name up front, from the diff.
+- **Never reuse a branch whose PR merged.** Restart from `main` under a new name — a reused ref ends up carrying a second, unrelated change under a name that says otherwise.
+- **Name every ref you leave behind.** Finish the task with a `Branches on origin:` line naming the PR's branch and any other ref the task pushed or found pre-created. Deleting a remote ref is often not permitted from a session, so that line is the only record that one is left over.
+
 ### Commit rules
 
 > [!REQUIRED]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,7 +324,7 @@ If the task harness pre-created a branch with a different prefix, rename it befo
 
 > [!REQUIRED]
 
-A task must leave **one** branch on `origin`: the one its PR is opened from. What accumulates here is never the PR head — GitHub deletes those on merge — but the refs no PR ever pointed at, which nothing can find afterwards: a squash merge leaves no ancestry, so a landed draft looks exactly like unmerged work.
+A task must leave **one** branch on `origin`: the one its PR is opened from. What accumulates here is usually not that ref — this repository deletes a merged PR's head automatically, unless a branch rule forbids it — but the refs no PR ever pointed at, which nothing can find afterwards: a squash merge leaves no ancestry, so a landed draft looks exactly like unmerged work.
 
 Three habits prevent that, and the fourth reports what they cannot:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`origin` had accumulated well over a hundred branches whose work had already landed. The cause is that the ref a PR is opened from is usually not the ref the work was first pushed to — a session branch gets renamed, a draft gets a new name, or a commit stack gets one name per commit — and a squash merge leaves no ancestry, so afterwards a landed draft is indistinguishable from unmerged work. This adds a `> [!REQUIRED]` section to `AGENTS.md` with the three habits that prevent the leftover ref, plus a closing report line for the case an agent cannot fix itself: deleting a remote ref is usually not permitted from a session, so naming the leftover is the only record that one exists.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — documentation only, no code changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the change is itself documentation and affects no user-facing option or API.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Written with Claude Code: it audited the repository's branches to establish the cause — checking each branch's commits against the squash bodies on `main` to determine which had already landed and via which PR — and drafted the section from what that audit showed. I reviewed the wording before it was pushed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGmwDxjnBYNsmqYVwUmVir)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for branch renaming before pushing and avoiding reuse of merged branches.
  * Added requirements to report any remaining remote references after completing a task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->