### PR TITLE
chore: re-add Claudio to TSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ For information about the governance of the webpack project, see [GOVERNANCE.md]
   **Aviv Keller** <<me@aviv.sh>> (he/him)
 - [evenstensberg](https://github.com/evenstensberg) -
   **Even Stensberg** <<evenstensberg@gmail.com>> (he/him)
+- [ovflowd](https://github.com/ovflowd) -
+  **Claudio Wunder** <<cwunder@gnome.org>> (he/they)
 - [thelarkinn](https://github.com/thelarkinn) -
   **Sean Larkin** <<selarkin@microsoft.com>> (he/him)
 


### PR DESCRIPTION
Regardless of the intentions or reasons for Claudio's removal, it was not discussed with the TSC and violates our charter, and cannot land without a formal TSC vote. 

This PR undoes that change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new member to the Technical Steering Committee listing in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->