### PR TITLE
test(benchmark): add e2e build benchmarks

### DIFF
--- a/.github/scripts/select-benchmarks.mjs
+++ b/.github/scripts/select-benchmarks.mjs
@@ -4,12 +4,17 @@ import { execFileSync } from "child_process";
 import fs from "fs";
 
 const fullMatrix = {
-	include: [{ dir: "unit", shard: "1/1" }]
+	include: [
+		{ dir: "unit", shard: "1/1" },
+		{ dir: "e2e", shard: "1/3" },
+		{ dir: "e2e", shard: "2/3" },
+		{ dir: "e2e", shard: "3/3" }
+	]
 };
 
 const benchmarkFiles = execFileSync(
 	"git",
-	["ls-files", "-z", "test/benchmark/unit"],
+	["ls-files", "-z", "test/benchmark/unit", "test/benchmark/e2e"],
 	{ encoding: "utf8" }
 )
 	.split("\0")
@@ -17,16 +22,62 @@ const benchmarkFiles = execFileSync(
 	.sort();
 
 const suiteByFile = new Map(
-	benchmarkFiles.map((file) => [
-		file,
-		file
-			.slice("test/benchmark/".length, -".bench.mjs".length)
-			.replaceAll("\\", "/")
-	])
+	benchmarkFiles.map((file) => {
+		if (file.startsWith("test/benchmark/e2e/")) {
+			return [file, file.split("/").slice(2, 4).join("/")];
+		}
+		return [
+			file,
+			file
+				.slice("test/benchmark/".length, -".bench.mjs".length)
+				.replaceAll("\\", "/")
+		];
+	})
 );
 const fileBySuite = new Map(
 	[...suiteByFile].map(([file, suite]) => [suite, file])
 );
+const e2eFiles = benchmarkFiles.filter((file) =>
+	file.startsWith("test/benchmark/e2e/")
+);
+
+const e2eRules = [
+	["e2e/asset-modules", [/^lib\/asset\//, /^lib\/AssetModulesPlugin\.js$/]],
+	[
+		"e2e/code-splitting",
+		[
+			/^lib\/optimize\//,
+			/^lib\/(?:Chunk|ChunkGraph|ChunkGroup|Entrypoint|buildChunkGraph)\.js$/
+		]
+	],
+	["e2e/css-modules", [/^lib\/css\//]],
+	[
+		"e2e/filesystem-cache",
+		[
+			/^lib\/cache\//,
+			/^lib\/serialization\//,
+			/^lib\/(?:Cache|CacheFacade)\.js$/,
+			/^lib\/util\/serialization\.js$/
+		]
+	],
+	["e2e/json-modules", [/^lib\/json\//]],
+	[
+		"e2e/rebuild",
+		[
+			/^hot\//,
+			/^lib\/hmr\//,
+			/^lib\/cache\//,
+			/^lib\/(?:Compilation|Compiler|FileSystemInfo|NormalModule|Watching)\.js$/
+		]
+	],
+	[
+		"e2e/source-map",
+		[
+			/^lib\/(?:EvalSourceMapDevToolPlugin|SourceMapDevToolModuleOptionsPlugin|SourceMapDevToolPlugin)\.js$/,
+			/^lib\/util\/extractSourceMap\.js$/
+		]
+	]
+];
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -72,8 +123,17 @@ const recommendedSelection = (changedFiles) => {
 			addSuite(`unit/${file.slice("lib/".length, -".js".length)}`);
 		}
 
+		if (/^(lib|schemas)\//.test(file)) {
+			addSuite("e2e/many-modules-commonjs");
+			addSuite("e2e/many-modules-esm");
+		}
+
 		if (file.startsWith("assembly/")) {
 			addSuite("unit/util/createHash");
+		}
+
+		for (const [suite, patterns] of e2eRules) {
+			if (patterns.some((pattern) => pattern.test(file))) addSuite(suite);
 		}
 	}
 
@@ -83,6 +143,17 @@ const recommendedSelection = (changedFiles) => {
 	const include = [];
 	if (sortedSuites.some((suite) => suite.startsWith("unit/"))) {
 		include.push({ dir: "unit", shard: "1/1" });
+	}
+
+	const e2eShards = new Set();
+	for (const suite of sortedSuites) {
+		if (!suite.startsWith("e2e/")) continue;
+		const file = fileBySuite.get(suite);
+		const index = file === undefined ? -1 : e2eFiles.indexOf(file);
+		if (index >= 0) e2eShards.add((index % 3) + 1);
+	}
+	for (const shard of [...e2eShards].sort()) {
+		include.push({ dir: "e2e", shard: `${shard}/3` });
 	}
 
 	return {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,10 @@ jobs:
 
       - run: yarn cover:unit --ci --cacheDirectory .jest-cache
 
+      # test/Benchmarks.unittest.js smoke-runs the unit suites; the e2e ones
+      # build real projects, so they run here instead of under jest.
+      - run: yarn benchmark:e2e --smoke
+
       - name: Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ The directory listings below are the canonical map of the repository. **Whenever
 **Tests** — see [TESTING_DOCS.md](TESTING_DOCS.md) for directory structure, naming, and how to run a single case.
 
 - `test/` — All test suites (`cases/`, `configCases/`, `watchCases/`, `hotCases/`, `statsCases/`, `typesCases/`, `test262-cases/`, `html5lib-tests/`, `wpt/`, `css-parsing-tests/`, `benchmarkCases/`, `memoryLimitCases/`, etc.). `RoundTripConfigCases` re-bundles the output of `configCases` marked with a `roundTrip.js` file. `wpt/` is web-platform-tests, checked out one commit deep by the `html5lib` job alone — it is where the HTML tree-construction corpus lives since html5lib-tests dropped it.
-- `test/benchmark/` — Non-comparative benchmark harness (`lib/`) and unit benchmarks (`unit/`); see `test/benchmark/README.md`.
+- `test/benchmark/` — Non-comparative benchmark harness (`lib/`), unit benchmarks (`unit/`) and full-build benchmarks (`e2e/`); see `test/benchmark/README.md`.
 
 **Examples & changesets**
 

--- a/TESTING_DOCS.md
+++ b/TESTING_DOCS.md
@@ -23,9 +23,9 @@ This document explains the structure of the `test/` directory in the Webpack pro
 
 ### 2b. `benchmark/`
 
-- **Purpose**: Non-comparative, CodSpeed-integrated benchmarks: `unit/` for webpack internals, `lib/` for the harness itself.
-- **Usage**: `yarn benchmark:unit` or `yarn benchmark:suite`; see [test/benchmark/README.md](test/benchmark/README.md).
-- **Kept working by**: `test/Benchmarks.unittest.js`, which runs every suite once (`--smoke`) as part of `yarn test:unit`. Measurement itself only runs on schedule or behind a label, so without it a suite broken by a `lib/` change would stay unnoticed until then.
+- **Purpose**: Non-comparative, CodSpeed-integrated benchmarks: `unit/` for webpack internals, `e2e/` for full builds, `lib/` for the harness itself.
+- **Usage**: `yarn benchmark:unit`, `yarn benchmark:e2e` or `yarn benchmark:suite`; see [test/benchmark/README.md](test/benchmark/README.md).
+- **Kept working by**: `test/Benchmarks.unittest.js`, which runs every `unit/` suite once (`--smoke`) as part of `yarn test:unit`, and the `yarn benchmark:e2e --smoke` step in the `unit` CI job. Measurement itself only runs on schedule or behind a label, so without these a suite broken by a `lib/` change would stay unnoticed until then.
 
 ### 3. `cases/`
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "benchmark:html-minifiers": "node tooling/compare-html-minifiers.js",
     "benchmark:suite": "node --perf-prof --perf-basic-prof --interpreted-frames-native-stack --allow-natives-syntax ./test/benchmark/lib/cli.mjs",
     "benchmark:unit": "yarn benchmark:suite --dir unit",
+    "benchmark:e2e": "yarn benchmark:suite --dir e2e",
     "pretest": "yarn lint",
     "test": "yarn test:base",
     "test:base": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules --trace-deprecation node_modules/jest-cli/bin/jest --workerIdleMemoryLimit=512MB --logHeapUsage",

--- a/test/Benchmarks.unittest.js
+++ b/test/Benchmarks.unittest.js
@@ -89,9 +89,11 @@ const importDefault = async (file) => {
 
 describe("Benchmarks", () => {
 	const unitFiles = findBenchmarkFiles(path.join(benchmarkRoot, "unit"));
+	const e2eFiles = findBenchmarkFiles(path.join(benchmarkRoot, "e2e"));
 
 	it("should discover the benchmark suites", () => {
 		expect(unitFiles).not.toHaveLength(0);
+		expect(e2eFiles).not.toHaveLength(0);
 	});
 
 	// the scheduled run is the only one that measures everything, and its shard
@@ -105,21 +107,23 @@ describe("Benchmarks", () => {
 			expect(selection.run).toBe(true);
 			expect(selection.filter).toBe("");
 
-			const shards = selection.matrix.include
-				.filter((entry) => entry.dir === "unit")
-				.map((entry) => entry.shard);
-			expect(shards).not.toHaveLength(0);
+			for (const dir of ["unit", "e2e"]) {
+				const shards = selection.matrix.include
+					.filter((entry) => entry.dir === dir)
+					.map((entry) => entry.shard);
+				expect(shards).not.toHaveLength(0);
 
-			const sharded = shards
-				.flatMap((shard) => listBenchmarks(["--dir", "unit", "--shard", shard]))
-				.sort();
-			// equality, so a benchmark cannot be dropped or measured twice
-			expect(sharded).toEqual(listBenchmarks(["--dir", "unit"]));
+				const sharded = shards
+					.flatMap((shard) => listBenchmarks(["--dir", dir, "--shard", shard]))
+					.sort();
+				// equality, so a benchmark cannot be dropped or measured twice
+				expect(sharded).toEqual(listBenchmarks(["--dir", dir]));
+			}
 		},
 		120000
 	);
 
-	for (const file of unitFiles) {
+	for (const file of [...unitFiles, ...e2eFiles]) {
 		const id = suiteIdOf(file);
 
 		itNode(`should name suite ${id} after its location`, async () => {
@@ -130,6 +134,10 @@ describe("Benchmarks", () => {
 				suite.benches.length
 			);
 		});
+	}
+
+	for (const file of unitFiles) {
+		const id = suiteIdOf(file);
 
 		it(`should keep ${id} mirroring a core file`, () => {
 			const core = path.join(

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -7,8 +7,9 @@ wall-clock latency.
 ## Layout
 
 - `unit/` contains focused core benchmarks and mirrors `lib/`.
+- `e2e/` contains full webpack builds grouped by workload.
 - `helpers/` contains deterministic fixture generators.
-- `lib/` contains suite discovery and execution.
+- `lib/` contains suite discovery, execution and webpack lifecycle helpers.
 
 A unit suite has the same relative path and exact basename as its primary core
 file. For example:
@@ -29,11 +30,13 @@ should primarily belong to the named core file.
 
 ```bash
 yarn benchmark:unit
+yarn benchmark:e2e
 yarn benchmark:suite
 yarn benchmark:suite --filter "JavascriptParser"
 yarn benchmark:suite --dir unit --smoke
-yarn benchmark:suite --dir unit --shard 1/2
+yarn benchmark:suite --dir e2e --shard 1/2
 yarn benchmark:suite --list
+yarn benchmark:suite --json test/js/benchmark-results.json
 yarn benchmark:suite --max-rme 5
 ```
 
@@ -42,6 +45,24 @@ before a full run when adding or changing suites.
 
 Wall-time runs warn when any benchmark exceeds 15% RME. Use `--max-rme` or
 `MAX_RME` to select a different threshold.
+
+## Adding an e2e suite
+
+Use `createBuildScenarios` for each configuration. It creates development and
+production builds plus a development rebuild in temporary output directories:
+
+```js
+const name = "e2e/many-modules-esm";
+
+export default {
+	name,
+	benches: createBuildScenarios({
+		case: "without-module-concatenation",
+		entryFile,
+		config: { entry }
+	})
+};
+```
 
 ## Adding a unit suite
 
@@ -80,4 +101,6 @@ selects affected suites and shards from the changed files. CodSpeed fills
 unmeasured benchmarks from the baseline as a
 [partial run](https://codspeed.io/docs/features/partial-runs).
 
-Fixtures must not depend on time, ambient files or `Math.random()`.
+Fixtures must not depend on time, ambient files or `Math.random()`. Generated
+e2e projects belong in a `generated/` directory, which is ignored by Git and
+recreated by the suite.

--- a/test/benchmark/e2e/asset-modules/index.bench.mjs
+++ b/test/benchmark/e2e/asset-modules/index.bench.mjs
@@ -1,0 +1,72 @@
+import path from "path";
+import { generateAssetProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const name = "e2e/asset-modules";
+
+/**
+ * @param {"asset" | "asset/bytes" | "asset/inline" | "asset/resource" | "asset/source"} type module type
+ * @param {number=} maxSize automatic inline threshold
+ * @returns {import("../../../..").Configuration} configuration
+ */
+const assetConfig = (type, maxSize) => ({
+	entry,
+	module: {
+		rules: [
+			{
+				test: /\.bin$/,
+				type,
+				...(maxSize === undefined
+					? {}
+					: { parser: { dataUrlCondition: { maxSize } } })
+			}
+		]
+	}
+});
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateAssetProject({
+			dir: generated,
+			count: 150,
+			size: (index) => (index % 2 === 0 ? 512 : 16_384)
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			case: "asset/resource",
+			entryFile: entry,
+			config: assetConfig("asset/resource")
+		}),
+		...createBuildScenarios({
+			case: "asset/inline",
+			entryFile: entry,
+			config: assetConfig("asset/inline")
+		}),
+		...createBuildScenarios({
+			case: "asset/source",
+			entryFile: entry,
+			config: assetConfig("asset/source")
+		}),
+		...createBuildScenarios({
+			case: "asset/bytes",
+			entryFile: entry,
+			config: assetConfig("asset/bytes")
+		}),
+		...createBuildScenarios({
+			case: "automatic-mixed",
+			entryFile: entry,
+			config: assetConfig("asset", 8192)
+		}),
+		...createBuildScenarios({
+			case: "automatic-resource",
+			entryFile: entry,
+			config: assetConfig("asset", 256)
+		})
+	]
+};

--- a/test/benchmark/e2e/code-splitting/index.bench.mjs
+++ b/test/benchmark/e2e/code-splitting/index.bench.mjs
@@ -1,0 +1,77 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const esmGenerated = path.join(caseDir, "generated", "esm");
+const esmEntry = path.join(esmGenerated, "module-0.js");
+const commonJsGenerated = path.join(caseDir, "generated", "commonjs");
+const commonJsEntry = path.join(commonJsGenerated, "module-0.js");
+const name = "e2e/code-splitting";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		// Every 7th edge is a dynamic import → dozens of async chunks, which
+		// exercises chunk graph building and splitChunks.
+		await Promise.all([
+			generateModuleTree({
+				dir: esmGenerated,
+				count: 200,
+				format: "esm",
+				dynamicEvery: 7
+			}),
+			generateModuleTree({
+				dir: commonJsGenerated,
+				count: 200,
+				format: "cjs",
+				dynamicEvery: 7
+			})
+		]);
+	},
+	benches: [
+		...createBuildScenarios({
+			case: "esm",
+			entryFile: esmEntry,
+			config: { entry: esmEntry }
+		}),
+		...createBuildScenarios({
+			case: "commonjs",
+			entryFile: commonJsEntry,
+			config: { entry: commonJsEntry }
+		}),
+		...createBuildScenarios({
+			case: "esm/split-chunks-all",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: {
+					splitChunks: { chunks: "all", minSize: 1000 }
+				}
+			}
+		}),
+		...createBuildScenarios({
+			case: "esm/split-chunks-max-size",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: {
+					splitChunks: {
+						chunks: "all",
+						minSize: 1000,
+						maxSize: 20_000
+					}
+				}
+			}
+		}),
+		...createBuildScenarios({
+			case: "esm/single-runtime-chunk",
+			entryFile: esmEntry,
+			config: {
+				entry: esmEntry,
+				optimization: { runtimeChunk: "single" }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/css-modules/index.bench.mjs
+++ b/test/benchmark/e2e/css-modules/index.bench.mjs
@@ -1,0 +1,29 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { generateCssProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = path.dirname(fileURLToPath(import.meta.url));
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const name = "e2e/css-modules";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateCssProject({
+			dir: generated,
+			count: 40,
+			rulesPerFile: 30
+		});
+	},
+	benches: createBuildScenarios({
+		entryFile: entry,
+		config: {
+			entry,
+			target: "web",
+			experiments: { css: true }
+		}
+	})
+};

--- a/test/benchmark/e2e/filesystem-cache/index.bench.mjs
+++ b/test/benchmark/e2e/filesystem-cache/index.bench.mjs
@@ -1,0 +1,147 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { prepareConfig, runBuild } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/filesystem-cache";
+
+const createOutputPath = () =>
+	fs.mkdtemp(path.join(os.tmpdir(), "webpack-benchmark-"));
+
+/**
+ * @param {string} outputPath temporary output directory
+ * @param {string} benchName benchmark name
+ * @param {"development" | "production"} mode mode
+ * @param {false | "gzip" | "brotli"} compression cache compression
+ * @returns {{ write: import("../../../..").Configuration, read: import("../../../..").Configuration, cacheDirectory: string }} cache configurations
+ */
+const cacheConfigs = (outputPath, benchName, mode, compression) => {
+	const write = prepareConfig(outputPath, benchName, {
+		mode,
+		entry,
+		cache: {
+			type: "filesystem",
+			compression,
+			maxMemoryGenerations: 0,
+			idleTimeoutForInitialStore: 0
+		}
+	});
+	const fileCache = /** @type {import("../../../..").FileCacheOptions} */ (
+		write.cache
+	);
+	return {
+		write,
+		read: {
+			...write,
+			cache: {
+				...fileCache,
+				readonly: true
+			}
+		},
+		cacheDirectory: /** @type {string} */ (fileCache.cacheDirectory)
+	};
+};
+
+/**
+ * @param {string} caseName benchmark case
+ * @param {"development" | "production"} mode mode
+ * @param {false | "gzip" | "brotli"} compression cache compression
+ * @returns {{ name: string, async: boolean, beforeAll: () => Promise<void>, fn: () => Promise<void>, afterAll: () => Promise<void> }} benchmark
+ */
+const warmCacheBench = (caseName, mode, compression) => {
+	const benchName = `${caseName}/${mode}-build`;
+	/** @type {ReturnType<typeof cacheConfigs> | undefined} */
+	let config;
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+			config = cacheConfigs(outputPath, benchName, mode, compression);
+			try {
+				await runBuild(config.write);
+			} catch (error) {
+				await fs.rm(outputPath, { recursive: true, force: true });
+				outputPath = undefined;
+				config = undefined;
+				throw error;
+			}
+		},
+		fn() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return runBuild(config.read);
+		},
+		async afterAll() {
+			config = undefined;
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+};
+
+const coldCacheBench = () => {
+	const benchName = "cold/development-build";
+	/** @type {ReturnType<typeof cacheConfigs> | undefined} */
+	let config;
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+			config = cacheConfigs(outputPath, benchName, "development", false);
+		},
+		beforeEach() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return fs.rm(config.cacheDirectory, {
+				recursive: true,
+				force: true
+			});
+		},
+		fn() {
+			if (config === undefined) {
+				throw new Error("Cache benchmark is not initialized");
+			}
+			return runBuild(config.write);
+		},
+		async afterAll() {
+			config = undefined;
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+};
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 300,
+			format: "esm"
+		});
+	},
+	benches: [
+		warmCacheBench("warm", "development", false),
+		warmCacheBench("warm", "production", false),
+		warmCacheBench("warm-gzip", "development", "gzip"),
+		warmCacheBench("warm-brotli", "development", "brotli"),
+		coldCacheBench()
+	]
+};

--- a/test/benchmark/e2e/json-modules/index.bench.mjs
+++ b/test/benchmark/e2e/json-modules/index.bench.mjs
@@ -1,0 +1,48 @@
+import path from "path";
+import { generateJsonProject } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "index.js");
+const selectedEntry = path.join(generated, "selected.js");
+const name = "e2e/json-modules";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateJsonProject({
+			dir: generated,
+			count: 60,
+			entriesPerFile: 200
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "deep-export-analysis",
+			entryFile: entry,
+			config: {
+				entry,
+				module: { parser: { json: { exportsDepth: Infinity } } }
+			}
+		}),
+		...createBuildScenarios({
+			case: "selected-exports",
+			entryFile: selectedEntry,
+			config: { entry: selectedEntry }
+		}),
+		...createBuildScenarios({
+			case: "without-json-parse",
+			entryFile: entry,
+			config: {
+				entry,
+				module: { generator: { json: { JSONParse: false } } }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/many-modules-commonjs/index.bench.mjs
+++ b/test/benchmark/e2e/many-modules-commonjs/index.bench.mjs
@@ -1,0 +1,39 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/many-modules-commonjs";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 250,
+			format: "cjs"
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "node",
+			entryFile: entry,
+			config: { entry, target: "node" }
+		}),
+		...createBuildScenarios({
+			case: "without-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { minimize: false }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/many-modules-esm/index.bench.mjs
+++ b/test/benchmark/e2e/many-modules-esm/index.bench.mjs
@@ -1,0 +1,58 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/many-modules-esm";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 250,
+			format: "esm"
+		});
+	},
+	benches: [
+		...createBuildScenarios({
+			entryFile: entry,
+			config: { entry }
+		}),
+		...createBuildScenarios({
+			case: "with-module-concatenation",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: true }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-module-concatenation",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: false }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { minimize: false }
+			}
+		}),
+		...createBuildScenarios({
+			case: "without-concatenation-or-minimization",
+			entryFile: entry,
+			config: {
+				entry,
+				optimization: { concatenateModules: false, minimize: false }
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/rebuild/index.bench.mjs
+++ b/test/benchmark/e2e/rebuild/index.bench.mjs
@@ -1,0 +1,48 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createWatchRebuildBench } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const dependency = path.join(generated, "module-1.js");
+const leaf = path.join(generated, "module-149.js");
+const name = "e2e/rebuild";
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 150,
+			format: "esm"
+		});
+	},
+	benches: [
+		createWatchRebuildBench({
+			case: "entry-change",
+			entryFile: entry,
+			config: {
+				mode: "development",
+				entry
+			}
+		}),
+		createWatchRebuildBench({
+			case: "dependency-change",
+			entryFile: dependency,
+			config: {
+				mode: "development",
+				entry
+			}
+		}),
+		createWatchRebuildBench({
+			case: "leaf-change",
+			entryFile: leaf,
+			config: {
+				mode: "development",
+				entry
+			}
+		})
+	]
+};

--- a/test/benchmark/e2e/source-map/index.bench.mjs
+++ b/test/benchmark/e2e/source-map/index.bench.mjs
@@ -1,0 +1,40 @@
+import path from "path";
+import { generateModuleTree } from "../../helpers/project.mjs";
+import { createBuildScenarios } from "../../lib/webpack.mjs";
+
+const caseDir = import.meta.dirname;
+const generated = path.join(caseDir, "generated");
+const entry = path.join(generated, "module-0.js");
+const name = "e2e/source-map";
+
+/**
+ * @param {false | string} devtool devtool
+ * @returns {ReturnType<typeof createBuildScenarios>} benchmarks
+ */
+const sourceMapScenarios = (devtool) =>
+	createBuildScenarios({
+		case: devtool === false ? "none" : devtool,
+		entryFile: entry,
+		config: { entry, devtool }
+	});
+
+export default {
+	name,
+	iterations: 8,
+	async setup() {
+		await generateModuleTree({
+			dir: generated,
+			count: 150,
+			format: "esm"
+		});
+	},
+	benches: [
+		...sourceMapScenarios(false),
+		...sourceMapScenarios("eval"),
+		...sourceMapScenarios("eval-source-map"),
+		...sourceMapScenarios("eval-cheap-source-map"),
+		...sourceMapScenarios("cheap-module-source-map"),
+		...sourceMapScenarios("source-map"),
+		...sourceMapScenarios("hidden-nosources-source-map")
+	]
+};

--- a/test/benchmark/helpers/project.mjs
+++ b/test/benchmark/helpers/project.mjs
@@ -1,0 +1,229 @@
+import fs from "fs/promises";
+import path from "path";
+import { deterministicBytes } from "./prng.mjs";
+import { generateCssSource, generateJavaScriptSource } from "./sources.mjs";
+
+/**
+ * Deterministic on-disk project generators for e2e benchmarks. Output goes to
+ * `<caseDir>/generated` (gitignored via /test/`**`/generated/`**`) and is
+ * recreated from scratch on every run — content depends only on the arguments.
+ */
+
+/**
+ * @param {string} dir directory to recreate
+ * @returns {Promise<void>}
+ */
+async function recreate(dir) {
+	await fs.rm(dir, { recursive: true, force: true });
+	await fs.mkdir(dir, { recursive: true });
+}
+
+/**
+ * @typedef {object} ModuleTreeOptions
+ * @property {string} dir output directory
+ * @property {number} count number of modules
+ * @property {"esm" | "cjs"} format module format
+ * @property {number=} fanout imports per non-leaf module (default 4)
+ * @property {number=} dynamicEvery every n-th edge becomes a dynamic import (0 = none)
+ * @property {number=} paragraphs body size per module (default 2)
+ */
+
+/**
+ * Generate a module tree: module i imports its children by index
+ * (i * fanout + 1 … i * fanout + fanout), giving a balanced tree with
+ * deterministic shape and content. Entry is `<dir>/module-0.js`.
+ * @param {ModuleTreeOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateModuleTree(options) {
+	const {
+		dir,
+		count,
+		format,
+		fanout = 4,
+		dynamicEvery = 0,
+		paragraphs = 2
+	} = options;
+	await recreate(dir);
+	const esm = format === "esm";
+	for (let i = 0; i < count; i++) {
+		/** @type {string[]} */
+		const head = [];
+		/** @type {string[]} */
+		const body = [];
+		for (let child = i * fanout + 1, k = 0; k < fanout; k++, child++) {
+			if (child >= count) break;
+			const specifier = `./module-${child}.js`;
+			const isDynamic = dynamicEvery > 0 && child % dynamicEvery === 0;
+			if (isDynamic) {
+				body.push(
+					esm
+						? `export const lazy${k} = import(${JSON.stringify(specifier)});`
+						: `require.ensure([], () => { total += require(${JSON.stringify(specifier)}); });`
+				);
+			} else if (esm) {
+				head.push(`import child${k} from ${JSON.stringify(specifier)};`);
+				body.push(`total += child${k};`);
+			} else {
+				head.push(`const child${k} = require(${JSON.stringify(specifier)});`);
+				body.push(`total += child${k};`);
+			}
+		}
+		const source = [
+			...head,
+			"let total = 1;",
+			...body,
+			generateJavaScriptSource(paragraphs, esm),
+			esm ? "export default total;" : "module.exports = total;"
+		].join("\n");
+		await fs.writeFile(path.join(dir, `module-${i}.js`), source);
+	}
+	return path.join(dir, "module-0.js");
+}
+
+/**
+ * @typedef {object} CssProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of css/js module pairs
+ * @property {number=} rulesPerFile rules per css file (default 30)
+ */
+
+/**
+ * Generate plain/module CSS files with static and dynamic imports.
+ * @param {CssProjectOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateCssProject(options) {
+	const { dir, count, rulesPerFile = 30 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	for (let i = 0; i < count; i++) {
+		const isModule = i % 2 !== 0;
+		const isDynamic = i % 4 === 0;
+		const request = `./style-${i}${isModule ? ".module" : ""}.css`;
+		await fs.writeFile(
+			path.join(dir, request.slice(2)),
+			generateCssSource(rulesPerFile, isModule)
+		);
+		if (isDynamic) {
+			imports.push(
+				isModule
+					? `used += Object.keys(await import(${JSON.stringify(request)})).length;`
+					: `await import(${JSON.stringify(request)});`
+			);
+		} else if (isModule) {
+			imports.push(
+				`import * as style${i} from ${JSON.stringify(request)};`,
+				`used += Object.keys(style${i}).length;`
+			);
+		} else {
+			imports.push(`import ${JSON.stringify(request)};`);
+		}
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`let used = 0;\n${imports.join("\n")}\nexport default used;\n`
+	);
+	return entry;
+}
+
+/**
+ * @typedef {object} AssetProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of assets
+ * @property {number | ((index: number) => number)=} size bytes per asset (default 4096)
+ */
+
+/**
+ * Generate binary assets plus a JS entry importing all of them as URLs.
+ * @param {AssetProjectOptions} options options
+ * @returns {Promise<string>} absolute path of the entry module
+ */
+export async function generateAssetProject(options) {
+	const { dir, count, size = 4096 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	for (let i = 0; i < count; i++) {
+		const assetSize = typeof size === "function" ? size(i) : size;
+		await fs.writeFile(
+			path.join(dir, `asset-${i}.bin`),
+			deterministicBytes(i + 1, assetSize)
+		);
+		imports.push(
+			`import asset${i} from ${JSON.stringify(`./asset-${i}.bin`)};`,
+			`urls.push(asset${i});`
+		);
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`/** @type {string[]} */\nconst urls = [];\n${imports.join("\n")}\nexport default urls;\n`
+	);
+	return entry;
+}
+
+/**
+ * @typedef {object} JsonProject
+ * @property {string} entry entry importing every JSON export
+ * @property {string} selectedEntry entry importing one export per JSON file
+ */
+
+/**
+ * @typedef {object} JsonProjectOptions
+ * @property {string} dir output directory
+ * @property {number} count number of JSON modules
+ * @property {number=} entriesPerFile keys per JSON file (default 200)
+ */
+
+/**
+ * Generate JSON modules with whole-object and selected-property imports.
+ * @param {JsonProjectOptions} options options
+ * @returns {Promise<JsonProject>} absolute paths of the entry modules
+ */
+export async function generateJsonProject(options) {
+	const { dir, count, entriesPerFile = 200 } = options;
+	await recreate(dir);
+	/** @type {string[]} */
+	const imports = [];
+	/** @type {string[]} */
+	const selectedImports = [];
+	for (let i = 0; i < count; i++) {
+		/** @type {Record<string, unknown>} */
+		const data = {};
+		for (let k = 0; k < entriesPerFile; k++) {
+			data[`key_${i}_${k}`] =
+				k % 3 === 0
+					? { nested: k, list: [k, `${k}`, k % 2 === 0] }
+					: k % 3 === 1
+						? `value ${i}-${k}`
+						: k * 1.5;
+		}
+		await fs.writeFile(
+			path.join(dir, `data-${i}.json`),
+			JSON.stringify(data, null, "\t")
+		);
+		const request = `./data-${i}.json`;
+		imports.push(
+			`import data${i} from ${JSON.stringify(request)}${i % 2 === 0 ? ' with { type: "json" }' : ""};`,
+			`total += Object.keys(data${i}).length;`
+		);
+		selectedImports.push(
+			`import selected${i} from ${JSON.stringify(request)}${i % 2 === 0 ? ' with { type: "json" }' : ""};`,
+			`selected += selected${i}.key_${i}_0.nested;`
+		);
+	}
+	const entry = path.join(dir, "index.js");
+	await fs.writeFile(
+		entry,
+		`let total = 0;\n${imports.join("\n")}\nexport default total;\n`
+	);
+	const selectedEntry = path.join(dir, "selected.js");
+	await fs.writeFile(
+		selectedEntry,
+		`let selected = 0;\n${selectedImports.join("\n")}\nexport default selected;\n`
+	);
+	return { entry, selectedEntry };
+}

--- a/test/benchmark/lib/webpack.mjs
+++ b/test/benchmark/lib/webpack.mjs
@@ -1,0 +1,332 @@
+import fs from "fs/promises";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+
+const require = createRequire(import.meta.url);
+
+/** @typedef {import("../../..")} Webpack */
+/** @typedef {import("../../..").Configuration} Configuration */
+/** @typedef {import("../../..").Stats} Stats */
+/** @typedef {import("../../..").Watching} Watching */
+/** @typedef {Configuration | (() => Configuration)} ConfigurationFactory */
+/** @typedef {() => unknown | Promise<unknown>} BenchFn */
+/** @typedef {() => void | Promise<void>} HookFn */
+
+/**
+ * @typedef {object} BenchmarkDefinition
+ * @property {string} name benchmark case
+ * @property {BenchFn} fn benchmarked function
+ * @property {boolean=} async whether the benchmark function is asynchronous
+ * @property {HookFn=} beforeEach hook before every round
+ * @property {HookFn=} afterEach hook after every round
+ * @property {HookFn=} beforeAll hook before the first execution
+ * @property {HookFn=} afterAll hook after the last execution
+ */
+
+/**
+ * @param {ConfigurationFactory} config configuration or factory
+ * @returns {Configuration} resolved configuration
+ */
+const resolveConfig = (config) =>
+	typeof config === "function" ? config() : config;
+
+/**
+ * @param {"build" | "rebuild"} operation benchmarked operation
+ * @param {ConfigurationFactory} config configuration or factory
+ * @param {string | undefined} caseName benchmark case
+ * @returns {string} benchmark case
+ */
+const createBenchmarkCase = (operation, config, caseName) => {
+	const mode = resolveConfig(config).mode;
+	if (mode === undefined) {
+		throw new Error("Benchmark configuration must specify `mode`");
+	}
+	return [caseName, `${mode}-${operation}`].filter(Boolean).join("/");
+};
+
+const createOutputPath = () =>
+	fs.mkdtemp(path.join(os.tmpdir(), "webpack-benchmark-"));
+
+/**
+ * The webpack of the current working tree. Non-comparative by design: no
+ * baseline revision is ever checked out or imported next to it.
+ * @returns {Webpack} webpack
+ */
+export function loadWebpack() {
+	return require("../../../lib/index.js");
+}
+
+/**
+ * Normalize an e2e case config with isolated output.
+ * @param {string} outputPath temporary output directory
+ * @param {string} benchName benchmark name within the case
+ * @param {Configuration} config partial configuration
+ * @returns {Configuration} built configuration
+ */
+export function prepareConfig(outputPath, benchName, config) {
+	/** @type {Configuration} */
+	const result = {
+		devtool: false,
+		performance: false,
+		...config,
+		name: benchName
+	};
+	result.output = {
+		...result.output,
+		path: outputPath
+	};
+	if (
+		result.cache &&
+		typeof result.cache === "object" &&
+		result.cache.type === "filesystem"
+	) {
+		result.cache.cacheDirectory = path.resolve(
+			/** @type {string} */ (result.output.path),
+			".cache"
+		);
+	}
+	return result;
+}
+
+/**
+ * Run a full build on a fresh compiler and force stats construction, matching
+ * what real builds pay for.
+ * @param {Configuration} config configuration
+ * @returns {Promise<void>}
+ */
+export function runBuild(config) {
+	const webpack = loadWebpack();
+	return new Promise(
+		/**
+		 * @param {(value: void) => void} resolve resolve
+		 * @param {(err?: Error) => void} reject reject
+		 */
+		(resolve, reject) => {
+			const compiler = webpack(config);
+			compiler.run((err, stats) => {
+				const statsError =
+					stats && (stats.hasWarnings() || stats.hasErrors())
+						? new Error(stats.toString())
+						: undefined;
+				compiler.close((closeErr) => {
+					const buildError = err || statsError || closeErr;
+					if (buildError) return reject(buildError);
+					if (stats) stats.toString();
+					resolve();
+				});
+			});
+		}
+	);
+}
+
+/**
+ * @typedef {object} BuildBenchOptions
+ * @property {string=} case benchmark case
+ * @property {ConfigurationFactory} config configuration or fresh config factory
+ */
+
+/**
+ * @param {BuildBenchOptions} options options
+ * @returns {BenchmarkDefinition} build benchmark
+ */
+export function createBuildBench(options) {
+	const { case: caseName, config } = options;
+	const benchName = createBenchmarkCase("build", config, caseName);
+	/** @type {string | undefined} */
+	let outputPath;
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			outputPath = await createOutputPath();
+		},
+		fn() {
+			if (outputPath === undefined) {
+				throw new Error("Benchmark output directory is not initialized");
+			}
+			return runBuild(
+				prepareConfig(outputPath, benchName, resolveConfig(config))
+			);
+		},
+		async afterAll() {
+			if (outputPath === undefined) return;
+			const currentOutputPath = outputPath;
+			outputPath = undefined;
+			await fs.rm(currentOutputPath, { recursive: true, force: true });
+		}
+	};
+}
+
+/**
+ * @typedef {object} WatchRebuildOptions
+ * @property {string=} case benchmark case
+ * @property {ConfigurationFactory} config partial configuration; entry must be a file path
+ * @property {string} entryFile absolute path of the file touched to trigger rebuilds
+ */
+
+/**
+ * Benchmark rebuilds while alternating between equal-length source changes.
+ * @param {WatchRebuildOptions} options options
+ * @returns {BenchmarkDefinition} a benchmark definition
+ */
+export function createWatchRebuildBench(options) {
+	const { case: caseName, config, entryFile } = options;
+	const benchName = createBenchmarkCase("rebuild", config, caseName);
+
+	/** @type {Watching | undefined} */
+	let watching;
+	/** @type {string | undefined} */
+	let outputPath;
+	/** @type {string} */
+	let originalContent = "";
+	/** @type {((err: Error | null, stats?: Stats) => void) | undefined} */
+	let next;
+	/** @type {Stats | undefined} */
+	let completedStats;
+	let iteration = 0;
+
+	/**
+	 * @returns {Promise<void>} resolves after the next successful build
+	 */
+	const nextBuild = () =>
+		new Promise(
+			/**
+			 * @param {(value: void) => void} resolve resolve
+			 * @param {(err?: Error | null) => void} reject reject
+			 */
+			(resolve, reject) => {
+				next = (err, stats) => {
+					next = undefined;
+					if (err || !stats) return reject(err);
+					resolve();
+				};
+			}
+		);
+
+	return {
+		name: benchName,
+		async: true,
+		async beforeAll() {
+			originalContent = await fs.readFile(entryFile, "utf8");
+			outputPath = await createOutputPath();
+			try {
+				const webpack = loadWebpack();
+				const watchConfig = prepareConfig(outputPath, benchName, {
+					...resolveConfig(config),
+					// Keep rebuilds warm but bounded, like a dev-server session.
+					cache: { type: "memory", maxGenerations: 1 }
+				});
+				const firstBuild = nextBuild();
+				const compiler = webpack(watchConfig);
+				compiler.hooks.afterDone.tap("BenchmarkWatchRebuild", () => {
+					if (next) next(null, completedStats);
+				});
+				watching = compiler.watch({}, (err, stats) => {
+					if (err || !stats) {
+						if (next) next(err, stats);
+						return;
+					}
+					if (stats.hasWarnings() || stats.hasErrors()) {
+						if (next) next(new Error(stats.toString()));
+						return;
+					}
+					stats.toString();
+					completedStats = stats;
+				});
+				await firstBuild;
+			} catch (err) {
+				const currentWatching = watching;
+				if (currentWatching) {
+					await new Promise((resolve) => {
+						currentWatching.close(() => resolve(undefined));
+					});
+				}
+				watching = undefined;
+				next = undefined;
+				const currentOutputPath = outputPath;
+				outputPath = undefined;
+				if (currentOutputPath !== undefined) {
+					await fs.rm(currentOutputPath, { recursive: true, force: true });
+				}
+				throw err;
+			}
+		},
+		async fn() {
+			const build = nextBuild();
+			iteration++;
+			await fs.writeFile(
+				entryFile,
+				`${originalContent};console.log(${iteration % 2});`
+			);
+			/** @type {Watching} */ (watching).invalidate();
+			await build;
+		},
+		async afterAll() {
+			try {
+				await new Promise(
+					/**
+					 * @param {(value: void) => void} resolve resolve
+					 * @param {(err?: Error | null) => void} reject reject
+					 */
+					(resolve, reject) => {
+						if (!watching) {
+							resolve();
+							return;
+						}
+						watching.close((closeErr) => {
+							if (closeErr) {
+								reject(closeErr);
+								return;
+							}
+							resolve();
+						});
+					}
+				);
+			} finally {
+				watching = undefined;
+				next = undefined;
+				completedStats = undefined;
+				try {
+					await fs.writeFile(entryFile, originalContent);
+				} finally {
+					if (outputPath !== undefined) {
+						const currentOutputPath = outputPath;
+						outputPath = undefined;
+						await fs.rm(currentOutputPath, { recursive: true, force: true });
+					}
+				}
+			}
+		}
+	};
+}
+
+/**
+ * @typedef {object} BuildScenarioOptions
+ * @property {string=} case benchmark case
+ * @property {string} entryFile entry file changed by the rebuild scenario
+ * @property {ConfigurationFactory} config shared configuration
+ */
+
+/**
+ * @param {BuildScenarioOptions} options options
+ * @returns {BenchmarkDefinition[]} development, production and rebuild benches
+ */
+export function createBuildScenarios(options) {
+	const { case: caseName, entryFile, config } = options;
+	return [
+		createBuildBench({
+			case: caseName,
+			config: () => ({ ...resolveConfig(config), mode: "development" })
+		}),
+		createBuildBench({
+			case: caseName,
+			config: () => ({ ...resolveConfig(config), mode: "production" })
+		}),
+		createWatchRebuildBench({
+			case: caseName,
+			entryFile,
+			config: () => ({ ...resolveConfig(config), mode: "development" })
+		})
+	];
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Split out of #21494 so the harness and the unit benchmarks can be reviewed separately from full-build ones. Adds nine e2e suites — asset modules, code splitting, CSS modules, filesystem cache, JSON modules, many-modules ESM/CJS, rebuild, source maps — plus the two harness files only they use (`lib/webpack.mjs`, `helpers/project.mjs`), their changed-file selection rules and shards, and a `--smoke` run of all of them in the `unit` CI job. Based on #21494; retarget to `main` once that lands. Refs #21494.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/Benchmarks.unittest.js` validates the naming conventions for these suites and asserts the scheduled run's shards cover every benchmark exactly once, and the `unit` CI job smoke-runs all 101 e2e benchmarks on every push.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — `test/benchmark/README.md` and `TESTING_DOCS.md` are updated in this PR.

**Use of AI**

Yes. Claude Code was used to split the e2e work out of #21494, verify the split lost nothing (the resulting tree is byte-identical to the pre-split branch), and run the checks: all 101 e2e and 61 unit benchmarks pass under `--smoke`, ESLint, Prettier, cspell and both `tsc` projects are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KSWaajEgxZmRMsYMSNykJ)_