### PR TITLE
feat(analyzable): bake a lazy context's chunk imports into its map

### DIFF
--- a/.changeset/029-analyzable-context-modules.md
+++ b/.changeset/029-analyzable-context-modules.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Bake the chunk imports of a lazy context into its own request map.

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1207,6 +1207,55 @@ module.exports = webpackAsyncContext;`;
 			}
 		}
 		const shortMode = hasNoChunk && hasNoModuleDeferred && !hasFakeMap;
+		let needEnsureChunk = !hasNoChunk;
+		/** @type {Map<string, string[]> | undefined} */
+		let loaders;
+		// Only module output can name a chunk in an `import()`, so nothing else pays for
+		// building the loaders just to throw them away.
+		if (!hasNoChunk && runtimeTemplate.isModule()) {
+			/** @type {Map<string, string[]>} */
+			const perRequest = new Map();
+			let hasAnalyzable = false;
+			let hasFallback = false;
+			/**
+			 * @param {Chunk} chunk one chunk a request needs
+			 * @returns {string} a thunk loading it, by literal name where the chunk has one
+			 */
+			const loaderFor = (chunk) => {
+				// `.ei` always imports, where `.e` skips a chunk already loaded — the same
+				// filter `blockPromise` applies before reaching for it.
+				const analyzable =
+					chunk.hasRuntime() || chunk.id === null
+						? null
+						: runtimeTemplate.analyzableChunkImport(
+								chunk,
+								"",
+								runtimeRequirements,
+								this,
+								chunkGraph
+							);
+				if (analyzable !== null) {
+					hasAnalyzable = true;
+					return runtimeTemplate.returningFunction(analyzable);
+				}
+				hasFallback = true;
+				return runtimeTemplate.returningFunction(
+					`${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)})`
+				);
+			};
+			for (const item of items) {
+				perRequest.set(
+					item.userRequest,
+					/** @type {Chunk[]} */ (item.chunks).map(loaderFor)
+				);
+			}
+			// Nothing gained when no chunk can be spelled out, and the plain id map is
+			// smaller, so the loaders are only written when at least one names its chunk.
+			if (hasAnalyzable) {
+				loaders = perRequest;
+				needEnsureChunk = hasFallback;
+			}
+		}
 		const sortedItems = items.sort((a, b) => {
 			if (a.userRequest === b.userRequest) return 0;
 			return a.userRequest < b.userRequest ? -1 : 1;
@@ -1244,11 +1293,16 @@ module.exports = webpackAsyncContext;`;
 		const asyncDepsPosition = hasNoChunk ? chunksPosition : chunksPosition + 1;
 		const requestPrefix = hasNoChunk
 			? "Promise.resolve()"
-			: hasMultipleOrNoChunks
-				? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
-				: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
-		// Only the id map reads it; nothing loads a chunk when there is none to load.
-		if (!hasNoChunk) {
+			: loaders !== undefined
+				? hasMultipleOrNoChunks
+					? `Promise.all(ids[${chunksPosition}].map(${runtimeTemplate.returningFunction("load()", "load")}))`
+					: `ids[${chunksPosition}][0]()`
+				: hasMultipleOrNoChunks
+					? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
+					: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
+		// Only the id map reads it; nothing loads a chunk when there is none to load, and
+		// a map of loaders spells out every one it could reach for.
+		if (needEnsureChunk) {
 			runtimeRequirements.add(RuntimeGlobals.ensureChunk);
 		}
 		const returnModuleObject = this.getReturnModuleObjectSource(
@@ -1292,7 +1346,28 @@ function webpackAsyncContext(req) {
 	return ${requestPrefix}.then(${runtimeTemplate.returningFunction(returnModuleObject)});
 }`;
 
-		return `${cst} map = ${JSON.stringify(map, null, "\t")};
+		// A loader is source, not data, so the map holding one is written out rather than
+		// serialized — one entry per line, keeping the request next to what loads it.
+		const mapSource =
+			loaders === undefined
+				? JSON.stringify(map, null, "\t")
+				: `{\n${Object.keys(map)
+						.map((request) => {
+							const slots =
+								/** @type {(ModuleId | FakeMapType | ChunkId[] | (ModuleId[] | undefined))[]} */
+								(map[request]).map((slot, index) =>
+									index === chunksPosition
+										? `[${/** @type {string[]} */ (loaders.get(request)).join(", ")}]`
+										: // An absent `asyncDeps` slot is `null` to `JSON.stringify`.
+											slot === undefined
+											? "null"
+											: JSON.stringify(slot)
+								);
+							return `\t${JSON.stringify(request)}: [${slots.join(", ")}]`;
+						})
+						.join(",\n")}\n}`;
+
+		return `${cst} map = ${mapSource};
 ${webpackAsyncContext}
 webpackAsyncContext.keys = ${runtimeTemplate.returningFunction(
 			"Object.keys(map)"

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1207,6 +1207,12 @@ module.exports = webpackAsyncContext;`;
 			}
 		}
 		const shortMode = hasNoChunk && hasNoModuleDeferred && !hasFakeMap;
+		// Sorted before anything is keyed by request, so two items sharing one leave the
+		// same last writer in the map and in the loaders beside it.
+		const sortedItems = items.sort((a, b) => {
+			if (a.userRequest === b.userRequest) return 0;
+			return a.userRequest < b.userRequest ? -1 : 1;
+		});
 		let needEnsureChunk = !hasNoChunk;
 		/** @type {Map<string, string[]> | undefined} */
 		let loaders;
@@ -1243,7 +1249,7 @@ module.exports = webpackAsyncContext;`;
 					`${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)})`
 				);
 			};
-			for (const item of items) {
+			for (const item of sortedItems) {
 				perRequest.set(
 					item.userRequest,
 					/** @type {Chunk[]} */ (item.chunks).map(loaderFor)
@@ -1256,10 +1262,6 @@ module.exports = webpackAsyncContext;`;
 				needEnsureChunk = hasFallback;
 			}
 		}
-		const sortedItems = items.sort((a, b) => {
-			if (a.userRequest === b.userRequest) return 0;
-			return a.userRequest < b.userRequest ? -1 : 1;
-		});
 		/** @type {Record<string, ModuleId | (ModuleId | FakeMapType | ChunkId[] | (ModuleId[] | undefined))[]>} */
 		const map = Object.create(null);
 		for (const item of sortedItems) {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2361,7 +2361,7 @@ class RuntimeTemplate {
 		// that changes.
 		const fetchPriority = chunkGroup.options.fetchPriority;
 		if (chunks.length === 1) {
-			const analyzable = this._analyzableChunkImport(
+			const analyzable = this.analyzableChunkImport(
 				chunks[0],
 				comment,
 				runtimeRequirements,
@@ -2389,7 +2389,7 @@ class RuntimeTemplate {
 			 * @returns {string} require chunk id code
 			 */
 			const requireChunkId = (chunk) => {
-				const analyzable = this._analyzableChunkImport(
+				const analyzable = this.analyzableChunkImport(
 					chunk,
 					"",
 					runtimeRequirements,
@@ -2427,7 +2427,7 @@ class RuntimeTemplate {
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @returns {string | null} the import expression, or `null`
 	 */
-	_analyzableChunkImport(
+	analyzableChunkImport(
 		chunk,
 		comment,
 		runtimeRequirements,

--- a/test/configCases/analyzable/context-module/defer-entry.js
+++ b/test/configCases/analyzable/context-module/defer-entry.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import.defer(`./defer/${name}.js`);
+
+it("should load a deferred candidate either way", async () => {
+	expect((await load("sync")).default).toBe("sync");
+	expect((await load("async")).default).toBe("async");
+});
+
+it("should keep the loaders ahead of the deferred slot", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	expect(bundle).toContain("return ids[1][0]()");
+	// An async candidate defers nothing, so its trailing slot is written out empty.
+	expect(bundle).toContain(`import("./${__NAME__}-defer_async_js.mjs")`);
+	expect(bundle).toContain("], null]");
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
+});

--- a/test/configCases/analyzable/context-module/defer/async.js
+++ b/test/configCases/analyzable/context-module/defer/async.js
@@ -1,0 +1,3 @@
+await Promise.resolve();
+
+export default "async";

--- a/test/configCases/analyzable/context-module/defer/sync.js
+++ b/test/configCases/analyzable/context-module/defer/sync.js
@@ -1,0 +1,1 @@
+export default "sync";

--- a/test/configCases/analyzable/context-module/fake-entry.js
+++ b/test/configCases/analyzable/context-module/fake-entry.js
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import(`./fake/${name}.js`);
+
+it("should load candidates of either exports type", async () => {
+	expect((await load("esm")).default).toBe("esm");
+	expect((await load("cjs")).default).toBe("cjs");
+});
+
+it("should keep the loaders behind the fake-map slot", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	// The exports type sits at 1, so the loaders moved one along.
+	expect(bundle).toContain("return ids[2][0]()");
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
+});

--- a/test/configCases/analyzable/context-module/fake/cjs.js
+++ b/test/configCases/analyzable/context-module/fake/cjs.js
@@ -1,0 +1,1 @@
+module.exports = "cjs";

--- a/test/configCases/analyzable/context-module/fake/esm.js
+++ b/test/configCases/analyzable/context-module/fake/esm.js
@@ -1,0 +1,1 @@
+export default "esm";

--- a/test/configCases/analyzable/context-module/locales/de.js
+++ b/test/configCases/analyzable/context-module/locales/de.js
@@ -1,0 +1,1 @@
+export default "de";

--- a/test/configCases/analyzable/context-module/locales/en.js
+++ b/test/configCases/analyzable/context-module/locales/en.js
@@ -1,0 +1,1 @@
+export default "en";

--- a/test/configCases/analyzable/context-module/mixed-entry.js
+++ b/test/configCases/analyzable/context-module/mixed-entry.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import(`./mixed/${name}.js`);
+
+it("should load a candidate either way round", async () => {
+	expect((await load("de")).default).toBe("de");
+	expect((await load("en")).default).toBe("en");
+});
+
+it("should keep the runtime form for the chunk it cannot import", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	// `de` was split into the chunk carrying the runtime: importing that from itself
+	// would be a cycle, so only `en` is baked.
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(2);
+	expect(bundle).toContain(`import("./${__NAME__}-mixed_en_js.mjs")`);
+	expect(bundle).toContain(`${"__webpack_require__"}.e(${JSON.stringify(__NAME__)})`);
+	// One loader still asks for it, so the runtime module has to ship.
+	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
+});

--- a/test/configCases/analyzable/context-module/mixed/de.js
+++ b/test/configCases/analyzable/context-module/mixed/de.js
@@ -1,0 +1,1 @@
+export default "de";

--- a/test/configCases/analyzable/context-module/mixed/en.js
+++ b/test/configCases/analyzable/context-module/mixed/en.js
@@ -1,0 +1,1 @@
+export default "en";

--- a/test/configCases/analyzable/context-module/plain-entry.js
+++ b/test/configCases/analyzable/context-module/plain-entry.js
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import(`./locales/${name}.js`);
+
+it("should load every candidate of the context", async () => {
+	expect((await load("de")).default).toBe("de");
+	expect((await load("en")).default).toBe("en");
+});
+
+it("should write a static import next to each request", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	// One per candidate, and every one of them in the map itself.
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	expect(bundle).toContain(`import("./${__NAME__}-locales_de_js.mjs")`);
+	expect(bundle).toContain(`import("./${__NAME__}-locales_en_js.mjs")`);
+	// A single chunk per request needs no `Promise.all` around it.
+	expect(bundle).toContain("return ids[1][0]()");
+	// Nothing loads a chunk by id any more, so neither runtime module ships.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
+});

--- a/test/configCases/analyzable/context-module/shared-lib.js
+++ b/test/configCases/analyzable/context-module/shared-lib.js
@@ -1,0 +1,1 @@
+export const suffix = "!";

--- a/test/configCases/analyzable/context-module/split-entry.js
+++ b/test/configCases/analyzable/context-module/split-entry.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import(`./split/${name}.js`);
+
+it("should load a candidate spread over two chunks", async () => {
+	expect((await load("de")).default).toBe("de!");
+	expect((await load("en")).default).toBe("en!");
+});
+
+it("should write one static import per chunk of the request", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	// Two candidates, each naming its own chunk and the one they share.
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(5);
+	expect(bundle).toContain(`import("./${__NAME__}-shared.mjs")`);
+	expect(bundle).toContain(`import("./${__NAME__}-split_de_js.mjs")`);
+	expect(bundle).toContain("Promise.all(ids[1].map(");
+	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
+});

--- a/test/configCases/analyzable/context-module/split/de.js
+++ b/test/configCases/analyzable/context-module/split/de.js
@@ -1,0 +1,3 @@
+import { suffix } from "../shared-lib";
+
+export default `de${suffix}`;

--- a/test/configCases/analyzable/context-module/split/en.js
+++ b/test/configCases/analyzable/context-module/split/en.js
@@ -1,0 +1,3 @@
+import { suffix } from "../shared-lib";
+
+export default `en${suffix}`;

--- a/test/configCases/analyzable/context-module/test.config.js
+++ b/test/configCases/analyzable/context-module/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const NAMES = ["plain", "split", "fake", "defer"];
+
+module.exports = {
+	findBundle(i) {
+		return [`./${NAMES[i]}.mjs`];
+	}
+};

--- a/test/configCases/analyzable/context-module/test.config.js
+++ b/test/configCases/analyzable/context-module/test.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const NAMES = ["plain", "split", "fake", "defer", "theme"];
+const NAMES = ["plain", "split", "fake", "defer", "theme", "mixed"];
 
 module.exports = {
 	findBundle(i) {

--- a/test/configCases/analyzable/context-module/test.config.js
+++ b/test/configCases/analyzable/context-module/test.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const NAMES = ["plain", "split", "fake", "defer"];
+const NAMES = ["plain", "split", "fake", "defer", "theme"];
 
 module.exports = {
 	findBundle(i) {

--- a/test/configCases/analyzable/context-module/test.filter.js
+++ b/test/configCases/analyzable/context-module/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// Reading the bundle back needs `require` in ESM output, which emits
+// `import { createRequire } from "module"` — older Node can't link that.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/context-module/theme-entry.js
+++ b/test/configCases/analyzable/context-module/theme-entry.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+const load = (name) => import(`./theme/${name}.css`);
+
+it("should load a candidate whose chunk carries more than javascript", async () => {
+	await load("dark");
+	await load("light");
+
+	const dir = __STATS__.children[__INDEX__].outputPath;
+
+	// The stylesheet the imported chunk pulls in has to be emitted beside it.
+	expect(fs.existsSync(path.join(dir, `${__NAME__}-theme_dark_css.css`))).toBe(
+		true
+	);
+});
+
+it("should keep dispatching the other chunk loading handlers", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	// The css of the chunk rides on its own handler, which the baked import runs too.
+	expect(bundle).toContain(`${"__webpack_require__"}.f.css =`);
+	expect(bundle).toContain(`Object.keys(${"__webpack_require__"}.f).forEach(`);
+});

--- a/test/configCases/analyzable/context-module/theme/dark.css
+++ b/test/configCases/analyzable/context-module/theme/dark.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/test/configCases/analyzable/context-module/theme/light.css
+++ b/test/configCases/analyzable/context-module/theme/light.css
@@ -1,0 +1,3 @@
+body {
+	color: blue;
+}

--- a/test/configCases/analyzable/context-module/webpack.config.js
+++ b/test/configCases/analyzable/context-module/webpack.config.js
@@ -59,5 +59,16 @@ module.exports = [
 	{
 		...base(3, "defer"),
 		experiments: { outputModule: true, deferImport: true, topLevelAwait: true }
+	},
+	// A chunk carrying css is loaded by more than the javascript handler, so the baked
+	// import has to keep dispatching the rest of them. Neutral platform so it runs here.
+	{
+		...base(4, "theme"),
+		target: ["web", "node"],
+		experiments: { outputModule: true, css: true },
+		output: {
+			...base(4, "theme").output,
+			cssChunkFilename: "theme-[name].css"
+		}
 	}
 ];

--- a/test/configCases/analyzable/context-module/webpack.config.js
+++ b/test/configCases/analyzable/context-module/webpack.config.js
@@ -1,0 +1,63 @@
+"use strict";
+
+// A lazy context loads a chunk per request. Under module output the loader is written
+// into the map next to the request it serves, so the pair reads as one object.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so an entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name) => ({
+	name,
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: { [name]: `./${name}-entry.js` },
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", splitChunks: false },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: `${name}-[name].mjs`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// One chunk per request, so the loader is reached without a `Promise.all`.
+	base(0, "plain"),
+	// A split chunk gives every request two, so each is loaded through its own thunk.
+	{
+		...base(1, "split"),
+		optimization: {
+			chunkIds: "named",
+			splitChunks: {
+				cacheGroups: {
+					shared: {
+						test: /shared-lib/,
+						chunks: "all",
+						name: "shared",
+						enforce: true
+					}
+				}
+			}
+		}
+	},
+	// Mixed exports types add a fake-map slot, moving the loaders one position along.
+	base(2, "fake"),
+	// A deferred context adds a trailing slot an async candidate leaves empty.
+	{
+		...base(3, "defer"),
+		experiments: { outputModule: true, deferImport: true, topLevelAwait: true }
+	}
+];

--- a/test/configCases/analyzable/context-module/webpack.config.js
+++ b/test/configCases/analyzable/context-module/webpack.config.js
@@ -70,5 +70,23 @@ module.exports = [
 			...base(4, "theme").output,
 			cssChunkFilename: "theme-[name].css"
 		}
+	},
+	// One candidate split into the entry's own chunk: importing that from itself would
+	// be a cycle, so it keeps the runtime form while its sibling is still baked.
+	{
+		...base(5, "mixed"),
+		optimization: {
+			chunkIds: "named",
+			splitChunks: {
+				cacheGroups: {
+					entry: {
+						test: /mixed[/\\]de/,
+						chunks: "all",
+						name: "mixed",
+						enforce: true
+					}
+				}
+			}
+		}
 	}
 ];

--- a/types.d.ts
+++ b/types.d.ts
@@ -25697,6 +25697,20 @@ declare abstract class RuntimeTemplate {
 	}): string;
 
 	/**
+	 * For ESM module output, load a single statically-named chunk through the
+	 * `analyzableChunkImport` helper — a literal `import("./chunk.js")` other bundlers
+	 * and webpack itself can follow, wrapped to keep `ensureChunk` timing and deduplication.
+	 * Returns `null` to fall back to the runtime `ensureChunk` form.
+	 */
+	analyzableChunkImport(
+		chunk: Chunk,
+		comment: string,
+		runtimeRequirements: Set<string>,
+		originModule: undefined | Module,
+		chunkGraph: ChunkGraph
+	): null | string;
+
+	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
 	 * module. Only called when `supportsAnalyzable("wasm")` holds.
 	 */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A lazy context (`import(\`./locales/${name}.js\`)`, `require.context(…, "lazy")`) mapped each request to a chunk **id** and loaded it through the runtime `ensureChunk`, so the only `import()` in the output was `import("./" + __webpack_require__.u(chunkId))` — nothing outside webpack could tell which files the context can reach. Under `output.module` the map now carries the loader itself next to the request it serves, so both live in one object:

```js
const map = {
	"./de.js": ["./src/locales/de.js", [() => (__webpack_require__.ei("src_locales_de_js", () => import("./chunks/src_locales_de_js.mjs")))]]
};
```

The `ensure chunk` and `get javascript chunk filename` runtime modules stop shipping when every chunk of the context can be named. Non-module output is byte-identical to before, verified by diffing every emitted file across all five context modes.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/analyzable/context-module/`, five configs covering one chunk per request, a split chunk, a fake-map slot, a deferred context, and a chunk carrying css whose other `.f` handlers must still be dispatched.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `__webpack_require__.ei` has the same contract as `ensureChunk`, and anything that cannot be named keeps the previous form.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used to draft the implementation and tests, and to run the differential builds against `main`. Every change was reviewed and the behaviour verified by executing the emitted bundles on both sides.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved lazy-loaded context imports by embedding eligible chunk loading directly into generated bundles.
  - Reduced reliance on runtime chunk-loading helpers when chunk relationships can be determined in advance.
  - Preserved fallback loading for scenarios requiring runtime resolution.
  - Improved consistency and ordering of generated lazy-load mappings.
  - Maintained reliable dynamic JavaScript and CSS imports across standard, split, deferred, and mixed module scenarios.

- **Documentation**
  - Added release documentation describing the updated lazy context chunk behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->