### PR TITLE
feat: improve tree shaking for namespace reexported as default

### DIFF
--- a/.changeset/eighty-jokes-shake.md
+++ b/.changeset/eighty-jokes-shake.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Improve tree-shaking for a namespace reexported as default.

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -107,6 +107,68 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			parser.state.current.addDependency(sideEffectDep);
 			return true;
 		});
+		// `export default <namespace binding>` is the same export as
+		// `export { ns as default }`, so it is claimed here and rewritten into the
+		// same re-export. Stage -10 runs before the inner-graph tap, which would
+		// otherwise wrap the identifier in a pure-expression guard whose insertions
+		// outlive the statement this removes.
+		parser.hooks.statement.tap(
+			{ name: PLUGIN_NAME, stage: -10 },
+			(statement) => {
+				if (
+					statement.type !== "ExportDefaultDeclaration" ||
+					statement.declaration.type !== "Identifier"
+				) {
+					return;
+				}
+				const name = statement.declaration.name;
+				const settings =
+					/** @type {HarmonySettings | undefined} */
+					(parser.getTagData(name, harmonySpecifierTag));
+				if (!settings || settings.ids.length !== 0) return;
+				if (ImportPhaseUtils.isDefer(settings.phase)) return;
+				const harmonyNamedExports = (parser.state.harmonyNamedExports =
+					parser.state.harmonyNamedExports || new Set());
+				harmonyNamedExports.add("default");
+				getInnerGraphUtils(parser.state.compilation).addVariableUsage(
+					parser,
+					name,
+					"default"
+				);
+				const dep = new HarmonyExportImportedSpecifierDependency(
+					settings.source,
+					settings.sourceOrder,
+					settings.ids,
+					"default",
+					harmonyNamedExports,
+					null,
+					exportPresenceMode,
+					null,
+					settings.phase,
+					settings.attributes
+				);
+
+				// lazy barrel: defer the re-export at parse time when the importing module is side-effect-free
+				const moduleFactoryMeta = parser.state.module.factoryMeta;
+				if (
+					moduleFactoryMeta !== undefined &&
+					moduleFactoryMeta.sideEffectFree
+				) {
+					dep.setLazy(true);
+				}
+				dep.setLocWithIndex(parser.getLocation(statement), -1);
+				parser.state.current.addDependency(dep);
+
+				// `false` erases the whole statement, as for `export { ns as default }`
+				const headerDep = new HarmonyExportHeaderDependency(
+					false,
+					/** @type {Range} */ (statement.range)
+				);
+				headerDep.setLocWithIndex(parser.getLocation(statement), -1);
+				parser.state.module.addPresentationalDependency(headerDep);
+				return true;
+			}
+		);
 		parser.hooks.exportExpression.tap(PLUGIN_NAME, (statement, node) => {
 			const isFunctionDeclaration = node.type === "FunctionDeclaration";
 			const exprRange = /** @type {Range} */ (node.range);

--- a/test/cases/parsing/harmony-export-expression/f.js
+++ b/test/cases/parsing/harmony-export-expression/f.js
@@ -1,0 +1,3 @@
+import * as ns from "./g.js";
+
+export default ns;

--- a/test/cases/parsing/harmony-export-expression/g.js
+++ b/test/cases/parsing/harmony-export-expression/g.js
@@ -1,0 +1,1 @@
+export const member = 42;

--- a/test/cases/parsing/harmony-export-expression/h.js
+++ b/test/cases/parsing/harmony-export-expression/h.js
@@ -1,0 +1,3 @@
+import { value } from "./i.js";
+
+export default value;

--- a/test/cases/parsing/harmony-export-expression/i.js
+++ b/test/cases/parsing/harmony-export-expression/i.js
@@ -1,0 +1,5 @@
+export let value = 1;
+
+export function bump() {
+	value = 2;
+}

--- a/test/cases/parsing/harmony-export-expression/index.js
+++ b/test/cases/parsing/harmony-export-expression/index.js
@@ -2,10 +2,23 @@ import a from "./a.js";
 import c from "./c.js";
 import d from "./d.js";
 import e from "./e.js";
+import f from "./f.js";
+import h from "./h.js";
+import { value, bump } from "./i.js";
 
 it("should work", async function() {
 	expect((await a).default(2, 3)).toBe(5);
 	expect(c).toBe(3);
 	expect(d()).toBe(2);
 	expect(e).toBe(10);
+});
+
+it("should export an imported namespace as default", function() {
+	expect(f.member).toBe(42);
+});
+
+it("should snapshot a named import exported as default", function() {
+	bump();
+	expect(h).toBe(1);
+	expect(value).toBe(2);
 });

--- a/test/configCases/optimization/default-export-namespace/index.js
+++ b/test/configCases/optimization/default-export-namespace/index.js
@@ -1,0 +1,10 @@
+import ns from "./module";
+
+it("should only mark the accessed properties of a namespace exported as default", () => {
+	expect(ns.member.name).toBe("member");
+	// `export default ns` must track usage like `export { ns as default }` does,
+	// instead of falling back to "the whole namespace object is referenced"
+	expect(ns.usedExportsOfSource.sort()).toEqual(
+		["member", "usedExportsOfSource"].sort()
+	);
+});

--- a/test/configCases/optimization/default-export-namespace/module.js
+++ b/test/configCases/optimization/default-export-namespace/module.js
@@ -1,0 +1,3 @@
+import * as ns from "./source";
+
+export default ns;

--- a/test/configCases/optimization/default-export-namespace/source.js
+++ b/test/configCases/optimization/default-export-namespace/source.js
@@ -1,0 +1,5 @@
+export const member = { name: "member" };
+export const unused1 = { name: "unused1" };
+export const unused2 = { name: "unused2" };
+
+export const usedExportsOfSource = __webpack_exports_info__.usedExports;

--- a/test/configCases/optimization/default-export-namespace/webpack.config.js
+++ b/test/configCases/optimization/default-export-namespace/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/**
+ * @param {string} name config name
+ * @param {boolean} concatenateModules whether to enable module concatenation
+ * @returns {import("../../../../").Configuration} config
+ */
+const config = (name, concatenateModules) => ({
+	name,
+	mode: "production",
+	optimization: {
+		concatenateModules,
+		minimize: false
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	config("default-export-namespace without module concatenation", false),
+	config("default-export-namespace with module concatenation", true)
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

We now generate the re-export dependency with `id: default` for the following case, which can be better for tree-shaking.

```js
// index.js
import * as ns from "./g.js";
export default ns;
```
**What kind of change does this PR introduce?**

feat
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tree-shaking for namespaces re-exported as default exports.
  * Better tracks which namespace properties are actually used, reducing unnecessary bundled code.

* **Bug Fixes**
  * Corrected handling of default exports from imported namespaces and named bindings.

* **Tests**
  * Added coverage for default-exported namespaces, property usage, live bindings, and optimized module concatenation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->