### PR TITLE
docs: fix dead ES5 compat-table link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Check out webpack's quick [**Get Started**](https://webpack.js.org/guides/gettin
 
 ### Browser Compatibility
 
-Webpack supports all browsers that are [ES5-compliant](https://kangax.github.io/compat-table/es5/) (IE8 and below are not supported).
+Webpack supports all browsers that are [ES5-compliant](https://kangax.github.io/compat-table/) (IE8 and below are not supported).
 Webpack also needs `Promise` for `import()` and `require.ensure()`. If you want to support older browsers, you will need to [load a polyfill](https://webpack.js.org/guides/shimming/) before using these expressions.
 
 ## Concepts


### PR DESCRIPTION
The README links to `https://kangax.github.io/compat-table/es5/` which returns 404 (the compat-table site restructured; deep paths like `/es5/` no longer resolve). The compatibility table root at `https://kangax.github.io/compat-table/` is live and shows the ES5 table by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Browser Compatibility link to point to the general Kangax compatibility table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->