### PR TITLE
feat(html): trim the body of a script holding a data block

### DIFF
--- a/.changeset/020-html-data-block-scripts.md
+++ b/.changeset/020-html-data-block-scripts.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Trim the body of a `<script>` holding a data block when collapsing whitespace.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -10430,7 +10430,9 @@ const _rewriteAttributeValue = (element, name, raw, viewport, enumeratedOn) => {
 const _scriptType = (path, element) => {
 	for (const attribute of path.attributes(element)) {
 		if (attribute.name === "type") {
-			return _asciiLowerCase(_asciiTrim(attribute.value));
+			// Decoded first: the value the spec matches is the one the parser read,
+			// so `text&#47;javascript` is a JavaScript type and not a data block.
+			return _asciiLowerCase(_asciiTrim(decodeEntities(attribute.value, true)));
 		}
 	}
 	return "";

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -12075,15 +12075,21 @@ const printer = (path, writer) => {
 					if (JSON_SCRIPT_TYPES.has(type) || _JSON_SUBTYPE_REGEXP.test(type)) {
 						return _minifyInlineJson(data);
 					}
+					const executable = JAVASCRIPT_SCRIPT_TYPES.has(type);
 					// No built-in: webpack ships no JS minifier, so an inline script is
 					// touched only by a caller's renderer.
 					if (
+						executable &&
 						(_renderEmbeddedSource !== undefined ||
 							_deferEmbeddedSource !== undefined) &&
-						JAVASCRIPT_SCRIPT_TYPES.has(type) &&
 						data.trim() !== ""
 					) {
 						return _renderEmbedded(data, JAVASCRIPT_TYPE);
+					}
+					// A data block — a template, a plain-text payload. Its own syntax is
+					// not ours to read, but nothing consumes the whitespace around it.
+					if (!executable && _collapseWhitespace !== "none") {
+						return _asciiTrim(data);
 					}
 				}
 				return data;

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4207,7 +4207,9 @@ describe("SourceProcessor — JSON <script> bodies", () => {
 			'<script type="text/x-template">  x  </script>',
 			{ mode: "minify", collapseWhitespace }
 		).code;
-		expect(out).toContain(">x<");
+		expect(out.slice(out.indexOf(">") + 1, out.lastIndexOf("</script>"))).toBe(
+			"x"
+		);
 	});
 
 	it("trims a data block in foreign content too", () => {
@@ -4215,7 +4217,7 @@ describe("SourceProcessor — JSON <script> bodies", () => {
 			'<svg><script type="text/x-template">  x  </script></svg>',
 			{ mode: "minify", collapseWhitespace: "all" }
 		).code;
-		expect(out).toContain(">x<");
+		expect(out).toBe("<svg><script type=text/x-template>x</script></svg>");
 	});
 
 	it("leaves a data block alone where whitespace is kept", () => {

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4189,6 +4189,22 @@ describe("SourceProcessor — JSON <script> bodies", () => {
 		expect(collapseBody("text/x-template", "   ")).toBe("");
 	});
 
+	it.each([
+		"text&#47;javascript",
+		"text&#x2F;javascript",
+		"&#116;ext/javascript"
+	])("reads %s as executable, since the parser decodes it", (type) => {
+		// Chrome runs each of these; classifying one as a data block would trim a
+		// body that is really a script.
+		expect(collapseBody(type, "  var a = 1  ")).toBe("  var a = 1  ");
+	});
+
+	it("reads an entity-encoded JSON type as JSON", () => {
+		expect(collapseBody("application&#47;ld&#43;json", '  { "a" : 1 }  ')).toBe(
+			'{"a":1}'
+		);
+	});
+
 	it("keeps a NBSP, which is a character and not whitespace", () => {
 		// `@swc/html` trims it, which edits what the body renders.
 		expect(collapseBody("text/x-template", "\u00A0\u00A0x\u00A0\u00A0")).toBe(

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4141,6 +4141,91 @@ describe("SourceProcessor — JSON <script> bodies", () => {
 		expect(minifyBody("text/template", '{ "a" : 1 }')).toBe('{ "a" : 1 }');
 	});
 
+	/**
+	 * @param {string} type the `<script type>` value
+	 * @param {string} body the raw body
+	 * @returns {string} the body, collapsing whitespace
+	 */
+	const collapseBody = (type, body) => {
+		const out = new SourceProcessor().process(
+			`<script type="${type}">${body}</script>`,
+			{ mode: "minify", collapseWhitespace: "all" }
+		).code;
+		return out.slice(out.indexOf(">") + 1, out.lastIndexOf("</script>"));
+	};
+
+	it.each([
+		"text/template",
+		"text/x-template",
+		"text/ng-template",
+		"text/x-handlebars-template",
+		"text/html",
+		"unknown/thing"
+	])("trims the body of the data block %s", (type) => {
+		expect(collapseBody(type, "  <div> x </div>  ")).toBe("<div> x </div>");
+	});
+
+	it("only trims — a data block's own syntax is not read", () => {
+		// The template language owns what is inside, `{{ }}` and its spacing too.
+		expect(
+			collapseBody("text/x-template", "  <p   class='a'>  {{ t }}  </p>  ")
+		).toBe("<p   class='a'>  {{ t }}  </p>");
+	});
+
+	it.each(["", "module", "text/javascript"])(
+		"leaves an executable body alone (%s)",
+		(type) => {
+			const body = "  var a = 1  ";
+			expect(collapseBody(type, body)).toBe(body);
+		}
+	);
+
+	it("reads a data block's type case- and whitespace-insensitively", () => {
+		expect(collapseBody(" TEXT/X-TEMPLATE ", "  x  ")).toBe("x");
+	});
+
+	it("takes every character HTML counts as whitespace", () => {
+		expect(collapseBody("text/x-template", "\t\n\f\r x \r\f\n\t")).toBe("x");
+		expect(collapseBody("text/x-template", "   ")).toBe("");
+	});
+
+	it("keeps a NBSP, which is a character and not whitespace", () => {
+		// `@swc/html` trims it, which edits what the body renders.
+		expect(collapseBody("text/x-template", "\u00A0\u00A0x\u00A0\u00A0")).toBe(
+			"\u00A0\u00A0x\u00A0\u00A0"
+		);
+	});
+
+	it.each(
+		/** @type {("conservative" | "smart" | "all")[]} */ ([
+			"conservative",
+			"smart",
+			"all"
+		])
+	)("trims where collapsing is %s", (collapseWhitespace) => {
+		const out = new SourceProcessor().process(
+			'<script type="text/x-template">  x  </script>',
+			{ mode: "minify", collapseWhitespace }
+		).code;
+		expect(out).toContain(">x<");
+	});
+
+	it("trims a data block in foreign content too", () => {
+		const out = new SourceProcessor().process(
+			'<svg><script type="text/x-template">  x  </script></svg>',
+			{ mode: "minify", collapseWhitespace: "all" }
+		).code;
+		expect(out).toContain(">x<");
+	});
+
+	it("leaves a data block alone where whitespace is kept", () => {
+		const out = new SourceProcessor().process(
+			'<script type="text/x-template">  <div> x </div>  </script>',
+			{ mode: "minify" }
+		).code;
+		expect(out).toContain(">  <div> x </div>  <");
+	});
+
 	it("copies every literal byte for byte", () => {
 		// Re-serializing would round the number through a double, drop the
 		// duplicate key and rewrite the escape.

--- a/test/configCases/html/minimize-script-data-blocks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/minimize-script-data-blocks/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html minimize-script-data-blocks minimize-script-data-blocks should compile 1`] = `"<!doctype html><html lang=en><head><title>Data blocks</title><script type=application/ld+json>{\\"a\\":1}</script></head><body> <script type=text/x-template><p   class=\\"a\\">  {{ t }}  </p></script> <script type=text/html><div> x </div></script> <script type=unknown/thing>raw   payload</script> <script src=__html_cbe5b59d_0.js></script> </body></html>"`;

--- a/test/configCases/html/minimize-script-data-blocks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/minimize-script-data-blocks/__snapshots__/ConfigTest.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html minimize-script-data-blocks minimize-script-data-blocks should compile 1`] = `"<!doctype html><html lang=en><head><title>Data blocks</title><script type=application/ld+json>{\\"a\\":1}</script></head><body> <script type=text/x-template><p   class=\\"a\\">  {{ t }}  </p></script> <script type=text/html><div> x </div></script> <script type=unknown/thing>raw   payload</script> <script src=__html_cbe5b59d_0.js></script> </body></html>"`;

--- a/test/configCases/html/minimize-script-data-blocks/index.js
+++ b/test/configCases/html/minimize-script-data-blocks/index.js
@@ -1,0 +1,6 @@
+import "./page.html";
+
+it("should trim a data block's body but not read its syntax", () => {
+	// The emitted file is the assertion — see the snapshot in test.config.js.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-script-data-blocks/page.html
+++ b/test/configCases/html/minimize-script-data-blocks/page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Data blocks</title>
+	<script type="application/ld+json">  { "a" :  1 }  </script>
+</head>
+<body>
+	<script type="text/x-template">  <p   class="a">  {{ t }}  </p>  </script>
+	<script type="text/html">  <div> x </div>  </script>
+	<script type="unknown/thing">  raw   payload  </script>
+	<script>  var a = 1  </script>
+</body>
+</html>

--- a/test/configCases/html/minimize-script-data-blocks/test.config.js
+++ b/test/configCases/html/minimize-script-data-blocks/test.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle(_i, options) {
+		const files = fs.readdirSync(options.output.path);
+		return files.includes("main.js") ? ["./main.js"] : undefined;
+	},
+	afterExecute(options) {
+		const page = fs.readFileSync(
+			path.join(options.output.path, "page.html"),
+			"utf8"
+		);
+		expect(page).toMatchSnapshot();
+		// The template language owns what is inside; only the edges go.
+		expect(page).toContain('<p   class="a">  {{ t }}  </p>');
+	}
+};

--- a/test/configCases/html/minimize-script-data-blocks/webpack.config.js
+++ b/test/configCases/html/minimize-script-data-blocks/webpack.config.js
@@ -1,0 +1,36 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	module: {
+		generator: {
+			html: {
+				extract: true
+			}
+		},
+		parser: {
+			html: {
+				sources: false
+			}
+		}
+	},
+	optimization: {
+		// `"..."` keeps the default minimizer, which hands
+		// `optimization.minimize.html` to `htmlMinify`.
+		minimize: {
+			html: {
+				collapseWhitespace: true
+			}
+		},
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	}
+};


### PR DESCRIPTION
Summary

A <script type> that is neither a JavaScript MIME nor JSON makes the element a data block — a text/x-template, a text/html fragment, a raw payload — which the browser never executes or parses. webpack left those bodies exactly as written, so the whitespace around one shipped even where collapseWhitespace was on. @swc/html trims it under the same switch; this matches that.

The body's own syntax stays as written: a template language owns what is inside, {{ }} and the spacing around it included, so only the edges go. Refs #21834.

One deliberate difference from @swc/html: a NBSP at the edge is kept. It is a character rather than whitespace, and trimming it edits what the body renders.

What kind of change does this PR introduce?

feat

Did you add tests for your changes?

Yes — 18 cases in test/HtmlSyntax.unittest.js (each data-block type, executable types left alone, every HTML whitespace character, NBSP kept, each collapse mode, foreign content, whitespace-only body) plus test/configCases/html/minimize-script-data-blocks.

Does this PR introduce a breaking change?

No. It only takes effect where collapseWhitespace is already on.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

n/a — no new option; the behaviour rides optimization.minimize.html.collapseWhitespace.

Use of AI

AI was used. It measured @swc/html's behaviour across nine script types to establish what the reference actually does (a trim gated by collapseWhitespaces, nothing more), wrote the implementation and tests, and ran the suites. Every guard was deliberately broken to confirm the tests fail without it, and the NBSP divergence was found by cross-checking against @swc/html rather than assumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Whitespace collapsing now trims the edges of non-executable `<script>` data blocks without altering their contents or interpreting their syntax.
  * Script type detection now handles case differences, surrounding whitespace, and encoded HTML characters correctly.
  * JSON-LD script blocks with encoded type values are minimized correctly, while executable JavaScript remains unchanged.
* **Tests**
  * Added coverage for templates, unknown script types, foreign content, whitespace modes, and preserved non-breaking spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->