### PR TITLE
fix(html): parse and print what the spec says around frameset, select and quirks

### DIFF
--- a/.changeset/030-html-frameset-and-quirks-p.md
+++ b/.changeset/030-html-frameset-and-quirks-p.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep frameset content and quirks-mode paragraphs as an engine parses them.

--- a/.changeset/030-html-frameset-and-quirks-p.md
+++ b/.changeset/030-html-frameset-and-quirks-p.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep frameset content and quirks-mode paragraphs as an engine parses them.
+Match the tree an engine builds for framesets, quirks-mode paragraphs and `<hr>`.

--- a/.changeset/030-html-frameset-and-quirks-p.md
+++ b/.changeset/030-html-frameset-and-quirks-p.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Match the tree an engine builds for framesets, quirks-mode paragraphs and `<hr>`.
+Match the spec's tree for frameset content, quirks paragraphs and selects.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7296,9 +7296,8 @@ const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		return;
 	}
 	if (name === "optgroup" || name === "option") {
-		// Inside a select these end whatever is open the way a list item does —
-		// an `<option>` keeps the `<optgroup>` grouping it, an `<optgroup>` ends
-		// that too. Outside one only a current `<option>` gives way.
+		// Inside a select these end what is open like a list item does, an
+		// `<option>` sparing its `<optgroup>`; outside one only an option gives way.
 		if (inScope("select")) {
 			generateImpliedEndTags(name === "option" ? "optgroup" : "");
 		} else if (
@@ -7982,10 +7981,9 @@ const currentNodeIsForeign = () => {
 	);
 };
 /**
- * Whether the tree builder did not run the algorithm that switches the
- * tokenizer for this start tag, so its content is ordinary markup: foreign
- * content, where the switch is vetoed outright, and the frameset modes, which
- * hand `noframes` to the head rules and ignore every other one of them.
+ * Whether the tree builder skips the tokenizer switch for this start tag, so
+ * its content stays markup: foreign content, and every frameset-mode tag but
+ * `noframes`, which those modes ignore rather than hand to the head rules.
  * @param {string} name the start tag's lowercased name
  * @returns {boolean} true when the tokenizer stays in the data state
  */

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -388,7 +388,8 @@ const isControlReference = (code) =>
  * @property {(input: string, start: number, end: number, dataStart: number, dataEnd: number) => number=} comment
  * @property {(input: string, start: number, end: number, nameStart: number, nameEnd: number, publicStart: number, publicEnd: number, systemStart: number, systemEnd: number, forceQuirks: boolean) => number=} doctype
  * @property {(input: string, code: string, start: number, end: number, severity: ParseErrorSeverity) => void=} parseError
- * @property {(() => boolean)=} isForeign returns true when the adjusted current node is in a foreign (SVG/MathML) namespace, vetoing RAWTEXT/RCDATA/script content-mode switches
+ * @property {(() => boolean)=} isForeign returns true when the adjusted current node is in a foreign (SVG/MathML) namespace, which is where a `<![CDATA[` opens a CDATA section
+ * @property {((name: string) => boolean)=} vetoesContentMode returns true when the tree builder will not run the algorithm that switches the tokenizer for this start tag, so it stays in the data state
  * @property {string=} fragmentContext context element tag name for fragment parsing; seeds the initial content mode
  */
 
@@ -621,16 +622,18 @@ const tokenize = (input, pos = 0, callbacks = {}) => {
 	// actually entered — ordinary tags never allocate it.
 	const contentModeAfterOpenTag = () => {
 		const m = getContentModeForRange(input, lastOpenTagStart, lastOpenTagEnd);
-		// Ordinary tags stay in data state regardless of `isForeign` (which only
-		// vetoes a switch *into* a special mode), so skip the per-open-tag
-		// `isForeign` callback for them.
+		// Ordinary tags stay in the data state whatever the tree builder did, so
+		// they pay for neither the name nor the callback.
 		if (m === STATE_DATA) return STATE_DATA;
-		if (callbacks.isForeign !== undefined && callbacks.isForeign()) {
-			return STATE_DATA;
-		}
 		lastOpenTagName = input
 			.slice(lastOpenTagStart, lastOpenTagEnd)
 			.toLowerCase();
+		if (
+			callbacks.vetoesContentMode !== undefined &&
+			callbacks.vetoesContentMode(lastOpenTagName)
+		) {
+			return STATE_DATA;
+		}
 		return m;
 	};
 
@@ -640,7 +643,8 @@ const tokenize = (input, pos = 0, callbacks = {}) => {
 	if (callbacks.fragmentContext !== undefined) {
 		lastOpenTagName = callbacks.fragmentContext;
 		state =
-			callbacks.isForeign !== undefined && callbacks.isForeign()
+			callbacks.vetoesContentMode !== undefined &&
+			callbacks.vetoesContentMode(lastOpenTagName)
 				? STATE_DATA
 				: getContentModeForTag(lastOpenTagName);
 	}
@@ -7979,6 +7983,23 @@ const currentNodeIsForeign = () => {
 		_namespaceOf(adjustedCurrentNode) !== NS_HTML
 	);
 };
+/**
+ * Whether the tree builder did not run the algorithm that switches the
+ * tokenizer for this start tag, so its content is ordinary markup: foreign
+ * content, where the switch is vetoed outright, and the frameset modes, which
+ * hand `noframes` to the head rules and ignore every other one of them.
+ * @param {string} name the start tag's lowercased name
+ * @returns {boolean} true when the tokenizer stays in the data state
+ */
+const vetoesContentMode = (name) => {
+	if (currentNodeIsForeign()) return true;
+	return (
+		name !== "noframes" &&
+		(mode === MODE_IN_FRAMESET ||
+			mode === MODE_AFTER_FRAMESET ||
+			mode === MODE_AFTER_AFTER_FRAMESET)
+	);
+};
 /** @type {(input: string, code: string) => void} */
 const handleParseError = (input, code) => {
 	if (code === "eof-in-tag") eofInTag = true;
@@ -8297,6 +8318,7 @@ const handleEndTagToken = (input, start, end, nameStart, nameEnd) => {
 /** @type {HtmlTokenCallbacks} */
 const PARSE_CALLBACKS = {
 	isForeign: currentNodeIsForeign,
+	vetoesContentMode,
 	fragmentContext: undefined,
 	parseError: handleParseError,
 	doctype: handleDoctypeToken,
@@ -8925,6 +8947,9 @@ const _canOmitEndTag = (path, name, node) => {
 	) {
 		return false;
 	}
+	// A `<table>` start tag closes an open `p` only outside quirks mode — the
+	// one follower whose reading the document mode decides.
+	if (quirks && name === "p" && path.tagName(next) === "table") return false;
 	// Outside a `ruby` the follower's start tag closes nothing, so this one would
 	// go on to hold it.
 	if (RUBY_SEGMENTS.has(name) && !_hasRubyInScope(path, node)) return false;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7247,17 +7247,10 @@ const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		return;
 	}
 	if (name === "hr") {
-		// An `<hr>` is a `<select>`'s own separator, so it leaves the option it
-		// was written in — outside one it is ordinary content and nests.
-		if (inScope("select")) {
-			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
-				popOpen();
-			}
-			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
-				popOpen();
-			}
-		}
 		closeIfPInButtonScope();
+		// An `<hr>` is a `<select>`'s own separator, so inside one it leaves what
+		// it was written in; outside one it is ordinary content and nests.
+		if (inScope("select")) generateImpliedEndTags();
 		insertHtmlElement("hr", t.attrs, t.pos);
 		popOpen();
 		framesetOk = false;
@@ -7303,13 +7296,14 @@ const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		return;
 	}
 	if (name === "optgroup" || name === "option") {
-		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
-			popOpen();
-		}
-		if (
-			name === "optgroup" &&
+		// Inside a select these end whatever is open the way a list item does —
+		// an `<option>` keeps the `<optgroup>` grouping it, an `<optgroup>` ends
+		// that too. Outside one only a current `<option>` gives way.
+		if (inScope("select")) {
+			generateImpliedEndTags(name === "option" ? "optgroup" : "");
+		} else if (
 			_namespaceOf(cur()) === NS_HTML &&
-			_tagNameOf(cur()) === "optgroup"
+			_tagNameOf(cur()) === "option"
 		) {
 			popOpen();
 		}

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -7247,11 +7247,15 @@ const startTagInBody = (/** @type {StartTagToken} */ t) => {
 		return;
 	}
 	if (name === "hr") {
-		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
-			popOpen();
-		}
-		if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
-			popOpen();
+		// An `<hr>` is a `<select>`'s own separator, so it leaves the option it
+		// was written in — outside one it is ordinary content and nests.
+		if (inScope("select")) {
+			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "option") {
+				popOpen();
+			}
+			if (_namespaceOf(cur()) === NS_HTML && _tagNameOf(cur()) === "optgroup") {
+				popOpen();
+			}
 		}
 		closeIfPInButtonScope();
 		insertHtmlElement("hr", t.attrs, t.pos);

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -5388,6 +5388,33 @@ describe("parseHtml — tree-construction edge cases (SoA columns)", () => {
 		expect(child(t2.children, "tbody")).toBeDefined();
 	});
 
+	it("ends what is open around an option only inside a select", () => {
+		// §"in body": with a `<select>` in scope an `<option>` generates implied end
+		// tags except `<optgroup>`, and an `<hr>` generates them all. Outside one
+		// only a current `<option>` gives way, so everything else nests.
+		const inSelect = child(bodyOf("<select><p><option>"), "select");
+		expect(
+			inSelect.children
+				.filter((c) => c.type === NodeType.Element)
+				.map((c) => /** @type {MatElement} */ (c).tagName)
+		).toEqual(["p", "option"]);
+		// An `<optgroup>` is kept by an `<option>` and ended by an `<hr>`.
+		const grouped = child(bodyOf("<select><optgroup><option>"), "select");
+		expect(
+			/** @type {MatElement} */ (child(grouped.children, "optgroup")).children
+		).toHaveLength(1);
+		// No select in scope: the option keeps the `<hr>` written inside it.
+		const loose = child(bodyOf("<div><option>o<hr>"), "div");
+		const option = child(loose.children, "option");
+		expect(
+			option.children.some(
+				(c) =>
+					c.type === NodeType.Element &&
+					/** @type {MatElement} */ (c).tagName === "hr"
+			)
+		).toBe(true);
+	});
+
 	it("moves an <hr> out of option/optgroup context in <select>", () => {
 		const select = child(
 			bodyOf("<select><option>a<optgroup><option>b<hr><option>c"),

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -5387,8 +5387,8 @@ describe("parseHtml — tree-construction edge cases (SoA columns)", () => {
 	});
 
 	it("ends what is open around an option only inside a select", () => {
-		// §"in body": in select scope an `<option>` implies end tags but
-		// `<optgroup>`, and an `<hr>` implies them all; outside one nothing does.
+		// §"in body": in select scope `<option>` implies end tags but `<optgroup>`,
+		// `<hr>` implies all; outside one only an open `<option>` gives way.
 		const inSelect = child(bodyOf("<select><p><option>"), "select");
 		expect(
 			inSelect.children

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4398,6 +4398,15 @@ describe("SourceProcessor — optional end tags read the output", () => {
 
 	const LIST = "<ul>\n<li><p>a</p>\n</li>\n<li><p>b</p>\n</li>\n</ul>";
 
+	it("keeps a `</p>` a quirks-mode `<table>` would not close", () => {
+		// A `<table>` start tag closes an open `p` only outside quirks mode, so
+		// there the two would nest instead of staying siblings.
+		expect(minify("<table><p>")).toBe("<p></p><table></table>");
+		expect(minify("<!doctype html><table><p>")).toBe(
+			"<!doctype html><p><table></table>"
+		);
+	});
+
 	it("reads past whitespace the collapse tier deletes", () => {
 		// The `\n` after each `</p>` is content in the tree and nothing in the
 		// output, so the tag it was keeping alive goes with it.
@@ -4903,6 +4912,20 @@ describe("parseHtml — insertion-mode edge cases", () => {
 			/** @type {MatText} */ (/** @type {unknown} */ (nodes[0])).data
 		).toBe("xy");
 		expect(nodes[1].type).toBe(NodeType.Element);
+	});
+
+	it("does not read raw text for a tag the frameset modes ignore", () => {
+		// Only `noframes` is handled there (§13.2.6.4.10 hands it to the head
+		// rules); every other one is ignored, and an ignored start tag never runs
+		// the algorithm that switches the tokenizer — so the `<frame>` after it is
+		// still a tag.
+		const frameset = find("<frameset><textarea><frame></textarea>", "frameset");
+		expect(/** @type {MatElement} */ (frameset.children[0]).tagName).toBe(
+			"frame"
+		);
+		// `noframes` keeps its raw text, so the `<frame>` inside it is not one.
+		const noframes = find("<frameset><noframes><frame></noframes>", "noframes");
+		expect(noframes.children[0].type).toBe(NodeType.Text);
 	});
 
 	it("keeps end tags and comments under foreign rules inside <svg>", () => {

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4915,10 +4915,8 @@ describe("parseHtml — insertion-mode edge cases", () => {
 	});
 
 	it("does not read raw text for a tag the frameset modes ignore", () => {
-		// Only `noframes` is handled there (§13.2.6.4.10 hands it to the head
-		// rules); every other one is ignored, and an ignored start tag never runs
-		// the algorithm that switches the tokenizer — so the `<frame>` after it is
-		// still a tag.
+		// §13.2.6.4.10 hands only `noframes` to the head rules; every other tag is
+		// ignored, and an ignored one never switches the tokenizer.
 		const frameset = find("<frameset><textarea><frame></textarea>", "frameset");
 		expect(/** @type {MatElement} */ (frameset.children[0]).tagName).toBe(
 			"frame"
@@ -5389,9 +5387,8 @@ describe("parseHtml — tree-construction edge cases (SoA columns)", () => {
 	});
 
 	it("ends what is open around an option only inside a select", () => {
-		// §"in body": with a `<select>` in scope an `<option>` generates implied end
-		// tags except `<optgroup>`, and an `<hr>` generates them all. Outside one
-		// only a current `<option>` gives way, so everything else nests.
+		// §"in body": in select scope an `<option>` implies end tags but
+		// `<optgroup>`, and an `<hr>` implies them all; outside one nothing does.
 		const inSelect = child(bodyOf("<select><p><option>"), "select");
 		expect(
 			inSelect.children
@@ -5413,6 +5410,13 @@ describe("parseHtml — tree-construction edge cases (SoA columns)", () => {
 					/** @type {MatElement} */ (c).tagName === "hr"
 			)
 		).toBe(true);
+		// `<li>` is implied-end-tag material too, so the `<hr>` ends it as well.
+		const separated = child(bodyOf("<select><li><hr>"), "select");
+		expect(
+			separated.children
+				.filter((c) => c.type === NodeType.Element)
+				.map((c) => /** @type {MatElement} */ (c).tagName)
+		).toEqual(["li", "hr"]);
 	});
 
 	it("moves an <hr> out of option/optgroup context in <select>", () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -10616,9 +10616,14 @@ declare interface HtmlTokenCallbacks {
 	) => void;
 
 	/**
-	 * returns true when the adjusted current node is in a foreign (SVG/MathML) namespace, vetoing RAWTEXT/RCDATA/script content-mode switches
+	 * returns true when the adjusted current node is in a foreign (SVG/MathML) namespace, which is where a `<![CDATA[` opens a CDATA section
 	 */
 	isForeign?: () => boolean;
+
+	/**
+	 * returns true when the tree builder will not run the algorithm that switches the tokenizer for this start tag, so it stays in the data state
+	 */
+	vetoesContentMode?: (name: string) => boolean;
 
 	/**
 	 * context element tag name for fragment parsing; seeds the initial content mode


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Four places where the HTML parser or printer built a tree the source does not describe, found by differential fuzzing against a headless engine and each one adjudicated against the spec text rather than against the engine:

- The tokenizer chose RAWTEXT/RCDATA from the tag name alone, but the frameset modes hand `noframes` to the head rules and ignore every other one — an ignored start tag never runs the algorithm that switches, so a `<frame>` written after one was swallowed as text.
- A `<table>` start tag closes an open `p` only outside quirks mode. The tree builder already knew that; the printer did not, so `</p>` was left out where the two would nest instead of staying siblings.
- `<hr>`, `<option>` and `<optgroup>` end what is open around them only with a `<select>` in scope (§"in body" gates all three on it, and `<option>` spares the `<optgroup>` grouping it). Ending them everywhere took an `<hr>` out of the option it was written in and an `<option>` out of the paragraph.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — four cases in `test/HtmlSyntax.unittest.js`: the frameset veto (with `noframes` still switching), both sides of the quirks/standards `</p>` decision, the comment branch of the implied-tag guard, and the select-scope rules for `option`/`optgroup`/`hr`. `html5lib` (22,251 tree-construction cases) and the `html` config cases stay green.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The tokenizer's content-mode veto moves to its own `vetoesContentMode` callback on `HtmlTokenCallbacks`; `isForeign` stays for the one question it actually answers, which is where `<![CDATA[` opens a CDATA section.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to fuzz the parser and printer against a headless engine, minimise the failures, and write the fixes and tests. Every divergence was then checked against the WHATWG HTML source and its tree-construction corpus before deciding which side was right — several turned out to be engine bugs and were deliberately left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnmztbjhQpVCTYnrextRu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML parsing for frameset content and `<noframes>` sections.
  * Corrected quirks-mode paragraph handling before tables.
  * Updated `<select>` parsing for `<option>`, `<optgroup>`, and `<hr>` elements.
  * Improved raw-text and RCDATA handling in context-sensitive HTML content.

* **Tests**
  * Added regression coverage for frameset, quirks-mode table, and select parsing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->