### PR TITLE
feat(esm): bake the prefetch/preload url of a javascript chunk

### DIFF
--- a/.changeset/020-analyzable-esm-output.md
+++ b/.changeset/020-analyzable-esm-output.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Emit analyzable ESM output: chunk imports, lazy context requests, asset, stylesheet and WebAssembly urls, worker references and prefetch/preload urls are written out as static `import()` / `new URL(..., import.meta.url)` so tools can follow them.

--- a/.changeset/020-analyzable-esm-output.md
+++ b/.changeset/020-analyzable-esm-output.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Emit analyzable ESM output: chunk imports, lazy context requests, asset, stylesheet and WebAssembly urls, worker references and prefetch/preload urls are written out as static `import()` / `new URL(..., import.meta.url)` so tools can follow them.
+Emit analyzable ESM output for chunk, asset, stylesheet, worker and wasm urls.

--- a/.changeset/020-analyzable-wasm-esm.md
+++ b/.changeset/020-analyzable-wasm-esm.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Emit analyzable `fetch(new URL(..., import.meta.url))` for fetch-based WebAssembly under ESM output.

--- a/.changeset/021-analyzable-import-coverage.md
+++ b/.changeset/021-analyzable-import-coverage.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Widen analyzable ESM output to HMR, hashed and function chunk names, and wasm.

--- a/.changeset/022-analyzable-public-path-and-wasm-names.md
+++ b/.changeset/022-analyzable-public-path-and-wasm-names.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Bake templated public paths, hashed wasm names and concatenated origins into analyzable output.

--- a/.changeset/023-analyzable-depths-digests-and-diagnostics.md
+++ b/.changeset/023-analyzable-depths-digests-and-diagnostics.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Bake analyzable ESM and wasm references per depth, digest and runtime; report fallbacks.

--- a/.changeset/024-analyzable-asset-urls-and-function-paths.md
+++ b/.changeset/024-analyzable-asset-urls-and-function-paths.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Bake analyzable asset urls per entry baseUri and keep stale deferred names out.

--- a/.changeset/026-analyzable-dead-asset-wrapper.md
+++ b/.changeset/026-analyzable-dead-asset-wrapper.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Stop emitting unused runtime helpers; load css chunks that only `@import`.

--- a/.changeset/027-analyzable-block-origins.md
+++ b/.changeset/027-analyzable-block-origins.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Bake analyzable imports for more block kinds; drop unread `__esModule` markers.

--- a/.changeset/029-analyzable-context-modules.md
+++ b/.changeset/029-analyzable-context-modules.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Bake the chunk imports of a lazy context into its own request map.

--- a/.changeset/029-analyzable-public-path-and-asset-wrapper.md
+++ b/.changeset/029-analyzable-public-path-and-asset-wrapper.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Fix analyzable url public paths, and bake more of them, wasm included.

--- a/.changeset/030-analyzable-css-chunk-href.md
+++ b/.changeset/030-analyzable-css-chunk-href.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Write out the stylesheet url a css chunk loads, so tools can follow it.

--- a/.changeset/analyzable-esm-output.md
+++ b/.changeset/analyzable-esm-output.md
@@ -1,5 +1,0 @@
----
-"webpack": minor
----
-
-Emit analyzable `new URL()` refs for async WebAssembly and keep them for prefetch/preload-hinted `new URL()`/`new Worker()` refs.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -3115,9 +3115,8 @@ class RuntimeTemplate {
 		if (!this.supportsAnalyzable("url", chunkGraph, consumingModule)) {
 			return null;
 		}
-		// Only a child named by some order ever reaches a handler, so nothing else is
-		// written out. Every order is read rather than the two that reach the javascript
-		// handler today: a name this does not know then costs bytes, not a missing url.
+		// Only a child some order names reaches a handler. Every order counts, not the
+		// two that reach javascript today: an unknown one costs bytes, not a missing url.
 		const orders = runtimeChunk.getChildIdsByOrdersMap(
 			chunkGraph,
 			true,

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -3070,17 +3070,103 @@ class RuntimeTemplate {
 			return null;
 		}
 		const { chunkHasCss } = getCssModulesPlugin();
-		const consumingChunks = [runtimeChunk];
-		/** @type {Map<ChunkId, string>} */
-		const urls = new Map();
 		// An initial stylesheet is already in the document, but the hot path re-loads it
 		// by id like any other, so it needs a url here too.
 		const reachable = new Set([
 			...runtimeChunk.getAllReferencedChunks(),
 			...runtimeChunk.getAllInitialChunks()
 		]);
+		const chunks = [];
 		for (const chunk of reachable) {
-			if (chunk.id === null || !chunkHasCss(chunk, chunkGraph)) continue;
+			if (chunkHasCss(chunk, chunkGraph)) chunks.push(chunk);
+		}
+		return this._analyzableChunkUrls(
+			chunks,
+			chunkGraph,
+			consumingModule,
+			[runtimeChunk],
+			CSS_TYPE
+		);
+	}
+
+	/**
+	 * Static `new URL(<file>, import.meta.url).href` for every javascript chunk a
+	 * runtime can hint at with `<link rel="prefetch"/"modulepreload">`, keyed by chunk
+	 * id, or `null` when any of them has to keep the runtime
+	 * `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
+	 * them and the plugin declaring what it needs ask this, so the two always agree.
+	 * @param {Chunk} runtimeChunk the chunk holding the hint handlers
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what that chunk needs
+	 * @param {Module=} consumingModule the runtime module, where one exists to report against
+	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 */
+	analyzableChunkScriptUrls(
+		runtimeChunk,
+		chunkGraph,
+		runtimeRequirements,
+		consumingModule
+	) {
+		// A hint is issued for whatever id an update names, which a map written now
+		// cannot answer for. Analyzable output is what ships, so it yields to HMR.
+		if (runtimeRequirements.has(RuntimeGlobals.hmrDownloadUpdateHandlers)) {
+			return null;
+		}
+		if (!this.supportsAnalyzable("url", chunkGraph, consumingModule)) {
+			return null;
+		}
+		// Only a child named by some order ever reaches a handler, so nothing else is
+		// written out. Every order is read rather than the two that reach the javascript
+		// handler today: a name this does not know then costs bytes, not a missing url.
+		const orders = runtimeChunk.getChildIdsByOrdersMap(
+			chunkGraph,
+			true,
+			JavascriptModulesPlugin.chunkHasJs
+		);
+		/** @type {Set<ChunkId>} */
+		const hinted = new Set();
+		for (const order of Object.keys(orders)) {
+			for (const from of Object.keys(orders[order])) {
+				for (const id of orders[order][/** @type {ChunkId} */ (from)]) {
+					hinted.add(id);
+				}
+			}
+		}
+		/** @type {Chunk[]} */
+		const chunks = [];
+		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
+			if (hinted.has(/** @type {ChunkId} */ (chunk.id))) chunks.push(chunk);
+		}
+		return this._analyzableChunkUrls(
+			chunks,
+			chunkGraph,
+			consumingModule,
+			[runtimeChunk],
+			JAVASCRIPT_TYPE
+		);
+	}
+
+	/**
+	 * The urls of one asset of each of `chunks`, written out so they can be read by
+	 * chunk id, or `null` as soon as one of them cannot be named here.
+	 * @param {Iterable<Chunk>} chunks the chunks whose asset is wanted
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Module | undefined} consumingModule the runtime module, where one exists to report against
+	 * @param {Chunk[]} consumingChunks the chunks the urls are written into
+	 * @param {string} sourceType which asset of each chunk to name
+	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 */
+	_analyzableChunkUrls(
+		chunks,
+		chunkGraph,
+		consumingModule,
+		consumingChunks,
+		sourceType
+	) {
+		/** @type {Map<ChunkId, string>} */
+		const urls = new Map();
+		for (const chunk of chunks) {
+			if (chunk.id === null) continue;
 			const specifier = this._getAnalyzableChunkSpecifier(
 				undefined,
 				chunk,
@@ -3088,7 +3174,7 @@ class RuntimeTemplate {
 				chunkGraph,
 				undefined,
 				consumingChunks,
-				CSS_TYPE
+				sourceType
 			);
 			if (specifier === null) return null;
 			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -111,24 +111,33 @@ class ModuleChunkLoadingPlugin {
 					);
 				});
 
-			// The prefetch/preload handlers build the chunk URL themselves, so they need
-			// the public path and script filename directly — without relying on
-			// `ensureChunkHandlers` to pull them in (an analyzable `import()` may replace it).
-			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.prefetchChunkHandlers)
-				.tap(PLUGIN_NAME, (chunk, set) => {
-					if (!isEnabledForChunk(chunk)) return;
-					set.add(RuntimeGlobals.publicPath);
-					set.add(RuntimeGlobals.getChunkScriptFilename);
-				});
-
-			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.preloadChunkHandlers)
-				.tap(PLUGIN_NAME, (chunk, set) => {
-					if (!isEnabledForChunk(chunk)) return;
-					set.add(RuntimeGlobals.publicPath);
-					set.add(RuntimeGlobals.getChunkScriptFilename);
-				});
+			// A prefetch/preload handler that builds its URL needs the public path and
+			// script filename directly — without relying on `ensureChunkHandlers` to pull
+			// them in (an analyzable `import()` may replace it).
+			for (const requirement of [
+				RuntimeGlobals.prefetchChunkHandlers,
+				RuntimeGlobals.preloadChunkHandlers
+			]) {
+				compilation.hooks.runtimeRequirementInTree
+					.for(requirement)
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+						if (!isEnabledForChunk(chunk)) return;
+						// A baked url carries where the chunk is, so neither the public path
+						// nor the name lookup is read for it. Asked exactly as the loading
+						// runtime module asks, so the two always agree.
+						if (
+							compilation.runtimeTemplate.analyzableChunkScriptUrls(
+								chunk,
+								chunkGraph,
+								set
+							) !== null
+						) {
+							return;
+						}
+						set.add(RuntimeGlobals.publicPath);
+						set.add(RuntimeGlobals.getChunkScriptFilename);
+					});
+			}
 
 			// Keyed on `ensureChunk`, not on the handler map: only the runtime chunk loader
 			// builds a URL from a chunk id, and an analyzable `import()` carries its own.

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -111,9 +111,8 @@ class ModuleChunkLoadingPlugin {
 					);
 				});
 
-			// A prefetch/preload handler that builds its URL needs the public path and
-			// script filename directly — without relying on `ensureChunkHandlers` to pull
-			// them in (an analyzable `import()` may replace it).
+			// A handler that builds its url asks for both directly: an analyzable
+			// `import()` may replace `ensureChunkHandlers`, which otherwise pulls them in.
 			for (const requirement of [
 				RuntimeGlobals.prefetchChunkHandlers,
 				RuntimeGlobals.preloadChunkHandlers
@@ -122,9 +121,8 @@ class ModuleChunkLoadingPlugin {
 					.for(requirement)
 					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
-						// A baked url carries where the chunk is, so neither the public path
-						// nor the name lookup is read for it. Asked exactly as the loading
-						// runtime module asks, so the two always agree.
+						// A baked url carries where the chunk is, so neither is read for it.
+						// Asked as the runtime module asks, so the two always agree.
 						if (
 							compilation.runtimeTemplate.analyzableChunkScriptUrls(
 								chunk,

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -131,6 +131,17 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 			(environment.document || isNeutralPlatform) &&
 			this._runtimeRequirements.has(RuntimeGlobals.preloadChunkHandlers) &&
 			chunk.hasChildByOrder(chunkGraph, "preload", true, chunkHasJs);
+		// Under module output each hinted chunk is a known file, so the urls are written
+		// out and read by id rather than built from the chunk id at runtime.
+		const chunkUrls =
+			withPrefetch || withPreload
+				? runtimeTemplate.analyzableChunkScriptUrls(
+						chunk,
+						chunkGraph,
+						this._runtimeRequirements,
+						this
+					)
+				: null;
 		const conditionMap = chunkGraph.getChunkConditionMap(chunk, chunkHasJs);
 		const hasJsMatcher = compileBooleanMatcher(conditionMap);
 		const initialChunkIds = getInitialChunkIds(chunk, chunkGraph, chunkHasJs);
@@ -182,11 +193,33 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 			withHmr ||
 			withPrefetch ||
 			withPreload;
+		// The url is read through a thunk so a runtime hinting at many chunks builds only
+		// the one it appends.
+		/**
+		 * @param {string} id expression naming the chunk whose url is wanted
+		 * @returns {string} expression evaluating to its url
+		 */
+		const chunkUrl = (id) =>
+			chunkUrls === null
+				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(${id})`
+				: `chunkUrls[${id}]()`;
 		return Template.asString([
 			withBaseURI
 				? this._generateBaseUri(chunk, rootOutputDir)
 				: "// no baseURI",
 			"",
+			...(chunkUrls
+				? [
+						`${cst} chunkUrls = {\n${Template.indent(
+							Array.from(
+								chunkUrls,
+								([id, url]) =>
+									`${JSON.stringify(String(id))}: ${runtimeTemplate.returningFunction(url)}`
+							).join(",\n")
+						)}\n};`,
+						""
+					]
+				: []),
 			withInstalledChunks
 				? Template.asString([
 						"// object to store loaded and loading chunks",
@@ -304,6 +337,9 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 							hasJsMatcher === true ? "true" : hasJsMatcher("chunkId")
 						}) {`,
 						Template.indent([
+							// A hint is best-effort, so an id no url was written for is
+							// skipped rather than turned into a bogus href.
+							...(chunkUrls ? ["if(!chunkUrls[chunkId]) return;"] : []),
 							"installedChunks[chunkId] = null;",
 							linkPrefetch.call(
 								Template.asString([
@@ -321,7 +357,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 									"}",
 									'link.rel = "prefetch";',
 									'link.as = "script";',
-									`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`
+									`link.href = ${chunkUrl("chunkId")};`
 								]),
 								chunk
 							),
@@ -358,6 +394,9 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 							hasJsMatcher === true ? "true" : hasJsMatcher("chunkId")
 						}) {`,
 						Template.indent([
+							// A hint is best-effort, so an id no url was written for is
+							// skipped rather than turned into a bogus href.
+							...(chunkUrls ? ["if(!chunkUrls[chunkId]) return;"] : []),
 							"installedChunks[chunkId] = null;",
 							linkPreload.call(
 								Template.asString([
@@ -369,7 +408,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 									),
 									"}",
 									'link.rel = "modulepreload";',
-									`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`,
+									`link.href = ${chunkUrl("chunkId")};`,
 									crossOriginLoading
 										? crossOriginLoading === "use-credentials"
 											? 'link.crossOrigin = "use-credentials";'

--- a/test/configCases/analyzable/chunk-hint-href/a.js
+++ b/test/configCases/analyzable/chunk-hint-href/a.js
@@ -1,0 +1,4 @@
+import(/* webpackChunkName: "b", webpackPreload: true */ "./b.js");
+import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared.js");
+
+export default "a";

--- a/test/configCases/analyzable/chunk-hint-href/auto-entry.js
+++ b/test/configCases/analyzable/chunk-hint-href/auto-entry.js
@@ -1,0 +1,88 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+it("should hint at every child and load them", async () => {
+	const a = await import(
+		/* webpackChunkName: "a", webpackPrefetch: true */ "./a.js"
+	);
+	// Reachable but hinted at by nothing, so no url is written out for it.
+	const plain = await import(
+		/* webpackChunkName: "plain" */ "./plain.js"
+	);
+
+	expect(a.default).toBe("a");
+	expect(plain.default).toBe("plain");
+
+	// The neutral runtime guards the DOM, so the hints only land where there is one.
+	if (typeof document !== "undefined") {
+		const links = document.head._children.filter((el) => el._type === "link");
+
+		expect(links.map((link) => link.rel).sort()).toEqual([
+			"modulepreload",
+			"prefetch",
+			"prefetch"
+		]);
+		// A baked href is absolute, so this is the emitted file itself rather than a
+		// name that only resolves against wherever the document happened to sit.
+		for (const link of links) {
+			expect(link.href).toMatch(/^file:\/\//);
+			expect(fs.existsSync(fileURLToPath(link.href))).toBe(true);
+		}
+	}
+});
+
+it("should write the hint urls out and drop what built them", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle).toContain("link.href = chunkUrls[chunkId]();");
+	expect(bundle).toContain(`new URL("./${__NAME__}-a.mjs"`);
+	expect(bundle).toContain(`new URL("./${__NAME__}-b.mjs"`);
+	// Both children hint at it, and it is written out once.
+	expect(bundle.split(`new URL("./${__NAME__}-shared.mjs"`)).toHaveLength(2);
+	// Nothing hints at it, so it is not in the map.
+	expect(bundle).not.toContain(`new URL("./${__NAME__}-plain.mjs"`);
+	// Nothing reads the id-keyed lookup or the public path any more, so neither ships.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u = `);
+	expect(bundle).not.toContain(`${"__webpack_require__"}.p = `);
+});
+
+it("should write a url out for every id a trigger can hand a handler", () => {
+	// Built from pieces so this file's own source, inlined into the bundle, is not
+	// what the patterns find.
+	const source = fs
+		.readFileSync(
+			path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+			"utf8"
+		)
+		.replace(/\/\*+\/ ?/g, "");
+	const find = (pattern) => new RegExp(pattern, "g");
+	const dispatched = new Set();
+
+	for (const match of source.matchAll(
+		find(`${"chunkToChildren"}Map = (\\{[\\s\\S]*?\\n\\t\\});`)
+	)) {
+		for (const ids of Object.values(JSON.parse(match[1]))) {
+			for (const id of ids) dispatched.add(id);
+		}
+	}
+	// The startup hint names its chunk directly rather than through a map.
+	for (const match of source.matchAll(
+		find(`${"__webpack_require__"}\\.[EG]\\("([^"]+)"\\)`)
+	)) {
+		dispatched.add(match[1]);
+	}
+
+	const block = source.match(find(`const ${"chunk"}Urls = \\{([\\s\\S]*?)\\n\\t\\};`));
+	const baked = new Set(
+		[...block[0].matchAll(find('"([^"]+)": \\(\\) =>'))].map((m) => m[1])
+	);
+
+	expect(dispatched.size).toBeGreaterThan(0);
+	// A handler reached with an id no url was written for would silently skip the hint,
+	// so the two sets have to agree exactly.
+	expect([...dispatched].sort()).toEqual([...baked].sort());
+});

--- a/test/configCases/analyzable/chunk-hint-href/b.js
+++ b/test/configCases/analyzable/chunk-hint-href/b.js
@@ -1,0 +1,3 @@
+import(/* webpackChunkName: "shared", webpackPrefetch: true */ "./shared.js");
+
+export default "b";

--- a/test/configCases/analyzable/chunk-hint-href/hashed-entry.js
+++ b/test/configCases/analyzable/chunk-hint-href/hashed-entry.js
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+it("should hint at every child and load them", async () => {
+	const a = await import(
+		/* webpackChunkName: "a", webpackPrefetch: true */ "./a.js"
+	);
+
+	expect(a.default).toBe("a");
+});
+
+it("should fill the reserved names in once the hashes exist", () => {
+	const outputPath = __STATS__.children[__INDEX__].outputPath;
+	const bundle = fs.readFileSync(
+		path.join(outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+	const emitted = fs.readdirSync(outputPath);
+
+	expect(bundle).toContain("link.href = chunkUrls[chunkId]();");
+
+	// Every config shares this directory, so each name has to be this one's shape as
+	// well as a file that exists — a stand-in never filled in is neither.
+	const baked = bundle.match(/new URL\("\.\/([^"]+\.mjs)"/g) || [];
+
+	expect(baked).toHaveLength(3);
+
+	for (const match of baked) {
+		const name = match.slice('new URL("./'.length, -1);
+
+		expect(name).toMatch(/^hashed-(?:a|b|shared)\.[\da-f]+\.mjs$/);
+		expect(emitted).toContain(name);
+	}
+});

--- a/test/configCases/analyzable/chunk-hint-href/hmr-entry.js
+++ b/test/configCases/analyzable/chunk-hint-href/hmr-entry.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+it("should still hint with the hot handler present", async () => {
+	const a = await import(
+		/* webpackChunkName: "a", webpackPrefetch: true */ "./a.js"
+	);
+
+	expect(a.default).toBe("a");
+});
+
+it("should keep the runtime url form for a runtime that can be updated", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	// An update hints at ids this map knows nothing about, so nothing is written out.
+	expect(bundle).not.toContain(`new URL("./${__NAME__}-a.mjs"`);
+	expect(bundle).toContain(
+		`link.href = ${"__webpack_require__"}.p + ${"__webpack_require__"}.u(chunkId);`
+	);
+});

--- a/test/configCases/analyzable/chunk-hint-href/override-entry.js
+++ b/test/configCases/analyzable/chunk-hint-href/override-entry.js
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+// Reassigned here, so where a chunk sits is only known once this runs.
+__webpack_public_path__ = "./";
+
+it("should still hint through the runtime form", async () => {
+	const a = await import(
+		/* webpackChunkName: "a", webpackPrefetch: true */ "./a.js"
+	);
+
+	expect(a.default).toBe("a");
+});
+
+it("should keep what builds the url when no literal can name it", () => {
+	const bundle = fs.readFileSync(
+		path.join(__STATS__.children[__INDEX__].outputPath, `${__NAME__}.mjs`),
+		"utf8"
+	);
+
+	expect(bundle).not.toContain(`new URL("./${__NAME__}-a.mjs"`);
+	// The hint still reaches for both, so both have to ship.
+	expect(bundle).toContain(
+		`link.href = ${"__webpack_require__"}.p + ${"__webpack_require__"}.u(chunkId);`
+	);
+});

--- a/test/configCases/analyzable/chunk-hint-href/plain.js
+++ b/test/configCases/analyzable/chunk-hint-href/plain.js
@@ -1,0 +1,1 @@
+export default "plain";

--- a/test/configCases/analyzable/chunk-hint-href/shared.js
+++ b/test/configCases/analyzable/chunk-hint-href/shared.js
@@ -1,0 +1,1 @@
+export default "shared";

--- a/test/configCases/analyzable/chunk-hint-href/test.config.js
+++ b/test/configCases/analyzable/chunk-hint-href/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const NAMES = ["auto", "hashed", "override", "hmr"];
+
+module.exports = {
+	findBundle(i) {
+		return [`./${NAMES[i]}.mjs`];
+	}
+};

--- a/test/configCases/analyzable/chunk-hint-href/test.filter.js
+++ b/test/configCases/analyzable/chunk-hint-href/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// Reading the bundle back needs `require` in ESM output, which emits
+// `import { createRequire } from "module"` — older Node can't link that.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/chunk-hint-href/webpack.config.js
+++ b/test/configCases/analyzable/chunk-hint-href/webpack.config.js
@@ -1,0 +1,63 @@
+"use strict";
+
+// Under module output a prefetch/preload href is written out, unless something about the
+// public path is only known where the hint runs.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position of this config, so an entry finds its own stats
+ * @param {string} name output prefix keeping the emitted files of each config apart
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, name) => ({
+	name,
+	target: ["web", "node"],
+	mode: "development",
+	devtool: false,
+	entry: { [name]: `./${name}-entry.js` },
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named", minimize: false },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: `${name}-[name].mjs`,
+		publicPath: "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			__NAME__: JSON.stringify(name)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	// The plain case. Both children hint at one shared chunk, so the same id is named
+	// twice and has to be written out once.
+	base(0, "auto"),
+	// A content hash settles long after this code is generated, so the name is reserved
+	// and filled in by the deferred pass.
+	{
+		...base(1, "hashed"),
+		output: {
+			...base(1, "hashed").output,
+			chunkFilename: "hashed-[name].[contenthash].mjs"
+		}
+	},
+	// Reassigned where the hint runs, so no literal can name where the chunk is and the
+	// runtime form has to stay.
+	base(2, "override"),
+	// The hot handler hints at whatever id an update names, so a runtime carrying it
+	// keeps the runtime form rather than a map that knows only today's ids.
+	{
+		...base(3, "hmr"),
+		plugins: [
+			.../** @type {NonNullable<import("../../../../").Configuration["plugins"]>} */ (
+				base(3, "hmr").plugins
+			),
+			new webpack.HotModuleReplacementPlugin()
+		]
+	}
+];

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -25,7 +25,7 @@ prefetch:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset mid_js.mjs X bytes [emitted] [javascript module]
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 9 modules
+  runtime modules X KiB 7 modules
   cacheable modules X bytes
     ./index-prefetch.js X bytes [built] [code generated]
     ./mid.js X bytes [built] [code generated]

--- a/types.d.ts
+++ b/types.d.ts
@@ -25817,6 +25817,20 @@ declare abstract class RuntimeTemplate {
 	): null | Map<ChunkId, string>;
 
 	/**
+	 * Static `new URL(<file>, import.meta.url).href` for every javascript chunk a
+	 * runtime can hint at with `<link rel="prefetch"/"modulepreload">`, keyed by chunk
+	 * id, or `null` when any of them has to keep the runtime
+	 * `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
+	 * them and the plugin declaring what it needs ask this, so the two always agree.
+	 */
+	analyzableChunkScriptUrls(
+		runtimeChunk: Chunk,
+		chunkGraph: ChunkGraph,
+		runtimeRequirements: ReadonlySet<string>,
+		consumingModule?: Module
+	): null | Map<ChunkId, string>;
+
+	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm
 	 * module. Only called when `supportsAnalyzable("wasm")` holds.
 	 */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Under `output.module` a `<link rel="prefetch">` / `<link rel="modulepreload">` built its href at runtime as `__webpack_require__.p + __webpack_require__.u(chunkId)`, so nothing static named the chunk file and no tool could follow it. This writes the url out per hinted chunk id as `new URL("./a.mjs", import.meta.url).href`, which was the last runtime-built url left under module output.

A runtime that only hints then drops both `publicPath` and `get javascript chunk filename` entirely. Over `configCases` matching `prefetch|preload|analyzable|universal`, `yarn test:size` reports -1.92 KiB gzip / -5.41 KiB raw across 13 changed assets, all shrinking, with 6 runtimes losing those two modules; `analyzable/prefetch-child-import` is -9.78% gzip. It yields to HMR, where the hot path hints at ids a build-time map cannot know, and non-module output is byte-identical.

Also folds the eleven pending `analyzable` changesets into one entry, per the union-same-topic rule.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/analyzable/chunk-hint-href/` covers four output shapes (plain, content-hashed, runtime public-path override, HMR). One case asserts that the set of ids the triggers can dispatch equals the set the map carries, which is the invariant the design rests on; it was verified to fail when a chunk is dropped from the map.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used to draft the implementation and tests, and to run the verification: targeted config/stats suites, differential builds against `main` to confirm the untouched output paths stay byte-identical, and the `test:size` comparison quoted above. Every result reported here was produced by running the repo's own tooling, and each change was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved ESM output for prefetched and preloaded chunks by embedding analyzable URLs when they can be determined during compilation.
  - Supports automatic, hashed, and shared chunk names, while retaining dynamic URL generation for runtime public-path overrides and HMR scenarios.
  - Preserves chunk hints and avoids emitting unnecessary runtime URL helpers when static URLs are available.

- **Bug Fixes**
  - Ensures hinted chunks resolve to existing files across supported output configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->