### PR TITLE
added <li> to P_FOLLOWED_BY

### DIFF
--- a/lib/html/data.js
+++ b/lib/html/data.js
@@ -36,6 +36,7 @@ const P_FOLLOWED_BY = new Set([
 	"header",
 	"hgroup",
 	"hr",
+	"li",
 	"main",
 	"menu",
 	"nav",

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4237,6 +4237,12 @@ describe("SourceProcessor — optional end tags read the output", () => {
 			"<table><thead><tr><th>h</thead>\n<tr><td>d</table>"
 		);
 	});
+
+	it("omits </p> before <li>", () => {
+		// <p> end tag can be omitted before <li> per §13.1.2.4
+		expect(minify("<p>one<li>two")).toBe("<p>one</p><li>two</li>");
+		expect(minify("<p>one</p><li>two")).toBe("<p>one</p><li>two</li>");
+	});
 });
 
 describe("SourceProcessor — an empty value is the bare name", () => {


### PR DESCRIPTION
# Summary

This PR adds the missing \<li\> tag to P_FOLLOWED_BY in the HTML parser.
According to the HTML Living Standard’s “in body insertion mode”, a <p> element must be implicitly closed when followed by a <li> start tag. Browsers implement this behavior, but webpack’s parser did not, causing incorrect parsing of malformed HTML.

This change aligns webpack’s HTML parser with browser behavior and the spec.

## What kind of change does this PR introduce?

fix — spec‑compliance correction in the HTML parser.

## Did you add tests for your changes?

Yes — a test was added to ensure <p> is implicitly closed when followed by <li>.

## Does this PR introduce a breaking change?

No.
This change only corrects parsing behavior to match browsers and the HTML Living Standard.

## If relevant, what needs to be documented once your changes are merged?

No documentation changes are required.

## Use of AI

The code fix was written manually. The corresponding test was written with AI (@mistralai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying consistent HTML minification when paragraph closing tags before list items are omitted or explicitly included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->