### PR TITLE
fix: accept the optimization.minimize true shorthand after normalization

### DIFF
--- a/.changeset/115-minimize-boolean-after-normalization.md
+++ b/.changeset/115-minimize-boolean-after-normalization.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Accept the `optimization.minimize: true` shorthand set by a plugin in `apply()`.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -2464,6 +2464,12 @@ const applyOptimizationDefaults = (
 	D(optimization, "portableRecords", records);
 	D(optimization, "realContentHash", production);
 	F(optimization, "minimize", () => (production ? {} : false));
+	// A plugin can assign the `true` shorthand in `apply()`, which runs after
+	// `getNormalizedOptimizationMinimize` and so never gets normalized. The
+	// normalized type does not allow it, hence the cast.
+	if (/** @type {unknown} */ (optimization.minimize) === true) {
+		optimization.minimize = {};
+	}
 	const { minimize } = optimization;
 	if (minimize) {
 		// Canonicalize the object form: the JS minimizer's defaults become

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -6012,3 +6012,23 @@ describe("Targets", () => {
 	`);
 	});
 });
+
+describe("optimization.minimize", () => {
+	it("should accept the `true` shorthand assigned after normalization", () => {
+		const { applyWebpackOptionsDefaults, getNormalizedWebpackOptions } =
+			require("..").config;
+
+		const normalized = getNormalizedWebpackOptions({ mode: "production" });
+
+		// What a plugin does in `apply()`, which runs between normalization and
+		// defaults, so `getNormalizedOptimizationMinimize` never sees this value.
+		normalized.optimization.minimize = /** @type {EXPECTED_ANY} */ (true);
+
+		expect(() => applyWebpackOptionsDefaults(normalized)).not.toThrow();
+		expect(normalized.optimization.minimize).toEqual({
+			css: {},
+			html: {},
+			javascript: { compress: { passes: 2 } }
+		});
+	});
+});


### PR DESCRIPTION
Fixes #21844

## What kind of change does this PR introduce?

Bug fix.

## Did you add tests for your changes?

Yes, a regression test in `test/Defaults.unittest.js`. It fails on `main` with `Cannot create property 'javascript' on boolean 'true'` and passes with the fix. The existing 82 tests and 53 snapshots in that file are unchanged.

The test has to assign the value *after* `getNormalizedWebpackOptions`, because `getDefaultConfig` normalizes first and so cannot reach this path.

## Summary

`getNormalizedOptimizationMinimize` already maps the `true` shorthand to `{}`, so a plain config object is fine. But `createCompiler` normalizes, then applies plugins, then fills defaults:

```js
let options = getNormalizedWebpackOptions(rawOptions);   // true -> {}
applyWebpackOptionsBaseDefaults(options);
...
for (const plugin of options.plugins) plugin.apply(compiler);   // plugin writes `true` back
const resolvedDefaultOptions = applyWebpackOptionsDefaults(options, compilerIndex);
```

A plugin assigning `compiler.options.optimization.minimize` in `apply()` writes a value normalization never gets to see. The per-asset-type canonicalization added in 5.110.0 (#21663, #21537) then guards on truthiness rather than type:

```js
const { minimize } = optimization;
if (minimize) {
  F(minimize, "javascript", () => ({ compress: { passes: 2 } }));
```

`F` assigns when the property is `undefined`, so this evaluates `true.javascript = {...}` and throws in strict mode.

This coerces the shorthand to the object form the normalizer would have produced, which keeps the new per-asset-type defaults applying rather than skipping them.

## Does this PR introduce a breaking change?

No. It restores 5.109.2 behaviour for a value `schemas/WebpackOptions.json` still declares valid:

```json
"minimize": {
  "anyOf": [{ "type": "boolean" }, { "$ref": "#/definitions/OptimizationMinimizeOptions" }]
}
```

## Other information

Found via `@nx/webpack`, which sets the option in `apply()`. Since `compiler.options` is a documented mutation point for plugins and the boolean is still schema-valid, other plugins are likely affected too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of the `optimization.minimize: true` shorthand when enabled by a plugin.
  - Ensured minimization settings are correctly expanded with the expected defaults, including JavaScript compression options.
  - Prevented errors during production configuration processing in this scenario.

- **Documentation**
  - Added a patch release note documenting support for this configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->