### PR TITLE
 fix(html): read past the whitespace collapseWhitespace removes when omitting an end tag

### DIFF
--- a/.changeset/160-html-end-tag-past-whitespace.md
+++ b/.changeset/160-html-end-tag-past-whitespace.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Let an HTML end tag go with the whitespace that collapseWhitespace removes.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8492,28 +8492,39 @@ const _isBlockLevel = (path, node) =>
 	BLOCK_LEVEL_ELEMENTS.has(path.tagName(node));
 
 /**
+ * Whether a node is a text node holding nothing but whitespace.
+ * @param {HtmlPath} path the accessor
+ * @param {HtmlNodeRef} node the node
+ * @returns {boolean} true when it is whitespace-only text
+ */
+const _isWhitespaceNode = (path, node) =>
+	path.type(node) === NodeType.Text && isAllWs(path.data(node));
+
+/**
  * Whether a text node's leading whitespace sits outside every line box, which is
  * so when it opens a block container. A block *sibling* in front of it would do
  * the same, but reading backwards costs a scan of the whole child list — so this
  * only keeps a space that renders, never drops one that does not.
- * @param {HtmlPath} path the accessor positioned on the text node
+ * @param {HtmlPath} path the accessor
+ * @param {HtmlNodeRef} node the text node
  * @param {HtmlNodeRef} parent its parent (0 = none)
  * @returns {boolean} true when the leading whitespace renders as nothing
  */
-const _startsOutsideLineBox = (path, parent) =>
+const _startsOutsideLineBox = (path, node, parent) =>
 	parent !== 0 &&
-	_nodeFirstChildren[parent] === path.node &&
+	_nodeFirstChildren[parent] === node &&
 	_isBlockLevel(path, parent);
 
 /**
  * Whether a text node's trailing whitespace sits outside every line box: it
  * closes a block container, or a block element follows it.
- * @param {HtmlPath} path the accessor positioned on the text node
+ * @param {HtmlPath} path the accessor
+ * @param {HtmlNodeRef} node the text node
  * @param {HtmlNodeRef} parent its parent (0 = none)
  * @returns {boolean} true when the trailing whitespace renders as nothing
  */
-const _endsOutsideLineBox = (path, parent) => {
-	const next = path.nextSibling(path.node);
+const _endsOutsideLineBox = (path, node, parent) => {
+	const next = path.nextSibling(node);
 	if (next === 0) return parent !== 0 && _isBlockLevel(path, parent);
 	return _isBlockLevel(path, next);
 };
@@ -8538,7 +8549,24 @@ const _canOmitEndTag = (path, name, node) => {
 	}
 	const followers = OPTIONAL_END_TAG_FOLLOWERS.get(name);
 	if (followers === undefined) return false;
-	const next = path.nextSibling(node);
+	let next = path.nextSibling(node);
+	// A whitespace node the mode empties is not in the output, so it cannot keep
+	// the end tag either.
+	if (_collapseWhitespace === "all") {
+		while (next !== 0 && _isWhitespaceNode(path, next)) {
+			next = path.nextSibling(next);
+		}
+	} else if (_collapseWhitespace === "smart") {
+		const parent = path.parentOf(node);
+		while (
+			next !== 0 &&
+			_isWhitespaceNode(path, next) &&
+			(_startsOutsideLineBox(path, next, parent) ||
+				_endsOutsideLineBox(path, next, parent))
+		) {
+			next = path.nextSibling(next);
+		}
+	}
 	if (next === 0) {
 		if (!OPTIONAL_END_TAG_AT_END.has(name)) return false;
 		const parent = path.parentOf(node);
@@ -9847,10 +9875,10 @@ const printer = (path, writer) => {
 					// reaches is dropped rather than kept as one space.
 					if (_collapseWhitespace !== "conservative") {
 						const all = _collapseWhitespace === "all";
-						if (all || _startsOutsideLineBox(path, parent)) {
+						if (all || _startsOutsideLineBox(path, path.node, parent)) {
 							collapsed = collapsed.replace(/^ /, "");
 						}
-						if (all || _endsOutsideLineBox(path, parent)) {
+						if (all || _endsOutsideLineBox(path, path.node, parent)) {
 							collapsed = collapsed.replace(/ $/, "");
 						}
 					}

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8492,6 +8492,29 @@ const _isBlockLevel = (path, node) =>
 	BLOCK_LEVEL_ELEMENTS.has(path.tagName(node));
 
 /**
+ * Whether an ancestor renders whitespace verbatim, which `white-space` inherits
+ * from — the one place minifying leaves a text node exactly as written.
+ * @param {HtmlPath} path the accessor
+ * @param {HtmlNodeRef} node the node to walk up from
+ * @returns {boolean} true when whitespace under it is kept
+ */
+const _isPreformatted = (path, node) => {
+	for (
+		let ancestor = node;
+		ancestor !== 0;
+		ancestor = path.parentOf(ancestor)
+	) {
+		if (
+			path.namespace(ancestor) === NS_HTML &&
+			LEADING_NEWLINE_ELEMENTS.has(path.tagName(ancestor))
+		) {
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
  * Whether a node is a text node holding nothing but whitespace.
  * @param {HtmlPath} path the accessor
  * @param {HtmlNodeRef} node the node
@@ -8552,24 +8575,24 @@ const _canOmitEndTag = (path, name, node) => {
 	let next = path.nextSibling(node);
 	// A whitespace node the mode empties is not in the output, so it cannot keep
 	// the end tag either.
-	if (_collapseWhitespace === "all") {
+	const parent = path.parentOf(node);
+	if (
+		(_collapseWhitespace === "all" || _collapseWhitespace === "smart") &&
+		!_isPreformatted(path, parent)
+	) {
 		while (next !== 0 && _isWhitespaceNode(path, next)) {
-			next = path.nextSibling(next);
-		}
-	} else if (_collapseWhitespace === "smart") {
-		const parent = path.parentOf(node);
-		while (
-			next !== 0 &&
-			_isWhitespaceNode(path, next) &&
-			(_startsOutsideLineBox(path, next, parent) ||
-				_endsOutsideLineBox(path, next, parent))
-		) {
+			if (
+				_collapseWhitespace === "smart" &&
+				!_startsOutsideLineBox(path, next, parent) &&
+				!_endsOutsideLineBox(path, next, parent)
+			) {
+				break;
+			}
 			next = path.nextSibling(next);
 		}
 	}
 	if (next === 0) {
 		if (!OPTIONAL_END_TAG_AT_END.has(name)) return false;
-		const parent = path.parentOf(node);
 		const parentIsHtml = parent !== 0 && path.namespace(parent) === NS_HTML;
 		// Left open inside a formatting element, this is the furthest block the
 		// adoption agency needs — the parent's end tag would then restructure both.
@@ -9852,38 +9875,25 @@ const printer = (path, writer) => {
 			}
 			// A `<` puts the node on the source-passthrough path below, which is what
 			// keeps `<%= x %>` off the escaper — worth more than the whitespace.
-			if (minify && _collapseWhitespace !== "none" && !data.includes("<")) {
-				// Only elements rendering whitespace verbatim without any CSS are
-				// excluded — by ancestor, since `white-space` inherits.
-				let preformatted = false;
-				for (
-					let ancestor = parent;
-					ancestor !== 0;
-					ancestor = path.parentOf(ancestor)
-				) {
-					if (
-						path.namespace(ancestor) === NS_HTML &&
-						LEADING_NEWLINE_ELEMENTS.has(path.tagName(ancestor))
-					) {
-						preformatted = true;
-						break;
+			if (
+				minify &&
+				_collapseWhitespace !== "none" &&
+				!data.includes("<") &&
+				!_isPreformatted(path, parent)
+			) {
+				let collapsed = collapseWhitespaceRuns(data);
+				// Past `"conservative"`, whitespace against a boundary no line box
+				// reaches is dropped rather than kept as one space.
+				if (_collapseWhitespace !== "conservative") {
+					const all = _collapseWhitespace === "all";
+					if (all || _startsOutsideLineBox(path, path.node, parent)) {
+						collapsed = collapsed.replace(/^ /, "");
+					}
+					if (all || _endsOutsideLineBox(path, path.node, parent)) {
+						collapsed = collapsed.replace(/ $/, "");
 					}
 				}
-				if (!preformatted) {
-					let collapsed = collapseWhitespaceRuns(data);
-					// Past `"conservative"`, whitespace against a boundary no line box
-					// reaches is dropped rather than kept as one space.
-					if (_collapseWhitespace !== "conservative") {
-						const all = _collapseWhitespace === "all";
-						if (all || _startsOutsideLineBox(path, path.node, parent)) {
-							collapsed = collapsed.replace(/^ /, "");
-						}
-						if (all || _endsOutsideLineBox(path, path.node, parent)) {
-							collapsed = collapsed.replace(/ $/, "");
-						}
-					}
-					if (collapsed !== data) return _escapeTextContent(collapsed, minify);
-				}
+				if (collapsed !== data) return _escapeTextContent(collapsed, minify);
 			}
 			const raw = path.source();
 			// Off-spec workaround: §13.3 escapes `<`/`>` in text, which would rewrite

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -3808,6 +3808,16 @@ describe("SourceProcessor — collapseWhitespace modes", () => {
 		);
 	});
 
+	it("lets an end tag go with the whitespace that was keeping it", () => {
+		// The `</li>` is only there because a text node sat between the items.
+		expect(
+			collapse("<ul>\n<li>a</li>\n<li>b</li>\n</ul>", "conservative")
+		).toBe("<ul> <li>a</li> <li>b</li> </ul>");
+		expect(collapse("<ul>\n<li>a</li>\n<li>b</li>\n</ul>", "smart")).toBe(
+			"<ul><li>a<li>b</ul>"
+		);
+	});
+
 	it("drops every text node's edges in `all`", () => {
 		expect(collapse(PAGE, "all")).toBe(
 			"<body><div>a b</div><div>c</div><span>d</span></body>"

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -3818,6 +3818,14 @@ describe("SourceProcessor — collapseWhitespace modes", () => {
 		);
 	});
 
+	it("keeps an end tag whose whitespace an ancestor renders verbatim", () => {
+		for (const mode of /** @type {("smart" | "all")[]} */ (["smart", "all"])) {
+			expect(collapse("<pre><p>a</p>\n<p>b</p></pre>", mode)).toBe(
+				"<pre><p>a</p>\n<p>b</pre>"
+			);
+		}
+	});
+
 	it("drops every text node's edges in `all`", () => {
 		expect(collapse(PAGE, "all")).toBe(
 			"<body><div>a b</div><div>c</div><span>d</span></body>"

--- a/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigCacheTest.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigCacheTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><pre>  verbatim   here  </pre></body></html>"`;
+exports[`ConfigCacheTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><pre>  verbatim   here  </pre></body></html>"`;

--- a/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigCacheTest.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigCacheTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><pre>  verbatim   here  </pre></body></html>"`;
+exports[`ConfigCacheTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `
+"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><div><p>a</p> <span>b</span></div><pre>  verbatim   here  </pre><pre><p>a</p>
+<p>b</pre></body></html>"
+`;

--- a/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigTest.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><pre>  verbatim   here  </pre></body></html>"`;
+exports[`ConfigTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `
+"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><div><p>a</p> <span>b</span></div><pre>  verbatim   here  </pre><pre><p>a</p>
+<p>b</pre></body></html>"
+`;

--- a/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/minimize-comments-and-whitespace/__snapshots__/ConfigTest.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><pre>  verbatim   here  </pre></body></html>"`;
+exports[`ConfigTestCases html minimize-comments-and-whitespace minimize-comments-and-whitespace should compile 1`] = `"<!doctype html><html><head><title>Comments and whitespace</title></head><body><div>a b</div><div>c</div> <span> d </span><span> e </span> <!-- @license MIT: kept by pattern -->  <!--[if IE 8]><p class=a>ie<![endif]--><ul><li>one<li>two</ul><table><tr><td>a<td>b</table><pre>  verbatim   here  </pre></body></html>"`;

--- a/test/configCases/html/minimize-comments-and-whitespace/page.html
+++ b/test/configCases/html/minimize-comments-and-whitespace/page.html
@@ -20,6 +20,9 @@
 <td>b</td>
 </tr>
 </table>
+<div><p>a</p> <span>b</span></div>
 <pre>  verbatim   here  </pre>
+<pre><p>a</p>
+<p>b</p></pre>
 </body>
 </html>

--- a/test/configCases/html/minimize-comments-and-whitespace/page.html
+++ b/test/configCases/html/minimize-comments-and-whitespace/page.html
@@ -10,6 +10,16 @@
 <!-- @license MIT: kept by pattern -->
 <!-- ordinary chatter: dropped -->
 <!--[if IE 8]><p  class="a" >ie</p><![endif]-->
+<ul>
+<li>one</li>
+<li>two</li>
+</ul>
+<table>
+<tr>
+<td>a</td>
+<td>b</td>
+</tr>
+</table>
 <pre>  verbatim   here  </pre>
 </body>
 </html>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #21685. `collapseWhitespace` in `"smart"` and `"all"` empties a whitespace-only text node, but `_canOmitEndTag` reads the AST, so the node was still there when it decided — and an optional end tag that only existed because of that whitespace stayed. `<li>a</li> <li>b</li>` collapsed to `<li>a</li><li>b</li>` rather than `<li>a<li>b`.

It now reads past a node the mode is certain to drop, which is what its own doc comment already described. Nothing changes in `"conservative"`, where the whitespace survives as one space and really does keep the tag.

Worth 4976 raw / 228 gzip bytes on top of `"smart"`, measured over html5-boilerplate, swagger-ui and the rendered README and CHANGELOG — most of what the mode saves on a document turns out to be the end tags rather than the spaces.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — a case in the existing collapseWhitespace unit suite, and list and table markup added to the smart-mode fixture under configCases/html so the snapshot and the real-Chrome DOM equivalence check both cover it. Every added line is covered. The output was also compared against parse5 over 36 fixtures: what a browser paints is unchanged.

**Does this PR introduce a breaking change?**

No. Only the two modes that already remove the whitespace are affected.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — no new option, the existing descriptions still hold.

**Use of AI**

AI was used. I found the gap while measuring the modes against other minifiers and decided the scope; Claude Code did the implementation and tests. I reviewed it before pushing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML whitespace collapsing so removed whitespace remains correctly associated with nearby end tags.
  - Smart and all whitespace-collapsing modes now handle optional closing tags more accurately.
  - Preserved meaningful whitespace and closing tags within preformatted content such as `<pre>` blocks.
  - Improved cleanup of redundant list-item closing tags when smart collapsing removes surrounding whitespace.

- **Tests**
  - Added coverage for lists, tables, inline elements, and preformatted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->