### PR TITLE
test(benchmark): cover the loader pipeline, a cold cache and HMR

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The only trigger that measures the `-on-schedule` cases; every other one
+  # filters them out as too expensive to run per pull request.
+  schedule:
+    - cron: "0 4 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -60,7 +64,7 @@ jobs:
           mode: "simulation"
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: on-schedule
+          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.
@@ -106,7 +110,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: on-schedule
+          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,6 +30,9 @@ jobs:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
+    # The harness has no deadline of its own and a watch bench waits on a
+    # rebuild callback; main's slowest shard is ~55m, so this only trips on a hang.
+    timeout-minutes: 120
     permissions:
       issues: write
       pull-requests: write
@@ -75,6 +78,9 @@ jobs:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
+    # The harness has no deadline of its own and a watch bench waits on a
+    # rebuild callback; main's slowest shard is ~55m, so this only trips on a hang.
+    timeout-minutes: 120
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ jobs:
           mode: "simulation"
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
+          NEGATIVE_FILTER: ${{ github.event_name != 'schedule' && 'on-schedule' || '' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.
@@ -110,7 +110,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
+          NEGATIVE_FILTER: ${{ github.event_name != 'schedule' && 'on-schedule' || '' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -294,9 +294,8 @@ class BenchmarkRunner {
 	 * @returns {Promise<string[]>} benchmark names
 	 */
 	async discoverBenchmarks() {
-		// Empty means unset: a workflow expression that resolves to "" would
-		// otherwise compile to `new RegExp("")`, which matches every case and so
-		// excludes all of them.
+		// Empty means unset: `new RegExp("")` matches every case, so an empty
+		// NEGATIVE_FILTER would exclude all of them.
 		const FILTER = process.env.FILTER
 			? new RegExp(process.env.FILTER)
 			: undefined;

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -294,15 +294,16 @@ class BenchmarkRunner {
 	 * @returns {Promise<string[]>} benchmark names
 	 */
 	async discoverBenchmarks() {
-		const FILTER =
-			typeof process.env.FILTER !== "undefined"
-				? new RegExp(process.env.FILTER)
-				: undefined;
+		// Empty means unset: a workflow expression that resolves to "" would
+		// otherwise compile to `new RegExp("")`, which matches every case and so
+		// excludes all of them.
+		const FILTER = process.env.FILTER
+			? new RegExp(process.env.FILTER)
+			: undefined;
 
-		const NEGATIVE_FILTER =
-			typeof process.env.NEGATIVE_FILTER !== "undefined"
-				? new RegExp(process.env.NEGATIVE_FILTER)
-				: undefined;
+		const NEGATIVE_FILTER = process.env.NEGATIVE_FILTER
+			? new RegExp(process.env.NEGATIVE_FILTER)
+			: undefined;
 
 		/** @type {string[]} */
 		const allBenchmarks = (await fs.readdir(this.casesPath))
@@ -463,12 +464,20 @@ class BenchmarkRunner {
 		const benchmarkResults = [];
 		/** @type {string[]} */
 		const failedTasks = [];
+		/** @type {unknown} */
+		let firstFailure;
 
 		for (const [index, settled] of settledResults.entries()) {
 			if (settled.status === "fulfilled") {
 				benchmarkResults.push(settled.value);
 			} else {
-				failedTasks.push(benchmarkTasks[index].id);
+				const { id } = benchmarkTasks[index];
+
+				failedTasks.push(id);
+				// The rejection is the only description of what broke; without it a
+				// failing case reports a task id and nothing else.
+				console.error(`Failed: ${id}`, settled.reason);
+				if (failedTasks.length === 1) firstFailure = settled.reason;
 			}
 		}
 
@@ -478,7 +487,8 @@ class BenchmarkRunner {
 
 		if (failedTasks.length > 0) {
 			throw new Error(
-				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(", ")}`
+				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(", ")}`,
+				{ cause: firstFailure }
 			);
 		}
 	}

--- a/test/benchmarkCases/cache-filesystem-cold/index.js
+++ b/test/benchmarkCases/cache-filesystem-cold/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/cache-filesystem-cold/options.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/options.mjs
@@ -13,12 +13,11 @@ export async function setup() {
 }
 
 /**
- * Drop the pack so each iteration builds from nothing and serializes a fresh
- * one — the store path `cache-filesystem` never reaches, since it restores.
+ * Drops the pack so each iteration measures the store path, not the restore one.
  * @param {import("../../..").Configuration} config built configuration
  * @returns {Promise<void>}
  */
-export async function beforeEach(config) {
+export async function beforeEachIteration(config) {
 	const { cache } = config;
 
 	if (

--- a/test/benchmarkCases/cache-filesystem-cold/options.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/options.mjs
@@ -1,0 +1,34 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}
+
+/**
+ * Drop the pack so each iteration builds from nothing and serializes a fresh
+ * one — the store path `cache-filesystem` never reaches, since it restores.
+ * @param {import("../../..").Configuration} config built configuration
+ * @returns {Promise<void>}
+ */
+export async function beforeEach(config) {
+	const { cache } = config;
+
+	if (
+		!cache ||
+		typeof cache === "boolean" ||
+		cache.type !== "filesystem" ||
+		!cache.cacheDirectory
+	) {
+		throw new Error("Expected a filesystem cache with a resolved directory");
+	}
+
+	await fs.rm(cache.cacheDirectory, { recursive: true, force: true });
+}

--- a/test/benchmarkCases/cache-filesystem-cold/webpack.config.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/webpack.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	cache: {
+		type: "filesystem",
+		// For benchmark stability
+		maxMemoryGenerations: 0,
+		idleTimeoutForInitialStore: 0
+	}
+};

--- a/test/benchmarkCases/hmr/index.js
+++ b/test/benchmarkCases/hmr/index.js
@@ -1,0 +1,7 @@
+import * as mod from "./generated/module.js";
+
+export { mod };
+
+if (import.meta.webpackHot) {
+	import.meta.webpackHot.accept();
+}

--- a/test/benchmarkCases/hmr/options.mjs
+++ b/test/benchmarkCases/hmr/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/hmr/webpack.config.mjs
+++ b/test/benchmarkCases/hmr/webpack.config.mjs
@@ -1,0 +1,15 @@
+/** @import Webpack, { WebpackPluginInstance } from "../../.." */
+
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	target: "web"
+};
+
+/**
+ * @param {Webpack} webpack the baseline's webpack
+ * @returns {WebpackPluginInstance[]} plugins
+ */
+export function createPlugins(webpack) {
+	return [new webpack.HotModuleReplacementPlugin()];
+}

--- a/test/benchmarkCases/loader-babel/index.js
+++ b/test/benchmarkCases/loader-babel/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/loader-babel/options.mjs
+++ b/test/benchmarkCases/loader-babel/options.mjs
@@ -1,0 +1,67 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+// Small in simulation/walltime mode: every module pays a full babel parse,
+// transform and print, so the count buys build time quickly.
+const count = memoryScaledCount(30, 90);
+
+/**
+ * @param {number} i index
+ * @returns {string} generated component source
+ */
+function generateComponent(i) {
+	return `import h from "./h.js";
+
+export const title${i} = "component-${i}";
+
+export default function Component${i}({ items, title }) {
+	const rows = items.map((item, index) => (
+		<li className="row" data-index={index} key={item.id}>
+			<span className="label">{item.label}</span>
+			<em className="value">{item.value * ${i}}</em>
+		</li>
+	));
+
+	return (
+		<section className="component component-${i}">
+			<h2 className="heading">{title || title${i}}</h2>
+			<ul className="rows">{rows}</ul>
+			{items.length > 0 ? <footer className="count">{items.length}</footer> : null}
+		</section>
+	);
+}
+`;
+}
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await fs.mkdir(generated, { recursive: true });
+
+	// The JSX factory, so the transformed output resolves without pulling a
+	// runtime package into the measured graph.
+	await fs.writeFile(
+		resolve(generated, "h.js"),
+		`export default function h(type, props, ...children) {
+	return { type, props, children };
+}
+`
+	);
+
+	let code = "";
+
+	for (let i = 0; i < count; i++) {
+		await fs.writeFile(
+			resolve(generated, `component-${i}.jsx`),
+			generateComponent(i)
+		);
+
+		code += `import Component${i} from "./component-${i}.jsx";\nconsole.log(Component${i});\nexport { Component${i} };\n`;
+	}
+
+	await fs.writeFile(resolve(generated, "module.js"), code);
+}

--- a/test/benchmarkCases/loader-babel/webpack.config.mjs
+++ b/test/benchmarkCases/loader-babel/webpack.config.mjs
@@ -1,0 +1,22 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	module: {
+		rules: [
+			{
+				test: /\.jsx$/,
+				loader: "babel-loader",
+				options: {
+					// Hermetic: no repo or user babel config leaks into the numbers,
+					// and no cache turns later iterations into a different benchmark.
+					babelrc: false,
+					configFile: false,
+					cacheDirectory: false,
+					presets: [
+						["@babel/preset-react", { runtime: "classic", pragma: "h" }]
+					]
+				}
+			}
+		]
+	}
+};

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -59,6 +59,12 @@ import { Bench, hrtimeNow } from "tinybench";
 /** @typedef {{ run: (seed: number) => unknown }} RuntimeBundleExports */
 /** @typedef {{ taskName: string, collectBy: string }} TaskNames */
 
+/**
+ * @typedef {object} CaseOptions
+ * @property {(() => Promise<void>)=} setup one-time fixture generation, run once by the orchestrator
+ * @property {((config: Configuration) => Promise<void> | void)=} beforeEach reset run before every iteration, outside the measured region
+ */
+
 const GENERATE_PROFILE = typeof process.env.PROFILE !== "undefined";
 const codspeedRunnerMode = getCodspeedRunnerMode();
 
@@ -827,9 +833,17 @@ function buildConfiguration(test, baseline, realConfig, scenario, testDirectory)
  * @param {string} params.collectBy collect-by key
  * @param {Webpack} params.webpack webpack
  * @param {Configuration} params.config config
+ * @param {((config: Configuration) => Promise<void> | void)=} params.beforeEachIteration per-iteration reset
  * @returns {void}
  */
-function addBuildBench({ bench, taskName, collectBy, webpack, config }) {
+function addBuildBench({
+	bench,
+	taskName,
+	collectBy,
+	webpack,
+	config,
+	beforeEachIteration
+}) {
 	bench.add(
 		taskName,
 		async () => {
@@ -838,7 +852,9 @@ function addBuildBench({ bench, taskName, collectBy, webpack, config }) {
 				: runWebpack(webpack, config));
 		},
 		{
-			beforeEach(mode) {
+			async beforeEach(mode) {
+				// Before the timer: the reset is setup, not part of the build.
+				if (beforeEachIteration) await beforeEachIteration(config);
 				console.time(`Time (${mode} mode): ${taskName}`);
 			},
 			afterEach(mode) {
@@ -1246,6 +1262,24 @@ function attachResultCollector(bench, results) {
 }
 
 /**
+ * @param {string} testDirectory benchmark case directory
+ * @returns {Promise<CaseOptions | undefined>} case options, or undefined when the case has none
+ */
+async function importCaseOptions(testDirectory) {
+	const optionsPath = path.resolve(testDirectory, "options.mjs");
+
+	try {
+		await fs.stat(optionsPath);
+	} catch (_err) {
+		return undefined;
+	}
+
+	// Imported outside the existence check so a broken `options.mjs` throws
+	// instead of reading as a case that has none.
+	return import(`${pathToFileURL(optionsPath)}`);
+}
+
+/**
  * Register one benchmark task's benches onto `bench`. `-unit` benchmarks
  * register their own tasks against the current lib, `-runtime` benchmarks
  * measure the compiled output; others add one build/watch bench per baseline.
@@ -1274,11 +1308,23 @@ async function registerBenchmark(bench, task, casesPath) {
 		throw new Error(`Missing scenario for benchmark "${benchmark}"`);
 	}
 
-	const realConfig = (
-		await import(
-			`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
-		)
-	).default;
+	const configModule = await import(
+		`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
+	);
+	const realConfig = configModule.default;
+	// `buildConfiguration` structuredClones the config, which strips a plugin's
+	// prototype (and with it `apply`) without erroring. A case declares plugins
+	// through this factory instead, so each baseline instantiates them from the
+	// webpack copy it is measuring.
+	const { createPlugins } = configModule;
+
+	if (realConfig.plugins && realConfig.plugins.length > 0) {
+		throw new Error(
+			`Benchmark "${benchmark}" declares \`plugins\` in its configuration, which cloning would silently empty. Export \`createPlugins(webpack)\` from its webpack.config.mjs instead.`
+		);
+	}
+
+	const caseOptions = await importCaseOptions(testDirectory);
 
 	// Register HEAD then BASE sequentially so task order in `bench.tasks` is
 	// deterministic; parallel registration would leak Promise-resolution order
@@ -1297,6 +1343,10 @@ async function registerBenchmark(bench, task, casesPath) {
 			scenario,
 			testDirectory
 		);
+
+		if (createPlugins) {
+			config.plugins = createPlugins(webpack);
+		}
 
 		const stringifiedScenario = JSON.stringify(scenario);
 
@@ -1324,7 +1374,12 @@ async function registerBenchmark(bench, task, casesPath) {
 
 		const params = { bench, ...createNames(""), webpack, config };
 
-		await (scenario.watch ? addWatchBench(params) : addBuildBench(params));
+		await (scenario.watch
+			? addWatchBench(params)
+			: addBuildBench({
+					...params,
+					beforeEachIteration: caseOptions?.beforeEach
+				}));
 	}
 }
 

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -62,7 +62,7 @@ import { Bench, hrtimeNow } from "tinybench";
 /**
  * @typedef {object} CaseOptions
  * @property {(() => Promise<void>)=} setup one-time fixture generation, run once by the orchestrator
- * @property {((config: Configuration) => Promise<void> | void)=} beforeEach reset run before every iteration, outside the measured region
+ * @property {((config: Configuration) => Promise<void> | void)=} beforeEachIteration reset run before every iteration, outside the measured region
  */
 
 const GENERATE_PROFILE = typeof process.env.PROFILE !== "undefined";
@@ -1312,10 +1312,8 @@ async function registerBenchmark(bench, task, casesPath) {
 		`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
 	);
 	const realConfig = configModule.default;
-	// `buildConfiguration` structuredClones the config, which strips a plugin's
-	// prototype (and with it `apply`) without erroring. A case declares plugins
-	// through this factory instead, so each baseline instantiates them from the
-	// webpack copy it is measuring.
+	// Cloning the config strips a plugin's prototype, and with it `apply`, so a
+	// case declares plugins here instead — bound to the baseline being measured.
 	const { createPlugins } = configModule;
 
 	if (realConfig.plugins && realConfig.plugins.length > 0) {
@@ -1378,7 +1376,7 @@ async function registerBenchmark(bench, task, casesPath) {
 			? addWatchBench(params)
 			: addBuildBench({
 					...params,
-					beforeEachIteration: caseOptions?.beforeEach
+					beforeEachIteration: caseOptions?.beforeEachIteration
 				}));
 	}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

The benchmark suite has no loader in the pipeline, measures the filesystem cache only on its restore path, and does not cover HMR — the scenarios [webpack/benchmark](https://github.com/webpack/benchmark) carried outside this repository, which is being deprecated (webpack/benchmark#13). Three cases close that: `loader-babel` (babel-loader over generated JSX, so the loader-runner and the source round trip are measured), `cache-filesystem-cold` (drops the pack each iteration, measuring the store path beside `cache-filesystem`'s restore) and `hmr` (`HotModuleReplacementPlugin`, which the rebuild scenario turns into an update round trip).

Two harness gaps blocked them. A config's `plugins` never survived `structuredClone` — it strips the prototype and with it `apply` — so a case now declares them via `createPlugins(webpack)`, bound to the baseline being measured, and declaring them directly throws instead of silently building without them. A case's `options.mjs` may export `beforeEachIteration`, run before every iteration and outside the measured region, which is what lets the cold case reset its pack.

Also here: `-on-schedule` cases ran nowhere, since `benchmarks.yml` filtered them out and had no `schedule` to run them on, so `typescript-long-on-schedule` was measured by no trigger at all. It gets a weekly one — say if a different cadence is wanted, or if those cases are parked deliberately and the filter should stay. Neither benchmark job set `timeout-minutes`, so both inherited the 6-hour default while the harness has no deadline of its own; they are now bounded at 120 minutes against a ~55-minute slowest shard on `main`. A failed task also reports the rejection it failed with rather than only its id.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

The change is tests: `test/benchmarkCases/{loader-babel,cache-filesystem-cold,hmr}/`, plus the harness in `test/BenchmarkTestCases.benchmark.mjs` and `test/harness/benchmark/benchmark.worker.mjs`. All three cases were run locally across the three scenarios (9/9 tasks passing); the HMR runtime was verified present in the `hmr` bundle and absent in a control case, and the per-iteration hook verified to fire on every iteration and find a pack to drop on all but the first.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no user-facing surface changes, so no changeset either.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to survey what webpack/benchmark measured that this repository does not, to write the cases and harness hooks, and to run and verify them locally. All output was reviewed before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly automated benchmark runs, including scheduled-only scenarios.
  * Added benchmark coverage for cold filesystem caching, hot module replacement, and Babel-based JSX loading.

* **Bug Fixes**
  * Improved benchmark filtering when optional filters are empty.
  * Enhanced failure reporting by preserving and displaying the original error cause.

* **Tests**
  * Added repeatable benchmark setup, validation, and per-iteration cache reset support.
  * Added execution time limits to improve scheduled benchmark reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->