### PR TITLE
fix: inherit sideEffects past type-only nested package.json

### DIFF
--- a/.changeset/047-inherit-nested-sideEffects.md
+++ b/.changeset/047-inherit-nested-sideEffects.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Inherit sideEffects past type-only nested package.json under node_modules.

--- a/lib/dependencies/ImportMetaGlobHelpers.js
+++ b/lib/dependencies/ImportMetaGlobHelpers.js
@@ -20,22 +20,12 @@ const {
 	normalizePathSeparatorsForPath,
 	resolveContextModuleGlobPattern
 } = require("../util/globUtils");
+const { relativePathToRequest } = require("../util/identifier");
 const memoize = require("../util/memoize");
 
 const getUnsupportedFeatureWarning = memoize(() =>
 	require("../errors/UnsupportedFeatureWarning")
 );
-
-/**
- * @param {string} relativePath relative path
- * @returns {string} request
- */
-const relativePathToRequest = (relativePath) => {
-	if (relativePath === "") return "./.";
-	if (relativePath === "..") return "../.";
-	if (relativePath.startsWith("../")) return relativePath;
-	return `./${relativePath}`;
-};
 
 /** @import { ContextModuleOptions } from "../ContextModule" */
 /** @import JavascriptParser, { Range } from "../javascript/JavascriptParser" */
@@ -48,6 +38,16 @@ const relativePathToRequest = (relativePath) => {
  * 	Property
  * } from "estree"
  */
+/** @typedef {import("../ContextModule").ContextModuleOptions} ContextModuleOptions */
+/** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
+/** @typedef {import("../javascript/JavascriptParser").Range} Range */
+/** @typedef {import("../Dependency").RawReferencedExports} RawReferencedExports */
+/** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("estree").CallExpression} CallExpression */
+/** @typedef {import("estree").Expression} Expression */
+/** @typedef {import("estree").ObjectExpression} ObjectExpression */
+/** @typedef {import("estree").Property} Property */
+/** @typedef {import("./ImportMetaGlobDependency").ImportMetaGlobDependencyOptions} ImportMetaGlobDependencyOptions */
 
 /**
  * @typedef {object} ParsedImportMetaGlobOptions

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -16,7 +16,12 @@ const HarmonyImportDependency = require("../dependencies/HarmonyImportDependency
 const HarmonyImportSpecifierDependency = require("../dependencies/HarmonyImportSpecifierDependency");
 const { ImportPhaseUtils } = require("../dependencies/ImportPhase");
 const formatLocation = require("../util/formatLocation");
+const { dirname, join, readJson, relative } = require("../util/fs");
 const { getGlobToRegExpSource } = require("../util/globUtils");
+const {
+	WINDOWS_PATH_SEPARATOR_REGEXP,
+	relativePathToRequest
+} = require("../util/identifier");
 const { CompilerHintNotationRegExp } = require("../util/magicComment");
 
 /**
@@ -52,9 +57,29 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
  * @property {boolean} checked if the export is conditional
  */
 
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+/** @typedef {import("../util/fs").JsonObject} JsonObject */
+/** @typedef {import("../NormalModuleFactory").CreateData} CreateData */
+
 /** @typedef {string | boolean | string[] | undefined} SideEffectsFlagValue */
 
 /** @typedef {Map<string, RegExp>} CacheItem */
+
+/**
+ * @typedef {object} ResolvedSideEffectsFlag
+ * @property {SideEffectsFlagValue} sideEffects package.json sideEffects value
+ * @property {string} relativePath path relative to the owning package root
+ */
+
+/**
+ * Owning-package sideEffects resolution cached per descriptionFileRoot.
+ * `null` means the walk finished with no applicable flag.
+ * @typedef {object} OwningSideEffectsFlag
+ * @property {SideEffectsFlagValue} sideEffects package.json sideEffects value
+ * @property {string} packageRoot directory of the declaring package.json
+ */
+
+/** @typedef {Map<string, OwningSideEffectsFlag | null>} OwningSideEffectsFlagCache */
 
 /**
  * Whether a resolved re-export target is reached through an `import defer` edge.
@@ -73,6 +98,30 @@ const isDeferredTargetConnection = (connection) =>
 /** @type {WeakMap<Compiler, CacheItem>} */
 const globToRegexpCache = new WeakMap();
 
+/** @type {WeakMap<EXPECTED_OBJECT, OwningSideEffectsFlagCache>} */
+const owningSideEffectsFlagCache = new WeakMap();
+
+/** @type {WeakMap<Partial<CreateData>, ResolvedSideEffectsFlag>} */
+const resolvedSideEffectsFlags = new WeakMap();
+
+/**
+ * Ancestor package.json read failures that must not fail unrelated modules.
+ * @param {NodeJS.ErrnoException | SyntaxError | Error} err error from readJson
+ * @returns {boolean} true when the walk should skip this directory
+ */
+const isSkippablePackageJsonError = (err) => {
+	if (err instanceof SyntaxError) return true;
+	if (!("code" in err)) return false;
+	switch (err.code) {
+		case "ENOENT":
+		case "ENOTDIR":
+		case "EISDIR":
+		case "ENAMETOOLONG":
+			return true;
+		default:
+			return false;
+	}
+};
 /**
  * Returns a regular expression.
  * @param {string} glob the pattern
@@ -115,6 +164,120 @@ const notSideEffectsTag = Symbol("NoSideEffects");
 
 /** @type {(target: { module: Module }) => boolean} */
 const RETURNS_FALSE = () => false;
+
+/**
+ * Resolve sideEffects from the owning package, inheriting past type-only nested
+ * package.json under node_modules. Globs are matched relative to that package root.
+ * @param {InputFileSystem} fs file system
+ * @param {string} descriptionFileRoot root directory of the nearest description file
+ * @param {JsonObject} descriptionFileData nearest description file data
+ * @param {string} relativePath path relative to descriptionFileRoot
+ * @param {OwningSideEffectsFlagCache} owningCache walk cache keyed by descriptionFileRoot
+ * @param {(err?: null | Error, result?: ResolvedSideEffectsFlag) => void} callback callback
+ * @returns {void}
+ */
+const resolveSideEffectsFlag = (
+	fs,
+	descriptionFileRoot,
+	descriptionFileData,
+	relativePath,
+	owningCache,
+	callback
+) => {
+	if (descriptionFileData.sideEffects !== undefined) {
+		return callback(null, {
+			sideEffects: /** @type {SideEffectsFlagValue} */ (
+				descriptionFileData.sideEffects
+			),
+			relativePath
+		});
+	}
+	// Named package with no sideEffects: do not inherit from outside.
+	if (descriptionFileData.name !== undefined) {
+		return callback();
+	}
+	// Only inherit inside node_modules; app-local nests must keep shadowing parents.
+	const normalizedRoot = descriptionFileRoot.replace(
+		WINDOWS_PATH_SEPARATOR_REGEXP,
+		"/"
+	);
+	if (!/(?:^|\/)node_modules(?:\/|$)/.test(normalizedRoot)) {
+		return callback();
+	}
+
+	const resourcePath = join(fs, descriptionFileRoot, relativePath);
+
+	/**
+	 * @param {OwningSideEffectsFlag | null} owning owning package flag or null
+	 * @returns {void}
+	 */
+	const finishFromOwning = (owning) => {
+		if (owning === null) return callback();
+		const ancestorRelative = relative(
+			fs,
+			owning.packageRoot,
+			resourcePath
+		).replace(WINDOWS_PATH_SEPARATOR_REGEXP, "/");
+		return callback(null, {
+			sideEffects: owning.sideEffects,
+			relativePath: relativePathToRequest(ancestorRelative)
+		});
+	};
+
+	const cached = owningCache.get(descriptionFileRoot);
+	if (cached !== undefined) {
+		return finishFromOwning(cached);
+	}
+
+	let dir = dirname(fs, descriptionFileRoot);
+
+	const next = () => {
+		const parent = dirname(fs, dir);
+		if (!parent || parent === dir) {
+			owningCache.set(descriptionFileRoot, null);
+			return callback();
+		}
+		const baseName = relative(fs, parent, dir).replace(
+			WINDOWS_PATH_SEPARATOR_REGEXP,
+			"/"
+		);
+		// Do not inherit an application's sideEffects across an install boundary.
+		if (baseName === "node_modules") {
+			owningCache.set(descriptionFileRoot, null);
+			return callback();
+		}
+
+		readJson(fs, join(fs, dir, "package.json"), (err, data) => {
+			if (err) {
+				if (isSkippablePackageJsonError(err)) {
+					dir = parent;
+					return next();
+				}
+				return callback(err);
+			}
+			if (!data || typeof data !== "object" || Array.isArray(data)) {
+				dir = parent;
+				return next();
+			}
+			if (data.sideEffects !== undefined) {
+				/** @type {OwningSideEffectsFlag} */
+				const owning = {
+					sideEffects: /** @type {SideEffectsFlagValue} */ (data.sideEffects),
+					packageRoot: dir
+				};
+				owningCache.set(descriptionFileRoot, owning);
+				return finishFromOwning(owning);
+			}
+			if (data.name !== undefined) {
+				owningCache.set(descriptionFileRoot, null);
+				return callback();
+			}
+			dir = parent;
+			next();
+		});
+	};
+	next();
+};
 
 /**
  * Detects if the module is "pure single-star passthrough": one whose entire export
@@ -165,31 +328,64 @@ class SideEffectsFlagPlugin {
 			cache = new Map();
 			globToRegexpCache.set(compiler.root, cache);
 		}
+		let owningCache = owningSideEffectsFlagCache.get(compiler.root);
+		if (owningCache === undefined) {
+			owningCache = new Map();
+			owningSideEffectsFlagCache.set(compiler.root, owningCache);
+		}
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const moduleGraph = compilation.moduleGraph;
-				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {
-					const resolveData = data.resourceResolveData;
-					if (
-						resolveData &&
-						resolveData.descriptionFileData &&
-						resolveData.relativePath
-					) {
-						const sideEffects = resolveData.descriptionFileData.sideEffects;
-						if (sideEffects !== undefined) {
-							if (module.factoryMeta === undefined) {
-								module.factoryMeta = {};
-							}
-							const hasSideEffects = SideEffectsFlagPlugin.moduleHasSideEffects(
-								resolveData.relativePath,
-								/** @type {SideEffectsFlagValue} */ (sideEffects),
-								/** @type {CacheItem} */ (cache)
-							);
-							module.factoryMeta.sideEffectFree = !hasSideEffects;
+				normalModuleFactory.hooks.afterResolve.tapAsync(
+					PLUGIN_NAME,
+					(resolveData, callback) => {
+						const inputFileSystem = compiler.inputFileSystem;
+						if (!inputFileSystem) return callback();
+						const { createData } = resolveData;
+						const resolveInfo = createData.resourceResolveData;
+						if (
+							!resolveInfo ||
+							!resolveInfo.descriptionFileData ||
+							!resolveInfo.relativePath
+						) {
+							return callback();
 						}
+						const descriptionFileRoot =
+							resolveInfo.descriptionFileRoot ||
+							(resolveInfo.descriptionFilePath
+								? dirname(inputFileSystem, resolveInfo.descriptionFilePath)
+								: undefined);
+						if (descriptionFileRoot === undefined) return callback();
+						resolveSideEffectsFlag(
+							inputFileSystem,
+							descriptionFileRoot,
+							resolveInfo.descriptionFileData,
+							resolveInfo.relativePath,
+							owningCache,
+							(err, resolved) => {
+								if (err) return callback(err);
+								if (resolved !== undefined) {
+									resolvedSideEffectsFlags.set(createData, resolved);
+								}
+								callback();
+							}
+						);
 					}
-
+				);
+				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {
+					const resolved = resolvedSideEffectsFlags.get(data);
+					if (resolved !== undefined) {
+						if (module.factoryMeta === undefined) {
+							module.factoryMeta = {};
+						}
+						const hasSideEffects = SideEffectsFlagPlugin.moduleHasSideEffects(
+							resolved.relativePath,
+							resolved.sideEffects,
+							/** @type {CacheItem} */ (cache)
+						);
+						module.factoryMeta.sideEffectFree = !hasSideEffects;
+					}
 					return module;
 				});
 				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -582,4 +582,5 @@ module.exports.parseResource = makeCacheable(_parseResource);
 module.exports.parseResourceWithoutFragment = makeCacheable(
 	_parseResourceWithoutFragment
 );
+module.exports.relativePathToRequest = relativePathToRequest;
 module.exports.toJsStringLiteral = toJsStringLiteral;

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_OUTSIDE_CONTEXT_SEF";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/node_modules/outside-context-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "outside-context-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-package-json-sideEffects-outside-context",
+  "sideEffects": false
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_CLIMB_PAST_CONTEXT";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/climb-nested/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/src/index.js
@@ -1,0 +1,31 @@
+import { light as outsideLight } from "outside-context-sef";
+import { light as climbLight } from "./climb-nested/esm";
+
+const OUTSIDE_HEAVY = ["HEAVY", "OUTSIDE", "CONTEXT", "SEF"].join("_");
+const CLIMB_HEAVY = ["HEAVY", "CLIMB", "PAST", "CONTEXT"].join("_");
+
+/**
+ * @param {string} marker
+ * @returns {boolean}
+ */
+function moduleSourceIncludes(marker) {
+	return Object.keys(__webpack_modules__).some((id) =>
+		String(__webpack_modules__[id]).includes(marker)
+	);
+}
+
+it("still runs the used exports", () => {
+	expect(outsideLight).toBe("light");
+	expect(climbLight).toBe("light");
+});
+
+it("inherits package-root sideEffects when node_modules lies outside context", () => {
+	// context: src/; dependency is ../node_modules (entities-like layout).
+	expect(moduleSourceIncludes(OUTSIDE_HEAVY)).toBe(false);
+});
+
+it("does not inherit app sideEffects past a local nested package.json", () => {
+	// Case-root package.json has sideEffects: false but sits above context;
+	// app-local stubs are not climbed (only node_modules stubs are).
+	expect(moduleSourceIncludes(CLIMB_HEAVY)).toBe(true);
+});

--- a/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/webpack.config.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-outside-context/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	context: path.join(__dirname, "src"),
+	mode: "production",
+	entry: "./index.js",
+	resolve: {
+		modules: [path.join(__dirname, "node_modules"), "node_modules"]
+	},
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};

--- a/test/configCases/side-effects/nested-package-json-sideEffects/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/index.js
@@ -1,0 +1,66 @@
+import { light as shadowedLight } from "shadowed-sef";
+import { light as declaredLight } from "declared-nested-sef";
+import { light as explicitLight } from "explicit-nested-true";
+import { light as localAppLight } from "./local-app-nested/esm";
+import { light as globArrayLight } from "glob-array-sef";
+import { light as globStringLight } from "glob-string-sef";
+import { light as stopAtNmLight } from "stop-at-node-modules";
+
+const SHADOWED_HEAVY = ["HEAVY", "SHADOWED", "BY", "TYPE", "ONLY"].join("_");
+const DECLARED_HEAVY = ["HEAVY", "DECLARED", "NESTED", "SEF"].join("_");
+const EXPLICIT_TRUE_HEAVY = ["HEAVY", "EXPLICIT", "NESTED", "TRUE"].join("_");
+const LOCAL_APP_HEAVY = ["HEAVY", "LOCAL", "APP", "NESTED"].join("_");
+const GLOB_ARRAY_HEAVY = ["HEAVY", "GLOB", "ARRAY", "SEF"].join("_");
+const GLOB_STRING_HEAVY = ["HEAVY", "GLOB", "STRING", "SEF"].join("_");
+const STOP_AT_NM_HEAVY = ["HEAVY", "STOP", "AT", "NODE", "MODULES"].join("_");
+
+/**
+ * @param {string} marker
+ * @returns {boolean}
+ */
+function moduleSourceIncludes(marker) {
+	return Object.keys(__webpack_modules__).some((id) =>
+		String(__webpack_modules__[id]).includes(marker)
+	);
+}
+
+it("still runs the used export from all fixtures", () => {
+	expect(shadowedLight).toBe("light");
+	expect(declaredLight).toBe("light");
+	expect(explicitLight).toBe("light");
+	expect(localAppLight).toBe("light");
+	expect(globArrayLight).toBe("light");
+	expect(globStringLight).toBe("light");
+	expect(stopAtNmLight).toBe("light");
+});
+
+it("drops unused heavy when the nested package.json also declares sideEffects: false", () => {
+	expect(moduleSourceIncludes(DECLARED_HEAVY)).toBe(false);
+});
+
+it("should drop unused heavy when only the package root declares sideEffects: false", () => {
+	// Root sideEffects: false; nested is type-only (entities-like).
+	expect(moduleSourceIncludes(SHADOWED_HEAVY)).toBe(false);
+});
+
+it("keeps unused heavy when the nested package.json explicitly sets sideEffects: true", () => {
+	expect(moduleSourceIncludes(EXPLICIT_TRUE_HEAVY)).toBe(true);
+});
+
+it("does not inherit app-root sideEffects past a local nested package.json", () => {
+	expect(moduleSourceIncludes(LOCAL_APP_HEAVY)).toBe(true);
+});
+
+it("rebases relativePath when inheriting array sideEffects globs", () => {
+	// Root sideEffects: ["./index.js"]; without rebase, esm/index.js looks like ./index.js.
+	expect(moduleSourceIncludes(GLOB_ARRAY_HEAVY)).toBe(false);
+});
+
+it("rebases relativePath when inheriting string sideEffects globs", () => {
+	expect(moduleSourceIncludes(GLOB_STRING_HEAVY)).toBe(false);
+});
+
+it("does not inherit app sideEffects across a node_modules directory", () => {
+	// Package root has no name/sideEffects so walk continues; must stop at node_modules.
+	expect(moduleSourceIncludes(STOP_AT_NM_HEAVY)).toBe(true);
+});

--- a/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_LOCAL_APP_NESTED";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/local-app-nested/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_DECLARED_NESTED_SEF";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/declared-nested-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "declared-nested-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_EXPLICIT_NESTED_TRUE";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": true
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/explicit-nested-true/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "explicit-nested-true",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_GLOB_ARRAY_SEF";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-array-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "glob-array-sef",
+  "version": "1.0.0",
+  "sideEffects": ["./index.js"],
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_GLOB_STRING_SEF";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/glob-string-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "glob-string-sef",
+  "version": "1.0.0",
+  "sideEffects": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_SHADOWED_BY_TYPE_ONLY";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/shadowed-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "shadowed-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_STOP_AT_NODE_MODULES";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/stop-at-node-modules/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-package-json-sideEffects-fixture",
+  "sideEffects": false
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/webpack.config.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Nested type-only `package.json` files (e.g. `{"type":"module"}`) were shadowing a parent `sideEffects` flag, so unused modules from packages like entities stayed in the graph. Inherit the ancestor flag within `compiler.context`, rebase globs to the declaring package root, and stop at named packages / `node_modules` directory boundaries.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/side-effects/nested-package-json-sideEffects` and `nested-package-json-sideEffects-outside-context`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — AI assisted implementation, tests, and PR drafting; changes were reviewed and verified locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inherited `sideEffects` settings in nested packages.
  * More accurately removes unused modules while retaining modules that may have side effects.
  * Preserved deferred-import re-export modules during optimization.
  * Improved behavior across package boundaries and configured build contexts.
  * Improved reliability when resolving package metadata from nested directories.

* **Chores**
  * Added a patch release entry documenting the updated side-effects behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->