### PR TITLE
feat(analyzable): bake the stylesheet url a css chunk loads

### DIFF
--- a/.changeset/030-analyzable-css-chunk-href.md
+++ b/.changeset/030-analyzable-css-chunk-href.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Bake the stylesheet url a css chunk loads into the chunk that loads it.

--- a/.changeset/030-analyzable-css-chunk-href.md
+++ b/.changeset/030-analyzable-css-chunk-href.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Bake the stylesheet url a css chunk loads into the chunk that loads it.
+Write out the stylesheet url a css chunk loads, so tools can follow it.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -188,6 +188,7 @@ const SERVED_BAILOUT =
 /** @typedef {import("./config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
 /** @typedef {import("../declarations/WebpackOptions").WasmLoading} WasmLoading */
+/** @typedef {import("./Module").ReadOnlyRuntimeRequirements} ReadOnlyRuntimeRequirements */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPartKind} SpecifierPartKind */
 /** @typedef {"import" | "url" | "url-inline" | "wasm" | "wasm-relative"} AnalyzableForm */
@@ -3046,13 +3047,25 @@ class RuntimeTemplate {
 	 * and the plugin declaring what it needs ask this, so the two always agree. The
 	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
 	 * resolves the element against the document, which is not where the chunk sits, and
-	 * the loader reads the url as text either way.
+	 * the loader reads the url as text either way. Nothing is written out for a runtime
+	 * that also carries the hot handler; see below.
 	 * @param {Chunk} runtimeChunk the chunk holding the stylesheet loader
 	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what that chunk needs
 	 * @param {Module=} consumingModule the runtime module, where one exists to report against
 	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
 	 */
-	analyzableCssChunkUrls(runtimeChunk, chunkGraph, consumingModule) {
+	analyzableCssChunkUrls(
+		runtimeChunk,
+		chunkGraph,
+		runtimeRequirements,
+		consumingModule
+	) {
+		// The hot path re-loads by whatever id an update names, which a map written now
+		// cannot answer for. Analyzable output is what ships, so it yields to HMR.
+		if (runtimeRequirements.has(RuntimeGlobals.hmrDownloadUpdateHandlers)) {
+			return null;
+		}
 		if (!this.supportsAnalyzable("url", chunkGraph, consumingModule)) {
 			return null;
 		}
@@ -3060,7 +3073,13 @@ class RuntimeTemplate {
 		const consumingChunks = [runtimeChunk];
 		/** @type {Map<ChunkId, string>} */
 		const urls = new Map();
-		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
+		// An initial stylesheet is already in the document, but the hot path re-loads it
+		// by id like any other, so it needs a url here too.
+		const reachable = new Set([
+			...runtimeChunk.getAllReferencedChunks(),
+			...runtimeChunk.getAllInitialChunks()
+		]);
+		for (const chunk of reachable) {
 			if (chunk.id === null || !chunkHasCss(chunk, chunkGraph)) continue;
 			const specifier = this._getAnalyzableChunkSpecifier(
 				undefined,

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2675,7 +2675,8 @@ class RuntimeTemplate {
 	 * statically — a content hash in the filename, or a dynamic/templated publicPath.
 	 * @param {string | undefined} overridePublicPath per-dependency public path (wins over `output.publicPath`)
 	 * @param {Chunk} chunk the chunk to reference
-	 * @param {Module} consumingModule the module the reference is emitted into
+	 * @param {Module | undefined} consumingModule the module the reference is emitted
+	 * into, or `undefined` when `consumingChunks` names where it goes instead
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {RuntimeRequirements=} runtimeRequirements set when the caller wraps the result in
 	 * `new URL(...)` and so accepts a runtime public path prefix around the literal filename
@@ -2712,8 +2713,10 @@ class RuntimeTemplate {
 		// An id names the chunk in the stand-in, and one nothing could resolve would
 		// reach the bundle verbatim. The whole name is re-resolved later rather than
 		// carrying a stand-in of its own, so any hash spelling is fine here.
+		// One of the two always names where the reference goes.
 		const chunks =
-			consumingChunks || this._moduleChunks(consumingModule, chunkGraph);
+			consumingChunks ||
+			this._moduleChunks(/** @type {Module} */ (consumingModule), chunkGraph);
 		// Baking makes the consuming chunk's content depend on this one's hash. A pair that
 		// reaches back has no fixed point if both bake, so only the lower id's name does.
 		const cycles =
@@ -2776,9 +2779,7 @@ class RuntimeTemplate {
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
-			const { undo } = consumingChunks
-				? this._placementOf(consumingChunks)
-				: this._modulePlacement(consumingModule, chunkGraph);
+			const { undo } = this._placementOf(chunks);
 			if (undo !== null) return specifier([["literal", undo]]);
 			// Different depths — no one `../` path is right for every asset the reference
 			// lands in, so the deferred pass builds each asset's own.
@@ -2809,7 +2810,7 @@ class RuntimeTemplate {
 	 * names the place it started from. An entry `baseUri` sits between the two, so
 	 * there both are written. Never asked of an `auto` public path, which is no path
 	 * to walk back over.
-	 * @param {Module} module the module the reference is emitted into
+	 * @param {Module | undefined} module the module the reference is emitted into
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {Iterable<Chunk>} chunks the chunks a stand-in would be written into
 	 * @param {string=} relativeBase an entry `baseUri` read against the output root
@@ -2824,7 +2825,7 @@ class RuntimeTemplate {
 		const resolve = () =>
 			this._resolvePublicPathPrefix(publicPath, module, chunks);
 		if (isBaseIndependent(shape)) return resolve();
-		const { undo, loaded } = this._modulePlacement(module, chunkGraph);
+		const { undo, loaded } = this._placementOf(chunks);
 		const climb =
 			loaded === null ? null : loaded ? this._publicPathClimb() : "";
 		if (climb === null) {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -11,6 +11,7 @@ const InitFragment = require("./InitFragment");
 const {
 	ASSET_TYPE,
 	ASSET_URL_TYPE,
+	CSS_TYPE,
 	HTML_TYPE,
 	JAVASCRIPT_TYPE,
 	RUNTIME_TYPE
@@ -49,6 +50,7 @@ const {
 	subtractRuntime
 } = require("./util/runtime");
 
+const getCssModulesPlugin = memoize(() => require("./css/CssModulesPlugin"));
 const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 const getAnalyzableChunkHashPlugin = memoize(() =>
 	require("./esm/AnalyzableChunkHashPlugin")
@@ -673,7 +675,8 @@ class RuntimeTemplate {
 				chunk,
 				this.outputOptions
 			),
-			chunk
+			chunk,
+			JAVASCRIPT_TYPE
 		);
 		let independent = false;
 		if (typeof template === "string") {
@@ -2631,13 +2634,23 @@ class RuntimeTemplate {
 	 * @returns {Placement} where a literal in it is read from
 	 */
 	_modulePlacement(module, chunkGraph) {
+		return this._placementOf(this._moduleChunks(module, chunkGraph));
+	}
+
+	/**
+	 * The one answer every chunk in `chunks` agrees on, with either half `null` where
+	 * they do not.
+	 * @param {Iterable<Chunk>} chunks the chunks a literal is written into
+	 * @returns {Placement} where a literal in them is read from
+	 */
+	_placementOf(chunks) {
 		/** @type {Placement | undefined} */
 		let first;
 		/** @type {string | null} */
 		let undo = null;
 		/** @type {boolean | null} */
 		let loaded = null;
-		for (const chunk of this._moduleChunks(module, chunkGraph)) {
+		for (const chunk of chunks) {
 			const own = this._chunkPlacement(chunk);
 			if (first === undefined) {
 				first = own;
@@ -2666,6 +2679,10 @@ class RuntimeTemplate {
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {RuntimeRequirements=} runtimeRequirements set when the caller wraps the result in
 	 * `new URL(...)` and so accepts a runtime public path prefix around the literal filename
+	 * @param {Chunk[]=} consumingChunks the chunks the reference is written into, where
+	 * they are known without a module to read them from
+	 * @param {string=} sourceType which half of the chunk is named — its javascript by
+	 * default, or its stylesheet
 	 * @returns {string | null} a JS string literal or expression, or `null` to fall back to the runtime form
 	 */
 	_getAnalyzableChunkSpecifier(
@@ -2673,17 +2690,20 @@ class RuntimeTemplate {
 		chunk,
 		consumingModule,
 		chunkGraph,
-		runtimeRequirements
+		runtimeRequirements,
+		consumingChunks,
+		sourceType = JAVASCRIPT_TYPE
 	) {
 		const { compilation } = this;
 		const { outputOptions } = compilation;
-		const filenameTemplate = JavascriptModulesPlugin.getChunkFilenameTemplate(
-			chunk,
-			outputOptions
-		);
+		const css = sourceType === CSS_TYPE;
+		const filenameTemplate = css
+			? getCssModulesPlugin().getChunkFilenameTemplate(chunk, outputOptions)
+			: JavascriptModulesPlugin.getChunkFilenameTemplate(chunk, outputOptions);
 		const template = this._resolveChunkFilenameTemplate(
 			filenameTemplate,
-			chunk
+			chunk,
+			sourceType
 		);
 		if (template === null) return null;
 		// A hashed name is settled long after this code is generated, so a stand-in is
@@ -2692,7 +2712,8 @@ class RuntimeTemplate {
 		// An id names the chunk in the stand-in, and one nothing could resolve would
 		// reach the bundle verbatim. The whole name is re-resolved later rather than
 		// carrying a stand-in of its own, so any hash spelling is fine here.
-		const chunks = this._moduleChunks(consumingModule, chunkGraph);
+		const chunks =
+			consumingChunks || this._moduleChunks(consumingModule, chunkGraph);
 		// Baking makes the consuming chunk's content depend on this one's hash. A pair that
 		// reaches back has no fixed point if both bake, so only the lower id's name does.
 		const cycles =
@@ -2725,7 +2746,7 @@ class RuntimeTemplate {
 					// Matches what names the asset, or a placeholder resolved here would
 					// not be the one on disk.
 					runtime: chunk.runtime,
-					contentHashType: JAVASCRIPT_TYPE
+					contentHashType: sourceType
 				});
 		/**
 		 * @param {SpecifierPart[]} prefix what goes in front of the chunk's filename
@@ -2741,7 +2762,7 @@ class RuntimeTemplate {
 			return toJsStringLiteral(
 				getAnalyzableChunkHashPlugin().reserveSpecifier([
 					...prefix,
-					["chunk", /** @type {ChunkId} */ (chunk.id)]
+					[css ? "cssChunk" : "chunk", /** @type {ChunkId} */ (chunk.id)]
 				])
 			);
 		};
@@ -2755,7 +2776,9 @@ class RuntimeTemplate {
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
-			const { undo } = this._modulePlacement(consumingModule, chunkGraph);
+			const { undo } = consumingChunks
+				? this._placementOf(consumingChunks)
+				: this._modulePlacement(consumingModule, chunkGraph);
 			if (undo !== null) return specifier([["literal", undo]]);
 			// Different depths — no one `../` path is right for every asset the reference
 			// lands in, so the deferred pass builds each asset's own.
@@ -2984,6 +3007,44 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Static `new URL(<file>, import.meta.url)` for every stylesheet a runtime can load,
+	 * keyed by chunk id, or `null` when any of them has to keep the runtime
+	 * `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
+	 * and the plugin declaring what it needs ask this, so the two always agree. The
+	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
+	 * resolves the element against the document, which is not where the chunk sits, and
+	 * the loader reads the url as text either way.
+	 * @param {Chunk} runtimeChunk the chunk holding the stylesheet loader
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Module=} consumingModule the runtime module, where one exists to report against
+	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 */
+	analyzableCssChunkUrls(runtimeChunk, chunkGraph, consumingModule) {
+		if (!this.supportsAnalyzable("url", chunkGraph, consumingModule)) {
+			return null;
+		}
+		const { chunkHasCss } = getCssModulesPlugin();
+		const consumingChunks = [runtimeChunk];
+		/** @type {Map<ChunkId, string>} */
+		const urls = new Map();
+		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
+			if (chunk.id === null || !chunkHasCss(chunk, chunkGraph)) continue;
+			const specifier = this._getAnalyzableChunkSpecifier(
+				undefined,
+				chunk,
+				consumingModule,
+				chunkGraph,
+				undefined,
+				consumingChunks,
+				CSS_TYPE
+			);
+			if (specifier === null) return null;
+			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);
+		}
+		return urls.size > 0 ? urls : null;
+	}
+
+	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
 	 * module. Only called when `supportsAnalyzable("wasm")` holds.
 	 * @param {Module} module the async wasm module
@@ -3036,10 +3097,11 @@ class RuntimeTemplate {
 	 * deferred pass to ask again once the hashes are settled.
 	 * @param {ChunkFilenameTemplate} filenameTemplate the configured template
 	 * @param {Chunk} chunk the chunk being referenced
+	 * @param {string} contentHashType which of the chunk's hashes the name reads
 	 * @returns {string | undefined | null} the template, `undefined` to defer, or
 	 * `null` to fall back
 	 */
-	_resolveChunkFilenameTemplate(filenameTemplate, chunk) {
+	_resolveChunkFilenameTemplate(filenameTemplate, chunk, contentHashType) {
 		if (typeof filenameTemplate === "string") return filenameTemplate;
 		try {
 			// Everything the naming call is given except the hashes, so only a hash can
@@ -3047,14 +3109,14 @@ class RuntimeTemplate {
 			const template = filenameTemplate({
 				chunk: createHashProbeChunk(chunk, HASH_PROBE, true),
 				runtime: chunk.runtime,
-				contentHashType: JAVASCRIPT_TYPE,
+				contentHashType,
 				hash: HASH_PROBE,
 				contentHash: HASH_PROBE
 			});
 			const probe = filenameTemplate({
 				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE, false),
 				runtime: chunk.runtime,
-				contentHashType: JAVASCRIPT_TYPE,
+				contentHashType,
 				hash: HASH_PROBE_ALTERNATE,
 				contentHash: HASH_PROBE_ALTERNATE
 			});

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -51,6 +51,38 @@ const {
 } = require("./util/runtime");
 
 const getCssModulesPlugin = memoize(() => require("./css/CssModulesPlugin"));
+
+/**
+ * @typedef {object} ChunkAssetNaming
+ * @property {(chunk: Chunk, outputOptions: OutputOptions) => ChunkFilenameTemplate} template what names the asset
+ * @property {SpecifierPartKind} standIn the stand-in kind that spells it once the hashes exist
+ */
+
+/**
+ * What names the asset a chunk emits for one source type. Keyed rather than branched
+ * on, so a type nothing here answers for keeps the runtime form instead of silently
+ * taking another type's name and hash. A plugin emitting a new kind of chunk asset
+ * registers it here to have its urls baked.
+ * @type {Map<string, ChunkAssetNaming>}
+ */
+const CHUNK_ASSET_NAMING = new Map([
+	[
+		JAVASCRIPT_TYPE,
+		{
+			template: (chunk, outputOptions) =>
+				JavascriptModulesPlugin.getChunkFilenameTemplate(chunk, outputOptions),
+			standIn: "chunk"
+		}
+	],
+	[
+		CSS_TYPE,
+		{
+			template: (chunk, outputOptions) =>
+				getCssModulesPlugin().getChunkFilenameTemplate(chunk, outputOptions),
+			standIn: "cssChunk"
+		}
+	]
+]);
 const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 const getAnalyzableChunkHashPlugin = memoize(() =>
 	require("./esm/AnalyzableChunkHashPlugin")
@@ -157,6 +189,7 @@ const SERVED_BAILOUT =
 /** @typedef {import("../declarations/WebpackOptions").PublicPath} PublicPath */
 /** @typedef {import("../declarations/WebpackOptions").WasmLoading} WasmLoading */
 /** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPart} SpecifierPart */
+/** @typedef {import("./esm/AnalyzableChunkHashPlugin").SpecifierPartKind} SpecifierPartKind */
 /** @typedef {"import" | "url" | "url-inline" | "wasm" | "wasm-relative"} AnalyzableForm */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./Chunk")} Chunk */
@@ -2697,12 +2730,11 @@ class RuntimeTemplate {
 	) {
 		const { compilation } = this;
 		const { outputOptions } = compilation;
-		const css = sourceType === CSS_TYPE;
-		const filenameTemplate = css
-			? getCssModulesPlugin().getChunkFilenameTemplate(chunk, outputOptions)
-			: JavascriptModulesPlugin.getChunkFilenameTemplate(chunk, outputOptions);
+		const naming = CHUNK_ASSET_NAMING.get(sourceType);
+		// Nothing here names this type's asset, so nothing can spell where it will be.
+		if (naming === undefined) return null;
 		const template = this._resolveChunkFilenameTemplate(
-			filenameTemplate,
+			naming.template(chunk, outputOptions),
 			chunk,
 			sourceType
 		);
@@ -2765,7 +2797,7 @@ class RuntimeTemplate {
 			return toJsStringLiteral(
 				getAnalyzableChunkHashPlugin().reserveSpecifier([
 					...prefix,
-					[css ? "cssChunk" : "chunk", /** @type {ChunkId} */ (chunk.id)]
+					[naming.standIn, /** @type {ChunkId} */ (chunk.id)]
 				])
 			);
 		};

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -115,9 +115,8 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				// `parser.javascript.dynamicImportCssPreload` — CSS-only preload order.
 				chunk.hasChildByOrder(chunkGraph, "cssPreload", true, chunkHasCss));
 
-		// A stylesheet's url is built from the chunk id at runtime, so nothing outside
-		// webpack can tell which files a chunk pulls in. Under module output each is a
-		// known file, so they are written out and read by id instead.
+		// Under module output each stylesheet is a known file, so the urls are written
+		// out and read by id rather than built from the chunk id at runtime.
 		const cssUrls = runtimeTemplate.analyzableCssChunkUrls(
 			chunk,
 			chunkGraph,

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -121,6 +121,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		const cssUrls = runtimeTemplate.analyzableCssChunkUrls(
 			chunk,
 			chunkGraph,
+			_runtimeRequirements,
 			this
 		);
 
@@ -578,8 +579,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 								"// Read CSS removed chunks from update manifest",
 								`${cst} cssRemovedChunks = css && css.r;`,
 								`chunkIds.forEach(${runtimeTemplate.basicFunction("chunkId", [
-									`${cst} filename = ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
-									`${cst} url = ${RuntimeGlobals.publicPath} + filename;`,
+									`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
 									`${cst} oldTag = loadStylesheet(chunkId, url);`,
 									`if(!oldTag && !${withHmr} ) return;`,
 									"// Skip if CSS was removed",

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -115,6 +115,15 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				// `parser.javascript.dynamicImportCssPreload` — CSS-only preload order.
 				chunk.hasChildByOrder(chunkGraph, "cssPreload", true, chunkHasCss));
 
+		// A stylesheet's url is built from the chunk id at runtime, so nothing outside
+		// webpack can tell which files a chunk pulls in. Under module output each is a
+		// known file, so they are written out and read by id instead.
+		const cssUrls = runtimeTemplate.analyzableCssChunkUrls(
+			chunk,
+			chunkGraph,
+			this
+		);
+
 		const { linkPreload, linkPrefetch, createStylesheet, linkInsert } =
 			CssLoadingRuntimeModule.getCompilationHooks(compilation);
 
@@ -169,7 +178,24 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				",\n"
 			)
 		)}\n}`;
+		// The url is read through a thunk so a runtime carrying many stylesheets builds
+		// only the one it loads.
+		const cssUrl = (id) =>
+			cssUrls === undefined || cssUrls === null
+				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(${id})`
+				: `cssUrls[${id}]()`;
 		return Template.asString([
+			...(cssUrls
+				? [
+						`${cst} cssUrls = {\n${Template.indent(
+							Array.from(
+								cssUrls,
+								([id, url]) =>
+									`${JSON.stringify(String(id))}: ${runtimeTemplate.returningFunction(url)}`
+							).join(",\n")
+						)}\n};`
+					]
+				: []),
 			"// object to store loaded and loading chunks",
 			"// undefined = chunk not loaded, null = chunk preloaded/prefetched",
 			"// [resolve, reject, Promise] = chunk loading, 0 = chunk loaded",
@@ -289,7 +315,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 											"promises.push(installedChunkData[2] = promise);",
 											"",
 											"// start chunk loading",
-											`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
+											`${cst} url = ${cssUrl("chunkId")};`,
 											"// create error before stack unwound to get useful stacktrace later",
 											`${cst} error = new Error();`,
 											`${cst} loadingEnded = ${runtimeTemplate.basicFunction(
@@ -395,7 +421,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 									"}",
 									'link.rel = "prefetch";',
 									'link.as = "style";',
-									`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`
+									`link.href = ${cssUrl("chunkId")};`
 								]),
 								chunk
 							),
@@ -444,7 +470,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 									"}",
 									'link.rel = "preload";',
 									'link.as = "style";',
-									`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
+									`link.href = ${cssUrl("chunkId")};`,
 									crossOriginLoading
 										? crossOriginLoading === "use-credentials"
 											? 'link.crossOrigin = "use-credentials";'

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -180,6 +180,10 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		)}\n}`;
 		// The url is read through a thunk so a runtime carrying many stylesheets builds
 		// only the one it loads.
+		/**
+		 * @param {string} id expression naming the chunk whose stylesheet is wanted
+		 * @returns {string} expression evaluating to its url
+		 */
 		const cssUrl = (id) =>
 			cssUrls === undefined || cssUrls === null
 				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(${id})`

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -774,12 +774,13 @@ class CssModulesPlugin {
 
 						set.add(RuntimeGlobals.hasOwnProperty);
 						// A baked url carries where the stylesheet is, so neither the public
-						// path nor the name lookup is read for it. Asked the same way the
+						// path nor the name lookup is read for it. Asked exactly as the
 						// loading runtime module asks, so the two always agree.
 						if (
 							compilation.runtimeTemplate.analyzableCssChunkUrls(
 								chunk,
-								chunkGraph
+								chunkGraph,
+								set
 							) === null
 						) {
 							set.add(RuntimeGlobals.publicPath);

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -773,8 +773,18 @@ class CssModulesPlugin {
 						if (!hasCssToLoad(chunk, chunkGraph)) return;
 
 						set.add(RuntimeGlobals.hasOwnProperty);
-						set.add(RuntimeGlobals.publicPath);
-						set.add(RuntimeGlobals.getChunkCssFilename);
+						// A baked url carries where the stylesheet is, so neither the public
+						// path nor the name lookup is read for it. Asked the same way the
+						// loading runtime module asks, so the two always agree.
+						if (
+							compilation.runtimeTemplate.analyzableCssChunkUrls(
+								chunk,
+								chunkGraph
+							) === null
+						) {
+							set.add(RuntimeGlobals.publicPath);
+							set.add(RuntimeGlobals.getChunkCssFilename);
+						}
 						// Asked here rather than for `hasCssModules`: the loading runtime
 						// module renders nothing without loading or hmr, so declaring it
 						// there ships the polyfill to a build that never reads it.

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -13,6 +13,8 @@ const memoize = require("../util/memoize");
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Chunk").ChunkId} ChunkId */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Chunk").ChunkFilenameTemplate} ChunkFilenameTemplate */
+/** @typedef {import("../config/defaults").OutputNormalizedWithDefaults} OutputOptions */
 
 const getJavascriptModulesPlugin = memoize(() =>
 	require("../javascript/JavascriptModulesPlugin")
@@ -65,7 +67,7 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 
 /**
  * @typedef {object} ChunkAssetNaming
- * @property {(chunk: Chunk, outputOptions: EXPECTED_ANY) => EXPECTED_ANY} template what names the asset
+ * @property {(chunk: Chunk, outputOptions: OutputOptions) => ChunkFilenameTemplate} template what names the asset
  * @property {string} contentHashType which of the chunk's hashes the name reads
  */
 

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -64,10 +64,44 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 };
 
 /**
+ * @typedef {object} ChunkAssetNaming
+ * @property {(chunk: Chunk, outputOptions: EXPECTED_ANY) => EXPECTED_ANY} template what names the asset
+ * @property {string} contentHashType which of the chunk's hashes the name reads
+ */
+
+/**
+ * How each chunk-naming stand-in is spelled once the hashes exist, keyed rather than
+ * branched on so a kind this pass does not answer for resolves to nothing instead of
+ * silently taking another's name. `RuntimeTemplate` reserves only what is keyed here.
+ * @type {Map<string, ChunkAssetNaming>}
+ */
+const CHUNK_ASSET_NAMING = new Map([
+	[
+		"chunk",
+		{
+			template: (chunk, outputOptions) =>
+				getJavascriptModulesPlugin().getChunkFilenameTemplate(
+					chunk,
+					outputOptions
+				),
+			contentHashType: "javascript"
+		}
+	],
+	[
+		"cssChunk",
+		{
+			template: (chunk, outputOptions) =>
+				getCssModulesPlugin().getChunkFilenameTemplate(chunk, outputOptions),
+			contentHashType: "css"
+		}
+	]
+]);
+
+/**
  * One piece of a name only the deferred pass can spell: text as it stands, the `../`
  * path from the asset it sits in to the output root, a template or `output.publicPath`
- * resolved once the hashes exist, the javascript or stylesheet filename of the chunk
- * with this id, or the base everything else is resolved against once it is spelled.
+ * resolved once the hashes exist, one of the assets the chunk with this id emits, or
+ * the base everything else is resolved against once it is spelled.
  * @typedef {"literal" | "undo" | "template" | "publicPath" | "chunk" | "cssChunk" | "base"} SpecifierPartKind
  */
 
@@ -78,9 +112,8 @@ const SPECIFIER_PART_KINDS = new Set([
 	"undo",
 	"template",
 	"publicPath",
-	"chunk",
-	"cssChunk",
-	"base"
+	"base",
+	...CHUNK_ASSET_NAMING.keys()
 ]);
 
 /**
@@ -119,8 +152,7 @@ const readSpecifier = (payload) => {
 		// Only a chunk id may be a number; the rest are read as text.
 		if (
 			typeof part[1] !== "string" &&
-			((part[0] !== "chunk" && part[0] !== "cssChunk") ||
-				typeof part[1] !== "number")
+			(!CHUNK_ASSET_NAMING.has(part[0]) || typeof part[1] !== "number")
 		) {
 			return null;
 		}
@@ -213,6 +245,10 @@ class AnalyzableChunkHashPlugin {
 									{}
 								);
 							} else {
+								const naming = CHUNK_ASSET_NAMING.get(kind);
+								// Nothing reserves a kind this pass cannot spell, so one arriving
+								// here was written by something else and names no asset of ours.
+								if (naming === undefined) return null;
 								if (chunksById === undefined) {
 									chunksById = new Map();
 									for (const chunk of compilation.chunks) {
@@ -223,23 +259,14 @@ class AnalyzableChunkHashPlugin {
 								}
 								const chunk = chunksById.get(String(value));
 								if (chunk === undefined) return null;
-								const css = kind === "cssChunk";
 								specifier += compilation.getPath(
-									css
-										? getCssModulesPlugin().getChunkFilenameTemplate(
-												chunk,
-												outputOptions
-											)
-										: getJavascriptModulesPlugin().getChunkFilenameTemplate(
-												chunk,
-												outputOptions
-											),
+									naming.template(chunk, outputOptions),
 									// Matches what names the asset, or a placeholder resolved here would
 									// not be the one on disk.
 									{
 										chunk,
 										runtime: chunk.runtime,
-										contentHashType: css ? "css" : "javascript"
+										contentHashType: naming.contentHashType
 									}
 								);
 							}

--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -17,6 +17,7 @@ const memoize = require("../util/memoize");
 const getJavascriptModulesPlugin = memoize(() =>
 	require("../javascript/JavascriptModulesPlugin")
 );
+const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 const getTemplatedPathPlugin = memoize(() => require("../TemplatedPathPlugin"));
 
 // Looks like a relative specifier, so the code around it needs no special case, and
@@ -65,9 +66,9 @@ const DEFERRED_FULL_HASH_PATH_DATA = {
 /**
  * One piece of a name only the deferred pass can spell: text as it stands, the `../`
  * path from the asset it sits in to the output root, a template or `output.publicPath`
- * resolved once the hashes exist, the filename of the chunk with this id, or the base
- * everything else is resolved against once it is spelled.
- * @typedef {"literal" | "undo" | "template" | "publicPath" | "chunk" | "base"} SpecifierPartKind
+ * resolved once the hashes exist, the javascript or stylesheet filename of the chunk
+ * with this id, or the base everything else is resolved against once it is spelled.
+ * @typedef {"literal" | "undo" | "template" | "publicPath" | "chunk" | "cssChunk" | "base"} SpecifierPartKind
  */
 
 /** @typedef {[SpecifierPartKind, string | number]} SpecifierPart */
@@ -78,6 +79,7 @@ const SPECIFIER_PART_KINDS = new Set([
 	"template",
 	"publicPath",
 	"chunk",
+	"cssChunk",
 	"base"
 ]);
 
@@ -117,7 +119,8 @@ const readSpecifier = (payload) => {
 		// Only a chunk id may be a number; the rest are read as text.
 		if (
 			typeof part[1] !== "string" &&
-			(part[0] !== "chunk" || typeof part[1] !== "number")
+			((part[0] !== "chunk" && part[0] !== "cssChunk") ||
+				typeof part[1] !== "number")
 		) {
 			return null;
 		}
@@ -220,17 +223,23 @@ class AnalyzableChunkHashPlugin {
 								}
 								const chunk = chunksById.get(String(value));
 								if (chunk === undefined) return null;
+								const css = kind === "cssChunk";
 								specifier += compilation.getPath(
-									getJavascriptModulesPlugin().getChunkFilenameTemplate(
-										chunk,
-										outputOptions
-									),
-									// Matches what `JavascriptModulesPlugin` names the asset with, or a
-									// placeholder resolved here would not be the one on disk.
+									css
+										? getCssModulesPlugin().getChunkFilenameTemplate(
+												chunk,
+												outputOptions
+											)
+										: getJavascriptModulesPlugin().getChunkFilenameTemplate(
+												chunk,
+												outputOptions
+											),
+									// Matches what names the asset, or a placeholder resolved here would
+									// not be the one on disk.
 									{
 										chunk,
 										runtime: chunk.runtime,
-										contentHashType: "javascript"
+										contentHashType: css ? "css" : "javascript"
 									}
 								);
 							}

--- a/test/configCases/analyzable/css-chunk-href/auto-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/auto-entry.js
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+it("should load the stylesheet the baked url names", async () => {
+	await import("./lazy.css");
+
+	// The neutral runtime guards the DOM, so the stylesheet only lands where there is one.
+	if (typeof document !== "undefined") {
+		expect(getComputedStyle(document.body).getPropertyValue("background")).toBe(
+			" red"
+		);
+	}
+});
+
+it("should write the stylesheet url out and drop what built it", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle).toContain(`new URL("./${__NAME__}-lazy_css.css"`);
+	// Nothing reads the id-keyed lookup or the public path any more, so neither ships.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.k = `);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.p = `);
+});

--- a/test/configCases/analyzable/css-chunk-href/hashed-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/hashed-entry.js
@@ -24,4 +24,5 @@ it("should fill the reserved name in with the hash the file was emitted under", 
 	expect(baked).toHaveLength(1);
 	expect(emitted).toContain(baked[0].slice('new URL("./'.length, -1));
 	expect(bundle).not.toContain(`${"__webpack_require__"}.k = `);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.p = `);
 });

--- a/test/configCases/analyzable/css-chunk-href/hashed-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/hashed-entry.js
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+it("should load the stylesheet its hashed name points at", async () => {
+	await import("./lazy.css");
+
+	// The neutral runtime guards the DOM, so the stylesheet only lands where there is one.
+	if (typeof document !== "undefined") {
+		expect(getComputedStyle(document.body).getPropertyValue("background")).toBe(
+			" red"
+		);
+	}
+});
+
+it("should fill the reserved name in with the hash the file was emitted under", () => {
+	const dir = __STATS__.children[__INDEX__].outputPath;
+	const bundle = fs.readFileSync(path.join(dir, `${__NAME__}.mjs`), "utf8");
+	const emitted = fs.readdirSync(dir).filter((n) => n.endsWith(".css"));
+
+	// Whatever it baked has to be a file that was actually emitted, so a stand-in the
+	// deferred pass never filled in cannot pass.
+	const baked = bundle.match(/new URL\("\.\/([^"]+\.css)"/g) || [];
+
+	expect(baked).toHaveLength(1);
+	expect(emitted).toContain(baked[0].slice('new URL("./'.length, -1));
+	expect(bundle).not.toContain(`${"__webpack_require__"}.k = `);
+});

--- a/test/configCases/analyzable/css-chunk-href/hashed-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/hashed-entry.js
@@ -17,12 +17,15 @@ it("should fill the reserved name in with the hash the file was emitted under", 
 	const bundle = fs.readFileSync(path.join(dir, `${__NAME__}.mjs`), "utf8");
 	const emitted = fs.readdirSync(dir).filter((n) => n.endsWith(".css"));
 
-	// Whatever it baked has to be a file that was actually emitted, so a stand-in the
-	// deferred pass never filled in cannot pass.
+	// Every config shares this directory, so the name has to be this one's shape as
+	// well as a file that exists — a stand-in never filled in is neither.
 	const baked = bundle.match(/new URL\("\.\/([^"]+\.css)"/g) || [];
 
 	expect(baked).toHaveLength(1);
-	expect(emitted).toContain(baked[0].slice('new URL("./'.length, -1));
+	const name = baked[0].slice('new URL("./'.length, -1);
+
+	expect(name).toMatch(/^hashed-lazy_css\.[\da-f]+\.css$/);
+	expect(emitted).toContain(name);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.k = `);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.p = `);
 });

--- a/test/configCases/analyzable/css-chunk-href/hmr-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/hmr-entry.js
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+it("should still load the stylesheet with the hot handler present", async () => {
+	await import("./lazy.css");
+
+	// The neutral runtime guards the DOM, so the stylesheet only lands where there is one.
+	if (typeof document !== "undefined") {
+		expect(getComputedStyle(document.body).getPropertyValue("background")).toBe(
+			" red"
+		);
+	}
+});
+
+it("should keep the runtime url form for a runtime that can be updated", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	// The hot path re-loads by whatever id an update names, which a map written at build
+	// time knows nothing about, so nothing here is written out and the lookup ships.
+	expect(bundle).not.toContain(`new URL("./${__NAME__}-lazy_css.css"`);
+	expect(bundle).toContain(`${"__webpack_require__"}.k = `);
+	expect(bundle).toContain(`${"__webpack_require__"}.k(`);
+});

--- a/test/configCases/analyzable/css-chunk-href/lazy.css
+++ b/test/configCases/analyzable/css-chunk-href/lazy.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/analyzable/css-chunk-href/override-entry.js
+++ b/test/configCases/analyzable/css-chunk-href/override-entry.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+// Reassigned here, so where the stylesheet sits is only known once this runs.
+__webpack_public_path__ = "./";
+
+it("should still load the stylesheet through the runtime form", async () => {
+	await import("./lazy.css");
+
+	// The neutral runtime guards the DOM, so the stylesheet only lands where there is one.
+	if (typeof document !== "undefined") {
+		expect(getComputedStyle(document.body).getPropertyValue("background")).toBe(
+			" red"
+		);
+	}
+});
+
+it("should keep what builds the url when no literal can name it", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle).not.toContain(`new URL("./${__NAME__}-lazy_css.css"`);
+	// The loader still reaches for both, so both have to ship.
+	expect(bundle).toContain(`${"__webpack_require__"}.k = `);
+	expect(bundle).toContain(`${"__webpack_require__"}.p = `);
+});

--- a/test/configCases/analyzable/css-chunk-href/test.config.js
+++ b/test/configCases/analyzable/css-chunk-href/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const NAMES = ["auto", "hashed", "override"];
+
+module.exports = {
+	findBundle(i) {
+		return [`./${NAMES[i]}.mjs`];
+	}
+};

--- a/test/configCases/analyzable/css-chunk-href/test.config.js
+++ b/test/configCases/analyzable/css-chunk-href/test.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const NAMES = ["auto", "hashed", "override"];
+const NAMES = ["auto", "hashed", "override", "hmr"];
 
 module.exports = {
 	findBundle(i) {

--- a/test/configCases/analyzable/css-chunk-href/test.filter.js
+++ b/test/configCases/analyzable/css-chunk-href/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// Reading the bundle back needs `require` in ESM output, which emits
+// `import { createRequire } from "module"` — older Node can't link that.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/css-chunk-href/webpack.config.js
+++ b/test/configCases/analyzable/css-chunk-href/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// A stylesheet is loaded by a `<link href>` the runtime builds from the chunk id. Under
-// module output the file is known, so the href is written out — unless something about
-// the public path can only be known where the chunk runs.
+// Under module output a stylesheet's href is written out, unless something about the
+// public path is only known where the chunk runs.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/analyzable/css-chunk-href/webpack.config.js
+++ b/test/configCases/analyzable/css-chunk-href/webpack.config.js
@@ -51,5 +51,16 @@ module.exports = [
 	},
 	// Reassigned where the chunk runs, so no literal can name where the stylesheet is
 	// and the runtime form has to stay.
-	base(2, "override", false)
+	base(2, "override", false),
+	// The hot handler re-loads by whatever id an update names, so a runtime carrying it
+	// keeps the runtime form everywhere rather than a map that knows only today's ids.
+	{
+		...base(3, "hmr", false),
+		plugins: [
+			.../** @type {NonNullable<import("../../../../").Configuration["plugins"]>} */ (
+				base(3, "hmr", false).plugins
+			),
+			new webpack.HotModuleReplacementPlugin()
+		]
+	}
 ];

--- a/test/configCases/analyzable/css-chunk-href/webpack.config.js
+++ b/test/configCases/analyzable/css-chunk-href/webpack.config.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// A stylesheet is loaded by a `<link href>` the runtime builds from the chunk id. Under
+// module output the file is known, so the href is written out — unless something about
+// the public path can only be known where the chunk runs.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so an entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @param {boolean} baked whether the href is expected to be written out
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, baked) => ({
+	name,
+	target: ["web", "node"],
+	mode: "development",
+	devtool: false,
+	entry: { [name]: `./${name}-entry.js` },
+	experiments: { outputModule: true, css: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: `${name}-[name].mjs`,
+		cssChunkFilename: `${name}-[name].css`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name),
+			__BAKED__: JSON.stringify(baked)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// The plain case: one lazy stylesheet under an `auto` public path.
+	base(0, "auto", true),
+	// A content hash settles long after this code is generated, so the name is reserved
+	// and filled in by the deferred pass.
+	{
+		...base(1, "hashed", true),
+		output: {
+			...base(1, "hashed", true).output,
+			cssChunkFilename: "hashed-[name].[contenthash].css"
+		}
+	},
+	// Reassigned where the chunk runs, so no literal can name where the stylesheet is
+	// and the runtime form has to stay.
+	base(2, "override", false)
+];

--- a/test/configCases/analyzable/reference-integrity/add.wat
+++ b/test/configCases/analyzable/reference-integrity/add.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/analyzable/reference-integrity/asset.txt
+++ b/test/configCases/analyzable/reference-integrity/asset.txt
@@ -1,0 +1,1 @@
+hello asset

--- a/test/configCases/analyzable/reference-integrity/entry.js
+++ b/test/configCases/analyzable/reference-integrity/entry.js
@@ -56,8 +56,9 @@ it("should leave no reserved name behind and call nothing it did not ship", () =
 		expect(text).not.toContain(token("@@webpack", "AnalyzableChunk"));
 		expect(text).not.toContain(token("@@webpack", "FullHash"));
 
-		// A chunk reads the runtime the entry defines, so only the entry is asked.
-		if (path.relative(root, file).includes(path.sep)) continue;
+		// Only the entry carries the runtime; a chunk reads what it defined. Named
+		// rather than inferred from depth, since one config emits its entry nested.
+		if (path.basename(file) !== `${__NAME__}.mjs`) continue;
 		for (const helper of ["u", "k", "p", "b"]) {
 			const used =
 				text.includes(token("__webpack_require__.", helper, "(")) ||

--- a/test/configCases/analyzable/reference-integrity/entry.js
+++ b/test/configCases/analyzable/reference-integrity/entry.js
@@ -1,0 +1,72 @@
+import fs from "fs";
+import path from "path";
+
+// One of every reference analyzable output writes out.
+export const chunk = () => import("./mods/a.js");
+export const context = (name) => import(`./mods/${name}.js`);
+export const stylesheet = () => import("./style.css");
+export const prefetched = () => import(/* webpackPrefetch: true */ "./mods/b.js");
+export const binary = () => import("./add.wat");
+export const asset = new URL("./asset.txt", import.meta.url);
+export const worker = () =>
+	new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+
+const walk = (directory) => {
+	const found = [];
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		const full = path.join(directory, entry.name);
+		if (entry.isDirectory()) found.push(...walk(full));
+		else found.push(full);
+	}
+	return found;
+};
+
+it("should resolve every written-out reference to a file that was emitted", () => {
+	const root = __STATS__.children[__INDEX__].outputPath;
+	const files = walk(root).filter((f) => /\.(mjs|css)$/.test(f));
+
+	expect(files.length).toBeGreaterThan(1);
+
+	const dangling = [];
+	for (const file of files) {
+		const text = fs.readFileSync(file, "utf8");
+		// Resolved against the file that carries it, which is what the browser does.
+		for (const match of text.matchAll(
+			/(?:new URL|import)\(\s*"(\.{1,2}\/[^"]*)"/g
+		)) {
+			if (!fs.existsSync(path.resolve(path.dirname(file), match[1]))) {
+				dangling.push(`${path.relative(root, file)} -> ${match[1]}`);
+			}
+		}
+	}
+
+	expect(dangling).toEqual([]);
+});
+
+it("should leave no reserved name behind and call nothing it did not ship", () => {
+	const root = __STATS__.children[__INDEX__].outputPath;
+	const files = walk(root).filter((f) => f.endsWith(".mjs"));
+	// Needles are built at runtime so they are not source string literals here.
+	const token = (...parts) => parts.join("");
+	const undeclared = [];
+
+	for (const file of files) {
+		const text = fs.readFileSync(file, "utf8");
+
+		expect(text).not.toContain(token("@@webpack", "AnalyzableChunk"));
+		expect(text).not.toContain(token("@@webpack", "FullHash"));
+
+		// A chunk reads the runtime the entry defines, so only the entry is asked.
+		if (path.relative(root, file).includes(path.sep)) continue;
+		for (const helper of ["u", "k", "p", "b"]) {
+			const used =
+				text.includes(token("__webpack_require__.", helper, "(")) ||
+				text.includes(token("__webpack_require__.", helper, " +"));
+			if (used && !text.includes(token("__webpack_require__.", helper, " = "))) {
+				undeclared.push(`${path.relative(root, file)} .${helper}`);
+			}
+		}
+	}
+
+	expect(undeclared).toEqual([]);
+});

--- a/test/configCases/analyzable/reference-integrity/mods/a.js
+++ b/test/configCases/analyzable/reference-integrity/mods/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/configCases/analyzable/reference-integrity/mods/b.js
+++ b/test/configCases/analyzable/reference-integrity/mods/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/test/configCases/analyzable/reference-integrity/style.css
+++ b/test/configCases/analyzable/reference-integrity/style.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/test/configCases/analyzable/reference-integrity/test.config.js
+++ b/test/configCases/analyzable/reference-integrity/test.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const NAMES = ["flat", "deep", "hashed"];
+
+module.exports = {
+	findBundle(i) {
+		// The `deep` config emits its entry one directory down.
+		return [i === 1 ? `./deep/${NAMES[i]}.mjs` : `./${NAMES[i]}.mjs`];
+	}
+};

--- a/test/configCases/analyzable/reference-integrity/test.filter.js
+++ b/test/configCases/analyzable/reference-integrity/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// Reading the bundle back needs `require` in ESM output, which emits
+// `import { createRequire } from "module"` — older Node can't link that.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/reference-integrity/webpack.config.js
+++ b/test/configCases/analyzable/reference-integrity/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// Every kind of reference analyzable output writes out — a chunk `import()`, a lazy
-// context, a stylesheet, an asset url, a worker, a prefetched chunk and a wasm binary —
-// in one build, so a name that stops resolving is caught wherever it regressed.
+// Every kind of reference analyzable output writes out, in one build, so a name that
+// stops resolving is caught wherever it regressed.
 
 const webpack = require("../../../../");
 

--- a/test/configCases/analyzable/reference-integrity/webpack.config.js
+++ b/test/configCases/analyzable/reference-integrity/webpack.config.js
@@ -1,0 +1,67 @@
+"use strict";
+
+// Every kind of reference analyzable output writes out — a chunk `import()`, a lazy
+// context, a stylesheet, an asset url, a worker, a prefetched chunk and a wasm binary —
+// in one build, so a name that stops resolving is caught wherever it regressed.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so the entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @param {string} chunkDirectory directory the chunks are emitted under
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name, chunkDirectory) => ({
+	name,
+	target: ["web", "node"],
+	mode: "development",
+	devtool: false,
+	entry: { [name]: "./entry.js" },
+	experiments: { outputModule: true, css: true, asyncWebAssembly: true },
+	module: {
+		rules: [
+			{ test: /\.txt$/, type: "asset/resource" },
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", minimize: false },
+	output: {
+		module: true,
+		filename: `${name}.mjs`,
+		chunkFilename: `${chunkDirectory}${name}-[name].mjs`,
+		cssChunkFilename: `${chunkDirectory}${name}-[name].css`,
+		assetModuleFilename: `${chunkDirectory}${name}-[name][ext]`,
+		webassemblyModuleFilename: `${chunkDirectory}${name}-[hash].wasm`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// Flat output: every name is settled during code generation.
+	base(0, "flat", ""),
+	// The entry itself one directory down, so every reference it carries has to climb
+	// back to the output root first.
+	{
+		...base(1, "deep", ""),
+		output: { ...base(1, "deep", "").output, filename: "deep/[name].mjs" }
+	},
+	// Hashed names are reserved during code generation and filled in once the hashes
+	// exist, so this drives the deferred pass over every reference kind at once.
+	{
+		...base(2, "hashed", ""),
+		output: {
+			...base(2, "hashed", "").output,
+			chunkFilename: "hashed-[name].[contenthash].mjs",
+			cssChunkFilename: "hashed-[name].[contenthash].css",
+			assetModuleFilename: "hashed-[name].[contenthash][ext]"
+		}
+	}
+];

--- a/test/configCases/analyzable/reference-integrity/worker.js
+++ b/test/configCases/analyzable/reference-integrity/worker.js
@@ -1,0 +1,3 @@
+self.onmessage = () => {
+	self.postMessage("pong");
+};

--- a/test/hotCases/universal/analyzable-css/index.js
+++ b/test/hotCases/universal/analyzable-css/index.js
@@ -1,0 +1,25 @@
+import update from "../../update.esm";
+
+import.meta.webpackHot.accept("./style.module.css");
+
+// A runtime carrying the hot handler keeps the runtime url form — the `css-chunk-href`
+// config case pins that in the emitted source. What this drives is that an update still
+// applies through it, with the stylesheet loaded on demand under module output.
+it("should apply a stylesheet update under module output", (done) => {
+	import("./style.module.css")
+		.then(() => {
+			NEXT(
+				update(done, true, () => {
+					import("./style.module.css")
+						.then((updated) => {
+							expect(updated).toMatchObject({
+								"class-other": "style_module_css-class-other"
+							});
+							done();
+						})
+						.catch(done);
+				})
+			);
+		})
+		.catch(done);
+});

--- a/test/hotCases/universal/analyzable-css/index.js
+++ b/test/hotCases/universal/analyzable-css/index.js
@@ -2,9 +2,8 @@ import update from "../../update.esm";
 
 import.meta.webpackHot.accept("./style.module.css");
 
-// A runtime carrying the hot handler keeps the runtime url form — the `css-chunk-href`
-// config case pins that in the emitted source. What this drives is that an update still
-// applies through it, with the stylesheet loaded on demand under module output.
+// `css-chunk-href` pins the emitted form; this drives that an update still applies
+// through it, with the stylesheet loaded on demand under module output.
 it("should apply a stylesheet update under module output", (done) => {
 	import("./style.module.css")
 		.then(() => {

--- a/test/hotCases/universal/analyzable-css/style.module.css
+++ b/test/hotCases/universal/analyzable-css/style.module.css
@@ -1,0 +1,7 @@
+.class {
+	color: red;
+}
+---
+.class-other {
+	color: blue;
+}

--- a/test/hotCases/universal/analyzable-css/webpack.config.js
+++ b/test/hotCases/universal/analyzable-css/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+// A runtime carrying the hot handler keeps the runtime url form: the hot path re-loads
+// by whatever chunk id an update names, and a map written at build time knows only the
+// stylesheets that existed then. What ships has no hot handler, and does bake.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true, css: true },
+	optimization: { chunkIds: "named", minimize: false },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		chunkFilename: "[name].mjs",
+		cssChunkFilename: "[name].css",
+		publicPath: "auto"
+	},
+	node: { __dirname: false }
+};

--- a/test/hotCases/universal/analyzable-css/webpack.config.js
+++ b/test/hotCases/universal/analyzable-css/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// A runtime carrying the hot handler keeps the runtime url form: the hot path re-loads
-// by whatever chunk id an update names, and a map written at build time knows only the
-// stylesheets that existed then. What ships has no hot handler, and does bake.
+// The hot path re-loads by whatever chunk id an update names, which a map written at
+// build time cannot answer for, so a runtime carrying it keeps the runtime url form.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -25797,11 +25797,13 @@ declare abstract class RuntimeTemplate {
 	 * and the plugin declaring what it needs ask this, so the two always agree. The
 	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
 	 * resolves the element against the document, which is not where the chunk sits, and
-	 * the loader reads the url as text either way.
+	 * the loader reads the url as text either way. Nothing is written out for a runtime
+	 * that also carries the hot handler; see below.
 	 */
 	analyzableCssChunkUrls(
 		runtimeChunk: Chunk,
 		chunkGraph: ChunkGraph,
+		runtimeRequirements: ReadonlySet<string>,
 		consumingModule?: Module
 	): null | Map<ChunkId, string>;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -25791,6 +25791,21 @@ declare abstract class RuntimeTemplate {
 	): null | string;
 
 	/**
+	 * Static `new URL(<file>, import.meta.url)` for every stylesheet a runtime can load,
+	 * keyed by chunk id, or `null` when any of them has to keep the runtime
+	 * `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
+	 * and the plugin declaring what it needs ask this, so the two always agree. The
+	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
+	 * resolves the element against the document, which is not where the chunk sits, and
+	 * the loader reads the url as text either way.
+	 */
+	analyzableCssChunkUrls(
+		runtimeChunk: Chunk,
+		chunkGraph: ChunkGraph,
+		consumingModule?: Module
+	): null | Map<ChunkId, string>;
+
+	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
 	 * module. Only called when `supportsAnalyzable("wasm")` holds.
 	 */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A css chunk's `<link href>` was assembled at runtime from the public path and a name lookup keyed by chunk id, so nothing outside webpack could tell which stylesheets a chunk pulls in. Under module output each is a known file, so the urls are written out and read by id instead:

```js
const cssUrls = {
	"src_lazy_css": () => (new URL("./chunks/src_lazy_css.css", import.meta.url).href)
};
const url = cssUrls[chunkId]();   // was: __webpack_require__.p + __webpack_require__.k(chunkId)
```

`_getAnalyzableChunkSpecifier` now names either half of a chunk, keyed by a descriptor rather than branching on the type, so a source type nothing answers for keeps the runtime form instead of silently taking javascript's name. The deferred pass gained a `cssChunk` stand-in so a content-hashed stylesheet name still settles. A runtime carrying the hot handler keeps the runtime form everywhere — it re-loads by whatever id an update names, which a map written at build time cannot answer for — and both requirement hooks read that same fact, so neither leaves the other short.

`yarn test:size --filter "css/"` against `main`: 29 assets changed, all smaller — **-1.21 KiB gzip, -4.14 KiB raw** — and 7 runtimes dropped `get css chunk filename` and `publicPath`. Largest single asset -925 B raw / -302 B gzip. Non-module output is byte-identical.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/configCases/analyzable/css-chunk-href/` covers an `auto` public path, a content-hashed stylesheet name, a public path reassigned at runtime, and a runtime carrying the hot handler — each loading the stylesheet and checking it applied. `test/hotCases/universal/analyzable-css/` drives a real update through it. `test/configCases/analyzable/reference-integrity/` builds one of every reference analyzable output writes — chunk import, lazy context, stylesheet, asset url, worker, prefetched chunk, wasm binary — flat, one directory down, and content-hashed, then resolves each written-out specifier against the file that carries it.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Anything that cannot be named keeps the previous runtime form, and non-module output is unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used to draft the implementation and tests, to sweep 70 configurations for dangling references and undeclared runtime helpers, and to verify each new test fails on injected faults. Every change was reviewed and the behaviour checked by executing the emitted bundles against `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS chunk URLs can be embedded directly into generated bundles when safely analyzable.
  * Supports hashed CSS filenames and custom public paths.
  * CSS loading, preloading, and prefetching use generated URLs when available.
* **Bug Fixes**
  * Preserves runtime CSS URL resolution during hot module replacement and other dynamic scenarios.
  * Improves reference integrity for emitted CSS and related assets.
* **Tests**
  * Added coverage for automatic, hashed, overridden, and HMR CSS loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->