### PR TITLE
fix(css): skip the loading runtime when every css chunk is initial

### DIFF
--- a/.changeset/027-css-dead-loading-runtime.md
+++ b/.changeset/027-css-dead-loading-runtime.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Stop emitting the CSS chunk loading runtime when every CSS chunk is initial.

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -76,10 +76,26 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		} = compilation;
 		const dedupePrefetch = Boolean(resourceHints && resourceHints.dedupe);
 		const fn = RuntimeGlobals.ensureChunkHandlers;
+		/** @type {Set<ChunkId>} */
+		const initialChunkIds = new Set();
+		for (const c of chunk.getAllInitialChunks()) {
+			if (chunkHasCss(c, chunkGraph)) {
+				initialChunkIds.add(/** @type {ChunkId} */ (c.id));
+			}
+		}
 		// The predicate the stylesheet is emitted from: an `@import` external gives a
 		// chunk a css asset without a `CSS_TYPE` module, and it still has to load.
 		const conditionMap = chunkGraph.getChunkConditionMap(chunk, chunkHasCss);
-		const hasCssMatcher = compileBooleanMatcher(conditionMap);
+		// An initial chunk is installed before the handler can run, so it never
+		// reaches the loading path — with no other one there is nothing to load.
+		const loadableConditionMap = { ...conditionMap };
+		for (const id of initialChunkIds) {
+			loadableConditionMap[id] = false;
+		}
+		const hasCssMatcher =
+			compileBooleanMatcher(loadableConditionMap) === false
+				? false
+				: compileBooleanMatcher(conditionMap);
 
 		const withLoading =
 			_runtimeRequirements.has(RuntimeGlobals.ensureChunkHandlers) &&
@@ -88,13 +104,6 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		const withHmr = _runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadUpdateHandlers
 		);
-		/** @type {Set<ChunkId>} */
-		const initialChunkIds = new Set();
-		for (const c of chunk.getAllInitialChunks()) {
-			if (chunkHasCss(c, chunkGraph)) {
-				initialChunkIds.add(/** @type {ChunkId} */ (c.id));
-			}
-		}
 
 		if (!withLoading && !withHmr) {
 			return null;

--- a/test/configCases/css/no-async-css-loading-runtime/index.js
+++ b/test/configCases/css/no-async-css-loading-runtime/index.js
@@ -1,0 +1,23 @@
+import "./style.css";
+
+it("should apply the initial stylesheet", done => {
+	import("./lazy.js").then(({ default: value }) => {
+		expect(value).toBe(42);
+		const style = getComputedStyle(document.body);
+		expect(style.getPropertyValue("background")).toBe(" red");
+		done();
+	}, done);
+});
+
+it("should not emit the css chunk loading runtime", () => {
+	// Every chunk with css is initial here, so the loading runtime could never
+	// run — only the javascript one is needed.
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	// Split so this module's own source, which the bundle embeds, is not a match.
+	const handler = suffix => `__webpack_require__.f.${suffix}`;
+	expect(source).toContain(handler("j"));
+	expect(source).not.toContain(handler("css"));
+	expect(source).not.toContain(`data-webpack-${"loading"}`);
+});

--- a/test/configCases/css/no-async-css-loading-runtime/index.js
+++ b/test/configCases/css/no-async-css-loading-runtime/index.js
@@ -1,11 +1,18 @@
 import "./style.css";
 
-it("should apply the initial stylesheet", done => {
+it("should apply the initial stylesheet", () => {
+	const style = getComputedStyle(document.body);
+	expect(style.getPropertyValue("background")).toBe(" red");
+});
+
+it("should load a javascript-only chunk", done => {
 	import("./lazy.js").then(({ default: value }) => {
-		expect(value).toBe(42);
-		const style = getComputedStyle(document.body);
-		expect(style.getPropertyValue("background")).toBe(" red");
-		done();
+		try {
+			expect(value).toBe(42);
+			done();
+		} catch (err) {
+			done(err);
+		}
 	}, done);
 });
 

--- a/test/configCases/css/no-async-css-loading-runtime/lazy.js
+++ b/test/configCases/css/no-async-css-loading-runtime/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/css/no-async-css-loading-runtime/style.css
+++ b/test/configCases/css/no-async-css-loading-runtime/style.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/css/no-async-css-loading-runtime/test.config.js
+++ b/test/configCases/css/no-async-css-loading-runtime/test.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["lazy_js.bundle0.js", "bundle0.js"];
+	},
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/no-async-css-loading-runtime/webpack.config.js
+++ b/test/configCases/css/no-async-css-loading-runtime/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	externalsPresets: { web: false, webAsync: true },
+	experiments: {
+		css: true
+	},
+	node: {
+		__dirname: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`CssLoadingRuntimeModule` emits the async css chunk-loading runtime whenever any chunk has css, without excluding the ones that are already initial — but an initial chunk is seeded into `installedChunks` as loaded, so the handler can never reach its loading path for it. Where every css chunk is initial the whole runtime, and `__webpack_require__.k` with it, is dead code that still ships.

`yarn test:size` reports one changed asset over the css cases, the new one, at 🟢 ↓ -4.50 KiB raw / -526 B gzip, and no runtime gained or lost a module. On webpack.js.org's own production build it is 1,225 raw / 388 gzip bytes off the entry bundle, which is what remained of its `mini-css-extract-plugin` → built-in css migration.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/configCases/css/no-async-css-loading-runtime`, which fails on `main` and passes here; `basic-web-async` already covers the mixed initial + async case that must keep the runtime.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was prepared with Claude Code. It was used to isolate the dead runtime against a real build (webpack.js.org built both ways, runtime split into its own chunk to attribute the bytes), to write the failing case first, and to re-measure with `yarn test:size` — which caught that a first version narrowed the emitted matcher and grew six other bundles, so the fix now only decides whether the runtime is emitted at all. All output was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwjXQBKW6nPrk5SgMWH8Hh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary CSS loading runtime code from being included when all CSS is loaded initially.
  - Ensured initial stylesheets are applied correctly without relying on asynchronous CSS loading.
  - Preserved asynchronous loading behavior for JavaScript-only content.

- **Tests**
  - Added coverage confirming initial styles apply correctly.
  - Added validation that unnecessary CSS loading runtime markers are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->