### PR TITLE
perf(performance): ask each chunk once what is loaded where it runs

### DIFF
--- a/lib/performance/RedundantDynamicImportsPlugin.js
+++ b/lib/performance/RedundantDynamicImportsPlugin.js
@@ -59,7 +59,7 @@ class RedundantDynamicImportsPlugin {
 				 * @param {Chunk} chunk the chunk the importer runs in
 				 * @returns {Set<Chunk>} the chunks loaded before it runs
 				 */
-				const getLoadedChunks = (chunk) => {
+				const computeLoadedChunks = (chunk) => {
 					const chunks = new Set([chunk]);
 					/** @type {Set<ChunkGroup>} */
 					const queue = new Set(chunk.groupsIterable);
@@ -76,6 +76,26 @@ class RedundantDynamicImportsPlugin {
 					}
 
 					return chunks;
+				};
+
+				// The answer depends on the chunk alone, and every module sharing one
+				// asks the same question. Dropped with the hook it is built in.
+				/** @type {Map<Chunk, Set<Chunk>>} */
+				const loadedChunks = new Map();
+
+				/**
+				 * @param {Chunk} chunk the chunk the importer runs in
+				 * @returns {Set<Chunk>} the chunks loaded before it runs
+				 */
+				const getLoadedChunks = (chunk) => {
+					let loaded = loadedChunks.get(chunk);
+
+					if (loaded === undefined) {
+						loaded = computeLoadedChunks(chunk);
+						loadedChunks.set(chunk, loaded);
+					}
+
+					return loaded;
 				};
 
 				/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`getLoadedChunks` in `RedundantDynamicImportsPlugin` depends on its chunk alone, but was walked again for every module in that chunk — on a hub chunk 30 entrypoints reach, 330 walks where 31 answer the question. It is memoized per chunk now, in the hook that builds it, so the map is dropped with the seal rather than held on the compilation.

This is bounded work rather than a build-time win, and the measurements say so. Over 9 interleaved builds per arm: on that shared-hub fixture the hook goes 4.79ms → 1.40ms with the spreads apart (3.31–11.53 against 1.02–3.06); where 400 `import()` holders sit in one chunk the calls collapse 400 → 1 but the time does not move (2.44ms → 2.30ms, inside the spread); and where each holder has a chunk of its own the map never pays (156 → 156). The hook is under 1% of build time throughout, so total build time does not move measurably in any of the three. Refs #21746.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No new ones — memoizing adds no branch to cover, and the existing `configCases/performance` cases (287) pin the behaviour as unchanged.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Same answers, computed once per chunk.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to write the change and to measure it. The plugin was temporarily instrumented to count calls and time the hook, three fixtures of different graph shapes were built to find where the cache does and does not pay, and the instrumentation was removed before committing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved processing efficiency when analyzing dynamically loaded content.
  * Reused previously calculated results to reduce redundant work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->