### PR TITLE
fix: do not emit a JS chunk for an output.html generated page

### DIFF
--- a/.changeset/025-output-html-dead-chunk.md
+++ b/.changeset/025-output-html-dead-chunk.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Stop `output.html` emitting an unused JS chunk for each generated page.

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -222,6 +222,9 @@ const isIntegrityEnabled = (integrity) =>
 // `\.html`/`\.css` request matchers for the synthetic `output.html` wrapper.
 const HTML_REQUEST_RE = /\.html(\?|$)/i;
 const CSS_REQUEST_RE = /\.css(\?|$)/i;
+// The wrapper's own resource — the media type must end here, so that a
+// `data:text/htmlx,` entry (JavaScript to `DataUriPlugin`) is not one.
+const HTML_DATA_URL_RE = /^data:text\/html[,;]/i;
 
 /**
  * Requests an `output.html` page must load for an entry: its `dependOn`
@@ -716,9 +719,8 @@ class HtmlModulesPlugin {
 						// a content-hashed filename makes a substring hit a real reference.
 						/** @type {Set<string>} */
 						const deletionCandidates = new Set(inlinedFiles);
-						// The synthetic `output.html` wrapper entry emits a JS chunk whose
-						// only module re-exports the page's own markup — the page loads the
-						// `<script src>` entries the parser split out of it instead.
+						// A wrapper entry's chunk only rebuilds the page's own markup; the
+						// page loads the `<script src>` entries the parser split out of it.
 						for (const entrypoint of compilation.entrypoints.values()) {
 							const chunk = entrypoint.getEntrypointChunk();
 							if (!chunk) continue;
@@ -731,7 +733,7 @@ class HtmlModulesPlugin {
 								);
 								wrapperOnly =
 									typeof resource === "string" &&
-									resource.startsWith("data:text/html");
+									HTML_DATA_URL_RE.test(resource);
 								if (!wrapperOnly) break;
 							}
 							if (!wrapperOnly) continue;
@@ -755,6 +757,22 @@ class HtmlModulesPlugin {
 								for (const file of deletionCandidates) {
 									if (!stillReferenced.has(file) && source.includes(file)) {
 										stillReferenced.add(file);
+									}
+								}
+							}
+							// A candidate kept alive can reference another through its async
+							// chunk map, so follow each newly kept one until nothing is added.
+							const pending = [...stillReferenced];
+							while (pending.length > 0) {
+								const source =
+									compilation.assets[
+										/** @type {string} */ (pending.pop())
+									].source();
+								if (typeof source !== "string") continue;
+								for (const file of deletionCandidates) {
+									if (!stillReferenced.has(file) && source.includes(file)) {
+										stillReferenced.add(file);
+										pending.push(file);
 									}
 								}
 							}

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -714,28 +714,51 @@ class HtmlModulesPlugin {
 						// An inlined chunk file is dead weight once nothing else references
 						// it by URL (another page's tag, or the runtime's async chunk map);
 						// a content-hashed filename makes a substring hit a real reference.
+						/** @type {Set<string>} */
+						const deletionCandidates = new Set(inlinedFiles);
+						// The synthetic `output.html` wrapper entry emits a JS chunk whose
+						// only module re-exports the page's own markup — the page loads the
+						// `<script src>` entries the parser split out of it instead.
+						for (const entrypoint of compilation.entrypoints.values()) {
+							const chunk = entrypoint.getEntrypointChunk();
+							if (!chunk) continue;
+							let wrapperOnly = false;
+							for (const entryModule of compilation.chunkGraph.getChunkEntryModulesIterable(
+								chunk
+							)) {
+								const { resource } = /** @type {import("../NormalModule")} */ (
+									entryModule
+								);
+								wrapperOnly =
+									typeof resource === "string" &&
+									resource.startsWith("data:text/html");
+								if (!wrapperOnly) break;
+							}
+							if (!wrapperOnly) continue;
+							for (const file of chunk.files) deletionCandidates.add(file);
+						}
 						// Materialize each other asset's source once (it can be expensive to
-						// render) and test all inlined files against it, rather than
-						// re-materializing every asset per inlined file.
-						if (inlinedFiles.size > 0) {
+						// render) and test all candidates against it, rather than
+						// re-materializing every asset per candidate.
+						if (deletionCandidates.size > 0) {
 							/** @type {Set<string>} */
 							const stillReferenced = new Set();
 							for (const name of Object.keys(compilation.assets)) {
 								if (
-									inlinedFiles.has(name) ||
-									stillReferenced.size === inlinedFiles.size
+									deletionCandidates.has(name) ||
+									stillReferenced.size === deletionCandidates.size
 								) {
 									continue;
 								}
 								const source = compilation.assets[name].source();
 								if (typeof source !== "string") continue;
-								for (const file of inlinedFiles) {
+								for (const file of deletionCandidates) {
 									if (!stillReferenced.has(file) && source.includes(file)) {
 										stillReferenced.add(file);
 									}
 								}
 							}
-							for (const file of inlinedFiles) {
+							for (const file of deletionCandidates) {
 								if (!stillReferenced.has(file)) compilation.deleteAsset(file);
 							}
 						}

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -745,6 +745,21 @@ class HtmlModulesPlugin {
 						if (deletionCandidates.size > 0) {
 							/** @type {Set<string>} */
 							const stillReferenced = new Set();
+							/** @type {string[]} */
+							const pending = [];
+							/**
+							 * @param {string} name asset whose source may name a candidate
+							 */
+							const markReferenced = (name) => {
+								const source = compilation.assets[name].source();
+								if (typeof source !== "string") return;
+								for (const file of deletionCandidates) {
+									if (!stillReferenced.has(file) && source.includes(file)) {
+										stillReferenced.add(file);
+										pending.push(file);
+									}
+								}
+							};
 							for (const name of Object.keys(compilation.assets)) {
 								if (
 									deletionCandidates.has(name) ||
@@ -752,29 +767,12 @@ class HtmlModulesPlugin {
 								) {
 									continue;
 								}
-								const source = compilation.assets[name].source();
-								if (typeof source !== "string") continue;
-								for (const file of deletionCandidates) {
-									if (!stillReferenced.has(file) && source.includes(file)) {
-										stillReferenced.add(file);
-									}
-								}
+								markReferenced(name);
 							}
-							// A candidate kept alive can reference another through its async
-							// chunk map, so follow each newly kept one until nothing is added.
-							const pending = [...stillReferenced];
+							// A kept candidate can reference another through its async chunk
+							// map, so follow each until nothing new is kept.
 							while (pending.length > 0) {
-								const source =
-									compilation.assets[
-										/** @type {string} */ (pending.pop())
-									].source();
-								if (typeof source !== "string") continue;
-								for (const file of deletionCandidates) {
-									if (!stillReferenced.has(file) && source.includes(file)) {
-										stillReferenced.add(file);
-										pending.push(file);
-									}
-								}
+								markReferenced(/** @type {string} */ (pending.pop()));
 							}
 							for (const file of deletionCandidates) {
 								if (!stillReferenced.has(file)) compilation.deleteAsset(file);

--- a/test/configCases/html/output-html-data-url-media-type/src/page.js
+++ b/test/configCases/html/output-html-data-url-media-type/src/page.js
@@ -1,0 +1,1 @@
+export default "page";

--- a/test/configCases/html/output-html-data-url-media-type/test.config.js
+++ b/test/configCases/html/output-html-data-url-media-type/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/output-html-data-url-media-type/test.js
+++ b/test/configCases/html/output-html-data-url-media-type/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+const chunks = (prefix) =>
+	fs
+		.readdirSync(__dirname)
+		.filter((f) => f.startsWith(prefix) && f.endsWith(".js"));
+
+it("keeps a data:text/htmlx entry chunk, which is not an output.html wrapper", () => {
+	expect(chunks("data-url.").length).toBeGreaterThan(0);
+});
+
+it("still drops the JS chunk of a real generated page", () => {
+	expect(chunks("page.")).toHaveLength(0);
+});

--- a/test/configCases/html/output-html-data-url-media-type/webpack.config.js
+++ b/test/configCases/html/output-html-data-url-media-type/webpack.config.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").WebpackPluginInstance} */
+const copyTest = {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "copy-test",
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+				},
+				() => {
+					compilation.emitAsset(
+						"test.js",
+						new webpack.sources.RawSource(
+							fs.readFileSync(path.resolve(__dirname, "test.js"))
+						)
+					);
+				}
+			);
+		});
+	}
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: {
+		// `text/htmlx` is JavaScript to DataUriPlugin, not an `output.html`
+		// wrapper — its chunk must survive the wrapper cleanup.
+		"data-url": { import: "data:text/htmlx,module.exports = 42;", html: false },
+		page: "./src/page.js"
+	},
+	output: { filename: "[name].[contenthash].js", html: true },
+	experiments: { html: true },
+	plugins: [copyTest]
+};

--- a/test/configCases/html/output-html-inline/test.js
+++ b/test/configCases/html/output-html-inline/test.js
@@ -116,10 +116,20 @@ it("inline: true + integrity does not emit integrity attr on inlined tags", () =
 });
 
 it("JS importing HTML module does not leave inline sentinel in the JS chunk", () => {
-	const files = fs.readdirSync(__dirname).filter((f) => f.startsWith("js-imports-html.") && f.endsWith(".js"));
-	expect(files.length).toBeGreaterThan(0);
-	const jsContent = fs.readFileSync(path.resolve(__dirname, files[0]), "utf-8");
-	expect(jsContent).not.toContain("__WEBPACK_HTML_INLINE__");
+	// The chunk holding `main-with-html.js` is inlined into the page, so the
+	// sentinel has to be gone from the `<script>` the page now carries.
+	const html = readHtml("js-imports-html-wrapper.html");
+	const scripts = inlineScripts(html);
+	expect(scripts.length).toBeGreaterThan(0);
+	expect(scripts.join("")).toContain("main-with-html");
+	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
+});
+
+it("output.html does not emit a JS chunk for the generated page itself", () => {
+	const files = fs
+		.readdirSync(__dirname)
+		.filter((f) => f.startsWith("js-imports-html.") && f.endsWith(".js"));
+	expect(files).toHaveLength(0);
 });
 
 it("inline: true with authored <link rel=stylesheet> entry inlines CSS as <style>", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`output.html` wraps a non-HTML entry in a synthetic `data:text/html` module, so the entry-named chunk ended up holding a module whose only export is the page's own markup, while the application moved to the `__html_*` entry the parser split out of that page. Nothing ever requested that chunk — the page loads `__html_*` — but it was still emitted, so every generated page shipped a dead file that also owned the entry's name (2.5 KB in development, 313 B minified in the repro).

The fix reuses the existing inline-cleanup reference scan, so the chunk stays in the graph — resource hints and `dependOn` wiring read it — and only the unreferenced file is dropped.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/html/output-html-inline/test.js` gains a case asserting no JS chunk is emitted for the generated page. The existing "does not leave inline sentinel in the JS chunk" test there was asserting against that dead wrapper (the chunk it means to check is inlined into the page), so it now reads the page's inline `<script>` instead.

**Does this PR introduce a breaking change?**

No. The removed file was never referenced by any emitted asset.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was prepared with Claude Code. The dead chunk was found while documenting `output.html` for webpack.js.org, then reproduced from scratch and confirmed by reading the emitted chunk's contents; two broader fixes were tried and discarded first because they moved the chunk out of the graph and broke resource hints. All output was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwjXQBKW6nPrk5SgMWH8Hh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated HTML pages from emitting unused JavaScript chunk files.
  * Improved cleanup of temporary wrapper assets while preserving scripts referenced by generated HTML.
  * Preserved JavaScript files for data URLs that are not genuine HTML documents.

* **Tests**
  * Added coverage for script inlining, unnecessary chunk removal, and distinguishing HTML from JavaScript data URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->