### PR TITLE
fix: resolve member access for default reexport namespace

### DIFF
--- a/.changeset/lucky-pianos-repeat.md
+++ b/.changeset/lucky-pianos-repeat.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `import d from "./mod"; d.member` reading `undefined` when `mod` re-exports a namespace as `default`.

--- a/lib/util/chainedImports.js
+++ b/lib/util/chainedImports.js
@@ -78,7 +78,11 @@ function trimIdsToThoseImported(ids, moduleGraph, dependency) {
 	);
 	for (let i = 0; i < ids.length; i++) {
 		if (i === 0 && ids[i] === "default") {
-			continue; // ExportInfo for the next level under default is still at the root ExportsInfo, so don't advance currentExportsInfo
+			const nestedInfo = currentExportsInfo
+				.getExportInfo(ids[i])
+				.getNestedExportsInfo();
+			if (nestedInfo) currentExportsInfo = nestedInfo;
+			continue;
 		}
 		const exportInfo = currentExportsInfo.getExportInfo(ids[i]);
 		if (exportInfo.provided === false) {

--- a/test/configCases/optimization/mangled-namespace-default-reexport/expression.js
+++ b/test/configCases/optimization/mangled-namespace-default-reexport/expression.js
@@ -1,0 +1,3 @@
+import * as ns from "./source";
+
+export default ns;

--- a/test/configCases/optimization/mangled-namespace-default-reexport/index.js
+++ b/test/configCases/optimization/mangled-namespace-default-reexport/index.js
@@ -1,0 +1,7 @@
+import fromSpecifier from "./specifier";
+import fromExpression from "./expression";
+
+it("should mangle a property read through a namespace re-exported as default", () => {
+	expect(fromSpecifier.member.value).toBe(42);
+	expect(fromExpression.member.value).toBe(42);
+});

--- a/test/configCases/optimization/mangled-namespace-default-reexport/source.js
+++ b/test/configCases/optimization/mangled-namespace-default-reexport/source.js
@@ -1,0 +1,2 @@
+export const member = { value: 42 };
+export const other = { value: 7 };

--- a/test/configCases/optimization/mangled-namespace-default-reexport/specifier.js
+++ b/test/configCases/optimization/mangled-namespace-default-reexport/specifier.js
@@ -1,0 +1,3 @@
+import * as ns from "./source";
+
+export { ns as default };

--- a/test/configCases/optimization/mangled-namespace-default-reexport/webpack.config.js
+++ b/test/configCases/optimization/mangled-namespace-default-reexport/webpack.config.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * @param {string} name config name
+ * @param {boolean} concatenateModules whether to enable module concatenation
+ * @returns {import("../../../../").Configuration} config
+ */
+const config = (name, concatenateModules) => ({
+	name,
+	mode: "production",
+	optimization: {
+		concatenateModules,
+		// keeps the re-exporting module in the graph; when it is skipped the ids
+		// are rewritten to point straight at `source.js` and never reach the
+		// cross-module lookup this exercises
+		sideEffects: false,
+		minimize: false
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	config(
+		"mangled-namespace-default-reexport without module concatenation",
+		false
+	),
+	config("mangled-namespace-default-reexport with module concatenation", true)
+];


### PR DESCRIPTION

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fix `trimIdsToThoseImported` trimming away the ids that follow a leading `default`. For `["default", "member"]` it now keeps both, so each is rendered with its mangled name and the access stays consistent with the export it reads.

```js
// index.js
import d from "./mod";
console.log(d.member); // `.member` was left unmangled at the call site

// mod.js
import * as ns from "./ns";
export default ns;

// ns.js
export const member = {}; // while `member` is mangled here
```

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact aisting applications. -->

No.

**If relevant, what needs to be documented once your changes are merged orumented?**

<!-- List all the information that needs to be added to the documentation dy been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default imports so values remain accessible when a module re-exports a namespace as its default export.
  * Prevented default-imported properties from resolving to `undefined` in affected optimization scenarios.

* **Tests**
  * Added coverage for namespace default re-exports with and without module concatenation.
  * Verified that re-exported property values resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->