### PR TITLE
perf: reuse the asset when no new baked name move

### DIFF
--- a/lib/esm/AnalyzableChunkHashPlugin.js
+++ b/lib/esm/AnalyzableChunkHashPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { ReplaceSource } = require("webpack-sources");
+const { CachedSource, ReplaceSource } = require("webpack-sources");
 const Compilation = require("../Compilation");
 const { getUndoPath } = require("../util/identifier");
 const memoize = require("../util/memoize");
@@ -17,6 +17,7 @@ const memoize = require("../util/memoize");
  * 	OutputNormalizedWithDefaults as OutputOptions
  * } from "../config/defaults"
  */
+/** @import { Source } from "webpack-sources" */
 
 const getJavascriptModulesPlugin = memoize(() =>
 	require("../javascript/JavascriptModulesPlugin")
@@ -164,6 +165,11 @@ const readSpecifier = (payload) => {
 	return decoded;
 };
 
+/**
+ * first character, last character, replacement.
+ * @typedef {[number, number, string]} Replacement
+ */
+
 const PLUGIN_NAME = "AnalyzableChunkHashPlugin";
 
 // More than one plugin reserves stand-ins, and each has to bring the pass that fills
@@ -188,7 +194,8 @@ class AnalyzableChunkHashPlugin {
 		if (appliedTo.has(compiler)) return;
 		appliedTo.add(compiler);
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
-			compilation.hooks.processAssets.tap(
+			const cache = compilation.getCache(PLUGIN_NAME);
+			compilation.hooks.processAssets.tapPromise(
 				{
 					name: PLUGIN_NAME,
 					// Before source maps are written and before a minifier runs: both read
@@ -198,7 +205,7 @@ class AnalyzableChunkHashPlugin {
 					// the names afterwards.
 					stage: Compilation.PROCESS_ASSETS_STAGE_DERIVED
 				},
-				() => {
+				async () => {
 					const { outputOptions } = compilation;
 					const fullHash = compilation.hash;
 					/** @type {Map<string, Chunk> | undefined} */
@@ -293,8 +300,12 @@ class AnalyzableChunkHashPlugin {
 								: `./${specifier}`
 						);
 					};
+					/** @type {{ name: string, source: Source, replacements: Replacement[] }[]} */
+					const tasks = [];
+
 					for (const name of Object.keys(compilation.assets)) {
-						const content = compilation.assets[name].source();
+						const source = compilation.assets[name];
+						const content = source.source();
 						if (typeof content !== "string") continue;
 						TOKEN_REGEXP.lastIndex = 0;
 						FULL_HASH_TOKEN_REGEXP.lastIndex = 0;
@@ -302,43 +313,62 @@ class AnalyzableChunkHashPlugin {
 						const hasFullHashToken =
 							fullHash !== undefined && FULL_HASH_TOKEN_REGEXP.test(content);
 						if (!hasChunkToken && !hasFullHashToken) continue;
-						// Replaced in place rather than rebuilt from a string: a stand-in and
-						// the name filling it in are different lengths, so everything after it
-						// shifts and the asset's existing mappings have to move with it.
-						const replaced = new ReplaceSource(compilation.assets[name]);
+						/** @type {Replacement[]} */
+						const replacements = [];
 						/**
-						 * @param {RegExp} source what to look for
+						 * @param {RegExp} pattern what to look for
 						 * @param {(match: string, group: string) => string | null} fill what to put there
 						 * @returns {void}
 						 */
-						const replaceAll = (source, fill) => {
+						const collect = (pattern, fill) => {
 							// Its own instance: `fill` may run the shared one over what it
 							// returns, and a `replace` there would rewind this scan.
-							const regexp = new RegExp(source.source, source.flags);
+							const regexp = new RegExp(pattern.source, pattern.flags);
 							/** @type {RegExpExecArray | null} */
 							let match;
 							while ((match = regexp.exec(content)) !== null) {
 								const value = fill(match[0], match[1]);
 								if (value === null) continue;
-								replaced.replace(
+								replacements.push([
 									match.index,
 									match.index + match[0].length - 1,
 									value
-								);
+								]);
 							}
 						};
 						if (hasChunkToken) {
-							replaceAll(TOKEN_REGEXP, (_match, payload) =>
+							collect(TOKEN_REGEXP, (_match, payload) =>
 								resolve(payload, name)
 							);
 						}
 						if (hasFullHashToken) {
-							replaceAll(FULL_HASH_TOKEN_REGEXP, (match) =>
-								fillFullHash(match)
-							);
+							collect(FULL_HASH_TOKEN_REGEXP, (match) => fillFullHash(match));
 						}
-						compilation.updateAsset(name, replaced);
+						if (replacements.length === 0) continue;
+
+						tasks.push({ name, source, replacements });
 					}
+					if (tasks.length === 0) return;
+
+					await Promise.all(
+						tasks.map(async ({ name, source, replacements }) => {
+							const replaced = await cache.providePromise(
+								name,
+								cache.mergeEtags(
+									cache.getLazyHashedEtag(source),
+									JSON.stringify(replacements)
+								),
+								() => {
+									const replacedSource = new ReplaceSource(source);
+									for (const [start, end, value] of replacements) {
+										replacedSource.replace(start, end, value);
+									}
+									return new CachedSource(replacedSource);
+								}
+							);
+							compilation.updateAsset(name, replaced);
+						})
+					);
 				}
 			);
 		});

--- a/test/configCases/analyzable/stand-in-lookalike/index.js
+++ b/test/configCases/analyzable/stand-in-lookalike/index.js
@@ -18,3 +18,16 @@ it("should leave a stand-in it cannot read exactly as written", () => {
 		expect([name, bundle.includes(text)]).toEqual([name, true]);
 	}
 });
+
+it("should leave an asset alone when it can read none of its stand-ins", async () => {
+	const { unreadable } = await load();
+	const lazyName = __STATS__.assets.find((asset) =>
+		/^lazy\./.test(asset.name)
+	).name;
+	const chunk = fs.readFileSync(
+		path.join(__STATS__.outputPath, lazyName),
+		"utf8"
+	);
+
+	expect(chunk).toContain(unreadable);
+});

--- a/test/configCases/analyzable/stand-in-lookalike/lazy.js
+++ b/test/configCases/analyzable/stand-in-lookalike/lazy.js
@@ -1,1 +1,4 @@
+// The only stand-in in this chunk, and nothing can read it, so the pass has nothing to
+// replace here and leaves the asset it found alone.
+export const unreadable = "./@@webpackAnalyzableChunk:qqqq@@";
 export const value = "lazy";

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/index.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/index.js
@@ -1,0 +1,24 @@
+const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+const EXPECTED_VALUE = { 0: "zero", 1: "one", 2: "one" };
+
+it("should reach the deferred chunk that exists now", async () => {
+	const lazy = STATS_JSON.assets.find((asset) => /^lazy\./.test(asset.name));
+	expect(lazy).toBeDefined();
+	expect((await load()).value).toBe(EXPECTED_VALUE[WATCH_STEP]);
+	if (WATCH_STEP === "1") expect(lazy.name).not.toBe(STATE.lazyName);
+	if (WATCH_STEP === "2") {
+		expect(lazy.name).toBe(STATE.lazyName);
+		delete STATE.lazyName;
+	} else {
+		STATE.lazyName = lazy.name;
+	}
+});
+
+it("should write the parent again only when the name it bakes moves", () => {
+	const bundle = STATS_JSON.assets.find((asset) => asset.name === "bundle.mjs");
+	expect(bundle).toBeDefined();
+	// Step 2 touches the other entry alone, so this one keeps the very source it
+	// emitted last time and is not written out again.
+	expect(bundle.emitted).toBe(WATCH_STEP !== "2");
+});

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/lazy.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/lazy.js
@@ -1,0 +1,1 @@
+export const value = "zero";

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/side-dep.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/side-dep.js
@@ -1,0 +1,1 @@
+export const dep = "zero";

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/side.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/0/side.js
@@ -1,0 +1,3 @@
+import { dep } from "./side-dep";
+
+export const side = dep;

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/1/lazy.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/1/lazy.js
@@ -1,0 +1,1 @@
+export const value = "one";

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/2/side-dep.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/2/side-dep.js
@@ -1,0 +1,1 @@
+export const dep = "two";

--- a/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/webpack.config.js
+++ b/test/watchCases/long-term-caching/analyzable-deferred-chunk-name/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+// A deferred chunk's name is baked into the parent that references it, so a rebuild
+// that moves the child's hash has to re-bake the parent — and one that moves nothing
+// must leave the parent's asset alone.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	devtool: false,
+	entry: {
+		bundle: "./index.js",
+		side: "./side.js"
+	},
+	experiments: { outputModule: true },
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: "[name].[contenthash].mjs",
+		publicPath: "auto"
+	},
+	optimization: {
+		chunkIds: "named",
+		moduleIds: "named",
+		splitChunks: false,
+		realContentHash: false
+	}
+};


### PR DESCRIPTION
**Summary**

`AnalyzableChunkHashPlugin` now caches sources which is the way `RealContentHashPlugin` does, the `etag` is keyed by the asset and the baked name.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asset processing for analyzable chunk replacements, including safer caching and asynchronous handling.
  - Preserved unreadable stand-in text when no valid replacement is available.
  - Improved stability of deferred chunk names and asset re-emission during watch mode.

- **Tests**
  - Added coverage for lazy assets, deferred imports, long-term caching, and content-hashed chunk changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->