### PR TITLE
fix: use the module argument in amd define() output

### DIFF
--- a/.changeset/035-amd-define-module-argument.md
+++ b/.changeset/035-amd-define-module-argument.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix AMD `define()` output using the wrong module and exports argument names.

--- a/lib/dependencies/AMDDefineDependency.js
+++ b/lib/dependencies/AMDDefineDependency.js
@@ -17,93 +17,115 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[Range, Range | null, Range | null, Range | null, string | null, LocalModule | null]>} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[Range, Range | null, Range | null, Range | null, string | null, LocalModule | null]>} ObjectSerializerContext */
 
-/** @type {Record<string, { definition: string, content: string, requests: string[] }>} */
-const DEFINITIONS = {
-	f: {
-		definition: "var __WEBPACK_AMD_DEFINE_RESULT__;",
-		content: `!(__WEBPACK_AMD_DEFINE_RESULT__ = (#).call(exports, ${RuntimeGlobals.require}, exports, module),
-		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
-		requests: [
-			RuntimeGlobals.require,
-			RuntimeGlobals.exports,
-			RuntimeGlobals.module
-		]
-	},
-	o: {
-		definition: "",
-		content: "!(module.exports = #)",
-		requests: [RuntimeGlobals.module]
-	},
-	of: {
-		definition:
-			"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-		content: `!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#),
+/**
+ * @typedef {object} Definition
+ * @property {string} definition variable declarations
+ * @property {string} content replacement text
+ * @property {string[]} requests runtime requirements
+ */
+
+/** @type {Map<string, Record<string, Definition>>} */
+const definitionsCache = new Map();
+
+/**
+ * @param {string} moduleArgument the module argument name
+ * @param {string} exportsArgument the exports argument name
+ * @returns {Record<string, Definition>} definitions by branch
+ */
+const getDefinitions = (moduleArgument, exportsArgument) => {
+	const key = `${moduleArgument} ${exportsArgument}`;
+	const cached = definitionsCache.get(key);
+	if (cached !== undefined) return cached;
+	/** @type {Record<string, Definition>} */
+	const definitions = {
+		f: {
+			definition: "var __WEBPACK_AMD_DEFINE_RESULT__;",
+			content: `!(__WEBPACK_AMD_DEFINE_RESULT__ = (#).call(${exportsArgument}, ${RuntimeGlobals.require}, ${exportsArgument}, ${moduleArgument}),
+		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (${moduleArgument}.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
+			requests: [
+				RuntimeGlobals.require,
+				RuntimeGlobals.exports,
+				RuntimeGlobals.module
+			]
+		},
+		o: {
+			definition: "",
+			content: `!(${moduleArgument}.exports = #)`,
+			requests: [RuntimeGlobals.module]
+		},
+		of: {
+			definition:
+				"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+			content: `!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#),
 		__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-		(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, ${RuntimeGlobals.require}, exports, module)) :
+		(__WEBPACK_AMD_DEFINE_FACTORY__.call(${exportsArgument}, ${RuntimeGlobals.require}, ${exportsArgument}, ${moduleArgument})) :
 		__WEBPACK_AMD_DEFINE_FACTORY__),
-		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
-		requests: [
-			RuntimeGlobals.require,
-			RuntimeGlobals.exports,
-			RuntimeGlobals.module
-		]
-	},
-	af: {
-		definition:
-			"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-		content: `!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = (#).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
-		requests: [RuntimeGlobals.exports, RuntimeGlobals.module]
-	},
-	ao: {
-		definition: "",
-		content: "!(#, module.exports = #)",
-		requests: [RuntimeGlobals.module]
-	},
-	aof: {
-		definition:
-			"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-		content: `!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#),
+		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (${moduleArgument}.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
+			requests: [
+				RuntimeGlobals.require,
+				RuntimeGlobals.exports,
+				RuntimeGlobals.module
+			]
+		},
+		af: {
+			definition:
+				"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+			content: `!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = (#).apply(${exportsArgument}, __WEBPACK_AMD_DEFINE_ARRAY__),
+		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (${moduleArgument}.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
+			requests: [RuntimeGlobals.exports, RuntimeGlobals.module]
+		},
+		ao: {
+			definition: "",
+			content: `!(#, ${moduleArgument}.exports = #)`,
+			requests: [RuntimeGlobals.module]
+		},
+		aof: {
+			definition:
+				"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+			content: `!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#),
 		__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-		(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
-		requests: [RuntimeGlobals.exports, RuntimeGlobals.module]
-	},
-	lf: {
-		definition: "var XXX, XXXmodule;",
-		content: `!(XXXmodule = { id: YYY, exports: {}, loaded: false }, XXX = (#).call(XXXmodule.exports, ${RuntimeGlobals.require}, XXXmodule.exports, XXXmodule), XXXmodule.loaded = true, XXX === undefined && (XXX = XXXmodule.exports))`,
-		requests: [RuntimeGlobals.require, RuntimeGlobals.module]
-	},
-	lo: {
-		definition: "var XXX;",
-		content: "!(XXX = #)",
-		requests: []
-	},
-	lof: {
-		definition: "var XXX, XXXfactory, XXXmodule;",
-		content: `!(XXXfactory = (#), (typeof XXXfactory === 'function' ? ((XXXmodule = { id: YYY, exports: {}, loaded: false }), (XXX = XXXfactory.call(XXXmodule.exports, ${RuntimeGlobals.require}, XXXmodule.exports, XXXmodule)), (XXXmodule.loaded = true), XXX === undefined && (XXX = XXXmodule.exports)) : XXX = XXXfactory))`,
-		requests: [RuntimeGlobals.require, RuntimeGlobals.module]
-	},
-	laf: {
-		definition: "var __WEBPACK_AMD_DEFINE_ARRAY__, XXX, XXXexports;",
-		content:
-			"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = (#).apply(XXXexports = {}, __WEBPACK_AMD_DEFINE_ARRAY__), XXX === undefined && (XXX = XXXexports))",
-		requests: []
-	},
-	lao: {
-		definition: "var XXX;",
-		content: "!(#, XXX = #)",
-		requests: []
-	},
-	laof: {
-		definition: "var XXXarray, XXXfactory, XXXexports, XXX;",
-		content: `!(XXXarray = #, XXXfactory = (#),
+		(__WEBPACK_AMD_DEFINE_FACTORY__.apply(${exportsArgument}, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
+		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (${moduleArgument}.exports = __WEBPACK_AMD_DEFINE_RESULT__))`,
+			requests: [RuntimeGlobals.exports, RuntimeGlobals.module]
+		},
+		lf: {
+			definition: "var XXX, XXXmodule;",
+			content: `!(XXXmodule = { id: YYY, exports: {}, loaded: false }, XXX = (#).call(XXXmodule.exports, ${RuntimeGlobals.require}, XXXmodule.exports, XXXmodule), XXXmodule.loaded = true, XXX === undefined && (XXX = XXXmodule.exports))`,
+			requests: [RuntimeGlobals.require, RuntimeGlobals.module]
+		},
+		lo: {
+			definition: "var XXX;",
+			content: "!(XXX = #)",
+			requests: []
+		},
+		lof: {
+			definition: "var XXX, XXXfactory, XXXmodule;",
+			content: `!(XXXfactory = (#), (typeof XXXfactory === 'function' ? ((XXXmodule = { id: YYY, exports: {}, loaded: false }), (XXX = XXXfactory.call(XXXmodule.exports, ${RuntimeGlobals.require}, XXXmodule.exports, XXXmodule)), (XXXmodule.loaded = true), XXX === undefined && (XXX = XXXmodule.exports)) : XXX = XXXfactory))`,
+			requests: [RuntimeGlobals.require, RuntimeGlobals.module]
+		},
+		laf: {
+			definition: "var __WEBPACK_AMD_DEFINE_ARRAY__, XXX, XXXexports;",
+			content:
+				"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = (#).apply(XXXexports = {}, __WEBPACK_AMD_DEFINE_ARRAY__), XXX === undefined && (XXX = XXXexports))",
+			requests: []
+		},
+		lao: {
+			definition: "var XXX;",
+			content: "!(#, XXX = #)",
+			requests: []
+		},
+		laof: {
+			definition: "var XXXarray, XXXfactory, XXXexports, XXX;",
+			content: `!(XXXarray = #, XXXfactory = (#),
 		(typeof XXXfactory === 'function' ?
 			((XXX = XXXfactory.apply(XXXexports = {}, XXXarray)), XXX === undefined && (XXX = XXXexports)) :
 			(XXX = XXXfactory)
 		))`,
-		requests: []
-	}
+			requests: []
+		}
+	};
+	definitionsCache.set(key, definitions);
+	return definitions;
 };
 
 class AMDDefineDependency extends NullDependency {
@@ -181,10 +203,13 @@ AMDDefineDependency.Template = class AMDDefineDependencyTemplate extends (
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeRequirements }) {
+	apply(dependency, source, { module, runtimeRequirements }) {
 		const dep = /** @type {AMDDefineDependency} */ (dependency);
 		const branch = this.branch(dep);
-		const { definition, content, requests } = DEFINITIONS[branch];
+		const { definition, content, requests } = getDefinitions(
+			module.moduleArgument,
+			module.exportsArgument
+		)[branch];
 		for (const req of requests) {
 			runtimeRequirements.add(req);
 		}

--- a/test/cases/amd/define-local-module/af.js
+++ b/test/cases/amd/define-local-module/af.js
@@ -1,0 +1,4 @@
+define([], function () {
+	const module = { value: "af" };
+	return module;
+});

--- a/test/cases/amd/define-local-module/ao.js
+++ b/test/cases/amd/define-local-module/ao.js
@@ -1,0 +1,2 @@
+const module = { value: "ao" };
+define([], { value: module.value });

--- a/test/cases/amd/define-local-module/aof.js
+++ b/test/cases/amd/define-local-module/aof.js
@@ -1,0 +1,5 @@
+const module = { value: "aof" };
+const factory = function (dep) {
+	return { value: module.value + dep.value };
+};
+define(["./f"], factory);

--- a/test/cases/amd/define-local-module/f.js
+++ b/test/cases/amd/define-local-module/f.js
@@ -1,0 +1,4 @@
+define(function () {
+	const module = { value: "f" };
+	return module;
+});

--- a/test/cases/amd/define-local-module/index.js
+++ b/test/cases/amd/define-local-module/index.js
@@ -1,0 +1,8 @@
+it("should export the factory result when the module declares `module`", () => {
+	expect(require("./f").value).toBe("f");
+	expect(require("./af").value).toBe("af");
+	expect(require("./of").value).toBe("of");
+	expect(require("./aof").value).toBe("aoff");
+	expect(require("./o").value).toBe("o");
+	expect(require("./ao").value).toBe("ao");
+});

--- a/test/cases/amd/define-local-module/o.js
+++ b/test/cases/amd/define-local-module/o.js
@@ -1,0 +1,2 @@
+const module = { value: "o" };
+define({ value: module.value });

--- a/test/cases/amd/define-local-module/of.js
+++ b/test/cases/amd/define-local-module/of.js
@@ -1,0 +1,5 @@
+const module = { value: "of" };
+const factory = function () {
+	return module;
+};
+define(factory);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes https://github.com/webpack/webpack/pull/21813 and https://github.com/webpack/webpack/issues/21812.

The amd define templates now respect `module.moduleArgument` / `module.exportsArgument`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected AMD `define()` output when modules use custom names for `module` and `exports` arguments.
  - Preserved correct behavior for local modules and factory-generated exports.

- **Tests**
  - Added coverage for AMD modules that declare and return local module values across multiple dependency combinations.

- **Documentation**
  - Added a patch release note documenting the AMD output fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->