### PR TITLE
fix(analyzable): bake urls past cycles, mixed-served wasm and partial style maps

### DIFF
--- a/.changeset/005-analyzable-limitations.md
+++ b/.changeset/005-analyzable-limitations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix analyzable ESM baking around cycles, mixed-served wasm and style url maps.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -155,26 +155,24 @@ reviews:
       mode: "warning"
     issue_assessment:
       mode: "warning"
-
-tools:
-  eslint:
-    enabled: true
-  actionlint:
-    enabled: true
-  gitleaks:
-    enabled: true
-  shellcheck:
-    enabled: true
-  yamllint:
-    enabled: true
-  # Prettier + cspell own Markdown/prose style in this repo (yarn fix / yarn lint)
-  markdownlint:
-    enabled: false
-  languagetool:
-    enabled: false
-  github-checks:
-    enabled: true
-    timeout_ms: 90000
+  tools:
+    eslint:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    shellcheck:
+      enabled: true
+    yamllint:
+      enabled: true
+    # Prettier + cspell own Markdown/prose style in this repo (yarn fix / yarn lint)
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+    github-checks:
+      enabled: true
 
 chat:
   art: false

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -249,6 +249,10 @@ const SPECIFIER_PART_KINDS = new Set([
 // Only these carry a chunk id, which is the one part value that may be a number.
 const CHUNK_SPECIFIER_PART_KINDS = new Set(["chunk", "cssChunk"]);
 
+// Only these are spelled out of the compilation hash, so a stand-in holding one moves
+// the chunk it lands in into the round after that hash settles.
+const FULL_HASH_PART_KINDS = new Set(["publicPath", "template", "unserved"]);
+
 // What the deferred pass scans for — the other half of what the class spells.
 const ANALYZABLE_TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
 
@@ -866,9 +870,7 @@ class RuntimeTemplate {
 	 */
 	_partsBakeFullHash(parts) {
 		for (const [kind, value] of parts) {
-			if (kind === "publicPath" || kind === "template" || kind === "unserved") {
-				return true;
-			}
+			if (FULL_HASH_PART_KINDS.has(kind)) return true;
 			if (kind === "literal" && this._hasReservedFullHash(String(value))) {
 				return true;
 			}
@@ -967,95 +969,83 @@ class RuntimeTemplate {
 		const base = this.analyzableUrlReadsBaseUri()
 			? this.entryBaseUri(runtime)
 			: undefined;
-		if (base !== undefined) {
-			if (base === null) {
-				return this._analyzableBailout(
-					module,
-					"the entries this module is generated for set different baseUri values, so no one url resolves for all of them",
-					null
-				);
-			}
-			// A relative one is no base of its own: the runtime reads it against the
-			// chunk, so the literal spells it there rather than resolving against it.
-			if (isChunkRelativeBaseUri(base)) {
-				return this._getAnalyzableFileSpecifier(
-					module,
-					chunkGraph,
-					[["literal", filename]],
-					true,
-					base
-				);
-			}
-			const chunks = this._moduleChunks(module, chunkGraph);
-			// A protocol-relative base names a host but no scheme, and the runtime reads it
-			// against the chunk's own url to get one — the very url this literal is
-			// resolved against — so it may stay protocol-relative instead of being settled
-			// here. Nothing walks back to the output root first: the base replaces it.
-			if (base.startsWith("//")) {
-				const relative = this._resolvePublicPathPrefix(
-					publicPath,
-					module,
-					chunks
-				);
-				return relative === null
-					? null
-					: this._specifierOf(
-							[
-								["literal", base],
-								...rootedParts(relative),
-								["literal", filename]
-							],
-							chunks,
-							module
-						);
-			}
-			if (!isAbsoluteBaseUri(base)) {
-				return this._analyzableBailout(
-					module,
-					`an entry sets a baseUri of ${JSON.stringify(base)}, whose scheme names no base anything can be resolved against`,
-					null
-				);
-			}
-			const parts = this._resolvePublicPathPrefix(publicPath, module, chunks);
-			if (parts === null) return null;
-			// Resolved here rather than against the output root, and only an absolute base
-			// settles it — a relative one has no base of its own to be read against.
-			const spelled = literalText(parts);
-			// A hash the deferred pass still has to fill in cannot be resolved against the
-			// base here: the fill would land inside an already-resolved url, where a hash
-			// opening with a letter reads as a scheme and drops the base entirely.
-			const text =
-				spelled !== null && !this._hasReservedFullHash(spelled)
-					? spelled
-					: null;
-			/** @type {URL} */
-			let resolved;
-			try {
-				// Empty where only the deferred pass can spell the rest, which still settles
-				// whether the base itself is one anything may be resolved against.
-				resolved = new URL(text === null ? "" : text + filename, base);
-			} catch (_error) {
-				return this._analyzableBailout(
-					module,
-					`an entry sets a baseUri of ${JSON.stringify(base)}, which is not absolute, so no url can be resolved against it here`,
-					null
-				);
-			}
-			if (text !== null) return toJsStringLiteral(resolved.href);
-			if (!this._canDeferOrBail(chunks, module)) return null;
-			return toJsStringLiteral(
-				this._reserveAnalyzableSpecifier([
-					["base", base],
-					...parts,
-					["literal", filename]
-				])
+		// No base of its own: the name is spelled against the output root, as a chunk is.
+		if (base === undefined) {
+			return this._getAnalyzableFileSpecifier(
+				module,
+				chunkGraph,
+				[["literal", filename]],
+				true
 			);
 		}
-		return this._getAnalyzableFileSpecifier(
-			module,
-			chunkGraph,
-			[["literal", filename]],
-			true
+		if (base === null) {
+			return this._analyzableBailout(
+				module,
+				"the entries this module is generated for set different baseUri values, so no one url resolves for all of them",
+				null
+			);
+		}
+		// A relative one is no base of its own: the runtime reads it against the
+		// chunk, so the literal spells it there rather than resolving against it.
+		if (isChunkRelativeBaseUri(base)) {
+			return this._getAnalyzableFileSpecifier(
+				module,
+				chunkGraph,
+				[["literal", filename]],
+				true,
+				base
+			);
+		}
+		const chunks = this._moduleChunks(module, chunkGraph);
+		const parts = this._resolvePublicPathPrefix(publicPath, module, chunks);
+		if (parts === null) return null;
+		// A protocol-relative base names a host but no scheme, and the runtime reads it
+		// against the chunk's own url to get one — the very url this literal is
+		// resolved against — so it may stay protocol-relative instead of being settled
+		// here. Nothing walks back to the output root first: the base replaces it.
+		if (base.startsWith("//")) {
+			return this._specifierOf(
+				[["literal", base], ...rootedParts(parts), ["literal", filename]],
+				chunks,
+				module
+			);
+		}
+		if (!isAbsoluteBaseUri(base)) {
+			return this._analyzableBailout(
+				module,
+				`an entry sets a baseUri of ${JSON.stringify(base)}, whose scheme names no base anything can be resolved against`,
+				null
+			);
+		}
+		// Resolved here rather than against the output root, and only an absolute base
+		// settles it — a relative one has no base of its own to be read against.
+		const spelled = literalText(parts);
+		// A hash the deferred pass still has to fill in cannot be resolved against the
+		// base here: the fill would land inside an already-resolved url, where a hash
+		// opening with a letter reads as a scheme and drops the base entirely.
+		const text =
+			spelled !== null && !this._hasReservedFullHash(spelled) ? spelled : null;
+		/** @type {URL} */
+		let resolved;
+		try {
+			// Empty where only the deferred pass can spell the rest, which still settles
+			// whether the base itself is one anything may be resolved against.
+			resolved = new URL(text === null ? "" : text + filename, base);
+		} catch (_error) {
+			return this._analyzableBailout(
+				module,
+				`an entry sets a baseUri of ${JSON.stringify(base)}, which is not absolute, so no url can be resolved against it here`,
+				null
+			);
+		}
+		if (text !== null) return toJsStringLiteral(resolved.href);
+		if (!this._canDeferOrBail(chunks, module)) return null;
+		return toJsStringLiteral(
+			this._reserveAnalyzableSpecifier([
+				["base", base],
+				...parts,
+				["literal", filename]
+			])
 		);
 	}
 
@@ -2636,6 +2626,22 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Whether any module of `chunk` carries a source type with a chunk handler of its
+	 * own, which `.ei` dispatches alongside the javascript one.
+	 * @param {Chunk} chunk the chunk being imported
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {boolean} true when a handler beyond the javascript one is reached
+	 */
+	_chunkLoadsBeyondJs(chunk, chunkGraph) {
+		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
+			for (const type of chunkGraph.getModuleSourceTypes(module)) {
+				if (!TYPES_WITHOUT_CHUNK_HANDLER.has(type)) return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * For ESM module output, load a single statically-named chunk through the
 	 * `analyzableChunkImport` helper — a literal `import("./chunk.js")` other bundlers
 	 * and webpack itself can follow, wrapped to keep `ensureChunk` timing and deduplication.
@@ -2662,12 +2668,6 @@ class RuntimeTemplate {
 		) {
 			return null;
 		}
-		// Prefetch/preload children are injected by the runtime `.f` handlers, which `.ei`
-		// runs too — but they attach to `.f`, so it has to exist.
-		const needsHintHandlers =
-			chunk.hasChildByOrder(chunkGraph, "prefetch", true) ||
-			chunk.hasChildByOrder(chunkGraph, "preload", true) ||
-			chunk.hasChildByOrder(chunkGraph, "cssPreload", true);
 		// `.ei` always performs the import, where `.e` only reaches the javascript
 		// loader when there is javascript to load. A module federation remote is the
 		// case that matters: its chunk is emitted by the container's build, not this one.
@@ -2677,15 +2677,6 @@ class RuntimeTemplate {
 				"this compilation emits no javascript for the chunk, so there is nothing to import",
 				null
 			);
-		}
-		let hasNonJsTypes = false;
-		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-			for (const type of chunkGraph.getModuleSourceTypes(module)) {
-				if (!TYPES_WITHOUT_CHUNK_HANDLER.has(type)) {
-					// Loaded by that type's own `.f` handler, which `.ei` still dispatches.
-					hasNonJsTypes = true;
-				}
-			}
 		}
 		// Relative to the consuming chunk (`import.meta.url`) for `auto`, else an
 		// absolute publicPath prefix.
@@ -2707,9 +2698,15 @@ class RuntimeTemplate {
 			? specifier
 			: `"./${specifier.slice(1)}`;
 		runtimeRequirements.add(RuntimeGlobals.analyzableChunkImport);
-		if (needsHintHandlers || hasNonJsTypes) {
-			// Those handlers attach to the `.f` map, which has to exist — but the runtime
-			// `ensureChunk` around it does not, since `.ei` dispatches them itself.
+		// Prefetch/preload children and every non-javascript source type are loaded by a
+		// `.f` handler, which `.ei` dispatches — but they attach to `.f`, so it has to
+		// exist. The runtime `ensureChunk` around it does not.
+		if (
+			chunk.hasChildByOrder(chunkGraph, "prefetch", true) ||
+			chunk.hasChildByOrder(chunkGraph, "preload", true) ||
+			chunk.hasChildByOrder(chunkGraph, "cssPreload", true) ||
+			this._chunkLoadsBeyondJs(chunk, chunkGraph)
+		) {
 			runtimeRequirements.add(RuntimeGlobals.ensureChunkHandlers);
 		}
 		// Drop-in for `ensureChunk(id)`: the literal `import()` can be statically
@@ -2879,6 +2876,11 @@ class RuntimeTemplate {
 		/** @type {Set<string>} */
 		const names = new Set();
 		let found = false;
+		// Its own copy, since `lastIndex` is walked below; reset by the loop that ends it.
+		const regexp = new RegExp(
+			ANALYZABLE_TOKEN_REGEXP.source,
+			ANALYZABLE_TOKEN_REGEXP.flags
+		);
 		for (const module of modules) {
 			if (!results.has(module, chunk.runtime)) continue;
 			const source = results.getSource(module, chunk.runtime, JAVASCRIPT_TYPE);
@@ -2888,10 +2890,6 @@ class RuntimeTemplate {
 				carriesFullHash = true;
 				found = true;
 			}
-			const regexp = new RegExp(
-				ANALYZABLE_TOKEN_REGEXP.source,
-				ANALYZABLE_TOKEN_REGEXP.flags
-			);
 			/** @type {RegExpExecArray | null} */
 			let match;
 			while ((match = regexp.exec(content)) !== null) {
@@ -2899,11 +2897,7 @@ class RuntimeTemplate {
 				if (parts === null) continue;
 				found = true;
 				for (const [kind, value] of parts) {
-					if (
-						kind === "publicPath" ||
-						kind === "template" ||
-						kind === "unserved"
-					) {
+					if (FULL_HASH_PART_KINDS.has(kind)) {
 						carriesFullHash = true;
 					} else if (CHUNK_SPECIFIER_PART_KINDS.has(kind)) {
 						names.add(String(value));
@@ -3438,16 +3432,10 @@ class RuntimeTemplate {
 		if (climb !== "" && relativeBase === undefined) return head;
 		const resolved = resolve();
 		if (resolved === null) return null;
-		return [
-			...head,
-			.../** @type {SpecifierPart[]} */ (
-				climb === "" ? [] : [["literal", climb]]
-			),
-			.../** @type {SpecifierPart[]} */ (
-				relativeBase === undefined ? [] : [["literal", relativeBase]]
-			),
-			...rootedParts(resolved)
-		];
+		if (climb !== "") head.push(["literal", climb]);
+		if (relativeBase !== undefined) head.push(["literal", relativeBase]);
+		head.push(...rootedParts(resolved));
+		return head;
 	}
 
 	/**
@@ -3573,11 +3561,6 @@ class RuntimeTemplate {
 	) {
 		const { publicPath } = this.outputOptions;
 		const chunks = this._moduleChunks(module, chunkGraph);
-		/**
-		 * @param {SpecifierPart[]} parts the whole specifier
-		 * @returns {string | null} it already quoted, or `null` when no stand-in may be reserved
-		 */
-		const specifier = (parts) => this._specifierOf(parts, chunks, module);
 		if (bakePublicPath && publicPath !== "auto") {
 			const prefix = this._analyzablePathPrefix(
 				module,
@@ -3585,19 +3568,18 @@ class RuntimeTemplate {
 				chunks,
 				relativeBase
 			);
-			return prefix === null ? null : specifier([...prefix, ...file]);
+			if (prefix === null) return null;
+			return this._specifierOf([...prefix, ...file], chunks, module);
 		}
 		// No public path to place it against, so the `../` path back to the output root
 		// is the whole prefix. Different depths — no one is right for every asset the
 		// reference is emitted into, so the deferred pass builds each asset's own.
 		const { undo } = this._modulePlacement(module, chunkGraph);
-		return specifier([
-			undo === null ? ["undo", ""] : ["literal", undo],
-			...(relativeBase === undefined
-				? []
-				: /** @type {SpecifierPart[]} */ ([["literal", relativeBase]])),
-			...file
-		]);
+		/** @type {SpecifierPart[]} */
+		const parts = [undo === null ? ["undo", ""] : ["literal", undo]];
+		if (relativeBase !== undefined) parts.push(["literal", relativeBase]);
+		parts.push(...file);
+		return this._specifierOf(parts, chunks, module);
 	}
 
 	/**
@@ -3669,11 +3651,9 @@ class RuntimeTemplate {
 		);
 		/** @type {Set<ChunkId>} */
 		const hinted = new Set();
-		for (const order of Object.keys(orders)) {
-			for (const from of Object.keys(orders[order])) {
-				for (const id of orders[order][/** @type {ChunkId} */ (from)]) {
-					hinted.add(id);
-				}
+		for (const byParent of Object.values(orders)) {
+			for (const ids of Object.values(byParent)) {
+				for (const id of ids) hinted.add(id);
 			}
 		}
 		/** @type {Chunk[]} */

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -178,6 +178,13 @@ const DEFER_BAILOUT =
  * @property {boolean | null} loaded whether the chunk loader fetched the chunk
  */
 
+/**
+ * @typedef {object} WasmGroups
+ * @property {(key: string) => string} groupOf the group a runtime key answers with
+ * @property {Set<string>} fetching groups an entry of which reads binaries with `fetch`
+ * @property {Map<string, boolean>} onlyFetching groups every entry of which fetches
+ */
+
 // A reference in no chunk at all: nothing is known about where it is read from.
 /** @type {Placement} */
 const NO_PLACEMENT = { undo: null, loaded: null };
@@ -426,14 +433,10 @@ class RuntimeTemplate {
 		this._placementByChunk = new WeakMap();
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
-		/** @type {Map<string, string> | undefined} */
-		this._wasmRuntimeGroupsByKey = undefined;
-		/** @type {Set<string> | false | undefined} */
-		this._wasmFetchingGroupSet = undefined;
+		/** @type {WasmGroups | undefined} */
+		this._wasmGroupsValue = undefined;
 		/** @type {Map<string, boolean> | undefined} */
 		this._wasmAnchorKnownByGroup = undefined;
-		/** @type {Map<string, boolean> | undefined} */
-		this._wasmGroupOnlyFetchesMap = undefined;
 	}
 
 	isIIFE() {
@@ -630,28 +633,28 @@ class RuntimeTemplate {
 				placedModule
 			)
 		) {
-			this._analyzableBailout(
+			return this._analyzableBailout(
 				module,
-				"__webpack_public_path__ is reassigned in a runtime this module belongs to"
+				"__webpack_public_path__ is reassigned in a runtime this module belongs to",
+				false
 			);
-			return false;
 		}
 
 		if (form === "import") {
 			// Read through a native `import()`, or it is not this feature at all.
 			if (outputOptions.chunkFormat !== "module") {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					`output.chunkFormat is ${JSON.stringify(outputOptions.chunkFormat)}, so chunks are not read through a native import()`
+					`output.chunkFormat is ${JSON.stringify(outputOptions.chunkFormat)}, so chunks are not read through a native import()`,
+					false
 				);
-				return false;
 			}
 			if (outputOptions.importFunctionName !== "import") {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, so the call site is not a native import()`
+					`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, so the call site is not a native import()`,
+					false
 				);
-				return false;
 			}
 			// A worker loading its own chunks some other way keeps that runtime; one on
 			// `import` uses the same ESM loader as the main graph, so it can be analyzable.
@@ -662,11 +665,11 @@ class RuntimeTemplate {
 				if (!entryOptions || !entryOptions.worker) continue;
 				// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
 				if (entryOptions.chunkLoading !== "import") {
-					this._analyzableBailout(
+					return this._analyzableBailout(
 						module,
-						`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`
+						`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`,
+						false
 					);
-					return false;
 				}
 			}
 			return true;
@@ -679,11 +682,11 @@ class RuntimeTemplate {
 		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
 		// emitted by the module chunk loader either way, so only the url forms check.
 		if (!this.supportsEcmaScriptModuleSyntax()) {
-			this._analyzableBailout(
+			return this._analyzableBailout(
 				module,
-				"output.environment.module is false, so the target does not read the import.meta this form needs"
+				"output.environment.module is false, so the target does not read the import.meta this form needs",
+				false
 			);
-			return false;
 		}
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error. Runtime modules are emitted beside them, never wrapped.
@@ -693,22 +696,22 @@ class RuntimeTemplate {
 			typeof devtool === "string" &&
 			devtool.includes("eval")
 		) {
-			this._analyzableBailout(
+			return this._analyzableBailout(
 				module,
-				`devtool ${JSON.stringify(devtool)} wraps the module in eval(), where import.meta does not parse`
+				`devtool ${JSON.stringify(devtool)} wraps the module in eval(), where import.meta does not parse`,
+				false
 			);
-			return false;
 		}
 		if (form === "url" || form === "url-runtime") return true;
 		// A bare relative URL is what `__webpack_require__.p + path` means only under an
 		// `auto` public path; anything else has to be baked, which is the "wasm" form.
 		if (form === "wasm-relative") {
 			if (outputOptions.publicPath === "auto") return true;
-			this._analyzableBailout(
+			return this._analyzableBailout(
 				module,
-				"output.publicPath is set, so a bare relative url no longer means what the public path would have resolved to"
+				"output.publicPath is set, so a bare relative url no longer means what the public path would have resolved to",
+				false
 			);
-			return false;
 		}
 
 		// The rest is the `"wasm"` form: whether the whole binary url can be spelled
@@ -727,11 +730,11 @@ class RuntimeTemplate {
 				this._anyWasmChunkFetches(runtime) &&
 				!this._wasmFetchAnchorIsKnown(runtime)
 			) {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					"output.publicPath needs a base, and no one path back to the document fits every chunk `fetch` reads it from"
+					"output.publicPath needs a base, and no one path back to the document fits every chunk `fetch` reads it from",
+					false
 				);
-				return false;
 			}
 		}
 		// The compilation hash is settled after code generation, so a name carrying one
@@ -753,19 +756,22 @@ class RuntimeTemplate {
 	 * the channel `ModuleConcatenationPlugin` already reports through, so it reaches
 	 * `stats.optimizationBailout`. Silent unless the build asked for ESM output, where
 	 * alone the answer is actionable; deduplicated because a module may write many.
+	 * Answers with `answer` so a caller states the refusal and its reason at once —
+	 * `false` where it answers a question, `null` where it was building a specifier.
+	 * @template {false | null} T
 	 * @param {Module | undefined} module the module the reference is emitted into
 	 * @param {string} reason why no literal could be baked
-	 * @returns {void}
+	 * @param {T} answer what the caller hands back
+	 * @returns {T} that answer
 	 */
-	_analyzableBailout(module, reason) {
-		if (module === undefined || !this.outputOptions.module) return;
-		const text = `Analyzable ESM bailout: ${reason}`;
-		const bailouts =
-			this.compilation.moduleGraph.getOptimizationBailout(module);
-		for (const existing of bailouts) {
-			if (existing === text) return;
+	_analyzableBailout(module, reason, answer) {
+		if (module !== undefined && this.outputOptions.module) {
+			const text = `Analyzable ESM bailout: ${reason}`;
+			const bailouts =
+				this.compilation.moduleGraph.getOptimizationBailout(module);
+			if (!bailouts.includes(text)) bailouts.push(text);
 		}
-		bailouts.push(text);
+		return answer;
 	}
 
 	/**
@@ -810,8 +816,7 @@ class RuntimeTemplate {
 	 */
 	_canDeferOrBail(chunks, module) {
 		if (this._canDeferAnalyzableName(chunks)) return true;
-		this._analyzableBailout(module, DEFER_BAILOUT);
-		return false;
+		return this._analyzableBailout(module, DEFER_BAILOUT, false);
 	}
 
 	/**
@@ -964,11 +969,11 @@ class RuntimeTemplate {
 			: undefined;
 		if (base !== undefined) {
 			if (base === null) {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					"the entries this module is generated for set different baseUri values, so no one url resolves for all of them"
+					"the entries this module is generated for set different baseUri values, so no one url resolves for all of them",
+					null
 				);
-				return null;
 			}
 			// A relative one is no base of its own: the runtime reads it against the
 			// chunk, so the literal spells it there rather than resolving against it.
@@ -1005,11 +1010,11 @@ class RuntimeTemplate {
 						);
 			}
 			if (!isAbsoluteBaseUri(base)) {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					`an entry sets a baseUri of ${JSON.stringify(base)}, whose scheme names no base anything can be resolved against`
+					`an entry sets a baseUri of ${JSON.stringify(base)}, whose scheme names no base anything can be resolved against`,
+					null
 				);
-				return null;
 			}
 			const parts = this._resolvePublicPathPrefix(publicPath, module, chunks);
 			if (parts === null) return null;
@@ -1030,11 +1035,11 @@ class RuntimeTemplate {
 				// whether the base itself is one anything may be resolved against.
 				resolved = new URL(text === null ? "" : text + filename, base);
 			} catch (_error) {
-				this._analyzableBailout(
+				return this._analyzableBailout(
 					module,
-					`an entry sets a baseUri of ${JSON.stringify(base)}, which is not absolute, so no url can be resolved against it here`
+					`an entry sets a baseUri of ${JSON.stringify(base)}, which is not absolute, so no url can be resolved against it here`,
+					null
 				);
-				return null;
 			}
 			if (text !== null) return toJsStringLiteral(resolved.href);
 			if (!this._canDeferOrBail(chunks, module)) return null;
@@ -1122,155 +1127,18 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a chunk loads WebAssembly through `fetch`, which is the only loader the
-	 * public path reaches: `readFile` resolves the binary's name against the chunk it is
-	 * read from, exactly as a baked literal does, so a public path is irrelevant to it.
-	 * Answered per runtime rather than per chunk on purpose — a module's generated source
-	 * and the runtime module of every chunk holding it have to agree on the shape, and
-	 * they ask from opposite ends; one loader serves a whole runtime, so that is the
-	 * finest scope on which they can. Without a runtime, or where the runtimes cannot be
-	 * told apart, the answer covers the compilation.
-	 * @param {RuntimeSpec=} runtime the runtime being asked about
-	 * @returns {boolean} true when a chunk of that runtime fetches its binaries
-	 */
-	_anyWasmChunkFetches(runtime) {
-		const fetching = this._wasmFetchingGroups();
-		if (fetching === undefined) return false;
-		// Without a runtime to place it in there is nothing to narrow by, so any chunk
-		// answers for all of them.
-		if (runtime === undefined) return true;
-		const groups = this._wasmRuntimeGroups();
-		if (typeof runtime === "string") {
-			return fetching.has(this._wasmGroupOf(groups, runtime));
-		}
-		for (const key of runtime) {
-			if (fetching.has(this._wasmGroupOf(groups, key))) return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Whether every entry of a wasm runtime group reads its binaries with `fetch`. Only
-	 * an entry names a loader, so the scan is of entries, as `_wasmFetchingGroups` is.
-	 * @returns {Map<string, boolean>} whether each group fetches and nothing else
-	 */
-	_wasmGroupOnlyFetches() {
-		if (this._wasmGroupOnlyFetchesMap === undefined) {
-			const groups = this._wasmRuntimeGroups();
-			/** @type {Map<string, boolean>} */
-			const only = new Map();
-			for (const chunk of this.compilation.chunks) {
-				if (!chunk.getEntryOptions()) continue;
-				const fetches = this._chunkWasmLoading(chunk) === "fetch";
-				forEachRuntime(chunk.runtime, (key) => {
-					const group = this._wasmGroupOf(groups, /** @type {string} */ (key));
-					only.set(group, only.get(group) !== false && fetches);
-				});
-			}
-			this._wasmGroupOnlyFetchesMap = only;
-		}
-		return this._wasmGroupOnlyFetchesMap;
-	}
-
-	/**
-	 * Whether a public path needing a base can be spelled from the chunk every binary of
-	 * a runtime sits in — `fetch` reads it against the document, so a literal climbs back
-	 * there first. Per group, as `_anyWasmChunkFetches` is, since the two ends must agree.
-	 * @param {RuntimeSpec=} runtime the runtime being asked about
-	 * @returns {boolean} true when every binary of that group can be spelled
-	 */
-	_wasmFetchAnchorIsKnown(runtime) {
-		if (this._wasmAnchorKnownByGroup === undefined) {
-			const { chunkGraph, modules } = this.compilation;
-			const publicPath = /** @type {PublicPath} */ (
-				this.outputOptions.publicPath
-			);
-			const groups = this._wasmRuntimeGroups();
-			/** @type {Map<string, boolean>} */
-			const known = new Map();
-			for (const module of modules) {
-				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
-				const spellable =
-					this._modulePlacement(module, chunkGraph).loaded !== null &&
-					this._resolvePublicPathPrefix(publicPath, module) !== null;
-				for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
-					forEachRuntime(moduleRuntime, (key) => {
-						const group = this._wasmGroupOf(
-							groups,
-							/** @type {string} */ (key)
-						);
-						known.set(group, known.get(group) !== false && spellable);
-					});
-				}
-			}
-			// A group one entry reads with `readFile` cannot take a prefix meant for the
-			// document, and only an entry names its loader.
-			for (const [group, only] of this._wasmGroupOnlyFetches()) {
-				if (!only) known.set(group, false);
-			}
-			this._wasmAnchorKnownByGroup = known;
-		}
-		const known = this._wasmAnchorKnownByGroup;
-		// No runtime to place it in leaves every group answering, so one that cannot be
-		// spelled speaks for all of them.
-		if (runtime === undefined) {
-			for (const value of known.values()) if (!value) return false;
-			return known.size > 0;
-		}
-		const groups = this._wasmRuntimeGroups();
-		if (typeof runtime === "string") {
-			return known.get(this._wasmGroupOf(groups, runtime)) === true;
-		}
-		for (const key of runtime) {
-			if (known.get(this._wasmGroupOf(groups, key)) !== true) return false;
-		}
-		return true;
-	}
-
-	/**
-	 * The runtime groups an entry of which asked for the `fetch` loader, or `undefined`
-	 * where none did — the cheap answer for a compilation with no fetching entry at all,
-	 * which is every non-web target. Only an entry names a loader; every other chunk of
-	 * the runtime is served by the one its entry asked for.
-	 * @returns {Set<string> | undefined} the groups that fetch
-	 */
-	_wasmFetchingGroups() {
-		if (this._wasmFetchingGroupSet === undefined) {
-			/** @type {Set<string>} */
-			const fetching = new Set();
-			/** @type {Map<string, string> | undefined} */
-			let groups;
-			for (const chunk of this.compilation.chunks) {
-				// Only an entry names a loader; every other chunk of the runtime is served
-				// by the one its entry asked for, so it says nothing on its own.
-				if (!chunk.getEntryOptions()) continue;
-				if (this._chunkWasmLoading(chunk) !== "fetch") continue;
-				// Built only once something fetches, so nothing pays for the grouping.
-				if (groups === undefined) groups = this._wasmRuntimeGroups();
-				const named = /** @type {Map<string, string>} */ (groups);
-				forEachRuntime(chunk.runtime, (key) => {
-					fetching.add(this._wasmGroupOf(named, /** @type {string} */ (key)));
-				});
-			}
-			this._wasmFetchingGroupSet = fetching.size === 0 ? false : fetching;
-		}
-		return this._wasmFetchingGroupSet === false
-			? undefined
-			: this._wasmFetchingGroupSet;
-	}
-
-	/**
-	 * Runtime keys mapped to the group they answer with, named by one key of it. Code
-	 * generation runs once for runtimes a module hashes alike in, and nothing in a
-	 * binary's hash knows which loader will read it — so a binary two runtimes reach
-	 * carries one shape into both, and a third runtime sharing another binary with
-	 * either is pulled in after them. A key in no group answers as itself. Asked of the
+	 * Runtime keys grouped by the binaries they share, with what the entries of each
+	 * group asked for. Code generation runs once for runtimes a module hashes alike in,
+	 * and nothing in a binary's hash knows which loader will read it — so a binary two
+	 * runtimes reach carries one shape into both, and a third runtime sharing another
+	 * binary with either is pulled in after them. Only an entry names a loader; every
+	 * other chunk of the runtime is served by the one its entry asked for. Asked of the
 	 * same modules the loaders are created for, and only once per compilation.
-	 * @returns {Map<string, string>} runtime key to the group it answers with
+	 * @returns {WasmGroups} the grouping, and which groups fetch
 	 */
-	_wasmRuntimeGroups() {
-		if (this._wasmRuntimeGroupsByKey === undefined) {
-			const { chunkGraph } = this.compilation;
+	_wasmGroups() {
+		if (this._wasmGroupsValue === undefined) {
+			const { chunkGraph, chunks, modules } = this.compilation;
 			/** @type {Map<string, string>} */
 			const parent = new Map();
 			/**
@@ -1296,24 +1164,15 @@ class RuntimeTemplate {
 			};
 			/** @type {string[]} */
 			const keys = [];
-			/**
-			 * @param {RuntimeSpec} runtime a runtime the module is generated for
-			 * @returns {void}
-			 */
-			const collectKeys = (runtime) => {
-				forEachRuntime(runtime, (key) => {
-					keys.push(/** @type {string} */ (key));
-				});
-			};
-			for (const module of this.compilation.modules) {
+			for (const module of modules) {
 				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
 				keys.length = 0;
 				for (const runtime of chunkGraph.getModuleRuntimes(module)) {
-					collectKeys(runtime);
+					forEachRuntime(runtime, (key) => {
+						keys.push(/** @type {string} */ (key));
+					});
 				}
-				for (const key of keys) {
-					if (!parent.has(key)) parent.set(key, key);
-				}
+				for (const key of keys) if (!parent.has(key)) parent.set(key, key);
 				// Every runtime this binary reaches answers with the first one.
 				for (let i = 1; i < keys.length; i++) {
 					parent.set(find(keys[i]), find(keys[0]));
@@ -1321,20 +1180,112 @@ class RuntimeTemplate {
 			}
 			// Flattened once, so a lookup is a single `get` rather than a chain walk.
 			for (const key of parent.keys()) parent.set(key, find(key));
-			this._wasmRuntimeGroupsByKey = parent;
+			/**
+			 * @param {string} key a runtime key
+			 * @returns {string} the group it answers with, or itself when it shares nothing
+			 */
+			const groupOf = (key) => {
+				const group = parent.get(key);
+				// An entry named "" makes "" a runtime key, so test absence, not a falsy value.
+				return group === undefined ? key : group;
+			};
+			/** @type {Set<string>} */
+			const fetching = new Set();
+			/** @type {Map<string, boolean>} */
+			const onlyFetching = new Map();
+			for (const chunk of chunks) {
+				if (!chunk.getEntryOptions()) continue;
+				const fetches = this._chunkWasmLoading(chunk) === "fetch";
+				forEachRuntime(chunk.runtime, (key) => {
+					const group = groupOf(/** @type {string} */ (key));
+					if (fetches) fetching.add(group);
+					onlyFetching.set(group, onlyFetching.get(group) !== false && fetches);
+				});
+			}
+			this._wasmGroupsValue = { groupOf, fetching, onlyFetching };
 		}
-		return this._wasmRuntimeGroupsByKey;
+		return this._wasmGroupsValue;
 	}
 
 	/**
-	 * @param {Map<string, string>} groups runtime key to the group it answers with
-	 * @param {string} key a runtime key
-	 * @returns {string} the group it answers with, or itself when it shares nothing
+	 * @param {RuntimeSpec} runtime the runtime being asked about
+	 * @returns {string[]} the wasm runtime groups it reaches
 	 */
-	_wasmGroupOf(groups, key) {
-		const group = groups.get(key);
-		// An entry named "" makes "" a runtime key, so test absence, not a falsy value.
-		return group === undefined ? key : group;
+	_wasmGroupsOf(runtime) {
+		const { groupOf } = this._wasmGroups();
+		/** @type {string[]} */
+		const reached = [];
+		forEachRuntime(runtime, (key) => {
+			reached.push(groupOf(/** @type {string} */ (key)));
+		});
+		return reached;
+	}
+
+	/**
+	 * Whether a chunk loads WebAssembly through `fetch`, which is the only loader the
+	 * public path reaches: `readFile` resolves the binary's name against the chunk it is
+	 * read from, exactly as a baked literal does, so a public path is irrelevant to it.
+	 * Answered per group rather than per chunk on purpose — a module's generated source
+	 * and the runtime module of every chunk holding it have to agree on the shape, and
+	 * they ask from opposite ends; one loader serves a whole group, so that is the finest
+	 * scope on which they can. Without a runtime the answer covers the compilation.
+	 * @param {RuntimeSpec=} runtime the runtime being asked about
+	 * @returns {boolean} true when a chunk of that runtime fetches its binaries
+	 */
+	_anyWasmChunkFetches(runtime) {
+		const { fetching } = this._wasmGroups();
+		if (fetching.size === 0) return false;
+		// Without a runtime to place it in there is nothing to narrow by, so any chunk
+		// answers for all of them.
+		if (runtime === undefined) return true;
+		return this._wasmGroupsOf(runtime).some((group) => fetching.has(group));
+	}
+
+	/**
+	 * Whether a public path needing a base can be spelled from the chunk every binary of
+	 * a runtime sits in — `fetch` reads it against the document, so a literal climbs back
+	 * there first. Per group, as `_anyWasmChunkFetches` is, since the two ends must agree.
+	 * @param {RuntimeSpec=} runtime the runtime being asked about
+	 * @returns {boolean} true when every binary of that group can be spelled
+	 */
+	_wasmFetchAnchorIsKnown(runtime) {
+		if (this._wasmAnchorKnownByGroup === undefined) {
+			const { chunkGraph, modules } = this.compilation;
+			const publicPath = /** @type {PublicPath} */ (
+				this.outputOptions.publicPath
+			);
+			const { groupOf, onlyFetching } = this._wasmGroups();
+			/** @type {Map<string, boolean>} */
+			const known = new Map();
+			for (const module of modules) {
+				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
+				const spellable =
+					this._modulePlacement(module, chunkGraph).loaded !== null &&
+					this._resolvePublicPathPrefix(publicPath, module) !== null;
+				for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
+					forEachRuntime(moduleRuntime, (key) => {
+						const group = groupOf(/** @type {string} */ (key));
+						known.set(group, known.get(group) !== false && spellable);
+					});
+				}
+			}
+			// A group one entry reads with `readFile` cannot take a prefix meant for the
+			// document, and only an entry names its loader.
+			for (const [group, only] of onlyFetching) {
+				if (!only) known.set(group, false);
+			}
+			this._wasmAnchorKnownByGroup = known;
+		}
+		const known = this._wasmAnchorKnownByGroup;
+		// No runtime to place it in leaves every group answering, so one that cannot be
+		// spelled speaks for all of them.
+		if (runtime === undefined) {
+			for (const value of known.values()) if (!value) return false;
+			return known.size > 0;
+		}
+		return this._wasmGroupsOf(runtime).every(
+			(group) => known.get(group) === true
+		);
 	}
 
 	supportTemplateLiteral() {
@@ -2721,11 +2672,11 @@ class RuntimeTemplate {
 		// loader when there is javascript to load. A module federation remote is the
 		// case that matters: its chunk is emitted by the container's build, not this one.
 		if (!JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)) {
-			this._analyzableBailout(
+			return this._analyzableBailout(
 				originModule,
-				"this compilation emits no javascript for the chunk, so there is nothing to import"
+				"this compilation emits no javascript for the chunk, so there is nothing to import",
+				null
 			);
-			return null;
 		}
 		let hasNonJsTypes = false;
 		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
@@ -3358,12 +3309,10 @@ class RuntimeTemplate {
 		const chunks =
 			consumingChunks ||
 			this._moduleChunks(/** @type {Module} */ (consumingModule), chunkGraph);
+		const namesFirst = this._namesBeforeAll(chunk, chunks);
 		// Baking makes the consuming chunk's content depend on this one's hash. A pair that
 		// reaches back has no fixed point if both bake, so only the lower id's name does.
-		const cycles =
-			deferred &&
-			this._reachesAny(chunk, chunks) &&
-			!this._namesBeforeAll(chunk, chunks);
+		const cycles = deferred && !namesFirst && this._reachesAny(chunk, chunks);
 		// An id names the chunk in the stand-in. No reference reaches here without one —
 		// `blockPromise` drops an id-less chunk before asking, and one the whole build
 		// keeps has no name to be emitted under — so the guard carries no reason of its
@@ -3372,19 +3321,18 @@ class RuntimeTemplate {
 			chunk.id !== null && !cycles && this._canDeferAnalyzableName(chunks);
 		// A content-named consumer bakes anyway when this chunk settles first: the fold
 		// puts the name into its hash. Only what `_foldsWholeName` covers, though.
-		const canFold = !canReserve && this._namesBeforeAll(chunk, chunks);
+		const canFold = !canReserve && namesFirst;
 		/**
 		 * @returns {null} always, having recorded why no stand-in may be reserved
 		 */
-		const cannotReserve = () => {
+		const cannotReserve = () =>
 			this._analyzableBailout(
 				consumingModule,
 				cycles
 					? "this chunk and the one it references name each other, so neither hash could settle"
-					: DEFER_BAILOUT
+					: DEFER_BAILOUT,
+				null
 			);
-			return null;
-		};
 		if (deferred && !canReserve && !canFold) return cannotReserve();
 		const filename = deferred
 			? ""
@@ -3483,8 +3431,7 @@ class RuntimeTemplate {
 			// Each knows its own answer, so the fill asks per asset — where each has one,
 			// and where nothing else goes between the two shapes.
 			if (relativeBase !== undefined || !this._eachChunkServedOneWay(chunks)) {
-				this._analyzableBailout(module, SERVED_BAILOUT);
-				return null;
+				return this._analyzableBailout(module, SERVED_BAILOUT, null);
 			}
 			return [...head, ["unserved", ""]];
 		}
@@ -3882,21 +3829,16 @@ class RuntimeTemplate {
 	 * @returns {boolean} true when every runtime reaching it fetches
 	 */
 	_wasmModuleFetches(module, chunkGraph) {
-		/** @type {string[]} */
-		const keys = [];
+		const { onlyFetching } = this._wasmGroups();
+		let placed = false;
 		for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
-			forEachRuntime(moduleRuntime, (key) => {
-				keys.push(/** @type {string} */ (key));
-			});
+			for (const group of this._wasmGroupsOf(moduleRuntime)) {
+				placed = true;
+				if (!onlyFetching.get(group)) return false;
+			}
 		}
 		// In no runtime at all nothing named a loader, so `output` answers.
-		if (keys.length === 0) return this.outputOptions.wasmLoading === "fetch";
-		const only = this._wasmGroupOnlyFetches();
-		const groups = this._wasmRuntimeGroups();
-		for (const key of keys) {
-			if (!only.get(this._wasmGroupOf(groups, key))) return false;
-		}
-		return true;
+		return placed || this.outputOptions.wasmLoading === "fetch";
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -343,6 +343,25 @@ const createHashProbeChunk = (chunk, hash, present) => {
 };
 
 /**
+ * A filename function's answer to the stand-in hash, which says what shape the name
+ * has before any real hash exists.
+ * @param {Exclude<ChunkFilenameTemplate, string>} template the filename function
+ * @param {Chunk} chunk the chunk being referenced
+ * @param {string} contentHashType which of the chunk's hashes the name reads
+ * @param {string} hash the stand-in hash
+ * @param {boolean} present whether the chunk is claimed to carry content hashes
+ * @returns {string} what the function names it
+ */
+const probeTemplateName = (template, chunk, contentHashType, hash, present) =>
+	template({
+		chunk: createHashProbeChunk(chunk, hash, present),
+		runtime: chunk.runtime,
+		contentHashType,
+		hash,
+		contentHash: hash
+	});
+
+/**
  * No module id error message.
  * @param {Module} module the module
  * @param {ChunkGraph} chunkGraph the chunk graph
@@ -3158,13 +3177,13 @@ class RuntimeTemplate {
 			return template.replace(HASH_IN_FILENAME_GLOBAL, "x");
 		}
 		try {
-			return template({
-				chunk: createHashProbeChunk(chunk, HASH_PROBE, true),
-				runtime: chunk.runtime,
-				contentHashType: JAVASCRIPT_TYPE,
-				hash: HASH_PROBE,
-				contentHash: HASH_PROBE
-			}).replace(HASH_IN_FILENAME_GLOBAL, "x");
+			return probeTemplateName(
+				template,
+				chunk,
+				JAVASCRIPT_TYPE,
+				HASH_PROBE,
+				true
+			).replace(HASH_IN_FILENAME_GLOBAL, "x");
 		} catch (_error) {
 			// Nothing to report: the naming call is given strictly less than this probe, so
 			// one that throws here fails the build where the name is actually needed.
@@ -3254,6 +3273,41 @@ class RuntimeTemplate {
 		return undo === first.undo && loaded === first.loaded
 			? first
 			: { undo, loaded };
+	}
+
+	/**
+	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`
+	 * a worker or worklet entry chunk bakes to, or `null` to keep the runtime form. The
+	 * gate and the build are asked together so every call site agrees on both — the
+	 * `new Worker(...)` emit, and the resource hint `ResourceHintPlugin` spells for it.
+	 * @param {string | undefined} overridePublicPath a `publicPath` set on the worker itself
+	 * @param {Chunk} chunk the worker's entry chunk
+	 * @param {Module} module the module the reference is emitted into
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {RuntimeRequirements} runtimeRequirements what the consuming chunk needs
+	 * @returns {string | null} a quoted literal, or `null` to fall back
+	 */
+	getAnalyzableWorkerUrl(
+		overridePublicPath,
+		chunk,
+		module,
+		chunkGraph,
+		runtimeRequirements
+	) {
+		// Without an id nothing can name the chunk in a stand-in.
+		if (
+			chunk.id === null ||
+			!this.supportsAnalyzable("url", chunkGraph, module)
+		) {
+			return null;
+		}
+		return this._getAnalyzableChunkSpecifier(
+			overridePublicPath,
+			chunk,
+			module,
+			chunkGraph,
+			runtimeRequirements
+		);
 	}
 
 	/**
@@ -3779,20 +3833,20 @@ class RuntimeTemplate {
 		try {
 			// Everything the naming call is given except the hashes, so only a hash can
 			// make the two answers differ.
-			const template = filenameTemplate({
-				chunk: createHashProbeChunk(chunk, HASH_PROBE, true),
-				runtime: chunk.runtime,
+			const template = probeTemplateName(
+				filenameTemplate,
+				chunk,
 				contentHashType,
-				hash: HASH_PROBE,
-				contentHash: HASH_PROBE
-			});
-			const probe = filenameTemplate({
-				chunk: createHashProbeChunk(chunk, HASH_PROBE_ALTERNATE, false),
-				runtime: chunk.runtime,
+				HASH_PROBE,
+				true
+			);
+			const probe = probeTemplateName(
+				filenameTemplate,
+				chunk,
 				contentHashType,
-				hash: HASH_PROBE_ALTERNATE,
-				contentHash: HASH_PROBE_ALTERNATE
-			});
+				HASH_PROBE_ALTERNATE,
+				false
+			);
 			return template === probe ? template : undefined;
 		} catch (_error) {
 			// Nothing to report: the probe is given strictly more than the naming call,
@@ -3995,6 +4049,18 @@ class RuntimeTemplate {
 					let chunksById;
 					/** @type {Map<string, Chunk> | undefined} */
 					let chunkByAsset;
+					/** @type {string | undefined} */
+					let publicPathText;
+					// One value for the whole pass, however many stand-ins read it.
+					const resolvedPublicPath = () => {
+						if (publicPathText === undefined) {
+							publicPathText = compilation.getPath(
+								outputOptions.publicPath || "",
+								{}
+							);
+						}
+						return publicPathText;
+					};
 					/**
 					 * @param {string} name an emitted asset's name
 					 * @returns {Chunk | undefined} the chunk it was emitted for
@@ -4049,10 +4115,7 @@ class RuntimeTemplate {
 									{}
 								);
 							} else if (kind === "publicPath") {
-								specifier += compilation.getPath(
-									outputOptions.publicPath || "",
-									{}
-								);
+								specifier += resolvedPublicPath();
 							} else if (kind === "unserved") {
 								const holder = chunkOf(assetName);
 								if (holder === undefined) return null;
@@ -4063,10 +4126,7 @@ class RuntimeTemplate {
 									compilation.runtimeTemplate._chunkPlacement(holder).loaded ===
 									false
 								) {
-									const path = compilation.getPath(
-										outputOptions.publicPath || "",
-										{}
-									);
+									const path = resolvedPublicPath();
 									// The `../` already reached the root this is read from.
 									specifier += path.startsWith("./") ? path.slice(2) : path;
 								}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -179,6 +179,13 @@ const DEFER_BAILOUT =
  */
 
 /**
+ * @typedef {object} AnalyzableChunkUrls
+ * @property {Map<ChunkId, string>} urls the urls that could be written, by chunk id
+ * @property {boolean} complete false when some chunk kept the runtime form, whose
+ * ids the consumer then still resolves through the runtime name lookup
+ */
+
+/**
  * @typedef {object} WasmGroups
  * @property {(key: string) => string} groupOf the group a runtime key answers with
  * @property {Set<string>} fetching groups an entry of which reads binaries with `fetch`
@@ -699,18 +706,12 @@ class RuntimeTemplate {
 		}
 
 		// `url-inline` asks whether the file can be named at the call site at all, and
-		// its `.p + <file>` fallback spells that without `import.meta` — so neither gate
-		// below rules it out, and the asset's javascript wrapper stays dropped.
+		// its `.p + <file>` fallback spells that without `import.meta` — so the gate
+		// below does not rule it out, and the asset's javascript wrapper stays dropped.
+		// `environment.module` is deliberately not consulted: ESM output writes
+		// `import.meta` regardless (the public path, the chunk loader), so the url forms
+		// only match what the rest of the bundle already assumes the target reads.
 		if (form === "url-inline") return true;
-		// `import.meta` is ESM syntax the target has to read. A chunk `import()` is
-		// emitted by the module chunk loader either way, so only the url forms check.
-		if (!this.supportsEcmaScriptModuleSyntax()) {
-			return this._analyzableBailout(
-				module,
-				"output.environment.module is false, so the target does not read the import.meta this form needs",
-				false
-			);
-		}
 		// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a
 		// syntax error. Runtime modules are emitted beside them, never wrapped.
 		const { devtool } = this.compilation.options;
@@ -3638,8 +3639,8 @@ class RuntimeTemplate {
 
 	/**
 	 * Static `new URL(<file>, import.meta.url)` for every stylesheet a runtime can load,
-	 * keyed by chunk id, or `null` when any of them has to keep the runtime
-	 * `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
+	 * keyed by chunk id — one that cannot be named leaves the map incomplete, and its
+	 * id keeps the runtime `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
 	 * and the plugin declaring what it needs ask this, so the two always agree. The
 	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
 	 * resolves the element against the document, which is not where the chunk sits, and
@@ -3649,7 +3650,7 @@ class RuntimeTemplate {
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what that chunk needs
 	 * @param {Module=} consumingModule the runtime module, where one exists to report against
-	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 * @returns {AnalyzableChunkUrls | null} the urls, or `null` to keep the runtime form
 	 */
 	analyzableCssChunkUrls(
 		runtimeChunk,
@@ -3681,14 +3682,14 @@ class RuntimeTemplate {
 	/**
 	 * Static `new URL(<file>, import.meta.url).href` for every javascript chunk a
 	 * runtime can hint at with `<link rel="prefetch"/"modulepreload">`, keyed by chunk
-	 * id, or `null` when any of them has to keep the runtime
-	 * `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
+	 * id — one that cannot be named leaves the map incomplete, and its id keeps the
+	 * runtime `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
 	 * them and the plugin declaring what it needs ask this, so the two always agree.
 	 * @param {Chunk} runtimeChunk the chunk holding the hint handlers
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what that chunk needs
 	 * @param {Module=} consumingModule the runtime module, where one exists to report against
-	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 * @returns {AnalyzableChunkUrls | null} the urls, or `null` to keep the runtime form
 	 */
 	analyzableChunkScriptUrls(
 		runtimeChunk,
@@ -3727,14 +3728,15 @@ class RuntimeTemplate {
 
 	/**
 	 * The urls of one asset of each of `chunks`, written out so they can be read by
-	 * chunk id, or `null` as soon as one of them cannot be named here.
+	 * chunk id. A chunk that cannot be named here leaves the map incomplete rather
+	 * than losing it — the consumer keeps the runtime form for the ids the map lacks.
 	 * @param {Iterable<Chunk>} chunks the chunks whose asset is wanted
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {Module | undefined} consumingModule the runtime module, where one exists to report against
 	 * @param {Chunk[]} consumingChunks the chunks the urls are written into
 	 * @param {string} sourceType which asset of each chunk to name
 	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what the runtime chunk needs
-	 * @returns {Map<ChunkId, string> | null} the urls, or `null` to keep the runtime form
+	 * @returns {AnalyzableChunkUrls | null} the urls, or `null` to keep the runtime form
 	 */
 	_analyzableChunkUrls(
 		chunks,
@@ -3754,6 +3756,7 @@ class RuntimeTemplate {
 		}
 		/** @type {Map<ChunkId, string>} */
 		const urls = new Map();
+		let complete = true;
 		for (const chunk of chunks) {
 			if (chunk.id === null) continue;
 			const specifier = this._getAnalyzableChunkSpecifier(
@@ -3765,10 +3768,14 @@ class RuntimeTemplate {
 				consumingChunks,
 				sourceType
 			);
-			if (specifier === null) return null;
+			// `_getAnalyzableChunkSpecifier` has already recorded why.
+			if (specifier === null) {
+				complete = false;
+				continue;
+			}
 			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);
 		}
-		return urls.size > 0 ? urls : null;
+		return urls.size > 0 ? { urls, complete } : null;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -1261,17 +1261,21 @@ class RuntimeTemplate {
 	_wasmFetchAnchorIsKnown(runtime) {
 		if (this._wasmAnchorKnownByGroup === undefined) {
 			const { chunkGraph, modules } = this.compilation;
-			const publicPath = /** @type {PublicPath} */ (
-				this.outputOptions.publicPath
-			);
 			const { groupOf, onlyFetching } = this._wasmGroups();
 			/** @type {Map<string, boolean>} */
 			const known = new Map();
 			for (const module of modules) {
 				if (module.type !== WEBASSEMBLY_MODULE_TYPE_ASYNC) continue;
+				// Probed through the very builder the generator runs, so the gate is
+				// exact: a prefix it can spell — the per-asset deferrals included — is
+				// one the group may bake. The probe name stands in for the binary's.
 				const spellable =
-					this._modulePlacement(module, chunkGraph).loaded !== null &&
-					this._resolvePublicPathPrefix(publicPath, module) !== null;
+					this._getAnalyzableFileSpecifier(
+						module,
+						/** @type {ChunkGraph} */ (chunkGraph),
+						[["literal", "x"]],
+						true
+					) !== null;
 				for (const moduleRuntime of chunkGraph.getModuleRuntimes(module)) {
 					forEachRuntime(moduleRuntime, (key) => {
 						const group = groupOf(/** @type {string} */ (key));
@@ -3359,17 +3363,17 @@ class RuntimeTemplate {
 			consumingChunks ||
 			this._moduleChunks(/** @type {Module} */ (consumingModule), chunkGraph);
 		const namesFirst = this._namesBeforeAll(chunk, chunks);
-		// Baking makes the consuming chunk's content depend on this one's hash. A pair that
-		// reaches back has no fixed point if both bake, so only the lower id's name does.
-		const cycles = deferred && !namesFirst && this._reachesAny(chunk, chunks);
 		// An id names the chunk in the stand-in. No reference reaches here without one —
 		// `blockPromise` drops an id-less chunk before asking, and one the whole build
 		// keeps has no name to be emitted under — so the guard carries no reason of its
-		// own; it only keeps `null` out of a name.
+		// own; it only keeps `null` out of a name. A pair naming each other is fine here:
+		// `RealContentHashPlugin`, which deferring requires, re-hashes the pair as one
+		// group, so neither hash chases the other.
 		const canReserve =
-			chunk.id !== null && !cycles && this._canDeferAnalyzableName(chunks);
+			chunk.id !== null && this._canDeferAnalyzableName(chunks);
 		// A content-named consumer bakes anyway when this chunk settles first: the fold
-		// puts the name into its hash. Only what `_foldsWholeName` covers, though.
+		// puts the name into its hash. Only what `_foldsWholeName` covers, though — and
+		// a pair that reaches back has no fold order, so only the one hashing first does.
 		const canFold = !canReserve && namesFirst;
 		/**
 		 * @returns {null} always, having recorded why no stand-in may be reserved
@@ -3377,8 +3381,8 @@ class RuntimeTemplate {
 		const cannotReserve = () =>
 			this._analyzableBailout(
 				consumingModule,
-				cycles
-					? "this chunk and the one it references name each other, so neither hash could settle"
+				!namesFirst && this._reachesAny(chunk, chunks)
+					? "this chunk and the one it references name each other, which only optimization.realContentHash could settle"
 					: DEFER_BAILOUT,
 				null
 			);

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -176,22 +176,32 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				",\n"
 			)
 		)}\n}`;
+		/**
+		 * @param {string} id expression naming the chunk whose stylesheet is wanted
+		 * @returns {string} expression building its url at runtime
+		 */
+		const runtimeCssUrl = (id) =>
+			`${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(${id})`;
 		// The url is read through a thunk so a runtime carrying many stylesheets builds
 		// only the one it loads.
 		/**
 		 * @param {string} id expression naming the chunk whose stylesheet is wanted
 		 * @returns {string} expression evaluating to its url
 		 */
-		const cssUrl = (id) =>
-			cssUrls === undefined || cssUrls === null
-				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(${id})`
-				: `cssUrls[${id}]()`;
+		const cssUrl = (id) => {
+			if (!cssUrls) return runtimeCssUrl(id);
+			// An id the incomplete map lacks still resolves through the runtime lookup,
+			// which the plugin kept required for exactly this case.
+			return cssUrls.complete
+				? `cssUrls[${id}]()`
+				: `(cssUrls[${id}] ? cssUrls[${id}]() : ${runtimeCssUrl(id)})`;
+		};
 		return Template.asString([
 			...(cssUrls
 				? [
 						`${cst} cssUrls = {\n${Template.indent(
 							Array.from(
-								cssUrls,
+								cssUrls.urls,
 								([id, url]) =>
 									`${JSON.stringify(String(id))}: ${runtimeTemplate.returningFunction(url)}`
 							).join(",\n")

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -779,13 +779,12 @@ class CssModulesPlugin {
 						// A baked url carries where the stylesheet is, so neither the public
 						// path nor the name lookup is read for it. Asked exactly as the
 						// loading runtime module asks, so the two always agree.
-						if (
-							compilation.runtimeTemplate.analyzableCssChunkUrls(
-								chunk,
-								chunkGraph,
-								set
-							) === null
-						) {
+						const baked = compilation.runtimeTemplate.analyzableCssChunkUrls(
+							chunk,
+							chunkGraph,
+							set
+						);
+						if (baked === null || !baked.complete) {
 							set.add(RuntimeGlobals.publicPath);
 							set.add(RuntimeGlobals.getChunkCssFilename);
 						}

--- a/lib/dependencies/WorkerDependency.js
+++ b/lib/dependencies/WorkerDependency.js
@@ -136,19 +136,13 @@ WorkerDependency.Template = class WorkerDependencyTemplate extends (
 		// and webpack itself can statically follow the worker. A resource hint doesn't
 		// block it: the `<link>` is emitted at chunk startup instead of wrapping the href,
 		// which would turn the specifier into a non-analyzable expression.
-		const analyzableSpecifier = runtimeTemplate.supportsAnalyzable(
-			"url",
+		const analyzableSpecifier = runtimeTemplate.getAnalyzableWorkerUrl(
+			dep.options.publicPath,
+			chunk,
+			templateContext.module,
 			chunkGraph,
-			templateContext.module
-		)
-			? runtimeTemplate._getAnalyzableChunkSpecifier(
-					dep.options.publicPath,
-					chunk,
-					templateContext.module,
-					chunkGraph,
-					runtimeRequirements
-				)
-			: null;
+			runtimeRequirements
+		);
 
 		if (analyzableSpecifier !== null) {
 			// No `<link>` helper is asked for here: this form emits no call, and

--- a/lib/dependencies/WorkletDependency.js
+++ b/lib/dependencies/WorkletDependency.js
@@ -140,17 +140,13 @@ WorkletDependency.Template = class WorkletDependencyTemplate extends (
 		// import.meta.url)` form (literal specifier, no runtime helpers) so other bundlers
 		// and webpack itself can statically follow the worklet. The worklet chunk links its
 		// splits via native `import`, so only the entry chunk is referenced.
-		const analyzableSpecifier =
-			runtimeTemplate.supportsAnalyzable("url", chunkGraph, module) &&
-			entryChunk.id !== null
-				? runtimeTemplate._getAnalyzableChunkSpecifier(
-						dep.options.publicPath,
-						entryChunk,
-						module,
-						chunkGraph,
-						runtimeRequirements
-					)
-				: null;
+		const analyzableSpecifier = runtimeTemplate.getAnalyzableWorkerUrl(
+			dep.options.publicPath,
+			entryChunk,
+			module,
+			chunkGraph,
+			runtimeRequirements
+		);
 		if (analyzableSpecifier !== null) {
 			source.replace(
 				dep.callRange[0],

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -120,15 +120,12 @@ class ModuleChunkLoadingPlugin {
 						if (!isEnabledForChunk(chunk)) return;
 						// A baked url carries where the chunk is, so neither is read for it.
 						// Asked as the runtime module asks, so the two always agree.
-						if (
-							compilation.runtimeTemplate.analyzableChunkScriptUrls(
-								chunk,
-								chunkGraph,
-								set
-							) !== null
-						) {
-							return;
-						}
+						const baked = compilation.runtimeTemplate.analyzableChunkScriptUrls(
+							chunk,
+							chunkGraph,
+							set
+						);
+						if (baked !== null && baked.complete) return;
 						set.add(RuntimeGlobals.publicPath);
 						set.add(RuntimeGlobals.getChunkScriptFilename);
 					});

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -129,7 +129,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 			chunk.hasChildByOrder(chunkGraph, "preload", true, chunkHasJs);
 		// Under module output each hinted chunk is a known file, so the urls are written
 		// out and read by id rather than built from the chunk id at runtime.
-		const chunkUrls =
+		const bakedChunkUrls =
 			withPrefetch || withPreload
 				? runtimeTemplate.analyzableChunkScriptUrls(
 						chunk,
@@ -137,6 +137,12 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 						this._runtimeRequirements,
 						this
 					)
+				: null;
+		// A hint is best-effort, so an id an incomplete map lacks is not worth a per-id
+		// fallback — only a complete map replaces the runtime name lookup.
+		const chunkUrls =
+			bakedChunkUrls !== null && bakedChunkUrls.complete
+				? bakedChunkUrls.urls
 				: null;
 		const conditionMap = chunkGraph.getChunkConditionMap(chunk, chunkHasJs);
 		const hasJsMatcher = compileBooleanMatcher(conditionMap);

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -62,27 +62,20 @@ class ReadFileCompileAsyncWasmPlugin {
 			// settled while the plugin is being applied.
 			/**
 			 * @param {string} path rendered path to the wasm file
-			 * @param {RuntimeSpec} runtime the runtime this loader serves
+			 * @param {boolean} analyzable whether the call site bakes a complete URL
 			 * @returns {string} the argument to hand the reader
 			 */
-			const wasmUrlArg = (path, runtime) =>
-				compilation.runtimeTemplate.supportsAnalyzable(
-					"wasm",
-					undefined,
-					undefined,
-					runtime
-				)
-					? path
-					: compilation.runtimeTemplate.importMetaUrl(path);
+			const wasmUrlArg = (path, analyzable) =>
+				analyzable ? path : compilation.runtimeTemplate.importMetaUrl(path);
 			/**
-			 * @type {(path: string, runtime: RuntimeSpec) => string} callback to generate code to load the wasm file
+			 * @type {(path: string, runtime: RuntimeSpec, analyzable: boolean) => string} callback to generate code to load the wasm file
 			 */
 			const generateLoadBinaryCode = this._import
-				? (path, runtime) =>
+				? (path, runtime, analyzable) =>
 						Template.asString([
 							"Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 							Template.indent([
-								`readFile(${wasmUrlArg(path, runtime)}, (err, buffer) => {`,
+								`readFile(${wasmUrlArg(path, analyzable)}, (err, buffer) => {`,
 								Template.indent([
 									"if (err) return reject(err);",
 									"",
@@ -154,7 +147,7 @@ class ReadFileCompileAsyncWasmPlugin {
 					if (
 						!compilation.runtimeTemplate.supportsAnalyzable(
 							"wasm",
-							undefined,
+							chunkGraph,
 							undefined,
 							chunk.runtime
 						) &&
@@ -196,7 +189,7 @@ class ReadFileCompileAsyncWasmPlugin {
 					if (
 						!compilation.runtimeTemplate.supportsAnalyzable(
 							"wasm",
-							undefined,
+							chunkGraph,
 							undefined,
 							chunk.runtime
 						) &&

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -345,47 +345,69 @@ ${referencingAssets
 						}
 						return hashes;
 					};
+					// Tarjan, so hashes naming each other — two chunk names baked into each
+					// other's content — come out as one group where a chain walk would never
+					// terminate. Groups arrive dependencies-first, which the assignment needs.
+					/** @type {string[][]} */
+					const groupsInOrder = [];
+					/** @type {Map<string, number>} */
+					const indexOf = new Map();
+					/** @type {Map<string, number>} */
+					const lowOf = new Map();
+					/** @type {Set<string>} */
+					const onStack = new Set();
+					/** @type {string[]} */
+					const stack = [];
 					/**
-					 * Returns the hash info.
+					 * Visits one hash and everything its assets reference.
 					 * @param {string} hash the hash
-					 * @returns {string} the hash info
+					 * @returns {void}
 					 */
-					const hashInfo = (hash) => {
-						const assets = hashToAssets.get(hash);
-						return `${hash} (${Array.from(
-							/** @type {AssetInfoForRealContentHash[]} */ (assets),
-							(a) => a.name
-						)})`;
-					};
-					/** @type {Hashes} */
-					const hashesInOrder = new Set();
-					for (const hash of hashToAssets.keys()) {
-						/**
-						 * Processes the provided hash.
-						 * @param {string} hash the hash
-						 * @param {Set<string>} stack stack of hashes
-						 */
-						const add = (hash, stack) => {
-							const deps = getDependencies(hash);
-							if (!deps) return;
-							stack.add(hash);
+					const strongConnect = (hash) => {
+						const index = indexOf.size;
+						indexOf.set(hash, index);
+						lowOf.set(hash, index);
+						stack.push(hash);
+						onStack.add(hash);
+						// An unowned reference reports the caching problem and stays a leaf.
+						const deps = getDependencies(hash);
+						if (deps) {
 							for (const dep of deps) {
-								if (hashesInOrder.has(dep)) continue;
-								if (stack.has(dep)) {
-									throw new Error(
-										`Circular hash dependency ${Array.from(
-											stack,
-											hashInfo
-										).join(" -> ")} -> ${hashInfo(dep)}`
+								if (!indexOf.has(dep)) {
+									strongConnect(dep);
+									lowOf.set(
+										hash,
+										Math.min(
+											/** @type {number} */ (lowOf.get(hash)),
+											/** @type {number} */ (lowOf.get(dep))
+										)
+									);
+								} else if (onStack.has(dep)) {
+									lowOf.set(
+										hash,
+										Math.min(
+											/** @type {number} */ (lowOf.get(hash)),
+											/** @type {number} */ (indexOf.get(dep))
+										)
 									);
 								}
-								add(dep, stack);
 							}
-							hashesInOrder.add(hash);
-							stack.delete(hash);
-						};
-						if (hashesInOrder.has(hash)) continue;
-						add(hash, new Set());
+						}
+						if (lowOf.get(hash) === indexOf.get(hash)) {
+							/** @type {string[]} */
+							const group = [];
+							/** @type {string} */
+							let member;
+							do {
+								member = /** @type {string} */ (stack.pop());
+								onStack.delete(member);
+								if (hashToAssets.has(member)) group.push(member);
+							} while (member !== hash);
+							if (group.length > 0) groupsInOrder.push(group);
+						}
+					};
+					for (const hash of hashToAssets.keys()) {
+						if (!indexOf.has(hash)) strongConnect(hash);
 					}
 					/** @type {Map<string, string>} */
 					const hashToNewHash = new Map();
@@ -474,7 +496,63 @@ ${referencingAssets
 					};
 					/** @type {Comparator<AssetInfoForRealContentHash>} */
 					const comparator = compareSelect((a) => a.name, compareStrings);
-					for (const oldHash of hashesInOrder) {
+					for (const group of groupsInOrder) {
+						// A cycle — names baked into each other — is assigned as one group:
+						// every member's occurrences are told apart by a stable marker, so the
+						// group hashes to a fixed point instead of chasing one around it.
+						if (group.length > 1) {
+							const members = group.sort();
+							/** @type {Map<string, string>} */
+							const markerOf = new Map(
+								members.map((hash, i) => [hash, `|webpack/scc/${i}|`])
+							);
+							for (let i = 0; i < members.length; i++) {
+								const oldHash = members[i];
+								const memberAssets =
+									/** @type {AssetInfoForRealContentHash[]} */
+									(hashToAssets.get(oldHash));
+								memberAssets.sort(comparator);
+								const hash = createHash(this._hashFunction);
+								if (compilation.outputOptions.hashSalt) {
+									hash.update(compilation.outputOptions.hashSalt);
+								}
+								// Two members can normalize to the same text; the position keeps
+								// their hashes apart, and sorting keeps the position stable.
+								hash.update(`${i}`);
+								for (const asset of memberAssets) {
+									if (Buffer.isBuffer(asset.content)) {
+										hash.update(asset.content);
+										continue;
+									}
+									const withoutOwn =
+										/** @type {Hashes} */
+										(asset.ownHashes).has(oldHash);
+									hash.update(
+										asset.content.replace(hashRegExp, (matched) => {
+											// Its own occurrences vanish, exactly as a lone hash's do.
+											if (
+												withoutOwn &&
+												/** @type {Hashes} */ (asset.ownHashes).has(matched)
+											) {
+												return "";
+											}
+											const marker = markerOf.get(matched);
+											if (marker !== undefined) return marker;
+											const mapped = hashToNewHash.get(matched);
+											return mapped === undefined ? matched : mapped;
+										})
+									);
+								}
+								const digest = hash.digest(
+									/** @type {HashDigest} */ (
+										hashToDigest.get(oldHash) || this._hashDigest
+									)
+								);
+								hashToNewHash.set(oldHash, digest.slice(0, oldHash.length));
+							}
+							continue;
+						}
+						const oldHash = group[0];
 						const assets =
 							/** @type {AssetInfoForRealContentHash[]} */
 							(hashToAssets.get(oldHash));

--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -345,9 +345,8 @@ ${referencingAssets
 						}
 						return hashes;
 					};
-					// Tarjan, so hashes naming each other — two chunk names baked into each
-					// other's content — come out as one group where a chain walk would never
-					// terminate. Groups arrive dependencies-first, which the assignment needs.
+					// Tarjan: hashes naming each other come out as one group where a chain
+					// walk would never end, and groups arrive dependencies-first as needed.
 					/** @type {string[][]} */
 					const groupsInOrder = [];
 					/** @type {Map<string, number>} */
@@ -497,9 +496,8 @@ ${referencingAssets
 					/** @type {Comparator<AssetInfoForRealContentHash>} */
 					const comparator = compareSelect((a) => a.name, compareStrings);
 					for (const group of groupsInOrder) {
-						// A cycle — names baked into each other — is assigned as one group:
-						// every member's occurrences are told apart by a stable marker, so the
-						// group hashes to a fixed point instead of chasing one around it.
+						// A cycle is assigned as one group: members are told apart by stable
+						// markers, so the group hashes to a fixed point instead of chasing one.
 						if (group.length > 1) {
 							const members = group.sort();
 							/** @type {Map<string, string>} */

--- a/lib/prefetch/ResourceHintPlugin.js
+++ b/lib/prefetch/ResourceHintPlugin.js
@@ -481,19 +481,13 @@ const collectStartupAssetHintLines = (
 				seenWorkerChunks.add(workerChunk.id);
 				// The same specifier the `new Worker(...)` call site bakes, asked of the
 				// same module, so the two agree on whether a literal is spellable.
-				const specifier = runtimeTemplate.supportsAnalyzable(
-					"url",
+				const specifier = runtimeTemplate.getAnalyzableWorkerUrl(
+					dep.options.publicPath,
+					workerChunk,
+					module,
 					chunkGraph,
-					module
-				)
-					? runtimeTemplate._getAnalyzableChunkSpecifier(
-							dep.options.publicPath,
-							workerChunk,
-							module,
-							chunkGraph,
-							set
-						)
-					: null;
+					set
+				);
 				// Without one the call site keeps the runtime form, where it wraps its own
 				// href — firing the `<link>` here too would emit the call twice.
 				if (specifier === null) continue;

--- a/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmCompileRuntimeModule.js
@@ -11,11 +11,12 @@ const Template = require("../Template");
 const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @import Chunk from "../Chunk" */
+/** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compilation from "../Compilation" */
 /** @import { RuntimeSpec } from "../util/runtime" */
 
 /** @typedef {(wasmModuleSrcPath: string) => string} GenerateBeforeLoadBinaryCode */
-/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec) => string} GenerateLoadBinaryCode */
+/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec, analyzable: boolean) => string} GenerateLoadBinaryCode */
 /** @typedef {() => string} GenerateBeforeCompileStreaming */
 
 /**
@@ -69,7 +70,7 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 		// Analyzable output bakes the binary's URL into the call site instead.
 		const analyzable = runtimeTemplate.supportsAnalyzable(
 			"wasm",
-			undefined,
+			/** @type {ChunkGraph} */ (this.chunkGraph),
 			undefined,
 			chunk.runtime
 		);
@@ -92,7 +93,8 @@ class AsyncWasmCompileRuntimeModule extends RuntimeModule {
 
 		const loader = this.generateLoadBinaryCode(
 			wasmModuleSrcPath,
-			chunk.runtime
+			chunk.runtime,
+			analyzable
 		);
 
 		// Fallback path: fetch -> arrayBuffer -> WebAssembly.compile

--- a/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
+++ b/lib/wasm-async/AsyncWasmLoadingRuntimeModule.js
@@ -11,11 +11,12 @@ const Template = require("../Template");
 const { fullHashPathData } = require("../wasm/wasmModuleFilename");
 
 /** @import Chunk from "../Chunk" */
+/** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compilation from "../Compilation" */
 /** @import { RuntimeSpec } from "../util/runtime" */
 
 /** @typedef {(wasmModuleSrcPath: string) => string} GenerateBeforeLoadBinaryCode */
-/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec) => string} GenerateLoadBinaryCode */
+/** @typedef {(wasmModuleSrcPath: string, runtime: RuntimeSpec, analyzable: boolean) => string} GenerateLoadBinaryCode */
 /** @typedef {() => string} GenerateBeforeInstantiateStreaming */
 
 /**
@@ -70,7 +71,7 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 		// Analyzable output bakes the binary's URL into the call site instead.
 		const analyzable = runtimeTemplate.supportsAnalyzable(
 			"wasm",
-			undefined,
+			/** @type {ChunkGraph} */ (this.chunkGraph),
 			undefined,
 			chunk.runtime
 		);
@@ -93,7 +94,8 @@ class AsyncWasmLoadingRuntimeModule extends RuntimeModule {
 
 		const loader = this.generateLoadBinaryCode(
 			wasmModuleSrcPath,
-			chunk.runtime
+			chunk.runtime,
+			analyzable
 		);
 		const fallback = [
 			`.then(${runtimeTemplate.returningFunction("x.arrayBuffer()", "x")})`,

--- a/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
+++ b/lib/wasm-async/UniversalCompileAsyncWasmPlugin.js
@@ -67,31 +67,26 @@ class UniversalCompileAsyncWasmPlugin {
 			// per call: it depends on parse results, so it is not settled while the plugin
 			// is being applied.
 			/**
-			 * @param {RuntimeSpec} runtime the runtime this loader serves
+			 * @param {boolean} analyzable whether the call site bakes a complete URL
 			 * @returns {string} the argument to hand the reader
 			 */
-			const wasmUrlArg = (runtime) =>
-				compilation.runtimeTemplate.supportsAnalyzable(
-					"wasm",
-					undefined,
-					undefined,
-					runtime
-				)
+			const wasmUrlArg = (analyzable) =>
+				analyzable
 					? "wasmUrl"
 					: compilation.runtimeTemplate.importMetaUrl("wasmUrl");
 			/**
 			 * Generates the runtime expression that fetches the binary in browsers
 			 * or reads it from the filesystem in Node.js.
-			 * @type {(path: string, runtime: RuntimeSpec) => string}
+			 * @type {(path: string, runtime: RuntimeSpec, analyzable: boolean) => string}
 			 */
-			const generateLoadBinaryCode = (path, runtime) =>
+			const generateLoadBinaryCode = (path, runtime, analyzable) =>
 				Template.asString([
 					"(useFetch",
-					Template.indent([`? fetch(${wasmUrlArg(runtime)})`]),
+					Template.indent([`? fetch(${wasmUrlArg(analyzable)})`]),
 					Template.indent([
 						": Promise.all([import('fs'), import('url')]).then(([{ readFile }, { URL }]) => new Promise((resolve, reject) => {",
 						Template.indent([
-							`readFile(${wasmUrlArg(runtime)}, (err, buffer) => {`,
+							`readFile(${wasmUrlArg(analyzable)}, (err, buffer) => {`,
 							Template.indent([
 								"if (err) return reject(err);",
 								"",

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -91,12 +91,14 @@ class FetchCompileAsyncWasmPlugin {
 					}
 					const baked = compilation.runtimeTemplate.supportsAnalyzable(
 						"wasm",
-						undefined,
+						chunkGraph,
 						undefined,
 						chunk.runtime
 					);
-					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
+					const analyzable = compilation.runtimeTemplate.supportsAnalyzable(
+						"wasm-relative",
+						chunkGraph
+					);
 					// A baked URL carries the public path already, and a settled one is written
 					// out below; only a path nothing but the global knows asks for it.
 					const constant =
@@ -151,12 +153,14 @@ class FetchCompileAsyncWasmPlugin {
 					}
 					const baked = compilation.runtimeTemplate.supportsAnalyzable(
 						"wasm",
-						undefined,
+						chunkGraph,
 						undefined,
 						chunk.runtime
 					);
-					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
+					const analyzable = compilation.runtimeTemplate.supportsAnalyzable(
+						"wasm-relative",
+						chunkGraph
+					);
 					// A baked URL carries the public path already, and a settled one is written
 					// out below; only a path nothing but the global knows asks for it.
 					const constant =

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -99,8 +99,10 @@ class FetchCompileWasmPlugin {
 						return;
 					}
 					set.add(RuntimeGlobals.moduleCache);
-					const analyzable =
-						compilation.runtimeTemplate.supportsAnalyzable("wasm-relative");
+					const analyzable = compilation.runtimeTemplate.supportsAnalyzable(
+						"wasm-relative",
+						chunkGraph
+					);
 					const constant = analyzable
 						? undefined
 						: compilation.runtimeTemplate.constantPublicPath();

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -349,9 +349,10 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 		});
 	});
 
-	// A chunk `import()` is emitted by the module chunk loader whatever the target
-	// reads; `import.meta` in a url is syntax the target has to read itself.
-	it("should ask for ESM syntax only where the reference spells it", () => {
+	// ESM output writes `import.meta` whatever `environment.module` claims — the
+	// public path and the chunk loader already assume the target reads it — so the
+	// url forms bake to match rather than reading the flag.
+	it("should not read environment.module, which ESM output already ignores", () => {
 		const reads = create({});
 		const doesNot = create({ output: { environment: { module: false } } });
 		const { chunkGraph } = countingChunkGraph();
@@ -365,7 +366,7 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 			readsImport: true,
 			readsUrl: true,
 			doesNotImport: true,
-			doesNotUrl: false
+			doesNotUrl: true
 		});
 	});
 

--- a/test/configCases/analyzable/circular-chunk-hashes/index.js
+++ b/test/configCases/analyzable/circular-chunk-hashes/index.js
@@ -7,20 +7,25 @@ it("should build rather than deadlock on two chunks that name each other", async
 	expect(b.default).toBe(2);
 });
 
-it("should bake one direction of the cycle and keep the other", () => {
+it("should bake both directions of the cycle", () => {
 	const dir = __STATS__.outputPath;
 	const names = fs.readdirSync(dir).filter((n) => n.endsWith(".mjs"));
 	const read = (prefix) =>
 		fs.readFileSync(
-			path.join(dir, /** @type {string} */ (names.find((n) => n.startsWith(prefix)))),
+			path.join(
+				dir,
+				/** @type {string} */ (names.find((n) => n.startsWith(prefix)))
+			),
 			"utf8"
 		);
 	const helper = `${"__webpack_require__"}.ei`;
 	const baked = [read("a_js"), read("b_js")].filter((s) => s.includes(helper));
-	// One of the pair bakes; the other keeps `.u` so no hash feeds back into it.
-	expect(baked).toHaveLength(1);
-	// Whatever it baked has to be a file that was actually emitted.
-	for (const ref of baked[0].match(/"\.\/[^"]+\.mjs"/g) || []) {
-		expect(names).toContain(ref.slice(3, -1));
+	// Both bake: the repair re-hashes the pair as one group, so each name on disk is
+	// the one the other file spells.
+	expect(baked).toHaveLength(2);
+	for (const source of baked) {
+		for (const ref of source.match(/"\.\/[^"]+\.mjs"/g) || []) {
+			expect(names).toContain(ref.slice(3, -1));
+		}
 	}
 });

--- a/test/configCases/analyzable/circular-chunk-hashes/webpack.config.js
+++ b/test/configCases/analyzable/circular-chunk-hashes/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// Two chunks naming each other cannot both bake — each hash would feed the other. The
-// lower id bakes and the other keeps the runtime form, so the hashes settle in order.
+// Two chunks naming each other both bake: `optimization.realContentHash` re-hashes
+// the pair as one group, so neither name chases the other.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/split-runtime-css-href/index.js
+++ b/test/configCases/analyzable/split-runtime-css-href/index.js
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+
+import "./initial.css";
+
+it("should load the stylesheet the baked url names", async () => {
+	await import("./lazy.css");
+
+	// The neutral runtime guards the DOM, so the stylesheet only lands where there is one.
+	if (typeof document !== "undefined") {
+		expect(getComputedStyle(document.body).getPropertyValue("background")).toBe(
+			" red"
+		);
+	}
+});
+
+it("should bake the lazy url and leave the entry's to the runtime lookup", () => {
+	const dir = __STATS__.outputPath;
+	const runtime = __STATS__.assets.find((asset) =>
+		asset.name.startsWith("runtime.")
+	).name;
+	const lazy = __STATS__.assets.find(
+		(asset) => asset.name.startsWith("lazy_css.") && asset.name.endsWith(".css")
+	).name;
+	const source = fs.readFileSync(path.join(dir, runtime), "utf8");
+
+	// The map holds what could be named, and only that.
+	const map = /cssUrls = \{[^}]*\}/.exec(source);
+	expect(map).not.toBe(null);
+	expect(map[0]).toContain(`"./${lazy}"`);
+	expect(map[0]).not.toContain('"main":');
+	// An id the map lacks builds its url the runtime way, so both globals still ship.
+	expect(source).toContain(
+		`cssUrls[chunkId] ? cssUrls[chunkId]() : ${"__webpack_require__"}.p + ${"__webpack_require__"}.k(chunkId)`
+	);
+});

--- a/test/configCases/analyzable/split-runtime-css-href/initial.css
+++ b/test/configCases/analyzable/split-runtime-css-href/initial.css
@@ -1,0 +1,1 @@
+body { border: 1px solid green; }

--- a/test/configCases/analyzable/split-runtime-css-href/lazy.css
+++ b/test/configCases/analyzable/split-runtime-css-href/lazy.css
@@ -1,0 +1,1 @@
+body { background: red; }

--- a/test/configCases/analyzable/split-runtime-css-href/test.config.js
+++ b/test/configCases/analyzable/split-runtime-css-href/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const fs = require("fs");
+
+module.exports = {
+	findBundle(index, options) {
+		const dir = /** @type {string} */ (options.output.path);
+		const names = fs.readdirSync(dir);
+		return [
+			`./${names.find((name) => name.startsWith("runtime."))}`,
+			`./${names.find((name) => name.startsWith("main.") && name.endsWith(".mjs"))}`
+		];
+	}
+};

--- a/test/configCases/analyzable/split-runtime-css-href/test.filter.js
+++ b/test/configCases/analyzable/split-runtime-css-href/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const supportsRequireInModule = require("../../../helpers/supportsRequireInModule");
+
+// Reading the bundle back needs `require` in ESM output, which emits
+// `import { createRequire } from "module"` — older Node can't link that.
+module.exports = () => supportsRequireInModule();

--- a/test/configCases/analyzable/split-runtime-css-href/webpack.config.js
+++ b/test/configCases/analyzable/split-runtime-css-href/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// The entry chunk hashes after the runtime chunk that names its stylesheet, so its
-// url cannot be baked — the lazy stylesheet's still is, and the id the map lacks
-// falls back to the runtime name lookup instead of costing the whole map.
+// The entry chunk hashes after the runtime chunk naming its stylesheet, so only
+// the lazy url bakes and the missing id falls back to the runtime name lookup.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/split-runtime-css-href/webpack.config.js
+++ b/test/configCases/analyzable/split-runtime-css-href/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// The entry chunk hashes after the runtime chunk that names its stylesheet, so its
+// url cannot be baked — the lazy stylesheet's still is, and the id the map lacks
+// falls back to the runtime name lookup instead of costing the whole map.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "node"],
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true, css: true },
+	output: {
+		module: true,
+		filename: "[name].[contenthash].mjs",
+		chunkFilename: "[name].[contenthash].mjs",
+		cssChunkFilename: "[name].[contenthash].css",
+		publicPath: "auto"
+	},
+	optimization: {
+		realContentHash: false,
+		chunkIds: "named",
+		runtimeChunk: "single"
+	}
+};

--- a/test/configCases/wasm/analyzable-served-both-ways/a.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/a.js
@@ -1,0 +1,4 @@
+// Statically here, so this copy sits in the initial chunk the host fetched.
+import { value } from "./shared";
+
+export const read = value;

--- a/test/configCases/wasm/analyzable-served-both-ways/b.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/b.js
@@ -1,0 +1,2 @@
+// Dynamically here, so the loader fetches a second copy through the public path.
+export const load = () => import("./shared");

--- a/test/configCases/wasm/analyzable-served-both-ways/index.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/index.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+const read = (file) =>
+	fs.readFileSync(path.join(__STATS__.outputPath, file), "utf8");
+const wasmUrl = (source) =>
+	/\.v\(exports, [^,]+/.exec(source.replace(/\n/g, " "));
+
+it("should bake the binary's url from the chunk the host fetched", () => {
+	const match = wasmUrl(read("a.mjs"));
+	expect(match).not.toBe(null);
+	// The host fetched this chunk, so the public path is spelled from the root.
+	expect(match[0]).toContain('new URL("./assets/');
+});
+
+it("should bake the binary's url from the chunk the loader fetched", () => {
+	const match = wasmUrl(read(path.join("chunks", "shared_js.mjs")));
+	expect(match).not.toBe(null);
+	// The loader fetched this chunk through the public path, so the literal only
+	// climbs back out of the chunk directory.
+	expect(match[0]).toContain('new URL("../');
+});
+
+it("should not assemble either url at runtime", () => {
+	const needle = `new URL(${"__webpack_require__"}.p + `;
+	expect(read("a.mjs")).not.toContain(needle);
+	expect(read(path.join("chunks", "shared_js.mjs"))).not.toContain(needle);
+});

--- a/test/configCases/wasm/analyzable-served-both-ways/shared.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/shared.js
@@ -1,0 +1,3 @@
+import { getNumber } from "./wasm.wat";
+
+export const value = () => getNumber();

--- a/test/configCases/wasm/analyzable-served-both-ways/test.config.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		// Only the entry holding the assertions: the others exist for their emitted
+		// text, and running them would fetch the binary, which Node cannot.
+		return ["./main.mjs"];
+	}
+};

--- a/test/configCases/wasm/analyzable-served-both-ways/wasm.wat
+++ b/test/configCases/wasm/analyzable-served-both-ways/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/analyzable-served-both-ways/webpack.config.js
+++ b/test/configCases/wasm/analyzable-served-both-ways/webpack.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// One wasm module in a chunk the host fetched and in one the loader fetched through a
+// base-needing public path — each asset gets its own literal, so the pair still bakes.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: { main: "./index.js", a: "./a.js", b: "./b.js" },
+	module: {
+		rules: [
+			{ test: /\.wat$/, loader: "wast-loader", type: "webassembly/async" }
+		]
+	},
+	optimization: { chunkIds: "named", splitChunks: false },
+	experiments: { outputModule: true, asyncWebAssembly: true },
+	output: {
+		module: true,
+		wasmLoading: "fetch",
+		filename: "[name].mjs",
+		chunkFilename: "chunks/[name].mjs",
+		publicPath: "./assets/"
+	}
+};

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -143,7 +143,7 @@ environment-module:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
   asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
-  runtime modules X KiB 5 modules
+  runtime modules X KiB 4 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-asset.js X bytes [built] [code generated]
     ./asset.txt X bytes [built] [code generated]

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -54,12 +54,9 @@ const CASES = {
 		expect: "fallback",
 		bailout: "output.importFunctionName is"
 	},
-	// Only the url forms need `import.meta`, so the chunk `import()` still bakes.
-	"environment-module": {
-		file: "main.mjs",
-		expect: "partial",
-		bailout: "output.environment.module is false"
-	},
+	// ESM output writes `import.meta` whatever `environment.module` claims, so the
+	// url forms bake too.
+	"environment-module": { file: "main.mjs", expect: "analyzable" },
 	// Only the pair that names each other falls back; the entry's own imports still
 	// bake, so the helper stays and the reason is what marks the limitation.
 	circular: {

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -109,8 +109,8 @@ module.exports = [
 	base("import-function-name", {
 		output: { importFunctionName: "__import__" }
 	}),
-	// The target does not read `import.meta`, so only the url forms fall back — the
-	// chunk `import()` is emitted by the module chunk loader either way.
+	// Also analyzable: ESM output writes `import.meta` whatever `environment.module`
+	// claims, so the url forms bake to match what the bundle already assumes.
 	base("environment-module", {
 		entry: "./index-asset",
 		module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },

--- a/types.d.ts
+++ b/types.d.ts
@@ -355,6 +355,18 @@ declare interface AllCodeGenerationSchemas {
 	 */
 	"share-init": [{ shareScope: string; initStage: number; init: string }];
 }
+declare interface AnalyzableChunkUrls {
+	/**
+	 * the urls that could be written, by chunk id
+	 */
+	urls: Map<ChunkId, string>;
+
+	/**
+	 * false when some chunk kept the runtime form, whose
+	 * ids the consumer then still resolves through the runtime name lookup
+	 */
+	complete: boolean;
+}
 type AnalyzableForm =
 	"import" | "url" | "url-runtime" | "url-inline" | "wasm" | "wasm-relative";
 type AnyLoaderContext = NormalModuleLoaderContext<any> &
@@ -26106,8 +26118,8 @@ declare abstract class RuntimeTemplate {
 
 	/**
 	 * Static `new URL(<file>, import.meta.url)` for every stylesheet a runtime can load,
-	 * keyed by chunk id, or `null` when any of them has to keep the runtime
-	 * `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
+	 * keyed by chunk id — one that cannot be named leaves the map incomplete, and its
+	 * id keeps the runtime `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them
 	 * and the plugin declaring what it needs ask this, so the two always agree. The
 	 * runtime hands an absolute url string to `link.href`, and so does this — the browser
 	 * resolves the element against the document, which is not where the chunk sits, and
@@ -26119,13 +26131,13 @@ declare abstract class RuntimeTemplate {
 		chunkGraph: ChunkGraph,
 		runtimeRequirements: ReadonlySet<string>,
 		consumingModule?: Module
-	): null | Map<ChunkId, string>;
+	): null | AnalyzableChunkUrls;
 
 	/**
 	 * Static `new URL(<file>, import.meta.url).href` for every javascript chunk a
 	 * runtime can hint at with `<link rel="prefetch"/"modulepreload">`, keyed by chunk
-	 * id, or `null` when any of them has to keep the runtime
-	 * `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
+	 * id — one that cannot be named leaves the map incomplete, and its id keeps the
+	 * runtime `publicPath + getChunkScriptFilename(id)` form. Both the runtime module reading
 	 * them and the plugin declaring what it needs ask this, so the two always agree.
 	 */
 	analyzableChunkScriptUrls(
@@ -26133,7 +26145,7 @@ declare abstract class RuntimeTemplate {
 		chunkGraph: ChunkGraph,
 		runtimeRequirements: ReadonlySet<string>,
 		consumingModule?: Module
-	): null | Map<ChunkId, string>;
+	): null | AnalyzableChunkUrls;
 
 	/**
 	 * Static `new URL(<file>, import.meta.url)` for the binary emitted for an async wasm

--- a/types.d.ts
+++ b/types.d.ts
@@ -26091,6 +26091,20 @@ declare abstract class RuntimeTemplate {
 	chunkRootOutputDir(chunk: Chunk, enforceRelative: boolean): string;
 
 	/**
+	 * Static literal specifier (already quoted) for the `new URL(<here>, import.meta.url)`
+	 * a worker or worklet entry chunk bakes to, or `null` to keep the runtime form. The
+	 * gate and the build are asked together so every call site agrees on both — the
+	 * `new Worker(...)` emit, and the resource hint `ResourceHintPlugin` spells for it.
+	 */
+	getAnalyzableWorkerUrl(
+		overridePublicPath: undefined | string,
+		chunk: Chunk,
+		module: Module,
+		chunkGraph: ChunkGraph,
+		runtimeRequirements: Set<string>
+	): null | string;
+
+	/**
 	 * Static `new URL(<file>, import.meta.url)` for every stylesheet a runtime can load,
 	 * keyed by chunk id, or `null` when any of them has to keep the runtime
 	 * `publicPath + getChunkCssFilename(id)` form. Both the runtime module reading them


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Analyzable ESM output kept the runtime form in cases it can actually bake: two chunks naming each other with hashed names (`RealContentHashPlugin` threw `Circular hash dependency` — circles are now assigned as one hash group, so both directions bake and that error is gone for all builds), a wasm binary served both through a base-needing `publicPath` and not (now a per-asset literal), a stylesheet url map that lost every entry when one chunk could not be named (now kept, with a per-id runtime fallback), and an `environment.module: false` gate that withheld `import.meta` urls ESM output already emits. Also fixes a latent bug where build-time execution (`this.importModule`) could receive a baked `import.meta` its vm wrapper cannot parse, and simplifies the analyzable internals (single-pass wasm runtime grouping, one call for the worker url gate and build, deduplicated bailouts and probes).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new cases `analyzable/split-runtime-css-href` and `wasm/analyzable-served-both-ways`, and updated `analyzable/circular-chunk-hashes` (both directions now bake) plus the `analyzable-esm-fallbacks` stats case.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was developed with AI assistance (Claude Code): the analysis, implementation, and tests were AI-generated under human direction and review, and validated against webpack's test suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESM URL analysis for cyclic chunk references and mixed WebAssembly loading paths.
  - Fixed CSS and JavaScript chunk URL generation when only some URLs are known at build time.
  - Added reliable runtime fallbacks for unresolved asset URLs.
  - Improved analyzable worker and worklet URLs.
  - Corrected ESM URL handling when module environment settings differ from emitted output.

- **Tests**
  - Added coverage for circular chunk hashes, split-runtime CSS loading, and WebAssembly served through multiple paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->