### PR TITLE
test(css): cover a loader-added BOM in the css pipeline

### DIFF
--- a/test/configCases/css/bom-from-loader/first.css
+++ b/test/configCases/css/bom-from-loader/first.css
@@ -1,0 +1,3 @@
+.first::after {
+	content: "©";
+}

--- a/test/configCases/css/bom-from-loader/index.js
+++ b/test/configCases/css/bom-from-loader/index.js
@@ -1,0 +1,10 @@
+import "./first.css";
+import "./second.css";
+import * as styles from "./third.module.css";
+
+const BOM = "\uFEFF";
+
+it("should still scope a css module whose loader added a BOM", () => {
+	expect(styles.third).toBeDefined();
+	expect(styles.third).not.toContain(BOM);
+});

--- a/test/configCases/css/bom-from-loader/loader.js
+++ b/test/configCases/css/bom-from-loader/loader.js
@@ -1,0 +1,6 @@
+// Emulates sass-loader's production default (`outputStyle: "compressed"` with
+// `charset: true`), which prefixes a BOM whenever the stylesheet is non-ASCII.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(content) {
+	return `\uFEFF${content}`;
+};

--- a/test/configCases/css/bom-from-loader/second.css
+++ b/test/configCases/css/bom-from-loader/second.css
@@ -1,0 +1,3 @@
+.second::after {
+	content: "→";
+}

--- a/test/configCases/css/bom-from-loader/test.config.js
+++ b/test/configCases/css/bom-from-loader/test.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const BOM = "\uFEFF";
+
+module.exports = {
+	afterExecute(options) {
+		const outputPath = options.output.path;
+		const emitted = fs
+			.readdirSync(outputPath)
+			.filter((file) => file.endsWith(".css") || file.endsWith(".js"));
+		const stylesheets = emitted.filter((file) => file.endsWith(".css"));
+
+		expect(stylesheets).not.toHaveLength(0);
+
+		for (const file of emitted) {
+			const source = fs.readFileSync(path.resolve(outputPath, file), "utf8");
+
+			// A BOM past byte 0 is the corrupting case: concatenation puts it
+			// mid-file and the browser silently drops the rule that follows.
+			expect(source).not.toContain(BOM);
+		}
+
+		for (const file of stylesheets) {
+			const source = fs.readFileSync(path.resolve(outputPath, file), "utf8");
+
+			expect(source).toContain(".first::after");
+			expect(source).toContain(".second::after");
+		}
+	}
+};

--- a/test/configCases/css/bom-from-loader/third.module.css
+++ b/test/configCases/css/bom-from-loader/third.module.css
@@ -1,0 +1,3 @@
+.third {
+	content: "★";
+}

--- a/test/configCases/css/bom-from-loader/webpack.config.js
+++ b/test/configCases/css/bom-from-loader/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				type: "css/auto",
+				use: [path.resolve(__dirname, "loader.js")]
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Checking whether webpack's own CSS pipeline has the bug behind webpack/css-loader#1678, where a BOM added by a loader (`sass-loader` with `charset: true`) reaches the output and corrupts concatenated stylesheets. It does not — `CssModulesPlugin` strips it from the loader result via `NormalModule.processResult` — but nothing covered the loader-added case: `configCases/parsing/bom` covers a BOM in the source file, which is a different path. This adds that coverage so the protection cannot be removed silently.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/bom-from-loader/`: a loader prepends a BOM to three stylesheets (including a `css/auto` module), and the emitted assets are checked for a BOM anywhere plus both rules surviving. Confirmed it fails when the `removeBOM` call in `CssModulesPlugin` is dropped, and it passes under both `ConfigTestCases` and `ConfigCacheTestCases`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — test-only, no `lib/` change.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code traced the BOM handling to `removeBOM` in `CssModulesPlugin`, wrote the case, and verified it fails with that call removed and passes with it restored. Reviewed and edited by me before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016QSvzSBtKeonvxX89LtMSB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Unicode byte-order marks from appearing in generated CSS and JavaScript output when stylesheets contain non-ASCII characters.
  - Preserved CSS content values and CSS Module class scoping during stylesheet processing.

- **Tests**
  - Added coverage for CSS loaded with a prepended byte-order mark, including validation of emitted files and special-character content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->