### PR TITLE
perf: remove the unread `__webpack_esm_id__` and `exports.id`

### DIFF
--- a/.changeset/511-chunk-format-drop-unread-id.md
+++ b/.changeset/511-chunk-format-drop-unread-id.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Remove the unread `__webpack_esm_id__` and `exports.id` chunk exports.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -155,11 +155,6 @@ module.exports.ensureChunkIncludeEntries =
 module.exports.entryModuleId = "__webpack_require__.s";
 
 /**
- * esm module id
- */
-module.exports.esmId = "__webpack_esm_id__";
-
-/**
  * esm module ids
  */
 module.exports.esmIds = "__webpack_esm_ids__";

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -190,11 +190,6 @@ class ModuleChunkFormatPlugin {
 				const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
 				const source = new ConcatSource();
 				source.add(
-					`export const ${RuntimeGlobals.esmId} = ${JSON.stringify(
-						chunk.id
-					)};\n`
-				);
-				source.add(
 					`export const ${RuntimeGlobals.esmIds} = ${JSON.stringify(
 						chunk.ids
 					)};\n`

--- a/lib/javascript/CommonJsChunkFormatPlugin.js
+++ b/lib/javascript/CommonJsChunkFormatPlugin.js
@@ -54,7 +54,6 @@ class CommonJsChunkFormatPlugin {
 			hooks.renderChunk.tap(PLUGIN_NAME, (modules, renderContext) => {
 				const { chunk, chunkGraph, runtimeTemplate } = renderContext;
 				const source = new ConcatSource();
-				source.add(`exports.id = ${JSON.stringify(chunk.id)};\n`);
 				source.add(`exports.ids = ${JSON.stringify(chunk.ids)};\n`);
 				source.add("exports.modules = ");
 				source.add(modules);

--- a/test/configCases/chunks-order/cjs/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/chunks-order/cjs/__snapshots__/ConfigCacheTest.snap
@@ -4,7 +4,6 @@ exports[`ConfigCacheTestCases chunks-order cjs exported tests The dependOn chunk
 "\\"use strict\\";
 (() => {
 var exports = {};
-exports.id = \\"foo\\";
 exports.ids = [\\"foo\\"];
 exports.modules = {
 

--- a/test/configCases/chunks-order/cjs/__snapshots__/ConfigTest.snap
+++ b/test/configCases/chunks-order/cjs/__snapshots__/ConfigTest.snap
@@ -4,7 +4,6 @@ exports[`ConfigTestCases chunks-order cjs exported tests The dependOn chunk must
 "\\"use strict\\";
 (() => {
 var exports = {};
-exports.id = \\"foo\\";
 exports.ids = [\\"foo\\"];
 exports.modules = {
 

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
@@ -3,7 +3,6 @@
 exports[`ConfigCacheTestCases chunks-order module exported tests The dependOn chunk must be loaded before the common chunk. 1`] = `
 "import {fileURLToPath as __webpack_fileURLToPath__} from \\"node:url\\";
 var __webpack_filename__ = __webpack_fileURLToPath__(import.meta.url);
-export const __webpack_esm_id__ = \\"foo\\";
 export const __webpack_esm_ids__ = [\\"foo\\"];
 export const __webpack_esm_modules__ = {
 

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
@@ -3,7 +3,6 @@
 exports[`ConfigTestCases chunks-order module exported tests The dependOn chunk must be loaded before the common chunk. 1`] = `
 "import {fileURLToPath as __webpack_fileURLToPath__} from \\"node:url\\";
 var __webpack_filename__ = __webpack_fileURLToPath__(import.meta.url);
-export const __webpack_esm_id__ = \\"foo\\";
 export const __webpack_esm_ids__ = [\\"foo\\"];
 export const __webpack_esm_modules__ = {
 

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -161,8 +161,7 @@ globalThis.__moduleA = moduleA;
 `;
 
 exports[`ConfigCacheTestCases html script-src-mixed exported tests should chain multiple <script type=module src> via dependOn and share modules across them 2`] = `
-"export const __webpack_esm_id__ = \\"__html_cbe5b59d_3\\";
-export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_3\\"];
+"export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_3\\"];
 export const __webpack_esm_modules__ = {
 
 /***/ 942
@@ -296,8 +295,7 @@ globalThis.__classicA = \\"classic-a value\\";
 `;
 
 exports[`ConfigCacheTestCases html script-src-mixed exported tests should chain multiple classic <script src> via dependOn 2`] = `
-"export const __webpack_esm_id__ = \\"__html_cbe5b59d_2\\";
-export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_2\\"];
+"export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_2\\"];
 export const __webpack_esm_modules__ = {
 
 /***/ 702

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -161,8 +161,7 @@ globalThis.__moduleA = moduleA;
 `;
 
 exports[`ConfigTestCases html script-src-mixed exported tests should chain multiple <script type=module src> via dependOn and share modules across them 2`] = `
-"export const __webpack_esm_id__ = \\"__html_cbe5b59d_3\\";
-export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_3\\"];
+"export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_3\\"];
 export const __webpack_esm_modules__ = {
 
 /***/ 942
@@ -296,8 +295,7 @@ globalThis.__classicA = \\"classic-a value\\";
 `;
 
 exports[`ConfigTestCases html script-src-mixed exported tests should chain multiple classic <script src> via dependOn 2`] = `
-"export const __webpack_esm_id__ = \\"__html_cbe5b59d_2\\";
-export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_2\\"];
+"export const __webpack_esm_ids__ = [\\"__html_cbe5b59d_2\\"];
 export const __webpack_esm_modules__ = {
 
 /***/ 702

--- a/types.d.ts
+++ b/types.d.ts
@@ -29603,7 +29603,6 @@ declare namespace exports {
 		export let ensureChunkHandlers: "__webpack_require__.f";
 		export let ensureChunkIncludeEntries: "__webpack_require__.f (include entries)";
 		export let entryModuleId: "__webpack_require__.s";
-		export let esmId: "__webpack_esm_id__";
 		export let esmIds: "__webpack_esm_ids__";
 		export let esmModules: "__webpack_esm_modules__";
 		export let esmRuntime: "__webpack_esm_runtime__";


### PR DESCRIPTION

**Summary**

For `export const __webpack_esm_id__` and `exports.id`, there is no runtime ever read and `installChunk` marks chunks installed from the `__webpack_esm_ids__` / `exports.ids`, and the HMR path reads only the modules and runtime exports. So this PR remove them.
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

Hopefully no, users may use this export downstream, but it's very rare. The export is the chunk id, which is `webpack-specific`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the unread `__webpack_esm_id__` export from generated ES module chunks.
  * Removed the unread `exports.id` property from generated CommonJS chunks.
  * Existing chunk identifier exports, including `exports.ids`, remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->