### PR TITLE
fix: short-circuit an optional call on an undefined DefinePlugin member

### DIFF
--- a/.changeset/051-define-plugin-optional-member-call.md
+++ b/.changeset/051-define-plugin-optional-member-call.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep the optional chain in `OBJ.MISSING?.method()` short-circuiting under `DefinePlugin`.

--- a/.changeset/051-define-plugin-optional-member-call.md
+++ b/.changeset/051-define-plugin-optional-member-call.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep the optional chain in `OBJ.MISSING?.method()` short-circuiting under `DefinePlugin`.
+Fix `DefinePlugin` dropping the optional chain in `OBJ.MISSING?.method()`.

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -1157,12 +1157,12 @@ class DefinePlugin {
 						 * Inherited members (e.g. `toString`) stay defined.
 						 * @param {Members} members chain members (after the root)
 						 * @param {string[]} deps consulted define keys (mutated)
-						 * @returns {boolean} true when the access resolves to `undefined`
+						 * @returns {number} index of the member resolving to `undefined`, or -1
 						 */
-						const isUndefinedMemberAccess = (members, deps) => {
-							if (members.length <= chainPrefix.length) return false;
+						const findUndefinedMemberAccess = (members, deps) => {
+							if (members.length <= chainPrefix.length) return -1;
 							for (let i = 0; i < chainPrefix.length; i++) {
-								if (members[i] !== chainPrefix[i]) return false;
+								if (members[i] !== chainPrefix[i]) return -1;
 							}
 							/** @type {MergedDefinitionNode | undefined} */
 							let value = definition;
@@ -1175,9 +1175,9 @@ class DefinePlugin {
 										deps.push(nextPath);
 										value = value.get(member);
 									} else if (member in EMPTY_OBJECT) {
-										return false;
+										return -1;
 									} else {
-										return true;
+										return i;
 									}
 								} else if (isObjectDefinition(value)) {
 									// non-expandable object leaf (e.g. an array)
@@ -1193,21 +1193,21 @@ class DefinePlugin {
 										deps.push(nextPath);
 										value = mergedDefinitions.definitions[nextPath];
 									} else {
-										return true;
+										return i;
 									}
 								} else {
 									// a leaf with members left is a real property access on a value
-									return false;
+									return -1;
 								}
 								path = nextPath;
 							}
-							return false;
+							return -1;
 						};
 						parser.hooks.expressionMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members) => {
 								const deps = [key];
-								if (!isUndefinedMemberAccess(members, deps)) return;
+								if (findUndefinedMemberAccess(members, deps) === -1) return;
 								for (const dep of deps) addValueDependency(dep);
 								return toConstantDependency(parser, "undefined")(expr);
 							});
@@ -1216,10 +1216,17 @@ class DefinePlugin {
 						// short-circuits, with the object never inlined.
 						parser.hooks.callMemberChain
 							.for(chainRoot)
-							.tap(PLUGIN_NAME, (expr, members) => {
+							.tap(PLUGIN_NAME, (expr, members, membersOptionals) => {
 								const deps = [key];
-								if (!isUndefinedMemberAccess(members, deps)) return;
+								const undefinedIndex = findUndefinedMemberAccess(members, deps);
+								if (undefinedIndex === -1) return;
 								for (const dep of deps) addValueDependency(dep);
+								for (let i = undefinedIndex + 1; i < members.length; i++) {
+									// an optional link after it short-circuits the whole call
+									if (membersOptionals[i]) {
+										return toConstantDependency(parser, "undefined")(expr);
+									}
+								}
 								toConstantDependency(
 									parser,
 									"undefined"

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -1149,7 +1149,7 @@ class DefinePlugin {
 						const chainRoot = isMeta ? "import.meta" : chainParts[0];
 						const chainPrefix = chainParts.slice(isMeta ? 2 : 1);
 						/**
-						 * Whether a member chain reads a property that is not defined.
+						 * Finds the member of a chain that reads a property that is not defined.
 						 * Walks the merged view so dotted keys of every instance count.
 						 * Collects every define key consulted so the caller can record a
 						 * value dependency on each (a sibling key like `OBJECT.SUB2` affects
@@ -1213,7 +1213,8 @@ class DefinePlugin {
 							});
 						// In a call, replace only the callee so the call itself is kept:
 						// `x.MISSING()` stays a (throwing) call and `x.MISSING?.()`
-						// short-circuits, with the object never inlined.
+						// short-circuits, with the object never inlined. An optional link
+						// right after the undefined member short-circuits the whole call.
 						parser.hooks.callMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members, membersOptionals) => {
@@ -1221,11 +1222,8 @@ class DefinePlugin {
 								const undefinedIndex = findUndefinedMemberAccess(members, deps);
 								if (undefinedIndex === -1) return;
 								for (const dep of deps) addValueDependency(dep);
-								for (let i = undefinedIndex + 1; i < members.length; i++) {
-									// an optional link after it short-circuits the whole call
-									if (membersOptionals[i]) {
-										return toConstantDependency(parser, "undefined")(expr);
-									}
+								if (membersOptionals[undefinedIndex + 1]) {
+									return toConstantDependency(parser, "undefined")(expr);
 								}
 								toConstantDependency(
 									parser,

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -41,11 +41,16 @@ it("should short-circuit a call on a member read from an unknown member (issue 2
 	const a = function () { return OBJECT.SUB1.UNKNOWN?.includes("foo"); };
 	const b = function () { return OBJECT?.SUB1?.UNKNOWN?.toUpperCase(); };
 	const c = function () { return NOT_DEFINED.SUB2.b?.["includes"]("foo"); };
+	const d = function () { return OBJECT.SUB1.UNKNOWN?.a.b(); };
+	const e = function () { return OBJECT.SUB1.UNKNOWN.a?.b(); };
 	expect(a.toString()).toBe("function () { return undefined; }");
 	expect(b.toString()).toBe("function () { return undefined; }");
 	expect(c.toString()).toBe("function () { return undefined; }");
+	expect(d.toString()).toBe("function () { return undefined; }");
+	expect(e.toString()).toBe("function () { return undefined(); }");
 	expect(OBJECT.SUB1.UNKNOWN?.includes("foo")).toBe(undefined);
 	expect(NOT_DEFINED.SUB2.b?.["includes"]("foo")).toBe(undefined);
+	expect(() => OBJECT.SUB1.UNKNOWN.a?.b()).toThrow();
 });
 it("should still substitute arguments of an unknown member call (issue 15559)", function () {
 	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -37,6 +37,16 @@ it("should resolve unknown member calls with optional members without inlining t
 	expect(c.toString()).toBe("function () { return undefined(); }");
 	expect(() => OBJECT.SUB1?.UNKNOWN()).toThrow();
 });
+it("should short-circuit a call on a member read from an unknown member (issue 21822)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN?.includes("foo"); };
+	const b = function () { return OBJECT?.SUB1?.UNKNOWN?.toUpperCase(); };
+	const c = function () { return NOT_DEFINED.SUB2.b?.["includes"]("foo"); };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined; }");
+	expect(OBJECT.SUB1.UNKNOWN?.includes("foo")).toBe(undefined);
+	expect(NOT_DEFINED.SUB2.b?.["includes"]("foo")).toBe(undefined);
+});
 it("should still substitute arguments of an unknown member call (issue 15559)", function () {
 	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };
 	expect(a.toString()).toBe('function () { return undefined?.("string"); }');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Since #21040, a call on a member read from an undefined define key replaces only the callee, so `process.env.MISSING?.includes("foo")` is emitted as `undefined("foo")` and throws at runtime instead of short-circuiting. The callee is now only replaced when nothing between the undefined member and the call is optional; otherwise the whole call expression becomes `undefined`, which is what it evaluates to.

Fixes #21822

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, a case in `test/configCases/plugins/define-plugin-optional-chaining/index.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. I used Claude Code to help trace the regression to #21040 and draft the patch. I reproduced the bug and verified the fix and the tests locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional member calls on undefined or unknown properties so they correctly short-circuit to `undefined`.
  * Preserved expected behavior for optional chaining across nested member access, bracket notation, and chained optional calls.
  * Maintained errors for non-optional access to unknown properties.
  * Added coverage for these scenarios in generated code and runtime evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->