### PR TITLE
feat(esm): widen where analyzable references bake, and report why they don't

### DIFF
--- a/.changeset/023-analyzable-depths-digests-and-diagnostics.md
+++ b/.changeset/023-analyzable-depths-digests-and-diagnostics.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable ESM specifiers per output depth and per hash digest, and report fallbacks.
+Bake analyzable ESM and wasm references per output depth and hash digest, and report fallbacks.

--- a/.changeset/023-analyzable-depths-digests-and-diagnostics.md
+++ b/.changeset/023-analyzable-depths-digests-and-diagnostics.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable ESM and wasm references per output depth and hash digest, and report fallbacks.
+Bake analyzable ESM and wasm references per depth and digest; report fallbacks.

--- a/.changeset/023-analyzable-depths-digests-and-diagnostics.md
+++ b/.changeset/023-analyzable-depths-digests-and-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Bake analyzable ESM specifiers per output depth and per hash digest, and report fallbacks.

--- a/.changeset/023-analyzable-fallback-diagnostics.md
+++ b/.changeset/023-analyzable-fallback-diagnostics.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Report why analyzable ESM output fell back, via `optimizationBailout`.

--- a/.changeset/023-analyzable-fallback-diagnostics.md
+++ b/.changeset/023-analyzable-fallback-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Report why analyzable ESM output fell back, via `optimizationBailout`.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -543,28 +543,49 @@ class RuntimeTemplate {
 		const filename = /** @type {string} */ (webassemblyModuleFilename);
 		if (!this.supportsAnalyzableEsm(chunkGraph, module)) return false;
 		if (publicPath !== "auto") {
-			if (!this._hasUrlPublicPath()) {
+			if (this._hasUrlPublicPath()) {
+				// A templated one is settled no earlier than the hash it reads, so it is
+				// baked only where the deferred pass may fill it in.
+				if (
+					/** @type {string} */ (publicPath).includes("[") &&
+					!this.canDeferAnalyzableName()
+				) {
+					return false;
+				}
+			} else if (this._anyWasmChunkFetches()) {
 				this._analyzableBailout(
 					module,
 					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
 				);
 				return false;
 			}
-			// A templated one is settled no earlier than the hash it reads, so it is baked
-			// only where the deferred pass may fill it in.
-			if (
-				/** @type {string} */ (publicPath).includes("[") &&
-				!this.canDeferAnalyzableName()
-			) {
-				return false;
-			}
 		}
 		return (
 			// The compilation hash is settled after code generation, so a name carrying
-			// one is baked only where the deferred pass can fill it in.
+			// one is baked only where the deferred pass can fill it in. `[hash]` is the
+			// module's own here, which code generation already knows.
 			!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") ||
 			this.canDeferAnalyzableName(filename)
 		);
+	}
+
+	/**
+	 * Whether any chunk loads WebAssembly through `fetch`, which is the only loader the
+	 * public path reaches: `readFile` resolves the binary's name against the chunk it is
+	 * read from, exactly as a baked literal does, so a public path is irrelevant to it.
+	 * Answered for the compilation rather than per chunk on purpose — a module's
+	 * generated source and the runtime module of every chunk holding it have to agree
+	 * on the shape, and they ask from opposite ends.
+	 * @returns {boolean} true when some chunk fetches its binaries
+	 */
+	_anyWasmChunkFetches() {
+		const { wasmLoading } = this.outputOptions;
+		if (wasmLoading === "fetch") return true;
+		for (const chunk of this.compilation.chunks) {
+			const entryOptions = chunk.getEntryOptions();
+			if (entryOptions && entryOptions.wasmLoading === "fetch") return true;
+		}
+		return false;
 	}
 
 	/**
@@ -2180,10 +2201,15 @@ class RuntimeTemplate {
 			}
 		);
 		const { publicPath } = this.outputOptions;
-		// Only a chunk that fetches may carry the public path into the literal: `readFile`
-		// takes a `file:` URL alone, and those loaders address the binary relative to the
-		// chunk anyway, ignoring the public path exactly as the runtime form does.
-		if (publicPath !== "auto" && this._wasmChunksFetch(module, chunkGraph)) {
+		// Only a chunk that fetches may carry the public path into the literal, and only
+		// an absolute one: `readFile` takes a `file:` URL alone, and those loaders address
+		// the binary relative to the chunk anyway, ignoring the public path exactly as the
+		// runtime form does.
+		if (
+			publicPath !== "auto" &&
+			this._hasUrlPublicPath() &&
+			this._wasmChunksFetch(module, chunkGraph)
+		) {
 			const resolved = this._resolvePublicPathPrefix(
 				/** @type {string} */ (publicPath)
 			);

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -340,10 +340,17 @@ class RuntimeTemplate {
 		// syntax error, so the literal `new URL(…, import.meta.url)` form can't be used.
 		// A literal `import()` survives it, which is why the import form does not check.
 		const { devtool } = this.compilation.options;
+		if (!this.isModule() || !this.supportsEcmaScriptModuleSyntax()) {
+			return false;
+		}
+		if (typeof devtool === "string" && devtool.includes("eval")) {
+			this._analyzableBailout(
+				module,
+				`devtool ${JSON.stringify(devtool)} wraps the module in eval(), where import.meta does not parse`
+			);
+			return false;
+		}
 		return (
-			this.isModule() &&
-			this.supportsEcmaScriptModuleSyntax() &&
-			!(typeof devtool === "string" && devtool.includes("eval")) &&
 			// Build-time execution keeps the runtime form — `import.meta` does not parse
 			// in its vm script wrapper. `getTypes` has no chunk graph and does not care:
 			// `AssetModulesPlugin` emulates the wrapper there.
@@ -374,6 +381,26 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Records why a reference kept the runtime form, on the module that wrote it —
+	 * the channel `ModuleConcatenationPlugin` already reports through, so it reaches
+	 * `stats.optimizationBailout`. Silent unless the build asked for ESM output, where
+	 * alone the answer is actionable; deduplicated because a module may write many.
+	 * @param {Module=} module the module the reference is emitted into
+	 * @param {string} reason why no literal could be baked
+	 * @returns {void}
+	 */
+	_analyzableBailout(module, reason) {
+		if (module === undefined || !this.outputOptions.module) return;
+		const text = `Analyzable ESM bailout: ${reason}`;
+		const bailouts =
+			this.compilation.moduleGraph.getOptimizationBailout(module);
+		for (const existing of bailouts) {
+			if (existing === text) return;
+		}
+		bailouts.push(text);
+	}
+
+	/**
 	 * Whether a chunk reference emitted into `originModule` may be a literal
 	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
 	 * @param {ChunkGraph} chunkGraph the chunk graph
@@ -382,12 +409,15 @@ class RuntimeTemplate {
 	 */
 	supportsAnalyzableImport(chunkGraph, originModule) {
 		const { outputOptions } = this;
-		if (
-			!outputOptions.module ||
-			outputOptions.chunkFormat !== "module" ||
-			// Only a native `import()` is a specifier a foreign bundler reads.
-			outputOptions.importFunctionName !== "import"
-		) {
+		if (!outputOptions.module || outputOptions.chunkFormat !== "module") {
+			return false;
+		}
+		// Only a native `import()` is a specifier a foreign bundler reads.
+		if (outputOptions.importFunctionName !== "import") {
+			this._analyzableBailout(
+				originModule,
+				`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, not "import"`
+			);
 			return false;
 		}
 		const placedModule = /** @type {Module} */ (
@@ -402,6 +432,10 @@ class RuntimeTemplate {
 				placedModule
 			)
 		) {
+			this._analyzableBailout(
+				originModule,
+				"__webpack_public_path__ is reassigned in a runtime this module belongs to"
+			);
 			return false;
 		}
 		// A worker loading its own chunks some other way keeps that runtime; one on
@@ -412,7 +446,13 @@ class RuntimeTemplate {
 			const entryOptions = originChunk.getEntryOptions();
 			if (!entryOptions || !entryOptions.worker) continue;
 			// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
-			if (entryOptions.chunkLoading !== "import") return false;
+			if (entryOptions.chunkLoading !== "import") {
+				this._analyzableBailout(
+					originModule,
+					`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`
+				);
+				return false;
+			}
 		}
 		return true;
 	}
@@ -1887,6 +1927,10 @@ class RuntimeTemplate {
 		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
 			// Module federation (remote/shared/provide) loads through its own runtime.
 			if (FEDERATION_MODULE_TYPES.has(module.type)) {
+				this._analyzableBailout(
+					originModule,
+					`the chunk holds a module federation module (${module.type})`
+				);
 				return null;
 			}
 			for (const type of chunkGraph.getModuleSourceTypes(module)) {
@@ -2009,6 +2053,12 @@ class RuntimeTemplate {
 			// carrying a stand-in of its own, so any hash spelling is fine here.
 			(chunk.id === null || !this.canDeferAnalyzableName())
 		) {
+			this._analyzableBailout(
+				consumingModule,
+				chunk.id === null
+					? "the referenced chunk has no id"
+					: "a hashed name needs optimization.realContentHash, or no emitted javascript named by its content"
+			);
 			return null;
 		}
 		const filename = deferred
@@ -2044,7 +2094,13 @@ class RuntimeTemplate {
 			// Different depths — no single relative literal. No bundler follows a
 			// concatenation, but a `new URL(...)` caller still sheds the `.u(id)` lookup
 			// this way; `import()` needs a static specifier, so it gets nothing.
-			if (deferred || !runtimeRequirements) return null;
+			if (deferred || !runtimeRequirements) {
+				this._analyzableBailout(
+					consumingModule,
+					"this module is in chunks at different output depths, so no one relative specifier reaches the chunk under an auto public path"
+				);
+				return null;
+			}
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2084,7 +2084,10 @@ class RuntimeTemplate {
 		// reach the bundle verbatim. The whole name is re-resolved later rather than
 		// carrying a stand-in of its own, so any hash spelling is fine here.
 		const canReserve = chunk.id !== null && this.canDeferAnalyzableName();
-		if (deferred && !canReserve) {
+		/**
+		 * @returns {null} always, having recorded why no stand-in may be reserved
+		 */
+		const cannotReserve = () => {
 			this._analyzableBailout(
 				consumingModule,
 				chunk.id === null
@@ -2092,7 +2095,8 @@ class RuntimeTemplate {
 					: "a hashed name needs optimization.realContentHash, or no emitted javascript named by its content"
 			);
 			return null;
-		}
+		};
+		if (deferred && !canReserve) return cannotReserve();
 		const filename = deferred
 			? ""
 			: compilation.getPath(/** @type {string} */ (template), {
@@ -2112,7 +2116,7 @@ class RuntimeTemplate {
 			if (!deferred && kind === undefined) {
 				return toJsStringLiteral(prefix + filename);
 			}
-			if (!canReserve) return null;
+			if (!canReserve) return cannotReserve();
 			return toJsStringLiteral(
 				getAnalyzableChunkHashPlugin().reserveSpecifier({
 					prefix,

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -78,6 +78,7 @@ const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./Dependency")} Dependency */
+/** @typedef {import("./esm/AnalyzableChunkHashPlugin").PrefixKind} PrefixKind */
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./Module").BuildMeta} BuildMeta */
 /** @typedef {import("./Module").RuntimeRequirements} RuntimeRequirements */
@@ -329,8 +330,7 @@ class RuntimeTemplate {
 	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
 	 *
 	 * What still forces the runtime form, and is not covered by any of the three:
-	 * a module federation module in the chunk, a chunk reachable at more than one
-	 * output depth under an `auto` public path, and a chunk with no id.
+	 * a module federation module in the chunk, and a chunk with no id.
 	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
 	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when a `new URL(…, import.meta.url)` literal may be emitted
@@ -385,7 +385,7 @@ class RuntimeTemplate {
 	 * the channel `ModuleConcatenationPlugin` already reports through, so it reaches
 	 * `stats.optimizationBailout`. Silent unless the build asked for ESM output, where
 	 * alone the answer is actionable; deduplicated because a module may write many.
-	 * @param {Module=} module the module the reference is emitted into
+	 * @param {Module | undefined} module the module the reference is emitted into
 	 * @param {string} reason why no literal could be baked
 	 * @returns {void}
 	 */
@@ -409,15 +409,13 @@ class RuntimeTemplate {
 	 */
 	supportsAnalyzableImport(chunkGraph, originModule) {
 		const { outputOptions } = this;
-		if (!outputOptions.module || outputOptions.chunkFormat !== "module") {
-			return false;
-		}
-		// Only a native `import()` is a specifier a foreign bundler reads.
-		if (outputOptions.importFunctionName !== "import") {
-			this._analyzableBailout(
-				originModule,
-				`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, not "import"`
-			);
+		// Analyzable output is ESM output read through a native `import()` — anything
+		// else is a different feature, not a limitation of this one.
+		if (
+			!outputOptions.module ||
+			outputOptions.chunkFormat !== "module" ||
+			outputOptions.importFunctionName !== "import"
+		) {
 			return false;
 		}
 		const placedModule = /** @type {Module} */ (
@@ -2046,13 +2044,11 @@ class RuntimeTemplate {
 		// A hashed name is settled long after this code is generated, so a stand-in is
 		// emitted and filled in once the hash exists.
 		const deferred = template === undefined || HASH_IN_FILENAME.test(template);
-		if (
-			deferred &&
-			// An id names the chunk in the stand-in, and one nothing could resolve would
-			// reach the bundle verbatim. The whole name is re-resolved later rather than
-			// carrying a stand-in of its own, so any hash spelling is fine here.
-			(chunk.id === null || !this.canDeferAnalyzableName())
-		) {
+		// An id names the chunk in the stand-in, and one nothing could resolve would
+		// reach the bundle verbatim. The whole name is re-resolved later rather than
+		// carrying a stand-in of its own, so any hash spelling is fine here.
+		const canReserve = chunk.id !== null && this.canDeferAnalyzableName();
+		if (deferred && !canReserve) {
 			this._analyzableBailout(
 				consumingModule,
 				chunk.id === null
@@ -2072,28 +2068,35 @@ class RuntimeTemplate {
 				});
 		/**
 		 * @param {string} prefix what goes in front of the chunk's filename
-		 * @returns {string} the specifier, already quoted
+		 * @param {PrefixKind=} kind how the deferred pass builds `prefix`, literal when omitted
+		 * @returns {string | null} the specifier already quoted, or `null` when the
+		 * recipe needs a stand-in that cannot be reserved
 		 */
-		const specifier = (prefix) =>
-			toJsStringLiteral(
-				deferred
-					? getAnalyzableChunkHashPlugin().reserveSpecifier(
-							prefix,
-							/** @type {ChunkId} */ (chunk.id)
-						)
-					: prefix + filename
+		const specifier = (prefix, kind) => {
+			if (!deferred && kind === undefined) {
+				return toJsStringLiteral(prefix + filename);
+			}
+			if (!canReserve) return null;
+			return toJsStringLiteral(
+				getAnalyzableChunkHashPlugin().reserveSpecifier(
+					prefix,
+					/** @type {ChunkId} */ (chunk.id),
+					kind
+				)
 			);
+		};
 		if (overridePublicPath) {
-			const prefix = this._resolvePublicPathPrefix(overridePublicPath);
-			return prefix === null ? null : specifier(prefix);
+			const resolved = this._resolvePublicPathPrefix(overridePublicPath);
+			return resolved === null ? null : specifier(resolved[0], resolved[1]);
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
 			const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
 			if (undo !== null) return specifier(undo);
-			// Different depths — no single relative literal. No bundler follows a
-			// concatenation, but a `new URL(...)` caller still sheds the `.u(id)` lookup
-			// this way; `import()` needs a static specifier, so it gets nothing.
+			// Different depths — no one `../` path is right for every asset the reference
+			// lands in, so the deferred pass builds each asset's own.
+			const perAsset = specifier("", "undo");
+			if (perAsset !== null) return perAsset;
 			if (deferred || !runtimeRequirements) {
 				this._analyzableBailout(
 					consumingModule,
@@ -2101,31 +2104,42 @@ class RuntimeTemplate {
 				);
 				return null;
 			}
+			// No bundler follows a concatenation, but a `new URL(...)` caller still sheds
+			// the `.u(id)` lookup this way; `import()` needs a static specifier.
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
 		if (typeof publicPath === "string") {
-			const prefix = this._resolvePublicPathPrefix(publicPath);
-			if (prefix !== null) return specifier(prefix);
+			const resolved = this._resolvePublicPathPrefix(publicPath);
+			if (resolved !== null) return specifier(resolved[0], resolved[1]);
 		}
 		return null;
 	}
 
 	/**
-	 * What a public path puts in front of a filename, as a literal. A templated one is
+	 * How to build what a public path puts in front of a filename. A templated one is
 	 * resolved as far as code generation can — the compilation hash it may carry is
 	 * left as a stand-in for the deferred pass, exactly as `PublicPathRuntimeModule`
-	 * resolves the same string once that hash exists.
+	 * resolves the same string once that hash exists. A hash re-encoded to another
+	 * digest is not spellable that way, so the template is handed over whole instead.
 	 * @param {string} publicPath the configured public path
-	 * @returns {string | null} the prefix, or `null` when it cannot be known here
+	 * @returns {[string, PrefixKind | undefined] | null} the prefix and how to build
+	 * it, or `null` when it cannot be known at all
 	 */
 	_resolvePublicPathPrefix(publicPath) {
-		if (!publicPath.includes("[")) return publicPath;
-		if (!this.canDeferAnalyzableName(publicPath)) return null;
-		return this.compilation.getPath(
-			publicPath,
-			getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
-		);
+		if (!publicPath.includes("[")) return [publicPath, undefined];
+		if (!this.canDeferAnalyzableName()) return null;
+		const analyzableChunkHashPlugin = getAnalyzableChunkHashPlugin();
+		if (!analyzableChunkHashPlugin.canDeferFullHash(publicPath)) {
+			return [publicPath, "path"];
+		}
+		return [
+			this.compilation.getPath(
+				publicPath,
+				analyzableChunkHashPlugin.DEFERRED_FULL_HASH_PATH_DATA
+			),
+			undefined
+		];
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -539,16 +539,31 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the literal form is emitted
 	 */
 	supportsAnalyzableWasm(chunkGraph, module) {
-		const filename =
-			/** @type {string} */
-			(this.outputOptions.webassemblyModuleFilename);
+		const { publicPath, webassemblyModuleFilename } = this.outputOptions;
+		const filename = /** @type {string} */ (webassemblyModuleFilename);
+		if (!this.supportsAnalyzableEsm(chunkGraph, module)) return false;
+		if (publicPath !== "auto") {
+			if (!this._hasUrlPublicPath()) {
+				this._analyzableBailout(
+					module,
+					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
+				);
+				return false;
+			}
+			// A templated one is settled no earlier than the hash it reads, so it is baked
+			// only where the deferred pass may fill it in.
+			if (
+				/** @type {string} */ (publicPath).includes("[") &&
+				!this.canDeferAnalyzableName()
+			) {
+				return false;
+			}
+		}
 		return (
-			this.supportsAnalyzableEsm(chunkGraph, module) &&
-			(this.outputOptions.publicPath === "auto" || this._hasUrlPublicPath()) &&
 			// The compilation hash is settled after code generation, so a name carrying
 			// one is baked only where the deferred pass can fill it in.
-			(!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") ||
-				this.canDeferAnalyzableName(filename))
+			!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") ||
+			this.canDeferAnalyzableName(filename)
 		);
 	}
 
@@ -557,14 +572,14 @@ class RuntimeTemplate {
 	 * same target, because `new URL(...)` ignores its base for an absolute specifier.
 	 * A root- or directory-relative public path does not: the runtime form resolves it
 	 * against the document and a baked one against the chunk, which differ exactly
-	 * where a public path is worth setting.
+	 * where a public path is worth setting. (`import()` is not affected — it resolves
+	 * against the importing module either way — so only the URL form checks this.)
 	 * @returns {boolean} true for a static, absolute-URL public path
 	 */
 	_hasUrlPublicPath() {
 		const { publicPath } = this.outputOptions;
 		return (
 			typeof publicPath === "string" &&
-			!publicPath.includes("[") &&
 			(publicPath.startsWith("//") || getScheme(publicPath) !== undefined)
 		);
 	}
@@ -2078,11 +2093,11 @@ class RuntimeTemplate {
 			}
 			if (!canReserve) return null;
 			return toJsStringLiteral(
-				getAnalyzableChunkHashPlugin().reserveSpecifier(
+				getAnalyzableChunkHashPlugin().reserveSpecifier({
 					prefix,
-					/** @type {ChunkId} */ (chunk.id),
-					kind
-				)
+					prefixKind: kind,
+					chunkId: /** @type {ChunkId} */ (chunk.id)
+				})
 			);
 		};
 		if (overridePublicPath) {
@@ -2164,31 +2179,51 @@ class RuntimeTemplate {
 				...getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
 			}
 		);
+		const { publicPath } = this.outputOptions;
 		// Only a chunk that fetches may carry the public path into the literal: `readFile`
 		// takes a `file:` URL alone, and those loaders address the binary relative to the
 		// chunk anyway, ignoring the public path exactly as the runtime form does.
-		if (
-			this.outputOptions.publicPath !== "auto" &&
-			this._wasmChunksFetch(module, chunkGraph)
-		) {
+		if (publicPath !== "auto" && this._wasmChunksFetch(module, chunkGraph)) {
+			const resolved = this._resolvePublicPathPrefix(
+				/** @type {string} */ (publicPath)
+			);
+			if (resolved !== null) {
+				const [prefix, prefixKind] = resolved;
+				return this.importMetaUrl(
+					toJsStringLiteral(
+						prefixKind === undefined
+							? prefix + filename
+							: getAnalyzableChunkHashPlugin().reserveSpecifier({
+									prefix,
+									prefixKind,
+									file: filename
+								})
+					)
+				);
+			}
+		}
+		const undo = this._getModuleUndoPath(module, chunkGraph);
+		if (undo !== null) {
+			return this.importMetaUrl(toJsStringLiteral(undo + filename));
+		}
+		// Different depths — no one `../` path is right for every asset the binary is
+		// referenced from, so the deferred pass builds each asset's own.
+		if (this.canDeferAnalyzableName()) {
 			return this.importMetaUrl(
 				toJsStringLiteral(
-					/** @type {string} */ (this.outputOptions.publicPath) + filename
+					getAnalyzableChunkHashPlugin().reserveSpecifier({
+						prefixKind: "undo",
+						file: filename
+					})
 				)
 			);
 		}
-		const undo = this._getModuleUndoPath(module, chunkGraph);
-		/** @type {string} */
-		let specifier;
-		if (undo === null) {
-			// Different depths — no single literal. No bundler follows a concatenation,
-			// but this still sheds the module id and hash the runtime form would need.
-			runtimeRequirements.add(RuntimeGlobals.publicPath);
-			specifier = `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
-		} else {
-			specifier = toJsStringLiteral(undo + filename);
-		}
-		return this.importMetaUrl(specifier);
+		// No bundler follows a concatenation, but this still sheds the module id and
+		// hash the runtime form would need.
+		runtimeRequirements.add(RuntimeGlobals.publicPath);
+		return this.importMetaUrl(
+			`${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`
+		);
 	}
 
 	/**

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -53,26 +53,37 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 };
 
 /**
- * How the deferred pass builds what goes in front of the chunk's filename, when the
- * reserved text is not already it.
- * - `"path"` — a public-path template, resolved once the hash exists, so any spelling
- * of it works, including a digest no stand-in of ours could carry.
+ * How the deferred pass builds what goes in front of the tail, when `prefix` is not
+ * already it.
+ * - `"path"` — `prefix` is a public-path template, resolved once the hash exists, so
+ * any spelling of it works, including a digest no stand-in of ours could carry.
  * - `"undo"` — the `../` path from the asset the reference sits in back to the output
  * root, which only that asset knows: one module can be in chunks at several depths.
  * @typedef {"path" | "undo"} PrefixKind
  */
 
 /**
- * @param {string} prefix literal prefix, public-path template, or `""` for `undo`
- * @param {ChunkId} chunkId id of the chunk being addressed
- * @param {PrefixKind=} kind how to build the prefix, literal when omitted
+ * A name only the deferred pass can spell, as the recipe it is built from: a prefix,
+ * then the referenced chunk's filename, then any literal text of its own.
+ * @typedef {object} Specifier
+ * @property {string=} prefix literal prefix, or the template `prefixKind` reads
+ * @property {PrefixKind=} prefixKind how to build the prefix, literal when omitted
+ * @property {ChunkId=} chunkId chunk whose filename follows the prefix, if any
+ * @property {string=} file literal text after that — an emitted binary's own name
+ */
+
+/**
+ * @param {Specifier} specifier what the stand-in resolves to
  * @returns {string} the stand-in to emit
  */
-const reserveSpecifier = (prefix, chunkId, kind) =>
+const reserveSpecifier = ({ prefix, prefixKind, chunkId, file }) =>
 	`./@@webpackAnalyzableChunk:${Buffer.from(
-		JSON.stringify(
-			kind === undefined ? [prefix, chunkId] : [prefix, chunkId, kind]
-		)
+		JSON.stringify([
+			prefix === undefined ? "" : prefix,
+			chunkId === undefined ? null : chunkId,
+			prefixKind === undefined ? null : prefixKind,
+			file === undefined ? "" : file
+		])
 	)
 		.toString("base64")
 		.replace(/\+/g, "-")
@@ -81,8 +92,7 @@ const reserveSpecifier = (prefix, chunkId, kind) =>
 
 /**
  * @param {string} payload the encoded half of a stand-in
- * @returns {[string, ChunkId, PrefixKind | undefined] | null} prefix, chunk id and how
- * to build the prefix, or `null` if unreadable
+ * @returns {Specifier | null} what it resolves to, or `null` if unreadable
  */
 const readSpecifier = (payload) => {
 	/** @type {EXPECTED_ANY} */
@@ -98,14 +108,25 @@ const readSpecifier = (payload) => {
 		return null;
 	}
 	// Source of our own can spell the token too, so nothing about its payload is given.
-	if (!Array.isArray(decoded) || decoded.length < 2 || decoded.length > 3) {
+	if (!Array.isArray(decoded) || decoded.length !== 4) return null;
+	const [prefix, chunkId, prefixKind, file] = decoded;
+	if (typeof prefix !== "string" || typeof file !== "string") return null;
+	if (
+		chunkId !== null &&
+		typeof chunkId !== "string" &&
+		typeof chunkId !== "number"
+	) {
 		return null;
 	}
-	const [prefix, chunkId, kind] = decoded;
-	if (typeof prefix !== "string") return null;
-	if (typeof chunkId !== "string" && typeof chunkId !== "number") return null;
-	if (kind !== undefined && kind !== "path" && kind !== "undo") return null;
-	return [prefix, chunkId, kind];
+	if (prefixKind !== null && prefixKind !== "path" && prefixKind !== "undo") {
+		return null;
+	}
+	return {
+		prefix,
+		prefixKind: prefixKind === null ? undefined : prefixKind,
+		chunkId: chunkId === null ? undefined : chunkId,
+		file
+	};
 };
 
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
@@ -168,30 +189,31 @@ class AnalyzableChunkHashPlugin {
 					const resolve = (payload, assetName) => {
 						const decoded = readSpecifier(payload);
 						if (decoded === null) return null;
-						const [reserved, chunkId, kind] = decoded;
-						const prefix =
-							kind === "undo"
+						const { prefix, prefixKind, chunkId, file } = decoded;
+						let specifier =
+							prefixKind === "undo"
 								? getUndoPath(
 										assetName,
 										/** @type {string} */ (outputOptions.path),
 										true
 									)
-								: kind === "path"
+								: prefixKind === "path"
 									? // Resolved whole rather than carrying a stand-in of its own, so a
 										// re-encoded digest in it is spelled by `getPath`, not by us.
-										compilation.getPath(reserved, {})
-									: reserved;
-						if (chunksById === undefined) {
-							chunksById = new Map();
-							for (const chunk of compilation.chunks) {
-								if (chunk.id !== null) chunksById.set(String(chunk.id), chunk);
+										compilation.getPath(/** @type {string} */ (prefix), {})
+									: /** @type {string} */ (prefix);
+						if (chunkId !== undefined) {
+							if (chunksById === undefined) {
+								chunksById = new Map();
+								for (const chunk of compilation.chunks) {
+									if (chunk.id !== null) {
+										chunksById.set(String(chunk.id), chunk);
+									}
+								}
 							}
-						}
-						const chunk = chunksById.get(String(chunkId));
-						if (chunk === undefined) return null;
-						const specifier =
-							prefix +
-							compilation.getPath(
+							const chunk = chunksById.get(String(chunkId));
+							if (chunk === undefined) return null;
+							specifier += compilation.getPath(
 								getJavascriptModulesPlugin().getChunkFilenameTemplate(
 									chunk,
 									outputOptions
@@ -204,6 +226,8 @@ class AnalyzableChunkHashPlugin {
 									contentHashType: "javascript"
 								}
 							);
+						}
+						specifier += file;
 						// A bare specifier is a package name, so make it explicitly relative
 						// the way the chunk loader does. A templated public path left its own
 						// stand-in in the prefix, so finish that here rather than scanning again.

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -7,6 +7,7 @@
 
 const { ReplaceSource } = require("webpack-sources");
 const Compilation = require("../Compilation");
+const { getUndoPath } = require("../util/identifier");
 const memoize = require("../util/memoize");
 
 /** @typedef {import("../Chunk")} Chunk */
@@ -52,12 +53,27 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 };
 
 /**
- * @param {string} prefix what goes in front of the chunk's filename
+ * How the deferred pass builds what goes in front of the chunk's filename, when the
+ * reserved text is not already it.
+ * - `"path"` — a public-path template, resolved once the hash exists, so any spelling
+ * of it works, including a digest no stand-in of ours could carry.
+ * - `"undo"` — the `../` path from the asset the reference sits in back to the output
+ * root, which only that asset knows: one module can be in chunks at several depths.
+ * @typedef {"path" | "undo"} PrefixKind
+ */
+
+/**
+ * @param {string} prefix literal prefix, public-path template, or `""` for `undo`
  * @param {ChunkId} chunkId id of the chunk being addressed
+ * @param {PrefixKind=} kind how to build the prefix, literal when omitted
  * @returns {string} the stand-in to emit
  */
-const reserveSpecifier = (prefix, chunkId) =>
-	`./@@webpackAnalyzableChunk:${Buffer.from(JSON.stringify([prefix, chunkId]))
+const reserveSpecifier = (prefix, chunkId, kind) =>
+	`./@@webpackAnalyzableChunk:${Buffer.from(
+		JSON.stringify(
+			kind === undefined ? [prefix, chunkId] : [prefix, chunkId, kind]
+		)
+	)
 		.toString("base64")
 		.replace(/\+/g, "-")
 		.replace(/\//g, "_")
@@ -65,7 +81,8 @@ const reserveSpecifier = (prefix, chunkId) =>
 
 /**
  * @param {string} payload the encoded half of a stand-in
- * @returns {[string, ChunkId] | null} prefix and chunk id, or `null` if unreadable
+ * @returns {[string, ChunkId, PrefixKind | undefined] | null} prefix, chunk id and how
+ * to build the prefix, or `null` if unreadable
  */
 const readSpecifier = (payload) => {
 	/** @type {EXPECTED_ANY} */
@@ -81,11 +98,14 @@ const readSpecifier = (payload) => {
 		return null;
 	}
 	// Source of our own can spell the token too, so nothing about its payload is given.
-	if (!Array.isArray(decoded) || decoded.length !== 2) return null;
-	const [prefix, chunkId] = decoded;
+	if (!Array.isArray(decoded) || decoded.length < 2 || decoded.length > 3) {
+		return null;
+	}
+	const [prefix, chunkId, kind] = decoded;
 	if (typeof prefix !== "string") return null;
 	if (typeof chunkId !== "string" && typeof chunkId !== "number") return null;
-	return [prefix, chunkId];
+	if (kind !== undefined && kind !== "path" && kind !== "undo") return null;
+	return [prefix, chunkId, kind];
 };
 
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
@@ -142,12 +162,25 @@ class AnalyzableChunkHashPlugin {
 					};
 					/**
 					 * @param {string} payload the encoded half of a stand-in
+					 * @param {string} assetName name of the asset the stand-in sits in
 					 * @returns {string | null} the specifier, or `null` if unresolvable
 					 */
-					const resolve = (payload) => {
+					const resolve = (payload, assetName) => {
 						const decoded = readSpecifier(payload);
 						if (decoded === null) return null;
-						const [prefix, chunkId] = decoded;
+						const [reserved, chunkId, kind] = decoded;
+						const prefix =
+							kind === "undo"
+								? getUndoPath(
+										assetName,
+										/** @type {string} */ (outputOptions.path),
+										true
+									)
+								: kind === "path"
+									? // Resolved whole rather than carrying a stand-in of its own, so a
+										// re-encoded digest in it is spelled by `getPath`, not by us.
+										compilation.getPath(reserved, {})
+									: reserved;
 						if (chunksById === undefined) {
 							chunksById = new Map();
 							for (const chunk of compilation.chunks) {
@@ -215,7 +248,9 @@ class AnalyzableChunkHashPlugin {
 							}
 						};
 						if (hasChunkToken) {
-							replaceAll(TOKEN_REGEXP, (_match, payload) => resolve(payload));
+							replaceAll(TOKEN_REGEXP, (_match, payload) =>
+								resolve(payload, name)
+							);
 						}
 						if (hasFullHashToken) {
 							replaceAll(FULL_HASH_TOKEN_REGEXP, (match) =>

--- a/test/configCases/analyzable/shared-depths-import-fallback/deep.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/deep.js
@@ -1,0 +1,1 @@
+export { load } from "./shared";

--- a/test/configCases/analyzable/shared-depths-import-fallback/flat.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/flat.js
@@ -1,0 +1,1 @@
+export { load } from "./shared";

--- a/test/configCases/analyzable/shared-depths-import-fallback/index.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+it("should load through the runtime form from chunks at different depths", async () => {
+	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
+	expect((await flat.load()).value).toBe("lazy");
+	// Pull in the second, deeper copy so the module really sits at two depths.
+	const deep = await import(/* webpackChunkName: "nested/deep" */ "./deep");
+	expect((await deep.load()).value).toBe("lazy");
+});
+
+it("should not bake a specifier no depth-independent name can carry", () => {
+	const source = fs.readFileSync(
+		path.join(__STATS__.outputPath, "flat.mjs"),
+		"utf8"
+	);
+
+	expect(source).toContain(`${"__webpack_require__"}.e(`);
+	expect(source).not.toContain(`${"__webpack_require__"}.ei(`);
+});

--- a/test/configCases/analyzable/shared-depths-import-fallback/lazy.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/shared-depths-import-fallback/shared.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/shared.js
@@ -1,0 +1,2 @@
+// This module ends up in two chunks emitted at different depths.
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");

--- a/test/configCases/analyzable/shared-depths-import-fallback/test.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const fs = require("fs");
+
+module.exports = {
+	findBundle(index, options) {
+		return fs
+			.readdirSync(options.output.path)
+			.filter((name) => /^main\..+\.mjs$/.test(name));
+	}
+};

--- a/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// Multi-depth is answered by reserving a stand-in, which rewrites the asset after its
-// own content hash was taken — so with `realContentHash` off and javascript named by
-// its content, there is nothing to repair the name and the runtime form stays.
+// Reserving a stand-in rewrites the asset after its content hash was taken, so with
+// `realContentHash` off and javascript named by content nothing repairs it.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// Multi-depth is answered by reserving a stand-in, which rewrites the asset after its
+// own content hash was taken — so with `realContentHash` off and javascript named by
+// its content, there is nothing to repair the name and the runtime form stays.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		filename: "main.[contenthash].mjs",
+		chunkFilename: "[name].mjs",
+		publicPath: "auto"
+	},
+	optimization: {
+		chunkIds: "named",
+		splitChunks: false,
+		realContentHash: false
+	}
+};

--- a/test/configCases/analyzable/shared-depths-import/index.js
+++ b/test/configCases/analyzable/shared-depths-import/index.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-it("should load through the runtime form from chunks at different depths", async () => {
+it("should load through the analyzable form from chunks at different depths", async () => {
 	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
 	expect((await flat.load()).value).toBe("lazy");
 	// Pull in the second, deeper copy so the module really sits at two depths.
@@ -9,12 +9,11 @@ it("should load through the runtime form from chunks at different depths", async
 	expect((await deep.load()).value).toBe("lazy");
 });
 
-it("should not bake a specifier that only holds at one depth", () => {
-	const source = fs.readFileSync(
-		path.join(__STATS__.outputPath, "flat.mjs"),
-		"utf8"
-	);
+it("should bake the specifier each depth needs", () => {
+	const read = (name) =>
+		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
 
-	expect(source).toContain(`${"__webpack_require__"}.e(`);
-	expect(source).not.toContain(`${"__webpack_require__"}.ei(`);
+	expect(read("flat.mjs")).toContain('"./lazy.mjs"');
+	expect(read("nested/deep.mjs")).toContain('"../lazy.mjs"');
+	expect(read("flat.mjs")).not.toContain(`${"__webpack_require__"}.e(`);
 });

--- a/test/configCases/analyzable/shared-depths-import/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// The module holding the `import()` lives in chunks at two depths, so no one relative
-// literal addresses the target from both — the specifier is reserved instead and each
-// emitted asset gets its own `../` path once the names exist.
+// The module holding the `import()` sits at two depths, so the specifier is reserved
+// and each emitted asset gets its own `../` path once the names exist.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/shared-depths-import/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import/webpack.config.js
@@ -1,8 +1,8 @@
 "use strict";
 
-// The module holding the `import()` lives in chunks at two depths, so no single
-// relative literal addresses the target from both — and unlike `new URL(...)`, an
-// `import()` specifier can't be a runtime concatenation. It keeps the runtime form.
+// The module holding the `import()` lives in chunks at two depths, so no one relative
+// literal addresses the target from both — the specifier is reserved instead and each
+// emitted asset gets its own `../` path once the names exist.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/templated-public-path/index.js
+++ b/test/configCases/analyzable/templated-public-path/index.js
@@ -27,9 +27,17 @@ if (__BAKED__) {
 			/^([^/]+)\/(.+)$/
 		);
 
-		expect(hash).toBe(
-			__SLICE__ ? stats.hash.slice(0, __SLICE__) : stats.hash
-		);
+		if (__DIGEST__) {
+			// A digest re-encodes the hash, so decode it back to compare.
+			const hex = Buffer.from(
+				hash.replace(/-/g, "+").replace(/_/g, "/"),
+				"base64"
+			).toString("hex");
+
+			expect(hex.startsWith(stats.hash)).toBe(true);
+		} else {
+			expect(hash).toBe(__SLICE__ ? stats.hash.slice(0, __SLICE__) : stats.hash);
+		}
 		// The name in the specifier is the one that reached disk.
 		expect(fs.existsSync(path.join(stats.outputPath, file))).toBe(true);
 	});

--- a/test/configCases/analyzable/templated-public-path/webpack.config.js
+++ b/test/configCases/analyzable/templated-public-path/webpack.config.js
@@ -36,7 +36,8 @@ const base = (
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
 			__BAKED__: JSON.stringify(baked),
-			__SLICE__: JSON.stringify(hashPart.includes(":8") ? 8 : 0)
+			__SLICE__: JSON.stringify(hashPart.includes(":8") ? 8 : 0),
+			__DIGEST__: JSON.stringify(hashPart.includes("base64safe"))
 		})
 	]
 });
@@ -47,9 +48,9 @@ module.exports = [
 	base(1, "sliced", "[fullhash:8]", true),
 	// Both halves of the name are deferred: the public path's hash and the chunk's own.
 	base(2, "hashed-chunk", "[fullhash]", true, ".[contenthash]"),
-	// A digest re-encodes the hash rather than reading it, which a stand-in cannot
-	// survive, so the whole specifier stays on the runtime form.
-	base(3, "digest", "[fullhash:base64]", false),
+	// A digest re-encodes the hash rather than reading it, so no stand-in can spell it:
+	// the deferred pass resolves the whole public path itself once the hash exists.
+	base(3, "digest", "[fullhash:base64safe]", true),
 	// No javascript here is named by its content, so rewriting one invalidates
 	// nothing and there is no repair to need.
 	base(4, "no-repair-hash-free", "[fullhash]", true, "", false),

--- a/test/configCases/wasm/analyzable-esm/webpack.config.js
+++ b/test/configCases/wasm/analyzable-esm/webpack.config.js
@@ -62,19 +62,19 @@ module.exports = [
 		]
 	}),
 	base({
-		// A non-`auto` public path keeps the runtime form: the node backends ignore
-		// `output.publicPath`, so it can't be baked into a shared literal.
+		// A relative public path does not stop the node backends: they read the binary
+		// relative to the chunk, which is what the baked literal addresses too.
 		output: { chunkFilename: "c-[name].mjs", publicPath: "./" },
-		plugins: [expectations("c-flat.mjs", "module.id, ")]
+		plugins: [expectations("c-flat.mjs", 'new URL("./')]
 	}),
 	base({
-		// Truncated `[hash:<n>]` on the runtime form: the helper slices the hash it is
-		// handed rather than reading a baked literal.
+		// Truncated `[hash:<n>]` is the module's own hash, which code generation already
+		// knows, so it is baked rather than sliced by the runtime helper.
 		output: {
 			chunkFilename: "d-[name].mjs",
 			publicPath: "./",
 			webassemblyModuleFilename: "[id].[hash:6].wasm"
 		},
-		plugins: [expectations("d-flat.mjs", "module.id, ")]
+		plugins: [expectations("d-flat.mjs", 'new URL("./')]
 	})
 ];

--- a/test/configCases/wasm/analyzable-relative-public-path/index.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/index.js
@@ -1,0 +1,15 @@
+// Referenced but never called — the binary's reference is what is under test.
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+const fs = require("fs");
+const path = require("path");
+
+it("should reference the binary in the expected form", () => {
+	// Only the wasm chunk — this file's own needles would satisfy the assertion.
+	const source = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, __CHUNK__),
+		"utf8"
+	);
+
+	expect(source).toContain(__WASM_REF__);
+});

--- a/test/configCases/wasm/analyzable-relative-public-path/index.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/index.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
 export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
 

--- a/test/configCases/wasm/analyzable-relative-public-path/index.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/index.js
@@ -1,8 +1,13 @@
-// Referenced but never called — the binary's reference is what is under test.
-export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
-
 const fs = require("fs");
 const path = require("path");
+
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+if (__RUNS__) {
+	it("should reach the binary through the baked relative url", async () => {
+		expect((await load()).run()).toBe(42);
+	});
+}
 
 it("should reference the binary in the expected form", () => {
 	// Only the wasm chunk — this file's own needles would satisfy the assertion.

--- a/test/configCases/wasm/analyzable-relative-public-path/lazy.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./wasm.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-relative-public-path/wasm.wat
+++ b/test/configCases/wasm/analyzable-relative-public-path/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
@@ -1,0 +1,50 @@
+"use strict";
+
+// `fetch` is the one loader a public path reaches; `readFile` resolves the binary's
+// name against the chunk it is read from, exactly as a baked literal does.
+
+const webpack = require("../../../../");
+
+const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {NonNullable<import("../../../../").Configuration["output"]>["wasmLoading"]} wasmLoading how the binary is loaded
+ * @param {string} wasmRef expected start of the binary's reference
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, wasmLoading, wasmRef) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading,
+		chunkFilename: `${name}-[name].mjs`,
+		webassemblyModuleFilename: `${name}-[id].wasm`,
+		publicPath: "/assets/"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__CHUNK__: JSON.stringify(`${name}-lazy.mjs`),
+			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "node", "async-node", 'new URL("./'),
+	// The public path reaches this one, and a relative one means something different
+	// against the chunk than against the document, so the runtime form stays.
+	base(1, "fetch", "fetch", "module.id, ")
+];

--- a/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
@@ -12,9 +12,11 @@ const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
  * @param {string} name prefix keeping the emitted files of each config apart
  * @param {NonNullable<import("../../../../").Configuration["output"]>["wasmLoading"]} wasmLoading how the binary is loaded
  * @param {string} wasmRef expected start of the binary's reference
+ * @param {boolean} runs whether the harness can load the binary that way
+ * @param {string} publicPath the relative public path under test
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, name, wasmLoading, wasmRef) => ({
+const base = (index, name, wasmLoading, wasmRef, runs, publicPath) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -30,21 +32,26 @@ const base = (index, name, wasmLoading, wasmRef) => ({
 		wasmLoading,
 		chunkFilename: `${name}-[name].mjs`,
 		webassemblyModuleFilename: `${name}-[id].wasm`,
-		publicPath: "/assets/"
+		publicPath
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
 			__CHUNK__: JSON.stringify(`${name}-lazy.mjs`),
-			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef)
+			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef),
+			__RUNS__: JSON.stringify(runs)
 		})
 	]
 });
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	base(0, "node", "async-node", 'new URL("./'),
+	// Not loaded: the harness cannot resolve an `import()` of a `/assets/` specifier.
+	base(0, "node", "async-node", 'new URL("./', false, "/assets/"),
 	// The public path reaches this one, and a relative one means something different
 	// against the chunk than against the document, so the runtime form stays.
-	base(1, "fetch", "fetch", "module.id, ")
+	base(1, "fetch", "fetch", "module.id, ", false, "/assets/"),
+	// A chunk-relative public path resolves the same way the harness does, so this one
+	// runs the binary the baked url points at.
+	base(2, "run", "async-node", 'new URL("./', true, "./")
 ];

--- a/test/configCases/wasm/analyzable-shared-depths/deep.js
+++ b/test/configCases/wasm/analyzable-shared-depths/deep.js
@@ -1,0 +1,1 @@
+export { run } from "./shared";

--- a/test/configCases/wasm/analyzable-shared-depths/flat.js
+++ b/test/configCases/wasm/analyzable-shared-depths/flat.js
@@ -1,0 +1,1 @@
+export { run } from "./shared";

--- a/test/configCases/wasm/analyzable-shared-depths/index.js
+++ b/test/configCases/wasm/analyzable-shared-depths/index.js
@@ -1,0 +1,19 @@
+import fs from "fs";
+import path from "path";
+
+it("should run the binary from chunks at different depths", async () => {
+	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
+	expect(await flat.run()).toBe(42);
+	// Pull in the second, deeper copy so the binary really sits at two depths.
+	const deep = await import(/* webpackChunkName: "nested/deep" */ "./deep");
+	expect(await deep.run()).toBe(42);
+});
+
+it("should bake the url each depth needs", () => {
+	const read = (name) =>
+		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+
+	expect(read("flat.mjs")).toMatch(/new URL\("\.\/[^"]+\.wasm"/);
+	expect(read("nested/deep.mjs")).toMatch(/new URL\("\.\.\/[^"]+\.wasm"/);
+	expect(read("flat.mjs")).not.toContain(`new URL(${"__webpack_require__"}.p + `);
+});

--- a/test/configCases/wasm/analyzable-shared-depths/shared.js
+++ b/test/configCases/wasm/analyzable-shared-depths/shared.js
@@ -1,0 +1,4 @@
+import { getNumber } from "./wasm.wat";
+
+// Duplicated into both chunks below, so the binary is referenced from two depths.
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-shared-depths/wasm.wat
+++ b/test/configCases/wasm/analyzable-shared-depths/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-shared-depths/webpack.config.js
+++ b/test/configCases/wasm/analyzable-shared-depths/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// The binary is referenced from chunks at two depths, so no one relative literal
+// addresses it from both — each emitted asset gets its own `../` path instead.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "async-node",
+		chunkFilename: "[name].mjs",
+		webassemblyModuleFilename: "[id].wasm",
+		publicPath: "auto"
+	}
+};

--- a/test/configCases/wasm/analyzable-templated-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/index.js
@@ -1,0 +1,32 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced but never called — the baked url is what is under test.
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+const stats = __STATS__.children[__INDEX__];
+// Only the wasm chunk — this file's own needles would satisfy the assertions.
+const chunk = () =>
+	fs.readFileSync(path.join(stats.outputPath, __CHUNK__), "utf8");
+
+it("should bake the compilation hash into the binary's url", () => {
+	const url = chunk().match(/new URL\("https:\/\/example\.com\/([^/]+)\//);
+
+	expect(url).not.toBe(null);
+	if (__DIGEST__) {
+		// A digest re-encodes the hash, so decode it back to compare.
+		const hex = Buffer.from(
+			url[1].replace(/-/g, "+").replace(/_/g, "/"),
+			"base64"
+		).toString("hex");
+
+		expect(hex.startsWith(stats.hash)).toBe(true);
+	} else {
+		expect(stats.hash.startsWith(url[1])).toBe(true);
+	}
+});
+
+it("should not assemble the binary's url at runtime", () => {
+	// Needle built at runtime so it is not a source string literal here.
+	expect(chunk()).not.toContain(`new URL(${"__webpack_require__"}.p + `);
+});

--- a/test/configCases/wasm/analyzable-templated-url-public-path/lazy.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./wasm.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-templated-url-public-path/wasm.wat
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
@@ -1,0 +1,47 @@
+"use strict";
+
+// A public path that is a complete URL stays absolute however it is spelled, so a
+// `[fullhash]` in it — read plainly or re-encoded to another digest — bakes too.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name prefix keeping the emitted files of each config apart
+ * @param {string} hashPart the `[fullhash]` form under test
+ * @param {boolean} digest whether that form re-encodes the hash
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, hashPart, digest) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "fetch",
+		chunkFilename: `${name}-chunks/[name].mjs`,
+		webassemblyModuleFilename: `${name}-[id].wasm`,
+		publicPath: `https://example.com/${hashPart}/`
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__CHUNK__: JSON.stringify(`${name}-chunks/lazy.mjs`),
+			__DIGEST__: JSON.stringify(digest)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "plain", "[fullhash]", false),
+	base(1, "sliced", "[fullhash:8]", false),
+	base(2, "digest", "[fullhash:base64safe]", true)
+];

--- a/test/configCases/worker/worker-shared-depths-runtime-path/deep.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/deep.js
@@ -1,0 +1,1 @@
+export { spawn } from "./shared";

--- a/test/configCases/worker/worker-shared-depths-runtime-path/flat.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/flat.js
@@ -1,0 +1,1 @@
+export { spawn } from "./shared";

--- a/test/configCases/worker/worker-shared-depths-runtime-path/index.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/index.js
@@ -16,11 +16,12 @@ it("should run a worker referenced from chunks at different depths", async () =>
 	await import(/* webpackChunkName: "nested/deep" */ "./deep");
 });
 
-it("should bake the specifier each depth needs", () => {
-	const read = (name) =>
-		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+it("should keep the worker filename a literal behind the runtime public path", () => {
+	const source = fs.readFileSync(
+		path.join(__STATS__.outputPath, "flat.mjs"),
+		"utf8"
+	);
 
-	expect(read("flat.mjs")).toContain('"./worker_js.mjs"');
-	expect(read("nested/deep.mjs")).toContain('"../worker_js.mjs"');
-	expect(read("flat.mjs")).not.toContain(`${"__webpack_require__"}.p`);
+	expect(source).toContain(`${"__webpack_require__"}.p + "worker_js.mjs"`);
+	expect(source).not.toContain(`${"__webpack_require__"}.u`);
 });

--- a/test/configCases/worker/worker-shared-depths-runtime-path/shared.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/shared.js
@@ -1,0 +1,6 @@
+import { Worker } from "worker_threads";
+
+// This module ends up in two chunks emitted at different depths, and no stand-in may
+// be reserved here, so the worker is addressed through the runtime public path.
+export const spawn = () =>
+	new Worker(new URL("./worker.js", import.meta.url), { type: "module" });

--- a/test/configCases/worker/worker-shared-depths-runtime-path/test.config.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const fs = require("fs");
+
+module.exports = {
+	moduleScope(scope) {
+		scope.URL = URL;
+	},
+	findBundle(index, options) {
+		return fs
+			.readdirSync(options.output.path)
+			.filter((name) => /^main\..+\.mjs$/.test(name));
+	}
+};

--- a/test/configCases/worker/worker-shared-depths-runtime-path/test.filter.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// Rewriting an asset after its own content hash was taken needs `realContentHash` to
-// bring the two back in line; without it no stand-in may be reserved, so a module in
-// chunks at two depths keeps the runtime public path in front of a literal filename.
+// Without `realContentHash` nothing repairs a rewritten name, so no stand-in may be
+// reserved and two depths keep the runtime public path before a literal filename.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// Rewriting an asset after its own content hash was taken needs `realContentHash` to
+// bring the two back in line; without it no stand-in may be reserved, so a module in
+// chunks at two depths keeps the runtime public path in front of a literal filename.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node14",
+	mode: "development",
+	devtool: false,
+	optimization: {
+		chunkIds: "named",
+		splitChunks: false,
+		realContentHash: false
+	},
+	output: {
+		module: true,
+		filename: "main.[contenthash].mjs",
+		chunkFilename: "[name].mjs",
+		workerChunkFilename: "[name].mjs",
+		publicPath: "auto"
+	},
+	experiments: { outputModule: true }
+};

--- a/test/configCases/worker/worker-shared-depths-runtime-path/worker.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/worker.js
@@ -1,0 +1,3 @@
+import { parentPort } from "worker_threads";
+
+parentPort.postMessage("from-worker");

--- a/test/configCases/worker/worker-shared-depths/shared.js
+++ b/test/configCases/worker/worker-shared-depths/shared.js
@@ -1,6 +1,6 @@
 import { Worker } from "worker_threads";
 
-// This module ends up in two chunks emitted at different depths, so no single
-// relative literal can address the worker from both.
+// This module ends up in two chunks emitted at different depths, so the worker is
+// addressed by a different relative literal from each.
 export const spawn = () =>
 	new Worker(new URL("./worker.js", import.meta.url), { type: "module" });

--- a/test/configCases/worker/worker-shared-depths/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// The module holding `new Worker(new URL(...))` lives in chunks at two depths, so no
-// one relative literal addresses the worker from both — each emitted asset gets its
-// own, filled in once the names exist.
+// The module holding `new Worker(new URL(...))` sits at two depths, so each emitted
+// asset gets its own relative literal once the names exist.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/worker/worker-shared-depths/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths/webpack.config.js
@@ -1,8 +1,8 @@
 "use strict";
 
-// The module holding `new Worker(new URL(...))` lives in chunks at two depths, so the
-// specifier can't be one relative literal. The filename still gets to be a literal
-// behind the runtime public path, instead of collapsing to a `.u(id)` lookup.
+// The module holding `new Worker(new URL(...))` lives in chunks at two depths, so no
+// one relative literal addresses the worker from both — each emitted asset gets its
+// own, filled in once the names exist.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -84,5 +84,19 @@ content-hash:
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
-  content-hash (webpack x.x.x) compiled successfully in X ms"
+  content-hash (webpack x.x.x) compiled successfully in X ms
+
+shared-depths:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset nested/deep.mjs X KiB [emitted] [javascript module] (name: nested/deep)
+  asset flat.mjs X KiB [emitted] [javascript module] (name: flat)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 6 modules
+  cacheable modules X bytes
+    ./index-depths.js X bytes [built] [code generated]
+    ./depths-flat.js X bytes [built] [code generated]
+    ./depths-deep.js X bytes [built] [code generated]
+    ./depths-shared.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  shared-depths (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/analyzable-esm-fallbacks/depths-deep.js
+++ b/test/statsCases/analyzable-esm-fallbacks/depths-deep.js
@@ -1,0 +1,1 @@
+export { load } from "./depths-shared";

--- a/test/statsCases/analyzable-esm-fallbacks/depths-flat.js
+++ b/test/statsCases/analyzable-esm-fallbacks/depths-flat.js
@@ -1,0 +1,1 @@
+export { load } from "./depths-shared";

--- a/test/statsCases/analyzable-esm-fallbacks/depths-shared.js
+++ b/test/statsCases/analyzable-esm-fallbacks/depths-shared.js
@@ -1,0 +1,2 @@
+// Duplicated into both chunks above, so it sits at two output depths at once.
+export const load = () => import("./async").then((m) => m.value);

--- a/test/statsCases/analyzable-esm-fallbacks/index-depths.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-depths.js
@@ -1,0 +1,7 @@
+// One module in chunks at two depths: each needs its own `../` path to the same chunk,
+// which only a stand-in can carry — and here none may be reserved.
+export const load = () =>
+	Promise.all([
+		import(/* webpackChunkName: "flat" */ "./depths-flat"),
+		import(/* webpackChunkName: "nested/deep" */ "./depths-deep")
+	]);

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -6,9 +6,8 @@ const path = require("path");
 const HELPER = "__webpack_require__.ei";
 const BAILOUT = "Analyzable ESM bailout:";
 
-// Per case: which emitted entry to inspect and what to assert.
-// - "analyzable": the baseline — emits the `.ei` helper.
-// - "fallback": the whole build has no analyzable import, so no `.ei` is emitted at all.
+// Per case: which emitted file to inspect, and whether it emits the `.ei` helper
+// ("analyzable") or keeps the runtime form and names its reason ("fallback").
 const CASES = {
 	analyzable: { file: "main.mjs", expect: "analyzable" },
 	"public-path-override": {

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -32,7 +32,14 @@ const CASES = {
 	prefetch: { file: "main.mjs", expect: "analyzable" },
 	// The hot require wraps `.ei` like `.e`, so an update still blocks on a chunk
 	// load in flight and HMR does not force the runtime form.
-	hmr: { file: "main.mjs", expect: "analyzable" }
+	hmr: { file: "main.mjs", expect: "analyzable" },
+	// The entry reaches both copies from one depth, so only the chunk they share
+	// falls back — read that one rather than the entry.
+	"shared-depths": {
+		file: "flat.mjs",
+		expect: "fallback",
+		bailout: "chunks at different output depths"
+	}
 };
 
 module.exports = {

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -4,17 +4,26 @@ const fs = require("fs");
 const path = require("path");
 
 const HELPER = "__webpack_require__.ei";
+const BAILOUT = "Analyzable ESM bailout:";
 
 // Per case: which emitted entry to inspect and what to assert.
 // - "analyzable": the baseline — emits the `.ei` helper.
 // - "fallback": the whole build has no analyzable import, so no `.ei` is emitted at all.
 const CASES = {
 	analyzable: { file: "main.mjs", expect: "analyzable" },
-	"public-path-override": { file: "main.mjs", expect: "fallback" },
+	"public-path-override": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: "__webpack_public_path__ is reassigned"
+	},
 	// `fetchPriority` is unsupported for ESM output, so it must not degrade the
 	// output — the analyzable form is still emitted (documented limitation).
 	"fetch-priority": { file: "main.mjs", expect: "analyzable" },
-	"content-hash": { file: "main.mjs", expect: "fallback" },
+	"content-hash": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: "optimization.realContentHash"
+	},
 	// The public path's hash is filled in by the deferred pass, and no name here is
 	// built from content, so there is none for the rewrite to invalidate.
 	"templated-public-path": { file: "main.mjs", expect: "analyzable" },
@@ -45,11 +54,25 @@ module.exports = {
 				),
 				"utf8"
 			);
+			// A bailout is recorded exactly when the runtime form is kept, so a limitation
+			// that is later lifted fails here until its reason is dropped too.
+			const bailouts = [];
+			for (const module of child.toJson({
+				all: false,
+				modules: true,
+				optimizationBailout: true
+			}).modules || []) {
+				for (const bailout of module.optimizationBailout || []) {
+					if (bailout.startsWith(BAILOUT)) bailouts.push(bailout);
+				}
+			}
 			if (testCase.expect === "analyzable") {
 				expect(output).toContain(HELPER);
+				expect(bailouts).toEqual([]);
 			} else {
 				// A limitation must not emit extra runtime — the `.ei` helper stays out.
 				expect(output).not.toContain(HELPER);
+				expect(bailouts.join("\n")).toContain(testCase.bailout);
 			}
 		}
 	}

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -61,5 +61,12 @@ module.exports = [
 	// development — so the name it would be rewritten under has nothing to repair it.
 	base("content-hash", {
 		output: { chunkFilename: "[name].[contenthash].mjs" }
+	}),
+	// Two depths need two different specifiers, which only a stand-in can carry — and
+	// naming any emitted javascript by its content, worker chunks included, is enough
+	// to rule the rewrite a stand-in needs out.
+	base("shared-depths", {
+		entry: "./index-depths",
+		output: { workerChunkFilename: "[name].[contenthash].mjs" }
 	})
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -62,9 +62,8 @@ module.exports = [
 	base("content-hash", {
 		output: { chunkFilename: "[name].[contenthash].mjs" }
 	}),
-	// Two depths need two different specifiers, which only a stand-in can carry — and
-	// naming any emitted javascript by its content, worker chunks included, is enough
-	// to rule the rewrite a stand-in needs out.
+	// Two depths need a stand-in, and naming any emitted javascript by its content —
+	// worker chunks included — rules out the rewrite one needs.
 	base("shared-depths", {
 		entry: "./index-depths",
 		output: { workerChunkFilename: "[name].[contenthash].mjs" }

--- a/types.d.ts
+++ b/types.d.ts
@@ -24700,8 +24700,7 @@ declare abstract class RuntimeTemplate {
 	 * Either way a name that is not settled during code generation may still be baked,
 	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
 	 * What still forces the runtime form, and is not covered by any of the three:
-	 * a module federation module in the chunk, a chunk reachable at more than one
-	 * output depth under an `auto` public path, and a chunk with no id.
+	 * a module federation module in the chunk, and a chunk with no id.
 	 */
 	supportsAnalyzableEsm(chunkGraph?: ChunkGraph, module?: Module): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Analyzable ESM output silently fell back to the runtime form in four cases, with no way to tell from the outside that it had. Each gate now records its reason through `optimizationBailout`, and the deferred stand-in carries a prefix *recipe* rather than a resolved prefix — so a public path whose hash is re-encoded to another digest, a module in chunks at several output depths, and a wasm binary behind a relative public path on a `readFile` loader all bake. Refs #21669.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new `configCases/analyzable/shared-depths-import-fallback`, `configCases/worker/worker-shared-depths-runtime-path`, `configCases/wasm/analyzable-{shared-depths,templated-url-public-path,relative-public-path}`, plus updated `configCases/analyzable/{shared-depths-import,templated-public-path}`, `configCases/worker/worker-shared-depths`, `configCases/wasm/analyzable-esm` and `statsCases/analyzable-esm-fallbacks`, which now asserts both ways: a build that bakes records no bailout, and each fallback names its cause.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Emitted output changes only where a reference previously used the runtime form and can now be a literal; the referenced target is the same in each case.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Worth a note that `stats.optimizationBailout` now explains analyzable-ESM fallbacks, and that a `fetch`-loaded wasm binary still needs an absolute-URL `output.publicPath` — `fetch` resolves a relative one against the document, `new URL(..., import.meta.url)` against the chunk.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code was used to explore the existing gates, draft the implementation and tests, and run the targeted suites. Every behaviour change was verified by building the fixtures and reading the emitted bundles, and each new test was confirmed to fail on unmodified `lib/` before the fix. I reviewed and edited all of it; two of its conclusions were wrong and corrected before committing (`[hash]` in `webassemblyModuleFilename` is the module hash, not the compilation hash; a relative public path cannot be composed with the undo path).

---
_Generated by [Claude Code](https://claude.ai/code/session_011gLkJyyoJtX2BVpZNPndbb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved analyzable ESM, WebAssembly, and worker URLs across nested output paths.
  - Added support for content hashes, truncated hashes, base64-safe digests, and relative public paths.
  - Added clearer diagnostics when URLs cannot be statically analyzed.

- **Bug Fixes**
  - Corrected asset and chunk references for varying output depths and public-path configurations.

- **Tests**
  - Expanded coverage for dynamic imports, WebAssembly loading, workers, hashed URLs, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->