### PR TITLE
feat(esm): bake analyzable references per asset, and drop the asset wrapper no one reads

### DIFF
--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable references per asset, and behind hashed, digested and function public paths.
+Bake analyzable references per asset, and drop the asset wrapper no consumer reads.

--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable references per asset, and drop the asset wrapper no consumer reads.
+Bake analyzable asset references and drop the asset wrapper no consumer reads.

--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable asset `new URL` references per depth, hashed and function public paths.
+Bake analyzable references per depth, and behind hashed, digested and function public paths.

--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Bake analyzable asset `new URL` references per depth, hashed and function public paths.

--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable references per depth, and behind hashed, digested and function public paths.
+Bake analyzable references per asset, and behind hashed, digested and function public paths.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -218,8 +218,10 @@ class RuntimeTemplate {
 		this._javascriptNamedWithoutContent = undefined;
 		/** @type {string | false | undefined} */
 		this._publicPathShapeText = undefined;
-		/** @type {{ base: string | null | undefined } | undefined} */
+		/** @type {string | null | undefined} */
 		this._entryBaseUriValue = undefined;
+		/** @type {boolean} */
+		this._entryBaseUriResolved = false;
 	}
 
 	isIIFE() {
@@ -367,16 +369,20 @@ class RuntimeTemplate {
 	supportsAnalyzable(form, chunkGraph, module) {
 		// Analyzable output is ESM output — anything else is a different feature.
 		if (!this.isModule()) return false;
+		const { outputOptions } = this;
 		// One loader per runtime serves every wasm module in it, so the answer has to
 		// hold compilation-wide — else a baked url reaches the id-and-hash signature.
 		const scoped = form !== "wasm" && form !== "wasm-relative";
+		// Resolved once: concatenation may have absorbed the module that wrote the
+		// reference, and both the scope below and the worker loop ask about the same one.
+		const placedModule = scoped ? this._chunkGraphModule(module) : undefined;
 		// A reassigned `__webpack_public_path__` cannot reach a baked literal, and `.p`
 		// belongs to a runtime, so only the runtimes it reaches keep the runtime form.
 		if (
 			APIPlugin.runtimeUsesPublicPathOverride(
 				this.compilation,
 				scoped ? chunkGraph : undefined,
-				scoped ? this._chunkGraphModule(module) : undefined
+				placedModule
 			)
 		) {
 			this._analyzableBailout(
@@ -385,27 +391,39 @@ class RuntimeTemplate {
 			);
 			return false;
 		}
-		return form === "import"
-			? this._supportsAnalyzableImport(
-					/** @type {ChunkGraph} */ (chunkGraph),
-					/** @type {Module} */ (module)
-				)
-			: this._supportsAnalyzableUrl(form, chunkGraph, module);
-	}
 
-	/**
-	 * The `new URL(…, import.meta.url)` half of `supportsAnalyzable`.
-	 * @param {Exclude<AnalyzableForm, "import">} form which reference is being emitted
-	 * @param {ChunkGraph=} chunkGraph the chunk graph
-	 * @param {Module=} module the module the reference is emitted into
-	 * @returns {boolean} true when the literal form may be emitted
-	 */
-	_supportsAnalyzableUrl(form, chunkGraph, module) {
+		if (form === "import") {
+			// Read through a native `import()`, or it is not this feature at all.
+			if (
+				outputOptions.chunkFormat !== "module" ||
+				outputOptions.importFunctionName !== "import"
+			) {
+				return false;
+			}
+			// A worker loading its own chunks some other way keeps that runtime; one on
+			// `import` uses the same ESM loader as the main graph, so it can be analyzable.
+			for (const originChunk of /** @type {ChunkGraph} */ (
+				chunkGraph
+			).getModuleChunksIterable(/** @type {Module} */ (placedModule))) {
+				const entryOptions = originChunk.getEntryOptions();
+				if (!entryOptions || !entryOptions.worker) continue;
+				// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
+				if (entryOptions.chunkLoading !== "import") {
+					this._analyzableBailout(
+						module,
+						`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`
+					);
+					return false;
+				}
+			}
+			return true;
+		}
+
 		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
-		// emitted by the module chunk loader either way, so only this half checks.
+		// emitted by the module chunk loader either way, so only the url forms check.
 		if (!this.supportsEcmaScriptModuleSyntax()) return false;
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
-		// syntax error. A literal `import()` survives it, so only this half checks.
+		// syntax error. A literal `import()` survives it, so only the url forms check.
 		const { devtool } = this.compilation.options;
 		if (typeof devtool === "string" && devtool.includes("eval")) {
 			this._analyzableBailout(
@@ -421,9 +439,7 @@ class RuntimeTemplate {
 		if (form === "url") return true;
 		// A bare relative URL is what `__webpack_require__.p + path` means only under an
 		// `auto` public path; anything else has to be baked, which is the "wasm" form.
-		if (form === "wasm-relative") {
-			return this.outputOptions.publicPath === "auto";
-		}
+		if (form === "wasm-relative") return outputOptions.publicPath === "auto";
 		return this._supportsAnalyzableWasm(module);
 	}
 
@@ -462,43 +478,6 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The `import("./chunk.js")` half of `supportsAnalyzable`.
-	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @param {Module} originModule the module the `import()` is emitted into
-	 * @returns {boolean} true when the literal form may be emitted
-	 */
-	_supportsAnalyzableImport(chunkGraph, originModule) {
-		const { outputOptions } = this;
-		// Read through a native `import()`, or it is not this feature at all.
-		if (
-			outputOptions.chunkFormat !== "module" ||
-			outputOptions.importFunctionName !== "import"
-		) {
-			return false;
-		}
-		const placedModule = /** @type {Module} */ (
-			this._chunkGraphModule(originModule)
-		);
-		// A worker loading its own chunks some other way keeps that runtime; one on
-		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
-		for (const originChunk of chunkGraph.getModuleChunksIterable(
-			placedModule
-		)) {
-			const entryOptions = originChunk.getEntryOptions();
-			if (!entryOptions || !entryOptions.worker) continue;
-			// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
-			if (entryOptions.chunkLoading !== "import") {
-				this._analyzableBailout(
-					originModule,
-					`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`
-				);
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Whether a name that code generation cannot settle may be reserved as a stand-in
 	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
 	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
@@ -511,22 +490,8 @@ class RuntimeTemplate {
 	 */
 	_canDeferAnalyzableName(chunks) {
 		if (this.compilation.options.optimization.realContentHash) return true;
-		return chunks === undefined
-			? this._namesJavascriptWithoutContent()
-			: this._chunksNamedWithoutContent(chunks);
-	}
-
-	/**
-	 * Whether no javascript asset takes its name from its own content, which is what
-	 * rewriting one after hashing would invalidate. Asked of the names the chunks
-	 * actually carry rather than of `output`, so a template nothing is emitted under
-	 * does not rule the rewrite out and a `chunk.filenameTemplate` does not slip past
-	 * it. A function template could name a chunk anything, so it counts as one that
-	 * does. The compilation-wide answer is memoized: the chunk graph is settled before
-	 * any caller asks.
-	 * @returns {boolean} true when no emitted javascript is named by its content
-	 */
-	_namesJavascriptWithoutContent() {
+		if (chunks !== undefined) return this._chunksNamedWithoutContent(chunks);
+		// Memoized: the chunk graph is settled before any caller asks compilation-wide.
 		if (this._javascriptNamedWithoutContent === undefined) {
 			this._javascriptNamedWithoutContent = this._chunksNamedWithoutContent(
 				this.compilation.chunks
@@ -536,6 +501,11 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Whether none of these takes its name from its own content, which is what rewriting
+	 * one after hashing would invalidate. Asked of the names the chunks actually carry
+	 * rather than of `output`, so a template nothing is emitted under does not rule the
+	 * rewrite out and a `chunk.filenameTemplate` does not slip past it. A function
+	 * template could name a chunk anything, so it counts as one that does.
 	 * @param {Iterable<Chunk>} chunks the chunks to ask about
 	 * @returns {boolean} true when none of them is named by its own content
 	 */
@@ -684,7 +654,8 @@ class RuntimeTemplate {
 	 * @returns {string | null | undefined} the base every entry agrees on
 	 */
 	_entryBaseUri() {
-		if (this._entryBaseUriValue === undefined) {
+		// Its own flag rather than a wrapper object: `undefined` is an answer here.
+		if (!this._entryBaseUriResolved) {
 			/** @type {string | null | undefined} */
 			let base;
 			let found = false;
@@ -698,9 +669,10 @@ class RuntimeTemplate {
 				base = entryOptions.baseUri;
 				found = true;
 			}
-			this._entryBaseUriValue = { base };
+			this._entryBaseUriValue = base;
+			this._entryBaseUriResolved = true;
 		}
-		return this._entryBaseUriValue.base;
+		return this._entryBaseUriValue;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -356,29 +356,28 @@ class RuntimeTemplate {
 	 * - `"wasm"` — the same, fully baked for a wasm binary the runtime would name
 	 * - `"wasm-relative"` — a wasm path built at runtime under an `import.meta.url` base
 	 *
-	 * A name code generation cannot settle may still be baked, by reserving a stand-in
-	 * the deferred pass fills in. What no form here covers, because only the reference
-	 * itself can tell: a chunk with no id, and one this compilation emits no javascript
-	 * for. Every no is recorded on `module` through `_analyzableBailout`.
+	 * A name code generation cannot settle may still be baked, through a stand-in the
+	 * deferred pass fills in. Not covered here, because only the reference can tell: a
+	 * chunk with no id, and one this compilation emits no javascript for.
 	 * @param {AnalyzableForm} form which reference is being emitted
 	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
 	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when the literal form may be emitted
 	 */
 	supportsAnalyzable(form, chunkGraph, module) {
-		// Analyzable output is ESM output — anything else is a different feature, not a
-		// limitation of this one, so it is not worth a bailout.
-		if (!this.isModule() || !this.supportsEcmaScriptModuleSyntax()) {
-			return false;
-		}
-		// A runtime `__webpack_public_path__` override cannot reach a baked literal, so
-		// keep the runtime form that reads `__webpack_require__.p` — but only where the
-		// reassignment reaches, since `.p` belongs to a runtime.
+		// Analyzable output is ESM output — anything else is a different feature.
+		if (!this.isModule()) return false;
+		// A wasm loader is emitted once per runtime and shared by every wasm module in
+		// it, so its answer has to hold compilation-wide — a per-module one may disagree
+		// with the loader's own and hand a baked url to the signature that expects an id.
+		const scoped = form !== "wasm" && form !== "wasm-relative";
+		// A reassigned `__webpack_public_path__` cannot reach a baked literal, and `.p`
+		// belongs to a runtime, so only the runtimes it reaches keep the runtime form.
 		if (
 			APIPlugin.runtimeUsesPublicPathOverride(
 				this.compilation,
-				chunkGraph,
-				this._chunkGraphModule(module)
+				scoped ? chunkGraph : undefined,
+				scoped ? this._chunkGraphModule(module) : undefined
 			)
 		) {
 			this._analyzableBailout(
@@ -403,6 +402,9 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the literal form may be emitted
 	 */
 	_supportsAnalyzableUrl(form, chunkGraph, module) {
+		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
+		// emitted by the module chunk loader either way, so only this half checks.
+		if (!this.supportsEcmaScriptModuleSyntax()) return false;
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error. A literal `import()` survives it, so only this half checks.
 		const { devtool } = this.compilation.options;

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -70,7 +70,12 @@ const HASH_PROBE = "0123456789abcdef0123";
 const HASH_PROBE_ALTERNATE = "3210fedcba9876543210";
 const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 
+// Why a name only the deferred pass could settle was not deferred.
+const DEFER_BAILOUT =
+	"a hashed name needs optimization.realContentHash, or no emitted javascript named by its content";
+
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
+/** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
@@ -192,6 +197,8 @@ class RuntimeTemplate {
 			(getGlobalObject(outputOptions.globalObject));
 		/** @type {string} */
 		this.contentHashReplacement = "X".repeat(outputOptions.hashDigestLength);
+		/** @type {boolean | undefined} */
+		this._javascriptNamedWithoutContent = undefined;
 	}
 
 	isIIFE() {
@@ -481,22 +488,33 @@ class RuntimeTemplate {
 
 	/**
 	 * Whether no javascript asset takes its name from its own content, which is what
-	 * rewriting one after hashing would invalidate. A function template could name a
-	 * chunk anything, so it counts as one that does.
+	 * rewriting one after hashing would invalidate. Asked of the names the chunks
+	 * actually carry rather than of `output`, so a template nothing is emitted under
+	 * does not rule the rewrite out and a `chunk.filenameTemplate` does not slip past
+	 * it. A function template could name a chunk anything, so it counts as one that
+	 * does. The compilation-wide answer is memoized: the chunk graph is settled before
+	 * any caller asks.
 	 * @returns {boolean} true when no emitted javascript is named by its content
 	 */
 	_namesJavascriptWithoutContent() {
-		const { filename, chunkFilename, workerChunkFilename } = this.outputOptions;
-		for (const template of [filename, chunkFilename, workerChunkFilename]) {
-			if (template === undefined) continue;
-			if (typeof template !== "string") return false;
-			if (
-				getTemplatedPathPlugin().getPresentKinds(template).has("contenthash")
-			) {
-				return false;
+		if (this._javascriptNamedWithoutContent === undefined) {
+			const templatedPathPlugin = getTemplatedPathPlugin();
+			this._javascriptNamedWithoutContent = true;
+			for (const chunk of this.compilation.chunks) {
+				const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
+					chunk,
+					this.outputOptions
+				);
+				if (
+					typeof template !== "string" ||
+					templatedPathPlugin.getPresentKinds(template).has("contenthash")
+				) {
+					this._javascriptNamedWithoutContent = false;
+					break;
+				}
 			}
 		}
-		return true;
+		return this._javascriptNamedWithoutContent;
 	}
 
 	/**
@@ -550,6 +568,7 @@ class RuntimeTemplate {
 					/** @type {string} */ (publicPath).includes("[") &&
 					!this.canDeferAnalyzableName()
 				) {
+					this._analyzableBailout(module, DEFER_BAILOUT);
 					return false;
 				}
 			} else if (this._anyWasmChunkFetches()) {
@@ -560,13 +579,17 @@ class RuntimeTemplate {
 				return false;
 			}
 		}
-		return (
-			// The compilation hash is settled after code generation, so a name carrying
-			// one is baked only where the deferred pass can fill it in. `[hash]` is the
-			// module's own here, which code generation already knows.
-			!getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") ||
-			this.canDeferAnalyzableName(filename)
-		);
+		// The compilation hash is settled after code generation, so a name carrying one
+		// is baked only where the deferred pass can fill it in. `[hash]` is the module's
+		// own here, which code generation already knows.
+		if (
+			getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") &&
+			!this.canDeferAnalyzableName(filename)
+		) {
+			this._analyzableBailout(module, DEFER_BAILOUT);
+			return false;
+		}
+		return true;
 	}
 
 	/**
@@ -2090,9 +2113,7 @@ class RuntimeTemplate {
 		const cannotReserve = () => {
 			this._analyzableBailout(
 				consumingModule,
-				chunk.id === null
-					? "the referenced chunk has no id"
-					: "a hashed name needs optimization.realContentHash, or no emitted javascript named by its content"
+				chunk.id === null ? "the referenced chunk has no id" : DEFER_BAILOUT
 			);
 			return null;
 		};
@@ -2149,10 +2170,8 @@ class RuntimeTemplate {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
-		if (typeof publicPath === "string") {
-			const resolved = this._resolvePublicPathPrefix(publicPath);
-			if (resolved !== null) return specifier(resolved[0], resolved[1]);
-		}
+		const resolved = this._resolvePublicPathPrefix(publicPath);
+		if (resolved !== null) return specifier(resolved[0], resolved[1]);
 		return null;
 	}
 
@@ -2162,11 +2181,20 @@ class RuntimeTemplate {
 	 * left as a stand-in for the deferred pass, exactly as `PublicPathRuntimeModule`
 	 * resolves the same string once that hash exists. A hash re-encoded to another
 	 * digest is not spellable that way, so the template is handed over whole instead.
-	 * @param {string} publicPath the configured public path
+	 * @param {PublicPath} publicPath the configured public path
 	 * @returns {[string, PrefixKind | undefined] | null} the prefix and how to build
 	 * it, or `null` when it cannot be known at all
 	 */
 	_resolvePublicPathPrefix(publicPath) {
+		if (typeof publicPath === "function") {
+			// A function is called for its value rather than read as a template, so the
+			// deferred pass has nothing to hand back to; bake it only where the answer
+			// does not move with the compilation hash. Same probe as a function chunk
+			// name, and `PublicPathRuntimeModule` calls it with the hash the same way.
+			const resolved = this._resolveHashIndependent(publicPath);
+			if (resolved === null) return null;
+			publicPath = resolved;
+		}
 		if (!publicPath.includes("[")) return [publicPath, undefined];
 		if (!this.canDeferAnalyzableName()) return null;
 		const analyzableChunkHashPlugin = getAnalyzableChunkHashPlugin();
@@ -2180,6 +2208,68 @@ class RuntimeTemplate {
 			),
 			undefined
 		];
+	}
+
+	/**
+	 * A path built by a function, resolved to the value it will have — or `null` when
+	 * it moves with the compilation hash, which code generation does not know.
+	 * @param {import("./TemplatedPathPlugin").TemplatePathFn<EXPECTED_ANY>} fn the function
+	 * @returns {string | null} the settled value, or `null` when it is hash-dependent
+	 */
+	_resolveHashIndependent(fn) {
+		const { compilation } = this;
+		try {
+			const value = compilation.getPath(fn, { hash: HASH_PROBE });
+			const probe = compilation.getPath(fn, { hash: HASH_PROBE_ALTERNATE });
+			return value === probe ? value : null;
+		} catch (_error) {
+			// One that needs more than a hash can't be resolved here.
+			return null;
+		}
+	}
+
+	/**
+	 * Static literal specifier (already quoted) for a `new URL(<here>, import.meta.url)`
+	 * pointing at an emitted file whose name is already settled — an asset, or a wasm
+	 * binary. The base is the asset the reference sits in, which is what the runtime
+	 * form resolves against too, so any spelling of the public path may be baked.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {string} filename the emitted file's name, relative to the output root
+	 * @param {boolean} bakePublicPath whether the public path belongs in the literal
+	 * @returns {string | null} a quoted literal, or `null` to fall back
+	 */
+	_getAnalyzableFileSpecifier(module, chunkGraph, filename, bakePublicPath) {
+		const { publicPath } = this.outputOptions;
+		if (bakePublicPath && publicPath !== "auto") {
+			const resolved = this._resolvePublicPathPrefix(
+				/** @type {PublicPath} */ (publicPath)
+			);
+			if (resolved === null) return null;
+			const [prefix, prefixKind] = resolved;
+			return toJsStringLiteral(
+				prefixKind === undefined
+					? prefix + filename
+					: getAnalyzableChunkHashPlugin().reserveSpecifier({
+							prefix,
+							prefixKind,
+							file: filename
+						})
+			);
+		}
+		const undo = this._getModuleUndoPath(module, chunkGraph);
+		if (undo !== null) return toJsStringLiteral(undo + filename);
+		// Different depths — no one `../` path is right for every asset the reference is
+		// emitted into, so the deferred pass builds each asset's own.
+		if (this.canDeferAnalyzableName()) {
+			return toJsStringLiteral(
+				getAnalyzableChunkHashPlugin().reserveSpecifier({
+					prefixKind: "undo",
+					file: filename
+				})
+			);
+		}
+		return null;
 	}
 
 	/**
@@ -2204,50 +2294,17 @@ class RuntimeTemplate {
 				...getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
 			}
 		);
-		const { publicPath } = this.outputOptions;
 		// Only a chunk that fetches may carry the public path into the literal, and only
 		// an absolute one: `readFile` takes a `file:` URL alone, and those loaders address
 		// the binary relative to the chunk anyway, ignoring the public path exactly as the
 		// runtime form does.
-		if (
-			publicPath !== "auto" &&
-			this._hasUrlPublicPath() &&
-			this._wasmChunksFetch(module, chunkGraph)
-		) {
-			const resolved = this._resolvePublicPathPrefix(
-				/** @type {string} */ (publicPath)
-			);
-			if (resolved !== null) {
-				const [prefix, prefixKind] = resolved;
-				return this.importMetaUrl(
-					toJsStringLiteral(
-						prefixKind === undefined
-							? prefix + filename
-							: getAnalyzableChunkHashPlugin().reserveSpecifier({
-									prefix,
-									prefixKind,
-									file: filename
-								})
-					)
-				);
-			}
-		}
-		const undo = this._getModuleUndoPath(module, chunkGraph);
-		if (undo !== null) {
-			return this.importMetaUrl(toJsStringLiteral(undo + filename));
-		}
-		// Different depths — no one `../` path is right for every asset the binary is
-		// referenced from, so the deferred pass builds each asset's own.
-		if (this.canDeferAnalyzableName()) {
-			return this.importMetaUrl(
-				toJsStringLiteral(
-					getAnalyzableChunkHashPlugin().reserveSpecifier({
-						prefixKind: "undo",
-						file: filename
-					})
-				)
-			);
-		}
+		const specifier = this._getAnalyzableFileSpecifier(
+			module,
+			chunkGraph,
+			filename,
+			this._hasUrlPublicPath() && this._wasmChunksFetch(module, chunkGraph)
+		);
+		if (specifier !== null) return this.importMetaUrl(specifier);
 		// No bundler follows a concatenation, but this still sheds the module id and
 		// hash the runtime form would need.
 		runtimeRequirements.add(RuntimeGlobals.publicPath);
@@ -2287,7 +2344,8 @@ class RuntimeTemplate {
 			});
 			return template === probe ? template : undefined;
 		} catch (_error) {
-			// A template that needs more than this chunk can't be resolved here.
+			// Nothing to report: the probe is given strictly more than the naming call,
+			// so one that throws here throws there too and fails the build regardless.
 			return null;
 		}
 	}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -70,9 +70,36 @@ const HASH_PROBE = "0123456789abcdef0123";
 const HASH_PROBE_ALTERNATE = "3210fedcba9876543210";
 const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 
-// Why a relative public path could not be walked back to the output root.
-const RELATIVE_PATH_BAILOUT =
-	"output.publicPath is relative and re-encodes a hash, so no one prefix reaches the output root";
+/**
+ * @param {SpecifierPart} part one piece of a reserved name
+ * @returns {boolean} true when it is text the deferred pass adds nothing to
+ */
+const isLiteralPart = (part) => part[0] === "literal";
+
+/**
+ * @param {SpecifierPart[]} parts pieces that are all literal
+ * @returns {string} the text they spell
+ */
+const joinLiteralParts = (parts) => parts.map((part) => part[1]).join("");
+
+/**
+ * Drops the `./` a public path may open with: what follows it is already walked back
+ * to the output root, so it would only lengthen the name.
+ * @param {SpecifierPart[]} parts a public path's pieces
+ * @returns {SpecifierPart[]} them, without that `./`
+ */
+const rootedParts = (parts) =>
+	parts.length > 0 &&
+	isLiteralPart(parts[0]) &&
+	/** @type {string} */ (parts[0][1]).startsWith("./")
+		? [
+				/** @type {SpecifierPart} */ ([
+					"literal",
+					/** @type {string} */ (parts[0][1]).slice(2)
+				]),
+				...parts.slice(1)
+			]
+		: parts;
 
 // Why a name only the deferred pass could settle was not deferred.
 const DEFER_BAILOUT =
@@ -80,6 +107,7 @@ const DEFER_BAILOUT =
 
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
+/** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
@@ -87,7 +115,6 @@ const DEFER_BAILOUT =
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
 /** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./Dependency")} Dependency */
-/** @typedef {import("./esm/AnalyzableChunkHashPlugin").PrefixKind} PrefixKind */
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./Module").BuildMeta} BuildMeta */
 /** @typedef {import("./Module").RuntimeRequirements} RuntimeRequirements */
@@ -204,7 +231,7 @@ class RuntimeTemplate {
 		/** @type {boolean | undefined} */
 		this._javascriptNamedWithoutContent = undefined;
 		/** @type {string | false | undefined} */
-		this._publicPath = undefined;
+		this._publicPathShapeText = undefined;
 		/** @type {boolean | undefined} */
 		this._entryBaseUri = undefined;
 	}
@@ -476,21 +503,12 @@ class RuntimeTemplate {
 	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
 	 * back in line, or no emitted javascript may be named by its content in the first
 	 * place — with a name like `[name].js` there is nothing to go stale.
-	 * @param {string=} template a name whose compilation hash is left as a stand-in
-	 * inside it; omit when the whole name is re-resolved later instead, which puts no
-	 * stand-in of its own into the output and so accepts any hash spelling
 	 * @returns {boolean} true when deferring is safe
 	 */
-	canDeferAnalyzableName(template) {
-		if (
-			!this.compilation.options.optimization.realContentHash &&
-			!this._namesJavascriptWithoutContent()
-		) {
-			return false;
-		}
+	canDeferAnalyzableName() {
 		return (
-			template === undefined ||
-			getAnalyzableChunkHashPlugin().canDeferFullHash(template)
+			Boolean(this.compilation.options.optimization.realContentHash) ||
+			this._namesJavascriptWithoutContent()
 		);
 	}
 
@@ -565,18 +583,14 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the literal form is emitted
 	 */
 	supportsAnalyzableWasm(chunkGraph, module) {
-		const { webassemblyModuleFilename } = this.outputOptions;
+		const { publicPath, webassemblyModuleFilename } = this.outputOptions;
 		const filename = /** @type {string} */ (webassemblyModuleFilename);
 		if (!this.supportsAnalyzableEsm(chunkGraph, module)) return false;
-		const publicPath = this._resolvedPublicPath();
 		if (publicPath !== "auto") {
 			if (this._hasUrlPublicPath()) {
-				// A templated one is settled no earlier than the hash it reads, so it is
-				// baked only where the deferred pass may fill it in.
-				if (
-					/** @type {string} */ (publicPath).includes("[") &&
-					!this.canDeferAnalyzableName()
-				) {
+				// Settled no earlier than the hash it reads or is called with, so it is
+				// baked only where the deferred pass may finish it.
+				if (this._resolvePublicPathPrefix(publicPath) === null) {
 					this._analyzableBailout(module, DEFER_BAILOUT);
 					return false;
 				}
@@ -593,7 +607,7 @@ class RuntimeTemplate {
 		// own here, which code generation already knows.
 		if (
 			getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") &&
-			!this.canDeferAnalyzableName(filename)
+			!this.canDeferAnalyzableName()
 		) {
 			this._analyzableBailout(module, DEFER_BAILOUT);
 			return false;
@@ -611,10 +625,11 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the runtime form has to be kept
 	 */
 	reportsEntryBaseUri(module) {
-		const publicPath = this._resolvedPublicPath();
+		const { publicPath } = this.outputOptions;
+		const shape = this._publicPathShape();
 		if (
 			publicPath === "auto" ||
-			(publicPath !== undefined && this._isBaseIndependent(publicPath))
+			(shape !== undefined && this._isBaseIndependent(shape))
 		) {
 			return false;
 		}
@@ -667,7 +682,7 @@ class RuntimeTemplate {
 	 * @returns {boolean} true for an absolute-URL public path
 	 */
 	_hasUrlPublicPath() {
-		const publicPath = this._resolvedPublicPath();
+		const publicPath = this._publicPathShape();
 		return (
 			publicPath !== undefined &&
 			(publicPath.startsWith("//") || getScheme(publicPath) !== undefined)
@@ -675,29 +690,11 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * `output.publicPath` as the string it will be. A function is called for its value
-	 * the same way `PublicPathRuntimeModule` calls it, so one whose answer moves with
-	 * the compilation hash has none to give here.
-	 * @returns {string | undefined} the settled public path, or `undefined`
-	 */
-	_resolvedPublicPath() {
-		if (this._publicPath === undefined) {
-			const { publicPath } = this.outputOptions;
-			const resolved =
-				typeof publicPath === "function"
-					? this._resolveHashIndependent(publicPath)
-					: publicPath;
-			this._publicPath = resolved === null ? false : resolved;
-		}
-		return this._publicPath === false ? undefined : this._publicPath;
-	}
-
-	/**
 	 * Whether a public path reaches the same place from any base — a full URL, a
 	 * protocol-relative one, or one rooted at the origin. A relative one does not, and
 	 * is only equivalent behind the `../` path back to the output root, which is what
 	 * the runtime resolves it against.
-	 * @param {string} publicPath the resolved public path, or the template of one
+	 * @param {string} publicPath the resolved public path, or the shape of one
 	 * @returns {boolean} true when no base is needed
 	 */
 	_isBaseIndependent(publicPath) {
@@ -2204,35 +2201,33 @@ class RuntimeTemplate {
 					contentHashType: JAVASCRIPT_TYPE
 				});
 		/**
-		 * @param {string} prefix what goes in front of the chunk's filename
-		 * @param {PrefixKind=} kind how the deferred pass builds `prefix`, literal when omitted
+		 * @param {SpecifierPart[]} prefix what goes in front of the chunk's filename
 		 * @returns {string | null} the specifier already quoted, or `null` when the
 		 * recipe needs a stand-in that cannot be reserved
 		 */
-		const specifier = (prefix, kind) => {
-			if (!deferred && kind === undefined) {
-				return toJsStringLiteral(prefix + filename);
+		const specifier = (prefix) => {
+			if (!deferred && prefix.every(isLiteralPart)) {
+				return toJsStringLiteral(joinLiteralParts(prefix) + filename);
 			}
 			if (!canReserve) return cannotReserve();
 			return toJsStringLiteral(
-				getAnalyzableChunkHashPlugin().reserveSpecifier({
-					prefix,
-					prefixKind: kind,
-					chunkId: /** @type {ChunkId} */ (chunk.id)
-				})
+				getAnalyzableChunkHashPlugin().reserveSpecifier([
+					...prefix,
+					["chunk", /** @type {ChunkId} */ (chunk.id)]
+				])
 			);
 		};
 		if (overridePublicPath) {
 			const resolved = this._resolvePublicPathPrefix(overridePublicPath);
-			return resolved === null ? null : specifier(resolved[0], resolved[1]);
+			return resolved === null ? null : specifier(resolved);
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
 			const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
-			if (undo !== null) return specifier(undo);
+			if (undo !== null) return specifier([["literal", undo]]);
 			// Different depths — no one `../` path is right for every asset the reference
 			// lands in, so the deferred pass builds each asset's own.
-			const perAsset = specifier("", "undo");
+			const perAsset = specifier([["undo", ""]]);
 			if (perAsset !== null) return perAsset;
 			if (deferred || !runtimeRequirements) {
 				this._analyzableBailout(
@@ -2248,53 +2243,82 @@ class RuntimeTemplate {
 		}
 		const resolved = this._resolvePublicPathPrefix(publicPath);
 		if (resolved === null) return null;
-		const [prefix, prefixKind] = resolved;
-		if (this._isBaseIndependent(prefix)) return specifier(prefix, prefixKind);
 		// The runtime imports it from the chunk holding the runtime, which is the output
-		// root; a baked one is read from the chunk it sits in, so the `../` path back to
-		// that root goes first. A recipe the deferred pass builds cannot carry both.
-		if (prefixKind !== undefined) {
-			this._analyzableBailout(consumingModule, RELATIVE_PATH_BAILOUT);
-			return null;
-		}
-		const rooted = prefix.startsWith("./") ? prefix.slice(2) : prefix;
+		// root; a baked one is read from the chunk it sits in, so a public path that
+		// needs a base gets the `../` path back to that root in front of it.
+		const shape = this._publicPathShape();
+		if (shape === undefined) return null;
+		if (this._isBaseIndependent(shape)) return specifier(resolved);
 		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
-		return undo === null ? specifier(rooted, "undo") : specifier(undo + rooted);
+		return specifier(
+			undo === null
+				? [["undo", ""], ...rootedParts(resolved)]
+				: [["literal", undo], ...rootedParts(resolved)]
+		);
 	}
 
 	/**
-	 * How to build what a public path puts in front of a filename. A templated one is
-	 * resolved as far as code generation can — the compilation hash it may carry is
-	 * left as a stand-in for the deferred pass, exactly as `PublicPathRuntimeModule`
-	 * resolves the same string once that hash exists. A hash re-encoded to another
-	 * digest is not spellable that way, so the template is handed over whole instead.
+	 * What a public path puts in front of a filename, as the parts it is built from.
+	 * A plain one is literal text. A templated one is resolved as far as code
+	 * generation can, leaving the compilation hash it may carry as a stand-in exactly
+	 * as `PublicPathRuntimeModule` resolves the same string once that hash exists — and
+	 * a hash re-encoded to another digest, which no stand-in can carry, is handed to
+	 * the deferred pass whole instead. A function is called for its value rather than
+	 * read as a template, so one whose answer moves with the hash is called again there.
 	 * @param {PublicPath} publicPath the configured public path
-	 * @returns {[string, PrefixKind | undefined] | null} the prefix and how to build
-	 * it, or `null` when it cannot be known at all
+	 * @returns {SpecifierPart[] | null} the parts, or `null` when it cannot be known
 	 */
 	_resolvePublicPathPrefix(publicPath) {
 		if (typeof publicPath === "function") {
-			// A function is called for its value rather than read as a template, so the
-			// deferred pass has nothing to hand back to; bake it only where the answer
-			// does not move with the compilation hash. Same probe as a function chunk
-			// name, and `PublicPathRuntimeModule` calls it with the hash the same way.
+			// One that answers nothing to a probe cannot be placed, absolute or not.
+			if (this._publicPathShape() === undefined) return null;
 			const resolved = this._resolveHashIndependent(publicPath);
-			if (resolved === null) return null;
-			publicPath = resolved;
+			if (resolved !== null) return [["literal", resolved]];
+			return this.canDeferAnalyzableName() ? [["publicPath", ""]] : null;
 		}
-		if (!publicPath.includes("[")) return [publicPath, undefined];
+		if (!publicPath.includes("[")) return [["literal", publicPath]];
 		if (!this.canDeferAnalyzableName()) return null;
 		const analyzableChunkHashPlugin = getAnalyzableChunkHashPlugin();
 		if (!analyzableChunkHashPlugin.canDeferFullHash(publicPath)) {
-			return [publicPath, "path"];
+			return [["template", publicPath]];
 		}
 		return [
-			this.compilation.getPath(
-				publicPath,
-				analyzableChunkHashPlugin.DEFERRED_FULL_HASH_PATH_DATA
-			),
-			undefined
+			[
+				"literal",
+				this.compilation.getPath(
+					publicPath,
+					analyzableChunkHashPlugin.DEFERRED_FULL_HASH_PATH_DATA
+				)
+			]
 		];
+	}
+
+	/**
+	 * `output.publicPath` as the text it will have the shape of — a function's answer to
+	 * a stand-in hash, which says whether it is absolute even when its value is not
+	 * settled yet. `"auto"` reads as the empty string, which needs a base and so takes
+	 * the path that needs no answer; a function that answers nothing says nothing about
+	 * its shape either, and nothing may be built on it.
+	 * @returns {string | undefined} the shape of the public path
+	 */
+	_publicPathShape() {
+		if (this._publicPathShapeText === undefined) {
+			const { publicPath } = this.outputOptions;
+			if (typeof publicPath !== "function") {
+				this._publicPathShapeText = publicPath === "auto" ? "" : publicPath;
+			} else {
+				try {
+					this._publicPathShapeText = this.compilation.getPath(publicPath, {
+						hash: HASH_PROBE
+					});
+				} catch (_error) {
+					this._publicPathShapeText = false;
+				}
+			}
+		}
+		return this._publicPathShapeText === false
+			? undefined
+			: this._publicPathShapeText;
 	}
 
 	/**
@@ -2317,57 +2341,55 @@ class RuntimeTemplate {
 
 	/**
 	 * Static literal specifier (already quoted) for a `new URL(<here>, import.meta.url)`
-	 * pointing at an emitted file whose name is already settled — an asset, or a wasm
-	 * binary. The base is the asset the reference sits in; the runtime form resolves
-	 * against the output root instead, so a public path that needs a base is put behind
-	 * the `../` path back to that root rather than baked as the whole prefix.
+	 * pointing at an emitted file — an asset, or a wasm binary. The base is the asset the
+	 * reference sits in; the runtime form resolves against the output root instead, so a
+	 * public path that needs a base is put behind the `../` path back to that root rather
+	 * than baked as the whole prefix.
 	 * @param {Module} module the module the reference is emitted into
 	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @param {string} filename the emitted file's name, relative to the output root
+	 * @param {SpecifierPart[]} file the emitted file's name, relative to the output root
 	 * @param {boolean} bakePublicPath whether the public path belongs in the literal
 	 * @returns {string | null} a quoted literal, or `null` to fall back
 	 */
-	_getAnalyzableFileSpecifier(module, chunkGraph, filename, bakePublicPath) {
+	_getAnalyzableFileSpecifier(module, chunkGraph, file, bakePublicPath) {
 		const { publicPath } = this.outputOptions;
-		let tail = filename;
+		/**
+		 * @param {SpecifierPart[]} parts the whole specifier
+		 * @returns {string | null} it already quoted, or `null` when no stand-in may be reserved
+		 */
+		const specifier = (parts) => {
+			if (parts.every(isLiteralPart)) {
+				return toJsStringLiteral(joinLiteralParts(parts));
+			}
+			if (!this.canDeferAnalyzableName()) {
+				this._analyzableBailout(module, DEFER_BAILOUT);
+				return null;
+			}
+			return toJsStringLiteral(
+				getAnalyzableChunkHashPlugin().reserveSpecifier(parts)
+			);
+		};
+		/** @type {SpecifierPart[]} */
+		let prefix = [];
 		if (bakePublicPath && publicPath !== "auto") {
 			const resolved = this._resolvePublicPathPrefix(
 				/** @type {PublicPath} */ (publicPath)
 			);
-			if (resolved === null) return null;
-			const [prefix, prefixKind] = resolved;
-			if (this._isBaseIndependent(prefix)) {
-				return toJsStringLiteral(
-					prefixKind === undefined
-						? prefix + filename
-						: getAnalyzableChunkHashPlugin().reserveSpecifier({
-								prefix,
-								prefixKind,
-								file: filename
-							})
-				);
+			const shape = this._publicPathShape();
+			if (resolved === null || shape === undefined) return null;
+			if (this._isBaseIndependent(shape)) {
+				return specifier([...resolved, ...file]);
 			}
-			// A recipe the deferred pass builds cannot also carry the `../` path.
-			if (prefixKind !== undefined) {
-				this._analyzableBailout(module, RELATIVE_PATH_BAILOUT);
-				return null;
-			}
-			// `./` names the root it is already walked back to, so it only lengthens.
-			tail = (prefix.startsWith("./") ? prefix.slice(2) : prefix) + filename;
+			prefix = rootedParts(resolved);
 		}
 		const undo = this._getModuleUndoPath(module, chunkGraph);
-		if (undo !== null) return toJsStringLiteral(undo + tail);
 		// Different depths — no one `../` path is right for every asset the reference is
 		// emitted into, so the deferred pass builds each asset's own.
-		if (this.canDeferAnalyzableName()) {
-			return toJsStringLiteral(
-				getAnalyzableChunkHashPlugin().reserveSpecifier({
-					prefixKind: "undo",
-					file: tail
-				})
-			);
-		}
-		return null;
+		return specifier([
+			undo === null ? ["undo", ""] : ["literal", undo],
+			...prefix,
+			...file
+		]);
 	}
 
 	/**
@@ -2381,17 +2403,17 @@ class RuntimeTemplate {
 	 */
 	_getAnalyzableWasmUrl(module, chunkGraph, runtime, runtimeRequirements) {
 		const { compilation } = this;
-		const filename = compilation.getPath(
-			/** @type {string} */ (this.outputOptions.webassemblyModuleFilename),
-			{
-				module,
-				runtime,
-				chunkGraph,
-				// The module's own hash and id are settled here; the compilation's is not,
-				// so it is left as a stand-in for the deferred pass to fill in.
-				...getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
-			}
+		const template = /** @type {string} */ (
+			this.outputOptions.webassemblyModuleFilename
 		);
+		// The module's own hash and id are settled here, the compilation's is not — and
+		// a placeholder nothing answers is left in the name, so what comes back is either
+		// the final name or a template carrying only `[fullhash]`.
+		const filename = compilation.getPath(template, {
+			module,
+			runtime,
+			chunkGraph
+		});
 		// Only a chunk that fetches may carry the public path into the literal, and only
 		// an absolute one: `readFile` takes a `file:` URL alone, and those loaders address
 		// the binary relative to the chunk anyway, ignoring the public path exactly as the
@@ -2399,7 +2421,7 @@ class RuntimeTemplate {
 		const specifier = this._getAnalyzableFileSpecifier(
 			module,
 			chunkGraph,
-			filename,
+			[[filename.includes("[") ? "template" : "literal", filename]],
 			this._hasUrlPublicPath() && this._wasmChunksFetch(module, chunkGraph)
 		);
 		if (specifier !== null) return this.importMetaUrl(specifier);
@@ -2407,7 +2429,14 @@ class RuntimeTemplate {
 		// hash the runtime form would need.
 		runtimeRequirements.add(RuntimeGlobals.publicPath);
 		return this.importMetaUrl(
-			`${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`
+			`${RuntimeGlobals.publicPath} + ${toJsStringLiteral(
+				compilation.getPath(template, {
+					module,
+					runtime,
+					chunkGraph,
+					...getAnalyzableChunkHashPlugin().DEFERRED_FULL_HASH_PATH_DATA
+				})
+			)}`
 		);
 	}
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -68,6 +68,25 @@ const isLiteralPart = (part) => part[0] === "literal";
 const joinLiteralParts = (parts) => parts.map((part) => part[1]).join("");
 
 /**
+ * Whether a public path reaches the same place from any base. A relative one does
+ * not, and is equivalent only behind the `../` path back to the output root.
+ * @param {string} publicPath the resolved public path, or the shape of one
+ * @returns {boolean} true when no base is needed
+ */
+const isBaseIndependent = (publicPath) =>
+	publicPath.startsWith("/") || getScheme(publicPath) !== undefined;
+
+/**
+ * Whether it is a complete URL of its own, which is only about `fetch`: that
+ * resolves a relative one against the document and a baked one against the chunk.
+ * @param {string | undefined} publicPath the shape of the public path
+ * @returns {boolean} true for an absolute-URL public path
+ */
+const isUrlPublicPath = (publicPath) =>
+	publicPath !== undefined &&
+	(publicPath.startsWith("//") || getScheme(publicPath) !== undefined);
+
+/**
  * Drops the `./` a public path may open with: what follows it is already walked back
  * to the output root, so it would only lengthen the name.
  * @param {SpecifierPart[]} parts a public path's pieces
@@ -445,7 +464,7 @@ class RuntimeTemplate {
 		// here, rather than built at runtime under an `import.meta.url` base.
 		const { publicPath, webassemblyModuleFilename } = outputOptions;
 		if (publicPath !== "auto") {
-			if (this._hasUrlPublicPath()) {
+			if (isUrlPublicPath(this._publicPathShape())) {
 				// Settled no earlier than the hash it reads or is called with, so it is
 				// baked only where the deferred pass may finish it.
 				if (this._resolvePublicPathPrefix(publicPath) === null) {
@@ -591,7 +610,7 @@ class RuntimeTemplate {
 		// what it is set to does not matter — `auto` resolves to an absolute url too.
 		const base =
 			publicPath !== "auto" &&
-			(shape === undefined || !this._isBaseIndependent(shape))
+			(shape === undefined || !isBaseIndependent(shape))
 				? this._entryBaseUri()
 				: undefined;
 		if (base !== undefined) {
@@ -693,36 +712,6 @@ class RuntimeTemplate {
 			if (entryOptions && entryOptions.wasmLoading === "fetch") return true;
 		}
 		return false;
-	}
-
-	/**
-	 * Whether `output.publicPath` is a complete URL of its own. Baking one keeps the
-	 * same target, because `new URL(...)` ignores its base for an absolute specifier.
-	 * A root- or directory-relative public path does not: `fetch` resolves it against
-	 * the document and a baked one against the chunk, which differ exactly where a
-	 * public path is worth setting. What the deferred pass can still spell — a rooted
-	 * path, or a relative one behind the `../` path to the output root — is decided by
-	 * `_isBaseIndependent` instead; this is only about `fetch`.
-	 * @returns {boolean} true for an absolute-URL public path
-	 */
-	_hasUrlPublicPath() {
-		const publicPath = this._publicPathShape();
-		return (
-			publicPath !== undefined &&
-			(publicPath.startsWith("//") || getScheme(publicPath) !== undefined)
-		);
-	}
-
-	/**
-	 * Whether a public path reaches the same place from any base — a full URL, a
-	 * protocol-relative one, or one rooted at the origin. A relative one does not, and
-	 * is only equivalent behind the `../` path back to the output root, which is what
-	 * the runtime resolves it against.
-	 * @param {string} publicPath the resolved public path, or the shape of one
-	 * @returns {boolean} true when no base is needed
-	 */
-	_isBaseIndependent(publicPath) {
-		return publicPath.startsWith("/") || getScheme(publicPath) !== undefined;
 	}
 
 	supportTemplateLiteral() {
@@ -2291,7 +2280,7 @@ class RuntimeTemplate {
 		// needs a base gets the `../` path back to that root in front of it.
 		const shape = this._publicPathShape();
 		if (shape === undefined) return null;
-		if (this._isBaseIndependent(shape)) return specifier(resolved);
+		if (isBaseIndependent(shape)) return specifier(resolved);
 		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
 		return specifier(
 			undo === null
@@ -2423,7 +2412,7 @@ class RuntimeTemplate {
 			);
 			const shape = this._publicPathShape();
 			if (resolved === null || shape === undefined) return null;
-			if (this._isBaseIndependent(shape)) {
+			if (isBaseIndependent(shape)) {
 				return specifier([...resolved, ...file]);
 			}
 			prefix = rootedParts(resolved);
@@ -2468,7 +2457,8 @@ class RuntimeTemplate {
 			module,
 			chunkGraph,
 			[[filename.includes("[") ? "template" : "literal", filename]],
-			this._hasUrlPublicPath() && this._wasmChunksFetch(module, chunkGraph)
+			isUrlPublicPath(this._publicPathShape()) &&
+				this._wasmChunksFetch(module, chunkGraph)
 		);
 		if (specifier !== null) return this.importMetaUrl(specifier);
 		// No bundler follows a concatenation, but this still sheds the module id and

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -93,6 +93,7 @@ const DEFER_BAILOUT =
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
+/** @typedef {"import" | "url" | "wasm" | "wasm-relative"} AnalyzableForm */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
@@ -347,29 +348,64 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Analyzable output — a reference a foreign bundler can follow without running
-	 * webpack's runtime — comes in two forms, and what rules them out differs:
+	 * Whether a reference a foreign bundler can follow without running webpack's runtime
+	 * may be emitted — the one question every caller asks, in the form it is asking for:
 	 *
-	 * - a literal `import("./chunk.js")`, gated by `supportsAnalyzableImport`
-	 * - a literal `new URL(<file>, import.meta.url)`, gated by `supportsAnalyzableEsm`
+	 * - `"import"` — a literal `import("./chunk.js")` in place of `ensureChunk(id)`
+	 * - `"url"` — a literal `new URL(<file>, import.meta.url)`
+	 * - `"wasm"` — the same, fully baked for a wasm binary the runtime would name
+	 * - `"wasm-relative"` — a wasm path built at runtime under an `import.meta.url` base
 	 *
-	 * Either way a name that is not settled during code generation may still be baked,
-	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
-	 *
-	 * What still forces the runtime form, and is not covered by any of the three:
-	 * a module federation module in the chunk, and a chunk with no id.
+	 * A name code generation cannot settle may still be baked, by reserving a stand-in
+	 * the deferred pass fills in. What no form here covers, because only the reference
+	 * itself can tell: a chunk with no id, and one this compilation emits no javascript
+	 * for. Every no is recorded on `module` through `_analyzableBailout`.
+	 * @param {AnalyzableForm} form which reference is being emitted
 	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
 	 * @param {Module=} module the module the reference is emitted into
-	 * @returns {boolean} true when a `new URL(…, import.meta.url)` literal may be emitted
+	 * @returns {boolean} true when the literal form may be emitted
 	 */
-	supportsAnalyzableEsm(chunkGraph, module) {
-		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
-		// syntax error, so the literal `new URL(…, import.meta.url)` form can't be used.
-		// A literal `import()` survives it, which is why the import form does not check.
-		const { devtool } = this.compilation.options;
+	supportsAnalyzable(form, chunkGraph, module) {
+		// Analyzable output is ESM output — anything else is a different feature, not a
+		// limitation of this one, so it is not worth a bailout.
 		if (!this.isModule() || !this.supportsEcmaScriptModuleSyntax()) {
 			return false;
 		}
+		// A runtime `__webpack_public_path__` override cannot reach a baked literal, so
+		// keep the runtime form that reads `__webpack_require__.p` — but only where the
+		// reassignment reaches, since `.p` belongs to a runtime.
+		if (
+			APIPlugin.runtimeUsesPublicPathOverride(
+				this.compilation,
+				chunkGraph,
+				this._chunkGraphModule(module)
+			)
+		) {
+			this._analyzableBailout(
+				module,
+				"__webpack_public_path__ is reassigned in a runtime this module belongs to"
+			);
+			return false;
+		}
+		return form === "import"
+			? this._supportsAnalyzableImport(
+					/** @type {ChunkGraph} */ (chunkGraph),
+					/** @type {Module} */ (module)
+				)
+			: this._supportsAnalyzableUrl(form, chunkGraph, module);
+	}
+
+	/**
+	 * The `new URL(…, import.meta.url)` half of `supportsAnalyzable`.
+	 * @param {Exclude<AnalyzableForm, "import">} form which reference is being emitted
+	 * @param {ChunkGraph=} chunkGraph the chunk graph
+	 * @param {Module=} module the module the reference is emitted into
+	 * @returns {boolean} true when the literal form may be emitted
+	 */
+	_supportsAnalyzableUrl(form, chunkGraph, module) {
+		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
+		// syntax error. A literal `import()` survives it, so only this half checks.
+		const { devtool } = this.compilation.options;
 		if (typeof devtool === "string" && devtool.includes("eval")) {
 			this._analyzableBailout(
 				module,
@@ -377,20 +413,17 @@ class RuntimeTemplate {
 			);
 			return false;
 		}
-		return (
-			// Build-time execution keeps the runtime form — `import.meta` does not parse
-			// in its vm script wrapper. `getTypes` has no chunk graph and does not care:
-			// `AssetModulesPlugin` emulates the wrapper there.
-			!(chunkGraph && chunkGraph.buildTimeExecution) &&
-			// A runtime `__webpack_public_path__` override can't be reflected in a baked
-			// literal, so keep the runtime form that reads `__webpack_require__.p` — but
-			// only where the reassignment reaches, since `.p` belongs to a runtime.
-			!APIPlugin.runtimeUsesPublicPathOverride(
-				this.compilation,
-				chunkGraph,
-				this._chunkGraphModule(module)
-			)
-		);
+		// Build-time execution keeps the runtime form — `import.meta` does not parse in
+		// its vm script wrapper. `getTypes` has no chunk graph and does not care:
+		// `AssetModulesPlugin` emulates the wrapper there.
+		if (chunkGraph && chunkGraph.buildTimeExecution) return false;
+		if (form === "url") return true;
+		// A bare relative URL is what `__webpack_require__.p + path` means only under an
+		// `auto` public path; anything else has to be baked, which is the "wasm" form.
+		if (form === "wasm-relative") {
+			return this.outputOptions.publicPath === "auto";
+		}
+		return this._supportsAnalyzableWasm(module);
 	}
 
 	/**
@@ -428,18 +461,15 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a chunk reference emitted into `originModule` may be a literal
-	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
+	 * The `import("./chunk.js")` half of `supportsAnalyzable`.
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {Module} originModule the module the `import()` is emitted into
 	 * @returns {boolean} true when the literal form may be emitted
 	 */
-	supportsAnalyzableImport(chunkGraph, originModule) {
+	_supportsAnalyzableImport(chunkGraph, originModule) {
 		const { outputOptions } = this;
-		// Analyzable output is ESM output read through a native `import()` — anything
-		// else is a different feature, not a limitation of this one.
+		// Read through a native `import()`, or it is not this feature at all.
 		if (
-			!outputOptions.module ||
 			outputOptions.chunkFormat !== "module" ||
 			outputOptions.importFunctionName !== "import"
 		) {
@@ -448,21 +478,6 @@ class RuntimeTemplate {
 		const placedModule = /** @type {Module} */ (
 			this._chunkGraphModule(originModule)
 		);
-		// A runtime `__webpack_public_path__` override can't reach a baked literal, but
-		// `.p` belongs to a runtime, so only this module's own runtimes matter.
-		if (
-			APIPlugin.runtimeUsesPublicPathOverride(
-				this.compilation,
-				chunkGraph,
-				placedModule
-			)
-		) {
-			this._analyzableBailout(
-				originModule,
-				"__webpack_public_path__ is reassigned in a runtime this module belongs to"
-			);
-			return false;
-		}
 		// A worker loading its own chunks some other way keeps that runtime; one on
 		// `import` uses the same ESM loader as the main graph, so it can be analyzable.
 		for (const originChunk of chunkGraph.getModuleChunksIterable(
@@ -493,7 +508,7 @@ class RuntimeTemplate {
 	 * runtime module asks from the other end
 	 * @returns {boolean} true when deferring is safe
 	 */
-	canDeferAnalyzableName(chunks) {
+	_canDeferAnalyzableName(chunks) {
 		if (this.compilation.options.optimization.realContentHash) return true;
 		return chunks === undefined
 			? this._namesJavascriptWithoutContent()
@@ -544,25 +559,6 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm
-	 * binary path built from `wasmModuleId`) may be referenced with the analyzable
-	 * chunk-relative `new URL(path, import.meta.url)` form. Requires ESM output
-	 * (`supportsAnalyzableEsm`) and an `auto` public path — only then is the bare
-	 * relative URL equivalent to the runtime `__webpack_require__.p + path` form.
-	 * Callers that can bake the public path into a static literal specifier should
-	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
-	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
-	 * @param {Module=} module the module the reference is emitted into
-	 * @returns {boolean} true when the analyzable chunk-relative URL applies
-	 */
-	supportsAnalyzableEsmUrl(chunkGraph, module) {
-		return (
-			this.supportsAnalyzableEsm(chunkGraph, module) &&
-			this.outputOptions.publicPath === "auto"
-		);
-	}
-
-	/**
 	 * Builds the analyzable `new URL(specifier, import.meta.url)` expression the ESM
 	 * wasm/asset loader backends use to reference an emitted binary relative to the
 	 * current module (via `output.importMetaName`) instead of the runtime public-path
@@ -575,17 +571,14 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether async wasm binaries are referenced by a fully baked
-	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
-	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
-	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
+	 * The `"wasm"` half of `supportsAnalyzable`: whether the whole binary URL can be
+	 * spelled here, rather than built at runtime under an `import.meta.url` base.
 	 * @param {Module=} module the module the reference is emitted into
 	 * @returns {boolean} true when the literal form is emitted
 	 */
-	supportsAnalyzableWasm(chunkGraph, module) {
+	_supportsAnalyzableWasm(module) {
 		const { publicPath, webassemblyModuleFilename } = this.outputOptions;
 		const filename = /** @type {string} */ (webassemblyModuleFilename);
-		if (!this.supportsAnalyzableEsm(chunkGraph, module)) return false;
 		if (publicPath !== "auto") {
 			if (this._hasUrlPublicPath()) {
 				// Settled no earlier than the hash it reads or is called with, so it is
@@ -607,7 +600,7 @@ class RuntimeTemplate {
 		// own here, which code generation already knows.
 		if (
 			getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") &&
-			!this.canDeferAnalyzableName()
+			!this._canDeferAnalyzableName()
 		) {
 			this._analyzableBailout(module, DEFER_BAILOUT);
 			return false;
@@ -2122,7 +2115,7 @@ class RuntimeTemplate {
 		// a lazy-once context, a container entry — and nothing can be relative to it.
 		if (
 			!originModule ||
-			!this.supportsAnalyzableImport(chunkGraph, originModule)
+			!this.supportsAnalyzable("import", chunkGraph, originModule)
 		) {
 			return null;
 		}
@@ -2273,7 +2266,8 @@ class RuntimeTemplate {
 		// reach the bundle verbatim. The whole name is re-resolved later rather than
 		// carrying a stand-in of its own, so any hash spelling is fine here.
 		const chunks = this._moduleChunks(consumingModule, chunkGraph);
-		const canReserve = chunk.id !== null && this.canDeferAnalyzableName(chunks);
+		const canReserve =
+			chunk.id !== null && this._canDeferAnalyzableName(chunks);
 		/**
 		 * @returns {null} always, having recorded why no stand-in may be reserved
 		 */
@@ -2372,10 +2366,10 @@ class RuntimeTemplate {
 			if (this._publicPathShape() === undefined) return null;
 			const resolved = this._resolveHashIndependent(publicPath);
 			if (resolved !== null) return [["literal", resolved]];
-			return this.canDeferAnalyzableName(chunks) ? [["publicPath", ""]] : null;
+			return this._canDeferAnalyzableName(chunks) ? [["publicPath", ""]] : null;
 		}
 		if (!publicPath.includes("[")) return [["literal", publicPath]];
-		if (!this.canDeferAnalyzableName(chunks)) return null;
+		if (!this._canDeferAnalyzableName(chunks)) return null;
 		const analyzableChunkHashPlugin = getAnalyzableChunkHashPlugin();
 		if (!analyzableChunkHashPlugin.canDeferFullHash(publicPath)) {
 			return [["template", publicPath]];
@@ -2460,7 +2454,7 @@ class RuntimeTemplate {
 			if (parts.every(isLiteralPart)) {
 				return toJsStringLiteral(joinLiteralParts(parts));
 			}
-			if (!this.canDeferAnalyzableName(chunks)) {
+			if (!this._canDeferAnalyzableName(chunks)) {
 				this._analyzableBailout(module, DEFER_BAILOUT);
 				return null;
 			}
@@ -2494,7 +2488,7 @@ class RuntimeTemplate {
 
 	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
-	 * module. Only called when `supportsAnalyzableWasm()` holds.
+	 * module. Only called when `supportsAnalyzable("wasm")` holds.
 	 * @param {Module} module the async wasm module
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {RuntimeSpec} runtime the runtime

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -217,8 +217,8 @@ class RuntimeTemplate {
 		this._javascriptNamedWithoutContent = undefined;
 		/** @type {string | false | undefined} */
 		this._publicPathShapeText = undefined;
-		/** @type {boolean | undefined} */
-		this._entryBaseUri = undefined;
+		/** @type {{ base: string | null | undefined } | undefined} */
+		this._entryBaseUriValue = undefined;
 	}
 
 	isIIFE() {
@@ -616,40 +616,118 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether an entry `baseUri` decides where an asset URL points. It replaces the
-	 * output root the runtime resolves one against, and no literal read from its own
-	 * chunk shares that base — but only a public path that needs a base ever reaches
-	 * it, so an absolute one, `auto` included, is unaffected. Answered for the
-	 * compilation: a module reached from two entries is generated once.
-	 * @param {Module=} module the module the reference is emitted into
-	 * @returns {boolean} true when the runtime form has to be kept
+	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`
+	 * an asset reference bakes to, or `null` to keep the runtime form. Unlike a wasm
+	 * binary, the runtime resolves an asset url against `__webpack_require__.b` — the
+	 * output root, or an entry `baseUri` where one is set — so that base is settled here
+	 * before the rest of the name is.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {string} filename the asset's name, relative to the output root
+	 * @returns {string | null} a quoted literal, or `null` to fall back
 	 */
-	reportsEntryBaseUri(module) {
+	getAnalyzableAssetUrl(module, chunkGraph, filename) {
 		const { publicPath } = this.outputOptions;
 		const shape = this._publicPathShape();
+		// A public path that reaches the same place from any base never reads `.b`, so
+		// what it is set to does not matter — `auto` resolves to an absolute url too.
 		if (
-			publicPath === "auto" ||
-			(shape !== undefined && this._isBaseIndependent(shape))
+			publicPath !== "auto" &&
+			(shape === undefined || !this._isBaseIndependent(shape))
 		) {
-			return false;
-		}
-		if (this._entryBaseUri === undefined) {
-			this._entryBaseUri = false;
-			for (const chunk of this.compilation.chunks) {
-				const entryOptions = chunk.getEntryOptions();
-				if (entryOptions && entryOptions.baseUri !== undefined) {
-					this._entryBaseUri = true;
-					break;
-				}
+			const base = this._entryBaseUri();
+			if (base !== undefined) {
+				return this._bakeAgainstBaseUri(module, base, publicPath, filename);
 			}
 		}
-		if (this._entryBaseUri) {
+		return this._getAnalyzableFileSpecifier(
+			module,
+			chunkGraph,
+			[["literal", filename]],
+			true
+		);
+	}
+
+	/**
+	 * The whole url, resolved here, for a reference the runtime would resolve against an
+	 * entry `baseUri` instead of the output root. Only an absolute base settles it — a
+	 * relative one has no base of its own to be read against.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {string | null} base the base every entry agrees on, `null` when they do not
+	 * @param {PublicPath} publicPath the configured public path
+	 * @param {string} filename the asset's name, relative to the output root
+	 * @returns {string | null} a quoted literal, or `null` to fall back
+	 */
+	_bakeAgainstBaseUri(module, base, publicPath, filename) {
+		/**
+		 * @returns {null} always, having recorded why the base could not be baked
+		 */
+		const cannotBake = () => {
 			this._analyzableBailout(
 				module,
 				"an entry sets baseUri, which the runtime resolves this url against instead of the output root"
 			);
+			return null;
+		};
+		if (base === null) return cannotBake();
+		const parts = this._resolvePublicPathPrefix(publicPath);
+		if (parts === null || !parts.every(isLiteralPart)) return cannotBake();
+		try {
+			return toJsStringLiteral(
+				new URL(joinLiteralParts(parts) + filename, base).href
+			);
+		} catch (_error) {
+			// A base that is not absolute cannot be resolved against, here or at runtime.
+			return cannotBake();
 		}
-		return this._entryBaseUri;
+	}
+
+	/**
+	 * The `baseUri` every entry sets, which replaces the output root the runtime resolves
+	 * an asset url against. `undefined` when none sets one, `null` when they disagree —
+	 * a module reached from both is generated once, so one answer has to serve both.
+	 * @returns {string | null | undefined} the base every entry agrees on
+	 */
+	_entryBaseUri() {
+		if (this._entryBaseUriValue === undefined) {
+			/** @type {string | null | undefined} */
+			let base;
+			let found = false;
+			for (const chunk of this.compilation.chunks) {
+				const entryOptions = chunk.getEntryOptions();
+				if (!entryOptions || entryOptions.baseUri === undefined) continue;
+				if (found && base !== entryOptions.baseUri) {
+					base = null;
+					break;
+				}
+				base = entryOptions.baseUri;
+				found = true;
+			}
+			this._entryBaseUriValue = { base };
+		}
+		return this._entryBaseUriValue.base;
+	}
+
+	/**
+	 * `output.publicPath` as the constant it will be, for code that would otherwise read
+	 * `__webpack_require__.p` for a value that never changes. `undefined` when only the
+	 * hash could say, or when a runtime reassigns `__webpack_public_path__` — then the
+	 * global is the only thing that knows.
+	 * @returns {string | undefined} the settled public path
+	 */
+	constantPublicPath() {
+		const { publicPath } = this.outputOptions;
+		if (
+			publicPath === "auto" ||
+			APIPlugin.usesRuntimePublicPathOverride(this.compilation)
+		) {
+			return undefined;
+		}
+		if (typeof publicPath === "function") {
+			const resolved = this._resolveHashIndependent(publicPath);
+			return resolved === null ? undefined : resolved;
+		}
+		return publicPath.includes("[") ? undefined : publicPath;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -440,7 +440,39 @@ class RuntimeTemplate {
 		// A bare relative URL is what `__webpack_require__.p + path` means only under an
 		// `auto` public path; anything else has to be baked, which is the "wasm" form.
 		if (form === "wasm-relative") return outputOptions.publicPath === "auto";
-		return this._supportsAnalyzableWasm(module);
+
+		// The rest is the `"wasm"` form: whether the whole binary url can be spelled
+		// here, rather than built at runtime under an `import.meta.url` base.
+		const { publicPath, webassemblyModuleFilename } = outputOptions;
+		if (publicPath !== "auto") {
+			if (this._hasUrlPublicPath()) {
+				// Settled no earlier than the hash it reads or is called with, so it is
+				// baked only where the deferred pass may finish it.
+				if (this._resolvePublicPathPrefix(publicPath) === null) {
+					this._analyzableBailout(module, DEFER_BAILOUT);
+					return false;
+				}
+			} else if (this._anyWasmChunkFetches()) {
+				this._analyzableBailout(
+					module,
+					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
+				);
+				return false;
+			}
+		}
+		// The compilation hash is settled after code generation, so a name carrying one
+		// is baked only where the deferred pass can fill it in. `[hash]` is the module's
+		// own here, which code generation already knows.
+		if (
+			getTemplatedPathPlugin()
+				.getPresentKinds(/** @type {string} */ (webassemblyModuleFilename))
+				.has("fullhash") &&
+			!this._canDeferAnalyzableName()
+		) {
+			this._analyzableBailout(module, DEFER_BAILOUT);
+			return false;
+		}
+		return true;
 	}
 
 	/**
@@ -542,44 +574,6 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The `"wasm"` half of `supportsAnalyzable`: whether the whole binary URL can be
-	 * spelled here, rather than built at runtime under an `import.meta.url` base.
-	 * @param {Module=} module the module the reference is emitted into
-	 * @returns {boolean} true when the literal form is emitted
-	 */
-	_supportsAnalyzableWasm(module) {
-		const { publicPath, webassemblyModuleFilename } = this.outputOptions;
-		const filename = /** @type {string} */ (webassemblyModuleFilename);
-		if (publicPath !== "auto") {
-			if (this._hasUrlPublicPath()) {
-				// Settled no earlier than the hash it reads or is called with, so it is
-				// baked only where the deferred pass may finish it.
-				if (this._resolvePublicPathPrefix(publicPath) === null) {
-					this._analyzableBailout(module, DEFER_BAILOUT);
-					return false;
-				}
-			} else if (this._anyWasmChunkFetches()) {
-				this._analyzableBailout(
-					module,
-					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
-				);
-				return false;
-			}
-		}
-		// The compilation hash is settled after code generation, so a name carrying one
-		// is baked only where the deferred pass can fill it in. `[hash]` is the module's
-		// own here, which code generation already knows.
-		if (
-			getTemplatedPathPlugin().getPresentKinds(filename).has("fullhash") &&
-			!this._canDeferAnalyzableName()
-		) {
-			this._analyzableBailout(module, DEFER_BAILOUT);
-			return false;
-		}
-		return true;
-	}
-
-	/**
 	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`
 	 * an asset reference bakes to, or `null` to keep the runtime form. Unlike a wasm
 	 * binary, the runtime resolves an asset url against `__webpack_require__.b` — the
@@ -595,14 +589,33 @@ class RuntimeTemplate {
 		const shape = this._publicPathShape();
 		// A public path that reaches the same place from any base never reads `.b`, so
 		// what it is set to does not matter — `auto` resolves to an absolute url too.
-		if (
+		const base =
 			publicPath !== "auto" &&
 			(shape === undefined || !this._isBaseIndependent(shape))
-		) {
-			const base = this._entryBaseUri();
-			if (base !== undefined) {
-				return this._bakeAgainstBaseUri(module, base, publicPath, filename);
+				? this._entryBaseUri()
+				: undefined;
+		if (base !== undefined) {
+			// Resolved here rather than against the output root, and only an absolute base
+			// settles it — a relative one has no base of its own to be read against.
+			const parts =
+				base === null ? null : this._resolvePublicPathPrefix(publicPath);
+			if (parts !== null && parts.every(isLiteralPart)) {
+				try {
+					return toJsStringLiteral(
+						new URL(
+							joinLiteralParts(parts) + filename,
+							/** @type {string} */ (base)
+						).href
+					);
+				} catch (_error) {
+					// Not absolute, so it cannot be resolved against here or at runtime.
+				}
 			}
+			this._analyzableBailout(
+				module,
+				"an entry sets baseUri, which the runtime resolves this url against instead of the output root"
+			);
+			return null;
 		}
 		return this._getAnalyzableFileSpecifier(
 			module,
@@ -610,40 +623,6 @@ class RuntimeTemplate {
 			[["literal", filename]],
 			true
 		);
-	}
-
-	/**
-	 * The whole url, resolved here, for a reference the runtime would resolve against an
-	 * entry `baseUri` instead of the output root. Only an absolute base settles it — a
-	 * relative one has no base of its own to be read against.
-	 * @param {Module} module the module the reference is emitted into
-	 * @param {string | null} base the base every entry agrees on, `null` when they do not
-	 * @param {PublicPath} publicPath the configured public path
-	 * @param {string} filename the asset's name, relative to the output root
-	 * @returns {string | null} a quoted literal, or `null` to fall back
-	 */
-	_bakeAgainstBaseUri(module, base, publicPath, filename) {
-		/**
-		 * @returns {null} always, having recorded why the base could not be baked
-		 */
-		const cannotBake = () => {
-			this._analyzableBailout(
-				module,
-				"an entry sets baseUri, which the runtime resolves this url against instead of the output root"
-			);
-			return null;
-		};
-		if (base === null) return cannotBake();
-		const parts = this._resolvePublicPathPrefix(publicPath);
-		if (parts === null || !parts.every(isLiteralPart)) return cannotBake();
-		try {
-			return toJsStringLiteral(
-				new URL(joinLiteralParts(parts) + filename, base).href
-			);
-		} catch (_error) {
-			// A base that is not absolute cannot be resolved against, here or at runtime.
-			return cannotBake();
-		}
 	}
 
 	/**
@@ -2468,7 +2447,7 @@ class RuntimeTemplate {
 	 * @param {RuntimeRequirements} runtimeRequirements runtime requirements
 	 * @returns {string} expression evaluating to the binary's URL
 	 */
-	_getAnalyzableWasmUrl(module, chunkGraph, runtime, runtimeRequirements) {
+	getAnalyzableWasmUrl(module, chunkGraph, runtime, runtimeRequirements) {
 		const { compilation } = this;
 		const template = /** @type {string} */ (
 			this.outputOptions.webassemblyModuleFilename

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -12,12 +12,6 @@ const {
 	JAVASCRIPT_TYPE,
 	RUNTIME_TYPE
 } = require("./ModuleSourceTypeConstants");
-const {
-	WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE,
-	WEBPACK_MODULE_TYPE_FALLBACK,
-	WEBPACK_MODULE_TYPE_PROVIDE,
-	WEBPACK_MODULE_TYPE_REMOTE
-} = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
 const {
@@ -49,15 +43,6 @@ const getAnalyzableChunkHashPlugin = memoize(() =>
 const getConcatenatedModule = memoize(() =>
 	require("./optimize/ConcatenatedModule")
 );
-
-// Module-federation module types whose chunks load through the federation runtime.
-/** @type {Set<string>} */
-const FEDERATION_MODULE_TYPES = new Set([
-	WEBPACK_MODULE_TYPE_REMOTE,
-	WEBPACK_MODULE_TYPE_PROVIDE,
-	WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE,
-	WEBPACK_MODULE_TYPE_FALLBACK
-]);
 
 // Any `[hash]`/`[fullhash]`/`[chunkhash]`/`[contenthash]` token, incl. a `:<length>`
 // or `:<digest>[:<length>]` suffix (e.g. `[contenthash:base64:8]`). Its value is only
@@ -2068,16 +2053,18 @@ class RuntimeTemplate {
 			chunk.hasChildByOrder(chunkGraph, "prefetch", true) ||
 			chunk.hasChildByOrder(chunkGraph, "preload", true) ||
 			chunk.hasChildByOrder(chunkGraph, "cssPreload", true);
+		// `.ei` always performs the import, where `.e` only reaches the javascript
+		// loader when there is javascript to load. A module federation remote is the
+		// case that matters: its chunk is emitted by the container's build, not this one.
+		if (!JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)) {
+			this._analyzableBailout(
+				originModule,
+				"this compilation emits no javascript for the chunk, so there is nothing to import"
+			);
+			return null;
+		}
 		let hasNonJsTypes = false;
 		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-			// Module federation (remote/shared/provide) loads through its own runtime.
-			if (FEDERATION_MODULE_TYPES.has(module.type)) {
-				this._analyzableBailout(
-					originModule,
-					`the chunk holds a module federation module (${module.type})`
-				);
-				return null;
-			}
 			for (const type of chunkGraph.getModuleSourceTypes(module)) {
 				if (type !== JAVASCRIPT_TYPE && type !== RUNTIME_TYPE) {
 					// Loaded by that type's own `.f` handler, which `.ei` still dispatches.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -367,9 +367,8 @@ class RuntimeTemplate {
 	supportsAnalyzable(form, chunkGraph, module) {
 		// Analyzable output is ESM output — anything else is a different feature.
 		if (!this.isModule()) return false;
-		// A wasm loader is emitted once per runtime and shared by every wasm module in
-		// it, so its answer has to hold compilation-wide — a per-module one may disagree
-		// with the loader's own and hand a baked url to the signature that expects an id.
+		// One loader per runtime serves every wasm module in it, so the answer has to
+		// hold compilation-wide — else a baked url reaches the id-and-hash signature.
 		const scoped = form !== "wasm" && form !== "wasm-relative";
 		// A reassigned `__webpack_public_path__` cannot reach a baked literal, and `.p`
 		// belongs to a runtime, so only the runtimes it reaches keep the runtime form.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2231,8 +2231,9 @@ class RuntimeTemplate {
 	/**
 	 * Static literal specifier (already quoted) for a `new URL(<here>, import.meta.url)`
 	 * pointing at an emitted file whose name is already settled — an asset, or a wasm
-	 * binary. The base is the asset the reference sits in, which is what the runtime
-	 * form resolves against too, so any spelling of the public path may be baked.
+	 * binary. The base is the asset the reference sits in; the runtime form resolves
+	 * against the output root instead, so a public path that needs a base is put behind
+	 * the `../` path back to that root rather than baked as the whole prefix.
 	 * @param {Module} module the module the reference is emitted into
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {string} filename the emitted file's name, relative to the output root
@@ -2241,31 +2242,38 @@ class RuntimeTemplate {
 	 */
 	_getAnalyzableFileSpecifier(module, chunkGraph, filename, bakePublicPath) {
 		const { publicPath } = this.outputOptions;
+		let tail = filename;
 		if (bakePublicPath && publicPath !== "auto") {
 			const resolved = this._resolvePublicPathPrefix(
 				/** @type {PublicPath} */ (publicPath)
 			);
 			if (resolved === null) return null;
 			const [prefix, prefixKind] = resolved;
-			return toJsStringLiteral(
-				prefixKind === undefined
-					? prefix + filename
-					: getAnalyzableChunkHashPlugin().reserveSpecifier({
-							prefix,
-							prefixKind,
-							file: filename
-						})
-			);
+			if (prefix.startsWith("/") || getScheme(prefix) !== undefined) {
+				return toJsStringLiteral(
+					prefixKind === undefined
+						? prefix + filename
+						: getAnalyzableChunkHashPlugin().reserveSpecifier({
+								prefix,
+								prefixKind,
+								file: filename
+							})
+				);
+			}
+			// A recipe the deferred pass builds cannot also carry the `../` path.
+			if (prefixKind !== undefined) return null;
+			// `./` names the root it is already walked back to, so it only lengthens.
+			tail = (prefix.startsWith("./") ? prefix.slice(2) : prefix) + filename;
 		}
 		const undo = this._getModuleUndoPath(module, chunkGraph);
-		if (undo !== null) return toJsStringLiteral(undo + filename);
+		if (undo !== null) return toJsStringLiteral(undo + tail);
 		// Different depths — no one `../` path is right for every asset the reference is
 		// emitted into, so the deferred pass builds each asset's own.
 		if (this.canDeferAnalyzableName()) {
 			return toJsStringLiteral(
 				getAnalyzableChunkHashPlugin().reserveSpecifier({
 					prefixKind: "undo",
-					file: filename
+					file: tail
 				})
 			);
 		}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -683,9 +683,10 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The `baseUri` every entry sets, which replaces the output root the runtime resolves
-	 * an asset url against. `undefined` when none sets one, `null` when they disagree —
-	 * a module reached from both is generated once, so one answer has to serve both.
+	 * The `baseUri` every entry agrees on, which replaces the output root an asset url
+	 * resolves against. `undefined` when no entry sets one, `null` when they disagree —
+	 * an entry that omits it disagrees with one that sets it, and a module reached from
+	 * both is generated once, so one answer has to serve both.
 	 * @returns {string | null | undefined} the base every entry agrees on
 	 */
 	_entryBaseUri() {
@@ -695,7 +696,7 @@ class RuntimeTemplate {
 			let found = false;
 			for (const chunk of this.compilation.chunks) {
 				const entryOptions = chunk.getEntryOptions();
-				if (!entryOptions || entryOptions.baseUri === undefined) continue;
+				if (!entryOptions) continue;
 				if (found && base !== entryOptions.baseUri) {
 					base = null;
 					break;

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -70,6 +70,10 @@ const HASH_PROBE = "0123456789abcdef0123";
 const HASH_PROBE_ALTERNATE = "3210fedcba9876543210";
 const HASH_IN_FILENAME_GLOBAL = /\[(?:full|chunk|content)?hash(?::[^\]]+)?\]/g;
 
+// Why a relative public path could not be walked back to the output root.
+const RELATIVE_PATH_BAILOUT =
+	"output.publicPath is relative and re-encodes a hash, so no one prefix reaches the output root";
+
 // Why a name only the deferred pass could settle was not deferred.
 const DEFER_BAILOUT =
 	"a hashed name needs optimization.realContentHash, or no emitted javascript named by its content";
@@ -199,6 +203,10 @@ class RuntimeTemplate {
 		this.contentHashReplacement = "X".repeat(outputOptions.hashDigestLength);
 		/** @type {boolean | undefined} */
 		this._javascriptNamedWithoutContent = undefined;
+		/** @type {string | false | undefined} */
+		this._publicPath = undefined;
+		/** @type {boolean | undefined} */
+		this._entryBaseUri = undefined;
 	}
 
 	isIIFE() {
@@ -557,9 +565,10 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when the literal form is emitted
 	 */
 	supportsAnalyzableWasm(chunkGraph, module) {
-		const { publicPath, webassemblyModuleFilename } = this.outputOptions;
+		const { webassemblyModuleFilename } = this.outputOptions;
 		const filename = /** @type {string} */ (webassemblyModuleFilename);
 		if (!this.supportsAnalyzableEsm(chunkGraph, module)) return false;
+		const publicPath = this._resolvedPublicPath();
 		if (publicPath !== "auto") {
 			if (this._hasUrlPublicPath()) {
 				// A templated one is settled no earlier than the hash it reads, so it is
@@ -593,6 +602,42 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Whether an entry `baseUri` decides where an asset URL points. It replaces the
+	 * output root the runtime resolves one against, and no literal read from its own
+	 * chunk shares that base — but only a public path that needs a base ever reaches
+	 * it, so an absolute one, `auto` included, is unaffected. Answered for the
+	 * compilation: a module reached from two entries is generated once.
+	 * @param {Module=} module the module the reference is emitted into
+	 * @returns {boolean} true when the runtime form has to be kept
+	 */
+	reportsEntryBaseUri(module) {
+		const publicPath = this._resolvedPublicPath();
+		if (
+			publicPath === "auto" ||
+			(publicPath !== undefined && this._isBaseIndependent(publicPath))
+		) {
+			return false;
+		}
+		if (this._entryBaseUri === undefined) {
+			this._entryBaseUri = false;
+			for (const chunk of this.compilation.chunks) {
+				const entryOptions = chunk.getEntryOptions();
+				if (entryOptions && entryOptions.baseUri !== undefined) {
+					this._entryBaseUri = true;
+					break;
+				}
+			}
+		}
+		if (this._entryBaseUri) {
+			this._analyzableBailout(
+				module,
+				"an entry sets baseUri, which the runtime resolves this url against instead of the output root"
+			);
+		}
+		return this._entryBaseUri;
+	}
+
+	/**
 	 * Whether any chunk loads WebAssembly through `fetch`, which is the only loader the
 	 * public path reaches: `readFile` resolves the binary's name against the chunk it is
 	 * read from, exactly as a baked literal does, so a public path is irrelevant to it.
@@ -614,18 +659,49 @@ class RuntimeTemplate {
 	/**
 	 * Whether `output.publicPath` is a complete URL of its own. Baking one keeps the
 	 * same target, because `new URL(...)` ignores its base for an absolute specifier.
-	 * A root- or directory-relative public path does not: the runtime form resolves it
-	 * against the document and a baked one against the chunk, which differ exactly
-	 * where a public path is worth setting. (`import()` is not affected — it resolves
-	 * against the importing module either way — so only the URL form checks this.)
-	 * @returns {boolean} true for a static, absolute-URL public path
+	 * A root- or directory-relative public path does not: `fetch` resolves it against
+	 * the document and a baked one against the chunk, which differ exactly where a
+	 * public path is worth setting. What the deferred pass can still spell — a rooted
+	 * path, or a relative one behind the `../` path to the output root — is decided by
+	 * `_isBaseIndependent` instead; this is only about `fetch`.
+	 * @returns {boolean} true for an absolute-URL public path
 	 */
 	_hasUrlPublicPath() {
-		const { publicPath } = this.outputOptions;
+		const publicPath = this._resolvedPublicPath();
 		return (
-			typeof publicPath === "string" &&
+			publicPath !== undefined &&
 			(publicPath.startsWith("//") || getScheme(publicPath) !== undefined)
 		);
+	}
+
+	/**
+	 * `output.publicPath` as the string it will be. A function is called for its value
+	 * the same way `PublicPathRuntimeModule` calls it, so one whose answer moves with
+	 * the compilation hash has none to give here.
+	 * @returns {string | undefined} the settled public path, or `undefined`
+	 */
+	_resolvedPublicPath() {
+		if (this._publicPath === undefined) {
+			const { publicPath } = this.outputOptions;
+			const resolved =
+				typeof publicPath === "function"
+					? this._resolveHashIndependent(publicPath)
+					: publicPath;
+			this._publicPath = resolved === null ? false : resolved;
+		}
+		return this._publicPath === false ? undefined : this._publicPath;
+	}
+
+	/**
+	 * Whether a public path reaches the same place from any base — a full URL, a
+	 * protocol-relative one, or one rooted at the origin. A relative one does not, and
+	 * is only equivalent behind the `../` path back to the output root, which is what
+	 * the runtime resolves it against.
+	 * @param {string} publicPath the resolved public path, or the template of one
+	 * @returns {boolean} true when no base is needed
+	 */
+	_isBaseIndependent(publicPath) {
+		return publicPath.startsWith("/") || getScheme(publicPath) !== undefined;
 	}
 
 	supportTemplateLiteral() {
@@ -2171,8 +2247,19 @@ class RuntimeTemplate {
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
 		const resolved = this._resolvePublicPathPrefix(publicPath);
-		if (resolved !== null) return specifier(resolved[0], resolved[1]);
-		return null;
+		if (resolved === null) return null;
+		const [prefix, prefixKind] = resolved;
+		if (this._isBaseIndependent(prefix)) return specifier(prefix, prefixKind);
+		// The runtime imports it from the chunk holding the runtime, which is the output
+		// root; a baked one is read from the chunk it sits in, so the `../` path back to
+		// that root goes first. A recipe the deferred pass builds cannot carry both.
+		if (prefixKind !== undefined) {
+			this._analyzableBailout(consumingModule, RELATIVE_PATH_BAILOUT);
+			return null;
+		}
+		const rooted = prefix.startsWith("./") ? prefix.slice(2) : prefix;
+		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
+		return undo === null ? specifier(rooted, "undo") : specifier(undo + rooted);
 	}
 
 	/**
@@ -2249,7 +2336,7 @@ class RuntimeTemplate {
 			);
 			if (resolved === null) return null;
 			const [prefix, prefixKind] = resolved;
-			if (prefix.startsWith("/") || getScheme(prefix) !== undefined) {
+			if (this._isBaseIndependent(prefix)) {
 				return toJsStringLiteral(
 					prefixKind === undefined
 						? prefix + filename
@@ -2261,7 +2348,10 @@ class RuntimeTemplate {
 				);
 			}
 			// A recipe the deferred pass builds cannot also carry the `../` path.
-			if (prefixKind !== undefined) return null;
+			if (prefixKind !== undefined) {
+				this._analyzableBailout(module, RELATIVE_PATH_BAILOUT);
+				return null;
+			}
 			// `./` names the root it is already walked back to, so it only lengthens.
 			tail = (prefix.startsWith("./") ? prefix.slice(2) : prefix) + filename;
 		}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -503,13 +503,16 @@ class RuntimeTemplate {
 	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
 	 * back in line, or no emitted javascript may be named by its content in the first
 	 * place — with a name like `[name].js` there is nothing to go stale.
+	 * @param {Iterable<Chunk>=} chunks the chunks the stand-in is written into; omit
+	 * where the answer has to hold for the whole compilation, as it does for a gate a
+	 * runtime module asks from the other end
 	 * @returns {boolean} true when deferring is safe
 	 */
-	canDeferAnalyzableName() {
-		return (
-			Boolean(this.compilation.options.optimization.realContentHash) ||
-			this._namesJavascriptWithoutContent()
-		);
+	canDeferAnalyzableName(chunks) {
+		if (this.compilation.options.optimization.realContentHash) return true;
+		return chunks === undefined
+			? this._namesJavascriptWithoutContent()
+			: this._chunksNamedWithoutContent(chunks);
 	}
 
 	/**
@@ -524,23 +527,35 @@ class RuntimeTemplate {
 	 */
 	_namesJavascriptWithoutContent() {
 		if (this._javascriptNamedWithoutContent === undefined) {
-			const templatedPathPlugin = getTemplatedPathPlugin();
-			this._javascriptNamedWithoutContent = true;
-			for (const chunk of this.compilation.chunks) {
-				const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
-					chunk,
-					this.outputOptions
-				);
-				if (
-					typeof template !== "string" ||
-					templatedPathPlugin.getPresentKinds(template).has("contenthash")
-				) {
-					this._javascriptNamedWithoutContent = false;
-					break;
-				}
-			}
+			this._javascriptNamedWithoutContent = this._chunksNamedWithoutContent(
+				this.compilation.chunks
+			);
 		}
 		return this._javascriptNamedWithoutContent;
+	}
+
+	/**
+	 * @param {Iterable<Chunk>} chunks the chunks to ask about
+	 * @returns {boolean} true when none of them is named by its own content
+	 */
+	_chunksNamedWithoutContent(chunks) {
+		const templatedPathPlugin = getTemplatedPathPlugin();
+		let found = false;
+		for (const chunk of chunks) {
+			found = true;
+			const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
+				chunk,
+				this.outputOptions
+			);
+			if (
+				typeof template !== "string" ||
+				templatedPathPlugin.getPresentKinds(template).has("contenthash")
+			) {
+				return false;
+			}
+		}
+		// None at all names nothing to reason about — the asset is unknown, not safe.
+		return found;
 	}
 
 	/**
@@ -2103,6 +2118,20 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * The chunks a reference emitted into `module` is written into — the assets a
+	 * stand-in of ours would land in, and so the only ones a deferred fill could go
+	 * stale in.
+	 * @param {Module} module the module a reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {Iterable<Chunk>} the chunks holding it
+	 */
+	_moduleChunks(module, chunkGraph) {
+		return chunkGraph.getModuleChunksIterable(
+			/** @type {Module} */ (this._chunkGraphModule(module))
+		);
+	}
+
+	/**
 	 * Computes the `../`-path from the consuming module's chunk(s) back to the output
 	 * root, so a chunk or asset can be referenced relative to `import.meta.url`. Returns
 	 * `null` when the module lives in chunks of different depths (no single path works).
@@ -2117,9 +2146,7 @@ class RuntimeTemplate {
 		/** @type {string | null} */
 		let result = null;
 		let found = false;
-		for (const chunk of chunkGraph.getModuleChunksIterable(
-			/** @type {Module} */ (this._chunkGraphModule(module))
-		)) {
+		for (const chunk of this._moduleChunks(module, chunkGraph)) {
 			const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
 				chunk,
 				outputOptions
@@ -2179,7 +2206,8 @@ class RuntimeTemplate {
 		// An id names the chunk in the stand-in, and one nothing could resolve would
 		// reach the bundle verbatim. The whole name is re-resolved later rather than
 		// carrying a stand-in of its own, so any hash spelling is fine here.
-		const canReserve = chunk.id !== null && this.canDeferAnalyzableName();
+		const chunks = this._moduleChunks(consumingModule, chunkGraph);
+		const canReserve = chunk.id !== null && this.canDeferAnalyzableName(chunks);
 		/**
 		 * @returns {null} always, having recorded why no stand-in may be reserved
 		 */
@@ -2218,7 +2246,10 @@ class RuntimeTemplate {
 			);
 		};
 		if (overridePublicPath) {
-			const resolved = this._resolvePublicPathPrefix(overridePublicPath);
+			const resolved = this._resolvePublicPathPrefix(
+				overridePublicPath,
+				chunks
+			);
 			return resolved === null ? null : specifier(resolved);
 		}
 		const { publicPath } = outputOptions;
@@ -2241,7 +2272,7 @@ class RuntimeTemplate {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
-		const resolved = this._resolvePublicPathPrefix(publicPath);
+		const resolved = this._resolvePublicPathPrefix(publicPath, chunks);
 		if (resolved === null) return null;
 		// The runtime imports it from the chunk holding the runtime, which is the output
 		// root; a baked one is read from the chunk it sits in, so a public path that
@@ -2266,18 +2297,19 @@ class RuntimeTemplate {
 	 * the deferred pass whole instead. A function is called for its value rather than
 	 * read as a template, so one whose answer moves with the hash is called again there.
 	 * @param {PublicPath} publicPath the configured public path
+	 * @param {Iterable<Chunk>=} chunks the chunks a stand-in would be written into
 	 * @returns {SpecifierPart[] | null} the parts, or `null` when it cannot be known
 	 */
-	_resolvePublicPathPrefix(publicPath) {
+	_resolvePublicPathPrefix(publicPath, chunks) {
 		if (typeof publicPath === "function") {
 			// One that answers nothing to a probe cannot be placed, absolute or not.
 			if (this._publicPathShape() === undefined) return null;
 			const resolved = this._resolveHashIndependent(publicPath);
 			if (resolved !== null) return [["literal", resolved]];
-			return this.canDeferAnalyzableName() ? [["publicPath", ""]] : null;
+			return this.canDeferAnalyzableName(chunks) ? [["publicPath", ""]] : null;
 		}
 		if (!publicPath.includes("[")) return [["literal", publicPath]];
-		if (!this.canDeferAnalyzableName()) return null;
+		if (!this.canDeferAnalyzableName(chunks)) return null;
 		const analyzableChunkHashPlugin = getAnalyzableChunkHashPlugin();
 		if (!analyzableChunkHashPlugin.canDeferFullHash(publicPath)) {
 			return [["template", publicPath]];
@@ -2353,6 +2385,7 @@ class RuntimeTemplate {
 	 */
 	_getAnalyzableFileSpecifier(module, chunkGraph, file, bakePublicPath) {
 		const { publicPath } = this.outputOptions;
+		const chunks = this._moduleChunks(module, chunkGraph);
 		/**
 		 * @param {SpecifierPart[]} parts the whole specifier
 		 * @returns {string | null} it already quoted, or `null` when no stand-in may be reserved
@@ -2361,7 +2394,7 @@ class RuntimeTemplate {
 			if (parts.every(isLiteralPart)) {
 				return toJsStringLiteral(joinLiteralParts(parts));
 			}
-			if (!this.canDeferAnalyzableName()) {
+			if (!this.canDeferAnalyzableName(chunks)) {
 				this._analyzableBailout(module, DEFER_BAILOUT);
 				return null;
 			}
@@ -2373,7 +2406,8 @@ class RuntimeTemplate {
 		let prefix = [];
 		if (bakePublicPath && publicPath !== "auto") {
 			const resolved = this._resolvePublicPathPrefix(
-				/** @type {PublicPath} */ (publicPath)
+				/** @type {PublicPath} */ (publicPath),
+				chunks
 			);
 			const shape = this._publicPathShape();
 			if (resolved === null || shape === undefined) return null;

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -774,7 +774,7 @@ class AssetGenerator extends Generator {
 		// Build-time execution instead emulates the wrapper (`AssetModulesPlugin`).
 		const isModule = Boolean(
 			this._compilation &&
-			this._compilation.runtimeTemplate.supportsAnalyzableEsm()
+			this._compilation.runtimeTemplate.supportsAnalyzable("url")
 		);
 
 		// Collapse the incoming origin types into flags instead of a Set of prefixes:

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -822,14 +822,10 @@ class AssetGenerator extends Generator {
 			if (hasOtherJs && hasUrl) break;
 		}
 
-		// Every javascript consumer is an analyzable `new URL()`, which builds its own
-		// literal from the asset's filename — so the `module.exports = .p + name` wrapper
-		// is read by no one. An absolute public path settles the same url for every
-		// consumer, which `asset-url` can carry; a relative one differs per chunk, so
-		// there is nothing to expose and `URLDependency` reads the filename instead.
+		// Every javascript consumer names the file itself, so nothing reads the wrapper.
+		// Only an absolute public path settles one url for all of them to share.
 		const jsWrapperUnused = isModule && hasUrlJs && !hasOtherJs;
-		// One that emits nothing has no name to build a literal from, so its url has to
-		// be exposed; one that does is read from its name, per consuming chunk.
+		// One that emits nothing has no name to build a literal from, so expose its url.
 		const emits =
 			!(
 				module.buildInfo &&
@@ -859,11 +855,11 @@ class AssetGenerator extends Generator {
 				return ASSET_AND_JAVASCRIPT_AND_ASSET_URL_TYPES;
 			} else if (wantUrl) {
 				return ASSET_AND_ASSET_URL_TYPES;
-			} else if (wantJs) {
-				return ASSET_AND_JAVASCRIPT_TYPES;
+			} else if (jsWrapperUnused) {
+				// Every javascript consumer names the file itself, so nothing reads it.
+				return ASSET_TYPES;
 			}
-			// Every consumer bakes its own literal from the asset's name.
-			return ASSET_TYPES;
+			return ASSET_AND_JAVASCRIPT_TYPES;
 		}
 
 		return ASSET_TYPES;

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -822,17 +822,26 @@ class AssetGenerator extends Generator {
 			if (hasOtherJs && hasUrl) break;
 		}
 
+		// Every javascript consumer is an analyzable `new URL()`, which builds its own
+		// literal from the asset's filename — so the `module.exports = .p + name` wrapper
+		// is read by no one. An absolute public path settles the same url for every
+		// consumer, which `asset-url` can carry; a relative one differs per chunk, so
+		// there is nothing to expose and `URLDependency` reads the filename instead.
+		const jsWrapperUnused = isModule && hasUrlJs && !hasOtherJs;
+		// One that emits nothing has no name to build a literal from, so its url has to
+		// be exposed; one that does is read from its name, per consuming chunk.
+		const emits =
+			!(
+				module.buildInfo &&
+				/** @type {AssetModuleBuildInfo} */ (module.buildInfo).dataUrl
+			) && this.emit !== false;
 		const jsAsAssetUrl =
-			isModule && hasUrlJs && !hasOtherJs && this._hasAbsolutePublicPath();
-		// JS wrapper is needed for non-URL JS consumers, or URL consumers not dropped to asset-url.
-		const wantJs = hasOtherJs || (hasUrlJs && !jsAsAssetUrl);
+			jsWrapperUnused && (!emits || this._hasAbsolutePublicPath());
+		// JS wrapper is needed for non-URL JS consumers, or URL consumers still reading it.
+		const wantJs = hasOtherJs || (hasUrlJs && !jsWrapperUnused);
 		const wantUrl = hasUrl || jsAsAssetUrl;
 
-		if (
-			(module.buildInfo &&
-				/** @type {AssetModuleBuildInfo} */ (module.buildInfo).dataUrl) ||
-			this.emit === false
-		) {
+		if (!emits) {
 			if (hasOrigin) {
 				if (wantJs && wantUrl) {
 					return JAVASCRIPT_AND_ASSET_URL_TYPES;
@@ -850,8 +859,11 @@ class AssetGenerator extends Generator {
 				return ASSET_AND_JAVASCRIPT_AND_ASSET_URL_TYPES;
 			} else if (wantUrl) {
 				return ASSET_AND_ASSET_URL_TYPES;
+			} else if (wantJs) {
+				return ASSET_AND_JAVASCRIPT_TYPES;
 			}
-			return ASSET_AND_JAVASCRIPT_TYPES;
+			// Every consumer bakes its own literal from the asset's name.
+			return ASSET_TYPES;
 		}
 
 		return ASSET_TYPES;

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -222,7 +222,11 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		// chunk startup (`StartupAssetHintRuntimeModule`), independent of the call site.
 		if (
 			!dep.relative &&
-			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, templateContext.module)
+			runtimeTemplate.supportsAnalyzable(
+				"url",
+				chunkGraph,
+				templateContext.module
+			)
 		) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -75,7 +75,7 @@ const getAnalyzableUrlSpecifier = (dep, templateContext) => {
 			return runtimeTemplate._getAnalyzableFileSpecifier(
 				consumingModule,
 				chunkGraph,
-				filename,
+				[["literal", filename]],
 				true
 			);
 		}

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -69,9 +69,8 @@ const getAnalyzableUrlSpecifier = (dep, templateContext) => {
 		const assetUrl = urlData[ASSET_URL_TYPE];
 		return typeof assetUrl === "string" ? toJsStringLiteral(assetUrl) : null;
 	}
-	// The wrapper concatenates the runtime public path, or was dropped as read by no
-	// one — either way the name is what the literal is built from, against the base the
-	// runtime form resolves against too.
+	// The wrapper concatenates the runtime public path, or was dropped as unread —
+	// either way the name is what the literal is built from.
 	const filename = codeGenerationResults.getData(
 		assetModule,
 		runtime,
@@ -246,9 +245,8 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		}
 
 		const module = moduleGraph.getModule(dep);
-		// A wrapper-less asset has no exports to require: every javascript consumer was
-		// going to bake its own literal, and this one no longer can. Concatenate what the
-		// wrapper would have — build-time execution emulates the same in `AssetModulesPlugin`.
+		// A wrapper-less asset has no exports to require, so concatenate what the wrapper
+		// would have — `AssetModulesPlugin` emulates the same for build-time execution.
 		const wrapperLess =
 			module !== null && !module.getSourceTypes().has(JAVASCRIPT_TYPE);
 		const filename =

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -57,37 +57,32 @@ const getAnalyzableUrlSpecifier = (dep, templateContext) => {
 		return null;
 	}
 	const urlData = codeGenerationResults.getData(assetModule, runtime, "url");
-	if (!urlData) return null;
-
-	const jsUrl = urlData[JAVASCRIPT_TYPE];
-	if (typeof jsUrl === "string") {
-		// The asset concatenates the runtime publicPath; rebuild a literal from the
-		// resolved filename. The base is the consuming chunk (`import.meta.url`), which
-		// is what the runtime form resolves against too — so any public path may be
-		// baked, and one the deferred pass has to finish is reserved as a stand-in.
-		if (jsUrl.includes(RuntimeGlobals.require)) {
-			const filename = codeGenerationResults.getData(
-				assetModule,
-				runtime,
-				"filename"
-			);
-			if (typeof filename !== "string") return null;
-			return runtimeTemplate._getAnalyzableFileSpecifier(
-				consumingModule,
-				chunkGraph,
-				[["literal", filename]],
-				true
-			);
-		}
+	const jsUrl = urlData && urlData[JAVASCRIPT_TYPE];
+	if (typeof jsUrl === "string" && !jsUrl.includes(RuntimeGlobals.require)) {
 		// An already-quoted literal (generator `publicPath` / data: url) is used as-is;
 		// a raw value (external asset) is normalized to a quoted string.
 		return jsUrl.startsWith('"') ? jsUrl : toJsStringLiteral(jsUrl);
 	}
-
-	// Wrapper dropped: the asset is consumed as `asset-url` (absolute publicPath),
-	// so its resolved url is already a chunk-independent literal.
-	const assetUrl = urlData[ASSET_URL_TYPE];
-	return typeof assetUrl === "string" ? toJsStringLiteral(assetUrl) : null;
+	if (urlData && jsUrl === undefined) {
+		// Wrapper dropped for an `asset-url` consumer: an absolute public path resolves
+		// the same url from every chunk, so it is already a literal.
+		const assetUrl = urlData[ASSET_URL_TYPE];
+		return typeof assetUrl === "string" ? toJsStringLiteral(assetUrl) : null;
+	}
+	// The wrapper concatenates the runtime public path, or was dropped as read by no
+	// one — either way the name is what the literal is built from, against the base the
+	// runtime form resolves against too.
+	const filename = codeGenerationResults.getData(
+		assetModule,
+		runtime,
+		"filename"
+	);
+	if (typeof filename !== "string") return null;
+	return runtimeTemplate.getAnalyzableAssetUrl(
+		consumingModule,
+		chunkGraph,
+		filename
+	);
 };
 
 class URLDependency extends ModuleDependency {
@@ -206,6 +201,7 @@ URLDependency.Template = class URLDependencyTemplate extends (
 			moduleGraph,
 			runtimeRequirements,
 			runtimeTemplate,
+			codeGenerationResults,
 			runtime
 		} = templateContext;
 		const dep = /** @type {URLDependency} */ (dependency);
@@ -227,13 +223,7 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		// chunk startup (`StartupAssetHintRuntimeModule`), independent of the call site.
 		if (
 			!dep.relative &&
-			runtimeTemplate.supportsAnalyzableEsm(
-				chunkGraph,
-				templateContext.module
-			) &&
-			// An entry `baseUri` replaces the output root the runtime resolves against,
-			// and no literal read from its own chunk shares that base.
-			!runtimeTemplate.reportsEntryBaseUri(templateContext.module)
+			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, templateContext.module)
 		) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {
@@ -255,25 +245,31 @@ URLDependency.Template = class URLDependencyTemplate extends (
 			}
 		}
 
-		runtimeRequirements.add(RuntimeGlobals.require);
-
 		const module = moduleGraph.getModule(dep);
-		// Wrapper-less asset exports are emulated from `__webpack_require__.p`
-		// at build time (`AssetModulesPlugin`) — ensure the publicPath runtime.
-		if (
-			chunkGraph.buildTimeExecution &&
-			module &&
-			!module.getSourceTypes().has(JAVASCRIPT_TYPE)
-		) {
+		// A wrapper-less asset has no exports to require: every javascript consumer was
+		// going to bake its own literal, and this one no longer can. Concatenate what the
+		// wrapper would have — build-time execution emulates the same in `AssetModulesPlugin`.
+		const wrapperLess =
+			module !== null && !module.getSourceTypes().has(JAVASCRIPT_TYPE);
+		const filename =
+			wrapperLess && codeGenerationResults.has(module, runtime)
+				? codeGenerationResults.getData(module, runtime, "filename")
+				: undefined;
+		let moduleRaw;
+		if (wrapperLess && typeof filename === "string") {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
+			moduleRaw = `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
+		} else {
+			runtimeRequirements.add(RuntimeGlobals.require);
+			if (wrapperLess) runtimeRequirements.add(RuntimeGlobals.publicPath);
+			moduleRaw = runtimeTemplate.moduleRaw({
+				chunkGraph,
+				module,
+				request: dep.request,
+				runtimeRequirements,
+				weak: false
+			});
 		}
-		const moduleRaw = runtimeTemplate.moduleRaw({
-			chunkGraph,
-			module,
-			request: dep.request,
-			runtimeRequirements,
-			weak: false
-		});
 
 		// Resource hints fire eagerly at chunk startup via the marker
 		// requirement / `StartupAssetHintRuntimeModule`; the call site stays

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -62,7 +62,9 @@ const getAnalyzableUrlSpecifier = (dep, templateContext) => {
 	const jsUrl = urlData[JAVASCRIPT_TYPE];
 	if (typeof jsUrl === "string") {
 		// The asset concatenates the runtime publicPath; rebuild a literal from the
-		// resolved filename. The base is the consuming chunk (`import.meta.url`).
+		// resolved filename. The base is the consuming chunk (`import.meta.url`), which
+		// is what the runtime form resolves against too — so any public path may be
+		// baked, and one the deferred pass has to finish is reserved as a stand-in.
 		if (jsUrl.includes(RuntimeGlobals.require)) {
 			const filename = codeGenerationResults.getData(
 				assetModule,
@@ -70,18 +72,12 @@ const getAnalyzableUrlSpecifier = (dep, templateContext) => {
 				"filename"
 			);
 			if (typeof filename !== "string") return null;
-			const { publicPath } = runtimeTemplate.outputOptions;
-			if (publicPath === "auto") {
-				const undo = runtimeTemplate._getModuleUndoPath(
-					consumingModule,
-					chunkGraph
-				);
-				return undo === null ? null : toJsStringLiteral(undo + filename);
-			}
-			if (typeof publicPath === "string" && !publicPath.includes("[")) {
-				return toJsStringLiteral(publicPath + filename);
-			}
-			return null;
+			return runtimeTemplate._getAnalyzableFileSpecifier(
+				consumingModule,
+				chunkGraph,
+				filename,
+				true
+			);
 		}
 		// An already-quoted literal (generator `publicPath` / data: url) is used as-is;
 		// a raw value (external asset) is normalized to a quoted string.

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -227,7 +227,13 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		// chunk startup (`StartupAssetHintRuntimeModule`), independent of the call site.
 		if (
 			!dep.relative &&
-			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, templateContext.module)
+			runtimeTemplate.supportsAnalyzableEsm(
+				chunkGraph,
+				templateContext.module
+			) &&
+			// An entry `baseUri` replaces the output root the runtime resolves against,
+			// and no literal read from its own chunk shares that base.
+			!runtimeTemplate.reportsEntryBaseUri(templateContext.module)
 		) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -138,7 +138,8 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 		// and webpack itself can statically follow the worker. A resource hint doesn't
 		// block it: the `<link>` is emitted at chunk startup instead of wrapping the href,
 		// which would turn the specifier into a non-analyzable expression.
-		const analyzableSpecifier = runtimeTemplate.supportsAnalyzableEsm(
+		const analyzableSpecifier = runtimeTemplate.supportsAnalyzable(
+			"url",
 			chunkGraph,
 			templateContext.module
 		)

--- a/lib/dependencies/WorkletDependency.js
+++ b/lib/dependencies/WorkletDependency.js
@@ -143,7 +143,7 @@ WorkletDependency.Template = class WorkletDependencyTemplate extends (
 		// and webpack itself can statically follow the worklet. The worklet chunk links its
 		// splits via native `import`, so only the entry chunk is referenced.
 		const analyzableSpecifier =
-			runtimeTemplate.supportsAnalyzableEsm(chunkGraph, module) &&
+			runtimeTemplate.supportsAnalyzable("url", chunkGraph, module) &&
 			entryChunk.id !== null
 				? runtimeTemplate._getAnalyzableChunkSpecifier(
 						dep.options.publicPath,

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -53,15 +53,9 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 };
 
 /**
- * One piece of a name only the deferred pass can spell.
- * - `"literal"` — the text as it stands, compilation-hash stand-ins included.
- * - `"undo"` — the `../` path from the asset the reference sits in back to the output
- * root, which only that asset knows: one module can be in chunks at several depths.
- * - `"template"` — a path template resolved once the hashes exist, so any spelling of
- * it works, including a digest that re-encodes a hash and no stand-in could carry.
- * - `"publicPath"` — `output.publicPath` resolved the same way, which is the only way
- * to read one written as a function: it is called for its value, never templated.
- * - `"chunk"` — the filename of the chunk with this id.
+ * One piece of a name only the deferred pass can spell: text as it stands, the `../`
+ * path from the asset it sits in to the output root, a template or `output.publicPath`
+ * resolved once the hashes exist, or the filename of the chunk with this id.
  * @typedef {"literal" | "undo" | "template" | "publicPath" | "chunk"} SpecifierPartKind
  */
 
@@ -108,7 +102,13 @@ const readSpecifier = (payload) => {
 	for (const part of decoded) {
 		if (!Array.isArray(part) || part.length !== 2) return null;
 		if (!SPECIFIER_PART_KINDS.has(part[0])) return null;
-		if (typeof part[1] !== "string" && typeof part[1] !== "number") return null;
+		// Only a chunk id may be a number; the rest are read as text.
+		if (
+			typeof part[1] !== "string" &&
+			(part[0] !== "chunk" || typeof part[1] !== "number")
+		) {
+			return null;
+		}
 	}
 	return decoded;
 };

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -53,39 +53,34 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 };
 
 /**
- * How the deferred pass builds what goes in front of the tail, when `prefix` is not
- * already it.
- * - `"path"` — `prefix` is a public-path template, resolved once the hash exists, so
- * any spelling of it works, including a digest no stand-in of ours could carry.
+ * One piece of a name only the deferred pass can spell.
+ * - `"literal"` — the text as it stands, compilation-hash stand-ins included.
  * - `"undo"` — the `../` path from the asset the reference sits in back to the output
  * root, which only that asset knows: one module can be in chunks at several depths.
- * `prefix` follows it, for a public path named relative to that root.
- * @typedef {"path" | "undo"} PrefixKind
+ * - `"template"` — a path template resolved once the hashes exist, so any spelling of
+ * it works, including a digest that re-encodes a hash and no stand-in could carry.
+ * - `"publicPath"` — `output.publicPath` resolved the same way, which is the only way
+ * to read one written as a function: it is called for its value, never templated.
+ * - `"chunk"` — the filename of the chunk with this id.
+ * @typedef {"literal" | "undo" | "template" | "publicPath" | "chunk"} SpecifierPartKind
  */
 
-/**
- * A name only the deferred pass can spell, as the recipe it is built from: a prefix,
- * then the referenced chunk's filename, then any literal text of its own.
- * @typedef {object} Specifier
- * @property {string=} prefix literal prefix, or the template `prefixKind` reads
- * @property {PrefixKind=} prefixKind how to build the prefix, literal when omitted
- * @property {ChunkId=} chunkId chunk whose filename follows the prefix, if any
- * @property {string=} file literal text after that — an emitted binary's own name
- */
+/** @typedef {[SpecifierPartKind, string | number]} SpecifierPart */
+
+const SPECIFIER_PART_KINDS = new Set([
+	"literal",
+	"undo",
+	"template",
+	"publicPath",
+	"chunk"
+]);
 
 /**
- * @param {Specifier} specifier what the stand-in resolves to
+ * @param {SpecifierPart[]} parts what the stand-in resolves to, in order
  * @returns {string} the stand-in to emit
  */
-const reserveSpecifier = ({ prefix, prefixKind, chunkId, file }) =>
-	`./@@webpackAnalyzableChunk:${Buffer.from(
-		JSON.stringify([
-			prefix === undefined ? "" : prefix,
-			chunkId === undefined ? null : chunkId,
-			prefixKind === undefined ? null : prefixKind,
-			file === undefined ? "" : file
-		])
-	)
+const reserveSpecifier = (parts) =>
+	`./@@webpackAnalyzableChunk:${Buffer.from(JSON.stringify(parts))
 		.toString("base64")
 		.replace(/\+/g, "-")
 		.replace(/\//g, "_")
@@ -93,7 +88,7 @@ const reserveSpecifier = ({ prefix, prefixKind, chunkId, file }) =>
 
 /**
  * @param {string} payload the encoded half of a stand-in
- * @returns {Specifier | null} what it resolves to, or `null` if unreadable
+ * @returns {SpecifierPart[] | null} what it resolves to, or `null` if unreadable
  */
 const readSpecifier = (payload) => {
 	/** @type {EXPECTED_ANY} */
@@ -109,25 +104,13 @@ const readSpecifier = (payload) => {
 		return null;
 	}
 	// Source of our own can spell the token too, so nothing about its payload is given.
-	if (!Array.isArray(decoded) || decoded.length !== 4) return null;
-	const [prefix, chunkId, prefixKind, file] = decoded;
-	if (typeof prefix !== "string" || typeof file !== "string") return null;
-	if (
-		chunkId !== null &&
-		typeof chunkId !== "string" &&
-		typeof chunkId !== "number"
-	) {
-		return null;
+	if (!Array.isArray(decoded)) return null;
+	for (const part of decoded) {
+		if (!Array.isArray(part) || part.length !== 2) return null;
+		if (!SPECIFIER_PART_KINDS.has(part[0])) return null;
+		if (typeof part[1] !== "string" && typeof part[1] !== "number") return null;
 	}
-	if (prefixKind !== null && prefixKind !== "path" && prefixKind !== "undo") {
-		return null;
-	}
-	return {
-		prefix,
-		prefixKind: prefixKind === null ? undefined : prefixKind,
-		chunkId: chunkId === null ? undefined : chunkId,
-		file
-	};
+	return decoded;
 };
 
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
@@ -188,50 +171,57 @@ class AnalyzableChunkHashPlugin {
 					 * @returns {string | null} the specifier, or `null` if unresolvable
 					 */
 					const resolve = (payload, assetName) => {
-						const decoded = readSpecifier(payload);
-						if (decoded === null) return null;
-						const { prefix, prefixKind, chunkId, file } = decoded;
-						let specifier =
-							prefixKind === "undo"
-								? getUndoPath(
-										assetName,
-										/** @type {string} */ (outputOptions.path),
-										true
-									) + /** @type {string} */ (prefix)
-								: prefixKind === "path"
-									? // Resolved whole rather than carrying a stand-in of its own, so a
-										// re-encoded digest in it is spelled by `getPath`, not by us.
-										compilation.getPath(/** @type {string} */ (prefix), {})
-									: /** @type {string} */ (prefix);
-						if (chunkId !== undefined) {
-							if (chunksById === undefined) {
-								chunksById = new Map();
-								for (const chunk of compilation.chunks) {
-									if (chunk.id !== null) {
-										chunksById.set(String(chunk.id), chunk);
+						const parts = readSpecifier(payload);
+						if (parts === null) return null;
+						let specifier = "";
+						for (const [kind, value] of parts) {
+							if (kind === "literal") {
+								specifier += value;
+							} else if (kind === "undo") {
+								specifier += getUndoPath(
+									assetName,
+									/** @type {string} */ (outputOptions.path),
+									true
+								);
+							} else if (kind === "template") {
+								specifier += compilation.getPath(
+									/** @type {string} */ (value),
+									{}
+								);
+							} else if (kind === "publicPath") {
+								specifier += compilation.getPath(
+									outputOptions.publicPath || "",
+									{}
+								);
+							} else {
+								if (chunksById === undefined) {
+									chunksById = new Map();
+									for (const chunk of compilation.chunks) {
+										if (chunk.id !== null) {
+											chunksById.set(String(chunk.id), chunk);
+										}
 									}
 								}
+								const chunk = chunksById.get(String(value));
+								if (chunk === undefined) return null;
+								specifier += compilation.getPath(
+									getJavascriptModulesPlugin().getChunkFilenameTemplate(
+										chunk,
+										outputOptions
+									),
+									// Matches what `JavascriptModulesPlugin` names the asset with, or a
+									// placeholder resolved here would not be the one on disk.
+									{
+										chunk,
+										runtime: chunk.runtime,
+										contentHashType: "javascript"
+									}
+								);
 							}
-							const chunk = chunksById.get(String(chunkId));
-							if (chunk === undefined) return null;
-							specifier += compilation.getPath(
-								getJavascriptModulesPlugin().getChunkFilenameTemplate(
-									chunk,
-									outputOptions
-								),
-								// Matches what `JavascriptModulesPlugin` names the asset with, or a
-								// placeholder resolved here would not be the one on disk.
-								{
-									chunk,
-									runtime: chunk.runtime,
-									contentHashType: "javascript"
-								}
-							);
 						}
-						specifier += file;
-						// A bare specifier is a package name, so make it explicitly relative
-						// the way the chunk loader does. A templated public path left its own
-						// stand-in in the prefix, so finish that here rather than scanning again.
+						// A bare specifier is a package name, so make it explicitly relative the way
+						// the chunk loader does. A literal part may still carry a stand-in of its own,
+						// so finish those here rather than scanning again.
 						return fillFullHash(
 							/^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(specifier)
 								? specifier

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -283,4 +283,5 @@ class AnalyzableChunkHashPlugin {
 module.exports = AnalyzableChunkHashPlugin;
 module.exports.DEFERRED_FULL_HASH_PATH_DATA = DEFERRED_FULL_HASH_PATH_DATA;
 module.exports.canDeferFullHash = canDeferFullHash;
+module.exports.readSpecifier = readSpecifier;
 module.exports.reserveSpecifier = reserveSpecifier;

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -59,6 +59,7 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
  * any spelling of it works, including a digest no stand-in of ours could carry.
  * - `"undo"` — the `../` path from the asset the reference sits in back to the output
  * root, which only that asset knows: one module can be in chunks at several depths.
+ * `prefix` follows it, for a public path named relative to that root.
  * @typedef {"path" | "undo"} PrefixKind
  */
 
@@ -196,7 +197,7 @@ class AnalyzableChunkHashPlugin {
 										assetName,
 										/** @type {string} */ (outputOptions.path),
 										true
-									)
+									) + /** @type {string} */ (prefix)
 								: prefixKind === "path"
 									? // Resolved whole rather than carrying a stand-in of its own, so a
 										// re-encoded digest in it is spelled by `getPath`, not by us.

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -64,7 +64,7 @@ class ReadFileCompileAsyncWasmPlugin {
 			 * @returns {string} the argument to hand the reader
 			 */
 			const wasmUrlArg = (path) =>
-				compilation.runtimeTemplate.supportsAnalyzableWasm()
+				compilation.runtimeTemplate.supportsAnalyzable("wasm")
 					? path
 					: compilation.runtimeTemplate.importMetaUrl(path);
 			/**
@@ -135,7 +135,7 @@ class ReadFileCompileAsyncWasmPlugin {
 					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
-						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
+						!compilation.runtimeTemplate.supportsAnalyzable("wasm") &&
 						needsRuntimeFullHash(
 							/** @type {string} */ (
 								compilation.outputOptions.webassemblyModuleFilename
@@ -172,7 +172,7 @@ class ReadFileCompileAsyncWasmPlugin {
 					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
-						!compilation.runtimeTemplate.supportsAnalyzableWasm() &&
+						!compilation.runtimeTemplate.supportsAnalyzable("wasm") &&
 						needsRuntimeFullHash(
 							/** @type {string} */ (
 								compilation.outputOptions.webassemblyModuleFilename

--- a/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
@@ -66,7 +66,7 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.compileWasm;
 		// Analyzable output bakes the binary's URL into the call site instead.
-		const analyzable = runtimeTemplate.supportsAnalyzableWasm();
+		const analyzable = runtimeTemplate.supportsAnalyzable("wasm");
 		const wasmModuleSrcPath = analyzable
 			? "wasmModuleUrl"
 			: compilation.getPath(

--- a/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
@@ -67,7 +67,7 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.instantiateWasm;
 		// Analyzable output bakes the binary's URL into the call site instead.
-		const analyzable = runtimeTemplate.supportsAnalyzableWasm();
+		const analyzable = runtimeTemplate.supportsAnalyzable("wasm");
 		const wasmModuleSrcPath = analyzable
 			? "wasmModuleUrl"
 			: compilation.getPath(

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -77,7 +77,7 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 			chunkGraph,
 			module
 		)
-			? runtimeTemplate._getAnalyzableWasmUrl(
+			? runtimeTemplate.getAnalyzableWasmUrl(
 					module,
 					chunkGraph,
 					runtime,
@@ -249,7 +249,7 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 			chunkGraph,
 			module
 		)
-			? runtimeTemplate._getAnalyzableWasmUrl(
+			? runtimeTemplate.getAnalyzableWasmUrl(
 					module,
 					chunkGraph,
 					runtime,

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -72,7 +72,8 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 			return this._generateSourcePhase(module, generateContext);
 		}
 
-		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm(
+		const analyzableUrl = runtimeTemplate.supportsAnalyzable(
+			"wasm",
 			chunkGraph,
 			module
 		)
@@ -243,7 +244,8 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 		const { chunkGraph, runtimeTemplate, runtimeRequirements, runtime } =
 			generateContext;
 
-		const analyzableUrl = runtimeTemplate.supportsAnalyzableWasm(
+		const analyzableUrl = runtimeTemplate.supportsAnalyzable(
+			"wasm",
 			chunkGraph,
 			module
 		)

--- a/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
+++ b/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
@@ -66,7 +66,7 @@ class UniversalCompileAsyncWasmPlugin {
 			// per call: it depends on parse results, so it is not settled while the plugin
 			// is being applied.
 			const wasmUrlArg = () =>
-				compilation.runtimeTemplate.supportsAnalyzableWasm()
+				compilation.runtimeTemplate.supportsAnalyzable("wasm")
 					? "wasmUrl"
 					: compilation.runtimeTemplate.importMetaUrl("wasmUrl");
 			/**

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -81,9 +81,9 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
+					const baked = compilation.runtimeTemplate.supportsAnalyzable("wasm");
 					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
+						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
 					// A baked URL carries the public path already, or asks for the global itself
 					// when the module sits at several depths.
 					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
@@ -128,9 +128,9 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const baked = compilation.runtimeTemplate.supportsAnalyzableWasm();
+					const baked = compilation.runtimeTemplate.supportsAnalyzable("wasm");
 					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
+						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
 					// A baked URL carries the public path already, or asks for the global itself
 					// when the module sits at several depths.
 					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -77,6 +77,14 @@ class FetchCompileWasmPlugin {
 			 */
 			const generateAnalyzableLoadBinaryCode = (path) =>
 				`fetch(${compilation.runtimeTemplate.importMetaUrl(path)})`;
+			/**
+			 * A public path that never changes is the same string the global would hold,
+			 * so it is inlined and the runtime module that sets it is not needed.
+			 * @param {string} constant the settled public path
+			 * @returns {(path: string) => string} code to load the wasm file
+			 */
+			const generateConstantLoadBinaryCode = (constant) => (path) =>
+				`fetch(${JSON.stringify(constant)} + ${path})`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunkHandlers)
@@ -93,7 +101,12 @@ class FetchCompileWasmPlugin {
 					set.add(RuntimeGlobals.moduleCache);
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
-					if (!analyzable) set.add(RuntimeGlobals.publicPath);
+					const constant = analyzable
+						? undefined
+						: compilation.runtimeTemplate.constantPublicPath();
+					if (!analyzable && constant === undefined) {
+						set.add(RuntimeGlobals.publicPath);
+					}
 					if (
 						needsRuntimeFullHash(
 							/** @type {string} */ (
@@ -113,7 +126,9 @@ class FetchCompileWasmPlugin {
 							),
 							generateLoadBinaryCode: analyzable
 								? generateAnalyzableLoadBinaryCode
-								: generateLoadBinaryCode,
+								: constant === undefined
+									? generateLoadBinaryCode
+									: generateConstantLoadBinaryCode(constant),
 							supportsStreaming: true,
 							mangleImports: this.options.mangleImports,
 							runtimeRequirements: set

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -100,7 +100,7 @@ class FetchCompileWasmPlugin {
 					}
 					set.add(RuntimeGlobals.moduleCache);
 					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzableEsmUrl();
+						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
 					const constant = analyzable
 						? undefined
 						: compilation.runtimeTemplate.constantPublicPath();

--- a/test/AnalyzableChunkHashPlugin.unittest.js
+++ b/test/AnalyzableChunkHashPlugin.unittest.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const {
+	canDeferFullHash,
+	reserveSpecifier
+} = require("../lib/esm/AnalyzableChunkHashPlugin");
+
+describe("AnalyzableChunkHashPlugin", () => {
+	describe("reserveSpecifier", () => {
+		// The stand-in sits in javascript source and is matched by `[\w-]+`, so anything
+		// outside the url-safe alphabet would end the token early and reach the bundle.
+		it("should encode a payload in the url-safe alphabet only", () => {
+			const specifier = reserveSpecifier([
+				["literal", "../a+b/c?d=e&f/"],
+				["undo", ""],
+				["template", "https://cdn.test/[fullhash:base64safe]/"],
+				["publicPath", ""],
+				["chunk", "ü-chunk/name"]
+			]);
+
+			expect(specifier).toMatch(/^\.\/@@webpackAnalyzableChunk:[\w-]+@@$/);
+		});
+
+		it("should look like a relative specifier, so nothing special-cases it", () => {
+			expect(reserveSpecifier([["chunk", 0]]).startsWith("./")).toBe(true);
+		});
+
+		it("should carry a numeric chunk id apart from the same digits as a string", () => {
+			expect(reserveSpecifier([["chunk", 12]])).not.toBe(
+				reserveSpecifier([["chunk", "12"]])
+			);
+		});
+	});
+
+	describe("canDeferFullHash", () => {
+		it("should accept a hash read as it is stored", () => {
+			for (const template of [
+				"[name].js",
+				"[name].[fullhash].js",
+				"[name].[fullhash:8].js",
+				"[name].[contenthash:base64:8].js"
+			]) {
+				expect([template, canDeferFullHash(template)]).toEqual([
+					template,
+					true
+				]);
+			}
+		});
+
+		it("should refuse one that re-encodes it to another digest", () => {
+			for (const template of [
+				"[name].[fullhash:base64].js",
+				"[name].[fullhash:base64safe].js",
+				"[name].[hash:base36].js"
+			]) {
+				expect([template, canDeferFullHash(template)]).toEqual([
+					template,
+					false
+				]);
+			}
+		});
+	});
+});

--- a/test/AnalyzableChunkHashPlugin.unittest.js
+++ b/test/AnalyzableChunkHashPlugin.unittest.js
@@ -1,9 +1,38 @@
 "use strict";
 
 const {
+	DEFERRED_FULL_HASH_PATH_DATA,
 	canDeferFullHash,
+	readSpecifier,
 	reserveSpecifier
 } = require("../lib/esm/AnalyzableChunkHashPlugin");
+const lookalikes = require("./configCases/analyzable/stand-in-lookalike/lookalikes.json");
+
+const PAYLOAD_REGEXP = /^\.\/@@webpackAnalyzableChunk:([\w-]+)@@$/;
+
+// Stands for a payload that is not json at all — its bytes are not printable, and a
+// snapshot of them would make git treat this file as binary.
+const NOT_JSON = Symbol("not json");
+
+/**
+ * @param {string} specifier a reserved stand-in
+ * @returns {string} its encoded half
+ */
+const payloadOf = (specifier) => {
+	const match = PAYLOAD_REGEXP.exec(specifier);
+	if (!match) throw new Error(`Not a stand-in: ${specifier}`);
+	return match[1];
+};
+
+/**
+ * @param {string} payload the encoded half of a stand-in
+ * @returns {string} what it spells
+ */
+const decode = (payload) =>
+	Buffer.from(
+		payload.replace(/-/g, "+").replace(/_/g, "/"),
+		"base64"
+	).toString();
 
 describe("AnalyzableChunkHashPlugin", () => {
 	describe("reserveSpecifier", () => {
@@ -29,6 +58,66 @@ describe("AnalyzableChunkHashPlugin", () => {
 			expect(reserveSpecifier([["chunk", 12]])).not.toBe(
 				reserveSpecifier([["chunk", "12"]])
 			);
+		});
+	});
+
+	describe("readSpecifier", () => {
+		it("should read back every part kind as it was reserved", () => {
+			/** @type {import("../lib/esm/AnalyzableChunkHashPlugin").SpecifierPart[]} */
+			const parts = [
+				["undo", "assets/"],
+				["publicPath", ""],
+				["template", "[fullhash]/"],
+				["literal", "../a+b/c?d=e&f/"],
+				["chunk", 12]
+			];
+
+			expect(readSpecifier(payloadOf(reserveSpecifier(parts)))).toEqual(parts);
+		});
+
+		it("should read an empty part list, which resolves to an empty name", () => {
+			expect(readSpecifier(payloadOf(reserveSpecifier([])))).toEqual([]);
+		});
+
+		// Source of our own can spell the token, so every shape it does not produce has
+		// to be refused rather than reached for — each one would throw further in.
+		it("should refuse a payload it did not produce", () => {
+			for (const [name, specifier] of Object.entries(lookalikes)) {
+				// `unknownChunk` is well-formed: it is refused later, by chunk lookup.
+				const expected = name === "unknownChunk" ? "read" : "refused";
+				const read = readSpecifier(payloadOf(specifier));
+				expect([name, read === null ? "refused" : "read"]).toEqual([
+					name,
+					expected
+				]);
+			}
+		});
+
+		// The case drives these through a real build, which cannot state what they mean.
+		// Naming each one here keeps a payload-format change from leaving it testing
+		// nothing: a blob that stopped spelling its own name would still reach the bundle.
+		it("should carry the shape each lookalike is named for", () => {
+			/** @type {Record<string, unknown>} */
+			const decoded = {};
+			for (const [name, specifier] of Object.entries(lookalikes)) {
+				try {
+					decoded[name] = JSON.parse(decode(payloadOf(specifier)));
+				} catch (_error) {
+					decoded[name] = NOT_JSON;
+				}
+			}
+
+			expect(decoded).toEqual({
+				notJson: NOT_JSON,
+				notArray: { a: 1 },
+				notTuples: ["literal", "x"],
+				wrongLength: [["literal"]],
+				unknownKind: [["nonsense", "x"]],
+				wrongValueType: [["literal", { a: 1 }]],
+				numericTemplate: [["template", 0]],
+				numericLiteral: [["literal", 7]],
+				unknownChunk: [["chunk", "no-such-chunk-id"]]
+			});
 		});
 	});
 
@@ -58,6 +147,23 @@ describe("AnalyzableChunkHashPlugin", () => {
 					false
 				]);
 			}
+		});
+	});
+
+	describe("DEFERRED_FULL_HASH_PATH_DATA", () => {
+		// `TemplatedPathPlugin` reads `hash` for `[fullhash]` and calls `hashWithLength`
+		// for `[fullhash:n]`, so both have to spell a stand-in the fill pass matches.
+		it("should stand in for the compilation hash at any length", () => {
+			expect(DEFERRED_FULL_HASH_PATH_DATA.hash).toBe("@@webpackFullHash@@");
+			expect(DEFERRED_FULL_HASH_PATH_DATA.hashWithLength(8)).toBe(
+				"@@webpackFullHash-8@@"
+			);
+		});
+
+		it("should close over nothing, so one object serves every asset", () => {
+			expect(DEFERRED_FULL_HASH_PATH_DATA.hashWithLength(8)).toBe(
+				DEFERRED_FULL_HASH_PATH_DATA.hashWithLength(8)
+			);
 		});
 	});
 });

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -288,6 +288,11 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 		);
 
 	/** Places the module in no chunk, so no runtime reassigns the public path. */
+	/** Stands for the module the reference is emitted into; no field is read. */
+	const module = /** @type {import("../lib/Module")} */ (
+		/** @type {unknown} */ ({})
+	);
+
 	const chunkGraph = /** @type {import("../lib/ChunkGraph")} */ (
 		/** @type {unknown} */ ({ getModuleChunksIterable: () => [] })
 	);
@@ -299,9 +304,9 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 		const doesNot = create(false);
 
 		expect({
-			readsImport: reads.supportsAnalyzable("import", chunkGraph, {}),
+			readsImport: reads.supportsAnalyzable("import", chunkGraph, module),
 			readsUrl: reads.supportsAnalyzable("url"),
-			doesNotImport: doesNot.supportsAnalyzable("import", chunkGraph, {}),
+			doesNotImport: doesNot.supportsAnalyzable("import", chunkGraph, module),
 			doesNotUrl: doesNot.supportsAnalyzable("url")
 		}).toEqual({
 			readsImport: true,

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -257,3 +257,57 @@ describe("RuntimeTemplate.assignOr", () => {
 		);
 	});
 });
+
+describe("RuntimeTemplate.supportsAnalyzable", () => {
+	/**
+	 * @param {boolean} environmentModule whether the target reads ESM syntax
+	 * @returns {RuntimeTemplate} runtime template
+	 */
+	const create = (environmentModule) =>
+		new RuntimeTemplate(
+			/** @type {import("../lib/Compilation")} */ (
+				/** @type {unknown} */ ({
+					options: { devtool: false },
+					chunks: [],
+					modules: [],
+					moduleGraph: { getOptimizationBailout: () => [] }
+				})
+			),
+			/** @type {OutputOptions} */ (
+				/** @type {unknown} */ ({
+					module: true,
+					chunkFormat: "module",
+					importFunctionName: "import",
+					publicPath: "auto",
+					globalObject: "self",
+					hashDigestLength: 20,
+					environment: { module: environmentModule }
+				})
+			),
+			new RequestShortener(__dirname)
+		);
+
+	/** Places the module in no chunk, so no runtime reassigns the public path. */
+	const chunkGraph = /** @type {import("../lib/ChunkGraph")} */ (
+		/** @type {unknown} */ ({ getModuleChunksIterable: () => [] })
+	);
+
+	// A chunk `import()` is emitted by the module chunk loader whatever the target
+	// reads; `import.meta` in a url is syntax the target has to read itself.
+	it("should ask for ESM syntax only where the reference spells it", () => {
+		const reads = create(true);
+		const doesNot = create(false);
+
+		expect({
+			readsImport: reads.supportsAnalyzable("import", chunkGraph, {}),
+			readsUrl: reads.supportsAnalyzable("url"),
+			doesNotImport: doesNot.supportsAnalyzable("import", chunkGraph, {}),
+			doesNotUrl: doesNot.supportsAnalyzable("url")
+		}).toEqual({
+			readsImport: true,
+			readsUrl: true,
+			doesNotImport: true,
+			doesNotUrl: false
+		});
+	});
+});

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -259,18 +259,30 @@ describe("RuntimeTemplate.assignOr", () => {
 });
 
 describe("RuntimeTemplate.supportsAnalyzable", () => {
+	/** @typedef {import("../lib/ChunkGraph")} ChunkGraph */
+	/** @typedef {import("../lib/Chunk")} Chunk */
+	/** @typedef {import("../lib/Compilation")} Compilation */
+	/** @typedef {import("../lib/Module")} Module */
+
+	/** Stands for the module a reference is emitted into; no field of it is read. */
+	const module = /** @type {Module} */ (/** @type {unknown} */ ({}));
+
 	/**
-	 * @param {boolean} environmentModule whether the target reads ESM syntax
+	 * @param {object} options overrides
+	 * @param {Record<string, EXPECTED_ANY>=} options.output `output` overrides
+	 * @param {(string | false)=} options.devtool the configured devtool
+	 * @param {EXPECTED_ANY[]=} options.chunks the compilation's chunks
+	 * @param {string[]=} options.bailouts collects the recorded bailout reasons
 	 * @returns {RuntimeTemplate} runtime template
 	 */
-	const create = (environmentModule) =>
+	const create = ({ output, devtool = false, chunks = [], bailouts = [] }) =>
 		new RuntimeTemplate(
-			/** @type {import("../lib/Compilation")} */ (
+			/** @type {Compilation} */ (
 				/** @type {unknown} */ ({
-					options: { devtool: false },
-					chunks: [],
+					options: { devtool, optimization: { realContentHash: true } },
+					chunks,
 					modules: [],
-					moduleGraph: { getOptimizationBailout: () => [] }
+					moduleGraph: { getOptimizationBailout: () => bailouts }
 				})
 			),
 			/** @type {OutputOptions} */ (
@@ -279,29 +291,68 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 					chunkFormat: "module",
 					importFunctionName: "import",
 					publicPath: "auto",
+					webassemblyModuleFilename: "[hash].module.wasm",
 					globalObject: "self",
 					hashDigestLength: 20,
-					environment: { module: environmentModule }
+					environment: { module: true },
+					...output
 				})
 			),
 			new RequestShortener(__dirname)
 		);
 
-	/** Places the module in no chunk, so no runtime reassigns the public path. */
-	/** Stands for the module the reference is emitted into; no field is read. */
-	const module = /** @type {import("../lib/Module")} */ (
-		/** @type {unknown} */ ({})
-	);
+	/**
+	 * @param {EXPECTED_ANY[]=} chunksOfModule chunks the module is placed in
+	 * @returns {{ chunkGraph: ChunkGraph, reads: () => number }} a counting chunk graph
+	 */
+	const countingChunkGraph = (chunksOfModule = []) => {
+		let reads = 0;
+		const chunkGraph = /** @type {ChunkGraph} */ (
+			/** @type {unknown} */ ({
+				getModuleChunksIterable: () => {
+					reads++;
+					return chunksOfModule;
+				},
+				getModuleRuntimes: () => {
+					reads++;
+					return [];
+				}
+			})
+		);
+		return { chunkGraph, reads: () => reads };
+	};
 
-	const chunkGraph = /** @type {import("../lib/ChunkGraph")} */ (
-		/** @type {unknown} */ ({ getModuleChunksIterable: () => [] })
-	);
+	/**
+	 * @param {string | undefined} chunkLoading how this worker entry loads chunks
+	 * @returns {EXPECTED_ANY} a chunk standing for a worker entry
+	 */
+	const workerChunk = (chunkLoading) => ({
+		getEntryOptions: () => ({ worker: true, chunkLoading })
+	});
+
+	it("should refuse every form unless the build emits ESM", () => {
+		const template = create({ output: { module: false } });
+		const { chunkGraph } = countingChunkGraph();
+
+		expect({
+			import: template.supportsAnalyzable("import", chunkGraph, module),
+			url: template.supportsAnalyzable("url", chunkGraph, module),
+			wasm: template.supportsAnalyzable("wasm"),
+			wasmRelative: template.supportsAnalyzable("wasm-relative")
+		}).toEqual({
+			import: false,
+			url: false,
+			wasm: false,
+			wasmRelative: false
+		});
+	});
 
 	// A chunk `import()` is emitted by the module chunk loader whatever the target
 	// reads; `import.meta` in a url is syntax the target has to read itself.
 	it("should ask for ESM syntax only where the reference spells it", () => {
-		const reads = create(true);
-		const doesNot = create(false);
+		const reads = create({});
+		const doesNot = create({ output: { environment: { module: false } } });
+		const { chunkGraph } = countingChunkGraph();
 
 		expect({
 			readsImport: reads.supportsAnalyzable("import", chunkGraph, module),
@@ -314,5 +365,134 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 			doesNotImport: true,
 			doesNotUrl: false
 		});
+	});
+
+	// The literal replaces `__webpack_require__.e`, which only a native `import()`
+	// chunk loader is interchangeable with.
+	it("should refuse an import the chunk loader would not spell", () => {
+		const { chunkGraph } = countingChunkGraph();
+
+		expect({
+			array: create({
+				output: { chunkFormat: "array-push" }
+			}).supportsAnalyzable("import", chunkGraph, module),
+			renamed: create({
+				output: { importFunctionName: "__webpack_import__" }
+			}).supportsAnalyzable("import", chunkGraph, module),
+			both: create({}).supportsAnalyzable("import", chunkGraph, module)
+		}).toEqual({ array: false, renamed: false, both: true });
+	});
+
+	// A worker on its own chunk loader keeps that runtime; one on `import` shares the
+	// ESM loader with the main graph, so the literal reaches the same chunk.
+	it("should follow a worker entry's own chunk loading", () => {
+		const cases = {
+			importWorker: workerChunk("import"),
+			jsonpWorker: workerChunk("jsonp"),
+			nodeWorker: workerChunk("async-node")
+		};
+		/** @type {Record<string, boolean>} */
+		const answers = {};
+		for (const [name, chunk] of Object.entries(cases)) {
+			const { chunkGraph } = countingChunkGraph([chunk]);
+			answers[name] = create({}).supportsAnalyzable(
+				"import",
+				chunkGraph,
+				module
+			);
+		}
+
+		expect(answers).toEqual({
+			importWorker: true,
+			jsonpWorker: false,
+			nodeWorker: false
+		});
+	});
+
+	// A non-worker entry carries `chunkLoading` too, and it is not the worker's.
+	it("should ignore chunk loading on an entry that is not a worker", () => {
+		const { chunkGraph } = countingChunkGraph([
+			{ getEntryOptions: () => ({ chunkLoading: "jsonp" }) },
+			{ getEntryOptions: () => undefined }
+		]);
+
+		expect(create({}).supportsAnalyzable("import", chunkGraph, module)).toBe(
+			true
+		);
+	});
+
+	// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a syntax
+	// error — but a literal `import()` parses inside it unharmed.
+	it("should keep import but drop url under an eval devtool", () => {
+		const template = create({ devtool: "eval-cheap-source-map" });
+		const { chunkGraph } = countingChunkGraph();
+
+		expect({
+			import: template.supportsAnalyzable("import", chunkGraph, module),
+			url: template.supportsAnalyzable("url", chunkGraph, module)
+		}).toEqual({ import: true, url: false });
+	});
+
+	// Build-time execution runs the module in a vm wrapper that does not parse
+	// `import.meta`; without a chunk graph there is no such wrapper to worry about.
+	it("should drop a url under build-time execution only", () => {
+		const template = create({});
+		const buildTime = /** @type {ChunkGraph} */ (
+			/** @type {unknown} */ ({ buildTimeExecution: true })
+		);
+
+		expect({
+			buildTime: template.supportsAnalyzable("url", buildTime, module),
+			noGraph: template.supportsAnalyzable("url", undefined, module)
+		}).toEqual({ buildTime: false, noGraph: true });
+	});
+
+	// A bare relative url is what `__webpack_require__.p + path` means only under an
+	// `auto` public path; anything else has to be baked whole instead.
+	it("should allow a relative wasm path only under an auto public path", () => {
+		expect({
+			auto: create({}).supportsAnalyzable("wasm-relative"),
+			rooted: create({
+				output: { publicPath: "/static/" }
+			}).supportsAnalyzable("wasm-relative"),
+			url: create({
+				output: { publicPath: "https://cdn.test/" }
+			}).supportsAnalyzable("wasm-relative")
+		}).toEqual({ auto: true, rooted: false, url: false });
+	});
+
+	// A wasm loader is emitted once per runtime, so its answer cannot depend on where
+	// one module sits. That the two wasm forms therefore skip the chunk graph is not
+	// unit-testable — the decision short-circuits before reading it unless a real
+	// build registered a `__webpack_public_path__` reassignment — so the case that
+	// pins it is configCases/wasm/analyzable-runtime-scope.
+	it("should walk the origin module's chunks once for an import", () => {
+		const { chunkGraph, reads } = countingChunkGraph();
+		create({}).supportsAnalyzable("import", chunkGraph, module);
+
+		expect(reads()).toBe(1);
+	});
+
+	// `stats.optimizationBailout` is the channel this reports through, and one module
+	// may write many references that bail for the same reason.
+	it("should record each distinct bailout reason once", () => {
+		/** @type {string[]} */
+		const bailouts = [];
+		const template = create({ devtool: "eval", bailouts });
+		template.supportsAnalyzable("url", undefined, module);
+		template.supportsAnalyzable("url", undefined, module);
+
+		expect(bailouts).toEqual([
+			'Analyzable ESM bailout: devtool "eval" wraps the module in eval(), where import.meta does not parse'
+		]);
+	});
+
+	// Nothing to report against, and reporting is silent outside ESM output anyway.
+	it("should record nothing without a module to hang it on", () => {
+		/** @type {string[]} */
+		const bailouts = [];
+		create({ devtool: "eval", bailouts }).supportsAnalyzable("url");
+
+		expect(bailouts).toEqual([]);
 	});
 });

--- a/test/configCases/analyzable/asset-url-base-uri/asset.txt
+++ b/test/configCases/analyzable/asset-url-base-uri/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-base-uri/index.js
+++ b/test/configCases/analyzable/asset-url-base-uri/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+export const url = new URL("./asset.txt", import.meta.url);
+
+it("should resolve the asset against the entry's baseUri", () => {
+	expect(url.href).toBe("https://example.com/base/asset.txt");
+});
+
+it("should keep the runtime form so the base is the one the runtime knows", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+	// Needle built at runtime so it is not a source string literal here.
+	const baked = `${"/* asset"} import */ "`;
+
+	expect(bundle).not.toContain(baked);
+	expect(bundle).toContain(`${"__webpack_require__"}.b`);
+});

--- a/test/configCases/analyzable/asset-url-base-uri/index.js
+++ b/test/configCases/analyzable/asset-url-base-uri/index.js
@@ -1,20 +1,25 @@
 import fs from "fs";
 import path from "path";
+import { url } from "./shared";
 
-export const url = new URL("./asset.txt", import.meta.url);
+const stats = __STATS__.children[__BAKED__ ? 0 : 1];
+const bundle = () =>
+	fs.readFileSync(path.join(stats.outputPath, __BUNDLE__), "utf8");
+// Needle built at runtime so it is not a source string literal here.
+const baked = `${"/* asset"} import */ "`;
 
 it("should resolve the asset against the entry's baseUri", () => {
-	expect(url.href).toBe("https://example.com/base/asset.txt");
+	expect(url.href).toBe(`${__BASE__}asset.txt`);
 });
 
-it("should keep the runtime form so the base is the one the runtime knows", () => {
-	const bundle = fs.readFileSync(
-		path.join(__STATS__.outputPath, "bundle0.mjs"),
-		"utf8"
-	);
-	// Needle built at runtime so it is not a source string literal here.
-	const baked = `${"/* asset"} import */ "`;
-
-	expect(bundle).not.toContain(baked);
-	expect(bundle).toContain(`${"__webpack_require__"}.b`);
-});
+if (__BAKED__) {
+	it("should settle the whole url here, base and all", () => {
+		expect(bundle()).toContain(`${baked}${__BASE__}asset.txt"`);
+		expect(bundle()).not.toContain(`${"__webpack_require__"}.b`);
+	});
+} else {
+	it("should keep the runtime form when the entries disagree on the base", () => {
+		expect(bundle()).not.toContain(baked);
+		expect(bundle()).toContain(`${"__webpack_require__"}.b`);
+	});
+}

--- a/test/configCases/analyzable/asset-url-base-uri/index.js
+++ b/test/configCases/analyzable/asset-url-base-uri/index.js
@@ -2,9 +2,9 @@ import fs from "fs";
 import path from "path";
 import { url } from "./shared";
 
-const stats = __STATS__.children[__BAKED__ ? 0 : 1];
-const bundle = () =>
-	fs.readFileSync(path.join(stats.outputPath, __BUNDLE__), "utf8");
+const stats = __STATS__.children[__INDEX__];
+const read = (name) =>
+	fs.readFileSync(path.join(stats.outputPath, `${__PREFIX__}-${name}.mjs`), "utf8");
 // Needle built at runtime so it is not a source string literal here.
 const baked = `${"/* asset"} import */ "`;
 
@@ -14,12 +14,16 @@ it("should resolve the asset against the entry's baseUri", () => {
 
 if (__BAKED__) {
 	it("should settle the whole url here, base and all", () => {
-		expect(bundle()).toContain(`${baked}${__BASE__}asset.txt"`);
-		expect(bundle()).not.toContain(`${"__webpack_require__"}.b`);
+		expect(read("main")).toContain(`${baked}${__BASE__}asset.txt"`);
+		expect(read("main")).not.toContain(`${"__webpack_require__"}.b`);
 	});
 } else {
 	it("should keep the runtime form when the entries disagree on the base", () => {
-		expect(bundle()).not.toContain(baked);
-		expect(bundle()).toContain(`${"__webpack_require__"}.b`);
+		// Read the other entry too: this one's own base is the one that would be baked,
+		// so only the entry that disagrees shows a wrong literal.
+		for (const source of [read("main"), read("other")]) {
+			expect(source).not.toContain(baked);
+			expect(source).toContain(`${"__webpack_require__"}.b`);
+		}
 	});
 }

--- a/test/configCases/analyzable/asset-url-base-uri/other.js
+++ b/test/configCases/analyzable/asset-url-base-uri/other.js
@@ -1,0 +1,3 @@
+import { url } from "./shared";
+
+export default url;

--- a/test/configCases/analyzable/asset-url-base-uri/shared.js
+++ b/test/configCases/analyzable/asset-url-base-uri/shared.js
@@ -1,0 +1,1 @@
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-base-uri/test.config.js
+++ b/test/configCases/analyzable/asset-url-base-uri/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(index) {
+		return index === 0 ? "./bundle0.mjs" : "./main.mjs";
+	}
+};

--- a/test/configCases/analyzable/asset-url-base-uri/test.config.js
+++ b/test/configCases/analyzable/asset-url-base-uri/test.config.js
@@ -2,6 +2,6 @@
 
 module.exports = {
 	findBundle(index) {
-		return index === 0 ? "./bundle0.mjs" : "./main.mjs";
+		return `./${["a", "b", "c"][index]}-main.mjs`;
 	}
 };

--- a/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
@@ -1,21 +1,21 @@
 "use strict";
 
-// `baseUri` replaces the output root the runtime resolves an asset url against. Only a
-// public path that needs a base ever reaches it, hence the empty one here — and only
-// one base every entry agrees on settles the url, since the module is generated once.
+// `baseUri` replaces the output root an asset url resolves against, and only a public
+// path that needs a base ever reaches it — hence the empty one here. The module is
+// generated once, so only a base every entry agrees on can be settled into it.
 
 const webpack = require("../../../../");
 
 const BASE = "https://example.com/base/";
 
 /**
- * @param {string} filename the `output.filename` template
- * @param {string} read the emitted file `index.js` reads back
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} prefix keeping the emitted files of each config apart
  * @param {import("../../../../").Configuration["entry"]} entry the entries under test
  * @param {boolean} baked whether the url is expected to be a literal
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (filename, read, entry, baked) => ({
+const base = (index, prefix, entry, baked) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -23,7 +23,7 @@ const base = (filename, read, entry, baked) => ({
 	experiments: { outputModule: true },
 	output: {
 		module: true,
-		filename,
+		filename: `${prefix}-[name].mjs`,
 		library: { type: "module" },
 		publicPath: "",
 		assetModuleFilename: "[name][ext]"
@@ -33,7 +33,8 @@ const base = (filename, read, entry, baked) => ({
 	},
 	plugins: [
 		new webpack.DefinePlugin({
-			__BUNDLE__: JSON.stringify(read),
+			__INDEX__: JSON.stringify(index),
+			__PREFIX__: JSON.stringify(prefix),
 			__BASE__: JSON.stringify(BASE),
 			__BAKED__: JSON.stringify(baked)
 		})
@@ -42,19 +43,24 @@ const base = (filename, read, entry, baked) => ({
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
+	base(0, "a", { main: { import: "./index.js", baseUri: BASE } }, true),
+	// Two bases leave the module they share none to bake against.
 	base(
-		"bundle0.mjs",
-		"bundle0.mjs",
-		{ main: { import: "./index.js", baseUri: BASE } },
-		true
-	),
-	// The shared module is generated once, so two bases leave it none to bake against.
-	base(
-		"[name].mjs",
-		"main.mjs",
+		1,
+		"b",
 		{
 			main: { import: "./index.js", baseUri: BASE },
 			other: { import: "./other.js", baseUri: "https://other.example.com/" }
+		},
+		false
+	),
+	// An entry that sets none disagrees just the same: it resolves against the root.
+	base(
+		2,
+		"c",
+		{
+			main: { import: "./index.js", baseUri: BASE },
+			other: { import: "./other.js" }
 		},
 		false
 	)

--- a/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
@@ -1,25 +1,61 @@
 "use strict";
 
-// `baseUri` replaces the output root the runtime resolves an asset url against, and a
-// literal read from its own chunk cannot share that base — so the runtime form stays.
-// Only a public path that needs a base reaches it, hence the empty one here.
+// `baseUri` replaces the output root the runtime resolves an asset url against. Only a
+// public path that needs a base ever reaches it, hence the empty one here — and only
+// one base every entry agrees on settles the url, since the module is generated once.
 
-/** @type {import("../../../../").Configuration} */
-module.exports = {
+const webpack = require("../../../../");
+
+const BASE = "https://example.com/base/";
+
+/**
+ * @param {string} filename the `output.filename` template
+ * @param {string} read the emitted file `index.js` reads back
+ * @param {import("../../../../").Configuration["entry"]} entry the entries under test
+ * @param {boolean} baked whether the url is expected to be a literal
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (filename, read, entry, baked) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
-	entry: {
-		main: { import: "./index.js", baseUri: "https://example.com/base/" }
-	},
+	entry,
 	experiments: { outputModule: true },
 	output: {
 		module: true,
+		filename,
 		library: { type: "module" },
 		publicPath: "",
 		assetModuleFilename: "[name][ext]"
 	},
 	module: {
 		rules: [{ test: /\.txt$/, type: "asset/resource" }]
-	}
-};
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__BUNDLE__: JSON.stringify(read),
+			__BASE__: JSON.stringify(BASE),
+			__BAKED__: JSON.stringify(baked)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(
+		"bundle0.mjs",
+		"bundle0.mjs",
+		{ main: { import: "./index.js", baseUri: BASE } },
+		true
+	),
+	// The shared module is generated once, so two bases leave it none to bake against.
+	base(
+		"[name].mjs",
+		"main.mjs",
+		{
+			main: { import: "./index.js", baseUri: BASE },
+			other: { import: "./other.js", baseUri: "https://other.example.com/" }
+		},
+		false
+	)
+];

--- a/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-base-uri/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// `baseUri` replaces the output root the runtime resolves an asset url against, and a
+// literal read from its own chunk cannot share that base — so the runtime form stays.
+// Only a public path that needs a base reaches it, hence the empty one here.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: {
+		main: { import: "./index.js", baseUri: "https://example.com/base/" }
+	},
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		library: { type: "module" },
+		publicPath: "",
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	}
+};

--- a/test/configCases/analyzable/asset-url-function-public-path/asset.txt
+++ b/test/configCases/analyzable/asset-url-function-public-path/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-function-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-function-public-path/index.js
@@ -14,8 +14,13 @@ it("should keep the asset referenced", () => {
 
 if (__BAKED__) {
 	it("should bake the value the function returns", () => {
-		expect(bundle()).toContain(
-			'/* asset import */ "https://cdn.example.com/asset.txt"'
+		const specifier = bundle().match(
+			/asset import \*\/ "(https:\/\/cdn\.example\.com\/[^"]+)"/
+		);
+
+		expect(specifier).not.toBe(null);
+		expect(specifier[1]).toBe(
+			`https://cdn.example.com/${__HASHED__ ? `${stats.hash}/` : ""}asset.txt`
 		);
 		expect(bundle()).not.toContain(`${"__webpack_require__"}.b`);
 	});

--- a/test/configCases/analyzable/asset-url-function-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-function-public-path/index.js
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+// Never dereferenced — the harness cannot fetch an absolute CDN url.
+export const url = new URL("./asset.txt", import.meta.url);
+
+const stats = __STATS__.children[__INDEX__];
+const bundle = () =>
+	fs.readFileSync(path.join(stats.outputPath, `bundle${__INDEX__}.mjs`), "utf8");
+
+it("should keep the asset referenced", () => {
+	expect(typeof url).toBe("object");
+});
+
+if (__BAKED__) {
+	it("should bake the value the function returns", () => {
+		expect(bundle()).toContain(
+			'/* asset import */ "https://cdn.example.com/asset.txt"'
+		);
+		expect(bundle()).not.toContain(`${"__webpack_require__"}.b`);
+	});
+} else {
+	it("should keep the runtime form when the value moves with the hash", () => {
+		expect(bundle()).not.toMatch(/\/\* asset import \*\/ "https:/);
+		expect(bundle()).toContain(`${"__webpack_require__"}.b`);
+	});
+}

--- a/test/configCases/analyzable/asset-url-function-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-function-public-path/webpack.config.js
@@ -9,9 +9,10 @@ const webpack = require("../../../../");
  * @param {number} index position of this config, so `index.js` finds its own stats
  * @param {NonNullable<import("../../../../").Configuration["output"]>["publicPath"]} publicPath the public path under test
  * @param {boolean} baked whether the specifier is expected to be a literal
+ * @param {boolean=} hashed whether the value it bakes carries the compilation hash
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, publicPath, baked) => ({
+const base = (index, publicPath, baked, hashed = false) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -29,7 +30,8 @@ const base = (index, publicPath, baked) => ({
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
-			__BAKED__: JSON.stringify(baked)
+			__BAKED__: JSON.stringify(baked),
+			__HASHED__: JSON.stringify(hashed)
 		})
 	]
 });
@@ -43,8 +45,14 @@ module.exports = [
 		(pathData) => (pathData.hash ? "https://cdn.example.com/" : ""),
 		true
 	),
-	// This one moves with a hash code generation does not have yet.
-	base(2, (pathData) => `https://cdn.example.com/${pathData.hash}/`, false),
+	// This one moves with a hash code generation does not have yet, so the deferred
+	// pass calls it again once that hash exists.
+	base(
+		2,
+		(pathData) => `https://cdn.example.com/${pathData.hash}/`,
+		true,
+		true
+	),
 	// Probing must never fail a build the real naming call would have completed, so
 	// one that throws on the two stand-in hashes still builds and keeps its runtime.
 	base(

--- a/test/configCases/analyzable/asset-url-function-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-function-public-path/webpack.config.js
@@ -1,0 +1,62 @@
+"use strict";
+
+// A function public path is called for its value rather than read as a template, so
+// it is baked only where that value does not move with the compilation hash.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {NonNullable<import("../../../../").Configuration["output"]>["publicPath"]} publicPath the public path under test
+ * @param {boolean} baked whether the specifier is expected to be a literal
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, publicPath, baked) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		library: { type: "module" },
+		publicPath,
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__BAKED__: JSON.stringify(baked)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, () => "https://cdn.example.com/", true),
+	// The same answer whatever the hash is, so it is still bakeable.
+	base(
+		1,
+		(pathData) => (pathData.hash ? "https://cdn.example.com/" : ""),
+		true
+	),
+	// This one moves with a hash code generation does not have yet.
+	base(2, (pathData) => `https://cdn.example.com/${pathData.hash}/`, false),
+	// Probing must never fail a build the real naming call would have completed, so
+	// one that throws on the two stand-in hashes still builds and keeps its runtime.
+	base(
+		3,
+		(pathData) => {
+			if (
+				/^(?:0123456789|3210fedcba)/.test(/** @type {string} */ (pathData.hash))
+			) {
+				throw new Error("probed");
+			}
+			return "https://cdn.example.com/";
+		},
+		false
+	)
+];

--- a/test/configCases/analyzable/asset-url-matrix/asset.txt
+++ b/test/configCases/analyzable/asset-url-matrix/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-matrix/deep.js
+++ b/test/configCases/analyzable/asset-url-matrix/deep.js
@@ -1,0 +1,1 @@
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-matrix/flat.js
+++ b/test/configCases/analyzable/asset-url-matrix/flat.js
@@ -1,0 +1,1 @@
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-matrix/index.js
+++ b/test/configCases/analyzable/asset-url-matrix/index.js
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced so both chunks exist; the baked specifier is what is under test.
+const flat = () => import(/* webpackChunkName: "flat" */ "./flat");
+const deep = () => import(/* webpackChunkName: "nested/deep" */ "./deep");
+
+const stats = __STATS__.children[__INDEX__];
+const specifier = (name) =>
+	fs
+		.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8")
+		.match(/asset import \*\/ "([^"]+)"/)[1];
+
+it("should keep both chunks referenced", () => {
+	expect(typeof flat).toBe("function");
+	expect(typeof deep).toBe("function");
+});
+
+it("should bake what each depth needs", () => {
+	expect(specifier("flat.mjs")).toBe(__ROOT__);
+	expect(specifier("nested/deep.mjs")).toBe(__DEEP__);
+});

--- a/test/configCases/analyzable/asset-url-matrix/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-matrix/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// The same asset reference, read from chunks at two depths, under every shape a public
-// path comes in. Both have to name the same file — the runtime resolves a public path
-// against the output root, so one that needs a base is walked back there first and one
-// that reaches the same place from any base is left alone.
+// The runtime resolves a public path against the output root, so one that needs a base
+// is walked back there first — read from chunks at two depths, under every shape.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/analyzable/asset-url-matrix/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-matrix/webpack.config.js
@@ -1,0 +1,69 @@
+"use strict";
+
+// The same asset reference, read from chunks at two depths, under every shape a public
+// path comes in. Both have to name the same file — the runtime resolves a public path
+// against the output root, so one that needs a base is walked back there first and one
+// that reaches the same place from any base is left alone.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} dir subdirectory keeping the emitted chunks of each config apart
+ * @param {NonNullable<import("../../../../").Configuration["output"]>["publicPath"]} publicPath the shape under test
+ * @param {string} root what the chunk one directory down is expected to bake
+ * @param {string} deep what the chunk a directory down is expected to bake
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, dir, publicPath, root, deep) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: `${dir}/[name].mjs`,
+		publicPath,
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__DIR__: JSON.stringify(dir),
+			__ROOT__: JSON.stringify(root),
+			__DEEP__: JSON.stringify(deep)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Chunk-relative already: the `../` path back to the root is the whole prefix.
+	base(0, "a", "auto", "../asset.txt", "../../asset.txt"),
+	// Relative to the output root, so it follows that same `../` path.
+	base(1, "b", "", "../asset.txt", "../../asset.txt"),
+	base(2, "c", "./", "../asset.txt", "../../asset.txt"),
+	base(3, "d", "media/", "../media/asset.txt", "../../media/asset.txt"),
+	// Rooted at the origin, or a url of its own: the same place from any base.
+	base(4, "e", "/media/", "/media/asset.txt", "/media/asset.txt"),
+	base(5, "f", "//cdn.test/", "//cdn.test/asset.txt", "//cdn.test/asset.txt"),
+	base(
+		6,
+		"g",
+		"https://cdn.test/",
+		"https://cdn.test/asset.txt",
+		"https://cdn.test/asset.txt"
+	),
+	// A function is called for its value, which here does not move with the hash.
+	base(
+		7,
+		"h",
+		() => "https://cdn.test/fn/",
+		"https://cdn.test/fn/asset.txt",
+		"https://cdn.test/fn/asset.txt"
+	)
+];

--- a/test/configCases/analyzable/asset-url-relative-public-path/asset.txt
+++ b/test/configCases/analyzable/asset-url-relative-public-path/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-relative-public-path/deep.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/deep.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-relative-public-path/flat.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/flat.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-relative-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+const stats = __STATS__.children[__INDEX__];
+
+it("should resolve the asset from chunks at different depths", async () => {
+	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
+	expect(fs.readFileSync(flat.url, "utf8")).toContain("the asset content");
+	// Pull in the second, deeper copy so the module really sits at two depths.
+	const deep = await import(/* webpackChunkName: "nested/deep" */ "./deep");
+	expect(fs.readFileSync(deep.url, "utf8")).toContain("the asset content");
+});
+
+it("should walk back to the output root before the public path", () => {
+	const read = (name) =>
+		fs.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8");
+
+	expect(read("flat.mjs")).toContain(`"${__FLAT__}", import.meta.url`);
+	expect(read("nested/deep.mjs")).toContain(`"${__DEEP__}", import.meta.url`);
+});

--- a/test/configCases/analyzable/asset-url-relative-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/index.js
@@ -1,20 +1,54 @@
 import fs from "fs";
 import path from "path";
 
+// Referenced so both chunks exist; only loaded where they can be found.
+const flat = () => import(/* webpackChunkName: "flat" */ "./flat");
+const deep = () => import(/* webpackChunkName: "nested/deep" */ "./deep");
+
 const stats = __STATS__.children[__INDEX__];
+const specifier = (name) =>
+	fs
+		.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8")
+		.match(/asset import \*\/ "([^"]+)"/)[1];
 
-it("should resolve the asset from chunks at different depths", async () => {
-	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
-	expect(fs.readFileSync(flat.url, "utf8")).toContain("the asset content");
-	// Pull in the second, deeper copy so the module really sits at two depths.
-	const deep = await import(/* webpackChunkName: "nested/deep" */ "./deep");
-	expect(fs.readFileSync(deep.url, "utf8")).toContain("the asset content");
-});
+if (__DIGEST__) {
+	it("should keep both chunks referenced", () => {
+		expect(typeof flat).toBe("function");
+		expect(typeof deep).toBe("function");
+	});
 
-it("should walk back to the output root before the public path", () => {
-	const read = (name) =>
-		fs.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8");
+	it("should walk back to the output root before the digest", () => {
+		for (const [name, undo] of [
+			["flat.mjs", "../"],
+			["nested/deep.mjs", "../../"]
+		]) {
+			const match = new RegExp(`^${undo}media/([^/]+)/asset\\.txt$`).exec(
+				specifier(name)
+			);
 
-	expect(read("flat.mjs")).toContain(`"${__FLAT__}", import.meta.url`);
-	expect(read("nested/deep.mjs")).toContain(`"${__DEEP__}", import.meta.url`);
-});
+			expect(match).not.toBe(null);
+			// A digest re-encodes the hash, so decode it back to compare.
+			const hex = Buffer.from(
+				match[1].replace(/-/g, "+").replace(/_/g, "/"),
+				"base64"
+			).toString("hex");
+
+			expect(hex.startsWith(stats.hash)).toBe(true);
+		}
+	});
+} else {
+	it("should resolve the asset from chunks at different depths", async () => {
+		expect(fs.readFileSync((await flat()).url, "utf8")).toContain(
+			"the asset content"
+		);
+		// Pull in the second, deeper copy so the module really sits at two depths.
+		expect(fs.readFileSync((await deep()).url, "utf8")).toContain(
+			"the asset content"
+		);
+	});
+
+	it("should walk back to the output root before the public path", () => {
+		expect(specifier("flat.mjs")).toBe("../asset.txt");
+		expect(specifier("nested/deep.mjs")).toBe("../../asset.txt");
+	});
+}

--- a/test/configCases/analyzable/asset-url-relative-public-path/shared.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/shared.js
@@ -1,0 +1,2 @@
+// This module ends up in two chunks emitted at different depths.
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
@@ -1,0 +1,46 @@
+"use strict";
+
+// The runtime resolves a public path against the output root, not against the chunk
+// the reference sits in, so a relative one only bakes behind that chunk's `../` path.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} dir subdirectory keeping the emitted chunks of each config apart
+ * @param {string} publicPath the public path under test
+ * @param {string} flat what the root-level chunk is expected to bake
+ * @param {string} deep what the nested chunk is expected to bake
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, dir, publicPath, flat, deep) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: `${dir}/[name].mjs`,
+		publicPath,
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__DIR__: JSON.stringify(dir),
+			__FLAT__: JSON.stringify(flat),
+			__DEEP__: JSON.stringify(deep)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "a", "./", "../asset.txt", "../../asset.txt"),
+	// An empty one names the output root just the same.
+	base(1, "b", "", "../asset.txt", "../../asset.txt")
+];

--- a/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
@@ -9,11 +9,10 @@ const webpack = require("../../../../");
  * @param {number} index position of this config, so `index.js` finds its own stats
  * @param {string} dir subdirectory keeping the emitted chunks of each config apart
  * @param {string} publicPath the public path under test
- * @param {string} flat what the root-level chunk is expected to bake
- * @param {string} deep what the nested chunk is expected to bake
+ * @param {boolean=} digest whether the public path re-encodes the compilation hash
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, dir, publicPath, flat, deep) => ({
+const base = (index, dir, publicPath, digest = false) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -32,15 +31,17 @@ const base = (index, dir, publicPath, flat, deep) => ({
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
 			__DIR__: JSON.stringify(dir),
-			__FLAT__: JSON.stringify(flat),
-			__DEEP__: JSON.stringify(deep)
+			__DIGEST__: JSON.stringify(digest)
 		})
 	]
 });
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	base(0, "a", "./", "../asset.txt", "../../asset.txt"),
+	base(0, "a", "./"),
 	// An empty one names the output root just the same.
-	base(1, "b", "", "../asset.txt", "../../asset.txt")
+	base(1, "b", ""),
+	// A digest no stand-in can carry, so the deferred pass spells the whole template —
+	// behind the same `../` path. Nothing is emitted there, so it is not read back.
+	base(2, "c", "media/[fullhash:base64safe]/", true)
 ];

--- a/test/configCases/analyzable/asset-url-shared-depths/asset.txt
+++ b/test/configCases/analyzable/asset-url-shared-depths/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-shared-depths/deep.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/deep.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-shared-depths/flat.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/flat.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-shared-depths/index.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/index.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+
+it("should resolve the asset from chunks at different depths", async () => {
+	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
+	expect(fs.readFileSync(flat.url, "utf8")).toContain("the asset content");
+	// Pull in the second, deeper copy so the module really sits at two depths.
+	const deep = await import(/* webpackChunkName: "nested/deep" */ "./deep");
+	expect(fs.readFileSync(deep.url, "utf8")).toContain("the asset content");
+});
+
+it("should bake the specifier each depth needs", () => {
+	const read = (name) =>
+		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+
+	expect(read("flat.mjs")).toContain('"./asset.txt", import.meta.url');
+	expect(read("nested/deep.mjs")).toContain('"../asset.txt", import.meta.url');
+	// No `__webpack_require__.b` — the runtime form resolves against the base uri.
+	expect(read("flat.mjs")).not.toContain(`${"__webpack_require__"}.b`);
+	expect(read("nested/deep.mjs")).not.toContain(`${"__webpack_require__"}.b`);
+});

--- a/test/configCases/analyzable/asset-url-shared-depths/roundTrip.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/roundTrip.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Marker: RoundTripConfigCases re-bundles this case's output and asserts every baked
+// specifier in it is still one webpack can follow.
+module.exports = true;

--- a/test/configCases/analyzable/asset-url-shared-depths/shared.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/shared.js
@@ -1,0 +1,2 @@
+// This module ends up in two chunks emitted at different depths.
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-shared-depths/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-shared-depths/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+// The module holding the `new URL` sits at two depths, so the specifier is reserved
+// and each emitted asset gets its own `../` path once the names exist.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: "[name].mjs",
+		publicPath: "auto",
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	optimization: { chunkIds: "named", splitChunks: false }
+};

--- a/test/configCases/analyzable/asset-url-templated-public-path/asset.txt
+++ b/test/configCases/analyzable/asset-url-templated-public-path/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-templated-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-templated-public-path/index.js
@@ -1,0 +1,41 @@
+import fs from "fs";
+import path from "path";
+
+// Never dereferenced — the harness cannot fetch an absolute CDN url.
+export const url = new URL("./asset.txt", import.meta.url);
+
+const stats = __STATS__.children[__INDEX__];
+const bundle = () =>
+	fs.readFileSync(path.join(stats.outputPath, `bundle${__INDEX__}.mjs`), "utf8");
+
+it("should keep the asset referenced", () => {
+	expect(typeof url).toBe("object");
+});
+
+it("should bake the public path's compilation hash into the specifier", () => {
+	const specifier = bundle().match(
+		/\/\* asset import \*\/ "(https:\/\/cdn\.example\.com\/[^"]+)"/
+	);
+
+	expect(specifier).not.toBe(null);
+	const [, hash, file] = specifier[1]
+		.split("https://cdn.example.com/")[1]
+		.match(/^([^/]+)\/(.+)$/);
+
+	if (__DIGEST__) {
+		// A digest re-encodes the hash, so decode it back to compare.
+		const hex = Buffer.from(
+			hash.replace(/-/g, "+").replace(/_/g, "/"),
+			"base64"
+		).toString("hex");
+
+		expect(hex.startsWith(stats.hash)).toBe(true);
+	} else {
+		expect(hash).toBe(__SLICE__ ? stats.hash.slice(0, __SLICE__) : stats.hash);
+	}
+	expect(fs.existsSync(path.join(stats.outputPath, file))).toBe(true);
+});
+
+it("should not fall back to the runtime asset url", () => {
+	expect(bundle()).not.toContain(`${"__webpack_require__"}.b`);
+});

--- a/test/configCases/analyzable/asset-url-templated-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-templated-public-path/webpack.config.js
@@ -1,0 +1,43 @@
+"use strict";
+
+// A public path carrying `[fullhash]` is settled no earlier than the hash it reads,
+// so the asset's specifier reserves a stand-in the deferred pass fills in.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} hashPart the `[fullhash]` form under test
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, hashPart) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		library: { type: "module" },
+		publicPath: `https://cdn.example.com/${hashPart}/`,
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__SLICE__: JSON.stringify(hashPart.includes(":8") ? 8 : 0),
+			__DIGEST__: JSON.stringify(hashPart.includes("base64safe"))
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "[fullhash]"),
+	base(1, "[fullhash:8]"),
+	// A digest no stand-in of ours could carry, so the whole template is handed over.
+	base(2, "[fullhash:base64safe]")
+];

--- a/test/configCases/analyzable/asset-url-wrapperless/asset.txt
+++ b/test/configCases/analyzable/asset-url-wrapperless/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-wrapperless/deep.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/deep.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-wrapperless/flat.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/flat.js
@@ -1,0 +1,1 @@
+export { url } from "./shared";

--- a/test/configCases/analyzable/asset-url-wrapperless/index.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/index.js
@@ -27,11 +27,17 @@ it("should emit no wrapper for an asset every consumer names itself", () => {
 			"utf8"
 		);
 
-	for (const source of [read("bundle0"), read("flat.")]) {
+	// Both depths, since only their own chunk can carry a wrapper for them.
+	const deep = fs.readFileSync(
+		path.join(dir, "nested", fs.readdirSync(path.join(dir, "nested"))[0]),
+		"utf8"
+	);
+	const inline = `/* asset import */ ${"__webpack_require__"}.p + "asset.txt"`;
+
+	for (const source of [read("bundle0"), read("flat."), deep]) {
 		expect(source).not.toContain(wrapper);
 	}
-	// The reference this one cannot bake concatenates the same thing inline instead.
-	expect(read("flat.")).toContain(
-		`/* asset import */ ${"__webpack_require__"}.p + "asset.txt"`
-	);
+	// Neither depth can bake, so each concatenates what the wrapper would have said.
+	expect(read("flat.")).toContain(inline);
+	expect(deep).toContain(inline);
 });

--- a/test/configCases/analyzable/asset-url-wrapperless/index.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/index.js
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+
+const load = () => ({
+	flat: import(/* webpackChunkName: "flat" */ "./flat"),
+	deep: import(/* webpackChunkName: "nested/deep" */ "./deep")
+});
+
+// Needle built at runtime so it is not a source string literal here.
+const wrapper = `${"module"}.exports = ${"__webpack_require__"}.p + `;
+
+it("should resolve the asset whichever form the reference takes", async () => {
+	const { flat, deep } = load();
+	expect(fs.readFileSync((await flat).url, "utf8")).toContain(
+		"the asset content"
+	);
+	expect(fs.readFileSync((await deep).url, "utf8")).toContain(
+		"the asset content"
+	);
+});
+
+it("should emit no wrapper for an asset every consumer names itself", () => {
+	const dir = __STATS__.outputPath;
+	const read = (prefix) =>
+		fs.readFileSync(
+			path.join(dir, fs.readdirSync(dir).find((f) => f.startsWith(prefix))),
+			"utf8"
+		);
+
+	for (const source of [read("bundle0"), read("flat.")]) {
+		expect(source).not.toContain(wrapper);
+	}
+	// The reference this one cannot bake concatenates the same thing inline instead.
+	expect(read("flat.")).toContain(
+		`/* asset import */ ${"__webpack_require__"}.p + "asset.txt"`
+	);
+});

--- a/test/configCases/analyzable/asset-url-wrapperless/shared.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/shared.js
@@ -1,0 +1,2 @@
+// This module ends up in two chunks emitted at different depths.
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-wrapperless/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// Every javascript consumer of the asset is a `new URL()` that names it itself, so the
-// `module.exports = .p + name` wrapper is read by no one and is not emitted. The two
-// depths here cannot bake — the chunks they sit in are named by their own content —
-// and that reference concatenates what the wrapper would have, inline.
+// Nothing reads the wrapper, so it is not emitted — and the two depths here cannot
+// bake, so that reference concatenates what it would have said, inline.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/asset-url-wrapperless/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-wrapperless/webpack.config.js
@@ -1,0 +1,48 @@
+"use strict";
+
+// Every javascript consumer of the asset is a `new URL()` that names it itself, so the
+// `module.exports = .p + name` wrapper is read by no one and is not emitted. The two
+// depths here cannot bake — the chunks they sit in are named by their own content —
+// and that reference concatenates what the wrapper would have, inline.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: "[name].mjs",
+		publicPath: "auto",
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	optimization: {
+		chunkIds: "named",
+		splitChunks: false,
+		realContentHash: false
+	},
+	plugins: [
+		(compiler) => {
+			compiler.hooks.compilation.tap(
+				"NameConsumersByContent",
+				(compilation) => {
+					compilation.hooks.afterChunks.tap(
+						"NameConsumersByContent",
+						(chunks) => {
+							for (const chunk of chunks) {
+								const name = chunk.name;
+								if (name === "flat" || name === "nested/deep") {
+									chunk.filenameTemplate = "[name].[contenthash].mjs";
+								}
+							}
+						}
+					);
+				}
+			);
+		}
+	]
+};

--- a/test/configCases/analyzable/asset-wrapper-retention/asset.txt
+++ b/test/configCases/analyzable/asset-wrapper-retention/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-wrapper-retention/index-override.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/index-override.js
@@ -1,0 +1,3 @@
+__webpack_public_path__ = `${__webpack_public_path__}`;
+
+export * from "./index";

--- a/test/configCases/analyzable/asset-wrapper-retention/index-plain.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/index-plain.js
@@ -1,0 +1,4 @@
+import { raw } from "./plain-import";
+
+export { raw };
+export * from "./index";

--- a/test/configCases/analyzable/asset-wrapper-retention/index.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/index.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+import { url } from "./url-only";
+
+const stats = __STATS__.children[__INDEX__];
+const bundle = () =>
+	fs.readFileSync(path.join(stats.outputPath, `bundle${__INDEX__}.mjs`), "utf8");
+// Needle built at runtime so it is not a source string literal here.
+const wrapper = `${"module"}.exports = ${"__webpack_require__"}.p + `;
+
+it("should point at the asset whatever the module exposes", () => {
+	expect(String(url).endsWith("/asset.txt")).toBe(true);
+});
+
+if (__WRAPPER__) {
+	it("should keep the wrapper while something still reads it", () => {
+		expect(bundle()).toContain(wrapper);
+	});
+} else {
+	it("should drop the wrapper no one reads", () => {
+		expect(bundle()).not.toContain(wrapper);
+	});
+}

--- a/test/configCases/analyzable/asset-wrapper-retention/plain-import.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/plain-import.js
@@ -1,0 +1,3 @@
+import assetUrl from "./asset.txt";
+
+export const raw = assetUrl;

--- a/test/configCases/analyzable/asset-wrapper-retention/url-only.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/url-only.js
@@ -1,0 +1,1 @@
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// The `module.exports = .p + name` wrapper exists for javascript that reads the asset's
+// url out of the module. A `new URL()` reference names the file itself and reads none,
+// so the wrapper goes — but only once every javascript consumer is one of those.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own bundle
+ * @param {boolean} wrapper whether the asset module is expected to keep its wrapper
+ * @param {import("../../../../").Configuration} extra per-case overrides
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, wrapper, extra = {}) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: extra.entry || "./index.js",
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		publicPath: "auto",
+		assetModuleFilename: "[name][ext]",
+		...extra.output
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }],
+		parser: extra.module && extra.module.parser
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__WRAPPER__: JSON.stringify(wrapper)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Only `new URL()` consumers — nothing reads the wrapper.
+	base(0, false),
+	// A plain import wants the url as a value, which only the wrapper provides.
+	base(1, true, { entry: "./index-plain.js" }),
+	// `url: "relative"` keeps the runtime form, which requires the module.
+	base(2, true, {
+		module: { parser: { javascript: { url: "relative" } } }
+	}),
+	// A reassigned public path is only knowable at runtime, so is the wrapper's value.
+	base(3, true, { entry: "./index-override.js" })
+];

--- a/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// The `module.exports = .p + name` wrapper exists for javascript that reads the asset's
-// url out of the module. A `new URL()` reference names the file itself and reads none,
-// so the wrapper goes — but only once every javascript consumer is one of those.
+// The wrapper goes only once every javascript consumer is a `new URL()` that names
+// the file itself; anything reading the url out of the module still needs it.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/analyzable/dynamic-import-contenthash/index.js
+++ b/test/configCases/analyzable/dynamic-import-contenthash/index.js
@@ -9,13 +9,24 @@ it("should load a chunk whose filename uses a digest-suffixed content hash", asy
 	expect(value).toBe(42);
 });
 
-it("should fall back to the runtime form for a hashed chunk filename", () => {
+it("should bake a hashed chunk name the deferred pass fills in", () => {
 	const bundle = fs.readFileSync(
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// The content hash isn't known at code generation, so the analyzable literal
-	// can't be baked — the runtime `ensureChunk` form is kept instead of `.ei`.
-	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.ei(`);
+	// Needle built at runtime so it is not a source string literal here.
+	const helper = `${"__webpack_require__"}.ei(`;
+
+	expect(bundle).toContain(helper);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
+	// No stand-in may reach the bundle, and what is baked has to be on disk.
+	expect(bundle).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
+	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+		bundle.slice(bundle.indexOf(helper))
+	);
+
+	expect(specifier).not.toBe(null);
+	expect(
+		fs.existsSync(path.join(__STATS__.outputPath, specifier[1]))
+	).toBe(true);
 });

--- a/test/configCases/analyzable/dynamic-import-contenthash/webpack.config.js
+++ b/test/configCases/analyzable/dynamic-import-contenthash/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = {
 	output: {
 		module: true,
 		publicPath: "auto",
-		// A digest-suffixed content hash is unknown during code generation, so the
-		// name is reserved and filled in once it exists. The entry the stand-in lands
+		// The name is reserved and filled in once the hash exists; the entry it lands
 		// in is not named by its own content, so the rewrite invalidates nothing.
 		chunkFilename: "[name].[contenthash:base64:8].mjs"
 	}

--- a/test/configCases/analyzable/dynamic-import-contenthash/webpack.config.js
+++ b/test/configCases/analyzable/dynamic-import-contenthash/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
 		module: true,
 		publicPath: "auto",
 		// A digest-suffixed content hash is unknown during code generation, so the
-		// analyzable literal can't be baked — this must fall back, not throw.
+		// name is reserved and filled in once it exists. The entry the stand-in lands
+		// in is not named by its own content, so the rewrite invalidates nothing.
 		chunkFilename: "[name].[contenthash:base64:8].mjs"
 	}
 };

--- a/test/configCases/analyzable/function-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/function-chunk-filename/webpack.config.js
@@ -1,7 +1,8 @@
 "use strict";
 
 // A function `chunkFilename` bakes right away when its answer holds no hash, and is
-// asked again by the deferred pass when it does — or falls back if nothing corrects it.
+// asked again by the deferred pass when it does. `realContentHash` is beside the point
+// here: the entry the stand-in lands in is not named by its own content either way.
 
 const webpack = require("../../../../");
 
@@ -32,7 +33,7 @@ module.exports = [
 	// Returns a plain template — the same answer whatever the hashes are.
 	base(0, (pathData) => `a-${pathData.chunk.name}/[name].mjs`, true),
 	// Returns a template carrying a hash placeholder.
-	base(1, () => "b-[name].[contenthash].mjs", false),
+	base(1, () => "b-[name].[contenthash].mjs", true),
 	// The same template, deferred: the pass asks again once the hash is settled.
 	base(2, () => "d-[name].[contenthash].mjs", true, true),
 	// Builds the name from a hash itself, and is asked again the same way.
@@ -46,7 +47,7 @@ module.exports = [
 		true,
 		true
 	),
-	// Builds the name from a hash itself, so nothing is left to test for.
+	// Builds the name from a hash itself, and is asked again the same way.
 	base(
 		4,
 		(pathData) =>
@@ -54,7 +55,7 @@ module.exports = [
 				/** @type {Record<string, string>} */ (pathData.chunk.contentHash)
 					.javascript
 			}.mjs`,
-		false
+		true
 	),
 	// Reads what names the asset but is not a hash — the same answer both times.
 	base(5, (pathData) => `f-[name].${pathData.runtime}.mjs`, true),

--- a/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/webpack.config.js
@@ -3,7 +3,8 @@
 let INDEX = 0;
 
 // A hashed chunk name is emitted as a stand-in and filled in once the hash exists.
-// Without `realContentHash` nothing repairs the stale hash, so the runtime form stays.
+// What the rewrite could invalidate is the name of the chunk the stand-in lands in —
+// the entry here, which no template names by its content — not the one referenced.
 
 /**
  * @param {string} name prefix keeping the emitted files of each config apart
@@ -25,7 +26,7 @@ const base = (name, chunkFilename, realContentHash = true) => ({
 	plugins: [
 		new (require("../../../../").DefinePlugin)({
 			__INDEX__: JSON.stringify(INDEX++),
-			__ANALYZABLE__: JSON.stringify(realContentHash)
+			__ANALYZABLE__: JSON.stringify(true)
 		})
 	],
 	output: {
@@ -44,6 +45,7 @@ module.exports = [
 	// `[runtime]` is only filled in when the runtime is handed to the path as well.
 	base("e", "[name].[runtime].[contenthash].mjs"),
 	base("f", "nested/dir/[name].[contenthash].mjs"),
-	// No correction for a stale name, so the runtime form is kept.
+	// The referenced chunk is named by its content and nothing repairs a stale name,
+	// but the entry the stand-in is written into is not, so there is none to repair.
 	base("g", "[name].[contenthash].mjs", false)
 ];

--- a/test/configCases/analyzable/import-relative-public-path/index.js
+++ b/test/configCases/analyzable/import-relative-public-path/index.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const stats = __STATS__.children[__INDEX__];
+
+it("should load a chunk imported from a chunk below the output root", async () => {
+	const mid = await import(/* webpackChunkName: "nested/mid" */ "./mid");
+	expect((await mid.deeper()).value).toBe("lazy");
+});
+
+it("should walk back to the output root before the public path", () => {
+	const source = fs.readFileSync(
+		path.join(stats.outputPath, __DIR__, "nested/mid.mjs"),
+		"utf8"
+	);
+
+	expect(source).toContain(`"${__SPECIFIER__}")`);
+});

--- a/test/configCases/analyzable/import-relative-public-path/lazy.js
+++ b/test/configCases/analyzable/import-relative-public-path/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/import-relative-public-path/mid.js
+++ b/test/configCases/analyzable/import-relative-public-path/mid.js
@@ -1,0 +1,1 @@
+export const deeper = () => import(/* webpackChunkName: "lazy" */ "./lazy");

--- a/test/configCases/analyzable/import-relative-public-path/webpack.config.js
+++ b/test/configCases/analyzable/import-relative-public-path/webpack.config.js
@@ -1,0 +1,40 @@
+"use strict";
+
+// The runtime imports a chunk from the chunk holding the runtime — the output root —
+// so a relative public path only bakes behind the `../` path back to that root.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} dir subdirectory keeping the emitted chunks of each config apart
+ * @param {string} publicPath the public path under test
+ * @param {string} specifier what the chunk below the root is expected to bake
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, dir, publicPath, specifier) => ({
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: `${dir}/[name].mjs`,
+		publicPath
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__DIR__: JSON.stringify(dir),
+			__SPECIFIER__: JSON.stringify(specifier)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, "a", "./", "../../a/lazy.mjs"),
+	// An empty one names the output root just the same.
+	base(1, "b", "", "../../b/lazy.mjs")
+];

--- a/test/configCases/analyzable/shared-depths-import-fallback/index.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/index.js
@@ -10,10 +10,10 @@ it("should load through the runtime form from chunks at different depths", async
 });
 
 it("should not bake a specifier no depth-independent name can carry", () => {
-	const source = fs.readFileSync(
-		path.join(__STATS__.outputPath, "flat.mjs"),
-		"utf8"
-	);
+	// Found rather than named: these chunks carry a content hash.
+	const dir = __STATS__.outputPath;
+	const name = fs.readdirSync(dir).find((file) => file.startsWith("flat."));
+	const source = fs.readFileSync(path.join(dir, name), "utf8");
 
 	expect(source).toContain(`${"__webpack_require__"}.e(`);
 	expect(source).not.toContain(`${"__webpack_require__"}.ei(`);

--- a/test/configCases/analyzable/shared-depths-import-fallback/test.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/test.config.js
@@ -6,6 +6,6 @@ module.exports = {
 	findBundle(index, options) {
 		return fs
 			.readdirSync(options.output.path)
-			.filter((name) => /^main\..+\.mjs$/.test(name));
+			.filter((name) => /^bundle0\.mjs$/.test(name));
 	}
 };

--- a/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
@@ -1,7 +1,10 @@
 "use strict";
 
-// Reserving a stand-in rewrites the asset after its content hash was taken, so with
-// `realContentHash` off and javascript named by content nothing repairs it.
+// Reserving a stand-in rewrites the asset it lands in after that asset's own content
+// hash was taken, so with `realContentHash` off a chunk named by its content can hold
+// none — and the two depths here need one, since no single `../` path reaches the
+// chunk from both. Only the chunks holding the reference are named that way, so the
+// referenced one is settled during code generation and the depth is what is missing.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
@@ -11,7 +14,6 @@ module.exports = {
 	experiments: { outputModule: true },
 	output: {
 		module: true,
-		filename: "main.[contenthash].mjs",
 		chunkFilename: "[name].mjs",
 		publicPath: "auto"
 	},
@@ -19,5 +21,24 @@ module.exports = {
 		chunkIds: "named",
 		splitChunks: false,
 		realContentHash: false
-	}
+	},
+	plugins: [
+		(compiler) => {
+			compiler.hooks.compilation.tap(
+				"NameConsumersByContent",
+				(compilation) => {
+					compilation.hooks.afterChunks.tap(
+						"NameConsumersByContent",
+						(chunks) => {
+							for (const chunk of chunks) {
+								if (chunk.name === "flat" || chunk.name === "nested/deep") {
+									chunk.filenameTemplate = "[name].[contenthash].mjs";
+								}
+							}
+						}
+					);
+				}
+			);
+		}
+	]
 };

--- a/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import-fallback/webpack.config.js
@@ -1,10 +1,7 @@
 "use strict";
 
-// Reserving a stand-in rewrites the asset it lands in after that asset's own content
-// hash was taken, so with `realContentHash` off a chunk named by its content can hold
-// none — and the two depths here need one, since no single `../` path reaches the
-// chunk from both. Only the chunks holding the reference are named that way, so the
-// referenced one is settled during code generation and the depth is what is missing.
+// Two depths need a stand-in, and with `realContentHash` off the chunks holding the
+// reference are named by their content, so none may be written into them.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/shared-module-chunk/index.js
+++ b/test/configCases/analyzable/shared-module-chunk/index.js
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+it("should load a chunk that also holds a shared module", async () => {
+	const lazy = await import(/* webpackChunkName: "lazy" */ "./lazy");
+	expect(lazy.load()).toBe("shared");
+});
+
+it("should bake the specifier — the chunk's javascript is emitted here", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+
+	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	expect(bundle).toContain('"./lazy.mjs"');
+});

--- a/test/configCases/analyzable/shared-module-chunk/lazy.js
+++ b/test/configCases/analyzable/shared-module-chunk/lazy.js
@@ -1,0 +1,3 @@
+import { value } from "shared-lib";
+
+export const load = () => value;

--- a/test/configCases/analyzable/shared-module-chunk/lib.js
+++ b/test/configCases/analyzable/shared-module-chunk/lib.js
@@ -1,0 +1,1 @@
+export const value = "shared";

--- a/test/configCases/analyzable/shared-module-chunk/roundTrip.js
+++ b/test/configCases/analyzable/shared-module-chunk/roundTrip.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Marker: RoundTripConfigCases re-bundles this case's output and asserts every baked
+// specifier in it is still one webpack can follow.
+module.exports = true;

--- a/test/configCases/analyzable/shared-module-chunk/webpack.config.js
+++ b/test/configCases/analyzable/shared-module-chunk/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+// A chunk holding a shared module still has javascript of its own, so `.ei` has
+// something to import — only a chunk this compilation emits nothing for has not.
+
+const path = require("path");
+const { SharePlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	resolve: {
+		alias: { "shared-lib": path.resolve(__dirname, "lib.js") }
+	},
+	output: {
+		module: true,
+		chunkFilename: "[name].mjs",
+		publicPath: "auto"
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	plugins: [
+		new SharePlugin({
+			shared: { "shared-lib": { singleton: true, requiredVersion: false } }
+		})
+	]
+};

--- a/test/configCases/analyzable/stand-in-lookalike/index.js
+++ b/test/configCases/analyzable/stand-in-lookalike/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { lookalikes } from "./lookalikes";
+
+// A real reference next to them, so the pass definitely ran over this asset.
+const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+it("should leave a stand-in it cannot read exactly as written", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+
+	expect(typeof load).toBe("function");
+	// The pass ran: the real reference next to these was filled in.
+	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	for (const [name, text] of Object.entries(lookalikes)) {
+		expect([name, bundle.includes(text)]).toEqual([name, true]);
+	}
+});

--- a/test/configCases/analyzable/stand-in-lookalike/lazy.js
+++ b/test/configCases/analyzable/stand-in-lookalike/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
+++ b/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
@@ -1,13 +1,6 @@
 // Text of our own that spells the stand-in the deferred pass fills in. Nothing about
 // a payload is given, so each of these has to reach the bundle exactly as written.
-export const lookalikes = {
-	notJson: "./@@webpackAnalyzableChunk:zzzz@@",
-	notArray: "./@@webpackAnalyzableChunk:eyJhIjoxfQ@@",
-	notTuples: "./@@webpackAnalyzableChunk:WyJsaXRlcmFsIiwieCJd@@",
-	wrongLength: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCJdXQ@@",
-	unknownKind: "./@@webpackAnalyzableChunk:W1sibm9uc2Vuc2UiLCJ4Il1d@@",
-	wrongValueType: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIseyJhIjoxfV1d@@",
-	numericTemplate: "./@@webpackAnalyzableChunk:W1sidGVtcGxhdGUiLDBdXQ@@",
-	numericLiteral: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIsN11d@@",
-	unknownChunk: "./@@webpackAnalyzableChunk:W1siY2h1bmsiLCJuby1zdWNoLWNodW5rLWlkIl1d@@"
-};
+// Held as json so the unit test can state what each one decodes to.
+import lookalikes from "./lookalikes.json";
+
+export { lookalikes };

--- a/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
+++ b/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
@@ -1,0 +1,11 @@
+// Text of our own that spells the stand-in the deferred pass fills in. Nothing about
+// a payload is given, so each of these has to reach the bundle exactly as written.
+export const lookalikes = {
+	notJson: "./@@webpackAnalyzableChunk:zzzz@@",
+	notArray: "./@@webpackAnalyzableChunk:eyJhIjoxfQ@@",
+	notTuples: "./@@webpackAnalyzableChunk:WyJsaXRlcmFsIiwieCJd@@",
+	wrongLength: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCJdXQ@@",
+	unknownKind: "./@@webpackAnalyzableChunk:W1sibm9uc2Vuc2UiLCJ4Il1d@@",
+	wrongValueType: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIseyJhIjoxfV1d@@",
+	unknownChunk: "./@@webpackAnalyzableChunk:W1siY2h1bmsiLCJuby1zdWNoLWNodW5rLWlkIl1d@@"
+};

--- a/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
+++ b/test/configCases/analyzable/stand-in-lookalike/lookalikes.js
@@ -7,5 +7,7 @@ export const lookalikes = {
 	wrongLength: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCJdXQ@@",
 	unknownKind: "./@@webpackAnalyzableChunk:W1sibm9uc2Vuc2UiLCJ4Il1d@@",
 	wrongValueType: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIseyJhIjoxfV1d@@",
+	numericTemplate: "./@@webpackAnalyzableChunk:W1sidGVtcGxhdGUiLDBdXQ@@",
+	numericLiteral: "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIsN11d@@",
 	unknownChunk: "./@@webpackAnalyzableChunk:W1siY2h1bmsiLCJuby1zdWNoLWNodW5rLWlkIl1d@@"
 };

--- a/test/configCases/analyzable/stand-in-lookalike/lookalikes.json
+++ b/test/configCases/analyzable/stand-in-lookalike/lookalikes.json
@@ -1,0 +1,11 @@
+{
+	"notJson": "./@@webpackAnalyzableChunk:zzzz@@",
+	"notArray": "./@@webpackAnalyzableChunk:eyJhIjoxfQ@@",
+	"notTuples": "./@@webpackAnalyzableChunk:WyJsaXRlcmFsIiwieCJd@@",
+	"wrongLength": "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCJdXQ@@",
+	"unknownKind": "./@@webpackAnalyzableChunk:W1sibm9uc2Vuc2UiLCJ4Il1d@@",
+	"wrongValueType": "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIseyJhIjoxfV1d@@",
+	"numericTemplate": "./@@webpackAnalyzableChunk:W1sidGVtcGxhdGUiLDBdXQ@@",
+	"numericLiteral": "./@@webpackAnalyzableChunk:W1sibGl0ZXJhbCIsN11d@@",
+	"unknownChunk": "./@@webpackAnalyzableChunk:W1siY2h1bmsiLCJuby1zdWNoLWNodW5rLWlkIl1d@@"
+}

--- a/test/configCases/analyzable/stand-in-lookalike/webpack.config.js
+++ b/test/configCases/analyzable/stand-in-lookalike/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+// Source of our own can spell the stand-in too, so nothing about a payload is given:
+// one the deferred pass cannot read is left alone rather than replaced with a guess.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		chunkFilename: "[name].[contenthash].mjs",
+		publicPath: "auto"
+	},
+	optimization: { chunkIds: "named", splitChunks: false }
+};

--- a/test/configCases/analyzable/templated-public-path/webpack.config.js
+++ b/test/configCases/analyzable/templated-public-path/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = [
 	// No javascript here is named by its content, so rewriting one invalidates
 	// nothing and there is no repair to need.
 	base(4, "no-repair-hash-free", "[fullhash]", true, "", false),
-	// This one is: substituting rewrites the chunk after its own content hash was
-	// taken, and `RealContentHashPlugin` is what brings the two back in line.
-	base(5, "no-repair-hashed", "[fullhash]", false, ".[contenthash]", false)
+	// Nor is it here: what the rewrite would invalidate is the name of the chunk the
+	// stand-in lands in, and that is the entry, which no template names by its content.
+	base(5, "no-repair-hashed", "[fullhash]", true, ".[contenthash]", false)
 ];

--- a/test/configCases/module/public-path/test.config.js
+++ b/test/configCases/module/public-path/test.config.js
@@ -12,7 +12,10 @@ module.exports = {
 			return `./${module}`;
 		}
 
-		if (i === 6 || i === 7 || i === 10 || i === 11) {
+		// Only the absolute-URL configs need this: their specifier is rewritten to `./`
+		// before it gets here. An empty public path is baked behind the `../` path back
+		// to the output root, so it already reaches the chunk.
+		if (i === 10 || i === 11) {
 			if (/async/.test(module)) {
 				return `../${module}`;
 			}

--- a/test/configCases/module/public-path/test.config.js
+++ b/test/configCases/module/public-path/test.config.js
@@ -13,8 +13,7 @@ module.exports = {
 		}
 
 		// Only the absolute-URL configs need this: their specifier is rewritten to `./`
-		// before it gets here. An empty public path is baked behind the `../` path back
-		// to the output root, so it already reaches the chunk.
+		// before it gets here, while an empty one already reaches the chunk.
 		if (i === 10 || i === 11) {
 			if (/async/.test(module)) {
 				return `../${module}`;

--- a/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
+++ b/test/configCases/wasm/analyzable-fullhash-filename/webpack.config.js
@@ -55,11 +55,9 @@ const base = (
 module.exports = [
 	base(0, "plain", "[fullhash]", true, true),
 	base(1, "sliced", "[fullhash:8]", true, true),
-	// A digest re-encodes the hash rather than reading it, which a stand-in cannot
-	// survive, so the name stays on the runtime form. That form drops the hash
-	// entirely (a bug of its own, and the reason this one is not loaded back), so
-	// only the fall back itself is asserted here.
-	base(2, "digest", "[fullhash:base64]", false, false),
+	// A digest re-encodes the hash rather than reading it, which no stand-in survives,
+	// so the whole name is handed to the deferred pass and spelled by `getPath` there.
+	base(2, "digest", "[fullhash:base64]", true, true),
 	// Substituting rewrites the chunk after its own content hash was taken, and
 	// `RealContentHashPlugin` is what brings the two back in line. Without a content
 	// hash in the name there would be nothing to bring back in line, so it carries one.

--- a/test/configCases/wasm/analyzable-runtime-scope/index.js
+++ b/test/configCases/wasm/analyzable-runtime-scope/index.js
@@ -1,0 +1,5 @@
+it("should load wasm from a runtime the public-path override does not reach", async () => {
+	const { run } = await import("./module");
+
+	expect(run()).toBe(84);
+});

--- a/test/configCases/wasm/analyzable-runtime-scope/module.js
+++ b/test/configCases/wasm/analyzable-runtime-scope/module.js
@@ -1,0 +1,3 @@
+import { add, getNumber } from "./wasm.wat";
+
+export const run = () => add(getNumber(), getNumber());

--- a/test/configCases/wasm/analyzable-runtime-scope/override.js
+++ b/test/configCases/wasm/analyzable-runtime-scope/override.js
@@ -1,0 +1,2 @@
+// Reassigned in this runtime only; the wasm below is reached from the other one.
+__webpack_public_path__ = "/elsewhere/";

--- a/test/configCases/wasm/analyzable-runtime-scope/test.config.js
+++ b/test/configCases/wasm/analyzable-runtime-scope/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	// The overriding runtime is loaded first, so its reassignment has happened by the
+	// time the wasm one runs.
+	findBundle() {
+		return ["./other.mjs", "./main.mjs"];
+	}
+};

--- a/test/configCases/wasm/analyzable-runtime-scope/wasm.wat
+++ b/test/configCases/wasm/analyzable-runtime-scope/wasm.wat
@@ -1,0 +1,9 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))

--- a/test/configCases/wasm/analyzable-runtime-scope/webpack.config.js
+++ b/test/configCases/wasm/analyzable-runtime-scope/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+// One runtime reassigns `__webpack_public_path__`, the wasm lives in another. The
+// loader is emitted once per runtime and shared, so the call site must not bake a
+// url the loader's own signature does not take.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: { main: "./index", other: "./override" },
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "async-node",
+		filename: "[name].mjs",
+		chunkFilename: "chunks/[name].mjs",
+		publicPath: "auto"
+	}
+};

--- a/test/configCases/wasm/analyzable-templated-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/index.js
@@ -19,7 +19,9 @@ if (__BAKED__) {
 		const url = chunk().match(/new URL\("https:\/\/example\.com\/([^/]+)\//);
 
 		expect(url).not.toBe(null);
-		if (__DIGEST__) {
+		if (__HASH_FREE__) {
+			expect(url[1]).toBe("fn");
+		} else if (__DIGEST__) {
 			// A digest re-encodes the hash, so decode it back to compare.
 			const hex = Buffer.from(
 				url[1].replace(/-/g, "+").replace(/_/g, "/"),

--- a/test/configCases/wasm/analyzable-templated-url-public-path/index.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/index.js
@@ -6,27 +6,40 @@ export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
 
 const stats = __STATS__.children[__INDEX__];
 // Only the wasm chunk — this file's own needles would satisfy the assertions.
-const chunk = () =>
-	fs.readFileSync(path.join(stats.outputPath, __CHUNK__), "utf8");
+// Found rather than named: the chunk's filename may carry a content hash.
+const chunk = () => {
+	const dir = path.join(stats.outputPath, __CHUNK_DIR__);
+	const file = fs.readdirSync(dir).find((name) => name.startsWith("lazy"));
 
-it("should bake the compilation hash into the binary's url", () => {
-	const url = chunk().match(/new URL\("https:\/\/example\.com\/([^/]+)\//);
+	return fs.readFileSync(path.join(dir, file), "utf8");
+};
 
-	expect(url).not.toBe(null);
-	if (__DIGEST__) {
-		// A digest re-encodes the hash, so decode it back to compare.
-		const hex = Buffer.from(
-			url[1].replace(/-/g, "+").replace(/_/g, "/"),
-			"base64"
-		).toString("hex");
+if (__BAKED__) {
+	it("should bake the compilation hash into the binary's url", () => {
+		const url = chunk().match(/new URL\("https:\/\/example\.com\/([^/]+)\//);
 
-		expect(hex.startsWith(stats.hash)).toBe(true);
-	} else {
-		expect(stats.hash.startsWith(url[1])).toBe(true);
-	}
-});
+		expect(url).not.toBe(null);
+		if (__DIGEST__) {
+			// A digest re-encodes the hash, so decode it back to compare.
+			const hex = Buffer.from(
+				url[1].replace(/-/g, "+").replace(/_/g, "/"),
+				"base64"
+			).toString("hex");
 
-it("should not assemble the binary's url at runtime", () => {
-	// Needle built at runtime so it is not a source string literal here.
-	expect(chunk()).not.toContain(`new URL(${"__webpack_require__"}.p + `);
-});
+			expect(hex.startsWith(stats.hash)).toBe(true);
+		} else {
+			expect(stats.hash.startsWith(url[1])).toBe(true);
+		}
+	});
+
+	it("should not assemble the binary's url at runtime", () => {
+		// Needle built at runtime so it is not a source string literal here.
+		expect(chunk()).not.toContain(`new URL(${"__webpack_require__"}.p + `);
+	});
+} else {
+	it("should keep the runtime form when the public path cannot be filled in", () => {
+		expect(chunk()).not.toMatch(/new URL\("https:/);
+		// The loader names the binary from the module id and hash instead.
+		expect(chunk()).toContain(`${"__webpack_require__"}.v(exports, module.id, "`);
+	});
+}

--- a/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
@@ -10,7 +10,7 @@ const webpack = require("../../../../");
  * @param {string} name prefix keeping the emitted files of each config apart
  * @param {string} hashPart the `[fullhash]` form under test
  * @param {boolean} digest whether that form re-encodes the hash
- * @param {{ baked?: boolean, chunkSuffix?: string, workerChunkFilename?: string, realContentHash?: boolean }=} extra per-case overrides
+ * @param {{ baked?: boolean, chunkSuffix?: string, workerChunkFilename?: string, realContentHash?: boolean, publicPath?: NonNullable<import("../../../../").Configuration["output"]>["publicPath"] }=} extra per-case overrides
  * @returns {import("../../../../").Configuration} configuration
  */
 const base = (index, name, hashPart, digest, extra = {}) => ({
@@ -34,13 +34,14 @@ const base = (index, name, hashPart, digest, extra = {}) => ({
 		chunkFilename: `${name}-chunks/[name]${extra.chunkSuffix || ""}.mjs`,
 		workerChunkFilename: extra.workerChunkFilename,
 		webassemblyModuleFilename: `${name}-[id].wasm`,
-		publicPath: `https://example.com/${hashPart}/`
+		publicPath: extra.publicPath || `https://example.com/${hashPart}/`
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
 			__CHUNK_DIR__: JSON.stringify(`${name}-chunks`),
 			__DIGEST__: JSON.stringify(digest),
+			__HASH_FREE__: JSON.stringify(extra.publicPath !== undefined),
 			__BAKED__: JSON.stringify(extra.baked !== false)
 		})
 	]
@@ -63,5 +64,10 @@ module.exports = [
 		baked: false,
 		realContentHash: false,
 		chunkSuffix: ".[contenthash]"
+	}),
+	// A function is called for its value, so one that answers with an absolute URL is
+	// as bakeable as the same URL written out.
+	base(5, "function", "[fullhash]", false, {
+		publicPath: () => "https://example.com/fn/"
 	})
 ];

--- a/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-templated-url-public-path/webpack.config.js
@@ -10,9 +10,10 @@ const webpack = require("../../../../");
  * @param {string} name prefix keeping the emitted files of each config apart
  * @param {string} hashPart the `[fullhash]` form under test
  * @param {boolean} digest whether that form re-encodes the hash
+ * @param {{ baked?: boolean, chunkSuffix?: string, workerChunkFilename?: string, realContentHash?: boolean }=} extra per-case overrides
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, name, hashPart, digest) => ({
+const base = (index, name, hashPart, digest, extra = {}) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -21,20 +22,26 @@ const base = (index, name, hashPart, digest) => ({
 			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
 		]
 	},
-	optimization: { chunkIds: "named", splitChunks: false },
+	optimization: {
+		chunkIds: "named",
+		splitChunks: false,
+		realContentHash: extra.realContentHash !== false
+	},
 	experiments: { outputModule: true, asyncWebAssembly: true },
 	output: {
 		module: true,
 		wasmLoading: "fetch",
-		chunkFilename: `${name}-chunks/[name].mjs`,
+		chunkFilename: `${name}-chunks/[name]${extra.chunkSuffix || ""}.mjs`,
+		workerChunkFilename: extra.workerChunkFilename,
 		webassemblyModuleFilename: `${name}-[id].wasm`,
 		publicPath: `https://example.com/${hashPart}/`
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
-			__CHUNK__: JSON.stringify(`${name}-chunks/lazy.mjs`),
-			__DIGEST__: JSON.stringify(digest)
+			__CHUNK_DIR__: JSON.stringify(`${name}-chunks`),
+			__DIGEST__: JSON.stringify(digest),
+			__BAKED__: JSON.stringify(extra.baked !== false)
 		})
 	]
 });
@@ -43,5 +50,18 @@ const base = (index, name, hashPart, digest) => ({
 module.exports = [
 	base(0, "plain", "[fullhash]", false),
 	base(1, "sliced", "[fullhash:8]", false),
-	base(2, "digest", "[fullhash:base64safe]", true)
+	base(2, "digest", "[fullhash:base64safe]", true),
+	// A content-named template nothing is emitted under leaves nothing for the
+	// deferred pass to invalidate, so the url still bakes.
+	base(3, "unused-content-name", "[fullhash]", false, {
+		realContentHash: false,
+		workerChunkFilename: "[name].[contenthash].mjs"
+	}),
+	// The chunk the url is written into is named by its own content, and nothing
+	// repairs that name after the deferred pass rewrites it — so it stays runtime.
+	base(4, "no-repair", "[fullhash]", false, {
+		baked: false,
+		realContentHash: false,
+		chunkSuffix: ".[contenthash]"
+	})
 ];

--- a/test/configCases/wasm/sync-constant-public-path/index.js
+++ b/test/configCases/wasm/sync-constant-public-path/index.js
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+// Referenced but never loaded — the harness cannot fetch, and the emitted loader is
+// what is under test.
+export const load = () => import(/* webpackChunkName: "lazy" */ "./module");
+
+it("should inline a public path that never changes", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.mjs"),
+		"utf8"
+	);
+
+	expect(bundle).toContain('fetch("https://cdn.test/" + ');
+	// Nothing reads the global for a value that is already known.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.p`);
+});

--- a/test/configCases/wasm/sync-constant-public-path/module.js
+++ b/test/configCases/wasm/sync-constant-public-path/module.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./wasm.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/sync-constant-public-path/wasm.wat
+++ b/test/configCases/wasm/sync-constant-public-path/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/sync-constant-public-path/webpack.config.js
+++ b/test/configCases/wasm/sync-constant-public-path/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// The binary's name is built at runtime from the module id either way, but the public
+// path in front of it is settled — so it is inlined instead of read from the global,
+// and the runtime module that would set that global is not emitted at all.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	// The bundle is only read back, never fetched — but the harness runs it on node.
+	externalsType: "module",
+	externals: { fs: "fs", path: "path" },
+	devtool: false,
+	module: {
+		rules: [{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/sync" }]
+	},
+	experiments: { outputModule: true, syncWebAssembly: true },
+	optimization: { chunkIds: "named", splitChunks: false },
+	output: {
+		module: true,
+		chunkFilename: "[name].mjs",
+		publicPath: "https://cdn.test/"
+	}
+};

--- a/test/configCases/wasm/sync-constant-public-path/webpack.config.js
+++ b/test/configCases/wasm/sync-constant-public-path/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// The binary's name is built at runtime from the module id either way, but the public
-// path in front of it is settled — so it is inlined instead of read from the global,
-// and the runtime module that would set that global is not emitted at all.
+// A settled public path is inlined instead of read from the global, so the runtime
+// module that would set it is not emitted at all.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/worker/worker-module-hashed/index.js
+++ b/test/configCases/worker/worker-module-hashed/index.js
@@ -17,14 +17,17 @@ it("should run an ESM worker with a content-hashed chunk filename", async () => 
 	await worker.terminate();
 });
 
-it("should fall back to the runtime form when the chunk filename is hashed", () => {
+it("should bake a hashed worker chunk name the deferred pass fills in", () => {
 	const bundle = fs.readFileSync(
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	const chunkFilename = `${"__webpack_require__"}.u`;
+	const specifier = new RegExp(`worker ${"import"} \\*/ "([^"]+)"`).exec(bundle);
 
-	// A hashed filename isn't known at code-gen time, so the runtime helper stays.
-	expect(bundle).toContain(chunkFilename);
-	expect(bundle).not.toContain(`/* worker ${"import"} */ "./worker`);
+	expect(specifier).not.toBe(null);
+	expect(fs.existsSync(path.join(__STATS__.outputPath, specifier[1]))).toBe(
+		true
+	);
+	// The name is settled, so nothing looks it up by chunk id any more.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u`);
 });

--- a/test/configCases/worker/worker-module-hashed/webpack.config.js
+++ b/test/configCases/worker/worker-module-hashed/webpack.config.js
@@ -1,5 +1,8 @@
 "use strict";
 
+// The worker chunk is named by its own content, so its name is reserved and filled
+// in later — into the entry, which no template names by its content.
+
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	target: "node14",

--- a/test/configCases/worker/worker-shared-depths-runtime-path/index.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/index.js
@@ -16,12 +16,11 @@ it("should run a worker referenced from chunks at different depths", async () =>
 	await import(/* webpackChunkName: "nested/deep" */ "./deep");
 });
 
-it("should keep the worker filename a literal behind the runtime public path", () => {
-	const source = fs.readFileSync(
-		path.join(__STATS__.outputPath, "flat.mjs"),
-		"utf8"
-	);
+it("should bake the specifier each depth needs", () => {
+	const read = (name) =>
+		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
 
-	expect(source).toContain(`${"__webpack_require__"}.p + "worker_js.mjs"`);
-	expect(source).not.toContain(`${"__webpack_require__"}.u`);
+	expect(read("flat.mjs")).toContain('"./worker_js.mjs"');
+	expect(read("nested/deep.mjs")).toContain('"../worker_js.mjs"');
+	expect(read("flat.mjs")).not.toContain(`${"__webpack_require__"}.p + "worker`);
 });

--- a/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// Two depths need a stand-in, and without `realContentHash` one may only be written
-// into an asset no template names by its own content. The entry is named that way and
-// the chunks holding the reference are not — and they are the ones rewritten.
+// A stand-in may only be written into an asset not named by its own content. Here the
+// entry is, and the chunks holding the reference — the ones rewritten — are not.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
+++ b/test/configCases/worker/worker-shared-depths-runtime-path/webpack.config.js
@@ -1,7 +1,8 @@
 "use strict";
 
-// Without `realContentHash` nothing repairs a rewritten name, so no stand-in may be
-// reserved and two depths keep the runtime public path before a literal filename.
+// Two depths need a stand-in, and without `realContentHash` one may only be written
+// into an asset no template names by its own content. The entry is named that way and
+// the chunks holding the reference are not — and they are the ones rewritten.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -87,7 +87,7 @@ content-hash:
   content-hash (webpack x.x.x) compiled successfully in X ms
 
 shared-depths:
-  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset main.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: main)
   asset nested/deep.mjs X KiB [emitted] [javascript module] (name: nested/deep)
   asset flat.mjs X KiB [emitted] [javascript module] (name: flat)
   asset async_js.mjs X bytes [emitted] [javascript module]

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -78,7 +78,7 @@ public-path-override:
   public-path-override (webpack x.x.x) compiled successfully in X ms
 
 content-hash:
-  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset main.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: main)
   asset async_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
   runtime modules X KiB 6 modules
   cacheable modules X bytes
@@ -87,9 +87,10 @@ content-hash:
   content-hash (webpack x.x.x) compiled successfully in X ms
 
 shared-depths:
-  asset main.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: main)
-  asset nested/deep.mjs X KiB [emitted] [javascript module] (name: nested/deep)
-  asset flat.mjs X KiB [emitted] [javascript module] (name: flat)
+  assets by info X KiB [immutable]
+    asset nested/deep.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: nested/deep)
+    asset flat.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: flat)
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
   runtime modules X KiB 6 modules
   cacheable modules X bytes

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -99,5 +99,25 @@ shared-depths:
     ./depths-deep.js X bytes [built] [code generated]
     ./depths-shared.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
-  shared-depths (webpack x.x.x) compiled successfully in X ms"
+  shared-depths (webpack x.x.x) compiled successfully in X ms
+
+eval-devtool:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
+  runtime modules X KiB 5 modules
+  cacheable modules X bytes (javascript) X bytes (asset)
+    ./index-eval.js X bytes [built] [code generated]
+    ./asset.txt X bytes (asset) X bytes (javascript) [built] [code generated]
+  eval-devtool (webpack x.x.x) compiled successfully in X ms
+
+worker-chunk-loading:
+  asset worker_js.mjs X KiB [emitted] [javascript module]
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset worker-async.mjs X bytes [emitted] [javascript module] (name: worker-async)
+  runtime modules X KiB 9 modules
+  cacheable modules X bytes
+    ./index-worker.js X bytes [built] [code generated]
+    ./worker.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  worker-chunk-loading (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/analyzable-esm-fallbacks/asset.txt
+++ b/test/statsCases/analyzable-esm-fallbacks/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/statsCases/analyzable-esm-fallbacks/index-eval.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-eval.js
@@ -1,0 +1,2 @@
+// `import.meta` is a syntax error inside the `eval()` this devtool wraps a module in.
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/statsCases/analyzable-esm-fallbacks/index-worker.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-worker.js
@@ -1,0 +1,3 @@
+// A worker loading its own chunks some other way keeps that runtime.
+export const spawn = () =>
+	new Worker(new URL("./worker.js", import.meta.url), { type: "module" });

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -38,6 +38,16 @@ const CASES = {
 		file: /^flat\./,
 		expect: "fallback",
 		bailout: "chunks at different output depths"
+	},
+	"eval-devtool": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: "wraps the module in eval()"
+	},
+	"worker-chunk-loading": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: 'not "import"'
 	}
 };
 

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -19,7 +19,7 @@ const CASES = {
 	// output — the analyzable form is still emitted (documented limitation).
 	"fetch-priority": { file: "main.mjs", expect: "analyzable" },
 	"content-hash": {
-		file: "main.mjs",
+		file: /^main\./,
 		expect: "fallback",
 		bailout: "optimization.realContentHash"
 	},
@@ -35,7 +35,7 @@ const CASES = {
 	// The entry reaches both copies from one depth, so only the chunk they share
 	// falls back — read that one rather than the entry.
 	"shared-depths": {
-		file: "flat.mjs",
+		file: /^flat\./,
 		expect: "fallback",
 		bailout: "chunks at different output depths"
 	}
@@ -53,13 +53,17 @@ module.exports = {
 			const { compilation } = child;
 			const name = /** @type {string} */ (compilation.name);
 			const testCase = CASES[name];
-			const output = fs.readFileSync(
-				path.join(
-					/** @type {string} */ (compilation.outputOptions.path),
-					testCase.file
-				),
-				"utf8"
-			);
+			const outputPath = /** @type {string} */ (compilation.outputOptions.path);
+			// Found rather than named where the chunk carries a content hash.
+			const file =
+				typeof testCase.file === "string"
+					? testCase.file
+					: /** @type {string} */ (
+							fs
+								.readdirSync(outputPath)
+								.find((name) => testCase.file.test(name))
+						);
+			const output = fs.readFileSync(path.join(outputPath, file), "utf8");
 			// A bailout is recorded exactly when the runtime form is kept, so a limitation
 			// that is later lifted fails here until its reason is dropped too.
 			const bailouts = [];

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -76,18 +76,15 @@ module.exports = [
 	}),
 	// Every case below must fall back with no `.ei` emitted.
 	base("public-path-override", { entry: "./index-public-path-override" }),
-	// Deferrable in itself; what stops it here is that the chunk the stand-in would be
-	// written into is named by its own content while `optimization.realContentHash` is
-	// off, as it is by default in development — so nothing repairs the name it is
-	// rewritten under. That chunk is the entry, which is where the reference sits.
+	// The entry the stand-in would land in is named by its own content, and with
+	// `realContentHash` off nothing repairs the name it is rewritten under.
 	base("content-hash", {
 		output: {
 			filename: "[name].[contenthash].mjs",
 			chunkFilename: "[name].[contenthash].mjs"
 		}
 	}),
-	// Two depths need a stand-in, and the chunks it would land in are named by their
-	// content — the referenced one is not, so the depth is what cannot be spelled.
+	// Two depths need a stand-in, and the chunks it would land in are content-named.
 	base("shared-depths", {
 		entry: "./index-depths",
 		plugins: [nameConsumersByContent(["flat", "nested/deep"])]

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -63,9 +63,9 @@ module.exports = [
 		output: { chunkFilename: "[name].[contenthash].mjs" }
 	}),
 	// Two depths need a stand-in, and naming any emitted javascript by its content —
-	// worker chunks included — rules out the rewrite one needs.
+	// the entry here, not the chunks themselves — rules out the rewrite one needs.
 	base("shared-depths", {
 		entry: "./index-depths",
-		output: { workerChunkFilename: "[name].[contenthash].mjs" }
+		output: { filename: "[name].[contenthash].mjs" }
 	})
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -4,13 +4,6 @@ const path = require("path");
 const webpack = require("../../../");
 
 /**
- * One analyzable-ESM build. `name` is both the output subdir and the label; `extra`
- * overrides entry/output/plugins to trigger a single analyzable-import limitation.
- * @param {string} name case name
- * @param {import("../../../").Configuration} extra per-case overrides
- * @returns {import("../../../").Configuration} configuration
- */
-/**
  * Names the given chunks by their own content, which `output` alone cannot do for
  * some chunks and not others.
  * @param {string[]} names chunk names to rename
@@ -20,7 +13,8 @@ const nameConsumersByContent = (names) => (compiler) => {
 	compiler.hooks.compilation.tap("NameConsumersByContent", (compilation) => {
 		compilation.hooks.afterChunks.tap("NameConsumersByContent", (chunks) => {
 			for (const chunk of chunks) {
-				if (chunk.name !== null && names.includes(chunk.name)) {
+				const chunkName = chunk.name;
+				if (typeof chunkName === "string" && names.includes(chunkName)) {
 					chunk.filenameTemplate = "[name].[contenthash].mjs";
 				}
 			}
@@ -28,6 +22,13 @@ const nameConsumersByContent = (names) => (compiler) => {
 	});
 };
 
+/**
+ * One analyzable-ESM build. `name` is both the output subdir and the label; `extra`
+ * overrides entry/output/plugins to trigger a single analyzable-import limitation.
+ * @param {string} name case name
+ * @param {import("../../../").Configuration} extra per-case overrides
+ * @returns {import("../../../").Configuration} configuration
+ */
 const base = (name, extra = {}) => ({
 	name,
 	mode: "development",

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -32,10 +32,11 @@ const nameConsumersByContent = (names) => (compiler) => {
 const base = (name, extra = {}) => ({
 	name,
 	mode: "development",
-	devtool: false,
 	experiments: { outputModule: true },
 	entry: extra.entry || "./index",
 	plugins: extra.plugins,
+	devtool: extra.devtool === undefined ? false : extra.devtool,
+	module: extra.module,
 	output: {
 		module: true,
 		path: path.resolve(
@@ -90,5 +91,16 @@ module.exports = [
 	base("shared-depths", {
 		entry: "./index-depths",
 		plugins: [nameConsumersByContent(["flat", "nested/deep"])]
+	}),
+	// `import.meta` does not parse inside the `eval()` this devtool wraps a module in.
+	base("eval-devtool", {
+		entry: "./index-eval",
+		devtool: "eval",
+		module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] }
+	}),
+	// The worker runs its own chunk loader, which a native `import()` is not.
+	base("worker-chunk-loading", {
+		entry: "./index-worker",
+		output: { workerChunkLoading: "async-node" }
 	})
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -10,6 +10,24 @@ const webpack = require("../../../");
  * @param {import("../../../").Configuration} extra per-case overrides
  * @returns {import("../../../").Configuration} configuration
  */
+/**
+ * Names the given chunks by their own content, which `output` alone cannot do for
+ * some chunks and not others.
+ * @param {string[]} names chunk names to rename
+ * @returns {import("../../../").WebpackPluginFunction} the plugin
+ */
+const nameConsumersByContent = (names) => (compiler) => {
+	compiler.hooks.compilation.tap("NameConsumersByContent", (compilation) => {
+		compilation.hooks.afterChunks.tap("NameConsumersByContent", (chunks) => {
+			for (const chunk of chunks) {
+				if (chunk.name !== null && names.includes(chunk.name)) {
+					chunk.filenameTemplate = "[name].[contenthash].mjs";
+				}
+			}
+		});
+	});
+};
+
 const base = (name, extra = {}) => ({
 	name,
 	mode: "development",
@@ -56,16 +74,20 @@ module.exports = [
 	}),
 	// Every case below must fall back with no `.ei` emitted.
 	base("public-path-override", { entry: "./index-public-path-override" }),
-	// Deferrable in itself; what stops it here is that the chunk is named by its own
-	// content while `optimization.realContentHash` is off, as it is by default in
-	// development — so the name it would be rewritten under has nothing to repair it.
+	// Deferrable in itself; what stops it here is that the chunk the stand-in would be
+	// written into is named by its own content while `optimization.realContentHash` is
+	// off, as it is by default in development — so nothing repairs the name it is
+	// rewritten under. That chunk is the entry, which is where the reference sits.
 	base("content-hash", {
-		output: { chunkFilename: "[name].[contenthash].mjs" }
+		output: {
+			filename: "[name].[contenthash].mjs",
+			chunkFilename: "[name].[contenthash].mjs"
+		}
 	}),
-	// Two depths need a stand-in, and naming any emitted javascript by its content —
-	// the entry here, not the chunks themselves — rules out the rewrite one needs.
+	// Two depths need a stand-in, and the chunks it would land in are named by their
+	// content — the referenced one is not, so the depth is what cannot be spelled.
 	base("shared-depths", {
 		entry: "./index-depths",
-		output: { filename: "[name].[contenthash].mjs" }
+		plugins: [nameConsumersByContent(["flat", "nested/deep"])]
 	})
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/worker.js
+++ b/test/statsCases/analyzable-esm-fallbacks/worker.js
@@ -1,0 +1,1 @@
+export const load = () => import(/* webpackChunkName: "worker-async" */ "./async");

--- a/types.d.ts
+++ b/types.d.ts
@@ -356,6 +356,7 @@ declare interface AllCodeGenerationSchemas {
 	 */
 	"share-init": [{ shareScope: string; initStage: number; init: string }];
 }
+type AnalyzableForm = "import" | "url" | "wasm" | "wasm-relative";
 type AnyLoaderContext = NormalModuleLoaderContext<any> &
 	LoaderRunnerLoaderContext<any> &
 	LoaderPluginLoaderContext &
@@ -24693,45 +24694,22 @@ declare abstract class RuntimeTemplate {
 	supportsModulePreload(): boolean;
 
 	/**
-	 * Analyzable output — a reference a foreign bundler can follow without running
-	 * webpack's runtime — comes in two forms, and what rules them out differs:
-	 * - a literal `import("./chunk.js")`, gated by `supportsAnalyzableImport`
-	 * - a literal `new URL(<file>, import.meta.url)`, gated by `supportsAnalyzableEsm`
-	 * Either way a name that is not settled during code generation may still be baked,
-	 * by reserving a stand-in the deferred pass fills in — see `canDeferAnalyzableName`.
-	 * What still forces the runtime form, and is not covered by any of the three:
-	 * a module federation module in the chunk, and a chunk with no id.
+	 * Whether a reference a foreign bundler can follow without running webpack's runtime
+	 * may be emitted — the one question every caller asks, in the form it is asking for:
+	 * - `"import"` — a literal `import("./chunk.js")` in place of `ensureChunk(id)`
+	 * - `"url"` — a literal `new URL(<file>, import.meta.url)`
+	 * - `"wasm"` — the same, fully baked for a wasm binary the runtime would name
+	 * - `"wasm-relative"` — a wasm path built at runtime under an `import.meta.url` base
+	 * A name code generation cannot settle may still be baked, by reserving a stand-in
+	 * the deferred pass fills in. What no form here covers, because only the reference
+	 * itself can tell: a chunk with no id, and one this compilation emits no javascript
+	 * for. Every no is recorded on `module` through `_analyzableBailout`.
 	 */
-	supportsAnalyzableEsm(chunkGraph?: ChunkGraph, module?: Module): boolean;
-
-	/**
-	 * Whether a chunk reference emitted into `originModule` may be a literal
-	 * `import("./chunk.js")` rather than a runtime `ensureChunk(id)` call.
-	 */
-	supportsAnalyzableImport(
-		chunkGraph: ChunkGraph,
-		originModule: Module
+	supportsAnalyzable(
+		form: AnalyzableForm,
+		chunkGraph?: ChunkGraph,
+		module?: Module
 	): boolean;
-
-	/**
-	 * Whether a name that code generation cannot settle may be reserved as a stand-in
-	 * and filled in once the hashes exist. Substituting rewrites a chunk after its own
-	 * content hash was taken, so either `RealContentHashPlugin` has to bring the two
-	 * back in line, or no emitted javascript may be named by its content in the first
-	 * place — with a name like `[name].js` there is nothing to go stale.
-	 */
-	canDeferAnalyzableName(chunks?: Iterable<Chunk>): boolean;
-
-	/**
-	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm
-	 * binary path built from `wasmModuleId`) may be referenced with the analyzable
-	 * chunk-relative `new URL(path, import.meta.url)` form. Requires ESM output
-	 * (`supportsAnalyzableEsm`) and an `auto` public path — only then is the bare
-	 * relative URL equivalent to the runtime `__webpack_require__.p + path` form.
-	 * Callers that can bake the public path into a static literal specifier should
-	 * use `_getAnalyzableChunkSpecifier` instead, which also handles a fixed path.
-	 */
-	supportsAnalyzableEsmUrl(chunkGraph?: ChunkGraph, module?: Module): boolean;
 
 	/**
 	 * Builds the analyzable `new URL(specifier, import.meta.url)` expression the ESM
@@ -24740,13 +24718,6 @@ declare abstract class RuntimeTemplate {
 	 * global — the form other bundlers and webpack itself can statically follow.
 	 */
 	importMetaUrl(specifier: string): string;
-
-	/**
-	 * Whether async wasm binaries are referenced by a fully baked
-	 * `new URL("./<file>.wasm", import.meta.url)` at the module call site, rather than
-	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
-	 */
-	supportsAnalyzableWasm(chunkGraph?: ChunkGraph, module?: Module): boolean;
 
 	/**
 	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`

--- a/types.d.ts
+++ b/types.d.ts
@@ -25252,6 +25252,17 @@ declare abstract class RuntimeTemplate {
 	}): string;
 
 	/**
+	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
+	 * module. Only called when `supportsAnalyzable("wasm")` holds.
+	 */
+	getAnalyzableWasmUrl(
+		module: Module,
+		chunkGraph: ChunkGraph,
+		runtime: RuntimeSpec,
+		runtimeRequirements: Set<string>
+	): string;
+
+	/**
 	 * Async module factory.
 	 */
 	asyncModuleFactory(__0: {

--- a/types.d.ts
+++ b/types.d.ts
@@ -24720,7 +24720,7 @@ declare abstract class RuntimeTemplate {
 	 * back in line, or no emitted javascript may be named by its content in the first
 	 * place — with a name like `[name].js` there is nothing to go stale.
 	 */
-	canDeferAnalyzableName(): boolean;
+	canDeferAnalyzableName(chunks?: Iterable<Chunk>): boolean;
 
 	/**
 	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm

--- a/types.d.ts
+++ b/types.d.ts
@@ -24749,13 +24749,25 @@ declare abstract class RuntimeTemplate {
 	supportsAnalyzableWasm(chunkGraph?: ChunkGraph, module?: Module): boolean;
 
 	/**
-	 * Whether an entry `baseUri` decides where an asset URL points. It replaces the
-	 * output root the runtime resolves one against, and no literal read from its own
-	 * chunk shares that base — but only a public path that needs a base ever reaches
-	 * it, so an absolute one, `auto` included, is unaffected. Answered for the
-	 * compilation: a module reached from two entries is generated once.
+	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`
+	 * an asset reference bakes to, or `null` to keep the runtime form. Unlike a wasm
+	 * binary, the runtime resolves an asset url against `__webpack_require__.b` — the
+	 * output root, or an entry `baseUri` where one is set — so that base is settled here
+	 * before the rest of the name is.
 	 */
-	reportsEntryBaseUri(module?: Module): boolean;
+	getAnalyzableAssetUrl(
+		module: Module,
+		chunkGraph: ChunkGraph,
+		filename: string
+	): null | string;
+
+	/**
+	 * `output.publicPath` as the constant it will be, for code that would otherwise read
+	 * `__webpack_require__.p` for a value that never changes. `undefined` when only the
+	 * hash could say, or when a runtime reassigns `__webpack_public_path__` — then the
+	 * global is the only thing that knows.
+	 */
+	constantPublicPath(): undefined | string;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -24700,10 +24700,9 @@ declare abstract class RuntimeTemplate {
 	 * - `"url"` — a literal `new URL(<file>, import.meta.url)`
 	 * - `"wasm"` — the same, fully baked for a wasm binary the runtime would name
 	 * - `"wasm-relative"` — a wasm path built at runtime under an `import.meta.url` base
-	 * A name code generation cannot settle may still be baked, by reserving a stand-in
-	 * the deferred pass fills in. What no form here covers, because only the reference
-	 * itself can tell: a chunk with no id, and one this compilation emits no javascript
-	 * for. Every no is recorded on `module` through `_analyzableBailout`.
+	 * A name code generation cannot settle may still be baked, through a stand-in the
+	 * deferred pass fills in. Not covered here, because only the reference can tell: a
+	 * chunk with no id, and one this compilation emits no javascript for.
 	 */
 	supportsAnalyzable(
 		form: AnalyzableForm,

--- a/types.d.ts
+++ b/types.d.ts
@@ -24720,7 +24720,7 @@ declare abstract class RuntimeTemplate {
 	 * back in line, or no emitted javascript may be named by its content in the first
 	 * place — with a name like `[name].js` there is nothing to go stale.
 	 */
-	canDeferAnalyzableName(template?: string): boolean;
+	canDeferAnalyzableName(): boolean;
 
 	/**
 	 * Whether an asset whose URL argument is only known at runtime (e.g. a wasm

--- a/types.d.ts
+++ b/types.d.ts
@@ -24747,6 +24747,15 @@ declare abstract class RuntimeTemplate {
 	 * by `supportsAnalyzableEsmUrl`'s runtime-built path under an `import.meta.url` base.
 	 */
 	supportsAnalyzableWasm(chunkGraph?: ChunkGraph, module?: Module): boolean;
+
+	/**
+	 * Whether an entry `baseUri` decides where an asset URL points. It replaces the
+	 * output root the runtime resolves one against, and no literal read from its own
+	 * chunk shares that base — but only a public path that needs a base ever reaches
+	 * it, so an absolute one, `auto` included, is unaffected. Answered for the
+	 * compilation: a module reached from two entries is generated once.
+	 */
+	reportsEntryBaseUri(module?: Module): boolean;
 	supportTemplateLiteral(): boolean;
 	supportNodePrefixForCoreModules(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Follow-up to #21680. Analyzable ESM output kept the runtime form in a long list of cases that turned out to share one cause: a reserved name had a fixed shape (`prefix + chunk filename + tail`), and the gate deciding whether one could be reserved asked about the whole compilation rather than the asset the name is written into. Both are now per-asset, which settles a hashed `chunkFilename`, a `[fullhash]` or function public path, a re-encoded digest and a two-depth reference in a plain `mode: "development"` build. On top of that, an asset whose every JavaScript consumer is a `new URL()` no longer gets a `module.exports = __webpack_require__.p + name` wrapper that nothing reads.

Two of the commits are fixes for references that resolved somewhere the runtime form does not — a relative `output.publicPath` produced a specifier a chunk below the output root resolved one directory too deep (`test/configCases/module/public-path` carried a `resolveModule` shim for exactly that, now removed), and an entry `baseUri` was ignored outright.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. New `test/configCases/analyzable/`: `asset-url-matrix` (one reference read from two depths under eight shapes of public path), `asset-wrapper-retention`, `asset-url-relative-public-path`, `asset-url-templated-public-path`, `asset-url-function-public-path`, `asset-url-shared-depths`, `asset-url-base-uri`, `asset-url-wrapperless`, `import-relative-public-path`, `shared-module-chunk`, `stand-in-lookalike`; `test/configCases/wasm/sync-constant-public-path`; extra configs on the existing wasm cases; two more bailout reasons in `statsCases/analyzable-esm-fallbacks`; round-trip markers; and `test/AnalyzableChunkHashPlugin.unittest.js` for the payload alphabet and the digest rule no build can reach. Each behavioural change was verified failing on the unmodified `lib/` first.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Output changes only where a reference already had to be analyzable — cases that previously fell back now bake, and one that previously baked a wrong relative URL now bakes the right one.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no new option. What still keeps the runtime form is reported per module in `stats.optimizationBailout`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used. Claude Code implemented the changes and tests under my direction and review: I set the scope, it investigated each fallback, proposed and wrote the patches, and each behavioural claim was checked against a build (failing test first, then passing) rather than accepted from the model. I reviewed every diff before it was committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011gLkJyyoJtX2BVpZNPndbb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved asset and WebAssembly URL generation across relative, rooted, CDN, templated, and function-based public paths.
  - More URLs and dynamic imports are resolved directly in generated bundles, including hashed filenames and nested chunks.
  - Reduces runtime URL handling when paths are statically known.
  - Improves handling of asset wrappers used only when necessary.

- **Bug Fixes**
  - Corrected resolution across entry paths, chunk depths, shared modules, workers, and deferred filenames.

- **Tests**
  - Expanded coverage for URL generation, hashing, WebAssembly, workers, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->