### PR TITLE
fix(loaders): strip a BOM from a string result in the loader chain

### DIFF
--- a/.changeset/030-loader-bom.md
+++ b/.changeset/030-loader-bom.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Strip a BOM a loader put on a string before the next loader reads it.

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -59,6 +59,8 @@ const HASH_ESCAPE_REGEXP = /#/g;
 const UTF8_BOM_0 = 0xef;
 const UTF8_BOM_1 = 0xbb;
 const UTF8_BOM_2 = 0xbf;
+// U+FEFF, the BOM once decoded
+const BOM_CHAR_CODE = 0xfeff;
 
 /**
  * @param {Buffer} buf buffer
@@ -74,6 +76,14 @@ function utf8BufferToString(buf) {
 		return buf.toString("utf8", 3);
 	}
 	return buf.toString("utf8");
+}
+
+/**
+ * @param {string} str string
+ * @returns {string} string, with a leading BOM removed
+ */
+function stringWithoutBOM(str) {
+	return str.charCodeAt(0) === BOM_CHAR_CODE ? str.slice(1) : str;
 }
 
 /**
@@ -295,10 +305,13 @@ function runSyncOrAsync(fn, context, args, callback) {
  * @returns {void}
  */
 function convertArgs(args, raw) {
-	if (!raw && Buffer.isBuffer(args[0])) {
-		args[0] = utf8BufferToString(args[0]);
-	} else if (raw && typeof args[0] === "string") {
-		args[0] = Buffer.from(args[0], "utf8");
+	if (Buffer.isBuffer(args[0])) {
+		if (!raw) args[0] = utf8BufferToString(args[0]);
+	} else if (typeof args[0] === "string") {
+		// A BOM only means anything at the start of a file, so one a loader
+		// produced is content the next loader must not see.
+		const str = stringWithoutBOM(args[0]);
+		args[0] = raw ? Buffer.from(str, "utf8") : str;
 	}
 }
 

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -302,16 +302,19 @@ function runSyncOrAsync(fn, context, args, callback) {
 /**
  * @param {EXPECTED_ANY[]} args arguments
  * @param {boolean | null=} raw whether the loader wants a Buffer
+ * @param {boolean=} fromLoader whether args came from a loader rather than the resource
  * @returns {void}
  */
-function convertArgs(args, raw) {
-	if (Buffer.isBuffer(args[0])) {
-		if (!raw) args[0] = utf8BufferToString(args[0]);
-	} else if (typeof args[0] === "string") {
-		// A BOM only means anything at the start of a file, so one a loader
-		// produced is content the next loader must not see.
-		const str = stringWithoutBOM(args[0]);
-		args[0] = raw ? Buffer.from(str, "utf8") : str;
+function convertArgs(args, raw, fromLoader) {
+	// A BOM only means anything at the start of a file, so one a loader produced
+	// is content the next loader must not see. The resource keeps its own.
+	if (fromLoader && typeof args[0] === "string") {
+		args[0] = stringWithoutBOM(args[0]);
+	}
+	if (!raw && Buffer.isBuffer(args[0])) {
+		args[0] = utf8BufferToString(args[0]);
+	} else if (raw && typeof args[0] === "string") {
+		args[0] = Buffer.from(args[0], "utf8");
 	}
 }
 
@@ -320,9 +323,16 @@ function convertArgs(args, raw) {
  * @param {LoaderContext} loaderContext the loader context
  * @param {EXPECTED_ANY[]} args arguments
  * @param {(err: Error | null, args?: EXPECTED_ANY[]) => void} callback callback
+ * @param {boolean=} fromLoader whether args came from a loader rather than the resource
  * @returns {void}
  */
-function iterateNormalLoaders(options, loaderContext, args, callback) {
+function iterateNormalLoaders(
+	options,
+	loaderContext,
+	args,
+	callback,
+	fromLoader
+) {
 	while (loaderContext.loaderIndex >= 0) {
 		const currentLoaderObject =
 			loaderContext.loaders[loaderContext.loaderIndex];
@@ -340,11 +350,11 @@ function iterateNormalLoaders(options, loaderContext, args, callback) {
 			continue;
 		}
 
-		convertArgs(args, currentLoaderObject.raw);
+		convertArgs(args, currentLoaderObject.raw, fromLoader);
 
 		return runSyncOrAsync(fn, loaderContext, args, (err, ...nextArgs) => {
 			if (err) return callback(err);
-			iterateNormalLoaders(options, loaderContext, nextArgs, callback);
+			iterateNormalLoaders(options, loaderContext, nextArgs, callback, true);
 		});
 	}
 
@@ -423,7 +433,7 @@ function iteratePitchingLoaders(options, loaderContext, callback) {
 					}
 					if (hasArg) {
 						loaderContext.loaderIndex--;
-						iterateNormalLoaders(options, loaderContext, args, callback);
+						iterateNormalLoaders(options, loaderContext, args, callback, true);
 					} else {
 						iteratePitchingLoaders(options, loaderContext, callback);
 					}

--- a/test/LoaderRunner.unittest.js
+++ b/test/LoaderRunner.unittest.js
@@ -505,6 +505,25 @@ describe("runLoaders", () => {
 		);
 	});
 
+	it("should keep a BOM the resource itself came with", (done) => {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [path.resolve(fixtures, "raw-loader.js")],
+				processResource: (loaderContext, resource, callback) => {
+					callback(null, "\uFEFFvirtual");
+				}
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.result[0].toString("utf8")).toBe(
+					"efbbbf7669727475616c\uFEFFvirtual"
+				);
+				done();
+			}
+		);
+	});
+
 	it("should have to correct keys in context without resource", (done) => {
 		runLoaders(
 			{

--- a/test/LoaderRunner.unittest.js
+++ b/test/LoaderRunner.unittest.js
@@ -469,6 +469,42 @@ describe("runLoaders", () => {
 		);
 	});
 
+	it("should omit a BOM a loader put on a string", (done) => {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [
+					path.resolve(fixtures, "simple-loader.js"),
+					path.resolve(fixtures, "bom-loader.js")
+				]
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.result[0]).toBe("resource-simple");
+				done();
+			}
+		);
+	});
+
+	it("should omit a BOM a loader put on a string handed to a raw loader", (done) => {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [
+					path.resolve(fixtures, "raw-loader.js"),
+					path.resolve(fixtures, "bom-loader.js")
+				]
+			},
+			(err, result) => {
+				if (err) return done(err);
+				expect(result.result[0].toString("utf8")).toBe(
+					"7265736f75726365resource"
+				);
+				done();
+			}
+		);
+	});
+
 	it("should have to correct keys in context without resource", (done) => {
 		runLoaders(
 			{

--- a/test/configCases/loaders/bom-between-loaders/bom-loader.js
+++ b/test/configCases/loaders/bom-between-loaders/bom-loader.js
@@ -1,0 +1,6 @@
+// Emulates a loader whose tool prepends a BOM to its string output, the way
+// dart-sass does for non-ASCII `compressed` output.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(source) {
+	return `\uFEFF${source}`;
+};

--- a/test/configCases/loaders/bom-between-loaders/buffer.js
+++ b/test/configCases/loaders/bom-between-loaders/buffer.js
@@ -1,0 +1,1 @@
+module.exports = "buffer ©";

--- a/test/configCases/loaders/bom-between-loaders/check-buffer-loader.js
+++ b/test/configCases/loaders/bom-between-loaders/check-buffer-loader.js
@@ -1,0 +1,12 @@
+/** @type {import("../../../../").RawLoaderDefinition} */
+const loader = function loader(source) {
+	return `module.exports = ${JSON.stringify({
+		startsWithBOM:
+			source[0] === 0xef && source[1] === 0xbb && source[2] === 0xbf,
+		source: source.toString("utf8")
+	})};`;
+};
+
+loader.raw = true;
+
+module.exports = loader;

--- a/test/configCases/loaders/bom-between-loaders/check-string-loader.js
+++ b/test/configCases/loaders/bom-between-loaders/check-string-loader.js
@@ -1,0 +1,7 @@
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader(source) {
+	return `module.exports = ${JSON.stringify({
+		startsWithBOM: source.charCodeAt(0) === 0xfeff,
+		source
+	})};`;
+};

--- a/test/configCases/loaders/bom-between-loaders/index.js
+++ b/test/configCases/loaders/bom-between-loaders/index.js
@@ -1,0 +1,13 @@
+it("should not pass a BOM a loader produced to the next loader", () => {
+	const seen = require("./string");
+
+	expect(seen.startsWithBOM).toBe(false);
+	expect(seen.source).toBe('module.exports = "string ©";\n');
+});
+
+it("should not pass a BOM a loader produced to the next raw loader", () => {
+	const seen = require("./buffer");
+
+	expect(seen.startsWithBOM).toBe(false);
+	expect(seen.source).toBe('module.exports = "buffer ©";\n');
+});

--- a/test/configCases/loaders/bom-between-loaders/index.js
+++ b/test/configCases/loaders/bom-between-loaders/index.js
@@ -1,13 +1,17 @@
+// The fixtures are checked out with CRLF on Windows, and the BOM is what this
+// case is about, so compare the content with line endings normalized.
+const normalize = (source) => source.replace(/\r\n/g, "\n");
+
 it("should not pass a BOM a loader produced to the next loader", () => {
 	const seen = require("./string");
 
 	expect(seen.startsWithBOM).toBe(false);
-	expect(seen.source).toBe('module.exports = "string ©";\n');
+	expect(normalize(seen.source)).toBe('module.exports = "string ©";\n');
 });
 
 it("should not pass a BOM a loader produced to the next raw loader", () => {
 	const seen = require("./buffer");
 
 	expect(seen.startsWithBOM).toBe(false);
-	expect(seen.source).toBe('module.exports = "buffer ©";\n');
+	expect(normalize(seen.source)).toBe('module.exports = "buffer ©";\n');
 });

--- a/test/configCases/loaders/bom-between-loaders/string.js
+++ b/test/configCases/loaders/bom-between-loaders/string.js
@@ -1,0 +1,1 @@
+module.exports = "string ©";

--- a/test/configCases/loaders/bom-between-loaders/webpack.config.js
+++ b/test/configCases/loaders/bom-between-loaders/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /string\.js$/,
+				use: ["./check-string-loader", "./bom-loader"]
+			},
+			{
+				test: /buffer\.js$/,
+				use: ["./check-buffer-loader", "./bom-loader"]
+			}
+		]
+	}
+};

--- a/test/configCases/source-map/bom-from-loader/bom-loader.js
+++ b/test/configCases/source-map/bom-from-loader/bom-loader.js
@@ -1,0 +1,22 @@
+// Emulates a tool that maps the content it compiled and only then prepends a
+// BOM, the way dart-sass does for non-ASCII `compressed` output.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function bomLoader(source) {
+	const mappings = source
+		.split("\n")
+		.map((_, i) => (i === 0 ? "AAAA" : "AACA"))
+		.join(";");
+
+	this.callback(
+		null,
+		`\uFEFF${source}`,
+		/** @type {import("webpack-sources").RawSourceMap} */ ({
+			version: 3,
+			file: "mod.js",
+			sources: ["mod.js"],
+			sourcesContent: [source],
+			names: [],
+			mappings
+		})
+	);
+};

--- a/test/configCases/source-map/bom-from-loader/index.js
+++ b/test/configCases/source-map/bom-from-loader/index.js
@@ -1,0 +1,5 @@
+import value from "./mod.js";
+
+it("should run a module whose loader produced a BOM", () => {
+	expect(value).toBe("BOM_SOURCE_MAP_TOKEN");
+});

--- a/test/configCases/source-map/bom-from-loader/mod.js
+++ b/test/configCases/source-map/bom-from-loader/mod.js
@@ -1,0 +1,2 @@
+const VALUE = "BOM_SOURCE_MAP_TOKEN";
+export default VALUE;

--- a/test/configCases/source-map/bom-from-loader/next-loader.js
+++ b/test/configCases/source-map/bom-from-loader/next-loader.js
@@ -1,0 +1,13 @@
+// Runs after the BOM-emitting loader, so its input is what `convertArgs`
+// handed over: a throw here fails the case.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function nextLoader(source, sourceMap) {
+	if (source.charCodeAt(0) === 0xfeff) {
+		throw new Error("the previous loader's BOM reached the next loader");
+	}
+	if (!sourceMap) {
+		throw new Error("the previous loader's source map was dropped");
+	}
+
+	this.callback(null, source, sourceMap);
+};

--- a/test/configCases/source-map/bom-from-loader/test.config.js
+++ b/test/configCases/source-map/bom-from-loader/test.config.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+// eslint-disable-next-line import/no-extraneous-dependencies -- transitive via webpack-sources, used only to verify the emitted map
+const { SourceMapConsumer } = require("source-map");
+
+const BOM = "\uFEFF";
+
+module.exports = {
+	afterExecute(options) {
+		const dir = options.output.path;
+		const bundle = fs.readFileSync(path.join(dir, "bundle0.js"), "utf8");
+		const map = JSON.parse(
+			fs.readFileSync(path.join(dir, "bundle0.js.map"), "utf8")
+		);
+
+		expect(bundle.startsWith(BOM)).toBe(false);
+		expect(map.version).toBe(3);
+
+		const source = map.sources.find((name) => /mod\.js$/.test(name));
+
+		expect(source).toBeDefined();
+
+		// The BOM must not survive into what a debugger shows as the original file.
+		const original = map.sourcesContent[map.sources.indexOf(source)];
+
+		expect(original.startsWith(BOM)).toBe(false);
+		expect(original).toContain('const VALUE = "BOM_SOURCE_MAP_TOKEN";');
+
+		// Stripping the BOM must not shift the mappings: the first line of the
+		// module has to point at the column the module's code actually starts on.
+		const lines = bundle.split("\n");
+		const line =
+			lines.findIndex((text) =>
+				text.includes('const VALUE = "BOM_SOURCE_MAP_TOKEN";')
+			) + 1;
+
+		expect(line).toBeGreaterThan(0);
+
+		const consumer = new SourceMapConsumer(map);
+
+		expect(
+			consumer.generatedPositionFor({ source, line: 1, column: 0 })
+		).toMatchObject({
+			line,
+			column: lines[line - 1].indexOf("const VALUE")
+		});
+	}
+};

--- a/test/configCases/source-map/bom-from-loader/webpack.config.js
+++ b/test/configCases/source-map/bom-from-loader/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: "source-map",
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				test: /mod\.js$/,
+				use: [
+					require.resolve("./next-loader.js"),
+					require.resolve("./bom-loader.js")
+				]
+			}
+		]
+	}
+};

--- a/test/fixtures/loader-runner/bom-loader.js
+++ b/test/fixtures/loader-runner/bom-loader.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+	return `\uFEFF${source}`;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

`convertArgs` already dropped a leading BOM when decoding a `Buffer` for a loader, but not when a loader returned a **string** — so a loader whose tool prepends one (dart-sass does for non-ASCII `compressed` output, see webpack/sass-loader#1335) handed it straight to the next loader, where it is no longer at the start of a file and corrupts the module content. Only a BOM a loader produced is stripped; one belonging to the resource itself is left alone on every path, so a raw loader still sees the bytes it does today.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/loaders/bom-between-loaders/` (string and raw next-loader), `test/configCases/source-map/bom-from-loader/` (the map, its `sourcesContent` and its mapping columns survive the strip), and three cases in `test/LoaderRunner.unittest.js`, one of which pins that the resource's own BOM is preserved.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to write the fix and the tests from a description of the bug, and to run the tests and lint; the change was reviewed before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed leading byte-order marks added by loaders before passing string output to subsequent loaders.
  - Applied consistent BOM handling for both regular and raw loader workflows.
  - Preserved BOMs originating from source resources.
  - Maintained source-map accuracy when loader output includes a BOM.

- **Tests**
  - Added coverage for BOM handling across loader chains, raw content, and source maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->