### PR TITLE
fix(externals): render an asset-url external for its consumer

### DIFF
--- a/.changeset/026-asset-url-external-consumers.md
+++ b/.changeset/026-asset-url-external-consumers.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Emit no dead module and no failing require for an `asset-url` external.

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -869,9 +869,8 @@ class ExternalModule extends Module {
 	 * @returns {SourceTypes} types available (do not mutate)
 	 */
 	getSourceTypes() {
-		// the resolved type, so a type that renders no javascript is never
-		// reported as a javascript module — that would render it as a dead
-		// `false` factory in the chunk and let consumers require it
+		// resolved, so a type rendering no javascript is never reported as a
+		// javascript module — that would emit a dead `false` factory in the chunk
 		const type = this._resolveExternalType(this.externalType);
 		// TODO webpack 6 drop "css-url" once the alias is removed
 		if (type === ASSET_URL_TYPE || type === "css-url") {
@@ -1160,9 +1159,8 @@ class ExternalModule extends Module {
 			externalType === ASSET_URL_TYPE ||
 			externalType === "css-url"
 		) {
-			// the consumer decides: a css `url()` reads the url out of the module,
-			// which the factory marks with a `sourceType`; a javascript `new URL()`
-			// requires it instead and gets the `asset` wrapper exporting the url
+			// the consumer decides: a css `url()` reads the url out of the module
+			// (marked by the factory), a `new URL()` requires the `asset` wrapper
 			if (
 				this.dependencyMeta &&
 				/** @type {AssetDependencyMeta} */

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -869,17 +869,15 @@ class ExternalModule extends Module {
 	 * @returns {SourceTypes} types available (do not mutate)
 	 */
 	getSourceTypes() {
-		if (this.externalType === "asset" && this.dependencyMeta) {
-			const sourceType =
-				/** @type {AssetDependencyMeta} */
-				(this.dependencyMeta).sourceType;
-			// TODO webpack 6 drop "css-url" once the alias is removed
-			if (sourceType === ASSET_URL_TYPE || sourceType === "css-url") {
-				return ASSET_URL_TYPES;
-			}
-		} else if (this.externalType === "css-import") {
-			return CSS_IMPORT_TYPES;
+		// the resolved type, so a type that renders no javascript is never
+		// reported as a javascript module — that would render it as a dead
+		// `false` factory in the chunk and let consumers require it
+		const type = this._resolveExternalType(this.externalType);
+		// TODO webpack 6 drop "css-url" once the alias is removed
+		if (type === ASSET_URL_TYPE || type === "css-url") {
+			return ASSET_URL_TYPES;
 		}
+		if (type === "css-import") return CSS_IMPORT_TYPES;
 
 		return JAVASCRIPT_TYPES;
 	}
@@ -1156,7 +1154,15 @@ class ExternalModule extends Module {
 					.externalType;
 			}
 			return "module";
-		} else if (externalType === "asset") {
+		} else if (
+			// TODO webpack 6 drop "css-url" once the alias is removed
+			externalType === "asset" ||
+			externalType === ASSET_URL_TYPE ||
+			externalType === "css-url"
+		) {
+			// the consumer decides: a css `url()` reads the url out of the module,
+			// which the factory marks with a `sourceType`; a javascript `new URL()`
+			// requires it instead and gets the `asset` wrapper exporting the url
 			if (
 				this.dependencyMeta &&
 				/** @type {AssetDependencyMeta} */

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -244,8 +244,7 @@ class ExternalModuleFactoryPlugin {
 						};
 					}
 
-					// a css `url()` reads the url out of the external directly, so it
-					// gets no javascript wrapper — however the type was spelled
+					// a css `url()` reads the url out of the external: no js wrapper
 					// TODO webpack 6 drop "css-url" once the alias is removed
 					if (
 						(resolvedType === "asset" ||

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -244,8 +244,13 @@ class ExternalModuleFactoryPlugin {
 						};
 					}
 
+					// a css `url()` reads the url out of the external directly, so it
+					// gets no javascript wrapper — however the type was spelled
+					// TODO webpack 6 drop "css-url" once the alias is removed
 					if (
-						resolvedType === "asset" &&
+						(resolvedType === "asset" ||
+							resolvedType === ASSET_URL_TYPE ||
+							resolvedType === "css-url") &&
 						dependency instanceof CssUrlDependency
 					) {
 						dependencyMeta = { sourceType: ASSET_URL_TYPE };

--- a/test/configCases/externals/asset-url/index.js
+++ b/test/configCases/externals/asset-url/index.js
@@ -5,10 +5,12 @@ const path = __non_webpack_require__("path");
 
 const jsAsset = new URL("js-asset", import.meta.url);
 const jsAssetUrl = new URL("js-asset-url", import.meta.url);
+const jsCssUrl = new URL("js-css-url", import.meta.url);
 
 it("should resolve an asset external from javascript, whichever type it is", () => {
 	expect(jsAsset.toString()).toBe("https://example.test/js-asset.png");
 	expect(jsAssetUrl.toString()).toBe("https://example.test/js-asset-url.png");
+	expect(jsCssUrl.toString()).toBe("https://example.test/js-css-url.png");
 });
 
 it("should keep an asset external in the stylesheet, whichever type it is", () => {
@@ -20,4 +22,5 @@ it("should keep an asset external in the stylesheet, whichever type it is", () =
 
 	expect(css).toContain("url(https://example.test/css-asset.png)");
 	expect(css).toContain("url(https://example.test/css-asset-url.png)");
+	expect(css).toContain("url(https://example.test/css-css-url.png)");
 });

--- a/test/configCases/externals/asset-url/index.js
+++ b/test/configCases/externals/asset-url/index.js
@@ -1,0 +1,23 @@
+import "./style.css";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+const jsAsset = new URL("js-asset", import.meta.url);
+const jsAssetUrl = new URL("js-asset-url", import.meta.url);
+
+it("should resolve an asset external from javascript, whichever type it is", () => {
+	expect(jsAsset.toString()).toBe("https://example.test/js-asset.png");
+	expect(jsAssetUrl.toString()).toBe("https://example.test/js-asset-url.png");
+});
+
+it("should keep an asset external in the stylesheet, whichever type it is", () => {
+	// a web target has no `__dirname`, so take the directory from the stats
+	const css = fs.readFileSync(
+		path.join(__STATS__.outputPath, `bundle${__STATS_I__}.css`),
+		"utf-8"
+	);
+
+	expect(css).toContain("url(https://example.test/css-asset.png)");
+	expect(css).toContain("url(https://example.test/css-asset-url.png)");
+});

--- a/test/configCases/externals/asset-url/style.css
+++ b/test/configCases/externals/asset-url/style.css
@@ -1,4 +1,5 @@
 body {
 	background: url("css-asset");
 	border-image: url("css-asset-url");
+	mask-image: url("css-css-url");
 }

--- a/test/configCases/externals/asset-url/style.css
+++ b/test/configCases/externals/asset-url/style.css
@@ -1,0 +1,4 @@
+body {
+	background: url("css-asset");
+	border-image: url("css-asset-url");
+}

--- a/test/configCases/externals/asset-url/test.config.js
+++ b/test/configCases/externals/asset-url/test.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = `bundle${scope.__STATS_I__}.css`;
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/externals/asset-url/webpack.config.js
+++ b/test/configCases/externals/asset-url/webpack.config.js
@@ -9,8 +9,10 @@ const PLUGIN_NAME = "AssertAssetExternalSourceTypesPlugin";
 const EXPECTED_SOURCE_TYPES = {
 	"css-asset": ["asset-url"],
 	"css-asset-url": ["asset-url"],
+	"css-css-url": ["asset-url"],
 	"js-asset": ["javascript"],
-	"js-asset-url": ["javascript"]
+	"js-asset-url": ["javascript"],
+	"js-css-url": ["javascript"]
 };
 
 /** @type {import("../../../../").Configuration} */
@@ -25,8 +27,11 @@ module.exports = {
 	externals: {
 		"css-asset": "asset https://example.test/css-asset.png",
 		"css-asset-url": "asset-url https://example.test/css-asset-url.png",
+		// TODO webpack 6 remove, `css-url` is the old spelling of `asset-url`
+		"css-css-url": "css-url https://example.test/css-css-url.png",
 		"js-asset": "asset https://example.test/js-asset.png",
-		"js-asset-url": "asset-url https://example.test/js-asset-url.png"
+		"js-asset-url": "asset-url https://example.test/js-asset-url.png",
+		"js-css-url": "css-url https://example.test/js-css-url.png"
 	},
 	plugins: [
 		/**

--- a/test/configCases/externals/asset-url/webpack.config.js
+++ b/test/configCases/externals/asset-url/webpack.config.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const { ExternalModule } = require("../../../../");
+
+const PLUGIN_NAME = "AssertAssetExternalSourceTypesPlugin";
+
+// a css `url()` reads the url out of the external, a javascript `new URL()`
+// requires it — so only the css consumer is wrapper-less
+const EXPECTED_SOURCE_TYPES = {
+	"css-asset": ["asset-url"],
+	"css-asset-url": ["asset-url"],
+	"js-asset": ["javascript"],
+	"js-asset-url": ["javascript"]
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	experiments: {
+		css: true
+	},
+	optimization: {
+		minimize: false
+	},
+	externals: {
+		"css-asset": "asset https://example.test/css-asset.png",
+		"css-asset-url": "asset-url https://example.test/css-asset-url.png",
+		"js-asset": "asset https://example.test/js-asset.png",
+		"js-asset-url": "asset-url https://example.test/js-asset-url.png"
+	},
+	plugins: [
+		/**
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterSeal.tap(PLUGIN_NAME, () => {
+					/** @type {Record<string, string[]>} */
+					const actual = {};
+					for (const module of compilation.modules) {
+						if (!(module instanceof ExternalModule)) continue;
+						actual[module.userRequest] = [...module.getSourceTypes()];
+					}
+					expect(actual).toEqual(EXPECTED_SOURCE_TYPES);
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

An `asset-url` external (or its `css-url` alias) reported `javascript` as its source type but generated no javascript, so every chunk holding one carried a dead `false` factory — including the correct css `url()` use, where the same external spelled `asset` emits nothing — and a javascript `new URL()` that required that factory threw `TypeError: __webpack_modules__[moduleId] is not a function`. The consumer decides now, as it already did for `asset`: a css `url()` gets the wrapper-less module it reads the url out of, a `new URL()` gets the wrapper exporting the url.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/externals/asset-url`, which pins the source types per consumer, both urls at runtime, and both urls in the emitted stylesheet, for the `asset` and `asset-url` spellings alike.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Output changes only where it was dead or throwing; `asset` externals and css output are unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — written with Claude Code, which located the cause, made the change and wrote the test. Both symptoms were reproduced on unmodified `main` first, the fix was verified by rebuilding the same cases, and the externals/css/asset/url/html suites were run before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeikjhsPfa6nDAs6pjqrtB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset URL externals so generated bundles no longer include unused modules or failing `require` calls.
  * Improved handling of asset and CSS URL references from JavaScript and stylesheets.
  * Preserved external asset URLs correctly in generated CSS.

* **Tests**
  * Added coverage for asset URL resolution across JavaScript and CSS imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->