### PR TITLE
feat(umd): add sap.ui.define branch to UMD wrapper

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1490,7 +1490,7 @@ export interface LibraryOptions {
 	umdNamedDefine?: UmdNamedDefine;
 }
 /**
- * Set explicit comments for `commonjs`, `commonjs2`, `amd`, and `root`.
+ * Set explicit comments for `commonjs`, `commonjs2`, `amd`, `sapUiDefine`, and `root`.
  */
 export interface LibraryCustomUmdCommentObject {
 	/**
@@ -1509,6 +1509,10 @@ export interface LibraryCustomUmdCommentObject {
 	 * Set comment for `root` (global variable) section in UMD.
 	 */
 	root?: string;
+	/**
+	 * Set comment for `sapUiDefine` (sap.ui.define) section in UMD.
+	 */
+	sapUiDefine?: string;
 }
 /**
  * Description object for all UMD variants of the library name.

--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -329,6 +329,20 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 							: names.amd && namedDefine === true
 								? `		define(${libraryName(names.amd)}, [], ${amdFactory});\n`
 								: `		define([], ${amdFactory});\n`
+					}${getAuxiliaryComment(
+						"sapUiDefine"
+					)}	else if(typeof sap !== 'undefined' && sap.ui && typeof sap.ui.define === 'function')\n${
+						requiredExternals.length > 0
+							? names.amd && namedDefine === true
+								? `		sap.ui.define(${libraryName(names.amd)}, ${externalsDepsArray(
+										requiredExternals
+									)}, ${amdFactory});\n`
+								: `		sap.ui.define(${externalsDepsArray(requiredExternals)}, ${
+										amdFactory
+									});\n`
+							: names.amd && namedDefine === true
+								? `		sap.ui.define(${libraryName(names.amd)}, [], ${amdFactory});\n`
+								: `		sap.ui.define([], ${amdFactory});\n`
 					}${
 						names.root || names.commonjs
 							? `${getAuxiliaryComment(

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3026,7 +3026,7 @@
       ]
     },
     "LibraryCustomUmdCommentObject": {
-      "description": "Set explicit comments for `commonjs`, `commonjs2`, `amd`, and `root`.",
+      "description": "Set explicit comments for `commonjs`, `commonjs2`, `amd`, `sapUiDefine`, and `root`.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -3044,6 +3044,10 @@
         },
         "root": {
           "description": "Set comment for `root` (global variable) section in UMD.",
+          "type": "string"
+        },
+        "sapUiDefine": {
+          "description": "Set comment for `sapUiDefine` (sap.ui.define) section in UMD.",
           "type": "string"
         }
       }

--- a/test/UmdLibraryPlugin.test.js
+++ b/test/UmdLibraryPlugin.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const path = require("path");
+const vm = require("vm");
+const fs = require("graceful-fs");
+const webpack = require("..");
+
+const outputDir = path.join(__dirname, "js", "UmdLibraryPlugin");
+
+/**
+ * Compiles a UMD bundle from an inline entry and returns the output source.
+ * @param {import("../").Configuration} config webpack configuration
+ * @returns {Promise<string>} emitted bundle source
+ */
+const compile = (config) =>
+	new Promise((resolve, reject) => {
+		const compiler = webpack(config);
+		compiler.run((err, stats) => {
+			if (err) return reject(err);
+			if (stats && stats.hasErrors()) {
+				return reject(new Error(stats.toString()));
+			}
+			const outputFile = path.join(
+				/** @type {string} */ (config.output && config.output.path),
+				/** @type {string} */ (
+					(config.output && config.output.filename) || "main.js"
+				)
+			);
+			resolve(fs.readFileSync(outputFile, "utf8"));
+		});
+	});
+
+const baseConfig = (name, extra = {}) => ({
+	mode: "none",
+	entry: path.join(__dirname, "fixtures", "umd-sap-entry.js"),
+	output: {
+		path: path.join(outputDir, name),
+		filename: "bundle.js",
+		library: {
+			name: "MyLib",
+			type: "umd"
+		}
+	},
+	...extra
+});
+
+describe("UmdLibraryPlugin — sap.ui.define branch", () => {
+	beforeAll(() => {
+		fs.mkdirSync(outputDir, { recursive: true });
+	});
+
+	it("emits sap.ui.define branch in generated wrapper", async () => {
+		const src = await compile(baseConfig("basic"));
+		expect(src).toContain(
+			"typeof sap !== 'undefined' && sap.ui && typeof sap.ui.define === 'function'"
+		);
+		expect(src).toContain("sap.ui.define(");
+	});
+
+	it("places sap.ui.define check after define.amd and before exports check", async () => {
+		const src = await compile(baseConfig("ordering"));
+		const amdPos = src.indexOf("define.amd");
+		const sapPos = src.indexOf("sap.ui.define");
+		const exportsPos = src.indexOf("typeof exports === 'object'", sapPos + 1);
+		expect(amdPos).toBeLessThan(sapPos);
+		expect(sapPos).toBeLessThan(exportsPos);
+	});
+
+	it("uses named define with sap.ui.define when namedDefine and library name set", async () => {
+		const src = await compile(
+			baseConfig("named-define", {
+				output: {
+					path: path.join(outputDir, "named-define"),
+					filename: "bundle.js",
+					library: {
+						name: "MyLib",
+						type: "umd",
+						umdNamedDefine: true
+					}
+				}
+			})
+		);
+		expect(src).toContain('sap.ui.define("MyLib"');
+	});
+
+	it("uses anonymous sap.ui.define when namedDefine is not set", async () => {
+		const src = await compile(baseConfig("anon-define"));
+		expect(src).toContain("sap.ui.define([],");
+		expect(src).not.toContain('sap.ui.define("MyLib"');
+	});
+
+	it("includes auxiliaryComment for sapUiDefine section", async () => {
+		const src = await compile(
+			baseConfig("auxiliary-comment", {
+				output: {
+					path: path.join(outputDir, "auxiliary-comment"),
+					filename: "bundle.js",
+					library: {
+						name: "MyLib",
+						type: "umd",
+						auxiliaryComment: {
+							sapUiDefine: "sap.ui.define loader"
+						}
+					}
+				}
+			})
+		);
+		expect(src).toContain("//sap.ui.define loader");
+	});
+
+	it("executes via sap.ui.define at runtime and returns the correct export", async () => {
+		const src = await compile(baseConfig("runtime-sap"));
+		const registeredModules = /** @type {Record<string, unknown>} */ ({});
+		const context = {
+			module: undefined,
+			exports: undefined,
+			define: undefined,
+			sap: {
+				ui: {
+					/**
+					 * @param {string | string[]} _nameOrDeps module name or deps array
+					 * @param {((...args: unknown[]) => unknown) | unknown[]} depsOrFactory deps array or factory
+					 * @param {((...args: unknown[]) => unknown)=} maybeFactory factory when name provided
+					 */
+					define(_nameOrDeps, depsOrFactory, maybeFactory) {
+						const factory =
+							typeof maybeFactory === "function"
+								? maybeFactory
+								: /** @type {(...args: unknown[]) => unknown} */ (
+										depsOrFactory
+									);
+						registeredModules.default = factory();
+					}
+				}
+			}
+		};
+		vm.runInNewContext(src, context);
+		expect(registeredModules.default).toEqual({ value: 42 });
+		expect(context.module).toBeUndefined();
+	});
+
+	it("falls back to global when sap.ui.define is absent", async () => {
+		const src = await compile(baseConfig("runtime-global"));
+		const context = /** @type {Record<string, unknown>} */ ({
+			module: undefined,
+			exports: undefined,
+			define: undefined,
+			sap: undefined
+		});
+		vm.runInNewContext(src, context);
+		expect(context.MyLib).toEqual({ value: 42 });
+	});
+
+	it("sap.ui.define branch is skipped when sap is undefined", async () => {
+		const src = await compile(baseConfig("runtime-no-sap"));
+		let sapDefineCalled = false;
+		const context = /** @type {Record<string, unknown>} */ ({
+			module: undefined,
+			exports: undefined,
+			define: undefined,
+			sap: {
+				ui: {
+					/**
+					 * @param {...unknown} _args unused args
+					 */
+					define(..._args) {
+						sapDefineCalled = true;
+					}
+				},
+				// sap.ui.define is not a function — guard should reject it
+				notAFunction: true
+			}
+		});
+		// Override so the guard `typeof sap.ui.define === 'function'` is false
+		context.sap = /** @type {unknown} */ ({ ui: { define: "not-a-function" } });
+		vm.runInNewContext(src, context);
+		expect(sapDefineCalled).toBe(false);
+		expect(context.MyLib).toEqual({ value: 42 });
+	});
+});

--- a/test/fixtures/umd-sap-entry.js
+++ b/test/fixtures/umd-sap-entry.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { value: 42 };


### PR DESCRIPTION
Inserts an else-if branch for sap.ui.define immediately after the define.amd check in the UMD wrapper, making SAP UI5's module loader a first-class UMD target. Supports named/anonymous define, externals, and auxiliaryComment.sapUiDefine.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

[SAPUI5](https://ui5.sap.com/#/) and its open-source equivalent, [OpenUI5](https://openui5.org/), is the primary UI framework used for SAP products, and used widely in SAP customer systems.  It uses an AMD-style module loader similar to require.js, with "sap.ui.require" and "sap.ui.define" as the module factory wrappers.

Currently integration with third party libraries is problematic since they cannot be integrated with the module loader, requiring the use of shims that result in global variables for the module imports or alterations to webpack-bundled deliverables to add the module loader to the factory checks.

We would like to add the sap.ui.define signature to the UMD wrapper so that we can support third party libraries natively.

<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

Feature

**Did you add tests for your changes?**

Yes

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The sap.ui.define module loader has been added to the existing checks for requirejs and ESM environments.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

AI used for initial analysis, proposed plan and first draft code, then cleaned up in human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UMD libraries can now load through SAP UI5’s `sap.ui.define`, including named or anonymous module definitions and external dependencies.
  * Added configurable comments for the SAP UI5 module section.

* **Bug Fixes**
  * Improved fallback behavior when SAP UI5 module loading is unavailable or invalid.

* **Tests**
  * Added coverage for SAP UI5 integration, branch selection, dependency handling, comments, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->