### PR TITLE
fix(performance): judge a dynamic import by every path that can load it

### DIFF
--- a/lib/performance/RedundantDynamicImportsPlugin.js
+++ b/lib/performance/RedundantDynamicImportsPlugin.js
@@ -51,16 +51,19 @@ class RedundantDynamicImportsPlugin {
 				const descriptions = [];
 
 				/**
-				 * The chunks certain to be loaded when `chunk` runs: itself, plus the
-				 * initial chunks of every entrypoint that can reach it. A shared
-				 * runtime name is not enough — with `runtimeChunk: "single"` two
-				 * entrypoints share one runtime while neither loads the other's
-				 * initial chunks.
+				 * The chunks certain to be loaded when `chunk` runs: itself, plus what
+				 * every entrypoint able to reach it brings. Entrypoints are alternative
+				 * load paths, so they are intersected — one that carries the target says
+				 * nothing about a page that loads another. A shared runtime name is not
+				 * enough either: with `runtimeChunk: "single"` two entrypoints share one
+				 * runtime while neither loads the other's initial chunks.
 				 * @param {Chunk} chunk the chunk the importer runs in
 				 * @returns {Set<Chunk>} the chunks loaded before it runs
 				 */
 				const getLoadedChunks = (chunk) => {
 					const chunks = new Set([chunk]);
+					/** @type {Set<ChunkGroup>} */
+					const entrypoints = new Set();
 					/** @type {Set<ChunkGroup>} */
 					const queue = new Set(chunk.groupsIterable);
 
@@ -68,11 +71,43 @@ class RedundantDynamicImportsPlugin {
 						// Only initial chunks are certain: an async ancestor is loaded on
 						// the path taken, and a group can be reached by several.
 						if (group.isInitial()) {
-							for (const member of group.chunks) chunks.add(member);
+							entrypoints.add(group);
+							continue;
 						}
 
-						// An entrypoint reached through `dependOn` is loaded first too.
 						for (const parent of group.getParents()) queue.add(parent);
+					}
+
+					if (entrypoints.size === 0) return chunks;
+
+					/** @type {Set<Chunk> | undefined} */
+					let common;
+
+					for (const entrypoint of entrypoints) {
+						/** @type {Set<Chunk>} */
+						const loaded = new Set();
+						/** @type {Set<ChunkGroup>} */
+						const chain = new Set([entrypoint]);
+
+						// An entrypoint reached through `dependOn` is loaded first too, so
+						// within one path they add up rather than cancel each other out.
+						for (const group of chain) {
+							for (const member of group.chunks) loaded.add(member);
+							for (const parent of group.getParents()) chain.add(parent);
+						}
+
+						if (common === undefined) {
+							common = loaded;
+							continue;
+						}
+
+						for (const member of common) {
+							if (!loaded.has(member)) common.delete(member);
+						}
+					}
+
+					for (const member of /** @type {Set<Chunk>} */ (common)) {
+						chunks.add(member);
 					}
 
 					return chunks;

--- a/lib/performance/RedundantDynamicImportsPlugin.js
+++ b/lib/performance/RedundantDynamicImportsPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const Entrypoint = require("../Entrypoint");
 const RedundantDynamicImportWarning = require("../errors/RedundantDynamicImportWarning");
 const { compareStrings } = require("../util/comparators");
 const formatLocation = require("../util/formatLocation");
@@ -68,13 +69,16 @@ class RedundantDynamicImportsPlugin {
 					const queue = new Set(chunk.groupsIterable);
 
 					for (const group of queue) {
-						// Only initial chunks are certain: an async ancestor is loaded on
-						// the path taken, and a group can be reached by several.
-						if (group.isInitial()) {
+						// An entrypoint is a load path in itself and carries nothing of
+						// what reaches it: an async one — a worker — starts from its own
+						// chunks, however much the module spawning it had loaded.
+						if (group.isInitial() || group instanceof Entrypoint) {
 							entrypoints.add(group);
 							continue;
 						}
 
+						// Only initial chunks are certain: an async ancestor is loaded on
+						// the path taken, and a group can be reached by several.
 						for (const parent of group.getParents()) queue.add(parent);
 					}
 

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/entry-a.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/entry-a.js
@@ -1,0 +1,8 @@
+it("should still defer the target in the entry that lacks it", () => {
+	expect(__STATS__.hints).toHaveLength(0);
+	return import("./mid").then((module) =>
+		module.load().then((loaded) => {
+			expect(loaded.target).toBe(1);
+		})
+	);
+});

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/entry-b.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/entry-b.js
@@ -1,0 +1,10 @@
+import { target } from "./target";
+
+it("should carry the target up front in this entry", () => {
+	expect(target).toBe(1);
+	return import("./mid").then((module) =>
+		module.load().then((loaded) => {
+			expect(loaded.target).toBe(1);
+		})
+	);
+});

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/mid.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/mid.js
@@ -1,0 +1,3 @@
+export function load() {
+	return import("./target");
+}

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/target.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/target.js
@@ -1,0 +1,1 @@
+export const target = 1;

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/test.config.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["a.js", "b.js"];
+	}
+};

--- a/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/webpack.config.js
+++ b/test/configCases/performance/redundant-dynamic-imports-shared-async-importer/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+// `mid` is one async chunk both entries reach. Only `b` carries the target up
+// front, so the `import()` still defers for `a` and must not be reported.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		a: "./entry-a",
+		b: "./entry-b"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: false
+	},
+	performance: {
+		hints: "stats",
+		redundantDynamicImports: true
+	}
+};

--- a/test/configCases/performance/redundant-dynamic-imports-worker/index.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/index.js
@@ -1,0 +1,13 @@
+import { target } from "./target";
+
+// Parsed, never run: the worker entrypoint and the `mid` chunk both paths share
+// are in the graph whether or not the page reaches for them.
+if (target !== 1) {
+	new Worker(new URL("./worker.js", import.meta.url));
+	import("./mid");
+}
+
+it("should still defer the target inside the worker that lacks it", () => {
+	expect(target).toBe(1);
+	expect(__STATS__.hints).toHaveLength(0);
+});

--- a/test/configCases/performance/redundant-dynamic-imports-worker/mid.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/mid.js
@@ -1,0 +1,3 @@
+export function load() {
+	return import("./target");
+}

--- a/test/configCases/performance/redundant-dynamic-imports-worker/target.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/target.js
@@ -1,0 +1,1 @@
+export const target = 1;

--- a/test/configCases/performance/redundant-dynamic-imports-worker/test.filter.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/performance/redundant-dynamic-imports-worker/webpack.config.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+// `mid` is reached from the page and from the worker. Only the page carries the
+// target up front, and a worker starts from its own chunks however much spawned
+// it, so the `import()` still defers there and must not be reported.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "web",
+	optimization: {
+		splitChunks: false
+	},
+	performance: {
+		hints: "stats",
+		redundantDynamicImports: true
+	}
+};

--- a/test/configCases/performance/redundant-dynamic-imports-worker/worker.js
+++ b/test/configCases/performance/redundant-dynamic-imports-worker/worker.js
@@ -1,0 +1,6 @@
+self.onmessage = async () => {
+	const mid = await import("./mid");
+	const loaded = await mid.load();
+
+	postMessage(loaded.target);
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`performance.redundantDynamicImports` decided what is loaded where an `import()` runs by unioning every entrypoint that can reach its chunk, so an `import()` in an async chunk two entrypoints share was called redundant as soon as *one* of them carried the target up front — a page loading the other never has it, and removing the `import()` on that advice breaks it. Entrypoints are alternative load paths, so they are intersected now, while a `dependOn` chain stays a union within one path. The same walk stepped over async entrypoints entirely (a worker's is neither initial nor reached through a parent), which claimed the page's chunks are loaded inside a worker that never sees them; an async entrypoint now joins the paths being intersected. Refs #21746.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/performance/redundant-dynamic-imports-shared-async-importer/` (one async chunk two entrypoints reach) and `test/configCases/performance/redundant-dynamic-imports-worker/` (a page and a worker sharing one). Both report the import before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The hint is opt-in and unreleased; only what it reports changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to review the recent commits, where it found both cases, and to write the failing test cases and the fixes. Each was reproduced against a real build before any change, each test case was checked to fail without its fix, and the `performance` and `worker` config suites were run after. The hook's own cost was measured over 7 interleaved builds and did not move beyond the run-to-run spread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of dynamically imported resources that are guaranteed to be loaded across multiple entry paths.
  - Prevented unnecessary preload hints and premature loading when resources remain deferred.
  - Corrected behavior for shared asynchronous imports and dynamically loaded worker resources.

- **Tests**
  - Added coverage for shared asynchronous imports across multiple entry points.
  - Added regression coverage confirming deferred loading behavior in workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->