### PR TITLE
fix(analyzable): report the silent fallbacks, group wasm by shared binary, drop unread runtime

### DIFF
--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting runtime helpers, chunk loaders, hints and wrappers nothing calls.
+Stop emitting runtime helpers nothing calls; load css chunks that only `@import`.

--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting uncalled runtime helpers, chunk loaders, resource hints, state and wrappers.
+Stop emitting uncalled runtime helpers, chunk loaders, resource hints, public path, state and wrappers.

--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting runtime helpers nothing calls; load css chunks that only `@import`.
+Stop emitting unused runtime helpers; load css chunks that only `@import`.

--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Stop emitting uncalled runtime helpers, chunk loaders, resource hints, public path, state and wrappers.
+Stop emitting runtime helpers, chunk loaders, hints and wrappers nothing calls.

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -383,12 +383,22 @@ class APIPlugin {
 								throw err;
 							});
 						} else if (key === "__webpack_public_path__") {
-							// Flag the runtime override (still let the default handler emit
-							// `__webpack_require__.p = …`); returning nothing keeps that path.
-							parser.hooks.assign.for(key).tap(PLUGIN_NAME, () => {
+							// Emitted here rather than by the read handler below: writing the
+							// slot needs the scope it lives on, not the runtime module that
+							// computes the value this very assignment replaces. A read asks
+							// for that one itself, so it is emitted exactly where it is used.
+							const writePublicPath = toConstantDependency(parser, info.expr, [
+								RuntimeGlobals.requireScope
+							]);
+							parser.hooks.assign.for(key).tap(PLUGIN_NAME, (expr) => {
 								/** @type {JavascriptModuleBuildInfo} */
 								(parser.state.module.buildInfo).usingPublicPathOverride = true;
 								addRuntimePublicPathOverride(compilation, parser.state.module);
+								// A destructuring target is no expression to replace; leaving it
+								// to the read handler still spells the global, just with the
+								// requirement a read carries.
+								if (expr.left.type !== "Identifier") return;
+								return writePublicPath(expr.left);
 							});
 						}
 						if (info.type) {

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -383,10 +383,8 @@ class APIPlugin {
 								throw err;
 							});
 						} else if (key === "__webpack_public_path__") {
-							// Emitted here rather than by the read handler below: writing the
-							// slot needs the scope it lives on, not the runtime module that
-							// computes the value this very assignment replaces. A read asks
-							// for that one itself, so it is emitted exactly where it is used.
+							// Writing the slot needs the scope it lives on, not the runtime
+							// module computing the value it replaces; a read asks for that.
 							const writePublicPath = toConstantDependency(parser, info.expr, [
 								RuntimeGlobals.requireScope
 							]);
@@ -394,9 +392,8 @@ class APIPlugin {
 								/** @type {JavascriptModuleBuildInfo} */
 								(parser.state.module.buildInfo).usingPublicPathOverride = true;
 								addRuntimePublicPathOverride(compilation, parser.state.module);
-								// A destructuring target is no expression to replace; leaving it
-								// to the read handler still spells the global, just with the
-								// requirement a read carries.
+								// A destructuring target is no expression to replace; the read
+								// handler still spells the global, with a read's requirement.
 								if (expr.left.type !== "Identifier") return;
 								return writePublicPath(expr.left);
 							});

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -271,7 +271,7 @@ class RuntimeTemplate {
 		this._publicPathShapeText = undefined;
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
-		/** @type {Map<string, Set<string>> | undefined} */
+		/** @type {Map<string, string> | undefined} */
 		this._wasmRuntimeGroupsByKey = undefined;
 	}
 
@@ -834,10 +834,20 @@ class RuntimeTemplate {
 	 */
 	_anyWasmChunkFetches(runtime) {
 		const { wasmLoading: globalWasmLoading } = this.outputOptions;
-		const scope =
-			runtime === undefined ? undefined : this._wasmAnswerScope(runtime);
+		const groups =
+			runtime === undefined ? undefined : this._wasmRuntimeGroups();
+		// Named once here so a chunk costs one `get` and a compare, not a set of its own.
+		const group =
+			groups !== undefined && typeof runtime === "string"
+				? groups.get(runtime) || runtime
+				: undefined;
 		for (const chunk of this.compilation.chunks) {
-			if (scope !== undefined && !this._runtimeInScope(chunk.runtime, scope)) {
+			if (
+				groups !== undefined &&
+				!(group === undefined
+					? this._wasmRuntimeSharesAny(groups, chunk.runtime, runtime)
+					: this._wasmRuntimeAnswersWith(groups, chunk.runtime, group))
+			) {
 				continue;
 			}
 			const entryOptions = chunk.getEntryOptions();
@@ -854,13 +864,13 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Runtime keys grouped by the binaries they share. Code generation runs once for
-	 * runtimes a module hashes alike in, and nothing in a binary's hash knows which
-	 * loader will read it — so a binary two runtimes reach carries one shape into both,
-	 * and a third runtime sharing another binary with either is pulled in after them.
-	 * Every key of a group has to be answered alike; keys in no group answer alone.
-	 * Asked of the same modules the loaders are created for.
-	 * @returns {Map<string, Set<string>>} runtime key to the keys it answers with
+	 * Runtime keys mapped to the group they answer with, named by one key of it. Code
+	 * generation runs once for runtimes a module hashes alike in, and nothing in a
+	 * binary's hash knows which loader will read it — so a binary two runtimes reach
+	 * carries one shape into both, and a third runtime sharing another binary with
+	 * either is pulled in after them. A key in no group answers as itself. Asked of the
+	 * same modules the loaders are created for, and only once per compilation.
+	 * @returns {Map<string, string>} runtime key to the group it answers with
 	 */
 	_wasmRuntimeGroups() {
 		if (this._wasmRuntimeGroupsByKey === undefined) {
@@ -869,7 +879,7 @@ class RuntimeTemplate {
 			const parent = new Map();
 			/**
 			 * @param {string} key runtime key
-			 * @returns {string} the key representing its group
+			 * @returns {string} the key naming its group
 			 */
 			const find = (key) => {
 				let root = key;
@@ -888,22 +898,22 @@ class RuntimeTemplate {
 				}
 				return root;
 			};
+			/** @type {string[]} */
+			const keys = [];
 			/**
 			 * @param {RuntimeSpec} runtime a runtime the module is generated for
-			 * @param {string[]} into keys collected so far
 			 * @returns {void}
 			 */
-			const collectKeys = (runtime, into) => {
+			const collectKeys = (runtime) => {
 				forEachRuntime(runtime, (key) => {
-					into.push(/** @type {string} */ (key));
+					keys.push(/** @type {string} */ (key));
 				});
 			};
 			for (const module of this.compilation.modules) {
 				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
-				/** @type {string[]} */
-				const keys = [];
+				keys.length = 0;
 				for (const runtime of chunkGraph.getModuleRuntimes(module)) {
-					collectKeys(runtime, keys);
+					collectKeys(runtime);
 				}
 				for (const key of keys) {
 					if (!parent.has(key)) parent.set(key, key);
@@ -913,53 +923,55 @@ class RuntimeTemplate {
 					parent.set(find(keys[i]), find(keys[0]));
 				}
 			}
-			/** @type {Map<string, Set<string>>} */
-			const groups = new Map();
-			for (const key of parent.keys()) {
-				const root = find(key);
-				let group = groups.get(root);
-				if (group === undefined) groups.set(root, (group = new Set()));
-				group.add(key);
-			}
-			/** @type {Map<string, Set<string>>} */
-			const byKey = new Map();
-			for (const group of groups.values()) {
-				for (const key of group) byKey.set(key, group);
-			}
-			this._wasmRuntimeGroupsByKey = byKey;
+			// Flattened once, so a lookup is a single `get` rather than a chain walk.
+			for (const key of parent.keys()) parent.set(key, find(key));
+			this._wasmRuntimeGroupsByKey = parent;
 		}
 		return this._wasmRuntimeGroupsByKey;
 	}
 
 	/**
-	 * Every runtime key that has to be answered together with this runtime.
-	 * @param {RuntimeSpec} runtime the runtime being asked about
-	 * @returns {Set<string>} the keys the answer covers
+	 * The multi-key case: a runtime chunk several entries share answers for each of
+	 * their groups at once.
+	 * @param {Map<string, string>} groups runtime key to the group it answers with
+	 * @param {RuntimeSpec} runtime a runtime
+	 * @param {RuntimeSpec} asked the runtime being asked about
+	 * @returns {boolean} true when the runtime is one that answer has to cover
 	 */
-	_wasmAnswerScope(runtime) {
-		const byKey = this._wasmRuntimeGroups();
-		/** @type {Set<string>} */
-		const scope = new Set();
-		forEachRuntime(runtime, (key) => {
-			const name = /** @type {string} */ (key);
-			scope.add(name);
-			const group = byKey.get(name);
-			if (group !== undefined) for (const other of group) scope.add(other);
-		});
-		return scope;
+	_wasmRuntimeSharesAny(groups, runtime, asked) {
+		if (asked === undefined) return false;
+		if (typeof asked === "string") {
+			return this._wasmRuntimeAnswersWith(
+				groups,
+				runtime,
+				groups.get(asked) || asked
+			);
+		}
+		for (const key of asked) {
+			if (
+				this._wasmRuntimeAnswersWith(groups, runtime, groups.get(key) || key)
+			) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
-	 * @param {RuntimeSpec} runtime the chunk's runtime
-	 * @param {Set<string>} scope the keys the answer covers
-	 * @returns {boolean} true when the chunk is one the answer has to cover
+	 * @param {Map<string, string>} groups runtime key to the group it answers with
+	 * @param {RuntimeSpec} runtime a runtime
+	 * @param {string} group the group being answered for
+	 * @returns {boolean} true when the runtime is one that answer has to cover
 	 */
-	_runtimeInScope(runtime, scope) {
-		let inScope = false;
-		forEachRuntime(runtime, (key) => {
-			if (scope.has(/** @type {string} */ (key))) inScope = true;
-		});
-		return inScope;
+	_wasmRuntimeAnswersWith(groups, runtime, group) {
+		if (runtime === undefined) return false;
+		if (typeof runtime === "string") {
+			return (groups.get(runtime) || runtime) === group;
+		}
+		for (const key of runtime) {
+			if ((groups.get(key) || key) === group) return true;
+		}
+		return false;
 	}
 
 	supportTemplateLiteral() {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -271,8 +271,8 @@ class RuntimeTemplate {
 		this._publicPathShapeText = undefined;
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
-		/** @type {boolean | undefined} */
-		this._wasmRuntimesAnswerApart = undefined;
+		/** @type {Map<string, Set<string>> | undefined} */
+		this._wasmRuntimeGroupsByKey = undefined;
 	}
 
 	isIIFE() {
@@ -437,7 +437,10 @@ class RuntimeTemplate {
 		if (!this.isModule()) return false;
 		// Build-time execution keeps the runtime form — `import.meta` does not parse in
 		// its vm script wrapper. `getTypes` has no chunk graph and does not care:
-		// `AssetModulesPlugin` emulates the wrapper there.
+		// `AssetModulesPlugin` emulates the wrapper there. The one fallback that stays
+		// unreported, and has to: `executeModule` builds its chunk graph over the
+		// compilation's own module graph, so a reason recorded here would surface on a
+		// module the real build also ships, about code the real build never emits.
 		if (chunkGraph && chunkGraph.buildTimeExecution) return false;
 		const { outputOptions } = this;
 		// One loader per runtime serves every wasm module in it, so the answer has to
@@ -831,9 +834,10 @@ class RuntimeTemplate {
 	 */
 	_anyWasmChunkFetches(runtime) {
 		const { wasmLoading: globalWasmLoading } = this.outputOptions;
-		const scope = this._wasmLoadersAnswerApart() ? runtime : undefined;
+		const scope =
+			runtime === undefined ? undefined : this._wasmAnswerScope(runtime);
 		for (const chunk of this.compilation.chunks) {
-			if (scope !== undefined && !intersectRuntime(chunk.runtime, scope)) {
+			if (scope !== undefined && !this._runtimeInScope(chunk.runtime, scope)) {
 				continue;
 			}
 			const entryOptions = chunk.getEntryOptions();
@@ -850,26 +854,112 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether one runtime's loader may be answered without the others. Code generation
-	 * runs once for runtimes a module hashes alike in, and nothing in a binary's hash
-	 * knows which loader will read it — so a binary two runtimes share would carry one
-	 * shape into both, and the loader that did not ask for it takes arguments it is not
-	 * handed. Asked of the same modules the loaders are created for.
-	 * @returns {boolean} true when each runtime may be answered on its own
+	 * Runtime keys grouped by the binaries they share. Code generation runs once for
+	 * runtimes a module hashes alike in, and nothing in a binary's hash knows which
+	 * loader will read it — so a binary two runtimes reach carries one shape into both,
+	 * and a third runtime sharing another binary with either is pulled in after them.
+	 * Every key of a group has to be answered alike; keys in no group answer alone.
+	 * Asked of the same modules the loaders are created for.
+	 * @returns {Map<string, Set<string>>} runtime key to the keys it answers with
 	 */
-	_wasmLoadersAnswerApart() {
-		if (this._wasmRuntimesAnswerApart === undefined) {
+	_wasmRuntimeGroups() {
+		if (this._wasmRuntimeGroupsByKey === undefined) {
 			const { chunkGraph } = this.compilation;
-			this._wasmRuntimesAnswerApart = true;
+			/** @type {Map<string, string>} */
+			const parent = new Map();
+			/**
+			 * @param {string} key runtime key
+			 * @returns {string} the key representing its group
+			 */
+			const find = (key) => {
+				let root = key;
+				let seen = parent.get(root);
+				while (seen !== undefined && seen !== root) {
+					root = seen;
+					seen = parent.get(root);
+				}
+				// Path compression keeps a long share chain from costing more than once.
+				let walk = key;
+				let next = parent.get(walk);
+				while (next !== undefined && next !== root) {
+					parent.set(walk, root);
+					walk = next;
+					next = parent.get(walk);
+				}
+				return root;
+			};
+			/**
+			 * @param {RuntimeSpec} runtime a runtime the module is generated for
+			 * @param {string[]} into keys collected so far
+			 * @returns {void}
+			 */
+			const collectKeys = (runtime, into) => {
+				forEachRuntime(runtime, (key) => {
+					into.push(/** @type {string} */ (key));
+				});
+			};
 			for (const module of this.compilation.modules) {
 				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
-				if (chunkGraph.getModuleRuntimes(module).size > 1) {
-					this._wasmRuntimesAnswerApart = false;
-					break;
+				/** @type {string[]} */
+				const keys = [];
+				for (const runtime of chunkGraph.getModuleRuntimes(module)) {
+					collectKeys(runtime, keys);
+				}
+				for (const key of keys) {
+					if (!parent.has(key)) parent.set(key, key);
+				}
+				// Every runtime this binary reaches answers with the first one.
+				for (let i = 1; i < keys.length; i++) {
+					parent.set(find(keys[i]), find(keys[0]));
 				}
 			}
+			/** @type {Map<string, Set<string>>} */
+			const groups = new Map();
+			for (const key of parent.keys()) {
+				const root = find(key);
+				let group = groups.get(root);
+				if (group === undefined) groups.set(root, (group = new Set()));
+				group.add(key);
+			}
+			/** @type {Map<string, Set<string>>} */
+			const byKey = new Map();
+			for (const group of groups.values()) {
+				for (const key of group) byKey.set(key, group);
+			}
+			this._wasmRuntimeGroupsByKey = byKey;
 		}
-		return this._wasmRuntimesAnswerApart;
+		return this._wasmRuntimeGroupsByKey;
+	}
+
+	/**
+	 * Every runtime key that has to be answered together with this runtime.
+	 * @param {RuntimeSpec} runtime the runtime being asked about
+	 * @returns {Set<string>} the keys the answer covers
+	 */
+	_wasmAnswerScope(runtime) {
+		const byKey = this._wasmRuntimeGroups();
+		/** @type {Set<string>} */
+		const scope = new Set();
+		forEachRuntime(runtime, (key) => {
+			const name = /** @type {string} */ (key);
+			scope.add(name);
+			const group = byKey.get(name);
+			if (group !== undefined) for (const other of group) scope.add(other);
+		});
+		return scope;
+	}
+
+	/**
+	 * @param {RuntimeSpec} runtime the chunk's runtime
+	 * @param {Set<string>} scope the keys the answer covers
+	 * @returns {boolean} true when the chunk is one the answer has to cover
+	 */
+	_runtimeInScope(runtime, scope) {
+		let inScope = false;
+		forEachRuntime(runtime, (key) => {
+			if (scope.has(/** @type {string} */ (key))) inScope = true;
+		});
+		return inScope;
 	}
 
 	supportTemplateLiteral() {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -152,6 +152,7 @@ const DEFER_BAILOUT =
 /** @typedef {import("./ModuleGraph")} ModuleGraph */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
+/** @typedef {import("./util/runtime").RuntimeSpecSortableSet} RuntimeSpecSortableSet */
 /** @typedef {import("./dependencies/ImportPhase").ImportPhaseType} ImportPhaseType */
 /** @typedef {import("./NormalModuleFactory").ModuleDependency} ModuleDependency */
 
@@ -837,11 +838,13 @@ class RuntimeTemplate {
 			groups !== undefined && typeof runtime === "string"
 				? this._wasmGroupOf(groups, runtime)
 				: undefined;
+		// Only read where `group` is undefined, which is where the runtime has many keys.
+		const asked = /** @type {RuntimeSpecSortableSet} */ (runtime);
 		for (const chunk of this.compilation.chunks) {
 			if (
 				groups !== undefined &&
 				!(group === undefined
-					? this._wasmRuntimeSharesAny(groups, chunk.runtime, runtime)
+					? this._wasmRuntimeSharesAny(groups, chunk.runtime, asked)
 					: this._wasmRuntimeAnswersWith(groups, chunk.runtime, group))
 			) {
 				continue;
@@ -931,18 +934,11 @@ class RuntimeTemplate {
 	 * their groups at once.
 	 * @param {Map<string, string>} groups runtime key to the group it answers with
 	 * @param {RuntimeSpec} runtime a runtime
-	 * @param {RuntimeSpec} asked the runtime being asked about
+	 * @param {RuntimeSpecSortableSet} asked the runtime being asked about
 	 * @returns {boolean} true when the runtime is one that answer has to cover
 	 */
 	_wasmRuntimeSharesAny(groups, runtime, asked) {
-		if (asked === undefined) return false;
-		if (typeof asked === "string") {
-			return this._wasmRuntimeAnswersWith(
-				groups,
-				runtime,
-				this._wasmGroupOf(groups, asked)
-			);
-		}
+		// Several keys only: a single-key runtime names its group before the chunk loop.
 		for (const key of asked) {
 			if (
 				this._wasmRuntimeAnswersWith(

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -470,10 +470,18 @@ class RuntimeTemplate {
 
 		if (form === "import") {
 			// Read through a native `import()`, or it is not this feature at all.
-			if (
-				outputOptions.chunkFormat !== "module" ||
-				outputOptions.importFunctionName !== "import"
-			) {
+			if (outputOptions.chunkFormat !== "module") {
+				this._analyzableBailout(
+					module,
+					`output.chunkFormat is ${JSON.stringify(outputOptions.chunkFormat)}, so chunks are not read through a native import()`
+				);
+				return false;
+			}
+			if (outputOptions.importFunctionName !== "import") {
+				this._analyzableBailout(
+					module,
+					`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, so the call site is not a native import()`
+				);
 				return false;
 			}
 			// A worker loading its own chunks some other way keeps that runtime; one on
@@ -497,7 +505,13 @@ class RuntimeTemplate {
 
 		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
 		// emitted by the module chunk loader either way, so only the url forms check.
-		if (!this.supportsEcmaScriptModuleSyntax()) return false;
+		if (!this.supportsEcmaScriptModuleSyntax()) {
+			this._analyzableBailout(
+				module,
+				"output.environment.module is false, so the target does not read the import.meta this form needs"
+			);
+			return false;
+		}
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error. A literal `import()` survives it, so only the url forms check.
 		const { devtool } = this.compilation.options;
@@ -511,7 +525,14 @@ class RuntimeTemplate {
 		if (form === "url" || form === "url-inline") return true;
 		// A bare relative URL is what `__webpack_require__.p + path` means only under an
 		// `auto` public path; anything else has to be baked, which is the "wasm" form.
-		if (form === "wasm-relative") return outputOptions.publicPath === "auto";
+		if (form === "wasm-relative") {
+			if (outputOptions.publicPath === "auto") return true;
+			this._analyzableBailout(
+				module,
+				"output.publicPath is set, so a bare relative url no longer means what the public path would have resolved to"
+			);
+			return false;
+		}
 
 		// The rest is the `"wasm"` form: whether the whole binary url can be spelled
 		// here, rather than built at runtime under an `import.meta.url` base.
@@ -2375,6 +2396,10 @@ class RuntimeTemplate {
 		// A hashed name written here makes this chunk's content depend on the referenced
 		// one's hash, so a chunk that can reach back leaves the pair with no fixed point.
 		const cycles = deferred && this._reachesAny(chunk, chunks);
+		// An id names the chunk in the stand-in. No reference reaches here without one —
+		// `blockPromise` drops an id-less chunk before asking, and one the whole build
+		// keeps has no name to be emitted under — so the guard carries no reason of its
+		// own; it only keeps `null` out of a name.
 		const canReserve =
 			chunk.id !== null && !cycles && this._canDeferAnalyzableName(chunks);
 		/**
@@ -2383,11 +2408,9 @@ class RuntimeTemplate {
 		const cannotReserve = () => {
 			this._analyzableBailout(
 				consumingModule,
-				chunk.id === null
-					? "the referenced chunk has no id"
-					: cycles
-						? "this chunk and the one it references name each other, so neither hash could settle"
-						: DEFER_BAILOUT
+				cycles
+					? "this chunk and the one it references name each other, so neither hash could settle"
+					: DEFER_BAILOUT
 			);
 			return null;
 		};

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -435,12 +435,8 @@ class RuntimeTemplate {
 	supportsAnalyzable(form, chunkGraph, module, runtime) {
 		// Analyzable output is ESM output — anything else is a different feature.
 		if (!this.isModule()) return false;
-		// Build-time execution keeps the runtime form — `import.meta` does not parse in
-		// its vm script wrapper. `getTypes` has no chunk graph and does not care:
-		// `AssetModulesPlugin` emulates the wrapper there. The one fallback that stays
-		// unreported, and has to: `executeModule` builds its chunk graph over the
-		// compilation's own module graph, so a reason recorded here would surface on a
-		// module the real build also ships, about code the real build never emits.
+		// Build-time execution keeps the runtime form — `import.meta` does not parse in its
+		// vm wrapper. Unreported on purpose: its chunk graph shares the real module graph.
 		if (chunkGraph && chunkGraph.buildTimeExecution) return false;
 		const { outputOptions } = this;
 		// One loader per runtime serves every wasm module in it, so the answer has to
@@ -839,7 +835,7 @@ class RuntimeTemplate {
 		// Named once here so a chunk costs one `get` and a compare, not a set of its own.
 		const group =
 			groups !== undefined && typeof runtime === "string"
-				? groups.get(runtime) || runtime
+				? this._wasmGroupOf(groups, runtime)
 				: undefined;
 		for (const chunk of this.compilation.chunks) {
 			if (
@@ -944,17 +940,32 @@ class RuntimeTemplate {
 			return this._wasmRuntimeAnswersWith(
 				groups,
 				runtime,
-				groups.get(asked) || asked
+				this._wasmGroupOf(groups, asked)
 			);
 		}
 		for (const key of asked) {
 			if (
-				this._wasmRuntimeAnswersWith(groups, runtime, groups.get(key) || key)
+				this._wasmRuntimeAnswersWith(
+					groups,
+					runtime,
+					this._wasmGroupOf(groups, key)
+				)
 			) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * @param {Map<string, string>} groups runtime key to the group it answers with
+	 * @param {string} key a runtime key
+	 * @returns {string} the group it answers with, or itself when it shares nothing
+	 */
+	_wasmGroupOf(groups, key) {
+		const group = groups.get(key);
+		// An entry named "" makes "" a runtime key, so test absence, not a falsy value.
+		return group === undefined ? key : group;
 	}
 
 	/**
@@ -966,10 +977,10 @@ class RuntimeTemplate {
 	_wasmRuntimeAnswersWith(groups, runtime, group) {
 		if (runtime === undefined) return false;
 		if (typeof runtime === "string") {
-			return (groups.get(runtime) || runtime) === group;
+			return this._wasmGroupOf(groups, runtime) === group;
 		}
 		for (const key of runtime) {
-			if ((groups.get(key) || key) === group) return true;
+			if (this._wasmGroupOf(groups, key) === group) return true;
 		}
 		return false;
 	}

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -7,7 +7,6 @@
 
 const { SyncWaterfallHook } = require("tapable");
 /** @typedef {import("../Compilation")} Compilation */
-const { CSS_TYPE } = require("../ModuleSourceTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
@@ -79,16 +78,9 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		} = compilation;
 		const dedupePrefetch = Boolean(resourceHints && resourceHints.dedupe);
 		const fn = RuntimeGlobals.ensureChunkHandlers;
-		const conditionMap = chunkGraph.getChunkConditionMap(
-			chunk,
-			/**
-			 * @param {Chunk} chunk the chunk
-			 * @param {ChunkGraph} chunkGraph the chunk graph
-			 * @returns {boolean} true, if the chunk has css
-			 */
-			(chunk, chunkGraph) =>
-				Boolean(chunkGraph.getChunkModulesIterableBySourceType(chunk, CSS_TYPE))
-		);
+		// The predicate the stylesheet is emitted from: an `@import` external gives a
+		// chunk a css asset without a `CSS_TYPE` module, and it still has to load.
+		const conditionMap = chunkGraph.getChunkConditionMap(chunk, chunkHasCss);
 		const hasCssMatcher = compileBooleanMatcher(conditionMap);
 
 		const withLoading =

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -718,6 +718,39 @@ class CssModulesPlugin {
 							: globalChunkLoading;
 					return chunkLoading === "jsonp" || chunkLoading === "import";
 				};
+				/**
+				 * The neutral platform's no-DOM branch stores styles on the global.
+				 * @param {RuntimeRequirements} set runtime requirements
+				 */
+				const addNoDomStyleRegistry = (set) => {
+					if (
+						compilation.runtimeTemplate.isNeutralPlatform() &&
+						!compilation.outputOptions.environment.globalThis
+					) {
+						set.add(RuntimeGlobals.global);
+					}
+				};
+				/**
+				 * Whether a chunk reachable from this one is emitted as a stylesheet, which
+				 * is what the loading branch is rendered from. A css module in the graph is
+				 * not enough: a target may carry one without emitting css at all.
+				 * @param {Chunk} chunk the chunk
+				 * @param {ChunkGraph} chunkGraph the chunk graph
+				 * @returns {boolean} true, when there is a stylesheet to load
+				 */
+				const hasCssToLoad = (chunk, chunkGraph) => {
+					for (const referenced of chunk.getAllReferencedChunks()) {
+						if (
+							chunkGraph.getChunkModulesIterableBySourceType(
+								referenced,
+								CSS_TYPE
+							)
+						) {
+							return true;
+						}
+					}
+					return false;
+				};
 				/** @type {WeakSet<Chunk>} */
 				const onceForChunkSet = new WeakSet();
 				/**
@@ -730,13 +763,6 @@ class CssModulesPlugin {
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
 
-					// The neutral platform's no-DOM branch stores styles on the global.
-					if (
-						compilation.runtimeTemplate.isNeutralPlatform() &&
-						!compilation.outputOptions.environment.globalThis
-					) {
-						set.add(RuntimeGlobals.global);
-					}
 					compilation.addLazyRuntimeModule(
 						chunk,
 						getCssLoadingRuntimeModule,
@@ -750,22 +776,15 @@ class CssModulesPlugin {
 					.for(RuntimeGlobals.ensureChunkHandlers)
 					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
-						if (
-							!chunkGraph.hasModuleInGraph(
-								chunk,
-								(m) =>
-									m.type === CSS_MODULE_TYPE ||
-									m.type === CSS_MODULE_TYPE_GLOBAL ||
-									m.type === CSS_MODULE_TYPE_MODULE ||
-									m.type === CSS_MODULE_TYPE_AUTO
-							)
-						) {
-							return;
-						}
+						if (!hasCssToLoad(chunk, chunkGraph)) return;
 
 						set.add(RuntimeGlobals.hasOwnProperty);
 						set.add(RuntimeGlobals.publicPath);
 						set.add(RuntimeGlobals.getChunkCssFilename);
+						// Asked here rather than for `hasCssModules`: the loading runtime
+						// module renders nothing without loading or hmr, so declaring it
+						// there ships the polyfill to a build that never reads it.
+						addNoDomStyleRegistry(set);
 					});
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.hmrDownloadUpdateHandlers)
@@ -785,6 +804,7 @@ class CssModulesPlugin {
 						}
 						set.add(RuntimeGlobals.publicPath);
 						set.add(RuntimeGlobals.getChunkCssFilename);
+						addNoDomStyleRegistry(set);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
@@ -792,13 +812,7 @@ class CssModulesPlugin {
 					.tap(PLUGIN_NAME, (chunk, set) => {
 						// Same as above: namespace stub is enough.
 						set.add(RuntimeGlobals.requireScope);
-						// The neutral platform's no-DOM branch stores styles on the global.
-						if (
-							compilation.runtimeTemplate.isNeutralPlatform() &&
-							!compilation.outputOptions.environment.globalThis
-						) {
-							set.add(RuntimeGlobals.global);
-						}
+						addNoDomStyleRegistry(set);
 						compilation.addLazyRuntimeModule(
 							chunk,
 							getCssInjectStyleRuntimeModule,

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -739,12 +739,7 @@ class CssModulesPlugin {
 				 */
 				const hasCssToLoad = (chunk, chunkGraph) => {
 					for (const referenced of chunk.getAllReferencedChunks()) {
-						if (
-							chunkGraph.getChunkModulesIterableBySourceType(
-								referenced,
-								CSS_TYPE
-							)
-						) {
+						if (CssModulesPlugin.chunkHasCss(referenced, chunkGraph)) {
 							return true;
 						}
 					}
@@ -784,6 +779,9 @@ class CssModulesPlugin {
 						// module renders nothing without loading or hmr, so declaring it
 						// there ships the polyfill to a build that never reads it.
 						addNoDomStyleRegistry(set);
+						// A chunk whose only stylesheet is an `@import` external has no css
+						// module, so `hasCssModules` never asks for the loading runtime.
+						handler(chunk, set);
 					});
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.hmrDownloadUpdateHandlers)

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -731,9 +731,8 @@ class CssModulesPlugin {
 					}
 				};
 				/**
-				 * Whether a chunk reachable from this one is emitted as a stylesheet, which
-				 * is what the loading branch is rendered from. A css module in the graph is
-				 * not enough: a target may carry one without emitting css at all.
+				 * Whether a reachable chunk carries css, which is what the loading branch is
+				 * rendered from — a css module in the graph is not enough.
 				 * @param {Chunk} chunk the chunk
 				 * @param {ChunkGraph} chunkGraph the chunk graph
 				 * @returns {boolean} true, when there is a stylesheet to load

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -19,6 +19,7 @@ const {
 	getChunkFilenameTemplate,
 	getCompilationHooks
 } = require("../javascript/JavascriptModulesPlugin");
+const { entryModuleIdExpression } = require("../javascript/StartupHelpers");
 const { getUndoPath } = require("../util/identifier");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -229,7 +230,11 @@ class ModuleChunkFormatPlugin {
 					if (needExec) {
 						startupSource.add(
 							`var __webpack_exec__ = ${runtimeTemplate.returningFunction(
-								`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
+								`${RuntimeGlobals.require}(${entryModuleIdExpression(
+									chunkGraph,
+									chunk,
+									"moduleId"
+								)})`,
 								"moduleId"
 							)}\n`
 						);

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -25,9 +25,8 @@ const EXPORT_PREFIX = `var ${RuntimeGlobals.exports} = `;
 /** @typedef {ModuleId[]} ModuleIds */
 
 /**
- * The module id an entry helper runs, assigned to `entryModuleId` only where something
- * reads it back — `require.main` and `import.meta.main` are its readers, and each asks
- * for the global itself. The inlined startup already renders it this way.
+ * The module id an entry helper runs, assigned to `entryModuleId` only where a reader
+ * (`require.main`, `import.meta.main`) asked for that global itself.
  * @param {ChunkGraph} chunkGraph chunkGraph
  * @param {Chunk} chunk the chunk the helper is rendered into
  * @param {string} moduleIdExpression the module id the helper runs

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -25,6 +25,22 @@ const EXPORT_PREFIX = `var ${RuntimeGlobals.exports} = `;
 /** @typedef {ModuleId[]} ModuleIds */
 
 /**
+ * The module id an entry helper runs, assigned to `entryModuleId` only where something
+ * reads it back — `require.main` and `import.meta.main` are its readers, and each asks
+ * for the global itself. The inlined startup already renders it this way.
+ * @param {ChunkGraph} chunkGraph chunkGraph
+ * @param {Chunk} chunk the chunk the helper is rendered into
+ * @param {string} moduleIdExpression the module id the helper runs
+ * @returns {string} what to hand `__webpack_require__`
+ */
+const entryModuleIdExpression = (chunkGraph, chunk, moduleIdExpression) =>
+	chunkGraph.getTreeRuntimeRequirements(chunk).has(RuntimeGlobals.entryModuleId)
+		? `${RuntimeGlobals.entryModuleId} = ${moduleIdExpression}`
+		: moduleIdExpression;
+
+module.exports.entryModuleIdExpression = entryModuleIdExpression;
+
+/**
  * Whether the startup rendered for this chunk waits on other chunks — the one shape
  * `generateEntryStartup` gives a startup helper, rather than calling the entry module
  * straight. Asked while runtime requirements are still open, where that render is long
@@ -68,7 +84,11 @@ module.exports.generateEntryStartup = (
 	/** @type {string[]} */
 	const runtime = [
 		`var __webpack_exec__ = ${runtimeTemplate.returningFunction(
-			`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
+			`${RuntimeGlobals.require}(${entryModuleIdExpression(
+				chunkGraph,
+				chunk,
+				"moduleId"
+			)})`,
 			"moduleId"
 		)}`
 	];

--- a/lib/runtime/StartupEntrypointRuntimeModule.js
+++ b/lib/runtime/StartupEntrypointRuntimeModule.js
@@ -6,7 +6,9 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
+const { entryModuleIdExpression } = require("../javascript/StartupHelpers");
 
+/** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compilation")} Compilation */
 
 class StartupEntrypointRuntimeModule extends RuntimeModule {
@@ -35,7 +37,8 @@ class StartupEntrypointRuntimeModule extends RuntimeModule {
 	 */
 	generate() {
 		const compilation = /** @type {Compilation} */ (this.compilation);
-		const { runtimeTemplate } = compilation;
+		const { runtimeTemplate, chunkGraph } = compilation;
+		const chunk = /** @type {Chunk} */ (this.chunk);
 		const cst = runtimeTemplate.renderConst();
 		return `${
 			RuntimeGlobals.startupEntrypoint
@@ -43,7 +46,11 @@ class StartupEntrypointRuntimeModule extends RuntimeModule {
 			"// arguments: chunkIds, moduleId are deprecated",
 			`${cst} moduleId = chunkIds;`,
 			`if(!fn) chunkIds = result, fn = ${runtimeTemplate.returningFunction(
-				`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`
+				`${RuntimeGlobals.require}(${entryModuleIdExpression(
+					chunkGraph,
+					chunk,
+					"moduleId"
+				)})`
 			)};`,
 			...(this.asyncChunkLoading
 				? [

--- a/test/configCases/chunks-order/cjs/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/chunks-order/cjs/__snapshots__/ConfigCacheTest.snap
@@ -39,7 +39,7 @@ it(\\"The dependOn chunk must be loaded before the common chunk.\\", () => {
 // load runtime
 var __webpack_require__ = require(\\"./runtime~nested-shared.js\\");
 __webpack_require__.C(exports);
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 var __webpack_exports__ = __webpack_require__.X(0, [\\"shared\\",\\"nested-shared\\",\\"commons-dependency_js\\"], () => (__webpack_exec__(552)));
 const __webpack_export_target__ = exports;
 for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];

--- a/test/configCases/chunks-order/cjs/__snapshots__/ConfigTest.snap
+++ b/test/configCases/chunks-order/cjs/__snapshots__/ConfigTest.snap
@@ -39,7 +39,7 @@ it(\\"The dependOn chunk must be loaded before the common chunk.\\", () => {
 // load runtime
 var __webpack_require__ = require(\\"./runtime~nested-shared.js\\");
 __webpack_require__.C(exports);
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 var __webpack_exports__ = __webpack_require__.X(0, [\\"shared\\",\\"nested-shared\\",\\"commons-dependency_js\\"], () => (__webpack_exec__(552)));
 const __webpack_export_target__ = exports;
 for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
@@ -33,7 +33,7 @@ it(\\"The dependOn chunk must be loaded before the common chunk.\\", async () =>
 
 // load runtime
 import { __webpack_require__ } from \\"./runtime~nested-shared.mjs\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./shared.mjs\\";
 __webpack_require__.C(__webpack_chunk_1__);

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
@@ -33,7 +33,7 @@ it(\\"The dependOn chunk must be loaded before the common chunk.\\", async () =>
 
 // load runtime
 import { __webpack_require__ } from \\"./runtime~nested-shared.mjs\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./shared.mjs\\";
 __webpack_require__.C(__webpack_chunk_1__);

--- a/test/configCases/css/import-only-chunk-loads/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/import-only-chunk-loads/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css import-only-chunk-loads exported tests should cover a chunk whose only css is an external import 1`] = `"/******/ 					if(\\"main\\" != chunkId) {"`;

--- a/test/configCases/css/import-only-chunk-loads/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/import-only-chunk-loads/__snapshots__/ConfigTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css import-only-chunk-loads exported tests should cover a chunk whose only css is an external import 1`] = `"/******/ 					if(\\"main\\" != chunkId) {"`;

--- a/test/configCases/css/import-only-chunk-loads/ext.css
+++ b/test/configCases/css/import-only-chunk-loads/ext.css
@@ -1,0 +1,1 @@
+.external { color: red; }

--- a/test/configCases/css/import-only-chunk-loads/index.js
+++ b/test/configCases/css/import-only-chunk-loads/index.js
@@ -1,0 +1,22 @@
+// Never awaited: the assertions are about what the runtime was built to load.
+export const load = () => [import("./real-lazy.js"), import("./lazy.js")];
+
+// `lazy_js`'s only css is an `@import` external, so it has no `CSS_TYPE` module --
+// but a stylesheet is emitted for it, so the loader has to name it too.
+it("should cover a chunk whose only css is an external import", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const { outputPath } = __STATS__;
+
+	expect(
+		fs.readFileSync(path.join(outputPath, "lazy_js.css"), "utf-8")
+	).toContain("@import");
+
+	const source = fs.readFileSync(path.join(outputPath, "bundle0.js"), "utf-8");
+	const condition = source
+		.split(`webpack/runtime/css ${"loading"}`)[1]
+		.split("\n")
+		.find((line) => line.includes("chunkId") && line.includes("if("));
+
+	expect(condition.trim()).toMatchSnapshot();
+});

--- a/test/configCases/css/import-only-chunk-loads/index.js
+++ b/test/configCases/css/import-only-chunk-loads/index.js
@@ -10,7 +10,7 @@ it("should cover a chunk whose only css is an external import", () => {
 
 	expect(
 		fs.readFileSync(path.join(outputPath, "lazy_js.css"), "utf-8")
-	).toContain("@import");
+	).toContain('@import url("./ext.css");');
 
 	const source = fs.readFileSync(path.join(outputPath, "bundle0.js"), "utf-8");
 	const condition = source

--- a/test/configCases/css/import-only-chunk-loads/lazy.js
+++ b/test/configCases/css/import-only-chunk-loads/lazy.js
@@ -1,0 +1,3 @@
+import "./ext.css";
+
+export const lazy = "lazy";

--- a/test/configCases/css/import-only-chunk-loads/real-lazy.js
+++ b/test/configCases/css/import-only-chunk-loads/real-lazy.js
@@ -1,0 +1,3 @@
+import "./real.css";
+
+export const real = "real";

--- a/test/configCases/css/import-only-chunk-loads/real.css
+++ b/test/configCases/css/import-only-chunk-loads/real.css
@@ -1,0 +1,1 @@
+.real { color: green; }

--- a/test/configCases/css/import-only-chunk-loads/webpack.config.js
+++ b/test/configCases/css/import-only-chunk-loads/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// A lazy chunk whose only css is an `@import` external still emits a stylesheet, so
+// the css loading runtime has to cover it -- its predicate is the emitting one.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: false,
+	experiments: { css: true },
+	optimization: { chunkIds: "named", minimize: false },
+	externals: { "./ext.css": "css-import ./ext.css" },
+	output: { chunkFilename: "[name].js" }
+};

--- a/test/configCases/css/import-only-no-css-module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/import-only-no-css-module/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css import-only-no-css-module exported tests should load a stylesheet no css module produced 1`] = `"/******/ 					if(\\"lazy_js\\" == chunkId) {"`;

--- a/test/configCases/css/import-only-no-css-module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/import-only-no-css-module/__snapshots__/ConfigTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css import-only-no-css-module exported tests should load a stylesheet no css module produced 1`] = `"/******/ 					if(\\"lazy_js\\" == chunkId) {"`;

--- a/test/configCases/css/import-only-no-css-module/ext.css
+++ b/test/configCases/css/import-only-no-css-module/ext.css
@@ -1,0 +1,1 @@
+.external { color: red; }

--- a/test/configCases/css/import-only-no-css-module/index.js
+++ b/test/configCases/css/import-only-no-css-module/index.js
@@ -1,0 +1,26 @@
+// Never awaited: the assertions are about what the runtime was built to load.
+export const load = () => import("./lazy.js");
+
+// The build has no css module at all, so `hasCssModules` is never required -- the
+// loading runtime still has to exist, or the emitted stylesheet never loads.
+it("should load a stylesheet no css module produced", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const { outputPath } = __STATS__;
+
+	expect(
+		fs.readFileSync(path.join(outputPath, "lazy_js.css"), "utf-8")
+	).toContain("@import");
+
+	const source = fs.readFileSync(path.join(outputPath, "bundle0.js"), "utf-8");
+	const runtime = `webpack/runtime/css ${"loading"}`;
+
+	expect(source).toContain(runtime);
+
+	const condition = source
+		.split(runtime)[1]
+		.split("\n")
+		.find((line) => line.includes("chunkId") && line.includes("if("));
+
+	expect(condition.trim()).toMatchSnapshot();
+});

--- a/test/configCases/css/import-only-no-css-module/index.js
+++ b/test/configCases/css/import-only-no-css-module/index.js
@@ -10,7 +10,7 @@ it("should load a stylesheet no css module produced", () => {
 
 	expect(
 		fs.readFileSync(path.join(outputPath, "lazy_js.css"), "utf-8")
-	).toContain("@import");
+	).toContain('@import url("./ext.css");');
 
 	const source = fs.readFileSync(path.join(outputPath, "bundle0.js"), "utf-8");
 	const runtime = `webpack/runtime/css ${"loading"}`;

--- a/test/configCases/css/import-only-no-css-module/lazy.js
+++ b/test/configCases/css/import-only-no-css-module/lazy.js
@@ -1,0 +1,3 @@
+import "./ext.css";
+
+export default "lazy";

--- a/test/configCases/css/import-only-no-css-module/webpack.config.js
+++ b/test/configCases/css/import-only-no-css-module/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// No css module anywhere: the only stylesheet in the build is an `@import` external,
+// so nothing requires `hasCssModules` and the loading runtime has to be asked for here.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: false,
+	experiments: { css: true },
+	optimization: { chunkIds: "named", minimize: false },
+	externals: { "./ext.css": "css-import ./ext.css" },
+	output: { chunkFilename: "[name].js" }
+};

--- a/test/configCases/css/loading-runtime-only-when-rendered/lazy-style.css
+++ b/test/configCases/css/loading-runtime-only-when-rendered/lazy-style.css
@@ -1,0 +1,1 @@
+.lazy { color: blue; }

--- a/test/configCases/css/loading-runtime-only-when-rendered/lazy.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/lazy.js
@@ -1,0 +1,3 @@
+import "./lazy-style.css";
+
+export const lazy = "lazy";

--- a/test/configCases/css/loading-runtime-only-when-rendered/loading-entry.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/loading-entry.js
@@ -1,0 +1,18 @@
+import "./style.css";
+import fs from "fs";
+import path from "path";
+import { GLOBAL_HELPER, GLOBAL_MODULE } from "./needles.js";
+
+// A chunk carrying css is loaded here, so the loading runtime module renders and
+// reads the registry the polyfill provides.
+it("should ship the global polyfill when a css chunk is loaded", async () => {
+	const { lazy } = await import("./lazy.js");
+	expect(lazy).toBe("lazy");
+	const { outputPath } = __STATS__.children[__STATS_I__];
+	const source = fs.readFileSync(
+		path.join(outputPath, "loading/main.mjs"),
+		"utf-8"
+	);
+	expect(source).toContain(GLOBAL_MODULE);
+	expect(source).toContain(GLOBAL_HELPER);
+});

--- a/test/configCases/css/loading-runtime-only-when-rendered/needles.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/needles.js
@@ -1,0 +1,5 @@
+// Split so the needles do not match this test's own source once bundled.
+export const GLOBAL_MODULE = `webpack/runtime/${"global"}`;
+export const GLOBAL_HELPER = `${"__webpack_require__"}.g`;
+export const CSS_FILENAME_MODULE = `webpack/runtime/get css ${"chunk"} filename`;
+export const CSS_FILENAME_HELPER = `${"__webpack_require__"}.k`;

--- a/test/configCases/css/loading-runtime-only-when-rendered/node-entry.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/node-entry.js
@@ -1,0 +1,16 @@
+import "./style.css";
+import fs from "fs";
+import path from "path";
+import { CSS_FILENAME_HELPER, CSS_FILENAME_MODULE } from "./needles.js";
+
+// Targeting node turns a stylesheet into a javascript module, so no chunk is
+// emitted as css and the loading branch that names one is never rendered.
+it("should not ship the css chunk filename without a stylesheet to load", async () => {
+	const name = "lazy";
+	const { lazy } = await import(`./${name}.js`);
+	expect(lazy).toBe("lazy");
+	const { outputPath } = __STATS__.children[__STATS_I__];
+	const source = fs.readFileSync(path.join(outputPath, "node/main.mjs"), "utf-8");
+	expect(source).not.toContain(CSS_FILENAME_MODULE);
+	expect(source).not.toContain(CSS_FILENAME_HELPER);
+});

--- a/test/configCases/css/loading-runtime-only-when-rendered/static-entry.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/static-entry.js
@@ -1,0 +1,16 @@
+import "./style.css";
+import fs from "fs";
+import path from "path";
+import { GLOBAL_HELPER, GLOBAL_MODULE } from "./needles.js";
+
+// Nothing loads a chunk, so the css loading runtime module renders nothing and
+// the `globalThis` polyfill it would have used is not shipped.
+it("should not ship the global polyfill without chunk loading", () => {
+	const { outputPath } = __STATS__.children[__STATS_I__];
+	const source = fs.readFileSync(
+		path.join(outputPath, "no-loading/main.mjs"),
+		"utf-8"
+	);
+	expect(source).not.toContain(GLOBAL_MODULE);
+	expect(source).not.toContain(GLOBAL_HELPER);
+});

--- a/test/configCases/css/loading-runtime-only-when-rendered/style.css
+++ b/test/configCases/css/loading-runtime-only-when-rendered/style.css
@@ -1,0 +1,1 @@
+.static { color: red; }

--- a/test/configCases/css/loading-runtime-only-when-rendered/test.config.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const NAMES = ["no-loading", "loading", "node"];
+
+module.exports = {
+	findBundle(i) {
+		return [`./${NAMES[i]}/main.mjs`];
+	}
+};

--- a/test/configCases/css/loading-runtime-only-when-rendered/webpack.config.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// What the css loading runtime module needs is asked for only where it renders: it
-// emits nothing without chunk loading or hmr, and its loading branch needs a chunk
-// actually emitted as css -- which a node target has none of, stylesheets being
-// javascript modules there.
+// The css loading runtime module renders nothing without chunk loading or hmr, and its
+// loading branch needs a chunk emitted as css -- which a node target has none of.
 
 /**
  * @param {string} name output sub-directory

--- a/test/configCases/css/loading-runtime-only-when-rendered/webpack.config.js
+++ b/test/configCases/css/loading-runtime-only-when-rendered/webpack.config.js
@@ -1,0 +1,37 @@
+"use strict";
+
+// What the css loading runtime module needs is asked for only where it renders: it
+// emits nothing without chunk loading or hmr, and its loading branch needs a chunk
+// actually emitted as css -- which a node target has none of, stylesheets being
+// javascript modules there.
+
+/**
+ * @param {string} name output sub-directory
+ * @param {string} entry entry module
+ * @param {import("../../../../").Configuration["target"]} target build target
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const variant = (name, entry, target = ["web", "node"]) => ({
+	name,
+	target,
+	mode: "development",
+	devtool: false,
+	entry,
+	experiments: { css: true, outputModule: true },
+	optimization: { chunkIds: "named", minimize: false },
+	output: {
+		module: true,
+		environment: { globalThis: false },
+		filename: `${name}/main.mjs`,
+		chunkFilename: `${name}/[name].mjs`,
+		cssFilename: `${name}/[name].css`,
+		cssChunkFilename: `${name}/[name].css`
+	}
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	variant("no-loading", "./static-entry.js"),
+	variant("loading", "./loading-entry.js"),
+	variant("node", "./node-entry.js", "node")
+];

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -187,7 +187,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_3.chunk.js\\";
 __webpack_require__.C(__webpack_chunk_1__);
@@ -318,7 +318,7 @@ globalThis.__classicB = \\"classic-b value\\";
 
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_2.chunk.js\\";
 __webpack_require__.C(__webpack_chunk_1__);

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -187,7 +187,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_3.chunk.js\\";
 __webpack_require__.C(__webpack_chunk_1__);
@@ -318,7 +318,7 @@ globalThis.__classicB = \\"classic-b value\\";
 
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
-var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
+var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 
 import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_2.chunk.js\\";
 __webpack_require__.C(__webpack_chunk_1__);

--- a/test/configCases/output/public-path-assign-only/assign.js
+++ b/test/configCases/output/public-path-assign-only/assign.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+// Assigns the public path and never reads it back.
+__webpack_public_path__ = "/from-runtime/";
+
+export const value = "assigned";
+
+it("should ship the publicPath runtime module only where something reads it", () => {
+	const source = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, __NAME__, "main.mjs"),
+		"utf-8"
+	);
+
+	// The assignment itself survives either way.
+	expect(source).toMatch(/__webpack_require__\.p = "\/from-runtime\/"/);
+	expect(/webpack\/runtime\/publicPath/.test(source)).toBe(__READS__);
+});

--- a/test/configCases/output/public-path-assign-only/read-entry.js
+++ b/test/configCases/output/public-path-assign-only/read-entry.js
@@ -1,0 +1,7 @@
+import { value } from "./assign.js";
+import { seen } from "./reader.js";
+
+it("should still resolve the public path a module reads back", () => {
+	expect(value).toBe("assigned");
+	expect(seen()).toBe("/from-runtime/");
+});

--- a/test/configCases/output/public-path-assign-only/reader.js
+++ b/test/configCases/output/public-path-assign-only/reader.js
@@ -1,0 +1,2 @@
+// Reads it, so the runtime module that computes the initial value is needed.
+export const seen = () => __webpack_public_path__;

--- a/test/configCases/output/public-path-assign-only/test.config.js
+++ b/test/configCases/output/public-path-assign-only/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i) {
+		return [`./${i === 0 ? "assign-only" : "read"}/main.mjs`];
+	}
+};

--- a/test/configCases/output/public-path-assign-only/webpack.config.js
+++ b/test/configCases/output/public-path-assign-only/webpack.config.js
@@ -1,0 +1,45 @@
+"use strict";
+
+// Assigning `__webpack_public_path__` writes the slot; it does not read the value the
+// `publicPath` runtime module computes, and that module is what auto-detection costs.
+// So it ships only where something reads `__webpack_require__.p` back — in this entry
+// or in any other module of the runtime.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so the entry finds its own stats
+ * @param {string} name output sub-directory
+ * @param {string} entry entry module
+ * @param {boolean} reads whether any module reads the public path back
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const variant = (index, name, entry, reads) => ({
+	mode: "development",
+	devtool: false,
+	target: "node",
+	entry,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", minimize: false },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: `${name}/main.mjs`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name),
+			__READS__: JSON.stringify(reads)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Nothing reads it back, so auto-detection has no reader to serve.
+	variant(0, "assign-only", "./assign.js", false),
+	// Another module reads it, so the computed value has to be there first.
+	variant(1, "read", "./read-entry.js", true)
+];

--- a/test/configCases/output/public-path-assign-only/webpack.config.js
+++ b/test/configCases/output/public-path-assign-only/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// Assigning `__webpack_public_path__` writes the slot; it does not read the value the
-// `publicPath` runtime module computes, and that module is what auto-detection costs.
-// So it ships only where something reads `__webpack_require__.p` back — in this entry
-// or in any other module of the runtime.
+// Assigning `__webpack_public_path__` writes the slot without reading the value the
+// `publicPath` module computes, so that module ships only where something reads it back.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/alone-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/alone-entry.js
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+it("should reach a binary no other runtime shares", async () => {
+	const { run } = await import(
+		/* webpackChunkName: "alone-lazy" */ "./alone-lazy"
+	);
+
+	expect(run()).toBe(42);
+});
+
+it("should bake for a runtime the sharing ones never reach", () => {
+	const source = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			`${__NAME__}-alone-lazy.mjs`
+		),
+		"utf8"
+	);
+
+	expect(source).toContain(__BAKED__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/alone-lazy.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/alone-lazy.js
@@ -1,0 +1,4 @@
+// Its own binary: nothing else reaches it, so this runtime answers alone.
+import { getNumber } from "./alone.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/alone.wat
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/alone.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-a-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-a-entry.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+// Both entries reach this one chunk, so its runtime is a set of keys rather than a
+// single one -- and neither fetches, so every chunk is scanned before the answer.
+it("should reach the binary of a chunk two runtimes share", async () => {
+	const { run } = await import(
+		/* webpackChunkName: "multi-lazy" */ "./multi-lazy"
+	);
+
+	expect(run()).toBe(42);
+});
+
+it("should bake for a shared chunk no runtime fetches", () => {
+	const source = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			`${__NAME__}-multi-lazy.mjs`
+		),
+		"utf8"
+	);
+
+	expect(source).toContain(__BAKED__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-b-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-b-entry.js
@@ -1,0 +1,8 @@
+// Loads the same chunk as `multi-a`, so the chunk carries both runtime keys.
+it("should reach the shared chunk from the second runtime too", async () => {
+	const { run } = await import(
+		/* webpackChunkName: "multi-lazy" */ "./multi-lazy"
+	);
+
+	expect(run()).toBe(42);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-lazy.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-lazy.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./multi.wat";
+
+export const run = () => getNumber();

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi.wat
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
@@ -3,6 +3,6 @@
 module.exports = {
 	findBundle(i) {
 		const name = i === 0 ? "split" : "shared";
-		return [`./${name}-node.mjs`, `./${name}-web.mjs`];
+		return [`./${name}-node.mjs`, `./${name}-web.mjs`, `./${name}-alone.mjs`];
 	}
 };

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
@@ -1,8 +1,12 @@
 "use strict";
 
+const NAMES = ["split", "shared", "multi"];
+
 module.exports = {
 	findBundle(i) {
-		const name = i === 0 ? "split" : "shared";
-		return [`./${name}-node.mjs`, `./${name}-web.mjs`, `./${name}-alone.mjs`];
+		const name = NAMES[i];
+		return i === 2
+			? [`./${name}-a.mjs`, `./${name}-b.mjs`]
+			: [`./${name}-node.mjs`, `./${name}-web.mjs`, `./${name}-alone.mjs`];
 	}
 };

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -5,7 +5,8 @@
 // so it is the only one that has to keep the runtime form — the `readFile` entry
 // resolves the binary against the chunk it is read from, exactly as a baked literal
 // does, and must still bake one. Unless the two share a binary: it is generated once
-// for both, so neither loader can be told the other's shape.
+// for both, so neither loader can be told the other's shape — and only those two, a
+// runtime reaching neither still answers on its own.
 
 const webpack = require("../../../../");
 
@@ -25,7 +26,12 @@ const base = (index, name, second, nodeRef) => ({
 	devtool: false,
 	entry: {
 		[`${name}-node`]: { import: "./node-entry.js", wasmLoading: "async-node" },
-		[`${name}-web`]: { import: second, wasmLoading: "fetch" }
+		[`${name}-web`]: { import: second, wasmLoading: "fetch" },
+		// Shares no binary with either, so the sharing pair says nothing about it.
+		[`${name}-alone`]: {
+			import: "./alone-entry.js",
+			wasmLoading: "async-node"
+		}
 	},
 	module: {
 		rules: [
@@ -46,6 +52,7 @@ const base = (index, name, second, nodeRef) => ({
 			__INDEX__: JSON.stringify(index),
 			__NAME__: JSON.stringify(name),
 			__NODE_REF__: JSON.stringify(INSTANTIATE + nodeRef),
+			__BAKED__: JSON.stringify(`${INSTANTIATE}new URL("./`),
 			__RUNTIME_FORM__: JSON.stringify(`${INSTANTIATE}module.id, `)
 		})
 	]

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -1,12 +1,7 @@
 "use strict";
 
-// Two entries of ONE compilation loading wasm differently, under a public path that is
-// neither `auto` nor an absolute URL. `fetch` is the only loader such a path reaches,
-// so it is the only one that has to keep the runtime form — the `readFile` entry
-// resolves the binary against the chunk it is read from, exactly as a baked literal
-// does, and must still bake one. Unless the two share a binary: it is generated once
-// for both, so neither loader can be told the other's shape — and only those two, a
-// runtime reaching neither still answers on its own.
+// Two entries loading wasm differently under a non-`auto` public path: only `fetch`
+// keeps the runtime form, unless the two share a binary and neither can be told apart.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -53,10 +53,26 @@ const base = (index, name, second, nodeRef) => ({
 	]
 });
 
+/**
+ * Two entries reaching ONE async chunk, so its runtime is a set of keys -- the shape
+ * the group lookup answers key by key. Neither fetches, so no chunk cuts the scan.
+ * @param {number} index position of this config, so an entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const multi = (index, name) => ({
+	...base(index, name, "./web-entry.js", 'new URL("./'),
+	entry: {
+		[`${name}-a`]: { import: "./multi-a-entry.js", wasmLoading: "async-node" },
+		[`${name}-b`]: { import: "./multi-b-entry.js", wasmLoading: "async-node" }
+	}
+});
+
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
 	// A binary each: the runtimes are told apart, so only the fetching one bails.
 	base(0, "split", "./web-entry.js", 'new URL("./'),
 	// One binary between them: neither runtime can be answered on its own.
-	base(1, "shared", "./shared-entry.js", "module.id, ")
+	base(1, "shared", "./shared-entry.js", "module.id, "),
+	multi(2, "multi")
 ];

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -53,13 +53,9 @@ const base = (index, name, second, nodeRef) => ({
 	]
 });
 
-/**
- * Two entries reaching ONE async chunk, so its runtime is a set of keys -- the shape
- * the group lookup answers key by key. Neither fetches, so no chunk cuts the scan.
- * @param {number} index position of this config, so an entry finds its own stats
- * @param {string} name output prefix keeping the emitted files of each config apart
- * @returns {import("../../../../").Configuration} configuration
- */
+// Two entries reaching ONE async chunk, so its runtime is a set of keys -- the shape
+// the group lookup answers key by key. Neither fetches, so no chunk cuts the scan.
+/** @type {(index: number, name: string) => import("../../../../").Configuration} */
 const multi = (index, name) => ({
 	...base(index, name, "./web-entry.js", 'new URL("./'),
 	entry: {

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -150,6 +150,17 @@ environment-module:
     ./async.js X bytes [built] [code generated]
   environment-module (webpack x.x.x) compiled successfully in X ms
 
+circular:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset a-cycle_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
+  asset b-cycle_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
+  runtime modules X KiB 6 modules
+  cacheable modules X bytes
+    ./index-cycle.js X bytes [built] [code generated]
+    ./a-cycle.js X bytes [built] [code generated]
+    ./b-cycle.js X bytes [built] [code generated]
+  circular (webpack x.x.x) compiled successfully in X ms
+
 base-uri:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -119,5 +119,45 @@ worker-chunk-loading:
     ./index-worker.js X bytes [built] [code generated]
     ./worker.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
-  worker-chunk-loading (webpack x.x.x) compiled successfully in X ms"
+  worker-chunk-loading (webpack x.x.x) compiled successfully in X ms
+
+chunk-format:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 8 modules
+  cacheable modules X bytes
+    ./index.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  chunk-format (webpack x.x.x) compiled successfully in X ms
+
+import-function-name:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  runtime modules X KiB 6 modules
+  cacheable modules X bytes
+    ./index.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  import-function-name (webpack x.x.x) compiled successfully in X ms
+
+environment-module:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
+  runtime modules X KiB 5 modules
+  cacheable modules X bytes (javascript) X bytes (asset)
+    ./index-asset.js X bytes [built] [code generated]
+    ./asset.txt X bytes (asset) X bytes (javascript) [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  environment-module (webpack x.x.x) compiled successfully in X ms
+
+base-uri:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
+  runtime modules X KiB 5 modules
+  cacheable modules X bytes (javascript) X bytes (asset)
+    ./index-asset.js X bytes [built] [code generated]
+    ./asset.txt X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  base-uri (webpack x.x.x) compiled successfully in X ms"
 `;

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -71,7 +71,7 @@ templated-public-path:
 public-path-override:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 7 modules
+  runtime modules X KiB 6 modules
   cacheable modules X bytes
     ./index-public-path-override.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]

--- a/test/statsCases/analyzable-esm-fallbacks/a-cycle.js
+++ b/test/statsCases/analyzable-esm-fallbacks/a-cycle.js
@@ -1,0 +1,2 @@
+export default 1;
+import("./b-cycle.js");

--- a/test/statsCases/analyzable-esm-fallbacks/b-cycle.js
+++ b/test/statsCases/analyzable-esm-fallbacks/b-cycle.js
@@ -1,0 +1,2 @@
+export default 2;
+import("./a-cycle.js");

--- a/test/statsCases/analyzable-esm-fallbacks/index-asset.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-asset.js
@@ -1,0 +1,4 @@
+// Both forms: the url is what a missing `import.meta` or an unusable base blocks,
+// while the chunk `import()` is emitted by the module chunk loader either way.
+export const url = new URL("./asset.txt", import.meta.url);
+export const load = () => import("./async").then((m) => m.value);

--- a/test/statsCases/analyzable-esm-fallbacks/index-cycle.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-cycle.js
@@ -1,0 +1,2 @@
+// Two chunks naming each other: each hash would feed the other.
+export const load = () => Promise.all([import("./a-cycle.js"), import("./b-cycle.js")]);

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -48,6 +48,28 @@ const CASES = {
 		file: "main.mjs",
 		expect: "fallback",
 		bailout: 'not "import"'
+	},
+	"chunk-format": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: "output.chunkFormat is"
+	},
+	"import-function-name": {
+		file: "main.mjs",
+		expect: "fallback",
+		bailout: "output.importFunctionName is"
+	},
+	// Only the url forms need `import.meta`, so the chunk `import()` still bakes and
+	// the helper stays — the fallback is the asset url alone.
+	"environment-module": {
+		file: "main.mjs",
+		expect: "url-fallback",
+		bailout: "output.environment.module is false"
+	},
+	"base-uri": {
+		file: "main.mjs",
+		expect: "url-fallback",
+		bailout: "which is not absolute"
 	}
 };
 
@@ -89,6 +111,11 @@ module.exports = {
 			if (testCase.expect === "analyzable") {
 				expect(output).toContain(HELPER);
 				expect(bailouts).toEqual([]);
+			} else if (testCase.expect === "url-fallback") {
+				// A limitation that stops only the url forms leaves the chunk `import()`
+				// baked, so the helper is still the right thing to find.
+				expect(output).toContain(HELPER);
+				expect(bailouts.join("\n")).toContain(testCase.bailout);
 			} else {
 				// A limitation must not emit extra runtime — the `.ei` helper stays out.
 				expect(output).not.toContain(HELPER);

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -59,16 +59,22 @@ const CASES = {
 		expect: "fallback",
 		bailout: "output.importFunctionName is"
 	},
-	// Only the url forms need `import.meta`, so the chunk `import()` still bakes and
-	// the helper stays — the fallback is the asset url alone.
+	// Only the url forms need `import.meta`, so the chunk `import()` still bakes.
 	"environment-module": {
 		file: "main.mjs",
-		expect: "url-fallback",
+		expect: "partial",
 		bailout: "output.environment.module is false"
+	},
+	// Only the pair that names each other falls back; the entry's own imports still
+	// bake, so the helper stays and the reason is what marks the limitation.
+	circular: {
+		file: "main.mjs",
+		expect: "partial",
+		bailout: "name each other"
 	},
 	"base-uri": {
 		file: "main.mjs",
-		expect: "url-fallback",
+		expect: "partial",
 		bailout: "which is not absolute"
 	}
 };
@@ -111,8 +117,8 @@ module.exports = {
 			if (testCase.expect === "analyzable") {
 				expect(output).toContain(HELPER);
 				expect(bailouts).toEqual([]);
-			} else if (testCase.expect === "url-fallback") {
-				// A limitation that stops only the url forms leaves the chunk `import()`
+			} else if (testCase.expect === "partial") {
+				// A limitation that stops some references and not others leaves the rest
 				// baked, so the helper is still the right thing to find.
 				expect(output).toContain(HELPER);
 				expect(bailouts.join("\n")).toContain(testCase.bailout);

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -113,6 +113,11 @@ module.exports = [
 		module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },
 		output: { environment: { module: false, dynamicImport: true } }
 	}),
+	// Two chunks that reference each other cannot both be named by their content.
+	base("circular", {
+		entry: "./index-cycle",
+		output: { chunkFilename: "[name].[contenthash].mjs" }
+	}),
 	// A relative base has no base of its own for an asset url to resolve against.
 	base("base-uri", {
 		entry: { main: { import: "./index-asset", baseUri: "not-a-url" } },

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -99,5 +99,24 @@ module.exports = [
 	base("worker-chunk-loading", {
 		entry: "./index-worker",
 		output: { workerChunkLoading: "async-node" }
+	}),
+	// Chunks are not read through a native `import()` at all under this format.
+	base("chunk-format", { output: { chunkFormat: "array-push" } }),
+	// The call site is whatever this names, which is not a native `import()`.
+	base("import-function-name", {
+		output: { importFunctionName: "__import__" }
+	}),
+	// The target does not read `import.meta`, so only the url forms fall back — the
+	// chunk `import()` is emitted by the module chunk loader either way.
+	base("environment-module", {
+		entry: "./index-asset",
+		module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },
+		output: { environment: { module: false, dynamicImport: true } }
+	}),
+	// A relative base has no base of its own for an asset url to resolve against.
+	base("base-uri", {
+		entry: { main: { import: "./index-asset", baseUri: "not-a-url" } },
+		module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },
+		output: { publicPath: "./" }
 	})
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Two gaps, both found by measuring what a build actually emits.

*Analyzable ESM output* dropped four references to the runtime form without recording why, so `stats.optimizationBailout` said nothing an ESM build could act on: a `chunkFormat` chunks are not imported through, a renamed `importFunctionName`, a target whose `environment.module` is false, and a set `publicPath` under the wasm-relative form. Each names itself now. The wasm form also gave up on the whole compilation as soon as one binary was reached from two runtimes; it groups runtime keys by the binaries they share instead, so a runtime reaching neither keeps its baked url while the sharing pair falls back together.

*Dead runtime code*: helpers were emitted that nothing calls — the public path under an assign-only `__webpack_public_path__`, the entry module id, `startupEntrypoint` where no chunk is awaited, and the `globalThis` polyfill plus chunk-css filename for a css loading runtime module that renders `null`. Each is the same shape: a runtime requirement declared before the decision that would have used it. `yarn test:size` reports −997 B on `target/universal-all-module-types node/main` and −342 B on each of six runtimes that lose their `global` block, with no asset growing.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. New config cases `wasm/analyzable-mixed-wasm-loading`, `runtime/startup-entrypoint-only-when-awaited`, `output/public-path-assign-only` and `css/loading-runtime-only-when-rendered`; new stats configs under `statsCases/analyzable-esm-fallbacks` covering each newly reported reason. Every assertion was checked to fail on the unmodified `lib/`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no option changed; the new bailout reasons surface through the existing `stats.optimizationBailout`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used throughout: to search for candidates by analysing emitted bundles for runtime helpers nothing reads, to write the implementation and the test cases, and to run the verification. Every candidate it proposed was hand-verified in the emitted output before being acted on — several early ones were false positives and were discarded rather than "fixed". All claims here are backed by runs reported in the session: `yarn test:size` against a baseline for the byte figures, and each new assertion confirmed to fail without the corresponding `lib/` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary runtime code when public paths, entry metadata, or CSS loading are unused.
  - CSS loading now supports chunks containing only external `@import` stylesheets.

- **Compatibility**
  - Improved public-path assignment and read-back behavior.
  - Improved support for analyzable ES modules, dynamic imports, and WebAssembly across varied runtime configurations.
  - Startup output avoids unnecessary entry-module metadata and better supports shared runtime scenarios.

- **Bug Fixes**
  - Corrected CSS loading decisions for chunks whose styles originate from external imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->