### PR TITLE
fix(performance): report the cache-effectiveness reasons in a stable order

### DIFF
--- a/.changeset/077-cache-effectiveness-reason-order.md
+++ b/.changeset/077-cache-effectiveness-reason-order.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Report the cache-effectiveness hint's reasons in a stable order.

--- a/lib/performance/CacheEffectivenessPlugin.js
+++ b/lib/performance/CacheEffectivenessPlugin.js
@@ -79,7 +79,13 @@ class CacheEffectivenessPlugin {
 
 				if (!warmRebuild && uncacheable === 0) return;
 
-				const sorted = [...modulesByReason].sort((a, b) => b[1] - a[1]);
+				// Most frequent first, and by reason where two are as frequent: the
+				// map is keyed in the order the modules were walked, which is not the
+				// same twice, and only three reasons are reported — so an unbroken tie
+				// would vary which of them a build names at all.
+				const sorted = [...modulesByReason].sort(
+					(a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
+				);
 				const reasons = sorted
 					.slice(0, MAX_REPORTED_REASONS)
 					.map(

--- a/test/StatsTestCases.basictest.js
+++ b/test/StatsTestCases.basictest.js
@@ -289,19 +289,6 @@ describe("StatsTestCases", () => {
 						// Jest v27: at Object.<anonymous>.module.exports
 						// Jest v30: at Object.module.exports
 						.replace(/Object\.<anonymous>\./g, "Object.");
-					actual = actual.replace(
-						/(HINT in module caching:[^\n]*? on every build: )([^\n]+?)(\.)/g,
-						(_, prefix, value, suffix) => {
-							const reasons = value.split(", ");
-							const tail = reasons[reasons.length - 1];
-							const hasTail = /^and \d+ other reason/.test(tail);
-							const sortable = hasTail ? reasons.slice(0, -1) : reasons;
-							sortable.sort();
-							return `${prefix}${[...sortable, ...(hasTail ? [tail] : [])].join(
-								", "
-							)}${suffix}`;
-						}
-					);
 					// Normalize logger trace frames across engines: V8 emits one
 					// "at fn (file:line:col)" frame, while JSC (Bun) emits extra
 					// internal frames, omits the function name, and reports different

--- a/test/statsCases/performance-cache-effectiveness/__snapshots__/StatsTest.snap
+++ b/test/statsCases/performance-cache-effectiveness/__snapshots__/StatsTest.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`StatsTestCases performance-cache-effectiveness should print correct stats for performance-cache-effectiveness 1`] = `
-"HINT in module caching: 6 modules are not cacheable, so they rebuild on every build: Xdir/performance-cache-effectiveness/no-cache-loader.js (2 modules), a runtime value changes every build (1 module), an external resource is read at build time (1 module), and 2 other reasons.
+"HINT in module caching: 6 modules are not cacheable, so they rebuild on every build: Xdir/performance-cache-effectiveness/no-cache-loader.js (2 modules), a generated file has no stable content (1 module), a runtime value changes every build (1 module), and 2 other reasons.
 A loader calling 'this.cacheable(false)', or a value that changes every build, prevents reuse. Stats list the modules individually as '[not cacheable]'.
 For more info visit https://webpack.js.org/configuration/cache/"
 `;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`CacheEffectivenessPlugin` sorts the hint's reasons by module count alone, so two reasons as frequent as each other keep the order `modulesByReason` happened to key them in — which is the order the module walk reached them, and not the same twice. Only `MAX_REPORTED_REASONS` (3) are reported, so the unbroken tie decides not merely their order but **which of them a build names at all**: the same input reports a different pair on consecutive runs. The `performance-cache-effectiveness` stats snapshot has now failed this way four times across two pull requests and three platforms (Linux/V8, Bun/JSC, macOS), each time naming a different set of reasons, and it fails PRs whose diffs are nowhere near this code. Breaking the tie on the reason itself makes the report deterministic, and the sort that `StatsTestCases.basictest.js` had grown to hide the symptom comes back out — it could only reorder the reasons that survived the truncation, never restore one the tie had dropped.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No new case: `test/statsCases/performance-cache-effectiveness` already covers it and its snapshot is updated here — the fixture ties four reasons at one module each, which is what made it the case that kept failing. The masking normalization in `test/StatsTestCases.basictest.js` is removed in the same commit.

**Does this PR introduce a breaking change?**

No. The hint reports the same reasons; only the order among equally frequent ones is now fixed, and with it which are kept when more than three exist.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. Claude traced the non-determinism from a CI failure to the sort, confirmed it by the snapshot diff (the reported reasons changed, not just their order), wrote the tie-break and removed the test-side normalization, and re-ran the stats suite (145 tests, 144 snapshots) before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnmztbjhQpVCTYnrextRu9)_