### PR TITLE
fix: keep the runtime out of strict mode when output.globalObject reads this

### DIFF
--- a/.changeset/111-global-object-this-strict-runtime.md
+++ b/.changeset/111-global-object-this-strict-runtime.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep the runtime out of strict mode when `output.globalObject` reads `this`.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -202,6 +202,9 @@ Module has these incoming connections: ${Array.from(
 		}`
 ).join("")}`;
 
+// `this` as a value, not as a property name or part of a longer identifier
+const THIS_REFERENCE_REGEXP = /(?:^|[^\w$.])this(?![\w$])/;
+
 /**
  * Gets global object.
  * @param {string | undefined} definition global object definition
@@ -254,6 +257,15 @@ class RuntimeTemplate {
 
 	isIIFE() {
 		return this.outputOptions.iife;
+	}
+
+	/**
+	 * Whether the global object expression reads the `this` binding, which only
+	 * refers to the global object outside of strict mode.
+	 * @returns {boolean} true, when it reads `this`
+	 */
+	globalObjectUsesThis() {
+		return THIS_REFERENCE_REGEXP.test(this.globalObject);
 	}
 
 	isModule() {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -203,7 +203,8 @@ Module has these incoming connections: ${Array.from(
 ).join("")}`;
 
 // `this` as a value, not as a property name or part of a longer identifier
-const THIS_REFERENCE_REGEXP = /(?:^|[^\w$.])this(?![\w$])/;
+// (identifier characters per `getGlobalObject` below, so `globalThis` is not one)
+const THIS_REFERENCE_REGEXP = /(?:^|[^\p{L}\p{N}_$.])this(?![\p{L}\p{N}_$])/u;
 
 /**
  * Gets global object.

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -157,9 +157,9 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				dep.setLocWithIndex(parser.getLocation(statement), -1);
 				parser.state.current.addDependency(dep);
 
-				// `false` erases the whole statement, as for `export { ns as default }`
+				// no range erases the whole statement, as for `export { ns as default }`
 				const headerDep = new HarmonyExportHeaderDependency(
-					false,
+					undefined,
 					/** @type {Range} */ (statement.range)
 				);
 				headerDep.setLocWithIndex(parser.getLocation(statement), -1);

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1229,7 +1229,17 @@ class JavascriptModulesPlugin {
 			!allStrict &&
 			allModules.every((m) => /** @type {BuildInfo} */ (m.buildInfo).strict)
 		) {
-			const strictBailout = hooks.strictRuntimeBailout.call(renderContext);
+			// a non-arrow bootstrap IIFE is called without a receiver, so in strict
+			// mode the `this` that `output.globalObject` reads would be undefined
+			const globalObjectNeedsThis =
+				iife &&
+				!runtimeTemplate.supportsArrowFunction() &&
+				runtimeTemplate.globalObjectUsesThis();
+			const strictBailout =
+				hooks.strictRuntimeBailout.call(renderContext) ||
+				(globalObjectNeedsThis
+					? "'output.globalObject' reads 'this'"
+					: undefined);
 			if (strictBailout) {
 				source.add(
 					`${prefix}// runtime can't be in strict mode because ${strictBailout}.\n`

--- a/test/configCases/output/global-object-this-strict-runtime/dependency.js
+++ b/test/configCases/output/global-object-this-strict-runtime/dependency.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/output/global-object-this-strict-runtime/index.js
+++ b/test/configCases/output/global-object-this-strict-runtime/index.js
@@ -1,0 +1,9 @@
+import { value } from "./dependency.js";
+
+it("should run the runtime when output.globalObject is 'this'", () => {
+	expect(value).toBe(42);
+	// the jsonp runtime registered itself on the object `this` resolved to
+	expect(Array.isArray(self.webpackChunkGlobalObjectThisStrictRuntime)).toBe(
+		true
+	);
+});

--- a/test/configCases/output/global-object-this-strict-runtime/test.config.js
+++ b/test/configCases/output/global-object-this-strict-runtime/test.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+let globalContext;
+
+module.exports = {
+	moduleScope(scope) {
+		globalContext = scope.window;
+	},
+	// the runtime reads the sloppy-mode `this`, which is the global object
+	nonEsmThis: () => globalContext,
+	findBundle: () => ["./runtime.js", "./main.js"]
+};

--- a/test/configCases/output/global-object-this-strict-runtime/webpack.config.js
+++ b/test/configCases/output/global-object-this-strict-runtime/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// es5 has no arrow functions, so the bootstrap IIFE is a plain function
+	target: ["web", "es5"],
+	entry: { main: "./index.js" },
+	optimization: { runtimeChunk: "single" },
+	output: {
+		filename: "[name].js",
+		globalObject: "this",
+		chunkLoadingGlobal: "webpackChunkGlobalObjectThisStrictRuntime"
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -24811,6 +24811,12 @@ declare abstract class RuntimeTemplate {
 	globalObject: string;
 	contentHashReplacement: string;
 	isIIFE(): boolean;
+
+	/**
+	 * Whether the global object expression reads the `this` binding, which only
+	 * refers to the global object outside of strict mode.
+	 */
+	globalObjectUsesThis(): boolean;
 	isModule(): boolean;
 	isNeutralPlatform(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

When every module in the runtime chunk is strict, `renderMain` adds `"use strict"` to the bootstrap IIFE; without arrow functions that IIFE is a plain `function` called with no receiver, so `this` is `undefined` and `this[chunkLoadingGlobal]` throws as the bundle loads. `renderMain` now takes the existing `strictRuntimeBailout` path when `output.globalObject` reads `this`, so each strict module carries its own `"use strict"` instead — the same output shape any chunk with a non-strict module already has. Fixes #12031.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/output/global-object-this-strict-runtime/`, which fails on `main` with `TypeError: Cannot read properties of undefined (reading 'webpackChunk…')`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Output changes only when `output.globalObject` reads `this` and arrow functions are unavailable; strict-mode semantics of user modules are unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the fix removes the need for the undocumented `output.globalObject: "window"` workaround reported in the issue.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to reproduce the issue, locate the cause in `renderMain`, write the fix and the test case, and verify it. Every claim was checked by building and executing the affected bundles: the emitted diff is one line, and strict-mode behaviour of user code (undeclared assignment, module `this`, frozen writes, poisoned `fn.caller`) was confirmed identical before and after in both development and production. Reviewed by a human before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hWJcGG8eUbw4uzCjGQK8M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved runtime compatibility when the configured global object references `this`.
  - Prevented strict mode from being applied in scenarios where it could cause incorrect global-object resolution.
  - Ensured JSONP chunk registration continues to use the intended global object.

- **Tests**
  - Added coverage for strict-mode builds targeting web ES5 with `output.globalObject` set to `this`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->