### PR TITLE
feat(analyzable): bake a wasm url under a relative public path

### DIFF
--- a/.changeset/029-analyzable-public-path-and-asset-wrapper.md
+++ b/.changeset/029-analyzable-public-path-and-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Fix the public path an analyzable url carries, and widen where one is baked, wasm included.
+Fix analyzable url public paths, and bake more of them, wasm included.

--- a/.changeset/029-analyzable-public-path-and-asset-wrapper.md
+++ b/.changeset/029-analyzable-public-path-and-asset-wrapper.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Fix the public path an analyzable url carries, and widen where one is baked.
+Fix the public path an analyzable url carries, and widen where one is baked, wasm included.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -297,6 +297,10 @@ class RuntimeTemplate {
 		this._wasmRuntimeGroupsByKey = undefined;
 		/** @type {Set<string> | false | undefined} */
 		this._wasmFetchingGroupSet = undefined;
+		/** @type {Map<string, boolean> | undefined} */
+		this._wasmAnchorKnownByGroup = undefined;
+		/** @type {Map<string, boolean> | undefined} */
+		this._wasmGroupOnlyFetchesMap = undefined;
 	}
 
 	isIIFE() {
@@ -573,10 +577,13 @@ class RuntimeTemplate {
 				if (this._resolvePublicPathPrefix(publicPath, module) === null) {
 					return false;
 				}
-			} else if (this._anyWasmChunkFetches(runtime)) {
+			} else if (
+				this._anyWasmChunkFetches(runtime) &&
+				!this._wasmFetchAnchorIsKnown(runtime)
+			) {
 				this._analyzableBailout(
 					module,
-					"output.publicPath needs a base, and `fetch` reads it against the document while a baked url reads it against the chunk"
+					"output.publicPath needs a base, and no one path back to the document fits every chunk `fetch` reads it from"
 				);
 				return false;
 			}
@@ -901,6 +908,93 @@ class RuntimeTemplate {
 			if (fetching.has(this._wasmGroupOf(groups, key))) return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Whether every entry of a wasm runtime group reads its binaries with `fetch`, keyed
+	 * by group. Only an entry names a loader — a chunk that is none answers with what
+	 * `output` says, which is not what its entry asked for — so the scan is of entries,
+	 * as `_wasmFetchingGroups` is.
+	 * @returns {Map<string, boolean>} whether each group fetches and nothing else
+	 */
+	_wasmGroupOnlyFetches() {
+		if (this._wasmGroupOnlyFetchesMap === undefined) {
+			const groups = this._wasmRuntimeGroups();
+			/** @type {Map<string, boolean>} */
+			const only = new Map();
+			for (const chunk of this.compilation.chunks) {
+				if (!chunk.getEntryOptions()) continue;
+				const fetches = this._chunkWasmLoading(chunk) === "fetch";
+				forEachRuntime(chunk.runtime, (key) => {
+					const group = this._wasmGroupOf(groups, /** @type {string} */ (key));
+					only.set(group, only.get(group) !== false && fetches);
+				});
+			}
+			this._wasmGroupOnlyFetchesMap = only;
+		}
+		return this._wasmGroupOnlyFetchesMap;
+	}
+
+	/**
+	 * Whether a public path needing a base can be spelled from the chunk every binary of
+	 * a runtime sits in. `fetch` reads it against the document, so a literal has to climb
+	 * from its own chunk back to that document first — the same arithmetic an asset url
+	 * walks. Answered per runtime group rather than per binary, for the reason
+	 * `_anyWasmChunkFetches` is: the two ends have to agree and the runtime module names
+	 * no module. A binary is spellable when it is reached the one way the climb assumes —
+	 * every holding chunk fetching, so `readFile` never takes a prefix meant for the
+	 * document — from chunks that agree on whether the loader fetched them, and under a
+	 * path that resolves, which keeps the `.p` fallback unreachable here.
+	 * @param {RuntimeSpec=} runtime the runtime being asked about
+	 * @returns {boolean} true when every binary of that group can be spelled
+	 */
+	_wasmFetchAnchorIsKnown(runtime) {
+		if (this._wasmAnchorKnownByGroup === undefined) {
+			const { chunkGraph, modules } = this.compilation;
+			const publicPath = /** @type {PublicPath} */ (
+				this.outputOptions.publicPath
+			);
+			const groups = this._wasmRuntimeGroups();
+			/** @type {Map<string, boolean>} */
+			const known = new Map();
+			for (const module of modules) {
+				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
+				const spellable =
+					this._modulePlacement(module, chunkGraph).loaded !== null &&
+					this._resolvePublicPathPrefix(publicPath, module) !== null;
+				for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
+					forEachRuntime(moduleRuntime, (key) => {
+						const group = this._wasmGroupOf(
+							groups,
+							/** @type {string} */ (key)
+						);
+						known.set(group, known.get(group) !== false && spellable);
+					});
+				}
+			}
+			// A group one entry reads with `readFile` cannot take a prefix meant for the
+			// document, and only an entry names its loader, so this is asked of the group
+			// rather than of the chunks a binary sits in.
+			for (const [group, only] of this._wasmGroupOnlyFetches()) {
+				if (!only) known.set(group, false);
+			}
+			this._wasmAnchorKnownByGroup = known;
+		}
+		const known = this._wasmAnchorKnownByGroup;
+		// No runtime to place it in leaves every group answering, so one that cannot be
+		// spelled speaks for all of them.
+		if (runtime === undefined) {
+			for (const value of known.values()) if (!value) return false;
+			return known.size > 0;
+		}
+		const groups = this._wasmRuntimeGroups();
+		if (typeof runtime === "string") {
+			return known.get(this._wasmGroupOf(groups, runtime)) === true;
+		}
+		for (const key of runtime) {
+			if (known.get(this._wasmGroupOf(groups, key)) !== true) return false;
+		}
+		return true;
 	}
 
 	/**
@@ -2920,15 +3014,16 @@ class RuntimeTemplate {
 			runtime,
 			chunkGraph
 		});
-		// Only a chunk that fetches may carry the public path into the literal, and only
-		// one needing no base: `readFile` takes a `file:` URL alone, and those loaders
-		// address the binary relative to the chunk anyway, ignoring the public path
-		// exactly as the runtime form does.
+		// Only a chunk that fetches may carry the public path into the literal: `readFile`
+		// takes a `file:` URL alone, and those loaders address the binary relative to the
+		// chunk anyway, ignoring the public path exactly as the runtime form does. One
+		// needing a base is spelled from the chunk the same way an asset url is — the gate
+		// answered first that every binary's climb back to the document is determinate.
 		const specifier = this._getAnalyzableFileSpecifier(
 			module,
 			chunkGraph,
 			[[filename.includes("[") ? "template" : "literal", filename]],
-			this._publicPathNeedsNoBase() && this._wasmChunksFetch(module, chunkGraph)
+			this._wasmModuleFetches(module, chunkGraph)
 		);
 		if (specifier !== null) return this.importMetaUrl(specifier);
 		// No bundler follows a concatenation, but this still sheds the module id and
@@ -2984,16 +3079,30 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether every chunk holding `module` loads WebAssembly through `fetch`, which is
-	 * what makes an absolute URL usable — the `async-node` and `universal` loaders hand
-	 * the result to `readFile`, and that accepts a `file:` URL alone.
+	 * Whether `module`'s binary is read through `fetch`, which is what makes the public
+	 * path reach it — the `async-node` and `universal` loaders hand the result to
+	 * `readFile`, which resolves the name against the chunk and takes a `file:` URL
+	 * alone. Asked of the runtimes the binary belongs to rather than of the chunks it
+	 * sits in: only an entry names a loader, so an async chunk of a fetching entry would
+	 * otherwise answer with the unrelated `output` default.
 	 * @param {Module} module the async wasm module
 	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @returns {boolean} true when every holding chunk fetches
+	 * @returns {boolean} true when every runtime reaching it fetches
 	 */
-	_wasmChunksFetch(module, chunkGraph) {
-		for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
-			if (this._chunkWasmLoading(chunk) !== "fetch") return false;
+	_wasmModuleFetches(module, chunkGraph) {
+		/** @type {string[]} */
+		const keys = [];
+		for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
+			forEachRuntime(moduleRuntime, (key) => {
+				keys.push(/** @type {string} */ (key));
+			});
+		}
+		// In no runtime at all nothing named a loader, so `output` answers.
+		if (keys.length === 0) return this.outputOptions.wasmLoading === "fetch";
+		const only = this._wasmGroupOnlyFetches();
+		const groups = this._wasmRuntimeGroups();
+		for (const key of keys) {
+			if (!only.get(this._wasmGroupOf(groups, key))) return false;
 		}
 		return true;
 	}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -911,10 +911,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether every entry of a wasm runtime group reads its binaries with `fetch`, keyed
-	 * by group. Only an entry names a loader — a chunk that is none answers with what
-	 * `output` says, which is not what its entry asked for — so the scan is of entries,
-	 * as `_wasmFetchingGroups` is.
+	 * Whether every entry of a wasm runtime group reads its binaries with `fetch`. Only
+	 * an entry names a loader, so the scan is of entries, as `_wasmFetchingGroups` is.
 	 * @returns {Map<string, boolean>} whether each group fetches and nothing else
 	 */
 	_wasmGroupOnlyFetches() {
@@ -937,14 +935,8 @@ class RuntimeTemplate {
 
 	/**
 	 * Whether a public path needing a base can be spelled from the chunk every binary of
-	 * a runtime sits in. `fetch` reads it against the document, so a literal has to climb
-	 * from its own chunk back to that document first — the same arithmetic an asset url
-	 * walks. Answered per runtime group rather than per binary, for the reason
-	 * `_anyWasmChunkFetches` is: the two ends have to agree and the runtime module names
-	 * no module. A binary is spellable when it is reached the one way the climb assumes —
-	 * every holding chunk fetching, so `readFile` never takes a prefix meant for the
-	 * document — from chunks that agree on whether the loader fetched them, and under a
-	 * path that resolves, which keeps the `.p` fallback unreachable here.
+	 * a runtime sits in — `fetch` reads it against the document, so a literal climbs back
+	 * there first. Per group, as `_anyWasmChunkFetches` is, since the two ends must agree.
 	 * @param {RuntimeSpec=} runtime the runtime being asked about
 	 * @returns {boolean} true when every binary of that group can be spelled
 	 */
@@ -973,8 +965,7 @@ class RuntimeTemplate {
 				}
 			}
 			// A group one entry reads with `readFile` cannot take a prefix meant for the
-			// document, and only an entry names its loader, so this is asked of the group
-			// rather than of the chunks a binary sits in.
+			// document, and only an entry names its loader.
 			for (const [group, only] of this._wasmGroupOnlyFetches()) {
 				if (!only) known.set(group, false);
 			}
@@ -3014,11 +3005,8 @@ class RuntimeTemplate {
 			runtime,
 			chunkGraph
 		});
-		// Only a chunk that fetches may carry the public path into the literal: `readFile`
-		// takes a `file:` URL alone, and those loaders address the binary relative to the
-		// chunk anyway, ignoring the public path exactly as the runtime form does. One
-		// needing a base is spelled from the chunk the same way an asset url is — the gate
-		// answered first that every binary's climb back to the document is determinate.
+		// Only a fetched binary carries the public path: `readFile` addresses it relative
+		// to the chunk anyway. One needing a base is spelled as an asset url is.
 		const specifier = this._getAnalyzableFileSpecifier(
 			module,
 			chunkGraph,
@@ -3079,12 +3067,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether `module`'s binary is read through `fetch`, which is what makes the public
-	 * path reach it — the `async-node` and `universal` loaders hand the result to
-	 * `readFile`, which resolves the name against the chunk and takes a `file:` URL
-	 * alone. Asked of the runtimes the binary belongs to rather than of the chunks it
-	 * sits in: only an entry names a loader, so an async chunk of a fetching entry would
-	 * otherwise answer with the unrelated `output` default.
+	 * Whether `module`'s binary is read through `fetch`, the one loader the public path
+	 * reaches. Asked of its runtimes, not its chunks: only an entry names a loader.
 	 * @param {Module} module the async wasm module
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @returns {boolean} true when every runtime reaching it fetches

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -68,6 +68,15 @@ class FetchCompileAsyncWasmPlugin {
 			 * @returns {string} code to load the wasm file
 			 */
 			const generateBakedLoadBinaryCode = (path) => `fetch(${path})`;
+			/**
+			 * A public path that never changes is the same string the global would hold,
+			 * and `fetch` reads both against the document, so it is inlined and the runtime
+			 * module that sets it is not needed.
+			 * @param {string} constant the settled public path
+			 * @returns {(path: string) => string} code to load the wasm file
+			 */
+			const generateConstantLoadBinaryCode = (constant) => (path) =>
+				`fetch(${JSON.stringify(constant)} + ${path})`;
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.instantiateWasm)
@@ -89,9 +98,15 @@ class FetchCompileAsyncWasmPlugin {
 					);
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
-					// A baked URL carries the public path already, or asks for the global itself
-					// when the module sits at several depths.
-					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL carries the public path already, and a settled one is written
+					// out below; only a path nothing but the global knows asks for it.
+					const constant =
+						baked || analyzable
+							? undefined
+							: compilation.runtimeTemplate.constantPublicPath();
+					if (!baked && !analyzable && constant === undefined) {
+						set.add(RuntimeGlobals.publicPath);
+					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!baked &&
@@ -115,7 +130,9 @@ class FetchCompileAsyncWasmPlugin {
 								? generateBakedLoadBinaryCode
 								: analyzable
 									? generateAnalyzableLoadBinaryCode
-									: generateLoadBinaryCode,
+									: constant === undefined
+										? generateLoadBinaryCode
+										: generateConstantLoadBinaryCode(constant),
 							supportsStreaming: true
 						})
 					);
@@ -141,9 +158,15 @@ class FetchCompileAsyncWasmPlugin {
 					);
 					const analyzable =
 						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
-					// A baked URL carries the public path already, or asks for the global itself
-					// when the module sits at several depths.
-					if (!baked && !analyzable) set.add(RuntimeGlobals.publicPath);
+					// A baked URL carries the public path already, and a settled one is written
+					// out below; only a path nothing but the global knows asks for it.
+					const constant =
+						baked || analyzable
+							? undefined
+							: compilation.runtimeTemplate.constantPublicPath();
+					if (!baked && !analyzable && constant === undefined) {
+						set.add(RuntimeGlobals.publicPath);
+					}
 					// A baked URL is already a literal, so nothing interpolates the name.
 					if (
 						!baked &&
@@ -167,7 +190,9 @@ class FetchCompileAsyncWasmPlugin {
 								? generateBakedLoadBinaryCode
 								: analyzable
 									? generateAnalyzableLoadBinaryCode
-									: generateLoadBinaryCode,
+									: constant === undefined
+										? generateLoadBinaryCode
+										: generateConstantLoadBinaryCode(constant),
 							supportsStreaming: true
 						})
 					);

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -69,9 +69,8 @@ class FetchCompileAsyncWasmPlugin {
 			 */
 			const generateBakedLoadBinaryCode = (path) => `fetch(${path})`;
 			/**
-			 * A public path that never changes is the same string the global would hold,
-			 * and `fetch` reads both against the document, so it is inlined and the runtime
-			 * module that sets it is not needed.
+			 * A settled public path is the same string the global would hold, and `fetch`
+			 * reads both against the document, so the runtime module is not needed.
 			 * @param {string} constant the settled public path
 			 * @returns {(path: string) => string} code to load the wasm file
 			 */

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-fetch-a-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-fetch-a-entry.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+// Never awaited: `fetch` cannot reach a relative public path from the test harness.
+export const load = () =>
+	import(/* webpackChunkName: "multi-lazy" */ "./multi-lazy");
+
+// Both entries reach this one chunk and both fetch, so the group is keyed by two
+// runtime keys and every one of them has to answer before the url is baked.
+it("should bake for a shared chunk every runtime fetches", () => {
+	const source = fs.readFileSync(
+		path.join(
+			__STATS__.children[__INDEX__].outputPath,
+			`${__NAME__}-multi-lazy.mjs`
+		),
+		"utf8"
+	);
+
+	expect(source).toContain(__BAKED__);
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-fetch-b-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/multi-fetch-b-entry.js
@@ -1,0 +1,7 @@
+// Loads the same chunk as `multi-fetch-a`, so the chunk carries both runtime keys.
+export const load = () =>
+	import(/* webpackChunkName: "multi-lazy" */ "./multi-lazy");
+
+it("should keep the shared chunk reachable from the second runtime", () => {
+	expect(typeof load).toBe("function");
+});

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/shared-entry.js
@@ -5,14 +5,25 @@ import path from "path";
 export const load = () =>
 	import(/* webpackChunkName: "shared-lazy" */ "./shared-lazy");
 
-it("should keep the runtime form for the binary both runtimes reach", () => {
-	const source = fs.readFileSync(
-		path.join(
-			__STATS__.children[__INDEX__].outputPath,
-			`${__NAME__}-shared-lazy.mjs`
-		),
+const read = (chunk) =>
+	fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}-${chunk}`),
 		"utf8"
 	);
 
-	expect(source).toContain(__RUNTIME_FORM__);
+it("should keep the runtime form for the binary both runtimes reach", () => {
+	expect(read("shared-lazy.mjs")).toContain(__RUNTIME_FORM__);
+});
+
+// Joined at runtime: this file is the web entry, so a needle written whole would be
+// inlined into the very bundle the assertions read.
+const needle = (...parts) => parts.join("");
+
+it("should write the settled public path into the loader that names it", () => {
+	const source = read("web.mjs");
+
+	// `fetch` reads both the inlined path and the global against the document, so a
+	// settled one is written out and the runtime module that sets it is not emitted.
+	expect(source).toContain(needle("fetch(", '"./"', " + "));
+	expect(source).not.toContain(needle("__webpack", "_require__.p = "));
 });

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/test.config.js
@@ -1,11 +1,13 @@
 "use strict";
 
-const NAMES = ["split", "shared", "multi"];
+const NAMES = ["split", "shared", "multi", "multi-fetch"];
+// The two shared-chunk configs run a pair of entries; the rest run three.
+const PAIRS = new Set([2, 3]);
 
 module.exports = {
 	findBundle(i) {
 		const name = NAMES[i];
-		return i === 2
+		return PAIRS.has(i)
 			? [`./${name}-a.mjs`, `./${name}-b.mjs`]
 			: [`./${name}-node.mjs`, `./${name}-web.mjs`, `./${name}-alone.mjs`];
 	}

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/web-entry.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/web-entry.js
@@ -4,7 +4,7 @@ import path from "path";
 // Never awaited: `fetch` cannot reach a relative public path from the test harness.
 export const load = () => import(/* webpackChunkName: "web-lazy" */ "./web-lazy");
 
-it("should keep the runtime form for the runtime that fetches the binary", () => {
+it("should bake the binary of a runtime that only fetches", () => {
 	const source = fs.readFileSync(
 		path.join(
 			__STATS__.children[__INDEX__].outputPath,
@@ -13,5 +13,5 @@ it("should keep the runtime form for the runtime that fetches the binary", () =>
 		"utf8"
 	);
 
-	expect(source).toContain(__RUNTIME_FORM__);
+	expect(source).toContain(__BAKED__);
 });

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -1,7 +1,8 @@
 "use strict";
 
-// Two entries loading wasm differently under a non-`auto` public path: only `fetch`
-// keeps the runtime form, unless the two share a binary and neither can be told apart.
+// Two entries loading wasm differently under a non-`auto` public path: each bakes the
+// url its own loader reads, unless the two share a binary and neither can be told
+// apart — one literal cannot be both what `readFile` and what `fetch` resolve.
 
 const webpack = require("../../../../");
 
@@ -66,7 +67,8 @@ const multi = (index, name) => ({
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	// A binary each: the runtimes are told apart, so only the fetching one bails.
+	// A binary each: the runtimes are told apart, so both bake the url their own
+	// loader reads.
 	base(0, "split", "./web-entry.js", 'new URL("./'),
 	// One binary between them: neither runtime can be answered on its own.
 	base(1, "shared", "./shared-entry.js", "module.id, "),

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -64,6 +64,17 @@ const multi = (index, name) => ({
 	}
 });
 
+// The same shared chunk, but every entry fetches under a public path needing a base:
+// the group answers key by key, and each key has to say the climb is knowable.
+/** @type {(index: number, name: string) => import("../../../../").Configuration} */
+const multiFetch = (index, name) => ({
+	...base(index, name, "./web-entry.js", 'new URL("./'),
+	entry: {
+		[`${name}-a`]: { import: "./multi-fetch-a-entry.js", wasmLoading: "fetch" },
+		[`${name}-b`]: { import: "./multi-fetch-b-entry.js", wasmLoading: "fetch" }
+	}
+});
+
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
 	// A binary each: the runtimes are told apart, so both bake the url their own
@@ -71,5 +82,6 @@ module.exports = [
 	base(0, "split", "./web-entry.js", 'new URL("./'),
 	// One binary between them: neither runtime can be answered on its own.
 	base(1, "shared", "./shared-entry.js", "module.id, "),
-	multi(2, "multi")
+	multi(2, "multi"),
+	multiFetch(3, "multi-fetch")
 ];

--- a/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
+++ b/test/configCases/wasm/analyzable-mixed-wasm-loading/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
 // Two entries loading wasm differently under a non-`auto` public path: each bakes the
-// url its own loader reads, unless the two share a binary and neither can be told
-// apart — one literal cannot be both what `readFile` and what `fetch` resolve.
+// url its own loader reads, unless a shared binary leaves one literal serving both.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
@@ -14,9 +14,19 @@ const INSTANTIATE = `${"__webpack_require__"}.v(exports, `;
  * @param {string} wasmRef expected start of the binary's reference
  * @param {boolean} runs whether the harness can load the binary that way
  * @param {string} publicPath the relative public path under test
+ * @param {string=} chunkDir directory the chunk is emitted under, so the path back to
+ * the output root is more than the `./` a flat name gives
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, name, wasmLoading, wasmRef, runs, publicPath) => ({
+const base = (
+	index,
+	name,
+	wasmLoading,
+	wasmRef,
+	runs,
+	publicPath,
+	chunkDir = ""
+) => ({
 	target: "node",
 	mode: "development",
 	devtool: false,
@@ -30,14 +40,14 @@ const base = (index, name, wasmLoading, wasmRef, runs, publicPath) => ({
 	output: {
 		module: true,
 		wasmLoading,
-		chunkFilename: `${name}-[name].mjs`,
+		chunkFilename: `${chunkDir}${name}-[name].mjs`,
 		webassemblyModuleFilename: `${name}-[id].wasm`,
 		publicPath
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
-			__CHUNK__: JSON.stringify(`${name}-lazy.mjs`),
+			__CHUNK__: JSON.stringify(`${chunkDir}${name}-lazy.mjs`),
 			__WASM_REF__: JSON.stringify(INSTANTIATE + wasmRef),
 			__RUNS__: JSON.stringify(runs)
 		})
@@ -54,7 +64,11 @@ module.exports = [
 	// A chunk-relative public path resolves the same way the harness does, so this one
 	// runs the binary the baked url points at.
 	base(2, "run", "async-node", 'new URL("./', true, "./"),
-	// `fetch` reads a relative public path against the document, which no literal
-	// anchored at the chunk can spell, so this one keeps the runtime form.
-	base(3, "relative", "fetch", "module.id, ", false, "./")
+	// `fetch` reads a relative public path against the document, and the chunk holding
+	// the reference was itself fetched through that path — so climbing out of the chunk
+	// lands back on the document and the literal spells the same place.
+	base(3, "relative", "fetch", 'new URL("./', false, "./"),
+	// The same, with the chunk a directory down and the public path a directory deep:
+	// the climb is what the `../` has to get right, which a flat `./` would hide.
+	base(4, "deep", "fetch", 'new URL("../deep-', false, "dist/", "nested/")
 ];

--- a/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
+++ b/test/configCases/wasm/analyzable-relative-public-path/webpack.config.js
@@ -64,11 +64,9 @@ module.exports = [
 	// A chunk-relative public path resolves the same way the harness does, so this one
 	// runs the binary the baked url points at.
 	base(2, "run", "async-node", 'new URL("./', true, "./"),
-	// `fetch` reads a relative public path against the document, and the chunk holding
-	// the reference was itself fetched through that path — so climbing out of the chunk
-	// lands back on the document and the literal spells the same place.
+	// The chunk was itself fetched through the public path, so climbing out of it lands
+	// back on the document the runtime form reads against.
 	base(3, "relative", "fetch", 'new URL("./', false, "./"),
-	// The same, with the chunk a directory down and the public path a directory deep:
-	// the climb is what the `../` has to get right, which a flat `./` would hide.
+	// The same one directory down, so the `../` climb is exercised, not a flat `./`.
 	base(4, "deep", "fetch", 'new URL("../deep-', false, "dist/", "nested/")
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A wasm binary read with `fetch` kept the runtime form whenever `output.publicPath` needed a base, because `fetch` resolves the public path against the document while a baked url resolves against the chunk. The chunk's own placement closes that gap — an entry chunk carries the public path, one the loader fetched climbs out of it — which is the arithmetic an analyzable asset url already walks. Follow-up to #21757, which did the same for asset urls.

Second commit: the async wasm loader read `__webpack_require__.p` for a public path that never changes, pulling the runtime module that sets it into every chunk holding a binary. `fetch` reads the inlined string and the global against the same document, so it is written out instead — the sync wasm loader has always done this.

Refusals over the ESM `configCases` drop from 181 to 176, and the base-needing wasm bucket from 12 to 6; the remaining 6 are binaries shared between a fetching and a `readFile` runtime, where one literal cannot be both. Both changes remove the `publicPath` runtime module from the builds they touch.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat — a wasm url is now baked in configurations that previously kept the runtime form.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/configCases/wasm/analyzable-relative-public-path` gains a config with the public path a directory deep and the chunk a directory down, so the `../` climb is exercised rather than the zero climb a flat `./` gives; `test/configCases/wasm/analyzable-mixed-wasm-loading` gains an assertion that the settled public path is written into the loader and the runtime module that sets it is gone. Two fixtures that documented the old bailouts were updated to document the new behaviour.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The baked url resolves to the same file the runtime form fetched, verified against the emitted output.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to survey where the analyzable gate refuses across the ESM `configCases`, to write the implementation and tests, and to verify the baked urls resolve to the same files as the runtime form. Every change was reviewed and the results checked against real builds and the test suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - WebAssembly requests now embed settled public paths directly when asset locations are known at build time.
  - Relative and nested asset paths resolve more reliably across split, shared, and mixed WebAssembly bundles.
  - Reduced reliance on runtime public-path configuration, improving portability.

- **Bug Fixes**
  - Improved handling of mixed WebAssembly loading scenarios.
  - Corrected generated asset URLs across different runtime configurations, including shared and asynchronously loaded binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->