### PR TITLE
chore(ci): rely on latest quality checks

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   anti-slop:
-    uses: webpack/.github/.github/workflows/pr-quality.yml@a03552c758d8c244b3cfc2985aff7020469e0473
+    uses: webpack/.github/.github/workflows/pr-quality.yml@main


### PR DESCRIPTION
As titled, should be fine from a security standpoint since we control both repos, but cc @webpack/security-wg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request quality checks to use the latest shared workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->