### PR TITLE
fix(performance): name the request cap that actually refused a split

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -1679,15 +1679,17 @@ module.exports = class SplitChunksPlugin {
 								Number.isFinite(item.cacheGroup.maxAsyncRequests))
 						) {
 							for (const chunk of usedChunks) {
-								// respect max requests
-								const maxRequests = chunk.isOnlyInitial()
-									? item.cacheGroup.maxInitialRequests
-									: chunk.canBeInitial()
-										? Math.min(
-												item.cacheGroup.maxInitialRequests,
-												item.cacheGroup.maxAsyncRequests
-											)
-										: item.cacheGroup.maxAsyncRequests;
+								// respect max requests: a chunk that is both initial and
+								// async answers to the stricter of the two caps
+								const isOnlyInitial = chunk.isOnlyInitial();
+								const byAsyncRequests =
+									!isOnlyInitial &&
+									(!chunk.canBeInitial() ||
+										item.cacheGroup.maxAsyncRequests <
+											item.cacheGroup.maxInitialRequests);
+								const maxRequests = byAsyncRequests
+									? item.cacheGroup.maxAsyncRequests
+									: item.cacheGroup.maxInitialRequests;
 								if (
 									Number.isFinite(maxRequests) &&
 									getRequests(chunk) >= maxRequests
@@ -1696,10 +1698,11 @@ module.exports = class SplitChunksPlugin {
 										cappedSplits.push({
 											cacheGroup: item.cacheGroup.key,
 											chunk,
-											limit:
-												maxRequests === item.cacheGroup.maxAsyncRequests
-													? "maxAsyncRequests"
-													: "maxInitialRequests",
+											// which cap it was cannot be read back off the value:
+											// the two are equal by default in production
+											limit: byAsyncRequests
+												? "maxAsyncRequests"
+												: "maxInitialRequests",
 											maxRequests:
 												/** @type {number} */
 												(maxRequests),

--- a/test/configCases/performance/split-chunks-capped-equal-limits/index.js
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/index.js
@@ -1,0 +1,5 @@
+const vendor = require("vendor-lib");
+
+it("should name the cap that refused the split of an initial chunk", () => {
+	expect(vendor).toBe("vendor");
+});

--- a/test/configCases/performance/split-chunks-capped-equal-limits/node_modules/vendor-lib/index.js
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/node_modules/vendor-lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "vendor";

--- a/test/configCases/performance/split-chunks-capped-equal-limits/node_modules/vendor-lib/package.json
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/node_modules/vendor-lib/package.json
@@ -1,0 +1,1 @@
+{ "name": "vendor-lib", "version": "1.0.0", "main": "index.js" }

--- a/test/configCases/performance/split-chunks-capped-equal-limits/test.config.js
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "./main.js";
+	}
+};

--- a/test/configCases/performance/split-chunks-capped-equal-limits/warnings.js
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/warnings.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = [
+	[
+		/split chunks capped: 'optimization\.splitChunks' refused these splits/,
+		// `main` is initial only, so `maxInitialRequests` is what refused it.
+		/cacheGroup 'vendor' out of main \(1 modules, maxInitialRequests is 1\)/
+	]
+];

--- a/test/configCases/performance/split-chunks-capped-equal-limits/webpack.config.js
+++ b/test/configCases/performance/split-chunks-capped-equal-limits/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: { main: "./index.js" },
+	output: { filename: "[name].js" },
+	performance: {
+		hints: "warning",
+		splitChunksCapped: true
+	},
+	optimization: {
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			// Equal, as they are by default in production: only the chunk decides
+			// which of the two refused the split.
+			maxInitialRequests: 1,
+			maxAsyncRequests: 1,
+			cacheGroups: {
+				default: false,
+				defaultVendors: false,
+				vendor: { test: /node_modules/, name: "vendor" }
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`performance.splitChunksCapped` re-derived which option refused a split by comparing the value it held against `maxAsyncRequests`, so wherever the two caps are equal — the default in production, both `30` — an initial-only chunk held to `maxInitialRequests` was reported as `maxAsyncRequests`, and raising the named option changed nothing. The label now comes from the same branch as the value; `maxRequests` itself is unchanged in all three branches, so nothing about the split decision moves. Refs #21769.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/performance/split-chunks-capped-equal-limits/`, an initial-only chunk with both caps set to `1`, which reported the wrong option before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Only the warning text changes; the hint is opt-in and unreleased.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to review the recent commits, where it found this mislabel, and to write the failing test case and the fix. The test was run before the change to confirm it reproduces the wrong label, and the `split-chunks-capped`, `split-chunks` and stats cases were run after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-chunk request-cap handling when initial and asynchronous limits are equal.
  * Ensured capped split reports consistently reflect the applicable request limit.
  * Corrected vendor chunk behavior under strict initial request limits.

* **Tests**
  * Added coverage for capped initial chunk splitting, bundle naming, and related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->