### PR TITLE
fix(concatenate-modules): parenthesize a wrapped module's accessor call

### DIFF
--- a/.changeset/020-concatenate-modules-new-expression.md
+++ b/.changeset/020-concatenate-modules-new-expression.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `new` on a default import of a wrapped CommonJS module.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -181,6 +181,7 @@ const findIdentifiers = (source) => {
  * @property {string=} comment
  * @property {ExportName} ids
  * @property {ExportName} exportName
+ * @property {boolean=} accessorCall the raw name is the wrapper accessor call itself, so it binds looser than the identifier it replaces
  */
 
 /**
@@ -494,7 +495,8 @@ const getFinalBinding = (
 				/** @type {NonNullable<ConcatenatedModuleInfo["namespaceObjectName"]>} */
 				(info.namespaceObjectName),
 			ids: /** @type {ExportName} */ (usedName),
-			exportName
+			exportName,
+			accessorCall: info.wrapped
 		};
 	}
 
@@ -509,7 +511,8 @@ const getFinalBinding = (
 						? /** @type {string} */ (info.deferredNamespaceObjectName)
 						: getInteropExpr(info, info.interopNamespaceObject2Name),
 					ids: exportName,
-					exportName
+					exportName,
+					accessorCall: !deferred && info.wrapped
 				};
 			case "default-with-named":
 				if (deferred) info.deferredNamespaceObjectUsed = true;
@@ -520,7 +523,8 @@ const getFinalBinding = (
 						? /** @type {string} */ (info.deferredNamespaceObjectName)
 						: getInteropExpr(info, info.interopNamespaceObjectName),
 					ids: exportName,
-					exportName
+					exportName,
+					accessorCall: !deferred && info.wrapped
 				};
 			case "namespace":
 			case "dynamic":
@@ -611,7 +615,8 @@ const getFinalBinding = (
 								info,
 								rawName: getExternalModuleExpr(info),
 								ids: exportName,
-								exportName
+								exportName,
+								accessorCall: info.wrapped
 							};
 						}
 						info.interopDefaultAccessUsed = true;
@@ -657,7 +662,8 @@ const getFinalBinding = (
 						/** @type {NonNullable<ConcatenatedModuleInfo["namespaceObjectName"]>} */
 						(info.namespaceObjectName),
 					ids: exportName,
-					exportName
+					exportName,
+					accessorCall: info.wrapped
 				};
 			case "external":
 				if (deferred) {
@@ -673,7 +679,8 @@ const getFinalBinding = (
 					info,
 					rawName: getExternalModuleExpr(info),
 					ids: exportName,
-					exportName
+					exportName,
+					accessorCall: info.wrapped
 				};
 		}
 	}
@@ -938,9 +945,13 @@ const getFinalName = (
 		let reference;
 		/** @type {boolean} */
 		let isPropertyAccess;
+		// the raw name is the wrapper accessor call itself, so the reference binds
+		// looser than the identifier it stands in for
+		let accessorCall = false;
 		if ("rawName" in binding) {
 			reference = `${binding.rawName}${comment || ""}${propertyAccess(ids)}`;
 			isPropertyAccess = ids.length > 0;
+			accessorCall = binding.accessorCall === true;
 		} else {
 			const { info, name: exportId } = binding;
 			const name = info.internalNames.get(exportId);
@@ -970,6 +981,10 @@ const getFinalName = (
 			} else if (binding.info.wrapped) {
 				return asiSafe === false ? `;(${reference})` : `(${reference})`;
 			}
+		} else if (accessorCall && !asCall) {
+			// without parentheses `new X()` would construct the accessor rather
+			// than what it returns
+			return asiSafe === false ? `;(${reference})` : `(${reference})`;
 		}
 
 		return reference;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,429 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-external-new-expression commonjs-wrapped-external-new-expression should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: external \\"events\\"
+var external_events_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+module.exports = require(\\"events\\");
+});
+
+// MODULE: ./mid.cjs
+var mid_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const { make, raw } = (esm_user_namespaceFn());
+
+exports.L = make;
+exports.l = raw;
+
+});
+
+// MODULE: ./esm-user.mjs
+var esm_user_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(__webpack_module__, __webpack_exports__) {
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   make: () => (/* binding */ make)
+/* harmony export */ });
+(external_events_namespaceFn());
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+
+
+function make() {
+	return new (external_events_namespaceFn())();
+}
+
+const raw = (external_events_namespaceFn());
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"raw\\", 0, /* binding */ raw
+/* harmony export */ ]);
+
+});
+
+;// ./mid.cjs
+mid_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to a wrapped external's accessor result\\", () => {
+	const emitter = (0,mid_namespaceFn().L)();
+
+	expect(emitter).toBeInstanceOf((mid_namespaceFn().l));
+	expect(typeof emitter.on).toBe(\\"function\\");
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-external-new-expression commonjs-wrapped-external-new-expression should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: external \\"events\\"
+var external_events_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+module.exports = require(\\"events\\");
+});
+
+// MODULE: ./mid.cjs
+var mid_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const { make, raw } = (esm_user_namespaceFn());
+
+exports.L = make;
+exports.l = raw;
+
+});
+
+// MODULE: ./esm-user.mjs
+var esm_user_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(__webpack_module__, __webpack_exports__) {
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   make: () => (/* binding */ make)
+/* harmony export */ });
+(external_events_namespaceFn());
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+
+
+function make() {
+	return new (external_events_namespaceFn())();
+}
+
+const raw = (external_events_namespaceFn());
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"raw\\", 0, /* binding */ raw
+/* harmony export */ ]);
+
+});
+
+;// ./mid.cjs
+mid_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to a wrapped external's accessor result\\", () => {
+	const emitter = (0,mid_namespaceFn().L)();
+
+	expect(emitter).toBeInstanceOf((mid_namespaceFn().l));
+	expect(typeof emitter.on).toBe(\\"function\\");
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-external-new-expression commonjs-wrapped-external-new-expression should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: external \\"events\\"
+var external_events_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+module.exports = require(\\"events\\");
+});
+
+// MODULE: ./mid.cjs
+var mid_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const { make, raw } = (esm_user_namespaceFn());
+
+exports.L = make;
+exports.l = raw;
+
+});
+
+// MODULE: ./esm-user.mjs
+var esm_user_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(__webpack_module__, __webpack_exports__) {
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   make: () => (/* binding */ make)
+/* harmony export */ });
+(external_events_namespaceFn());
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+
+
+function make() {
+	return new (external_events_namespaceFn())();
+}
+
+const raw = (external_events_namespaceFn());
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"raw\\", 0, /* binding */ raw
+/* harmony export */ ]);
+
+});
+
+;// ./mid.cjs
+mid_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to a wrapped external's accessor result\\", () => {
+	const emitter = (0,mid_namespaceFn().L)();
+
+	expect(emitter).toBeInstanceOf((mid_namespaceFn().l));
+	expect(typeof emitter.on).toBe(\\"function\\");
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-external-new-expression commonjs-wrapped-external-new-expression should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: external \\"events\\"
+var external_events_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+module.exports = require(\\"events\\");
+});
+
+// MODULE: ./mid.cjs
+var mid_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const { make, raw } = (esm_user_namespaceFn());
+
+exports.L = make;
+exports.l = raw;
+
+});
+
+// MODULE: ./esm-user.mjs
+var esm_user_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(__webpack_module__, __webpack_exports__) {
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   make: () => (/* binding */ make)
+/* harmony export */ });
+(external_events_namespaceFn());
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+
+
+function make() {
+	return new (external_events_namespaceFn())();
+}
+
+const raw = (external_events_namespaceFn());
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"raw\\", 0, /* binding */ raw
+/* harmony export */ ]);
+
+});
+
+;// ./mid.cjs
+mid_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to a wrapped external's accessor result\\", () => {
+	const emitter = (0,mid_namespaceFn().L)();
+
+	expect(emitter).toBeInstanceOf((mid_namespaceFn().l));
+	expect(typeof emitter.on).toBe(\\"function\\");
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/__snapshots__/ConfigTest.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-external-new-expression commonjs-wrapped-external-new-expression should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		if(Array.isArray(definition)) {
+/******/ 			var i = 0;
+/******/ 			while(i < definition.length) {
+/******/ 				var key = definition[i++];
+/******/ 				var binding = definition[i++];
+/******/ 				var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+/******/ 				if(!__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, descriptor);
+/******/ 			}
+/******/ 		} else {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: external \\"events\\"
+var external_events_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+module.exports = require(\\"events\\");
+});
+
+// MODULE: ./mid.cjs
+var mid_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const { make, raw } = (esm_user_namespaceFn());
+
+exports.L = make;
+exports.l = raw;
+
+});
+
+// MODULE: ./esm-user.mjs
+var esm_user_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(__webpack_module__, __webpack_exports__) {
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   make: () => (/* binding */ make)
+/* harmony export */ });
+(external_events_namespaceFn());
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+
+
+function make() {
+	return new (external_events_namespaceFn())();
+}
+
+const raw = (external_events_namespaceFn());
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   \\"raw\\", 0, /* binding */ raw
+/* harmony export */ ]);
+
+});
+
+;// ./mid.cjs
+mid_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to a wrapped external's accessor result\\", () => {
+	const emitter = (0,mid_namespaceFn().L)();
+
+	expect(emitter).toBeInstanceOf((mid_namespaceFn().l));
+	expect(typeof emitter.on).toBe(\\"function\\");
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/esm-user.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/esm-user.mjs
@@ -1,0 +1,9 @@
+// required by a CommonJS module, so wrapping propagates from here to the
+// external: the default import becomes the external's accessor call
+import EventEmitter from "events";
+
+export function make() {
+	return new EventEmitter();
+}
+
+export const raw = EventEmitter;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/index.js
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+import { make, raw } from "./mid.cjs";
+
+it("should apply `new` to a wrapped external's accessor result", () => {
+	const emitter = make();
+
+	expect(emitter).toBeInstanceOf(raw);
+	expect(typeof emitter.on).toBe("function");
+});
+
+it("should really reach the external through a wrapper accessor", () => {
+	const source = readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(
+		/external_events_namespaceFn = \/\*#__PURE__\*\/__webpack_require__\.cw\(/
+	);
+	expect(source).toMatch(/return new \(external_events_namespaceFn\(\)\)\(\)/);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/index.js
@@ -1,4 +1,3 @@
-import { readFileSync } from "fs";
 import { make, raw } from "./mid.cjs";
 
 it("should apply `new` to a wrapped external's accessor result", () => {
@@ -6,13 +5,4 @@ it("should apply `new` to a wrapped external's accessor result", () => {
 
 	expect(emitter).toBeInstanceOf(raw);
 	expect(typeof emitter.on).toBe("function");
-});
-
-it("should really reach the external through a wrapper accessor", () => {
-	const source = readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(
-		/external_events_namespaceFn = \/\*#__PURE__\*\/__webpack_require__\.cw\(/
-	);
-	expect(source).toMatch(/return new \(external_events_namespaceFn\(\)\)\(\)/);
 });

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/mid.cjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/mid.cjs
@@ -1,0 +1,6 @@
+"use strict";
+
+const { make, raw } = require("./esm-user.mjs");
+
+exports.make = make;
+exports.raw = raw;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
@@ -16,8 +16,7 @@ module.exports = {
 	},
 	plugins: [
 		/**
-		 * `new` on a wrapped module's accessor call is printed code, so the whole
-		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * What this case checks is printed code, so review the bundle as a whole.
 		 * @param {import("../../../../").Compiler} compiler compiler
 		 */
 		(compiler) => {

--- a/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-external-new-expression/webpack.config.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "production",
@@ -11,5 +13,19 @@ module.exports = {
 		usedExports: true,
 		moduleIds: "named",
 		chunkIds: "named"
-	}
+	},
+	plugins: [
+		/**
+		 * `new` on a wrapped module's accessor call is printed code, so the whole
+		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
 };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,429 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-new-expression-output-module commonjs-wrapped-new-expression-output-module should compile 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+function thing_default() { return thing_default.c || (thing_default.c = __webpack_require__.n(thing_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import goes through the interop helper instead
+
+
+function construct(options) {
+	return new (thing_default()())(options);
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly
+
+
+function strict_construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+const ctor = (thing_namespaceFn());
+
+;// ./index.js
+
+
+
+it(\\"should construct through a strict ESM default import\\", () => {
+	const thing = strict_construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it(\\"should construct through the javascript/auto interop\\", () => {
+	const thing = construct({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-new-expression-output-module commonjs-wrapped-new-expression-output-module should compile 2`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+function thing_default() { return thing_default.c || (thing_default.c = __webpack_require__.n(thing_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import goes through the interop helper instead
+
+
+function construct(options) {
+	return new (thing_default()())(options);
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly
+
+
+function strict_construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+const ctor = (thing_namespaceFn());
+
+;// ./index.js
+
+
+
+it(\\"should construct through a strict ESM default import\\", () => {
+	const thing = strict_construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it(\\"should construct through the javascript/auto interop\\", () => {
+	const thing = construct({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-new-expression-output-module commonjs-wrapped-new-expression-output-module should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+function thing_default() { return thing_default.c || (thing_default.c = __webpack_require__.n(thing_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import goes through the interop helper instead
+
+
+function construct(options) {
+	return new (thing_default()())(options);
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly
+
+
+function strict_construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+const ctor = (thing_namespaceFn());
+
+;// ./index.js
+
+
+
+it(\\"should construct through a strict ESM default import\\", () => {
+	const thing = strict_construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it(\\"should construct through the javascript/auto interop\\", () => {
+	const thing = construct({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-new-expression-output-module commonjs-wrapped-new-expression-output-module should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+function thing_default() { return thing_default.c || (thing_default.c = __webpack_require__.n(thing_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import goes through the interop helper instead
+
+
+function construct(options) {
+	return new (thing_default()())(options);
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly
+
+
+function strict_construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+const ctor = (thing_namespaceFn());
+
+;// ./index.js
+
+
+
+it(\\"should construct through a strict ESM default import\\", () => {
+	const thing = strict_construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it(\\"should construct through the javascript/auto interop\\", () => {
+	const thing = construct({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/__snapshots__/ConfigTest.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-new-expression-output-module commonjs-wrapped-new-expression-output-module should compile 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+function thing_default() { return thing_default.c || (thing_default.c = __webpack_require__.n(thing_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import goes through the interop helper instead
+
+
+function construct(options) {
+	return new (thing_default()())(options);
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly
+
+
+function strict_construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+const ctor = (thing_namespaceFn());
+
+;// ./index.js
+
+
+
+it(\\"should construct through a strict ESM default import\\", () => {
+	const thing = strict_construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it(\\"should construct through the javascript/auto interop\\", () => {
+	const thing = construct({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/index.js
@@ -1,0 +1,24 @@
+import { readFileSync } from "fs";
+import { construct as constructLoose } from "./loose.js";
+import { construct as constructStrict, ctor } from "./strict.mjs";
+
+it("should construct through a strict ESM default import", () => {
+	const thing = constructStrict({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it("should construct through the javascript/auto interop", () => {
+	const thing = constructLoose({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(ctor);
+});
+
+it("should emit both constructions with the callee parenthesized", () => {
+	const source = readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/new \(thing_namespaceFn\(\)\)\(options\)/);
+	expect(source).toMatch(/new \(thing_default\(\)\(\)\)\(options\)/);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/index.js
@@ -1,4 +1,3 @@
-import { readFileSync } from "fs";
 import { construct as constructLoose } from "./loose.js";
 import { construct as constructStrict, ctor } from "./strict.mjs";
 
@@ -14,11 +13,4 @@ it("should construct through the javascript/auto interop", () => {
 
 	expect(thing.options).toEqual({ b: 2 });
 	expect(thing).toBeInstanceOf(ctor);
-});
-
-it("should emit both constructions with the callee parenthesized", () => {
-	const source = readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(/new \(thing_namespaceFn\(\)\)\(options\)/);
-	expect(source).toMatch(/new \(thing_default\(\)\(\)\)\(options\)/);
 });

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/loose.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/loose.js
@@ -1,0 +1,6 @@
+// javascript/auto: the default import goes through the interop helper instead
+import Thing from "./thing.cjs";
+
+export function construct(options) {
+	return new Thing(options);
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/strict.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/strict.mjs
@@ -1,0 +1,8 @@
+// strict ESM: the default import binds to the wrapper accessor directly
+import Thing from "./thing.cjs";
+
+export function construct(options) {
+	return new Thing(options);
+}
+
+export const ctor = Thing;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/thing.cjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/thing.cjs
@@ -1,0 +1,9 @@
+"use strict";
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "production",
@@ -14,5 +16,19 @@ module.exports = {
 		usedExports: true,
 		moduleIds: "named",
 		chunkIds: "named"
-	}
+	},
+	plugins: [
+		/**
+		 * `new` on a wrapped module's accessor call is printed code, so the whole
+		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.mjs"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
 };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-new-expression-output-module/webpack.config.js
@@ -19,8 +19,7 @@ module.exports = {
 	},
 	plugins: [
 		/**
-		 * `new` on a wrapped module's accessor call is printed code, so the whole
-		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * What this case checks is printed code, so review the bundle as a whole.
 		 * @param {import("../../../../").Compiler} compiler compiler
 		 */
 		(compiler) => {

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,589 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-strict-esm-new-expression commonjs-wrapped-strict-esm-new-expression should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./identity.cjs
+var identity_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./identity.cjs
+identity_namespaceFn();
+
+;// ./reexport.mjs
+
+
+;// ./entry.mjs
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the \`__webpack_require__.n\` interop
+
+
+
+
+
+function construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughNamespace(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughReexport(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function call(value) {
+	return identity_namespaceFn()(value);
+}
+
+function tag(value) {
+	return identity_namespaceFn()\`tag\${value}\`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	;(thing_namespaceFn())
+	return seen
+}
+
+function read() {
+	return (thing_namespaceFn());
+}
+
+const kind = typeof (thing_namespaceFn());
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to the wrapper accessor's result, not to the accessor\\", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a namespace default access\\", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a re-exported default\\", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should keep the default import readable as a plain value\\", () => {
+	expect(kind).toBe(\\"function\\");
+	expect(read().name).toBe(\\"Thing\\");
+});
+
+it(\\"should call a wrapped default import in call and tagged-template position\\", () => {
+	expect(call(\\"value\\")).toBe(\\"value\\");
+	expect(tag(\\"value\\")).toBe(\\"tag\\");
+});
+
+it(\\"should read a wrapped default import opening an ASI position\\", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-strict-esm-new-expression commonjs-wrapped-strict-esm-new-expression should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./identity.cjs
+var identity_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./identity.cjs
+identity_namespaceFn();
+
+;// ./reexport.mjs
+
+
+;// ./entry.mjs
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the \`__webpack_require__.n\` interop
+
+
+
+
+
+function construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughNamespace(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughReexport(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function call(value) {
+	return identity_namespaceFn()(value);
+}
+
+function tag(value) {
+	return identity_namespaceFn()\`tag\${value}\`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	;(thing_namespaceFn())
+	return seen
+}
+
+function read() {
+	return (thing_namespaceFn());
+}
+
+const kind = typeof (thing_namespaceFn());
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to the wrapper accessor's result, not to the accessor\\", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a namespace default access\\", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a re-exported default\\", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should keep the default import readable as a plain value\\", () => {
+	expect(kind).toBe(\\"function\\");
+	expect(read().name).toBe(\\"Thing\\");
+});
+
+it(\\"should call a wrapped default import in call and tagged-template position\\", () => {
+	expect(call(\\"value\\")).toBe(\\"value\\");
+	expect(tag(\\"value\\")).toBe(\\"tag\\");
+});
+
+it(\\"should read a wrapped default import opening an ASI position\\", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-strict-esm-new-expression commonjs-wrapped-strict-esm-new-expression should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./identity.cjs
+var identity_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./identity.cjs
+identity_namespaceFn();
+
+;// ./reexport.mjs
+
+
+;// ./entry.mjs
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the \`__webpack_require__.n\` interop
+
+
+
+
+
+function construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughNamespace(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughReexport(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function call(value) {
+	return identity_namespaceFn()(value);
+}
+
+function tag(value) {
+	return identity_namespaceFn()\`tag\${value}\`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	;(thing_namespaceFn())
+	return seen
+}
+
+function read() {
+	return (thing_namespaceFn());
+}
+
+const kind = typeof (thing_namespaceFn());
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to the wrapper accessor's result, not to the accessor\\", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a namespace default access\\", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a re-exported default\\", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should keep the default import readable as a plain value\\", () => {
+	expect(kind).toBe(\\"function\\");
+	expect(read().name).toBe(\\"Thing\\");
+});
+
+it(\\"should call a wrapped default import in call and tagged-template position\\", () => {
+	expect(call(\\"value\\")).toBe(\\"value\\");
+	expect(tag(\\"value\\")).toBe(\\"tag\\");
+});
+
+it(\\"should read a wrapped default import opening an ASI position\\", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-strict-esm-new-expression commonjs-wrapped-strict-esm-new-expression should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./identity.cjs
+var identity_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./identity.cjs
+identity_namespaceFn();
+
+;// ./reexport.mjs
+
+
+;// ./entry.mjs
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the \`__webpack_require__.n\` interop
+
+
+
+
+
+function construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughNamespace(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughReexport(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function call(value) {
+	return identity_namespaceFn()(value);
+}
+
+function tag(value) {
+	return identity_namespaceFn()\`tag\${value}\`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	;(thing_namespaceFn())
+	return seen
+}
+
+function read() {
+	return (thing_namespaceFn());
+}
+
+const kind = typeof (thing_namespaceFn());
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to the wrapper accessor's result, not to the accessor\\", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a namespace default access\\", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a re-exported default\\", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should keep the default import readable as a plain value\\", () => {
+	expect(kind).toBe(\\"function\\");
+	expect(read().name).toBe(\\"Thing\\");
+});
+
+it(\\"should call a wrapped default import in call and tagged-template position\\", () => {
+	expect(call(\\"value\\")).toBe(\\"value\\");
+	expect(tag(\\"value\\")).toBe(\\"tag\\");
+});
+
+it(\\"should read a wrapped default import opening an ASI position\\", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/__snapshots__/ConfigTest.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-strict-esm-new-expression commonjs-wrapped-strict-esm-new-expression should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./identity.cjs
+var identity_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;
+
+});
+
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./identity.cjs
+identity_namespaceFn();
+
+;// ./reexport.mjs
+
+
+;// ./entry.mjs
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the \`__webpack_require__.n\` interop
+
+
+
+
+
+function construct(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughNamespace(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function constructThroughReexport(options) {
+	return new (thing_namespaceFn())(options);
+}
+
+function call(value) {
+	return identity_namespaceFn()(value);
+}
+
+function tag(value) {
+	return identity_namespaceFn()\`tag\${value}\`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	;(thing_namespaceFn())
+	return seen
+}
+
+function read() {
+	return (thing_namespaceFn());
+}
+
+const kind = typeof (thing_namespaceFn());
+
+;// ./index.js
+
+
+it(\\"should apply \`new\` to the wrapper accessor's result, not to the accessor\\", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a namespace default access\\", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should apply \`new\` through a re-exported default\\", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it(\\"should keep the default import readable as a plain value\\", () => {
+	expect(kind).toBe(\\"function\\");
+	expect(read().name).toBe(\\"Thing\\");
+});
+
+it(\\"should call a wrapped default import in call and tagged-template position\\", () => {
+	expect(call(\\"value\\")).toBe(\\"value\\");
+	expect(tag(\\"value\\")).toBe(\\"tag\\");
+});
+
+it(\\"should read a wrapped default import opening an ASI position\\", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/entry.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/entry.mjs
@@ -1,0 +1,41 @@
+// strict ESM: the default import of a CommonJS module resolves straight to the
+// wrapper accessor call, skipping the `__webpack_require__.n` interop
+import Thing from "./thing.cjs";
+import * as namespace from "./thing.cjs";
+import identity from "./identity.cjs";
+import { Reexported } from "./reexport.mjs";
+
+export function construct(options) {
+	return new Thing(options);
+}
+
+export function constructThroughNamespace(options) {
+	return new namespace.default(options);
+}
+
+export function constructThroughReexport(options) {
+	return new Reexported(options);
+}
+
+export function call(value) {
+	return identity(value);
+}
+
+export function tag(value) {
+	return identity`tag${value}`;
+}
+
+// the reference opens a statement that ASI could glue to the previous one, so
+// it must be emitted with a leading semicolon
+export function readInAsiPosition() {
+	const seen = []
+	seen.push(1)
+	Thing
+	return seen
+}
+
+export function read() {
+	return Thing;
+}
+
+export const kind = typeof Thing;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/identity.cjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/identity.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function identity(value) {
+	return value.raw ? value.raw[0] : value;
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/index.js
@@ -1,4 +1,3 @@
-import { readFileSync } from "fs";
 import {
 	call,
 	construct,
@@ -36,29 +35,11 @@ it("should keep the default import readable as a plain value", () => {
 	expect(read().name).toBe("Thing");
 });
 
-it("should call a wrapped default import without extra parentheses", () => {
+it("should call a wrapped default import in call and tagged-template position", () => {
 	expect(call("value")).toBe("value");
 	expect(tag("value")).toBe("tag");
-
-	const source = readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(/return identity_namespaceFn\(\)\(value\)/);
-	expect(source).toMatch(/return identity_namespaceFn\(\)`tag\$\{value\}`/);
 });
 
-it("should guard an accessor reference that opens an ASI position", () => {
+it("should read a wrapped default import opening an ASI position", () => {
 	expect(readInAsiPosition()).toEqual([1]);
-
-	expect(readFileSync(__filename, "utf-8")).toMatch(
-		/\n\t;\(thing_namespaceFn\(\)\)\n/
-	);
-});
-
-it("should really reach the modules through a wrapper accessor", () => {
-	const source = readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(
-		/thing_namespaceFn = \/\*#__PURE__\*\/__webpack_require__\.cw\(/
-	);
-	expect(source).toMatch(/new \(thing_namespaceFn\(\)\)\(/);
 });

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/index.js
@@ -1,0 +1,64 @@
+import { readFileSync } from "fs";
+import {
+	call,
+	construct,
+	constructThroughNamespace,
+	constructThroughReexport,
+	kind,
+	read,
+	readInAsiPosition,
+	tag
+} from "./entry.mjs";
+
+it("should apply `new` to the wrapper accessor's result, not to the accessor", () => {
+	const thing = construct({ a: 1 });
+
+	expect(thing.options).toEqual({ a: 1 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it("should apply `new` through a namespace default access", () => {
+	const thing = constructThroughNamespace({ b: 2 });
+
+	expect(thing.options).toEqual({ b: 2 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it("should apply `new` through a re-exported default", () => {
+	const thing = constructThroughReexport({ c: 3 });
+
+	expect(thing.options).toEqual({ c: 3 });
+	expect(thing).toBeInstanceOf(read());
+});
+
+it("should keep the default import readable as a plain value", () => {
+	expect(kind).toBe("function");
+	expect(read().name).toBe("Thing");
+});
+
+it("should call a wrapped default import without extra parentheses", () => {
+	expect(call("value")).toBe("value");
+	expect(tag("value")).toBe("tag");
+
+	const source = readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/return identity_namespaceFn\(\)\(value\)/);
+	expect(source).toMatch(/return identity_namespaceFn\(\)`tag\$\{value\}`/);
+});
+
+it("should guard an accessor reference that opens an ASI position", () => {
+	expect(readInAsiPosition()).toEqual([1]);
+
+	expect(readFileSync(__filename, "utf-8")).toMatch(
+		/\n\t;\(thing_namespaceFn\(\)\)\n/
+	);
+});
+
+it("should really reach the modules through a wrapper accessor", () => {
+	const source = readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(
+		/thing_namespaceFn = \/\*#__PURE__\*\/__webpack_require__\.cw\(/
+	);
+	expect(source).toMatch(/new \(thing_namespaceFn\(\)\)\(/);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/reexport.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/reexport.mjs
@@ -1,0 +1,1 @@
+export { default as Reexported } from "./thing.cjs";

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/thing.cjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/thing.cjs
@@ -1,0 +1,9 @@
+"use strict";
+
+class Thing {
+	constructor(options) {
+		this.options = options;
+	}
+}
+
+module.exports = Thing;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
@@ -16,8 +16,7 @@ module.exports = {
 	},
 	plugins: [
 		/**
-		 * `new` on a wrapped module's accessor call is printed code, so the whole
-		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * What this case checks is printed code, so review the bundle as a whole.
 		 * @param {import("../../../../").Compiler} compiler compiler
 		 */
 		(compiler) => {

--- a/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-strict-esm-new-expression/webpack.config.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "production",
@@ -11,5 +13,19 @@ module.exports = {
 		usedExports: true,
 		moduleIds: "named",
 		chunkIds: "named"
-	}
+	},
+	plugins: [
+		/**
+		 * `new` on a wrapped module's accessor call is printed code, so the whole
+		 * emitted bundle is reviewed as one rather than pinned substring by substring.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Since 5.110.0 a wrapped CommonJS module is reached through the lazy accessor `X_namespaceFn()`, so a reference standing in for an identifier is a call expression; `getFinalName` only parenthesized inside its `isPropertyAccess` branch, and a strict-ESM default import resolves with `ids.length === 0`, so `new X_namespaceFn()(…)` applied `new` to the accessor and threw at runtime. The binding now carries an `accessorCall` flag, set where the raw name really is an accessor call, and those references are parenthesized outside call position. Closes #21873

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — three `test/configCases/concatenate-modules/` cases, each confirmed to fail on unmodified `lib/` with the reported `TypeError`: `commonjs-wrapped-strict-esm-new-expression` (default import, `ns.default`, re-exported default, plus guards that call/tagged-template positions stay unparenthesized and that an ASI-position reference keeps its leading `;`), `commonjs-wrapped-external-new-expression` (wrapped external), and `commonjs-wrapped-new-expression-output-module` (the reported `experiments.outputModule` shape, covering the `javascript/auto` interop path too).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to locate the faulty branch in `getFinalName`, write the fix and the three regression cases, and run the verification below; every change was reviewed before committing. Verified with `yarn test:basic` (28789 passed, 1624 snapshots pass; the only failures are the sandbox-known `Cli createColors`, `profiling-plugin` and `many-replacements`), full `yarn lint` green, and `yarn test:size` against a baseline of the same tree without the `lib/` change: +70 B gzip / +221 B raw over 33 assets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AedhdUFkhcQTdywNZoGKoB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `new` expressions using default imports from wrapped CommonJS modules.
  * Ensured the imported value, rather than the module accessor, is instantiated.
  * Preserved correct behavior across ESM, interop, namespace, and re-exported imports.
  * Improved generated expressions for safe evaluation in edge cases.

* **Tests**
  * Added coverage for constructors, calls, tagged templates, type checks, and wrapped module access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->