### PR TITLE
docs: fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ or packaging just about any resource or asset.
 
 **TL;DR**
 
-- Bundles [ES Modules](https://www.2ality.com/2014/09/es6-modules-final.html), [CommonJS](https://wiki.commonjs.org/), and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
+- Bundles [ES Modules](https://web.archive.org/web/20201226153522/https://2ality.com/2014/09/es6-modules-final.html), [CommonJS](https://wiki.commonjs.org/), and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
 - Can create a single bundle or multiple chunks that are asynchronously loaded at runtime (to reduce initial loading time).
 - Dependencies are resolved during compilation, reducing the runtime size.
 - Loaders can preprocess files while compiling, e.g. TypeScript to JavaScript, Handlebars strings to compiled functions, images to Base64, etc.
@@ -86,7 +86,7 @@ Check out webpack's quick [**Get Started**](https://webpack.js.org/guides/gettin
 
 ### Browser Compatibility
 
-Webpack supports all browsers that are [ES5-compliant](https://kangax.github.io/compat-table/es5/) (IE8 and below are not supported).
+Webpack supports all browsers that are [ES5-compliant](https://compat-table.github.io/compat-table/es5/) (IE8 and below are not supported).
 Webpack also needs `Promise` for `import()` and `require.ensure()`. If you want to support older browsers, you will need to [load a polyfill](https://webpack.js.org/guides/shimming/) before using these expressions.
 
 ## Concepts


### PR DESCRIPTION
Two links in the README are dead; this fixes both:

1. **ES5 compat-table** — `https://kangax.github.io/compat-table/es5/` returns 404: the project moved from `kangax/compat-table` to the `compat-table` org (the old repo redirects there). Replaced with the current pages URL `https://compat-table.github.io/compat-table/es5/` (HTTP 200).
2. **"ES6 modules: the final syntax"** (2ality) — `https://www.2ality.com/2014/09/es6-modules-final.html` returns 404: 2ality.com was reduced to a landing page and the old posts are gone (the article isn't on the author's new site either). Replaced with the Internet Archive snapshot (HTTP 200).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ES Modules reference to point to an archived article.
  * Replaced the browser compatibility link with the current compat-table reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->