### PR TITLE
fix(css): keep minification from changing whether a declaration parses

### DIFF
--- a/.changeset/076-css-minify-value-validity.md
+++ b/.changeset/076-css-minify-value-validity.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep CSS minification from changing whether a declaration parses.

--- a/lib/css/data.js
+++ b/lib/css/data.js
@@ -669,8 +669,13 @@ const MERGE_LONGHANDS = new Set([
 ]);
 
 // The initial keyword each of these may drop when another component stands
-// beside it: omitting the group it belongs to leaves exactly that keyword.
-const OMITTABLE_INITIAL_KEYWORDS = new Map([["grid-auto-flow", "row"]]);
+// beside it: omitting the group it belongs to leaves exactly that keyword. The
+// second half is every keyword that group offers — a value naming two of them
+// (`grid-auto-flow:row dense column`) fills the slot twice and is invalid, so
+// dropping the initial there would print a value the author never wrote.
+/** @type {Map<string, [string, string[]]>} */
+// prettier-ignore
+const OMITTABLE_INITIAL_KEYWORDS = new Map([["grid-auto-flow", ["row", ["column","row"]]]]);
 
 // What each of those longhands accepts as a whole value: the keywords it names,
 // and the value classes it reaches. A value acceptable to a second slot is what
@@ -2220,9 +2225,31 @@ const LEGACY_PSEUDO_ELEMENTS = new Set([
 // combinator instead, and `|` makes the `*` a namespace's, not a redundant one.
 const COMPOUND_CONTINUATIONS = new Set([":", ".", "#", "["]);
 
-// The properties whose zero length keeps its unit — the one place it is still
-// load-bearing.
-const ZERO_UNIT_KEEPING_PROPERTIES = new Set(["flex", "flex-basis"]);
+// The properties whose zero length keeps its unit: those whose own grammar
+// offers a bare number beside the length, so the unit is what picks the
+// reading, and the two an engine reads its own way.
+const ZERO_UNIT_KEEPING_PROPERTIES = new Set([
+	"border-image",
+	"border-image-outset",
+	"border-image-width",
+	"columns",
+	"flex",
+	"flex-basis",
+	"font",
+	"line-height",
+	"mask-border",
+	"mask-border-outset",
+	"mask-border-width",
+	"overflow-clip-margin",
+	"stroke-dasharray",
+	"stroke-dashoffset",
+	"stroke-width",
+	"tab-size"
+]);
+
+// The properties an engine takes no `calc()` in, so one stays as written
+// rather than folding to the value it equals.
+const CALC_REJECTING_PROPERTIES = new Set(["overflow-clip-margin"]);
 
 // At-rules whose empty block is inert, so dropping it changes nothing.
 const DROPPABLE_WHEN_EMPTY_AT_RULES = new Set([
@@ -7826,6 +7853,7 @@ module.exports.AUTO_SECOND_VALUE_PROPERTIES = AUTO_SECOND_VALUE_PROPERTIES;
 module.exports.BOX_FAMILY_PREFIX = BOX_FAMILY_PREFIX;
 module.exports.BOX_LONGHANDS = BOX_LONGHANDS;
 module.exports.BOX_SHORTHANDS = BOX_SHORTHANDS;
+module.exports.CALC_REJECTING_PROPERTIES = CALC_REJECTING_PROPERTIES;
 module.exports.COLOR_ARGUMENT_FUNCTIONS = COLOR_ARGUMENT_FUNCTIONS;
 module.exports.COLOR_KEYWORDS = COLOR_KEYWORDS;
 module.exports.COLOR_NAME_TO_SHORTEST = COLOR_NAME_TO_SHORTEST;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -16,6 +16,7 @@ const {
 	BOX_FAMILY_PREFIX,
 	BOX_LONGHANDS,
 	BOX_SHORTHANDS,
+	CALC_REJECTING_PROPERTIES,
 	COLOR_ARGUMENT_FUNCTIONS,
 	COLOR_KEYWORDS,
 	COLOR_NAME_TO_SHORTEST,
@@ -5369,6 +5370,38 @@ const _convertUnit = (num, unit) => {
 };
 
 /**
+ * Whether the declaration being printed has an `<integer>` anywhere in its
+ * grammar, so a number in it may be one.
+ * @returns {boolean} true inside such a declaration
+ */
+const _inIntegerProperty = () =>
+	_valueDeclaration !== null &&
+	INTEGER_PROPERTIES.has(toLowerCaseIfNeeded(A.name(_valueDeclaration)));
+
+/**
+ * Whether the declaration being printed is one an engine takes no `calc()` in,
+ * so a folded term keeps the `calc()` it was written with.
+ * @returns {boolean} true inside such a declaration
+ */
+const _inCalcRejectingProperty = () =>
+	_valueDeclaration !== null &&
+	CALC_REJECTING_PROPERTIES.has(toLowerCaseIfNeeded(A.name(_valueDeclaration)));
+
+/**
+ * Put back the fraction that keeps a number a `<number>` token, in the spelling
+ * the rest of the printer uses — one fractional digit, and no leading zero.
+ * @param {string} num a normalized number with no fraction left
+ * @returns {string} the same value, still spelled as a `<number>`
+ */
+const _keepFraction = (num) => {
+	const out = `${num}.0`;
+	if (out.charCodeAt(0) === CC_0) return out.slice(1);
+	return out.charCodeAt(0) === CC_HYPHEN_MINUS && out.charCodeAt(1) === CC_0
+		? `-${out.slice(2)}`
+		: out;
+};
+
+/**
  * Normalize a number / dimension / percentage token: normalize the numeric part,
  * then round it and reach for a shorter equal unit. Neither is done inside a
  * `@supports` prelude, where the declaration is being tested rather than applied
@@ -5381,6 +5414,22 @@ const _normalizeNumericToken = (text) => {
 	const end = _numberEnd(text);
 	const unit = text.slice(end);
 	const num = _normalizeNumber(text.slice(0, end));
+	// A fraction is what makes this a `<number>` token rather than an `<integer>`
+	// one, and only the latter matches an `<integer>` — so dropping an all-zero
+	// fraction where the grammar can reach one turns a declaration the engine
+	// threw away into one it keeps (`grid-row:1.0` computes `auto`, `grid-row:1`
+	// computes `1`). Checked before the property, which is the costlier read: a
+	// number whose fraction survives normalization is already spelled right.
+	const dot = text.indexOf(".");
+	if (
+		unit === "" &&
+		dot !== -1 &&
+		dot < end &&
+		!num.includes(".") &&
+		_inIntegerProperty()
+	) {
+		return _keepFraction(num);
+	}
 	// `round()`, `mod()` and `rem()` are step functions of their arguments, so a
 	// rewrite that holds everywhere else does not hold in one: `4.5cm` and `45mm`
 	// are the same length, and headless Chromium reads `round(down,4.5cm,1.5cm)`
@@ -7097,6 +7146,38 @@ const _inFontFamily = () =>
 	_valueDeclaration !== null &&
 	equalsLowerCase(A.name(_valueDeclaration), "font-family");
 
+/**
+ * Whether the string being printed is the whole entry in its comma-separated
+ * slot. `<family-name>` is `<string> | <custom-ident>+`, so a string standing
+ * beside an identifier matches neither alternative and the declaration is
+ * invalid — unquoting it would hand the engine a family list it reads.
+ * @param {CssPath} path the accessor positioned on the string token
+ * @returns {boolean} true when nothing else shares its slot
+ */
+const _isLoneFamilyName = (path) => {
+	const parent = path.parent;
+	// Directly in the declaration's value: inside a function the string is an
+	// argument rather than a family.
+	if (parent === null || path.type(parent) !== T_DECLARATION) return false;
+	const self = path.start(path.node);
+	const count = path.childCount(parent);
+	let sharedSlot = false;
+	let seenSelf = false;
+	for (let at = 0; at < count; at++) {
+		const child = path.childAt(parent, at);
+		const type = path.type(child);
+		if (type === T_COMMA) {
+			if (seenSelf) return !sharedSlot;
+			sharedSlot = false;
+			continue;
+		}
+		if (type === T_WHITESPACE || type === T_COMMENT) continue;
+		if (path.start(child) === self) seenSelf = true;
+		else sharedSlot = true;
+	}
+	return seenSelf && !sharedSlot;
+};
+
 // One identifier, and a family name is a run of them parted by whitespace. The
 // escapes a quoted name may carry are not identifier text, so one declines.
 const _PLAIN_IDENT_RE = /^-?[A-Za-z_-￿][\w-￿-]*$/;
@@ -8803,7 +8884,17 @@ const _collapseShorthand = (path, property, node, writer) => {
 	// omitting the group it belongs to leaves exactly that keyword.
 	const omittable = OMITTABLE_INITIAL_KEYWORDS.get(property);
 	if (omittable !== undefined && components.length > 1) {
-		const kept = components.filter((one) => !equalsLowerCase(one, omittable));
+		const [keyword, slot] = omittable;
+		// Only when the slot the keyword fills is named once. A value naming it
+		// twice is invalid, and dropping the initial would leave the valid value
+		// the author did not write.
+		const filled = components.filter((one) =>
+			slot.includes(toLowerCaseIfNeeded(one))
+		);
+		const kept =
+			filled.length === 1
+				? components.filter((one) => !equalsLowerCase(one, keyword))
+				: components;
 		if (kept.length !== 0 && kept.length !== components.length) {
 			components = kept;
 			dropped = kept;
@@ -9616,6 +9707,9 @@ const _NESTED_TERM_RE = /^(?:\d*\.\d+|\d+)(?:%|[a-z]+)?$/i;
 const _unwrapCalc = (fragment, property) => {
 	const match = _LONE_CALC_RE.exec(fragment);
 	if (match === null) return fragment;
+	// Where the engine takes no `calc()`, the bare value is the one it reads —
+	// so unwrapping would switch on a declaration it had thrown away.
+	if (CALC_REJECTING_PROPERTIES.has(property)) return fragment;
 	const number = match[1];
 	if (
 		number.charCodeAt(0) === 0x2d &&
@@ -9904,7 +9998,10 @@ const printer = (path, writer) => {
 					// declaration printer to judge against the property.
 					const shape =
 						_mathFunctionDepth > 1 ? _NESTED_TERM_RE : _BARE_TERM_RE;
-					const folded = shape.test(term) ? term : `calc(${term})`;
+					const folded =
+						shape.test(term) && !_inCalcRejectingProperty()
+							? term
+							: `calc(${term})`;
 					// A division can land on a value needing every digit of a double,
 					// which is longer than the expression that produced it.
 					if (folded.length < fn.length + inner.length + 2) return folded;
@@ -10014,7 +10111,8 @@ const printer = (path, writer) => {
 				_isClosedString(raw) &&
 				!_inSupportsPrelude &&
 				!_inSubstitutedValue &&
-				_inFontFamily()
+				_inFontFamily() &&
+				_isLoneFamilyName(path)
 			) {
 				const unquoted = _unquoteFontFamily(raw);
 				if (unquoted !== null) return unquoted;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -5414,12 +5414,8 @@ const _normalizeNumericToken = (text) => {
 	const end = _numberEnd(text);
 	const unit = text.slice(end);
 	const num = _normalizeNumber(text.slice(0, end));
-	// A fraction is what makes this a `<number>` token rather than an `<integer>`
-	// one, and only the latter matches an `<integer>` — so dropping an all-zero
-	// fraction where the grammar can reach one turns a declaration the engine
-	// threw away into one it keeps (`grid-row:1.0` computes `auto`, `grid-row:1`
-	// computes `1`). Checked before the property, which is the costlier read: a
-	// number whose fraction survives normalization is already spelled right.
+	// An all-zero fraction still makes this a `<number>`, not an `<integer>`
+	// (`grid-row:1.0` computes `auto`). Property read last, it is the costlier one.
 	const dot = text.indexOf(".");
 	if (
 		unit === "" &&
@@ -7147,10 +7143,8 @@ const _inFontFamily = () =>
 	equalsLowerCase(A.name(_valueDeclaration), "font-family");
 
 /**
- * Whether the string being printed is the whole entry in its comma-separated
- * slot. `<family-name>` is `<string> | <custom-ident>+`, so a string standing
- * beside an identifier matches neither alternative and the declaration is
- * invalid — unquoting it would hand the engine a family list it reads.
+ * Whether the string is the whole entry in its comma-separated slot:
+ * `<family-name>` takes `<string> | <custom-ident>+`, never a mix of the two.
  * @param {CssPath} path the accessor positioned on the string token
  * @returns {boolean} true when nothing else shares its slot
  */

--- a/test/CssValueSyntax.unittest.js
+++ b/test/CssValueSyntax.unittest.js
@@ -15,6 +15,7 @@ const {
 	collectOmittableInitialKeywords,
 	collectRatioProperties,
 	collectUnsharedLonghandKeywords,
+	collectZeroUnitAmbiguousProperties,
 	isSpelledSyntax,
 	longhandType,
 	parseValueSyntax,
@@ -504,8 +505,16 @@ describe("CssValueSyntax", () => {
 	describe("collectOmittableInitialKeywords", () => {
 		it("keeps only a stated keyword the property table agrees is its initial", () => {
 			expect(collectOmittableInitialKeywords()).toEqual([
-				["grid-auto-flow", "row"]
+				["grid-auto-flow", ["row", ["column", "row"]]]
 			]);
+		});
+
+		it("reads the whole slot the keyword is chosen among", () => {
+			expect(
+				collectOmittableInitialKeywords(["a"], {
+					a: { initial: "row", syntax: "[ row | column | page ] || dense" }
+				})
+			).toEqual([["a", ["row", ["column", "page", "row"]]]]);
 		});
 
 		it("refuses a keyword the grammar no longer offers beside another", () => {
@@ -514,6 +523,34 @@ describe("CssValueSyntax", () => {
 					a: { initial: "row", syntax: "row | column" }
 				})
 			).toThrow("No omittable 'row' in 'a': row | column");
+		});
+	});
+
+	describe("collectZeroUnitAmbiguousProperties", () => {
+		it("names a property offering a bare number beside the length", () => {
+			expect(collectZeroUnitAmbiguousProperties()).toContain("tab-size");
+			expect(collectZeroUnitAmbiguousProperties()).toContain("line-height");
+			expect(collectZeroUnitAmbiguousProperties()).toContain(
+				"border-image-outset"
+			);
+		});
+
+		it("reads only the value's own level, not what a function takes", () => {
+			// `width` reaches `<number>` through the gradients `<image>` offers, and
+			// none of them is something `width` could have been written as.
+			expect(collectZeroUnitAmbiguousProperties()).not.toContain("width");
+			expect(collectZeroUnitAmbiguousProperties()).not.toContain("margin");
+		});
+
+		it("follows a shorthand into the longhand that states the pair", () => {
+			expect(
+				collectZeroUnitAmbiguousProperties({
+					a: { syntax: "<'b'>" },
+					b: { syntax: "<number> | <length>" },
+					c: { syntax: "<length>" },
+					d: { syntax: "steps(<number>) | <length>" }
+				})
+			).toEqual(["a", "b"]);
 		});
 	});
 

--- a/test/configCases/css/minimize-value-validity/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-value-validity/__snapshots__/ConfigCacheTest.snap
@@ -14,5 +14,8 @@ Array [
   "/*! a bare number here is a multiple of the border width, not a length */.j{border-image-outset:0px}",
   "/*! the same, and neither was found by a test — the grammar says both */.k{border-image-width:0px}",
   "/*! \`flex:0\` is grow=0,basis=0%; \`flex:0px\` is grow=1,basis=0px */.l{flex:0px}",
+  "/*! a negative zero keeps its fraction too, and still drops the leading zero */.m{grid-row:-.0}",
+  "/*! the shared slot is the second entry here, not the first */.n{font-family:serif,\\"My Font\\" Extra}",
+  "/*! a lone string in a later slot still unquotes */.o{font-family:serif,My Font,monospace}",
 ]
 `;

--- a/test/configCases/css/minimize-value-validity/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-value-validity/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css minimize-value-validity minimize-value-validity should compile 1`] = `
+Array [
+  "/*! invalid: a quoted family beside a bare identifier matches no family list */.a{font-family:\\"Lucida\\" Grande,sans-serif}",
+  "/*! valid: a lone string is a family, so unquoting it stays one */.b{font-family:Lucida Grande,sans-serif}",
+  "/*! invalid: \`<integer>\` takes no fraction, so this computes \`auto\` */.c{grid-row:1.0}",
+  "/*! valid: the fraction is the value, not a spelling of an integer */.d{opacity:1}",
+  "/*! invalid: \`row\` and \`column\` are one slot, so naming both drops the value */.e{grid-auto-flow:row dense column}",
+  "/*! valid: \`row\` is the initial value and says nothing beside \`dense\` */.f{grid-auto-flow:dense}",
+  "/*! \`tab-size\` reads a bare number as characters, so the unit is the value */.g{tab-size:0px}",
+  "/*! valid either way: a bare \`0\` is the length every other property accepts */.h{margin:0}",
+  "/*! Chrome rejects the unitless zero here that the spec allows */.i{overflow-clip-margin:0px content-box}",
+  "/*! a bare number here is a multiple of the border width, not a length */.j{border-image-outset:0px}",
+  "/*! the same, and neither was found by a test — the grammar says both */.k{border-image-width:0px}",
+  "/*! \`flex:0\` is grow=0,basis=0%; \`flex:0px\` is grow=1,basis=0px */.l{flex:0px}",
+]
+`;

--- a/test/configCases/css/minimize-value-validity/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-value-validity/__snapshots__/ConfigTest.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css minimize-value-validity minimize-value-validity should compile 1`] = `
+Array [
+  "/*! invalid: a quoted family beside a bare identifier matches no family list */.a{font-family:\\"Lucida\\" Grande,sans-serif}",
+  "/*! valid: a lone string is a family, so unquoting it stays one */.b{font-family:Lucida Grande,sans-serif}",
+  "/*! invalid: \`<integer>\` takes no fraction, so this computes \`auto\` */.c{grid-row:1.0}",
+  "/*! valid: the fraction is the value, not a spelling of an integer */.d{opacity:1}",
+  "/*! invalid: \`row\` and \`column\` are one slot, so naming both drops the value */.e{grid-auto-flow:row dense column}",
+  "/*! valid: \`row\` is the initial value and says nothing beside \`dense\` */.f{grid-auto-flow:dense}",
+  "/*! \`tab-size\` reads a bare number as characters, so the unit is the value */.g{tab-size:0px}",
+  "/*! valid either way: a bare \`0\` is the length every other property accepts */.h{margin:0}",
+  "/*! Chrome rejects the unitless zero here that the spec allows */.i{overflow-clip-margin:0px content-box}",
+  "/*! a bare number here is a multiple of the border width, not a length */.j{border-image-outset:0px}",
+  "/*! the same, and neither was found by a test — the grammar says both */.k{border-image-width:0px}",
+  "/*! \`flex:0\` is grow=0,basis=0%; \`flex:0px\` is grow=1,basis=0px */.l{flex:0px}",
+]
+`;

--- a/test/configCases/css/minimize-value-validity/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-value-validity/__snapshots__/ConfigTest.snap
@@ -14,5 +14,8 @@ Array [
   "/*! a bare number here is a multiple of the border width, not a length */.j{border-image-outset:0px}",
   "/*! the same, and neither was found by a test — the grammar says both */.k{border-image-width:0px}",
   "/*! \`flex:0\` is grow=0,basis=0%; \`flex:0px\` is grow=1,basis=0px */.l{flex:0px}",
+  "/*! a negative zero keeps its fraction too, and still drops the leading zero */.m{grid-row:-.0}",
+  "/*! the shared slot is the second entry here, not the first */.n{font-family:serif,\\"My Font\\" Extra}",
+  "/*! a lone string in a later slot still unquotes */.o{font-family:serif,My Font,monospace}",
 ]
 `;

--- a/test/configCases/css/minimize-value-validity/index.js
+++ b/test/configCases/css/minimize-value-validity/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should keep every value's validity", () => {
+	// The emitted stylesheet is snapshotted in test.config.js (afterExecute);
+	// this keeps a runnable entry so the chunk and its `.css` are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-value-validity/style.css
+++ b/test/configCases/css/minimize-value-validity/style.css
@@ -32,3 +32,10 @@
 .k { border-image-width: 0px }
 /*! `flex:0` is grow=0,basis=0%; `flex:0px` is grow=1,basis=0px */
 .l { flex: 0px }
+
+/*! a negative zero keeps its fraction too, and still drops the leading zero */
+.m { grid-row: -0.0 }
+/*! the shared slot is the second entry here, not the first */
+.n { font-family: serif, "My Font" Extra }
+/*! a lone string in a later slot still unquotes */
+.o { font-family: serif, "My Font", monospace }

--- a/test/configCases/css/minimize-value-validity/style.css
+++ b/test/configCases/css/minimize-value-validity/style.css
@@ -1,0 +1,34 @@
+/* Values where a rewrite decides whether the declaration parses at all. Each
+   was found by the wpt DOM/CSSOM tier: the printer normalized a value the
+   engine had rejected into one it accepts, or the other way round. Verified in
+   headless Chrome — the comment states what the engine does with each. */
+
+/*! invalid: a quoted family beside a bare identifier matches no family list */
+.a { font-family: "Lucida" Grande, sans-serif }
+/*! valid: a lone string is a family, so unquoting it stays one */
+.b { font-family: "Lucida Grande", sans-serif }
+
+/*! invalid: `<integer>` takes no fraction, so this computes `auto` */
+.c { grid-row: 1.0 }
+/*! valid: the fraction is the value, not a spelling of an integer */
+.d { opacity: 1.0 }
+
+/*! invalid: `row` and `column` are one slot, so naming both drops the value */
+.e { grid-auto-flow: row dense column }
+/*! valid: `row` is the initial value and says nothing beside `dense` */
+.f { grid-auto-flow: row dense }
+
+/*! `tab-size` reads a bare number as characters, so the unit is the value */
+.g { tab-size: 0px }
+/*! valid either way: a bare `0` is the length every other property accepts */
+.h { margin: 0px }
+
+/*! Chrome rejects the unitless zero here that the spec allows */
+.i { overflow-clip-margin: 0px content-box }
+
+/*! a bare number here is a multiple of the border width, not a length */
+.j { border-image-outset: 0px }
+/*! the same, and neither was found by a test — the grammar says both */
+.k { border-image-width: 0px }
+/*! `flex:0` is grow=0,basis=0%; `flex:0px` is grow=1,basis=0px */
+.l { flex: 0px }

--- a/test/configCases/css/minimize-value-validity/style.css
+++ b/test/configCases/css/minimize-value-validity/style.css
@@ -1,7 +1,5 @@
-/* Values where a rewrite decides whether the declaration parses at all. Each
-   was found by the wpt DOM/CSSOM tier: the printer normalized a value the
-   engine had rejected into one it accepts, or the other way round. Verified in
-   headless Chrome — the comment states what the engine does with each. */
+/* Values where a rewrite decides whether the declaration parses. Found by the
+   wpt DOM/CSSOM tier, each verified in headless Chrome. */
 
 /*! invalid: a quoted family beside a bare identifier matches no family list */
 .a { font-family: "Lucida" Grande, sans-serif }

--- a/test/configCases/css/minimize-value-validity/test.config.js
+++ b/test/configCases/css/minimize-value-validity/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const readMinifiedSections = require("../../../helpers/readMinifiedSections");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		expect(
+			readMinifiedSections(options.output.path, "bundle0.css")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/css/minimize-value-validity/webpack.config.js
+++ b/test/configCases/css/minimize-value-validity/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+const cssMinify = require("../../../../lib/css/cssMinify");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		// Mirror a real production build: no per-module pathinfo banners.
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// Same wiring as the production default (lib/config/defaults.js): one
+		// minimizer plugin holding both minify functions, each routed by its filter.
+		minimizer: [
+			{
+				apply: (compiler) => {
+					new MinimizerPlugin({
+						test: /\.(?:[cm]?js|css)(\?.*)?$/i,
+						minify: [MinimizerPlugin.terserMinify, cssMinify],
+						minimizerOptions: [{ compress: { passes: 2 } }, {}]
+					}).apply(/** @type {EXPECTED_ANY} */ (compiler));
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -131,9 +131,7 @@ const FILED_WPT_TREE_DEFECTS = new Map();
 const FILED_WPT_VALUE_DEFECTS = new Map([
 	[
 		// `calc()` is clamped at computed-value time and a literal is not, so
-		// `oblique calc(100deg)` computes `oblique 90deg` while `oblique 100deg` is
-		// out of `<angle [-90deg,90deg]>` and drops the declaration. Folding one to
-		// the other therefore turns a working declaration off.
+		// `oblique calc(100deg)` computes `90deg` where `oblique 100deg` is dropped.
 		"font-style:oblique calc(100deg)",
 		"folding a clamped `calc()` to its literal leaves an out-of-range value"
 	],

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -121,15 +121,7 @@ const FILED_WPT_HTML_DEFECTS = new Map([
 	]
 ]);
 
-const FILED_WPT_CSS_DEFECTS = new Map([
-	[
-		// The same defect as `font-family:"Lucida" Grande` below, reached from a
-		// stylesheet: a quoted family beside a bare identifier matches no family
-		// list, and unquoting it makes the engine read one name where it read none.
-		"test/wpt/tools/wave/export/css/result.css",
-		"unquoting a string makes an invalid family list parse"
-	]
-]);
+const FILED_WPT_CSS_DEFECTS = new Map();
 
 // The same, for what webpack's own parser sees over the whole corpus.
 const FILED_WPT_TREE_DEFECTS = new Map();
@@ -138,26 +130,12 @@ const FILED_WPT_TREE_DEFECTS = new Map();
 // the value as written. A printer defect unless the reason says otherwise.
 const FILED_WPT_VALUE_DEFECTS = new Map([
 	[
-		'font-family:"Lucida" Grande, sans-serif',
-		"unquoting a string makes an invalid family list parse"
-	],
-	["grid-row:1.0", "printing `1.0` as `1` makes an invalid <integer> parse"],
-	[
-		"grid-auto-flow:row dense column",
-		"dropping `row` makes an invalid value parse"
-	],
-	["tab-size:0px", "dropping the unit turns a <length> into a <number>"],
-	[
-		"overflow-clip-margin:0px content-box",
-		"dropping the unit changes what the engine computes"
-	],
-	[
-		"overflow-clip-margin:calc(100px - 50px)",
-		"not a printer defect: Chromium echoes the authored `calc()` in the computed value"
-	],
-	[
+		// `calc()` is clamped at computed-value time and a literal is not, so
+		// `oblique calc(100deg)` computes `oblique 90deg` while `oblique 100deg` is
+		// out of `<angle [-90deg,90deg]>` and drops the declaration. Folding one to
+		// the other therefore turns a working declaration off.
 		"font-style:oblique calc(100deg)",
-		"not a printer defect: Chromium echoes the authored `calc()` in the computed value"
+		"folding a clamped `calc()` to its literal leaves an out-of-range value"
 	],
 	[
 		"animation-timing-function:steps(1, jump-start)",

--- a/tooling/generate-css-data.js
+++ b/tooling/generate-css-data.js
@@ -1437,12 +1437,8 @@ const valueLevelNumericTypes = (syntax, propertyTable = properties) => {
 };
 
 /**
- * The properties where dropping a zero length's unit changes what it is.
- * `0px` is a `<dimension>` token and `0` a `<number>` one, so the rewrite is
- * safe only where the grammar offers no `<number>` beside the `<length>` for
- * the bare zero to bind to instead — `tab-size:0` is zero characters where
- * `tab-size:0px` is zero width. Derived, so a property the specs give a second
- * reading tomorrow is covered without anyone noticing it.
+ * The properties whose grammar offers a `<number>` beside the `<length>`, so a
+ * zero losing its unit binds to the other reading (`tab-size:0` is characters).
  * @param {PartialSyntaxTable} propertyTable the `properties.json` to read
  * @returns {string[]} the property names, sorted
  */
@@ -3042,18 +3038,11 @@ const SUPPLEMENT = {
 	// What may follow the `*` a compound selector implies: another simple
 	// selector in the same compound. Selector syntax, not a value grammar.
 	compoundContinuations: [":", ".", "#", "["],
-	// The two a zero's unit is load-bearing in that no grammar says so — every
-	// property whose own syntax offers a bare number beside the length is
-	// derived instead (`collectZeroUnitAmbiguousProperties`). IE 11 drops a
-	// `flex` shorthand whose basis has no unit, and `flex-basis` carries the
-	// same. Chrome rejects `overflow-clip-margin:0` outright, unitless zero
-	// being a length the spec does allow.
+	// Not derivable, no grammar says the unit matters here: IE 11 drops a unitless
+	// `flex-basis`, and Chrome rejects `overflow-clip-margin:0` the spec allows.
 	zeroUnitKeepingProperties: ["flex-basis", "overflow-clip-margin"],
-	// Where an engine rejects a `calc()` the spec allows, so folding one to the
-	// plain value it equals would switch a declaration the engine threw away back
-	// on. Chrome takes no `calc()` at all in `overflow-clip-margin` — the same
-	// property whose bare `0` it also refuses. Not derivable: a grammar naming
-	// `<length>` says `calc()` is valid there.
+	// Not derivable, a grammar naming `<length>` says `calc()` is valid there:
+	// Chrome takes no `calc()` in `overflow-clip-margin`, as it takes no bare `0`.
 	calcRejectingProperties: ["overflow-clip-margin"],
 	// CSS Backgrounds 3 §3.9 / CSS Masking 1 §4.5: these spell an omitted second
 	// value `auto`, not the first repeated. Their shared grammar cannot say so.

--- a/tooling/generate-css-data.js
+++ b/tooling/generate-css-data.js
@@ -1365,6 +1365,102 @@ const collectIntegerProperties = () => {
 };
 
 /**
+ * The numeric types a value may itself be, following `<production>` and
+ * `<'property'>` references but stopping at a function — a `<number>` inside
+ * `rgb()` or a gradient is that function's argument, not something the value
+ * could have been written as.
+ * @param {string} syntax a value definition
+ * @param {PartialSyntaxTable} propertyTable where a `<'property'>` is read
+ * @returns {Set<string>} the numeric type names reachable at the value's level
+ */
+const valueLevelNumericTypes = (syntax, propertyTable = properties) => {
+	/** @type {Set<string>} */
+	const found = new Set();
+	/** @type {Set<string>} */
+	const seen = new Set();
+	/**
+	 * @param {SyntaxNode} node the node to read
+	 * @returns {void}
+	 */
+	const walk = (node) => {
+		switch (node.type) {
+			case "oneOf":
+			case "anyOf":
+			case "allOf":
+			case "sequence":
+				for (const item of node.items) walk(item);
+				return;
+			case "group":
+			case "parens":
+			case "multiplier":
+				walk(node.body);
+				return;
+			// Deliberately not entered: what a function takes is not what the
+			// property takes.
+			case "function":
+				return;
+			case "property": {
+				const nested = propertyTable[node.name];
+				if (
+					nested !== undefined &&
+					typeof nested.syntax === "string" &&
+					!seen.has(`'${node.name}`)
+				) {
+					seen.add(`'${node.name}`);
+					walk(grammarOf(nested.syntax));
+				}
+				return;
+			}
+			case "type": {
+				if (NUMERIC_TYPES.has(node.name)) {
+					found.add(node.name);
+					return;
+				}
+				if (node.name === "length-percentage") {
+					found.add("length");
+					found.add("percentage");
+					return;
+				}
+				const nested = definitions.get(node.name);
+				if (nested !== undefined && !seen.has(node.name)) {
+					seen.add(node.name);
+					walk(grammarOf(nested));
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	};
+	walk(grammarOf(syntax));
+	return found;
+};
+
+/**
+ * The properties where dropping a zero length's unit changes what it is.
+ * `0px` is a `<dimension>` token and `0` a `<number>` one, so the rewrite is
+ * safe only where the grammar offers no `<number>` beside the `<length>` for
+ * the bare zero to bind to instead — `tab-size:0` is zero characters where
+ * `tab-size:0px` is zero width. Derived, so a property the specs give a second
+ * reading tomorrow is covered without anyone noticing it.
+ * @param {PartialSyntaxTable} propertyTable the `properties.json` to read
+ * @returns {string[]} the property names, sorted
+ */
+const collectZeroUnitAmbiguousProperties = (propertyTable = properties) => {
+	const out = [];
+	for (const [name, entry] of Object.entries(propertyTable)) {
+		if (typeof entry.syntax !== "string") continue;
+		const kinds = valueLevelNumericTypes(entry.syntax, propertyTable);
+		// `<integer>` spells the same token an `<integer>`-only grammar takes, so
+		// `tab-size:0` binds to it exactly as `line-height:0` binds to `<number>`.
+		if (kinds.has("length") && (kinds.has("number") || kinds.has("integer"))) {
+			out.push(name);
+		}
+	}
+	return out.sort();
+};
+
+/**
  * The properties whose whole value is `<number> | <percentage>` reading the two
  * as one quantity, a percentage being the number hundredfold. Only the whole
  * value: a percentage beside a length means something else again.
@@ -2597,18 +2693,20 @@ const collectNthNamedEquivalents = () => {
 
 /**
  * Each property whose initial keyword may be dropped from a multi-component
- * value, as `property -> keyword`. The keyword comes from the property table,
- * and it must really be the initial and really be one alternative of a top-level
- * `||` group, so a spec moving either way fails generation rather than the page.
+ * value, as `property -> [keyword, slot]`. The keyword comes from the property
+ * table, and it must really be the initial and really be one alternative of a
+ * top-level `||` group, so a spec moving either way fails generation rather than
+ * the page. `slot` is every keyword that group offers — the alternatives the
+ * keyword is chosen among, which a value may name only once.
  * @param {string[]} names the properties stated to have one
  * @param {PartialPropertyTable} propertyTable where their grammars are read
- * @returns {[string, string][]} `[property, keyword]`, sorted
+ * @returns {[string, [string, string[]]][]} `[property, [keyword, slot]]`, sorted
  */
 const collectOmittableInitialKeywords = (
 	names = SUPPLEMENT.omittableInitialKeywords,
 	propertyTable = properties
 ) => {
-	/** @type {[string, string][]} */
+	/** @type {[string, [string, string[]]][]} */
 	const out = [];
 	for (const name of [...names].sort()) {
 		const property = propertyTable[name];
@@ -2625,11 +2723,27 @@ const collectOmittableInitialKeywords = (
 				: node.type === "oneOf"
 					? node.items.some(isInitial)
 					: node.type === "keyword" && node.name === initial;
+		/**
+		 * @param {SyntaxNode} node the group the keyword was found in
+		 * @returns {string[]} every keyword it offers
+		 */
+		const keywords = (node) => {
+			/** @type {string[]} */
+			const found = [];
+			walkValueSyntax(node, (each) => {
+				if (each.type === "keyword") found.push(each.name);
+			});
+			return found;
+		};
+		const group =
+			tree.type === "anyOf"
+				? tree.items.find((item) => isInitial(item))
+				: undefined;
 		// The supplement states the keyword is droppable; mdn-data must still agree.
-		if (tree.type !== "anyOf" || !tree.items.some(isInitial)) {
+		if (group === undefined) {
 			throw new Error(`No omittable '${initial}' in '${name}': ${syntax}`);
 		}
-		out.push([name, initial]);
+		out.push([name, [initial, keywords(group).sort()]]);
 	}
 	return out;
 };
@@ -2855,7 +2969,7 @@ const eighthTurnEntries = (values) => {
 // Spec prose no dataset states: an equivalence between two spellings, or a
 // judgement about what a construct still does. Each carries the reason it has to
 // be written out rather than derived.
-/** @type {{ cssWideKeywords: string[], cubicBezierKeywords: [string, string][], flexKeywords: [string, string][], fontWeightNumbers: [string, string][], fontStretchPercentages: [string, string][], filterFunctionOmitted: [string, string][], positionKeywordPercentages: [string, string][], legacyPseudoElements: string[], compoundContinuations: string[], zeroUnitKeepingProperties: string[], autoSecondValueProperties: string[], defaultGradientDirections: string[], xAxisTransforms: [string, string][], negativeAcceptingProperties: string[], placeShorthands: string[], oneValuePairShorthands: string[], familyShorthands: string[], omittableInitialKeywords: string[], pairLonghandOverrides: [string, string[]][], droppableWhenEmptyAtRules: string[], replacedByNameAtRules: string[], classSpellings: [string, string[]][], absoluteUnitScale: [string, string, number][], unitConversionTargets: string[], angleUnits: string[], quarterTurnAngle: [string, number][], eighthTurnSine: (number | null)[], eighthTurnTangent: (number | null)[], mathFunctionFold: [string, string, string, string, string | null, boolean][], mathPrimitives: [string, string][], predefinedCounterStyles: string[], predefinedCounterNames: string[], cssModulesKeywordSupplement: [string, string, number][] }} */
+/** @type {{ cssWideKeywords: string[], cubicBezierKeywords: [string, string][], flexKeywords: [string, string][], fontWeightNumbers: [string, string][], fontStretchPercentages: [string, string][], filterFunctionOmitted: [string, string][], positionKeywordPercentages: [string, string][], legacyPseudoElements: string[], compoundContinuations: string[], zeroUnitKeepingProperties: string[], calcRejectingProperties: string[], autoSecondValueProperties: string[], defaultGradientDirections: string[], xAxisTransforms: [string, string][], negativeAcceptingProperties: string[], placeShorthands: string[], oneValuePairShorthands: string[], familyShorthands: string[], omittableInitialKeywords: string[], pairLonghandOverrides: [string, string[]][], droppableWhenEmptyAtRules: string[], replacedByNameAtRules: string[], classSpellings: [string, string[]][], absoluteUnitScale: [string, string, number][], unitConversionTargets: string[], angleUnits: string[], quarterTurnAngle: [string, number][], eighthTurnSine: (number | null)[], eighthTurnTangent: (number | null)[], mathFunctionFold: [string, string, string, string, string | null, boolean][], mathPrimitives: [string, string][], predefinedCounterStyles: string[], predefinedCounterNames: string[], cssModulesKeywordSupplement: [string, string, number][] }} */
 
 const SUPPLEMENT = {
 	// CSS Values 4's list. `mdn-data` has no `css-wide-keyword` production.
@@ -2928,10 +3042,19 @@ const SUPPLEMENT = {
 	// What may follow the `*` a compound selector implies: another simple
 	// selector in the same compound. Selector syntax, not a value grammar.
 	compoundContinuations: [":", ".", "#", "["],
-	// `flex-basis` is the one place a zero's unit is still load-bearing: IE 11
-	// drops a `flex` shorthand whose basis has none, and the shorthand carries
-	// one too.
-	zeroUnitKeepingProperties: ["flex", "flex-basis"],
+	// The two a zero's unit is load-bearing in that no grammar says so — every
+	// property whose own syntax offers a bare number beside the length is
+	// derived instead (`collectZeroUnitAmbiguousProperties`). IE 11 drops a
+	// `flex` shorthand whose basis has no unit, and `flex-basis` carries the
+	// same. Chrome rejects `overflow-clip-margin:0` outright, unitless zero
+	// being a length the spec does allow.
+	zeroUnitKeepingProperties: ["flex-basis", "overflow-clip-margin"],
+	// Where an engine rejects a `calc()` the spec allows, so folding one to the
+	// plain value it equals would switch a declaration the engine threw away back
+	// on. Chrome takes no `calc()` at all in `overflow-clip-margin` — the same
+	// property whose bare `0` it also refuses. Not derivable: a grammar naming
+	// `<length>` says `calc()` is valid there.
+	calcRejectingProperties: ["overflow-clip-margin"],
 	// CSS Backgrounds 3 §3.9 / CSS Masking 1 §4.5: these spell an omitted second
 	// value `auto`, not the first repeated. Their shared grammar cannot say so.
 	autoSecondValueProperties: ["background-size", "mask-size"],
@@ -4966,6 +5089,12 @@ const collectData = () => {
 		mathFunctionArity
 	);
 	const integerProperties = collectIntegerProperties();
+	const zeroUnitKeepingProperties = [
+		...new Set([
+			...SUPPLEMENT.zeroUnitKeepingProperties,
+			...collectZeroUnitAmbiguousProperties()
+		])
+	].sort();
 	const alphaValueProperties = collectAlphaValueProperties();
 	const ratioProperties = collectRatioProperties();
 	const cssModulesKeywords = collectCssModulesKeywords();
@@ -5110,8 +5239,18 @@ const SLASH_LONGHANDS = new Map([${slashLonghands
 const MERGE_LONGHANDS = ${setLiteral(lowerSorted(mergeLonghands))};
 
 // The initial keyword each of these may drop when another component stands
-// beside it: omitting the group it belongs to leaves exactly that keyword.
-const OMITTABLE_INITIAL_KEYWORDS = ${mapLiteral(omittableInitialKeywords)};
+// beside it: omitting the group it belongs to leaves exactly that keyword. The
+// second half is every keyword that group offers — a value naming two of them
+// (\`grid-auto-flow:row dense column\`) fills the slot twice and is invalid, so
+// dropping the initial there would print a value the author never wrote.
+/** @type {Map<string, [string, string[]]>} */
+// prettier-ignore
+const OMITTABLE_INITIAL_KEYWORDS = new Map([${omittableInitialKeywords
+		.map(
+			([name, [keyword, slot]]) =>
+				`["${name}", ["${keyword}", ${JSON.stringify(slot)}]]`
+		)
+		.join(", ")}]);
 
 // What each of those longhands accepts as a whole value: the keywords it names,
 // and the value classes it reaches. A value acceptable to a second slot is what
@@ -5371,10 +5510,15 @@ const LEGACY_PSEUDO_ELEMENTS = ${setLiteral(SUPPLEMENT.legacyPseudoElements)};
 // combinator instead, and \`|\` makes the \`*\` a namespace's, not a redundant one.
 const COMPOUND_CONTINUATIONS = ${setLiteral(SUPPLEMENT.compoundContinuations)};
 
-// The properties whose zero length keeps its unit — the one place it is still
-// load-bearing.
-const ZERO_UNIT_KEEPING_PROPERTIES = ${setLiteral(
-		SUPPLEMENT.zeroUnitKeepingProperties
+// The properties whose zero length keeps its unit: those whose own grammar
+// offers a bare number beside the length, so the unit is what picks the
+// reading, and the two an engine reads its own way.
+const ZERO_UNIT_KEEPING_PROPERTIES = ${setLiteral(zeroUnitKeepingProperties)};
+
+// The properties an engine takes no \`calc()\` in, so one stays as written
+// rather than folding to the value it equals.
+const CALC_REJECTING_PROPERTIES = ${setLiteral(
+		SUPPLEMENT.calcRejectingProperties
 	)};
 
 // At-rules whose empty block is inert, so dropping it changes nothing.
@@ -5593,7 +5737,7 @@ module.exports.AUTO_SECOND_VALUE_PROPERTIES = AUTO_SECOND_VALUE_PROPERTIES;
 module.exports.BOX_FAMILY_PREFIX = BOX_FAMILY_PREFIX;
 module.exports.BOX_LONGHANDS = BOX_LONGHANDS;
 module.exports.BOX_SHORTHANDS = BOX_SHORTHANDS;
-module.exports.COLOR_ARGUMENT_FUNCTIONS = COLOR_ARGUMENT_FUNCTIONS;
+module.exports.CALC_REJECTING_PROPERTIES = CALC_REJECTING_PROPERTIES;\nmodule.exports.COLOR_ARGUMENT_FUNCTIONS = COLOR_ARGUMENT_FUNCTIONS;
 module.exports.COLOR_KEYWORDS = COLOR_KEYWORDS;\nmodule.exports.COLOR_NAME_TO_SHORTEST = COLOR_NAME_TO_SHORTEST;\nmodule.exports.COLOR_ONLY_PROPERTIES = COLOR_ONLY_PROPERTIES;
 module.exports.COMPOUND_CONTINUATIONS = COMPOUND_CONTINUATIONS;
 module.exports.CSS_MODULES_KEYWORDS = CSS_MODULES_KEYWORDS;
@@ -5717,6 +5861,8 @@ module.exports.collectOmittableInitialKeywords =
 module.exports.collectRatioProperties = collectRatioProperties;
 module.exports.collectUnsharedLonghandKeywords =
 	collectUnsharedLonghandKeywords;
+module.exports.collectZeroUnitAmbiguousProperties =
+	collectZeroUnitAmbiguousProperties;
 module.exports.isSpelledSyntax = isSpelledSyntax;
 module.exports.longhandType = longhandType;
 module.exports.parseValueSyntax = parseValueSyntax;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The wpt DOM/CSSOM tier added in #21743 caught the CSS printer rewriting values across the line an engine draws between a declaration it keeps and one it throws away — in both directions. `font-family:"Lucida" Grande` and `grid-row:1.0` are invalid, and the printed forms parse; `overflow-clip-margin:0px content-box` is valid, and the printed form does not. Each is now answered from the property's grammar rather than by name: the slot an omittable initial keyword belongs to is read off the value definition, and the properties a bare zero is ambiguous in are those whose own syntax offers a number beside the length — read at the value's own level, so a number inside a gradient is not mistaken for one the property could take. That derivation covers 14 properties, two of which (`border-image-outset`, `border-image-width`) no test had reported, and it subsumes the `flex` entry previously stated by hand for an unrelated reason. What stays stated is what no grammar says, each with the engine behaviour it rests on: IE 11 dropping a unitless `flex-basis`, and Chrome refusing both the bare zero and any `calc()` in `overflow-clip-margin`. Refs #21743.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/css/minimize-value-validity` (a new case pairing each rewritten value with a valid one that must still shorten), three cases in `test/CssValueSyntax.unittest.js` pinning the derivation, and seven filed defects deleted from `test/syntaxEquivalence.spectest.js`, which asserts both directions so a stale entry fails as loudly as a live one.

**Does this PR introduce a breaking change?**

No. Output grows only where a rewrite was unsafe: six of the fourteen derived properties (`columns`, `font`, `line-height`, `mask-border-*`, `stroke-*`) keep a unit they did not strictly need, which is the conservative side of a rule that stays correct as the specs move.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. Claude reproduced each divergence in headless Chrome, located the rewrite site, wrote the derivation and the tests, and re-verified every value's computed style against the engine before and after. All findings were checked against a real engine rather than accepted from the model; the two previously unreported bugs came out of the derivation and were confirmed the same way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnmztbjhQpVCTYnrextRu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS minification to preserve valid output for integer-only properties, zero values, shorthand declarations, and font-family lists.
  * Prevented invalid transformations when simplifying `calc()` expressions in properties that require `calc()` syntax.
  * Corrected handling of initial keywords and negative zero values to maintain browser-compatible CSS behavior.

* **Tests**
  * Added coverage for CSS value grammar edge cases and production minification output.

* **Release**
  * Included as a patch-level fix for webpack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->