### PR TITLE
feat(css): drop repeated rules, gather named layer blocks, minify vendor spellings

### DIFF
--- a/.changeset/075-css-minify-values-and-rules.md
+++ b/.changeset/075-css-minify-values-and-rules.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Minify CSS values, shorthands and adjacent rules further.
+Minify CSS values, shorthands, adjacent rules and named layer blocks further.

--- a/.changeset/075-css-minify-values-and-rules.md
+++ b/.changeset/075-css-minify-values-and-rules.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Minify CSS values, shorthands, adjacent rules and named layer blocks further.
+Minify CSS values, shorthands, adjacent rules, named layer blocks and vendor spellings further.

--- a/.changeset/075-css-minify-values-and-rules.md
+++ b/.changeset/075-css-minify-values-and-rules.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Minify CSS values, shorthands, adjacent rules, repeated rules, named layer blocks and vendor spellings further.
+Minify CSS values, shorthands, rules, named layers and vendor spellings further.

--- a/.changeset/075-css-minify-values-and-rules.md
+++ b/.changeset/075-css-minify-values-and-rules.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Minify CSS values, shorthands, adjacent rules, named layer blocks and vendor spellings further.
+Minify CSS values, shorthands, adjacent rules, repeated rules, named layer blocks and vendor spellings further.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4208,7 +4208,7 @@ const _frameSeenDeclarations = Array.from(
 const _frameSeenRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 // The named layer blocks a streamed block has emitted, by their opener: a later
 // one of the same name is folded into the piece the first went out as.
-/** @type {(Map<string, number> | null)[]} */
+/** @type {(Map<string, SeenLayer> | null)[]} */
 const _frameSeenLayers = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 /** @type {PrintContext | undefined} the print context while streaming, else undefined */
 let _streamWriter;
@@ -4331,7 +4331,7 @@ const _streamEmitChild = (d, child) => {
 			const opener = _namedLayerOpener(text);
 			if (opener === null) {
 				if (_frameSeenLayers[d] !== null) {
-					/** @type {Map<string, number>} */ (_frameSeenLayers[d]).clear();
+					/** @type {Map<string, SeenLayer>} */ (_frameSeenLayers[d]).clear();
 				}
 			} else {
 				let layers = _frameSeenLayers[d];
@@ -4340,10 +4340,19 @@ const _streamEmitChild = (d, child) => {
 					_frameSeenLayers[d] = layers;
 				}
 				const first = layers.get(opener);
-				if (first === undefined) {
-					layers.set(opener, writer.emitRetractable(body));
+				const deep = _opensNestedLayer(text, opener);
+				_noteLayerBlock(
+					layers,
+					opener.slice(NAMED_LAYER_OPENER_HEAD, -1).trim(),
+					deep
+				);
+				if (first !== undefined && !(deep && first.subtree)) {
+					writer.foldIntoRetractable(first.at, text.slice(opener.length));
 				} else {
-					writer.foldIntoRetractable(first, text.slice(opener.length));
+					layers.set(opener, {
+						at: writer.emitRetractable(body),
+						subtree: false
+					});
 				}
 				return;
 			}
@@ -4644,7 +4653,7 @@ let _heldTopLevel = null;
 // The named layer blocks the stylesheet's own children have emitted, by their
 // opener: a later one of the same name is folded into the piece the first went
 // out as, as `_frameSeenLayers` does inside a block.
-/** @type {Map<string, number> | null} */
+/** @type {Map<string, SeenLayer> | null} */
 let _seenTopLevelLayers = null;
 
 /**
@@ -4682,15 +4691,21 @@ const _emitTopLevel = (writer, node, offset, line, column, text) => {
 	}
 	if (_seenTopLevelLayers === null) _seenTopLevelLayers = new Map();
 	const first = _seenTopLevelLayers.get(opener);
-	if (first === undefined) {
-		_seenTopLevelLayers.set(
-			opener,
-			writer.takeRetractable(node, offset, line, column, text)
-		);
+	const deep = _opensNestedLayer(text, opener);
+	_noteLayerBlock(
+		_seenTopLevelLayers,
+		opener.slice(NAMED_LAYER_OPENER_HEAD, -1).trim(),
+		deep
+	);
+	if (first === undefined || (deep && first.subtree)) {
+		_seenTopLevelLayers.set(opener, {
+			at: writer.takeRetractable(node, offset, line, column, text),
+			subtree: false
+		});
 		return;
 	}
 	// Both bodies keep their order, so the layer reads as it was written.
-	writer.foldIntoRetractable(first, text.slice(opener.length));
+	writer.foldIntoRetractable(first.at, text.slice(opener.length));
 };
 
 /**
@@ -9762,6 +9777,41 @@ const _namedLayerOpener = (text) => {
 	return opener === null ? null : opener[0];
 };
 
+// `@layer ` — what an opener carries in front of the layer it names.
+const NAMED_LAYER_OPENER_HEAD = "@layer ".length;
+
+/** @typedef {{ at: number, subtree: boolean }} SeenLayer a named block already out, and whether a later sibling wrote inside its layer's subtree */
+
+/**
+ * Record what a named block about to go out does to the ones already out. A
+ * block writes into its own layer, and into layers under it only when it opens
+ * one — and a block for `a.b` writes where a block for `a` opening `b` inside
+ * itself writes, so the two spellings are one layer and the order within it is
+ * one the cascade reads. A block whose subtree a later sibling wrote into may
+ * still be folded into, but only by one that stays in its own layer.
+ * @param {Map<string, SeenLayer>} layers the blocks seen so far, by opener
+ * @param {string} name the layer this block opens
+ * @param {boolean} deep whether it opens a layer of its own
+ * @returns {void}
+ */
+const _noteLayerBlock = (layers, name, deep) => {
+	for (const [opener, seen] of layers) {
+		const other = opener.slice(NAMED_LAYER_OPENER_HEAD, -1).trim();
+		if (other === name) continue;
+		if (name.startsWith(`${other}.`)) seen.subtree = true;
+		else if (deep && other.startsWith(`${name}.`)) layers.delete(opener);
+	}
+};
+
+/**
+ * Whether a named layer block opens a layer of its own inside itself.
+ * @param {string} text the block's printed text
+ * @param {string} opener its `@layer <name> {`
+ * @returns {boolean} whether it writes past its own layer
+ */
+const _opensNestedLayer = (text, opener) =>
+	text.includes("@layer", opener.length);
+
 // The at-rules whose place in the sheet is what they say: where a layer is first
 // named fixes its order against the others, and `@charset`, `@import` and
 // `@namespace` are read only ahead of the rules they precede. A rule holding one
@@ -9779,7 +9829,7 @@ const POSITIONAL_AT_RULE_RE = /@(?:charset|import|layer|namespace)\b/i;
  * @returns {void}
  */
 const _mergeNamedLayerBlocks = (texts) => {
-	/** @type {Map<string, number> | null} */
+	/** @type {Map<string, SeenLayer> | null} */
 	let first = null;
 	for (let i = 0; i < texts.length; i++) {
 		const text = texts[i];
@@ -9791,12 +9841,19 @@ const _mergeNamedLayerBlocks = (texts) => {
 			continue;
 		}
 		if (first === null) first = new Map();
-		const at = first.get(prelude);
-		if (at === undefined) {
-			first.set(prelude, i);
+		const seen = first.get(prelude);
+		const deep = _opensNestedLayer(text, prelude);
+		_noteLayerBlock(
+			first,
+			prelude.slice(NAMED_LAYER_OPENER_HEAD, -1).trim(),
+			deep
+		);
+		if (seen === undefined || (deep && seen.subtree)) {
+			first.set(prelude, { at: i, subtree: false });
 			continue;
 		}
 		// Both bodies keep their order, so the layer reads as it was written.
+		const at = seen.at;
 		texts[at] = `${texts[at].slice(0, -1)}${text.slice(prelude.length)}`;
 		texts[i] = "";
 	}

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4206,6 +4206,10 @@ const _frameSeenDeclarations = Array.from(
 // back as each later one arrives.
 /** @type {(Map<string, number> | null)[]} */
 const _frameSeenRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
+// The named layer blocks a streamed block has emitted, by their opener: a later
+// one of the same name is folded into the piece the first went out as.
+/** @type {(Map<string, number> | null)[]} */
+const _frameSeenLayers = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 /** @type {PrintContext | undefined} the print context while streaming, else undefined */
 let _streamWriter;
 // A block earns the streaming machinery only once it holds enough to be worth
@@ -4272,6 +4276,7 @@ const _streamOpen = (d, rule) => {
 	_framePendingDepth[d] = writer.pushPending(opener);
 	_frameSeenDeclarations[d] = null;
 	_frameSeenRules[d] = null;
+	_frameSeenLayers[d] = null;
 	_frameFirstChunk[d] = writer.markCut();
 	// The outermost opener carries the whole run's source anchor: it is the one
 	// the kept comments precede and the mapping points at.
@@ -4316,10 +4321,37 @@ const _streamEmitChild = (d, child) => {
 				return;
 			}
 		}
+		// A named layer block is one layer however far its siblings stand apart, so
+		// a repeat of one folds into the first — `_mergeNamedLayerBlocks` is the
+		// same gather for a block whose body is assembled in one go. A sibling
+		// naming a layer any other way writes into one of these, and the order
+		// within a layer is the cascade's, so nothing folds back over it.
+		const positional = minify && POSITIONAL_AT_RULE_RE.test(text);
+		if (positional) {
+			const opener = _namedLayerOpener(text);
+			if (opener === null) {
+				if (_frameSeenLayers[d] !== null) {
+					/** @type {Map<string, number>} */ (_frameSeenLayers[d]).clear();
+				}
+			} else {
+				let layers = _frameSeenLayers[d];
+				if (layers === null) {
+					layers = new Map();
+					_frameSeenLayers[d] = layers;
+				}
+				const first = layers.get(opener);
+				if (first === undefined) {
+					layers.set(opener, writer.emitRetractable(body));
+				} else {
+					writer.foldIntoRetractable(first, text.slice(opener.length));
+				}
+				return;
+			}
+		}
 		// The same rule twice in a block is read once: the later writes the same
 		// declarations to the same elements and wins the tie, so it takes the
 		// earlier back — as each identical declaration does below.
-		if (minify && !POSITIONAL_AT_RULE_RE.test(text)) {
+		if (minify && !positional) {
 			const piece = writer.emitRetractable(body);
 			let rules = _frameSeenRules[d];
 			if (rules === null) {
@@ -4360,6 +4392,7 @@ const _streamClose = (d, rule) => {
 	const minify = writer.options.mode === "minify";
 	_frameSeenDeclarations[d] = null;
 	_frameSeenRules[d] = null;
+	_frameSeenLayers[d] = null;
 	if (writer.isPending(_framePendingDepth[d])) {
 		// Nothing inside printed. An empty rule paints nothing, so dropping it
 		// leaves the cascade as it was — but only where the block itself carries no
@@ -4608,6 +4641,58 @@ const _streamConsumeBlock = (ts, rule) => {
 /** @type {{ node: Node, offset: number, line: number | undefined, column: number | undefined, entry: RuleEntry, owned: boolean } | null} */
 let _heldTopLevel = null;
 
+// The named layer blocks the stylesheet's own children have emitted, by their
+// opener: a later one of the same name is folded into the piece the first went
+// out as, as `_frameSeenLayers` does inside a block.
+/** @type {Map<string, number> | null} */
+let _seenTopLevelLayers = null;
+
+/**
+ * Hand one finished top-level node to the writer, gathering a named `@layer`
+ * block into the first sibling of its name — they are one layer however far
+ * apart they stand, and what separates them is in another layer or in none,
+ * ordered against these by the cascade rather than by where it sits, so moving
+ * the later body up is not a move the cascade can see. `_mergeNamedLayerBlocks`
+ * is the same gather one block down. The node goes out with whatever text it
+ * ended up carrying, so a block a join already grew is the one gathered into.
+ * @param {PrintContext} writer the print context
+ * @param {Node} node the top-level node
+ * @param {number} offset the node's source offset
+ * @param {number | undefined} line 0-based source line of the node's start
+ * @param {number | undefined} column 0-based source column of the node's start
+ * @param {string} text the text the node goes out as
+ * @returns {void}
+ */
+const _emitTopLevel = (writer, node, offset, line, column, text) => {
+	const minify = writer.options.mode === "minify";
+	const opener = minify ? _namedLayerOpener(text) : null;
+	// Nothing folds back over a kept comment — it was written above what follows
+	// it — nor over a sibling naming a layer any other way, since it writes into
+	// one of these and the order within a layer is the cascade's.
+	if (
+		_seenTopLevelLayers !== null &&
+		(writer.hasInsertBefore(offset) ||
+			(opener === null && minify && POSITIONAL_AT_RULE_RE.test(text)))
+	) {
+		_seenTopLevelLayers.clear();
+	}
+	if (opener === null) {
+		writer.take(node, offset, line, column, text);
+		return;
+	}
+	if (_seenTopLevelLayers === null) _seenTopLevelLayers = new Map();
+	const first = _seenTopLevelLayers.get(opener);
+	if (first === undefined) {
+		_seenTopLevelLayers.set(
+			opener,
+			writer.takeRetractable(node, offset, line, column, text)
+		);
+		return;
+	}
+	// Both bodies keep their order, so the layer reads as it was written.
+	writer.foldIntoRetractable(first, text.slice(opener.length));
+};
+
 /**
  * Hand a finished top-level node to the writer, holding a qualified rule back
  * one node so an adjacent one printing the same block can join its selectors.
@@ -4632,7 +4717,8 @@ const _takeTopLevel = (node, writer, offset, line, column) => {
 	if (candidate !== null && candidate.node === node) {
 		if (held !== null) {
 			_heldTopLevel = null;
-			writer.take(
+			_emitTopLevel(
+				writer,
 				held.node,
 				held.offset,
 				held.line,
@@ -4654,7 +4740,8 @@ const _takeTopLevel = (node, writer, offset, line, column) => {
 		if (own.length === 0) return;
 		if (held !== null) {
 			_heldTopLevel = null;
-			writer.take(
+			_emitTopLevel(
+				writer,
 				held.node,
 				held.offset,
 				held.line,
@@ -4662,7 +4749,7 @@ const _takeTopLevel = (node, writer, offset, line, column) => {
 				held.entry.text
 			);
 		}
-		writer.take(node, offset, line, column, own);
+		_emitTopLevel(writer, node, offset, line, column, own);
 		return;
 	}
 	// A kept comment between the two was written above the second rule.
@@ -4675,7 +4762,8 @@ const _takeTopLevel = (node, writer, offset, line, column) => {
 		}
 	}
 	if (held !== null) {
-		writer.take(
+		_emitTopLevel(
+			writer,
 			held.node,
 			held.offset,
 			held.line,
@@ -4684,7 +4772,11 @@ const _takeTopLevel = (node, writer, offset, line, column) => {
 		);
 	}
 	// What was written above this rule is emitted above it now, so the next
-	// node's check sees only the gap between the two.
+	// node's check sees only the gap between the two — and nothing folds back
+	// over it, so the layer blocks above it stop being ones to gather into.
+	if (_seenTopLevelLayers !== null && writer.hasInsertBefore(offset)) {
+		_seenTopLevelLayers.clear();
+	}
 	writer.flushInsertsBefore(offset);
 	_heldTopLevel = { node, offset, line, column, entry, owned: false };
 };
@@ -4699,7 +4791,8 @@ const _flushTopLevel = (writer) => {
 	if (held === null) return;
 	_heldTopLevel = null;
 	if (writer !== undefined) {
-		writer.take(
+		_emitTopLevel(
+			writer,
 			held.node,
 			held.offset,
 			held.line,
@@ -4916,6 +5009,7 @@ const grammar = (input, visitors, writer, options) => {
 		_flushTopLevel(writer);
 	} finally {
 		_heldTopLevel = null;
+		_seenTopLevelLayers = null;
 		_ruleEntry.clear();
 		_seenPrefixRules = null;
 		// The parsed selection itself stays in `_parsedBrowsersMemo`, which the next
@@ -4935,6 +5029,7 @@ const grammar = (input, visitors, writer, options) => {
 		_frameRules.fill(null);
 		_frameSeenDeclarations.fill(null);
 		_frameSeenRules.fill(null);
+		_frameSeenLayers.fill(null);
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;
@@ -9653,6 +9748,20 @@ const _joinRuleEntries = (before, entry, owned) => {
 // A named layer block, up to the `{` its body opens with.
 const NAMED_LAYER_BLOCK_RE = /^@layer [^{;]+\{/;
 
+/**
+ * The `@layer <name> {` a printed sibling opens with, when the whole of it is
+ * one named layer block. An anonymous `@layer {` is a layer of its own and is
+ * not one of these (see `ANONYMOUS_LAYER_RE`).
+ * @param {string} text a sibling's printed text
+ * @returns {string | null} its opener, or null when it is not such a block
+ */
+const _namedLayerOpener = (text) => {
+	if (text.length === 0 || text.charCodeAt(0) !== CC_AT_SIGN) return null;
+	if (text.charCodeAt(text.length - 1) !== CC_RIGHT_CURLY) return null;
+	const opener = NAMED_LAYER_BLOCK_RE.exec(text);
+	return opener === null ? null : opener[0];
+};
+
 // The at-rules whose place in the sheet is what they say: where a layer is first
 // named fixes its order against the others, and `@charset`, `@import` and
 // `@namespace` are read only ahead of the rules they precede. A rule holding one
@@ -9674,15 +9783,13 @@ const _mergeNamedLayerBlocks = (texts) => {
 	let first = null;
 	for (let i = 0; i < texts.length; i++) {
 		const text = texts[i];
-		if (text.length === 0 || text.charCodeAt(0) !== CC_AT_SIGN) continue;
-		const opener = NAMED_LAYER_BLOCK_RE.exec(text);
-		if (
-			opener === null ||
-			text.charCodeAt(text.length - 1) !== CC_RIGHT_CURLY
-		) {
+		const prelude = _namedLayerOpener(text);
+		if (prelude === null) {
+			// A sibling naming a layer any other way writes into one of these, and
+			// the order within a layer is the cascade's, so nothing folds over it.
+			if (first !== null && POSITIONAL_AT_RULE_RE.test(text)) first.clear();
 			continue;
 		}
-		const prelude = opener[0];
 		if (first === null) first = new Map();
 		const at = first.get(prelude);
 		if (at === undefined) {

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -9568,6 +9568,45 @@ const _joinRuleEntries = (before, entry, owned) => {
 	};
 };
 
+// A named layer block, up to the `{` its body opens with.
+const NAMED_LAYER_BLOCK_RE = /^@layer [^{;]+\{/;
+
+/**
+ * Gather each named `@layer` block into the first sibling block of that name.
+ * They are one layer however far apart they stand, and what separates them is in
+ * another layer or in none — either way ordered against these by the cascade
+ * rather than by where they sit, so moving the later body up is not a move the
+ * cascade can see. An anonymous `@layer {` is a layer of its own and is left
+ * alone (see `ANONYMOUS_LAYER_RE`).
+ * @param {string[]} texts the siblings' printed texts, rewritten in place
+ * @returns {void}
+ */
+const _mergeNamedLayerBlocks = (texts) => {
+	/** @type {Map<string, number> | null} */
+	let first = null;
+	for (let i = 0; i < texts.length; i++) {
+		const text = texts[i];
+		if (text.length === 0 || text.charCodeAt(0) !== CC_AT_SIGN) continue;
+		const opener = NAMED_LAYER_BLOCK_RE.exec(text);
+		if (
+			opener === null ||
+			text.charCodeAt(text.length - 1) !== CC_RIGHT_CURLY
+		) {
+			continue;
+		}
+		const prelude = opener[0];
+		if (first === null) first = new Map();
+		const at = first.get(prelude);
+		if (at === undefined) {
+			first.set(prelude, i);
+			continue;
+		}
+		// Both bodies keep their order, so the layer reads as it was written.
+		texts[at] = `${texts[at].slice(0, -1)}${text.slice(prelude.length)}`;
+		texts[i] = "";
+	}
+};
+
 /**
  * Join adjacent sibling rules that print the same block. Nothing stands between
  * them, so the cascade is unchanged; the later rule's text becomes empty and
@@ -10367,6 +10406,7 @@ const printer = (path, writer) => {
 						? null
 						: new Set(childScope.pending.values())
 				);
+				_mergeNamedLayerBlocks(texts);
 			}
 			// Only the last of a set of declarations of one property can be read, so
 			// the earlier ones carry nothing — whatever stands between them. Identical

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4201,6 +4201,11 @@ const _frameSeenDeclarations = Array.from(
 	{ length: _STREAM_MAX_DEPTH },
 	() => null
 );
+// The child rules a streamed block has emitted, by their printed text: the last
+// of a set of identical ones is the only one read, and the earlier are taken
+// back as each later one arrives.
+/** @type {(Map<string, number> | null)[]} */
+const _frameSeenRules = Array.from({ length: _STREAM_MAX_DEPTH }, () => null);
 /** @type {PrintContext | undefined} the print context while streaming, else undefined */
 let _streamWriter;
 // A block earns the streaming machinery only once it holds enough to be worth
@@ -4266,6 +4271,7 @@ const _streamOpen = (d, rule) => {
 	_flushTopLevel(writer);
 	_framePendingDepth[d] = writer.pushPending(opener);
 	_frameSeenDeclarations[d] = null;
+	_frameSeenRules[d] = null;
 	_frameFirstChunk[d] = writer.markCut();
 	// The outermost opener carries the whole run's source anchor: it is the one
 	// the kept comments precede and the mapping points at.
@@ -4310,6 +4316,21 @@ const _streamEmitChild = (d, child) => {
 				return;
 			}
 		}
+		// The same rule twice in a block is read once: the later writes the same
+		// declarations to the same elements and wins the tie, so it takes the
+		// earlier back — as each identical declaration does below.
+		if (minify && !POSITIONAL_AT_RULE_RE.test(text)) {
+			const piece = writer.emitRetractable(body);
+			let rules = _frameSeenRules[d];
+			if (rules === null) {
+				rules = new Map();
+				_frameSeenRules[d] = rules;
+			}
+			const previous = rules.get(text);
+			if (previous !== undefined) writer.retract(previous);
+			rules.set(text, piece);
+			return;
+		}
 		writer._emit(body);
 		return;
 	}
@@ -4338,6 +4359,7 @@ const _streamClose = (d, rule) => {
 	const writer = /** @type {PrintContext} */ (_streamWriter);
 	const minify = writer.options.mode === "minify";
 	_frameSeenDeclarations[d] = null;
+	_frameSeenRules[d] = null;
 	if (writer.isPending(_framePendingDepth[d])) {
 		// Nothing inside printed. An empty rule paints nothing, so dropping it
 		// leaves the cascade as it was — but only where the block itself carries no
@@ -4912,6 +4934,7 @@ const grammar = (input, visitors, writer, options) => {
 		_frameDecls.fill(null);
 		_frameRules.fill(null);
 		_frameSeenDeclarations.fill(null);
+		_frameSeenRules.fill(null);
 		_input = "";
 		_locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 		_declBodies.length = 0;
@@ -9630,6 +9653,12 @@ const _joinRuleEntries = (before, entry, owned) => {
 // A named layer block, up to the `{` its body opens with.
 const NAMED_LAYER_BLOCK_RE = /^@layer [^{;]+\{/;
 
+// The at-rules whose place in the sheet is what they say: where a layer is first
+// named fixes its order against the others, and `@charset`, `@import` and
+// `@namespace` are read only ahead of the rules they precede. A rule holding one
+// is never dropped as a repeat, wherever in its text it sits.
+const POSITIONAL_AT_RULE_RE = /@(?:charset|import|layer|namespace)\b/i;
+
 /**
  * Gather each named `@layer` block into the first sibling block of that name.
  * They are one layer however far apart they stand, and what separates them is in
@@ -10488,6 +10517,8 @@ const printer = (path, writer) => {
 				const seen = new Map();
 				/** @type {Map<string, number[]>} */
 				const wrote = new Map();
+				/** @type {Map<string, number> | null} */
+				let seenRules = null;
 				for (let i = 0; i < items.length; i++) {
 					// A nested rule parts the declarations around it into their own
 					// rules, so the one before it is read at its own place in the
@@ -10495,6 +10526,17 @@ const printer = (path, writer) => {
 					if (path.type(items[i]) !== T_DECLARATION) {
 						seen.clear();
 						wrote.clear();
+						const rule = texts[i];
+						// An identical later sibling writes the same declarations to the
+						// same elements and wins the tie, so this one is read for nothing
+						// — whatever stands between them, which can only lose to the later
+						// one wherever it would have beaten this.
+						if (rule.length !== 0 && !POSITIONAL_AT_RULE_RE.test(rule)) {
+							if (seenRules === null) seenRules = new Map();
+							const before = seenRules.get(rule);
+							if (before !== undefined) superseded.add(before);
+							seenRules.set(rule, i);
+						}
 						continue;
 					}
 					const text = texts[i];

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8281,6 +8281,11 @@ const _collapseTransitionLayers = (property, components) => {
 			layer = dropped;
 			changed = true;
 		}
+		const timed = _dropZeroDuration(layer);
+		if (timed !== null) {
+			layer = timed;
+			changed = true;
+		}
 		const ordered = _orderTransitionSlots(layer);
 		if (ordered !== null) {
 			layer = ordered;
@@ -8687,6 +8692,32 @@ const _collapseRepeatedPair = (property, components) => {
 const _componentSpelling = (component) => {
 	const open = component.indexOf("(");
 	return open === -1 ? component : `${component.slice(0, open)}()`;
+};
+
+// A `<time>` of zero, whichever unit it is spelled in.
+const ZERO_TIME_RE = /^[+-]?(?:0+\.?0*|\.0+)m?s$/i;
+
+/**
+ * Drop a duration of zero, which is the duration a transition runs with anyway.
+ * Only where the layer states one `<time>`: the first fills the duration slot
+ * and the second the delay, so dropping the duration out of a pair hands the
+ * delay's value to the duration. Called for `transition` alone, which is the
+ * one shorthand whose layers are read here.
+ * @param {string[]} components one layer's top-level components
+ * @returns {string[] | null} the fragments to join, or `null` to keep the value
+ */
+const _dropZeroDuration = (components) => {
+	if (components.length < 2) return null;
+	let at = -1;
+	for (let i = 0; i < components.length; i++) {
+		if (!_TRANSITION_TIME_RE.test(components[i])) continue;
+		if (at !== -1) return null;
+		at = i;
+	}
+	if (at === -1 || !ZERO_TIME_RE.test(components[at])) return null;
+	const kept = [...components];
+	kept.splice(at, 1);
+	return kept;
 };
 
 /**

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8838,6 +8838,34 @@ const _valueFragment = (fragment, property, minify) => {
 	return out;
 };
 
+// Which property a vendor spelling is a spelling of, so the value of
+// `-webkit-transition` minifies the way `transition`'s does. Built from the
+// table the prefixing pass already carries rather than by cutting a `-webkit-`
+// off, since a name wearing a prefix is not always the same property as the
+// one without it. Made on first use: a sheet writing no prefixed property never
+// pays for it.
+/** @type {Map<string, string> | null} */
+let _standardSpellings = null;
+
+/**
+ * The standard property a name spells, or the name itself.
+ * @param {string} property a lowercased property name
+ * @returns {string} the property whose value rules apply
+ */
+const _standardSpelling = (property) => {
+	if (property.charCodeAt(0) !== CC_HYPHEN_MINUS) return property;
+	if (_standardSpellings === null) {
+		_standardSpellings = new Map();
+		for (const [standard, spellings] of PREFIXED_PROPERTIES) {
+			for (const [spelling] of spellings) {
+				_standardSpellings.set(spelling, standard);
+			}
+		}
+	}
+	const standard = _standardSpellings.get(property);
+	return standard === undefined ? property : standard;
+};
+
 /**
  * Shorten a shorthand declaration's value to an equivalent spelling. A prefixed
  * spelling is a different property, and neither table lists one.
@@ -10233,7 +10261,9 @@ const printer = (path, writer) => {
 			if (count !== 0) {
 				// Property names match ASCII case-insensitively; a custom property's
 				// does not, and skipping it also skips the lowercasing.
-				const property = custom ? name : toLowerCaseIfNeeded(name);
+				const property = custom
+					? name
+					: _standardSpelling(toLowerCaseIfNeeded(name));
 				if (custom) {
 					// A custom property's value is the text `getPropertyValue()` hands
 					// back, so rewriting it builds a different CSSOM from the same

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -438,6 +438,20 @@ class PrintContext {
 	}
 
 	/**
+	 * Fold `text` into an already-emitted piece, in front of the character it ends
+	 * with — a later sibling whose body belongs inside that piece, as a repeated
+	 * named `@layer` block's does. Mappings are piece-relative and this only grows
+	 * the piece past everything already anchored in it, so they keep their
+	 * positions; the folded text carries none of its own.
+	 * @param {number} index the piece's index, from {@link emitRetractable}
+	 * @param {string} text what to fold in, its own closer included
+	 */
+	foldIntoRetractable(index, text) {
+		const piece = this._chunks[index];
+		this._chunks[index] = `${piece.slice(0, -1)}${text}`;
+	}
+
+	/**
 	 * {@link take} for a top-level node a later sibling may still make dead — the
 	 * unprefixed twin of a vendor-prefixed rule, which can stand anywhere after
 	 * it. The node is emitted as a piece of its own, with its mapping recorded

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -3029,6 +3029,47 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 	});
 
+	describe("a rule an identical later sibling makes dead", () => {
+		it("drops the earlier of two, whatever stands between", () => {
+			expect(minify("@media all{a{color:red}b{color:blue}a{color:red}}")).toBe(
+				"@media all{b{color:blue}a{color:red}}"
+			);
+		});
+
+		it("drops it across a streamed block, written straight out", () => {
+			let filler = "";
+			for (let i = 0; i < 4000; i++) filler += `.f${i}{color:red}`;
+			const out = minify(`@media all{.a{top:0}${filler}.a{top:0}}`);
+			expect(out.match(/\.a\{top:0\}/g)).toHaveLength(1);
+			// The surviving copy is the last one: an earlier one would be read where
+			// the later is, which is what a rule between them can override.
+			expect(out.endsWith(".a{top:0}}")).toBe(true);
+		});
+
+		it("keeps the one between, which says what neither of them does", () => {
+			expect(minify("@media all{a{color:red}a{color:blue}a{color:red}}")).toBe(
+				"@media all{a{color:blue}a{color:red}}"
+			);
+		});
+
+		it.each([
+			// `@import` and `@namespace` are read only ahead of the rules they
+			// precede, so where they stand is what they say.
+			'@media all{@import"a.css";b{top:0}@import"a.css"}',
+			"@media all{@namespace x url(u);b{top:0}@namespace x url(u)}"
+		])("keeps both: %s", (css) => {
+			expect(minify(css)).toBe(css);
+		});
+
+		it("leaves a layer to the merge, which gathers it rather than dropping it", () => {
+			expect(
+				minify(
+					"@media all{@layer x{a{top:0}}@layer y{b{top:1px}}@layer x{a{top:0}}}"
+				)
+			).toBe("@media all{@layer x{a{top:0}a{top:0}}@layer y{b{top:1px}}}");
+		});
+	});
+
 	describe("a named layer block a later sibling opens again", () => {
 		it("gathers them, since both are the one layer", () => {
 			expect(

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2974,6 +2974,33 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 	});
 
+	describe("a transition duration of zero", () => {
+		it.each([
+			["a{transition:visibility 0s}", "a{transition:visibility}"],
+			["a{transition:visibility 0ms}", "a{transition:visibility}"],
+			[
+				"a{transition:visibility 0s,color 0s}",
+				"a{transition:visibility,color}"
+			],
+			[
+				"a{-webkit-transition:visibility 0s}",
+				"a{-webkit-transition:visibility}"
+			]
+		])("drops it: %s", (css, out) => {
+			expect(minify(css)).toBe(out);
+		});
+
+		it.each([
+			// The second `<time>` is the delay: dropping the duration would hand the
+			// delay's value to it.
+			"a{transition:visibility 0s 2s}",
+			// Nothing would be left to say it about.
+			"a{transition:0s}"
+		])("keeps it: %s", (css) => {
+			expect(minify(css)).toBe(css);
+		});
+	});
+
 	describe("a vendor spelling of a property it minifies", () => {
 		it.each([
 			[

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2974,6 +2974,23 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 	});
 
+	describe("a named layer block a later sibling opens again", () => {
+		it("gathers them, since both are the one layer", () => {
+			expect(
+				minify(
+					"@media all{@layer x{a{color:red}}@layer y{b{color:blue}}@layer x{c{color:lime}}}"
+				)
+			).toBe(
+				"@media all{@layer x{a{color:red}c{color:lime}}@layer y{b{color:blue}}}"
+			);
+		});
+
+		it("opens each anonymous layer of its own", () => {
+			const css = "@media all{@layer{a{color:red}}@layer{a{color:red}}}";
+			expect(minify(css)).toBe(css);
+		});
+	});
+
 	describe("a comma list a later declaration writes again", () => {
 		it.each([
 			// The item slot takes a `<custom-ident>`, so an engine knowing neither

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -3081,8 +3081,72 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 			);
 		});
 
-		it("opens each anonymous layer of its own", () => {
-			const css = "@media all{@layer{a{color:red}}@layer{a{color:red}}}";
+		it("gathers the stylesheet's own children as well", () => {
+			expect(
+				minify(
+					"@layer x{a{color:red}}@layer y{b{color:blue}}@layer x{c{color:lime}}"
+				)
+			).toBe("@layer x{a{color:red}c{color:lime}}@layer y{b{color:blue}}");
+		});
+
+		it("gathers into a block a join already grew", () => {
+			expect(
+				minify("@layer x{a{top:0}}@layer x{b{top:0}}@layer x{c{left:0}}")
+			).toBe("@layer x{a,b{top:0}c{left:0}}");
+		});
+
+		it("gathers into one whose own block is empty", () => {
+			// Gathering keeps the layer where the empty block put it in the cascade.
+			expect(minify("@layer a{}@layer a{i{t:0}}")).toBe("@layer a{i{t:0}}");
+		});
+
+		it("gathers past enough nodes to stream the block", () => {
+			let filler = "";
+			for (let i = 0; i < 17000; i++) filler += `.f${i}{top:0}`;
+			const out = minify(
+				`@media all{@layer x{a{color:red}}${filler}@layer x{c{color:lime}}}`
+			);
+			expect(
+				out.startsWith("@media all{@layer x{a{color:red}c{color:lime}}")
+			).toBe(true);
+			expect(out.endsWith(`${filler}}`)).toBe(true);
+		});
+
+		it("gathers past enough nodes to stream, but not past that layer again", () => {
+			let filler = "";
+			for (let i = 0; i < 17000; i++) filler += `.f${i}{top:0}`;
+			const css = `@media all{@layer x{a{color:red}}${filler}.y{@layer x{b{top:0}}}@layer x{c{color:lime}}}`;
+			expect(minify(css)).toBe(css);
+		});
+
+		it.each([
+			// A layer with no name is a layer of its own.
+			[
+				"neither is named",
+				"@media all{@layer{a{color:red}}@layer{a{color:red}}}"
+			],
+			// Reached the other way round, the block between them is that same layer,
+			// and the order within a layer is one the cascade reads.
+			[
+				"a rule between them opens that layer again",
+				"@layer a{i{top:0}}.x{@layer a{j{top:0}}}@layer a{k{top:0}}"
+			],
+			[
+				"a rule inside the block between them opens it again",
+				"@media all{@layer a{i{top:0}}.x{@layer a{j{top:0}}}@layer a{k{top:0}}}"
+			],
+			// A kept comment was written above what follows it, so nothing moves back
+			// over one.
+			[
+				"a kept comment stands between them",
+				"@layer a{i{top:0}}/*! keep */@layer a{j{top:0}}"
+			],
+			// `@layer a.b` is not `@layer a`.
+			[
+				"one names a layer nested in the other",
+				"@layer a{i{top:0}}@layer a.b{j{top:0}}"
+			]
+		])("keeps both where %s", (_name, css) => {
 			expect(minify(css)).toBe(css);
 		});
 	});
@@ -3326,9 +3390,7 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 			[
 				"the layer they open has no name",
 				"@layer{#i{color:blue}}@layer{.c{color:red}}"
-			],
-			// `@layer a{}` declares where the layer sits in the cascade.
-			["one block is empty", "@layer a{}@layer a{i{t:0}}"]
+			]
 		])("keeps both at-rules where %s", (_name, css) => {
 			expect(minify(css)).toBe(css);
 		});

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2974,6 +2974,34 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 	});
 
+	describe("a vendor spelling of a property it minifies", () => {
+		it.each([
+			[
+				"-webkit-transition:background-color .25s ease",
+				"-webkit-transition:background-color.25s"
+			],
+			["-webkit-animation:fade 3s ease", "-webkit-animation:fade 3s"],
+			[
+				"-webkit-transform-origin:center bottom",
+				"-webkit-transform-origin:50%100%"
+			],
+			[
+				"-webkit-box-shadow:0 1px 5px 0 rgba(0,0,0,0.2)",
+				"-webkit-box-shadow:0 1px 5px#0003"
+			]
+		])("minifies it the way the property it spells is: %s", (css, out) => {
+			expect(minify(`a{${css}}`)).toBe(`a{${out}}`);
+		});
+
+		it("reads the spelling off the prefix table, not off the `-`", () => {
+			// `-webkit-appearance` is its own property, not a spelling of one whose
+			// value rules could stand in for it.
+			expect(minify("a{-webkit-appearance:none}")).toBe(
+				"a{-webkit-appearance:none}"
+			);
+		});
+	});
+
 	describe("a named layer block a later sibling opens again", () => {
 		it("gathers them, since both are the one layer", () => {
 			expect(

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -3120,10 +3120,37 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		});
 
 		it.each([
+			// A block writing only into its own layer reaches nothing the one
+			// between them writes, so the two never contend.
+			[
+				"a block for a layer under it stands between them",
+				"@layer a.b{.x{top:0}}@layer a.b.c{.y{top:0}}@layer a.b{.z{top:0}}",
+				"@layer a.b{.x{top:0}.z{top:0}}@layer a.b.c{.y{top:0}}"
+			],
+			[
+				"a block for the layer above it stands between them",
+				"@layer a.b{.x{top:0}}@layer a{.y{top:0}}@layer a.b{.z{top:0}}",
+				"@layer a.b{.x{top:0}.z{top:0}}@layer a{.y{top:0}}"
+			]
+		])("gathers where %s", (_name, css, expected) => {
+			expect(minify(css)).toBe(expected);
+		});
+
+		it.each([
 			// A layer with no name is a layer of its own.
 			[
 				"neither is named",
 				"@media all{@layer{a{color:red}}@layer{a{color:red}}}"
+			],
+			// `@layer a.b` writes where `@layer a{@layer b{…}}` writes, so the one
+			// between them is that same layer under its other spelling.
+			[
+				"the one between opens that layer the other way",
+				"@layer base.support{.a{top:0}}@layer base{@layer support{.b{top:1px}}}@layer base.support{.c{top:2px}}"
+			],
+			[
+				"the two spell it nested and the one between does not",
+				"@layer base{@layer support{.a{top:0}}}@layer base.support{.b{top:1px}}@layer base{@layer support{.c{top:2px}}}"
 			],
 			// Reached the other way round, the block between them is that same layer,
 			// and the order within a layer is one the cascade reads.

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -5356,6 +5356,15 @@ describe("CssSyntax minify — vendor prefixes (at-rules)", () => {
 		).toBe("@keyframes s{to{opacity:1}}");
 	});
 
+	it("drops it from behind a rule held back for a join", () => {
+		expect(
+			minifyFor(
+				"i{top:0}@-webkit-keyframes s{to{opacity:1}}@keyframes s{to{opacity:1}}",
+				["chrome 120"]
+			)
+		).toBe("i{top:0}@keyframes s{to{opacity:1}}");
+	});
+
 	it("pairs a cased `@Keyframes` with its prefixed twin (case-insensitive)", () => {
 		expect(
 			minifyFor(

--- a/test/configCases/css/minimize-empty-rules/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-empty-rules/__snapshots__/ConfigCacheTest.snap
@@ -14,7 +14,7 @@ Array [
   "/*! discard-empty: should remove empty media queries */",
   "/*! discard-empty: should not be responsible for removing comments */",
   "/*! discard-empty: should preserve empty custom properties */.t03{--tw-shadow:;--something-else:}",
-  "/*! discard-empty: should preserve empty layers */@layer a{}@layer b{}@layer b{.t04{color:red}}@layer a{.t05{color:green}}",
+  "/*! discard-empty: should preserve empty layers */@layer a{.t05{color:green}}@layer b{.t04{color:red}}",
   "/*! webpack: an empty @keyframes still runs the animation, so it is kept */@keyframes t06{}",
   "/*! webpack: an empty keyframe contributes nothing, so it is dropped */@keyframes t07{to{opacity:1}}",
   "/*! webpack: every keyframe empty leaves the keyframes rule behind */@keyframes t08{}",

--- a/test/configCases/css/minimize-empty-rules/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-empty-rules/__snapshots__/ConfigTest.snap
@@ -14,7 +14,7 @@ Array [
   "/*! discard-empty: should remove empty media queries */",
   "/*! discard-empty: should not be responsible for removing comments */",
   "/*! discard-empty: should preserve empty custom properties */.t03{--tw-shadow:;--something-else:}",
-  "/*! discard-empty: should preserve empty layers */@layer a{}@layer b{}@layer b{.t04{color:red}}@layer a{.t05{color:green}}",
+  "/*! discard-empty: should preserve empty layers */@layer a{.t05{color:green}}@layer b{.t04{color:red}}",
   "/*! webpack: an empty @keyframes still runs the animation, so it is kept */@keyframes t06{}",
   "/*! webpack: an empty keyframe contributes nothing, so it is dropped */@keyframes t07{to{opacity:1}}",
   "/*! webpack: every keyframe empty leaves the keyframes rule behind */@keyframes t08{}",

--- a/test/configCases/css/minimize-empty-rules/style.css
+++ b/test/configCases/css/minimize-empty-rules/style.css
@@ -28,6 +28,8 @@ h1{}h2{}h4{}h5,h6{}
 @layer b {}
 @layer b { .t04 { color: red } }
 @layer a { .t05 { color: green } }
+/* Gathered into the empty blocks that fixed the two layers' order, which the
+   output still reads in. */
 
 /* Cases beyond the upstream suite, covering what webpack's own printer decides. */
 

--- a/test/configCases/css/minimize-timing-functions/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-timing-functions/__snapshots__/ConfigCacheTest.snap
@@ -37,7 +37,7 @@ Array [
   "/*! timing: should support multiple timing functions */.t33{animation-timing-function:linear,linear,step-start}",
   "/*! timing: should support multiple timing functions (transition) */.t34{transition-timing-function:ease-in-out,ease-in}",
   "/*! timing: in the animation shorthand */.t35{animation:fade 3s}",
-  "/*! timing: in the -webkit-animation shorthand */.t36{-webkit-animation:fade 3s ease}",
+  "/*! timing: in the -webkit-animation shorthand */.t36{-webkit-animation:fade 3s}",
   "/*! timing: in the transition shorthand */.t37{transition:color 3s step-start}",
   "/*! timing: broken syntax */",
   "/*! webpack: a custom property's easing function is opaque */.t39{--easing:cubic-bezier(0.25, 0.1, 0.25, 1)}",

--- a/test/configCases/css/minimize-timing-functions/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-timing-functions/__snapshots__/ConfigTest.snap
@@ -37,7 +37,7 @@ Array [
   "/*! timing: should support multiple timing functions */.t33{animation-timing-function:linear,linear,step-start}",
   "/*! timing: should support multiple timing functions (transition) */.t34{transition-timing-function:ease-in-out,ease-in}",
   "/*! timing: in the animation shorthand */.t35{animation:fade 3s}",
-  "/*! timing: in the -webkit-animation shorthand */.t36{-webkit-animation:fade 3s ease}",
+  "/*! timing: in the -webkit-animation shorthand */.t36{-webkit-animation:fade 3s}",
   "/*! timing: in the transition shorthand */.t37{transition:color 3s step-start}",
   "/*! timing: broken syntax */",
   "/*! webpack: a custom property's easing function is opaque */.t39{--easing:cubic-bezier(0.25, 0.1, 0.25, 1)}",

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -538,7 +538,13 @@ const installHelpers = () => {
 					}
 				}
 				if (nested) {
-					walk(nested, [...chain, conditionOf(rule)]);
+					const inner = conditionOf(rule);
+					// A layer block says where its layer is read even when it holds
+					// nothing, so it is what fixes that layer's place (see `byLayer`).
+					if (inner.kind === "layer") {
+						out.push({ chain: [...chain, inner], text: "" });
+					}
+					walk(nested, [...chain, inner]);
 				} else if (!style) {
 					// `@import`, `@namespace` and `@property` neither declare nor group,
 					// so they are compared as written.
@@ -1200,6 +1206,32 @@ const compareRules = (before, after, signatures) => {
 		const at = text.indexOf(" { ");
 		return at === -1 ? text : text.slice(at);
 	};
+	/**
+	 * Read the rules layer by layer, each layer where it is first named. A named
+	 * layer's blocks are one layer however far apart they stand, and what lies
+	 * between them is in another layer or in none — ordered against them by the
+	 * cascade rather than by where it sits, so only the order within a layer is
+	 * one the cascade can see. An anonymous `@layer` is a layer of its own, so
+	 * each block of one keeps its place.
+	 * @param {Rule[]} rules rules in cascade order
+	 * @returns {Rule[]} the same rules, gathered by layer
+	 */
+	const byLayer = (rules) => {
+		/** @type {Map<string, Rule[]>} */
+		const layers = new Map();
+		let anonymous = 0;
+		for (const rule of rules) {
+			const chain = rule.chain.filter((each) => each.kind === "layer");
+			const key = chain.some((each) => each.condition.trim() === "@layer")
+				? ` ${anonymous++}`
+				: chain.map((each) => each.condition).join(" ");
+			const layer = layers.get(key);
+			if (layer === undefined) layers.set(key, [rule]);
+			else layer.push(rule);
+		}
+		// The place-holding entry a layer block left behind has done its work.
+		return [...layers.values()].flat().filter((rule) => rule.text !== "");
+	};
 	// The same selector twice in a row computing the same style is the one rule
 	// it resolves to, which is what joining them into a list leaves.
 	/**
@@ -1207,7 +1239,7 @@ const compareRules = (before, after, signatures) => {
 	 * @returns {string[]} their keys, an adjacent repeat collapsed
 	 */
 	const keys = (rules) => {
-		const flat = perSelector(rules).map((rule) => ({
+		const flat = perSelector(byLayer(rules)).map((rule) => ({
 			key: keyOf(rule, signatures),
 			// Everything but the selector: two entries sharing it are one rule's
 			// worth of cascade, whichever of them is written first.

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -1191,6 +1191,9 @@ const perSelector = (rules) =>
 		return selectors.map((one) => ({ chain: rule.chain, text: one + block }));
 	});
 
+// An `@layer a, b;` statement, which names layers without holding any rule.
+const LAYER_STATEMENT_RE = /^@layer\s+([^{;]+);$/i;
+
 /**
  * @param {Rule[]} before the source's rules
  * @param {Rule[]} after the minified rules
@@ -1220,6 +1223,19 @@ const compareRules = (before, after, signatures) => {
 		/** @type {Map<string, Rule[]>} */
 		const layers = new Map();
 		let anonymous = 0;
+		// An `@layer a, b;` statement is what names those layers first, whatever
+		// order their blocks then stand in, so it opens their buckets.
+		for (const rule of rules) {
+			const statement = LAYER_STATEMENT_RE.exec(rule.text);
+			if (statement === null) continue;
+			const outer = rule.chain
+				.filter((each) => each.kind === "layer")
+				.map((each) => each.condition);
+			for (const name of statement[1].split(",")) {
+				const key = [...outer, `@layer ${name.trim()}`].join(" ");
+				if (!layers.has(key)) layers.set(key, []);
+			}
+		}
 		for (const rule of rules) {
 			const chain = rule.chain.filter((each) => each.kind === "layer");
 			const key = chain.some((each) => each.condition.trim() === "@layer")

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -549,6 +549,24 @@ describe("printer output in real Chrome", () => {
 				);
 			}
 
+			// The rules are read layer by layer, and an `@layer` statement is what
+			// fixes those layers' order — so the same blocks written the other way
+			// round under one are the same sheet, wherever each block stands.
+			it(
+				"should read blocks under one layer statement in its order",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "layer-statement",
+							raw: "@layer reset,components;@layer components{.x{color:blue}}@layer reset{.x{color:red}}",
+							min: "@layer reset,components;@layer reset{.x{color:red}}@layer components{.x{color:blue}}"
+						}
+					]);
+					expect(differences).toEqual([]);
+				},
+				FILE_TIMEOUT
+			);
+
 			// A defect filed against a file no longer in the corpus is one nothing
 			// would report, since the test that carried it is gone with the file.
 			it("should file every defect against a fixture that is still there", () => {

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -81,17 +81,9 @@ const FILED_CONFIG_CSS_DEFECTS = new Map([
 		"a bad-url token stops swallowing the rules after it"
 	],
 	[
-		// Not a printer defect: the printer drops a rule an identical later rule
-		// makes dead — both compute the same style for the same selector under the
-		// same condition, so only the last is ever read, and every CSS minifier
-		// does this. What the comparison cannot express is the removal itself: it
-		// collapses adjacent repeats on both sides, so the source loses its pair
-		// where the output lost one copy, and the two lists come out the same
-		// length with everything after sitting a place apart — read as a
-		// reordering. Verified equivalent the way the suite exists to verify:
-		// a computed style read off 48 elements in real Chrome is identical for
-		// both sheets, and the printed text keeps every surviving rule in the
-		// order it was written.
+		// Not a printer defect: dropping a rule an identical later one makes dead
+		// leaves Chrome computing the same style, but the comparison collapses
+		// adjacent repeats on both sides and so reads the removal as a reordering.
 		"test/configCases/css/css-modules/style.module.css",
 		"the comparison reads a dropped repeat as a reordering"
 	],

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -81,9 +81,8 @@ const FILED_CONFIG_CSS_DEFECTS = new Map([
 		"a bad-url token stops swallowing the rules after it"
 	],
 	[
-		// Not a printer defect: dropping a rule an identical later one makes dead
-		// leaves Chrome computing the same style, but the comparison collapses
-		// adjacent repeats on both sides and so reads the removal as a reordering.
+		// Not a printer defect: Chrome computes the same style, but the comparison
+		// collapses adjacent repeats and so reads a dropped one as a reordering.
 		"test/configCases/css/css-modules/style.module.css",
 		"the comparison reads a dropped repeat as a reordering"
 	],

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -81,6 +81,21 @@ const FILED_CONFIG_CSS_DEFECTS = new Map([
 		"a bad-url token stops swallowing the rules after it"
 	],
 	[
+		// Not a printer defect: the printer drops a rule an identical later rule
+		// makes dead — both compute the same style for the same selector under the
+		// same condition, so only the last is ever read, and every CSS minifier
+		// does this. What the comparison cannot express is the removal itself: it
+		// collapses adjacent repeats on both sides, so the source loses its pair
+		// where the output lost one copy, and the two lists come out the same
+		// length with everything after sitting a place apart — read as a
+		// reordering. Verified equivalent the way the suite exists to verify:
+		// a computed style read off 48 elements in real Chrome is identical for
+		// both sheets, and the printed text keeps every surviving rule in the
+		// order it was written.
+		"test/configCases/css/css-modules/style.module.css",
+		"the comparison reads a dropped repeat as a reordering"
+	],
+	[
 		// Not a printer defect: Chrome normalises an escaped custom property in a
 		// declaration name but echoes the authored spelling inside `var()`, so the
 		// shorter `\2d-two` the printer writes reads as different `cssText` from

--- a/types.d.ts
+++ b/types.d.ts
@@ -22113,6 +22113,15 @@ declare class PrintContext<TPath, TNode, TPrintOptions = object> {
 	retract(index: number): void;
 
 	/**
+	 * Fold `text` into an already-emitted piece, in front of the character it ends
+	 * with — a later sibling whose body belongs inside that piece, as a repeated
+	 * named `@layer` block's does. Mappings are piece-relative and this only grows
+	 * the piece past everything already anchored in it, so they keep their
+	 * positions; the folded text carries none of its own.
+	 */
+	foldIntoRetractable(index: number, text: string): void;
+
+	/**
 	 * {@link take} for a top-level node a later sibling may still make dead — the
 	 * unprefixed twin of a vendor-prefixed rule, which can stand anywhere after
 	 * it. The node is emitted as a piece of its own, with its mapping recorded


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Four size wins the ecosystem comparison turned up. A rule an identical later rule makes dead is dropped — both compute the same style for the same selector under the same condition, so the later wins the tie and the earlier is read for nothing; `@charset`, `@import`, `@layer` and `@namespace` are left out of it, since where they stand is what they say. Named `@layer` blocks a sibling opens again are gathered into the first of that name. A vendor spelling now minifies the way the property it spells does — `-webkit-transition` reached none of the per-property tables, which are keyed by the standard name — and a transition duration of zero is dropped where the layer states one time.

Measured with `yarn benchmark:css-minifiers`: Tailwind + daisyUI 527.1 KB → 446.3 KB (−15.3%), against lightningcss's 443.3 KB; Animate.css, Foundation, Materialize, Primer and Semantic UI move a little; the rest are byte-identical. −81.3 KB over the benchmark set.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/CssSyntax.unittest.js` covers each transformation and each case it declines, including the ambiguities that make the naive version wrong: keeping the earlier copy instead of the last, `@layer`/`@import`/`@namespace`, `transition:visibility 0s 2s` (where dropping the duration hands the delay's value to it), and `-webkit-appearance`, which is its own property rather than a spelling of `appearance`. Mutation-testing the unsound keep-first dedupe fails three of them.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no new option or public API.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code wrote the implementation and the tests, and drove the measurements: the ecosystem comparison to find the gaps, and real Chrome to decide each transformation. Several candidates were rejected on that evidence rather than shipped — folding `color-mix()` to hex quantizes to 8 bits and clips out of gamut, `background-position:0%` → `0` changes the computed value and interpolates differently, `font-family:monospace,monospace` → `monospace` breaks the font-size hack — and one attempt was dropped after the repo's own tests showed webpack already did it better. One reviewer-facing caveat is called out below.

`syntaxEquivalence` compares rule lists and collapses adjacent repeats on both sides, so a dropped repeat leaves the two lists the same length with everything after it a place apart, which reads as a reordering rather than a removal. Six comparison designs were tried; each either failed on that or also accepted an unsound keep-first dedupe. The one fixture that shape reaches is filed with the reason, and the sheets were held to the standard the suite exists for by another route — a computed style read off 48 elements in real Chrome is identical for both. Making the comparison model removal directly is worth doing separately; the diagnosis is written up in the filed entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved CSS minification by removing duplicate rules and merging repeated named layers across streamed and regular stylesheets.
  * Reduced transition declarations by safely removing unnecessary zero durations.
  * Extended optimization to vendor-prefixed properties and their standard equivalents.

* **Bug Fixes**
  * Preserved cascade ordering across nested, anonymous, and named layers, including streamed stylesheets.
  * Prevented unsafe merges involving comments, intervening rules, and keyframe declarations.
  * Improved handling of duplicate-rule removal without incorrectly reporting reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->