### PR TITLE
feat: suggest the closest file name when a module is not found

### DIFF
--- a/.changeset/052-module-not-found-suggestion.md
+++ b/.changeset/052-module-not-found-suggestion.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Suggest the closest file name, or a casing fix, when a module is not found.

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -30,8 +30,9 @@ const UseEffectRulePlugin = require("./rules/UseEffectRulePlugin");
 const LazySet = require("./util/LazySet");
 const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const { cachedCleverMerge, cachedSetProperty } = require("./util/cleverMerge");
-const { join } = require("./util/fs");
+const { dirname, join, relative } = require("./util/fs");
 const {
+	ABSOLUTE_PATH_REGEXP,
 	escapeHashInPathRequest,
 	parseResource,
 	parseResourceWithoutFragment
@@ -162,6 +163,100 @@ const EMPTY_ELEMENTS = [];
 
 const MATCH_RESOURCE_REGEX = /^([^!]+)!=!/;
 const LEADING_DOT_EXTENSION_REGEX = /^[^.]/;
+// Nothing in `util/identifier` matches a request (as opposed to a path) shape.
+const RELATIVE_REQUEST_REGEXP = /^\.\.?[\\/]/;
+
+/**
+ * Computes the edit distance of two strings, counting swapped neighbors as one
+ * edit and giving up as soon as the distance exceeds `max`.
+ * @param {string} a first string
+ * @param {string} b second string
+ * @param {number} max largest distance worth distinguishing
+ * @returns {number} the distance, or a value greater than `max` when it exceeds `max`
+ */
+const editDistance = (a, b, max) => {
+	if (a === b) return 0;
+	if (Math.abs(a.length - b.length) > max) return max + 1;
+	/** @type {number[] | undefined} */
+	let rowBeforePrevious;
+	/** @type {number[]} */
+	let previousRow = [];
+	for (let column = 0; column <= b.length; column++) previousRow.push(column);
+	for (let row = 1; row <= a.length; row++) {
+		const currentRow = [row];
+		let rowMinimum = row;
+		for (let column = 1; column <= b.length; column++) {
+			let distance = Math.min(
+				previousRow[column - 1] + (a[row - 1] === b[column - 1] ? 0 : 1),
+				previousRow[column] + 1,
+				currentRow[column - 1] + 1
+			);
+			if (
+				rowBeforePrevious &&
+				a[row - 1] === b[column - 2] &&
+				a[row - 2] === b[column - 1]
+			) {
+				distance = Math.min(distance, rowBeforePrevious[column - 2] + 1);
+			}
+			currentRow.push(distance);
+			if (distance < rowMinimum) rowMinimum = distance;
+		}
+		if (rowMinimum > max) return max + 1;
+		rowBeforePrevious = previousRow;
+		previousRow = currentRow;
+	}
+	return previousRow[b.length];
+};
+
+/**
+ * Names an entry of a directory can be requested by: as written, and without
+ * the extension the resolver would have appended.
+ * @param {string} entry name of a directory entry
+ * @param {Set<string>} extensions the resolvable extensions
+ * @returns {string[]} names the entry answers to
+ */
+const namesForEntry = (entry, extensions) => {
+	const names = [entry];
+	for (const extension of extensions) {
+		if (entry.length > extension.length && entry.endsWith(extension)) {
+			names.push(entry.slice(0, -extension.length));
+		}
+	}
+	return names;
+};
+
+/**
+ * Picks the entry of a directory a failed request most likely meant. Ties are
+ * broken by name so the hint does not depend on the order the directory lists.
+ * @param {string} requested the requested file name
+ * @param {string[]} entries names in the directory
+ * @param {Set<string>} extensions the resolvable extensions
+ * @returns {{ entry: string, distance: number } | undefined} the closest entry and how far it is from the request
+ */
+const findClosestEntry = (requested, entries, extensions) => {
+	// A typo is only distinguishable from an unrelated name once the name is
+	// long enough, so short requests are matched by casing alone.
+	let allowedDistance = requested.length < 4 ? 0 : requested.length < 8 ? 1 : 2;
+	const lowerCaseRequested = requested.toLowerCase();
+	/** @type {{ entry: string, distance: number } | undefined} */
+	let best;
+	for (const entry of entries) {
+		// The entry exists as requested, so the request failed for another reason.
+		if (entry === requested) return;
+		for (const name of namesForEntry(entry, extensions)) {
+			const distance = editDistance(
+				lowerCaseRequested,
+				name.toLowerCase(),
+				allowedDistance
+			);
+			if (distance > allowedDistance) continue;
+			if (best && distance === allowedDistance && entry >= best.entry) continue;
+			allowedDistance = distance;
+			best = { entry, distance };
+		}
+	}
+	return best;
+};
 
 /**
  * Replays the file/context/missing dependencies captured by a loader resolve
@@ -1267,6 +1362,45 @@ ${hints.join("\n\n")}`;
 		resolveContext,
 		callback
 	) {
+		/**
+		 * Names the entry of the request's directory it comes closest to, for
+		 * requests that failed over a typo or the casing of a file name.
+		 * @param {(hint?: string) => void} callback callback
+		 * @returns {void}
+		 */
+		const suggestClosestEntry = (callback) => {
+			const { path: requestPath } = parseResource(unresolvedResource);
+			const isAbsolute = ABSOLUTE_PATH_REGEXP.test(requestPath);
+			if (!isAbsolute && !RELATIVE_REQUEST_REGEXP.test(requestPath)) {
+				return callback();
+			}
+			const absoluteRequest = isAbsolute
+				? requestPath
+				: join(this.fs, context, requestPath);
+			const directory = dirname(this.fs, absoluteRequest);
+			const requestedName = relative(this.fs, directory, absoluteRequest);
+			// A request ending in '.' or '..' names a directory, not an entry in one.
+			if (!requestPath.endsWith(requestedName)) return callback();
+			this.fs.readdir(directory, (err, entries) => {
+				if (err || !entries) return callback();
+				const closest = findClosestEntry(
+					requestedName,
+					/** @type {string[]} */ (entries),
+					resolver.options.extensions
+				);
+				if (!closest) return callback();
+				const suggestion =
+					requestPath.slice(0, -requestedName.length) + closest.entry;
+				callback(
+					closest.distance === 0
+						? `Did you mean '${suggestion}'?
+'${closest.entry}' exists in that directory and differs from the request only in casing. Case-sensitive filesystems (most Linux ones) fail to resolve it, even when the same build succeeds on a case-insensitive one.`
+						: `Did you mean '${suggestion}'?
+'${closest.entry}' is the closest name in that directory. It differs from the request by ${closest.distance === 1 ? "1 character" : `${closest.distance} characters`}, ignoring case and file extension.`
+				);
+			});
+		};
+
 		asyncLib.parallel(
 			[
 				(callback) => {
@@ -1368,7 +1502,11 @@ If changing the source code is not an option there is also a resolve options cal
 			],
 			(err, hints) => {
 				if (err) return callback(err);
-				callback(null, /** @type {string[]} */ (hints).filter(Boolean));
+				const resolveHints = /** @type {string[]} */ (hints).filter(Boolean);
+				// The hints above explain why an existing file was rejected and name it
+				// themselves, so only look for a similar name when none of them applied.
+				if (resolveHints.length > 0) return callback(null, resolveHints);
+				suggestClosestEntry((hint) => callback(null, hint ? [hint] : []));
 			}
 		);
 	}

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -321,7 +321,7 @@ describe("Errors", () => {
 			  "errors": Array [
 			    Object {
 			      "loc": "2:0-17",
-			      "message": "Module not found: Error: Can't resolve './FILE' in '<cwd>/test/fixtures/errors'",
+			      "message": "Module not found: Error: Can't resolve './FILE' in '<cwd>/test/fixtures/errors'\\nDid you mean './file.js'?\\n'file.js' exists in that directory and differs from the request only in casing. Case-sensitive filesystems (most Linux ones) fail to resolve it, even when the same build succeeds on a case-insensitive one.",
 			      "moduleId": "./case-sensitive.js",
 			      "moduleIdentifier": "<cwd>/test/fixtures/errors/case-sensitive.js",
 			      "moduleName": "./case-sensitive.js",

--- a/test/configCases/errors/module-not-found-case-suggestion/Button.js
+++ b/test/configCases/errors/module-not-found-case-suggestion/Button.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-case-suggestion/errors.js
+++ b/test/configCases/errors/module-not-found-case-suggestion/errors.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = [
+	[
+		/Can't resolve '\.\/button\.js'/,
+		/Did you mean '\.\/Button\.js'\?/,
+		/'Button\.js' exists in that directory and differs from the request only in casing/
+	],
+	[
+		/Can't resolve '\.\/button'/,
+		/Did you mean '\.\/Button\.js'\?/,
+		/'Button\.js' exists in that directory and differs from the request only in casing/
+	]
+];

--- a/test/configCases/errors/module-not-found-case-suggestion/index.js
+++ b/test/configCases/errors/module-not-found-case-suggestion/index.js
@@ -1,0 +1,8 @@
+var never = false;
+
+it("should point at the file a request only differs in casing from", function () {
+	if (never) {
+		require("./button.js");
+		require("./button");
+	}
+});

--- a/test/configCases/errors/module-not-found-case-suggestion/test.filter.js
+++ b/test/configCases/errors/module-not-found-case-suggestion/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// A case-only mismatch resolves fine on a case-insensitive filesystem,
+// so there is no failing request to hint about there.
+module.exports = () => !fs.existsSync(path.resolve(__dirname, "BUTTON.js"));

--- a/test/configCases/errors/module-not-found-case-suggestion/webpack.config.js
+++ b/test/configCases/errors/module-not-found-case-suggestion/webpack.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {};

--- a/test/configCases/errors/module-not-found-suggestion/Component.js
+++ b/test/configCases/errors/module-not-found-suggestion/Component.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-suggestion/__snapshots__/errors.snap
+++ b/test/configCases/errors/module-not-found-suggestion/__snapshots__/errors.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`errors 1`] = `
+Array [
+  "Module not found: Error: Can't resolve './Componet.js' in '<TEST_DIR>'
+Did you mean './Component.js'?
+'Component.js' is the closest name in that directory. It differs from the request by 1 character, ignoring case and file extension.",
+  "Module not found: Error: Can't resolve './Componet' in '<TEST_DIR>'
+Did you mean './Component.js'?
+'Component.js' is the closest name in that directory. It differs from the request by 1 character, ignoring case and file extension.",
+  "Module not found: Error: Can't resolve './utlis' in '<TEST_DIR>'
+Did you mean './utils.js'?
+'utils.js' is the closest name in that directory. It differs from the request by 1 character, ignoring case and file extension.",
+  "Module not found: Error: Can't resolve './tranlsatoins.js' in '<TEST_DIR>'
+Did you mean './translations.js'?
+'translations.js' is the closest name in that directory. It differs from the request by 2 characters, ignoring case and file extension.",
+  "Module not found: Error: Can't resolve './bundel' in '<TEST_DIR>'
+Did you mean './bundle.min.js'?
+'bundle.min.js' is the closest name in that directory. It differs from the request by 1 character, ignoring case and file extension.",
+  "Module not found: Error: Can't resolve './nothing-like-this-here.js' in '<TEST_DIR>'",
+  "Module not found: Error: Can't resolve './no-such-directory/Componet.js' in '<TEST_DIR>'",
+  "Module not found: Error: Can't resolve './directory-without-index' in '<TEST_DIR>'",
+  "Module not found: Error: Can't resolve '/definitely-not-a-file-in-the-filesystem-root.js' in '<TEST_DIR>'",
+]
+`;

--- a/test/configCases/errors/module-not-found-suggestion/bundle.min.js
+++ b/test/configCases/errors/module-not-found-suggestion/bundle.min.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-suggestion/directory-without-index/not-an-index.js
+++ b/test/configCases/errors/module-not-found-suggestion/directory-without-index/not-an-index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-suggestion/index.js
+++ b/test/configCases/errors/module-not-found-suggestion/index.js
@@ -1,0 +1,15 @@
+var never = false;
+
+it("should suggest a similar file when a module is not found", function () {
+	if (never) {
+		require("./Componet.js");
+		require("./Componet");
+		require("./utlis");
+		require("./tranlsatoins.js");
+		require("./bundel");
+		require("./nothing-like-this-here.js");
+		require("./no-such-directory/Componet.js");
+		require("./directory-without-index");
+		require("/definitely-not-a-file-in-the-filesystem-root.js");
+	}
+});

--- a/test/configCases/errors/module-not-found-suggestion/translations.js
+++ b/test/configCases/errors/module-not-found-suggestion/translations.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-suggestion/utils.js
+++ b/test/configCases/errors/module-not-found-suggestion/utils.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 42;

--- a/test/configCases/errors/module-not-found-suggestion/webpack.config.js
+++ b/test/configCases/errors/module-not-found-suggestion/webpack.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// '.min.js' ends with '.js', so both have to be tried when naming an entry.
+	resolve: { extensions: [".js", ".min.js"] }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

A failed resolve says only that a request could not be resolved, so a typo or a casing mismatch is left to the reader to spot. When no other hint applies, webpack now reads the request's directory and names the entry it comes closest to, stating why it thinks so — the edit distance, or that the file exists and only its casing differs. Refs #17122 (the `Did you mean ...` hint item), refs #5543, where a build that works on a case-insensitive filesystem fails on a case-sensitive one with no explanation.

```
Module not found: Error: Can't resolve './button.js' in '<dir>'
Did you mean './Button.js'?
'Button.js' exists in that directory and differs from the request only in casing. Case-sensitive filesystems (most Linux ones) fail to resolve it, even when the same build succeeds on a case-insensitive one.
```

Matching is a bounded edit distance (swapped neighbors count as one edit) against each entry, compared as written and with a resolvable extension stripped, so `./Componet` finds `Component.js`. The threshold scales with the request's length, ties break by name so the hint does not depend on `readdir` order, and only relative and absolute requests are considered. It runs solely on an already-failing resolve, and only when the existing hints produced nothing, so it neither costs anything on a successful build nor duplicates the `fullySpecified` hint.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/errors/module-not-found-suggestion` (typos of one and two characters, with and without the extension, plus the cases that must stay silent: an unrelated name, a missing directory, an absolute request and a directory without an index) and `test/configCases/errors/module-not-found-case-suggestion` (casing, gated by `test.filter.js` since a case-only mismatch resolves on a case-insensitive filesystem). The existing `case-sensitive` inline snapshot in `test/Errors.test.js` is updated.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Only the text of an error that was already failing changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to survey which hint items in #17122 are still open, to write the implementation and the test cases, and to run the suites and lint locally. Every change was reviewed by me before pushing, and the behaviour was checked against real builds on this branch and on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved unresolved module errors by suggesting the closest matching file or directory.
  * Highlights filename casing mismatches with an explanatory warning.
  * Provides suggestions for misspellings, extension variations, and absolute or relative paths.

* **Bug Fixes**
  * Preserves existing, more specific resolver guidance when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->