### PR TITLE
fix(define): throw on a non-optional read past an undefined member

### DIFF
--- a/.changeset/051-define-plugin-optional-member-call.md
+++ b/.changeset/051-define-plugin-optional-member-call.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Fix `DefinePlugin` dropping the optional chain in `OBJ.MISSING?.method()`.
+Fix `DefinePlugin` optional chains reading an undefined object member.

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -23,7 +23,7 @@ const {
 const createHash = require("./util/createHash");
 const createHooksRegistry = require("./util/createHooksRegistry");
 
-/** @import { Expression } from "estree" */
+/** @import { Expression, MemberExpression } from "estree" */
 /** @import Compiler from "./Compiler" */
 /**
  * @import {
@@ -163,6 +163,21 @@ const isObjectDefinition = (code) =>
 	typeof code === "object" &&
 	!(code instanceof RuntimeValue) &&
 	!(code instanceof RegExp);
+
+/**
+ * Walks a member chain up, dropping its last `count` members.
+ * @param {Expression} node member expression
+ * @param {number} count members to drop
+ * @returns {Expression} the chain without them
+ */
+const dropTrailingMembers = (node, count) => {
+	while (count--) {
+		node = /** @type {Expression} */ (
+			/** @type {MemberExpression} */ (node).object
+		);
+	}
+	return node;
+};
 
 /** @typedef {Set<string> | null} ObjKeys */
 /** @typedef {boolean | undefined | null} AsiSafe */
@@ -1211,10 +1226,13 @@ class DefinePlugin {
 								for (const dep of deps) addValueDependency(dep);
 								return toConstantDependency(parser, "undefined")(expr);
 							});
-						// In a call, replace only the callee so the call itself is kept:
-						// `x.MISSING()` stays a (throwing) call and `x.MISSING?.()`
-						// short-circuits, with the object never inlined. An optional link
-						// right after the undefined member short-circuits the whole call.
+						// In a call, replace the chain only up to the undefined member,
+						// so the call itself is kept and the object is never inlined:
+						// `x.MISSING()` stays a (throwing) call, and members left after
+						// the undefined one still read off `undefined` and still throw
+						// (`x.MISSING.a?.()`). An optional link right after the undefined
+						// member short-circuits the whole call instead — its arguments
+						// are never evaluated, so they go with it.
 						parser.hooks.callMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members, membersOptionals) => {
@@ -1228,7 +1246,12 @@ class DefinePlugin {
 								toConstantDependency(
 									parser,
 									"undefined"
-								)(/** @type {Expression} */ (expr.callee));
+								)(
+									dropTrailingMembers(
+										/** @type {Expression} */ (expr.callee),
+										members.length - 1 - undefinedIndex
+									)
+								);
 								parser.walkExpressions(expr.arguments);
 								return true;
 							});

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -1226,13 +1226,8 @@ class DefinePlugin {
 								for (const dep of deps) addValueDependency(dep);
 								return toConstantDependency(parser, "undefined")(expr);
 							});
-						// In a call, replace the chain only up to the undefined member,
-						// so the call itself is kept and the object is never inlined:
-						// `x.MISSING()` stays a (throwing) call, and members left after
-						// the undefined one still read off `undefined` and still throw
-						// (`x.MISSING.a?.()`). An optional link right after the undefined
-						// member short-circuits the whole call instead — its arguments
-						// are never evaluated, so they go with it.
+						// Cut the chain at the undefined member, so what follows still
+						// throws; an optional link there takes the call, arguments unevaluated.
 						parser.hooks.callMemberChain
 							.for(chainRoot)
 							.tap(PLUGIN_NAME, (expr, members, membersOptionals) => {

--- a/test/configCases/plugins/define-plugin-import-meta/index.js
+++ b/test/configCases/plugins/define-plugin-import-meta/index.js
@@ -12,3 +12,15 @@ it("should resolve unknown import.meta member access with undefined (issue 15559
 	expect(import.meta.config?.MISSING).toBe(undefined);
 	expect(import.meta.config.MISSING?.()).toBe(undefined);
 });
+it("should short-circuit a call reached through an unknown import.meta member (issue 21822)", function () {
+	const a = function () { return import.meta.config.MISSING?.includes("token"); };
+	const b = function () { return import.meta.config?.MISSING?.deep.method(); };
+	const c = function () { return import.meta.config.MISSING.deep?.method(); };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined.deep?.method(); }");
+	expect(import.meta.config.MISSING?.includes("token")).toBe(undefined);
+	expect(import.meta.config?.MISSING?.deep.method()).toBe(undefined);
+	expect(import.meta.config.TOKEN?.toUpperCase()).toBe("TOKEN");
+	expect(() => import.meta.config.MISSING.deep?.method()).toThrow();
+});

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -60,6 +60,7 @@ it("should short-circuit a call reached through an unknown member (issue 21822)"
 	expect(OBJECT?.SUB1?.UNKNOWN?.toUpperCase()).toBe(undefined);
 	expect(NOT_DEFINED.SUB2.b?.["includes"]("foo")).toBe(undefined);
 	expect(OBJECT.SUB1.UNKNOWN?.a.b()).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN?.a?.b()).toBe(undefined);
 });
 it("should not evaluate the arguments of a short-circuited call (issue 21822)", function () {
 	let calls = 0;

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -37,23 +37,53 @@ it("should resolve unknown member calls with optional members without inlining t
 	expect(c.toString()).toBe("function () { return undefined(); }");
 	expect(() => OBJECT.SUB1?.UNKNOWN()).toThrow();
 });
-it("should short-circuit a call on a member read from an unknown member (issue 21822)", function () {
-	const a = function () { return OBJECT.SUB1.UNKNOWN?.includes("foo"); };
-	const b = function () { return OBJECT?.SUB1?.UNKNOWN?.toUpperCase(); };
-	const c = function () { return NOT_DEFINED.SUB2.b?.["includes"]("foo"); };
-	const d = function () { return OBJECT.SUB1.UNKNOWN?.a.b(); };
-	const e = function () { return OBJECT.SUB1.UNKNOWN.a?.b(); };
-	expect(a.toString()).toBe("function () { return undefined; }");
-	expect(b.toString()).toBe("function () { return undefined; }");
-	expect(c.toString()).toBe("function () { return undefined; }");
-	expect(d.toString()).toBe("function () { return undefined; }");
-	expect(e.toString()).toBe("function () { return undefined(); }");
-	expect(OBJECT.SUB1.UNKNOWN?.includes("foo")).toBe(undefined);
-	expect(NOT_DEFINED.SUB2.b?.["includes"]("foo")).toBe(undefined);
-	expect(() => OBJECT.SUB1.UNKNOWN.a?.b()).toThrow();
-});
 it("should still substitute arguments of an unknown member call (issue 15559)", function () {
 	const a = function () { return OBJECT.SUB1.UNKNOWN?.(STRING); };
 	expect(a.toString()).toBe('function () { return undefined?.("string"); }');
 	expect(OBJECT.SUB1.UNKNOWN?.(STRING)).toBe(undefined);
+});
+it("should short-circuit a call reached through an unknown member (issue 21822)", function () {
+	const a = function () { return process.env.MISSING?.includes("foo"); };
+	const b = function () { return OBJECT.SUB1.UNKNOWN?.includes("foo"); };
+	const c = function () { return OBJECT?.SUB1?.UNKNOWN?.toUpperCase(); };
+	const d = function () { return NOT_DEFINED.SUB2.b?.["includes"]("foo"); };
+	const e = function () { return OBJECT.SUB1.UNKNOWN?.a.b(); };
+	const f = function () { return OBJECT.SUB1.UNKNOWN?.a?.b(); };
+	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(b.toString()).toBe("function () { return undefined; }");
+	expect(c.toString()).toBe("function () { return undefined; }");
+	expect(d.toString()).toBe("function () { return undefined; }");
+	expect(e.toString()).toBe("function () { return undefined; }");
+	expect(f.toString()).toBe("function () { return undefined; }");
+	expect(process.env.MISSING?.includes("foo")).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN?.includes("foo")).toBe(undefined);
+	expect(OBJECT?.SUB1?.UNKNOWN?.toUpperCase()).toBe(undefined);
+	expect(NOT_DEFINED.SUB2.b?.["includes"]("foo")).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN?.a.b()).toBe(undefined);
+});
+it("should not evaluate the arguments of a short-circuited call (issue 21822)", function () {
+	let calls = 0;
+	const arg = function () { calls++; return STRING; };
+	expect(OBJECT.SUB1.UNKNOWN?.includes(arg())).toBe(undefined);
+	expect(calls).toBe(0);
+});
+it("should keep a non-optional read after an unknown member throwing (issue 21822)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN.a?.(); };
+	const b = function () { return OBJECT.SUB1.UNKNOWN.a?.b(); };
+	const c = function () { return OBJECT.SUB1.UNKNOWN["a"]?.(); };
+	const d = function () { return OBJECT.SUB1.UNKNOWN.deep.method(); };
+	expect(a.toString()).toBe("function () { return undefined.a?.(); }");
+	expect(b.toString()).toBe("function () { return undefined.a?.b(); }");
+	expect(c.toString()).toBe('function () { return undefined["a"]?.(); }');
+	expect(d.toString()).toBe("function () { return undefined.deep.method(); }");
+	expect(() => OBJECT.SUB1.UNKNOWN.a?.()).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN.a?.b()).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN["a"]?.()).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN.deep.method()).toThrow();
+});
+it("should keep optional calls on defined members intact (issue 21822)", function () {
+	expect(OBJECT.SUB1.a?.toFixed(2)).toBe("1.00");
+	expect(STRING?.toUpperCase()).toBe("STRING");
+	expect(process.env.NODE_ENV?.toUpperCase()).toBe("PRODUCTION");
+	expect(OBJECT.SUB1?.a).toBe(1);
 });

--- a/test/configCases/plugins/define-plugin-optional-chaining/webpack.config.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/webpack.config.js
@@ -9,7 +9,9 @@ module.exports = {
 			OBJECT: { SUB1: { a: 1 } },
 			"OBJECT.SUB2": { a: 1 },
 			"NOT_DEFINED.SUB2": { a: 1 },
-			STRING: JSON.stringify("string")
+			STRING: JSON.stringify("string"),
+			// the shape issue 21822 was reported against
+			"process.env": { NODE_ENV: JSON.stringify("production") }
 		})
 	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #21823, which fixed `OBJ.MISSING?.method()` but left a second divergence: a call whose callee chain reads an undefined member had its *whole* callee replaced, so `OBJ.MISSING.a?.()` was emitted as `undefined?.()` and returned `undefined` where the source throws at `.a`. The chain is now replaced only up to the undefined member, leaving the members after it to read off `undefined` as they would natively. The object is still never inlined (#15559). Refs #21822.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, in `test/configCases/plugins/define-plugin-optional-chaining/index.js` (throwing and short-circuiting paths, computed members, arguments not evaluated, `process.env`) and `test/configCases/plugins/define-plugin-import-meta/index.js` (same on the `import.meta` chain root).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Affected expressions previously evaluated to `undefined` instead of throwing, which is what plain JavaScript does with the same source.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code was used to reproduce the remaining divergence against a real build, draft the patch and the test cases, and run the suites and `yarn lint`. Every emitted-code and throwing expectation was verified by running the affected config cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved optional chaining with `DefinePlugin` when accessing undefined members.
  - Optional calls now short-circuit correctly without evaluating their arguments.
  - Preserved expected errors for non-optional access after an undefined member.
  - Ensured optional calls on defined members continue to work correctly.

- **Tests**
  - Added coverage for missing environment and metadata properties, deep member chains, and argument evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->