### PR TITLE
refactor: emit the CommonJS default export as `export default`

### DIFF
--- a/.changeset/115-module-library-exports.md
+++ b/.changeset/115-module-library-exports.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix namespace object reexports and string export names in module library output.
+Fix namespace object reexports and string export names in module library output and emit a CommonJS entry's default as `export default`.

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -585,14 +585,14 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 			alreadyRenderedExports.add(originalName);
 		}
 
+		if (shortHandedExports.length > 0) {
+			result.add(`export { ${shortHandedExports.join(", ")} };\n`);
+		}
+
 		// Add default export `__webpack_exports__` statement to keep better compatibility
 		if (treatAsCommonJs) {
 			needExportsDeclaration = true;
-			shortHandedExports.push(`${RuntimeGlobals.exports} as default`);
-		}
-
-		if (shortHandedExports.length > 0) {
-			result.add(`export { ${shortHandedExports.join(", ")} };\n`);
+			result.add(`export default ${RuntimeGlobals.exports};\n`);
 		}
 
 		result = this._analyzeUnknownProvidedExports(

--- a/test/configCases/library/render-order-issue/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/library/render-order-issue/__snapshots__/ConfigCacheTest.snap
@@ -108,7 +108,8 @@ __WEBPACK_EXTERNAL_MODULE_externals1_v__;
 /******/ let __webpack_exports__ = __webpack_require__(\\"./entry.js\\");
 /******/ const __webpack_exports__entry1 = __webpack_exports__.entry1;
 /******/ const __webpack_exports__entry2 = __webpack_exports__.entry2;
-/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2, __webpack_exports__ as default };
+/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2 };
+/******/ export default __webpack_exports__;
 /******/ 
 "
 `;
@@ -221,7 +222,8 @@ __WEBPACK_EXTERNAL_MODULE_externals1_v__;
 /******/ let __webpack_exports__ = __webpack_require__(\\"./entry.js\\");
 /******/ const __webpack_exports__entry1 = __webpack_exports__.entry1;
 /******/ const __webpack_exports__entry2 = __webpack_exports__.entry2;
-/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2, __webpack_exports__ as default };
+/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2 };
+/******/ export default __webpack_exports__;
 /******/ 
 "
 `;
@@ -334,7 +336,8 @@ __WEBPACK_EXTERNAL_MODULE_externals1_v__;
 /******/ let __webpack_exports__ = __webpack_require__(\\"./entry.js\\");
 /******/ const __webpack_exports__entry1 = __webpack_exports__.entry1;
 /******/ const __webpack_exports__entry2 = __webpack_exports__.entry2;
-/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2, __webpack_exports__ as default };
+/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2 };
+/******/ export default __webpack_exports__;
 /******/ 
 "
 `;
@@ -447,7 +450,8 @@ __WEBPACK_EXTERNAL_MODULE_externals1_v__;
 /******/ let __webpack_exports__ = __webpack_require__(\\"./entry.js\\");
 /******/ const __webpack_exports__entry1 = __webpack_exports__.entry1;
 /******/ const __webpack_exports__entry2 = __webpack_exports__.entry2;
-/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2, __webpack_exports__ as default };
+/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2 };
+/******/ export default __webpack_exports__;
 /******/ 
 "
 `;

--- a/test/configCases/library/render-order-issue/__snapshots__/ConfigTest.snap
+++ b/test/configCases/library/render-order-issue/__snapshots__/ConfigTest.snap
@@ -108,7 +108,8 @@ __WEBPACK_EXTERNAL_MODULE_externals1_v__;
 /******/ let __webpack_exports__ = __webpack_require__(\\"./entry.js\\");
 /******/ const __webpack_exports__entry1 = __webpack_exports__.entry1;
 /******/ const __webpack_exports__entry2 = __webpack_exports__.entry2;
-/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2, __webpack_exports__ as default };
+/******/ export { __webpack_exports__entry1 as entry1, __webpack_exports__entry2 as entry2 };
+/******/ export default __webpack_exports__;
 /******/ 
 "
 `;


### PR DESCRIPTION
**Summary**

CommonJS `module.exports` is not a live binding: a consumer keeps whatever value `require()` returned, and a later `module.exports = …` never reaches it. 

But with `library: { type: "module" }` and a CommonJS entry, webpack output the default export as `export { __webpack_exports__ as default }` which is the ESM live-binding form and it's unlike CommonJS mechanism.

So now we emit `export default __webpack_exports__` instead, matching the actual CommonJS semantics.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CommonJS module compatibility by correctly emitting default exports.
  * Ensured default exports are available through a standalone `export default` statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->