### PR TITLE
fix(css): cut a dead rule where it stands after an earlier cut

### DIFF
--- a/.changeset/162-css-transition-drop-all.md
+++ b/.changeset/162-css-transition-drop-all.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Drop the spare `all` a `transition` layer names beside anything else.
+Drop spare `all` from `transition` layers with other components.

--- a/.changeset/162-css-transition-drop-all.md
+++ b/.changeset/162-css-transition-drop-all.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Drop the spare `all` a `transition` layer names beside anything else.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4952,9 +4952,8 @@ const _takeDeduped = (writer, piece, text, spans, own, chain) => {
  */
 const _noteSpans = (writer, taken, spans, chain) => {
 	if (_seenRuleKeys === null) _seenRuleKeys = new Map();
-	// Every span joins the piece before any cutting: a cut in this same piece
-	// moves what `taken.spans` holds, so one still waiting to be pushed would
-	// keep naming its pre-cut offset and be registered pointing at other text.
+	// Every span joins the piece before any cutting: a cut here moves what
+	// `taken.spans` holds, and one not yet pushed would keep its old offset.
 	for (const span of spans) {
 		if (chain.length !== 0) span.key = `${chain}${span.key}`;
 		taken.spans.push(span);

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -4952,11 +4952,16 @@ const _takeDeduped = (writer, piece, text, spans, own, chain) => {
  */
 const _noteSpans = (writer, taken, spans, chain) => {
 	if (_seenRuleKeys === null) _seenRuleKeys = new Map();
+	// Every span joins the piece before any cutting: a cut in this same piece
+	// moves what `taken.spans` holds, so one still waiting to be pushed would
+	// keep naming its pre-cut offset and be registered pointing at other text.
 	for (const span of spans) {
 		if (chain.length !== 0) span.key = `${chain}${span.key}`;
+		taken.spans.push(span);
+	}
+	for (const span of spans) {
 		const before = _seenRuleKeys.get(span.key);
 		if (before !== undefined) _cutSpan(writer, before.taken, before.span);
-		taken.spans.push(span);
 		_seenRuleKeys.set(span.key, { taken, span });
 	}
 };

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -8892,7 +8892,14 @@ const _orderTransitionSlots = (components) => {
 	// its own leaves which slot it fills to the engine — that one is left alone.
 	if (names.length !== 1 || times.length > 2 || easings.length > 1) return null;
 	if (behaviors.length > 1) return null;
-	const ordered = [...names, ...times, ...easings, ...behaviors];
+	// `all` is the property a layer naming none transitions, so writing it is
+	// spare — as long as something else is left to keep the layer from emptying.
+	const named =
+		toLowerCaseIfNeeded(names[0]) === "all" && components.length > 1
+			? []
+			: names;
+	const ordered = [...named, ...times, ...easings, ...behaviors];
+	if (ordered.length === 0) return null;
 	return ordered.join(" ") === components.join(" ") ? null : ordered;
 };
 

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -900,6 +900,22 @@ describe("CssSyntax — block streaming", () => {
 		expect(childCount(`@media screen{${SMALL}}`)).toBe(4);
 	});
 
+	it("cuts a dead rule where it stands after an earlier cut in the piece", () => {
+		// Sibling `@layer a` blocks fold into one piece, so a batch that takes two
+		// rules back cuts twice in it. Its own spans move with the first cut, and a
+		// span read after it must name its new place, not the one it went out at.
+		const dead = ".p{color:red}.q{color:blue}";
+		const victim =
+			".victim{align-items:flex-start;border-radius:0;opacity:1;background:red}";
+		const src = `@layer outer{${repeat(6000, (i) => `.f${i}{color:red}`)}@layer a{${dead}}@layer a{${dead}}@layer a{${victim}}@layer a{.q{color:blue}}}`;
+		// The outer block has to stream for the fold to be the one under test.
+		expect(childCount(src)).toBe(0);
+		const out = minify(src);
+		// Sliced, so a wrong cut reads as the mangled rule and not as the sheet.
+		const at = out.indexOf(".victim");
+		expect(out.slice(at, at + victim.length)).toBe(victim);
+	});
+
 	it("enters a streamed rule before its children and exits after them", () => {
 		const seq = walk(`@media screen{${SMALL}}`, { recurseBlocks: true });
 		expect(seq[0]).toBe("+AtRule|0|0");

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -901,9 +901,8 @@ describe("CssSyntax — block streaming", () => {
 	});
 
 	it("cuts a dead rule where it stands after an earlier cut in the piece", () => {
-		// Sibling `@layer a` blocks fold into one piece, so a batch that takes two
-		// rules back cuts twice in it. Its own spans move with the first cut, and a
-		// span read after it must name its new place, not the one it went out at.
+		// Sibling `@layer a` blocks fold into one piece, so a batch cuts twice in
+		// it — and its own second span must name where the first cut left it.
 		const dead = ".p{color:red}.q{color:blue}";
 		const victim =
 			".victim{align-items:flex-start;border-radius:0;opacity:1;background:red}";

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -907,7 +907,10 @@ describe("CssSyntax — block streaming", () => {
 		const dead = ".p{color:red}.q{color:blue}";
 		const victim =
 			".victim{align-items:flex-start;border-radius:0;opacity:1;background:red}";
-		const src = `@layer outer{${repeat(6000, (i) => `.f${i}{color:red}`)}@layer a{${dead}}@layer a{${dead}}@layer a{${victim}}@layer a{.q{color:blue}}}`;
+		const src = `@layer outer{${repeat(
+			6000,
+			(i) => `.f${i}{color:red}`
+		)}@layer a{${dead}}@layer a{${dead}}@layer a{${victim}}@layer a{.q{color:blue}}}`;
 		// The outer block has to stream for the fold to be the one under test.
 		expect(childCount(src)).toBe(0);
 		const out = minify(src);
@@ -3028,7 +3031,7 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 		it.each([
 			["a{transition:height .35s ease}", "a{transition:height.35s}"],
 			["a{transition:opacity 1s ease 2s}", "a{transition:opacity 1s 2s}"],
-			["a{transition:all 1s ease}", "a{transition:all 1s}"],
+			["a{transition:all 1s ease}", "a{transition:1s}"],
 			["a{transition:opacity 1s normal}", "a{transition:opacity 1s}"],
 			// A comma parts two layers, and each holds its own set of slots.
 			[
@@ -3037,7 +3040,7 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 			],
 			[
 				"a{transition:all .3s cubic-bezier(.4,0,.2,1),color .2s ease}",
-				"a{transition:all.3s cubic-bezier(.4,0,.2,1),color.2s}"
+				"a{transition:.3s cubic-bezier(.4,0,.2,1),color.2s}"
 			],
 			// Only the layer whose slots are unambiguous gives its keyword up.
 			[
@@ -3048,6 +3051,23 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 				"a{transition:1s ease color,2s opacity}",
 				"a{transition:color 1s,opacity 2s}"
 			],
+			// `all` is the property a layer naming none transitions, so it is spare
+			// beside anything else — but it is what a layer left alone still says.
+			["a{transition:all .5s}", "a{transition:.5s}"],
+			["a{transition:ALL .5s}", "a{transition:.5s}"],
+			["a{transition:all 5s linear}", "a{transition:5s linear}"],
+			["a{transition:all .5s 1s}", "a{transition:.5s 1s}"],
+			[
+				"a{transition:all .5s allow-discrete}",
+				"a{transition:.5s allow-discrete}"
+			],
+			["a{transition:all .5s,opacity 1s}", "a{transition:.5s,opacity 1s}"],
+			["a{-webkit-transition:all .5s}", "a{-webkit-transition:.5s}"],
+			["a{transition:all}", "a{transition:all}"],
+			// The zero duration goes first, which leaves `all` standing alone.
+			["a{transition:all 0s}", "a{transition:all}"],
+			["a{transition:none .5s}", "a{transition:none .5s}"],
+			["a{transition-property:all}", "a{transition-property:all}"],
 			["a{animation:x 1s ease}", "a{animation:x 1s}"],
 			["a{animation:x 2s ease normal running}", "a{animation:x 2s}"],
 			["a{border:2px none red}", "a{border:2px red}"],

--- a/test/configCases/css/minimize-rewrite-custom-properties/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-rewrite-custom-properties/__snapshots__/ConfigCacheTest.snap
@@ -28,5 +28,7 @@ Array [
   "/*! lightningcss custom_properties: attr() with a type, and with a fallback */.u16{background-color:attr(data-color type(<color>))}.u17{width:attr(data-width type(<length>),100px)}",
   "/*! a named color stays as authored, hex being invalid where the name is not */.v01{--c:white}.v02{--c:black}.v03{--c:rebeccapurple}",
   "/*! and the same name in a real color property does shorten */.v04{color:#fff}",
+  "/*! a fragment keeps every digit it was written with */.w01{--u:url(#fff)}.w02{--u:url(#ffffff)}",
+  "/*! a quoted value is text, hex-shaped or not */.w03{--s:\\"#fff\\"}.w04{--s:\\"0.50\\"}",
 ]
 `;

--- a/test/configCases/css/minimize-rewrite-custom-properties/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-rewrite-custom-properties/__snapshots__/ConfigTest.snap
@@ -28,5 +28,7 @@ Array [
   "/*! lightningcss custom_properties: attr() with a type, and with a fallback */.u16{background-color:attr(data-color type(<color>))}.u17{width:attr(data-width type(<length>),100px)}",
   "/*! a named color stays as authored, hex being invalid where the name is not */.v01{--c:white}.v02{--c:black}.v03{--c:rebeccapurple}",
   "/*! and the same name in a real color property does shorten */.v04{color:#fff}",
+  "/*! a fragment keeps every digit it was written with */.w01{--u:url(#fff)}.w02{--u:url(#ffffff)}",
+  "/*! a quoted value is text, hex-shaped or not */.w03{--s:\\"#fff\\"}.w04{--s:\\"0.50\\"}",
 ]
 `;

--- a/test/configCases/css/minimize-rewrite-custom-properties/style.css
+++ b/test/configCases/css/minimize-rewrite-custom-properties/style.css
@@ -2,10 +2,8 @@
    value be shortened like any other value's — off by default, on here. */
 
 /* cssom: rewriteCustomProperties */
-/* The note above is read by the browser-equivalence run: it minifies this file
-   with that option, and compares each custom property by what its tokens denote
-   rather than by how they are spelled — so a value shortened here reads as the
-   one it shortens, and a value that changed still does not. */
+/* The note above tells the browser-equivalence run to minify this file with
+   that option, so the engine is held to what it does. */
 
 /*! a six-digit hex shortens to three */
 .t01 { --a: #ffffff }
@@ -74,9 +72,8 @@
 /*! and the same name in a real color property does shorten */
 .v04 { color: white }
 
-/* A fragment names something and a string is text, so neither is a color the
-   `cssom:` note above may read through — `url(#fff)` and `url(#ffffff)` point
-   at two different elements. */
+/* A fragment names something and a string is text, so neither holds a color:
+   `url(#fff)` and `url(#ffffff)` point at two different elements. */
 
 /*! a fragment keeps every digit it was written with */
 .w01 { --u: url(#fff) }

--- a/test/configCases/css/minimize-rewrite-custom-properties/style.css
+++ b/test/configCases/css/minimize-rewrite-custom-properties/style.css
@@ -73,3 +73,14 @@
 .v03 { --c: rebeccapurple }
 /*! and the same name in a real color property does shorten */
 .v04 { color: white }
+
+/* A fragment names something and a string is text, so neither is a color the
+   `cssom:` note above may read through — `url(#fff)` and `url(#ffffff)` point
+   at two different elements. */
+
+/*! a fragment keeps every digit it was written with */
+.w01 { --u: url(#fff) }
+.w02 { --u: url(#ffffff) }
+/*! a quoted value is text, hex-shaped or not */
+.w03 { --s: "#fff" }
+.w04 { --s: "0.50" }

--- a/test/configCases/css/minimize-rewrite-custom-properties/style.css
+++ b/test/configCases/css/minimize-rewrite-custom-properties/style.css
@@ -1,6 +1,12 @@
 /* `optimization.minimize.css.rewriteCustomProperties` lets a custom property's
    value be shortened like any other value's — off by default, on here. */
 
+/* cssom: rewriteCustomProperties */
+/* The note above is read by the browser-equivalence run: it minifies this file
+   with that option, and compares each custom property by what its tokens denote
+   rather than by how they are spelled — so a value shortened here reads as the
+   one it shortens, and a value that changed still does not. */
+
 /*! a six-digit hex shortens to three */
 .t01 { --a: #ffffff }
 /*! an eight-digit hex shortens to four */

--- a/test/configCases/css/minimize-rewrite-custom-properties/style.css
+++ b/test/configCases/css/minimize-rewrite-custom-properties/style.css
@@ -72,8 +72,7 @@
 /*! and the same name in a real color property does shorten */
 .v04 { color: white }
 
-/* A fragment names something and a string is text, so neither holds a color:
-   `url(#fff)` and `url(#ffffff)` point at two different elements. */
+/* A fragment names something and a string is text, so neither holds a color. */
 
 /*! a fragment keeps every digit it was written with */
 .w01 { --u: url(#fff) }

--- a/test/configCases/css/minimize-shorthands/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-shorthands/__snapshots__/ConfigCacheTest.snap
@@ -72,7 +72,7 @@ Array [
   "/*! declined: the keyword means something else on every other property */.t62{font-variant:normal;line-height:normal}",
   "/*! transition: a comma parts two layers, and each holds its own slots */.t63{transition:opacity 1s,color 1s}",
   "/*! transition: ...so only the layer whose slots are unambiguous gives its keyword up */.t63b{transition:opacity 1s,ease 1s ease}",
-  "/*! transition: a comma inside a call parts no layer */.t63c{transition:all.3s cubic-bezier(.4,0,.2,1),color.2s}",
+  "/*! transition: a comma inside a call parts no layer */.t63c{transition:.3s cubic-bezier(.4,0,.2,1),color.2s}",
   "/*! declined: a string could carry the comma the layer split reads */.t63d{transition:\\"a\\" 1s ease}",
   "/*! declined: an empty layer is no layer to shorten */.t63e{transition:opacity 1s ease,,color 2s ease}",
   "/*! background-position: a second value naming the centre is what an omitted one means */.t64{background-position:50%}",

--- a/test/configCases/css/minimize-shorthands/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-shorthands/__snapshots__/ConfigTest.snap
@@ -72,7 +72,7 @@ Array [
   "/*! declined: the keyword means something else on every other property */.t62{font-variant:normal;line-height:normal}",
   "/*! transition: a comma parts two layers, and each holds its own slots */.t63{transition:opacity 1s,color 1s}",
   "/*! transition: ...so only the layer whose slots are unambiguous gives its keyword up */.t63b{transition:opacity 1s,ease 1s ease}",
-  "/*! transition: a comma inside a call parts no layer */.t63c{transition:all.3s cubic-bezier(.4,0,.2,1),color.2s}",
+  "/*! transition: a comma inside a call parts no layer */.t63c{transition:.3s cubic-bezier(.4,0,.2,1),color.2s}",
   "/*! declined: a string could carry the comma the layer split reads */.t63d{transition:\\"a\\" 1s ease}",
   "/*! declined: an empty layer is no layer to shorten */.t63e{transition:opacity 1s ease,,color 2s ease}",
   "/*! background-position: a second value naming the centre is what an omitted one means */.t64{background-position:50%}",

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -385,6 +385,32 @@ const installHelpers = () => {
 		);
 	};
 
+	// Set while a sheet whose fixture says its custom properties are rewritten is
+	// read, so both sides are canonicalized alike rather than either being skipped.
+	let rewrittenCustomProperties = false;
+
+	/**
+	 * A custom property's token stream with each color resolved through the
+	 * engine and each number spelled one way, so a shortened value reads as the
+	 * one it shortens and a changed value still does not.
+	 * @param {string} value the value as written
+	 * @returns {string} it, token by token
+	 */
+	const canonicalTokens = (value) => {
+		const probe = document.createElement("div");
+		return value.replace(
+			/#[\da-fA-F]{3,8}\b|\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([^()]*\)|(^|[\s,(])(-?)(?:0+(\.\d+)|(\d+\.\d*?)0+)(?=[a-z%]*(?:[\s,)]|$))/g,
+			(token, lead, sign, bare, trailing) => {
+				if (bare !== undefined || trailing !== undefined) {
+					return `${lead}${sign}${bare === undefined ? trailing.replace(/\.$/, "") : `0${bare}`}`;
+				}
+				probe.style.color = "";
+				probe.style.color = token;
+				return probe.style.color === "" ? token : probe.style.color;
+			}
+		);
+	};
+
 	/**
 	 * The engine's computed value for every property a declaration sets, so an
 	 * equivalent respelling (`bold` / `700`, `300ms` / `0.3s`, `rgb(255, 0, 0)` /
@@ -424,7 +450,9 @@ const installHelpers = () => {
 			const lost = probe.style.getPropertyValue(property) === "";
 			const resolved =
 				written || lost
-					? normalizeValue(specified)
+					? rewrittenCustomProperties && property.startsWith("--")
+						? canonicalTokens(normalizeValue(specified))
+						: normalizeValue(specified)
 					: style.getPropertyValue(property);
 			out.push(`${property}${bang}:${painted(canonical(resolved))}`);
 		}
@@ -438,9 +466,12 @@ const installHelpers = () => {
 	 * are resolved by it. A condition is returned as written; the caller replaces
 	 * it with what the engine makes of it.
 	 * @param {string} source the stylesheet
+	 * @param {boolean=} rewritten whether the fixture says its custom property
+	 * values are rewritten, which makes them compare by what they denote
 	 * @returns {Rule[] | null} its rules, or null when it does not parse
 	 */
-	const cssRules = (source) => {
+	const cssRules = (source, rewritten) => {
+		rewrittenCustomProperties = rewritten === true;
 		const sheet = new CSSStyleSheet();
 		try {
 			sheet.replaceSync(source);

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -135,6 +135,37 @@ const installHelpers = () => {
 		return `paints ${[...context.getImageData(0, 0, 1, 1).data].join(",")}`;
 	};
 
+	/**
+	 * Rewrite only what stands outside a string or a `url()` body, so a token that
+	 * looks like a color inside either is left as the text it is.
+	 * @param {string} value a value
+	 * @param {(run: string) => string} rewrite what to do with the rest
+	 * @returns {string} the value, rewritten in place
+	 */
+	const outsideText = (value, rewrite) => {
+		let out = "";
+		let run = "";
+		for (let at = 0; at < value.length; at++) {
+			const ch = value[at];
+			const url = /^url\(/i.test(value.slice(at, at + 4));
+			if (ch === '"' || ch === "'" || url) {
+				out += rewrite(run);
+				run = "";
+				const end = url ? ")" : ch;
+				const from = at;
+				if (url) at += 3;
+				for (at += 1; at < value.length; at++) {
+					if (value[at] === "\\") at++;
+					else if (value[at] === end) break;
+				}
+				out += value.slice(from, at + 1);
+				continue;
+			}
+			run += ch;
+		}
+		return out + rewrite(run);
+	};
+
 	// The three code points CSS Syntax §3.3 calls a newline, `\r\n` included.
 	const NEWLINE = /[\n\r\f]/;
 
@@ -320,9 +351,14 @@ const installHelpers = () => {
 		out = out.replace(/(^|[^\w-])transparent(?![\w-])/gi, "$1rgba(0, 0, 0, 0)");
 		// A color written into a value the engine cannot compute — a `var()`
 		// fallback — is still a color, and `#ff0` is `rgb(255,255,0)`.
-		out = out.replace(
-			/#[\da-f]{3,8}\b|\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([^()]*\)/gi,
-			(color) => painted(color)
+		// A string is text and a `url()` body names something rather than describing
+		// it, so neither holds a color to read: `url(#fff)` and `url(#ffffff)` point
+		// at two different elements.
+		out = outsideText(out, (run) =>
+			run.replace(
+				/#[\da-f]{3,8}\b|\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([^()]*\)/gi,
+				(color) => painted(color)
+			)
 		);
 		return (
 			out
@@ -385,32 +421,6 @@ const installHelpers = () => {
 		);
 	};
 
-	// Set while a sheet whose fixture says its custom properties are rewritten is
-	// read, so both sides are canonicalized alike rather than either being skipped.
-	let rewrittenCustomProperties = false;
-
-	/**
-	 * A custom property's token stream with each color resolved through the
-	 * engine and each number spelled one way, so a shortened value reads as the
-	 * one it shortens and a changed value still does not.
-	 * @param {string} value the value as written
-	 * @returns {string} it, token by token
-	 */
-	const canonicalTokens = (value) => {
-		const probe = document.createElement("div");
-		return value.replace(
-			/#[\da-fA-F]{3,8}\b|\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([^()]*\)|(^|[\s,(])(-?)(?:0+(\.\d+)|(\d+\.\d*?)0+)(?=[a-z%]*(?:[\s,)]|$))/g,
-			(token, lead, sign, bare, trailing) => {
-				if (bare !== undefined || trailing !== undefined) {
-					return `${lead}${sign}${bare === undefined ? trailing.replace(/\.$/, "") : `0${bare}`}`;
-				}
-				probe.style.color = "";
-				probe.style.color = token;
-				return probe.style.color === "" ? token : probe.style.color;
-			}
-		);
-	};
-
 	/**
 	 * The engine's computed value for every property a declaration sets, so an
 	 * equivalent respelling (`bold` / `700`, `300ms` / `0.3s`, `rgb(255, 0, 0)` /
@@ -450,9 +460,7 @@ const installHelpers = () => {
 			const lost = probe.style.getPropertyValue(property) === "";
 			const resolved =
 				written || lost
-					? rewrittenCustomProperties && property.startsWith("--")
-						? canonicalTokens(normalizeValue(specified))
-						: normalizeValue(specified)
+					? normalizeValue(specified)
 					: style.getPropertyValue(property);
 			out.push(`${property}${bang}:${painted(canonical(resolved))}`);
 		}
@@ -466,12 +474,9 @@ const installHelpers = () => {
 	 * are resolved by it. A condition is returned as written; the caller replaces
 	 * it with what the engine makes of it.
 	 * @param {string} source the stylesheet
-	 * @param {boolean=} rewritten whether the fixture says its custom property
-	 * values are rewritten, which makes them compare by what they denote
 	 * @returns {Rule[] | null} its rules, or null when it does not parse
 	 */
-	const cssRules = (source, rewritten) => {
-		rewrittenCustomProperties = rewritten === true;
+	const cssRules = (source) => {
 		const sheet = new CSSStyleSheet();
 		try {
 			sheet.replaceSync(source);

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -136,8 +136,8 @@ const installHelpers = () => {
 	};
 
 	/**
-	 * Rewrite only what stands outside a string or a `url()` body, so a token that
-	 * looks like a color inside either is left as the text it is.
+	 * Rewrite only what stands outside a string or a `url()` body, where a
+	 * color-shaped token is text.
 	 * @param {string} value a value
 	 * @param {(run: string) => string} rewrite what to do with the rest
 	 * @returns {string} the value, rewritten in place
@@ -154,9 +154,21 @@ const installHelpers = () => {
 				const end = url ? ")" : ch;
 				const from = at;
 				if (url) at += 3;
+				let quote = "";
 				for (at += 1; at < value.length; at++) {
-					if (value[at] === "\\") at++;
-					else if (value[at] === end) break;
+					const here = value[at];
+					if (here === "\\") {
+						at++;
+					}
+					// A `url()` body may be quoted, and a `)` inside those quotes is
+					// part of the address rather than the end of the call.
+					else if (quote !== "") {
+						if (here === quote) quote = "";
+					} else if (url && (here === '"' || here === "'")) {
+						quote = here;
+					} else if (here === end) {
+						break;
+					}
 				}
 				out += value.slice(from, at + 1);
 				continue;

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -157,7 +157,7 @@ const installHelpers = () => {
 				let quote = url ? "" : ch;
 				if (url) {
 					at += 3;
-					while (/\s/.test(value[at + 1] || "")) at++;
+					while (/[\t\n\f\r ]/.test(value[at + 1] || "")) at++;
 					const opens = value[at + 1];
 					if (opens === '"' || opens === "'") {
 						quote = opens;

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -351,9 +351,8 @@ const installHelpers = () => {
 		out = out.replace(/(^|[^\w-])transparent(?![\w-])/gi, "$1rgba(0, 0, 0, 0)");
 		// A color written into a value the engine cannot compute — a `var()`
 		// fallback — is still a color, and `#ff0` is `rgb(255,255,0)`.
-		// A string is text and a `url()` body names something rather than describing
-		// it, so neither holds a color to read: `url(#fff)` and `url(#ffffff)` point
-		// at two different elements.
+		// A string is text and a `url()` body names something, so neither holds a
+		// color: `url(#fff)` and `url(#ffffff)` are two different elements.
 		out = outsideText(out, (run) =>
 			run.replace(
 				/#[\da-f]{3,8}\b|\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([^()]*\)/gi,

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -151,24 +151,27 @@ const installHelpers = () => {
 			if (ch === '"' || ch === "'" || url) {
 				out += rewrite(run);
 				run = "";
-				const end = url ? ")" : ch;
 				const from = at;
-				if (url) at += 3;
-				let quote = "";
-				for (at += 1; at < value.length; at++) {
-					const here = value[at];
-					if (here === "\\") {
+				// CSS Syntax 4.3.6: only a quote opening the body makes it a string;
+				// one met later is a parse error whose recovery ends at the next `)`.
+				let quote = url ? "" : ch;
+				if (url) {
+					at += 3;
+					while (/\s/.test(value[at + 1] || "")) at++;
+					const opens = value[at + 1];
+					if (opens === '"' || opens === "'") {
+						quote = opens;
 						at++;
 					}
-					// A `url()` body may be quoted, and a `)` inside those quotes is
-					// part of the address rather than the end of the call.
-					else if (quote !== "") {
-						if (here === quote) quote = "";
-					} else if (url && (here === '"' || here === "'")) {
-						quote = here;
-					} else if (here === end) {
-						break;
-					}
+				}
+				const end = quote === "" ? ")" : quote;
+				for (at += 1; at < value.length; at++) {
+					if (value[at] === "\\") at++;
+					else if (value[at] === end) break;
+				}
+				// A quoted body leaves the call's own `)` still to step over.
+				if (url && quote !== "") {
+					while (at < value.length && value[at] !== ")") at++;
 				}
 				out += value.slice(from, at + 1);
 				continue;

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -502,6 +502,28 @@ describe("printer output in real Chrome", () => {
 				);
 			}
 
+			// A `)` inside a quoted `url()` belongs to the address, so the scan for
+			// the call's end must not stop there and read a color out of the rest.
+			it(
+				"reads no color out of a quoted url() body",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "quoted-url-fragment",
+							raw: '.a{--u:url("assets/)#fff")}',
+							min: '.a{--u:url("assets/)#ffffff")}'
+						}
+					]);
+					expect(differences).toEqual([
+						{
+							name: "quoted-url-fragment",
+							why: 'rule 0:  .a { --u:url("assets/)#fff") } vs  .a { --u:url("assets/)#ffffff") }'
+						}
+					]);
+				},
+				FILE_TIMEOUT
+			);
+
 			// The rules are read layer by layer, and an `@layer` statement is what
 			// fixes those layers' order — so the same blocks written the other way
 			// round under one are the same sheet, wherever each block stands.

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -100,9 +100,8 @@ const minifyHtml = (source, options) =>
  * @param {string} source a stylesheet
  * @returns {string} the same stylesheet, minified
  */
-// A fixture says which minimizer options its own claim is about, so the option
-// the file exists to cover is the one the engine is held to — and the same note
-// tells the comparison which differences the file means to produce.
+// A fixture names the minimizer options its own claim is about, so the engine
+// is held to the option the file exists to cover.
 const CSSOM_DIRECTIVE = /\/\*\s*cssom:([^*]*)\*\//;
 
 /**

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -169,14 +169,7 @@ const variant = (sources, options) =>
  */
 const buildCorpora = () => {
 	const configHtml = buildCorpus(CONFIG_CASES, ".html", (source) => source);
-	// A fixture's own `cssom:` note rides along, so the comparison reads its
-	// custom properties the way the option it names leaves them.
-	const configCss = buildCorpus(CONFIG_CASES, ".css", minifyCss).map(
-		(each) => ({
-			...each,
-			rewritten: cssomDirective(each.raw).includes("rewriteCustomProperties")
-		})
-	);
+	const configCss = buildCorpus(CONFIG_CASES, ".css", minifyCss);
 	/** @type {Corpus[]} */
 	const built = [
 		{
@@ -403,8 +396,8 @@ describe("printer output in real Chrome", () => {
 				).__eq;
 				return sheets.map((each) => ({
 					name: each.name,
-					before: cssRules(each.raw, each.rewritten),
-					after: cssRules(each.min, each.rewritten)
+					before: cssRules(each.raw),
+					after: cssRules(each.min)
 				}));
 			}, batch)
 		);

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -100,10 +100,33 @@ const minifyHtml = (source, options) =>
  * @param {string} source a stylesheet
  * @returns {string} the same stylesheet, minified
  */
-const minifyCss = (source) =>
-	/** @type {{ code: string }} */ (
-		new CssSourceProcessor().process(source, { mode: "minify" })
+// A fixture says which minimizer options its own claim is about, so the option
+// the file exists to cover is the one the engine is held to — and the same note
+// tells the comparison which differences the file means to produce.
+const CSSOM_DIRECTIVE = /\/\*\s*cssom:([^*]*)\*\//;
+
+/**
+ * @param {string} source the stylesheet as written
+ * @returns {string[]} the options its `cssom:` note names, empty when it has none
+ */
+const cssomDirective = (source) => {
+	const found = CSSOM_DIRECTIVE.exec(source);
+	return found === null
+		? []
+		: found[1]
+				.trim()
+				.split(/[\s,]+/)
+				.filter(Boolean);
+};
+
+const minifyCss = (source) => {
+	/** @type {{ mode: string, [k: string]: EXPECTED_ANY }} */
+	const options = { mode: "minify" };
+	for (const name of cssomDirective(source)) options[name] = true;
+	return /** @type {{ code: string }} */ (
+		new CssSourceProcessor().process(source, options)
 	).code;
+};
 
 /**
  * One declaration's minified value — `a{…}` is the smallest rule carrying one.
@@ -146,7 +169,14 @@ const variant = (sources, options) =>
  */
 const buildCorpora = () => {
 	const configHtml = buildCorpus(CONFIG_CASES, ".html", (source) => source);
-	const configCss = buildCorpus(CONFIG_CASES, ".css", minifyCss);
+	// A fixture's own `cssom:` note rides along, so the comparison reads its
+	// custom properties the way the option it names leaves them.
+	const configCss = buildCorpus(CONFIG_CASES, ".css", minifyCss).map(
+		(each) => ({
+			...each,
+			rewritten: cssomDirective(each.raw).includes("rewriteCustomProperties")
+		})
+	);
 	/** @type {Corpus[]} */
 	const built = [
 		{
@@ -373,8 +403,8 @@ describe("printer output in real Chrome", () => {
 				).__eq;
 				return sheets.map((each) => ({
 					name: each.name,
-					before: cssRules(each.raw),
-					after: cssRules(each.min)
+					before: cssRules(each.raw, each.rewritten),
+					after: cssRules(each.min, each.rewritten)
 				}));
 			}, batch)
 		);

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -109,13 +109,32 @@ const CSSOM_DIRECTIVE = /\/\*\s*cssom:([^*]*)\*\//;
  * @returns {string[]} the options its `cssom:` note names, empty when it has none
  */
 const cssomDirective = (source) => {
-	const found = CSSOM_DIRECTIVE.exec(source);
-	return found === null
-		? []
-		: found[1]
+	// Read from the comments alone: the same text inside a string is a value the
+	// fixture prints, not a note about how to minify it.
+	for (let at = 0; at < source.length; at++) {
+		const ch = source[at];
+		if (ch === '"' || ch === "'") {
+			for (at++; at < source.length; at++) {
+				if (source[at] === "\\") at++;
+				else if (source[at] === ch) break;
+			}
+			continue;
+		}
+		if (ch !== "/" || source[at + 1] !== "*") continue;
+		const close = source.indexOf("*/", at + 2);
+		const found = CSSOM_DIRECTIVE.exec(
+			source.slice(at, close === -1 ? source.length : close + 2)
+		);
+		if (found !== null) {
+			return found[1]
 				.trim()
 				.split(/[\s,]+/)
 				.filter(Boolean);
+		}
+		if (close === -1) break;
+		at = close + 1;
+	}
+	return [];
 };
 
 const minifyCss = (source) => {
@@ -502,8 +521,8 @@ describe("printer output in real Chrome", () => {
 				);
 			}
 
-			// A `)` inside a quoted `url()` belongs to the address, so the scan for
-			// the call's end must not stop there and read a color out of the rest.
+			// A `)` inside a quoted `url()` belongs to the address; one met after an
+			// illegal quote ends the bad url, and the rest is a color again.
 			it(
 				"reads no color out of a quoted url() body",
 				async () => {
@@ -520,6 +539,23 @@ describe("printer output in real Chrome", () => {
 							why: 'rule 0:  .a { --u:url("assets/)#fff") } vs  .a { --u:url("assets/)#ffffff") }'
 						}
 					]);
+				},
+				FILE_TIMEOUT
+			);
+
+			// CSS Syntax 4.3.6: the quote is a parse error, and recovery ends the url
+			// at the next `)`, so the hex after it is read as the color it is.
+			it(
+				"ends a bad url() at the paren its recovery reaches",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "bad-url-fragment",
+							raw: '.a{--u:url(foo")#fff)}',
+							min: '.a{--u:url(foo")#ffffff)}'
+						}
+					]);
+					expect(differences).toEqual([]);
 				},
 				FILE_TIMEOUT
 			);

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -120,6 +120,21 @@ const cssomDirective = (source) => {
 			}
 			continue;
 		}
+		// `/*` inside an unquoted `url()` is part of the address, not a comment.
+		if (/^url\(/i.test(source.slice(at, at + 4))) {
+			at += 3;
+			let quote = "";
+			while (/[\t\n\f\r ]/.test(source[at + 1] || "")) at++;
+			const opens = source[at + 1];
+			if (opens === '"' || opens === "'") quote = opens;
+			if (quote === "") {
+				for (at += 1; at < source.length; at++) {
+					if (source[at] === "\\") at++;
+					else if (source[at] === ")") break;
+				}
+			}
+			continue;
+		}
 		if (ch !== "/" || source[at + 1] !== "*") continue;
 		const close = source.indexOf("*/", at + 2);
 		const found = CSSOM_DIRECTIVE.exec(
@@ -559,6 +574,36 @@ describe("printer output in real Chrome", () => {
 				},
 				FILE_TIMEOUT
 			);
+
+			// CSS Syntax 4.2 counts five code points as whitespace, and U+00A0 is not
+			// one: it opens no quoted body, so the quote after it ends a bad url.
+			it(
+				"skips no non-breaking space before a url() body",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "nbsp-url-fragment",
+							raw: '.a{--u:url(\u00A0"foo)#fff")}',
+							min: '.a{--u:url(\u00A0"foo)#ffffff")}'
+						}
+					]);
+					expect(differences).toEqual([]);
+				},
+				FILE_TIMEOUT
+			);
+
+			// `/*` inside an unquoted `url()` is the address, so a fixture whose url
+			// spells one out is naming no option.
+			it("reads no cssom note out of a url() body", () => {
+				expect(
+					cssomDirective(
+						"a{background:url(/*cssom:rewriteCustomProperties*/x)}"
+					)
+				).toEqual([]);
+				expect(
+					cssomDirective("/* cssom: rewriteCustomProperties */a{color:red}")
+				).toEqual(["rewriteCustomProperties"]);
+			});
 
 			// The rules are read layer by layer, and an `@layer` statement is what
 			// fixes those layers' order — so the same blocks written the other way

--- a/tooling/compare-css-minifiers.js
+++ b/tooling/compare-css-minifiers.js
@@ -28,6 +28,13 @@ const path = require("path");
 const { promisify } = require("util");
 const zlib = require("zlib");
 
+// The assumption every other tool here makes when told no target: current
+// engines only. A broader query has webpack adding prefixes the others never
+// considered, which is a different sheet rather than a smaller one. Resolved
+// rather than written out, so it does not go stale as the browsers move.
+const MODERN_BROWSERS = require("browserslist")(
+	"last 1 chrome version, last 1 firefox version, last 1 safari version, last 1 edge version"
+);
 const cssMinify = require("../lib/css/cssMinify");
 
 const ROOT = path.resolve(__dirname, "..");
@@ -228,6 +235,16 @@ const fixtures = () => [
 /** @type {[string, () => (css: string) => string | Promise<string>][]} */
 const MINIFIERS = [
 	["webpack", () => (css) => cssMinify({ "input.css": css }).code],
+	[
+		// Every other tool here assumes a modern engine when told no target, and
+		// strips the vendor spellings it makes dead. webpack is told nothing, so it
+		// keeps them all — comparing the two rows says what the target is worth.
+		"webpack+target",
+		() => (css) =>
+			cssMinify({ "input.css": css }, undefined, {
+				environment: { browsers: MODERN_BROWSERS }
+			}).code
+	],
 	[
 		"esbuild",
 		() => {

--- a/tooling/compare-css-minifiers.js
+++ b/tooling/compare-css-minifiers.js
@@ -28,10 +28,8 @@ const path = require("path");
 const { promisify } = require("util");
 const zlib = require("zlib");
 
-// The assumption every other tool here makes when told no target: current
-// engines only. A broader query has webpack adding prefixes the others never
-// considered, which is a different sheet rather than a smaller one. Resolved
-// rather than written out, so it does not go stale as the browsers move.
+// What every other tool assumes when told no target: current engines only.
+// Resolved rather than written out, so it does not go stale.
 const MODERN_BROWSERS = require("browserslist")(
 	"last 1 chrome version, last 1 firefox version, last 1 safari version, last 1 edge version"
 );
@@ -236,9 +234,8 @@ const fixtures = () => [
 const MINIFIERS = [
 	["webpack", () => (css) => cssMinify({ "input.css": css }).code],
 	[
-		// Every other tool here assumes a modern engine when told no target, and
-		// strips the vendor spellings it makes dead. webpack is told nothing, so it
-		// keeps them all — comparing the two rows says what the target is worth.
+		// The rivals strip the spellings a modern engine makes dead; webpack, told
+		// nothing, keeps them. The two rows say what the target is worth.
 		"webpack+target",
 		() => (css) =>
 			cssMinify({ "input.css": css }, undefined, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`_noteSpans` pushed each span onto the piece only after cutting the earlier copy it made dead, and `_cutSpan` moves offsets by walking `taken.spans` — so a cut landing in that same piece left every span of the batch not yet pushed naming its pre-cut offset, and registered it pointing at other text. The next duplicate then cut there, splicing a live rule apart: on the daisyUI sheet #21804 prints `align-items;`, which no parser accepts. Pushing the whole batch before cutting fixes it; output is byte-identical on all twenty `benchmark:css-minifiers` fixtures.

Three smaller changes ride along. A `transition` layer's `all` is what a layer naming no property means, so it is dropped beside anything else. The minifier comparison gains a second webpack row built with a resolved browserslist, because every rival assumes current engines when told no target while webpack was told nothing — worth −92.9 KB raw / −4.6 KB gzip over the fixtures, and without it the table understates webpack rather than measuring it. And a `configCases` stylesheet can now name the minimizer options its own claim is about, so `rewriteCustomProperties` is checked against Chrome instead of passing with the option off.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/CssSyntax.unittest.js` covers both printer changes — the dead-rule case asserts the outer block actually streamed, so it cannot quietly stop testing that path if `_STREAM_MIN_NODES` moves. `test/configCases/css/minimize-rewrite-custom-properties/style.css` now carries a `/* cssom: … */` note, and the browser-equivalence run reads it: 2535 CSSOM checks pass, and corrupting one custom property (`#fff` → `#eee`) fails the run, so the note relaxes the spelling without relaxing the meaning.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no option changes; `rewriteCustomProperties` stays off by default.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code found the `align-items;` defect while investigating why the comparison tool errored on daisyUI, reduced it to a minimal case, wrote the fix and the tests, and ran the size, Chrome-equivalence and browser-verification measurements quoted above under my direction. I reviewed every change and checked the reasoning behind each transformation.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153XCvu1VvrWLasut6mjaXd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS transition shorthand optimization by removing redundant `all` entries while preserving valid standalone declarations.
  * Corrected streamed CSS rule processing to maintain accurate offsets after multiple edits.
  * Prevented unintended color normalization inside quoted strings, URL values, and custom-property content.
  * Prevented directive-like text in strings and malformed URLs from affecting CSS processing.
* **Improvements**
  * Added modern-browser targeting for CSS minifier comparisons.
* **Tests**
  * Expanded coverage for transitions, custom properties, URL fragments, directives, and streamed rule processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->