### PR TITLE
test(test262): assert link errors at build time instead of skipping

### DIFF
--- a/test/configCases/errors/link-errors-future-defaults/amb-1.js
+++ b/test/configCases/errors/link-errors-future-defaults/amb-1.js
@@ -1,0 +1,1 @@
+export var x;

--- a/test/configCases/errors/link-errors-future-defaults/amb-2.js
+++ b/test/configCases/errors/link-errors-future-defaults/amb-2.js
@@ -1,0 +1,1 @@
+export var x;

--- a/test/configCases/errors/link-errors-future-defaults/amb-export.js
+++ b/test/configCases/errors/link-errors-future-defaults/amb-export.js
@@ -1,0 +1,1 @@
+export { x } from "./amb.js";

--- a/test/configCases/errors/link-errors-future-defaults/amb.js
+++ b/test/configCases/errors/link-errors-future-defaults/amb.js
@@ -1,0 +1,2 @@
+export * from "./amb-1.js";
+export * from "./amb-2.js";

--- a/test/configCases/errors/link-errors-future-defaults/circ-1.js
+++ b/test/configCases/errors/link-errors-future-defaults/circ-1.js
@@ -1,0 +1,1 @@
+export { x } from "./circ-2.js";

--- a/test/configCases/errors/link-errors-future-defaults/circ-2.js
+++ b/test/configCases/errors/link-errors-future-defaults/circ-2.js
@@ -1,0 +1,1 @@
+export { x } from "./circ-1.js";

--- a/test/configCases/errors/link-errors-future-defaults/errors.js
+++ b/test/configCases/errors/link-errors-future-defaults/errors.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = [
+	[/conflicting star exports for the name 'x'/],
+	[/is part of a circular reexport chain/],
+	[/is part of a circular reexport chain/]
+];

--- a/test/configCases/errors/link-errors-future-defaults/index.js
+++ b/test/configCases/errors/link-errors-future-defaults/index.js
@@ -1,0 +1,7 @@
+import { x as ambiguous } from "./amb-export.js";
+import { x as circular } from "./circ-1.js";
+
+it("should report both link errors as build errors under futureDefaults", () => {
+	expect(ambiguous).toBe(undefined);
+	expect(circular).toBe(undefined);
+});

--- a/test/configCases/errors/link-errors-future-defaults/webpack.config.js
+++ b/test/configCases/errors/link-errors-future-defaults/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// `futureDefaults` sets `exportsPresence: "error"`, which the reexport
+	// variant falls back to, so both link errors fail the build.
+	experiments: {
+		futureDefaults: true
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -835,6 +835,44 @@ const runScript = async (
 const baseDir = path.posix.resolve(test262Dir, "./test/language/");
 
 /* cspell:disable */
+// The spec rejects `import()` for these link errors; webpack, like rollup,
+// esbuild and bun, resolves linking at build time and reports them there.
+const linkErrorsAtBuildTime = new Set([
+	// ambiguous star re-export
+	"expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-function-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-do-while-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-ambiguous-import.js",
+	"expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-ambiguous-import.js",
+
+	// circular re-export chain
+	"expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-function-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-do-while-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-circular.js",
+	"expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-circular.js"
+]);
+
 const knownBugs = [
 	// Expected error because we use `Promise` to load modules, but this test overrides global `Promise`
 	"expressions/dynamic-import/returns-promise.js",
@@ -974,44 +1012,6 @@ const knownBugs = [
 	"expressions/dynamic-import/namespace/promise-then-ns-set-prototype-of.js",
 	"expressions/dynamic-import/namespace/promise-then-ns-set-strict.js",
 
-	// An ambiguous re-export is a compile-time diagnostic and never a runtime
-	// failure — `configCases/compiletime/exports-presence` pins that contract.
-	"expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-function-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-do-while-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-ambiguous-import.js",
-	"expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-ambiguous-import.js",
-
-	// Tests expect a runtime SyntaxError from a circular re-export chain
-	// (`a` re-exports from `b`, `b` re-exports from `a`). webpack resolves
-	// circular exports during the build and does not surface this as a
-	// runtime rejection of `import()`.
-	"expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-function-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-do-while-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-circular.js",
-	"expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-circular.js",
-
 	// Dynamic-import edge cases that don't fit webpack's static module graph:
 	// - Self-importing script that asserts evaluation count.
 	// - `eval("import('...')")` and dynamic `import` reuse-namespace assertions
@@ -1148,26 +1148,27 @@ describe("test262", () => {
 							process.stdout.write(`Running ${name} ("${scenario}")\n`);
 						}
 
-						// A resolution error is a build error for webpack, not a throw,
-						// so the presence checks the other tests disable must be on.
-						const isResolutionTest =
-							meta.negative && meta.negative.phase === "resolution";
+						// A link error is a build error for webpack, not a throw, so the
+						// presence checks the other tests disable must be on.
+						const isLinkErrorTest =
+							(meta.negative && meta.negative.phase === "resolution") ||
+							linkErrorsAtBuildTime.has(name);
 
 						const stats = await compile(testFile, scenario, {
 							mode,
-							...(isResolutionTest ? { exportsPresence: "error" } : {}),
+							...(isLinkErrorTest ? { exportsPresence: "error" } : {}),
 							output: {
 								path: outputPath,
 								filename: path.relative(outputPath, outputFile)
 							}
 						});
 
-						if (isResolutionTest) {
+						if (isLinkErrorTest) {
 							// The bundle must not run: linking failed, so the body these
 							// tests guard against evaluation was never reached.
 							if (stats.compilation.errors.length === 0) {
 								throw new Error(
-									`Error in test file "${outputFile}" ("${testFile}"), expected a resolution error`
+									`Error in test file "${outputFile}" ("${testFile}"), expected a link error`
 								);
 							}
 


### PR DESCRIPTION
**Summary**

30 `expressions/dynamic-import/catch/*` tests expect `import()` to reject with a `SyntaxError` when the imported module's linking fails — 15 for an ambiguous star re-export, 15 for a circular re-export chain. webpack resolves linking during the build and reports the same failure as a build error, so the runtime rejection never happens and all 30 sat in `knownBugs`, skipped, with nothing about them verified.

Reporting a link failure at build time is what the whole bundler class does, not a webpack quirk. Running the same two fixtures through each:

| | ambiguous star re-export | circular re-export |
| --- | --- | --- |
| Node.js 22 (spec) | runtime `SyntaxError` | runtime `SyntaxError` |
| rollup 4.63.1 | build error `MISSING_EXPORT` | build error `CIRCULAR_REEXPORT` |
| esbuild 0.28.2 | build error | build error |
| bun 1.3.11 | build error | build error |
| webpack | diagnostic (error under `exportsPresence` / `reexportExportsPresence`) | same |

These tests now run with the presence checks on and assert the build error, then skip executing the bundle — exactly what the `negative: phase: resolution` tests already do. They carry no `negative:` metadata of their own, so the equivalence is applied through an explicit list rather than inferred. That takes `knownBugs` from 111 to 81 and moves 30 files from *skipped* to *asserted*, which is strictly stronger than before.

Also adds a config case pinning that `experiments.futureDefaults` makes both failures build errors: it sets `exportsPresence: "error"`, and `reexportExportsPresence` falls back to it, so the circular case is covered too. That was already true but nothing tested it.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `configCases/errors/link-errors-future-defaults`, verified to fail without `futureDefaults` and pass with it. The 30 test262 files were verified load-bearing by removing one entry from the new list and confirming that test then fails.

**Does this PR introduce a breaking change?**

No. No `lib/` or `schemas/` changes — test-only.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used throughout: to reproduce the divergences, run the same fixtures through Node.js, rollup, esbuild and bun to establish what the ecosystem does, and write the harness change and the config case. The cross-bundler table above is from runs made for this PR, not from recollection. All findings and reasoning were reviewed by me before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q5wyknx4aqgnfnZeytnhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-time reporting for ambiguous and circular module re-exports.
  * Ensured affected dynamic imports fail compilation with clear link errors instead of producing incorrect runtime results.

* **Tests**
  * Added coverage for conflicting exports, circular re-export chains, and future default settings.
  * Updated dynamic-import test handling to validate compilation failures appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->