### PR TITLE
feat(performance): recommend splitting the runtime out of a large entry chunk

### DIFF
--- a/.changeset/012-runtime-in-large-chunk-hint.md
+++ b/.changeset/012-runtime-in-large-chunk-hint.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Recommend `optimization.runtimeChunk` when a large entrypoint carries the runtime.

--- a/lib/performance/RuntimeInLargeChunkWarning.js
+++ b/lib/performance/RuntimeInLargeChunkWarning.js
@@ -1,0 +1,27 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const WebpackError = require("../errors/WebpackError");
+
+class RuntimeInLargeChunkWarning extends WebpackError {
+	/**
+	 * Creates an instance of RuntimeInLargeChunkWarning.
+	 * @param {string[]} entrypoints names of the entrypoints carrying the runtime
+	 */
+	constructor(entrypoints) {
+		super(
+			`webpack performance recommendations: \nThe runtime is part of the initial chunk of ${entrypoints.join(
+				", "
+			)}. It describes every other chunk, so a change anywhere in the build rewrites these assets and clients download them again.\nSet 'optimization.runtimeChunk' to emit the runtime as its own chunk.\nFor more info visit https://webpack.js.org/configuration/optimization/#optimizationruntimechunk`
+		);
+
+		/** @type {string} */
+		this.name = "RuntimeInLargeChunkWarning";
+	}
+}
+
+module.exports = RuntimeInLargeChunkWarning;

--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
 const { find } = require("../util/SetHelpers");
 const AssetsOverSizeLimitWarning = require("./AssetsOverSizeLimitWarning");
 const EntrypointsOverSizeLimitWarning = require("./EntrypointsOverSizeLimitWarning");
@@ -64,14 +65,17 @@ const BUILD_WIDE_RUNTIME_GLOBALS = [
  */
 const hasEmbeddedRuntime = (chunkGraph, entrypoint) => {
 	const runtimeChunk = entrypoint.getRuntimeChunk();
-	// A chunk of its own carries the runtime modules and nothing else.
-	if (
-		!runtimeChunk ||
-		chunkGraph.getNumberOfChunkModules(runtimeChunk) ===
-			chunkGraph.getNumberOfRuntimeModules(runtimeChunk)
-	) {
-		return false;
+	if (!runtimeChunk) return false;
+	// A chunk of its own carries the runtime modules and nothing else. Asking each
+	// module beats counting, which depends on runtime modules being counted twice.
+	let carriesCode = false;
+	for (const module of chunkGraph.getChunkModulesIterable(runtimeChunk)) {
+		if (!(module instanceof RuntimeModule)) {
+			carriesCode = true;
+			break;
+		}
 	}
+	if (!carriesCode) return false;
 	// The tree requirements are the ones the emitted runtime modules answer to.
 	const runtimeRequirements =
 		chunkGraph.getTreeRuntimeRequirements(runtimeChunk);

--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -5,13 +5,16 @@
 
 "use strict";
 
+const RuntimeGlobals = require("../RuntimeGlobals");
 const { find } = require("../util/SetHelpers");
 const AssetsOverSizeLimitWarning = require("./AssetsOverSizeLimitWarning");
 const EntrypointsOverSizeLimitWarning = require("./EntrypointsOverSizeLimitWarning");
 const NoAsyncChunksWarning = require("./NoAsyncChunksWarning");
+const RuntimeInLargeChunkWarning = require("./RuntimeInLargeChunkWarning");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").PerformanceOptions} PerformanceOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../ChunkGroup")} ChunkGroup */
 /** @typedef {import("../Compilation").Asset} Asset */
 /** @typedef {import("../Compiler")} Compiler */
@@ -40,6 +43,43 @@ const isOverSizeLimitSet = new WeakSet();
 
 /** @type {AssetFilter} */
 const excludeSourceMap = (name, source, info) => !info.development;
+
+// Runtime globals whose generated code describes the other chunks, so the chunk
+// holding them is rewritten whenever anything else in the build changes.
+const BUILD_WIDE_RUNTIME_GLOBALS = [
+	RuntimeGlobals.getChunkScriptFilename,
+	RuntimeGlobals.getChunkCssFilename,
+	RuntimeGlobals.getChunkUpdateScriptFilename,
+	RuntimeGlobals.getFullHash,
+	RuntimeGlobals.getUpdateManifestFilename
+];
+
+/**
+ * Tells whether an entrypoint ships its runtime inside a chunk that also carries
+ * modules, and that runtime describes the rest of the build. Only then does
+ * `optimization.runtimeChunk` win anything.
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {Entrypoint} entrypoint an entrypoint
+ * @returns {boolean} true when splitting the runtime off would keep the chunk stable
+ */
+const hasEmbeddedRuntime = (chunkGraph, entrypoint) => {
+	const runtimeChunk = entrypoint.getRuntimeChunk();
+	// A chunk of its own carries the runtime modules and nothing else.
+	if (
+		!runtimeChunk ||
+		chunkGraph.getNumberOfChunkModules(runtimeChunk) ===
+			chunkGraph.getNumberOfRuntimeModules(runtimeChunk)
+	) {
+		return false;
+	}
+	// The tree requirements are the ones the emitted runtime modules answer to.
+	const runtimeRequirements =
+		chunkGraph.getTreeRuntimeRequirements(runtimeChunk);
+	// A global nothing here names stays silent, so a new one costs a hint, not a wrong one.
+	return BUILD_WIDE_RUNTIME_GLOBALS.some((runtimeGlobal) =>
+		runtimeRequirements.has(runtimeGlobal)
+	);
+};
 
 const PLUGIN_NAME = "SizeLimitsPlugin";
 
@@ -132,6 +172,8 @@ module.exports = class SizeLimitsPlugin {
 
 			/** @type {EntrypointDetails[]} */
 			const entrypointsOverLimit = [];
+			/** @type {string[]} */
+			const entrypointsWithEmbeddedRuntime = [];
 			for (const [name, entry] of compilation.entrypoints) {
 				const size = getEntrypointSize(entry);
 
@@ -142,6 +184,9 @@ module.exports = class SizeLimitsPlugin {
 						files: entry.getFiles().filter(fileFilter)
 					});
 					isOverSizeLimitSet.add(entry);
+					if (hasEmbeddedRuntime(compilation.chunkGraph, entry)) {
+						entrypointsWithEmbeddedRuntime.push(name);
+					}
 				}
 			}
 
@@ -175,6 +220,12 @@ module.exports = class SizeLimitsPlugin {
 
 					if (!someAsyncChunk) {
 						warnings.push(new NoAsyncChunksWarning());
+					}
+
+					if (entrypointsWithEmbeddedRuntime.length > 0) {
+						warnings.push(
+							new RuntimeInLargeChunkWarning(entrypointsWithEmbeddedRuntime)
+						);
 					}
 
 					if (hints === "error") {

--- a/test/configCases/performance/runtime-in-large-chunk/index.js
+++ b/test/configCases/performance/runtime-in-large-chunk/index.js
@@ -1,0 +1,4 @@
+it("should load the async chunk", () =>
+	import("./lazy").then((m) => {
+		expect(m.default).toBe(42);
+	}));

--- a/test/configCases/performance/runtime-in-large-chunk/lazy.js
+++ b/test/configCases/performance/runtime-in-large-chunk/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/performance/runtime-in-large-chunk/warnings.js
+++ b/test/configCases/performance/runtime-in-large-chunk/warnings.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = [
+	[/entrypoint size limit/],
+	[
+		/The runtime is part of the initial chunk of main\./,
+		/Set 'optimization\.runtimeChunk' to emit the runtime as its own chunk\./
+	]
+];

--- a/test/configCases/performance/runtime-in-large-chunk/webpack.config.js
+++ b/test/configCases/performance/runtime-in-large-chunk/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// the runtime stays in the entry chunk, so it is rewritten whenever the
+	// async chunk changes
+	performance: {
+		hints: "warning",
+		maxEntrypointSize: 100,
+		maxAssetSize: 1000000
+	}
+};

--- a/test/configCases/performance/runtime-in-own-chunk/index.js
+++ b/test/configCases/performance/runtime-in-own-chunk/index.js
@@ -1,0 +1,4 @@
+it("should load the async chunk", () =>
+	import("./lazy").then((m) => {
+		expect(m.default).toBe(42);
+	}));

--- a/test/configCases/performance/runtime-in-own-chunk/lazy.js
+++ b/test/configCases/performance/runtime-in-own-chunk/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/performance/runtime-in-own-chunk/test.config.js
+++ b/test/configCases/performance/runtime-in-own-chunk/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["runtime.js", "main.js"];
+	}
+};

--- a/test/configCases/performance/runtime-in-own-chunk/warnings.js
+++ b/test/configCases/performance/runtime-in-own-chunk/warnings.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// The runtime has a chunk of its own, so only the size warning is left.
+module.exports = [[/entrypoint size limit/]];

--- a/test/configCases/performance/runtime-in-own-chunk/webpack.config.js
+++ b/test/configCases/performance/runtime-in-own-chunk/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	},
+	performance: {
+		hints: "warning",
+		maxEntrypointSize: 100,
+		maxAssetSize: 1000000
+	}
+};

--- a/test/statsCases/performance-error/__snapshots__/StatsTest.snap
+++ b/test/statsCases/performance-error/__snapshots__/StatsTest.snap
@@ -26,5 +26,10 @@ Entrypoints:
       main.js
 </CLR>
 
-webpack x.x.x compiled with <CLR=31,BOLD>2 errors</CLR> in X ms"
+<CLR=31,BOLD>ERROR</CLR> in <CLR=BOLD>webpack performance recommendations: 
+The runtime is part of the initial chunk of main. It describes every other chunk, so a change anywhere in the build rewrites these assets and clients download them again.
+Set 'optimization.runtimeChunk' to emit the runtime as its own chunk.
+For more info visit https://webpack.js.org/configuration/optimization/#optimizationruntimechunk</CLR>
+
+webpack x.x.x compiled with <CLR=31,BOLD>3 errors</CLR> in X ms"
 `;

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/__snapshots__/StatsTest.snap
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/__snapshots__/StatsTest.snap
@@ -25,5 +25,10 @@ Entrypoints:
       main.js
 </CLR>
 
-webpack x.x.x compiled with <CLR=33,BOLD>2 warnings</CLR> in X ms"
+<CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>webpack performance recommendations: 
+The runtime is part of the initial chunk of main. It describes every other chunk, so a change anywhere in the build rewrites these assets and clients download them again.
+Set 'optimization.runtimeChunk' to emit the runtime as its own chunk.
+For more info visit https://webpack.js.org/configuration/optimization/#optimizationruntimechunk</CLR>
+
+webpack x.x.x compiled with <CLR=33,BOLD>3 warnings</CLR> in X ms"
 `;

--- a/test/statsCases/preset-normal-performance/__snapshots__/StatsTest.snap
+++ b/test/statsCases/preset-normal-performance/__snapshots__/StatsTest.snap
@@ -25,5 +25,10 @@ Entrypoints:
       main.js
 </CLR>
 
-webpack x.x.x compiled with <CLR=33,BOLD>2 warnings</CLR> in X ms"
+<CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>webpack performance recommendations: 
+The runtime is part of the initial chunk of main. It describes every other chunk, so a change anywhere in the build rewrites these assets and clients download them again.
+Set 'optimization.runtimeChunk' to emit the runtime as its own chunk.
+For more info visit https://webpack.js.org/configuration/optimization/#optimizationruntimechunk</CLR>
+
+webpack x.x.x compiled with <CLR=33,BOLD>3 warnings</CLR> in X ms"
 `;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

An entry chunk that carries the runtime also carries a description of every other chunk — the chunk filename map, and the full hash under HMR — so a change anywhere in the build rewrites that chunk and clients download it again. When such an entrypoint is already over the size limit, the performance hints now say so and point at `optimization.runtimeChunk`. Refs #17122 (the `optimization.runtimeChunk` hint item); the effect is the one described in #12145, which was closed without a fix and still reproduces.

```
WARNING in webpack performance recommendations:
The runtime is part of the initial chunk of main. It describes every other chunk, so a change
anywhere in the build rewrites these assets and clients download them again.
Set 'optimization.runtimeChunk' to emit the runtime as its own chunk.
```

Two guards keep it quiet where splitting the runtime wins nothing: the runtime chunk must hold modules beyond its own runtime modules (a dedicated runtime chunk holds only those), and its tree runtime requirements must include a global whose emitted code describes the rest of the build. A global that no future entry names simply produces no hint rather than a wrong one.

It rides on `performance.hints` rather than a flag of its own, like `NoAsyncChunksWarning` next to it: the hint only refines an entrypoint that is already flagged as oversized, and that size gate is what keeps it from firing on every project that code-splits with the default configuration. Adding `performance.runtimeChunk` later stays backwards compatible if the hint should become default-off or reachable in development.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/performance/runtime-in-large-chunk` (the hint fires) and `test/configCases/performance/runtime-in-own-chunk` (the same build with the runtime split, where only the size warning is left). Three `statsCases` snapshots gain the recommendation; each of those fixtures has async chunks and an inline runtime, so the hint applies to them.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. It adds a recommendation to builds that already report a performance warning; with `performance.hints: "error"` it joins the existing errors, as the other hints do.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The performance hints page could mention the new recommendation, but no option or API changed.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to confirm the effect still reproduces on `main` (an edit confined to an async chunk rewrites the entry chunk and its source map unless the runtime is split), to write the implementation and tests, and to run the suites and lint locally. I reviewed every change before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a performance warning when an entrypoint contains runtime code in a large initial chunk.
  * Warning messages now recommend placing runtime code in a separate chunk to improve bundle efficiency.

* **Bug Fixes**
  * Improved detection of oversized entrypoints that include embedded runtime code.

* **Tests**
  * Added coverage for runtime code kept in entry chunks and runtime code extracted into its own chunk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->