### PR TITLE
docs: scope the short-comment rule to plain comments, not JSDoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ Every source file under `lib/` (and `hot/`, `tooling/`) opens with the MIT licen
 
 **So never trade a JSDoc block for a shorter comment.** Turning
 
-```js
+```
 /**
  * An async external is a promise, not a module record with an evaluating state.
  * @param {Module} module the imported module
@@ -231,7 +231,7 @@ const isAsyncExternal = (module) => …
 
 into
 
-```js
+```
 // An async external is a promise, not a module record with an evaluating state.
 const isAsyncExternal = (/** @type {Module} */ module) => …
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,9 +214,31 @@ Every source file under `lib/` (and `hot/`, `tooling/`) opens with the MIT licen
 
 > [!REQUIRED]
 
-Comments inside `lib/`, `hot/`, `tooling/`, and `test/` must be **as short as possible** — ideally one line, at most two short lines. Every line must add information a careful reader can't get from the code itself: a hidden invariant, a non-obvious ordering constraint, a workaround, or the name of the higher-level concept the block implements. **Never** write multi-paragraph essays, restate what the next line obviously does, narrate the diff, restate the PR description, or quote the user/task framing.
+**This rule is about plain comments only** — `//` and `/* … */` narration inside `lib/`, `hot/`, `tooling/`, and `test/`. Those must be **as short as possible** — ideally one line, at most two short lines. Every line must add information a careful reader can't get from the code itself: a hidden invariant, a non-obvious ordering constraint, a workaround, or the name of the higher-level concept the block implements. **Never** write multi-paragraph essays, restate what the next line obviously does, narrate the diff, restate the PR description, or quote the user/task framing.
 
-JSDoc on exported symbols stays as-is — that's the type contract, not commentary.
+**A JSDoc block is exempt — it is the type contract, not commentary, and it is multi-line by construction.** One `@param` per parameter, an `@returns`, `@template`/`@typedef` where they apply, and a description line when the name alone doesn't carry the intent. That holds for every documented symbol, exported or internal to one file — "as short as possible" never applies to it, and a JSDoc block is never something to shorten, flatten onto one line, or delete.
+
+**So never trade a JSDoc block for a shorter comment.** Turning
+
+```js
+/**
+ * An async external is a promise, not a module record with an evaluating state.
+ * @param {Module} module the imported module
+ * @returns {boolean} true when the module is an async external
+ */
+const isAsyncExternal = (module) => …
+```
+
+into
+
+```js
+// An async external is a promise, not a module record with an evaluating state.
+const isAsyncExternal = (/** @type {Module} */ module) => …
+```
+
+is a regression, not a cleanup: the parameter and return documentation is gone and the types now hide inside the signature. An inline `/** @type {T} */` cast on a parameter is for a throwaway callback argument, not for a named function — every named function, module-scope helper or not, gets a JSDoc block, and one carrying an explanation gets it whatever its scope.
+
+Prose about a documented symbol goes **inside** its JSDoc, as the description above the tags — never as a `//` comment stacked on top of the block, and never as a `//` comment standing in for the block.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,9 @@ Every source file under `lib/` (and `hot/`, `tooling/`) opens with the MIT licen
 
 **This rule is about plain comments only** — `//` and `/* … */` narration inside `lib/`, `hot/`, `tooling/`, and `test/`. Those must be **as short as possible** — ideally one line, at most two short lines. Every line must add information a careful reader can't get from the code itself: a hidden invariant, a non-obvious ordering constraint, a workaround, or the name of the higher-level concept the block implements. **Never** write multi-paragraph essays, restate what the next line obviously does, narrate the diff, restate the PR description, or quote the user/task framing.
 
-**A JSDoc block is exempt — it is the type contract, not commentary, and it is multi-line by construction.** One `@param` per parameter, an `@returns`, `@template`/`@typedef` where they apply, and a description line when the name alone doesn't carry the intent. That holds for every documented symbol, exported or internal to one file — "as short as possible" never applies to it, and a JSDoc block is never something to shorten, flatten onto one line, or delete.
+**A JSDoc block's tags are exempt — they are the type contract, not commentary, and they are multi-line by construction.** One `@param` per parameter, an `@returns`, `@template`/`@typedef` where they apply. That holds for every documented symbol, exported or internal to one file: the tags are never something to shorten, flatten onto one line, or delete.
+
+**The description above those tags is prose, so it is bound by the same brevity as a plain comment: one or two sentences, never more.** Say what the function does when the name alone doesn't carry it, plus the one invariant or non-obvious constraint a caller needs. A paragraph explaining the algorithm, the history, or the alternatives considered belongs in neither place — moving an essay from a `//` comment into a JSDoc description is not a fix, it is the same essay indented differently.
 
 **So never trade a JSDoc block for a shorter comment.** Turning
 

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -194,7 +194,11 @@ const getEntrypointChunksInLoadOrder = (entrypoint) => {
 	const chunksLoadedByAncestorTags = new Set();
 	/** @type {Set<import("../ChunkGroup")>} */
 	const visitedGroups = new Set();
-	const walk = (/** @type {import("../ChunkGroup")} */ group) => {
+	/**
+	 * Collects the chunks an ancestor entry's own tags already load.
+	 * @param {import("../ChunkGroup")} group chunk group to walk up from
+	 */
+	const walk = (group) => {
 		if (visitedGroups.has(group)) return;
 		visitedGroups.add(group);
 		for (const parent of group.parentsIterable) {
@@ -220,7 +224,11 @@ const getEntrypointChunksInLoadOrder = (entrypoint) => {
 	const ordered = [];
 	/** @type {Set<Chunk>} */
 	const seen = new Set();
-	const push = (/** @type {Chunk | null | undefined} */ chunk) => {
+	/**
+	 * Appends a chunk once, skipping the ones an ancestor entry already loads.
+	 * @param {Chunk | null | undefined} chunk chunk to append
+	 */
+	const push = (chunk) => {
 		if (!chunk || seen.has(chunk) || chunk === entryChunk) return;
 		if (chunksLoadedByAncestorTags.has(chunk)) return;
 		seen.add(chunk);

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -197,6 +197,7 @@ const getEntrypointChunksInLoadOrder = (entrypoint) => {
 	/**
 	 * Collects the chunks an ancestor entry's own tags already load.
 	 * @param {import("../ChunkGroup")} group chunk group to walk up from
+	 * @returns {void}
 	 */
 	const walk = (group) => {
 		if (visitedGroups.has(group)) return;
@@ -227,6 +228,7 @@ const getEntrypointChunksInLoadOrder = (entrypoint) => {
 	/**
 	 * Appends a chunk once, skipping the ones an ancestor entry already loads.
 	 * @param {Chunk | null | undefined} chunk chunk to append
+	 * @returns {void}
 	 */
 	const push = (chunk) => {
 		if (!chunk || seen.has(chunk) || chunk === entryChunk) return;

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -619,11 +619,8 @@ class HtmlModulesPlugin {
 				}
 				const { htmlModules } = getState(compilation);
 				/**
-				 * Records HTML modules as they appear — freshly built
-				 * (`succeedModule`) or restored from cache (`stillValidModule`) —
-				 * so `finishMake` creates their entries without scanning every
-				 * module in the graph. Tracking only records; entries are still
-				 * added (and awaited) in `finishMake`.
+				 * Records HTML modules as they are built or restored, so `finishMake`
+				 * creates their entries without scanning the whole module graph.
 				 * @param {import("../Module")} module built or restored module
 				 * @returns {void}
 				 */
@@ -991,11 +988,9 @@ class HtmlModulesPlugin {
 				const resolvedSentinelHashCache = new WeakMap();
 
 				/**
-				 * Computes a linked/entry HTML page's emitted filename + chunk-URL-resolved
-				 * content + content hash for one (module, chunk). Shared by the emit loop
-				 * below and the page-link resolver. The content hash covers only the
-				 * chunk-URL-resolved source — links to *other* pages stay sentinels here,
-				 * so a page's filename doesn't depend on the filenames of pages it links to.
+				 * Computes an HTML page's emitted filename, chunk-URL-resolved content and
+				 * content hash. Links to other pages stay sentinels, so a page's filename
+				 * never depends on the filenames of the pages it links to.
 				 * @param {NormalModule} module the page's html module
 				 * @param {import("../Chunk")} chunk chunk the page is emitted from
 				 * @returns {{ resolvedContent: string, contentHash: string, filename: string, info: import("../Compilation").AssetInfo } | undefined} the page's emit, or `undefined` when it generates no html
@@ -1080,9 +1075,8 @@ class HtmlModulesPlugin {
 				/** @type {Map<string, string>} */
 				const htmlPageFilenameCache = new Map();
 				/**
-				 * Emitted filename of a linked `type: "html"` page, keyed by its entry
-				 * name. Looked up from the page's own entry chunk so it's independent of
-				 * chunk render order; cached for the compilation.
+				 * Emitted filename of a linked `type: "html"` page, read from the page's
+				 * own entry chunk so chunk render order cannot affect it.
 				 * @param {string} entryName entry name of the linked page
 				 * @returns {string} the page's emitted filename, `"data:,"` when it has none
 				 */

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -241,7 +241,11 @@ const collectHtmlEntryRequests = (name, entries) => {
 	const seenRequests = new Set();
 	/** @type {Set<string>} */
 	const visited = new Set();
-	const walk = (/** @type {string} */ entryName) => {
+	/**
+	 * Collects an entry's non-html requests, `dependOn` entries included.
+	 * @param {string} entryName entry to walk
+	 */
+	const walk = (entryName) => {
 		if (visited.has(entryName)) return;
 		visited.add(entryName);
 		const desc = entries[entryName];
@@ -613,12 +617,15 @@ class HtmlModulesPlugin {
 					);
 				}
 				const { htmlModules } = getState(compilation);
-				// Record HTML modules as they appear — freshly built
-				// (`succeedModule`) or restored from cache (`stillValidModule`) —
-				// so `finishMake` creates their entries without scanning every
-				// module in the graph. Tracking only records; entries are still
-				// added (and awaited) in `finishMake`.
-				const trackHtmlModule = (/** @type {import("../Module")} */ module) => {
+				/**
+				 * Records HTML modules as they appear — freshly built
+				 * (`succeedModule`) or restored from cache (`stillValidModule`) —
+				 * so `finishMake` creates their entries without scanning every
+				 * module in the graph. Tracking only records; entries are still
+				 * added (and awaited) in `finishMake`.
+				 * @param {import("../Module")} module built or restored module
+				 */
+				const trackHtmlModule = (module) => {
 					if (module.type !== HTML_MODULE_TYPE) return;
 					// enabled here, not on the compilation hook: an integrity build
 					// with no html module must not load the generator
@@ -981,15 +988,17 @@ class HtmlModulesPlugin {
 				/** @type {WeakMap<import("webpack-sources").Source, { resolvedContent: string, contentHash: string }>} */
 				const resolvedSentinelHashCache = new WeakMap();
 
-				// Compute a linked/entry HTML page's emitted filename + chunk-URL-resolved
-				// content + content hash for one (module, chunk). Shared by the emit loop
-				// below and the page-link resolver. The content hash covers only the
-				// chunk-URL-resolved source — links to *other* pages stay sentinels here,
-				// so a page's filename doesn't depend on the filenames of pages it links to.
-				const computePageEmit = (
-					/** @type {NormalModule} */ module,
-					/** @type {import("../Chunk")} */ chunk
-				) => {
+				/**
+				 * Computes a linked/entry HTML page's emitted filename + chunk-URL-resolved
+				 * content + content hash for one (module, chunk). Shared by the emit loop
+				 * below and the page-link resolver. The content hash covers only the
+				 * chunk-URL-resolved source — links to *other* pages stay sentinels here,
+				 * so a page's filename doesn't depend on the filenames of pages it links to.
+				 * @param {NormalModule} module the page's html module
+				 * @param {import("../Chunk")} chunk chunk the page is emitted from
+				 * @returns {{ resolvedContent: string, contentHash: string, filename: string, info: import("../Compilation").AssetInfo } | undefined} the page's emit, or `undefined` when it generates no html
+				 */
+				const computePageEmit = (module, chunk) => {
 					const { chunkGraph, outputOptions } = compilation;
 					const codeGenResult =
 						/** @type {import("../CodeGenerationResults")} */ (
@@ -1066,14 +1075,16 @@ class HtmlModulesPlugin {
 					};
 				};
 
-				// Emitted filename of a linked `type: "html"` page, keyed by its entry
-				// name. Looked up from the page's own entry chunk so it's independent of
-				// chunk render order; cached for the compilation.
 				/** @type {Map<string, string>} */
 				const htmlPageFilenameCache = new Map();
-				const computePageFilenameByEntry = (
-					/** @type {string} */ entryName
-				) => {
+				/**
+				 * Emitted filename of a linked `type: "html"` page, keyed by its entry
+				 * name. Looked up from the page's own entry chunk so it's independent of
+				 * chunk render order; cached for the compilation.
+				 * @param {string} entryName entry name of the linked page
+				 * @returns {string} the page's emitted filename, `"data:,"` when it has none
+				 */
+				const computePageFilenameByEntry = (entryName) => {
 					const cached = htmlPageFilenameCache.get(entryName);
 					if (cached !== undefined) return cached;
 					let filename = "data:,";

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -244,6 +244,7 @@ const collectHtmlEntryRequests = (name, entries) => {
 	/**
 	 * Collects an entry's non-html requests, `dependOn` entries included.
 	 * @param {string} entryName entry to walk
+	 * @returns {void}
 	 */
 	const walk = (entryName) => {
 		if (visited.has(entryName)) return;
@@ -624,6 +625,7 @@ class HtmlModulesPlugin {
 				 * module in the graph. Tracking only records; entries are still
 				 * added (and awaited) in `finishMake`.
 				 * @param {import("../Module")} module built or restored module
+				 * @returns {void}
 				 */
 				const trackHtmlModule = (module) => {
 					if (module.type !== HTML_MODULE_TYPE) return;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -6875,7 +6875,7 @@ const adoptionAgency = (subject, pos) => {
 
 /**
  * @param {HtmlElement} commonAncestor common ancestor node of the adoption agency
- * @returns {InsertionPlace} where the reparented node goes
+ * @returns {InsertionPlace} where the moved node goes
  */
 const placeForCommonAncestor = (commonAncestor) => {
 	if (
@@ -6892,7 +6892,7 @@ const placeForCommonAncestor = (commonAncestor) => {
 };
 
 /**
- * Unlinks a node from its parent, leaving it reinsertable.
+ * Unlinks a node from its parent so it can be inserted again.
  * @param {HtmlNodeRef} node node to detach
  */
 const detach = (node) => {
@@ -6923,6 +6923,7 @@ const modes = {};
  * `modes[mode]` load + indirect call would defeat inlining on the per-token
  * hot path.
  * @param {Token} t token to process
+ * @returns {void}
  */
 const runMode = (t) => {
 	switch (mode) {
@@ -7292,6 +7293,7 @@ const anyOtherEndTag = (name) => {
 /**
  * "in body" start tag rules (§13.2.6.4.7).
  * @param {StartTagToken} t start tag token
+ * @returns {void}
  */
 const startTagInBody = (t) => {
 	const name = t.name;
@@ -7621,6 +7623,7 @@ const startTagInBody = (t) => {
 /**
  * "in body" end tag rules (§13.2.6.4.7).
  * @param {EndTagToken} t end tag token
+ * @returns {void}
  */
 const endTagInBody = (t) => {
 	const name = t.name;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5238,10 +5238,8 @@ const _makeProcessingInstructionNode = (target, data, start, end) => {
 const AFE_MARKER = -1;
 
 /**
- * Clones an element's attribute run: keeps name/value (and the serializer name
- * flag) but drops source offsets so the consumer doesn't emit a duplicate
- * dependency for the reopened element's spans. Values are materialized since
- * the offsets are gone.
+ * Clones an element's attribute run, dropping source offsets so the consumer
+ * emits no duplicate dependency for the reopened element's spans.
  * @param {HtmlElement} el element whose attributes are cloned
  * @returns {AttributeRun} the cloned run
  */
@@ -5257,10 +5255,9 @@ const cloneAttrs = (el) => {
 };
 
 /**
- * Merges a repeated `<html>`/`<body>` tag's attributes into the element: only
- * names not already present are added (in source order after the existing
- * ones). Runs are contiguous, so any addition re-allocates the whole run; the
- * old slots are orphaned (at most once per repeated tag, rare).
+ * Merges a repeated `<html>`/`<body>` tag's attributes into the element, adding
+ * only names not already present. Runs are contiguous, so any addition
+ * re-allocates the whole run and orphans the old slots.
  * @param {HtmlElement} el element receiving the attributes
  * @param {AttributeRun} run attributes of the repeated tag
  * @returns {void}
@@ -5743,9 +5740,8 @@ const isScopeBoundary = (el) => {
 };
 
 /**
- * Attribute values are stored raw (offsets into the source), so two unresolved
- * values compare by range — `_attrValueOf` would slice a string per side just
- * to throw it away.
+ * Compares two attribute values, by source range while both are unresolved —
+ * `_attrValueOf` would slice a string per side just to throw it away.
  * @param {number} i first attribute id
  * @param {number} j second attribute id
  * @returns {boolean} true when both values are equal
@@ -5884,9 +5880,8 @@ const htmlIntegrationPoint = (el) => {
 };
 
 /**
- * Adjusts a foreign start tag's attribute run in place (the run is consumed
- * only by this tag's element): SVG camelCase names are rewritten, and
- * namespaced names get the serializer-name flag (see `_attrSerializedName`).
+ * Rewrites SVG camelCase names and flags namespaced ones for the serializer.
+ * In place: the run is consumed only by this tag's element.
  * @param {AttributeRun} run the tag's attributes
  * @param {number} ns namespace flag of the tag
  * @returns {AttributeRun} the same run
@@ -6930,10 +6925,8 @@ const detach = (node) => {
 const modes = {};
 
 /**
- * Dispatches the current insertion mode. An integer switch (cases ordered by
- * frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
- * `modes[mode]` load + indirect call would defeat inlining on the per-token
- * hot path.
+ * Dispatches the current insertion mode. An integer switch keeps each
+ * `modes.x(t)` call site monomorphic, where `modes[mode]` would not.
  * @param {Token} t token to process
  * @returns {void}
  */
@@ -7733,9 +7726,8 @@ const endTagInBody = (t) => {
 };
 
 /**
- * Generic RAWTEXT: the tokenizer already emits the text + end tag, so this
- * only inserts the element and switches to "text" mode; text mode appends
- * characters and the matching end tag pops.
+ * Generic RAWTEXT: inserts the element and switches to "text" mode, which
+ * appends the characters the tokenizer already emits and pops on the end tag.
  * @param {StartTagToken} t start tag token
  * @returns {void}
  */

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5263,6 +5263,7 @@ const cloneAttrs = (el) => {
  * old slots are orphaned (at most once per repeated tag, rare).
  * @param {HtmlElement} el element receiving the attributes
  * @param {AttributeRun} run attributes of the repeated tag
+ * @returns {void}
  */
 const mergeAttrs = (el, run) => {
 	const start = _nodeAttrStarts[el];
@@ -6018,6 +6019,7 @@ const adjustedCurrent = () => {
  * Appends a node, merging it into the previous sibling when both are text.
  * @param {HtmlNodeRef} parent container
  * @param {HtmlNodeRef} node node to append
+ * @returns {void}
  */
 const appendTo = (parent, node) => {
 	const p = effParent(parent);
@@ -6096,6 +6098,7 @@ const appropriatePlace = () => {
  * Inserts a node at an insertion place, appending when `beforeNode` is `0`.
  * @param {InsertionPlace} place where the node goes
  * @param {HtmlNodeRef} node node to insert
+ * @returns {void}
  */
 const insertAtPlace = (place, node) => {
 	const before = place.beforeNode;
@@ -6153,6 +6156,7 @@ const _recordFostered = (table, node) => {
  * @param {string} data decoded text
  * @param {number} start source offset of the run
  * @param {number} end source offset past the run
+ * @returns {void}
  */
 const insertCharacters = (data, start, end) => {
 	const place = appropriatePlace();
@@ -6219,6 +6223,7 @@ const insertCharacters = (data, start, end) => {
  * comment (§13.2.6.4). `skip.comments` drops comments alone.
  * @param {CommentToken | ProcessingInstructionToken} t comment or processing instruction token
  * @param {InsertionPlace=} place explicit insertion place
+ * @returns {void}
  */
 const insertCommentOrProcessingInstruction = (t, place) => {
 	const isPi = t.type === TOKEN_PROCESSING_INSTRUCTION;
@@ -6376,6 +6381,7 @@ const generateImpliedEndTagsThorough = () => {
  * `splice` allocates an array for the removed element on every call; the list
  * is short, so shifting in place is both cheaper and allocation-free.
  * @param {number} i position in `afe` to remove
+ * @returns {void}
  */
 const afeRemoveAt = (i) => {
 	const last = afe.length - 1;
@@ -6386,6 +6392,7 @@ const afeRemoveAt = (i) => {
  * Pushes a formatting element, applying the "Noah's Ark" clause: a third
  * equal entry since the last marker drops the earliest of them.
  * @param {HtmlElement} el formatting element to push
+ * @returns {void}
  */
 const pushAfe = (el) => {
 	let count = 0;
@@ -6452,6 +6459,7 @@ const closePElement = () => {
 /**
  * Pops the open element stack through the named HTML element.
  * @param {string} tagName tag name to pop through
+ * @returns {void}
  */
 const popUntil = (tagName) => {
 	while (open.length) {
@@ -6465,6 +6473,7 @@ const popUntil = (tagName) => {
 /**
  * Pops the open element stack through the first of the named HTML elements.
  * @param {Set<string>} set tag names to pop through
+ * @returns {void}
  */
 const popUntilOneOf = (set) => {
 	while (open.length) {
@@ -6569,6 +6578,7 @@ const leadingWs = (t, insert) => {
 /**
  * Runs one token through tree construction (§13.2.6).
  * @param {Token} t token to process
+ * @returns {void}
  */
 const process = (t) => {
 	// Track the current token's end so explicit closes can set element `.end`.
@@ -6630,6 +6640,7 @@ const shouldUseForeignRules = (ac, t) => {
 /**
  * "in foreign content" rules (§13.2.6.5).
  * @param {Token} t token to process
+ * @returns {void}
  */
 const foreignContent = (t) => {
 	if (t.type === TOKEN_CHAR) {
@@ -6894,6 +6905,7 @@ const placeForCommonAncestor = (commonAncestor) => {
 /**
  * Unlinks a node from its parent so it can be inserted again.
  * @param {HtmlNodeRef} node node to detach
+ * @returns {void}
  */
 const detach = (node) => {
 	const p = _nodeParents[node];
@@ -7274,6 +7286,7 @@ const closeIfPInButtonScope = () => {
  * "any other end tag" in body: pops to the matching open element, stopping at
  * the first special element; also the adoption agency's no-element fallback.
  * @param {string} name tag name of the end tag
+ * @returns {void}
  */
 const anyOtherEndTag = (name) => {
 	for (let i = open.length - 1; i >= 0; i--) {
@@ -7724,6 +7737,7 @@ const endTagInBody = (t) => {
  * only inserts the element and switches to "text" mode; text mode appends
  * characters and the matching end tag pops.
  * @param {StartTagToken} t start tag token
+ * @returns {void}
  */
 const genericRawtext = (t) => {
 	insertHtmlElement(t.name, t.attrs, t.pos);
@@ -7734,6 +7748,7 @@ const genericRawtext = (t) => {
  * Generic RCDATA, as `genericRawtext` for the elements whose text is decoded.
  * @param {StartTagToken} t start tag token
  * @param {boolean=} swallow whether a newline right after the tag is dropped
+ * @returns {void}
  */
 const genericRcdata = (t, swallow = false) => {
 	insertHtmlElement(t.name, t.attrs, t.pos);

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -5237,11 +5237,15 @@ const _makeProcessingInstructionNode = (target, data, start, end) => {
 // Marker entry in the active-formatting-elements list (never a valid ref).
 const AFE_MARKER = -1;
 
-// Clone of an element's attribute run: keep name/value (and the serializer
-// name flag) but drop source offsets so the consumer doesn't emit a duplicate
-// dependency for the reopened element's spans. Values are materialized since
-// the offsets are gone.
-const cloneAttrs = (/** @type {HtmlElement} */ el) => {
+/**
+ * Clones an element's attribute run: keeps name/value (and the serializer name
+ * flag) but drops source offsets so the consumer doesn't emit a duplicate
+ * dependency for the reopened element's spans. Values are materialized since
+ * the offsets are gone.
+ * @param {HtmlElement} el element whose attributes are cloned
+ * @returns {AttributeRun} the cloned run
+ */
+const cloneAttrs = (el) => {
 	const start = _nodeAttrStarts[el];
 	const count = _nodeAttrCounts[el];
 	const newStart = _attrCount + 1;
@@ -5252,14 +5256,15 @@ const cloneAttrs = (/** @type {HtmlElement} */ el) => {
 	return { start: newStart, count };
 };
 
-// Merge a repeated `<html>`/`<body>` tag's attributes into the element: only
-// names not already present are added (in source order after the existing
-// ones). Runs are contiguous, so any addition re-allocates the whole run; the
-// old slots are orphaned (at most once per repeated tag, rare).
-const mergeAttrs = (
-	/** @type {HtmlElement} */ el,
-	/** @type {AttributeRun} */ run
-) => {
+/**
+ * Merges a repeated `<html>`/`<body>` tag's attributes into the element: only
+ * names not already present are added (in source order after the existing
+ * ones). Runs are contiguous, so any addition re-allocates the whole run; the
+ * old slots are orphaned (at most once per repeated tag, rare).
+ * @param {HtmlElement} el element receiving the attributes
+ * @param {AttributeRun} run attributes of the repeated tag
+ */
+const mergeAttrs = (el, run) => {
 	const start = _nodeAttrStarts[el];
 	const count = _nodeAttrCounts[el];
 	let extra = 0;
@@ -5335,9 +5340,13 @@ const TOKEN_PROCESSING_INSTRUCTION = 7;
 /** @typedef {{ type: typeof TOKEN_EOF }} EofToken */
 /** @typedef {{ type: typeof TOKEN_PROCESSING_INSTRUCTION, name: string, data: string, start: number, end: number }} ProcessingInstructionToken the target rides in `name`, as the doctype's does */
 
-// Every insertion mode handles a processing instruction token on the same arc
-// as a comment token, so the arcs test both.
-const isCommentOrProcessingInstruction = (/** @type {Token} */ t) =>
+/**
+ * Every insertion mode handles a processing instruction token on the same arc
+ * as a comment token, so the arcs test both.
+ * @param {Token} t current token
+ * @returns {t is CommentToken | ProcessingInstructionToken} true for a comment or processing instruction token
+ */
+const isCommentOrProcessingInstruction = (t) =>
 	t.type === TOKEN_COMMENT || t.type === TOKEN_PROCESSING_INSTRUCTION;
 
 /**
@@ -5399,9 +5408,12 @@ const TEMPLATE_START_TAG_MODES = new Map(
 	})
 );
 
-// MathML/SVG specials handled via namespace checks below.
-
-const isSpecial = (/** @type {HtmlElement} */ el) => {
+/**
+ * MathML/SVG specials are handled via namespace checks rather than one table.
+ * @param {HtmlElement} el element to test
+ * @returns {boolean} true when the element is "special" (§13.2.4.2)
+ */
+const isSpecial = (el) => {
 	const ns = _namespaceOf(el);
 	const tag = _tagNameOf(el);
 	if (ns === NS_HTML) return SPECIAL.has(tag);
@@ -5410,8 +5422,12 @@ const isSpecial = (/** @type {HtmlElement} */ el) => {
 	return false;
 };
 
-// `<font color|face|size>` breaks out of foreign content (§13.2.6.5).
-const hasFontBreakoutAttr = (/** @type {AttributeRun} */ run) => {
+/**
+ * `<font color|face|size>` breaks out of foreign content (§13.2.6.5).
+ * @param {AttributeRun} run the tag's attributes
+ * @returns {boolean} true when one of the breakout attributes is present
+ */
+const hasFontBreakoutAttr = (run) => {
 	for (let i = run.start; i < run.start + run.count; i++) {
 		if (FONT_BREAKOUT_ATTRS.has(_attrNames[i])) return true;
 	}
@@ -5590,9 +5606,13 @@ const ATTR_NAME_INTERN = buildNameInternTable(
 	)
 );
 
-// Hoisted so the many `open.some(...)` "is there an open HTML <template>?"
-// checks reuse one predicate instead of allocating an arrow per call.
-const isHtmlTemplateEl = (/** @type {HtmlElement} */ e) =>
+/**
+ * Hoisted so the many `open.some(...)` "is there an open HTML `<template>`?"
+ * checks reuse one predicate instead of allocating an arrow per call.
+ * @param {HtmlElement} e element to test
+ * @returns {boolean} true for an HTML `<template>` element
+ */
+const isHtmlTemplateEl = (e) =>
 	_tagNameOf(e) === "template" && _namespaceOf(e) === NS_HTML;
 
 /**
@@ -5651,12 +5671,15 @@ const isQuirky = (name, pub, sys) => {
 	return false;
 };
 
-const mkEl = (
-	/** @type {string} */ tagName,
-	/** @type {number} */ ns,
-	/** @type {AttributeRun} */ attrs,
-	/** @type {TagPos | null | undefined} */ pos
-) => {
+/**
+ * Allocates an element node.
+ * @param {string} tagName tag name
+ * @param {number} ns namespace flag (`NS_HTML`, `NS_MATHML`, `NS_SVG`)
+ * @param {AttributeRun} attrs the element's attributes
+ * @param {TagPos | null | undefined} pos source position, absent for synthesized elements
+ * @returns {HtmlElement} the new element
+ */
+const mkEl = (tagName, ns, attrs, pos) => {
 	// Inlined element allocation: every column is written exactly once (the
 	// generic _allocNode would zero five columns mkEl immediately overwrites).
 	const el = ++_nodeCount;
@@ -5702,7 +5725,12 @@ const effParent = (parent) => {
 	return tc !== 0 ? tc : parent;
 };
 
-const isScopeBoundary = (/** @type {HtmlElement} */ el) => {
+/**
+ * Elements that stop a "have an element in scope" walk (§13.2.4.2).
+ * @param {HtmlElement} el element to test
+ * @returns {boolean} true when the element bounds a scope
+ */
+const isScopeBoundary = (el) => {
 	if (_namespaceOf(el) === NS_HTML) return HTML_SCOPE.has(_tagNameOf(el));
 	if (_namespaceOf(el) === NS_MATHML) {
 		return MATHML_SPECIAL.has(_tagNameOf(el));
@@ -5713,10 +5741,14 @@ const isScopeBoundary = (/** @type {HtmlElement} */ el) => {
 	return false;
 };
 
-// Attribute values are stored raw (offsets into the source), so two unresolved
-// values compare by range — `_attrValueOf` would slice a string per side just
-// to throw it away.
-/** @type {(i: number, j: number) => boolean} */
+/**
+ * Attribute values are stored raw (offsets into the source), so two unresolved
+ * values compare by range — `_attrValueOf` would slice a string per side just
+ * to throw it away.
+ * @param {number} i first attribute id
+ * @param {number} j second attribute id
+ * @returns {boolean} true when both values are equal
+ */
 const _attrValueEquals = (i, j) => {
 	if (_attrValues[i] === null && _attrValues[j] === null) {
 		const start = _attrValueStarts[i];
@@ -5736,10 +5768,14 @@ const _attrValueEquals = (i, j) => {
 	return _attrValueOf(i) === _attrValueOf(j);
 };
 
-const sameAttrs = (
-	/** @type {HtmlElement} */ a,
-	/** @type {HtmlElement} */ b
-) => {
+/**
+ * Compares two elements' attribute runs, as the active-formatting-elements
+ * "Noah's Ark" clause does.
+ * @param {HtmlElement} a first element
+ * @param {HtmlElement} b second element
+ * @returns {boolean} true when both carry the same attributes
+ */
+const sameAttrs = (a, b) => {
 	const aStart = _nodeAttrStarts[a];
 	const aCount = _nodeAttrCounts[a];
 	const bStart = _nodeAttrStarts[b];
@@ -5754,12 +5790,20 @@ const sameAttrs = (
 	return true;
 };
 
-const startsWithWs = (/** @type {string} */ s) => {
+/**
+ * @param {string} s text to test
+ * @returns {boolean} true when the text starts with HTML whitespace
+ */
+const startsWithWs = (s) => {
 	const c = s.charCodeAt(0);
 	return c === 0x09 || c === 0x0a || c === 0x0c || c === 0x0d || c === 0x20;
 };
 
-const isAllWs = (/** @type {string} */ s) => {
+/**
+ * @param {string} s text to test
+ * @returns {boolean} true when the text is HTML whitespace only
+ */
+const isAllWs = (s) => {
 	for (let i = 0; i < s.length; i++) {
 		const c = s.charCodeAt(i);
 		// HTML whitespace: tab / LF / FF / CR / space. A charCodeAt loop avoids
@@ -5807,10 +5851,18 @@ const collapseWhitespaceRuns = (s) => {
 	return last === 0 ? s : out + s.slice(last);
 };
 
-const mathmlTextIntegrationPoint = (/** @type {HtmlElement} */ el) =>
+/**
+ * @param {HtmlElement} el element to test
+ * @returns {boolean} true for a MathML text integration point (§13.2.6.5)
+ */
+const mathmlTextIntegrationPoint = (el) =>
 	_namespaceOf(el) === NS_MATHML && MATHML_TEXT_INTEGRATION.has(_tagNameOf(el));
 
-const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
+/**
+ * @param {HtmlElement} el element to test
+ * @returns {boolean} true for an HTML integration point (§13.2.6.5)
+ */
+const htmlIntegrationPoint = (el) => {
 	if (_namespaceOf(el) === NS_MATHML && _tagNameOf(el) === "annotation-xml") {
 		const enc = _findAttr(_nodeAttrStarts[el], _nodeAttrCounts[el], "encoding");
 		if (enc !== 0) {
@@ -5830,13 +5882,15 @@ const htmlIntegrationPoint = (/** @type {HtmlElement} */ el) => {
 	return false;
 };
 
-// Adjust a foreign start tag's attribute run in place (the run is consumed
-// only by this tag's element): SVG camelCase names are rewritten, and
-// namespaced names get the serializer-name flag (see `_attrSerializedName`).
-const adjustForeignAttrs = (
-	/** @type {AttributeRun} */ run,
-	/** @type {number} */ ns
-) => {
+/**
+ * Adjusts a foreign start tag's attribute run in place (the run is consumed
+ * only by this tag's element): SVG camelCase names are rewritten, and
+ * namespaced names get the serializer-name flag (see `_attrSerializedName`).
+ * @param {AttributeRun} run the tag's attributes
+ * @param {number} ns namespace flag of the tag
+ * @returns {AttributeRun} the same run
+ */
+const adjustForeignAttrs = (run, ns) => {
 	for (let i = run.start; i < run.start + run.count; i++) {
 		const name = _attrNames[i];
 		if (
@@ -5854,9 +5908,13 @@ const adjustForeignAttrs = (
 	return run;
 };
 
-// Only `definitionurl` is rewritten (in place — the run is consumed only by
-// this tag's element); the camelCase name serializes as itself.
-const adjustMathmlAttrs = (/** @type {AttributeRun} */ run) => {
+/**
+ * Only `definitionurl` is rewritten (in place — the run is consumed only by
+ * this tag's element); the camelCase name serializes as itself.
+ * @param {AttributeRun} run the tag's attributes
+ * @returns {AttributeRun} the same run
+ */
+const adjustMathmlAttrs = (run) => {
 	for (let i = run.start; i < run.start + run.count; i++) {
 		if (_attrNames[i] === "definitionurl") _attrNames[i] = "definitionURL";
 	}
@@ -5956,10 +6014,12 @@ const adjustedCurrent = () => {
 	return cur();
 };
 
-const appendTo = (
-	/** @type {HtmlNodeRef} */ parent,
-	/** @type {HtmlNodeRef} */ node
-) => {
+/**
+ * Appends a node, merging it into the previous sibling when both are text.
+ * @param {HtmlNodeRef} parent container
+ * @param {HtmlNodeRef} node node to append
+ */
+const appendTo = (parent, node) => {
 	const p = effParent(parent);
 	const last = _nodeLastChildren[p];
 	if (
@@ -5979,10 +6039,12 @@ const appendTo = (
 // allocation per inserted node.
 /** @type {InsertionPlace} */
 const sharedPlace = { parent: doc, beforeNode: 0 };
-const placeAt = (
-	/** @type {HtmlNodeRef} */ parent,
-	/** @type {HtmlNodeRef} */ beforeNode
-) => {
+/**
+ * @param {HtmlNodeRef} parent container
+ * @param {HtmlNodeRef} beforeNode node to insert before (`0` = append)
+ * @returns {InsertionPlace} the shared insertion place
+ */
+const placeAt = (parent, beforeNode) => {
 	sharedPlace.parent = parent;
 	sharedPlace.beforeNode = beforeNode;
 	return sharedPlace;
@@ -6030,10 +6092,12 @@ const appropriatePlace = () => {
 	return placeAt(target, 0);
 };
 
-const insertAtPlace = (
-	/** @type {InsertionPlace} */ place,
-	/** @type {HtmlNodeRef} */ node
-) => {
+/**
+ * Inserts a node at an insertion place, appending when `beforeNode` is `0`.
+ * @param {InsertionPlace} place where the node goes
+ * @param {HtmlNodeRef} node node to insert
+ */
+const insertAtPlace = (place, node) => {
 	const before = place.beforeNode;
 	if (before !== 0) {
 		const p = effParent(place.parent);
@@ -6084,11 +6148,13 @@ const _recordFostered = (table, node) => {
 	_fosteredLog.push(table, node);
 };
 
-const insertCharacters = (
-	/** @type {string} */ data,
-	/** @type {number} */ start,
-	/** @type {number} */ end
-) => {
+/**
+ * Inserts a character run at the appropriate place (§13.2.6.1).
+ * @param {string} data decoded text
+ * @param {number} start source offset of the run
+ * @param {number} end source offset past the run
+ */
+const insertCharacters = (data, start, end) => {
 	const place = appropriatePlace();
 	if (_nodeTypes[place.parent] === NodeType.Document) return; // never insert text into document
 	// `skip.text`: drop every `Text` node — construction already used the
@@ -6149,11 +6215,11 @@ const insertCharacters = (
 };
 
 /**
+ * Every insertion mode inserts a processing instruction where it inserts a
+ * comment (§13.2.6.4). `skip.comments` drops comments alone.
  * @param {CommentToken | ProcessingInstructionToken} t comment or processing instruction token
  * @param {InsertionPlace=} place explicit insertion place
  */
-// Every insertion mode inserts a processing instruction where it inserts a
-// comment (§13.2.6.4). `skip.comments` drops comments alone.
 const insertCommentOrProcessingInstruction = (t, place) => {
 	const isPi = t.type === TOKEN_PROCESSING_INSTRUCTION;
 	if (skipComments && !isPi) return;
@@ -6166,11 +6232,14 @@ const insertCommentOrProcessingInstruction = (t, place) => {
 	);
 };
 
-const insertHtmlElement = (
-	/** @type {string} */ tagName,
-	/** @type {AttributeRun} */ attrs,
-	/** @type {TagPos | null} */ pos
-) => {
+/**
+ * Inserts an HTML element and pushes it onto the open element stack.
+ * @param {string} tagName tag name
+ * @param {AttributeRun} attrs the element's attributes
+ * @param {TagPos | null} pos source position, `null` for a synthesized element
+ * @returns {HtmlElement} the inserted element
+ */
+const insertHtmlElement = (tagName, attrs, pos) => {
 	const el = mkEl(tagName, NS_HTML, attrs, pos);
 	const place = appropriatePlace();
 	insertAtPlace(place, el);
@@ -6178,12 +6247,15 @@ const insertHtmlElement = (
 	return el;
 };
 
-const insertForeignElement = (
-	/** @type {string} */ tagName,
-	/** @type {number} */ ns,
-	/** @type {AttributeRun} */ attrs,
-	/** @type {TagPos | null} */ pos
-) => {
+/**
+ * Inserts a MathML/SVG element and pushes it onto the open element stack.
+ * @param {string} tagName tag name
+ * @param {number} ns namespace flag (`NS_MATHML`, `NS_SVG`)
+ * @param {AttributeRun} attrs the element's attributes
+ * @param {TagPos | null} pos source position, `null` for a synthesized element
+ * @returns {HtmlElement} the inserted element
+ */
+const insertForeignElement = (tagName, ns, attrs, pos) => {
 	const el = mkEl(tagName, ns, attrs, pos);
 	const place = appropriatePlace();
 	insertAtPlace(place, el);
@@ -6198,10 +6270,12 @@ const insertForeignElement = (
 const SCOPE_DEFAULT = 0;
 const SCOPE_BUTTON = 1;
 const SCOPE_LIST_ITEM = 2;
-const isBoundaryForKind = (
-	/** @type {HtmlElement} */ el,
-	/** @type {number} */ kind
-) => {
+/**
+ * @param {HtmlElement} el element to test
+ * @param {number} kind scope kind (`SCOPE_DEFAULT`, `SCOPE_BUTTON`, `SCOPE_LIST_ITEM`)
+ * @returns {boolean} true when the element bounds that scope
+ */
+const isBoundaryForKind = (el, kind) => {
 	if (isScopeBoundary(el)) return true;
 	if (_namespaceOf(el) !== NS_HTML) return false;
 	if (kind === SCOPE_BUTTON) return _tagNameOf(el) === "button";
@@ -6210,12 +6284,14 @@ const isBoundaryForKind = (
 	}
 	return false;
 };
-// "have an element in scope": walk the open stack from the top until the
-// named HTML element is found (true) or a scope boundary is hit (false).
-const hasNameInScope = (
-	/** @type {string} */ tagName,
-	/** @type {number} */ kind
-) => {
+/**
+ * "have an element in scope": walks the open stack from the top until the
+ * named HTML element is found (true) or a scope boundary is hit (false).
+ * @param {string} tagName tag name to look for
+ * @param {number} kind scope kind (`SCOPE_DEFAULT`, `SCOPE_BUTTON`, `SCOPE_LIST_ITEM`)
+ * @returns {boolean} true when the element is in that scope
+ */
+const hasNameInScope = (tagName, kind) => {
 	for (let i = open.length - 1; i >= 0; i--) {
 		const el = open[i];
 		if (_namespaceOf(el) === NS_HTML && _tagNameOf(el) === tagName) {
@@ -6225,13 +6301,26 @@ const hasNameInScope = (
 	}
 	return false;
 };
-const inScope = (/** @type {string} */ tagName) =>
-	hasNameInScope(tagName, SCOPE_DEFAULT);
-const inButtonScope = (/** @type {string} */ tagName) =>
-	hasNameInScope(tagName, SCOPE_BUTTON);
-const inListItemScope = (/** @type {string} */ tagName) =>
-	hasNameInScope(tagName, SCOPE_LIST_ITEM);
-const inScopeEl = (/** @type {HtmlElement} */ target) => {
+/**
+ * @param {string} tagName tag name to look for
+ * @returns {boolean} true when the element is in scope
+ */
+const inScope = (tagName) => hasNameInScope(tagName, SCOPE_DEFAULT);
+/**
+ * @param {string} tagName tag name to look for
+ * @returns {boolean} true when the element is in button scope
+ */
+const inButtonScope = (tagName) => hasNameInScope(tagName, SCOPE_BUTTON);
+/**
+ * @param {string} tagName tag name to look for
+ * @returns {boolean} true when the element is in list item scope
+ */
+const inListItemScope = (tagName) => hasNameInScope(tagName, SCOPE_LIST_ITEM);
+/**
+ * @param {HtmlElement} target element to look for
+ * @returns {boolean} true when that element itself is in scope
+ */
+const inScopeEl = (target) => {
 	for (let i = open.length - 1; i >= 0; i--) {
 		const el = open[i];
 		if (el === target) return true;
@@ -6239,8 +6328,11 @@ const inScopeEl = (/** @type {HtmlElement} */ target) => {
 	}
 	return false;
 };
-// `target` is a single tag name (the common case) or a Set of names.
-const inTableScope = (/** @type {string | Set<string>} */ target) => {
+/**
+ * @param {string | Set<string>} target a single tag name (the common case) or a set of names
+ * @returns {boolean} true when one of them is in table scope
+ */
+const inTableScope = (target) => {
 	const set = typeof target === "string" ? null : target;
 	for (let i = open.length - 1; i >= 0; i--) {
 		const el = open[i];
@@ -6279,15 +6371,23 @@ const generateImpliedEndTagsThorough = () => {
 };
 
 // ---- active formatting elements ----
-// `splice` allocates an array for the removed element on every call; the list
-// is short, so shifting in place is both cheaper and allocation-free.
-/** @type {(i: number) => void} */
+
+/**
+ * `splice` allocates an array for the removed element on every call; the list
+ * is short, so shifting in place is both cheaper and allocation-free.
+ * @param {number} i position in `afe` to remove
+ */
 const afeRemoveAt = (i) => {
 	const last = afe.length - 1;
 	for (let k = i; k < last; k++) afe[k] = afe[k + 1];
 	afe.pop();
 };
-const pushAfe = (/** @type {HtmlElement} */ el) => {
+/**
+ * Pushes a formatting element, applying the "Noah's Ark" clause: a third
+ * equal entry since the last marker drops the earliest of them.
+ * @param {HtmlElement} el formatting element to push
+ */
+const pushAfe = (el) => {
 	let count = 0;
 	for (let i = afe.length - 1; i >= 0; i--) {
 		const e = afe[i];
@@ -6349,7 +6449,11 @@ const closePElement = () => {
 	}
 };
 
-const popUntil = (/** @type {string} */ tagName) => {
+/**
+ * Pops the open element stack through the named HTML element.
+ * @param {string} tagName tag name to pop through
+ */
+const popUntil = (tagName) => {
 	while (open.length) {
 		const el = /** @type {HtmlElement} */ (popOpen());
 		_nodeEnds[el] = tokenEnd;
@@ -6358,7 +6462,11 @@ const popUntil = (/** @type {string} */ tagName) => {
 		}
 	}
 };
-const popUntilOneOf = (/** @type {Set<string>} */ set) => {
+/**
+ * Pops the open element stack through the first of the named HTML elements.
+ * @param {Set<string>} set tag names to pop through
+ */
+const popUntilOneOf = (set) => {
 	while (open.length) {
 		const el = /** @type {HtmlElement} */ (popOpen());
 		_nodeEnds[el] = tokenEnd;
@@ -6432,14 +6540,14 @@ const resetInsertionMode = () => {
 };
 
 // ---------- token processing ----------
-// Split a character token's leading whitespace; per the spec each character
-// is its own token, so a mixed run can straddle a mode change. Inserts the
-// leading whitespace when `insert`, returns the non-whitespace remainder
-// token (or null when the token was entirely whitespace).
-const leadingWs = (
-	/** @type {CharToken} */ t,
-	/** @type {boolean} */ insert
-) => {
+/**
+ * Splits a character token's leading whitespace; per the spec each character
+ * is its own token, so a mixed run can straddle a mode change.
+ * @param {CharToken} t character token
+ * @param {boolean} insert whether to insert the leading whitespace
+ * @returns {CharToken | null} the non-whitespace remainder, `null` when the token was all whitespace
+ */
+const leadingWs = (t, insert) => {
 	const m = /^[\t\n\f\r ]+/.exec(t.data);
 	const ws = m ? m[0] : "";
 	// `t.data` is decoded, the offsets are raw, so counting one in the other
@@ -6458,7 +6566,11 @@ const leadingWs = (
 	};
 };
 
-const process = (/** @type {Token} */ t) => {
+/**
+ * Runs one token through tree construction (§13.2.6).
+ * @param {Token} t token to process
+ */
+const process = (t) => {
 	// Track the current token's end so explicit closes can set element `.end`.
 	// Dispatch on `type` instead of the `in` operator, which goes megamorphic
 	// across the token union and shows up on the per-token hot path.
@@ -6480,10 +6592,12 @@ const process = (/** @type {Token} */ t) => {
 	runMode(t);
 };
 
-const shouldUseForeignRules = (
-	/** @type {HtmlElement} */ ac,
-	/** @type {Token} */ t
-) => {
+/**
+ * @param {HtmlElement} ac adjusted current node
+ * @param {Token} t token to process
+ * @returns {boolean} true when the token follows the foreign content rules
+ */
+const shouldUseForeignRules = (ac, t) => {
 	if (_namespaceOf(ac) === NS_HTML) return false;
 	if (t.type === TOKEN_START_TAG) {
 		if (
@@ -6513,7 +6627,11 @@ const shouldUseForeignRules = (
 	return false;
 };
 
-const foreignContent = (/** @type {Token} */ t) => {
+/**
+ * "in foreign content" rules (§13.2.6.5).
+ * @param {Token} t token to process
+ */
+const foreignContent = (t) => {
 	if (t.type === TOKEN_CHAR) {
 		const data = inputHasNul ? t.data.replace(/\0/g, "�") : t.data;
 		insertCharacters(data, t.start, t.end);
@@ -6612,10 +6730,13 @@ const foreignContent = (/** @type {Token} */ t) => {
 };
 
 // ---------- adoption agency algorithm ----------
-const adoptionAgency = (
-	/** @type {string} */ subject,
-	/** @type {TagPos | null} */ pos
-) => {
+/**
+ * Adoption agency algorithm (§13.2.6.4.7).
+ * @param {string} subject tag name of the end tag being handled
+ * @param {TagPos | null} pos source position of that end tag
+ * @returns {boolean} false when the caller must fall back to "any other end tag"
+ */
+const adoptionAgency = (subject, pos) => {
 	// step 1
 	const c = cur();
 	if (
@@ -6752,7 +6873,11 @@ const adoptionAgency = (
 	return true;
 };
 
-const placeForCommonAncestor = (/** @type {HtmlElement} */ commonAncestor) => {
+/**
+ * @param {HtmlElement} commonAncestor common ancestor node of the adoption agency
+ * @returns {InsertionPlace} where the reparented node goes
+ */
+const placeForCommonAncestor = (commonAncestor) => {
 	if (
 		TABLE_CONTEXT.has(_tagNameOf(commonAncestor)) &&
 		_namespaceOf(commonAncestor) === NS_HTML
@@ -6766,7 +6891,11 @@ const placeForCommonAncestor = (/** @type {HtmlElement} */ commonAncestor) => {
 	return { parent: commonAncestor, beforeNode: 0 };
 };
 
-const detach = (/** @type {HtmlNodeRef} */ node) => {
+/**
+ * Unlinks a node from its parent, leaving it reinsertable.
+ * @param {HtmlNodeRef} node node to detach
+ */
+const detach = (node) => {
 	const p = _nodeParents[node];
 	if (p === 0) return;
 	let prev = 0;
@@ -6788,11 +6917,14 @@ const detach = (/** @type {HtmlNodeRef} */ node) => {
 /** @type {Record<string, (t: Token) => void>} */
 const modes = {};
 
-// Dispatch the current insertion mode. An integer switch (cases ordered by
-// frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
-// `modes[mode]` load + indirect call would defeat inlining on the per-token
-// hot path.
-const runMode = (/** @type {Token} */ t) => {
+/**
+ * Dispatches the current insertion mode. An integer switch (cases ordered by
+ * frequency) keeps each `modes.x(t)` call site monomorphic, where a keyed
+ * `modes[mode]` load + indirect call would defeat inlining on the per-token
+ * hot path.
+ * @param {Token} t token to process
+ */
+const runMode = (t) => {
 	switch (mode) {
 		case MODE_IN_BODY:
 			return modes.inBody(t);
@@ -7137,9 +7269,12 @@ const closeIfPInButtonScope = () => {
 	if (inButtonScope("p")) closePElement();
 };
 
-// "any other end tag" in body: pop to the matching open element, stopping at
-// the first special element; also the adoption agency's no-element fallback.
-const anyOtherEndTag = (/** @type {string} */ name) => {
+/**
+ * "any other end tag" in body: pops to the matching open element, stopping at
+ * the first special element; also the adoption agency's no-element fallback.
+ * @param {string} name tag name of the end tag
+ */
+const anyOtherEndTag = (name) => {
 	for (let i = open.length - 1; i >= 0; i--) {
 		const node = open[i];
 		if (_namespaceOf(node) === NS_HTML && _tagNameOf(node) === name) {
@@ -7154,7 +7289,11 @@ const anyOtherEndTag = (/** @type {string} */ name) => {
 	}
 };
 
-const startTagInBody = (/** @type {StartTagToken} */ t) => {
+/**
+ * "in body" start tag rules (§13.2.6.4.7).
+ * @param {StartTagToken} t start tag token
+ */
+const startTagInBody = (t) => {
 	const name = t.name;
 	if (name === "html") {
 		if (open.some(isHtmlTemplateEl)) {
@@ -7479,7 +7618,11 @@ const startTagInBody = (/** @type {StartTagToken} */ t) => {
 	insertHtmlElement(name, t.attrs, t.pos);
 };
 
-const endTagInBody = (/** @type {EndTagToken} */ t) => {
+/**
+ * "in body" end tag rules (§13.2.6.4.7).
+ * @param {EndTagToken} t end tag token
+ */
+const endTagInBody = (t) => {
 	const name = t.name;
 	if (name === "template") return modes.inHead(t);
 	if (name === "select") {
@@ -7573,15 +7716,23 @@ const endTagInBody = (/** @type {EndTagToken} */ t) => {
 	anyOtherEndTag(name);
 };
 
-// generic RCDATA/RAWTEXT: tokenizer already emits the text + end tag, so we
-// just insert the element and switch to "text" mode; text mode appends chars
-// and the matching end tag pops.
-const genericRawtext = (/** @type {StartTagToken} */ t) => {
+/**
+ * Generic RAWTEXT: the tokenizer already emits the text + end tag, so this
+ * only inserts the element and switches to "text" mode; text mode appends
+ * characters and the matching end tag pops.
+ * @param {StartTagToken} t start tag token
+ */
+const genericRawtext = (t) => {
 	insertHtmlElement(t.name, t.attrs, t.pos);
 	originalMode = mode;
 	mode = MODE_TEXT;
 };
-const genericRcdata = (/** @type {StartTagToken} */ t, swallow = false) => {
+/**
+ * Generic RCDATA, as `genericRawtext` for the elements whose text is decoded.
+ * @param {StartTagToken} t start tag token
+ * @param {boolean=} swallow whether a newline right after the tag is dropped
+ */
+const genericRcdata = (t, swallow = false) => {
 	insertHtmlElement(t.name, t.attrs, t.pos);
 	if (swallow) t.swallowNewline = true;
 	originalMode = mode;

--- a/lib/prefetch/ResourceHintPlugin.js
+++ b/lib/prefetch/ResourceHintPlugin.js
@@ -300,7 +300,11 @@ const collectEntrypointHints = (compilation, entryName, hints) => {
 	const out = [];
 	/** @type {Set<string>} */
 	const seenKeys = new Set();
-	const push = (/** @type {EntrypointHint} */ h) => {
+	/**
+	 * Appends a hint, dropping one already emitted for the same rel + href.
+	 * @param {EntrypointHint} h hint to append
+	 */
+	const push = (h) => {
 		const key = `${h.rel}\0${h.href}`;
 		if (seenKeys.has(key)) return;
 		seenKeys.add(key);

--- a/lib/prefetch/ResourceHintPlugin.js
+++ b/lib/prefetch/ResourceHintPlugin.js
@@ -303,6 +303,7 @@ const collectEntrypointHints = (compilation, entryName, hints) => {
 	/**
 	 * Appends a hint, dropping one already emitted for the same rel + href.
 	 * @param {EntrypointHint} h hint to append
+	 * @returns {void}
 	 */
 	const push = (h) => {
 		const key = `${h.rel}\0${h.href}`;

--- a/lib/util/conventions.js
+++ b/lib/util/conventions.js
@@ -115,7 +115,10 @@ module.exports.cssExportConvention = (input, convention) => {
 	const set = new Set();
 	if (typeof convention === "function") {
 		const result = convention(input);
-		const validate = (/** @type {string} */ name) => {
+		/**
+		 * @param {string} name name returned by the convention function
+		 */
+		const validate = (name) => {
 			if (typeof name !== "string" || name.length === 0) {
 				throw new Error(
 					`exportsConvention function must return a non-empty string or an array of non-empty strings, got ${safeStringify(result)}`

--- a/lib/util/conventions.js
+++ b/lib/util/conventions.js
@@ -117,6 +117,7 @@ module.exports.cssExportConvention = (input, convention) => {
 		const result = convention(input);
 		/**
 		 * @param {string} name name returned by the convention function
+		 * @returns {void}
 		 */
 		const validate = (name) => {
 			if (typeof name !== "string" || name.length === 0) {

--- a/tooling/generate-css-data.js
+++ b/tooling/generate-css-data.js
@@ -1074,16 +1074,24 @@ const collectBoxLonghands = (shorthands) => {
 	for (const name of shorthands) {
 		const longhands = properties[name].computed;
 		if (!Array.isArray(longhands) || longhands.length !== 4) continue;
-		const match = (/** @type {string} */ part) =>
+		/**
+		 * @param {string} part side or corner name
+		 * @returns {string | undefined} the longhand naming that part, if any
+		 */
+		const match = (part) =>
 			longhands.find(
 				(longhand) =>
 					longhand === part ||
 					longhand.includes(`-${part}-`) ||
 					longhand.endsWith(`-${part}`)
 			);
-		// A corner name holds two side names (`border-top-left-radius` answers both
-		// `top` and `left`), so a sides match only counts when it is one-to-one.
-		const distinct = (/** @type {(string | undefined)[]} */ found) =>
+		/**
+		 * A corner name holds two side names (`border-top-left-radius` answers both
+		 * `top` and `left`), so a sides match only counts when it is one-to-one.
+		 * @param {(string | undefined)[]} found longhands matched per side/corner
+		 * @returns {boolean} true when every side matched a distinct longhand
+		 */
+		const distinct = (found) =>
 			!found.includes(undefined) && new Set(found).size === found.length;
 		let sides = BOX_SIDES.map(match);
 		if (!distinct(sides)) sides = BOX_CORNERS.map(match);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The "comments must be as short as possible" rule in `AGENTS.md` was being read as covering JSDoc too, so helper JSDoc got traded for a one-line comment plus inline `/** @type {T} */` param casts — losing the `@param`/`@returns` contract. The rule is now scoped to plain `//` and `/* … */` comments, with JSDoc explicitly exempt for every documented symbol (not just exported ones), and the named helpers already written that way are restored to real JSDoc.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs — `AGENTS.md` plus JSDoc-only prose and annotations in `lib/`/`tooling/`; no behavior change.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — comments and type annotations only, no runtime code paths touched.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — the documentation change is the `AGENTS.md` section in this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used (Claude Code) to draft the `AGENTS.md` wording, to find every helper written with inline param casts instead of JSDoc, and to rewrite those blocks; all output was reviewed. Note one AI-caught regression in its own edit: adding `@returns {boolean}` to `isCommentOrProcessingInstruction` overrode TypeScript's inferred type predicate and broke narrowing at three call sites, so it is declared as `@returns {t is CommentToken | ProcessingInstructionToken}`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKcTBokS58Bqw2jsQ82a5E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved internal documentation and type annotations for helper functions across HTML processing, resource hints, CSS conventions, and data-generation tooling.
  * Clarified comment and JSDoc conventions, including consistent parameter and return documentation.
  * No user-visible behavior or functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->