### PR TITLE
fix: treat top-level `this` in a classic worker entry as its global scope

### DIFF
--- a/.changeset/112-worker-entry-this-global.md
+++ b/.changeset/112-worker-entry-this-global.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Treat top-level `this` in a classic worker entry as its global scope.

--- a/lib/dependencies/CommonJsDependencyHelpers.js
+++ b/lib/dependencies/CommonJsDependencyHelpers.js
@@ -81,6 +81,14 @@ module.exports.getRequireEsmModuleExportsAccess =
 	getRequireEsmModuleExportsAccess;
 
 /**
+ * Whether the base keyword reads the module's top-level `this`.
+ * @param {CommonJSDependencyBaseKeywords} depBase commonjs dependency base
+ * @returns {boolean} true when the base is `this`
+ */
+const isThisBase = (depBase) =>
+	depBase === "this" || depBase === "Object.defineProperty(this)";
+
+/**
  * A classic worker script's top-level `this` is its global scope, not the
  * module's exports. True only for the worker entry's own runtime, so a module
  * that is also imported elsewhere keeps exports semantics in that runtime.
@@ -177,4 +185,5 @@ module.exports.handleDependencyBase = (
 };
 module.exports.isRequireEsmModuleExportsModule =
 	isRequireEsmModuleExportsModule;
+module.exports.isThisBase = isThisBase;
 module.exports.isWorkerEntryThis = isWorkerEntryThis;

--- a/lib/dependencies/CommonJsDependencyHelpers.js
+++ b/lib/dependencies/CommonJsDependencyHelpers.js
@@ -8,8 +8,11 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const { propertyAccess } = require("../util/property");
 
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../Entrypoint")} Entrypoint */
 /** @typedef {import("../Module")} Module */
+/** @typedef {import("../RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("../Module").RuntimeRequirements} RuntimeRequirements */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../NormalModule")} NormalModule */
@@ -78,16 +81,48 @@ module.exports.getRequireEsmModuleExportsAccess =
 	getRequireEsmModuleExportsAccess;
 
 /**
+ * A classic worker script's top-level `this` is its global scope, not the
+ * module's exports. True only for the worker entry's own runtime, so a module
+ * that is also imported elsewhere keeps exports semantics in that runtime.
+ * @param {Module} module the module
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {RuntimeSpec} runtime the runtime code is generated for
+ * @param {RuntimeTemplate=} runtimeTemplate the runtime template
+ * @returns {boolean} true when `this` is the worker's global scope
+ */
+const isWorkerEntryThis = (module, chunkGraph, runtime, runtimeTemplate) => {
+	// a module worker or worklet is an ES module, where `this` is undefined and
+	// there is nothing to resolve it to
+	if (
+		typeof runtime !== "string" ||
+		runtimeTemplate === undefined ||
+		runtimeTemplate.isModule()
+	) {
+		return false;
+	}
+	for (const chunk of chunkGraph.getModuleChunks(module)) {
+		if (chunk.runtime !== runtime) continue;
+		for (const group of chunk.groupsIterable) {
+			const options = /** @type {Entrypoint} */ (group).options;
+			if (options.worker && !options.worklet) return true;
+		}
+	}
+	return false;
+};
+
+/**
  * Returns type and base.
  * @param {CommonJSDependencyBaseKeywords} depBase commonjs dependency base
  * @param {Module} module module
  * @param {RuntimeRequirements} runtimeRequirements runtime requirements
+ * @param {boolean=} isWorkerEntry whether `this` is a classic worker's global scope
  * @returns {[string, string]} type and base
  */
 module.exports.handleDependencyBase = (
 	depBase,
 	module,
-	runtimeRequirements
+	runtimeRequirements,
+	isWorkerEntry
 ) => {
 	/** @type {string} */
 	let base;
@@ -105,8 +140,13 @@ module.exports.handleDependencyBase = (
 			type = "expression";
 			break;
 		case "this":
-			runtimeRequirements.add(RuntimeGlobals.thisAsExports);
-			base = "this";
+			if (isWorkerEntry) {
+				runtimeRequirements.add(RuntimeGlobals.global);
+				base = RuntimeGlobals.global;
+			} else {
+				runtimeRequirements.add(RuntimeGlobals.thisAsExports);
+				base = "this";
+			}
 			type = "expression";
 			break;
 		case "Object.defineProperty(exports)":
@@ -120,8 +160,13 @@ module.exports.handleDependencyBase = (
 			type = "Object.defineProperty";
 			break;
 		case "Object.defineProperty(this)":
-			runtimeRequirements.add(RuntimeGlobals.thisAsExports);
-			base = "this";
+			if (isWorkerEntry) {
+				runtimeRequirements.add(RuntimeGlobals.global);
+				base = RuntimeGlobals.global;
+			} else {
+				runtimeRequirements.add(RuntimeGlobals.thisAsExports);
+				base = "this";
+			}
 			type = "Object.defineProperty";
 			break;
 		default:
@@ -132,3 +177,4 @@ module.exports.handleDependencyBase = (
 };
 module.exports.isRequireEsmModuleExportsModule =
 	isRequireEsmModuleExportsModule;
+module.exports.isWorkerEntryThis = isWorkerEntryThis;

--- a/lib/dependencies/CommonJsDependencyHelpers.js
+++ b/lib/dependencies/CommonJsDependencyHelpers.js
@@ -5,12 +5,12 @@
 
 "use strict";
 
+const Entrypoint = require("../Entrypoint");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const { propertyAccess } = require("../util/property");
 
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Dependency")} Dependency */
-/** @typedef {import("../Entrypoint")} Entrypoint */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("../Module").RuntimeRequirements} RuntimeRequirements */
@@ -90,8 +90,8 @@ const isThisBase = (depBase) =>
 
 /**
  * A classic worker script's top-level `this` is its global scope, not the
- * module's exports. True only for the worker entry's own runtime, so a module
- * that is also imported elsewhere keeps exports semantics in that runtime.
+ * module's exports. True only for a runtime every entry of which is a worker,
+ * so a module imported elsewhere keeps exports semantics in that runtime.
  * @param {Module} module the module
  * @param {ChunkGraph} chunkGraph the chunk graph
  * @param {RuntimeSpec} runtime the runtime code is generated for
@@ -108,14 +108,19 @@ const isWorkerEntryThis = (module, chunkGraph, runtime, runtimeTemplate) => {
 	) {
 		return false;
 	}
+	let workerEntry = false;
 	for (const chunk of chunkGraph.getModuleChunks(module)) {
 		if (chunk.runtime !== runtime) continue;
 		for (const group of chunk.groupsIterable) {
-			const options = /** @type {Entrypoint} */ (group).options;
-			if (options.worker && !options.worklet) return true;
+			if (!(group instanceof Entrypoint)) continue;
+			const { options } = group;
+			// an entry may pin a worker to a non-worker entry's runtime, leaving one
+			// code generation for both roles: keep exports, the only safe answer
+			if (!options.worker || options.worklet) return false;
+			workerEntry = true;
 		}
 	}
-	return false;
+	return workerEntry;
 };
 
 /**

--- a/lib/dependencies/CommonJsExportsDependency.js
+++ b/lib/dependencies/CommonJsExportsDependency.js
@@ -10,6 +10,7 @@ const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
 const {
 	handleDependencyBase,
+	isThisBase,
 	isWorkerEntryThis
 } = require("./CommonJsDependencyHelpers");
 const NullDependency = require("./NullDependency");
@@ -82,7 +83,7 @@ class CommonJsExportsDependency extends NullDependency {
 	updateHash(hash, context) {
 		// a classic worker entry generates `this` as the global scope, so it must
 		// not share one code generation with a runtime that generates it as exports
-		if (!this.base.endsWith("this")) return;
+		if (!isThisBase(this.base)) return;
 		const { chunkGraph, runtime, runtimeTemplate } = context;
 		const module = chunkGraph.moduleGraph.getParentModule(this);
 		hash.update(
@@ -154,7 +155,7 @@ CommonJsExportsDependency.Template = class CommonJsExportsDependencyTemplate ext
 		// a classic worker entry writes to its global scope, not to an export, so
 		// the names stay as written and are never dropped as unused
 		const isWorkerEntry =
-			dep.base.endsWith("this") &&
+			isThisBase(dep.base) &&
 			isWorkerEntryThis(module, chunkGraph, runtime, runtimeTemplate);
 		// CJS exports are never inlined
 		const used = isWorkerEntry

--- a/lib/dependencies/CommonJsExportsDependency.js
+++ b/lib/dependencies/CommonJsExportsDependency.js
@@ -8,12 +8,18 @@
 const InitFragment = require("../InitFragment");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
-const { handleDependencyBase } = require("./CommonJsDependencyHelpers");
+const {
+	handleDependencyBase,
+	isWorkerEntryThis
+} = require("./CommonJsDependencyHelpers");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ExportsSpec} ExportsSpec */
+/** @typedef {import("../Dependency").UpdateHashContext} UpdateHashContext */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../Module")} Module */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
@@ -68,6 +74,26 @@ class CommonJsExportsDependency extends NullDependency {
 	}
 
 	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash to be updated
+	 * @param {UpdateHashContext} context context
+	 * @returns {void}
+	 */
+	updateHash(hash, context) {
+		// a classic worker entry generates `this` as the global scope, so it must
+		// not share one code generation with a runtime that generates it as exports
+		if (!this.base.endsWith("this")) return;
+		const { chunkGraph, runtime, runtimeTemplate } = context;
+		const module = chunkGraph.moduleGraph.getParentModule(this);
+		hash.update(
+			module !== undefined &&
+				isWorkerEntryThis(module, chunkGraph, runtime, runtimeTemplate)
+				? "worker global"
+				: "exports"
+		);
+	}
+
+	/**
 	 * Serializes this instance into the provided serializer context.
 	 * @param {ObjectSerializerContext} context context
 	 */
@@ -114,18 +140,34 @@ CommonJsExportsDependency.Template = class CommonJsExportsDependencyTemplate ext
 	apply(
 		dependency,
 		source,
-		{ module, moduleGraph, initFragments, runtimeRequirements, runtime }
+		{
+			module,
+			moduleGraph,
+			chunkGraph,
+			initFragments,
+			runtimeRequirements,
+			runtime,
+			runtimeTemplate
+		}
 	) {
 		const dep = /** @type {CommonJsExportsDependency} */ (dependency);
+		// a classic worker entry writes to its global scope, not to an export, so
+		// the names stay as written and are never dropped as unused
+		const isWorkerEntry =
+			dep.base.endsWith("this") &&
+			isWorkerEntryThis(module, chunkGraph, runtime, runtimeTemplate);
 		// CJS exports are never inlined
-		const used = /** @type {string | string[] | false} */ (
-			moduleGraph.getExportsInfo(module).getUsedName(dep.names, runtime)
-		);
+		const used = isWorkerEntry
+			? dep.names
+			: /** @type {string | string[] | false} */ (
+					moduleGraph.getExportsInfo(module).getUsedName(dep.names, runtime)
+				);
 
 		const [type, base] = handleDependencyBase(
 			dep.base,
 			module,
-			runtimeRequirements
+			runtimeRequirements,
+			isWorkerEntry
 		);
 
 		switch (type) {

--- a/lib/dependencies/CommonJsSelfReferenceDependency.js
+++ b/lib/dependencies/CommonJsSelfReferenceDependency.js
@@ -9,11 +9,15 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const { equals } = require("../util/ArrayHelpers");
 const makeSerializable = require("../util/makeSerializable");
 const { propertyAccess } = require("../util/property");
+const { isWorkerEntryThis } = require("./CommonJsDependencyHelpers");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../Dependency").ReferencedExports} ReferencedExports */
+/** @typedef {import("../Dependency").UpdateHashContext} UpdateHashContext */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../Module")} Module */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../ExportsInfo").ExportInfoName} ExportInfoName */
@@ -78,6 +82,26 @@ class CommonJsSelfReferenceDependency extends NullDependency {
 	}
 
 	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash to be updated
+	 * @param {UpdateHashContext} context context
+	 * @returns {void}
+	 */
+	updateHash(hash, context) {
+		// a classic worker entry generates `this` as the global scope, so it must
+		// not share one code generation with a runtime that generates it as exports
+		if (this.base !== "this") return;
+		const { chunkGraph, runtime, runtimeTemplate } = context;
+		const module = chunkGraph.moduleGraph.getParentModule(this);
+		hash.update(
+			module !== undefined &&
+				isWorkerEntryThis(module, chunkGraph, runtime, runtimeTemplate)
+				? "worker global"
+				: "exports"
+		);
+	}
+
+	/**
 	 * Serializes this instance into the provided serializer context.
 	 * @param {ObjectSerializerContext} context context
 	 */
@@ -124,12 +148,24 @@ CommonJsSelfReferenceDependency.Template = class CommonJsSelfReferenceDependency
 	apply(
 		dependency,
 		source,
-		{ module, moduleGraph, runtime, runtimeRequirements }
+		{
+			module,
+			moduleGraph,
+			chunkGraph,
+			runtime,
+			runtimeRequirements,
+			runtimeTemplate
+		}
 	) {
 		const dep = /** @type {CommonJsSelfReferenceDependency} */ (dependency);
+		// a classic worker entry reads its global scope, not an export, so the
+		// names stay as written
+		const isWorkerEntry =
+			dep.base === "this" &&
+			isWorkerEntryThis(module, chunkGraph, runtime, runtimeTemplate);
 		// CJS exports are never inlined
 		const used =
-			dep.names.length === 0
+			isWorkerEntry || dep.names.length === 0
 				? dep.names
 				: /** @type {string | string[] | false} */ (
 						moduleGraph.getExportsInfo(module).getUsedName(dep.names, runtime)
@@ -152,8 +188,13 @@ CommonJsSelfReferenceDependency.Template = class CommonJsSelfReferenceDependency
 				base = `${module.moduleArgument}.exports`;
 				break;
 			case "this":
-				runtimeRequirements.add(RuntimeGlobals.thisAsExports);
-				base = "this";
+				if (isWorkerEntry) {
+					runtimeRequirements.add(RuntimeGlobals.global);
+					base = RuntimeGlobals.global;
+				} else {
+					runtimeRequirements.add(RuntimeGlobals.thisAsExports);
+					base = "this";
+				}
 				break;
 			default:
 				throw new Error(`Unsupported base ${dep.base}`);

--- a/test/configCases/worker/this-in-module-worker/index.js
+++ b/test/configCases/worker/this-in-module-worker/index.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+import { Worker } from "worker_threads";
+
+it("should leave top-level this alone in a module worker", async () => {
+	const worker = new Worker(new URL("./w.js", import.meta.url), {
+		type: "module"
+	});
+	await worker.terminate();
+
+	// an ES module's top-level `this` is undefined, so there is nothing to
+	// resolve it to and the exports semantics stay
+	const emitted = fs
+		.readdirSync(__STATS__.outputPath)
+		.filter(name => name !== "bundle0.mjs")
+		.map(name => fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8"))
+		.join("\n");
+
+	expect(emitted).toContain("onmessage");
+	expect(emitted).not.toContain(`${"__webpack_require__"}.g`);
+});

--- a/test/configCases/worker/this-in-module-worker/test.config.js
+++ b/test/configCases/worker/this-in-module-worker/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		scope.URL = URL;
+	}
+};

--- a/test/configCases/worker/this-in-module-worker/test.filter.js
+++ b/test/configCases/worker/this-in-module-worker/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-module-worker/w.js
+++ b/test/configCases/worker/this-in-module-worker/w.js
@@ -1,0 +1,2 @@
+// a module worker is an ES module, where top-level `this` is undefined
+this.onmessage = () => {};

--- a/test/configCases/worker/this-in-module-worker/webpack.config.js
+++ b/test/configCases/worker/this-in-module-worker/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node14",
+	output: { module: true },
+	experiments: { outputModule: true }
+};

--- a/test/configCases/worker/this-in-shared-runtime-worker/index.js
+++ b/test/configCases/worker/this-in-shared-runtime-worker/index.js
@@ -1,0 +1,8 @@
+it("should keep exports semantics when a worker shares a non-worker runtime", () => {
+	const shared = require("./shared.js");
+	// eslint-disable-next-line no-unused-vars
+	const worker = new Worker(new URL("./shared.js", import.meta.url), {
+		/* webpackEntryOptions: { runtime: "shared-rt" } */
+	});
+	expect(shared.marker).toBe("assigned");
+});

--- a/test/configCases/worker/this-in-shared-runtime-worker/shared.js
+++ b/test/configCases/worker/this-in-shared-runtime-worker/shared.js
@@ -1,0 +1,2 @@
+// one runtime for both roles, so exports semantics is the only safe answer
+this.marker = "assigned";

--- a/test/configCases/worker/this-in-shared-runtime-worker/test.config.js
+++ b/test/configCases/worker/this-in-shared-runtime-worker/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["shared-rt.js", "main.js"];
+	}
+};

--- a/test/configCases/worker/this-in-shared-runtime-worker/test.filter.js
+++ b/test/configCases/worker/this-in-shared-runtime-worker/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-shared-runtime-worker/webpack.config.js
+++ b/test/configCases/worker/this-in-shared-runtime-worker/webpack.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: { import: "./index.js", runtime: "shared-rt" } },
+	output: { filename: "[name].js" }
+};

--- a/test/configCases/worker/this-in-worker-entry-shared/index.js
+++ b/test/configCases/worker/this-in-worker-entry-shared/index.js
@@ -1,0 +1,15 @@
+it("should keep exports semantics where the file is imported", () => {
+	const shared = require("./shared.js");
+	expect(shared.marker).toBe("assigned");
+	expect(typeof shared.onmessage).toBe("function");
+});
+
+it("should use the global scope where the same file is a worker entry", async () => {
+	const worker = new Worker(new URL("./shared.js", import.meta.url));
+	worker.postMessage("hello");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => resolve(event.data);
+	});
+	expect(result).toBe("hello:assigned");
+	await worker.terminate();
+});

--- a/test/configCases/worker/this-in-worker-entry-shared/shared.js
+++ b/test/configCases/worker/this-in-worker-entry-shared/shared.js
@@ -1,0 +1,5 @@
+// exports in the import role, the worker's global scope in the worker role
+this.marker = "assigned";
+this.onmessage = (event) => {
+	this.postMessage(`${event.data}:${this.marker}`);
+};

--- a/test/configCases/worker/this-in-worker-entry-shared/test.config.js
+++ b/test/configCases/worker/this-in-worker-entry-shared/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/this-in-worker-entry-shared/test.filter.js
+++ b/test/configCases/worker/this-in-worker-entry-shared/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-worker-entry-shared/webpack.config.js
+++ b/test/configCases/worker/this-in-worker-entry-shared/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: { filename: "[name].js" }
+};

--- a/test/configCases/worker/this-in-worker-entry-unused/index.js
+++ b/test/configCases/worker/this-in-worker-entry-unused/index.js
@@ -1,0 +1,12 @@
+// a bare side-effect import: no export of w.js is used in this runtime either
+import "./w.js";
+
+it("should use the global scope in the worker role even when exports are unused everywhere", async () => {
+	const worker = new Worker(new URL("./w.js", import.meta.url));
+	worker.postMessage("hello");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => resolve(event.data);
+	});
+	expect(result).toBe("got hello");
+	await worker.terminate();
+});

--- a/test/configCases/worker/this-in-worker-entry-unused/test.config.js
+++ b/test/configCases/worker/this-in-worker-entry-unused/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/this-in-worker-entry-unused/test.filter.js
+++ b/test/configCases/worker/this-in-worker-entry-unused/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-worker-entry-unused/w.js
+++ b/test/configCases/worker/this-in-worker-entry-unused/w.js
@@ -1,0 +1,4 @@
+// exports are unused in both roles, so only the runtime tells them apart
+this.onmessage = (event) => {
+	this.postMessage(`got ${event.data}`);
+};

--- a/test/configCases/worker/this-in-worker-entry-unused/webpack.config.js
+++ b/test/configCases/worker/this-in-worker-entry-unused/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: { filename: "[name].js" }
+};

--- a/test/configCases/worker/this-in-worker-entry/index.js
+++ b/test/configCases/worker/this-in-worker-entry/index.js
@@ -1,0 +1,9 @@
+it("should let a worker entry use top-level this as its global scope", async () => {
+	const worker = new Worker(new URL("./worker.js", import.meta.url));
+	worker.postMessage("hello");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => resolve(event.data);
+	});
+	expect(result).toBe("got hello");
+	await worker.terminate();
+});

--- a/test/configCases/worker/this-in-worker-entry/index.js
+++ b/test/configCases/worker/this-in-worker-entry/index.js
@@ -4,6 +4,6 @@ it("should let a worker entry use top-level this as its global scope", async () 
 	const result = await new Promise(resolve => {
 		worker.onmessage = event => resolve(event.data);
 	});
-	expect(result).toBe("got hello");
+	expect(result).toBe("got hello:defined");
 	await worker.terminate();
 });

--- a/test/configCases/worker/this-in-worker-entry/test.config.js
+++ b/test/configCases/worker/this-in-worker-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/this-in-worker-entry/test.filter.js
+++ b/test/configCases/worker/this-in-worker-entry/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-worker-entry/webpack.config.js
+++ b/test/configCases/worker/this-in-worker-entry/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: { filename: "[name].js" }
+};

--- a/test/configCases/worker/this-in-worker-entry/worker.js
+++ b/test/configCases/worker/this-in-worker-entry/worker.js
@@ -1,0 +1,4 @@
+// a classic worker script's top-level `this` is its global scope
+this.onmessage = (event) => {
+	this.postMessage(`got ${event.data}`);
+};

--- a/test/configCases/worker/this-in-worker-entry/worker.js
+++ b/test/configCases/worker/this-in-worker-entry/worker.js
@@ -1,4 +1,5 @@
 // a classic worker script's top-level `this` is its global scope
+Object.defineProperty(this, "marker", { value: "defined" });
 this.onmessage = (event) => {
-	this.postMessage(`got ${event.data}`);
+	this.postMessage(`got ${event.data}:${this.marker}`);
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A classic worker script's top-level `this` is its global scope, but webpack rewrites it to the module's exports object, so `this.onmessage = …` in a `new Worker(new URL("./worker.js", import.meta.url))` entry silently assigns to an object nothing reads — and is dropped entirely when the export is unused. `this` in a worker entry's own runtime now generates as `__webpack_require__.g`; every other runtime keeps exports semantics, so a file that is both imported and used as a worker entry behaves correctly in both roles. Module workers and worklets are unaffected (an ES module's top-level `this` is `undefined`). Refs #12031.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — four cases under `test/configCases/worker/`: `this-in-worker-entry`, `this-in-worker-entry-shared` (same file imported and used as a worker entry), `this-in-worker-entry-unused` (exports unused in both roles, so only the per-runtime hash tells them apart) and `this-in-module-worker` (regression guard).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate the reported behaviour, draft the change and the test cases, and run the test and lint suites. Every line was reviewed and verified locally before pushing.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hWJcGG8eUbw4uzCjGQK8M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected top-level `this` handling in classic worker entries so it refers to the worker’s global scope.
  * Preserved expected exports and runtime behavior for files shared between regular modules and worker entries.
  * Maintained existing behavior in non-worker contexts.

* **Tests**
  * Added coverage for classic and module workers, including messaging, exports, and global-scope behavior.

* **Documentation**
  * Documented the updated classic worker-entry behavior in the release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->