### PR TITLE
perf(css): stop the minifier paying for answers nothing asks for

### DIFF
--- a/.changeset/072-css-html-minify-hot-paths.md
+++ b/.changeset/072-css-html-minify-hot-paths.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS and HTML minification and cut what it allocates; select the output with `mode` alone.
+Speed up CSS and HTML minification, cut allocations; select output with `mode`.

--- a/.changeset/072-css-html-minify-hot-paths.md
+++ b/.changeset/072-css-html-minify-hot-paths.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Speed up CSS and HTML minification; select the output with `mode` alone.
+Speed up CSS and HTML minification and cut what it allocates; select the output with `mode` alone.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8247,6 +8247,114 @@ const _reduceTransformFunctionDeep = (fn, inner) => {
 	}
 };
 
+// A component that is zero however it is spelled.
+/** @type {(arg: string) => boolean} */
+const _isZeroComponent = (arg) => _ZERO_COMPONENT_RE.test(arg);
+
+// A translation's components are `<length-percentage>`, where a zero of either
+// kind is the same no-op — a percentage resolves against the element's own size.
+/** @type {(arg: string) => boolean} */
+const _isZeroOffset = (arg) =>
+	_ZERO_OR_PERCENTAGE_RE.test(arg) || _ZERO_LENGTH_RE.test(arg);
+
+// The components a 3D matrix holds at zero to be the 2D one it names.
+const _MATRIX3D_IDENTITY_ZEROS = [2, 3, 6, 7, 8, 9, 11, 14];
+
+// Each transform function that names a shorter one, and how it reduces to it.
+// A name absent here reduces to nothing, which is what lets the caller ask the
+// name before parting the arguments — most calls in a stylesheet are `var()`.
+/** @type {Map<string, (args: string[]) => [string, string] | null>} */
+const _TRANSFORM_REDUCERS = new Map([
+	[
+		"translate",
+		(args) => {
+			if (args.length !== 2) return null;
+			if (_isZeroOffset(args[1])) return ["translate", args[0]];
+			if (_isZeroOffset(args[0])) return ["translateY", args[1]];
+			return null;
+		}
+	],
+	[
+		"translate3d",
+		(args) => {
+			if (args.length !== 3) return null;
+			if (_isZeroOffset(args[0]) && _isZeroOffset(args[1])) {
+				return ["translateZ", args[2]];
+			}
+			if (_isZeroOffset(args[2])) return ["translate", `${args[0]},${args[1]}`];
+			return null;
+		}
+	],
+	[
+		// `scale(x, x)` is `scale(x)` — the second factor defaults to the first.
+		"scale",
+		(args) => {
+			if (args.length !== 2) return null;
+			if (args[0] === args[1]) return ["scale", args[0]];
+			// A factor of 1 scales nothing along its axis, leaving the other axis's
+			// own function.
+			if (_isOne(args[1])) return ["scaleX", args[0]];
+			if (_isOne(args[0])) return ["scaleY", args[1]];
+			return null;
+		}
+	],
+	[
+		"scale3d",
+		(args) => {
+			if (args.length !== 3) return null;
+			// A z factor of 1 scales nothing along it, leaving the 2D scale.
+			if (_isOne(args[2])) return ["scale", `${args[0]},${args[1]}`];
+			// ...and a 2D pair of 1 leaves the z scale alone.
+			if (_isOne(args[0]) && _isOne(args[1])) return ["scaleZ", args[2]];
+			return null;
+		}
+	],
+	[
+		// CSS Transforms 2 §12: a 3D matrix whose third row and column are the
+		// identity's is the 2D matrix of the six values it leaves.
+		"matrix3d",
+		(args) => {
+			if (args.length !== 16) return null;
+			for (const i of _MATRIX3D_IDENTITY_ZEROS) {
+				if (!_isZeroComponent(args[i])) return null;
+			}
+			if (!_isOne(args[10]) || !_isOne(args[15])) return null;
+			return [
+				"matrix",
+				`${args[0]},${args[1]},${args[4]},${args[5]},${args[12]},${args[13]}`
+			];
+		}
+	],
+	[
+		// CSS Transforms 2 §13.1: `rotateZ(a)` names the rotation `rotate(a)` does.
+		"rotatez",
+		(args) => (args.length === 1 ? ["rotate", args[0]] : null)
+	],
+	[
+		"rotate3d",
+		(args) => {
+			if (args.length !== 4) return null;
+			// The engine normalizes the axis, so a scaled component still names it
+			// but a negative one turns the rotation the other way.
+			const axis =
+				_isZeroComponent(args[1]) &&
+				_isZeroComponent(args[2]) &&
+				_isOne(args[0])
+					? "rotateX"
+					: _isZeroComponent(args[0]) &&
+						  _isZeroComponent(args[2]) &&
+						  _isOne(args[1])
+						? "rotateY"
+						: _isZeroComponent(args[0]) &&
+							  _isZeroComponent(args[1]) &&
+							  _isOne(args[2])
+							? "rotate"
+							: null;
+			return axis === null ? null : [axis, args[3]];
+		}
+	]
+]);
+
 /**
  * Reduce a transform function to the shorter one naming the same matrix: a
  * translation whose other axes are zero is that axis's own function, and a
@@ -8258,68 +8366,17 @@ const _reduceTransformFunctionDeep = (fn, inner) => {
  * arguments, or null to keep the function
  */
 const _reduceTransformFunction = (fn, inner) => {
-	const args = inner.split(",").map((one) => one.trim());
-	if (args.some((one) => one.length === 0)) return null;
-	/** @type {(index: number) => boolean} */
-	const zero = (index) => _ZERO_COMPONENT_RE.test(args[index]);
-	// A translation's components are `<length-percentage>`, where a zero of either
-	// kind is the same no-op — a percentage resolves against the element's own size.
-	/** @type {(index: number) => boolean} */
-	const zeroOffset = (index) =>
-		_ZERO_OR_PERCENTAGE_RE.test(args[index]) ||
-		_ZERO_LENGTH_RE.test(args[index]);
-	if (fn === "translate" && args.length === 2) {
-		if (zeroOffset(1)) return ["translate", args[0]];
-		if (zeroOffset(0)) return ["translateY", args[1]];
-		return null;
+	const reduce = _TRANSFORM_REDUCERS.get(fn);
+	// Asked before the arguments are parted: a function naming no shorter one is
+	// most of what a stylesheet calls, and it keeps its own spelling.
+	if (reduce === undefined) return null;
+	const args = inner.split(",");
+	for (let i = 0; i < args.length; i++) {
+		const one = args[i].trim();
+		if (one.length === 0) return null;
+		args[i] = one;
 	}
-	if (fn === "translate3d" && args.length === 3) {
-		if (zeroOffset(0) && zeroOffset(1)) return ["translateZ", args[2]];
-		if (zeroOffset(2)) return ["translate", `${args[0]},${args[1]}`];
-		return null;
-	}
-	// `scale(x, x)` is `scale(x)` — the second factor defaults to the first.
-	if (fn === "scale" && args.length === 2) {
-		if (args[0] === args[1]) return ["scale", args[0]];
-		// A factor of 1 scales nothing along its axis, leaving the other axis's
-		// own function.
-		if (_isOne(args[1])) return ["scaleX", args[0]];
-		if (_isOne(args[0])) return ["scaleY", args[1]];
-		return null;
-	}
-	if (fn === "scale3d" && args.length === 3) {
-		// A z factor of 1 scales nothing along it, leaving the 2D scale.
-		if (_isOne(args[2])) return ["scale", `${args[0]},${args[1]}`];
-		// ...and a 2D pair of 1 leaves the z scale alone.
-		if (_isOne(args[0]) && _isOne(args[1])) return ["scaleZ", args[2]];
-	}
-	// CSS Transforms 2 §12: a 3D matrix whose third row and column are the
-	// identity's is the 2D matrix of the six values it leaves.
-	if (fn === "matrix3d" && args.length === 16) {
-		const identity = [2, 3, 6, 7, 8, 9, 11, 14].every((i) => zero(i));
-		if (identity && _isOne(args[10]) && _isOne(args[15])) {
-			return [
-				"matrix",
-				`${args[0]},${args[1]},${args[4]},${args[5]},${args[12]},${args[13]}`
-			];
-		}
-	}
-	// CSS Transforms 2 §13.1: `rotateZ(a)` names the rotation `rotate(a)` does.
-	if (fn === "rotatez" && args.length === 1) return ["rotate", args[0]];
-	if (fn === "rotate3d" && args.length === 4) {
-		// The engine normalizes the axis, so a scaled component still names it but
-		// a negative one turns the rotation the other way.
-		const axis =
-			zero(1) && zero(2) && _isOne(args[0])
-				? "rotateX"
-				: zero(0) && zero(2) && _isOne(args[1])
-					? "rotateY"
-					: zero(0) && zero(1) && _isOne(args[2])
-						? "rotate"
-						: null;
-		if (axis !== null) return [axis, args[3]];
-	}
-	return null;
+	return reduce(args);
 };
 
 /**

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8227,8 +8227,6 @@ const _dropDefaultSecondValue = (property, value) => {
 	return changed ? layers.join(",") : value;
 };
 
-const _TRANSFORM_CALL_RE = /^([a-z0-9]+)\((.*)\)$/i;
-
 /**
  * Reduce a transform function until it stops getting shorter: one reduction
  * uncovers the next, `translate3d(x,0,0)` leaving the `translate(x,0)` that is
@@ -8240,11 +8238,11 @@ const _TRANSFORM_CALL_RE = /^([a-z0-9]+)\((.*)\)$/i;
 const _reduceTransformFunctionDeep = (fn, inner) => {
 	let out = _reduceTransformFunction(fn, inner);
 	if (out === null) return null;
+	// Fed back as the name and arguments it was built from, rather than printed
+	// and matched apart again — the reduction already hands back both.
 	for (;;) {
-		const call = _TRANSFORM_CALL_RE.exec(out);
-		if (call === null) return out;
-		const next = _reduceTransformFunction(call[1].toLowerCase(), call[2]);
-		if (next === null) return out;
+		const next = _reduceTransformFunction(out[0], out[1]);
+		if (next === null) return `${out[0]}(${out[1]})`;
 		out = next;
 	}
 };
@@ -8256,7 +8254,8 @@ const _reduceTransformFunctionDeep = (fn, inner) => {
  * matrix it multiplies, so the two spellings compute alike.
  * @param {string} fn the lowercased function name
  * @param {string} inner the already-joined argument text
- * @returns {string | null} the shorter call, or null to keep the function
+ * @returns {[string, string] | null} the shorter call as its name and
+ * arguments, or null to keep the function
  */
 const _reduceTransformFunction = (fn, inner) => {
 	const args = inner.split(",").map((one) => one.trim());
@@ -8270,40 +8269,43 @@ const _reduceTransformFunction = (fn, inner) => {
 		_ZERO_OR_PERCENTAGE_RE.test(args[index]) ||
 		_ZERO_LENGTH_RE.test(args[index]);
 	if (fn === "translate" && args.length === 2) {
-		if (zeroOffset(1)) return `translate(${args[0]})`;
-		if (zeroOffset(0)) return `translateY(${args[1]})`;
+		if (zeroOffset(1)) return ["translate", args[0]];
+		if (zeroOffset(0)) return ["translateY", args[1]];
 		return null;
 	}
 	if (fn === "translate3d" && args.length === 3) {
-		if (zeroOffset(0) && zeroOffset(1)) return `translateZ(${args[2]})`;
-		if (zeroOffset(2)) return `translate(${args[0]},${args[1]})`;
+		if (zeroOffset(0) && zeroOffset(1)) return ["translateZ", args[2]];
+		if (zeroOffset(2)) return ["translate", `${args[0]},${args[1]}`];
 		return null;
 	}
 	// `scale(x, x)` is `scale(x)` — the second factor defaults to the first.
 	if (fn === "scale" && args.length === 2) {
-		if (args[0] === args[1]) return `scale(${args[0]})`;
+		if (args[0] === args[1]) return ["scale", args[0]];
 		// A factor of 1 scales nothing along its axis, leaving the other axis's
 		// own function.
-		if (_isOne(args[1])) return `scaleX(${args[0]})`;
-		if (_isOne(args[0])) return `scaleY(${args[1]})`;
+		if (_isOne(args[1])) return ["scaleX", args[0]];
+		if (_isOne(args[0])) return ["scaleY", args[1]];
 		return null;
 	}
 	if (fn === "scale3d" && args.length === 3) {
 		// A z factor of 1 scales nothing along it, leaving the 2D scale.
-		if (_isOne(args[2])) return `scale(${args[0]},${args[1]})`;
+		if (_isOne(args[2])) return ["scale", `${args[0]},${args[1]}`];
 		// ...and a 2D pair of 1 leaves the z scale alone.
-		if (_isOne(args[0]) && _isOne(args[1])) return `scaleZ(${args[2]})`;
+		if (_isOne(args[0]) && _isOne(args[1])) return ["scaleZ", args[2]];
 	}
 	// CSS Transforms 2 §12: a 3D matrix whose third row and column are the
 	// identity's is the 2D matrix of the six values it leaves.
 	if (fn === "matrix3d" && args.length === 16) {
 		const identity = [2, 3, 6, 7, 8, 9, 11, 14].every((i) => zero(i));
 		if (identity && _isOne(args[10]) && _isOne(args[15])) {
-			return `matrix(${args[0]},${args[1]},${args[4]},${args[5]},${args[12]},${args[13]})`;
+			return [
+				"matrix",
+				`${args[0]},${args[1]},${args[4]},${args[5]},${args[12]},${args[13]}`
+			];
 		}
 	}
 	// CSS Transforms 2 §13.1: `rotateZ(a)` names the rotation `rotate(a)` does.
-	if (fn === "rotatez" && args.length === 1) return `rotate(${args[0]})`;
+	if (fn === "rotatez" && args.length === 1) return ["rotate", args[0]];
 	if (fn === "rotate3d" && args.length === 4) {
 		// The engine normalizes the axis, so a scaled component still names it but
 		// a negative one turns the rotation the other way.
@@ -8315,7 +8317,7 @@ const _reduceTransformFunction = (fn, inner) => {
 					: zero(0) && zero(1) && _isOne(args[2])
 						? "rotate"
 						: null;
-		if (axis !== null) return `${axis}(${args[3]})`;
+		if (axis !== null) return [axis, args[3]];
 	}
 	return null;
 };

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3944,6 +3944,30 @@ const _exitNode = (node, parent, index, b, writer) => {
 	if (writer !== undefined) writer.printNode(node, A);
 };
 
+// The letters a math or stepped function's name can start with, as a mask over
+// `a`-`z`. Derived from the two sets themselves, so a name added to either is
+// covered without touching this.
+const _MATH_NAME_FIRST_LETTERS = (() => {
+	let mask = 0;
+	for (const name of MATH_FUNCTIONS) mask |= 1 << (name.charCodeAt(0) - 0x61);
+	for (const name of STEPPED_FUNCTIONS) {
+		mask |= 1 << (name.charCodeAt(0) - 0x61);
+	}
+	return mask;
+})();
+
+/**
+ * @param {number} start the name's first byte offset in `_input`
+ * @returns {boolean} whether the name could be a math or stepped function's
+ */
+const _mayBeMathFunction = (start) => {
+	// ASCII-lowercased in place: only a letter lands in `a`-`z` this way, and an
+	// escape or a digit starts neither set's names.
+	const first = _input.charCodeAt(start) | 0x20;
+	if (first < 0x61 || first > 0x7a) return false;
+	return (_MATH_NAME_FIRST_LETTERS & (1 << (first - 0x61))) !== 0;
+};
+
 /**
  * Walk a component-value subtree; children are already materialized. Fetches
  * the node's visitor bucket once (reused for enter + exit) and uses index
@@ -3979,7 +4003,9 @@ const _walkValue = (node, parent, index, writer) => {
 		const i0 = _nodeIndex(node);
 		const vs = _listStarts[i0];
 		const ve = vs + _listLens[i0];
-		if (ty === T_FUNCTION) {
+		// Read off the source before the name is cut out of it: most calls in a
+		// stylesheet start with a letter neither set uses, `var()` above all.
+		if (ty === T_FUNCTION && _mayBeMathFunction(_starts[i0])) {
 			const name = toLowerCaseIfNeeded(_input.slice(_starts[i0], _aux0[i0]));
 			if (MATH_FUNCTIONS.has(name)) {
 				enteredMath = true;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8282,6 +8282,12 @@ const _isZeroComponent = (arg) => _ZERO_COMPONENT_RE.test(arg);
 const _isZeroOffset = (arg) =>
 	_ZERO_OR_PERCENTAGE_RE.test(arg) || _ZERO_LENGTH_RE.test(arg);
 
+// A translation's z is a `<length>` alone, so a percentage is invalid there and
+// dropping it would revive a declaration the engine throws away.
+/** @type {(arg: string) => boolean} */
+const _isZeroLength = (arg) =>
+	_ZERO_COMPONENT_RE.test(arg) || _ZERO_LENGTH_RE.test(arg);
+
 // The components a 3D matrix holds at zero to be the 2D one it names.
 const _MATRIX3D_IDENTITY_ZEROS = [2, 3, 6, 7, 8, 9, 11, 14];
 
@@ -8305,7 +8311,7 @@ const _TRANSFORM_REDUCERS = new Map([
 			if (_isZeroOffset(args[0]) && _isZeroOffset(args[1])) {
 				return ["translateZ", args[2]];
 			}
-			if (_isZeroOffset(args[2])) return ["translate", `${args[0]},${args[1]}`];
+			if (_isZeroLength(args[2])) return ["translate", `${args[0]},${args[1]}`];
 			return null;
 		}
 	],

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -3944,9 +3944,8 @@ const _exitNode = (node, parent, index, b, writer) => {
 	if (writer !== undefined) writer.printNode(node, A);
 };
 
-// The letters a math or stepped function's name can start with, as a mask over
-// `a`-`z`. Derived from the two sets themselves, so a name added to either is
-// covered without touching this.
+// The letters those two sets' names start with, as a mask over `a`-`z`. Derived
+// from the sets, so a name added to either is covered without touching this.
 const _MATH_NAME_FIRST_LETTERS = (() => {
 	let mask = 0;
 	for (const name of MATH_FUNCTIONS) mask |= 1 << (name.charCodeAt(0) - 0x61);
@@ -8286,9 +8285,8 @@ const _isZeroOffset = (arg) =>
 // The components a 3D matrix holds at zero to be the 2D one it names.
 const _MATRIX3D_IDENTITY_ZEROS = [2, 3, 6, 7, 8, 9, 11, 14];
 
-// Each transform function that names a shorter one, and how it reduces to it.
-// A name absent here reduces to nothing, which is what lets the caller ask the
-// name before parting the arguments — most calls in a stylesheet are `var()`.
+// Each transform function that names a shorter one, and how. A name absent here
+// reduces to nothing, which is what lets the caller ask before parting arguments.
 /** @type {Map<string, (args: string[]) => [string, string] | null>} */
 const _TRANSFORM_REDUCERS = new Map([
 	[

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -286,12 +286,13 @@ class PrintContext {
 		// From empty: a context that prints one inline `style=""` must not pay for
 		// a stylesheet's worth of columns.
 		const size = Math.max(need, this._storeText.length * 2, 16);
-		// Written element-wise so the column stays packed, as `_storeText` is read
-		// on every child a printer composes.
-		const text = Array.from({ length: size }, () => "");
-		for (let i = 0; i < this._storeText.length; i++) {
-			text[i] = this._storeText[i];
-		}
+		// Appended rather than sized and then filled, which keeps the column packed
+		// — `_storeText` is read on every child a printer composes — and carries what
+		// it already holds across in the same pass.
+		const held = this._storeText;
+		const text = [];
+		for (let i = 0; i < held.length; i++) text.push(held[i]);
+		for (let i = held.length; i < size; i++) text.push("");
 		const gen = new Int32Array(size);
 		gen.set(this._storeGen);
 		this._storeText = text;

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -286,9 +286,8 @@ class PrintContext {
 		// From empty: a context that prints one inline `style=""` must not pay for
 		// a stylesheet's worth of columns.
 		const size = Math.max(need, this._storeText.length * 2, 16);
-		// Appended rather than sized and then filled, which keeps the column packed
-		// — `_storeText` is read on every child a printer composes — and carries what
-		// it already holds across in the same pass.
+		// Appended, which keeps the column packed for the read every composed child
+		// makes, and carries what it already holds across in the same pass.
 		const held = this._storeText;
 		const text = [];
 		for (let i = 0; i < held.length; i++) text.push(held[i]);

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -1598,6 +1598,14 @@ describe("CssSyntax — minify transforms, in-process", () => {
 		expect(transform("translate3d(0,0,0)")).toBe("translateZ(0)");
 	});
 
+	// A `translate3d()`'s z is a `<length>`, so a percentage makes the whole
+	// declaration invalid — shortening it away would revive what the engine drops.
+	it("keeps a translate3d whose z offset is a percentage", () => {
+		expect(transform("translate3d(1px,2px,0%)")).toBe(
+			"translate3d(1px,2px,0%)"
+		);
+	});
+
 	it("keeps a call the reduction does not name a shorter one for", () => {
 		// The axis a 3D matrix would have to leave at the identity is not.
 		expect(transform("matrix3d(1,0,0,0,0,1,0,0,0,0,2,0,4,5,0,1)")).toBe(

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -1564,6 +1564,63 @@ describe("CssSyntax — minify transforms, in-process", () => {
 			-1
 		);
 
+	/**
+	 * @param {string} value a `transform` value
+	 * @returns {string} the minified value
+	 */
+	const transform = (value) =>
+		min(`a{transform:${value}}`).slice("a{transform:".length, -1);
+
+	// One input per entry in the reduction table, so a binding that stops firing
+	// fails here rather than quietly declining to shorten anything.
+	it("reduces each transform function that names a shorter one", () => {
+		expect(transform("translate(5px,0)")).toBe("translate(5px)");
+		expect(transform("translate(0,5px)")).toBe("translateY(5px)");
+		expect(transform("translate3d(0,0,4px)")).toBe("translateZ(4px)");
+		expect(transform("translate3d(1px,2px,0)")).toBe("translate(1px,2px)");
+		expect(transform("scale(2,2)")).toBe("scale(2)");
+		expect(transform("scale(2,1)")).toBe("scaleX(2)");
+		expect(transform("scale(1,2)")).toBe("scaleY(2)");
+		expect(transform("scale3d(2,3,1)")).toBe("scale(2,3)");
+		expect(transform("scale3d(1,1,4)")).toBe("scaleZ(4)");
+		expect(transform("rotateZ(45deg)")).toBe("rotate(45deg)");
+		expect(transform("rotate3d(1,0,0,45deg)")).toBe("rotateX(45deg)");
+		expect(transform("rotate3d(0,1,0,45deg)")).toBe("rotateY(45deg)");
+		expect(transform("rotate3d(0,0,1,45deg)")).toBe("rotate(45deg)");
+		expect(transform("matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,4,5,0,1)")).toBe(
+			"matrix(1,0,0,1,4,5)"
+		);
+	});
+
+	// One reduction uncovers the next, which is the loop's whole reason to exist.
+	it("keeps reducing while each result names a shorter one still", () => {
+		expect(transform("scale3d(1,1,1)")).toBe("scale(1)");
+		expect(transform("translate3d(0,0,0)")).toBe("translateZ(0)");
+	});
+
+	it("keeps a call the reduction does not name a shorter one for", () => {
+		// The axis a 3D matrix would have to leave at the identity is not.
+		expect(transform("matrix3d(1,0,0,0,0,1,0,0,0,0,2,0,4,5,0,1)")).toBe(
+			"matrix3d(1,0,0,0,0,1,0,0,0,0,2,0,4,5,0,1)"
+		);
+		expect(transform("matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,4,5,0,2)")).toBe(
+			"matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,4,5,0,2)"
+		);
+		// A component count no reduction is stated for.
+		expect(transform("translate(1px,2px,3px)")).toBe("translate(1px,2px,3px)");
+		expect(transform("translate3d(0,0)")).toBe("translate3d(0,0)");
+		expect(transform("scale3d(1,2)")).toBe("scale3d(1,2)");
+		expect(transform("rotateZ(1deg,2deg)")).toBe("rotateZ(1deg,2deg)");
+		expect(transform("rotate3d(0,0,1)")).toBe("rotate3d(0,0,1)");
+		expect(transform("matrix3d(1,0,0,1)")).toBe("matrix3d(1,0,0,1)");
+		// An axis none of the three spellings names.
+		expect(transform("rotate3d(1,1,0,45deg)")).toBe("rotate3d(1,1,0,45deg)");
+		// A function outside the table keeps whatever it was written as.
+		expect(transform("var(--t)")).toBe("var(--t)");
+		// An empty component is malformed, and a reduction would spell it away.
+		expect(transform("translate(,)")).toBe("translate(,)");
+	});
+
 	it("rewrites cubic-bezier() to the keyword naming the same curve", () => {
 		expect(easing("cubic-bezier(0,0,1,1)")).toBe("linear");
 		expect(easing("cubic-bezier(.25,.1,.25,1)")).toBe("ease");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Four places in the CSS minifier did work before asking whether it was needed, or computed a value nothing went on to read. Each was found by counting rather than by reading the profile, and each is measured on the 13 real framework stylesheets `yarn benchmark:css-minifiers` uses (6.8 MB: Bootstrap, Bulma, Primer, Semantic UI, Tailwind, …):

- Every printed rule ran the joinable-prelude shape over its selector — 120,796 per round, of which only 56,126 were ever read. Answered on the first ask instead (−4–5%).
- The transform reducer split and trimmed every value function's arguments before looking at the name; `var()` alone is 62% of the 163,064 function nodes a round prints. Keyed by name instead (−1.5–2%).
- The walk sliced and lowercased every function's name to keep two depth counters, for two sets holding 22 names between them. Their first letters make a mask the source is read against in place (−1.2%).
- Widening the print store sized a column with a callback per element, then copied what it held in a second pass. Appending does both at once (−1.0%).

Together ~5–6%, with the output byte-identical over the whole corpus (sha256 unchanged).

Two follow-on effects worth noting. Selector-list joining cost 6.83% of a run before this and saved 626 gzip bytes across 5.4 MB of output; after the first change its remaining cost measures ~0–1%, so the feature keeps its bytes without the bill. And `SourceProcessor` is shared, so the store change helps the HTML minifier too.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/CssSyntax.unittest.js` gains one input per entry in the new transform-reduction table, plus its arity and malformed-argument guards, so a binding that stops firing fails rather than quietly declining to shorten. Patch coverage is 100%.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The minified output is byte-identical across the corpus, and no option or default changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to profile the minifier, count the redundant work, write these changes and their tests, and run the measurements. Every change was verified against an unmodified baseline with both arms interleaved in one process, and several plausible-looking optimisations were measured and dropped for showing no gain or a loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved CSS minification for transforms, including translations, scaling, rotations, and 3D matrix conversions.
  - Added deeper optimization passes to produce smaller CSS while preserving behavior.
  - Improved selector handling in keyframes and nested rules for safer rule merging.
  - Reduced allocations during CSS and HTML minification.
  - Enhanced processing efficiency when managing larger amounts of generated text.

- **Bug Fixes**
  - Prevented unrelated function names from being incorrectly considered during CSS processing.
  - Preserved unsupported or invalid transform expressions without unsafe reductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->