### PR TITLE
perf(context): stop shipping a chunk loader a context module never calls

### DIFF
--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting unread runtime helpers, chunk state, and module wrappers.
+Stop emitting unread runtime helpers, chunk loaders, state, and module wrappers.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .eslintcache
 .cspellcache
 package-lock.json
+/events.json

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1147,9 +1147,15 @@ module.exports = webpackAsyncContext;`;
 	 * @param {object} context context
 	 * @param {ChunkGraph} context.chunkGraph the chunk graph
 	 * @param {RuntimeTemplate} context.runtimeTemplate the chunk graph
+	 * @param {RuntimeRequirements} context.runtimeRequirements runtime requirements
 	 * @returns {string} source code
 	 */
-	getLazySource(blocks, id, phase, { chunkGraph, runtimeTemplate }) {
+	getLazySource(
+		blocks,
+		id,
+		phase,
+		{ chunkGraph, runtimeTemplate, runtimeRequirements }
+	) {
 		const moduleGraph = chunkGraph.moduleGraph;
 		let hasMultipleOrNoChunks = false;
 		let hasNoChunk = true;
@@ -1241,6 +1247,10 @@ module.exports = webpackAsyncContext;`;
 			: hasMultipleOrNoChunks
 				? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
 				: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
+		// Only the id map reads it; nothing loads a chunk when there is none to load.
+		if (!hasNoChunk) {
+			runtimeRequirements.add(RuntimeGlobals.ensureChunk);
+		}
 		const returnModuleObject = this.getReturnModuleObjectSource(
 			fakeMap,
 			true,
@@ -1525,7 +1535,8 @@ module.exports = webpackEmptyAsyncContext;`;
 			if (this.blocks && this.blocks.length > 0) {
 				return this.getLazySource(this.blocks, id, phase, {
 					runtimeTemplate,
-					chunkGraph
+					chunkGraph,
+					runtimeRequirements
 				});
 			}
 			return this.getSourceForEmptyAsyncContext(id, runtimeTemplate);
@@ -1638,13 +1649,10 @@ module.exports = webpackEmptyAsyncContext;`;
 		if (allDeps.length > 0) {
 			const asyncMode = this.options.mode;
 			set.add(RuntimeGlobals.require);
-			if (asyncMode === "weak") {
+			// `ensureChunk` is not listed per mode: the source generators above add it
+			// where they emit a call, so a baked context or one with no chunk drops it.
+			if (asyncMode === "weak" || asyncMode === "async-weak") {
 				set.add(RuntimeGlobals.moduleFactories);
-			} else if (asyncMode === "async-weak") {
-				set.add(RuntimeGlobals.moduleFactories);
-				set.add(RuntimeGlobals.ensureChunk);
-			} else if (asyncMode === "lazy" || asyncMode === "lazy-once") {
-				set.add(RuntimeGlobals.ensureChunk);
 			}
 			if (this.getFakeMap(allDeps, chunkGraph) !== 9) {
 				set.add(RuntimeGlobals.createFakeNamespaceObject);

--- a/test/configCases/analyzable/glob-import/index.js
+++ b/test/configCases/analyzable/glob-import/index.js
@@ -21,4 +21,7 @@ it("should bake the import for every glob match", () => {
 	// One per match, and none of them left on the runtime form.
 	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
+	// Nothing calls them once every match is baked, so they must not ship either.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/defer-import/context-no-chunk/index.js
+++ b/test/configCases/defer-import/context-no-chunk/index.js
@@ -1,6 +1,9 @@
 import { pick } from "./pick.js";
 import { state } from "./state.js";
 
+const fs = require("fs");
+const path = require("path");
+
 it("defers evaluation of a context module kept in the initial chunk", async () => {
 	state.evaluated = 0;
 	const ns = await import(
@@ -11,4 +14,13 @@ it("defers evaluation of a context module kept in the initial chunk", async () =
 	expect(state.evaluated).toBe(0);
 	expect(ns.default).toBe("a-value");
 	expect(state.evaluated).toBe(1);
+});
+
+it("should not ship a chunk loader when the context has no chunk to load", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.outputPath, "bundle0.js"),
+		"utf8"
+	);
+
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`ContextModule` declared `ensureChunk` per async *mode* rather than per emitted code, so a context module dragged the chunk loader into the bundle even when its own generated source never calls it: `async-weak` never emits one (it resolves through `moduleFactories`), `lazy` emits none when there is no chunk to load, and a baked analyzable `import()` dispatches itself through `__webpack_require__.ei`. The source generators now declare the requirement where they emit the call.

`yarn test:size` against `main`: **-4.10 KiB** over 5 cases, nothing grew and no asset was added or removed. Five runtimes drop dead modules — `analyzable/glob-import` and `analyzable/block-origin-modules` and `externals/import-attributes` lose `ensure chunk` + `get javascript chunk filename`, `context-modules/context-options` and `defer-import/context-no-chunk` lose `ensure chunk`.

Also ignores `events.json`: `ProfilingPlugin` defaults its `outputPath` to that name relative to cwd, so running the profiling test cases leaves an 80 KB trace untracked in the repo root.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — assertions in `test/configCases/analyzable/glob-import/index.js` (baked context ships no `.e` / `.u`) and `test/configCases/defer-import/context-no-chunk/index.js` (no chunk to load ships no `.e`). Both fail without the change and pass with it.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Only runtime modules that nothing calls stop being emitted; every context mode keeps its behaviour.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used. It surveyed the emitted `configCases` output to find runtime helpers that are defined but never called, traced this one to the per-mode requirement in `ContextModule`, wrote the change and the two regression tests, and verified it (full `ConfigTestCases` + `ConfigCacheTestCases` + `WatchTestCases`, before/after `yarn test:size`, and the lint gate). All output was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wv3BaaGDfrN7Ahrjcrv9D4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Generated bundles now omit unused chunk-loading runtime code when lazy or deferred imports do not require it.
  * This can reduce bundle size and avoid unnecessary runtime overhead.

* **Bug Fixes**
  * Improved runtime requirement detection for lazy contexts, ensuring chunk-loading support is included only when needed.

* **Tests**
  * Added coverage verifying that unused chunk-loader implementations are excluded from generated bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->