### PR TITLE
fix(performance): read an alias's evidence from the request, not the module

### DIFF
--- a/lib/performance/UnusedAliasesPlugin.js
+++ b/lib/performance/UnusedAliasesPlugin.js
@@ -172,6 +172,10 @@ class UnusedAliasesPlugin {
 					// graph keeps nowhere else is on the dependency that asked for it.
 					if (unused > 0) {
 						const fs = compiler.inputFileSystem || undefined;
+						// One import states its request on several dependencies, and a
+						// request every module makes states it once per module.
+						/** @type {Set<string>} */
+						const seen = new Set();
 
 						for (const module of compilation.modules) {
 							if (unused === 0) break;
@@ -202,10 +206,14 @@ class UnusedAliasesPlugin {
 
 									if (request === undefined) continue;
 
-									consume(request);
+									if (!seen.has(request)) {
+										seen.add(request);
+										consume(request);
+									}
 
 									// An absolute name matches the path the resolver saw, which for
-									// a relative request is the issuer's context joined with it.
+									// a relative request is the issuer's context joined with it, so
+									// the same request answers differently per module.
 									if (
 										hasAbsoluteName &&
 										context !== null &&

--- a/lib/performance/UnusedAliasesPlugin.js
+++ b/lib/performance/UnusedAliasesPlugin.js
@@ -18,6 +18,7 @@ const getSourceModules = require("./getSourceModules");
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependenciesBlock")} DependenciesBlock */
+/** @typedef {import("../dependencies/ContextDependency").ContextDependencyOptions} ContextDependencyOptions */
 /** @typedef {import("../Module")} Module */
 
 /**
@@ -167,17 +168,15 @@ class UnusedAliasesPlugin {
 						}
 					}
 
-					// An absolute name matches the path the resolver saw: for a relative
-					// request that is the issuer's context joined with it, never a `rawRequest`.
-					if (unused > 0 && hasAbsoluteName) {
+					// Only what is left unaccounted for is worth the walk: a request the
+					// graph keeps nowhere else is on the dependency that asked for it.
+					if (unused > 0) {
 						const fs = compiler.inputFileSystem || undefined;
 
 						for (const module of compilation.modules) {
 							if (unused === 0) break;
 
 							const context = module.context;
-
-							if (context === null) continue;
 
 							/** @type {DependenciesBlock[]} */
 							const blocks = [module];
@@ -188,15 +187,32 @@ class UnusedAliasesPlugin {
 									(blocks.pop());
 
 								for (const dependency of block.dependencies) {
+									const typed =
+										/** @type {Dependency & { request?: string, options?: ContextDependencyOptions }} */
+										(dependency);
+									// A `ContextModule` keeps the request in its options, and one
+									// an alias sent to `false` reaches no `rawRequest` at all.
 									const request =
-										/** @type {Dependency & { request?: string }} */
-										(dependency).request;
+										typeof typed.request === "string"
+											? typed.request
+											: typed.options &&
+												  typeof typed.options.request === "string"
+												? typed.options.request
+												: undefined;
 
-									if (typeof request !== "string" || !request.startsWith(".")) {
-										continue;
+									if (request === undefined) continue;
+
+									consume(request);
+
+									// An absolute name matches the path the resolver saw, which for
+									// a relative request is the issuer's context joined with it.
+									if (
+										hasAbsoluteName &&
+										context !== null &&
+										request.startsWith(".")
+									) {
+										consume(join(fs, context, request), true);
 									}
-
-									consume(join(fs, context, request), true);
 								}
 
 								for (const child of block.blocks) blocks.push(child);

--- a/test/configCases/performance/unused-aliases-context/index.js
+++ b/test/configCases/performance/unused-aliases-context/index.js
@@ -1,0 +1,7 @@
+it("should not report an alias a context module resolved through", () => {
+	const lang = "en";
+
+	return import(`@locales/${lang}.js`).then((module) => {
+		expect(module.default).toBe("en");
+	});
+});

--- a/test/configCases/performance/unused-aliases-context/locales/de.js
+++ b/test/configCases/performance/unused-aliases-context/locales/de.js
@@ -1,0 +1,1 @@
+export default "de";

--- a/test/configCases/performance/unused-aliases-context/locales/en.js
+++ b/test/configCases/performance/unused-aliases-context/locales/en.js
@@ -1,0 +1,1 @@
+export default "en";

--- a/test/configCases/performance/unused-aliases-context/webpack.config.js
+++ b/test/configCases/performance/unused-aliases-context/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const path = require("path");
+
+// The elements resolve relative to the directory the alias named, so the
+// request as written survives only on the context dependency.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	performance: {
+		hints: "warning",
+		unusedAliases: true
+	},
+	resolve: {
+		alias: {
+			"@locales": path.resolve(__dirname, "locales")
+		}
+	}
+};

--- a/test/configCases/performance/unused-aliases-ignored/index.js
+++ b/test/configCases/performance/unused-aliases-ignored/index.js
@@ -1,0 +1,5 @@
+import stub from "stub-me";
+
+it("should not report an alias that stubs a request out", () => {
+	expect(stub).toEqual({});
+});

--- a/test/configCases/performance/unused-aliases-ignored/webpack.config.js
+++ b/test/configCases/performance/unused-aliases-ignored/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+// `false` is what the request resolves to, so it never reaches a module
+// carrying the request as written — the alias applied all the same.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	performance: {
+		hints: "warning",
+		unusedAliases: true
+	},
+	resolve: {
+		alias: {
+			"stub-me": false
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`performance.unusedAliases` looked for the request as written on `NormalModule.rawRequest`, which two kinds of applied alias never reach: one resolving to `false` leaves a `RawModule`, and a context module's elements are resolved relative to the directory the alias named, so `@locales/en.js` survives only on the context dependency. Both were reported as never applied — `alias: { fs: false }` is the common spelling of the first, and the advice is to delete an alias the build needs. The fallback pass now reads `dependency.request`, and a context dependency's `options.request`; it still runs only while something is unaccounted for, so a build whose aliases all match walks no dependencies and is unchanged. A second commit skips repeated requests, which one import states on several dependencies and every importer of a shared module states again. Refs #21776.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/performance/unused-aliases-ignored/` (an alias resolving to `false`) and `test/configCases/performance/unused-aliases-context/` (a context module resolved through an alias). Both report the alias before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The hint is opt-in and unreleased; an alias that is genuinely dead is still reported.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to review the recent commits, where it found both false positives, and to write the failing test cases and the fix. Each was reproduced against a real build and isolated from the other before any change, and both cases were checked to fail without it. The dedup commit is reported by call count rather than by time: over 9 interleaved builds the hook's spread swamped every difference on this machine, so only the deterministic counts are claimed (2403 calls down to 1803 where 600 modules share one import, 1802 to 1801 where every request is distinct).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unused-alias detection for dynamic context imports.
  * Correctly handles relative and non-relative requests and avoids duplicate checks.
  * Prevents intentionally ignored aliases from being incorrectly reported as unused.

* **Tests**
  * Added coverage for locale-based dynamic imports and ignored aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->