### PR TITLE
docs(agents): watch every pull request the session opens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,16 +452,17 @@ Required answer per section — **one sentence each is the target, two or three 
 
 After every `git push` of a new branch, check whether a PR was auto-created (webpack has this webhook). If so, `update_pull_request` to install the full template — the auto-created body never matches.
 
-### Watching a PR, and updating its branch — ask first
+### Watching a PR, and updating its branch
 
 > [!REQUIRED]
 
-Two things an agent reaches for by reflex are **not** defaults here, because webpack's maintainers usually land a PR through their own pipeline:
+**Subscribe to every pull request you open** (`subscribe_pr_activity`), as the last step of opening it. Not a question to put to the requester: a PR you opened is one you own until it lands, and [every check ends green](#after-opening-the-pr--every-check-ends-green) and [the automated reviews](#after-opening-the-pr--wait-for-the-automated-reviews) both need the session awake to be honoured at all. Stay subscribed until the PR is merged or closed, or the requester says to stop.
 
-- **Subscribing to a PR's activity** (`subscribe_pr_activity`), which keeps the session attached and wakes it on every check and review. Worth it when the requester wants the PR driven to green; wasted attention when they are about to merge it themselves. Offer it, name what it will do, and let them answer — then `unsubscribe_pr_activity` as soon as they say they are done.
+What an agent reaches for by the same reflex and must **not** do unasked, because webpack's maintainers usually land a PR through their own pipeline:
+
 - **Rebasing, or merging the base branch into the PR branch.** A branch merely behind `main` is not a defect to fix, and doing it unasked rewrites history someone else's pipeline was about to handle, restarts every check, and can drop an approval. Do it when the requester asks, or when the PR is reported genuinely un-mergeable — and say which of the two applies before pushing.
 
-Pushing your own commits to your own branch stays free. What needs asking is anything that changes how the PR gets landed, or how long the session stays attached to it.
+Pushing your own commits to your own branch stays free. What needs asking is anything that changes how the PR gets landed.
 
 ### Writing on GitHub — ask first
 
@@ -505,7 +506,7 @@ Once those suites are in, read the report; only then is a genuine patch gap wort
 
 Every webpack PR is reviewed automatically on the initial commit and on every subsequent push, by whichever automated reviewers the repository has enabled. You must always wait for them and address every comment from each. A finding from a bot is judged on the claim, never on the author: reproduce it before you decide.
 
-1. After `create_pull_request`, ask whether to subscribe to the PR (`subscribe_pr_activity`) — see [Watching a PR, and updating its branch](#watching-a-pr-and-updating-its-branch--ask-first); it is not automatic. Once subscribed, a review wakes the session, so do **not** poll.
+1. After `create_pull_request`, subscribe to the PR (`subscribe_pr_activity`) — see [Watching a PR, and updating its branch](#watching-a-pr-and-updating-its-branch). Once subscribed, a review wakes the session, so do **not** poll.
 2. When a review arrives, read every comment:
    - If correct, push a fix in a new commit — **including when the bug is one your own PR introduced**, which is the common case for a bot flagging a line you just wrote.
    - If wrong, draft the reply and ask the requester before posting it (see [Writing on GitHub — ask first](#writing-on-github--ask-first)) — never ignore silently.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`AGENTS.md` told an agent to *offer* subscribing to a PR it opened and wait for an answer, which put the requester in the loop for a decision that is not theirs to make: the two rules that follow it — every check ends green, and every automated review is answered — cannot be honoured at all by a session that is not awake. Subscribing is now the last step of opening a PR. Updating the branch stays ask-first, since that one really does change how the PR gets landed.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — `AGENTS.md` only; `lint:spellcheck` and `fmt:check` cover it.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this is the documentation.

**Use of AI**

AI was used: an agent following the previous wording stopped to ask whether to watch a PR it had just opened, the maintainer pointed out that it should not have asked, and the agent wrote this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_