### PR TITLE
fix(amd): assign the define result to the module argument

### DIFF
--- a/.changeset/035-amd-define-module-argument.md
+++ b/.changeset/035-amd-define-module-argument.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix `ReferenceError` from an AMD `define()` result assigned to the wrong module argument.
+Fix `ReferenceError` from AMD `define()` using the wrong module argument.

--- a/.changeset/035-amd-define-module-argument.md
+++ b/.changeset/035-amd-define-module-argument.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `ReferenceError` from an AMD `define()` result assigned to the wrong module argument.

--- a/lib/dependencies/AMDDefineDependency.js
+++ b/lib/dependencies/AMDDefineDependency.js
@@ -181,14 +181,19 @@ AMDDefineDependency.Template = class AMDDefineDependencyTemplate extends (
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeRequirements }) {
+	apply(dependency, source, { module, runtimeRequirements }) {
 		const dep = /** @type {AMDDefineDependency} */ (dependency);
 		const branch = this.branch(dep);
 		const { definition, content, requests } = DEFINITIONS[branch];
 		for (const req of requests) {
 			runtimeRequirements.add(req);
 		}
-		this.replace(dep, source, definition, content);
+		this.replace(
+			dep,
+			source,
+			definition,
+			content.replace(/\bmodule\b/g, module.moduleArgument)
+		);
 	}
 
 	/**

--- a/test/configCases/amd/module-variable-conflict/array-function.js
+++ b/test/configCases/amd/module-variable-conflict/array-function.js
@@ -1,0 +1,4 @@
+define([], function () {
+	const module = { value: "array-function" };
+	return module;
+});

--- a/test/configCases/amd/module-variable-conflict/function.js
+++ b/test/configCases/amd/module-variable-conflict/function.js
@@ -1,0 +1,4 @@
+define(function () {
+	const module = { value: "function" };
+	return module;
+});

--- a/test/configCases/amd/module-variable-conflict/index.js
+++ b/test/configCases/amd/module-variable-conflict/index.js
@@ -1,0 +1,5 @@
+it("should assign the AMD result to the renamed module argument", () => {
+	expect(require("./array-function").value).toBe("array-function");
+	expect(require("./function").value).toBe("function");
+	expect(require("./object").value).toBe("object");
+});

--- a/test/configCases/amd/module-variable-conflict/object.js
+++ b/test/configCases/amd/module-variable-conflict/object.js
@@ -1,0 +1,3 @@
+const module = { value: "object" };
+
+define({ value: module.value });

--- a/test/configCases/amd/module-variable-conflict/webpack.config.js
+++ b/test/configCases/amd/module-variable-conflict/webpack.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {};


### PR DESCRIPTION
**Summary**

`AMDDefineDependency` always emitted the factory-result assignment as `module.exports = ...`. When the module declares its own top-level `module`, webpack renames the module argument to `__webpack_module__` (#20265), so that assignment refers to an identifier that no longer exists and the bundle throws `ReferenceError: module is not defined` in the browser. The template now emits the module's actual `moduleArgument` instead of the hardcoded name.

Fixes #21812.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes, `test/configCases/amd/module-variable-conflict` covers the array+function, function and object forms of `define()`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. I used Claude Code to help trace the root cause and draft the fix and the test case; I reviewed the diff and verified it locally against the reproduction from the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AMD module results being assigned to the correct module argument, preventing `ReferenceError` issues.
  * Improved handling when module variables conflict with local names across supported AMD module patterns.
  * Ensured AMD modules continue to work correctly when returning arrays, functions, or objects.

* **Tests**
  * Added coverage for AMD modules returning arrays, functions, and objects in module-variable conflict scenarios.
  * Added regression coverage for renamed module arguments and conflicting local variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->