### PR TITLE
fix: skip esm interop for require() module outside the concatenation

### DIFF
--- a/.changeset/015-concat-external-require-interop.md
+++ b/.changeset/015-concat-external-require-interop.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip ESM interop when require() targets a module outside the concatenation.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -498,7 +498,9 @@ const getFinalBinding = (
 		};
 	}
 
-	if (exportName.length === 0) {
+	if (moduleExportsAccess) {
+		// Skip ESM interop when require() targets a module outside the concatenation
+	} else if (exportName.length === 0) {
 		switch (exportsType) {
 			case "default-only":
 				if (deferred) info.deferredNamespaceObjectUsed = true;

--- a/test/configCases/concatenate-modules/issue-21882/a.svg
+++ b/test/configCases/concatenate-modules/issue-21882/a.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"/>

--- a/test/configCases/concatenate-modules/issue-21882/consumer.js
+++ b/test/configCases/concatenate-modules/issue-21882/consumer.js
@@ -1,0 +1,8 @@
+export function render() {
+	return {
+		url: require("./a.svg"),
+		whole: require("./data.js"),
+		foo: require("./data.js").foo,
+		def: require("./data.js").default
+	};
+}

--- a/test/configCases/concatenate-modules/issue-21882/data.js
+++ b/test/configCases/concatenate-modules/issue-21882/data.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { foo: 42, default: "d" };

--- a/test/configCases/concatenate-modules/issue-21882/index.js
+++ b/test/configCases/concatenate-modules/issue-21882/index.js
@@ -1,0 +1,21 @@
+import { render } from "./consumer";
+
+it("should return raw module.exports for require() of modules split into another chunk", () => {
+	const result = render();
+	// a broken build wraps these in a fake namespace object { default: exports }
+	expect(typeof result.url).toBe("string");
+	expect(result.url).toMatch(/\.svg$/);
+	expect(result.whole).toEqual({ foo: 42, default: "d" });
+	expect(result.whole.__esModule).toBeUndefined();
+	expect(result.foo).toBe(42);
+	expect(result.def).toBe("d");
+});
+
+it("should keep the split require() targets outside the concatenation", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./consumer.js",
+		"./index.js"
+	]);
+});

--- a/test/configCases/concatenate-modules/issue-21882/test.config.js
+++ b/test/configCases/concatenate-modules/issue-21882/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["split.js", "main.js"];
+	}
+};

--- a/test/configCases/concatenate-modules/issue-21882/webpack.config.js
+++ b/test/configCases/concatenate-modules/issue-21882/webpack.config.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.svg$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		splitChunks: {
+			cacheGroups: {
+				split: {
+					test: /a\.svg$|data\.js$/,
+					name: "split",
+					chunks: "all",
+					enforce: true,
+					minSize: 0
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #21882. 

Keep raw access for `require()` targets outside the concatenation. And no fake namespace is needed to keep ESM interop.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fix
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a 
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `require()` behavior for modules outside concatenated bundles.
  - Preserved the original module exports instead of adding unnecessary ESM interop wrappers.
  - Improved handling of CommonJS modules, including default and named exports, when loaded from split chunks.

- **Tests**
  - Added coverage for required assets and modules across separate bundles.
  - Verified that split-module imports return expected raw exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->