### PR TITLE
fix(css): beautify without rewriting, and hold both printers to wpt

### DIFF
--- a/.changeset/077-css-beautify-keeps-every-rule.md
+++ b/.changeset/077-css-beautify-keeps-every-rule.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Beautify CSS without dropping rules, and close a comment the source left open.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -10625,6 +10625,25 @@ const _isClosedString = (text) => {
 };
 
 /**
+ * Whether a raw span ends inside a comment the source never closed. §4.3.2 runs
+ * such a comment to EOF, so a separator written after it lands inside it and the
+ * next parse reads a longer comment — output that grows on every pass.
+ * @param {string} text a raw span's text
+ * @returns {boolean} true when the span ends inside an open comment
+ */
+const _endsInsideComment = (text) => {
+	const out = createToken();
+	let lastType = TT_EOF;
+	for (let pos = 0; pos < text.length;) {
+		const token = readToken(text, pos, out);
+		if (token === undefined) break;
+		pos = token.end;
+		lastType = token.type;
+	}
+	return lastType === TT_COMMENT && !text.endsWith("*/");
+};
+
+/**
  * Print an attribute selector's children: the separators go (the grammar allows
  * whitespace anywhere inside `[…]`, and `_join` still parts two fragments that
  * would fuse — `[a=b i]`), and a quoted value that is also a bare identifier
@@ -11738,7 +11757,10 @@ const printer = (path, writer) => {
 			// Its parent counts it among its children, so it leaves the entry saying
 			// it carries no rule — without one, the rules after it read the next's.
 			if (minify) _blockSpans.push(_NO_BLOCK_ENTRY);
-			return `${path.source()};`;
+			{
+				const raw = path.source();
+				return `${raw}${_endsInsideComment(raw) ? "*/" : ""};`;
+			}
 		case T_HASH: {
 			const raw = path.source();
 			if (!minify) return raw;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -1719,6 +1719,9 @@ let _declBodies = [];
 /** @type {Node[][]} */
 let _ruleBodies = [];
 let _input = "";
+// Where a comment the source never closed opened, or -1. §4.3.2 runs one to
+// EOF, so at most one is open and only a span reaching the end sits inside it.
+let _openCommentStart = -1;
 let _locConverter = /** @type {LocConverter} */ (/** @type {unknown} */ (null));
 
 // Node refs are integers here but typed `Node` across the parser; these are
@@ -1909,6 +1912,7 @@ const _setRules = _setValue;
  */
 const _setupParse = (input, lc) => {
 	_input = input;
+	_openCommentStart = -1;
 	_locConverter = lc;
 	_nodeCount = 0;
 	_flatTop = 0;
@@ -2038,6 +2042,16 @@ class TokenStream {
 					break;
 				}
 				if (t.type === TT_COMMENT) {
+					// A closed comment is `/**/` at the shortest; anything else running to
+					// the end never closed, and the printer writes its `*/` back.
+					if (
+						t.end === input.length &&
+						(t.end - t.start < 4 ||
+							input.charCodeAt(t.end - 2) !== CC_ASTERISK ||
+							input.charCodeAt(t.end - 1) !== CC_SOLIDUS)
+					) {
+						_openCommentStart = t.start;
+					}
 					if (t.start >= this._commentHigh) {
 						if (this._onComment) this._onComment(input, t.start, t.end);
 						this._commentHigh = t.end;
@@ -10627,25 +10641,6 @@ const _isClosedString = (text) => {
 };
 
 /**
- * Whether a raw span ends inside a comment the source never closed. §4.3.2 runs
- * such a comment to EOF, so a separator written after it lands inside it and the
- * next parse reads a longer comment — output that grows on every pass.
- * @param {string} text a raw span's text
- * @returns {boolean} true when the span ends inside an open comment
- */
-const _endsInsideComment = (text) => {
-	const out = createToken();
-	let lastType = TT_EOF;
-	for (let pos = 0; pos < text.length;) {
-		const token = readToken(text, pos, out);
-		if (token === undefined) break;
-		pos = token.end;
-		lastType = token.type;
-	}
-	return lastType === TT_COMMENT && !text.endsWith("*/");
-};
-
-/**
  * Print an attribute selector's children: the separators go (the grammar allows
  * whitespace anywhere inside `[…]`, and `_join` still parts two fragments that
  * would fuse — `[a=b i]`), and a quoted value that is also a bare identifier
@@ -11761,7 +11756,14 @@ const printer = (path, writer) => {
 			if (minify) _blockSpans.push(_NO_BLOCK_ENTRY);
 			{
 				const raw = path.source();
-				return `${raw}${_endsInsideComment(raw) ? "*/" : ""};`;
+				// A comment the source never closed swallows the separator written
+				// after it, and the next parse reads a longer comment — output that
+				// grows on every pass. The parse said where it opened.
+				const open =
+					_openCommentStart !== -1 &&
+					_input.length - raw.length <= _openCommentStart &&
+					_input.endsWith(raw);
+				return `${raw}${open ? "*/" : ""};`;
 			}
 		case T_HASH: {
 			const raw = path.source();

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -11757,8 +11757,7 @@ const printer = (path, writer) => {
 			{
 				const raw = path.source();
 				// A comment the source never closed swallows the separator written
-				// after it, and the next parse reads a longer comment — output that
-				// grows on every pass. The parse said where it opened.
+				// after it, so the next parse reads a longer one. §4.3.2, via the parse.
 				const open =
 					_openCommentStart !== -1 &&
 					_input.length - raw.length <= _openCommentStart &&

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -5035,7 +5035,9 @@ const _emitTopLevel = (writer, node, offset, line, column, text, own) => {
 		_seenTopLevelLayers.clear();
 	}
 	if (opener === null) {
-		const spans = _topLevelSpans(own, text);
+		// Taking back a rule an identical later one makes dead is a rewrite, which
+		// is minifying's to make: beautifying hands back every rule it was given.
+		const spans = minify ? _topLevelSpans(own, text) : null;
 		if (spans === null) {
 			writer.take(node, offset, line, column, text);
 			return;

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2625,9 +2625,8 @@ describe("CssSyntax — print modes", () => {
 	});
 
 	it("closes a comment the source left open before writing after it", () => {
-		// §4.3.2 runs an unterminated comment to EOF, so a `;` or `}` written after
-		// it lands inside it — and the next parse reads a longer comment, growing
-		// the output on every pass (`{y/*` -> `{y/*}` -> `{y/*}}`).
+		// §4.3.2 runs an unterminated comment to EOF, so a `;` or `}` after it
+		// lands inside: `{y/*` grew to `{y/*}` to `{y/*}}` on every pass.
 		expect(print("{y/*", "minify")).toBe("{y/**/}");
 		expect(print("{y/*", "beautify")).toBe(" {\ny/**/;\n}");
 		for (const mode of /** @type {const} */ (["minify", "beautify"])) {
@@ -6383,9 +6382,8 @@ describe("CssSyntax minify — vendor prefixes (a twin written first)", () => {
 	});
 });
 
-// The corpus the tokenizer snapshots read, put through the other print mode.
-// Beautifying is the mode with no test corpus of its own, and it is the one a
-// consumer reads, so what it writes is snapshotted rather than described.
+// The tokenizer's corpus through the other print mode: beautifying had none of
+// its own, and it is what a consumer reads, so its output is snapshotted.
 describe("CssSyntax — beautifying the parsing corpus", () => {
 	const casesPath = path.resolve(__dirname, "./configCases/css/parsing/cases");
 	const cases = fs
@@ -6404,12 +6402,6 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 	const print = (src, mode) =>
 		new SourceProcessor().process(src, { mode }).code;
 
-	// Beautifying writes a terminator after content it echoed raw, so a comment
-	// the source never closed swallows it and the rule never ends. Minimal:
-	// Both modes drop a rule an identical later sibling supersedes, and minifying
-	// also joins adjacent rules sharing a selector — so the two forms keep a
-	// different copy of the same declarations. Every element still computes what
-
 	it("has a corpus", () => {
 		expect(cases.length).toBeGreaterThan(15);
 	});
@@ -6424,8 +6416,7 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 	}
 
 	// Both modes read the same stylesheet, so minifying either form answers the
-	// same — the property `print modes` states over its own handful of sources,
-	// here over every case the tokenizer reads.
+	// same — what `print modes` states over a handful, over every case here.
 	for (const [name, code] of cases) {
 		it(`should minify "${name}" the same from either form`, () => {
 			expect(print(print(code, "beautify"), "minify")).toBe(

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -2624,6 +2624,20 @@ describe("CssSyntax — print modes", () => {
 		);
 	});
 
+	it("closes a comment the source left open before writing after it", () => {
+		// §4.3.2 runs an unterminated comment to EOF, so a `;` or `}` written after
+		// it lands inside it — and the next parse reads a longer comment, growing
+		// the output on every pass (`{y/*` -> `{y/*}` -> `{y/*}}`).
+		expect(print("{y/*", "minify")).toBe("{y/**/}");
+		expect(print("{y/*", "beautify")).toBe(" {\ny/**/;\n}");
+		for (const mode of /** @type {const} */ (["minify", "beautify"])) {
+			const once = print("{y/*", mode);
+			expect(print(once, mode)).toBe(once);
+		}
+		// A comment the source did close is written back as it stands.
+		expect(print("{y/**/ z", "minify")).toBe("{y/**/ z}");
+	});
+
 	it("beautifies to something that minifies back the same", () => {
 		for (const src of [
 			"/*!k*/.a{color:#ff0000}",
@@ -6392,19 +6406,16 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 
 	// Beautifying writes a terminator after content it echoed raw, so a comment
 	// the source never closed swallows it and the rule never ends. Minimal:
-	// `{y/*` beautifies to ` {\ny/*;\n}`, where the `;}` is comment content.
-	const FILED_BEAUTIFY_DEFECTS = new Map([
-		[
-			"hacks.css",
-			"an unterminated comment swallows the terminator written after it"
-		],
-		[
-			"values.css",
-			"an unterminated block swallows the terminator written after it"
-		],
+	// Both modes drop a rule an identical later sibling supersedes, and minifying
+	// also joins adjacent rules sharing a selector — so the two forms keep a
+	// different copy of the same declarations. Every element still computes what
+	// the source said; only which redundant copy survives differs.
+	const KEPT_A_DIFFERENT_COPY = new Map([
+		["hacks.css", "a repeated `.selector` rule survives in a different place"],
+		["values.css", "a repeated declaration survives in a different place"],
 		[
 			"nesting.css",
-			"a nested rule is hoisted from the beautified form but not the source"
+			"a nested rule is kept beside the source's copy, not merged into it"
 		]
 	]);
 
@@ -6425,9 +6436,9 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 	// same — the property `print modes` states over its own handful of sources,
 	// here over every case the tokenizer reads.
 	for (const [name, code] of cases) {
-		const filed = FILED_BEAUTIFY_DEFECTS.get(name);
+		const filed = KEPT_A_DIFFERENT_COPY.get(name);
 
-		it(`should minify "${name}" the same from either form${filed ? " (filed)" : ""}`, () => {
+		it(`should minify "${name}" the same from either form${filed ? " (keeps a different copy)" : ""}`, () => {
 			const fromSource = print(code, "minify");
 			const fromBeautified = print(print(code, "beautify"), "minify");
 			if (filed === undefined) expect(fromBeautified).toBe(fromSource);

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -6409,15 +6409,6 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 	// Both modes drop a rule an identical later sibling supersedes, and minifying
 	// also joins adjacent rules sharing a selector — so the two forms keep a
 	// different copy of the same declarations. Every element still computes what
-	// the source said; only which redundant copy survives differs.
-	const KEPT_A_DIFFERENT_COPY = new Map([
-		["hacks.css", "a repeated `.selector` rule survives in a different place"],
-		["values.css", "a repeated declaration survives in a different place"],
-		[
-			"nesting.css",
-			"a nested rule is kept beside the source's copy, not merged into it"
-		]
-	]);
 
 	it("has a corpus", () => {
 		expect(cases.length).toBeGreaterThan(15);
@@ -6436,13 +6427,10 @@ describe("CssSyntax — beautifying the parsing corpus", () => {
 	// same — the property `print modes` states over its own handful of sources,
 	// here over every case the tokenizer reads.
 	for (const [name, code] of cases) {
-		const filed = KEPT_A_DIFFERENT_COPY.get(name);
-
-		it(`should minify "${name}" the same from either form${filed ? " (keeps a different copy)" : ""}`, () => {
-			const fromSource = print(code, "minify");
-			const fromBeautified = print(print(code, "beautify"), "minify");
-			if (filed === undefined) expect(fromBeautified).toBe(fromSource);
-			else expect(fromBeautified).not.toBe(fromSource);
+		it(`should minify "${name}" the same from either form`, () => {
+			expect(print(print(code, "beautify"), "minify")).toBe(
+				print(code, "minify")
+			);
 		});
 	}
 });

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -6368,3 +6368,70 @@ describe("CssSyntax minify — vendor prefixes (a twin written first)", () => {
 		).toBe("@media screen{a,b{color:red}}@keyframes s{to{opacity:1}}");
 	});
 });
+
+// The corpus the tokenizer snapshots read, put through the other print mode.
+// Beautifying is the mode with no test corpus of its own, and it is the one a
+// consumer reads, so what it writes is snapshotted rather than described.
+describe("CssSyntax — beautifying the parsing corpus", () => {
+	const casesPath = path.resolve(__dirname, "./configCases/css/parsing/cases");
+	const cases = fs
+		.readdirSync(casesPath)
+		.filter((name) => name.endsWith(".css"))
+		.map((name) => [
+			name,
+			fs.readFileSync(path.resolve(casesPath, name), "utf8")
+		]);
+
+	/**
+	 * @param {string} src css source
+	 * @param {import("../lib/util/SourceProcessor").PrintOptions["mode"]} mode print mode
+	 * @returns {string} its serialization
+	 */
+	const print = (src, mode) =>
+		new SourceProcessor().process(src, { mode }).code;
+
+	// Beautifying writes a terminator after content it echoed raw, so a comment
+	// the source never closed swallows it and the rule never ends. Minimal:
+	// `{y/*` beautifies to ` {\ny/*;\n}`, where the `;}` is comment content.
+	const FILED_BEAUTIFY_DEFECTS = new Map([
+		[
+			"hacks.css",
+			"an unterminated comment swallows the terminator written after it"
+		],
+		[
+			"values.css",
+			"an unterminated block swallows the terminator written after it"
+		],
+		[
+			"nesting.css",
+			"a nested rule is hoisted from the beautified form but not the source"
+		]
+	]);
+
+	it("has a corpus", () => {
+		expect(cases.length).toBeGreaterThan(15);
+	});
+
+	for (const [name, code] of cases) {
+		it(`should beautify "${name}"`, () => {
+			const beautified = print(code, "beautify");
+			expect(beautified).toMatchSnapshot();
+			// The printer has to accept what it wrote: beautifying is a fixed point.
+			expect(print(beautified, "beautify")).toBe(beautified);
+		});
+	}
+
+	// Both modes read the same stylesheet, so minifying either form answers the
+	// same — the property `print modes` states over its own handful of sources,
+	// here over every case the tokenizer reads.
+	for (const [name, code] of cases) {
+		const filed = FILED_BEAUTIFY_DEFECTS.get(name);
+
+		it(`should minify "${name}" the same from either form${filed ? " (filed)" : ""}`, () => {
+			const fromSource = print(code, "minify");
+			const fromBeautified = print(print(code, "beautify"), "minify");
+			if (filed === undefined) expect(fromBeautified).toBe(fromSource);
+			else expect(fromBeautified).not.toBe(fromSource);
+		});
+	}
+});

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -7840,9 +7840,8 @@ describe("SourceProcessor — re-serializing keeps the tree", () => {
 		).toBe("<nobr><table><b><colgroup><nobr>");
 	});
 
-	// Harvested from wpt's `html/syntax/serializing-html-fragments`, which states
-	// the cases §13.3 serialization has to get right; the tree is what we hold
-	// them to, since our printer echoes the source rather than re-serializing.
+	// From wpt's `html/syntax/serializing-html-fragments`. Held to the tree, not
+	// to §13.3's text: this printer echoes the source rather than re-serializing.
 	describe("wpt serialization cases", () => {
 		it.each([
 			["a bare ampersand in an attribute", "<span><a b='&'></a></span>"],
@@ -7891,9 +7890,8 @@ describe("SourceProcessor — re-serializing keeps the tree", () => {
 	});
 });
 
-// Beautifying is not a pretty-printer: it completes the tags the source left
-// out and echoes everything else byte for byte, so what it writes is
-// snapshotted rather than described.
+// Beautifying is no pretty-printer: it completes the tags the source left out
+// and echoes the rest byte for byte, so what it writes is snapshotted.
 describe("SourceProcessor — beautifying", () => {
 	const { SourceProcessor, parseHtml } = require("../lib/html/syntax");
 
@@ -7944,9 +7942,8 @@ describe("SourceProcessor — beautifying", () => {
 		expect(moved).toEqual([]);
 	});
 
-	// Echoing the source cannot be a fixed point in one pass: a tag the printer
-	// supplies is source the next pass reads, and a source-written tag is the
-	// one case that gets its pair written back. It settles on the second pass.
+	// A tag the printer supplies is source the next pass reads, and a written one
+	// gets its pair back — so echoing settles on the second pass, not the first.
 	it("should settle on the second pass", () => {
 		/** @type {string[]} */
 		const unsettled = [];

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -7839,4 +7839,54 @@ describe("SourceProcessor — re-serializing keeps the tree", () => {
 			}).code
 		).toBe("<nobr><table><b><colgroup><nobr>");
 	});
+
+	// Harvested from wpt's `html/syntax/serializing-html-fragments`, which states
+	// the cases §13.3 serialization has to get right; the tree is what we hold
+	// them to, since our printer echoes the source rather than re-serializing.
+	describe("wpt serialization cases", () => {
+		it.each([
+			["a bare ampersand in an attribute", "<span><a b='&'></a></span>"],
+			["a no-break space in an attribute", "<span><a b='&nbsp;'></a></span>"],
+			["a quote in an attribute", "<span><a b='\"'></a></span>"],
+			["a less-than in an attribute", '<span><a b="<"></a></span>'],
+			["a greater-than in an attribute", '<span><a b=">"></a></span>'],
+			[
+				"an escaped javascript url",
+				'<span><a href="javascript:&quot;&lt;>&quot;"></a></span>'
+			],
+			[
+				"a namespaced attribute on svg",
+				'<span><svg xlink:href="a"></svg></span>'
+			],
+			[
+				"an xmlns attribute on svg",
+				'<span><svg xmlns:svg="test"></svg></span>'
+			],
+			// Raw-text and escapable-raw-text elements: the markup inside them is
+			// text, and printing it back must not let it become tags again.
+			["markup inside style", "<span><style><&></style></span>"],
+			["markup inside xmp", "<span><xmp><&></xmp></span>"],
+			["markup inside iframe", "<span><iframe><&></iframe></span>"],
+			["markup inside noembed", "<span><noembed><&></noembed></span>"],
+			["markup inside noframes", "<span><noframes><&></noframes></span>"],
+			["a comment", "<span><!--data--></span>"],
+			[
+				"nested elements",
+				"<span><a><b><c></c></b><d>e</d><f><g>h</g></f></a></span>"
+			],
+			["an unquoted attribute value", "<span b=c></span>"],
+			// Scripting is off in webpack, so `<noscript>` holds markup rather than
+			// text — wpt's escaping.html is the case that says so.
+			["markup inside noscript", "<span><noscript><&></noscript></span>"],
+			["unescaped noscript content", "<noscript>& <></noscript>"],
+			["escaped noscript content", "<noscript>&amp;&nbsp;&lt;&gt;</noscript>"],
+			["an element inside noscript", "<noscript><b>x</b></noscript>"],
+			[
+				"a link inside noscript in head",
+				"<head><noscript><link href=x></noscript>"
+			]
+		])("keeps %s", (_name, source) => {
+			expect(reparsed(source)).toBe(serializeHtmlTree(parseHtml(source)));
+		});
+	});
 });

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -7890,3 +7890,73 @@ describe("SourceProcessor — re-serializing keeps the tree", () => {
 		});
 	});
 });
+
+// Beautifying is not a pretty-printer: it completes the tags the source left
+// out and echoes everything else byte for byte, so what it writes is
+// snapshotted rather than described.
+describe("SourceProcessor — beautifying", () => {
+	const { SourceProcessor, parseHtml } = require("../lib/html/syntax");
+
+	/**
+	 * @param {string} source html source
+	 * @returns {string} its beautified serialization
+	 */
+	const beautify = (source) =>
+		new SourceProcessor().process(source, { mode: "beautify" }).code;
+
+	const CASES = [
+		// End tags §4.13 lets a source omit are written back.
+		["implied list items", "<ul><li>a<li>b</ul>"],
+		["implied table sections", "<table><tr><td>1<td>2"],
+		["an implied paragraph", '<div   class="x"    id=y ><p>z'],
+		// Nothing the author wrote is rewritten: quoting, case and the spacing
+		// inside a tag all survive.
+		["attribute spelling", "<A HREF='x'   dATa-Y=1 >t</A>"],
+		["an unquoted attribute", "<img src=a.png alt=hi>"],
+		// The round-trip fallback: shapes no tag placement reproduces print from
+		// the source that built them.
+		["a fostered formatting run", "<nobr><table><b><colgroup><nobr>"],
+		["a list fostered out of a table", "<p><table><ol>"],
+		["a form the table kept", "<table><p><form>"],
+		// Raw text keeps its content, and a comment survives.
+		["raw text", "<style>a{b:c}</style><script>1<2</script>"],
+		["a comment", "<div><!--c--></div>"]
+	];
+
+	for (const [name, source] of CASES) {
+		it(`should beautify ${name}`, () => {
+			expect(beautify(source)).toMatchSnapshot();
+		});
+	}
+
+	it("should keep the tree every case was parsed from", () => {
+		/** @type {string[]} */
+		const moved = [];
+		for (const [name, source] of CASES) {
+			const printed = beautify(source);
+			if (
+				serializeHtmlTree(parseHtml(printed)) !==
+				serializeHtmlTree(parseHtml(source))
+			) {
+				moved.push(name);
+			}
+		}
+		expect(moved).toEqual([]);
+	});
+
+	// Echoing the source cannot be a fixed point in one pass: a tag the printer
+	// supplies is source the next pass reads, and a source-written tag is the
+	// one case that gets its pair written back. It settles on the second pass.
+	it("should settle on the second pass", () => {
+		/** @type {string[]} */
+		const unsettled = [];
+		for (const [name, source] of [
+			...CASES,
+			["a body implied before leading whitespace", "</html> leading ws"]
+		]) {
+			const twice = beautify(beautify(source));
+			if (beautify(twice) !== twice) unsettled.push(name);
+		}
+		expect(unsettled).toEqual([]);
+	});
+});

--- a/test/__snapshots__/CssSyntax.unittest.js.snap
+++ b/test/__snapshots__/CssSyntax.unittest.js.snap
@@ -1,5 +1,1917 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`CssSyntax — beautifying the parsing corpus should beautify "at-rule.css" 1`] = `
+"@unknown;@unknown x y;@unknown \\"blah\\";@unknown \\\\\\"blah\\\\\\";@unknown;@unknown x y;@unknown;@unknown x y;@unknown {
+}@\\\\unknown {
+}@unknown a b {
+}@unknown {
+p: v;
+}@unknown x y {
+p: v;
+}@unknown x, y x(1) {
+p: v;
+}@unknown x, y x(1+2) {
+p: v;
+}@unknown {
+p: v;
+}@unknown x y {
+p: v;
+}@unknown x,y x(1+ 2) {
+p: v;
+}@unknown {
+p: v;
+}@unknown x y {
+p: v;
+}@unknown x , y x(1 + 2) {
+p: v;
+}@unknown {
+s {
+p: v;
+}
+}@unknown x y {
+s {
+p: v;
+}
+}@unknown x, y f(1) {
+s {
+p: v;
+}
+}@unknown x, y f(1+2) {
+s {
+p: v;
+}
+}@unknown {
+.a {
+p: v;
+}
+.b {
+p: v;
+}
+}@unknown {
+s {
+p: v;
+}
+}@unknown x y {
+s {
+p: v;
+}
+}@unknown x,y f(1+ 2) {
+s {
+p: v;
+}
+}@unknown {
+s {
+p: v;
+}
+}@unknown x y {
+s {
+p: v;
+}
+}@unknown x , y f(1) {
+s {
+p: v;
+}
+}@unknown x , y f(1 2) {
+s {
+p: v;
+}
+}@unknown {
+--> {
+}
+<!-- {
+}
+}@unknown {
+@unknown {
+s {
+p: v;
+}
+}
+}@unknown {
+@unknown {
+s {
+p: v;
+}
+}
+color: red;
+}.foo {
+@unknown {
+s {
+p: v;
+}
+}
+color: red;
+}@unknown x (a , b);@unknown x (a , b) {
+foo: bar;
+}@unknown x(a, b) {
+foo: bar;
+}@unknown x (a + b);@unknown x (a - b);@unknown x (a * b);@unknown x (a / b);@unknown {
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "bad-string-token.css" 1`] = `
+".foo {
+value: \\"string
+;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "bad-url-token.css" 1`] = `
+"a {
+background-image: url(   ./image.jpg  a  );
+}div {
+background: url(image.png\\\\
+	);
+}a {
+background: \\\\url(te st);
+}div {
+background: url(image(.png);
+color: red;
+}div {
+background: url(image.
+	png);
+color: red;
+}p::before {
+content: \\"tes
+ t\\";
+;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "cdo-and-cdc.css" 1`] = `
+".foo {
+color: red;
+}div {
+color: red;
+}.class {
+color: red;
+}.test {
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "comment.css" 1`] = `
+"a {
+color: red;
+}div {
+color: black;
+background: red;
+}a {
+color: black;
+}@media screen {
+}@media screen {
+}/*!test*//*!te
+st*//*!te
+
+
+st*//*!te**st*/.a {
+background: red;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "dashed-ident.css" 1`] = `
+":root {
+--main-color: #06c;
+--accent-color: #006;
+}.foo {
+--fg-color: blue;
+}#foo h1 {
+color: var(--main-color);
+}@--custom {
+}@--library1-custom {
+}.class {
+--vendor-property: --vendor-function(\\"test\\");
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "declaration.css" 1`] = `
+"div {
+prop: value;
+prop: (value);
+prop: {value};
+prop: [value];
+prop: fn(value);
+prop: fn(value)fn(value);
+prop: value, value;
+prop: value ,value;
+prop: value,value;
+prop: value , value;
+prop: 100%100%;
+prop: \\"string\\"\\"string\\";
+prop: #ccc#ccc;
+prop: url(img.png)url(img.png);
+prop: (value)(value);
+prop: {
+value;
+}
+ {
+value;
+}
+prop: [value][value];
+prop: center/1em;
+prop: center/ 1em;
+prop: center /1em;
+prop: center / 1em;
+c\\\\olor: red;
+prop: big;
+prop: (;);
+prop: [;];
+prop: {;};
+}a {
+color: a b;
+}a {
+color: black;
+}a {
+color: \\\\\\\\ red \\\\\\\\ blue;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "delim.css" 1`] = `
+".foo {
+color: #;
+}.foo {
+color: +;
+}.foo {
+color: -;
+}.foo {
+color: <;
+}.foo {
+color: >;
+}.foo {
+color: @;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "dimension.css" 1`] = `
+"a {
+prop: 10px;
+prop: .10px;
+prop: 12.34px;
+prop: 0000.000px;
+prop: 1px\\\\\\\\9;
+prop: 1e;
+prop: 1unknown;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "function.css" 1`] = `
+"div {
+prod: fn(100px);
+prod: --fn(100px);
+prod: --fn--fn(100px);
+}:root {
+font-size: calc(100vw / 35);
+}div {
+--width: calc(10% + 30px);
+width: calc(0px);
+line-height: calc(0);
+line-height: calc(2 + 3 * 4);
+line-height: calc((2 + 3) * 4);
+line-height: calc(-5 * 0);
+width: calc((100px + 100px));
+width: calc((100px + 100px));
+width: calc(100px + 100px);
+width: calc(500px + 50%);
+width: calc(10% + 20%);
+width: calc(2pc + 3pt);
+width: calc(100% / 3 - 2 * 1em - 2 * 1px);
+width: calc(calc(50px));
+width: calc(calc(60%) - 20px);
+width: calc(calc(3 * 25%));
+width: calc(2 * var(--width));
+width: calc(pow(pow(30px / 1px, 3), 1/3) * 1px);
+width: calc(infinity);
+width: calc(InFiNiTy);
+width: calc(-InFiNiTy);
+width: calc(NaN);
+width: calc((1 * 2) * (5px + 20em / 2) - 80% / (3 - 1) + 5px);
+}.bar {
+font-size: calc(1rem * pow(1.5, -1));
+font-size: calc(1rem * pow(1.5, 0));
+font-size: calc(1rem * pow(1.5, 1));
+font-size: calc(1rem * pow(1.5, 2));
+font-size: calc(1rem * pow(1.5, 3));
+font-size: calc(1rem * pow(1.5, 4));
+}div {
+}div {
+width: calc(100% / 4);
+}div {
+margin-top: calc(-120% - 4px);
+}div {
+width: calc(50% - ((4%) * 0.5));
+}.fade {
+background-image: linear-gradient(silver 0%, white 20px, white calc(100% - 20px), silver 100%);
+}.type {
+font-size: max(10 * (1vw + 1vh) / 2, 12px);
+}.type {
+font-size: clamp(12px, 10 * (1vw + 1vh) / 2, 100px);
+}.more {
+width: mod(18px, 5px);
+transform: rotate(mod(-140deg, -90deg));
+transform: rotate(atan2(1, -1));
+transform: rotate(tan(90deg));
+transform: rotate(atan(tan(90deg)));
+font-size: hypot(2em);
+font-size: hypot(-2em);
+font-size: hypot(30px, 40px);
+background-position: sign(10%);
+width: calc(pow(e, pi) - pi);
+width: min(pi, 5, e);
+width: log(5);
+width: log(5, 5);
+width: round(var(--width), 50px);
+width: round(nearest, var(--width), 50px);
+width: round(up, var(--width), 50px);
+width: round(down, var(--width), 50px);
+width: round(to-zero, var(--width), 50px);
+}.min-max {
+width: min(10px, 20px, 40px, 100px);
+width: max(10px, 20px, 40px, 100px);
+width: min(10px , 20px , 40px , 100px);
+}.rem {
+width: rem(-18px, 5px);
+}.sin {
+transform: rotate(sin(45deg));
+transform: rotate(sin(3.14159 / 4));
+}.cos {
+transform: rotate(cos(45deg));
+transform: rotate(cos(3.14159 / 4));
+}.asin {
+transform: rotate(asin(45deg));
+transform: rotate(asin(pi / 4));
+}.acos {
+transform: rotate(acos(45deg));
+transform: rotate(acos(pi / 4));
+}.atan {
+transform: rotate(atan(1 / -1));
+}.atan2 {
+transform: rotate(atan2(1, -1));
+}.sqrt {
+size: sqrt(250);
+}.exp {
+size: exp(250 * 2);
+}.abs {
+background-position: calc(10% * abs(-10%));
+}.sign {
+background-position: sign(10%);
+background-position: sign(10% * 2);
+background-position: sign(10% * 2);
+background-position: sign(10%*2);
+background-position: sign(10 + 10);
+background-position: sign(10%);
+width: calc((100px + 100px) * 2);
+}a {
+background: element(#css-source) no-repeat;
+background: element(var(--foo)) no-repeat;
+background: -moz-element(#css-source) no-repeat;
+background: -moz-element(var(--foo)) no-repeat;
+}a {
+background: linear-gradient(white, gray);
+background: linear-gradient(yellow, blue);
+background: linear-gradient(to bottom, yellow, blue);
+background: linear-gradient(180deg, yellow, blue);
+background: linear-gradient(to top, blue, yellow);
+background: linear-gradient(to bottom, yellow 0%, blue 100%);
+background: linear-gradient(135deg, yellow, blue);
+background: linear-gradient(-45deg, blue, yellow);
+background: linear-gradient(yellow, blue 20%, #0f0);
+background: linear-gradient(to top right, red, white, blue);
+background: linear-gradient(0deg, blue, green 40%, red);
+background: linear-gradient(.25turn, red 10%, blue);
+background: linear-gradient(45deg, red 0 50%, blue 50% 100%);
+}div {
+opacity: mix(70% by ease ; 0% ; 100%);
+opacity: mix(70%;0%;100%);
+}a {
+background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+background-image: url(\\"./img.png\\");
+background-image: url('./img.png');
+background-image: URL('./img.png');
+background-image: url('./img.png');
+background-image: url('./img.png');
+background-image: url('./img.png');
+background-image: url('img.png');
+background-image: url();
+background-image: url(   );
+background-image: url(\\"\\");
+background-image: url(\\"\\");
+background-image: url('');
+background-image: url('');
+background-image: url(' ');
+background-image: url(./img.png);
+background-image: url(   ./img.png   );
+background-image: url(   ./image\\\\32.png   );
+background-image: url(
+	./image\\\\32.png
+	);
+background-image: url(
+
+
+
+		./image\\\\32.png
+
+
+
+	);
+background-image: url(
+
+
+
+	./image\\\\32.png
+
+
+
+		);
+}div {
+color: var(--a);
+color: var(--a,);
+color: var(--a, blue);
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "hacks.css" 1`] = `
+"html > body .selector {
+}head ~ body .selector {
+}.selector {
+_property: value;
+}.selector {
+-property: value;
+}.selector {
+property: value\\\\9;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "hex-colors.css" 1`] = `
+"a {
+color: #000000;
+color: #ffffff;
+color: #FFFFFF;
+color: #0000ffcc;
+color: #0000FFCC;
+color: #000;
+color: #fff;
+color: #FFF;
+color: #0000;
+color: #ffff;
+color: #FFFF;
+color: #1;
+color: #FF;
+color: #123456789;
+color: #abc;
+color: #aa\\\\61;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "important.css" 1`] = `
+".a {
+prop: important;
+color: red important;
+width: 1px !important;
+color: red !important;
+color: red !important;
+color: red !important;
+color: red !important;
+color: blue !important;
+color: white !important;
+margin: 10px !important;
+padding: 20px !important;
+width: 100px !important;
+height: 100px important;
+z-index: 1 \\"\\" !important;
+padding: 1px !important;
+prop: red !important;
+color: red !imp\\\\ortant;
+}/*! test *//*! test */"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "nesting.css" 1`] = `
+".foo {
+color: green;
+.bar {
+font-size: 1.4rem;
+}
+}main {
+div {
+color: red;
+}
+.bar {
+color: red;
+}
+#baz {
+color: red;
+}
+:has(p) {
+color: red;
+}
+::backdrop {
+color: red;
+}
+[lang|=\\"zh\\"] {
+color: red;
+}
+* {
+color: red;
+}
+}main {
++ article {
+color: red;
+}
+> p {
+color: red;
+}
+~ main {
+color: red;
+}
+}main {
+& + article {
+color: red;
+}
+& > p {
+color: red;
+}
+& ~ main {
+color: red;
+}
+}ul {
+padding-left: 1em;
+.component & {
+padding-left: 0;
+}
+}a {
+color: blue;
+&:hover {
+color: lightblue;
+}
+}.foo {
+color: blue;
+& > .bar {
+color: red;
+}
+> .baz {
+color: green;
+}
+}.foo {
+color: blue;
+&.bar {
+color: red;
+}
+}.foo, .bar {
+color: blue;
++ .baz, &.qux {
+color: red;
+}
+}.foo {
+color: blue;
+& .bar & .baz & .qux {
+color: red;
+}
+}.foo {
+color: red;
+.parent & {
+color: blue;
+}
+}.foo {
+color: red;
+:not(&) {
+color: blue;
+}
+}.foo {
+color: red;
++ .bar + & {
+color: blue;
+}
+}.foo {
+color: blue;
+& {
+padding: 2ch;
+}
+}.foo {
+color: blue;
+&& {
+padding: 2ch;
+}
+}.error, #404 {
+&:hover > .baz {
+color: red;
+}
+}.ancestor .el {
+.other-ancestor & {
+color: red;
+}
+}.foo {
+& :is(.bar, &.baz) {
+color: red;
+}
+}figure {
+margin: 0;
+> figcaption {
+background: hsl(0 0% 0% / 50%);
+> p {
+font-size: .9rem;
+}
+}
+}@layer base {
+html {
+block-size: 100%;
+body {
+min-block-size: 100%;
+}
+}
+}@layer base {
+html {
+block-size: 100%;
+@layer support {
+body {
+min-block-size: 100%;
+}
+}
+}
+}@scope (.card) to (> header) {
+:scope {
+inline-size: 40ch;
+aspect-ratio: 3/4;
+> header {
+border-block-end: 1px solid white;
+}
+}
+}.card {
+inline-size: 40ch;
+aspect-ratio: 3/4;
+@scope (&) to (> header > *) {
+:scope > header {
+border-block-end: 1px solid white;
+}
+}
+}.foo {
+display: grid;
+@media (orientation: landscape) {
+grid-auto-flow: column;
+}
+}@media (orientation: landscape) {
+.foo {
+grid-auto-flow: column;
+}
+}@media (orientation: landscape) {
+.foo {
+grid-auto-flow: column;
+}
+}.foo {
+display: grid;
+@media (orientation: landscape) {
+grid-auto-flow: column;
+@media (min-width > 1024px) {
+max-inline-size: 1024px;
+}
+}
+}.foo {
+display: grid;
+}@media (orientation: landscape) {
+.foo {
+grid-auto-flow: column;
+}
+}@media (orientation: landscape) and (min-width > 1024px) {
+.foo {
+max-inline-size: 1024px;
+}
+}html {
+@layer base {
+block-size: 100%;
+@layer support {
+& body {
+min-block-size: 100%;
+}
+}
+}
+}@layer base {
+html {
+block-size: 100%;
+}
+}@layer base.support {
+html body {
+min-block-size: 100%;
+}
+}.card {
+inline-size: 40ch;
+aspect-ratio: 3/4;
+@scope (&) {
+:scope {
+border: 1px solid white;
+}
+}
+}.card {
+inline-size: 40ch;
+aspect-ratio: 3/4;
+}@scope (.card) {
+:scope {
+border-block-end: 1px solid white;
+}
+}.parent {
+color: blue;
+@scope (& > .scope) to (& > .limit) {
+& .content {
+color: red;
+}
+}
+}article {
+color: green;
+& {
+color: blue;
+}
+color: red;
+}a, b {
+& c {
+color: blue;
+}
+}.foo, .foo::before, .foo::after {
+color: black;
+@media (prefers-color-scheme: dark) {
+& {
+color: white;
+}
+}
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "newline-windows.css" 1`] = `
+"a::before {
+content: \\"A really long \\\\
+awesome string\\";
+color: #00ff00;
+a24: \\\\123456
+ B;
+test: url(\\"./img.png\\");
+test: url(
+
+
+	 ./img.png
+
+
+	);
+test: url(\\"\\");
+test: url('');
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "number.css" 1`] = `
+"div {
+property: 10;
+property: +10;
+property: -10;
+property: 0.1;
+property: +0.1;
+property: -0.1;
+property: -.1;
+property: +.1;
+property: 0;
+property: 10;
+property: .10;
+property: 12.34;
+property: 0.1;
+property: 1.0;
+property: 0.0;
+property: +0.0;
+property: -0.0;
+property: .0;
+property: 1.200000;
+property: 1.2e2;
+property: 1e2;
+property: .2e2;
+property: 1.2E2;
+property: 1.2e+2;
+property: 1.2e-2;
+property: -1;
+property: -1.2;
+property: .2;
+property: -.2;
+property: +.2;
+property: -1.2e3;
+property: 1.75;
+property: +1.75;
+property: 1e0;
+property: 1e1;
+property: 1e+1;
+property: 1e-1;
+property: 1e-10;
+property: 1+2;
+property: 1 -2;
+property: 4.01;
+property: -456.8;
+property: .60;
+property: .0060;
+property: 10e3;
+property: -3.4e-2;
+property: 0.5600000000;
+property: 10e6;
+property: 10000000;
+property: 0.0;
+property: -0.0;
+property: +0.0;
+property: 1e1;
+property: 1e2;
+property: 1e3;
+property: 1e4;
+property: 100.1e-6;
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "pseudo-functions.css" 1`] = `
+":local(.class#id, .class:not(*:hover)) {
+color: red;
+}:import(something from \\":somewhere\\") {
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "revers-solidus.css" 1`] = `""`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors.css" 1`] = `
+"[title] {
+}[title=foo] {
+}[title=\\"foo\\"] {
+}[title = \\"foo\\"] {
+}[lang~=\\"en-us\\"] {
+}[lang|=\\"zh\\"] {
+}[href^=\\"#\\"] {
+}[href$=\\".org\\"] {
+}[href*=\\"example\\"] {
+}[href*=\\"insensitive\\" I] {
+}[href*=\\"cAsE\\" s] {
+}[href*=\\"cAsE\\" S] {
+}[foo|att=val] {
+}[*|att] {
+}[|att] {
+}[att] {
+}a[class = \\"test\\"] {
+}[href*=\\"insensitive\\" i] {
+}[href *= \\"insensitive\\" i] {
+}[href] {
+}[frame=hsides i] {
+}#id[target] {
+}[target].class {
+}[title='foo'] {
+}[data-style='value'][data-loading] {
+}a[href=\\"te's't\\"] {
+}a[href='te\\"s\\"t'] {
+}[ng\\\\:cloak] {
+}[ng\\\\3a cloak] {
+}[ng\\\\00003acloak] {
+}:not([foo=\\")\\"]) {
+}:not(div) {
+}[foo=\\\\\\"] {
+}[foo=\\\\{] {
+}[foo=\\\\(] {
+}[foo=yes\\\\:\\\\(it\\\\'s\\\\ work\\\\)] {
+}[attr=\\\\;] {
+}[*|attr|=\\"test\\"] {
+}[foo|attr|=\\"test\\"] {
+}.class {
+}.♥ {
+}.© {
+}.“‘’” {
+}.☺☃ {
+}.⌘⌥ {
+}.𝄞♪♩♫♬ {
+}.💩 {
+}.\\\\? {
+}.\\\\@ {
+}.\\\\. {
+}.\\\\3A \\\\) {
+}.\\\\3A \\\\\`\\\\( {
+}.\\\\<p\\\\> {
+}.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<\\\\-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. {
+}.\\\\#\\\\.\\\\#\\\\.\\\\# {
+}.\\\\_ {
+}.\\\\{\\\\} {
+}.\\\\.fake\\\\-class {
+}.f\\\\/o\\\\/o {
+}.f\\\\\\\\o\\\\\\\\o {
+}.f\\\\*o\\\\*o {
+}.f\\\\!o\\\\!o {
+}.f\\\\'o\\\\'o {
+}.f\\\\~o\\\\~o {
+}.f\\\\+o\\\\+o {
+}.-a-b-c- {
+}.\\\\#fake-id {
+}foo.class > .foo.class {
+}ul.list {
+}ul.list::before {
+}.\\\\31 a2b3c {
+}.\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> {
+}.\\\\31 23 {
+}.\\\\# {
+}.\\\\#\\\\# {
+}.\\\\#fake\\\\-id {
+}.foo\\\\.bar {
+}.\\\\3A hover {
+}.\\\\3A hover\\\\3A focus\\\\3A active {
+}.\\\\[attr\\\\=value\\\\] {
+}.not-pseudo\\\\:focus {
+}.not-pseudo\\\\:\\\\:focus {
+}.\\\\\\\\1D306 {
+}.\\\\; {
+}a/**/b {
+}a,b {
+}a , b {
+}article p {
+}article > p {
+}p + img {
+}p ~ img {
+}article > p > a {
+}div p {
+}.class p {
+}div .class {
+}.class .class {
+}#id p {
+}div #id {
+}#id #id {
+}[attribute] p {
+}div [attribute] {
+}[attribute] [src] {
+}div > p {
+}.class > p {
+}div > .class {
+}.class > .class {
+}#id > p {
+}div > #id {
+}#id > #id {
+}[attribute] > p {
+}div > [attribute] {
+}[attribute] > [src] {
+}div + p {
+}.class + p {
+}div + .class {
+}.class + .class {
+}#id + p {
+}div + #id {
+}#id + #id {
+}[attribute] + p {
+}div + [attribute] {
+}[attribute] + [src] {
+}div ~ p {
+}.class ~ p {
+}div ~ .class {
+}.class ~ .class {
+}#id ~ p {
+}div ~ #id {
+}#id ~ #id {
+}[attribute] ~ p {
+}div ~ [attribute] {
+}[attribute] ~ [src] {
+}a:hover [attribute] {
+}a:hover #id {
+}a:hover .class {
+}a:hover div#thing {
+}a + a[href='place'] {
+}ul.list + a {
+}.foo ~ a + bar {
+}a+ a {
+}a> a {
+}a~ a {
+}a +a {
+}a >a {
+}a ~a {
+}a+a {
+}a>a {
+}a~a {
+}a [type='button'] {
+}a a {
+}namespace|type#id > .foo {
+}#id > .cl + .cl2 {
+}a c, d + e h {
+}a ~ h + d {
+}div div div div div div div div div div div {
+}[href][class][name] h1 > h2 {
+}[href*=\\"test.com\\"][rel='external'][id][class~=\\"test\\"] > [name] {
+}[data-weird-attr*=\\"Something=weird\\"], [data-weird-attr^=\\"Something=weird\\"], [data-weird-attr$=\\"Something=weird\\"], [data-weird-attr|=\\"Something=weird\\"] {
+}* + * {
+}* * {
+}*[href] *:not(*.green) {
+}*::-webkit-media-controls-play-button {
+}col.selected || td {
+}col.selected||td {
+}.one {
+}.foo.bar {
+}.foo#id {
+}.class[target] {
+}.class#id[target] {
+}a[href='place']:hover {
+}a[href='place']::before {
+}.one.two.three {
+}button.btn-primary {
+}*#z98y {
+}#one#two {
+}#one.two.three {
+}#© {
+}#⌘⌥ {
+}#𝄞♪♩♫♬ {
+}#💩 {
+}#\\\\? {
+}#\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<\\\\-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. {
+}#f\\\\'o\\\\'o {
+}#id {
+}#id.class {
+}#id.class[target] {
+}div#thing:hover {
+}div#thing:nth-child(2n+1) {
+}div#thing::before {
+}#foo[lang^=en] {
+}#\\\\; {
+}#u-m\\\\00002b  {
+}#♥ {
+}#“‘’” {
+}#☺☃ {
+}#\\\\@ {
+}#\\\\. {
+}#\\\\3A \\\\) {
+}#\\\\3A \\\\\`\\\\( {
+}#\\\\31 23 {
+}#\\\\31 a2b3c {
+}#\\\\<p\\\\> {
+}#\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> {
+}#\\\\# {
+}#\\\\#\\\\# {
+}#\\\\#\\\\.\\\\#\\\\.\\\\# {
+}#\\\\_ {
+}#\\\\{\\\\} {
+}#\\\\.fake\\\\-class {
+}#foo\\\\.bar {
+}#\\\\3A hover {
+}#\\\\3A hover\\\\3A focus\\\\3A active {
+}#\\\\[attr\\\\=value\\\\] {
+}#f\\\\/o\\\\/o {
+}#f\\\\\\\\o\\\\\\\\o {
+}#f\\\\*o\\\\*o {
+}#f\\\\!o\\\\!o {
+}#f\\\\\\\\\\\\'o\\\\\\\\\\\\'o {
+}#f\\\\~o\\\\~o {
+}#f\\\\+o\\\\+o {
+}div, p {
+}div , p {
+}a, a[href='place'] {
+}a #foo > [foo='bar'], .FOO {
+}div, p, a {
+}div,p,a {
+}div , p , a {
+}.foo, .bar, *.baz {
+}input::-moz-placeholder, input::placeholder {
+}a,b,c,d,e,f,g {
+}a, b, c, d, e, f, g {
+}*, * {
+}#id, #id2 {
+}h1, h2 {
+}.class, .foo {
+}[attr], [attrtoo] {
+}a b {
+}table.colortable {
+& td {
+text-align: center;
+&.c {
+text-transform: uppercase;
+}
+&:first-child, &:first-child + td {
+border: 1px solid black;
+}
+}
+& th {
+text-align: center;
+background: black;
+color: white;
+}
+}.foo {
+color: blue;
+& > .bar {
+color: red;
+}
+}.foo {
+color: blue;
+&.bar {
+color: red;
+}
+}.foo, .bar {
+color: blue;
+& + .baz, &.qux {
+color: red;
+}
+}.foo {
+color: blue;
+& {
+padding: 2ch;
+}
+}.error, #test {
+&:hover > .baz {
+color: red;
+}
+}.foo {
+&:is(.bar, &.baz) {
+color: red;
+}
+}figure {
+margin: 0;
+& > figcaption {
+background: hsl(0 0% 0% / 50%);
+& > p {
+font-size: .9rem;
+}
+}
+}.foo {
+color: blue;
+&__bar {
+color: red;
+}
+}.foo {
+color: red;
+.bar {
+color: blue;
+}
+}.foo {
+color: red;
++ .bar {
+color: blue;
+}
+}.foo {
+color: blue;
+& > .bar {
+color: red;
+}
+> .baz {
+color: green;
+}
+}div {
+color: red;
+& input {
+margin: 1em;
+}
+:is(input) {
+margin: 1em;
+}
+}.foo, .bar {
+color: blue;
++ .baz, &.qux {
+color: red;
+}
+}.foo {
+color: blue;
+& .bar & .baz & .qux {
+color: red;
+}
+}.foo {
+color: red;
+.parent & {
+color: blue;
+}
+}.foo {
+color: red;
+:not(&) {
+color: blue;
+}
+}.foo {
+color: red;
++ .bar + & {
+color: blue;
+}
+}.ancestor .el {
+.other-ancestor & {
+color: red;
+}
+}.foo {
+& :is(.bar, &.baz) {
+color: red;
+}
+}@layer base {
+html {
+block-size: 100%;
+& body {
+min-block-size: 100%;
+}
+}
+}@layer base {
+html {
+block-size: 100%;
+@layer base.support {
+& body {
+min-block-size: 100%;
+}
+}
+}
+}article {
+color: green;
+& {
+color: blue;
+}
+color: red;
+}.foo {
+color: red;
+@media (min-width: 480px) {
+& h1, & h2 {
+color: blue;
+}
+}
+}:unknown {
+}:unknown() {
+}:unknown(foo) {
+}:unknown(foo bar) {
+}:unknown(foo, bar) {
+}:unknown([foo]) {
+}:unknown((foo bar)) {
+}:unknown(((foo bar))) {
+}:unknown({foo: bar}) {
+}:unknown({{foo: bar}}) {
+}:unknown({foo: bar !important}) {
+}:unknown(\\"string\\") {
+}:unknown(\\"string\\", foo) {
+}:unknown('string') {
+}:unknown(url(img.png)) {
+}:unknown({!}) {
+}:unknown(!) {
+}:unknown({;}) {
+}:unknown(;) {
+}:nth-child(2n+1) {
+}:nth-child(2n +1) {
+}:nth-child(2n-1) {
+}:nth-child(2n -1) {
+}:nth-child(2n- 1) {
+}:nth-child(2n - 1) {
+}:nth-child(-2n +1) {
+}:nth-child(-2n + 1) {
+}:nth-child(-2n+ 1) {
+}:nth-child(-2n-1) {
+}:nth-child(-2n -1) {
+}:nth-child(-2n - 1) {
+}:nth-child(+2n+1) {
+}:nth-child(+2n +1) {
+}:nth-child(+2n + 1) {
+}:nth-child(+2n+ 1) {
+}:nth-child(+2n-1) {
+}:nth-child(+2n -1) {
+}:nth-child(+2n- 1) {
+}:nth-child(+2n - 1) {
+}:nth-child(n+1) {
+}:nth-child(n +1) {
+}:nth-child(n + 1) {
+}:nth-child(n+ 1) {
+}:nth-child(n-1) {
+}:nth-child(n -1) {
+}:nth-child(n- 1) {
+}:nth-child(n - 1) {
+}:nth-child(-n+1) {
+}:nth-child(-n +1) {
+}:nth-child(-n + 1) {
+}:nth-child(-n+ 1) {
+}:nth-child(-n-1) {
+}:nth-child(-n -1) {
+}:nth-child(-n- 1) {
+}:nth-child(-n - 1) {
+}:nth-child(+n+1) {
+}:nth-child(+n +1) {
+}:nth-child(+n + 1) {
+}:nth-child(+n+ 1) {
+}:nth-child(+n-1) {
+}:nth-child(+n -1) {
+}:nth-child(+n- 1) {
+}:nth-child(+n - 1) {
+}:nth-child(n) {
+}:nth-child(-n) {
+}:nth-child(+n) {
+}:nth-child(2n) {
+}:nth-child(-2n) {
+}:nth-child(+2n) {
+}:nth-child(N) {
+}:nth-child(-N) {
+}:nth-child(+N) {
+}:nth-child(2N) {
+}:nth-child(-2N) {
+}:nth-child(+2N) {
+}:nth-child(1) {
+}:nth-child(-1) {
+}:nth-child(+1) {
+}:nth-child(123456n-12345678) {
+}:Nth-Child(2n+1) {
+}:NTH-CHILD(2n+1) {
+}:nth-child(odd) {
+}:nth-child(ODD) {
+}:nth-child(oDd) {
+}:nth-child(even) {
+}:nth-child(eVeN) {
+}:nth-child(EVEN) {
+}:nth-child(2n+ 1) {
+}:nth-child(2n + 1) {
+}:nth-last-child(+3n - 2) {
+}:nth-child(-2n+1) {
+}:nth-last-child(2n+1) {
+}:nth-of-type(2n+1) {
+}:nth-last-of-type(2n+1) {
+}:nth-col(odd) {
+}:nth-col(2n+1) {
+}:nth-last-col(odd) {
+}:nth-last-col(2n+1) {
+}p:nth-child(0) {
+}p:nth-child(+0) {
+}p:nth-child(-0) {
+}p:nth-child(1) {
+}p:nth-child(+1) {
+}p:nth-child(-1) {
+}p:nth-child(3) {
+}p:nth-child(+3) {
+}p:nth-child(-3) {
+}:nth-child(2n+1 of li) {
+}:nth-child(2n+1 of li,.test) {
+}:nth-child(2n+1 of li, .test) {
+}:nth-child(-n+3 of li.important) {
+}tr:nth-child(even of :not([hidden])) {
+}:root {
+}:any-link {
+}button:hover {
+}div\\\\::before {
+}iNpUt {
+}:matches(section, article, aside, nav) h1 {
+}input:not([type='submit']) {
+}div.sidebar:has(*:nth-child(5)):not(:has(*:nth-child(6))) {
+}::-webkit-scrollbar-thumb:window-inactive {
+}::-webkit-scrollbar-button:horizontal:decrement {
+}.test::-webkit-scrollbar-button:horizontal:decrement {
+}*:is(*) {
+}:--heading {
+}a:-moz-placeholder {
+}div :nth-child(2) {
+}a:hOvEr {
+}:-webkit-full-screen a {
+}a::after {
+}dialog::backdrop {
+}a::before {
+}video::cue {
+}video::cue(b) {
+}video::cue-region {
+}video::cue-region(#scroll) {
+}::grammar-error {
+}::marker {
+}tabbed-custom-element::part(tab) {
+}::placeholder {
+}::selection {
+}::slotted(*) {
+}::slotted(span) {
+}::spelling-error {
+}::target-text {
+}.form-range::-webkit-slider-thumb:active {
+}a::bEfOrE {
+}a:hover::before {
+}a:hover::-moz-placeholder {
+}a, b > .foo::before {
+}*:hover.class {
+}*|* {
+}foo|h1 {
+}foo|* {
+}|h1 {
+}*|h1 {
+}h1 {
+}\\\\2d  {
+}\\\\2d a {
+}div\\\\:before {
+}d\\\\iv {
+}foreignObject {
+}html textPath {
+}div#thing {
+}* {
+}* #foo {
+}*#foo {
+}#foo * {
+}.bar * {
+}*.bar {
+}*[lang^=en] {
+}*:hover {
+}*::before {
+}* *:not(*) {
+}a {
+}\\\\@noat {
+}h1\\\\\\\\ {
+color: \\\\\\\\;
+}. a {
+}# a {
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "urls.css" 1`] = `
+"body {
+background: url(
+	https://example\\\\2f4a8f.com\\\\image.png
+	);
+}--element name.class name#_id {
+background: url(\\"https://example.com/some url \\\\\\"with\\\\\\" 'spaces'.png\\") url('https://example.com/\\\\'\\"quotes\\"\\\\'.png');
+}div {
+color: red;
+a200: -webkit-image-set(\\"img.png\\"1x);
+}div {
+color: red;
+a201: url(\\"img.png\\");
+}div {
+color: red;
+a202: url(img.png);
+}"
+`;
+
+exports[`CssSyntax — beautifying the parsing corpus should beautify "values.css" 1`] = `
+"div {
+transform: rotate(45deg);
+transform: rotate(-50grad);
+transform: rotate(3.1416rad);
+transform: rotate(1.75turn);
+}.hex-color {
+color: #00ff00;
+color: #0000ffcc;
+color: #123;
+color: #123c;
+}.rgb {
+color: rgb(255, 165, 0);
+color: rgb(255,165,0);
+color: rGb(255,165,0);
+color: rgb(0 255 0);
+color: rgb(0%100%0%);
+color: rgb(29 164 192 / 95%);
+color: rgb(123 255 255 / .5);
+color: rgb(123 255 255 / 50%);
+color: rgb(48% 100% 100% / 50%);
+color: rgb(48% none 100% / 50%);
+color: rgb(48% 100% 100% / none);
+color: rgb(var(--red), var(--green), var(--blue));
+color: rgb(var(--red) var(--green) var(--blue));
+color: rgb(var(--red) var(--green) var(--blue) / var(--alpha));
+}.rgba {
+color: rgba(255, 0, 0, 100%);
+color: rgba(255, 255, 0, 1);
+color: rgba(255, 255, 0, 0.8);
+color: rgba(255, 165, 0);
+color: rgba(255,165,0);
+color: rGbA(255,165,0);
+color: rgba(0 255 0);
+color: rgba(0%100%0%);
+color: rgba(29 164 192 / 95%);
+color: rgba(123 255 255 / .5);
+color: rgba(123 255 255 / 50%);
+color: rgba(48% 100% 100% / 50%);
+color: rgba(48% none 100% / 50%);
+color: rgba(48% 100% 100% / none);
+color: rgba(123 none 123 / 50%);
+color: rgba(123 123 123 / none);
+color: rgb(var(--red), var(--green), var(--blue), var(--alpha));
+}.hsl {
+color: hsl(38.824 100% 50%);
+color: HsL(39 100% 50%);
+color: hsl(100deg, 100%, 50%);
+color: hsl(100, 100%, 50%);
+color: hsl(100 100% 50%);
+color: hsl(100, 100%, 50%, .8);
+color: hsl(100 100% 50% / .8);
+color: hsl(var(--a), var(--b), var(--c));
+color: hsl(var(--a), var(--b), var(--c), var(--d));
+color: hsl(var(--a) var(--b) var(--c));
+color: hsl(var(--a) var(--b) var(--c) / var(--d));
+}.hsla {
+color: hsla(100, 100%, 50%, .8);
+color: hsla(100 100% 50% / .8);
+color: hsla(var(--a), var(--b), var(--c), var(--d));
+}.hwb {
+color: hwb(194 0% 0%);
+color: hwb(194 0% 0% / 50%);
+color: hwb(194 0% 50%);
+color: hwb(194 50% 0%);
+color: hwb(194 50% 50%);
+color: hwb(var(--a) var(--b) var(--c));
+color: hwb(var(--a) var(--b) var(--c) / var(--d));
+}.lab {
+color: lab(29.2345% 39.3825 20.0664);
+color: lab(29.2345% 39.3825 20.0664 / 100%);
+color: lab(29.2345% 39.3825 20.0664 / 50%);
+color: lab(var(--a) var(--b) var(--c));
+color: lab(var(--a) var(--b) var(--c) / var(--d));
+}.lch {
+color: lch(52.2345% 72.2 56.2 / 1);
+color: lch(29.2345% 44.2 27);
+color: lch(29.2345% 44.2 45deg);
+color: lch(29.2345% 44.2 .5turn);
+color: lch(29.2345% 44.2 27 / 100%);
+color: lch(29.2345% 44.2 27 / 50%);
+color: lch(var(--a) var(--b) var(--c));
+color: lch(var(--a) var(--b) var(--c) / var(--d));
+}.oklab {
+color: oklab(40.101% 0.1147 0.0453);
+color: oklab(var(--a) var(--b) var(--c));
+}.oklch {
+color: oklch(42.1% 0.192 328.6 / 1);
+color: oklch(42.1% 0.192 328.6);
+color: oklch(var(--a) var(--b) var(--c));
+color: oklch(var(--a) var(--b) var(--c) / var(--d));
+}.color {
+color: color(sRGB 0 1 0);
+color: color(srgb-linear 0 1 0);
+color: color(display-p3 0 1 0);
+color: color(a98-rgb 0 1 0);
+color: color(prophoto-rgb 0 1 0);
+color: color(rec2020 0 1 0);
+color: color(sRGB 0 none 0);
+color: color(display-p3 0.823 0.6554 0.2537 /1);
+color: color(display-p3 0.823 0.6554 0.2537 / 1);
+color: color(display-p3 0.823 0.6554 0.2537/1);
+color: color(display-p3 0.823 0.6554 0.2537);
+color: color(xyz 0.472 0.372 0.131);
+color: color(xyz-d50 0.472 0.372 0.131);
+color: color(xyz-d65 0.472 0.372 0.131);
+color: color(display-p3 -0.6112 1.0079 -0.2192);
+color: color(sRGB 0.41587 0.503670 0.36664);
+color: color(display-p3 0.43313 0.50108 0.37950);
+color: color(a98-rgb 0.44091 0.49971 0.37408);
+color: color(prophoto-rgb 0.36589 0.41717 0.31333);
+color: color(rec2020 0.42210 0.47580 0.35605);
+color: color(profoto-rgb 0.4835 0.9167 0.2188);
+color: color(var(--a) var(--b) var(--c) var(--d));
+color: color(var(--a) var(--b) var(--c) var(--d) / var(--e));
+}@color-profile --fogra55beta {
+src: url('https://example.org/2020_13.003_FOGRA55beta_CL_Profile.icc');
+}.dark_skin {
+background-color: color(--fogra55beta 0.183596 0.464444 0.461729 0.612490 0.156903 0.000000 0.000000);
+background-color: color(--fogra55beta 0.070804 0.334971 0.321802 0.215606 0.103107 0.000000 0.000000);
+background-color: color(--fogra55beta 0.572088 0.229346 0.081708 0.282044 0.000000 0.000000 0.168260);
+background-color: color(--fogra55beta 0.314566 0.145687 0.661941 0.582879 0.000000 0.234362 0.000000);
+background-color: color(--fogra55beta 0.375515 0.259934 0.034849 0.107161 0.000000 0.000000 0.308200);
+background-color: color(--fogra55beta 0.397575 0.010047 0.223682 0.031140 0.000000 0.317066 0.000000);
+}.device-cmyk {
+color: device-cmyk(0 81% 81% 30%);
+color: device-cmyk(0% 70% 20% 0%);
+color: device-cmyk(0% 70% 20% 0%);
+color: device-cmyk(0 0.7 0.2 0);
+color: device-cmyk(var(--a) var(--b) var(--c) var(--d));
+}.color-mix {
+color: color-mix(in lch, purple 50%, plum 50%);
+color: color-mix(in lch, purple 50%, plum);
+color: color-mix(in lch, purple, plum 50%);
+color: color-mix(in lch, purple, plum);
+color: color-mix(in lch, plum, purple);
+color: color-mix(in lch, purple 80%, plum 80%);
+}.color-contrast {
+color: color-contrast(currentColor vs hsl(200 83% 23%), purple to AA);
+color: color-contrast(currentColor vs rgb(10 75 107), rgb(128 0 128) to 4.5);
+}.foo {
+color: device-cmyk(0 81% 81% 30%);
+color: rgb(178 34 34);
+color: firebrick;
+}.bar {
+color: device-cmyk(0 81% 81% 30%);
+color: lab(45.060% 45.477 35.459);
+color: rgb(70.690% 26.851% 19.724%);
+}.calc {
+color: rgba(calc(255 - 1), 255, 255, 1);
+color: rgba(255, calc(255 - 1), 255, 1);
+color: rgba(255, 255, calc(255 - 1), 1);
+color: rgba(255, 255, 255, calc(1 - 1));
+color: hsla(calc(120deg + 16deg) 100% 50%);
+color: hsla(120deg calc(20% + 10%) 50%);
+color: hsla(120deg 40% calc(20% + 10%));
+color: hsl(120deg 40% 20% / calc(20% + 10%));
+color: hwb(194 calc(20% + 10%) 0% / .5);
+color: device-cmyk(0 calc(20%) 81% 30%);
+color: color(display-p3 calc(1 + 2) 0.5 0);
+}.relative {
+color: rgb(from indianred 255 255 255);
+color: rgb(from transparent 255 255 255);
+color: lch(from var(--mygray) 62% 30 -34);
+color: rgb(from Canvas 255 255 255);
+color: rgb(from canvas 255 255 255);
+color: rgb(from ActiveBorder 255 255 255);
+color: rgb(from -moz-buttondefault 255 255 255);
+color: rgb(from -moz-activehyperlinktext 255 255 255);
+color: rgb(from currentColor 255 255 255);
+}.var {
+color: rgb(var(--red) var(--green) var(--blue));
+color: rgb(var(--red) var(--green) var(--blue) / var(--alpha));
+color: rgb(env(--red) env(--green) env(--blue));
+color: rgb(env(--red) env(--green) env(--blue) / env(--alpha));
+color: rgb(constant(--red) constant(--green) constant(--blue));
+color: rgb(constant(--red) constant(--green) constant(--blue) / constant(--alpha));
+}div {
+color: hsl(var(--b2, var(--b1)) / var(--tw-bg-opacity));
+color: lab(var(--mycolor));
+color: rgba(var(--bg-color) 1);
+color: rgba(var(--bg-color) / 1);
+color: lab(var(--mycolor) 0);
+color: lab(var(--mycolor) var(--mycolor));
+color: lab(from var(--mycolor) 0 0 0);
+color: lab(from var(--mycolor) var(--color));
+color: rgb(var(--bg-color));
+color: rgb(var(--bg-color), var(--bg-color-a));
+color: rgb(var(--bg-color) var(--bg-color-a));
+color: rgba(var(--bg-color) 1);
+color: rgb(var(--mycolor) var(--mycolor) var(--mycolor));
+color: lab(var(--mycolor) var(--mycolor) var(--mycolor));
+color: color(from var(--bg-color) var(--bg-color));
+color: color(from var(--bg-color) var(--bg-color) var(--bg-color));
+color: color(var(--bg-color) var(--bg-color));
+color: color(var(--bg-color));
+color: color(from var(--base) mi calc(pi * 2) calc(pi / 2));
+color: color(var(--bg-color));
+color: color(--unwise 35% 20% 8%);
+color: color(--unwise var(--bg-color));
+color: color(--unwise var(--bg-color) var(--bg-color));
+color: device-cmyk(var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color) var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color) var(--bg-color) var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color) var(--bg-color) var(--bg-color) / var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color) / var(--bg-color));
+color: device-cmyk(var(--bg-color) / var(--bg-color));
+color: device-cmyk(var(--bg-color) var(--bg-color));
+color: rgb(var(--bg-color));
+color: rgb(var(--bg-color) var(--bg-color));
+color: rgb(var(--bg-color) var(--bg-color) var(--bg-color));
+color: rgb(var(--bg-color) var(--bg-color) var(--bg-color) / var(--bg-color));
+color: rgb(var(--bg-color) var(--bg-color) / var(--bg-color));
+color: rgb(var(--bg-color) / var(--bg-color));
+color: rgb(var(--bg-color) var(--bg-color));
+color: rgb(var(--bg-color));
+color: rgb(var(--bg-color), var(--bg-color));
+color: rgb(var(--bg-color), var(--bg-color), var(--bg-color));
+color: rgb(var(--bg-color), var(--bg-color), var(--bg-color), var(--bg-color));
+color: rgb(var(--bg-color), var(--bg-color), var(--bg-color));
+color: hwb(var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color) var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color) var(--bg-color) / var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color) / var(--bg-color));
+color: hwb(var(--bg-color) / var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color));
+color: hwb(var(--bg-color));
+color: hwb(120 0% 49.8039%);
+color: hwb(120 var(--bg-color) 49.8039%);
+color: hwb(120 var(--bg-color) 49.8039% / 1);
+color: hwb(120 var(--bg-color) 49.8039% / 100);
+color: hwb(120 var(--bg-color) var(--bg-color));
+color: hwb(var(--bg-color) var(--bg-color) var(--bg-color));
+color: color(rec2020 0.42053 0.979780 0.00579);
+color: color(rec2020 0.42053 0.979780 0.00579 / var(--color));
+color: color(rec2020 0.42053 var(--color));
+color: color(rec2020 0.42053 var(--color) / 100%);
+color: color(rec2020 var(--color));
+color: color(rec2020 var(--color) / var(--color));
+color: color(var(--color) var(--color));
+color: color(var(--color));
+color: color(xyz-d50 0.2005 0.14089 0.4472);
+color: color(sRGB 0.41587 0.503670 0.36664);
+color: color(display-p3 0.43313 0.50108 0.37950);
+color: color(a98-rgb 0.44091 0.49971 0.37408);
+color: color(prophoto-rgb 0.36589 0.41717 0.31333);
+color: color(rec2020 0.42210 0.47580 0.35605);
+}:root {
+---: value;
+--important: value !important;
+--important1: value !important;
+--important2: value !important;
+--important3: value !important;
+--important4: calc(1) !important;
+--empty: ;
+--empty2: ;
+--empty3:  !important;
+--empty4:  !important;
+--empty5: ;
+--no-whitespace: ident;
+--number: 1;
+--unit: 100vw;
+--color: #06c;
+--function: calc(1 + 1);
+--variable: var(--unit);
+--string: 'single quoted string';
+--string: \\"double quoted string\\";
+--square-block: [1, 2, 3];
+--square-block1: [];
+--square-block2: [];
+--round-block: (1, 2, 3);
+--round-block1: ();
+--round-block2: ();
+--bracket-block: {1, 2, 3};
+--bracket-block1: {};
+--bracket-block2: {};
+--JSON: [1, \\"2\\", {\\"three\\": {\\"a\\":1}}, [4]];
+--javascript: function(rule) { console.log(rule) };
+--CDO: <!--;
+--CDC: -->;
+--complex-balanced: {[({()})()()[({})]]}[{()}]([]);
+--fake-important: {!important};
+--semicolon-not-top-level: (;);
+--delim-not-top-level: (!);
+--zero-size: {
+width: 0;
+height: 0;
+};
+--small-icon: {
+width: 16px;
+height: 16px;
+};
+}:root {
+--a: 1;
+}:root {
+--foo: ;
+}:root {
+--var: value;
+}div {
+width: 100\\\\%;
+width: 100px2p;
+width: 100px;
+width: 100PX;
+width: 100UNKNOWN;
+width: 100НЕИЗВЕСТНО;
+}table {
+color: \\\\red;
+}a {
+background: \\\\;a;
+}:not([foo=\\")\\"]) {
+}:not(div) {
+}:not(:nth-child(2n of [foo=\\")\\"])) {
+}[foo=\\\\\\"] {
+}[foo=\\\\{] {
+}[foo=\\\\(] {
+}[foo=yes\\\\:\\\\(it\\\\'s\\\\ work\\\\)] {
+}\\\\@noat {
+}h1\\\\\\\\ {
+color: \\\\\\\\;
+}[attr=\\"\\\\;\\"] {
+}.prop {
+\\\\62 olor: red;
+}div {
+prop: 1Hz;
+prop: 1kHz;
+}a {
+animation: test;
+}a {
+animation: тест;
+}a {
+animation: т\\\\ест;
+}a {
+animation: 😋;
+}a {
+animation: \\\\\\\\😋;
+}a {
+animation: \\\\😋;
+}div {
+z-index: 12;
+z-index: +123;
+z-index: -456;
+z-index: 0;
+z-index: +0;
+z-index: -0;
+}div {
+width: 100e\\\\x;
+width: 100ex;
+width: 100px;
+width: 100PX;
+width: 100pX;
+}div {
+width: 0%;
+width: 0.1%;
+width: 100%;
+width: 100.5%;
+width: 100.1000%;
+width: 1e0%;
+width: 1e1%;
+width: 1e2%;
+width: 10e-1%;
+width: 10e-5%;
+width: 10e+2%;
+}div {
+margin: -5%;
+margin: -5.5%;
+}a::before {
+content: \\"This string is demarcated by double quotes.\\";
+content: 'This string is demarcated by single quotes.';
+content: \\"This is a string with \\\\\\" an escaped double quote.\\";
+content: \\"This string also has \\\\22 an escaped double quote.\\";
+content: 'This is a string with \\\\' an escaped single quote.';
+content: 'This string also has \\\\27 an escaped single quote.';
+content: \\"This is a string with \\\\\\\\ an escaped backslash.\\";
+content: \\"This string also has \\\\22an escaped double quote.\\";
+content: \\"This string also has \\\\22  an escaped double quote.\\";
+content: \\"This string has a \\\\Aline break in it.\\";
+content: \\"A really long \\\\
+awesome string\\";
+content: \\";'@ /**/\\\\\\"\\";
+content: '\\\\'\\"\\\\\\\\';
+content: \\"a\\\\
+b\\";
+content: \\"a\\\\
+b\\";
+content: \\"a\\\\
+b\\";
+content: \\"a\\\\b\\";
+content: \\"a\\\\
+\\\\
+\\\\
+\\\\\\\\
+b\\";
+content: 'a\\\\62 c';
+}a[title=\\"a not s\\\\
+o very long title\\"] {
+color: red;
+}a[title=\\"a not so very long title\\"] {
+color: red;
+}div {
+family-name: \\"A;' /**/\\";
+}.foo {
+content: \\";'@ /**/\\\\\\"\\";
+content: '\\\\'\\"\\\\\\\\';
+}@media print and (min-resolution: 300dpi) {
+}@media print and (min-resolution: 300dpcm) {
+}@media print and (min-resolution: 300dppx) {
+}@media print and (min-resolution: 300x) {
+}div {
+prop: [];
+prop: [];
+prop: [row1-start];
+prop: [row1-start-with-spaces-around];
+prop: [red #fff 12px];
+prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+}#delay {
+font-size: 14px;
+transition-property: font-size;
+transition-duration: 4s;
+transition-delay: 2s;
+}.box {
+transition: width 2s, height 2s, background-color 2s, transform 2s;
+}.time {
+transition-duration: 4s;
+transition-duration: 4000ms;
+}@font-face {
+font-family: 'Ampersand';
+src: local('Times New Roman');
+unicode-range: U+26;
+unicode-range: u+26;
+unicode-range: U+0-7F;
+unicode-range: U+0025-00FF;
+unicode-range: U+4??;
+unicode-range: U+0025-00FF, U+4??;
+unicode-range: U+A5, U+4E00-9FFF, U+30??, U+FF00-FF9F;
+unicode-range: U+????;
+unicode-range: U+??????;
+unicode-range: U+12;
+unicode-range: U+12e112;
+unicode-range: U+1e1ee1;
+unicode-range: U+1e1ee1-FFFFFF;
+unicode-range: U+1e1ee?;
+unicode-range: U+12-13;
+}div {
+background: url(https://example.com/image.png);
+background: URL(https://example.com/image.png);
+background: \\\\URL(https://example.com/image.png);
+background: url(\\"https://example.com/image.png\\");
+background: url('https://example.com/image.png');
+background: URL('https://example.com/image.png');
+background: \\\\URL('https://example.com/image.png');
+background: url(data:image/png;base64,iRxVB0);
+background: url(#IDofSVGpath);
+background: url(\\"//aa.com/img.svg\\" prefetch);
+background: url(\\"//aa.com/img.svg\\" foo bar baz func(test));
+background: url(\\"http://example.com/image.svg\\" param(--color var(--primary-color)));
+background: url();
+background: url(\\"\\");
+background: url('');
+--foo: \\"http://www.example.com/pinkish.gif\\";
+background: src(\\"http://www.example.com/pinkish.gif\\");
+background: SRC(\\"http://www.example.com/pinkish.gif\\");
+background: src(var(--foo));
+background: url(   https://example.com/image.png   );
+background: u\\\\rl(   https://example.com/image.png   );
+background: url(
+	https://example.com/image.png
+	);
+background: url(
+
+
+	https://example.com/image.png
+
+
+	);
+background: URL(https://example.com/ima\\\\)ge.png);
+background: url(\\"https://example.com/image.png\\");
+}.delim {
+a1: @ 12;
+a2: 1 # 1;
+a3: (1 2 3);
+a4: 1 + 1;
+a5: +s1;
+a6: \\"test\\", \\"test\\";
+a7: 1 - 2 - 3;
+a8: fn(\\"test\\");
+a9: < >;
+a10: \\\\ ;
+a11: $;
+a12: --1;
+a13: -+1;
+a14: ident1<!-- abc -->ident2;
+a15: --fn(\\"test\\");
+a16: +3.4e2;
+a17: +3.4e-2;
+a18: +3.4e+2;
+a19: 12.1 .1;
+a20: +-12.2;
+a21: 12.;
+a22: \\\\A;
+a23: \\\\00000A;
+a23: \\\\00000AB;
+a24: \\\\123456 B;
+}"
+`;
+
 exports[`readToken should parse and print "at-rule.css" 1`] = `
 Array [
   Array [

--- a/test/__snapshots__/CssSyntax.unittest.js.snap
+++ b/test/__snapshots__/CssSyntax.unittest.js.snap
@@ -220,6 +220,8 @@ color: a b;
 }a {
 color: black;
 }a {
+color: black;
+}a {
 color: \\\\\\\\ red \\\\\\\\ blue;
 }"
 `;
@@ -290,6 +292,8 @@ font-size: calc(1rem * pow(1.5, 1));
 font-size: calc(1rem * pow(1.5, 2));
 font-size: calc(1rem * pow(1.5, 3));
 font-size: calc(1rem * pow(1.5, 4));
+}.fade {
+background-image: linear-gradient(silver 0%, white 20px, white calc(100% - 20px), silver 100%);
 }div {
 }div {
 width: calc(100% / 4);
@@ -434,6 +438,8 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "hacks.css
 _property: value;
 }.selector {
 -property: value;
+}.selector {
+property: value\\\\9;
 }.selector {
 property: value\\\\9;
 }"
@@ -645,10 +651,14 @@ display: grid;
 @media (orientation: landscape) {
 grid-auto-flow: column;
 }
+}.foo {
+display: grid;
 }@media (orientation: landscape) {
 .foo {
 grid-auto-flow: column;
 }
+}.foo {
+display: grid;
 }@media (orientation: landscape) {
 .foo {
 grid-auto-flow: column;
@@ -826,23 +836,33 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }[title=foo] {
 }[title=\\"foo\\"] {
 }[title = \\"foo\\"] {
+}[title = \\"foo\\"] {
 }[lang~=\\"en-us\\"] {
 }[lang|=\\"zh\\"] {
 }[href^=\\"#\\"] {
 }[href$=\\".org\\"] {
 }[href*=\\"example\\"] {
+}[href*=\\"insensitive\\" i] {
 }[href*=\\"insensitive\\" I] {
 }[href*=\\"cAsE\\" s] {
 }[href*=\\"cAsE\\" S] {
 }[foo|att=val] {
 }[*|att] {
+}[*|att] {
+}[|att] {
+}[|att] {
 }[|att] {
 }[att] {
+}[att] {
+}[att] {
 }a[class = \\"test\\"] {
+}a[class = \\"test\\"] {
+}[href*=\\"insensitive\\" i] {
 }[href*=\\"insensitive\\" i] {
 }[href *= \\"insensitive\\" i] {
 }[href] {
 }[frame=hsides i] {
+}#id.class[target] {
 }#id[target] {
 }[target].class {
 }[title='foo'] {
@@ -874,12 +894,21 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }.\\\\. {
 }.\\\\3A \\\\) {
 }.\\\\3A \\\\\`\\\\( {
+}.\\\\31 23 {
+}.\\\\31 a2b3c {
 }.\\\\<p\\\\> {
+}.\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> {
 }.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<\\\\-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. {
+}.\\\\# {
+}.\\\\#\\\\# {
 }.\\\\#\\\\.\\\\#\\\\.\\\\# {
 }.\\\\_ {
 }.\\\\{\\\\} {
 }.\\\\.fake\\\\-class {
+}.foo\\\\.bar {
+}.\\\\3A hover {
+}.\\\\3A hover\\\\3A focus\\\\3A active {
+}.\\\\[attr\\\\=value\\\\] {
 }.f\\\\/o\\\\/o {
 }.f\\\\\\\\o\\\\\\\\o {
 }.f\\\\*o\\\\*o {
@@ -890,6 +919,9 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }.-a-b-c- {
 }.\\\\#fake-id {
 }foo.class > .foo.class {
+}.foo#id {
+}.class[target] {
+}.class#id[target] {
 }ul.list {
 }ul.list::before {
 }.\\\\31 a2b3c {
@@ -906,13 +938,35 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }.not-pseudo\\\\:\\\\:focus {
 }.\\\\\\\\1D306 {
 }.\\\\; {
+}a b {
+}a b {
+}a b {
+}a b {
 }a/**/b {
+}a/**/b {
+}a b {
+}a b {
+}a b {
+}a b {
+}a b {
+}a b {
+}a b {
+}a b {
 }a,b {
 }a , b {
 }article p {
+}article p {
+}article p {
+}article > p {
+}article > p {
 }article > p {
 }p + img {
+}p + img {
+}p + img {
 }p ~ img {
+}p ~ img {
+}p ~ img {
+}article > p > a {
 }article > p > a {
 }div p {
 }.class p {
@@ -971,6 +1025,7 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }a>a {
 }a~a {
 }a [type='button'] {
+}a [type='button'] {
 }a a {
 }namespace|type#id > .foo {
 }#id > .cl + .cl2 {
@@ -982,8 +1037,10 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }[data-weird-attr*=\\"Something=weird\\"], [data-weird-attr^=\\"Something=weird\\"], [data-weird-attr$=\\"Something=weird\\"], [data-weird-attr|=\\"Something=weird\\"] {
 }* + * {
 }* * {
+}* * {
 }*[href] *:not(*.green) {
 }*::-webkit-media-controls-play-button {
+}col.selected || td {
 }col.selected || td {
 }col.selected||td {
 }.one {
@@ -991,6 +1048,10 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }.foo#id {
 }.class[target] {
 }.class#id[target] {
+}#id.class {
+}#id.class[target] {
+}div#thing:hover {
+}div#thing::before {
 }a[href='place']:hover {
 }a[href='place']::before {
 }.one.two.three {
@@ -998,13 +1059,41 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }*#z98y {
 }#one#two {
 }#one.two.three {
+}#id {
+}#♥ {
 }#© {
+}#“‘’” {
+}#☺☃ {
 }#⌘⌥ {
 }#𝄞♪♩♫♬ {
 }#💩 {
 }#\\\\? {
+}#\\\\@ {
+}#\\\\. {
+}#\\\\3A \\\\) {
+}#\\\\3A \\\\\`\\\\( {
+}#\\\\31 23 {
+}#\\\\31 a2b3c {
+}#\\\\<p\\\\> {
+}#\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> {
 }#\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<\\\\-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\-\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. {
+}#\\\\# {
+}#\\\\#\\\\# {
+}#\\\\#\\\\.\\\\#\\\\.\\\\# {
+}#\\\\_ {
+}#\\\\{\\\\} {
+}#\\\\.fake\\\\-class {
+}#foo\\\\.bar {
+}#\\\\3A hover {
+}#\\\\3A hover\\\\3A focus\\\\3A active {
+}#\\\\[attr\\\\=value\\\\] {
+}#f\\\\/o\\\\/o {
+}#f\\\\\\\\o\\\\\\\\o {
+}#f\\\\*o\\\\*o {
+}#f\\\\!o\\\\!o {
 }#f\\\\'o\\\\'o {
+}#f\\\\~o\\\\~o {
+}#f\\\\+o\\\\+o {
 }#id {
 }#id.class {
 }#id.class[target] {
@@ -1044,10 +1133,12 @@ exports[`CssSyntax — beautifying the parsing corpus should beautify "selectors
 }#f\\\\+o\\\\+o {
 }div, p {
 }div , p {
+}div , p {
 }a, a[href='place'] {
 }a #foo > [foo='bar'], .FOO {
 }div, p, a {
 }div,p,a {
+}div , p , a {
 }div , p , a {
 }.foo, .bar, *.baz {
 }input::-moz-placeholder, input::placeholder {
@@ -1087,6 +1178,11 @@ color: red;
 }.foo, .bar {
 color: blue;
 & + .baz, &.qux {
+color: red;
+}
+}.foo {
+color: blue;
+& .bar & .baz & .qux {
 color: red;
 }
 }.foo {
@@ -1224,10 +1320,13 @@ color: blue;
 }:unknown(;) {
 }:nth-child(2n+1) {
 }:nth-child(2n +1) {
+}:nth-child(2n + 1) {
+}:nth-child(2n+ 1) {
 }:nth-child(2n-1) {
 }:nth-child(2n -1) {
 }:nth-child(2n- 1) {
 }:nth-child(2n - 1) {
+}:nth-child(-2n+1) {
 }:nth-child(-2n +1) {
 }:nth-child(-2n + 1) {
 }:nth-child(-2n+ 1) {
@@ -1291,6 +1390,7 @@ color: blue;
 }:nth-child(eVeN) {
 }:nth-child(EVEN) {
 }:nth-child(2n+ 1) {
+}:nth-last-child(+3n - 2) {
 }:nth-child(2n + 1) {
 }:nth-last-child(+3n - 2) {
 }:nth-child(-2n+1) {
@@ -1311,6 +1411,7 @@ color: blue;
 }p:nth-child(+3) {
 }p:nth-child(-3) {
 }:nth-child(2n+1 of li) {
+}:nth-child(2n+1 of li) {
 }:nth-child(2n+1 of li,.test) {
 }:nth-child(2n+1 of li, .test) {
 }:nth-child(-n+3 of li.important) {
@@ -1318,6 +1419,7 @@ color: blue;
 }:root {
 }:any-link {
 }button:hover {
+}div\\\\:before {
 }div\\\\::before {
 }iNpUt {
 }:matches(section, article, aside, nav) h1 {
@@ -1329,6 +1431,7 @@ color: blue;
 }*:is(*) {
 }:--heading {
 }a:-moz-placeholder {
+}a:hover::before {
 }div :nth-child(2) {
 }a:hOvEr {
 }:-webkit-full-screen a {
@@ -1377,6 +1480,7 @@ color: blue;
 }*:hover {
 }*::before {
 }* *:not(*) {
+}a {
 }a {
 }\\\\@noat {
 }h1\\\\\\\\ {
@@ -1701,6 +1805,8 @@ height: 16px;
 };
 }:root {
 --a: 1;
+}:root {
+--foo: ;
 }:root {
 --foo: ;
 }:root {

--- a/test/__snapshots__/HtmlSyntax.unittest.js.snap
+++ b/test/__snapshots__/HtmlSyntax.unittest.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`SourceProcessor — beautifying should beautify a comment 1`] = `"<div><!--c--></div>"`;
+
+exports[`SourceProcessor — beautifying should beautify a form the table kept 1`] = `"<table><p><form></form></p></table>"`;
+
+exports[`SourceProcessor — beautifying should beautify a fostered formatting run 1`] = `"<nobr><table><b><colgroup><nobr>"`;
+
+exports[`SourceProcessor — beautifying should beautify a list fostered out of a table 1`] = `"<p><table><ol></ol></table></p>"`;
+
+exports[`SourceProcessor — beautifying should beautify an implied paragraph 1`] = `"<div   class=\\"x\\"    id=y ><p>z</p></div>"`;
+
+exports[`SourceProcessor — beautifying should beautify an unquoted attribute 1`] = `"<img src=a.png alt=hi>"`;
+
+exports[`SourceProcessor — beautifying should beautify attribute spelling 1`] = `"<A HREF='x'   dATa-Y=1 >t</A>"`;
+
+exports[`SourceProcessor — beautifying should beautify implied list items 1`] = `"<ul><li>a</li><li>b</li></ul>"`;
+
+exports[`SourceProcessor — beautifying should beautify implied table sections 1`] = `"<table><tr><td>1</td><td>2</td></tr></table>"`;
+
+exports[`SourceProcessor — beautifying should beautify raw text 1`] = `"<style>a{b:c}</style><script>1<2</script>"`;
+
 exports[`parseHtml — insertion modes appends a comment after the body to the html element 1`] = `
 "| <!DOCTYPE html>
 | <html>

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -7,7 +7,10 @@
 // DOM oracle, held to that corpus's expected trees by html5lib.spectest.js.
 
 const path = require("path");
-const { SourceProcessor: CssSourceProcessor } = require("../lib/css/syntax");
+const {
+	SourceProcessor: CssSourceProcessor,
+	readToken
+} = require("../lib/css/syntax");
 const {
 	BOOLEAN_ATTRIBUTES,
 	EMPTY_REMOVABLE_ATTRIBUTES,
@@ -34,6 +37,7 @@ const {
 	numericallyEqual
 } = require("./helpers/syntaxEquivalence");
 const {
+	WPT,
 	browserCorpus,
 	cssCorpus: wptCssCorpus,
 	cssDeclarations,
@@ -95,6 +99,21 @@ const minifyHtml = (source, options) =>
 	/** @type {{ code: string }} */ (
 		new HtmlSourceProcessor().process(source, { mode: "minify", ...options })
 	).code;
+
+/**
+ * @param {string} source HTML
+ * @returns {string} the same document, beautified
+ */
+const beautifyHtml = (source) =>
+	/** @type {{ code: string }} */ (
+		new HtmlSourceProcessor().process(source, { mode: "beautify" })
+	).code;
+
+/** @type {[string, (source: string) => string][]} both printing modes */
+const PRINT_MODES = [
+	["minify", (source) => minifyHtml(source)],
+	["beautify", beautifyHtml]
+];
 
 /**
  * @param {string} source a stylesheet
@@ -1021,6 +1040,8 @@ const whatMoved = (before, after) => {
 
 // The whole wpt corpus, with no engine: webpack's parser answers for the DOM,
 // which the tree-construction suite holds to this corpus's own expected trees.
+// Both print modes run — beautifying is where the round-trip fallback lives, so
+// the corpus is the only thing holding it to real documents.
 // One test per spec area rather than per document — 49k test names report
 // nothing a failing list does not, and the list shows every document at once.
 describe("wpt tree stability", () => {
@@ -1051,20 +1072,22 @@ describe("wpt tree stability", () => {
 	// nothing a failing list does not. Each area does its own parsing, so a slow
 	// one is named by its own timing rather than hidden in a corpus-wide pass.
 	for (const [group, files] of byGroup) {
-		it(`should build the same tree from ${group} and its minified form`, () => {
+		it(`should build the same tree from ${group} and its printed forms`, () => {
 			/** @type {{ name: string, why: string }[]} */
 			const differences = [];
 			for (const file of files) {
 				const source = readDocument(file);
 				if (source === null) continue;
-				const why = whatMoved(
-					domShapeOf(source),
-					domShapeOf(minifyHtml(source))
-				);
-				if (why === "") continue;
-				const name = nameOf(file);
-				diverging.add(name);
-				if (!FILED_WPT_TREE_DEFECTS.has(name)) differences.push({ name, why });
+				const before = domShapeOf(source);
+				for (const [mode, print] of PRINT_MODES) {
+					const why = whatMoved(before, domShapeOf(print(source)));
+					if (why === "") continue;
+					const name = nameOf(file);
+					diverging.add(name);
+					if (!FILED_WPT_TREE_DEFECTS.has(name)) {
+						differences.push({ name, why: `${mode} ${why}` });
+					}
+				}
 			}
 			expect(differences).toEqual([]);
 		}, 600000);
@@ -1075,5 +1098,69 @@ describe("wpt tree stability", () => {
 		expect(
 			[...FILED_WPT_TREE_DEFECTS.keys()].filter((name) => !diverging.has(name))
 		).toEqual([]);
+	});
+});
+
+// §serialization of css-syntax lists the token pairs that re-tokenize as
+// something else when written next to each other, so a minifier dropping the
+// whitespace between them has to leave a separator behind. wpt states that
+// table; this holds our minifier to it without an engine.
+describe("wpt css token adjacency", () => {
+	const table = path.resolve(
+		WPT,
+		"css/css-syntax/serialize-consecutive-tokens.html"
+	);
+
+	/**
+	 * @param {string} css a stylesheet
+	 * @returns {string} its tokens, whitespace and comments dropped
+	 */
+	const significantTokens = (css) => {
+		/** @type {string[]} */
+		const out = [];
+		for (let pos = 0; ;) {
+			const token = readToken(
+				css,
+				pos,
+				/** @type {import("../lib/css/syntax").MutableToken} */ ({})
+			);
+			if (token === undefined) break;
+			pos = token.end;
+			const text = css.slice(token.start, token.end);
+			if (text.trim() === "" || text.startsWith("/*")) continue;
+			out.push(`${token.type}:${text}`);
+		}
+		return out.join(" ");
+	};
+
+	if (!hasCorpus()) {
+		it(NO_CORPUS, () => {
+			// No-op: the corpus is an optional git submodule.
+		});
+
+		return;
+	}
+
+	const pairs = [
+		...readDocument(table).matchAll(/testTokenPairs\("([^"]*)",\s*"([^"]*)"\)/g)
+	].map((match) => [match[1], match[2]]);
+
+	// The table is read out of a test file, so an extraction that silently found
+	// nothing would report green over no cases at all.
+	it("should read the table", () => {
+		expect(pairs.length).toBeGreaterThan(50);
+	});
+
+	it("should keep every listed pair apart once minified", () => {
+		/** @type {{ pair: string, minified: string }[]} */
+		const fused = [];
+		for (const [first, second] of pairs) {
+			const source = `a{b:${first} ${second}}`;
+			const minified = minifyCss(source);
+			if (significantTokens(minified) !== significantTokens(source)) {
+				fused.push({ pair: `${first} ${second}`, minified });
+			}
+		}
+		expect(fused).toEqual([]);
 	});
 });

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -84,6 +84,7 @@ const FILED_WPT_HTML_DEFECTS = new Map([
 const FILED_WPT_CSS_DEFECTS = new Map();
 
 // The same, for what webpack's own parser sees over the whole corpus.
+// Keyed `"<mode> <document>"`, so filing one print mode leaves the other held.
 const FILED_WPT_TREE_DEFECTS = new Map();
 
 // Declarations Chromium computes a different style from once printed, keyed by
@@ -1082,10 +1083,13 @@ describe("wpt tree stability", () => {
 				for (const [mode, print] of PRINT_MODES) {
 					const why = whatMoved(before, domShapeOf(print(source)));
 					if (why === "") continue;
-					const name = nameOf(file);
+					// Keyed by mode as well as document: a file filed for one mode says
+					// nothing about the other, and exempting both would hide half of
+					// what this tier exists to catch.
+					const name = `${mode} ${nameOf(file)}`;
 					diverging.add(name);
 					if (!FILED_WPT_TREE_DEFECTS.has(name)) {
-						differences.push({ name, why: `${mode} ${why}` });
+						differences.push({ name, why });
 					}
 				}
 			}

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -1083,9 +1083,8 @@ describe("wpt tree stability", () => {
 				for (const [mode, print] of PRINT_MODES) {
 					const why = whatMoved(before, domShapeOf(print(source)));
 					if (why === "") continue;
-					// Keyed by mode as well as document: a file filed for one mode says
-					// nothing about the other, and exempting both would hide half of
-					// what this tier exists to catch.
+					// Keyed by mode too: a file filed for one says nothing about the
+					// other, and exempting both hides half of what this tier catches.
 					const name = `${mode} ${nameOf(file)}`;
 					diverging.add(name);
 					if (!FILED_WPT_TREE_DEFECTS.has(name)) {
@@ -1105,10 +1104,8 @@ describe("wpt tree stability", () => {
 	});
 });
 
-// §serialization of css-syntax lists the token pairs that re-tokenize as
-// something else when written next to each other, so a minifier dropping the
-// whitespace between them has to leave a separator behind. wpt states that
-// table; this holds our minifier to it without an engine.
+// css-syntax §serialization lists the token pairs that re-tokenize when written
+// together, so dropping the whitespace between them has to leave a separator.
 describe("wpt css token adjacency", () => {
 	const table = path.resolve(
 		WPT,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Beautifying had no corpus of its own in either printer — the wpt documents only ever ran through the minifier — and holding it to one found three defects in the CSS printer.

A comment the source never closed swallowed the separator written after a raw span, so the next parse read a longer comment and the output grew on every pass: `{y/*` minified to `{y/*}`, then `{y/*}}`. Both modes wrote it, and §4.3.5 leaves an unterminated string closed the same way, so the comment is now closed too. A top-level rule an identical later one makes dead was taken back in both modes, so beautifying dropped a rule the author wrote — taking one back is a rewrite, which is minifying's to make. That was the whole of `nesting.css`, `hacks.css` and `values.css` breaking the property `print modes` states, so it now holds over every case the tokenizer reads rather than a handful of sources.

Whether a raw span ends inside an open comment was asked by tokenizing that span a second time while printing it. The parse already reads every comment, and §4.3.2 runs an unclosed one to EOF, so at most one is open and where it opened is a number the parse hands over.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/CssSyntax.unittest.js` beautifies the parsing corpus, snapshots what it writes, and holds each case to being a fixed point and to minifying the same from either form; the unterminated comment has its own case. `test/HtmlSyntax.unittest.js` snapshots the html printer's beautified output, and carries round-trip cases harvested from wpt's `serializing-html-fragments`. `test/syntaxEquivalence.spectest.js` runs both print modes over all 49,571 wpt documents rather than the minifier alone, and holds the css minifier to the css-syntax table of token pairs that re-tokenize when written together.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Beautifying is an API-level mode no build configuration reaches, so no emitted asset changes. Minified output is unchanged except where a comment the source never closed was growing it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used throughout: it ran the corpus, delta-debugged each failure to a minimal input, wrote the fixes and the tests. Two claims it made were wrong and were corrected by measuring rather than by argument — that the two rule-merge cases were defects, when both forms compute the same styles, and that the `_printFromSource` half of the html round-trip check was redundant, which four regression cases disproved in one run. Chrome was asked the same round-trip question the html printer answers, and loses 6 of the 10 shapes it was given, so that check is left as it stands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnmztbjhQpVCTYnrextRu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSS beautification now preserves all rules and correctly closes unterminated comments.
  * CSS minification preserves significant token boundaries.
  * Repeated minification and beautification now produce stable, consistent output.

* **Improvements**
  * HTML beautification better preserves document structure, comments, attributes, namespaces, and raw-text content.
  * Beautified HTML can be safely reparsed without changing its structure.
  * Formatting is more reliable across repeated processing passes and varied HTML and CSS content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->