### PR TITLE
fix: guard the mkdirpSync retry against EEXIST and EISDIR

### DIFF
--- a/.changeset/049-mkdirp-sync-existing-directory.md
+++ b/.changeset/049-mkdirp-sync-existing-directory.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Do not fail directory creation when the file system reports it already exists.

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -652,7 +652,16 @@ const mkdirpSync = (fs, p) => {
 					throw err;
 				}
 				mkdirpSync(fs, dir);
-				fs.mkdirSync(p);
+				try {
+					fs.mkdirSync(p);
+				} catch (retryErr) {
+					// EEXIST: parent already created it; EISDIR: memfs/BSD for an
+					// existing dir such as the root "/" (#10544)
+					const code = /** @type {NodeJS.ErrnoException} */ (retryErr).code;
+					if (code !== "EEXIST" && code !== "EISDIR") {
+						throw retryErr;
+					}
+				}
 				return;
 			} else if (
 				/** @type {NodeJS.ErrnoException} */ (err).code === "EEXIST" ||

--- a/test/fs.unittest.js
+++ b/test/fs.unittest.js
@@ -76,6 +76,79 @@ const createBrokenFs = (code) => ({
 	}
 });
 
+/**
+ * An ordinary POSIX file system: ENOENT when the parent is missing, EEXIST for
+ * a directory that is already there, success otherwise.
+ * @returns {FakeFs} the file system
+ */
+const createWorkingFs = () => {
+	const dirs = new Set(["/"]);
+	/** @type {string[]} */
+	const created = [];
+	/**
+	 * @param {string} p the directory to create
+	 * @returns {NodeJS.ErrnoException | undefined} the reported error, if any
+	 */
+	const mkdir = (p) => {
+		const parent = p.slice(0, p.lastIndexOf("/")) || "/";
+		if (!dirs.has(parent)) return createError("ENOENT", p);
+		if (dirs.has(p)) return createError("EEXIST", p);
+		dirs.add(p);
+		created.push(p);
+		return undefined;
+	};
+	return {
+		created,
+		mkdir: (p, callback) => {
+			const err = mkdir(p);
+			process.nextTick(() => callback(err));
+		},
+		mkdirSync: (p) => {
+			const err = mkdir(p);
+			if (err) throw err;
+		}
+	};
+};
+
+/**
+ * A file system on which the first mkdir of a directory whose parent exists
+ * succeeds and a second one fails with `code` — so the retry that follows the
+ * ENOENT recursion is the call that fails.
+ * @param {string} code the code the retry fails with
+ * @returns {FakeFs} the file system
+ */
+const createRetryFs = (code) => {
+	const dirs = new Set(["/"]);
+	/** @type {string[]} */
+	const created = [];
+	const attempted = new Set();
+	/**
+	 * @param {string} p the directory to create
+	 * @returns {NodeJS.ErrnoException | undefined} the reported error, if any
+	 */
+	const mkdir = (p) => {
+		const seen = attempted.has(p);
+		attempted.add(p);
+		const parent = p.slice(0, p.lastIndexOf("/")) || "/";
+		if (!dirs.has(parent)) return createError("ENOENT", p);
+		if (seen) return createError(code, p);
+		dirs.add(p);
+		created.push(p);
+		return undefined;
+	};
+	return {
+		created,
+		mkdir: (p, callback) => {
+			const err = mkdir(p);
+			process.nextTick(() => callback(err));
+		},
+		mkdirSync: (p) => {
+			const err = mkdir(p);
+			if (err) throw err;
+		}
+	};
+};
+
 /** @type {[string, (fs: FakeFs, p: string) => Promise<void>][]} */
 const IMPLEMENTATIONS = [
 	[
@@ -106,6 +179,14 @@ const IMPLEMENTATIONS = [
 describe("util/fs", () => {
 	for (const [name, run] of IMPLEMENTATIONS) {
 		describe(name, () => {
+			it("creates every missing directory of the path", async () => {
+				const fs = createWorkingFs();
+
+				await run(fs, "/a/b/c");
+
+				expect(fs.created).toEqual(["/a", "/a/b", "/a/b/c"]);
+			});
+
 			for (const code of ["EEXIST", "EISDIR"]) {
 				it(`creates every missing directory when mkdir reports ${code} instead of success`, async () => {
 					const fs = createFs(code);
@@ -128,6 +209,15 @@ describe("util/fs", () => {
 				await expect(
 					run(createBrokenFs("EACCES"), "/a/b")
 				).rejects.toMatchObject({ code: "EACCES" });
+			});
+
+			it("propagates an error from the retry after the recursion", async () => {
+				const fs = createRetryFs("EACCES");
+
+				await expect(run(fs, "/a/b")).rejects.toMatchObject({
+					code: "EACCES"
+				});
+				expect(fs.created).toEqual(["/a"]);
 			});
 
 			it("propagates ENOENT when not even the root can be created", async () => {

--- a/test/fs.unittest.js
+++ b/test/fs.unittest.js
@@ -1,0 +1,140 @@
+"use strict";
+
+const { mkdirp, mkdirpSync } = require("../lib/util/fs");
+
+/** @typedef {import("../lib/util/fs").IntermediateFileSystem} IntermediateFileSystem */
+/** @typedef {import("../lib/util/fs").OutputFileSystem} OutputFileSystem */
+
+/**
+ * @typedef {object} FakeFs
+ * @property {string[]} created the directories that were created, in order
+ * @property {(p: string, callback: (err?: NodeJS.ErrnoException) => void) => void} mkdir async mkdir
+ * @property {(p: string) => void} mkdirSync sync mkdir
+ */
+
+/**
+ * @param {string} code the error code
+ * @param {string} p the path mkdir was called with
+ * @returns {NodeJS.ErrnoException} an error carrying that code
+ */
+const createError = (code, p) => {
+	const err = /** @type {NodeJS.ErrnoException} */ (
+		new Error(`${code}: mkdir '${p}'`)
+	);
+	err.code = code;
+	return err;
+};
+
+/**
+ * A file system whose mkdir never reports success: a directory whose parent is
+ * missing gets ENOENT, every other one gets `existingCode` — what memfs/BSD do
+ * for an existing directory such as the root "/" (#10544), and what a
+ * concurrent creation looks like on the retry after the recursion.
+ * @param {string} existingCode the code reported instead of success
+ * @returns {FakeFs} the file system
+ */
+const createFs = (existingCode) => {
+	const dirs = new Set(["/"]);
+	/** @type {string[]} */
+	const created = [];
+	/**
+	 * @param {string} p the directory to create
+	 * @returns {NodeJS.ErrnoException} the reported error
+	 */
+	const mkdir = (p) => {
+		const parent = p.slice(0, p.lastIndexOf("/")) || "/";
+		if (!dirs.has(parent)) return createError("ENOENT", p);
+		if (!dirs.has(p)) {
+			dirs.add(p);
+			created.push(p);
+		}
+		return createError(existingCode, p);
+	};
+	return {
+		created,
+		mkdir: (p, callback) => {
+			const err = mkdir(p);
+			process.nextTick(() => callback(err));
+		},
+		mkdirSync: (p) => {
+			throw mkdir(p);
+		}
+	};
+};
+
+/**
+ * @param {string} code the code every mkdir fails with
+ * @returns {FakeFs} a file system on which mkdir always fails
+ */
+const createBrokenFs = (code) => ({
+	created: [],
+	mkdir: (p, callback) => {
+		process.nextTick(() => callback(createError(code, p)));
+	},
+	mkdirSync: (p) => {
+		throw createError(code, p);
+	}
+});
+
+/** @type {[string, (fs: FakeFs, p: string) => Promise<void>][]} */
+const IMPLEMENTATIONS = [
+	[
+		"mkdirp",
+		(fs, p) =>
+			new Promise((resolve, reject) => {
+				mkdirp(
+					/** @type {OutputFileSystem} */ (/** @type {unknown} */ (fs)),
+					p,
+					(err) => {
+						if (err) reject(err);
+						else resolve();
+					}
+				);
+			})
+	],
+	[
+		"mkdirpSync",
+		async (fs, p) => {
+			mkdirpSync(
+				/** @type {IntermediateFileSystem} */ (/** @type {unknown} */ (fs)),
+				p
+			);
+		}
+	]
+];
+
+describe("util/fs", () => {
+	for (const [name, run] of IMPLEMENTATIONS) {
+		describe(name, () => {
+			for (const code of ["EEXIST", "EISDIR"]) {
+				it(`creates every missing directory when mkdir reports ${code} instead of success`, async () => {
+					const fs = createFs(code);
+
+					await run(fs, "/a/b/c");
+
+					expect(fs.created).toEqual(["/a", "/a/b", "/a/b/c"]);
+				});
+
+				it(`succeeds when the directory exists and mkdir reports ${code}`, async () => {
+					const fs = createFs(code);
+
+					await run(fs, "/");
+
+					expect(fs.created).toEqual([]);
+				});
+			}
+
+			it("propagates an unrelated mkdir error", async () => {
+				await expect(
+					run(createBrokenFs("EACCES"), "/a/b")
+				).rejects.toMatchObject({ code: "EACCES" });
+			});
+
+			it("propagates ENOENT when not even the root can be created", async () => {
+				await expect(
+					run(createBrokenFs("ENOENT"), "/a/b")
+				).rejects.toMatchObject({ code: "ENOENT" });
+			});
+		});
+	}
+});

--- a/test/fs.unittest.js
+++ b/test/fs.unittest.js
@@ -26,10 +26,8 @@ const createError = (code, p) => {
 };
 
 /**
- * A file system whose mkdir never reports success: a directory whose parent is
- * missing gets ENOENT, every other one gets `existingCode` — what memfs/BSD do
- * for an existing directory such as the root "/" (#10544), and what a
- * concurrent creation looks like on the retry after the recursion.
+ * A file system whose mkdir never reports success: ENOENT when the parent is
+ * missing, `existingCode` otherwise — as memfs/BSD do for the root "/" (#10544).
  * @param {string} existingCode the code reported instead of success
  * @returns {FakeFs} the file system
  */
@@ -111,9 +109,8 @@ const createWorkingFs = () => {
 };
 
 /**
- * A file system on which the first mkdir of a directory whose parent exists
- * succeeds and a second one fails with `code` — so the retry that follows the
- * ENOENT recursion is the call that fails.
+ * A file system where the first mkdir of a directory succeeds and a second
+ * fails with `code`, so the retry after the ENOENT recursion is what fails.
  * @param {string} code the code the retry fails with
  * @returns {FakeFs} the file system
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Finishes the `mkdirp` work from #21223. `mkdirp` treats `EEXIST`/`EISDIR` as "the directory is there" on the retry that follows its `ENOENT` recursion, but `mkdirpSync` did so only for its first `mkdir`, so a file system that reports `EISDIR` for an existing directory (memfs/BSD, #10544) or a concurrent creation reporting `EEXIST` still threw from the retry. Refs #10544; supersedes #10545, which can be closed.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

A fix.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/fs.unittest.js` runs the same scenarios against both `mkdirp` and `mkdirpSync`, so the two stay in sync; the two `mkdirpSync` cases fail without this change. The `mkdirpSync` branch is only reachable through `ProfilingPlugin`, whose config case is skipped on CI, so a unit test is used instead of an integration case.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to find the gap, write the regression test, and draft the fix. Every change was reviewed and verified locally: the new test fails on unmodified `main` and passes with the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AK6w4cdxoGT9ktV9KQJnQR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory creation to work reliably when the requested directory or its parent already exists.
  * Prevented expected “already exists” conditions from causing failures during recursive directory creation.
  * Continued reporting unexpected filesystem errors so genuine problems are not hidden.
* **Tests**
  * Added comprehensive coverage for asynchronous and synchronous directory creation, existing paths, retries, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->