### PR TITLE
refactor: cjs object export tree shaking

### DIFF
--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -26,9 +26,11 @@ const FUNCTION_PROPERTY_DROP_HEAD =
 /** @typedef {import("estree").AssignmentExpression} AssignmentExpression */
 /** @typedef {import("estree").CallExpression} CallExpression */
 /** @typedef {import("estree").Expression} Expression */
+/** @typedef {import("estree").FunctionExpression} FunctionExpression */
 /** @typedef {import("estree").Node} Node */
 /** @typedef {import("estree").ObjectExpression} ObjectExpression */
 /** @typedef {import("estree").Property} Property */
+/** @typedef {import("estree").SpreadElement} SpreadElement */
 /** @typedef {import("estree").Super} Super */
 /** @typedef {import("estree").ThisExpression} ThisExpression */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
@@ -297,6 +299,43 @@ const getThisAccessInExportedValue = (parser, expr) =>
 		? findOwnThisExpression(expr.body, expr.params)
 		: undefined;
 
+/**
+ * Returns the export name an object-literal property contributes, or
+ * `undefined` when it cannot contribute one: a spread, a computed or
+ * non-string key is unknown at compile time, and `__proto__` sets
+ * [[Prototype]] instead of an own property.
+ * @param {Property | SpreadElement} property property
+ * @returns {string | undefined} export name
+ */
+const getStaticPropertyName = (property) => {
+	if (property.type === "SpreadElement" || property.computed) return;
+	const key = property.key;
+	/** @type {string | undefined} */
+	let name;
+	if (key.type === "Identifier") {
+		name = key.name;
+	} else if (key.type === "Literal" && typeof key.value === "string") {
+		name = key.value;
+	}
+	return name === "__proto__" ? undefined : name;
+};
+
+/**
+ * @param {Property} property property
+ * @returns {CommonJsObjectExportKind} property kind
+ */
+const getObjectExportKind = (property) => {
+	if (property.kind === "get" || property.kind === "set") return property.kind;
+	if (property.method) {
+		const { async, generator } = /** @type {FunctionExpression} */ (
+			property.value
+		);
+		if (async) return generator ? "asyncGeneratorMethod" : "asyncMethod";
+		return generator ? "generatorMethod" : "method";
+	}
+	return property.shorthand ? "shorthand" : "keyValue";
+};
+
 const PLUGIN_NAME = "CommonJsExportsParserPlugin";
 
 class CommonJsExportsParserPlugin {
@@ -468,103 +507,53 @@ class CommonJsExportsParserPlugin {
 		const handleObjectLiteralExport = (expr, base) => {
 			// Only `module.exports = { … }` replaces the whole exports object.
 			if (base !== "module.exports") return;
-			const isTopLevel =
-				/** @type {StatementPath} */ (parser.statementPath).length === 1 &&
-				parser.isStatementLevelExpression(expr);
-			if (!isTopLevel) return;
-			const right = expr.right;
-			if (right.type !== "ObjectExpression") return;
+			if (
+				/** @type {StatementPath} */ (parser.statementPath).length !== 1 ||
+				!parser.isStatementLevelExpression(expr)
+			) {
+				return;
+			}
+			const object = expr.right;
+			if (object.type !== "ObjectExpression") return;
 
-			const bailoutObjectLiteral = () => {
-				bailout(
-					`module.exports = {…} cannot be statically analysed at ${formatLocation(
-						parser.getLocation(expr)
-					)}`
-				);
-				/** @type {JavascriptModuleBuildMeta} */ (
-					parser.state.module.buildMeta
-				).treatAsCommonJs = true;
-				// LHS stays as the text `module.exports` (moduleArgument is "module"
-				// unless a top-level `module` binding shadows it, which prevents this hook).
-				parser.state.module.addPresentationalDependency(
-					new RuntimeRequirementsDependency([RuntimeGlobals.module])
-				);
-				parser.walkExpression(right);
-			};
+			const module = parser.state.module;
+			/** @type {JavascriptModuleBuildMeta} */ (
+				module.buildMeta
+			).treatAsCommonJs = true;
+			// LHS stays as the text `module.exports` (moduleArgument is "module"
+			// unless a top-level `module` binding shadows it, which prevents this hook).
+			module.addPresentationalDependency(
+				new RuntimeRequirementsDependency([RuntimeGlobals.module])
+			);
 
-			const obj = /** @type {ObjectExpression} */ (right);
-			for (const prop of obj.properties) {
-				if (prop.type === "SpreadElement" || prop.computed) {
-					bailoutObjectLiteral();
+			// one unknown key makes the whole object opaque, so name them all first
+			/** @type {string[]} */
+			const names = [];
+			for (const property of object.properties) {
+				const name = getStaticPropertyName(property);
+				if (name === undefined) {
+					bailout(
+						`module.exports = {…} cannot be statically analysed at ${formatLocation(
+							parser.getLocation(expr)
+						)}`
+					);
+					parser.walkExpression(object);
 					return true;
 				}
-				const key = prop.key;
-				if (
-					key.type !== "Identifier" &&
-					!(key.type === "Literal" && typeof key.value === "string")
-				) {
-					bailoutObjectLiteral();
-					return true;
-				}
-				const name = key.type === "Identifier" ? key.name : String(key.value);
-				// `__proto__` sets [[Prototype]], not an own export.
-				if (name === "__proto__") {
-					bailoutObjectLiteral();
-					return true;
-				}
+				names.push(name);
 			}
 
 			enableStructuredExports();
-			// LHS stays as the text `module.exports` (moduleArgument is "module"
-			// unless a top-level `module` binding shadows it, which prevents this hook).
-			parser.state.module.addPresentationalDependency(
-				new RuntimeRequirementsDependency([RuntimeGlobals.module])
-			);
-			/** @type {JavascriptModuleBuildMeta} */ (
-				parser.state.module.buildMeta
-			).treatAsCommonJs = true;
 
-			for (const prop of obj.properties) {
-				const property = /** @type {Property} */ (prop);
-				const key = property.key;
-				const name =
-					key.type === "Identifier"
-						? key.name
-						: /** @type {string} */ (
-								/** @type {import("estree").Literal} */ (key).value
-							);
+			for (let i = 0; i < object.properties.length; i++) {
+				const property = /** @type {Property} */ (object.properties[i]);
+				const name = names[i];
 				const value = /** @type {Expression} */ (property.value);
-
-				/** @type {CommonJsObjectExportKind} */
-				let kind;
-				/** @type {Range} */
-				let valueRange;
-				if (property.kind === "get") {
-					kind = "get";
-					valueRange = /** @type {Range} */ (value.range);
-				} else if (property.kind === "set") {
-					kind = "set";
-					valueRange = /** @type {Range} */ (value.range);
-				} else if (property.method) {
-					valueRange = /** @type {Range} */ (value.range);
-					const fn = /** @type {import("estree").FunctionExpression} */ (value);
-					if (fn.async && fn.generator) {
-						kind = "asyncGeneratorMethod";
-					} else if (fn.async) {
-						kind = "asyncMethod";
-					} else if (fn.generator) {
-						kind = "generatorMethod";
-					} else {
-						kind = "method";
-					}
-				} else if (property.shorthand) {
-					kind = "shorthand";
-					valueRange = /** @type {Range} */ (property.range);
-				} else {
-					kind = "keyValue";
-					valueRange = /** @type {Range} */ (value.range);
-				}
-
+				const kind = getObjectExportKind(property);
+				// a shorthand has no value text of its own to replace
+				const valueRange = /** @type {Range} */ (
+					kind === "shorthand" ? property.range : value.range
+				);
 				// scans the key/value gap, so `/*#__PURE__*/` is picked up here
 				const pure =
 					kind === "keyValue" &&
@@ -583,17 +572,18 @@ class CommonJsExportsParserPlugin {
 					pure
 				);
 				dep.loc = parser.getLocation(property);
-				parser.state.module.addDependency(dep);
+				module.addDependency(dep);
 
 				keepAllExportsOnThisAccess(value, base);
 				// Tag nested requires so unused get/set/method can disconnect them.
-				if (FUNCTION_PROPERTY_DROP_HEAD.has(kind)) {
-					const mod = parser.state.module;
-					const start = mod.dependencies.length;
-					parser.walkExpression(value);
+				const start = FUNCTION_PROPERTY_DROP_HEAD.has(kind)
+					? module.dependencies.length
+					: -1;
+				parser.walkExpression(value);
+				if (start !== -1) {
 					const usedByExports = new Set([name]);
-					for (let i = start; i < mod.dependencies.length; i++) {
-						const nested = mod.dependencies[i];
+					for (let j = start; j < module.dependencies.length; j++) {
+						const nested = module.dependencies[j];
 						if (
 							nested instanceof CommonJsRequireDependency ||
 							nested instanceof CommonJsFullRequireDependency
@@ -601,8 +591,6 @@ class CommonJsExportsParserPlugin {
 							nested.usedByExports = usedByExports;
 						}
 					}
-				} else {
-					parser.walkExpression(value);
 				}
 			}
 			return true;

--- a/test/configCases/cjs-tree-shaking/object-literal-local-alias/index.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-local-alias/index.js
@@ -1,0 +1,5 @@
+const A = require("./mod.js");
+
+it("should keep module.exports = {…} intact when a local alias captures it", () => {
+	expect(A.b()).toBe(true)
+});

--- a/test/configCases/cjs-tree-shaking/object-literal-local-alias/mod.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-local-alias/mod.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var A = (module.exports = {
+	a: function () {},
+	b: function () {
+		A.a();
+		return true;
+	}
+});

--- a/test/configCases/cjs-tree-shaking/object-literal-local-alias/webpack.config.js
+++ b/test/configCases/cjs-tree-shaking/object-literal-local-alias/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	optimization: {
+		minimize: false,
+		usedExports: true,
+		concatenateModules: false
+	}
+};


### PR DESCRIPTION
**Summary**

Refactor handleObjectLiteralExport. Previously it walks each property's export name twice, and duplicated the `treatAsCommonJs` / `RuntimeGlobals.module` setup and the `parser.walkExpression(value)` call across both branches.

And add one test to covers `var A = (module.exports = {…})`, where the assignment is not statement level, so it must not be tree-shaked.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CommonJS modules that export object literals.
  * Preserved correct behavior when exported methods reference the exported object through a local alias.
  * Enhanced tree-shaking of individual object properties while retaining required dependencies.

* **Tests**
  * Added coverage verifying that aliased CommonJS object exports execute correctly during production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->