### PR TITLE
feat(externals): provide the original request of a context module element

### DIFF
--- a/.changeset/015-externals-context-element-original-request.md
+++ b/.changeset/015-externals-context-element-original-request.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Give externals the original request of a context module element.

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -100,6 +100,7 @@ const { propertyAccess } = require("./util/property");
 
 /**
  * @typedef {object} ContextModuleOptionsExtras
+ * @property {string=} request the request of the context as written by the user, before it was resolved
  * @property {false | string | string[]} resource
  * @property {string=} resourceQuery
  * @property {string=} resourceFragment

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -59,6 +59,22 @@ const {
 
 const EMPTY_RESOLVE_OPTIONS = {};
 
+/**
+ * Strips the query and fragment the elements of the context carry themselves, so
+ * the remainder can be joined with an element request again.
+ * @param {string | undefined} request the request of the context as written by the user
+ * @param {string | undefined} resourceQuery query of the resolved context
+ * @param {string | undefined} resourceFragment fragment of the resolved context
+ * @returns {string | undefined} the request without query and fragment
+ */
+const getContextRequest = (request, resourceQuery, resourceFragment) => {
+	if (request === undefined) return undefined;
+	const suffix = (resourceQuery || "") + (resourceFragment || "");
+	return suffix && request.endsWith(suffix)
+		? request.slice(0, -suffix.length)
+		: request;
+};
+
 class ContextModuleFactory extends ModuleFactory {
 	/**
 	 * Creates an instance of ContextModuleFactory.
@@ -344,6 +360,13 @@ class ContextModuleFactory extends ModuleFactory {
 		} = options;
 		const isImportMetaGlob = Boolean(patterns && requestContext);
 		if ((!regExp && !isImportMetaGlob) || !resource) return callback(null, []);
+		// the request the user wrote (`#configs`, `./dir`, …) before it was resolved
+		// to a directory — elements keep it so they can report an original request
+		const contextRequest = getContextRequest(
+			options.request,
+			resourceQuery,
+			resourceFragment
+		);
 
 		/**
 		 * Adds directory checked.
@@ -493,7 +516,8 @@ class ContextModuleFactory extends ModuleFactory {
 												(category),
 												referencedExports,
 												ctx,
-												attributes
+												attributes,
+												contextRequest
 											);
 											dep.optional = true;
 											globDeps.push(dep);
@@ -569,7 +593,8 @@ class ContextModuleFactory extends ModuleFactory {
 										(category),
 										referencedExports,
 										alt.context,
-										attributes
+										attributes,
+										contextRequest
 									);
 									dep.optional = true;
 									flattenedResult.push(dep);

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -153,9 +153,8 @@ class ExternalModuleFactoryPlugin {
 				const dependency = data.dependencies[0];
 				const dependencyType = data.dependencyType;
 				const request = dependency.request;
-				// an element of a context module carries a request relative to the
-				// resolved context directory (`./file.mjs`), while externals are
-				// written against the request as the user wrote it (`#configs/file.mjs`)
+				// a context element's request is relative to the resolved directory
+				// (`./file.mjs`), externals are written against what the user wrote
 				const originalRequest =
 					dependency instanceof ContextElementDependency
 						? dependency.originalRequest

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -44,6 +44,7 @@ const { cachedSetProperty, resolveByProperty } = require("./util/cleverMerge");
  * @property {string} dependencyType the category of the referencing dependency
  * @property {ExternalItemFunctionDataGetResolve} getResolve get a resolve function with the current resolver options
  * @property {string} request the request as written by the user in the require/import expression/statement
+ * @property {string} originalRequest same as `request`, except for an element of a context module (a request containing an expression), where it is the request as written by the user instead of the one relative to the resolved context directory
  */
 
 /** @typedef {((data: ExternalItemFunctionData, callback: (err?: (Error | null), result?: ExternalItemValue) => void) => void)} ExternalItemFunctionCallback */
@@ -151,6 +152,15 @@ class ExternalModuleFactoryPlugin {
 				const contextInfo = data.contextInfo;
 				const dependency = data.dependencies[0];
 				const dependencyType = data.dependencyType;
+				const request = dependency.request;
+				// an element of a context module carries a request relative to the
+				// resolved context directory (`./file.mjs`), while externals are
+				// written against the request as the user wrote it (`#configs/file.mjs`)
+				const originalRequest =
+					dependency instanceof ContextElementDependency
+						? dependency.originalRequest
+						: request;
+				const hasOriginalRequest = originalRequest !== request;
 
 				/** @typedef {(err?: Error | null, externalModule?: ExternalModule) => void} HandleExternalCallback */
 
@@ -188,7 +198,7 @@ class ExternalModuleFactoryPlugin {
 						return callback();
 					}
 					/** @type {ExternalModuleRequest} */
-					let externalConfig = target === true ? dependency.request : target;
+					let externalConfig = target === true ? originalRequest : target;
 					// `interop` is a reserved key on the object form, not a target;
 					// pull it out so the rest stays a pure externalsType->request map.
 					/** @type {ExternalItemInterop | undefined} */
@@ -287,7 +297,7 @@ class ExternalModuleFactoryPlugin {
 						new ExternalModule(
 							externalConfig,
 							resolvedType,
-							dependency.request,
+							originalRequest,
 							dependencyMeta,
 							interop,
 							sideEffects
@@ -304,10 +314,11 @@ class ExternalModuleFactoryPlugin {
 				const handleExternals = (externals, callback) => {
 					if (typeof externals === "string") {
 						if (
-							externals === dependency.request ||
-							externals === getAlternateCoreModuleRequest(dependency.request)
+							externals === request ||
+							(hasOriginalRequest && externals === originalRequest) ||
+							externals === getAlternateCoreModuleRequest(request)
 						) {
-							return handleExternal(dependency.request, undefined, callback);
+							return handleExternal(originalRequest, undefined, callback);
 						}
 					} else if (Array.isArray(externals)) {
 						let i = 0;
@@ -343,8 +354,11 @@ class ExternalModuleFactoryPlugin {
 						next();
 						return;
 					} else if (externals instanceof RegExp) {
-						if (externals.test(dependency.request)) {
-							return handleExternal(dependency.request, undefined, callback);
+						if (
+							externals.test(request) ||
+							(hasOriginalRequest && externals.test(originalRequest))
+						) {
+							return handleExternal(originalRequest, undefined, callback);
 						}
 					} else if (typeof externals === "function") {
 						/**
@@ -364,17 +378,13 @@ class ExternalModuleFactoryPlugin {
 						};
 						if (externals.length === 3) {
 							// TODO webpack 6 remove this
-							callDeprecatedExternals(
-								externals,
-								context,
-								dependency.request,
-								cb
-							);
+							callDeprecatedExternals(externals, context, request, cb);
 						} else {
 							const promise = externals(
 								{
 									context,
-									request: dependency.request,
+									request,
+									originalRequest,
 									dependencyType,
 									contextInfo,
 									getResolve: (options) => (context, request, callback) => {
@@ -433,21 +443,29 @@ class ExternalModuleFactoryPlugin {
 							(contextInfo.issuerLayer)
 						);
 						if (
+							Object.prototype.hasOwnProperty.call(resolvedExternals, request)
+						) {
+							return handleExternal(
+								resolvedExternals[request],
+								undefined,
+								callback
+							);
+						}
+						if (
+							hasOriginalRequest &&
 							Object.prototype.hasOwnProperty.call(
 								resolvedExternals,
-								dependency.request
+								originalRequest
 							)
 						) {
 							return handleExternal(
-								resolvedExternals[dependency.request],
+								resolvedExternals[originalRequest],
 								undefined,
 								callback
 							);
 						}
 						// Fall back to the `node:`-prefixed/unprefixed core module form.
-						const alternateRequest = getAlternateCoreModuleRequest(
-							dependency.request
-						);
+						const alternateRequest = getAlternateCoreModuleRequest(request);
 						if (
 							alternateRequest !== undefined &&
 							Object.prototype.hasOwnProperty.call(

--- a/lib/dependencies/ContextElementDependency.js
+++ b/lib/dependencies/ContextElementDependency.js
@@ -16,8 +16,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../javascript/JavascriptParser").ImportAttributes} ImportAttributes */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[string | undefined, string, RawReferencedExports | null | undefined, ImportAttributes | undefined]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[string | undefined, string, RawReferencedExports | null | undefined, ImportAttributes | undefined]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[string | undefined, string, RawReferencedExports | null | undefined, ImportAttributes | undefined, string | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[string | undefined, string, RawReferencedExports | null | undefined, ImportAttributes | undefined, string | undefined]>} ObjectSerializerContext */
 
 class ContextElementDependency extends ModuleDependency {
 	/**
@@ -29,6 +29,7 @@ class ContextElementDependency extends ModuleDependency {
 	 * @param {RawReferencedExports | null=} referencedExports referenced exports
 	 * @param {string=} context context
 	 * @param {ImportAttributes=} attributes import assertions
+	 * @param {string=} contextRequest the request of the context as written by the user, without query and fragment
 	 */
 	constructor(
 		request,
@@ -37,7 +38,8 @@ class ContextElementDependency extends ModuleDependency {
 		category,
 		referencedExports,
 		context,
-		attributes
+		attributes,
+		contextRequest
 	) {
 		super(request);
 
@@ -56,6 +58,22 @@ class ContextElementDependency extends ModuleDependency {
 		this._context = context || undefined;
 		/** @type {ImportAttributes | undefined} */
 		this.attributes = attributes;
+		/** @type {string | undefined} */
+		this._contextRequest = contextRequest || undefined;
+	}
+
+	/**
+	 * The request as the user wrote it, e.g. `#configs/file.mjs` for the element
+	 * `./file.mjs` of a `#configs` context. `request` is relative to the resolved
+	 * context directory instead, which no longer resembles what was written.
+	 * @returns {string} the original request
+	 */
+	get originalRequest() {
+		const request = this.request;
+		if (this._contextRequest === undefined || !request.startsWith("./")) {
+			return request;
+		}
+		return this._contextRequest + request.slice(1);
 	}
 
 	get type() {
@@ -132,7 +150,8 @@ class ContextElementDependency extends ModuleDependency {
 			.write(this._typePrefix)
 			.write(this._category)
 			.write(this.referencedExports)
-			.write(this.attributes);
+			.write(this.attributes)
+			.write(this._contextRequest);
 		super.serialize(context);
 	}
 
@@ -148,7 +167,9 @@ class ContextElementDependency extends ModuleDependency {
 		this.referencedExports = c2.read();
 		const c3 = c2.rest;
 		this.attributes = c3.read();
-		super.deserialize(c3.rest);
+		const c4 = c3.rest;
+		this._contextRequest = c4.read();
+		super.deserialize(c4.rest);
 	}
 }
 

--- a/lib/dependencies/ContextElementDependency.js
+++ b/lib/dependencies/ContextElementDependency.js
@@ -63,9 +63,8 @@ class ContextElementDependency extends ModuleDependency {
 	}
 
 	/**
-	 * The request as the user wrote it, e.g. `#configs/file.mjs` for the element
-	 * `./file.mjs` of a `#configs` context. `request` is relative to the resolved
-	 * context directory instead, which no longer resembles what was written.
+	 * The request as the user wrote it, e.g. `#configs/file.mjs` where `request`
+	 * is the `./file.mjs` relative to the resolved `#configs` directory.
 	 * @returns {string} the original request
 	 */
 	get originalRequest() {

--- a/test/ContextModuleFactory.unittest.js
+++ b/test/ContextModuleFactory.unittest.js
@@ -306,5 +306,88 @@ describe("ContextModuleFactory", () => {
 				}
 			);
 		});
+
+		it("should provide the request as written by the user as original request", (done) => {
+			memfs = createFsFromVolume(
+				Volume.fromJSON({ "/configs/a.js": "", "/configs/nested/b.js": "" })
+			);
+			factory.resolveDependencies(
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/configs",
+						request: "#configs",
+						resourceQuery: "",
+						resourceFragment: "",
+						recursive: true,
+						regExp: /\.js$/
+					})
+				),
+				(err, res) => {
+					expect(err).toBeFalsy();
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res)
+							.map((r) => r.originalRequest)
+							.sort()
+					).toEqual(["#configs/a.js", "#configs/nested/b.js"]);
+					done();
+				}
+			);
+		});
+
+		it("should not repeat query and fragment in the original request", (done) => {
+			memfs = createFsFromVolume(Volume.fromJSON({ "/configs/a.js": "" }));
+			factory.resolveDependencies(
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/configs",
+						request: "./configs?query#hash",
+						resourceQuery: "?query",
+						resourceFragment: "#hash",
+						recursive: true,
+						regExp: /\.js/
+					})
+				),
+				(err, res) => {
+					expect(err).toBeFalsy();
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res).map(
+							(r) => r.originalRequest
+						)
+					).toEqual(["./configs/a.js?query#hash"]);
+					done();
+				}
+			);
+		});
+
+		it("should keep an alternative request that is not relative", (done) => {
+			memfs = createFsFromVolume(Volume.fromJSON({ "/configs/a.js": "" }));
+			factory.hooks.alternativeRequests.tap("Test", (items) =>
+				items.map(({ context }) => ({ context, request: "package/a.js" }))
+			);
+			factory.resolveDependencies(
+				/** @type {InputFileSystem} */ (/** @type {unknown} */ (memfs)),
+				/** @type {ContextModuleOptions} */ (
+					/** @type {unknown} */ ({
+						resource: "/configs",
+						request: "#configs",
+						resourceQuery: "",
+						resourceFragment: "",
+						recursive: true,
+						regExp: /\.js$/
+					})
+				),
+				(err, res) => {
+					expect(err).toBeFalsy();
+					expect(
+						/** @type {NonNullable<typeof res>} */ (res).map(
+							(r) => r.originalRequest
+						)
+					).toEqual(["package/a.js"]);
+					done();
+				}
+			);
+		});
 	});
 });

--- a/test/configCases/externals/context-element-original-request/configs/a.js
+++ b/test/configCases/externals/context-element-original-request/configs/a.js
@@ -1,0 +1,1 @@
+module.exports = { value: "bundled a" };

--- a/test/configCases/externals/context-element-original-request/configs/b.js
+++ b/test/configCases/externals/context-element-original-request/configs/b.js
@@ -1,0 +1,1 @@
+module.exports = { value: "bundled b" };

--- a/test/configCases/externals/context-element-original-request/configs/c.js
+++ b/test/configCases/externals/context-element-original-request/configs/c.js
@@ -1,0 +1,1 @@
+module.exports = { value: "bundled c" };

--- a/test/configCases/externals/context-element-original-request/configs/d.js
+++ b/test/configCases/externals/context-element-original-request/configs/d.js
@@ -1,0 +1,1 @@
+module.exports = { value: "bundled d" };

--- a/test/configCases/externals/context-element-original-request/configs/e.txt
+++ b/test/configCases/externals/context-element-original-request/configs/e.txt
@@ -1,0 +1,1 @@
+inline loader e

--- a/test/configCases/externals/context-element-original-request/index.js
+++ b/test/configCases/externals/context-element-original-request/index.js
@@ -19,3 +19,9 @@ it("should match an externals string against the original request", async () => 
 it("should match an externals RegExp against the original request", async () => {
 	expect((await load("d")).default.value).toBe("external d");
 });
+
+it("should keep the request of an element with inline loaders", async () => {
+	const name = "e";
+	const module = await import(`./loader.js!./configs/${name}.txt`);
+	expect(module.default).toBe("inline loader e");
+});

--- a/test/configCases/externals/context-element-original-request/index.js
+++ b/test/configCases/externals/context-element-original-request/index.js
@@ -1,0 +1,21 @@
+/**
+ * @param {string} name name of the config
+ * @returns {Promise<EXPECTED_ANY>} the imported config
+ */
+const load = (name) => import(`#configs/${name}.js`);
+
+it("should provide the original request to an externals function", async () => {
+	expect((await load("a")).default.value).toBe("external a");
+});
+
+it("should match an externals object against the original request", async () => {
+	expect((await load("b")).default.value).toBe("external b");
+});
+
+it("should match an externals string against the original request", async () => {
+	expect((await load("c")).default.value).toBe("external c");
+});
+
+it("should match an externals RegExp against the original request", async () => {
+	expect((await load("d")).default.value).toBe("external d");
+});

--- a/test/configCases/externals/context-element-original-request/loader.js
+++ b/test/configCases/externals/context-element-original-request/loader.js
@@ -1,0 +1,7 @@
+"use strict";
+
+/**
+ * @param {string} source source
+ * @returns {string} generated module
+ */
+module.exports = (source) => `module.exports = ${JSON.stringify(source.trim())};`;

--- a/test/configCases/externals/context-element-original-request/package.json
+++ b/test/configCases/externals/context-element-original-request/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "context-element-original-request",
+  "imports": {
+    "#configs": "./configs",
+    "#configs/*": "./configs/*"
+  }
+}

--- a/test/configCases/externals/context-element-original-request/test.config.js
+++ b/test/configCases/externals/context-element-original-request/test.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+	modules: {
+		"#configs/a.js": { value: "external a" },
+		"#configs/b.js": { value: "external b" },
+		"#configs/c.js": { value: "external c" },
+		"#configs/d.js": { value: "external d" }
+	}
+};

--- a/test/configCases/externals/context-element-original-request/webpack.config.js
+++ b/test/configCases/externals/context-element-original-request/webpack.config.js
@@ -22,6 +22,8 @@ module.exports = {
 				if (request === "./a.js") return callback(null, true);
 				return callback();
 			}
+			// an element of a context module with inline loaders carries the resolved
+			// loaders in its request, which the context request must not be joined to
 			if (originalRequest !== request) {
 				return callback(
 					new Error(

--- a/test/configCases/externals/context-element-original-request/webpack.config.js
+++ b/test/configCases/externals/context-element-original-request/webpack.config.js
@@ -1,0 +1,38 @@
+"use strict";
+
+// elements of the `#configs` context module, whose `request` is relative to the
+// resolved directory while `originalRequest` is what the user wrote
+const CONTEXT_ELEMENTS = new Set(["./a.js", "./b.js", "./c.js", "./d.js"]);
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	externalsType: "commonjs",
+	externals: [
+		({ request, originalRequest }, callback) => {
+			if (CONTEXT_ELEMENTS.has(request)) {
+				const expected = `#configs/${request.slice(2)}`;
+				if (originalRequest !== expected) {
+					return callback(
+						new Error(
+							`Expected "${expected}" as original request, but got "${originalRequest}"`
+						)
+					);
+				}
+				// the other elements are matched by the externals below
+				if (request === "./a.js") return callback(null, true);
+				return callback();
+			}
+			if (originalRequest !== request) {
+				return callback(
+					new Error(
+						`Expected the original request of "${request}" to be unchanged, but got "${originalRequest}"`
+					)
+				);
+			}
+			callback();
+		},
+		{ "#configs/b.js": true },
+		"#configs/c.js",
+		/^#configs\/d\.js$/
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -5054,9 +5054,8 @@ declare abstract class ContextElementDependency extends ModuleDependency {
 	attributes?: ImportAttributes;
 
 	/**
-	 * The request as the user wrote it, e.g. `#configs/file.mjs` for the element
-	 * `./file.mjs` of a `#configs` context. `request` is relative to the resolved
-	 * context directory instead, which no longer resembles what was written.
+	 * The request as the user wrote it, e.g. `#configs/file.mjs` where `request`
+	 * is the `./file.mjs` relative to the resolved `#configs` directory.
 	 */
 	get originalRequest(): string;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -5052,6 +5052,13 @@ type ContextDependencyOptions = ContextOptions & { request: string };
 declare abstract class ContextElementDependency extends ModuleDependency {
 	referencedExports?: null | string[][];
 	attributes?: ImportAttributes;
+
+	/**
+	 * The request as the user wrote it, e.g. `#configs/file.mjs` for the element
+	 * `./file.mjs` of a `#configs` context. `request` is relative to the resolved
+	 * context directory instead, which no longer resembles what was written.
+	 */
+	get originalRequest(): string;
 }
 declare class ContextExclusionPlugin {
 	/**
@@ -5122,6 +5129,10 @@ declare abstract class ContextModuleFactory extends ModuleFactory {
 }
 type ContextModuleOptions = ContextOptions & ContextModuleOptionsExtras;
 declare interface ContextModuleOptionsExtras {
+	/**
+	 * the request of the context as written by the user, before it was resolved
+	 */
+	request?: string;
 	resource: string | false | string[];
 	resourceQuery?: string;
 	resourceFragment?: string;
@@ -8494,6 +8505,11 @@ declare interface ExternalItemFunctionData {
 	 * the request as written by the user in the require/import expression/statement
 	 */
 	request: string;
+
+	/**
+	 * same as `request`, except for an element of a context module (a request containing an expression), where it is the request as written by the user instead of the one relative to the resolved context directory
+	 */
+	originalRequest: string;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

An element of a context module (`import("#configs/" + name + ".mjs")`) is factorized with a request relative to the resolved directory (`./name.mjs`), so externals written against the request the user wrote (`#configs/name.mjs`) never matched and `external: true` emitted the relative request. Elements now keep the context request and report it as `originalRequest`, which externals functions receive next to the unchanged `request`, and which string, object and RegExp externals are matched against as well. Closes #16529.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/externals/context-element-original-request/` covers all four externals forms, and `test/ContextModuleFactory.unittest.js` covers nested elements, query/fragment and a non-relative alternative request.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — `request` keeps its current value and the new matching is additive.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The externals function data gains `originalRequest` and needs an entry in the `externals` docs.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to write the implementation and tests from the issue report, and to run the test and lint suites; the design and the diff were reviewed before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128MMPGp9JBQjaxBHeBoBcw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of original import requests when resolving context-based modules.
  * Ensured external configurations consistently match requests with queries, fragments, aliases, and relative paths.
  * Preserved correct behavior for dynamic imports, inline loaders, and built-in `node:` modules.
  * Prevented duplicated query or fragment components during request resolution.

* **Tests**
  * Added coverage for string, regular expression, object, and callback-based external configurations.
  * Added validation for original-request handling across context modules and external resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->