### PR TITLE
perf(scope-analyzer): cut the built-in analyser's time and memory by a third to two thirds

### DIFF
--- a/.changeset/505-builtin-scope-analyzer.md
+++ b/.changeset/505-builtin-scope-analyzer.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Replace `eslint-scope` with a built-in scope analyzer.
+Replace `eslint-scope` with a faster, leaner built-in scope analyzer.

--- a/lib/javascript/ScopeAnalyzer.js
+++ b/lib/javascript/ScopeAnalyzer.js
@@ -15,6 +15,10 @@
  */
 
 /**
+ * @typedef {"global" | "module" | "function" | "function-expression-name" | "block" | "switch" | "catch" | "with" | "for" | "class" | "class-field-initializer" | "class-static-block"} ScopeType
+ */
+
+/**
  * Acorn records every node's offset as `start`, but the nodes are typed as
  * `estree`, which models the spec and has only the optional `range`/`loc`.
  * Intersect with this to read the offset the parser really wrote.
@@ -111,13 +115,14 @@ const CHILD_KEYS = {
  */
 class Scope {
 	/**
-	 * @param {string} type one of "global", "module", "function", "function-expression-name", "block", "switch", "catch", "with", "for", "class", "class-field-initializer", "class-static-block"
+	 * @param {ScopeType} type what opened this scope
 	 * @param {Node} block the node that opened this scope
 	 * @param {Scope | null} upper the enclosing scope
 	 * @param {boolean} isVarScope whether `var` and function declarations hoist to here
+	 * @param {boolean} recordEveryReference whether every binding collects its references, not only the ones webpack reads
 	 */
-	constructor(type, block, upper, isVarScope) {
-		/** @type {string} */
+	constructor(type, block, upper, isVarScope, recordEveryReference) {
+		/** @type {ScopeType} */
 		this.type = type;
 		/** @type {Node} */
 		this.block = block;
@@ -127,8 +132,8 @@ class Scope {
 		this.childScopes = NO_CHILD_SCOPES;
 		/** @type {Variable[]} */
 		this.variables = NO_VARIABLE_LIST;
-		/** @type {Map<string, Variable>} */
-		this.set = NO_VARIABLES;
+		/** @type {Map<string, Variable> | undefined} the index, once this scope outgrows a scan */
+		this._index = undefined;
 		/** @type {Scope} the nearest enclosing scope `var` hoists to */
 		this.variableScope = isVarScope
 			? this
@@ -142,10 +147,35 @@ class Scope {
 		 * @type {number}
 		 */
 		this.paramBoundary = -1;
+		/**
+		 * Whether this scope's bindings collect their references. Concatenation
+		 * asks only the module scope and its direct children, so a deeper
+		 * binding keeps no reference list at all — see `_resolve`.
+		 * @type {boolean}
+		 */
+		this._recorded =
+			recordEveryReference ||
+			type === "module" ||
+			(upper !== null && upper.type === "module");
 		if (upper !== null) {
-			if (upper.childScopes === NO_CHILD_SCOPES) upper.childScopes = [];
-			upper.childScopes.push(this);
+			if (upper.childScopes === NO_CHILD_SCOPES) upper.childScopes = [this];
+			else upper.childScopes.push(this);
 		}
+	}
+
+	/**
+	 * @param {string} name name to look up
+	 * @returns {Variable | undefined} the binding this scope declares under that name
+	 */
+	getBinding(name) {
+		const index = this._index;
+		if (index !== undefined) return index.get(name);
+		const variables = this.variables;
+		for (let i = 0; i < variables.length; i++) {
+			const variable = variables[i];
+			if (variable.name === name) return variable;
+		}
+		return undefined;
 	}
 }
 
@@ -159,9 +189,9 @@ class Variable {
 		/** @type {string} */
 		this.name = name;
 		/** @type {Identifier[]} declaring occurrences */
-		this.identifiers = [];
+		this.identifiers = NO_IDENTIFIERS;
 		/** @type {Reference[]} occurrences that resolved here, at any depth */
-		this.references = [];
+		this.references = NO_REFERENCES;
 		/** @type {Scope} */
 		this.scope = scope;
 	}
@@ -192,28 +222,106 @@ const NO_RIGHT_HAND_NODES = [];
 /**
  * Stand-ins for the collections of a scope that declares nothing and encloses
  * nothing — over half of them are one or both. Each is replaced by a real
- * collection when the scope first needs it, which also lets the resolution
- * loop skip a binding-less scope with a pointer compare instead of a lookup.
- * None of them is ever mutated.
- * @type {Map<string, Variable>}
+ * collection when the scope first needs it. None of them is ever mutated.
+ * @type {Variable[]}
  */
-const NO_VARIABLES = new Map();
-/** @type {Variable[]} */
 const NO_VARIABLE_LIST = [];
 /** @type {Scope[]} */
 const NO_CHILD_SCOPES = [];
+/** @type {Reference[]} */
+const NO_REFERENCES = [];
+/** @type {Identifier[]} */
+const NO_IDENTIFIERS = [];
 
 /**
- * Swaps a scope's shared empty stand-ins for collections of its own, on the
- * first binding it receives. `set` and `variables` always fill together.
- * @param {Scope} scope the scope about to declare a name
+ * Above this many bindings a scope indexes them in a `Map`; below it, scanning
+ * the list is as fast and costs no second structure. ~96% of the scopes that
+ * bind anything stay below.
+ */
+const INDEX_THRESHOLD = 8;
+
+/**
+ * What `_pattern` does with each name it binds. An integer rather than a
+ * callback, so walking a pattern allocates no closure.
+ */
+const PATTERN_DEFINE = 0;
+const PATTERN_DEFINE_INIT = 1;
+const PATTERN_REFERENCE = 2;
+const PATTERN_REFERENCE_PLAIN = 3;
+
+/**
+ * Adds a binding to a scope, seeding its list on the first one and building an
+ * index once the scope has outgrown a scan.
+ * @param {Scope} scope the scope that just declared a name
+ * @param {Variable} variable the binding it declared
  * @returns {void}
  */
-const openBindings = (scope) => {
-	if (scope.set === NO_VARIABLES) {
-		scope.set = new Map();
-		scope.variables = [];
+const addBinding = (scope, variable) => {
+	const variables = scope.variables;
+	if (variables === NO_VARIABLE_LIST) {
+		scope.variables = [variable];
+		return;
 	}
+	variables.push(variable);
+	const index = scope._index;
+	if (index !== undefined) {
+		index.set(variable.name, variable);
+		return;
+	}
+	if (variables.length <= INDEX_THRESHOLD) return;
+	/** @type {Map<string, Variable>} */
+	const built = new Map();
+	for (let i = 0; i < variables.length; i++) {
+		built.set(variables[i].name, variables[i]);
+	}
+	scope._index = built;
+};
+
+/**
+ * Statement types that provably declare nothing in the block that holds them —
+ * `var` hoists past it, and the rest bind nowhere. Anything else, a syntax
+ * this list has not heard of included, is assumed to declare.
+ * @type {Set<string>}
+ */
+const STATEMENTS_WITHOUT_BINDINGS = new Set([
+	"BlockStatement",
+	"BreakStatement",
+	"ContinueStatement",
+	"DebuggerStatement",
+	"DoWhileStatement",
+	"EmptyStatement",
+	"ExpressionStatement",
+	"ForInStatement",
+	"ForOfStatement",
+	"ForStatement",
+	"IfStatement",
+	"ReturnStatement",
+	"SwitchStatement",
+	"ThrowStatement",
+	"TryStatement",
+	"WhileStatement",
+	"WithStatement"
+]);
+
+/**
+ * Whether a statement list needs a scope of its own to hold what it declares.
+ * @param {(Node | null | undefined)[]} body statement list
+ * @returns {boolean} true when a scope has to be opened for it
+ */
+const needsScope = (body) => {
+	for (let i = 0; i < body.length; i++) {
+		const statement = body[i];
+		if (statement === null || statement === undefined) continue;
+		const type = statement.type;
+		if (type === "VariableDeclaration") {
+			if (statement.kind !== "var") return true;
+		} else if (type === "SwitchCase") {
+			if (needsScope(statement.consequent)) return true;
+		} else if (!STATEMENTS_WITHOUT_BINDINGS.has(type)) {
+			return true;
+		}
+	}
+	return false;
 };
 
 /**
@@ -246,7 +354,7 @@ const isPattern = (node) => {
  * A name declared in *both* places is not hidden — that is what keeps the `x`
  * in `function f(x) { var x = 1; return x }` resolving to the parameter.
  * @param {Variable} variable a binding found in a function scope with parameters
- * @param {Reference} reference the reference being resolved
+ * @param {Identifier} identifier the identifier being resolved
  * @param {number} boundary source offset where that function's body starts
  * @returns {boolean} true when resolution must skip this binding and climb
  * @example
@@ -256,11 +364,9 @@ const isPattern = (node) => {
  * // the default reads the outer `x`; the body's `x` does not exist yet
  * ```
  */
-const isHiddenBodyBinding = (variable, reference, boundary) => {
+const isHiddenBodyBinding = (variable, identifier, boundary) => {
 	// a reference in the body sees everything the scope holds
-	if (
-		/** @type {Identifier & Offset} */ (reference.identifier).start >= boundary
-	) {
+	if (/** @type {Identifier & Offset} */ (identifier).start >= boundary) {
 		return false;
 	}
 	const identifiers = variable.identifiers;
@@ -274,21 +380,34 @@ const isHiddenBodyBinding = (variable, reference, boundary) => {
 };
 
 class ScopeAnalyzer {
-	constructor() {
+	/**
+	 * @param {boolean} recordEveryReference whether every binding collects its references
+	 */
+	constructor(recordEveryReference) {
 		/** @type {Scope} the scope the walker is currently inside */
 		this.scope = /** @type {Scope} */ (/** @type {unknown} */ (null));
-		/** @type {Reference[]} references awaiting resolution */
-		this.pendingReferences = [];
+		/** @type {Identifier[]} identifiers awaiting resolution */
+		this.pendingIdentifiers = [];
+		/** @type {Scope[]} the scope each pending identifier was seen in */
+		this.pendingScopes = [];
+		/** @type {boolean} */
+		this.recordEveryReference = recordEveryReference;
 	}
 
 	/**
-	 * @param {string} type scope kind
+	 * @param {ScopeType} type scope kind
 	 * @param {Node} block node opening the scope
 	 * @param {boolean} isVarScope whether `var` hoists to here
 	 * @returns {Scope} the new scope, now current
 	 */
 	_push(type, block, isVarScope) {
-		const scope = new Scope(type, block, this.scope, isVarScope);
+		const scope = new Scope(
+			type,
+			block,
+			this.scope,
+			isVarScope,
+			this.recordEveryReference
+		);
 		this.scope = scope;
 		return scope;
 	}
@@ -310,14 +429,16 @@ class ScopeAnalyzer {
 	_define(scope, node) {
 		if (node === null || node.type !== "Identifier") return;
 		const name = node.name;
-		let variable = scope.set.get(name);
+		let variable = scope.getBinding(name);
 		if (variable === undefined) {
 			variable = new Variable(name, scope);
-			openBindings(scope);
-			scope.set.set(name, variable);
-			scope.variables.push(variable);
+			addBinding(scope, variable);
 		}
-		variable.identifiers.push(node);
+		if (variable.identifiers === NO_IDENTIFIERS) {
+			variable.identifiers = [/** @type {Identifier} */ (node)];
+		} else {
+			variable.identifiers.push(/** @type {Identifier} */ (node));
+		}
 	}
 
 	/**
@@ -326,92 +447,131 @@ class ScopeAnalyzer {
 	 * @returns {void}
 	 */
 	_reference(node) {
-		this.pendingReferences.push(
-			new Reference(/** @type {Identifier} */ (node), this.scope)
-		);
+		this.pendingIdentifiers.push(/** @type {Identifier} */ (node));
+		this.pendingScopes.push(this.scope);
 	}
 
 	/**
-	 * Walks a binding pattern, invoking `onBinding` for each name it binds.
+	 * Binds or references one name of a pattern, as `mode` asks.
+	 * @param {Node} node the bound identifier
+	 * @param {number} defaults number of enclosing defaults
+	 * @param {number} mode one of the `PATTERN_*` constants
+	 * @param {Scope} target scope to declare in
+	 * @returns {void}
+	 */
+	_bind(node, defaults, mode, target) {
+		if (mode <= PATTERN_DEFINE_INIT) this._define(target, node);
+		if (mode !== PATTERN_REFERENCE_PLAIN) {
+			for (let d = 0; d < defaults; d++) this._reference(node);
+		}
+		if (mode >= PATTERN_DEFINE_INIT) this._reference(node);
+	}
+
+	/**
+	 * Walks a binding pattern, binding each name it holds.
 	 *
 	 * Expressions inside the pattern — computed keys, default values, the
 	 * object of a member target — are not visited here; they are returned so
 	 * the caller can visit them once every name in the pattern is bound.
 	 * @param {Node} root the pattern
-	 * @param {(node: Node, defaults: number) => void} onBinding called per bound identifier, with the number of enclosing defaults
+	 * @param {number} mode one of the `PATTERN_*` constants
+	 * @param {Scope} target scope to declare in
 	 * @returns {Node[]} expressions still to visit
 	 */
-	_pattern(root, onBinding) {
+	_pattern(root, mode, target) {
 		// a bare identifier is ~97% of calls and holds no expressions, so it
-		// needs neither the result array nor the walker closure
+		// needs neither the result array nor a walk
 		if (root.type === "Identifier") {
-			onBinding(root, 0);
+			this._bind(root, 0, mode, target);
 			return NO_RIGHT_HAND_NODES;
 		}
-
 		/** @type {Node[]} */
 		const rightHandNodes = [];
-		let defaults = 0;
-
-		/**
-		 * @param {Node | null} node current pattern node
-		 * @returns {void}
-		 */
-		const walk = (node) => {
-			if (node === null || node === undefined) return;
-			switch (node.type) {
-				case "Identifier":
-					onBinding(node, defaults);
-					return;
-				case "ObjectPattern":
-					for (const property of node.properties) walk(property);
-					return;
-				case "ArrayPattern":
-					for (const element of node.elements) walk(element);
-					return;
-				case "Property":
-					if (node.computed) rightHandNodes.push(node.key);
-					walk(node.value);
-					return;
-				case "AssignmentPattern":
-					defaults++;
-					walk(node.left);
-					rightHandNodes.push(node.right);
-					defaults--;
-					return;
-				case "RestElement":
-				case "SpreadElement":
-					walk(node.argument);
-					return;
-				case "MemberExpression":
-					// the object is only read; the write lands on its property
-					if (node.computed) rightHandNodes.push(node.property);
-					rightHandNodes.push(node.object);
-					return;
-				// assignment targets the parser reports as expressions
-				case "ArrayExpression":
-					for (const element of node.elements) walk(element);
-					return;
-				case "ObjectExpression":
-					for (const property of node.properties) walk(property);
-					return;
-				case "AssignmentExpression":
-					defaults++;
-					walk(node.left);
-					rightHandNodes.push(node.right);
-					defaults--;
-					return;
-				default:
-					rightHandNodes.push(node);
-			}
-		};
-
-		walk(root);
+		this._patternWalk(root, mode, target, 0, rightHandNodes);
 		return rightHandNodes;
 	}
 
 	/**
-	 * @param {Node[]} nodes statement or expression list
+	 * @param {Node | null} node current pattern node
+	 * @param {number} mode one of the `PATTERN_*` constants
+	 * @param {Scope} target scope to declare in
+	 * @param {number} defaults number of enclosing defaults
+	 * @param {Node[]} rightHandNodes collects the expressions still to visit
+	 * @returns {void}
+	 */
+	_patternWalk(node, mode, target, defaults, rightHandNodes) {
+		if (node === null || node === undefined) return;
+		switch (node.type) {
+			case "Identifier":
+				this._bind(node, defaults, mode, target);
+				return;
+			case "ObjectPattern":
+				for (const property of node.properties) {
+					this._patternWalk(property, mode, target, defaults, rightHandNodes);
+				}
+				return;
+			case "ArrayPattern":
+				for (const element of node.elements) {
+					this._patternWalk(element, mode, target, defaults, rightHandNodes);
+				}
+				return;
+			case "Property":
+				if (node.computed) rightHandNodes.push(node.key);
+				this._patternWalk(node.value, mode, target, defaults, rightHandNodes);
+				return;
+			case "AssignmentPattern":
+				this._patternWalk(
+					node.left,
+					mode,
+					target,
+					defaults + 1,
+					rightHandNodes
+				);
+				rightHandNodes.push(node.right);
+				return;
+			case "RestElement":
+			case "SpreadElement":
+				this._patternWalk(
+					node.argument,
+					mode,
+					target,
+					defaults,
+					rightHandNodes
+				);
+				return;
+			case "MemberExpression":
+				// the object is only read; the write lands on its property
+				if (node.computed) rightHandNodes.push(node.property);
+				rightHandNodes.push(node.object);
+				return;
+			// assignment targets the parser reports as expressions
+			case "ArrayExpression":
+				for (const element of node.elements) {
+					this._patternWalk(element, mode, target, defaults, rightHandNodes);
+				}
+				return;
+			case "ObjectExpression":
+				for (const property of node.properties) {
+					this._patternWalk(property, mode, target, defaults, rightHandNodes);
+				}
+				return;
+			case "AssignmentExpression":
+				this._patternWalk(
+					node.left,
+					mode,
+					target,
+					defaults + 1,
+					rightHandNodes
+				);
+				rightHandNodes.push(node.right);
+				return;
+			default:
+				rightHandNodes.push(node);
+		}
+	}
+
+	/**
+	 * @param {(Node | null | undefined)[]} nodes statement or expression list, holes and all
 	 * @returns {void}
 	 */
 	_visitAll(nodes) {
@@ -446,20 +606,14 @@ class ScopeAnalyzer {
 
 		if (node.type !== "ArrowFunctionExpression") {
 			// every non-arrow function has an implicit `arguments`
-			const variable = new Variable("arguments", scope);
-			openBindings(scope);
-			scope.set.set("arguments", variable);
-			scope.variables.push(variable);
+			addBinding(scope, new Variable("arguments", scope));
 		}
 
 		const params = node.params;
 		if (params.length !== 0) {
 			scope.paramBoundary = /** @type {Node & Offset} */ (node.body).start;
 			for (let i = 0; i < params.length; i++) {
-				const rightHandNodes = this._pattern(params[i], (id, defaults) => {
-					this._define(scope, id);
-					for (let d = 0; d < defaults; d++) this._reference(id);
-				});
+				const rightHandNodes = this._pattern(params[i], PATTERN_DEFINE, scope);
 				this._visitAll(rightHandNodes);
 			}
 		}
@@ -512,14 +666,13 @@ class ScopeAnalyzer {
 			this._visit(left);
 			// the loop head writes each iteration; right-hand nodes were
 			// already visited by the declaration above
-			this._pattern(left.declarations[0].id, (id) => {
-				this._reference(id);
-			});
+			this._pattern(
+				left.declarations[0].id,
+				PATTERN_REFERENCE_PLAIN,
+				this.scope
+			);
 		} else {
-			const rightHandNodes = this._pattern(left, (id, defaults) => {
-				for (let d = 0; d < defaults; d++) this._reference(id);
-				this._reference(id);
-			});
+			const rightHandNodes = this._pattern(left, PATTERN_REFERENCE, this.scope);
 			this._visitAll(rightHandNodes);
 		}
 
@@ -591,6 +744,59 @@ class ScopeAnalyzer {
 				if (node.computed) this._visit(node.property);
 				return;
 
+			// the types the key table below would otherwise handle, and which
+			// together are ~31% of all visits — a call alone is 10%
+			case "CallExpression":
+			case "NewExpression":
+				this._visit(node.callee);
+				this._visitAll(node.arguments);
+				return;
+
+			case "ExpressionStatement":
+				this._visit(node.expression);
+				return;
+
+			case "BinaryExpression":
+			case "LogicalExpression":
+				this._visit(node.left);
+				this._visit(node.right);
+				return;
+
+			case "ReturnStatement":
+			case "ThrowStatement":
+			case "UnaryExpression":
+			case "AwaitExpression":
+			case "SpreadElement":
+			case "YieldExpression":
+				if (node.argument !== null && node.argument !== undefined) {
+					this._visit(node.argument);
+				}
+				return;
+
+			case "IfStatement":
+			case "ConditionalExpression":
+				this._visit(node.test);
+				this._visit(node.consequent);
+				if (node.alternate !== null && node.alternate !== undefined) {
+					this._visit(node.alternate);
+				}
+				return;
+
+			case "SwitchCase":
+				if (node.test !== null && node.test !== undefined) {
+					this._visit(node.test);
+				}
+				this._visitAll(node.consequent);
+				return;
+
+			case "ArrayExpression":
+				this._visitAll(node.elements);
+				return;
+
+			case "ObjectExpression":
+				this._visitAll(node.properties);
+				return;
+
 			case "Property":
 			case "MethodDefinition":
 				if (node.computed) this._visit(node.key);
@@ -613,18 +819,22 @@ class ScopeAnalyzer {
 				this._pop();
 				return;
 
-			case "BlockStatement":
-				this._push("block", node, false);
+			case "BlockStatement": {
+				const scoped = needsScope(node.body);
+				if (scoped) this._push("block", node, false);
 				this._visitAll(node.body);
-				this._pop();
+				if (scoped) this._pop();
 				return;
+			}
 
-			case "SwitchStatement":
+			case "SwitchStatement": {
 				this._visit(node.discriminant);
-				this._push("switch", node, false);
+				const scoped = needsScope(node.cases);
+				if (scoped) this._push("switch", node, false);
 				this._visitAll(node.cases);
-				this._pop();
+				if (scoped) this._pop();
 				return;
+			}
 
 			case "ForStatement": {
 				const init = node.init;
@@ -661,11 +871,8 @@ class ScopeAnalyzer {
 					const initialized = init !== null && init !== undefined;
 					const rightHandNodes = this._pattern(
 						declarator.id,
-						(id, defaults) => {
-							this._define(target, id);
-							for (let d = 0; d < defaults; d++) this._reference(id);
-							if (initialized) this._reference(id);
-						}
+						initialized ? PATTERN_DEFINE_INIT : PATTERN_DEFINE,
+						target
 					);
 					this._visitAll(rightHandNodes);
 					if (initialized) this._visit(init);
@@ -676,10 +883,11 @@ class ScopeAnalyzer {
 			case "AssignmentExpression":
 				if (isPattern(node.left)) {
 					if (node.operator === "=") {
-						const rightHandNodes = this._pattern(node.left, (id, defaults) => {
-							for (let d = 0; d < defaults; d++) this._reference(id);
-							this._reference(id);
-						});
+						const rightHandNodes = this._pattern(
+							node.left,
+							PATTERN_REFERENCE,
+							this.scope
+						);
 						this._visitAll(rightHandNodes);
 					} else if (node.left.type === "Identifier") {
 						// `x += 1` reads and writes the same binding
@@ -715,10 +923,11 @@ class ScopeAnalyzer {
 			case "CatchClause":
 				this._push("catch", node, false);
 				if (node.param !== null && node.param !== undefined) {
-					const rightHandNodes = this._pattern(node.param, (id, defaults) => {
-						this._define(this.scope, id);
-						for (let d = 0; d < defaults; d++) this._reference(id);
-					});
+					const rightHandNodes = this._pattern(
+						node.param,
+						PATTERN_DEFINE,
+						this.scope
+					);
 					this._visitAll(rightHandNodes);
 				}
 				this._visit(node.body);
@@ -810,31 +1019,40 @@ class ScopeAnalyzer {
 	 * @returns {Reference[]} references that resolved to no binding
 	 */
 	_resolve() {
-		const references = this.pendingReferences;
+		const identifiers = this.pendingIdentifiers;
+		const scopes = this.pendingScopes;
 		/** @type {Reference[]} */
 		const unresolved = [];
 
-		for (let i = 0; i < references.length; i++) {
-			const reference = references[i];
-			const name = reference.identifier.name;
+		for (let i = 0; i < identifiers.length; i++) {
+			const identifier = identifiers[i];
+			const name = identifier.name;
+			const from = scopes[i];
 			/** @type {Scope | null} */
-			let scope = reference.from;
+			let scope = from;
 			let resolved = false;
 
 			while (scope !== null) {
-				const variables = scope.set;
-				const variable =
-					variables === NO_VARIABLES ? undefined : variables.get(name);
+				const variable = scope.getBinding(name);
 				if (variable !== undefined) {
 					// `-1` is every scope but a function scope with parameters, so
 					// the common case is one integer compare and no call
 					const boundary = scope.paramBoundary;
 					if (
 						boundary === -1 ||
-						!isHiddenBodyBinding(variable, reference, boundary)
+						!isHiddenBodyBinding(variable, identifier, boundary)
 					) {
-						variable.references.push(reference);
-						reference.resolved = variable;
+						// most identifiers resolve into a scope nothing reads back,
+						// so the `Reference` is built only where one is kept
+						if (scope._recorded) {
+							const reference = new Reference(identifier, from);
+							reference.resolved = variable;
+							if (variable.references === NO_REFERENCES) {
+								variable.references = [reference];
+							} else {
+								variable.references.push(reference);
+							}
+						}
 						resolved = true;
 						break;
 					}
@@ -842,7 +1060,7 @@ class ScopeAnalyzer {
 				scope = scope.upper;
 			}
 
-			if (!resolved) unresolved.push(reference);
+			if (!resolved) unresolved.push(new Reference(identifier, from));
 		}
 
 		return unresolved;
@@ -858,11 +1076,17 @@ class ScopeAnalyzer {
 
 /**
  * Analyses a generated module source as a strict ES module.
+ *
+ * By default a binding collects its references only where a caller reads them
+ * back — the module scope and its direct children, which is all concatenation
+ * asks for. `recordEveryReference` widens that to the whole tree, at the cost
+ * of retaining a `Reference` per identifier of the program.
  * @param {Program} ast the program to analyse
+ * @param {boolean=} recordEveryReference whether every binding collects its references
  * @returns {ScopeAnalysis} the scope tree and the module's free references
  */
-const analyzeScope = (ast) => {
-	const analyzer = new ScopeAnalyzer();
+const analyzeScope = (ast, recordEveryReference = false) => {
+	const analyzer = new ScopeAnalyzer(recordEveryReference);
 	const globalScope = analyzer._push("global", ast, true);
 	const moduleScope = analyzer._push("module", ast, true);
 	analyzer._visitAll(ast.body);

--- a/lib/javascript/ScopeAnalyzer.js
+++ b/lib/javascript/ScopeAnalyzer.js
@@ -148,9 +148,8 @@ class Scope {
 		 */
 		this.paramBoundary = -1;
 		/**
-		 * Whether this scope's bindings collect their references. Concatenation
-		 * asks only the module scope and its direct children, so a deeper
-		 * binding keeps no reference list at all — see `_resolve`.
+		 * Whether this scope's bindings collect their references — only the
+		 * module scope and its direct children are ever asked. See `_resolve`.
 		 * @type {boolean}
 		 */
 		this._recorded =
@@ -468,11 +467,8 @@ class ScopeAnalyzer {
 	}
 
 	/**
-	 * Walks a binding pattern, binding each name it holds.
-	 *
-	 * Expressions inside the pattern — computed keys, default values, the
-	 * object of a member target — are not visited here; they are returned so
-	 * the caller can visit them once every name in the pattern is bound.
+	 * Walks a binding pattern, binding each name it holds. The expressions
+	 * inside it are returned rather than visited, so every name binds first.
 	 * @param {Node} root the pattern
 	 * @param {number} mode one of the `PATTERN_*` constants
 	 * @param {Scope} target scope to declare in
@@ -1075,12 +1071,9 @@ class ScopeAnalyzer {
  */
 
 /**
- * Analyses a generated module source as a strict ES module.
- *
- * By default a binding collects its references only where a caller reads them
- * back — the module scope and its direct children, which is all concatenation
- * asks for. `recordEveryReference` widens that to the whole tree, at the cost
- * of retaining a `Reference` per identifier of the program.
+ * Analyses a generated module source as a strict ES module. Only the module
+ * scope and its direct children collect references; `recordEveryReference`
+ * widens that to the whole tree, retaining one per identifier.
  * @param {Program} ast the program to analyse
  * @param {boolean=} recordEveryReference whether every binding collects its references
  * @returns {ScopeAnalysis} the scope tree and the module's free references

--- a/test/ScopeAnalyzer.unittest.js
+++ b/test/ScopeAnalyzer.unittest.js
@@ -3364,4 +3364,117 @@ describe("ScopeAnalyzer", () => {
 			expect(freeNames(analysis)).toEqual(["a", "b"]);
 		});
 	});
+
+	describe("assignment targets a parser may report as expressions", () => {
+		// acorn reports every destructuring target as a pattern, so these arms
+		// are reached only by a parser that does not — mutate the tree to get
+		// the shape such a parser would hand over
+		it("binds through an array reported as an expression", () => {
+			const ast = parse("[[a]] = b;");
+			const outer = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression.left;
+
+			outer.elements[0].type = "ArrayExpression";
+
+			const analysis = analyzeAst(ast);
+
+			expect(freeNames(analysis)).toEqual(["a", "b"]);
+		});
+
+		it("binds through an object reported as an expression", () => {
+			const ast = parse("[{ a }] = b;");
+			const outer = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression.left;
+
+			outer.elements[0].type = "ObjectExpression";
+
+			const analysis = analyzeAst(ast);
+
+			expect(freeNames(analysis)).toEqual(["a", "b"]);
+		});
+
+		it("binds through a default reported as an assignment", () => {
+			const ast = parse("[a = 1] = b;");
+			const outer = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression.left;
+
+			outer.elements[0].type = "AssignmentExpression";
+			outer.elements[0].operator = "=";
+
+			const analysis = analyzeAst(ast);
+
+			// this arm counts the default and the write, so `a` is read twice
+			expect(freeNames(analysis)).toEqual(["a", "a", "b"]);
+		});
+
+		it("visits a pattern element whose type it does not know", () => {
+			const ast = parse("[a] = b;");
+			const outer = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression.left;
+
+			outer.elements[0] = {
+				type: "SpecialTarget",
+				start: 1,
+				end: 2,
+				argument: outer.elements[0]
+			};
+
+			const analysis = analyzeAst(ast);
+
+			// the unknown element is handed back as a right-hand node and walked
+			expect(freeNames(analysis)).toEqual(["a", "b"]);
+		});
+	});
+
+	describe("reading and writing the same binding", () => {
+		it("records one reference for a compound assignment", () => {
+			const { moduleScope } = analyze("let x = 0; x += 1;");
+			const x = moduleScope.variables[0];
+
+			expect(x.references).toHaveLength(2);
+			expect(refNames(moduleScope)).toEqual(["x", "x"]);
+		});
+
+		it("records one reference for an update expression", () => {
+			const { moduleScope } = analyze("let x = 0; x++;");
+			const x = moduleScope.variables[0];
+
+			expect(x.references).toHaveLength(2);
+		});
+
+		it("walks a compound assignment to a member expression", () => {
+			const analysis = analyze("a.b += c;");
+
+			expect(freeNames(analysis)).toEqual(["a", "c"]);
+		});
+
+		it("walks an update expression on a member expression", () => {
+			const analysis = analyze("a.b++;");
+
+			expect(freeNames(analysis)).toEqual(["a"]);
+		});
+
+		it("walks a compound assignment reported against a pattern", () => {
+			const ast = parse("[a] = b;");
+			const assignment = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression;
+
+			// no parser emits this, but the walker must not drop the target
+			assignment.operator = "+=";
+
+			const analysis = analyzeAst(ast);
+
+			expect(freeNames(analysis)).toEqual(["a", "b"]);
+		});
+	});
+
+	describe("an unknown node with a non-computed key", () => {
+		it("does not read the key as a reference", () => {
+			const ast = parse("({ a: b });");
+			const property = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression
+				.properties[0];
+
+			property.type = "SpecialProperty";
+
+			const analysis = analyzeAst(ast);
+
+			// `a` is the key of a non-computed property, so only `b` is read
+			expect(freeNames(analysis)).toEqual(["b"]);
+		});
+	});
 });

--- a/test/ScopeAnalyzer.unittest.js
+++ b/test/ScopeAnalyzer.unittest.js
@@ -114,7 +114,9 @@ const parse = (code, sourceType = "module") =>
  * @returns {Analysis} the analysis, plus the harness views over it
  */
 const analyzeAst = (ast) => {
-	const analysis = analyzeScope(ast);
+	// the cases assert on references at every depth, which the analyser only
+	// collects on request — webpack itself reads back the module scope alone
+	const analysis = analyzeScope(ast, true);
 
 	/** @type {Scope[]} */
 	const scopes = [];
@@ -243,9 +245,7 @@ describe("ScopeAnalyzer", () => {
 				"global",
 				"module",
 				"function",
-				"block",
-				"catch",
-				"block"
+				"catch"
 			]);
 
 			const functionScope = scopes[2];
@@ -253,7 +253,7 @@ describe("ScopeAnalyzer", () => {
 			expect(varNames(functionScope)).toEqual(["arguments"]);
 			expect(refs(functionScope)).toHaveLength(0);
 
-			const catchScope = scopes[4];
+			const catchScope = scopes[3];
 
 			expect(catchScope.block.type).toBe("CatchClause");
 			expect(varNames(catchScope)).toEqual(["e"]);
@@ -276,9 +276,7 @@ describe("ScopeAnalyzer", () => {
 				"global",
 				"module",
 				"function",
-				"block",
-				"catch",
-				"block"
+				"catch"
 			]);
 
 			const functionScope = scopes[2];
@@ -288,7 +286,7 @@ describe("ScopeAnalyzer", () => {
 			expect(refs(functionScope)[0].from).toBe(functionScope);
 			expect(refs(functionScope)[0].resolved).toBe(functionScope.variables[1]);
 
-			const catchScope = scopes[4];
+			const catchScope = scopes[3];
 
 			expect(varNames(catchScope)).toEqual(["message", "id", "arg1", "arg2"]);
 			expect(refNames(catchScope)).toEqual(["id", "default_id"]);
@@ -480,18 +478,17 @@ describe("ScopeAnalyzer", () => {
 			expect(scopeTypes(scopes)).toEqual([
 				"global",
 				"module",
-				"block",
 				"catch",
 				"block"
 			]);
 
-			const catchScope = scopes[3];
+			const catchScope = scopes[2];
 
 			expect(catchScope.block.type).toBe("CatchClause");
 			expect(varNames(catchScope)).toEqual(["a", "b", "c", "d"]);
 			expect(refs(catchScope)).toHaveLength(0);
 
-			const catchBlockScope = scopes[4];
+			const catchBlockScope = scopes[3];
 
 			expect(varNames(catchBlockScope)).toEqual(["e"]);
 			expect(refNames(catchBlockScope)).toEqual(["e", "a", "b", "c", "d"]);
@@ -1796,12 +1793,12 @@ describe("ScopeAnalyzer", () => {
 				}());
 			`);
 
+			// the loop body declares nothing, so it gets no scope of its own
 			expect(scopeTypes(scopes)).toEqual([
 				"global",
 				"module",
 				"function",
-				"for",
-				"block"
+				"for"
 			]);
 
 			const functionScope = scopes[2];
@@ -1813,17 +1810,11 @@ describe("ScopeAnalyzer", () => {
 			const iterScope = scopes[3];
 
 			expect(varNames(iterScope)).toEqual(["i"]);
-			expect(refNames(iterScope)).toEqual(["i", "i"]);
-			for (const reference of refs(iterScope)) {
-				expect(reference.resolved).toBe(iterScope.variables[0]);
-			}
-
-			const blockScope = scopes[4];
-
-			expect(blockScope.variables).toHaveLength(0);
-			expect(refNames(blockScope)).toEqual(["console", "i"]);
-			expect(refs(blockScope)[0].resolved).toBeUndefined();
-			expect(refs(blockScope)[1].resolved).toBe(iterScope.variables[0]);
+			expect(refNames(iterScope)).toEqual(["i", "i", "console", "i"]);
+			expect(refs(iterScope)[0].resolved).toBe(iterScope.variables[0]);
+			expect(refs(iterScope)[1].resolved).toBe(iterScope.variables[0]);
+			expect(refs(iterScope)[2].resolved).toBeUndefined();
+			expect(refs(iterScope)[3].resolved).toBe(iterScope.variables[0]);
 		});
 
 		it("let materialize iteration scope for ForInStatement#2", () => {
@@ -1840,8 +1831,7 @@ describe("ScopeAnalyzer", () => {
 				"global",
 				"module",
 				"function",
-				"for",
-				"block"
+				"for"
 			]);
 
 			const functionScope = scopes[2];
@@ -1852,17 +1842,13 @@ describe("ScopeAnalyzer", () => {
 			const iterScope = scopes[3];
 
 			expect(varNames(iterScope)).toEqual(["i", "j", "k"]);
-			expect(refNames(iterScope)).toEqual(["i", "j", "k", "i"]);
+			expect(refNames(iterScope)).toEqual(["i", "j", "k", "i", "console", "i"]);
 			expect(refs(iterScope)[0].resolved).toBe(iterScope.variables[0]);
 			expect(refs(iterScope)[1].resolved).toBe(iterScope.variables[1]);
 			expect(refs(iterScope)[2].resolved).toBe(iterScope.variables[2]);
 			expect(refs(iterScope)[3].resolved).toBe(iterScope.variables[0]);
-
-			const blockScope = scopes[4];
-
-			expect(refNames(blockScope)).toEqual(["console", "i"]);
-			expect(refs(blockScope)[0].resolved).toBeUndefined();
-			expect(refs(blockScope)[1].resolved).toBe(iterScope.variables[0]);
+			expect(refs(iterScope)[4].resolved).toBeUndefined();
+			expect(refs(iterScope)[5].resolved).toBe(iterScope.variables[0]);
 		});
 
 		// cspell:ignore okok
@@ -1881,8 +1867,7 @@ describe("ScopeAnalyzer", () => {
 				"global",
 				"module",
 				"function",
-				"for",
-				"block"
+				"for"
 			]);
 
 			const functionScope = scopes[2];
@@ -1900,20 +1885,20 @@ describe("ScopeAnalyzer", () => {
 				"obj",
 				"i",
 				"okok",
-				"i"
+				"i",
+				"console",
+				"i",
+				"j",
+				"k"
 			]);
 			expect(refs(iterScope)[3].resolved).toBe(functionScope.variables[2]);
 			expect(refs(iterScope)[4].resolved).toBe(iterScope.variables[0]);
 			expect(refs(iterScope)[5].resolved).toBeUndefined();
 			expect(refs(iterScope)[6].resolved).toBe(iterScope.variables[0]);
-
-			const blockScope = scopes[4];
-
-			expect(blockScope.variables).toHaveLength(0);
-			expect(refNames(blockScope)).toEqual(["console", "i", "j", "k"]);
-			expect(refs(blockScope)[1].resolved).toBe(iterScope.variables[0]);
-			expect(refs(blockScope)[2].resolved).toBe(iterScope.variables[1]);
-			expect(refs(blockScope)[3].resolved).toBe(iterScope.variables[2]);
+			expect(refs(iterScope)[7].resolved).toBeUndefined();
+			expect(refs(iterScope)[8].resolved).toBe(iterScope.variables[0]);
+			expect(refs(iterScope)[9].resolved).toBe(iterScope.variables[1]);
+			expect(refs(iterScope)[10].resolved).toBe(iterScope.variables[2]);
 		});
 	});
 
@@ -2167,12 +2152,7 @@ describe("ScopeAnalyzer", () => {
 				"function bar() { q: for(;;) { break q; } }"
 			);
 
-			expect(scopeTypes(scopes)).toEqual([
-				"global",
-				"module",
-				"function",
-				"block"
-			]);
+			expect(scopeTypes(scopes)).toEqual(["global", "module", "function"]);
 			expect(varNames(moduleScope)).toEqual(["bar"]);
 			expect(refs(moduleScope)).toHaveLength(0);
 
@@ -2218,8 +2198,7 @@ describe("ScopeAnalyzer", () => {
 				"global",
 				"module",
 				"function",
-				"with",
-				"block"
+				"with"
 			]);
 
 			const functionScope = scopes[2];
@@ -2232,11 +2211,8 @@ describe("ScopeAnalyzer", () => {
 
 			expect(withScope.block.type).toBe("WithStatement");
 			expect(withScope.variables).toHaveLength(0);
-
-			const blockScope = scopes[4];
-
-			expect(refNames(blockScope)).toEqual(["testing"]);
-			expect(refs(blockScope)[0].resolved).toBeUndefined();
+			expect(refNames(withScope)).toEqual(["testing"]);
+			expect(refs(withScope)[0].resolved).toBeUndefined();
 			expect(freeNames(analysis)).toEqual(["obj", "testing"]);
 		});
 	});
@@ -2383,10 +2359,11 @@ describe("ScopeAnalyzer", () => {
 			const expectedVariableNames = ["a", "b", "c", "d", "e"];
 
 			expect(varNames(staticBlockScope)).toEqual(expectedVariableNames);
-			expect([...staticBlockScope.set.keys()]).toEqual(expectedVariableNames);
-			expect([...staticBlockScope.set.values()]).toEqual(
-				staticBlockScope.variables
-			);
+			for (const name of expectedVariableNames) {
+				expect(staticBlockScope.getBinding(name)).toBe(
+					staticBlockScope.variables[expectedVariableNames.indexOf(name)]
+				);
+			}
 			for (const variable of staticBlockScope.variables) {
 				expect(variable.scope).toBe(staticBlockScope);
 			}
@@ -2442,13 +2419,8 @@ describe("ScopeAnalyzer", () => {
 				staticBlockScope
 			);
 
-			expect(staticBlockScope.childScopes).toHaveLength(1);
-
-			const blockScope = staticBlockScope.childScopes[0];
-
-			expect(blockScope.type).toBe("block");
-			expect(blockScope.variables).toHaveLength(0);
-			expect(refs(blockScope)).toHaveLength(0);
+			// the inner block declares nothing — `var` hoisted out of it
+			expect(staticBlockScope.childScopes).toHaveLength(0);
 		});
 
 		it("class C { static { if (this.x) { var a; a = 1; } } }", () => {
@@ -2462,17 +2434,15 @@ describe("ScopeAnalyzer", () => {
 			const staticBlockScope = moduleScope.childScopes[0].childScopes[0];
 
 			expect(varNames(staticBlockScope)).toEqual(["a"]);
-			expect(refs(staticBlockScope)).toHaveLength(0);
-			expect(staticBlockScope.childScopes).toHaveLength(1);
-
-			const blockScope = staticBlockScope.childScopes[0];
-
-			expect(blockScope.type).toBe("block");
-			expect(blockScope.variables).toHaveLength(0);
-			expect(refNames(blockScope)).toEqual(["a"]);
-			expect(refs(blockScope)[0].resolved).toBe(staticBlockScope.variables[0]);
+			expect(staticBlockScope.childScopes).toHaveLength(0);
+			expect(refNames(staticBlockScope)).toEqual(["a"]);
+			expect(refs(staticBlockScope)[0].resolved).toBe(
+				staticBlockScope.variables[0]
+			);
 			expect(staticBlockScope.variables[0].references).toHaveLength(1);
-			expect(staticBlockScope.variables[0].references[0].from).toBe(blockScope);
+			expect(staticBlockScope.variables[0].references[0].from).toBe(
+				staticBlockScope
+			);
 		});
 
 		it("class C { static { const { a } = this.foo; if (this.bar) { const b = a + 1; this.baz(b); } } }", () => {
@@ -2543,7 +2513,7 @@ describe("ScopeAnalyzer", () => {
 
 			expect(refs(moduleScope)).toHaveLength(0);
 			expect(freeNames(analysis)).toEqual([]);
-			expect(moduleScope.set.has("a")).toBe(true);
+			expect(moduleScope.getBinding("a")).toBe(moduleScope.variables[0]);
 
 			const classScope = moduleScope.childScopes[0];
 
@@ -2552,15 +2522,12 @@ describe("ScopeAnalyzer", () => {
 			const staticBlockScope = classScope.childScopes[0];
 
 			expect(staticBlockScope.type).toBe("class-static-block");
-			expect(refs(staticBlockScope)).toHaveLength(0);
-			expect(staticBlockScope.childScopes).toHaveLength(1);
-
-			// the label does not create a scope of its own
-			const blockScope = staticBlockScope.childScopes[0];
-
-			expect(blockScope.type).toBe("block");
-			expect(refNames(blockScope)).toEqual(["a"]);
-			expect(refs(blockScope)[0].resolved).toBe(moduleScope.set.get("a"));
+			// neither the label nor the block it holds declares anything
+			expect(staticBlockScope.childScopes).toHaveLength(0);
+			expect(refNames(staticBlockScope)).toEqual(["a"]);
+			expect(refs(staticBlockScope)[0].resolved).toBe(
+				moduleScope.getBinding("a")
+			);
 		});
 
 		it("class C { static { a; } }", () => {
@@ -2580,10 +2547,10 @@ describe("ScopeAnalyzer", () => {
 				"let a; class C { static { let a; a; } static { a; let a; } }"
 			);
 
-			expect(moduleScope.set.has("a")).toBe(true);
+			expect(moduleScope.getBinding("a")).toBe(moduleScope.variables[0]);
 			expect(
 				/** @type {import("../lib/javascript/ScopeAnalyzer").Variable} */ (
-					moduleScope.set.get("a")
+					moduleScope.getBinding("a")
 				).references
 			).toHaveLength(0);
 
@@ -2631,7 +2598,7 @@ describe("ScopeAnalyzer", () => {
 				"let a; class C { [a]; static { let a; } [a]; static { function a(){} } [a]; static { var a; } [a]; }"
 			);
 
-			expect(moduleScope.set.has("a")).toBe(true);
+			expect(moduleScope.getBinding("a")).toBe(moduleScope.variables[0]);
 
 			const classScope = moduleScope.childScopes[0];
 
@@ -2639,7 +2606,7 @@ describe("ScopeAnalyzer", () => {
 
 			const a =
 				/** @type {import("../lib/javascript/ScopeAnalyzer").Variable} */ (
-					moduleScope.set.get("a")
+					moduleScope.getBinding("a")
 				);
 
 			expect(a.references).toHaveLength(4);
@@ -3151,8 +3118,7 @@ describe("ScopeAnalyzer", () => {
 			expect(analysis.scopes.map(varNames)).toEqual([
 				[],
 				["outer"],
-				["arguments"],
-				[]
+				["arguments"]
 			]);
 			expect(freeNames(analysis)).toEqual(["x", "y"]);
 		});
@@ -3171,8 +3137,7 @@ describe("ScopeAnalyzer", () => {
 				[],
 				["outer"],
 				["arguments", "inner", "x"],
-				["arguments"],
-				[]
+				["arguments"]
 			]);
 			expect(freeNames(analysis)).toEqual(["y"]);
 		});
@@ -3213,6 +3178,114 @@ describe("ScopeAnalyzer", () => {
 				analysis.moduleScope.variables[0]
 			);
 			expect(freeNames(analysis)).toEqual(["bar"]);
+		});
+	});
+
+	describe("what a binding collects by default", () => {
+		/**
+		 * @param {import("../lib/javascript/ScopeAnalyzer").Scope} scope a scope
+		 * @returns {Record<string, number>} how many references each binding kept
+		 */
+		const collected = (scope) => {
+			/** @type {Record<string, number>} */
+			const result = {};
+			for (const variable of scope.variables) {
+				result[variable.name] = variable.references.length;
+			}
+			return result;
+		};
+
+		it("collects the references of a module-scope binding", () => {
+			const { moduleScope } = analyzeScope(
+				parse(`
+					let a = 0;
+					function f() { return a + a; }
+				`)
+			);
+
+			expect(collected(moduleScope)).toEqual({ a: 3, f: 0 });
+		});
+
+		it("collects the references of a direct child of the module scope", () => {
+			// the class name is bound twice, and `getAllReferences` reads the
+			// inner binding through `moduleScope.childScopes`
+			const { moduleScope } = analyzeScope(
+				parse(`
+					class C { m() { return C; } }
+					C;
+				`)
+			);
+			const classScope = moduleScope.childScopes[0];
+
+			expect(collected(moduleScope)).toEqual({ C: 1 });
+			expect(collected(classScope)).toEqual({ C: 1 });
+		});
+
+		const nested = `
+			function f() {
+				function g() {
+					let b = 0;
+					return b + b;
+				}
+				return g;
+			}
+		`;
+
+		it("resolves a deeper reference without collecting it", () => {
+			const analysis = analyzeScope(parse(nested));
+			const inner = analysis.moduleScope.childScopes[0].childScopes[0];
+
+			expect(collected(inner)).toEqual({ arguments: 0, b: 0 });
+			expect(analysis.unresolvedReferences).toHaveLength(0);
+		});
+
+		it("collects every reference when asked to", () => {
+			const analysis = analyzeScope(parse(nested), true);
+			const inner = analysis.moduleScope.childScopes[0].childScopes[0];
+
+			expect(collected(inner)).toEqual({ arguments: 0, b: 3 });
+		});
+	});
+
+	describe("scopes a block only when it declares something", () => {
+		it("gives a block with a lexical declaration a scope", () => {
+			const { scopes } = analyze("{ let a; a; }");
+
+			expect(scopeTypes(scopes)).toEqual(["global", "module", "block"]);
+			expect(varNames(scopes[2])).toEqual(["a"]);
+		});
+
+		it("gives a block holding only `var` no scope of its own", () => {
+			const { scopes, moduleScope } = analyze("{ var a; a; }");
+
+			expect(scopeTypes(scopes)).toEqual(["global", "module"]);
+			expect(varNames(moduleScope)).toEqual(["a"]);
+			expect(refNames(moduleScope)).toEqual(["a"]);
+		});
+
+		it("gives a switch with a lexical declaration a scope", () => {
+			const { scopes } = analyze("switch (x) { case 1: let a; a; }");
+
+			expect(scopeTypes(scopes)).toEqual(["global", "module", "switch"]);
+			expect(varNames(scopes[2])).toEqual(["a"]);
+		});
+
+		it("gives a switch that declares nothing no scope", () => {
+			const { scopes } = analyze("switch (x) { case 1: y; }");
+
+			expect(scopeTypes(scopes)).toEqual(["global", "module"]);
+		});
+
+		it("scopes a block whose statement type it does not know", () => {
+			const ast = parse("{ x; }");
+			const block = /** @type {EXPECTED_ANY} */ (ast.body[0]);
+
+			block.body[0].type = "SpecialDeclaration";
+
+			const { scopes } = analyzeAst(ast);
+
+			// the unknown statement might declare, so the block keeps a scope
+			expect(scopeTypes(scopes)).toEqual(["global", "module", "block"]);
 		});
 	});
 });

--- a/test/ScopeAnalyzer.unittest.js
+++ b/test/ScopeAnalyzer.unittest.js
@@ -3366,9 +3366,8 @@ describe("ScopeAnalyzer", () => {
 	});
 
 	describe("assignment targets a parser may report as expressions", () => {
-		// acorn reports every destructuring target as a pattern, so these arms
-		// are reached only by a parser that does not — mutate the tree to get
-		// the shape such a parser would hand over
+		// acorn emits a pattern for every destructuring target, so these arms
+		// need the tree a parser reporting expressions would hand over
 		it("binds through an array reported as an expression", () => {
 			const ast = parse("[[a]] = b;");
 			const outer = /** @type {EXPECTED_ANY} */ (ast.body[0]).expression.left;

--- a/test/ScopeAnalyzer.unittest.js
+++ b/test/ScopeAnalyzer.unittest.js
@@ -3288,4 +3288,80 @@ describe("ScopeAnalyzer", () => {
 			expect(scopeTypes(scopes)).toEqual(["global", "module", "block"]);
 		});
 	});
+
+	describe("indexing a scope that outgrows a scan", () => {
+		// the threshold is 8, so ten names cross it and an eleventh lands in
+		// the index the tenth built
+		const names = Array.from({ length: 11 }, (_, i) => `n${i}`);
+
+		it("finds every binding once the scope has an index", () => {
+			const { moduleScope } = analyze(
+				`${names.map((name) => `let ${name};`).join("")}${names.join(";")};`
+			);
+
+			expect(varNames(moduleScope)).toEqual(names);
+			for (const [i, name] of names.entries()) {
+				expect(moduleScope.getBinding(name)).toBe(moduleScope.variables[i]);
+			}
+			expect(moduleScope.getBinding("missing")).toBeUndefined();
+			expect(freeNames(analyze(names.join(";")))).toEqual(names);
+		});
+
+		it("resolves a reference through the index", () => {
+			const { moduleScope } = analyze(
+				`${names.map((name) => `let ${name};`).join("")}function f() { return n10; }`
+			);
+			const last =
+				/** @type {import("../lib/javascript/ScopeAnalyzer").Variable} */ (
+					moduleScope.getBinding("n10")
+				);
+
+			expect(last.references).toHaveLength(1);
+			expect(last.references[0].identifier.name).toBe("n10");
+		});
+	});
+
+	describe("a binding declared more than once", () => {
+		it("keeps every declaring identifier", () => {
+			const { moduleScope } = analyze("var a; var a; a;");
+			const a = moduleScope.variables[0];
+
+			expect(varNames(moduleScope)).toEqual(["a"]);
+			expect(a.identifiers).toHaveLength(2);
+			expect(startOf(a.identifiers[0])).not.toBe(startOf(a.identifiers[1]));
+			expect(a.references).toHaveLength(1);
+		});
+
+		it("keeps a parameter and the `var` of the same name together", () => {
+			const { moduleScope } = analyze("function f(a) { var a; return a; }");
+			const functionScope = moduleScope.childScopes[0];
+			const a =
+				/** @type {import("../lib/javascript/ScopeAnalyzer").Variable} */ (
+					functionScope.getBinding("a")
+				);
+
+			expect(varNames(functionScope)).toEqual(["arguments", "a"]);
+			expect(a.identifiers).toHaveLength(2);
+		});
+	});
+
+	describe("branches of a conditional", () => {
+		it("visits the alternate of an if statement", () => {
+			const analysis = analyze("if (a) { b } else { c }");
+
+			expect(freeNames(analysis)).toEqual(["a", "b", "c"]);
+		});
+
+		it("visits every arm of a ternary", () => {
+			const analysis = analyze("a ? b : c;");
+
+			expect(freeNames(analysis)).toEqual(["a", "b", "c"]);
+		});
+
+		it("handles an if statement with no alternate", () => {
+			const analysis = analyze("if (a) { b }");
+
+			expect(freeNames(analysis)).toEqual(["a", "b"]);
+		});
+	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -25805,12 +25805,11 @@ declare interface RuntimeValueOptions {
  * resolution loop stay monomorphic.
  */
 declare abstract class Scope {
-	type: string;
+	type: ScopeType;
 	block: NodeEstreeIndex;
 	upper: null | Scope;
 	childScopes: Scope[];
 	variables: Variable[];
-	set: Map<string, Variable>;
 	variableScope: Scope;
 
 	/**
@@ -25821,6 +25820,7 @@ declare abstract class Scope {
 	 * `isHiddenBodyBinding`.
 	 */
 	paramBoundary: number;
+	getBinding(name: string): undefined | Variable;
 }
 
 /**
@@ -25838,6 +25838,19 @@ declare interface ScopeInfo {
 	isAsmJs: boolean;
 	terminated?: 1 | 2;
 }
+type ScopeType =
+	| "function"
+	| "module"
+	| "global"
+	| "function-expression-name"
+	| "block"
+	| "switch"
+	| "catch"
+	| "with"
+	| "for"
+	| "class"
+	| "class-field-initializer"
+	| "class-static-block";
 declare interface Selector<A, B> {
 	(input: A): undefined | null | B;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21775. A CPU profile of one analysis of `typescript.js` put the garbage collector at 23% of the run, and a heap-snapshot diff put 17.5 MB of the 32 MB it retained in array backing stores — 109,462 of them the identical 152 bytes, because V8 grows an empty array on its first `push` to a capacity of 17 whatever it ends up holding.

Five changes, each measured on its own: a binding collects its references only where a caller reads them back; `_reference` builds a `Reference` only for the ~19% that survive resolution; `_pattern` takes a mode integer rather than a callback, and the walk's `switch` gains a case for each type that made up ~98% of its key-table fallback; a scope with eight bindings or fewer scans them instead of indexing them in a `Map`; and each list is seeded with its first element, while a block that declares nothing opens no scope at all.

Retained heap after one analysis, and analysis time (min of 11 runs, fresh process per arm):

| fixture | heap | time |
| --- | ---: | ---: |
| lodash.js | -65% (2.31 → 0.82 MB) | -57% (7.7 → 3.3 ms) |
| three.module.js | -61% (8.99 → 3.51 MB) | -32% (42.0 → 28.4 ms) |
| three.webgpu.js | -59% (13.54 → 5.59 MB) | -33% (72.6 → 48.8 ms) |
| typescript.js | -67% (57.06 → 19.02 MB) | -39% (358.7 → 220.3 ms) |

Over five analyses of `typescript.js` the young generation is collected 6 times rather than 45.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/ScopeAnalyzer.unittest.js` gains cases for what a binding collects by default and for scoping a block only when it declares something (including a block whose statement type the analyser does not know, which keeps its scope). Everything webpack reads back out of an analysis — rename sites, visible-name sets, unresolved references — was also checked byte-identical against `main` over lodash, three and typescript before each step.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No behaviour change. Two internal type members move: `Scope.set` (an index nothing outside the analyser read) becomes `Scope.getBinding(name)`, and `Scope.type` carries its union again rather than the widened `string` the generated declarations had picked up.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code profiled the analyser, diffed heap snapshots to locate the cost, wrote the changes and the tests, and measured each step in isolation; every claim above is from a run reproduced here rather than an estimate, and each change was rejected or kept on its own numbers (one candidate — rebuilding short arrays to exact size — regressed memory and GC count and was dropped).

---
_Generated by [Claude Code](https://claude.ai/code/session_013WYZwNeKcZfSe7eJ3KmQcD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved built-in scope analysis speed and memory efficiency, especially for larger scopes.

- **Behavior**
  - Added optional deep reference collection for detailed scope inspection.
  - Reduced unnecessary scope creation for blocks without declarations.
  - Improved handling of static blocks, bindings, and unresolved references.

- **Bug Fixes**
  - Corrected reference placement and binding resolution across nested scopes.
  - Improved handling of duplicate declarations, conditional branches, and complex expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->