### PR TITLE
fix: stop entry chunks from importing itself to install modules

### DIFF
--- a/.changeset/511-esm-entry-self-import.md
+++ b/.changeset/511-esm-entry-self-import.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Install an ESM entry chunk's own modules from its local bindings instead of importing itself.

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -240,6 +240,7 @@ class ModuleChunkFormatPlugin {
 
 					/** @type {Set<Chunk>} */
 					const loadedChunks = new Set();
+					let ownInstalled = false;
 					for (let i = 0; i < entries.length; i++) {
 						const [module, entrypoint] = entries[i];
 						if (!chunkGraph.getModuleSourceTypes(module).has(JAVASCRIPT_TYPE)) {
@@ -249,8 +250,8 @@ class ModuleChunkFormatPlugin {
 						const moduleId = chunkGraph.getModuleId(module);
 						const chunks = getAllChunks(
 							/** @type {Entrypoint} */ (entrypoint),
-							/** @type {Chunk} */ (runtimeChunk),
-							undefined
+							chunk,
+							/** @type {Chunk} */ (runtimeChunk)
 						);
 						/** @type {Set<Chunk>} */
 						const processChunks = new Set();
@@ -269,6 +270,19 @@ class ModuleChunkFormatPlugin {
 						if (sourceWithDependentChunks) {
 							startupSource.add("\n");
 							startupSource.add(sourceWithDependentChunks);
+						}
+						if (!ownInstalled) {
+							ownInstalled = true;
+							// Own chunk data comes from the `export const` bindings above.
+							startupSource.add(
+								`${RuntimeGlobals.externalInstallChunk}({ ${
+									RuntimeGlobals.esmIds
+								}, ${RuntimeGlobals.esmModules}${
+									runtimeModules.length > 0
+										? `, ${RuntimeGlobals.esmRuntime}`
+										: ""
+								} });\n`
+							);
 						}
 						if (module === inlinedEntryModule && inlinedEntrySource) {
 							// Inline the entry at the top level so its declarations stay

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigCacheTest.snap
@@ -40,8 +40,7 @@ import * as __webpack_chunk_2__ from \\"./nested-shared.mjs\\";
 __webpack_require__.C(__webpack_chunk_2__);
 import * as __webpack_chunk_3__ from \\"./commons-dependency_js.mjs\\";
 __webpack_require__.C(__webpack_chunk_3__);
-import * as __webpack_chunk_4__ from \\"./foo.mjs\\";
-__webpack_require__.C(__webpack_chunk_4__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(353);
 
 //# sourceMappingURL=foo.mjs.map"

--- a/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/chunks-order/module/__snapshots__/ConfigTest.snap
@@ -40,8 +40,7 @@ import * as __webpack_chunk_2__ from \\"./nested-shared.mjs\\";
 __webpack_require__.C(__webpack_chunk_2__);
 import * as __webpack_chunk_3__ from \\"./commons-dependency_js.mjs\\";
 __webpack_require__.C(__webpack_chunk_3__);
-import * as __webpack_chunk_4__ from \\"./foo.mjs\\";
-__webpack_require__.C(__webpack_chunk_4__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(353);
 
 //# sourceMappingURL=foo.mjs.map"

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -187,9 +187,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
-
-import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_3.chunk.js\\";
-__webpack_require__.C(__webpack_chunk_1__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(942);
 "
 `;
@@ -317,9 +315,7 @@ globalThis.__classicB = \\"classic-b value\\";
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
-
-import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_2.chunk.js\\";
-__webpack_require__.C(__webpack_chunk_1__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(702);
 "
 `;

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -187,9 +187,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
-
-import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_3.chunk.js\\";
-__webpack_require__.C(__webpack_chunk_1__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(942);
 "
 `;
@@ -317,9 +315,7 @@ globalThis.__classicB = \\"classic-b value\\";
 // load runtime
 import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
-
-import * as __webpack_chunk_1__ from \\"./__html_cbe5b59d_2.chunk.js\\";
-__webpack_require__.C(__webpack_chunk_1__);
+__webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(702);
 "
 `;


### PR DESCRIPTION
**Summary**

With `output.module` and a separate runtime chunk, an entry chunk emitted `import * as __webpack_chunk_N__ from "./main.mjs";` to import self to install its modules, but those `export const` bindings already in scope and can be accessed directly. 

This PR passes the chunk data directly, it can drop the self reference import and some bytes per entry chunk.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ESM entry chunks could incorrectly import themselves during startup.
  * Improved chunk initialization to ensure module data and runtime bindings are installed correctly and only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->