### PR TITLE
fix(side-effects): read the inherited flag from the resolved file

### DIFF
--- a/.changeset/047-inherit-nested-sideEffects.md
+++ b/.changeset/047-inherit-nested-sideEffects.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Inherit sideEffects past type-only nested package.json under node_modules.
+Inherit sideEffects past a type-only nested package.json for files under node_modules.

--- a/lib/dependencies/ImportMetaGlobHelpers.js
+++ b/lib/dependencies/ImportMetaGlobHelpers.js
@@ -38,17 +38,6 @@ const getUnsupportedFeatureWarning = memoize(() =>
  * 	Property
  * } from "estree"
  */
-/** @typedef {import("../ContextModule").ContextModuleOptions} ContextModuleOptions */
-/** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
-/** @typedef {import("../javascript/JavascriptParser").Range} Range */
-/** @typedef {import("../Dependency").RawReferencedExports} RawReferencedExports */
-/** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
-/** @typedef {import("estree").CallExpression} CallExpression */
-/** @typedef {import("estree").Expression} Expression */
-/** @typedef {import("estree").ObjectExpression} ObjectExpression */
-/** @typedef {import("estree").Property} Property */
-/** @typedef {import("./ImportMetaGlobDependency").ImportMetaGlobDependencyOptions} ImportMetaGlobDependencyOptions */
-
 /**
  * @typedef {object} ParsedImportMetaGlobOptions
  * @property {string[]} patterns patterns

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -165,11 +165,9 @@ const notSideEffectsTag = Symbol("NoSideEffects");
 const RETURNS_FALSE = () => false;
 
 /**
- * Resolve sideEffects from the package that declares it, inheriting past a
- * nested package.json that declares none — the `type`-only stub a package ships
- * next to its build output. Globs are matched relative to the declaring package
- * root, and every package.json the walk consults becomes a dependency of the
- * resolve so that changing one invalidates the modules it flagged.
+ * Resolve sideEffects from the package that declares it, inheriting past a nested
+ * package.json that declares none. Globs are rebased on the declaring package root,
+ * and each package.json the walk consults becomes a dependency of the resolve.
  * @param {InputFileSystem} fs file system
  * @param {ResolveData} resolveData resolve data
  * @param {string} descriptionFileRoot root directory of the nearest description file
@@ -204,9 +202,8 @@ const resolveSideEffectsFlag = (
 	if (descriptionFileData.name !== undefined) {
 		return callback();
 	}
-	// Only inherit for a file that lives under node_modules; app-local nests must keep
-	// shadowing parents. Read from the resolved path, not from descriptionFileRoot, so a
-	// symlinked package flags every one of its files alike whichever request reached it.
+	// Only inherit for a file living under node_modules; app-local nests keep shadowing.
+	// Read the resolved path so a symlinked package flags all of its files alike.
 	if (
 		typeof resolveInfo.path !== "string" ||
 		!NODE_MODULES_REGEXP.test(resolveInfo.path)
@@ -274,9 +271,13 @@ const resolveSideEffectsFlag = (
 
 		readJson(fs, packageJsonPath, (err, data) => {
 			if (err) {
-				// nothing else reads these ancestors, so one that is unreadable or
-				// unparsable declines the inheritance instead of failing the module
-				(isMissingPackageJsonError(err) ? missing : read).push(packageJsonPath);
+				if (!isMissingPackageJsonError(err)) {
+					// it is there but unreadable, so what it declares is unknown:
+					// decline rather than let an outer flag speak for it
+					read.push(packageJsonPath);
+					return done(null);
+				}
+				missing.push(packageJsonPath);
 				dir = parent;
 				return next();
 			}

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -19,6 +19,7 @@ const formatLocation = require("../util/formatLocation");
 const { dirname, join, readJson, relative } = require("../util/fs");
 const { getGlobToRegExpSource } = require("../util/globUtils");
 const {
+	NODE_MODULES_REGEXP,
 	WINDOWS_PATH_SEPARATOR_REGEXP,
 	relativePathToRequest
 } = require("../util/identifier");
@@ -43,6 +44,8 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
 /** @import ModuleGraphConnection from "../ModuleGraphConnection" */
 /** @import { ExportInfo, TargetItemWithConnection } from "../ExportsInfo" */
 /** @import JavascriptParser, { Range } from "../javascript/JavascriptParser" */
+/** @import { InputFileSystem } from "../util/fs" */
+/** @import { CreateData, ResolveData } from "../NormalModuleFactory" */
 /**
  * @import {
  * 	JavascriptParserOptions
@@ -57,9 +60,7 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
  * @property {boolean} checked if the export is conditional
  */
 
-/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
-/** @typedef {import("../util/fs").JsonObject} JsonObject */
-/** @typedef {import("../NormalModuleFactory").CreateData} CreateData */
+/** @typedef {NonNullable<CreateData["resourceResolveData"]>} ResourceResolveData */
 
 /** @typedef {string | boolean | string[] | undefined} SideEffectsFlagValue */
 
@@ -72,14 +73,21 @@ const { CompilerHintNotationRegExp } = require("../util/magicComment");
  */
 
 /**
- * Owning-package sideEffects resolution cached per descriptionFileRoot.
- * `null` means the walk finished with no applicable flag.
  * @typedef {object} OwningSideEffectsFlag
  * @property {SideEffectsFlagValue} sideEffects package.json sideEffects value
  * @property {string} packageRoot directory of the declaring package.json
  */
 
-/** @typedef {Map<string, OwningSideEffectsFlag | null>} OwningSideEffectsFlagCache */
+/**
+ * A finished ancestor walk, kept per descriptionFileRoot. The package.json
+ * paths it consulted are replayed as dependencies for every module reusing it.
+ * @typedef {object} OwningSideEffectsFlagWalk
+ * @property {OwningSideEffectsFlag | null} owning declaring package, `null` when the walk found none
+ * @property {string[]} read package.json files the walk read
+ * @property {string[]} missing package.json files the walk did not find
+ */
+
+/** @typedef {Map<string, OwningSideEffectsFlagWalk>} OwningSideEffectsFlagCache */
 
 /**
  * Whether a resolved re-export target is reached through an `import defer` edge.
@@ -98,30 +106,21 @@ const isDeferredTargetConnection = (connection) =>
 /** @type {WeakMap<Compiler, CacheItem>} */
 const globToRegexpCache = new WeakMap();
 
-/** @type {WeakMap<EXPECTED_OBJECT, OwningSideEffectsFlagCache>} */
+/** @type {WeakMap<Compiler, OwningSideEffectsFlagCache>} */
 const owningSideEffectsFlagCache = new WeakMap();
 
 /** @type {WeakMap<Partial<CreateData>, ResolvedSideEffectsFlag>} */
 const resolvedSideEffectsFlags = new WeakMap();
 
 /**
- * Ancestor package.json read failures that must not fail unrelated modules.
+ * Whether a failed ancestor package.json read means nothing is there, as
+ * opposed to something being there that cannot be used.
  * @param {NodeJS.ErrnoException | SyntaxError | Error} err error from readJson
- * @returns {boolean} true when the walk should skip this directory
+ * @returns {boolean} true when no file was found at that path
  */
-const isSkippablePackageJsonError = (err) => {
-	if (err instanceof SyntaxError) return true;
-	if (!("code" in err)) return false;
-	switch (err.code) {
-		case "ENOENT":
-		case "ENOTDIR":
-		case "EISDIR":
-		case "ENAMETOOLONG":
-			return true;
-		default:
-			return false;
-	}
-};
+const isMissingPackageJsonError = (err) =>
+	"code" in err && err.code === "ENOENT";
+
 /**
  * Returns a regular expression.
  * @param {string} glob the pattern
@@ -166,26 +165,35 @@ const notSideEffectsTag = Symbol("NoSideEffects");
 const RETURNS_FALSE = () => false;
 
 /**
- * Resolve sideEffects from the owning package, inheriting past type-only nested
- * package.json under node_modules. Globs are matched relative to that package root.
+ * Resolve sideEffects from the package that declares it, inheriting past a
+ * nested package.json that declares none — the `type`-only stub a package ships
+ * next to its build output. Globs are matched relative to the declaring package
+ * root, and every package.json the walk consults becomes a dependency of the
+ * resolve so that changing one invalidates the modules it flagged.
  * @param {InputFileSystem} fs file system
+ * @param {ResolveData} resolveData resolve data
  * @param {string} descriptionFileRoot root directory of the nearest description file
- * @param {JsonObject} descriptionFileData nearest description file data
- * @param {string} relativePath path relative to descriptionFileRoot
  * @param {OwningSideEffectsFlagCache} owningCache walk cache keyed by descriptionFileRoot
- * @param {(err?: null | Error, result?: ResolvedSideEffectsFlag) => void} callback callback
+ * @param {(result?: ResolvedSideEffectsFlag) => void} callback callback
  * @returns {void}
  */
 const resolveSideEffectsFlag = (
 	fs,
+	resolveData,
 	descriptionFileRoot,
-	descriptionFileData,
-	relativePath,
 	owningCache,
 	callback
 ) => {
+	const resolveInfo = /** @type {ResourceResolveData} */ (
+		resolveData.createData.resourceResolveData
+	);
+	const descriptionFileData =
+		/** @type {NonNullable<ResourceResolveData["descriptionFileData"]>} */ (
+			resolveInfo.descriptionFileData
+		);
+	const relativePath = /** @type {string} */ (resolveInfo.relativePath);
 	if (descriptionFileData.sideEffects !== undefined) {
-		return callback(null, {
+		return callback({
 			sideEffects: /** @type {SideEffectsFlagValue} */ (
 				descriptionFileData.sideEffects
 			),
@@ -196,29 +204,34 @@ const resolveSideEffectsFlag = (
 	if (descriptionFileData.name !== undefined) {
 		return callback();
 	}
-	// Only inherit inside node_modules; app-local nests must keep shadowing parents.
-	const normalizedRoot = descriptionFileRoot.replace(
-		WINDOWS_PATH_SEPARATOR_REGEXP,
-		"/"
-	);
-	if (!/(?:^|\/)node_modules(?:\/|$)/.test(normalizedRoot)) {
+	// Only inherit for a file that lives under node_modules; app-local nests must keep
+	// shadowing parents. Read from the resolved path, not from descriptionFileRoot, so a
+	// symlinked package flags every one of its files alike whichever request reached it.
+	if (
+		typeof resolveInfo.path !== "string" ||
+		!NODE_MODULES_REGEXP.test(resolveInfo.path)
+	) {
 		return callback();
 	}
 
+	// stays in descriptionFileRoot's space, which is the space packageRoot is found in
 	const resourcePath = join(fs, descriptionFileRoot, relativePath);
 
 	/**
-	 * @param {OwningSideEffectsFlag | null} owning owning package flag or null
+	 * @param {OwningSideEffectsFlagWalk} walk finished walk
 	 * @returns {void}
 	 */
-	const finishFromOwning = (owning) => {
+	const finishFromWalk = (walk) => {
+		for (const file of walk.read) resolveData.fileDependencies.add(file);
+		for (const file of walk.missing) resolveData.missingDependencies.add(file);
+		const owning = walk.owning;
 		if (owning === null) return callback();
 		const ancestorRelative = relative(
 			fs,
 			owning.packageRoot,
 			resourcePath
 		).replace(WINDOWS_PATH_SEPARATOR_REGEXP, "/");
-		return callback(null, {
+		return callback({
 			sideEffects: owning.sideEffects,
 			relativePath: relativePathToRequest(ancestorRelative)
 		});
@@ -226,52 +239,61 @@ const resolveSideEffectsFlag = (
 
 	const cached = owningCache.get(descriptionFileRoot);
 	if (cached !== undefined) {
-		return finishFromOwning(cached);
+		return finishFromWalk(cached);
 	}
+
+	/** @type {string[]} */
+	const read = [];
+	/** @type {string[]} */
+	const missing = [];
+
+	/**
+	 * @param {OwningSideEffectsFlag | null} owning declaring package or null
+	 * @returns {void}
+	 */
+	const done = (owning) => {
+		/** @type {OwningSideEffectsFlagWalk} */
+		const walk = { owning, read, missing };
+		owningCache.set(descriptionFileRoot, walk);
+		return finishFromWalk(walk);
+	};
 
 	let dir = dirname(fs, descriptionFileRoot);
 
 	const next = () => {
 		const parent = dirname(fs, dir);
-		if (!parent || parent === dir) {
-			owningCache.set(descriptionFileRoot, null);
-			return callback();
-		}
+		if (!parent || parent === dir) return done(null);
 		const baseName = relative(fs, parent, dir).replace(
 			WINDOWS_PATH_SEPARATOR_REGEXP,
 			"/"
 		);
 		// Do not inherit an application's sideEffects across an install boundary.
-		if (baseName === "node_modules") {
-			owningCache.set(descriptionFileRoot, null);
-			return callback();
-		}
+		if (baseName === "node_modules") return done(null);
 
-		readJson(fs, join(fs, dir, "package.json"), (err, data) => {
+		const packageJsonPath = join(fs, dir, "package.json");
+
+		readJson(fs, packageJsonPath, (err, data) => {
 			if (err) {
-				if (isSkippablePackageJsonError(err)) {
-					dir = parent;
-					return next();
-				}
-				return callback(err);
+				// nothing else reads these ancestors, so one that is unreadable or
+				// unparsable declines the inheritance instead of failing the module
+				(isMissingPackageJsonError(err) ? missing : read).push(packageJsonPath);
+				dir = parent;
+				return next();
 			}
+			read.push(packageJsonPath);
 			if (!data || typeof data !== "object" || Array.isArray(data)) {
 				dir = parent;
 				return next();
 			}
 			if (data.sideEffects !== undefined) {
-				/** @type {OwningSideEffectsFlag} */
-				const owning = {
+				return done({
 					sideEffects: /** @type {SideEffectsFlagValue} */ (data.sideEffects),
 					packageRoot: dir
-				};
-				owningCache.set(descriptionFileRoot, owning);
-				return finishFromOwning(owning);
+				});
 			}
-			if (data.name !== undefined) {
-				owningCache.set(descriptionFileRoot, null);
-				return callback();
-			}
+			// An unnamed manifest deeper in the package keeps the walk going; a named one
+			// is a package of its own, and its silence is its answer.
+			if (data.name !== undefined) return done(null);
 			dir = parent;
 			next();
 		});
@@ -359,12 +381,10 @@ class SideEffectsFlagPlugin {
 						if (descriptionFileRoot === undefined) return callback();
 						resolveSideEffectsFlag(
 							inputFileSystem,
+							resolveData,
 							descriptionFileRoot,
-							resolveInfo.descriptionFileData,
-							resolveInfo.relativePath,
 							owningCache,
-							(err, resolved) => {
-								if (err) return callback(err);
+							(resolved) => {
 								if (resolved !== undefined) {
 									resolvedSideEffectsFlags.set(createData, resolved);
 								}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/index.js
@@ -1,0 +1,24 @@
+import { light } from "symlinked-sef";
+
+const SYMLINKED_HEAVY = ["HEAVY", "SYMLINKED", "WORKSPACE"].join("_");
+
+/**
+ * @param {string} marker
+ * @returns {boolean}
+ */
+function moduleSourceIncludes(marker) {
+	return Object.keys(__webpack_modules__).some((id) =>
+		String(__webpack_modules__[id]).includes(marker)
+	);
+}
+
+it("still runs the used export", () => {
+	expect(light).toBe("light");
+});
+
+it("flags every file of a symlinked package alike", () => {
+	// The package request reaches esm/index.js through node_modules and its own
+	// imports reach their siblings through the real path. Reading the flag from
+	// the resolved file keeps the whole package on one answer.
+	expect(moduleSourceIncludes(SYMLINKED_HEAVY)).toBe(true);
+});

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/index.js
@@ -17,8 +17,7 @@ it("still runs the used export", () => {
 });
 
 it("flags every file of a symlinked package alike", () => {
-	// The package request reaches esm/index.js through node_modules and its own
-	// imports reach their siblings through the real path. Reading the flag from
-	// the resolved file keeps the whole package on one answer.
+	// The package request arrives through node_modules and its own imports through
+	// the real path; reading the resolved file keeps both on one answer.
 	expect(moduleSourceIncludes(SYMLINKED_HEAVY)).toBe(true);
 });

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-package-json-sideEffects-symlinked",
+  "sideEffects": false
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_SYMLINKED_WORKSPACE";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "symlinked-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
@@ -9,8 +9,11 @@ module.exports = () => {
 		__dirname,
 		"../../../js/side-effects-symlinked-probe"
 	);
+	fs.mkdirSync(path.dirname(probe), { recursive: true });
+	// clear a probe a failed cleanup left behind, or every later run reads its
+	// EEXIST as "no symlinks here" and skips the case for good
+	fs.rmSync(probe, { recursive: true, force: true });
 	try {
-		fs.mkdirSync(path.dirname(probe), { recursive: true });
 		fs.symlinkSync(path.join(__dirname, "package"), probe, "junction");
 	} catch (_err) {
 		return false;
@@ -18,7 +21,7 @@ module.exports = () => {
 	try {
 		fs.rmSync(probe, { recursive: true, force: true });
 	} catch (_err) {
-		// a leftover probe under test/js is harmless
+		// the next run clears it
 	}
 	return true;
 };

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
@@ -6,6 +6,24 @@ const path = require("path");
 // codes a machine that cannot make directory symlinks reports
 const SYMLINK_UNSUPPORTED = new Set(["EPERM", "EACCES", "ENOSYS", "UNKNOWN"]);
 
+/**
+ * @param {string} link path of a symlink or junction that may not exist
+ * @returns {void}
+ */
+const removeLink = (link) => {
+	try {
+		fs.unlinkSync(link);
+		return;
+	} catch (_err) {
+		// a junction on Windows unlinks as a directory
+	}
+	try {
+		fs.rmdirSync(link);
+	} catch (_err) {
+		// nothing was there
+	}
+};
+
 module.exports = () => {
 	const probe = path.resolve(
 		__dirname,
@@ -13,7 +31,7 @@ module.exports = () => {
 	);
 	fs.mkdirSync(path.dirname(probe), { recursive: true });
 	// a probe a failed cleanup left behind would read as EEXIST, i.e. "cannot"
-	fs.rmSync(probe, { recursive: true, force: true });
+	removeLink(probe);
 	try {
 		fs.symlinkSync(path.join(__dirname, "package"), probe, "junction");
 	} catch (err) {
@@ -25,10 +43,6 @@ module.exports = () => {
 		}
 		return false;
 	}
-	try {
-		fs.rmSync(probe, { recursive: true, force: true });
-	} catch (_err) {
-		// the next run clears it
-	}
+	removeLink(probe);
 	return true;
 };

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// creating a directory symlink needs privileges this machine may not grant
+module.exports = () => {
+	const probe = path.resolve(
+		__dirname,
+		"../../../js/side-effects-symlinked-probe"
+	);
+	try {
+		fs.mkdirSync(path.dirname(probe), { recursive: true });
+		fs.symlinkSync(path.join(__dirname, "package"), probe, "junction");
+	} catch (_err) {
+		return false;
+	}
+	try {
+		fs.rmSync(probe, { recursive: true, force: true });
+	} catch (_err) {
+		// a leftover probe under test/js is harmless
+	}
+	return true;
+};

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
@@ -6,10 +6,7 @@ const path = require("path");
 // codes a machine that cannot make directory symlinks reports
 const SYMLINK_UNSUPPORTED = new Set(["EPERM", "EACCES", "ENOSYS", "UNKNOWN"]);
 
-/**
- * @param {string} link path of a symlink or junction that may not exist
- * @returns {void}
- */
+/** @type {(link: string) => void} */
 const removeLink = (link) => {
 	try {
 		fs.unlinkSync(link);

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/test.filter.js
@@ -3,19 +3,26 @@
 const fs = require("fs");
 const path = require("path");
 
-// creating a directory symlink needs privileges this machine may not grant
+// codes a machine that cannot make directory symlinks reports
+const SYMLINK_UNSUPPORTED = new Set(["EPERM", "EACCES", "ENOSYS", "UNKNOWN"]);
+
 module.exports = () => {
 	const probe = path.resolve(
 		__dirname,
 		"../../../js/side-effects-symlinked-probe"
 	);
 	fs.mkdirSync(path.dirname(probe), { recursive: true });
-	// clear a probe a failed cleanup left behind, or every later run reads its
-	// EEXIST as "no symlinks here" and skips the case for good
+	// a probe a failed cleanup left behind would read as EEXIST, i.e. "cannot"
 	fs.rmSync(probe, { recursive: true, force: true });
 	try {
 		fs.symlinkSync(path.join(__dirname, "package"), probe, "junction");
-	} catch (_err) {
+	} catch (err) {
+		// anything else is a broken fixture, which must fail rather than skip
+		if (
+			!SYMLINK_UNSUPPORTED.has(/** @type {NodeJS.ErrnoException} */ (err).code)
+		) {
+			throw err;
+		}
 		return false;
 	}
 	try {

--- a/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/webpack.config.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects-symlinked/webpack.config.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// a workspace package: installed as a symlink, so its own files resolve to a
+// real path outside node_modules while the package request resolves through it
+const modulesDirectory = path.resolve(
+	__dirname,
+	"../../../js/side-effects-symlinked/node_modules"
+);
+
+fs.mkdirSync(modulesDirectory, { recursive: true });
+
+try {
+	fs.symlinkSync(
+		path.join(__dirname, "package"),
+		path.join(modulesDirectory, "symlinked-sef"),
+		"junction"
+	);
+} catch (err) {
+	if (/** @type {NodeJS.ErrnoException} */ (err).code !== "EEXIST") throw err;
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	resolve: {
+		modules: [modulesDirectory, "node_modules"]
+	},
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false,
+		minimize: false
+	}
+};

--- a/test/configCases/side-effects/nested-package-json-sideEffects/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/index.js
@@ -5,6 +5,11 @@ import { light as localAppLight } from "./local-app-nested/esm";
 import { light as globArrayLight } from "glob-array-sef";
 import { light as globStringLight } from "glob-string-sef";
 import { light as stopAtNmLight } from "stop-at-node-modules";
+import { light as unnamedInnerLight } from "unnamed-inner-sef";
+import { light as brokenAncestorLight } from "broken-ancestor-sef";
+import { light as arrayAncestorLight } from "array-ancestor-sef";
+import { light as missingMidLight } from "missing-mid-sef";
+import { light as namedAncestorLight } from "named-ancestor-no-sef";
 
 const SHADOWED_HEAVY = ["HEAVY", "SHADOWED", "BY", "TYPE", "ONLY"].join("_");
 const DECLARED_HEAVY = ["HEAVY", "DECLARED", "NESTED", "SEF"].join("_");
@@ -13,6 +18,13 @@ const LOCAL_APP_HEAVY = ["HEAVY", "LOCAL", "APP", "NESTED"].join("_");
 const GLOB_ARRAY_HEAVY = ["HEAVY", "GLOB", "ARRAY", "SEF"].join("_");
 const GLOB_STRING_HEAVY = ["HEAVY", "GLOB", "STRING", "SEF"].join("_");
 const STOP_AT_NM_HEAVY = ["HEAVY", "STOP", "AT", "NODE", "MODULES"].join("_");
+const UNNAMED_INNER_HEAVY = ["HEAVY", "UNNAMED", "INNER"].join("_");
+const BROKEN_ANCESTOR_HEAVY = ["HEAVY", "BROKEN", "ANCESTOR"].join("_");
+const ARRAY_ANCESTOR_HEAVY = ["HEAVY", "ARRAY", "ANCESTOR"].join("_");
+const MISSING_MID_HEAVY = ["HEAVY", "MISSING", "MID"].join("_");
+const NAMED_ANCESTOR_HEAVY = ["HEAVY", "NAMED", "ANCESTOR", "NO", "SEF"].join(
+	"_"
+);
 
 /**
  * @param {string} marker
@@ -32,6 +44,11 @@ it("still runs the used export from all fixtures", () => {
 	expect(globArrayLight).toBe("light");
 	expect(globStringLight).toBe("light");
 	expect(stopAtNmLight).toBe("light");
+	expect(unnamedInnerLight).toBe("light");
+	expect(brokenAncestorLight).toBe("light");
+	expect(arrayAncestorLight).toBe("light");
+	expect(missingMidLight).toBe("light");
+	expect(namedAncestorLight).toBe("light");
 });
 
 it("drops unused heavy when the nested package.json also declares sideEffects: false", () => {
@@ -63,4 +80,26 @@ it("rebases relativePath when inheriting string sideEffects globs", () => {
 it("does not inherit app sideEffects across a node_modules directory", () => {
 	// Package root has no name/sideEffects so walk continues; must stop at node_modules.
 	expect(moduleSourceIncludes(STOP_AT_NM_HEAVY)).toBe(true);
+});
+
+it("keeps walking past an unnamed package.json deeper inside the package", () => {
+	// dist/package.json names no package, so the root still speaks for dist/esm.
+	expect(moduleSourceIncludes(UNNAMED_INNER_HEAVY)).toBe(false);
+});
+
+it("keeps walking past an unparsable ancestor package.json", () => {
+	expect(moduleSourceIncludes(BROKEN_ANCESTOR_HEAVY)).toBe(false);
+});
+
+it("keeps walking past an ancestor package.json that is not an object", () => {
+	expect(moduleSourceIncludes(ARRAY_ANCESTOR_HEAVY)).toBe(false);
+});
+
+it("keeps walking past a directory that has no package.json", () => {
+	expect(moduleSourceIncludes(MISSING_MID_HEAVY)).toBe(false);
+});
+
+it("stops at a named ancestor that declares no sideEffects", () => {
+	// The package speaks for itself, and it said nothing.
+	expect(moduleSourceIncludes(NAMED_ANCESTOR_HEAVY)).toBe(true);
 });

--- a/test/configCases/side-effects/nested-package-json-sideEffects/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/index.js
@@ -87,11 +87,13 @@ it("keeps walking past an unnamed package.json deeper inside the package", () =>
 	expect(moduleSourceIncludes(UNNAMED_INNER_HEAVY)).toBe(false);
 });
 
-it("keeps walking past an unparsable ancestor package.json", () => {
-	expect(moduleSourceIncludes(BROKEN_ANCESTOR_HEAVY)).toBe(false);
+it("stops at an ancestor package.json it cannot read", () => {
+	// Unparsable: what it declares is unknown, so no outer flag may speak for it.
+	expect(moduleSourceIncludes(BROKEN_ANCESTOR_HEAVY)).toBe(true);
 });
 
-it("keeps walking past an ancestor package.json that is not an object", () => {
+it("keeps walking past an ancestor package.json that declares nothing", () => {
+	// It parsed, and an array declares no sideEffects — like any unnamed manifest.
 	expect(moduleSourceIncludes(ARRAY_ANCESTOR_HEAVY)).toBe(false);
 });
 

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_ARRAY_ANCESTOR";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/dist/package.json
@@ -1,0 +1,1 @@
+["not", "an", "object"]

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/array-ancestor-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "array-ancestor-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_BROKEN_ANCESTOR";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/dist/package.json
@@ -1,0 +1,2 @@
+{
+  "type": "module",

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/broken-ancestor-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "broken-ancestor-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_MISSING_MID";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/missing-mid-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "missing-mid-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_NAMED_ANCESTOR_NO_SEF";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/named-ancestor-no-sef/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "named-ancestor-no-sef",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/heavy.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/heavy.js
@@ -1,0 +1,6 @@
+export var HeavyMode;
+(function (HeavyMode) {
+	HeavyMode[(HeavyMode.A = 0)] = "A";
+})(HeavyMode || (HeavyMode = {}));
+
+export const heavy = "HEAVY_UNNAMED_INNER";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/index.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/index.js
@@ -1,0 +1,8 @@
+import { heavy } from "./heavy.js";
+import { light } from "./light.js";
+
+export function useHeavy() {
+	return heavy;
+}
+
+export { light, heavy };

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/light.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/light.js
@@ -1,0 +1,1 @@
+export const light = "light";

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/dist/package.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "main": "./esm/index.js"
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/package.json
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/node_modules/unnamed-inner-sef/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "unnamed-inner-sef",
+  "version": "1.0.0",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  }
+}

--- a/test/configCases/side-effects/nested-package-json-sideEffects/webpack.config.js
+++ b/test/configCases/side-effects/nested-package-json-sideEffects/webpack.config.js
@@ -1,13 +1,44 @@
 "use strict";
 
+const path = require("path");
+
+/**
+ * @param {...string} segments directory segments below the case's node_modules
+ * @returns {string} absolute path of that directory's package.json
+ */
+const packageJson = (...segments) =>
+	path.join(__dirname, "node_modules", ...segments, "package.json");
+
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "production",
+	module: {
+		// factory-level dependencies are dropped for unsafe-cached modules
+		unsafeCache: false
+	},
 	optimization: {
 		sideEffects: true,
 		usedExports: true,
 		providedExports: true,
 		concatenateModules: false,
 		minimize: false
-	}
+	},
+	plugins: [
+		(compiler) => {
+			compiler.hooks.afterEmit.tap("Test", (compilation) => {
+				// the walk reads ancestors the resolver never looks at, so it reports
+				// them itself — otherwise an edited sideEffects would not invalidate
+				expect(
+					compilation.fileDependencies.has(
+						packageJson("unnamed-inner-sef", "dist")
+					)
+				).toBe(true);
+				expect(
+					compilation.missingDependencies.has(
+						packageJson("missing-mid-sef", "dist")
+					)
+				).toBe(true);
+			});
+		}
+	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Follow-up to #21686, which is unreleased, so this folds into its changeset. Three things: the inherited flag was read from the description-file root, so a symlinked (workspace) package inherited for the request that came through `node_modules` and not for the relative imports its own files make — one package, two answers; it is now read from the resolved path, which is the same whichever request reaches the file. The ancestor `package.json` files the walk consults are now reported as file/missing dependencies of the resolve, since nothing else reads them (`module.unsafeCache` still drops factory dependencies for `node_modules` modules). And an unreadable or unparsable ancestor now declines the inheritance instead of failing the module that happens to sit under it.

Also reuses `NODE_MODULES_REGEXP` from `lib/util/identifier.js` instead of a second local path regexp, types the walk cache by `Compiler` rather than `EXPECTED_OBJECT`, and drops ten duplicate `@typedef` lines that #21686 left next to the `@import` block in `ImportMetaGlobHelpers.js`.

For the record on the ecosystem question raised in #21686: measured today, esbuild 0.28.2, rollup 4.62.5 with `@rollup/plugin-node-resolve`, rspack 2.1.10 and Parcel 2.16.4 all let the nested stub shadow the root flag, while rolldown 1.2.5 inherits — so webpack now agrees with rolldown, which goes further and inherits past a named nested manifest too.

Refs #21686

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/side-effects/nested-package-json-sideEffects-symlinked` (fails on current `main`) and five packages plus a dependency assertion in `test/configCases/side-effects/nested-package-json-sideEffects`, covering the unnamed, named, unparsable, non-object and absent ancestor manifests.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — it narrows behavior that has not been released yet.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code reviewed #21686, measured the other bundlers, and wrote these changes and tests; every claim above was verified by running the tests and the comparison locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9GpnQ7PiYsi6itUSe1GQq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `sideEffects` inheritance for modules nested within `node_modules`, including symlinked packages.
  * Handles missing, malformed, or unreadable package metadata without disrupting module processing.
  * Improved dependency tracking while traversing nested package metadata.

* **Tests**
  * Added coverage for nested package configurations, symlinked packages, and varied metadata scenarios.

* **Documentation**
  * Clarified that `sideEffects` inheritance can apply beyond type-only nested package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->