### PR TITLE
feat(config): emit no development source map for library builds

### DIFF
--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Keep a module library's development source map out of an `eval()` wrapper.
+Default a module library's development source map to cheap-module-source-map.

--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Default a module library's development source map to cheap-module-source-map.
+Emit no development source map for a module library, as other bundlers do.

--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -2,4 +2,5 @@
 "webpack": minor
 ---
 
-Emit no development source map for a module library, as other bundlers do.
+Emit no development source map for a module library, and under future defaults for
+every library type, as other bundlers do.

--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -2,5 +2,4 @@
 "webpack": minor
 ---
 
-Emit no development source map for a module library, and under future defaults for
-every library type, as other bundlers do.
+Emit no development source map for library builds, as other bundlers do.

--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Keep a module library's development source map out of an `eval()` wrapper.

--- a/.changeset/114-module-library-devtool.md
+++ b/.changeset/114-module-library-devtool.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Emit no development source map for library builds, as other bundlers do.
+Emit no development source map for module libraries, or any with futureDefaults.

--- a/cspell.json
+++ b/cspell.json
@@ -372,6 +372,7 @@
     "rotatey",
     "rotatez",
     "rowspan",
+    "rspack",
     "rrggbb",
     "rrggbbaa",
     "rrrlll",

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -443,10 +443,10 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 							{
 								type: "javascript",
 								// A library is read by another bundler, and an `eval()` wrapper
-								// hides `import.meta` from it — no other bundler emits one by
-								// default either. Applies to the whole build: one eval'd entry
-								// is enough to make the library unreadable.
-								use: emitsModuleLibrary ? "source-map" : "eval"
+								// hides `import.meta` from it — rspack, the one peer with the
+								// same `mode`, already defaults development to this map.
+								// Whole-build: one eval'd entry makes the library unreadable.
+								use: emitsModuleLibrary ? "cheap-module-source-map" : "eval"
 							}
 						].filter(Boolean)
 					: false

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -432,7 +432,11 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 		"devtool",
 		() =>
 			/** @type {Devtool} */ (
-				development
+				// A library is an artifact someone else reads, and an `eval()` wrapper
+				// hides `import.meta` from their bundler. rollup, esbuild and vite emit
+				// no source map for one unless asked, so neither does this. Whole-build:
+				// one eval'd entry is enough to make the library unreadable.
+				development && !emitsModuleLibrary
 					? [
 							options.experiments.css
 								? {
@@ -442,11 +446,7 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 								: undefined,
 							{
 								type: "javascript",
-								// A library is read by another bundler, and an `eval()` wrapper
-								// hides `import.meta` from it — rspack, the one peer with the
-								// same `mode`, already defaults development to this map.
-								// Whole-build: one eval'd entry makes the library unreadable.
-								use: emitsModuleLibrary ? "cheap-module-source-map" : "eval"
+								use: "eval"
 							}
 						].filter(Boolean)
 					: false

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -421,22 +421,26 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 	// After output: the dev source map reads the resolved `experiments.css` value and
 	// the library types, which `enabledLibraryTypes` collects from `output.library` and
 	// from every entry that names one.
-	const emitsModuleLibrary =
+	const enabledLibraryTypes =
 		/** @type {LibraryType[]} */
-		(options.output.enabledLibraryTypes).some(
-			(type) => type === "module" || type === "modern-module"
-		);
+		(options.output.enabledLibraryTypes);
+	// A library is an artifact someone else reads, and rollup, esbuild and vite all
+	// leave source maps off for one until asked. A module library takes that now, since
+	// an `eval()` wrapper additionally hides `import.meta` from the bundler reading it;
+	// every other library type waits for webpack@6. Whole-build either way: one eval'd
+	// entry is enough to make the library unreadable.
+	const librarySkipsDevSourceMap = futureDefaults
+		? enabledLibraryTypes.length > 0
+		: enabledLibraryTypes.some(
+				(type) => type === "module" || type === "modern-module"
+			);
 
 	F(
 		options,
 		"devtool",
 		() =>
 			/** @type {Devtool} */ (
-				// A library is an artifact someone else reads, and an `eval()` wrapper
-				// hides `import.meta` from their bundler. rollup, esbuild and vite emit
-				// no source map for one unless asked, so neither does this. Whole-build:
-				// one eval'd entry is enough to make the library unreadable.
-				development && !emitsModuleLibrary
+				development && !librarySkipsDevSourceMap
 					? [
 							options.experiments.css
 								? {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -367,30 +367,6 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 		rules: options.module.rules
 	});
 
-	// After experiments are resolved: the default dev source map depends on the
-	// (possibly "auto"-resolved) `experiments.css` value.
-	F(
-		options,
-		"devtool",
-		() =>
-			/** @type {Devtool} */ (
-				development
-					? [
-							options.experiments.css
-								? {
-										type: "css",
-										use: "source-map"
-									}
-								: undefined,
-							{
-								type: "javascript",
-								use: "eval"
-							}
-						].filter(Boolean)
-					: false
-			)
-	);
-
 	const futureDefaults =
 		/** @type {NonNullable<ExperimentsNormalized["futureDefaults"]>} */
 		(options.experiments.futureDefaults);
@@ -441,6 +417,41 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 			/** @type {boolean} */
 			(options.experiments.asyncWebAssembly)
 	});
+
+	// After output: the dev source map reads the resolved `experiments.css` value and
+	// the library types, which `enabledLibraryTypes` collects from `output.library` and
+	// from every entry that names one.
+	const emitsModuleLibrary =
+		/** @type {LibraryType[]} */
+		(options.output.enabledLibraryTypes).some(
+			(type) => type === "module" || type === "modern-module"
+		);
+
+	F(
+		options,
+		"devtool",
+		() =>
+			/** @type {Devtool} */ (
+				development
+					? [
+							options.experiments.css
+								? {
+										type: "css",
+										use: "source-map"
+									}
+								: undefined,
+							{
+								type: "javascript",
+								// A library is read by another bundler, and an `eval()` wrapper
+								// hides `import.meta` from it — no other bundler emits one by
+								// default either. Applies to the whole build: one eval'd entry
+								// is enough to make the library unreadable.
+								use: emitsModuleLibrary ? "source-map" : "eval"
+							}
+						].filter(Boolean)
+					: false
+			)
+	);
 
 	applyModuleDefaults(options.module, {
 		cache,

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -418,29 +418,20 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 			(options.experiments.asyncWebAssembly)
 	});
 
-	// After output: the dev source map reads the resolved `experiments.css` value and
-	// the library types, which `enabledLibraryTypes` collects from `output.library` and
-	// from every entry that names one.
-	const enabledLibraryTypes =
-		/** @type {LibraryType[]} */
-		(options.output.enabledLibraryTypes);
-	// A library is an artifact someone else reads, and rollup, esbuild and vite all
-	// leave source maps off for one until asked. A module library takes that now, since
-	// an `eval()` wrapper additionally hides `import.meta` from the bundler reading it;
-	// every other library type waits for webpack@6. Whole-build either way: one eval'd
-	// entry is enough to make the library unreadable.
-	const librarySkipsDevSourceMap = futureDefaults
-		? enabledLibraryTypes.length > 0
-		: enabledLibraryTypes.some(
-				(type) => type === "module" || type === "modern-module"
-			);
+	// Placed after `applyOutputDefaults`, which settles `enabledLibraryTypes`. A library
+	// is read by another bundler, where an eval wrapper hides `import.meta` from it.
+	const noDevSourceMap = /** @type {LibraryType[]} */ (
+		options.output.enabledLibraryTypes
+	).some(
+		(type) => futureDefaults || type === "module" || type === "modern-module"
+	);
 
 	F(
 		options,
 		"devtool",
 		() =>
 			/** @type {Devtool} */ (
-				development && !librarySkipsDevSourceMap
+				development && !noDevSourceMap
 					? [
 							options.experiments.css
 								? {

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1942,6 +1942,199 @@ describe("snapshots", () => {
 		`)
 	);
 
+	// Every other library type waits for webpack@6, where it joins the module ones.
+	test(
+		"non-module library in development with future defaults",
+		{
+			mode: "development",
+			experiments: { futureDefaults: true },
+			output: { library: { type: "var", name: "myLib" } }
+		},
+		(e) =>
+			e.toMatchInlineSnapshot(`
+			- Expected
+			+ Received
+
+			@@ ... @@
+			-   "cache": false,
+			+   "cache": Object {
+			+     "cacheUnaffected": true,
+			+     "maxGenerations": Infinity,
+			+     "type": "memory",
+			+   },
+			@@ ... @@
+			-     "backCompat": true,
+			+     "backCompat": false,
+			@@ ... @@
+			-     "cacheUnaffected": false,
+			-     "css": "auto",
+			+     "cacheUnaffected": true,
+			+     "css": true,
+			@@ ... @@
+			-     "futureDefaults": false,
+			-     "html": "auto",
+			+     "futureDefaults": true,
+			+     "html": true,
+			@@ ... @@
+			-     "progress": false,
+			+     "progress": "auto",
+			@@ ... @@
+			-   "mode": "none",
+			+   "mode": "development",
+			@@ ... @@
+			+       },
+			+       Object {
+			+         "oneOf": Array [
+			+           Object {
+			+             "resourceQuery": /(\\?|&)raw(&|$)/,
+			+             "type": "asset/source",
+			+           },
+			+           Object {
+			+             "resourceQuery": /(\\?|&)url(&|$)/,
+			+             "type": "asset/resource",
+			+           },
+			+           Object {
+			+             "resourceQuery": /(\\?|&)no-inline(&|$)/,
+			+             "type": "asset/resource",
+			+           },
+			+           Object {
+			+             "resourceQuery": /(\\?|&)inline(&|$)/,
+			+             "type": "asset/inline",
+			+           },
+			+         ],
+			@@ ... @@
+			-         "localIdentHashFunction": "md4",
+			+         "localIdentHashFunction": "xxhash64",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentHashFunction": "md4",
+			+         "localIdentHashFunction": "xxhash64",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentHashFunction": "md4",
+			+         "localIdentHashFunction": "xxhash64",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "anonymousDefaultExportName": true,
+			+         "anonymousDefaultExportName": false,
+			@@ ... @@
+			+         "exportsPresence": "error",
+			@@ ... @@
+			-         "strictModeViolations": "warn",
+			+         "strictModeViolations": "error",
+			@@ ... @@
+			-         "exportsDepth": Infinity,
+			+         "exportsDepth": 1,
+			@@ ... @@
+			-     "unsafeCache": false,
+			+     "unsafeCache": [Function anonymous],
+			@@ ... @@
+			-     "__dirname": "mock",
+			-     "__filename": "mock",
+			-     "global": true,
+			+     "__dirname": "warn-mock",
+			+     "__filename": "warn-mock",
+			+     "global": "warn",
+			@@ ... @@
+			-     "chunkIds": "natural",
+			+     "chunkIds": "named",
+			@@ ... @@
+			-     "moduleIds": "natural",
+			-     "nodeEnv": false,
+			+     "moduleIds": "named",
+			+     "nodeEnv": "development",
+			@@ ... @@
+			-       "minRemainingSize": undefined,
+			+       "minRemainingSize": 0,
+			@@ ... @@
+			-     "charset": true,
+			+     "charset": false,
+			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunkwebpack",
+			+     "chunkLoadingGlobal": "webpackChunkmyLib",
+			@@ ... @@
+			-     "devtoolNamespace": "webpack",
+			+     "devtoolNamespace": "myLib",
+			@@ ... @@
+			+     ],
+			+     "enabledLibraryTypes": Array [
+			+       "var",
+			@@ ... @@
+			-     "enabledLibraryTypes": Array [],
+			@@ ... @@
+			-     "hashDigestLength": 20,
+			-     "hashFunction": "md4",
+			+     "hashDigestLength": 16,
+			+     "hashFunction": "xxhash64",
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdatewebpack",
+			+     "hotUpdateGlobal": "webpackHotUpdatemyLib",
+			@@ ... @@
+			-     "library": undefined,
+			+     "library": Object {
+			+       "amdContainer": undefined,
+			+       "auxiliaryComment": undefined,
+			+       "export": undefined,
+			+       "name": "myLib",
+			+       "type": "var",
+			+       "umdAmdContainer": undefined,
+			+       "umdNamedDefine": undefined,
+			+     },
+			@@ ... @@
+			-     "pathinfo": false,
+			+     "pathinfo": true,
+			@@ ... @@
+			-     "strictModuleResolution": false,
+			+     "strictModuleResolution": true,
+			@@ ... @@
+			-     "uniqueName": "webpack",
+			+     "uniqueName": "myLib",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			+           ".html",
+			@@ ... @@
+			-           ".html",
+			@@ ... @@
+			+           ".html",
+			@@ ... @@
+			-           ".html",
+			@@ ... @@
+			+           ".html",
+			@@ ... @@
+			-           ".html",
+			@@ ... @@
+			+           ".html",
+			@@ ... @@
+			-           ".html",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+			@@ ... @@
+			-       "production",
+			+       "development",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+			@@ ... @@
+			-       "<cwd>/node_modules/",
+			+       /^(.+?[\\\\/]node_modules[\\\\/])/,
+		`)
+	);
+
 	test("library", { output: { library: ["myLib", "awesome"] } }, (e) =>
 		e.toMatchInlineSnapshot(`
 		- Expected

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1664,8 +1664,8 @@ describe("snapshots", () => {
 	`)
 	);
 
-	// A module library is read by another bundler, so development keeps its source map
-	// out of an `eval()` wrapper; every other build keeps `eval` and its rebuild speed.
+	// A module library is an artifact someone else reads, so development emits no source
+	// map for one; every other build keeps `eval` and its rebuild speed.
 	test(
 		"module library in development",
 		{
@@ -1685,18 +1685,6 @@ describe("snapshots", () => {
 			+     "maxGenerations": Infinity,
 			+     "type": "memory",
 			+   },
-			@@ ... @@
-			-   "devtool": false,
-			+   "devtool": Array [
-			+     Object {
-			+       "type": "css",
-			+       "use": "source-map",
-			+     },
-			+     Object {
-			+       "type": "javascript",
-			+       "use": "cheap-module-source-map",
-			+     },
-			+   ],
 			@@ ... @@
 			-     "outputModule": false,
 			+     "outputModule": true,
@@ -1758,11 +1746,11 @@ describe("snapshots", () => {
 			-       "jsonp",
 			-       "import-scripts",
 			+       "import",
-			@@ ... @@
-			-     "enabledLibraryTypes": Array [],
+			+     ],
 			+     "enabledLibraryTypes": Array [
 			+       "module",
-			+     ],
+			@@ ... @@
+			-     "enabledLibraryTypes": Array [],
 			@@ ... @@
 			-       "dynamicImport": undefined,
 			-       "dynamicImportInWorker": undefined,

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1664,6 +1664,296 @@ describe("snapshots", () => {
 	`)
 	);
 
+	// A module library is read by another bundler, so development keeps its source map
+	// out of an `eval()` wrapper; every other build keeps `eval` and its rebuild speed.
+	test(
+		"module library in development",
+		{
+			mode: "development",
+			experiments: { outputModule: true },
+			output: { module: true, library: { type: "module" } }
+		},
+		(e) =>
+			e.toMatchInlineSnapshot(`
+			- Expected
+			+ Received
+
+			@@ ... @@
+			-   "cache": false,
+			+   "cache": Object {
+			+     "cacheUnaffected": false,
+			+     "maxGenerations": Infinity,
+			+     "type": "memory",
+			+   },
+			@@ ... @@
+			-   "devtool": false,
+			+   "devtool": Array [
+			+     Object {
+			+       "type": "css",
+			+       "use": "source-map",
+			+     },
+			+     Object {
+			+       "type": "javascript",
+			+       "use": "cheap-module-source-map",
+			+     },
+			+   ],
+			@@ ... @@
+			-     "outputModule": false,
+			+     "outputModule": true,
+			@@ ... @@
+			-   "externalsType": "var",
+			+   "externalsType": "module",
+			@@ ... @@
+			-       "dynamicImport": undefined,
+			-       "dynamicImportInWorker": undefined,
+			+       "dynamicImport": true,
+			+       "dynamicImportInWorker": true,
+			@@ ... @@
+			-       "module": undefined,
+			+       "module": true,
+			@@ ... @@
+			-   "mode": "none",
+			+   "mode": "development",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "anonymousDefaultExportName": true,
+			+         "anonymousDefaultExportName": false,
+			@@ ... @@
+			-         "importMeta": true,
+			+         "importMeta": "preserve-unknown",
+			@@ ... @@
+			-         "exportsDepth": Infinity,
+			+         "exportsDepth": 1,
+			@@ ... @@
+			-     "unsafeCache": false,
+			+     "unsafeCache": [Function anonymous],
+			@@ ... @@
+			-     "chunkIds": "natural",
+			+     "chunkIds": "named",
+			@@ ... @@
+			-     "moduleIds": "natural",
+			-     "nodeEnv": false,
+			+     "moduleIds": "named",
+			+     "nodeEnv": "development",
+			@@ ... @@
+			-       "minRemainingSize": undefined,
+			+       "minRemainingSize": 0,
+			@@ ... @@
+			-     "chunkFilename": "[name].js",
+			-     "chunkFormat": "array-push",
+			+     "chunkFilename": "[name].mjs",
+			+     "chunkFormat": "module",
+			@@ ... @@
+			-     "chunkLoading": "jsonp",
+			+     "chunkLoading": "import",
+			@@ ... @@
+			-       "jsonp",
+			-       "import-scripts",
+			+       "import",
+			@@ ... @@
+			-     "enabledLibraryTypes": Array [],
+			+     "enabledLibraryTypes": Array [
+			+       "module",
+			+     ],
+			@@ ... @@
+			-       "dynamicImport": undefined,
+			-       "dynamicImportInWorker": undefined,
+			+       "dynamicImport": true,
+			+       "dynamicImportInWorker": true,
+			@@ ... @@
+			-       "module": undefined,
+			+       "module": true,
+			@@ ... @@
+			-     "filename": "[name].js",
+			+     "filename": "[name].mjs",
+			@@ ... @@
+			-     "hotUpdateChunkFilename": "[id].[fullhash].hot-update.js",
+			+     "hotUpdateChunkFilename": "[id].[fullhash].hot-update.mjs",
+			@@ ... @@
+			-     "hotUpdateMainFilename": "[runtime].[fullhash].hot-update.json",
+			+     "hotUpdateMainFilename": "[runtime].[fullhash].hot-update.json.mjs",
+			@@ ... @@
+			-     "iife": true,
+			+     "iife": false,
+			@@ ... @@
+			-     "library": undefined,
+			-     "module": false,
+			+     "library": Object {
+			+       "amdContainer": undefined,
+			+       "auxiliaryComment": undefined,
+			+       "export": undefined,
+			+       "name": undefined,
+			+       "type": "module",
+			+       "umdAmdContainer": undefined,
+			+       "umdNamedDefine": undefined,
+			+     },
+			+     "module": true,
+			@@ ... @@
+			-     "pathinfo": false,
+			+     "pathinfo": true,
+			@@ ... @@
+			-     "resourceHints": undefined,
+			-     "scriptType": false,
+			+     "resourceHints": Object {
+			+       "dedupe": false,
+			+       "initial": true,
+			+       "modulePreloadPolyfill": false,
+			+     },
+			+     "scriptType": "module",
+			@@ ... @@
+			-     "strictModuleResolution": false,
+			+     "strictModuleResolution": true,
+			@@ ... @@
+			-     "workerChunkFilename": "[name].js",
+			-     "workerChunkLoading": "import-scripts",
+			+     "workerChunkFilename": "[name].mjs",
+			+     "workerChunkLoading": "import",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+			@@ ... @@
+			-       "production",
+			+       "development",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+		`)
+	);
+
+	test(
+		"non-module library in development",
+		{
+			mode: "development",
+			output: { library: { type: "var", name: "myLib" } }
+		},
+		(e) =>
+			e.toMatchInlineSnapshot(`
+			- Expected
+			+ Received
+
+			@@ ... @@
+			-   "cache": false,
+			+   "cache": Object {
+			+     "cacheUnaffected": false,
+			+     "maxGenerations": Infinity,
+			+     "type": "memory",
+			+   },
+			@@ ... @@
+			-   "devtool": false,
+			+   "devtool": Array [
+			+     Object {
+			+       "type": "css",
+			+       "use": "source-map",
+			+     },
+			+     Object {
+			+       "type": "javascript",
+			+       "use": "eval",
+			+     },
+			+   ],
+			@@ ... @@
+			-   "mode": "none",
+			+   "mode": "development",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "localIdentName": "[fullhash]",
+			+         "localIdentName": "[uniqueName]-[id]-[local]",
+			@@ ... @@
+			-         "anonymousDefaultExportName": true,
+			+         "anonymousDefaultExportName": false,
+			@@ ... @@
+			-         "exportsDepth": Infinity,
+			+         "exportsDepth": 1,
+			@@ ... @@
+			-     "unsafeCache": false,
+			+     "unsafeCache": [Function anonymous],
+			@@ ... @@
+			-     "chunkIds": "natural",
+			+     "chunkIds": "named",
+			@@ ... @@
+			-     "moduleIds": "natural",
+			-     "nodeEnv": false,
+			+     "moduleIds": "named",
+			+     "nodeEnv": "development",
+			@@ ... @@
+			-       "minRemainingSize": undefined,
+			+       "minRemainingSize": 0,
+			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunkwebpack",
+			+     "chunkLoadingGlobal": "webpackChunkmyLib",
+			@@ ... @@
+			-     "devtoolNamespace": "webpack",
+			+     "devtoolNamespace": "myLib",
+			@@ ... @@
+			-     "enabledLibraryTypes": Array [],
+			+     "enabledLibraryTypes": Array [
+			+       "var",
+			+     ],
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdatewebpack",
+			+     "hotUpdateGlobal": "webpackHotUpdatemyLib",
+			@@ ... @@
+			-     "library": undefined,
+			+     "library": Object {
+			+       "amdContainer": undefined,
+			+       "auxiliaryComment": undefined,
+			+       "export": undefined,
+			+       "name": "myLib",
+			+       "type": "var",
+			+       "umdAmdContainer": undefined,
+			+       "umdNamedDefine": undefined,
+			+     },
+			@@ ... @@
+			-     "pathinfo": false,
+			+     "pathinfo": true,
+			@@ ... @@
+			-     "strictModuleResolution": false,
+			+     "strictModuleResolution": true,
+			@@ ... @@
+			-     "uniqueName": "webpack",
+			+     "uniqueName": "myLib",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-           "production",
+			+           "development",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+			@@ ... @@
+			-       "production",
+			+       "development",
+			@@ ... @@
+			-     "cache": false,
+			+     "cache": true,
+		`)
+	);
+
 	test("library", { output: { library: ["myLib", "awesome"] } }, (e) =>
 		e.toMatchInlineSnapshot(`
 		- Expected

--- a/test/configCases/analyzable/library-module-shipping/asset.txt
+++ b/test/configCases/analyzable/library-module-shipping/asset.txt
@@ -1,0 +1,1 @@
+library asset

--- a/test/configCases/analyzable/library-module-shipping/index.js
+++ b/test/configCases/analyzable/library-module-shipping/index.js
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+
+// Named exports make each of these an ESM library, so the analyzable literal is
+// asserted next to the library's own `export { ... }`. The loader is exported rather
+// than called behind a flag: a reference nothing exports is shaken out, taking the
+// chunk with it.
+export const value = 42;
+export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+
+const bundle = () =>
+	fs.readFileSync(
+		path.join(__STATS__.children[0].outputPath, `bundle${__INDEX__}.mjs`),
+		"utf8"
+	);
+
+if (__ON_DISK__) {
+	it("should load the chunk a module library names by a literal", async () => {
+		const lazy = await load();
+
+		expect(lazy.value).toBe("lazy");
+	});
+}
+
+it("should bake a literal chunk specifier into a module library", () => {
+	const source = bundle();
+	// Built at runtime so the needle is not a source string literal here.
+	const helper = `${"__webpack_require__"}.ei(`;
+
+	expect(source).toContain(helper);
+	expect(source).toMatch(/export\s*\{/);
+
+	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+		source.slice(source.indexOf(helper))
+	);
+
+	expect(specifier).not.toBe(null);
+	if (__ON_DISK__) {
+		// Whatever the name holds, what is baked has to be a file on disk.
+		expect(
+			fs.existsSync(path.join(__STATS__.children[0].outputPath, specifier[1]))
+		).toBe(true);
+	} else {
+		// The public path carries the compilation hash, so the deferred pass filled it
+		// in rather than leaving a stand-in behind.
+		expect(specifier[1]).toMatch(
+			/^https:\/\/cdn\.example\.invalid\/[\da-f]+\/2-lazy\.mjs$/
+		);
+	}
+});

--- a/test/configCases/analyzable/library-module-shipping/index.js
+++ b/test/configCases/analyzable/library-module-shipping/index.js
@@ -1,10 +1,8 @@
 import fs from "fs";
 import path from "path";
 
-// Named exports make each of these an ESM library, so the analyzable literals are
-// asserted next to the library's own `export { ... }`. Both are exported rather than
-// used behind a flag: a reference nothing exports is shaken out, taking the chunk
-// and the asset with it.
+// Exported, not used behind a flag: a reference nothing exports is shaken out, taking
+// the chunk and the asset with it.
 export const value = 42;
 export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
 export const assetUrl = new URL("./asset.txt", import.meta.url).href;

--- a/test/configCases/analyzable/library-module-shipping/index.js
+++ b/test/configCases/analyzable/library-module-shipping/index.js
@@ -1,12 +1,13 @@
 import fs from "fs";
 import path from "path";
 
-// Named exports make each of these an ESM library, so the analyzable literal is
-// asserted next to the library's own `export { ... }`. The loader is exported rather
-// than called behind a flag: a reference nothing exports is shaken out, taking the
-// chunk with it.
+// Named exports make each of these an ESM library, so the analyzable literals are
+// asserted next to the library's own `export { ... }`. Both are exported rather than
+// used behind a flag: a reference nothing exports is shaken out, taking the chunk
+// and the asset with it.
 export const value = 42;
 export const load = () => import(/* webpackChunkName: "lazy" */ "./lazy");
+export const assetUrl = new URL("./asset.txt", import.meta.url).href;
 
 const bundle = () =>
 	fs.readFileSync(
@@ -24,19 +25,21 @@ if (__ON_DISK__) {
 
 it("should bake a literal chunk specifier into a module library", () => {
 	const source = bundle();
-	// Built at runtime so the needle is not a source string literal here.
+	// Built at runtime so the needle is not a source string literal here — this file
+	// is bundled into what it reads back.
 	const helper = `${"__webpack_require__"}.ei(`;
 
-	expect(source).toContain(helper);
 	expect(source).toMatch(/export\s*\{/);
+	expect(source).toContain(helper);
 
-	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
+	// A chunk `import()` needs no `import.meta`, so it bakes even where the module
+	// body is wrapped for the eval devtool — quoted with escapes there, plain here.
+	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?\\?"([^"\\]+)\\?"\)/.exec(
 		source.slice(source.indexOf(helper))
 	);
 
 	expect(specifier).not.toBe(null);
 	if (__ON_DISK__) {
-		// Whatever the name holds, what is baked has to be a file on disk.
 		expect(
 			fs.existsSync(path.join(__STATS__.children[0].outputPath, specifier[1]))
 		).toBe(true);
@@ -46,5 +49,23 @@ it("should bake a literal chunk specifier into a module library", () => {
 		expect(specifier[1]).toMatch(
 			/^https:\/\/cdn\.example\.invalid\/[\da-f]+\/2-lazy\.mjs$/
 		);
+	}
+});
+
+it("should bake an asset url only where import.meta survives", () => {
+	const source = bundle();
+	const evalCall = `${"eval"}(`;
+	const baseUri = `${"__webpack_require__"}.b`;
+
+	if (__URL_FORMS_BAKE__) {
+		expect(source).not.toContain(evalCall);
+		expect(source).toMatch(/new URL\((?:\/\*[^*]*\*\/\s*)?"[^"]*asset\.txt"/);
+		expect(source).not.toContain(baseUri);
+	} else {
+		// `import.meta` does not parse inside an eval wrapper, so the url is built
+		// against the base uri the runtime holds instead of being spelled here.
+		expect(source).toContain(evalCall);
+		expect(source).toContain(baseUri);
+		expect(source).not.toMatch(/new URL\((?:\/\*[^*]*\*\/\s*)?\\?"[^"]*asset\.txt/);
 	}
 });

--- a/test/configCases/analyzable/library-module-shipping/lazy.js
+++ b/test/configCases/analyzable/library-module-shipping/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/test/configCases/analyzable/library-module-shipping/webpack.config.js
+++ b/test/configCases/analyzable/library-module-shipping/webpack.config.js
@@ -93,13 +93,11 @@ module.exports = [
 		chunkFilename: "[name].mjs",
 		devtool: "source-map"
 	}),
-	// The `mode: "development"` default is `eval`. A chunk `import()` needs no
-	// `import.meta`, so it still bakes; the url forms cannot and keep the runtime
-	// shape. Documented, not desired.
+	// No devtool set: a module library takes the one default that keeps the module
+	// body out of an eval wrapper, so the url forms bake here too.
 	base(6, {
 		libraryType: "module",
 		mode: "development",
-		chunkFilename: "[name].mjs",
-		urlFormsBake: false
+		chunkFilename: "[name].mjs"
 	})
 ];

--- a/test/configCases/analyzable/library-module-shipping/webpack.config.js
+++ b/test/configCases/analyzable/library-module-shipping/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// A module library is consumed by another bundler, so its chunk references have to be
-// literals whatever names the shipping config gives them — the library types, a
-// content-named chunk, a compilation-hashed public path, and a non-production mode.
+// A module library is read by another bundler, so its references have to be literals
+// whatever the shipping config names them.
 
 const webpack = require("../../../../");
 
@@ -79,8 +78,7 @@ module.exports = [
 		mode: "none",
 		chunkFilename: "[name].mjs"
 	}),
-	// Development builds bake too, whichever devtool keeps the module body out of an
-	// `eval()`.
+	// Development bakes too, whichever devtool keeps the body out of an eval wrapper.
 	base(4, {
 		libraryType: "module",
 		mode: "development",
@@ -93,11 +91,19 @@ module.exports = [
 		chunkFilename: "[name].mjs",
 		devtool: "source-map"
 	}),
-	// No devtool set: a module library takes the one default that keeps the module
-	// body out of an eval wrapper, so the url forms bake here too.
+	// No devtool set: the default a module library now takes emits no map at all.
 	base(6, {
 		libraryType: "module",
 		mode: "development",
 		chunkFilename: "[name].mjs"
+	}),
+	// Asking for `eval` still puts the body where `import.meta` cannot be spelled, so
+	// the url forms keep the runtime shape — the reason the default moved off it.
+	base(7, {
+		libraryType: "module",
+		mode: "development",
+		chunkFilename: "[name].mjs",
+		devtool: "eval",
+		urlFormsBake: false
 	})
 ];

--- a/test/configCases/analyzable/library-module-shipping/webpack.config.js
+++ b/test/configCases/analyzable/library-module-shipping/webpack.config.js
@@ -13,13 +13,20 @@ const webpack = require("../../../../");
  * @param {import("../../../../").Configuration["mode"]} options.mode mode
  * @param {string} options.chunkFilename chunk filename template
  * @param {string=} options.publicPath public path, when it is not `auto`
+ * @param {import("../../../../").Configuration["devtool"]=} options.devtool the
+ * devtool, left out to take whatever the mode defaults to
+ * @param {boolean=} options.urlFormsBake whether the `import.meta.url` forms bake
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, { libraryType, mode, chunkFilename, publicPath }) => ({
+const base = (
+	index,
+	{ libraryType, mode, chunkFilename, publicPath, devtool, urlFormsBake = true }
+) => ({
 	target: "node",
 	mode,
-	devtool: false,
+	...(devtool === undefined ? {} : { devtool }),
 	experiments: { outputModule: true },
+	module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },
 	optimization: {
 		chunkIds: "named",
 		splitChunks: false,
@@ -33,11 +40,13 @@ const base = (index, { libraryType, mode, chunkFilename, publicPath }) => ({
 		// Prefixed per config: every config here shares one output directory, and two
 		// that name a chunk alike would each load the other's module ids.
 		chunkFilename: `${index}-${chunkFilename}`,
+		assetModuleFilename: `${index}-[name][ext]`,
 		publicPath: publicPath || "auto"
 	},
 	plugins: [
 		new webpack.DefinePlugin({
 			__INDEX__: JSON.stringify(index),
+			__URL_FORMS_BAKE__: JSON.stringify(urlFormsBake),
 			// An absolute url names no file the case can read back or import.
 			__ON_DISK__: JSON.stringify(publicPath === undefined)
 		})
@@ -69,5 +78,28 @@ module.exports = [
 		libraryType: "module",
 		mode: "none",
 		chunkFilename: "[name].mjs"
+	}),
+	// Development builds bake too, whichever devtool keeps the module body out of an
+	// `eval()`.
+	base(4, {
+		libraryType: "module",
+		mode: "development",
+		chunkFilename: "[name].mjs",
+		devtool: false
+	}),
+	base(5, {
+		libraryType: "modern-module",
+		mode: "development",
+		chunkFilename: "[name].mjs",
+		devtool: "source-map"
+	}),
+	// The `mode: "development"` default is `eval`. A chunk `import()` needs no
+	// `import.meta`, so it still bakes; the url forms cannot and keep the runtime
+	// shape. Documented, not desired.
+	base(6, {
+		libraryType: "module",
+		mode: "development",
+		chunkFilename: "[name].mjs",
+		urlFormsBake: false
 	})
 ];

--- a/test/configCases/analyzable/library-module-shipping/webpack.config.js
+++ b/test/configCases/analyzable/library-module-shipping/webpack.config.js
@@ -1,0 +1,73 @@
+"use strict";
+
+// A module library is consumed by another bundler, so its chunk references have to be
+// literals whatever names the shipping config gives them — the library types, a
+// content-named chunk, a compilation-hashed public path, and a non-production mode.
+
+const webpack = require("../../../../");
+
+/**
+ * @param {number} index position in this array, and so the entry's emitted name
+ * @param {object} options the shipping config under test
+ * @param {"module" | "modern-module"} options.libraryType library type
+ * @param {import("../../../../").Configuration["mode"]} options.mode mode
+ * @param {string} options.chunkFilename chunk filename template
+ * @param {string=} options.publicPath public path, when it is not `auto`
+ * @returns {import("../../../../").Configuration} configuration
+ */
+const base = (index, { libraryType, mode, chunkFilename, publicPath }) => ({
+	target: "node",
+	mode,
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: {
+		chunkIds: "named",
+		splitChunks: false,
+		// Kept readable: what is asserted is the specifier, not how it was renamed.
+		minimize: false
+	},
+	output: {
+		module: true,
+		library: { type: libraryType },
+		filename: `bundle${index}.mjs`,
+		// Prefixed per config: every config here shares one output directory, and two
+		// that name a chunk alike would each load the other's module ids.
+		chunkFilename: `${index}-${chunkFilename}`,
+		publicPath: publicPath || "auto"
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			__INDEX__: JSON.stringify(index),
+			// An absolute url names no file the case can read back or import.
+			__ON_DISK__: JSON.stringify(publicPath === undefined)
+		})
+	]
+});
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	base(0, {
+		libraryType: "module",
+		mode: "production",
+		chunkFilename: "[name].[contenthash].mjs"
+	}),
+	base(1, {
+		libraryType: "modern-module",
+		mode: "production",
+		chunkFilename: "[name].[contenthash].mjs"
+	}),
+	// The compilation hash is settled after code generation, so this name is filled in
+	// by the deferred pass rather than baked where the reference is written.
+	base(2, {
+		libraryType: "module",
+		mode: "production",
+		chunkFilename: "[name].mjs",
+		publicPath: "https://cdn.example.invalid/[fullhash]/"
+	}),
+	// A library is analyzable without being a production build.
+	base(3, {
+		libraryType: "module",
+		mode: "none",
+		chunkFilename: "[name].mjs"
+	})
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A library is an artifact another bundler reads, and `mode: "development"` defaults its
javascript to `eval`, which puts the module body inside `eval("…")` — `import.meta` does
not parse there, so `new URL(…, import.meta.url)` asset and worker urls fall back to the
runtime form, the published file carries `eval()` into consumers that forbid it under
CSP, and webpack's own "neither made for production nor for readable output files" banner
ends up in the package. rollup, esbuild and vite were each run to check: none emits a
source map for a library build unless asked, and none emits `eval` in any configuration.
Module libraries take `false` now, since they are the ones an eval wrapper also makes
unreadable; every other library type joins under `experiments.futureDefaults`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/Defaults.unittest.js` pins all three arms (module library, non-module library,
non-module library under future defaults), and
`test/configCases/analyzable/library-module-shipping/` covers seven module-library
configs — both library types, production, a content-named chunk, a `[fullhash]` public
path, `mode: "none"`, and development with the devtool set and unset.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Only library builds change, and only their default: setting `devtool` explicitly
restores any previous behaviour. Application builds keep `eval` and its rebuild speed.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The `devtool` page's defaults per mode, noting that a library build defaults to `false`,
and the `experiments.futureDefaults` list, where the remaining library types join.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate the behaviour, run the rollup/esbuild/vite
comparison, write the change and the tests, and verify them. Every claim above was
checked by running the tools rather than from memory; all output was reviewed before
committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Module and modern-module library builds no longer generate development source maps by default.
  - Module-library bundles provide analyzable, fully resolved chunk references and asset URLs where applicable.

- **Bug Fixes**
  - Improved development configuration defaults for module-library outputs.
  - Preserved source-map behavior for non-module libraries unless future defaults are enabled.

- **Tests**
  - Added coverage for library defaults, asset resolution, and lazy-loaded module chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->