### PR TITLE
perf: remove props with inlined value when rendering a ns obj

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -2612,43 +2612,28 @@ ${defineGetters}`
 			for (const exportInfo of exportsInfo.orderedExports) {
 				if (exportInfo.provided === false) continue;
 				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (usedName) {
-					// TODO: Replace with the inlined value directly at the call site
-					if (usedName instanceof InlinedUsedName) {
-						nsObj.push(
-							`\n  ${propertyName(
-								exportInfo.name
-							)}: ${runtimeTemplate.returningFunction(
-								usedName.render(
-									Template.toNormalComment(
-										`inlined export ${propertyAccess([exportInfo.name])}`
-									)
-								)
-							)}`
-						);
-					} else {
-						const finalName = getFinalName(
-							moduleGraph,
-							info,
-							[exportInfo.name],
-							moduleToInfoMap,
-							runtime,
-							requestShortener,
-							runtimeTemplate,
-							neededNamespaceObjects,
-							false,
-							false,
-							undefined,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							true
-						);
-						nsObj.push(
-							`\n  ${propertyName(
-								usedName
-							)}: ${runtimeTemplate.returningFunction(finalName)}`
-						);
-					}
+				if (usedName && !(usedName instanceof InlinedUsedName)) {
+					const finalName = getFinalName(
+						moduleGraph,
+						info,
+						[exportInfo.name],
+						moduleToInfoMap,
+						runtime,
+						requestShortener,
+						runtimeTemplate,
+						neededNamespaceObjects,
+						false,
+						false,
+						undefined,
+						/** @type {BuildMeta} */
+						(info.module.buildMeta).strictHarmonyModule,
+						true
+					);
+					nsObj.push(
+						`\n  ${propertyName(
+							usedName
+						)}: ${runtimeTemplate.returningFunction(finalName)}`
+					);
 				}
 			}
 			const name = info.namespaceObjectName;


### PR DESCRIPTION
**Summary**

A concatenated module's namespace object emitted a getter for every inlined export, this PR drops those getters so `__webpack_require__.d` is handed only the exports that still need an real accessor.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace export generation by excluding unused or inlined exports.
  * Preserved correct resolution of regular exports and their used names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->