### PR TITLE
fix(analyzable): stop doubling a relative public path, widen what bakes

### DIFF
--- a/.changeset/029-analyzable-eval-wrapper-and-wasm-public-path.md
+++ b/.changeset/029-analyzable-eval-wrapper-and-wasm-public-path.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Drop the asset javascript wrapper under an `eval` devtool, and bake a wasm binary's url under an origin-rooted public path.

--- a/.changeset/029-analyzable-eval-wrapper-and-wasm-public-path.md
+++ b/.changeset/029-analyzable-eval-wrapper-and-wasm-public-path.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Drop the asset javascript wrapper under an `eval` devtool, and bake a wasm binary's url under an origin-rooted public path.

--- a/.changeset/029-analyzable-public-path-and-asset-wrapper.md
+++ b/.changeset/029-analyzable-public-path-and-asset-wrapper.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Stop doubling a relative `output.publicPath` in the chunks webpack loads through it, bake a wasm url under an origin-rooted one, and drop the asset javascript wrapper under an `eval` devtool.

--- a/.changeset/029-analyzable-public-path-and-asset-wrapper.md
+++ b/.changeset/029-analyzable-public-path-and-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Stop doubling a relative `output.publicPath` in the chunks webpack loads through it, bake a wasm url under an origin-rooted one, and drop the asset javascript wrapper under an `eval` devtool.
+Fix the public path an analyzable url carries, and widen where one is baked.

--- a/.changeset/029-asset-wrapper-under-eval-devtool.md
+++ b/.changeset/029-asset-wrapper-under-eval-devtool.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Drop the asset javascript wrapper under an `eval` devtool.

--- a/.changeset/029-asset-wrapper-under-eval-devtool.md
+++ b/.changeset/029-asset-wrapper-under-eval-devtool.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Drop the asset javascript wrapper under an `eval` devtool.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -80,10 +80,17 @@ const isLiteralPart = (part) => part[0] === "literal";
  * @param {SpecifierPart[] | null} parts pieces of a name
  * @returns {string | null} the text, or `null` when they are not all literal
  */
-const literalText = (parts) =>
-	parts !== null && parts.every(isLiteralPart)
-		? parts.map((part) => part[1]).join("")
-		: null;
+const literalText = (parts) => {
+	if (parts === null) return null;
+	// Built in one pass rather than tested and then joined: every specifier asks, and
+	// a stand-in in the first part answers without reading the rest.
+	let text = "";
+	for (const part of parts) {
+		if (!isLiteralPart(part)) return null;
+		text += part[1];
+	}
+	return text;
+};
 
 /**
  * Whether a public path reaches the same place from any base. A relative one does
@@ -146,6 +153,7 @@ const SERVED_BAILOUT =
 
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
+/** @typedef {import("../declarations/WebpackOptions").WasmLoading} WasmLoading */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
 /** @typedef {"import" | "url" | "url-inline" | "wasm" | "wasm-relative"} AnalyzableForm */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
@@ -904,19 +912,15 @@ class RuntimeTemplate {
 	 */
 	_wasmFetchingGroups() {
 		if (this._wasmFetchingGroupSet === undefined) {
-			const { wasmLoading: globalWasmLoading } = this.outputOptions;
 			/** @type {Set<string>} */
 			const fetching = new Set();
 			/** @type {Map<string, string> | undefined} */
 			let groups;
 			for (const chunk of this.compilation.chunks) {
-				const entryOptions = chunk.getEntryOptions();
-				if (!entryOptions) continue;
-				const wasmLoading =
-					entryOptions.wasmLoading !== undefined
-						? entryOptions.wasmLoading
-						: globalWasmLoading;
-				if (wasmLoading !== "fetch") continue;
+				// Only an entry names a loader; every other chunk of the runtime is served
+				// by the one its entry asked for, so it says nothing on its own.
+				if (!chunk.getEntryOptions()) continue;
+				if (this._chunkWasmLoading(chunk) !== "fetch") continue;
 				// Built only once something fetches, so nothing pays for the grouping.
 				if (groups === undefined) groups = this._wasmRuntimeGroups();
 				const named = /** @type {Map<string, string>} */ (groups);
@@ -2526,7 +2530,9 @@ class RuntimeTemplate {
 				/** @type {string} */ (outputOptions.path),
 				true
 			),
-			loaded: !chunk.canBeInitial()
+			// A chunk in an initial group and an async one both is served at two urls,
+			// one public path apart, so no one literal in it is right for both.
+			loaded: chunk.isOnlyInitial() ? false : chunk.canBeInitial() ? null : true
 		};
 		this._placementByChunk.set(chunk, placement);
 		return placement;
@@ -2986,16 +2992,24 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when every holding chunk fetches
 	 */
 	_wasmChunksFetch(module, chunkGraph) {
-		const { outputOptions } = this;
 		for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
-			const entryOptions = chunk.getEntryOptions();
-			const wasmLoading =
-				entryOptions && entryOptions.wasmLoading !== undefined
-					? entryOptions.wasmLoading
-					: outputOptions.wasmLoading;
-			if (wasmLoading !== "fetch") return false;
+			if (this._chunkWasmLoading(chunk) !== "fetch") return false;
 		}
 		return true;
+	}
+
+	/**
+	 * The loader a chunk's WebAssembly is read with. An entry names one, and every
+	 * other chunk of the runtime is served by the one its entry asked for — so one
+	 * that is no entry answers with what `output` says.
+	 * @param {Chunk} chunk the chunk
+	 * @returns {WasmLoading} the loader it is served by
+	 */
+	_chunkWasmLoading(chunk) {
+		const entryOptions = chunk.getEntryOptions();
+		return entryOptions && entryOptions.wasmLoading !== undefined
+			? entryOptions.wasmLoading
+			: this.outputOptions.wasmLoading;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -128,6 +128,10 @@ const TYPES_WITHOUT_CHUNK_HANDLER = new Set([
 const DEFER_BAILOUT =
 	"a hashed name needs optimization.realContentHash, or no emitted javascript named by its content";
 
+// Why a public path needing a base could not be spelled from the chunk holding it.
+const SERVED_BAILOUT =
+	"this module is in a chunk webpack loads through output.publicPath and in one it does not, so no one path back to the output root fits both";
+
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
@@ -2464,6 +2468,41 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * The `../` path back out of the public path the chunks holding a reference are
+	 * served under. The chunk loader fetches a chunk through `output.publicPath`, so
+	 * such a chunk sits one public path below the output root the runtime resolves
+	 * against, and a literal read from it climbs back out before spelling that path
+	 * again — where the two meet they cancel, which is why an initial chunk, fetched
+	 * by the host instead, needs neither. Asked only of a public path that needs a
+	 * base; one that does not names the same place from either.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {string | null} the path, `""` where nothing is served under it, or
+	 * `null` where the chunks disagree and no one path is right for all of them
+	 */
+	_publicPathUndo(module, chunkGraph) {
+		/** @type {boolean | undefined} */
+		let loaded;
+		for (const chunk of this._moduleChunks(module, chunkGraph)) {
+			const own = !chunk.canBeInitial();
+			if (loaded === undefined) {
+				loaded = own;
+			} else if (loaded !== own) {
+				return null;
+			}
+		}
+		if (loaded !== true) return "";
+		const shape = this._publicPathShape();
+		if (shape === undefined) return null;
+		const undo = getUndoPath(
+			`${shape}x`,
+			/** @type {string} */ (this.outputOptions.path),
+			true
+		);
+		return undo === "./" ? "" : undo;
+	}
+
+	/**
 	 * Computes the `../`-path from the consuming module's chunk(s) back to the output
 	 * root, so a chunk or asset can be referenced relative to `import.meta.url`. Returns
 	 * `null` when the module lives in chunks of different depths (no single path works).
@@ -2615,24 +2654,37 @@ class RuntimeTemplate {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
+		const shape = this._publicPathShape();
+		if (shape === undefined) return null;
+		if (isBaseIndependent(shape)) {
+			const resolved = this._resolvePublicPathPrefix(
+				publicPath,
+				consumingModule,
+				chunks
+			);
+			return resolved === null ? null : specifier(resolved);
+		}
+		const climb = this._publicPathUndo(consumingModule, chunkGraph);
+		if (climb === null) {
+			this._analyzableBailout(consumingModule, SERVED_BAILOUT);
+			return null;
+		}
+		// The runtime imports it from the chunk holding the runtime, which is the output
+		// root; a baked one is read from the chunk it sits in, so a public path that
+		// needs a base gets the `../` path back to that root in front of it.
+		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
+		/** @type {SpecifierPart[]} */
+		const head = [undo === null ? ["undo", ""] : ["literal", undo]];
+		// A chunk webpack loaded already sits inside the public path, so climbing back
+		// out of it only to spell it again names the place it started from.
+		if (climb !== "") return specifier(head);
 		const resolved = this._resolvePublicPathPrefix(
 			publicPath,
 			consumingModule,
 			chunks
 		);
 		if (resolved === null) return null;
-		// The runtime imports it from the chunk holding the runtime, which is the output
-		// root; a baked one is read from the chunk it sits in, so a public path that
-		// needs a base gets the `../` path back to that root in front of it.
-		const shape = this._publicPathShape();
-		if (shape === undefined) return null;
-		if (isBaseIndependent(shape)) return specifier(resolved);
-		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
-		return specifier(
-			undo === null
-				? [["undo", ""], ...rootedParts(resolved)]
-				: [["literal", undo], ...rootedParts(resolved)]
-		);
+		return specifier([...head, ...rootedParts(resolved)]);
 	}
 
 	/**
@@ -2773,24 +2825,43 @@ class RuntimeTemplate {
 		};
 		/** @type {SpecifierPart[]} */
 		let prefix = [];
+		/** @type {SpecifierPart[]} */
+		let climbParts = [];
 		if (bakePublicPath && publicPath !== "auto") {
-			const resolved = this._resolvePublicPathPrefix(
-				/** @type {PublicPath} */ (publicPath),
-				module,
-				chunks
-			);
 			const shape = this._publicPathShape();
-			if (resolved === null || shape === undefined) return null;
+			if (shape === undefined) return null;
+			const resolve = () =>
+				this._resolvePublicPathPrefix(
+					/** @type {PublicPath} */ (publicPath),
+					module,
+					chunks
+				);
 			if (isBaseIndependent(shape)) {
+				const resolved = resolve();
+				if (resolved === null) return null;
 				return specifier([...resolved, ...file]);
 			}
-			prefix = rootedParts(resolved);
+			const climb = this._publicPathUndo(module, chunkGraph);
+			if (climb === null) {
+				this._analyzableBailout(module, SERVED_BAILOUT);
+				return null;
+			}
+			// A chunk webpack loaded already sits inside the public path, so with nothing
+			// between them, climbing back out only to spell it again names the place it
+			// started from. A `baseUri` does sit between them, so both are written.
+			if (climb === "" || relativeBase !== undefined) {
+				const resolved = resolve();
+				if (resolved === null) return null;
+				prefix = rootedParts(resolved);
+				if (climb !== "") climbParts = [["literal", climb]];
+			}
 		}
 		const undo = this._getModuleUndoPath(module, chunkGraph);
 		// Different depths — no one `../` path is right for every asset the reference is
 		// emitted into, so the deferred pass builds each asset's own.
 		return specifier([
 			undo === null ? ["undo", ""] : ["literal", undo],
+			...climbParts,
 			...(relativeBase === undefined
 				? []
 				: /** @type {SpecifierPart[]} */ ([["literal", relativeBase]])),

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -507,6 +507,10 @@ class RuntimeTemplate {
 			return true;
 		}
 
+		// `url-inline` asks whether the file can be named at the call site at all, and
+		// its `.p + <file>` fallback spells that without `import.meta` — so neither gate
+		// below rules it out, and the asset's javascript wrapper stays dropped.
+		if (form === "url-inline") return true;
 		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
 		// emitted by the module chunk loader either way, so only the url forms check.
 		if (!this.supportsEcmaScriptModuleSyntax()) {
@@ -526,7 +530,7 @@ class RuntimeTemplate {
 			);
 			return false;
 		}
-		if (form === "url" || form === "url-inline") return true;
+		if (form === "url") return true;
 		// A bare relative URL is what `__webpack_require__.p + path` means only under an
 		// `auto` public path; anything else has to be baked, which is the "wasm" form.
 		if (form === "wasm-relative") {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -128,6 +128,18 @@ const TYPES_WITHOUT_CHUNK_HANDLER = new Set([
 const DEFER_BAILOUT =
 	"a hashed name needs optimization.realContentHash, or no emitted javascript named by its content";
 
+/**
+ * Where a literal is read from — the `../` path back to the output root, and whether
+ * the chunk loader fetched the chunk it sits in through `output.publicPath`.
+ * @typedef {object} Placement
+ * @property {string | null} undo the path back to the output root
+ * @property {boolean | null} loaded whether the chunk loader fetched the chunk
+ */
+
+// A reference in no chunk at all: nothing is known about where it is read from.
+/** @type {Placement} */
+const NO_PLACEMENT = { undo: null, loaded: null };
+
 // Why a public path needing a base could not be spelled from the chunk holding it.
 const SERVED_BAILOUT =
 	"this module is in a chunk webpack loads through output.publicPath and in one it does not, so no one path back to the output root fits both";
@@ -150,7 +162,6 @@ const SERVED_BAILOUT =
 /** @typedef {import("./ModuleGraph")} ModuleGraph */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
-/** @typedef {import("./util/runtime").RuntimeSpecSortableSet} RuntimeSpecSortableSet */
 /** @typedef {import("./dependencies/ImportPhase").ImportPhaseType} ImportPhaseType */
 /** @typedef {import("./NormalModuleFactory").ModuleDependency} ModuleDependency */
 
@@ -268,10 +279,16 @@ class RuntimeTemplate {
 		this._chunkNamedWithoutContent = new WeakMap();
 		/** @type {string | false | undefined} */
 		this._publicPathShapeText = undefined;
+		/** @type {string | null | undefined} */
+		this._publicPathClimbText = undefined;
+		/** @type {WeakMap<Chunk, Placement>} */
+		this._placementByChunk = new WeakMap();
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
 		/** @type {Map<string, string> | undefined} */
 		this._wasmRuntimeGroupsByKey = undefined;
+		/** @type {Set<string> | false | undefined} */
+		this._wasmFetchingGroupSet = undefined;
 	}
 
 	isIIFE() {
@@ -540,10 +557,9 @@ class RuntimeTemplate {
 		// here, rather than built at runtime under an `import.meta.url` base.
 		const { publicPath, webassemblyModuleFilename } = outputOptions;
 		if (publicPath !== "auto") {
-			const shape = this._publicPathShape();
 			// A public path that needs no base names the same place from the chunk as from
 			// the document, so a literal spells what `fetch` would have reached.
-			if (shape !== undefined && isBaseIndependent(shape)) {
+			if (this._publicPathNeedsNoBase()) {
 				// Settled no earlier than the hash it reads or is called with, so it is
 				// baked only where the deferred pass may finish it.
 				if (this._resolvePublicPathPrefix(publicPath, module) === null) {
@@ -683,8 +699,19 @@ class RuntimeTemplate {
 		if (!this.isModule()) return false;
 		const { publicPath } = this.outputOptions;
 		if (publicPath === "auto") return false;
+		return !this._publicPathNeedsNoBase();
+	}
+
+	/**
+	 * Whether `output.publicPath` reaches the same place from any base, so a literal may
+	 * carry it without walking back to the output root first. One whose shape nothing
+	 * answers needs a base as far as anything here can tell. Never asked of `auto`,
+	 * which is no path of its own.
+	 * @returns {boolean} true when no base is needed
+	 */
+	_publicPathNeedsNoBase() {
 		const shape = this._publicPathShape();
-		return shape === undefined || !isBaseIndependent(shape);
+		return shape !== undefined && isBaseIndependent(shape);
 	}
 
 	/**
@@ -853,36 +880,55 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when a chunk of that runtime fetches its binaries
 	 */
 	_anyWasmChunkFetches(runtime) {
-		const { wasmLoading: globalWasmLoading } = this.outputOptions;
-		const groups =
-			runtime === undefined ? undefined : this._wasmRuntimeGroups();
-		// Named once here so a chunk costs one `get` and a compare, not a set of its own.
-		const group =
-			groups !== undefined && typeof runtime === "string"
-				? this._wasmGroupOf(groups, runtime)
-				: undefined;
-		// Only read where `group` is undefined, which is where the runtime has many keys.
-		const asked = /** @type {RuntimeSpecSortableSet} */ (runtime);
-		for (const chunk of this.compilation.chunks) {
-			if (
-				groups !== undefined &&
-				!(group === undefined
-					? this._wasmRuntimeSharesAny(groups, chunk.runtime, asked)
-					: this._wasmRuntimeAnswersWith(groups, chunk.runtime, group))
-			) {
-				continue;
-			}
-			const entryOptions = chunk.getEntryOptions();
-			// Only an entry names a loader; every other chunk of the runtime is served by
-			// the one its entry asked for.
-			if (!entryOptions) continue;
-			const wasmLoading =
-				entryOptions.wasmLoading !== undefined
-					? entryOptions.wasmLoading
-					: globalWasmLoading;
-			if (wasmLoading === "fetch") return true;
+		const fetching = this._wasmFetchingGroups();
+		if (fetching === undefined) return false;
+		// Without a runtime to place it in there is nothing to narrow by, so any chunk
+		// answers for all of them.
+		if (runtime === undefined) return true;
+		const groups = this._wasmRuntimeGroups();
+		if (typeof runtime === "string") {
+			return fetching.has(this._wasmGroupOf(groups, runtime));
+		}
+		for (const key of runtime) {
+			if (fetching.has(this._wasmGroupOf(groups, key))) return true;
 		}
 		return false;
+	}
+
+	/**
+	 * The runtime groups an entry of which asked for the `fetch` loader, or `undefined`
+	 * where none did — the cheap answer for a compilation with no fetching entry at all,
+	 * which is every non-web target. Only an entry names a loader; every other chunk of
+	 * the runtime is served by the one its entry asked for.
+	 * @returns {Set<string> | undefined} the groups that fetch
+	 */
+	_wasmFetchingGroups() {
+		if (this._wasmFetchingGroupSet === undefined) {
+			const { wasmLoading: globalWasmLoading } = this.outputOptions;
+			/** @type {Set<string>} */
+			const fetching = new Set();
+			/** @type {Map<string, string> | undefined} */
+			let groups;
+			for (const chunk of this.compilation.chunks) {
+				const entryOptions = chunk.getEntryOptions();
+				if (!entryOptions) continue;
+				const wasmLoading =
+					entryOptions.wasmLoading !== undefined
+						? entryOptions.wasmLoading
+						: globalWasmLoading;
+				if (wasmLoading !== "fetch") continue;
+				// Built only once something fetches, so nothing pays for the grouping.
+				if (groups === undefined) groups = this._wasmRuntimeGroups();
+				const named = /** @type {Map<string, string>} */ (groups);
+				forEachRuntime(chunk.runtime, (key) => {
+					fetching.add(this._wasmGroupOf(named, /** @type {string} */ (key)));
+				});
+			}
+			this._wasmFetchingGroupSet = fetching.size === 0 ? false : fetching;
+		}
+		return this._wasmFetchingGroupSet === false
+			? undefined
+			: this._wasmFetchingGroupSet;
 	}
 
 	/**
@@ -953,30 +999,6 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The multi-key case: a runtime chunk several entries share answers for each of
-	 * their groups at once.
-	 * @param {Map<string, string>} groups runtime key to the group it answers with
-	 * @param {RuntimeSpec} runtime a runtime
-	 * @param {RuntimeSpecSortableSet} asked the runtime being asked about
-	 * @returns {boolean} true when the runtime is one that answer has to cover
-	 */
-	_wasmRuntimeSharesAny(groups, runtime, asked) {
-		// Several keys only: a single-key runtime names its group before the chunk loop.
-		for (const key of asked) {
-			if (
-				this._wasmRuntimeAnswersWith(
-					groups,
-					runtime,
-					this._wasmGroupOf(groups, key)
-				)
-			) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * @param {Map<string, string>} groups runtime key to the group it answers with
 	 * @param {string} key a runtime key
 	 * @returns {string} the group it answers with, or itself when it shares nothing
@@ -985,23 +1007,6 @@ class RuntimeTemplate {
 		const group = groups.get(key);
 		// An entry named "" makes "" a runtime key, so test absence, not a falsy value.
 		return group === undefined ? key : group;
-	}
-
-	/**
-	 * @param {Map<string, string>} groups runtime key to the group it answers with
-	 * @param {RuntimeSpec} runtime a runtime
-	 * @param {string} group the group being answered for
-	 * @returns {boolean} true when the runtime is one that answer has to cover
-	 */
-	_wasmRuntimeAnswersWith(groups, runtime, group) {
-		if (runtime === undefined) return false;
-		if (typeof runtime === "string") {
-			return this._wasmGroupOf(groups, runtime) === group;
-		}
-		for (const key of runtime) {
-			if (this._wasmGroupOf(groups, key) === group) return true;
-		}
-		return false;
 	}
 
 	supportTemplateLiteral() {
@@ -2468,77 +2473,96 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The `../` path back out of the public path the chunks holding a reference are
-	 * served under. The chunk loader fetches a chunk through `output.publicPath`, so
-	 * such a chunk sits one public path below the output root the runtime resolves
-	 * against, and a literal read from it climbs back out before spelling that path
-	 * again — where the two meet they cancel, which is why an initial chunk, fetched
-	 * by the host instead, needs neither. Asked only of a public path that needs a
-	 * base; one that does not names the same place from either.
-	 * @param {Module} module the module the reference is emitted into
-	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @returns {string | null} the path, `""` where nothing is served under it, or
-	 * `null` where the chunks disagree and no one path is right for all of them
+	 * The `../` path back out of a public path that needs a base, which is where the
+	 * chunk loader puts what it fetches. Reads nothing but `output`, so it is answered
+	 * once: `""` where the path adds no depth, `null` where its shape is unknown.
+	 * @returns {string | null} the path back out of it
 	 */
-	_publicPathUndo(module, chunkGraph) {
-		/** @type {boolean | undefined} */
-		let loaded;
-		for (const chunk of this._moduleChunks(module, chunkGraph)) {
-			const own = !chunk.canBeInitial();
-			if (loaded === undefined) {
-				loaded = own;
-			} else if (loaded !== own) {
-				return null;
-			}
+	_publicPathClimb() {
+		if (this._publicPathClimbText === undefined) {
+			const shape = this._publicPathShape();
+			const undo =
+				shape === undefined
+					? null
+					: getUndoPath(
+							`${shape}x`,
+							/** @type {string} */ (this.outputOptions.path),
+							true
+						);
+			this._publicPathClimbText = undo === "./" ? "" : undo;
 		}
-		if (loaded !== true) return "";
-		const shape = this._publicPathShape();
-		if (shape === undefined) return null;
-		const undo = getUndoPath(
-			`${shape}x`,
-			/** @type {string} */ (this.outputOptions.path),
-			true
-		);
-		return undo === "./" ? "" : undo;
+		return this._publicPathClimbText;
 	}
 
 	/**
-	 * Computes the `../`-path from the consuming module's chunk(s) back to the output
-	 * root, so a chunk or asset can be referenced relative to `import.meta.url`. Returns
-	 * `null` when the module lives in chunks of different depths (no single path works).
-	 * @param {Module} module the consuming module
-	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @returns {string | null} relative undo path, or `null` when ambiguous
+	 * Where a literal emitted into a chunk is read from: the `../` path back to the
+	 * output root, and whether the chunk loader fetched the chunk through
+	 * `output.publicPath` — such a chunk sits one public path below the root the runtime
+	 * resolves against, where an initial chunk the host fetched does not. Reads only the
+	 * chunk, so it is memoized on it and shared by every module in it.
+	 * @param {Chunk} chunk a chunk a reference is written into
+	 * @returns {Placement} where a literal in it is read from
 	 */
-	_getModuleUndoPath(module, chunkGraph) {
+	_chunkPlacement(chunk) {
+		const cached = this._placementByChunk.get(chunk);
+		if (cached !== undefined) return cached;
 		const { compilation } = this;
 		const { outputOptions } = compilation;
-		const outputPath = /** @type {string} */ (outputOptions.path);
+		const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
+			chunk,
+			outputOptions
+		);
+		const chunkName = compilation.getPath(
+			// Hashes aren't known during code generation and only sit in the basename
+			// (never a directory), so neutralize them — only the `../` depth matters.
+			typeof template === "string"
+				? template.replace(HASH_IN_FILENAME_GLOBAL, "x")
+				: template,
+			{ chunk, runtime: chunk.runtime, contentHashType: JAVASCRIPT_TYPE }
+		);
+		const placement = {
+			undo: getUndoPath(
+				chunkName,
+				/** @type {string} */ (outputOptions.path),
+				true
+			),
+			loaded: !chunk.canBeInitial()
+		};
+		this._placementByChunk.set(chunk, placement);
+		return placement;
+	}
+
+	/**
+	 * The one answer every chunk holding a reference agrees on, with either half `null`
+	 * where they do not — then no one literal is right for all of them.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {Placement} where a literal in it is read from
+	 */
+	_modulePlacement(module, chunkGraph) {
+		/** @type {Placement | undefined} */
+		let first;
 		/** @type {string | null} */
-		let result = null;
-		let found = false;
+		let undo = null;
+		/** @type {boolean | null} */
+		let loaded = null;
 		for (const chunk of this._moduleChunks(module, chunkGraph)) {
-			const template = JavascriptModulesPlugin.getChunkFilenameTemplate(
-				chunk,
-				outputOptions
-			);
-			const chunkName = compilation.getPath(
-				// Hashes aren't known during code generation and only sit in the basename
-				// (never a directory), so neutralize them — only the `../` depth matters.
-				typeof template === "string"
-					? template.replace(HASH_IN_FILENAME_GLOBAL, "x")
-					: template,
-				{ chunk, runtime: chunk.runtime, contentHashType: JAVASCRIPT_TYPE }
-			);
-			const undo = getUndoPath(chunkName, outputPath, true);
-			if (!found) {
-				result = undo;
-				found = true;
-			} else if (result !== undo) {
-				return null;
+			const own = this._chunkPlacement(chunk);
+			if (first === undefined) {
+				first = own;
+				undo = own.undo;
+				loaded = own.loaded;
+				continue;
 			}
+			if (undo !== own.undo) undo = null;
+			if (loaded !== own.loaded) loaded = null;
 		}
-		return found ? result : null;
+		if (first === undefined) return NO_PLACEMENT;
+		// A module in one chunk — nearly all of them — hands back what that chunk said,
+		// so the common answer costs no object of its own.
+		return undo === first.undo && loaded === first.loaded
+			? first
+			: { undo, loaded };
 	}
 
 	/**
@@ -2640,7 +2664,7 @@ class RuntimeTemplate {
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
-			const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
+			const { undo } = this._modulePlacement(consumingModule, chunkGraph);
 			if (undo !== null) return specifier([["literal", undo]]);
 			// Different depths — no one `../` path is right for every asset the reference
 			// lands in, so the deferred pass builds each asset's own.
@@ -2654,37 +2678,60 @@ class RuntimeTemplate {
 			runtimeRequirements.add(RuntimeGlobals.publicPath);
 			return `${RuntimeGlobals.publicPath} + ${toJsStringLiteral(filename)}`;
 		}
-		const shape = this._publicPathShape();
-		if (shape === undefined) return null;
-		if (isBaseIndependent(shape)) {
-			const resolved = this._resolvePublicPathPrefix(
-				publicPath,
-				consumingModule,
-				chunks
-			);
-			return resolved === null ? null : specifier(resolved);
-		}
-		const climb = this._publicPathUndo(consumingModule, chunkGraph);
-		if (climb === null) {
-			this._analyzableBailout(consumingModule, SERVED_BAILOUT);
-			return null;
-		}
-		// The runtime imports it from the chunk holding the runtime, which is the output
-		// root; a baked one is read from the chunk it sits in, so a public path that
-		// needs a base gets the `../` path back to that root in front of it.
-		const undo = this._getModuleUndoPath(consumingModule, chunkGraph);
-		/** @type {SpecifierPart[]} */
-		const head = [undo === null ? ["undo", ""] : ["literal", undo]];
-		// A chunk webpack loaded already sits inside the public path, so climbing back
-		// out of it only to spell it again names the place it started from.
-		if (climb !== "") return specifier(head);
-		const resolved = this._resolvePublicPathPrefix(
-			publicPath,
+		const prefix = this._analyzablePathPrefix(
 			consumingModule,
+			chunkGraph,
 			chunks
 		);
+		return prefix === null ? null : specifier(prefix);
+	}
+
+	/**
+	 * The parts that go in front of a name so a literal read from the chunk holding it
+	 * reaches what the runtime would. A public path needing no base is the whole answer.
+	 * One that needs a base is read from the output root, so the `../` path back there
+	 * comes first — and is the whole answer again where the chunk loader fetched this
+	 * chunk through that same path, since climbing out of it only to spell it again
+	 * names the place it started from. An entry `baseUri` sits between the two, so
+	 * there both are written. Never asked of an `auto` public path, which is no path
+	 * to walk back over.
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Iterable<Chunk>} chunks the chunks a stand-in would be written into
+	 * @param {string=} relativeBase an entry `baseUri` read against the output root
+	 * @returns {SpecifierPart[] | null} the parts, or `null` having recorded why not
+	 */
+	_analyzablePathPrefix(module, chunkGraph, chunks, relativeBase) {
+		const publicPath = /** @type {PublicPath} */ (
+			this.outputOptions.publicPath
+		);
+		const shape = this._publicPathShape();
+		if (shape === undefined) return null;
+		const resolve = () =>
+			this._resolvePublicPathPrefix(publicPath, module, chunks);
+		if (isBaseIndependent(shape)) return resolve();
+		const { undo, loaded } = this._modulePlacement(module, chunkGraph);
+		const climb =
+			loaded === null ? null : loaded ? this._publicPathClimb() : "";
+		if (climb === null) {
+			this._analyzableBailout(module, SERVED_BAILOUT);
+			return null;
+		}
+		/** @type {SpecifierPart[]} */
+		const head = [undo === null ? ["undo", ""] : ["literal", undo]];
+		if (climb !== "" && relativeBase === undefined) return head;
+		const resolved = resolve();
 		if (resolved === null) return null;
-		return specifier([...head, ...rootedParts(resolved)]);
+		return [
+			...head,
+			.../** @type {SpecifierPart[]} */ (
+				climb === "" ? [] : [["literal", climb]]
+			),
+			.../** @type {SpecifierPart[]} */ (
+				relativeBase === undefined ? [] : [["literal", relativeBase]]
+			),
+			...rootedParts(resolved)
+		];
 	}
 
 	/**
@@ -2823,49 +2870,24 @@ class RuntimeTemplate {
 				getAnalyzableChunkHashPlugin().reserveSpecifier(parts)
 			);
 		};
-		/** @type {SpecifierPart[]} */
-		let prefix = [];
-		/** @type {SpecifierPart[]} */
-		let climbParts = [];
 		if (bakePublicPath && publicPath !== "auto") {
-			const shape = this._publicPathShape();
-			if (shape === undefined) return null;
-			const resolve = () =>
-				this._resolvePublicPathPrefix(
-					/** @type {PublicPath} */ (publicPath),
-					module,
-					chunks
-				);
-			if (isBaseIndependent(shape)) {
-				const resolved = resolve();
-				if (resolved === null) return null;
-				return specifier([...resolved, ...file]);
-			}
-			const climb = this._publicPathUndo(module, chunkGraph);
-			if (climb === null) {
-				this._analyzableBailout(module, SERVED_BAILOUT);
-				return null;
-			}
-			// A chunk webpack loaded already sits inside the public path, so with nothing
-			// between them, climbing back out only to spell it again names the place it
-			// started from. A `baseUri` does sit between them, so both are written.
-			if (climb === "" || relativeBase !== undefined) {
-				const resolved = resolve();
-				if (resolved === null) return null;
-				prefix = rootedParts(resolved);
-				if (climb !== "") climbParts = [["literal", climb]];
-			}
+			const prefix = this._analyzablePathPrefix(
+				module,
+				chunkGraph,
+				chunks,
+				relativeBase
+			);
+			return prefix === null ? null : specifier([...prefix, ...file]);
 		}
-		const undo = this._getModuleUndoPath(module, chunkGraph);
-		// Different depths — no one `../` path is right for every asset the reference is
-		// emitted into, so the deferred pass builds each asset's own.
+		// No public path to place it against, so the `../` path back to the output root
+		// is the whole prefix. Different depths — no one is right for every asset the
+		// reference is emitted into, so the deferred pass builds each asset's own.
+		const { undo } = this._modulePlacement(module, chunkGraph);
 		return specifier([
 			undo === null ? ["undo", ""] : ["literal", undo],
-			...climbParts,
 			...(relativeBase === undefined
 				? []
 				: /** @type {SpecifierPart[]} */ ([["literal", relativeBase]])),
-			...prefix,
 			...file
 		]);
 	}
@@ -2896,14 +2918,11 @@ class RuntimeTemplate {
 		// one needing no base: `readFile` takes a `file:` URL alone, and those loaders
 		// address the binary relative to the chunk anyway, ignoring the public path
 		// exactly as the runtime form does.
-		const shape = this._publicPathShape();
 		const specifier = this._getAnalyzableFileSpecifier(
 			module,
 			chunkGraph,
 			[[filename.includes("[") ? "template" : "literal", filename]],
-			shape !== undefined &&
-				isBaseIndependent(shape) &&
-				this._wasmChunksFetch(module, chunkGraph)
+			this._publicPathNeedsNoBase() && this._wasmChunksFetch(module, chunkGraph)
 		);
 		if (specifier !== null) return this.importMetaUrl(specifier);
 		// No bundler follows a concatenation, but this still sheds the module id and

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -95,16 +95,6 @@ const isBaseIndependent = (publicPath) =>
 	publicPath.startsWith("/") || getScheme(publicPath) !== undefined;
 
 /**
- * Whether it is a complete URL of its own, which is only about `fetch`: that
- * resolves a relative one against the document and a baked one against the chunk.
- * @param {string | undefined} publicPath the shape of the public path
- * @returns {boolean} true for an absolute-URL public path
- */
-const isUrlPublicPath = (publicPath) =>
-	publicPath !== undefined &&
-	(publicPath.startsWith("//") || getScheme(publicPath) !== undefined);
-
-/**
  * Drops the `./` a public path may open with: what follows it is already walked back
  * to the output root, so it would only lengthen the name.
  * @param {SpecifierPart[]} parts a public path's pieces
@@ -546,7 +536,10 @@ class RuntimeTemplate {
 		// here, rather than built at runtime under an `import.meta.url` base.
 		const { publicPath, webassemblyModuleFilename } = outputOptions;
 		if (publicPath !== "auto") {
-			if (isUrlPublicPath(this._publicPathShape())) {
+			const shape = this._publicPathShape();
+			// A public path that needs no base names the same place from the chunk as from
+			// the document, so a literal spells what `fetch` would have reached.
+			if (shape !== undefined && isBaseIndependent(shape)) {
 				// Settled no earlier than the hash it reads or is called with, so it is
 				// baked only where the deferred pass may finish it.
 				if (this._resolvePublicPathPrefix(publicPath, module) === null) {
@@ -555,7 +548,7 @@ class RuntimeTemplate {
 			} else if (this._anyWasmChunkFetches(runtime)) {
 				this._analyzableBailout(
 					module,
-					"output.publicPath is not an absolute URL, so it means something different against the chunk than against the document"
+					"output.publicPath needs a base, and `fetch` reads it against the document while a baked url reads it against the chunk"
 				);
 				return false;
 			}
@@ -2829,14 +2822,16 @@ class RuntimeTemplate {
 			chunkGraph
 		});
 		// Only a chunk that fetches may carry the public path into the literal, and only
-		// an absolute one: `readFile` takes a `file:` URL alone, and those loaders address
-		// the binary relative to the chunk anyway, ignoring the public path exactly as the
-		// runtime form does.
+		// one needing no base: `readFile` takes a `file:` URL alone, and those loaders
+		// address the binary relative to the chunk anyway, ignoring the public path
+		// exactly as the runtime form does.
+		const shape = this._publicPathShape();
 		const specifier = this._getAnalyzableFileSpecifier(
 			module,
 			chunkGraph,
 			[[filename.includes("[") ? "template" : "literal", filename]],
-			isUrlPublicPath(this._publicPathShape()) &&
+			shape !== undefined &&
+				isBaseIndependent(shape) &&
 				this._wasmChunksFetch(module, chunkGraph)
 		);
 		if (specifier !== null) return this.importMetaUrl(specifier);

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -780,8 +780,8 @@ class AssetGenerator extends Generator {
 		// it every JS consumer needs the wrapper, so skip the per-connection dependency
 		// probe entirely and keep the pre-existing cheap path. Must match the condition
 		// `URLDependency` uses to emit the literal, or the wrapper is dropped while the
-		// call site still requires the module (e.g. under an `eval` devtool) — except for
-		// a reassigned public path, whose `.p + <file>` fallback needs a name to spell.
+		// call site still requires the module — except where the fallback spells the name
+		// itself (`.p + <file>`), which needs no wrapper to read it out of.
 		// Build-time execution instead emulates the wrapper (`AssetModulesPlugin`).
 		const isModule = Boolean(
 			this._compilation &&

--- a/test/configCases/analyzable/asset-url-matrix/index.js
+++ b/test/configCases/analyzable/asset-url-matrix/index.js
@@ -4,12 +4,16 @@ import path from "path";
 // Referenced so both chunks exist; the baked specifier is what is under test.
 const flat = () => import(/* webpackChunkName: "flat" */ "./flat");
 const deep = () => import(/* webpackChunkName: "nested/deep" */ "./deep");
+// The entry is loaded by the host rather than through the public path, so this one
+// spells it where a chunk webpack loaded is already inside it.
+export const own = new URL("./asset.txt", import.meta.url);
 
 const stats = __STATS__.children[__INDEX__];
-const specifier = (name) =>
+const read = (...parts) =>
 	fs
-		.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8")
+		.readFileSync(path.join(stats.outputPath, ...parts), "utf8")
 		.match(/asset import \*\/ "([^"]+)"/)[1];
+const specifier = (name) => read(__DIR__, name);
 
 it("should keep both chunks referenced", () => {
 	expect(typeof flat).toBe("function");
@@ -19,4 +23,8 @@ it("should keep both chunks referenced", () => {
 it("should bake what each depth needs", () => {
 	expect(specifier("flat.mjs")).toBe(__ROOT__);
 	expect(specifier("nested/deep.mjs")).toBe(__DEEP__);
+});
+
+it("should spell the public path in the chunk the host loads", () => {
+	expect(read(`bundle${__INDEX__}.mjs`)).toBe(__OWN__);
 });

--- a/test/configCases/analyzable/asset-url-matrix/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-matrix/webpack.config.js
@@ -1,7 +1,8 @@
 "use strict";
 
 // The runtime resolves a public path against the output root, so one that needs a base
-// is walked back there first — read from chunks at two depths, under every shape.
+// is walked back there first — and a chunk webpack loaded through that path is already
+// inside it. Read from chunks at two depths and from the entry, under every shape.
 
 const webpack = require("../../../../");
 
@@ -11,9 +12,10 @@ const webpack = require("../../../../");
  * @param {NonNullable<import("../../../../").Configuration["output"]>["publicPath"]} publicPath the shape under test
  * @param {string} root what the chunk one directory down is expected to bake
  * @param {string} deep what the chunk a directory down is expected to bake
+ * @param {string} own what the entry the host loads is expected to bake
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, dir, publicPath, root, deep) => ({
+const base = (index, dir, publicPath, root, deep, own) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -33,7 +35,8 @@ const base = (index, dir, publicPath, root, deep) => ({
 			__INDEX__: JSON.stringify(index),
 			__DIR__: JSON.stringify(dir),
 			__ROOT__: JSON.stringify(root),
-			__DEEP__: JSON.stringify(deep)
+			__DEEP__: JSON.stringify(deep),
+			__OWN__: JSON.stringify(own)
 		})
 	]
 });
@@ -41,18 +44,42 @@ const base = (index, dir, publicPath, root, deep) => ({
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
 	// Chunk-relative already: the `../` path back to the root is the whole prefix.
-	base(0, "a", "auto", "../asset.txt", "../../asset.txt"),
+	base(0, "a", "auto", "../asset.txt", "../../asset.txt", "./asset.txt"),
 	// Relative to the output root, so it follows that same `../` path.
-	base(1, "b", "", "../asset.txt", "../../asset.txt"),
-	base(2, "c", "./", "../asset.txt", "../../asset.txt"),
-	base(3, "d", "media/", "../media/asset.txt", "../../media/asset.txt"),
+	base(1, "b", "", "../asset.txt", "../../asset.txt", "./asset.txt"),
+	base(2, "c", "./", "../asset.txt", "../../asset.txt", "./asset.txt"),
+	// One with a directory of its own is where the two sides part: webpack loaded the
+	// chunks through it, so they are already inside it, and the entry is not.
+	base(
+		3,
+		"d",
+		"media/",
+		"../asset.txt",
+		"../../asset.txt",
+		"./media/asset.txt"
+	),
 	// Rooted at the origin, or a url of its own: the same place from any base.
-	base(4, "e", "/media/", "/media/asset.txt", "/media/asset.txt"),
-	base(5, "f", "//cdn.test/", "//cdn.test/asset.txt", "//cdn.test/asset.txt"),
+	base(
+		4,
+		"e",
+		"/media/",
+		"/media/asset.txt",
+		"/media/asset.txt",
+		"/media/asset.txt"
+	),
+	base(
+		5,
+		"f",
+		"//cdn.test/",
+		"//cdn.test/asset.txt",
+		"//cdn.test/asset.txt",
+		"//cdn.test/asset.txt"
+	),
 	base(
 		6,
 		"g",
 		"https://cdn.test/",
+		"https://cdn.test/asset.txt",
 		"https://cdn.test/asset.txt",
 		"https://cdn.test/asset.txt"
 	),
@@ -61,6 +88,7 @@ module.exports = [
 		7,
 		"h",
 		() => "https://cdn.test/fn/",
+		"https://cdn.test/fn/asset.txt",
 		"https://cdn.test/fn/asset.txt",
 		"https://cdn.test/fn/asset.txt"
 	)

--- a/test/configCases/analyzable/asset-url-mixed-serving/asset.txt
+++ b/test/configCases/analyzable/asset-url-mixed-serving/asset.txt
@@ -1,0 +1,1 @@
+the asset content

--- a/test/configCases/analyzable/asset-url-mixed-serving/index.js
+++ b/test/configCases/analyzable/asset-url-mixed-serving/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { url } from "./shared";
+
+const stats = __STATS__;
+const read = (...parts) =>
+	fs.readFileSync(path.join(stats.outputPath, ...parts), "utf8");
+
+it("should point at the asset through the public path", () => {
+	// Nothing is emitted there — the public path is where the output root is served.
+	expect(url.href.endsWith("/media/asset.txt")).toBe(true);
+});
+
+it("should keep the runtime form where the two chunks disagree", () => {
+	// Built at runtime so the needle is not a source string literal here.
+	const runtimeForm = `${"__webpack_require__"}.p + ${JSON.stringify("asset.txt")}`;
+
+	expect(read("bundle0.mjs")).toContain(runtimeForm);
+	expect(read("c/on-demand.mjs")).toContain(runtimeForm);
+});

--- a/test/configCases/analyzable/asset-url-mixed-serving/lazy-entry.js
+++ b/test/configCases/analyzable/asset-url-mixed-serving/lazy-entry.js
@@ -1,0 +1,1 @@
+export const load = () => import(/* webpackChunkName: "on-demand" */ "./shared");

--- a/test/configCases/analyzable/asset-url-mixed-serving/shared.js
+++ b/test/configCases/analyzable/asset-url-mixed-serving/shared.js
@@ -1,0 +1,3 @@
+// Reached synchronously from one entry and asynchronously from the other, so it sits
+// in a chunk the host loads and in one webpack loads through the public path.
+export const url = new URL("./asset.txt", import.meta.url);

--- a/test/configCases/analyzable/asset-url-mixed-serving/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-mixed-serving/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// A public path needing a base is spelled from a chunk the host loads and left out of
+// one webpack loads through it. A module in both has no one answer, so it falls back.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: { bundle0: "./index.js", lazy: "./lazy-entry.js" },
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: "c/[name].mjs",
+		publicPath: "media/",
+		assetModuleFilename: "[name][ext]"
+	},
+	module: {
+		rules: [{ test: /\.txt$/, type: "asset/resource" }]
+	},
+	optimization: { chunkIds: "named", splitChunks: false }
+};

--- a/test/configCases/analyzable/asset-url-relative-public-path/index.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/index.js
@@ -4,12 +4,16 @@ import path from "path";
 // Referenced so both chunks exist; only loaded where they can be found.
 const flat = () => import(/* webpackChunkName: "flat" */ "./flat");
 const deep = () => import(/* webpackChunkName: "nested/deep" */ "./deep");
+// The host loads the entry rather than webpack, so this one is outside the public path.
+export const own = new URL("./asset.txt", import.meta.url);
 
 const stats = __STATS__.children[__INDEX__];
-const specifier = (name) =>
+const read = (...parts) =>
 	fs
-		.readFileSync(path.join(stats.outputPath, __DIR__, name), "utf8")
+		.readFileSync(path.join(stats.outputPath, ...parts), "utf8")
 		.match(/asset import \*\/ "([^"]+)"/)[1];
+const specifier = (name) => read(__DIR__, name);
+const entry = () => read(`bundle${__INDEX__}.mjs`);
 
 if (__DIGEST__) {
 	it("should keep both chunks referenced", () => {
@@ -18,23 +22,21 @@ if (__DIGEST__) {
 	});
 
 	it("should walk back to the output root before the digest", () => {
-		for (const [name, undo] of [
-			["flat.mjs", "../"],
-			["nested/deep.mjs", "../../"]
-		]) {
-			const match = new RegExp(`^${undo}media/([^/]+)/asset\\.txt$`).exec(
-				specifier(name)
-			);
+		const match = /^\.\/media\/([^/]+)\/asset\.txt$/.exec(entry());
 
-			expect(match).not.toBe(null);
-			// A digest re-encodes the hash, so decode it back to compare.
-			const hex = Buffer.from(
-				match[1].replace(/-/g, "+").replace(/_/g, "/"),
-				"base64"
-			).toString("hex");
+		expect(match).not.toBe(null);
+		// A digest re-encodes the hash, so decode it back to compare.
+		const hex = Buffer.from(
+			match[1].replace(/-/g, "+").replace(/_/g, "/"),
+			"base64"
+		).toString("hex");
 
-			expect(hex.startsWith(stats.hash)).toBe(true);
-		}
+		expect(hex.startsWith(stats.hash)).toBe(true);
+	});
+
+	it("should leave the digest out of the chunks it already names", () => {
+		expect(specifier("flat.mjs")).toBe("../asset.txt");
+		expect(specifier("nested/deep.mjs")).toBe("../../asset.txt");
 	});
 } else {
 	it("should resolve the asset from chunks at different depths", async () => {
@@ -50,5 +52,6 @@ if (__DIGEST__) {
 	it("should walk back to the output root before the public path", () => {
 		expect(specifier("flat.mjs")).toBe("../asset.txt");
 		expect(specifier("nested/deep.mjs")).toBe("../../asset.txt");
+		expect(entry()).toBe("./asset.txt");
 	});
 }

--- a/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
+++ b/test/configCases/analyzable/asset-url-relative-public-path/webpack.config.js
@@ -42,6 +42,6 @@ module.exports = [
 	// An empty one names the output root just the same.
 	base(1, "b", ""),
 	// A digest no stand-in can carry, so the deferred pass spells the whole template —
-	// behind the same `../` path. Nothing is emitted there, so it is not read back.
+	// in the entry alone, since the chunks webpack loaded already sit inside it.
 	base(2, "c", "media/[fullhash:base64safe]/", true)
 ];

--- a/test/configCases/analyzable/asset-wrapper-retention/index.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/index.js
@@ -9,8 +9,11 @@ const bundle = () =>
 // reads the runtime public path, or bakes the url where analyzable output can.
 const runtimeWrapper = `${"module"}.exports = ${"__webpack_require__"}.p + `;
 const bakedWrapper = `${"module"}.exports = new URL(`;
-const hasWrapper = () =>
-	bundle().includes(runtimeWrapper) || bundle().includes(bakedWrapper);
+// An `eval` devtool hands the module body to `eval` as a string, so its quotes are
+// escaped in the file the needle is looked for in.
+const bundleHas = (needle) =>
+	bundle().includes(needle) || bundle().includes(needle.replace(/"/g, '\\"'));
+const hasWrapper = () => bundleHas(runtimeWrapper) || bundleHas(bakedWrapper);
 
 it("should point at the asset whatever the module exposes", () => {
 	expect(String(url).endsWith("/asset.txt")).toBe(true);
@@ -29,6 +32,6 @@ if (__WRAPPER__) {
 if (__INLINE__) {
 	it("should concatenate the runtime public path at the call site", () => {
 		const inlined = `${"__webpack_require__"}.p + ${JSON.stringify("asset.txt")}`;
-		expect(bundle().includes(inlined)).toBe(true);
+		expect(bundleHas(inlined)).toBe(true);
 	});
 }

--- a/test/configCases/analyzable/asset-wrapper-retention/index.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/index.js
@@ -9,10 +9,12 @@ const bundle = () =>
 // reads the runtime public path, or bakes the url where analyzable output can.
 const runtimeWrapper = `${"module"}.exports = ${"__webpack_require__"}.p + `;
 const bakedWrapper = `${"module"}.exports = new URL(`;
-// An `eval` devtool hands the module body to `eval` as a string, so its quotes are
-// escaped in the file the needle is looked for in.
+// An `eval` devtool hands the module body to `eval` as a JSON string, so the needle
+// is looked for as that spells it too — by the same function, rather than by a rule
+// of our own that would have to know every escape.
+const escaped = (needle) => JSON.stringify(needle).slice(1, -1);
 const bundleHas = (needle) =>
-	bundle().includes(needle) || bundle().includes(needle.replace(/"/g, '\\"'));
+	bundle().includes(needle) || bundle().includes(escaped(needle));
 const hasWrapper = () => bundleHas(runtimeWrapper) || bundleHas(bakedWrapper);
 
 it("should point at the asset whatever the module exposes", () => {

--- a/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
+++ b/test/configCases/analyzable/asset-wrapper-retention/webpack.config.js
@@ -15,7 +15,7 @@ const webpack = require("../../../../");
 const base = (index, wrapper, extra = {}, inline = false) => ({
 	target: "node",
 	mode: "development",
-	devtool: false,
+	devtool: extra.devtool !== undefined ? extra.devtool : false,
 	entry: extra.entry || "./index.js",
 	experiments: { outputModule: true },
 	output: {
@@ -49,5 +49,8 @@ module.exports = [
 	}),
 	// A reassigned public path rules the literal out, but the call site concatenates
 	// the runtime one itself — going through the wrapper to do it adds nothing.
-	base(3, false, { entry: "./index-override.js" }, true)
+	base(3, false, { entry: "./index-override.js" }, true),
+	// An `eval` devtool rules the literal out the same way, and leaves the same
+	// concatenation — `import.meta` is what does not parse there, not `.p`.
+	base(4, false, { devtool: "eval" }, true)
 ];

--- a/test/configCases/analyzable/chunk-import-mixed-chunk/index.js
+++ b/test/configCases/analyzable/chunk-import-mixed-chunk/index.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+import { load } from "./shared.js";
+
+const stats = __STATS__;
+const shared = () =>
+	fs.readFileSync(path.join(stats.outputPath, "shared.mjs"), "utf8");
+
+// Not loaded: the public path relocates the chunk, so the harness cannot resolve it.
+it("should keep the chunk referenced", () => {
+	expect(typeof load).toBe("function");
+});
+
+it("should keep the runtime form in a chunk served at two urls", () => {
+	// Built at runtime so the needles are not source string literals here.
+	expect(shared()).toContain(`${"__webpack_require__"}.e(`);
+	expect(shared()).not.toContain(`${"import"}("./media/`);
+});

--- a/test/configCases/analyzable/chunk-import-mixed-chunk/lazy.js
+++ b/test/configCases/analyzable/chunk-import-mixed-chunk/lazy.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/analyzable/chunk-import-mixed-chunk/other.js
+++ b/test/configCases/analyzable/chunk-import-mixed-chunk/other.js
@@ -1,0 +1,1 @@
+export const load = () => import("./shared.js");

--- a/test/configCases/analyzable/chunk-import-mixed-chunk/shared.js
+++ b/test/configCases/analyzable/chunk-import-mixed-chunk/shared.js
@@ -1,0 +1,3 @@
+// `splitChunks` lifts this into a chunk the first entry has at startup and the second
+// loads on demand, so it is served at two urls one public path apart.
+export const load = () => import("./lazy.js");

--- a/test/configCases/analyzable/chunk-import-mixed-chunk/webpack.config.js
+++ b/test/configCases/analyzable/chunk-import-mixed-chunk/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// `splitChunks` can put one chunk in an initial group and an async one at once, and
+// the two are served a public path apart. No literal in it can name either.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: { bundle0: "./index.js", other: "./other.js" },
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: "c/[name].mjs",
+		publicPath: "media/"
+	},
+	optimization: {
+		chunkIds: "named",
+		splitChunks: {
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					chunks: "all",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/asset-modules/url-module-eval-devtool/index.js
+++ b/test/configCases/asset-modules/url-module-eval-devtool/index.js
@@ -1,5 +1,5 @@
 it("should resolve new URL() under an eval devtool", () => {
-	// Without the asset's JS wrapper this throws "Cannot find module './file.png'".
+	// It resolved through the wrapper before, which the drop decision had to agree on.
 	const url = new URL("./file.png", import.meta.url);
 
 	expect(url.href).toBe("https://example.com/public/file.png");

--- a/test/configCases/asset-modules/url-module-eval-devtool/webpack.config.js
+++ b/test/configCases/asset-modules/url-module-eval-devtool/webpack.config.js
@@ -1,10 +1,9 @@
 "use strict";
 
 // An `eval` devtool disables the analyzable literal (`import.meta` is a syntax error
-// inside `eval`), so the `new URL()` call site keeps the runtime form and the asset's
-// JS wrapper must be kept with it. Regression test: the wrapper-drop decision used to
-// look only at `output.module` and dropped it here, leaving the call site requiring a
-// module that no longer existed.
+// inside `eval`), so the `new URL()` call site spells the runtime public path itself.
+// Regression test: the wrapper-drop decision and the call site have to reach the same
+// answer, or the call site requires a module that was never emitted.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
@@ -48,10 +48,13 @@ const base = (index, name, wasmLoading, wasmRef, runs, publicPath) => ({
 module.exports = [
 	// Not loaded: the harness cannot resolve an `import()` of a `/assets/` specifier.
 	base(0, "node", "async-node", 'new URL("./', false, "/assets/"),
-	// The public path reaches this one, and a relative one means something different
-	// against the chunk than against the document, so the runtime form stays.
-	base(1, "fetch", "fetch", "module.id, ", false, "/assets/"),
+	// The public path reaches this one, and one rooted at the origin names the same
+	// place from the chunk as from the document, so it is spelled out.
+	base(1, "fetch", "fetch", 'new URL("/assets/', false, "/assets/"),
 	// A chunk-relative public path resolves the same way the harness does, so this one
 	// runs the binary the baked url points at.
-	base(2, "run", "async-node", 'new URL("./', true, "./")
+	base(2, "run", "async-node", 'new URL("./', true, "./"),
+	// `fetch` reads a relative public path against the document, which no literal
+	// anchored at the chunk can spell, so this one keeps the runtime form.
+	base(3, "relative", "fetch", "module.id, ", false, "./")
 ];

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -107,7 +107,7 @@ eval-devtool:
   runtime modules X KiB 5 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-eval.js X bytes [built] [code generated]
-    ./asset.txt X bytes (asset) X bytes (javascript) [built] [code generated]
+    ./asset.txt X bytes [built] [code generated]
   eval-devtool (webpack x.x.x) compiled successfully in X ms
 
 worker-chunk-loading:
@@ -146,7 +146,7 @@ environment-module:
   runtime modules X KiB 5 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-asset.js X bytes [built] [code generated]
-    ./asset.txt X bytes (asset) X bytes (javascript) [built] [code generated]
+    ./asset.txt X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
   environment-module (webpack x.x.x) compiled successfully in X ms
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

A baked analyzable literal walked back from where its chunk is emitted and then spelled `output.publicPath` — but the chunk loader had already fetched that chunk through it, so every asset and chunk reference inside a loaded chunk named the public path twice and pointed where nothing is served. It is now spelled only from a chunk the host loads; where the two would meet they cancel, and a module in both kinds of chunk keeps the runtime form.

That correction also lets two refusals go. A wasm binary bakes under an origin-rooted public path, which needs no base at all and so names the same place from the chunk as from the document — matching what the ESM chunk loader already does with `/assets/chunk.mjs` in the same bundle. And an asset drops its javascript wrapper under an `eval` devtool: `url-inline` asks whether the file can be named at the call site, and its `__webpack_require__.p + <file>` fallback answers that without the `import.meta` an `eval` cannot parse.

The last commit is a no-behaviour-change follow-up: where a literal is read from is answered once per chunk instead of per reference, the two specifier builders share their public-path tail, and the wasm loader question is a set built once rather than a scan of every chunk per ask. Over a 200-chunk, 1000-asset ESM build that takes `Compilation.getPath` from 1402 calls to 403 and `_resolvePublicPathPrefix` from 1200 to 200, with the compilation hash unchanged and retained heap inside the run-to-run spread.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. New `test/configCases/analyzable/asset-url-mixed-serving`, and reworked `asset-url-matrix` (which now asserts the entry chunk as well as the two loaded ones, across all eight public-path shapes), `asset-url-relative-public-path`, `asset-wrapper-retention`, `wasm/analyzable-relative-public-path` and `asset-modules/url-module-eval-devtool`. Each fails without the matching change.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No API or option changes, but emitted urls move where they were wrong: a relative public path is no longer applied twice inside loaded chunks, and a wasm binary under an origin-rooted public path is fetched relative to the chunk rather than the document. Both bring those urls in line with what the rest of the ESM output already resolves to, so no migration is needed.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used throughout. It instrumented `RuntimeTemplate.supportsAnalyzable` and built every ESM `configCases/` case to census which references fall back to the runtime form and why, which is how the public-path doubling was found; it then wrote the code, the test cases and the counting/heap/timing harnesses. Every number quoted above comes from a run whose output was read and checked, not from an estimate.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated paths when using relative asset locations.
  * Corrected root-relative WebAssembly URLs and fetch behavior across loading scenarios.
  * Improved asset URL resolution for entry bundles and asynchronously loaded chunks.
  * Ensured assets served from mixed locations resolve correctly.
  * Preserved necessary asset wrappers when using `eval`-based development output.

* **Tests**
  * Added coverage for relative, absolute, rooted, protocol-relative, and mixed asset paths, plus WebAssembly and development-tool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->