### PR TITLE
fix: move the source map with a removed BOM

### DIFF
--- a/.changeset/030-loader-bom.md
+++ b/.changeset/030-loader-bom.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Strip a BOM a loader put on a string before the next loader reads it.
+Strip a BOM a loader put on a string, and shift a source map that counted it.

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -43,7 +43,7 @@ const {
 	PUBLIC_PATH_AUTO,
 	walkFullHashPlaceholders
 } = require("../util/publicPathPlaceholder");
-const removeBOM = require("../util/removeBOM");
+const { removeBOMFromResult } = require("../util/removeBOM");
 const CssModule = require("./CssModule");
 
 /** @import { Source } from "webpack-sources" */
@@ -516,15 +516,8 @@ class CssModulesPlugin {
 
 					NormalModule.getCompilationHooks(compilation).processResult.tap(
 						PLUGIN_NAME,
-						(result, module) => {
-							if (module.type === type) {
-								const [source, ...rest] = result;
-
-								return [removeBOM(source), ...rest];
-							}
-
-							return result;
-						}
+						(result, module) =>
+							module.type === type ? removeBOMFromResult(result) : result
 					);
 				}
 

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -31,7 +31,7 @@ const preloadModuleType = require("../util/preloadModuleType");
 const {
 	PUBLIC_PATH_AUTO: autoPlaceholder
 } = require("../util/publicPathPlaceholder");
-const removeBOM = require("../util/removeBOM");
+const { removeBOMFromResult } = require("../util/removeBOM");
 const HtmlModule = require("./HtmlModule");
 
 const getMimeTypes = memoize(() => require("../util/mimeTypes"));
@@ -935,14 +935,14 @@ class HtmlModulesPlugin {
 					PLUGIN_NAME,
 					(result, module) => {
 						if (module.type === HTML_MODULE_TYPE) {
-							const [source, ...rest] = result;
+							const [source, ...rest] = removeBOMFromResult(result);
 							// `applyTemplate` is a no-op unless `module.parser.html.template`
 							// is set. Running it here (where the returned source becomes the
 							// module's stored source) keeps the parser's dependency offsets
 							// and the generator's render base in sync.
 							const parser = /** @type {HtmlParser} */ (module.parser);
 
-							return [parser.applyTemplate(removeBOM(source), module), ...rest];
+							return [parser.applyTemplate(source, module), ...rest];
 						}
 
 						return result;

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -50,7 +50,7 @@ const {
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const { digestNonNumericOnlyWithFull } = require("../util/nonNumericOnlyHash");
-const removeBOM = require("../util/removeBOM");
+const { removeBOMFromResult } = require("../util/removeBOM");
 const { intersectRuntime } = require("../util/runtime");
 const { getAllChunks } = require("./ChunkHelpers");
 const JavascriptGenerator = require("./JavascriptGenerator");
@@ -528,15 +528,8 @@ class JavascriptModulesPlugin {
 
 					NormalModule.getCompilationHooks(compilation).processResult.tap(
 						PLUGIN_NAME,
-						(result, module) => {
-							if (module.type === type) {
-								const [source, ...rest] = result;
-
-								return [removeBOM(source), ...rest];
-							}
-
-							return result;
-						}
+						(result, module) =>
+							module.type === type ? removeBOMFromResult(result) : result
 					);
 				}
 

--- a/lib/loaders/LoaderRunner.js
+++ b/lib/loaders/LoaderRunner.js
@@ -7,6 +7,7 @@
 
 const { readFile } = require("fs");
 const { parseResource } = require("../util/identifier");
+const { adjustSourceMapForRemovedBOM } = require("../util/removeBOM");
 const loadLoader = require("./loadLoader");
 
 // Set on a loader context to have each loader's own run measured. Absent
@@ -309,7 +310,11 @@ function convertArgs(args, raw, fromLoader) {
 	// A BOM only means anything at the start of a file, so one a loader produced
 	// is content the next loader must not see. The resource keeps its own.
 	if (fromLoader && typeof args[0] === "string") {
-		args[0] = stringWithoutBOM(args[0]);
+		const withoutBOM = stringWithoutBOM(args[0]);
+		if (withoutBOM !== args[0]) {
+			args[0] = withoutBOM;
+			if (args[1]) args[1] = adjustSourceMapForRemovedBOM(args[1]);
+		}
 	}
 	if (!raw && Buffer.isBuffer(args[0])) {
 		args[0] = utf8BufferToString(args[0]);

--- a/lib/typescript/TypeScriptPlugin.js
+++ b/lib/typescript/TypeScriptPlugin.js
@@ -14,7 +14,7 @@ const {
 } = require("../ModuleTypeConstants");
 const NormalModule = require("../NormalModule");
 const memoize = require("../util/memoize");
-const removeBOM = require("../util/removeBOM");
+const { removeBOMFromResult } = require("../util/removeBOM");
 
 const getModuleBuildError = memoize(() =>
 	require("../errors/ModuleBuildError")
@@ -133,15 +133,11 @@ const stripTypes = (input) => {
 };
 
 /**
- * Coerce a Buffer-or-string source to a UTF-8 string, dropping any BOM.
  * @param {string | Buffer} source raw source from the loader pipeline
- * @returns {string} UTF-8 string without BOM
+ * @returns {string} UTF-8 string
  */
-const toBomFreeString = (source) => {
-	const text = Buffer.isBuffer(source) ? source.toString("utf8") : source;
-	const stripped = removeBOM(text);
-	return typeof stripped === "string" ? stripped : stripped.toString("utf8");
-};
+const asString = (source) =>
+	Buffer.isBuffer(source) ? source.toString("utf8") : source;
 
 class TypeScriptPlugin {
 	/**
@@ -181,8 +177,10 @@ class TypeScriptPlugin {
 			throw new (getModuleBuildError())(new Error(NODE_API_MISSING));
 		}
 
-		const [rawSource, loaderSourceMap, ...rest] = result;
-		const preStripSource = toBomFreeString(rawSource);
+		// A BOM must be off the source before it is stripped of types, and its
+		// map moved with it.
+		const [rawSource, loaderSourceMap, ...rest] = removeBOMFromResult(result);
+		const preStripSource = asString(rawSource);
 		const strippedSource = stripTypes(preStripSource);
 
 		const needSourceMap = module.useSourceMap || module.useSimpleSourceMap;

--- a/lib/util/createMappings.js
+++ b/lib/util/createMappings.js
@@ -13,9 +13,9 @@
  * while richer call sites can pass arrays of segments.
  *
  * TODO move this encoder into `webpack-sources` and replace the body of this
- * file with re-exports. The public shape (`encodeVLQ`, `encodeMappings(lines)`,
- * `MappingSegment`, `LineMappings`) is intended to match what would land
- * upstream so call sites don't have to change.
+ * file with re-exports. The public shape (`encodeVLQ`, `decodeVLQ`,
+ * `encodeMappings(lines)`, `MappingSegment`, `LineMappings`) is intended to
+ * match what would land upstream so call sites don't have to change.
  */
 
 const VLQ_BASE64 =
@@ -36,6 +36,27 @@ const encodeVLQ = (value) => {
 		result += VLQ_BASE64[digit];
 	} while (vlq > 0);
 	return result;
+};
+
+/**
+ * Decode one base64 VLQ value per the source-map V3 spec.
+ * @param {string} mappings a VLQ encoded `mappings` string
+ * @param {number} start index of the value's first character
+ * @returns {{ value: number, end: number }} the decoded value and the index just past it; `end` equals `start` when there is no valid value at `start`
+ */
+const decodeVLQ = (mappings, start) => {
+	let value = 0;
+	let shift = 0;
+	let index = start;
+	let digit;
+	do {
+		digit = index < mappings.length ? VLQ_BASE64.indexOf(mappings[index]) : -1;
+		if (digit < 0) return { value: 0, end: start };
+		value += (digit & 0x1f) << shift;
+		shift += 5;
+		index++;
+	} while (digit & 0x20);
+	return { value: value & 1 ? -(value >>> 1) : value >>> 1, end: index };
 };
 
 /**
@@ -114,5 +135,6 @@ const encodeMappings = (lines) => {
 	return encodedLines.join(";");
 };
 
+module.exports.decodeVLQ = decodeVLQ;
 module.exports.encodeMappings = encodeMappings;
 module.exports.encodeVLQ = encodeVLQ;

--- a/lib/util/removeBOM.js
+++ b/lib/util/removeBOM.js
@@ -5,12 +5,17 @@
 
 "use strict";
 
+const { decodeVLQ, encodeVLQ } = require("./createMappings");
+
+/** @import { RawSourceMap } from "webpack-sources" */
+/** @import { Result } from "../NormalModule" */
+
 /**
  * Returns result without BOM.
  * @param {string | Buffer} strOrBuffer string or buffer
  * @returns {string | Buffer} result without BOM
  */
-module.exports = (strOrBuffer) => {
+const removeBOM = (strOrBuffer) => {
 	if (typeof strOrBuffer === "string" && strOrBuffer.charCodeAt(0) === 0xfeff) {
 		return strOrBuffer.slice(1);
 	} else if (
@@ -24,3 +29,73 @@ module.exports = (strOrBuffer) => {
 
 	return strOrBuffer;
 };
+
+/**
+ * A BOM occupies generated column 0 of the first line, so a map describing
+ * BOM-prefixed content starts that line at column 1 or later. Removing the BOM
+ * moves the line one column left; the segments after the first are encoded
+ * relative to it, so only the first is rewritten. A map already starting at
+ * column 0 describes the content without its BOM and is left alone.
+ * @param {string} mappings VLQ encoded `mappings` of a map for BOM-prefixed content
+ * @returns {string} `mappings` for the same content without its BOM
+ */
+const shiftMappings = (mappings) => {
+	const { value, end } = decodeVLQ(mappings, 0);
+	if (end === 0 || value <= 0) return mappings;
+	return encodeVLQ(value - 1) + mappings.slice(end);
+};
+
+/**
+ * Adjust a source map that accompanied BOM-prefixed content for the removal of
+ * that BOM. Anything that is not a version 3 map is passed through untouched.
+ * @param {(string | RawSourceMap)=} sourceMap the map, as an object or as JSON
+ * @returns {(string | RawSourceMap)=} the adjusted map
+ */
+const adjustSourceMapForRemovedBOM = (sourceMap) => {
+	if (!sourceMap) return sourceMap;
+
+	if (typeof sourceMap === "string") {
+		/** @type {RawSourceMap} */
+		let parsed;
+		try {
+			parsed = JSON.parse(sourceMap);
+		} catch (_err) {
+			return sourceMap;
+		}
+		const adjusted = adjustSourceMapForRemovedBOM(parsed);
+		return adjusted === parsed ? sourceMap : JSON.stringify(adjusted);
+	}
+
+	if (typeof sourceMap.mappings !== "string") return sourceMap;
+
+	const mappings = shiftMappings(sourceMap.mappings);
+
+	return mappings === sourceMap.mappings
+		? sourceMap
+		: { ...sourceMap, mappings };
+};
+
+/**
+ * @param {Result} result a loader result: content, an optional source map, extra info
+ * @returns {Result} the result with a leading BOM removed from its content and its source map kept in sync
+ */
+const removeBOMFromResult = (result) => {
+	const content = result[0];
+	const withoutBOM = removeBOM(content);
+
+	if (withoutBOM === content) return result;
+
+	// Copied rather than rebuilt, so a result carrying no source map keeps its
+	// arity.
+	const adjusted = /** @type {Result} */ ([...result]);
+
+	adjusted[0] = withoutBOM;
+
+	if (adjusted[1]) adjusted[1] = adjustSourceMapForRemovedBOM(adjusted[1]);
+
+	return adjusted;
+};
+
+module.exports.adjustSourceMapForRemovedBOM = adjustSourceMapForRemovedBOM;
+module.exports.removeBOM = removeBOM;
+module.exports.removeBOMFromResult = removeBOMFromResult;

--- a/lib/util/removeBOM.js
+++ b/lib/util/removeBOM.js
@@ -47,7 +47,9 @@ const shiftMappings = (mappings) => {
 
 /**
  * Adjust a source map that accompanied BOM-prefixed content for the removal of
- * that BOM. Anything that is not a version 3 map is passed through untouched.
+ * that BOM. Anything without VLQ `mappings` is passed through untouched, as is
+ * a map declaring a version other than 3 — earlier versions spell `mappings`
+ * differently. A map that declares no version at all is taken as version 3.
  * @param {(string | RawSourceMap)=} sourceMap the map, as an object or as JSON
  * @returns {(string | RawSourceMap)=} the adjusted map
  */
@@ -64,6 +66,10 @@ const adjustSourceMapForRemovedBOM = (sourceMap) => {
 		}
 		const adjusted = adjustSourceMapForRemovedBOM(parsed);
 		return adjusted === parsed ? sourceMap : JSON.stringify(adjusted);
+	}
+
+	if (sourceMap.version !== undefined && sourceMap.version !== 3) {
+		return sourceMap;
 	}
 
 	if (typeof sourceMap.mappings !== "string") return sourceMap;

--- a/test/configCases/source-map/bom-from-loader-counting-map/bom-loader.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/bom-loader.js
@@ -1,6 +1,5 @@
-// Emulates dart-sass: the map describes the emitted string, so its first line
-// starts at generated column 1 - column 0 is the BOM. `options.stringifyMap`
-// hands the map over as JSON, the other shape a loader may return.
+// Emulates dart-sass: the map counts the BOM, so line 1 starts at column 1.
+// `options.stringifyMap` returns it as JSON, the other shape a loader may use.
 const { encodeMappings } = require("../../../../lib/util/createMappings");
 
 /** @type {import("../../../../").LoaderDefinition<{ stringifyMap?: boolean }>} */

--- a/test/configCases/source-map/bom-from-loader-counting-map/bom-loader.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/bom-loader.js
@@ -1,0 +1,54 @@
+// Emulates dart-sass: the map describes the emitted string, so its first line
+// starts at generated column 1 - column 0 is the BOM. `options.stringifyMap`
+// hands the map over as JSON, the other shape a loader may return.
+const { encodeMappings } = require("../../../../lib/util/createMappings");
+
+/** @type {import("../../../../").LoaderDefinition<{ stringifyMap?: boolean }>} */
+module.exports = function bomLoader(source) {
+	const lines = source.split("\n");
+	// Line 1 gets a second segment on the opening quote, so a shift that moved
+	// more than the first segment would misplace the string literal.
+	const quote = lines[0].indexOf('"');
+	const mappings = encodeMappings(
+		lines.map((_, line) =>
+			line === 0
+				? [
+						{
+							generatedColumn: 1,
+							sourceIndex: 0,
+							originalLine: 0,
+							originalColumn: 0
+						},
+						{
+							generatedColumn: 1 + quote,
+							sourceIndex: 0,
+							originalLine: 0,
+							originalColumn: quote
+						}
+					]
+				: {
+						generatedColumn: 0,
+						sourceIndex: 0,
+						originalLine: line,
+						originalColumn: 0
+					}
+		)
+	);
+	const name = /** @type {string} */ (this.resourcePath.split(/[\\/]/).pop());
+	const map = {
+		version: 3,
+		file: name,
+		sources: [name],
+		sourcesContent: [source],
+		names: [],
+		mappings
+	};
+
+	this.callback(
+		null,
+		`\uFEFF${source}`,
+		this.getOptions().stringifyMap
+			? JSON.stringify(map)
+			: /** @type {import("webpack-sources").RawSourceMap} */ (map)
+	);
+};

--- a/test/configCases/source-map/bom-from-loader-counting-map/chained.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/chained.js
@@ -1,0 +1,2 @@
+const CHAINED = "BOM_CHAINED_TOKEN";
+export default CHAINED;

--- a/test/configCases/source-map/bom-from-loader-counting-map/direct.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/direct.js
@@ -1,0 +1,2 @@
+const DIRECT = "BOM_DIRECT_TOKEN";
+export default DIRECT;

--- a/test/configCases/source-map/bom-from-loader-counting-map/index.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/index.js
@@ -1,0 +1,7 @@
+import chained from "./chained.js";
+import direct from "./direct.js";
+
+it("should run modules whose loader produced a BOM its map counted", () => {
+	expect(chained).toBe("BOM_CHAINED_TOKEN");
+	expect(direct).toBe("BOM_DIRECT_TOKEN");
+});

--- a/test/configCases/source-map/bom-from-loader-counting-map/next-loader.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/next-loader.js
@@ -1,0 +1,24 @@
+// Runs after the BOM-emitting loader, so its input is what `convertArgs`
+// handed over: a throw here fails the case.
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function nextLoader(source, sourceMap) {
+	if (source.charCodeAt(0) === 0xfeff) {
+		throw new Error("the previous loader's BOM reached the next loader");
+	}
+	if (!sourceMap) {
+		throw new Error("the previous loader's source map was dropped");
+	}
+
+	const { mappings } =
+		typeof sourceMap === "string" ? JSON.parse(sourceMap) : sourceMap;
+
+	// "A" is VLQ 0: with the BOM gone, the first line has to start at
+	// generated column 0 again.
+	if (!mappings.startsWith("A")) {
+		throw new Error(
+			`the source map still counts the removed BOM: ${mappings.split(";")[0]}`
+		);
+	}
+
+	this.callback(null, source, sourceMap);
+};

--- a/test/configCases/source-map/bom-from-loader-counting-map/test.config.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/test.config.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+// eslint-disable-next-line import/no-extraneous-dependencies -- transitive via webpack-sources, used only to verify the emitted map
+const { SourceMapConsumer } = require("source-map");
+
+const BOM = "\uFEFF";
+
+module.exports = {
+	afterExecute(options) {
+		const dir = options.output.path;
+		const bundle = fs.readFileSync(path.join(dir, "bundle0.js"), "utf8");
+		const map = JSON.parse(
+			fs.readFileSync(path.join(dir, "bundle0.js.map"), "utf8")
+		);
+
+		expect(bundle.startsWith(BOM)).toBe(false);
+
+		const lines = bundle.split("\n");
+		const consumer = new SourceMapConsumer(map);
+
+		for (const [name, token] of [
+			["chained.js", "BOM_CHAINED_TOKEN"],
+			["direct.js", "BOM_DIRECT_TOKEN"]
+		]) {
+			const source = map.sources.find((entry) => entry.endsWith(name));
+
+			expect(source).toBeDefined();
+
+			const original = map.sourcesContent[map.sources.indexOf(source)];
+
+			expect(original.startsWith(BOM)).toBe(false);
+
+			const declaration = `= "${token}";`;
+			const line = lines.findIndex((text) => text.includes(declaration)) + 1;
+
+			expect(line).toBeGreaterThan(0);
+
+			const text = lines[line - 1];
+			const start = text.indexOf("const ");
+			const quote = text.indexOf(`"${token}"`);
+
+			// The BOM is gone from the content, so the map must not count it any
+			// more: both segments of the module's first line point at the columns
+			// the code really occupies.
+			expect(
+				consumer.generatedPositionFor({ source, line: 1, column: 0 })
+			).toMatchObject({ line, column: start });
+			expect(
+				consumer.generatedPositionFor({
+					source,
+					line: 1,
+					column: original.indexOf('"')
+				})
+			).toMatchObject({ line, column: quote });
+			expect(
+				consumer.originalPositionFor({ line, column: start })
+			).toMatchObject({ source, line: 1, column: 0 });
+
+			// Only the first line moves - the BOM is on that line alone.
+			expect(
+				consumer.generatedPositionFor({ source, line: 2, column: 0 })
+			).toMatchObject({ column: 0 });
+		}
+	}
+};

--- a/test/configCases/source-map/bom-from-loader-counting-map/test.config.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/test.config.js
@@ -41,9 +41,8 @@ module.exports = {
 			const start = text.indexOf("const ");
 			const quote = text.indexOf(`"${token}"`);
 
-			// The BOM is gone from the content, so the map must not count it any
-			// more: both segments of the module's first line point at the columns
-			// the code really occupies.
+			// The BOM is gone, so both segments of line 1 must point at the
+			// columns the code really occupies.
 			expect(
 				consumer.generatedPositionFor({ source, line: 1, column: 0 })
 			).toMatchObject({ line, column: start });

--- a/test/configCases/source-map/bom-from-loader-counting-map/webpack.config.js
+++ b/test/configCases/source-map/bom-from-loader-counting-map/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: "source-map",
+	entry: "./index.js",
+	module: {
+		rules: [
+			// Two loaders: the BOM goes in `LoaderRunner`'s `convertArgs`, and the
+			// map handed on is JSON.
+			{
+				test: /chained\.js$/,
+				use: [
+					require.resolve("./next-loader.js"),
+					{
+						loader: require.resolve("./bom-loader.js"),
+						options: { stringifyMap: true }
+					}
+				]
+			},
+			// One loader: the BOM goes in the `processResult` tap instead.
+			{
+				test: /direct\.js$/,
+				use: [require.resolve("./bom-loader.js")]
+			}
+		]
+	}
+};

--- a/test/configCases/source-map/bom-from-loader-css/index.js
+++ b/test/configCases/source-map/bom-from-loader-css/index.js
@@ -1,0 +1,5 @@
+import "./style.css";
+
+it("should keep the CSS source map aligned after a loader's BOM is removed", () => {
+	expect(1).toBe(1);
+});

--- a/test/configCases/source-map/bom-from-loader-css/style.css
+++ b/test/configCases/source-map/bom-from-loader-css/style.css
@@ -1,0 +1,2 @@
+.token { content: "BOM_CSS_TOKEN"; }
+.other { color: red; }

--- a/test/configCases/source-map/bom-from-loader-css/test.config.js
+++ b/test/configCases/source-map/bom-from-loader-css/test.config.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+// eslint-disable-next-line import/no-extraneous-dependencies -- transitive via webpack-sources, used only to verify the emitted map
+const { SourceMapConsumer } = require("source-map");
+
+const BOM = "\uFEFF";
+const TOKEN = '"BOM_CSS_TOKEN"';
+
+module.exports = {
+	afterExecute(options) {
+		const dir = options.output.path;
+		const css = fs.readFileSync(path.join(dir, "bundle0.css"), "utf8");
+		const map = JSON.parse(
+			fs.readFileSync(path.join(dir, "bundle0.css.map"), "utf8")
+		);
+
+		expect(css.startsWith(BOM)).toBe(false);
+
+		const source = map.sources.find((entry) => entry.endsWith("style.css"));
+
+		expect(source).toBeDefined();
+
+		const original = map.sourcesContent[map.sources.indexOf(source)];
+
+		expect(original.startsWith(BOM)).toBe(false);
+
+		const lines = css.split("\n");
+		const line = lines.findIndex((text) => text.includes(TOKEN)) + 1;
+
+		expect(line).toBeGreaterThan(0);
+
+		// The extracted stylesheet lost its BOM, so its map must not count one:
+		// both segments of the first line point at the columns the rule occupies.
+		const consumer = new SourceMapConsumer(map);
+
+		expect(
+			consumer.generatedPositionFor({ source, line: 1, column: 0 })
+		).toMatchObject({ line, column: lines[line - 1].indexOf(".token") });
+		expect(
+			consumer.generatedPositionFor({
+				source,
+				line: 1,
+				column: original.indexOf('"')
+			})
+		).toMatchObject({ line, column: lines[line - 1].indexOf(TOKEN) });
+	}
+};

--- a/test/configCases/source-map/bom-from-loader-css/webpack.config.js
+++ b/test/configCases/source-map/bom-from-loader-css/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	devtool: "source-map",
+	entry: "./index.js",
+	experiments: {
+		css: true
+	},
+	module: {
+		rules: [
+			{
+				test: /style\.css$/,
+				use: [require.resolve("../bom-from-loader-counting-map/bom-loader.js")]
+			}
+		]
+	}
+};

--- a/test/configCases/source-map/bom-from-loader/bom-loader.js
+++ b/test/configCases/source-map/bom-from-loader/bom-loader.js
@@ -1,5 +1,6 @@
 // Emulates a tool that maps the content it compiled and only then prepends a
-// BOM, the way dart-sass does for non-ASCII `compressed` output.
+// BOM: the map starts the first line at column 0, so removing the BOM must
+// leave it alone. `bom-from-loader-counting-map` covers the other convention.
 /** @type {import("../../../../").LoaderDefinition} */
 module.exports = function bomLoader(source) {
 	const mappings = source

--- a/test/createMappings.unittest.js
+++ b/test/createMappings.unittest.js
@@ -1,7 +1,11 @@
 "use strict";
 
 // cspell:disable -- VLQ-encoded source-map mappings strings below
-const { encodeMappings, encodeVLQ } = require("../lib/util/createMappings");
+const {
+	decodeVLQ,
+	encodeMappings,
+	encodeVLQ
+} = require("../lib/util/createMappings");
 
 describe("encodeVLQ", () => {
 	const cases = [
@@ -19,6 +23,41 @@ describe("encodeVLQ", () => {
 			expect(encodeVLQ(/** @type {number} */ (input))).toBe(expected);
 		});
 	}
+});
+
+describe("decodeVLQ", () => {
+	const cases = [
+		["A", 0, 1],
+		["C", 1, 1],
+		["D", -1, 1],
+		["e", 15, 1],
+		["gB", 16, 2],
+		["hB", -16, 2],
+		["gkxH", 123456, 4]
+	];
+
+	for (const [input, value, end] of cases) {
+		it(`decodes ${input} -> ${value}`, () => {
+			expect(decodeVLQ(/** @type {string} */ (input), 0)).toEqual({
+				value,
+				end
+			});
+		});
+	}
+
+	it("decodes a value at an offset", () => {
+		expect(decodeVLQ("AAgB", 2)).toEqual({ value: 16, end: 4 });
+	});
+
+	it("reports no value for a separator, an unknown character or the end of the input", () => {
+		expect(decodeVLQ(";AAAA", 0)).toEqual({ value: 0, end: 0 });
+		expect(decodeVLQ("AAAA", 4)).toEqual({ value: 0, end: 4 });
+		expect(decodeVLQ("", 0)).toEqual({ value: 0, end: 0 });
+	});
+
+	it("reports no value for a continuation that runs off the end", () => {
+		expect(decodeVLQ("g", 0)).toEqual({ value: 0, end: 0 });
+	});
 });
 
 describe("encodeMappings", () => {

--- a/test/removeBOM.unittest.js
+++ b/test/removeBOM.unittest.js
@@ -68,6 +68,24 @@ describe("adjustSourceMapForRemovedBOM", () => {
 		expect(adjustSourceMapForRemovedBOM(map("EAAA"))).toEqual(map("CAAA"));
 	});
 
+	it("leaves a map declaring a version other than 3 alone, and shifts one declaring none", () => {
+		const older = { ...map("CAAA"), version: 2 };
+		const versionless = { mappings: "CAAA", sources: ["x.js"] };
+
+		expect(
+			adjustSourceMapForRemovedBOM(
+				/** @type {import("webpack-sources").RawSourceMap} */
+				(/** @type {unknown} */ (older))
+			)
+		).toBe(older);
+		expect(
+			adjustSourceMapForRemovedBOM(
+				/** @type {import("webpack-sources").RawSourceMap} */
+				(/** @type {unknown} */ (versionless))
+			)
+		).toEqual({ mappings: "AAAA", sources: ["x.js"] });
+	});
+
 	it("leaves a map whose first line has no mapping alone", () => {
 		const sourceMap = map(";CAAA");
 

--- a/test/removeBOM.unittest.js
+++ b/test/removeBOM.unittest.js
@@ -60,10 +60,8 @@ describe("adjustSourceMapForRemovedBOM", () => {
 		expect(adjustSourceMapForRemovedBOM(sourceMap)).toBe(sourceMap);
 	});
 
-	// Column 0 of a BOM-prefixed first line is the BOM, never source content, so
-	// a map starting the line further in is read as having counted the BOM. A
-	// map that ignored it and still skipped column 0 did not describe its own
-	// content, and is shifted with the rest.
+	// Column 0 of a BOM-prefixed line is the BOM, never source content, so a map
+	// that skipped it anyway did not describe its own content.
 	it("shifts a map that skipped the first column for a reason of its own", () => {
 		expect(adjustSourceMapForRemovedBOM(map("EAAA"))).toEqual(map("CAAA"));
 	});

--- a/test/removeBOM.unittest.js
+++ b/test/removeBOM.unittest.js
@@ -1,23 +1,125 @@
 "use strict";
 
-const removeBOM = require("../lib/util/removeBOM");
+// cspell:disable -- VLQ-encoded source-map mappings strings below
+const {
+	adjustSourceMapForRemovedBOM,
+	removeBOM,
+	removeBOMFromResult
+} = require("../lib/util/removeBOM");
+
+const BOM = "\uFEFF";
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+/**
+ * @param {string} mappings mappings
+ * @returns {import("webpack-sources").RawSourceMap} a source map carrying them
+ */
+const map = (mappings) => ({
+	version: 3,
+	file: "x.js",
+	sources: ["x.js"],
+	names: [],
+	mappings
+});
 
 describe("removeBOM", () => {
-	it("should strip a leading BOM from a string", () => {
-		expect(removeBOM("﻿hi")).toBe("hi");
+	it("removes a BOM from a string", () => {
+		expect(removeBOM(`${BOM}a`)).toBe("a");
 	});
 
-	it("should leave a string without a BOM untouched", () => {
-		expect(removeBOM("hi")).toBe("hi");
+	it("removes a UTF-8 BOM from a buffer", () => {
+		expect(removeBOM(Buffer.concat([UTF8_BOM, Buffer.from("a")]))).toEqual(
+			Buffer.from("a")
+		);
 	});
 
-	it("should strip a leading UTF-8 BOM from a buffer", () => {
-		const result = removeBOM(Buffer.from([0xef, 0xbb, 0xbf, 65, 66]));
-		expect(/** @type {Buffer} */ (result).toString()).toBe("AB");
-	});
+	it("returns content without a BOM as it is", () => {
+		const buffer = Buffer.from("a");
 
-	it("should leave a buffer without a BOM untouched", () => {
-		const input = Buffer.from([65, 66]);
-		expect(removeBOM(input)).toBe(input);
+		expect(removeBOM("a")).toBe("a");
+		expect(removeBOM(buffer)).toBe(buffer);
 	});
 });
+
+describe("adjustSourceMapForRemovedBOM", () => {
+	it("shifts the first line of a map that counted the BOM", () => {
+		expect(adjustSourceMapForRemovedBOM(map("CAAA;AACA"))).toEqual(
+			map("AAAA;AACA")
+		);
+	});
+
+	it("shifts only the first segment, leaving the ones after it relative to it", () => {
+		expect(adjustSourceMapForRemovedBOM(map("gBAAgB,eAAe"))).toEqual(
+			map("eAAgB,eAAe")
+		);
+	});
+
+	it("leaves a map that already starts at column 0 alone", () => {
+		const sourceMap = map("AAAA;AACA");
+
+		expect(adjustSourceMapForRemovedBOM(sourceMap)).toBe(sourceMap);
+	});
+
+	// Column 0 of a BOM-prefixed first line is the BOM, never source content, so
+	// a map starting the line further in is read as having counted the BOM. A
+	// map that ignored it and still skipped column 0 did not describe its own
+	// content, and is shifted with the rest.
+	it("shifts a map that skipped the first column for a reason of its own", () => {
+		expect(adjustSourceMapForRemovedBOM(map("EAAA"))).toEqual(map("CAAA"));
+	});
+
+	it("leaves a map whose first line has no mapping alone", () => {
+		const sourceMap = map(";CAAA");
+
+		expect(adjustSourceMapForRemovedBOM(sourceMap)).toBe(sourceMap);
+	});
+
+	it("adjusts a map handed over as JSON", () => {
+		expect(adjustSourceMapForRemovedBOM(JSON.stringify(map("CAAA")))).toBe(
+			JSON.stringify(map("AAAA"))
+		);
+	});
+
+	it("leaves anything that is not a map with mappings alone", () => {
+		const notJson = "/some/source.js";
+		const withoutMappings = { version: 3, sources: [] };
+
+		expect(adjustSourceMapForRemovedBOM(undefined)).toBeUndefined();
+		expect(adjustSourceMapForRemovedBOM(notJson)).toBe(notJson);
+		expect(adjustSourceMapForRemovedBOM(JSON.stringify(map("AAAA")))).toBe(
+			JSON.stringify(map("AAAA"))
+		);
+		expect(
+			adjustSourceMapForRemovedBOM(
+				/** @type {import("webpack-sources").RawSourceMap} */
+				(/** @type {unknown} */ (withoutMappings))
+			)
+		).toBe(withoutMappings);
+	});
+});
+
+describe("removeBOMFromResult", () => {
+	it("removes the BOM and adjusts the source map", () => {
+		expect(
+			removeBOMFromResult([`${BOM}const a = 1;`, map("CAAA"), undefined])
+		).toEqual(["const a = 1;", map("AAAA"), undefined]);
+	});
+
+	it("keeps the arity of a result carrying no source map", () => {
+		const result = removeBOMFromResult(
+			/** @type {import("../lib/NormalModule").Result} */
+			(/** @type {unknown} */ ([`${BOM}const a = 1;`]))
+		);
+
+		expect(result).toEqual(["const a = 1;"]);
+		expect(result).toHaveLength(1);
+	});
+
+	it("returns a result without a BOM as it is", () => {
+		/** @type {import("../lib/NormalModule").Result} */
+		const result = ["const a = 1;", map("CAAA"), undefined];
+
+		expect(removeBOMFromResult(result)).toBe(result);
+	});
+});
+// cspell:enable


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

A map that describes BOM-prefixed content starts its first line at generated column 1, because column 0 is the BOM — dart-sass emits exactly that (`compressed` + `charset` on a non-ASCII stylesheet gives a BOM and mappings starting `CAAA`). Every place webpack strips such a BOM left the map untouched, so every mapping on the first line pointed one column to the right: the `processResult` taps of the JavaScript, CSS, HTML and TypeScript plugins, and the between-loaders strip added in #21857. Now the first line's first segment is shifted one column left when a BOM is removed; the segments after it are relative to it, and a map already starting at column 0 described the content without its BOM and is left alone. Refs #21857.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/source-map/bom-from-loader-counting-map` (both strip sites, map as an object and as JSON), `test/configCases/source-map/bom-from-loader-css` (extracted stylesheet), `test/removeBOM.unittest.js` and `decodeVLQ` cases in `test/createMappings.unittest.js`. Each config case fails on `main` and passes here.

**Does this PR introduce a breaking change?**

No. The change is a no-op unless a BOM is actually removed and the accompanying map's first line starts at column >= 1, so the existing `bom-from-loader` case (the other convention, first segment at column 0) is untouched.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code (Claude Opus) was used to write the fix and its tests, and to verify them: it reproduced the misalignment, checked dart-sass's own output for the convention the fix assumes, and ran the affected `configCases`/unit suites and every `lint` stage locally. All of it was reviewed before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 BOM removal across JavaScript, CSS, HTML, and TypeScript processing.
  * Source maps now remain aligned when loader-generated BOMs are removed.
  * Preserved loader result structure and supported source maps provided as objects or JSON strings.
  * Corrected source-map positions when a BOM was counted in generated columns.

* **Tests**
  * Added coverage for BOM handling and source-map accuracy across JavaScript and CSS workflows.
  * Added tests for decoding source-map mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->