### PR TITLE
docs: document the post-minor stabilization week and out-of-band releases

### DIFF
--- a/RELEASE_SCHEDULE.md
+++ b/RELEASE_SCHEDULE.md
@@ -14,6 +14,24 @@ Feature work ships on a fixed cadence: a minor release every four weeks, on a Th
 
 A scheduled release may be skipped when nothing user-facing has landed since the previous one.
 
+#### The week after a minor — no new features
+
+The first week of every four-week cycle is a stabilization window: **pull requests adding features are not merged for one week after a minor release.** Only bug fixes go into `main` during that week, so a regression reported against the fresh minor can be fixed and patched out on its own.
+
+The point is that the patch releases of that week stay clean. If features were merged straight after a minor, every regression fix would drag whatever features had landed since out with it — a stream of small releases each mixing new behavior into what was meant to be a fix, and each one a new thing to bisect when the next report comes in.
+
+Once the week is over, feature pull requests are merged as usual for the remaining three weeks of the cycle. Approved feature pull requests simply wait during the window; there is no need to close or rebase them.
+
+### Out-of-band releases — critical fixes do not wait
+
+The cadence above is for feature work. A release is published as soon as the fix is on `main`, without waiting for the four-week slot or the end of the stabilization window, when it contains:
+
+- a security fix;
+- a fix for a breaking change that shipped unintentionally (behavior a release changed without saying so);
+- a fix for anything else critical — a regression that breaks common builds, corrupts output, or has no workaround.
+
+Such a release carries only the fix and whatever else has already landed; nothing is held back for it and no feature is merged to accompany it.
+
 ### Major releases — only after a roadmap discussion
 
 Major releases are not scheduled. A new major happens only after the roadmap and the other aspects requiring significant changes — breaking changes, the supported Node.js range, migration effort for the ecosystem, and the work needed in loaders, plugins and the documentation — have been discussed publicly and agreed on by the [Core Working Group](./WORKING_GROUP.md).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`RELEASE_SCHEDULE.md` described the 4-week minor cadence but not two rules we actually follow: feature pull requests are not merged for one week after a minor release (so that week's patch releases carry only regression fixes instead of mixing in newly landed features), and a security fix, an unintentionally shipped breaking change, or another critical regression is released immediately rather than waiting for the next 4-week slot.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the change is the documentation.

**Use of AI**

Claude Code wrote the wording of the two new sections in `RELEASE_SCHEDULE.md` from the release policy I described to it; I reviewed the result before pushing. No source code was changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMxzbVdNAi3QGt6C2aEZDD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release schedule guidance for a one-week stabilization period after minor releases.
  * Documented out-of-band releases for security fixes, unintended breaking changes, and other critical regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->