### PR TITLE
perf: stop emitting runtime helpers nothing calls, and scope analyzable wasm urls per runtime

### DIFF
--- a/.changeset/023-analyzable-depths-digests-and-diagnostics.md
+++ b/.changeset/023-analyzable-depths-digests-and-diagnostics.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake analyzable ESM and wasm references per depth and digest; report fallbacks.
+Bake analyzable ESM and wasm references per depth, digest and runtime; report fallbacks.

--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting unread runtime helpers, chunk loaders, state, and module wrappers.
+Stop emitting uncalled runtime helpers, chunk loaders, resource hints, state and wrappers.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -15,6 +15,7 @@ const {
 	JAVASCRIPT_TYPE,
 	RUNTIME_TYPE
 } = require("./ModuleSourceTypeConstants");
+const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
 const {
@@ -270,6 +271,8 @@ class RuntimeTemplate {
 		this._publicPathShapeText = undefined;
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
+		/** @type {boolean | undefined} */
+		this._wasmRuntimesAnswerApart = undefined;
 	}
 
 	isIIFE() {
@@ -426,9 +429,10 @@ class RuntimeTemplate {
 	 * @param {AnalyzableForm} form which reference is being emitted
 	 * @param {ChunkGraph=} chunkGraph the chunk graph, to place `module` in its runtimes
 	 * @param {Module=} module the module the reference is emitted into
+	 * @param {RuntimeSpec=} runtime the runtime the reference is emitted for; the wasm forms answer for the loader it shares rather than for every loader in the compilation
 	 * @returns {boolean} true when the literal form may be emitted
 	 */
-	supportsAnalyzable(form, chunkGraph, module) {
+	supportsAnalyzable(form, chunkGraph, module, runtime) {
 		// Analyzable output is ESM output — anything else is a different feature.
 		if (!this.isModule()) return false;
 		// Build-time execution keeps the runtime form — `import.meta` does not parse in
@@ -519,7 +523,7 @@ class RuntimeTemplate {
 				if (this._resolvePublicPathPrefix(publicPath, module) === null) {
 					return false;
 				}
-			} else if (this._anyWasmChunkFetches()) {
+			} else if (this._anyWasmChunkFetches(runtime)) {
 				this._analyzableBailout(
 					module,
 					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
@@ -793,22 +797,58 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether any chunk loads WebAssembly through `fetch`, which is the only loader the
+	 * Whether a chunk loads WebAssembly through `fetch`, which is the only loader the
 	 * public path reaches: `readFile` resolves the binary's name against the chunk it is
 	 * read from, exactly as a baked literal does, so a public path is irrelevant to it.
-	 * Answered for the compilation rather than per chunk on purpose — a module's
-	 * generated source and the runtime module of every chunk holding it have to agree
-	 * on the shape, and they ask from opposite ends.
-	 * @returns {boolean} true when some chunk fetches its binaries
+	 * Answered per runtime rather than per chunk on purpose — a module's generated source
+	 * and the runtime module of every chunk holding it have to agree on the shape, and
+	 * they ask from opposite ends; one loader serves a whole runtime, so that is the
+	 * finest scope on which they can. Without a runtime, or where the runtimes cannot be
+	 * told apart, the answer covers the compilation.
+	 * @param {RuntimeSpec=} runtime the runtime being asked about
+	 * @returns {boolean} true when a chunk of that runtime fetches its binaries
 	 */
-	_anyWasmChunkFetches() {
-		const { wasmLoading } = this.outputOptions;
-		if (wasmLoading === "fetch") return true;
+	_anyWasmChunkFetches(runtime) {
+		const { wasmLoading: globalWasmLoading } = this.outputOptions;
+		const scope = this._wasmLoadersAnswerApart() ? runtime : undefined;
 		for (const chunk of this.compilation.chunks) {
+			if (scope !== undefined && !intersectRuntime(chunk.runtime, scope)) {
+				continue;
+			}
 			const entryOptions = chunk.getEntryOptions();
-			if (entryOptions && entryOptions.wasmLoading === "fetch") return true;
+			// Only an entry names a loader; every other chunk of the runtime is served by
+			// the one its entry asked for.
+			if (!entryOptions) continue;
+			const wasmLoading =
+				entryOptions.wasmLoading !== undefined
+					? entryOptions.wasmLoading
+					: globalWasmLoading;
+			if (wasmLoading === "fetch") return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Whether one runtime's loader may be answered without the others. Code generation
+	 * runs once for runtimes a module hashes alike in, and nothing in a binary's hash
+	 * knows which loader will read it — so a binary two runtimes share would carry one
+	 * shape into both, and the loader that did not ask for it takes arguments it is not
+	 * handed. Asked of the same modules the loaders are created for.
+	 * @returns {boolean} true when each runtime may be answered on its own
+	 */
+	_wasmLoadersAnswerApart() {
+		if (this._wasmRuntimesAnswerApart === undefined) {
+			const { chunkGraph } = this.compilation;
+			this._wasmRuntimesAnswerApart = true;
+			for (const module of this.compilation.modules) {
+				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
+				if (chunkGraph.getModuleRuntimes(module).size > 1) {
+					this._wasmRuntimesAnswerApart = false;
+					break;
+				}
+			}
+		}
+		return this._wasmRuntimesAnswerApart;
 	}
 
 	supportTemplateLiteral() {

--- a/lib/dependencies/URLDependency.js
+++ b/lib/dependencies/URLDependency.js
@@ -277,15 +277,6 @@ URLDependency.Template = class URLDependencyTemplate extends (
 		) {
 			const specifier = getAnalyzableUrlSpecifier(dep, templateContext);
 			if (specifier !== null) {
-				if (dep.prefetch || dep.preload) {
-					runtimeRequirements.add(RuntimeGlobals.startupAssetHints);
-					if (dep.prefetch) {
-						runtimeRequirements.add(RuntimeGlobals.prefetchAsset);
-					}
-					if (dep.preload) {
-						runtimeRequirements.add(RuntimeGlobals.preloadAsset);
-					}
-				}
 				source.replace(
 					dep.range[0],
 					dep.range[1] - 1,
@@ -318,17 +309,6 @@ URLDependency.Template = class URLDependencyTemplate extends (
 				runtimeRequirements,
 				weak: false
 			});
-		}
-
-		// Resource hints fire eagerly at chunk startup via the marker
-		// requirement / `StartupAssetHintRuntimeModule`; the call site stays
-		// a plain URL expression, so the browser is already prefetching by
-		// the time user code reaches this line. Build-time execution skips
-		// them — browser markup, no DOM.
-		if ((dep.prefetch || dep.preload) && !chunkGraph.buildTimeExecution) {
-			runtimeRequirements.add(RuntimeGlobals.startupAssetHints);
-			if (dep.prefetch) runtimeRequirements.add(RuntimeGlobals.prefetchAsset);
-			if (dep.preload) runtimeRequirements.add(RuntimeGlobals.preloadAsset);
 		}
 
 		if (dep.relative) {

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -153,19 +153,9 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 			: null;
 
 		if (analyzableSpecifier !== null) {
-			const startupHint = dep.options.resourceHint;
-			if (startupHint && (startupHint.preload || startupHint.prefetch)) {
-				// Declared here, not in the runtime module: requirements added during
-				// `generate()` are too late for the corresponding modules to be created.
-				// What the `<link>` href itself reads is added by `ResourceHintPlugin`,
-				// which spells it — the same literal as here, so usually nothing.
-				runtimeRequirements.add(RuntimeGlobals.startupAssetHints);
-				runtimeRequirements.add(
-					startupHint.preload
-						? RuntimeGlobals.preloadAsset
-						: RuntimeGlobals.prefetchAsset
-				);
-			}
+			// No `<link>` helper is asked for here: this form emits no call, and
+			// `ResourceHintPlugin` — which spells the one that fires at startup —
+			// declares what that one reads while requirements are still open.
 			const urlArgs = `/* worker import */ ${analyzableSpecifier}, ${runtimeTemplate.outputOptions.importMetaName}.url`;
 			source.replace(
 				dep.range[0],

--- a/lib/javascript/CommonJsChunkFormatPlugin.js
+++ b/lib/javascript/CommonJsChunkFormatPlugin.js
@@ -17,7 +17,10 @@ const {
 	getChunkFilenameTemplate,
 	getCompilationHooks
 } = require("./JavascriptModulesPlugin");
-const { generateEntryStartup } = require("./StartupHelpers");
+const {
+	entryStartupAwaitsChunks,
+	generateEntryStartup
+} = require("./StartupHelpers");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
@@ -38,7 +41,11 @@ class CommonJsChunkFormatPlugin {
 					if (chunk.hasRuntime()) return;
 					if (chunkGraph.getNumberOfEntryModules(chunk) > 0) {
 						set.add(RuntimeGlobals.require);
-						set.add(RuntimeGlobals.startupEntrypoint);
+						// An entry with nothing to wait for is called straight, so the
+						// helper that waits would have no call site.
+						if (entryStartupAwaitsChunks(chunkGraph, chunk)) {
+							set.add(RuntimeGlobals.startupEntrypoint);
+						}
 						set.add(RuntimeGlobals.externalInstallChunk);
 					}
 				}

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -25,6 +25,31 @@ const EXPORT_PREFIX = `var ${RuntimeGlobals.exports} = `;
 /** @typedef {ModuleId[]} ModuleIds */
 
 /**
+ * Whether the startup rendered for this chunk waits on other chunks — the one shape
+ * `generateEntryStartup` gives a startup helper, rather than calling the entry module
+ * straight. Asked while runtime requirements are still open, where that render is long
+ * off, so it mirrors its loop rather than reading the output.
+ * @param {ChunkGraph} chunkGraph chunkGraph
+ * @param {Chunk} chunk chunk
+ * @returns {boolean} true when an entry module of this chunk runs behind a chunk load
+ */
+module.exports.entryStartupAwaitsChunks = (chunkGraph, chunk) => {
+	for (const [
+		module,
+		entrypoint
+	] of chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk)) {
+		if (!chunkGraph.getModuleSourceTypes(module).has("javascript")) {
+			continue;
+		}
+		const group = /** @type {Entrypoint} */ (entrypoint);
+		if (getAllChunks(group, chunk, group.getRuntimeChunk()).size > 0) {
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
  * Returns runtime code.
  * @param {ChunkGraph} chunkGraph chunkGraph
  * @param {RuntimeTemplate} runtimeTemplate runtimeTemplate

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -219,7 +219,6 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 				(chunk, set, { chunkGraph, codeGenerationResults }) => {
 					if (!set.has(RuntimeGlobals.definePropertyGetters)) return;
 					if (chunkGraph.getNumberOfEntryModules(chunk) !== 1) return;
-					if (chunkGraph.hasChunkEntryDependentChunks(chunk)) return;
 					if (
 						set.has(RuntimeGlobals.moduleFactories) ||
 						set.has(RuntimeGlobals.moduleCache) ||
@@ -266,32 +265,45 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 						}
 					}
 
-					// Check whether any other module in the chunk still needs
-					// the helpers we want to remove.
+					// The helpers land in the runtime, not in this chunk, so what still
+					// needs them is asked of every chunk sharing the entrypoint — the
+					// runtime chunk, and whatever `splitChunks` moved out of the entry.
+					/** @type {Set<Chunk>} */
+					const siblings = new Set([chunk]);
+					for (const [
+						,
+						entrypoint
+					] of chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk)) {
+						if (!entrypoint) continue;
+						for (const sibling of entrypoint.chunks) siblings.add(sibling);
+					}
+
 					let otherNeedsDefine = false;
 					let otherNeedsNamespaceObject = false;
 					let otherNeedsExports = false;
 					let otherNeedsRequireScope = false;
-					for (const m of chunkGraph.getChunkModulesIterable(chunk)) {
-						if (m === module) continue;
-						const requirements = chunkGraph.getModuleRuntimeRequirements(
-							m,
-							chunk.runtime
-						);
-						if (!requirements) continue;
-						if (requirements.has(RuntimeGlobals.definePropertyGetters)) {
-							otherNeedsDefine = true;
+					outer: for (const sibling of siblings) {
+						for (const m of chunkGraph.getChunkModulesIterable(sibling)) {
+							if (m === module) continue;
+							const requirements = chunkGraph.getModuleRuntimeRequirements(
+								m,
+								sibling.runtime
+							);
+							if (!requirements) continue;
+							if (requirements.has(RuntimeGlobals.definePropertyGetters)) {
+								otherNeedsDefine = true;
+							}
+							if (requirements.has(RuntimeGlobals.makeNamespaceObject)) {
+								otherNeedsNamespaceObject = true;
+							}
+							if (requirements.has(RuntimeGlobals.exports)) {
+								otherNeedsExports = true;
+							}
+							if (requirements.has(RuntimeGlobals.requireScope)) {
+								otherNeedsRequireScope = true;
+							}
+							if (otherNeedsDefine) break outer;
 						}
-						if (requirements.has(RuntimeGlobals.makeNamespaceObject)) {
-							otherNeedsNamespaceObject = true;
-						}
-						if (requirements.has(RuntimeGlobals.exports)) {
-							otherNeedsExports = true;
-						}
-						if (requirements.has(RuntimeGlobals.requireScope)) {
-							otherNeedsRequireScope = true;
-						}
-						if (otherNeedsDefine) break;
 					}
 
 					if (otherNeedsDefine) return;

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -15,6 +15,7 @@ const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRun
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
 /**
  * Defines the read file compile async wasm plugin options type used by this module.
@@ -61,21 +62,27 @@ class ReadFileCompileAsyncWasmPlugin {
 			// settled while the plugin is being applied.
 			/**
 			 * @param {string} path rendered path to the wasm file
+			 * @param {RuntimeSpec} runtime the runtime this loader serves
 			 * @returns {string} the argument to hand the reader
 			 */
-			const wasmUrlArg = (path) =>
-				compilation.runtimeTemplate.supportsAnalyzable("wasm")
+			const wasmUrlArg = (path, runtime) =>
+				compilation.runtimeTemplate.supportsAnalyzable(
+					"wasm",
+					undefined,
+					undefined,
+					runtime
+				)
 					? path
 					: compilation.runtimeTemplate.importMetaUrl(path);
 			/**
-			 * @type {(path: string) => string} callback to generate code to load the wasm file
+			 * @type {(path: string, runtime: RuntimeSpec) => string} callback to generate code to load the wasm file
 			 */
 			const generateLoadBinaryCode = this._import
-				? (path) =>
+				? (path, runtime) =>
 						Template.asString([
 							"Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 							Template.indent([
-								`readFile(${wasmUrlArg(path)}, (err, buffer) => {`,
+								`readFile(${wasmUrlArg(path, runtime)}, (err, buffer) => {`,
 								Template.indent([
 									"if (err) return reject(err);",
 									"",
@@ -135,7 +142,12 @@ class ReadFileCompileAsyncWasmPlugin {
 					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
-						!compilation.runtimeTemplate.supportsAnalyzable("wasm") &&
+						!compilation.runtimeTemplate.supportsAnalyzable(
+							"wasm",
+							undefined,
+							undefined,
+							chunk.runtime
+						) &&
 						needsRuntimeFullHash(
 							/** @type {string} */ (
 								compilation.outputOptions.webassemblyModuleFilename
@@ -172,7 +184,12 @@ class ReadFileCompileAsyncWasmPlugin {
 					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
-						!compilation.runtimeTemplate.supportsAnalyzable("wasm") &&
+						!compilation.runtimeTemplate.supportsAnalyzable(
+							"wasm",
+							undefined,
+							undefined,
+							chunk.runtime
+						) &&
 						needsRuntimeFullHash(
 							/** @type {string} */ (
 								compilation.outputOptions.webassemblyModuleFilename

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2467,15 +2467,14 @@ class ConcatenatedModule extends Module {
 			runtimeRequirements.add(RuntimeGlobals.exports);
 			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
 
-			if (shouldAddHarmonyFlag) {
-				result.add("// ESM COMPAT FLAG\n");
-				result.add(
-					runtimeTemplate.defineEsModuleFlagStatement({
+			// Goes with the definitions below: whoever takes those over emits both,
+			// and the marker has to stay in front of them.
+			const harmonyFlagSource = shouldAddHarmonyFlag
+				? `// ESM COMPAT FLAG\n${runtimeTemplate.defineEsModuleFlagStatement({
 						exportsArgument: this.exportsArgument,
 						runtimeRequirements
-					})
-				);
-			}
+					})}`
+				: "";
 
 			const exportsSource =
 				"\n// EXPORTS\n" +
@@ -2490,10 +2489,11 @@ class ConcatenatedModule extends Module {
 				!onDemandExportsGeneration.call(
 					this,
 					runtimes,
-					exportsSource,
+					`${harmonyFlagSource}${exportsSource}`,
 					exportsFinalName
 				)
 			) {
+				result.add(harmonyFlagSource);
 				result.add(exportsSource);
 			}
 		}

--- a/lib/prefetch/ChunkPrefetchFunctionRuntimeModule.js
+++ b/lib/prefetch/ChunkPrefetchFunctionRuntimeModule.js
@@ -22,12 +22,12 @@ class ChunkPrefetchFunctionRuntimeModule extends RuntimeModule {
 
 	/**
 	 * @param {"prefetch" | "preload"} type "prefetch" or "preload" chunk type function
-	 * @param {string} runtimeFunction the runtime function name
+	 * @param {string | null} runtimeFunction the runtime function name, or `null` where nothing fans out over the handlers
 	 * @param {string} runtimeHandlers the runtime handlers
 	 */
 	constructor(type, runtimeFunction, runtimeHandlers) {
 		super(`chunk ${type} function`);
-		/** @type {string} */
+		/** @type {string | null} */
 		this.runtimeFunction = runtimeFunction;
 		/** @type {string} */
 		this.runtimeHandlers = runtimeHandlers;
@@ -43,13 +43,17 @@ class ChunkPrefetchFunctionRuntimeModule extends RuntimeModule {
 		const { runtimeTemplate } = compilation;
 		return Template.asString([
 			`${runtimeHandlers} = {};`,
-			`${runtimeFunction} = ${runtimeTemplate.basicFunction("chunkId", [
-				// map is shorter than forEach
-				`Object.keys(${runtimeHandlers}).map(${runtimeTemplate.basicFunction(
-					"key",
-					`${runtimeHandlers}[key](chunkId);`
-				)});`
-			])};`
+			...(runtimeFunction === null
+				? []
+				: [
+						`${runtimeFunction} = ${runtimeTemplate.basicFunction("chunkId", [
+							// map is shorter than forEach
+							`Object.keys(${runtimeHandlers}).map(${runtimeTemplate.basicFunction(
+								"key",
+								`${runtimeHandlers}[key](chunkId);`
+							)});`
+						])};`
+					])
 		]);
 	}
 }

--- a/lib/prefetch/ChunkPrefetchPreloadPlugin.js
+++ b/lib/prefetch/ChunkPrefetchPreloadPlugin.js
@@ -82,10 +82,9 @@ class ChunkPrefetchPreloadPlugin {
 					}
 					if (chunkMap.cssPreload) {
 						// CSS-only preload (`parser.javascript.dynamicImportCssPreload`):
-						// reuse `preloadChunk` — with no JS `preload` order the JS
-						// handler is never registered, so only the CSS `.s` handler
-						// fires (`<link rel="preload" as="style">`).
-						set.add(RuntimeGlobals.preloadChunk);
+						// the trigger reaches the CSS `.s` handler itself
+						// (`<link rel="preload" as="style">`), so it asks for the handlers
+						// alone — nothing here calls the one that fans out over them.
 						set.add(RuntimeGlobals.preloadChunkHandlers);
 						compilation.addLazyRuntimeModule(
 							chunk,
@@ -95,36 +94,38 @@ class ChunkPrefetchPreloadPlugin {
 					}
 				}
 			);
-			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.prefetchChunk)
-				.tap(PLUGIN_NAME, (chunk, set) => {
-					compilation.addLazyRuntimeModule(
-						chunk,
-						getChunkPrefetchFunctionRuntimeModule,
-						(Ctor) =>
-							new Ctor(
-								"prefetch",
-								RuntimeGlobals.prefetchChunk,
-								RuntimeGlobals.prefetchChunkHandlers
-							)
-					);
-					set.add(RuntimeGlobals.prefetchChunkHandlers);
-				});
-			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.preloadChunk)
-				.tap(PLUGIN_NAME, (chunk, set) => {
-					compilation.addLazyRuntimeModule(
-						chunk,
-						getChunkPrefetchFunctionRuntimeModule,
-						(Ctor) =>
-							new Ctor(
-								"preload",
-								RuntimeGlobals.preloadChunk,
-								RuntimeGlobals.preloadChunkHandlers
-							)
-					);
-					set.add(RuntimeGlobals.preloadChunkHandlers);
-				});
+			// The handlers object is what carries the runtime module, so a chunk asking
+			// only for it — a trigger that reaches one handler by name — ships no
+			// fan-out function. Whether one is wanted is read here rather than in
+			// `create`, which runs after the requirement pass is over.
+			for (const [type, fn, handlers] of /** @type {const} */ ([
+				[
+					"prefetch",
+					RuntimeGlobals.prefetchChunk,
+					RuntimeGlobals.prefetchChunkHandlers
+				],
+				[
+					"preload",
+					RuntimeGlobals.preloadChunk,
+					RuntimeGlobals.preloadChunkHandlers
+				]
+			])) {
+				compilation.hooks.runtimeRequirementInTree
+					.for(fn)
+					.tap(PLUGIN_NAME, (chunk, set) => {
+						set.add(handlers);
+					});
+				compilation.hooks.runtimeRequirementInTree
+					.for(handlers)
+					.tap(PLUGIN_NAME, (chunk, set) => {
+						const runtimeFunction = set.has(fn) ? fn : null;
+						compilation.addLazyRuntimeModule(
+							chunk,
+							getChunkPrefetchFunctionRuntimeModule,
+							(Ctor) => new Ctor(type, runtimeFunction, handlers)
+						);
+					});
+			}
 		});
 	}
 }

--- a/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
@@ -12,9 +12,10 @@ const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
 /** @typedef {(wasmModuleSrcPath: string) => string} GenerateBeforeLoadBinaryCode */
-/** @typedef {(wasmModuleSrcPath: string) => string} GenerateLoadBinaryCode */
+/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec) => string} GenerateLoadBinaryCode */
 /** @typedef {() => string} GenerateBeforeCompileStreaming */
 
 /**
@@ -66,7 +67,12 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.compileWasm;
 		// Analyzable output bakes the binary's URL into the call site instead.
-		const analyzable = runtimeTemplate.supportsAnalyzable("wasm");
+		const analyzable = runtimeTemplate.supportsAnalyzable(
+			"wasm",
+			undefined,
+			undefined,
+			chunk.runtime
+		);
 		const wasmModuleSrcPath = analyzable
 			? "wasmModuleUrl"
 			: compilation.getPath(
@@ -84,7 +90,10 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 					}
 				);
 
-		const loader = this.generateLoadBinaryCode(wasmModuleSrcPath);
+		const loader = this.generateLoadBinaryCode(
+			wasmModuleSrcPath,
+			chunk.runtime
+		);
 
 		// Fallback path: fetch -> arrayBuffer -> WebAssembly.compile
 		const fallback = [

--- a/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
@@ -12,9 +12,10 @@ const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
 /** @typedef {(wasmModuleSrcPath: string) => string} GenerateBeforeLoadBinaryCode */
-/** @typedef {(wasmModuleSrcPath: string) => string} GenerateLoadBinaryCode */
+/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec) => string} GenerateLoadBinaryCode */
 /** @typedef {() => string} GenerateBeforeInstantiateStreaming */
 
 /**
@@ -67,7 +68,12 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		const streamingFallback = outputOptions.wasmStreamingFallback;
 		const fn = RuntimeGlobals.instantiateWasm;
 		// Analyzable output bakes the binary's URL into the call site instead.
-		const analyzable = runtimeTemplate.supportsAnalyzable("wasm");
+		const analyzable = runtimeTemplate.supportsAnalyzable(
+			"wasm",
+			undefined,
+			undefined,
+			chunk.runtime
+		);
 		const wasmModuleSrcPath = analyzable
 			? "wasmModuleUrl"
 			: compilation.getPath(
@@ -85,7 +91,10 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 					}
 				);
 
-		const loader = this.generateLoadBinaryCode(wasmModuleSrcPath);
+		const loader = this.generateLoadBinaryCode(
+			wasmModuleSrcPath,
+			chunk.runtime
+		);
 		const fallback = [
 			`.then(${runtimeTemplate.returningFunction("x.arrayBuffer()", "x")})`,
 			`.then(${runtimeTemplate.returningFunction(

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -75,7 +75,8 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 		const analyzableUrl = runtimeTemplate.supportsAnalyzable(
 			"wasm",
 			chunkGraph,
-			module
+			module,
+			runtime
 		)
 			? runtimeTemplate.getAnalyzableWasmUrl(
 					module,
@@ -247,7 +248,8 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 		const analyzableUrl = runtimeTemplate.supportsAnalyzable(
 			"wasm",
 			chunkGraph,
-			module
+			module,
+			runtime
 		)
 			? runtimeTemplate.getAnalyzableWasmUrl(
 					module,

--- a/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
+++ b/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
@@ -14,6 +14,7 @@ const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRun
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
 
 const PLUGIN_NAME = "UniversalCompileAsyncWasmPlugin";
 
@@ -65,23 +66,32 @@ class UniversalCompileAsyncWasmPlugin {
 			// `wasmUrl` already holds a complete `URL` when the call site bakes it. Read that
 			// per call: it depends on parse results, so it is not settled while the plugin
 			// is being applied.
-			const wasmUrlArg = () =>
-				compilation.runtimeTemplate.supportsAnalyzable("wasm")
+			/**
+			 * @param {RuntimeSpec} runtime the runtime this loader serves
+			 * @returns {string} the argument to hand the reader
+			 */
+			const wasmUrlArg = (runtime) =>
+				compilation.runtimeTemplate.supportsAnalyzable(
+					"wasm",
+					undefined,
+					undefined,
+					runtime
+				)
 					? "wasmUrl"
 					: compilation.runtimeTemplate.importMetaUrl("wasmUrl");
 			/**
 			 * Generates the runtime expression that fetches the binary in browsers
 			 * or reads it from the filesystem in Node.js.
-			 * @type {() => string}
+			 * @type {(path: string, runtime: RuntimeSpec) => string}
 			 */
-			const generateLoadBinaryCode = () =>
+			const generateLoadBinaryCode = (path, runtime) =>
 				Template.asString([
 					"(useFetch",
-					Template.indent([`? fetch(${wasmUrlArg()})`]),
+					Template.indent([`? fetch(${wasmUrlArg(runtime)})`]),
 					Template.indent([
 						": Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 						Template.indent([
-							`readFile(${wasmUrlArg()}, (err, buffer) => {`,
+							`readFile(${wasmUrlArg(runtime)}, (err, buffer) => {`,
 							Template.indent([
 								"if (err) return reject(err);",
 								"",

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -81,7 +81,12 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const baked = compilation.runtimeTemplate.supportsAnalyzable("wasm");
+					const baked = compilation.runtimeTemplate.supportsAnalyzable(
+						"wasm",
+						undefined,
+						undefined,
+						chunk.runtime
+					);
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
 					// A baked URL carries the public path already, or asks for the global itself
@@ -128,7 +133,12 @@ class FetchCompileAsyncWasmPlugin {
 					) {
 						return;
 					}
-					const baked = compilation.runtimeTemplate.supportsAnalyzable("wasm");
+					const baked = compilation.runtimeTemplate.supportsAnalyzable(
+						"wasm",
+						undefined,
+						undefined,
+						chunk.runtime
+					);
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
 					// A baked URL carries the public path already, or asks for the global itself

--- a/test/configCases/css/dynamic-import-css-preload/index.mjs
+++ b/test/configCases/css/dynamic-import-css-preload/index.mjs
@@ -25,3 +25,10 @@ it("should preload a nested dynamic-import chunk's CSS as style, not its JS", ()
 
 	return promise;
 });
+
+it("should not ship the preload fan-out function nothing calls", () => {
+	// The trigger reaches the CSS handler by name, so only the handlers object
+	// is needed — `__webpack_require__.G` would have no call site.
+	expect(__webpack_require__.H).toBeDefined();
+	expect(__webpack_require__.G).toBeUndefined();
+});

--- a/test/configCases/html/asset-url-hints-split/test.js
+++ b/test/configCases/html/asset-url-hints-split/test.js
@@ -18,9 +18,11 @@ it("should emit both entry-chunk and vendor-chunk asset hints into HTML head", (
 it("should skip the JS-runtime hint pass — HTML entries handle it themselves", () => {
 	// If both assets are HTML-hinted, the startup asset hint runtime module
 	// should short-circuit and produce nothing in any chunk emitted for this page.
+	// The `<link>` helpers it would have called must not ship either.
 	for (const file of fs.readdirSync(dir)) {
 		if (!file.endsWith(".mjs") && !file.endsWith(".chunk.mjs")) continue;
 		const src = fs.readFileSync(path.resolve(dir, file), "utf-8");
 		expect(src).not.toMatch(/webpack\/runtime\/startup asset hints/);
+		expect(src).not.toMatch(/webpack\/runtime\/asset (prefetch|preload)/);
 	}
 });

--- a/test/configCases/html/resource-hints-none/test.js
+++ b/test/configCases/html/resource-hints-none/test.js
@@ -14,7 +14,9 @@ it("should emit no resource-hint <link> in <head> with resourceHints: none", () 
 });
 
 it("should not emit the JS startup asset-hint runtime", () => {
-	// No preload/prefetch helper calls injected into any chunk.
+	// No preload/prefetch helper calls injected into any chunk, and with nothing
+	// left to call them the helpers themselves must not ship either.
 	const runtime = read("runtime.js");
 	expect(runtime).not.toMatch(/\.(PA|LA)\(/);
+	expect(runtime).not.toMatch(/webpack\/runtime\/asset (prefetch|preload)/);
 });

--- a/test/configCases/library/module-inlined-entry-direct-bindings/webpack.config.js
+++ b/test/configCases/library/module-inlined-entry-direct-bindings/webpack.config.js
@@ -6,6 +6,8 @@
  * `__webpack_exports__`. Covers both lookup sources for `topLevelDeclarations`:
  * concatenated entries read it from the code generation data, non-concatenated
  * ones from `module.buildInfo` (the guarded fallback, where `data` is undefined).
+ * Such an entry reads nothing off `__webpack_exports__`, so it must also ship no
+ * runtime helpers — including the `__esModule` marker on either generator path.
  * @param {string} assetName emitted entry asset to assert on
  * @param {string} binding exported binding expected to stay live
  * @returns {(this: import("../../../../").Compiler) => void} plugin
@@ -17,6 +19,7 @@ const assertLiveBindings = (assetName, binding) =>
 				const source = assets[assetName].source();
 				expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
 				expect(source).toMatch(new RegExp(`export \\{[^}]*\\b${binding}\\b`));
+				expect(source).not.toMatch(/__webpack_require__/);
 			});
 		});
 	};

--- a/test/configCases/library/module-live-bindings-0-create/webpack.config.js
+++ b/test/configCases/library/module-live-bindings-0-create/webpack.config.js
@@ -3,16 +3,23 @@
 /**
  * Asserts the emitted entry keeps live ESM bindings (direct top-level
  * declarations) instead of snapshotting them through `__webpack_exports__`.
+ * Reading nothing off `__webpack_exports__` also means the export helpers have no
+ * call site — including where a separate runtime chunk is what carries them.
  * @param {string} assetName emitted entry asset to assert on
+ * @param {string} runtimeAsset asset the runtime modules land in
  * @returns {(this: import("../../../../").Compiler) => void} plugin
  */
-const assertLiveBindings = (assetName) =>
+const assertLiveBindings = (assetName, runtimeAsset) =>
 	function apply() {
 		this.hooks.compilation.tap("testcase", (compilation) => {
 			compilation.hooks.afterProcessAssets.tap("testcase", (assets) => {
 				const source = assets[assetName].source();
 				expect(source).not.toMatch(/const __webpack_exports__\w+ =/);
 				expect(source).toMatch(/export \{[^}]*\bmutLet\b/);
+				const runtime = assets[runtimeAsset].source();
+				expect(runtime).not.toMatch(
+					/webpack\/runtime\/(define property getters|make namespace object)/
+				);
 			});
 		});
 	};
@@ -36,7 +43,12 @@ const variant = (name, entryAsset, mode, runtimeChunk) => ({
 	},
 	optimization: { concatenateModules: true, runtimeChunk, minimize: false },
 	experiments: { outputModule: true },
-	plugins: [assertLiveBindings(`${name}/${entryAsset}`)]
+	plugins: [
+		assertLiveBindings(
+			`${name}/${entryAsset}`,
+			runtimeChunk ? `${name}/runtime.mjs` : `${name}/${entryAsset}`
+		)
+	]
 });
 
 /** @type {import("../../../../").Configuration[]} */

--- a/test/configCases/runtime/startup-entrypoint-only-when-awaited/index.js
+++ b/test/configCases/runtime/startup-entrypoint-only-when-awaited/index.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+import { value } from "./sibling";
+
+it("should run the entry module", () => {
+	expect(value).toBe("sibling");
+});
+
+it("should ship the startup helper only where the startup calls it", () => {
+	const runtime = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			__NAME__,
+			"runtime.js"
+		),
+		"utf8"
+	);
+
+	expect(runtime.includes("webpack/runtime/startup entrypoint")).toBe(
+		__AWAITED__
+	);
+	expect(runtime.includes(`${"__webpack_require__"}.X =`)).toBe(__AWAITED__);
+});

--- a/test/configCases/runtime/startup-entrypoint-only-when-awaited/sibling.js
+++ b/test/configCases/runtime/startup-entrypoint-only-when-awaited/sibling.js
@@ -1,0 +1,1 @@
+export const value = "sibling";

--- a/test/configCases/runtime/startup-entrypoint-only-when-awaited/test.config.js
+++ b/test/configCases/runtime/startup-entrypoint-only-when-awaited/test.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		const name = i === 0 ? "straight" : "awaited";
+		return [`./${name}/runtime.js`, `./${name}/main.js`];
+	}
+};

--- a/test/configCases/runtime/startup-entrypoint-only-when-awaited/webpack.config.js
+++ b/test/configCases/runtime/startup-entrypoint-only-when-awaited/webpack.config.js
@@ -1,0 +1,57 @@
+"use strict";
+
+// `startupEntrypoint` is the helper that runs an entry module behind a chunk load, and
+// a separate runtime chunk is the only shape that can ask for it. Whether it is called
+// is decided by the startup render, long after runtime requirements close, so the
+// requirement mirrors that decision rather than assuming it.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so `index.js` finds its own stats
+ * @param {string} name output sub-directory keeping the two configs apart
+ * @param {boolean} awaited whether the entry runs behind another initial chunk
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, awaited) => ({
+	mode: "development",
+	devtool: false,
+	// Sync chunk loading: the sibling lands before the entry runs, so the harness
+	// sees no load outliving it.
+	target: "node",
+	entry: "./index.js",
+	output: {
+		filename: `${name}/[name].js`,
+		chunkFilename: `${name}/[name].js`
+	},
+	optimization: {
+		chunkIds: "named",
+		runtimeChunk: "single",
+		// An initial sibling in the entrypoint is what the entry has to wait for.
+		splitChunks: awaited && {
+			cacheGroups: {
+				sibling: {
+					test: /sibling\.js$/,
+					name: "sibling",
+					chunks: "initial",
+					enforce: true
+				}
+			}
+		}
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name),
+			__AWAITED__: JSON.stringify(awaited)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Nothing to wait for: the entry module is called straight.
+	base(0, "straight", false),
+	// An initial sibling chunk has to land first, so the helper is called.
+	base(1, "awaited", true)
+];

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/node-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/node-entry.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+const read = (chunk) =>
+	fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}-${chunk}`),
+		"utf8"
+	);
+
+it("should reach the binary through the loader its own runtime asked for", async () => {
+	const { run } = await import(
+		/* webpackChunkName: "node-lazy" */ "./node-lazy"
+	);
+
+	expect(run()).toBe(42);
+});
+
+it("should reference the binary in the form its runtime allows", () => {
+	expect(read("node-lazy.mjs")).toContain(__NODE_REF__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/node-lazy.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/node-lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./node.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/node.wat
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/node.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-entry.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+// Never awaited: `fetch` cannot reach a relative public path from the test harness.
+export const load = () =>
+	import(/* webpackChunkName: "shared-lazy" */ "./shared-lazy");
+
+it("should keep the runtime form for the binary both runtimes reach", () => {
+	const source = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			`${__NAME__}-shared-lazy.mjs`
+		),
+		"utf8"
+	);
+
+	expect(source).toContain(__RUNTIME_FORM__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-lazy.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-lazy.js
@@ -1,0 +1,4 @@
+// The same binary the `async-node` runtime bakes, reached from the fetching one.
+import { getNumber } from "./node.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		const name = i === 0 ? "split" : "shared";
+		return [`./${name}-node.mjs`, `./${name}-web.mjs`];
+	}
+};

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/web-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/web-entry.js
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+// Never awaited: `fetch` cannot reach a relative public path from the test harness.
+export const load = () => import(/* webpackChunkName: "web-lazy" */ "./web-lazy");
+
+it("should keep the runtime form for the runtime that fetches the binary", () => {
+	const source = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			`${__NAME__}-web-lazy.mjs`
+		),
+		"utf8"
+	);
+
+	expect(source).toContain(__RUNTIME_FORM__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/web-lazy.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/web-lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./web.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/web.wat
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/web.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -1,0 +1,60 @@
+"use strict";
+
+// Two entries of ONE compilation loading wasm differently, under a public path that is
+// neither `auto` nor an absolute URL. `fetch` is the only loader such a path reaches,
+// so it is the only one that has to keep the runtime form — the `readFile` entry
+// resolves the binary against the chunk it is read from, exactly as a baked literal
+// does, and must still bake one. Unless the two share a binary: it is generated once
+// for both, so neither loader can be told the other's shape.
+
+const webpack = require("../../../../");
+
+const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
+
+/**
+ * @param {number} index position of this config, so an entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @param {string} second the second entry, reaching a binary of its own or the `node` entry's
+ * @param {string} nodeRef expected start of the binary's reference in the `node` entry
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, second, nodeRef) => ({
+	name,
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: {
+		[`${name}-node`]: { import: "./node-entry.js", wasmLoading: "async-node" },
+		[`${name}-web`]: { import: second, wasmLoading: "fetch" }
+	},
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: `${name}-[name].mjs`,
+		webassemblyModuleFilename: `${name}-[id].wasm`,
+		publicPath: "./"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name),
+			__NODE_REF__: JSON.stringify(INSTANTIATE + nodeRef),
+			__RUNTIME_FORM__: JSON.stringify(`${INSTANTIATE}module.id, `)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// A binary each: the runtimes are told apart, so only the fetching one bails.
+	base(0, "split", "./web-entry.js", 'new URL("./'),
+	// One binary between them: neither runtime can be answered on its own.
+	base(1, "shared", "./shared-entry.js", "module.id, ")
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -25000,7 +25000,8 @@ declare abstract class RuntimeTemplate {
 	supportsAnalyzable(
 		form: AnalyzableForm,
 		chunkGraph?: ChunkGraph,
-		module?: Module
+		module?: Module,
+		runtime?: RuntimeSpec
 	): boolean;
 
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Several runtime requirements were declared before the decision that would have used them, so bundles shipped `__webpack_require__` helpers with no call site: the export helpers of an inlined `library: module` entry, the resource-hint helpers when a hint is hoisted into an HTML `<head>` or turned off, the preload fan-out function for a CSS-only trigger, and the startup helper of an entry with nothing to wait for. Each now asks the same question the render answers. Separately, whether an analyzable wasm url may be baked was decided compilation-wide, so one entry loading through `fetch` forced every other entry of the same compilation to keep the runtime form; it is answered per runtime instead — the scope a wasm loader is emitted on — falling back to the old answer when a binary is reached from more than one runtime, since it is generated once for all of them.

`yarn test:size` reports -50.48 KiB over 64 assets, with 54 runtimes carrying fewer runtime modules and 3 carrying none at all.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes: new `configCases/wasm/analyzable-mixed-wasm-loading` and `configCases/runtime/startup-entrypoint-only-when-awaited`, plus assertions added to `configCases/library/module-inlined-entry-direct-bindings`, `configCases/library/module-live-bindings-0-create`, `configCases/html/asset-url-hints-split`, `configCases/html/resource-hints-none` and `configCases/css/dynamic-import-css-preload`. Each was confirmed to fail without its fix.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a - no option, schema or public API changes.

**Use of AI**

Yes. Claude Code was used throughout: to survey the emitted `configCases` output for runtime helpers that are defined but never called, to root-cause each one, to write the fixes and the test cases, and to run the test suites, `yarn lint` and `yarn test:size`. Every finding was reproduced before being acted on, every new test was checked to fail without its fix, and all output was reviewed before committing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_