### PR TITLE
perf(runtime): emit less generated runtime code

### DIFF
--- a/.changeset/112-on-chunks-loaded-priority.md
+++ b/.changeset/112-on-chunks-loaded-priority.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `__webpack_require__.O` making every deferred handler wait, not just odd priorities.

--- a/.changeset/112-on-chunks-loaded-priority.md
+++ b/.changeset/112-on-chunks-loaded-priority.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix `__webpack_require__.O` making every deferred handler wait, not just odd priorities.
+Run an even-priority `__webpack_require__.O` handler without waiting.

--- a/.changeset/511-smaller-generated-runtime.md
+++ b/.changeset/511-smaller-generated-runtime.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Emit less runtime code for dynamic imports, `publicPath: "auto"` and the export helpers.
+Emit less runtime code for dynamic imports, chunk loading, `publicPath: "auto"` and the export helpers.

--- a/.changeset/511-smaller-generated-runtime.md
+++ b/.changeset/511-smaller-generated-runtime.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Emit less runtime code for dynamic imports, chunk loading and publicPath.
+Emit less runtime code, and shorter syntax where `output.environment` allows.

--- a/.changeset/511-smaller-generated-runtime.md
+++ b/.changeset/511-smaller-generated-runtime.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Emit less runtime code for dynamic imports, `publicPath: "auto"` and the export helpers.

--- a/.changeset/511-smaller-generated-runtime.md
+++ b/.changeset/511-smaller-generated-runtime.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Emit less runtime code for dynamic imports, chunk loading, `publicPath: "auto"` and the export helpers.
+Emit less runtime code for dynamic imports, chunk loading and publicPath.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -134,6 +134,11 @@ module.exports.deferredModuleAsyncTransitiveDependenciesSymbol =
 module.exports.definePropertyGetters = "__webpack_require__.d";
 
 /**
+ * a runtime requirement if definePropertyGetters is called with an array of bindings
+ */
+module.exports.definePropertyGettersFromArray = "__webpack_require__.d (array)";
+
+/**
  * the chunk ensure function
  */
 module.exports.ensureChunk = "__webpack_require__.e";

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -205,7 +205,6 @@ const TREE_DEPENDENCIES = {
 // module to the chunk. Conditional / argument-taking ones stay as explicit taps.
 /** @type {[string, () => Promise<new () => RuntimeModule>][]} */
 const SIMPLE_TREE_RUNTIME_MODULES = [
-	[RuntimeGlobals.definePropertyGetters, getDefinePropertyGettersRuntimeModule],
 	[RuntimeGlobals.makeNamespaceObject, getMakeNamespaceObjectRuntimeModule],
 	[
 		RuntimeGlobals.createFakeNamespaceObject,
@@ -314,6 +313,16 @@ class RuntimePlugin {
 						return true;
 					});
 			}
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.definePropertyGetters)
+				.tap(PLUGIN_NAME, (chunk, runtimeRequirement) => {
+					compilation.addLazyRuntimeModule(
+						chunk,
+						getDefinePropertyGettersRuntimeModule,
+						(Ctor) => new Ctor(runtimeRequirement)
+					);
+					return true;
+				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.makeOptimizedDeferredNamespaceObject)
 				.tap(PLUGIN_NAME, (chunk, runtimeRequirement) => {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1325,6 +1325,20 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Renders a `then` callback calling `fn` with `args`. An arrow is shorter than
+	 * the bound form and gives `fn` the same `this` a method call would, which is
+	 * what `__webpack_require__.t` reads; without arrows the bound form is shorter.
+	 * @param {string} fn callee, a member of `__webpack_require__` or itself
+	 * @param {string} args arguments
+	 * @returns {string} callback expression
+	 */
+	deferredCall(fn, args) {
+		return this.supportsArrowFunction()
+			? this.returningFunction(`${fn}(${args})`)
+			: `${fn}.bind(${RuntimeGlobals.require}, ${args})`;
+	}
+
+	/**
 	 * Renders an object-literal method, using method shorthand when supported
 	 * and falling back to a `prop: function/arrow` property otherwise.
 	 * @param {string} prop property name (or computed key like `[x]`)
@@ -1829,7 +1843,10 @@ class RuntimeTemplate {
 						}(${JSON.stringify(asyncDeps)})`
 					)})`;
 				}
-				appending += `.then(${RuntimeGlobals.makeDeferredNamespaceObject}.bind(${RuntimeGlobals.require}, ${comment}${idExpr}, ${mode}))`;
+				appending += `.then(${this.deferredCall(
+					RuntimeGlobals.makeDeferredNamespaceObject,
+					`${comment}${idExpr}, ${mode}`
+				)})`;
 			} else if (header) {
 				appending = `.then(${this.basicFunction(
 					"",
@@ -1837,7 +1854,10 @@ class RuntimeTemplate {
 				)})`;
 			} else {
 				runtimeRequirements.add(RuntimeGlobals.require);
-				appending = `.then(${RuntimeGlobals.makeDeferredNamespaceObject}.bind(${RuntimeGlobals.require}, ${comment}${idExpr}, ${mode}))`;
+				appending = `.then(${this.deferredCall(
+					RuntimeGlobals.makeDeferredNamespaceObject,
+					`${comment}${idExpr}, ${mode}`
+				)})`;
 			}
 		} else {
 			let fakeType = 16;
@@ -1857,7 +1877,10 @@ class RuntimeTemplate {
 						)})`;
 					} else {
 						runtimeRequirements.add(RuntimeGlobals.require);
-						appending = `.then(${RuntimeGlobals.require}.bind(${RuntimeGlobals.require}, ${comment}${idExpr}))`;
+						appending = `.then(${this.deferredCall(
+							RuntimeGlobals.require,
+							`${comment}${idExpr}`
+						)})`;
 					}
 					break;
 				case "dynamic":
@@ -1883,7 +1906,10 @@ class RuntimeTemplate {
 							)})`;
 						} else {
 							runtimeRequirements.add(RuntimeGlobals.require);
-							appending = `.then(${RuntimeGlobals.require}.bind(${RuntimeGlobals.require}, ${comment}${idExpr}))`;
+							appending = `.then(${this.deferredCall(
+								RuntimeGlobals.require,
+								`${comment}${idExpr}`
+							)})`;
 						}
 						appending += `.then(${this.returningFunction(
 							`${RuntimeGlobals.createFakeNamespaceObject}(m, ${fakeType})`,
@@ -1904,7 +1930,10 @@ class RuntimeTemplate {
 								`${header}return ${returnExpression};`
 							)})`;
 						} else {
-							appending = `.then(${RuntimeGlobals.createFakeNamespaceObject}.bind(${RuntimeGlobals.require}, ${comment}${idExpr}, ${fakeType}))`;
+							appending = `.then(${this.deferredCall(
+								RuntimeGlobals.createFakeNamespaceObject,
+								`${comment}${idExpr}, ${fakeType}`
+							)})`;
 						}
 					}
 					break;

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1291,6 +1291,8 @@ class RuntimeTemplate {
 	 * @returns {string} empty function code
 	 */
 	emptyFunction() {
+		// `x => {}` over `() => {}`: a minifier keeps the parameter, so the named
+		// one is a byte shorter.
 		return this.supportsArrowFunction() ? "x => {}" : "function() {}";
 	}
 

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1327,9 +1327,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Renders a `then` callback calling `fn` with `args`. An arrow is shorter than
-	 * the bound form and gives `fn` the same `this` a method call would, which is
-	 * what `__webpack_require__.t` reads; without arrows the bound form is shorter.
+	 * Renders a `then` callback calling `fn` with `args`. An arrow keeps the `this`
+	 * a method call gives; the bound form is shorter without arrows.
 	 * @param {string} fn callee, a member of `__webpack_require__` or itself
 	 * @param {string} args arguments
 	 * @returns {string} callback expression

--- a/lib/dependencies/ExportBindingInitFragment.js
+++ b/lib/dependencies/ExportBindingInitFragment.js
@@ -153,6 +153,9 @@ class ExportBindingInitFragment extends InitFragment {
 		// emit it, and by then the requirement set is closed.
 		runtimeRequirements.add(RuntimeGlobals.exports);
 		runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+		// Only this fragment emits the array form, so the runtime helper drops the
+		// branch reading it unless this asks for it.
+		runtimeRequirements.add(RuntimeGlobals.definePropertyGettersFromArray);
 		const definition = `/* harmony export */ ${
 			RuntimeGlobals.definePropertyGetters
 		}(${this.exportsArgument}, [${items.join(",")}\n/* harmony export */ ]);\n`;

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -265,7 +265,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 							`if(${RuntimeGlobals.hasOwnProperty}(installedChunks, chunkId) && installedChunks[chunkId]) {`,
 							Template.indent("installedChunks[chunkId][0]();"),
 							"}",
-							`installedChunks[${RuntimeGlobals.esmIds}[i]] = 0;`
+							"installedChunks[chunkId] = 0;"
 						]),
 						"}",
 						withOnChunkLoad ? `${RuntimeGlobals.onChunksLoaded}();` : ""

--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -85,7 +85,7 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 								"if(scripts.length) {",
 								Template.indent([
 									`${lt} i = scripts.length - 1;`,
-									"while (i > -1 && (!scriptUrl || !/^http(s?):/.test(scriptUrl))) scriptUrl = scripts[i--].src;"
+									"while (i > -1 && (!scriptUrl || !/^https?:/.test(scriptUrl))) scriptUrl = scripts[i--].src;"
 								]),
 								"}"
 							]),
@@ -96,7 +96,9 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 			"// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration",
 			'// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.',
 			'if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");',
-			'scriptUrl = scriptUrl.replace(/^blob:/, "").replace(/#.*$/, "").replace(/\\?.*$/, "").replace(/\\/[^\\/]+$/, "/");',
+			// One pass for the `blob:` prefix and the query/fragment: both stop at the
+			// first `?` or `#`, so stripping either first leaves the same url.
+			'scriptUrl = scriptUrl.replace(/^blob:|[?#].*$/g, "").replace(/\\/[^\\/]+$/, "/");',
 			!undoPath
 				? `${RuntimeGlobals.publicPath} = scriptUrl;`
 				: `${RuntimeGlobals.publicPath} = scriptUrl + ${JSON.stringify(

--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -98,7 +98,7 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 			'if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");',
 			// One pass for the `blob:` prefix and the query/fragment: both stop at the
 			// first `?` or `#`, so stripping either first leaves the same url.
-			'scriptUrl = scriptUrl.replace(/^blob:|[?#].*$/g, "").replace(/\\/[^\\/]+$/, "/");',
+			'scriptUrl = scriptUrl.replace(/^blob:|[?#].*$/g, "").replace(/\\/[^/]+$/, "/");',
 			!undoPath
 				? `${RuntimeGlobals.publicPath} = scriptUrl;`
 				: `${RuntimeGlobals.publicPath} = scriptUrl + ${JSON.stringify(

--- a/lib/runtime/CreateFakeNamespaceObjectRuntimeModule.js
+++ b/lib/runtime/CreateFakeNamespaceObjectRuntimeModule.js
@@ -26,10 +26,9 @@ class CreateFakeNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 		const cst = runtimeTemplate.renderConst();
 		const lt = runtimeTemplate.renderLet();
 		return Template.asString([
-			`${cst} getProto = Object.getPrototypeOf ? ${runtimeTemplate.returningFunction(
-				"Object.getPrototypeOf(obj)",
-				"obj"
-			)} : ${runtimeTemplate.returningFunction("obj.__proto__", "obj")};`,
+			// No `__proto__` fallback: `Object.create` and `Object.defineProperty`
+			// below already require the same ES5 baseline.
+			`${cst} getProto = Object.getPrototypeOf;`,
 			`${lt} leafPrototypes;`,
 			"// create a fake namespace object",
 			"// mode & 1: value is a module id, require it",

--- a/lib/runtime/CreateFakeNamespaceObjectRuntimeModule.js
+++ b/lib/runtime/CreateFakeNamespaceObjectRuntimeModule.js
@@ -50,7 +50,10 @@ class CreateFakeNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 				`${cst} ns = Object.create(null);`,
 				`${RuntimeGlobals.makeNamespaceObject}(ns);`,
 				`${cst} def = {};`,
-				"leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];",
+				`${runtimeTemplate.assignOr(
+					"leafPrototypes",
+					"[null, getProto({}), getProto([]), getProto(getProto)]"
+				)};`,
 				"for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {",
 				Template.indent([
 					`Object.getOwnPropertyNames(current).forEach(${runtimeTemplate.expressionFunction(

--- a/lib/runtime/DefinePropertyGettersRuntimeModule.js
+++ b/lib/runtime/DefinePropertyGettersRuntimeModule.js
@@ -43,19 +43,10 @@ class DefinePropertyGettersRuntimeModule extends HelperRuntimeModule {
 					Template.indent([
 						"var key = definition[i++];",
 						"var binding = definition[i++];",
-						`if(!${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
-						Template.indent([
-							"if(binding === 0) {",
-							Template.indent([
-								"Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });"
-							]),
-							"} else {",
-							Template.indent([
-								"Object.defineProperty(exports, key, { enumerable: true, get: binding });"
-							]),
-							"}"
-						]),
-						"} else if(binding === 0) { i++; }"
+						// The descriptor is built before the own-property check so a
+						// value binding consumes its slot either way.
+						"var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };",
+						`if(!${RuntimeGlobals.hasOwnProperty}(exports, key)) Object.defineProperty(exports, key, descriptor);`
 					]),
 					"}"
 				]),

--- a/lib/runtime/DefinePropertyGettersRuntimeModule.js
+++ b/lib/runtime/DefinePropertyGettersRuntimeModule.js
@@ -9,10 +9,16 @@ const Template = require("../Template");
 const HelperRuntimeModule = require("./HelperRuntimeModule");
 
 /** @import Compilation from "../Compilation" */
+/** @import { ReadOnlyRuntimeRequirements } from "../Module" */
 
 class DefinePropertyGettersRuntimeModule extends HelperRuntimeModule {
-	constructor() {
+	/**
+	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements runtime requirements
+	 */
+	constructor(runtimeRequirements) {
 		super("define property getters");
+		/** @type {ReadOnlyRuntimeRequirements} */
+		this.runtimeRequirements = runtimeRequirements;
 	}
 
 	/**
@@ -33,39 +39,51 @@ class DefinePropertyGettersRuntimeModule extends HelperRuntimeModule {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
 		const fn = RuntimeGlobals.definePropertyGetters;
-		return Template.asString([
-			"// define getter/value functions for harmony exports",
-			`${fn} = ${runtimeTemplate.basicFunction("exports, definition", [
-				"if(Array.isArray(definition)) {",
+		// Only webpack itself emits the array form, so a build that emits none
+		// cannot receive one and the branch reading it is dead. The object form
+		// stays either way — see the webpack 6 note below.
+		const withArray = this.runtimeRequirements.has(
+			RuntimeGlobals.definePropertyGettersFromArray
+		);
+		// TODO webpack 6: remove object format support. Internal code (e.g. ConcatenatedModule)
+		// and third-party libraries may still call __webpack_require__.d() with an object.
+		const fromObject = [
+			"for(var key in definition) {",
+			Template.indent([
+				`if(${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
 				Template.indent([
-					"var i = 0;",
-					"while(i < definition.length) {",
-					Template.indent([
-						"var key = definition[i++];",
-						"var binding = definition[i++];",
-						// The descriptor is built before the own-property check so a
-						// value binding consumes its slot either way.
-						"var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };",
-						`if(!${RuntimeGlobals.hasOwnProperty}(exports, key)) Object.defineProperty(exports, key, descriptor);`
-					]),
-					"}"
-				]),
-				// TODO webpack 6: remove object format support. Internal code (e.g. ConcatenatedModule)
-				// and third-party libraries may still call __webpack_require__.d() with an object.
-				"} else {",
-				Template.indent([
-					"for(var key in definition) {",
-					Template.indent([
-						`if(${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {`,
-						Template.indent([
-							"Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });"
-						]),
-						"}"
-					]),
-					"}"
+					"Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });"
 				]),
 				"}"
-			])};`
+			]),
+			"}"
+		];
+		return Template.asString([
+			"// define getter/value functions for harmony exports",
+			`${fn} = ${runtimeTemplate.basicFunction(
+				"exports, definition",
+				withArray
+					? [
+							"if(Array.isArray(definition)) {",
+							Template.indent([
+								"var i = 0;",
+								"while(i < definition.length) {",
+								Template.indent([
+									"var key = definition[i++];",
+									"var binding = definition[i++];",
+									// The descriptor is built before the own-property check so a
+									// value binding consumes its slot either way.
+									"var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };",
+									`if(!${RuntimeGlobals.hasOwnProperty}(exports, key)) Object.defineProperty(exports, key, descriptor);`
+								]),
+								"}"
+							]),
+							"} else {",
+							Template.indent(fromObject),
+							"}"
+						]
+					: fromObject
+			)};`
 		]);
 	}
 }

--- a/lib/runtime/DefinePropertyGettersRuntimeModule.js
+++ b/lib/runtime/DefinePropertyGettersRuntimeModule.js
@@ -39,9 +39,8 @@ class DefinePropertyGettersRuntimeModule extends HelperRuntimeModule {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
 		const fn = RuntimeGlobals.definePropertyGetters;
-		// Only webpack itself emits the array form, so a build that emits none
-		// cannot receive one and the branch reading it is dead. The object form
-		// stays either way — see the webpack 6 note below.
+		// Only webpack emits the array form, so a build emitting none cannot
+		// receive one; the object form stays either way (see the note below).
 		const withArray = this.runtimeRequirements.has(
 			RuntimeGlobals.definePropertyGettersFromArray
 		);

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -185,9 +185,8 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const dynamicUrlChunks = new Set();
 
 		/**
-		 * Drops the empty string a leading placeholder leaves behind. Only when a
-		 * quoted operand ends the expression, so the `+` chain keeps yielding a
-		 * string rather than a bare chunk id.
+		 * Drops the dead empty string a leading placeholder leaves, only when a
+		 * quoted operand ends the expression so the `+` chain stays a string.
 		 * @param {string} expr concatenation expression
 		 * @returns {string} the expression without its dead empty string
 		 */

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -185,22 +185,14 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const dynamicUrlChunks = new Set();
 
 		/**
-		 * Drops the empty string a placeholder at either end of the template leaves
-		 * behind. Each strip requires a quoted operand at the other end, so the `+`
-		 * chain keeps yielding a string rather than a bare chunk id.
+		 * Drops the empty string a leading placeholder leaves behind. Only when a
+		 * quoted operand ends the expression, so the `+` chain keeps yielding a
+		 * string rather than a bare chunk id.
 		 * @param {string} expr concatenation expression
-		 * @returns {string} the expression without its dead empty strings
+		 * @returns {string} the expression without its dead empty string
 		 */
-		const dropDeadConcatOperands = (expr) => {
-			let result = expr;
-			if (result.startsWith('"" + ') && result.endsWith('"')) {
-				result = result.slice(5);
-			}
-			if (result.endsWith(' + ""') && result.startsWith('"')) {
-				result = result.slice(0, -5);
-			}
-			return result;
-		};
+		const dropDeadConcatOperand = (expr) =>
+			expr.startsWith('"" + ') && expr.endsWith('"') ? expr.slice(5) : expr;
 
 		/**
 		 * @param {Chunk} c the chunk
@@ -273,7 +265,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				},
 				contentHashType: contentType
 			});
-			const url = dropDeadConcatOperands(staticChunkFilename);
+			const url = dropDeadConcatOperand(staticChunkFilename);
 			let set = staticUrls.get(url);
 			if (set === undefined) {
 				staticUrls.set(url, (set = new Set()));
@@ -373,7 +365,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				},
 				contentHashType: contentType
 			});
-		const url = dynamicUrl && dropDeadConcatOperands(dynamicUrl);
+		const url = dynamicUrl && dropDeadConcatOperand(dynamicUrl);
 
 		const comment = `// This function allow to reference ${includedChunksMessages.join(
 			" and "

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -355,34 +355,37 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				contentHashType: contentType
 			});
 
+		const comment = `// This function allow to reference ${includedChunksMessages.join(
+			" and "
+		)}`;
+		// Nothing to branch on, so the whole function is the template expression.
+		if (staticUrls.size === 0) {
+			return Template.asString([
+				comment,
+				// `url` is `undefined` when no chunk contributes a filename; the
+				// function then returns `undefined`, as it did before.
+				`${global} = ${runtimeTemplate.returningFunction(`${url}`, "chunkId")};`
+			]);
+		}
 		return Template.asString([
-			`// This function allow to reference ${includedChunksMessages.join(
-				" and "
-			)}`,
-			`${global} = ${runtimeTemplate.basicFunction(
-				"chunkId",
-
-				staticUrls.size > 0
-					? [
-							"// return url for filenames not based on template",
-							// it minimizes to `x===1?"...":x===2?"...":"..."`
-							Template.asString(
-								Array.from(staticUrls, ([url, ids]) => {
-									const condition =
-										ids.size === 1
-											? `chunkId === ${JSON.stringify(first(ids))}`
-											: `{${Array.from(
-													ids,
-													(id) => `${JSON.stringify(id)}:1`
-												).join(",")}}[chunkId]`;
-									return `if (${condition}) return ${url};`;
-								})
-							),
-							"// return url for filenames based on template",
-							`return ${url};`
-						]
-					: ["// return url for filenames based on template", `return ${url};`]
-			)};`
+			comment,
+			`${global} = ${runtimeTemplate.basicFunction("chunkId", [
+				"// return url for filenames not based on template",
+				// it minimizes to `x===1?"...":x===2?"...":"..."`
+				Template.asString(
+					Array.from(staticUrls, ([url, ids]) => {
+						const condition =
+							ids.size === 1
+								? `chunkId === ${JSON.stringify(first(ids))}`
+								: `{${Array.from(ids, (id) => `${JSON.stringify(id)}:1`).join(
+										","
+									)}}[chunkId]`;
+						return `if (${condition}) return ${url};`;
+					})
+				),
+				"// return url for filenames based on template",
+				`return ${url};`
+			])};`
 		]);
 	}
 }

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -185,6 +185,24 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const dynamicUrlChunks = new Set();
 
 		/**
+		 * Drops the empty string a placeholder at either end of the template leaves
+		 * behind. Each strip requires a quoted operand at the other end, so the `+`
+		 * chain keeps yielding a string rather than a bare chunk id.
+		 * @param {string} expr concatenation expression
+		 * @returns {string} the expression without its dead empty strings
+		 */
+		const dropDeadConcatOperands = (expr) => {
+			let result = expr;
+			if (result.startsWith('"" + ') && result.endsWith('"')) {
+				result = result.slice(5);
+			}
+			if (result.endsWith(' + ""') && result.startsWith('"')) {
+				result = result.slice(0, -5);
+			}
+			return result;
+		};
+
+		/**
 		 * @param {Chunk} c the chunk
 		 * @param {ChunkFilenameTemplate} chunkFilename the filename template for the chunk
 		 * @returns {void}
@@ -255,9 +273,10 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				},
 				contentHashType: contentType
 			});
-			let set = staticUrls.get(staticChunkFilename);
+			const url = dropDeadConcatOperands(staticChunkFilename);
+			let set = staticUrls.get(url);
 			if (set === undefined) {
-				staticUrls.set(staticChunkFilename, (set = new Set()));
+				staticUrls.set(url, (set = new Set()));
 			}
 			set.add(c.id);
 		};
@@ -317,7 +336,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const mapExprWithLength = (fn) => (length) =>
 			`" + ${createMap((c) => `${fn(c)}`.slice(0, length))} + "`;
 
-		const url =
+		const dynamicUrl =
 			dynamicFilename &&
 			compilation.getPath(JSON.stringify(dynamicFilename), {
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
@@ -354,6 +373,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				},
 				contentHashType: contentType
 			});
+		const url = dynamicUrl && dropDeadConcatOperands(dynamicUrl);
 
 		const comment = `// This function allow to reference ${includedChunksMessages.join(
 			" and "

--- a/lib/runtime/GetWorkletBootstrapRuntimeModule.js
+++ b/lib/runtime/GetWorkletBootstrapRuntimeModule.js
@@ -48,8 +48,11 @@ class GetWorkletBootstrapRuntimeModule extends RuntimeModule {
 			Template.indent([
 				"var script = [",
 				Template.indent([
-					// worklet scopes have no `self`; chunks assume a worker-like scope
-					'"globalThis.self = globalThis.self || globalThis;",',
+					// worklet scopes have no `self`; chunks assume a worker-like scope.
+					// `||=` is newer than worklets themselves, so it stays gated.
+					`${JSON.stringify(
+						`${runtimeTemplate.assignOr("globalThis.self", "globalThis")};`
+					)},`,
 					// some runtime modules read `location`; forward the document base
 					'"globalThis.location = " + JSON.stringify(base) + ";"'
 				]),

--- a/lib/runtime/GlobalRuntimeModule.js
+++ b/lib/runtime/GlobalRuntimeModule.js
@@ -8,6 +8,8 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 
+/** @typedef {import("../Compilation")} Compilation */
+
 class GlobalRuntimeModule extends RuntimeModule {
 	constructor() {
 		super("global");
@@ -28,6 +30,12 @@ class GlobalRuntimeModule extends RuntimeModule {
 	 * @returns {string | null} runtime code
 	 */
 	generate() {
+		const compilation = /** @type {Compilation} */ (this.compilation);
+		// `environment.globalThis` promises the binding is there, so nothing has to
+		// be searched for.
+		if (compilation.outputOptions.environment.globalThis) {
+			return `${RuntimeGlobals.global} = globalThis;`;
+		}
 		return Template.asString([
 			`${RuntimeGlobals.global} = (function() {`,
 			Template.indent([

--- a/lib/runtime/MakeNamespaceObjectRuntimeModule.js
+++ b/lib/runtime/MakeNamespaceObjectRuntimeModule.js
@@ -33,14 +33,20 @@ class MakeNamespaceObjectRuntimeModule extends HelperRuntimeModule {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
 		const fn = RuntimeGlobals.makeNamespaceObject;
+		const toStringTag =
+			"Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });";
 		return Template.asString([
 			"// define __esModule on exports",
 			`${fn} = ${runtimeTemplate.basicFunction("exports", [
-				`if(${runtimeTemplate.supportsSymbol() ? "" : "typeof Symbol !== 'undefined' && "}Symbol.toStringTag) {`,
-				Template.indent([
-					"Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });"
-				]),
-				"}",
+				// `environment.symbol` promises the well-known symbols too, so only an
+				// environment without it needs the feature test around the tag.
+				...(runtimeTemplate.supportsSymbol()
+					? [toStringTag]
+					: [
+							"if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {",
+							Template.indent([toStringTag]),
+							"}"
+						]),
 				"Object.defineProperty(exports, '__esModule', { value: true });"
 			])};`
 		]);

--- a/lib/runtime/OnChunksLoadedRuntimeModule.js
+++ b/lib/runtime/OnChunksLoadedRuntimeModule.js
@@ -29,7 +29,7 @@ class OnChunksLoadedRuntimeModule extends RuntimeModule {
 				[
 					"if(chunkIds) {",
 					Template.indent([
-						"priority = priority || 0;",
+						`${runtimeTemplate.assignOr("priority", "0")};`,
 						"for(var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--) deferred[i] = deferred[i - 1];",
 						"deferred[i] = [chunkIds, fn, priority];",
 						"return;"

--- a/lib/runtime/OnChunksLoadedRuntimeModule.js
+++ b/lib/runtime/OnChunksLoadedRuntimeModule.js
@@ -45,7 +45,9 @@ class OnChunksLoadedRuntimeModule extends RuntimeModule {
 						`${runtimeTemplate.renderLet()} fulfilled = true;`,
 						"for (var j = 0; j < chunkIds.length; j++) {",
 						Template.indent([
-							`if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(${
+							// Parenthesized: `&` binds looser than `===`, so `priority & 1 === 0`
+							// is `priority & false` and gates every priority, not just the odd ones.
+							`if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(${
 								RuntimeGlobals.onChunksLoaded
 							}).every(${runtimeTemplate.returningFunction(
 								`${RuntimeGlobals.onChunksLoaded}[key](chunkIds[j])`,

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -175,8 +175,6 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 													)});`,
 													"promises.push(installedChunkData[2] = promise);",
 													"",
-													"// start chunk loading",
-													`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`,
 													"// create error before stack unwound to get useful stacktrace later",
 													`${cst} error = new Error();`,
 													`${cst} loadingEnded = ${runtimeTemplate.basicFunction(
@@ -204,7 +202,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 													)};`,
 													`${
 														RuntimeGlobals.loadScript
-													}(url, loadingEnded, "chunk-" + chunkId, chunkId${
+													}(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId), loadingEnded, "chunk-" + chunkId, chunkId${
 														withFetchPriority ? ", fetchPriority" : ""
 													});`
 												]),

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -260,10 +260,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 3184,
+			          "size": 3014,
 			        },
 			      ],
-			      "assetsSize": 3184,
+			      "assetsSize": 3014,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -309,10 +309,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 3184,
+			        "size": 3014,
 			      },
 			      "name": "entryB.js",
-			      "size": 3184,
+			      "size": 3014,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -260,10 +260,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 3320,
+			          "size": 3184,
 			        },
 			      ],
-			      "assetsSize": 3320,
+			      "assetsSize": 3184,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -309,10 +309,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 3320,
+			        "size": 3184,
 			      },
 			      "name": "entryB.js",
-			      "size": 3320,
+			      "size": 3184,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/configCases/contenthash/hash-placeholders/test.config.js
+++ b/test/configCases/contenthash/hash-placeholders/test.config.js
@@ -140,9 +140,8 @@ module.exports = {
 			// reachable filename it produces actually exists on disk.
 			const bundleContent = fs.readFileSync(path.join(dir, bundle), "utf8");
 
-			// Locate a chunk-URL helper for a property (`u` / `k`) and extension.
-			// Anchored on `chunkId` and the `".<ext>"` tail, so a concise arrow, a
-			// `return` block and the `function` form all match. `<expr>` is one of:
+			// Locate a chunk-URL helper (`u` / `k`), anchored on `chunkId` and the
+			// `".<ext>"` tail so arrow, `return` and `function` forms all match. `<expr>`:
 			//   a) per-chunk map: `{"async_js":"<h>","async_css":"<h>"}[chunkId]`
 			//   b) inlined literal: `"<h>"` (when only one chunk applies)
 			//   c) compilation-hash helper: `__webpack_require__.h()`

--- a/test/configCases/contenthash/hash-placeholders/test.config.js
+++ b/test/configCases/contenthash/hash-placeholders/test.config.js
@@ -140,15 +140,9 @@ module.exports = {
 			// reachable filename it produces actually exists on disk.
 			const bundleContent = fs.readFileSync(path.join(dir, bundle), "utf8");
 
-			// Locate a chunk-URL helper for a given property (`u` / `k`)
-			// and extension. Webpack emits the body as a concise arrow
-			//   `(chunkId) => ("<dir>/async." + chunkId + "." + <expr> + ".<ext>")`
-			// when nothing has to be branched on, as a block with a `return`
-			// when some chunks carry a static url, and as the equivalent
-			// `function (chunkId) { … }` form when `output.environment.arrowFunction`
-			// is false. We accept all three — the regex anchors on `chunkId` and
-			// the `".<ext>"` tail, not on the surrounding function syntax.
-			// `<expr>` is one of:
+			// Locate a chunk-URL helper for a property (`u` / `k`) and extension.
+			// Anchored on `chunkId` and the `".<ext>"` tail, so a concise arrow, a
+			// `return` block and the `function` form all match. `<expr>` is one of:
 			//   a) per-chunk map: `{"async_js":"<h>","async_css":"<h>"}[chunkId]`
 			//   b) inlined literal: `"<h>"` (when only one chunk applies)
 			//   c) compilation-hash helper: `__webpack_require__.h()`

--- a/test/configCases/contenthash/hash-placeholders/test.config.js
+++ b/test/configCases/contenthash/hash-placeholders/test.config.js
@@ -141,12 +141,14 @@ module.exports = {
 			const bundleContent = fs.readFileSync(path.join(dir, bundle), "utf8");
 
 			// Locate a chunk-URL helper for a given property (`u` / `k`)
-			// and extension. Webpack emits the body as either
-			//   `(chunkId) => { … return "<dir>/async." + chunkId + "." + <expr> + ".<ext>"; }`
-			// or, when `output.environment.arrowFunction` is false, the
-			// equivalent `function (chunkId) { … }` form. We accept either
-			// — the regex anchors on `chunkId` and the `".<ext>"` tail,
-			// not on the surrounding function syntax. `<expr>` is one of:
+			// and extension. Webpack emits the body as a concise arrow
+			//   `(chunkId) => ("<dir>/async." + chunkId + "." + <expr> + ".<ext>")`
+			// when nothing has to be branched on, as a block with a `return`
+			// when some chunks carry a static url, and as the equivalent
+			// `function (chunkId) { … }` form when `output.environment.arrowFunction`
+			// is false. We accept all three — the regex anchors on `chunkId` and
+			// the `".<ext>"` tail, not on the surrounding function syntax.
+			// `<expr>` is one of:
 			//   a) per-chunk map: `{"async_js":"<h>","async_css":"<h>"}[chunkId]`
 			//   b) inlined literal: `"<h>"` (when only one chunk applies)
 			//   c) compilation-hash helper: `__webpack_require__.h()`
@@ -155,7 +157,7 @@ module.exports = {
 			// be an arrow or function form returning the hash literal.
 			const extractChunkHashExpr = (prop, ext) => {
 				const re = new RegExp(
-					`\\.${prop}\\s*=\\s*(?:\\(\\s*chunkId\\s*\\)|function\\s*\\(\\s*chunkId\\s*\\))[\\s\\S]*?return\\s+"[^"]+"\\s*\\+\\s*chunkId\\s*\\+\\s*"\\."\\s*\\+\\s*([\\s\\S]*?)\\s*\\+\\s*"\\.${ext}";`
+					`\\.${prop}\\s*=\\s*(?:\\(\\s*chunkId\\s*\\)|function\\s*\\(\\s*chunkId\\s*\\))[\\s\\S]*?(?:return|=>)\\s*\\(?\\s*"[^"]+"\\s*\\+\\s*chunkId\\s*\\+\\s*"\\."\\s*\\+\\s*([\\s\\S]*?)\\s*\\+\\s*"\\.${ext}"\\)?;`
 				);
 				const m = bundleContent.match(re);
 				return m ? m[1] : null;

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
@@ -69,7 +69,7 @@ exports[`ConfigCacheTestCases html inline-script-classic exported tests should e
 /******/ 				let [chunkIds, fn, priority] = deferred[i];
 /******/ 				let fulfilled = true;
 /******/ 				for (var j = 0; j < chunkIds.length; j++) {
-/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 					if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
 /******/ 						chunkIds.splice(j--, 1);
 /******/ 					} else {
 /******/ 						fulfilled = false;

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
@@ -69,7 +69,7 @@ exports[`ConfigTestCases html inline-script-classic exported tests should emit c
 /******/ 				let [chunkIds, fn, priority] = deferred[i];
 /******/ 				let fulfilled = true;
 /******/ 				for (var j = 0; j < chunkIds.length; j++) {
-/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 					if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
 /******/ 						chunkIds.splice(j--, 1);
 /******/ 					} else {
 /******/ 						fulfilled = false;

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -72,13 +72,8 @@ globalThis.__preloadLoaded = true;
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -72,13 +72,8 @@ globalThis.__preloadLoaded = true;
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
@@ -80,7 +80,7 @@ module.exports = \\"first entry\\";
 /******/ 				let [chunkIds, fn, priority] = deferred[i];
 /******/ 				let fulfilled = true;
 /******/ 				for (var j = 0; j < chunkIds.length; j++) {
-/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 					if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
 /******/ 						chunkIds.splice(j--, 1);
 /******/ 					} else {
 /******/ 						fulfilled = false;

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
@@ -80,7 +80,7 @@ module.exports = \\"first entry\\";
 /******/ 				let [chunkIds, fn, priority] = deferred[i];
 /******/ 				let fulfilled = true;
 /******/ 				for (var j = 0; j < chunkIds.length; j++) {
-/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 					if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
 /******/ 						chunkIds.splice(j--, 1);
 /******/ 					} else {
 /******/ 						fulfilled = false;

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -79,13 +79,8 @@ globalThis.__moduleA = moduleA;
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -124,7 +124,7 @@ globalThis.__moduleA = moduleA;
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}
@@ -257,7 +257,7 @@ exports[`ConfigCacheTestCases html script-src-mixed exported tests should chain 
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -79,13 +79,8 @@ globalThis.__moduleA = moduleA;
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -124,7 +124,7 @@ globalThis.__moduleA = moduleA;
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}
@@ -257,7 +257,7 @@ exports[`ConfigTestCases html script-src-mixed exported tests should chain multi
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}

--- a/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
@@ -94,7 +94,7 @@ module.exports = \\"first entry\\";
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}

--- a/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
@@ -94,7 +94,7 @@ module.exports = \\"first entry\\";
 /******/ 			if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
 /******/ 				installedChunks[chunkId][0]();
 /******/ 			}
-/******/ 			installedChunks[__webpack_esm_ids__[i]] = 0;
+/******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 	
 /******/ 	}

--- a/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigCacheTest.snap
@@ -150,13 +150,8 @@ module.exports = x({  });
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {
@@ -368,13 +363,8 @@ module.exports = x({  });
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {
@@ -586,13 +576,8 @@ module.exports = x({  });
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {
@@ -804,13 +789,8 @@ module.exports = x({  });
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigTest.snap
+++ b/test/configCases/library/modern-module-named-import-externals/__snapshots__/ConfigTest.snap
@@ -150,13 +150,8 @@ module.exports = x({  });
 /******/ 		while(i < definition.length) {
 /******/ 			var key = definition[i++];
 /******/ 			var binding = definition[i++];
-/******/ 			if(!__webpack_require__.o(exports, key)) {
-/******/ 				if(binding === 0) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 				} else {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 				}
-/******/ 			} else if(binding === 0) { i++; }
+/******/ 			var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 			if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 		}
 /******/ 	} else {
 /******/ 		for(var key in definition) {

--- a/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigCacheTest.snap
@@ -432,13 +432,8 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 			while(i < definition.length) {
 /******/ 				var key = definition[i++];
 /******/ 				var binding = definition[i++];
-/******/ 				if(!__webpack_require__.o(exports, key)) {
-/******/ 					if(binding === 0) {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 					} else {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 					}
-/******/ 				} else if(binding === 0) { i++; }
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 			}
 /******/ 		} else {
 /******/ 			for(var key in definition) {
@@ -455,9 +450,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = (exports) => {
-/******/ 		if(Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 	};
 /******/ 	
@@ -1125,13 +1118,8 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 			while(i < definition.length) {
 /******/ 				var key = definition[i++];
 /******/ 				var binding = definition[i++];
-/******/ 				if(!__webpack_require__.o(exports, key)) {
-/******/ 					if(binding === 0) {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 					} else {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 					}
-/******/ 				} else if(binding === 0) { i++; }
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 			}
 /******/ 		} else {
 /******/ 			for(var key in definition) {
@@ -1148,9 +1136,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = (exports) => {
-/******/ 		if(Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 	};
 /******/ 	
@@ -1818,13 +1804,8 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 			while(i < definition.length) {
 /******/ 				var key = definition[i++];
 /******/ 				var binding = definition[i++];
-/******/ 				if(!__webpack_require__.o(exports, key)) {
-/******/ 					if(binding === 0) {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 					} else {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 					}
-/******/ 				} else if(binding === 0) { i++; }
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 			}
 /******/ 		} else {
 /******/ 			for(var key in definition) {
@@ -1841,9 +1822,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = (exports) => {
-/******/ 		if(Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 	};
 /******/ 	
@@ -2511,13 +2490,8 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 			while(i < definition.length) {
 /******/ 				var key = definition[i++];
 /******/ 				var binding = definition[i++];
-/******/ 				if(!__webpack_require__.o(exports, key)) {
-/******/ 					if(binding === 0) {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 					} else {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 					}
-/******/ 				} else if(binding === 0) { i++; }
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 			}
 /******/ 		} else {
 /******/ 			for(var key in definition) {
@@ -2534,9 +2508,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = (exports) => {
-/******/ 		if(Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 	};
 /******/ 	

--- a/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigTest.snap
+++ b/test/configCases/optimization/static-export-bindings/__snapshots__/ConfigTest.snap
@@ -432,13 +432,8 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 			while(i < definition.length) {
 /******/ 				var key = definition[i++];
 /******/ 				var binding = definition[i++];
-/******/ 				if(!__webpack_require__.o(exports, key)) {
-/******/ 					if(binding === 0) {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
-/******/ 					} else {
-/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: binding });
-/******/ 					}
-/******/ 				} else if(binding === 0) { i++; }
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
 /******/ 			}
 /******/ 		} else {
 /******/ 			for(var key in definition) {
@@ -455,9 +450,7 @@ __webpack_require__.r(__webpack_exports__);
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = (exports) => {
-/******/ 		if(Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 	};
 /******/ 	

--- a/test/configCases/runtime/define-property-getters-no-value-binding/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases runtime define-property-getters-no-value-binding exported tests should drop the array branch of __webpack_require__.d 1`] = `
+Array [
+  "	__webpack_require__.d = (exports, definition) => {",
+  "		for(var key in definition) {",
+  "			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {",
+  "				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });",
+  "			}",
+  "		}",
+  "	};",
+]
+`;

--- a/test/configCases/runtime/define-property-getters-no-value-binding/__snapshots__/ConfigTest.snap
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/__snapshots__/ConfigTest.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases runtime define-property-getters-no-value-binding exported tests should drop the array branch of __webpack_require__.d 1`] = `
+Array [
+  "	__webpack_require__.d = (exports, definition) => {",
+  "		for(var key in definition) {",
+  "			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {",
+  "				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });",
+  "			}",
+  "		}",
+  "	};",
+]
+`;

--- a/test/configCases/runtime/define-property-getters-no-value-binding/dep.js
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/dep.js
@@ -1,0 +1,6 @@
+export function make() {
+	return Math.min(1, 2);
+}
+
+export let counter = 0;
+counter++;

--- a/test/configCases/runtime/define-property-getters-no-value-binding/index.js
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/index.js
@@ -1,0 +1,27 @@
+import { make, counter } from "./dep";
+
+const fs = __non_webpack_require__("fs");
+
+it("should read the mutable bindings back", () => {
+	expect(make() + counter).toBe(2);
+});
+
+it("should drop the array branch of __webpack_require__.d", () => {
+	expect(runtimeBody()).toMatchSnapshot();
+});
+
+// The whole `__webpack_require__.d` body, so which branches it carries is
+// reviewed as one diff rather than pinned by a substring.
+function runtimeBody() {
+	const lines = fs
+		.readFileSync(__filename, "utf-8")
+		.split("\n")
+		.map(line => line.replace(/^\/\*+\/\s?/, "").trimEnd());
+	const start = lines.findIndex(line =>
+		line.trim().startsWith("__webpack_require__.d = ")
+	);
+	const end = lines.findIndex(
+		(line, i) => i > start && line.trim() === "};"
+	);
+	return lines.slice(start, end + 1);
+}

--- a/test/configCases/runtime/define-property-getters-no-value-binding/webpack.config.js
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/webpack.config.js
@@ -2,9 +2,8 @@
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	// Production: the const-value optimization that feeds a value binding only
-	// runs there. Minifying would rewrite the runtime the test reads, and
-	// dropping unused exports would remove the `__webpack_require__.d` call.
+	// Production: only there does the const-value optimization feed a value
+	// binding. No minify or tree-shake: both rewrite what the test reads.
 	mode: "production",
 	devtool: false,
 	// Keep the real `__filename` so the test can read its own bundle.

--- a/test/configCases/runtime/define-property-getters-no-value-binding/webpack.config.js
+++ b/test/configCases/runtime/define-property-getters-no-value-binding/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// Production: the const-value optimization that feeds a value binding only
+	// runs there. Minifying would rewrite the runtime the test reads, and
+	// dropping unused exports would remove the `__webpack_require__.d` call.
+	mode: "production",
+	devtool: false,
+	// Keep the real `__filename` so the test can read its own bundle.
+	node: { __dirname: false, __filename: false },
+	optimization: {
+		minimize: false,
+		concatenateModules: false,
+		usedExports: false
+	}
+};

--- a/test/configCases/runtime/define-property-getters-value-binding/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/runtime/define-property-getters-value-binding/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases runtime define-property-getters-value-binding exported tests should keep the array branch of __webpack_require__.d 1`] = `
+Array [
+  "	__webpack_require__.d = (exports, definition) => {",
+  "		if(Array.isArray(definition)) {",
+  "			var i = 0;",
+  "			while(i < definition.length) {",
+  "				var key = definition[i++];",
+  "				var binding = definition[i++];",
+  "				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };",
+  "				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);",
+  "			}",
+  "		} else {",
+  "			for(var key in definition) {",
+  "				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {",
+  "					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });",
+  "				}",
+  "			}",
+  "		}",
+  "	};",
+]
+`;

--- a/test/configCases/runtime/define-property-getters-value-binding/__snapshots__/ConfigTest.snap
+++ b/test/configCases/runtime/define-property-getters-value-binding/__snapshots__/ConfigTest.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases runtime define-property-getters-value-binding exported tests should keep the array branch of __webpack_require__.d 1`] = `
+Array [
+  "	__webpack_require__.d = (exports, definition) => {",
+  "		if(Array.isArray(definition)) {",
+  "			var i = 0;",
+  "			while(i < definition.length) {",
+  "				var key = definition[i++];",
+  "				var binding = definition[i++];",
+  "				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };",
+  "				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);",
+  "			}",
+  "		} else {",
+  "			for(var key in definition) {",
+  "				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {",
+  "					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });",
+  "				}",
+  "			}",
+  "		}",
+  "	};",
+]
+`;

--- a/test/configCases/runtime/define-property-getters-value-binding/dep.js
+++ b/test/configCases/runtime/define-property-getters-value-binding/dep.js
@@ -1,0 +1,1 @@
+export const N = 42;

--- a/test/configCases/runtime/define-property-getters-value-binding/index.js
+++ b/test/configCases/runtime/define-property-getters-value-binding/index.js
@@ -1,0 +1,27 @@
+import { N } from "./dep";
+
+const fs = __non_webpack_require__("fs");
+
+it("should read the value binding back", () => {
+	expect(N).toBe(42);
+});
+
+it("should keep the array branch of __webpack_require__.d", () => {
+	expect(runtimeBody()).toMatchSnapshot();
+});
+
+// The whole `__webpack_require__.d` body, so which branches it carries is
+// reviewed as one diff rather than pinned by a substring.
+function runtimeBody() {
+	const lines = fs
+		.readFileSync(__filename, "utf-8")
+		.split("\n")
+		.map(line => line.replace(/^\/\*+\/\s?/, "").trimEnd());
+	const start = lines.findIndex(line =>
+		line.trim().startsWith("__webpack_require__.d = ")
+	);
+	const end = lines.findIndex(
+		(line, i) => i > start && line.trim() === "};"
+	);
+	return lines.slice(start, end + 1);
+}

--- a/test/configCases/runtime/define-property-getters-value-binding/webpack.config.js
+++ b/test/configCases/runtime/define-property-getters-value-binding/webpack.config.js
@@ -2,9 +2,8 @@
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	// Production: the const-value optimization that feeds a value binding only
-	// runs there. Minifying would rewrite the runtime the test reads, and
-	// dropping unused exports would remove the `__webpack_require__.d` call.
+	// Production: only there does the const-value optimization feed a value
+	// binding. No minify or tree-shake: both rewrite what the test reads.
 	mode: "production",
 	devtool: false,
 	// Keep the real `__filename` so the test can read its own bundle.

--- a/test/configCases/runtime/define-property-getters-value-binding/webpack.config.js
+++ b/test/configCases/runtime/define-property-getters-value-binding/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// Production: the const-value optimization that feeds a value binding only
+	// runs there. Minifying would rewrite the runtime the test reads, and
+	// dropping unused exports would remove the `__webpack_require__.d` call.
+	mode: "production",
+	devtool: false,
+	// Keep the real `__filename` so the test can read its own bundle.
+	node: { __dirname: false, __filename: false },
+	optimization: {
+		minimize: false,
+		concatenateModules: false,
+		usedExports: false
+	}
+};

--- a/test/configCases/runtime/make-namespace-object-no-symbol/esm.js
+++ b/test/configCases/runtime/make-namespace-object-no-symbol/esm.js
@@ -1,0 +1,2 @@
+export const value = 1;
+export default 2;

--- a/test/configCases/runtime/make-namespace-object-no-symbol/index.js
+++ b/test/configCases/runtime/make-namespace-object-no-symbol/index.js
@@ -1,0 +1,9 @@
+// `require`ing an ESM module reads `__esModule`, which is what emits
+// `__webpack_require__.r`.
+const ns = require("./esm");
+
+it("should mark the namespace without relying on Symbol", () => {
+	expect(ns.__esModule).toBe(true);
+	expect(ns.value).toBe(1);
+	expect(ns.default).toBe(2);
+});

--- a/test/configCases/runtime/make-namespace-object-no-symbol/webpack.config.js
+++ b/test/configCases/runtime/make-namespace-object-no-symbol/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: {
+		// no `Symbol`, so `__webpack_require__.r` has to feature-test the tag
+		environment: { symbol: false }
+	}
+};

--- a/test/configCases/runtime/on-chunks-loaded-priority/DeferredPriorityRuntimeModule.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/DeferredPriorityRuntimeModule.js
@@ -3,10 +3,8 @@
 const RuntimeGlobals = require("../../../../lib/RuntimeGlobals");
 const RuntimeModule = require("../../../../lib/RuntimeModule");
 
-// Registers two `__webpack_require__.O` handlers the way a plugin would: one at
-// priority 0 waiting on a chunk that never loads, one at an even priority whose
-// chunk is already there. Per the documented contract only an odd priority waits
-// for lower priorities, so the even one must run while the other stays deferred.
+// Only an odd priority waits for lower ones, so the even handler must run while
+// the blocked priority-0 one stays deferred.
 class DeferredPriorityRuntimeModule extends RuntimeModule {
 	constructor() {
 		super("deferred priority probe", RuntimeModule.STAGE_TRIGGER);

--- a/test/configCases/runtime/on-chunks-loaded-priority/DeferredPriorityRuntimeModule.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/DeferredPriorityRuntimeModule.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const RuntimeGlobals = require("../../../../lib/RuntimeGlobals");
+const RuntimeModule = require("../../../../lib/RuntimeModule");
+
+// Registers two `__webpack_require__.O` handlers the way a plugin would: one at
+// priority 0 waiting on a chunk that never loads, one at an even priority whose
+// chunk is already there. Per the documented contract only an odd priority waits
+// for lower priorities, so the even one must run while the other stays deferred.
+class DeferredPriorityRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("deferred priority probe", RuntimeModule.STAGE_TRIGGER);
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const chunk = /** @type {import("../../../../lib/Chunk")} */ (this.chunk);
+		const order = `${RuntimeGlobals.global}.__onChunksLoadedOrder`;
+		return [
+			`${order} = [];`,
+			`${RuntimeGlobals.onChunksLoaded}(0, ["__never_loaded__"], function() { ${order}.push("blocked"); }, 0);`,
+			`${RuntimeGlobals.onChunksLoaded}(0, [${JSON.stringify(
+				chunk.id
+			)}], function() { ${order}.push("even"); }, 2);`
+		].join("\n");
+	}
+}
+
+module.exports = DeferredPriorityRuntimeModule;

--- a/test/configCases/runtime/on-chunks-loaded-priority/index.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/index.js
@@ -1,6 +1,5 @@
-// Never taken. The `import()` is here so the build carries the jsonp chunk
-// loading runtime, which is what registers the `__webpack_require__.O` handler
-// the deferred queue consults — with no handler every chunk counts as loaded.
+// Never taken: the `import()` only pulls in the jsonp runtime, whose handler the
+// deferred queue consults — with none, every chunk counts as loaded.
 if (global.__neverLoaded) import("./lazy");
 
 it("should run an even-priority deferred handler without waiting for a blocked lower-priority one", () => {

--- a/test/configCases/runtime/on-chunks-loaded-priority/index.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/index.js
@@ -1,0 +1,8 @@
+// Never taken. The `import()` is here so the build carries the jsonp chunk
+// loading runtime, which is what registers the `__webpack_require__.O` handler
+// the deferred queue consults — with no handler every chunk counts as loaded.
+if (global.__neverLoaded) import("./lazy");
+
+it("should run an even-priority deferred handler without waiting for a blocked lower-priority one", () => {
+	expect(global.__onChunksLoadedOrder).toEqual(["even"]);
+});

--- a/test/configCases/runtime/on-chunks-loaded-priority/lazy.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/lazy.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/runtime/on-chunks-loaded-priority/webpack.config.js
+++ b/test/configCases/runtime/on-chunks-loaded-priority/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const RuntimeGlobals = require("../../../../lib/RuntimeGlobals");
+
+const PLUGIN_NAME = "OnChunksLoadedPriorityTestPlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						PLUGIN_NAME,
+						(chunk, set) => {
+							set.add(RuntimeGlobals.global);
+							set.add(RuntimeGlobals.onChunksLoaded);
+							compilation.addLazyRuntimeModule(
+								chunk,
+								() =>
+									Promise.resolve(require("./DeferredPriorityRuntimeModule")),
+								(DeferredPriorityRuntimeModule) =>
+									new DeferredPriorityRuntimeModule()
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/worker/this-in-worker-entry-global-this/index.js
+++ b/test/configCases/worker/this-in-worker-entry-global-this/index.js
@@ -1,0 +1,9 @@
+it("should reach a worker entry's global scope as globalThis", async () => {
+	const worker = new Worker(new URL("./worker.js", import.meta.url));
+	worker.postMessage("hello");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => resolve(event.data);
+	});
+	expect(result).toBe("got hello:defined:globalThis");
+	await worker.terminate();
+});

--- a/test/configCases/worker/this-in-worker-entry-global-this/test.config.js
+++ b/test/configCases/worker/this-in-worker-entry-global-this/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/this-in-worker-entry-global-this/test.filter.js
+++ b/test/configCases/worker/this-in-worker-entry-global-this/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/this-in-worker-entry-global-this/webpack.config.js
+++ b/test/configCases/worker/this-in-worker-entry-global-this/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: {
+		filename: "[name].js",
+		// the global scope is reached as `globalThis` instead of through the polyfill
+		environment: { globalThis: true }
+	}
+};

--- a/test/configCases/worker/this-in-worker-entry-global-this/worker.js
+++ b/test/configCases/worker/this-in-worker-entry-global-this/worker.js
@@ -1,0 +1,7 @@
+// a classic worker script's top-level `this` is its global scope
+Object.defineProperty(this, "marker", { value: "defined" });
+this.onmessage = (event) => {
+	this.postMessage(
+		`got ${event.data}:${this.marker}:${this === globalThis ? "globalThis" : "other"}`
+	);
+};

--- a/test/statsCases/chunk-module-id-range/__snapshots__/StatsTest.snap
+++ b/test/statsCases/chunk-module-id-range/__snapshots__/StatsTest.snap
@@ -6,18 +6,18 @@ asset main1.js X KiB [emitted] (name: main1)
 asset main2.js X KiB [emitted] (name: main2)
 Entrypoint main1 X KiB = main1.js
 Entrypoint main2 X KiB = main2.js
-chunk (runtime: main1) main1.js (main1) X bytes (javascript) X KiB (runtime) [entry] [rendered]
+chunk (runtime: main1) main1.js (main1) X bytes (javascript) X bytes (runtime) [entry] [rendered]
   > ./main1 main1
-  runtime modules X KiB 3 modules
+  runtime modules X bytes 3 modules
   cacheable modules X bytes
     ./a.js X bytes [dependent] [built] [code generated]
     ./b.js X bytes [dependent] [built] [code generated]
     ./c.js X bytes [dependent] [built] [code generated]
     ./d.js X bytes [dependent] [built] [code generated]
     ./main1.js X bytes [built] [code generated]
-chunk (runtime: main2) main2.js (main2) X bytes (javascript) X KiB (runtime) [entry] [rendered]
+chunk (runtime: main2) main2.js (main2) X bytes (javascript) X bytes (runtime) [entry] [rendered]
   > ./main2 main2
-  runtime modules X KiB 3 modules
+  runtime modules X bytes 3 modules
   cacheable modules X bytes
     ./a.js X bytes [dependent] [built] [code generated]
     ./d.js X bytes [dependent] [built] [code generated]

--- a/test/statsCases/split-chunks-max-size/__snapshots__/StatsTest.snap
+++ b/test/statsCases/split-chunks-max-size/__snapshots__/StatsTest.snap
@@ -400,10 +400,10 @@ enforce-min-size:
 
 only-async:
   Entrypoint main X KiB = only-async-main.js
-  chunk (runtime: main) only-async-main.js (main) X KiB (javascript) X KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) only-async-main.js (main) X KiB (javascript) X bytes (runtime) [entry] [rendered]
     > ./ main
     dependent modules X KiB [dependent] 44 modules
-    runtime modules X KiB 3 modules
+    runtime modules X bytes 3 modules
     ./index.js X KiB [built] [code generated]
   only-async (webpack x.x.x) compiled successfully"
 `;

--- a/test/statsCases/tree-shaking/__snapshots__/StatsTest.snap
+++ b/test/statsCases/tree-shaking/__snapshots__/StatsTest.snap
@@ -2,7 +2,7 @@
 
 exports[`StatsTestCases tree-shaking should print correct stats for tree-shaking 1`] = `
 "asset bundle.js X KiB [emitted] (name: main)
-runtime modules X KiB 3 modules
+runtime modules X bytes 3 modules
 orphan modules X bytes [orphan] 1 module
 cacheable modules X bytes
   ./index.js X bytes [built] [code generated] [1 warning]

--- a/types.d.ts
+++ b/types.d.ts
@@ -25198,9 +25198,8 @@ declare abstract class RuntimeTemplate {
 	getBuiltinModule(request: string, access?: string): string;
 
 	/**
-	 * Renders a `then` callback calling `fn` with `args`. An arrow is shorter than
-	 * the bound form and gives `fn` the same `this` a method call would, which is
-	 * what `__webpack_require__.t` reads; without arrows the bound form is shorter.
+	 * Renders a `then` callback calling `fn` with `args`. An arrow keeps the `this`
+	 * a method call gives; the bound form is shorter without arrows.
 	 */
 	deferredCall(fn: string, args: string): string;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -25198,6 +25198,13 @@ declare abstract class RuntimeTemplate {
 	getBuiltinModule(request: string, access?: string): string;
 
 	/**
+	 * Renders a `then` callback calling `fn` with `args`. An arrow is shorter than
+	 * the bound form and gives `fn` the same `this` a method call would, which is
+	 * what `__webpack_require__.t` reads; without arrows the bound form is shorter.
+	 */
+	deferredCall(fn: string, args: string): string;
+
+	/**
 	 * Renders an object-literal method, using method shorthand when supported
 	 * and falling back to a `prop: function/arrow` property otherwise.
 	 */

--- a/types.d.ts
+++ b/types.d.ts
@@ -29644,6 +29644,7 @@ declare namespace exports {
 		export let deferredModuleAsyncTransitiveDependencies: "__webpack_require__.zT";
 		export let deferredModuleAsyncTransitiveDependenciesSymbol: "__webpack_require__.zS";
 		export let definePropertyGetters: "__webpack_require__.d";
+		export let definePropertyGettersFromArray: "__webpack_require__.d (array)";
 		export let ensureChunk: "__webpack_require__.e";
 		export let ensureChunkHandlers: "__webpack_require__.f";
 		export let ensureChunkIncludeEntries: "__webpack_require__.f (include entries)";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The runtime helpers and the per-`import()` code ship in every bundle, so constant factors there are paid by every user. This trims them where an `output.environment` flag already promises what the emitted code re-checks, where the ES5 baseline the surrounding code needs makes a fallback dead, or where a value was bound only to be read once:

- `moduleNamespacePromise` renders `() => (__webpack_require__(id))` rather than binding `__webpack_require__`; the bound form stays where arrows are unavailable, being shorter there.
- `__webpack_require__.r` drops the `Symbol.toStringTag` feature test when `output.environment.symbol` is set — the option promises the well-known symbols too.
- `__webpack_require__.g` is `globalThis` when `output.environment.globalThis` is set.
- `__webpack_require__.t` reads `Object.getPrototypeOf` directly; its `__proto__` fallback is dead beside the `Object.create` two lines down.
- `__webpack_require__.d` builds one descriptor instead of repeating `Object.defineProperty` per branch, `__webpack_require__.u` is a concise arrow when no chunk carries a static url, the jsonp loader passes the chunk url straight to `__webpack_require__.l`, the ESM installer reuses the `chunkId` it already read, and auto-`publicPath` strips the `blob:` prefix and the query/fragment in one pass.

It also fixes `__webpack_require__.O`: `priority & 1 === 0` parses as `priority & (1 === 0)`, so *every* deferred handler waited for lower priorities to run first, where `RuntimeGlobals` documents only an odd priority as waiting. Webpack's own output is unaffected — it emits priority 0 (entry startup) and 5 (startup prefetch) only, and both readings agree there — so this surfaces for a plugin registering an even, non-zero priority.

`yarn test:size` over `test/configCases`, against a baseline built from this PR's merge base: 2082 assets change, **-24.46 KiB gzip / -208.79 KiB raw**; 1917 assets smaller, 104 larger by at most 7 bytes of compressor alignment. Error counts (486) and the runtime module set of every runtime are unchanged.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/runtime/on-chunks-loaded-priority` (registers an even, non-zero priority behind a blocked one; fails on the unfixed `__webpack_require__.O`) and `test/configCases/worker/this-in-worker-entry-global-this` (covers the new `globalThis` branch of `__webpack_require__.g`). The existing `contenthash/hash-placeholders` case had its helper regexp widened to accept the concise-arrow form of `__webpack_require__.u`, which it already intended to.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no option or public API changes.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes, Claude Code. It inventoried the runtime modules across eight target configurations, measured every candidate with terser + gzip and with `yarn test:size` against a baseline built from the merge base, wrote the changes and the config cases, and ran lint and the test suites. Each change is backed by a measurement rather than by inspection; two candidates were reverted when the measurement contradicted them — replacing `x => {}` with `() => {}` (a minifier keeps the parameter, so it was a byte longer), and reaching the global by `typeof` instead of `__webpack_require__.g` (`typeof` resolves lexically-scoped bindings, which a config case caught).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFhfHod2WzUTqFTwkTbiUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced generated runtime code and simplified output when supported by the target environment.
  * Avoided unnecessary branching and repeated lookups in chunk loading and URL generation.

* **Bug Fixes**
  * Corrected chunk-loading priority handling so eligible handlers run without waiting.
  * Improved public-path detection and export getter handling.
  * Enhanced compatibility with worker globals and environments without `Symbol`.

* **Tests**
  * Added coverage for deferred priorities, worker `globalThis`, namespace exports, generated chunk URL formats, and export bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->