### PR TITLE
test(concatenate-modules): cover the wrap helper as a chunk's sole runtime requirement

### DIFF
--- a/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/cjs.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/cjs.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// top-level `this` keeps this module unhoistable, so it takes the wrap path
+var extendsImpl = (this && this.extendsImpl) || function () {};
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.hello = void 0;
+function hello() {
+	return "hello " + typeof extendsImpl;
+}
+exports.hello = hello;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/index.js
@@ -1,0 +1,16 @@
+import { hello } from "./cjs";
+
+it("should run when the wrap helper is the chunk's only runtime requirement", () => {
+	// the helper assigns onto `__webpack_require__`, so the require scope has to
+	// be emitted even though nothing else in the chunk asks for it
+	expect(hello()).toBe("hello function");
+});
+
+it("should keep the wrap helper the chunk's only runtime module", () => {
+	const runtimeModules = __STATS__.modules.filter(
+		(m) => m.moduleType === "runtime"
+	);
+	expect(runtimeModules.map((m) => m.name)).toEqual([
+		"webpack/runtime/concatenation wrap"
+	]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Refs #21706. A chunk whose only runtime requirement is the concatenation wrap helper still has to emit the require scope, or `__webpack_require__.cw = …` assigns onto something that was never declared and the bundle throws on load. `main` already gets this right — `RuntimeGlobals.concatenationWrap` is in `GLOBALS_ON_REQUIRE` — but that landed as a side effect of the `#21519` rename, and every existing `commonjs-wrapped-*` case pulls in another runtime global, so none of them would catch it going away again.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/configCases/concatenate-modules/commonjs-wrapped-sole-runtime-requirement/`. It asserts both that the bundle runs and, via `__STATS__`, that the wrap helper is the chunk's only runtime module, so the case cannot silently stop being minimal. Removing `RuntimeGlobals.concatenationWrap` from `GLOBALS_ON_REQUIRE` fails it with `ReferenceError: __webpack_require__ is not defined`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code wrote the test case and verified it against the reported reproduction, under my review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZyWYqGRvipP8GHD9gSUFo)_