### PR TITLE
fix: handle HTTP module decompression errors

### DIFF
--- a/.changeset/020-http-uri-decompression-errors.md
+++ b/.changeset/020-http-uri-decompression-errors.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Report invalid compressed HTTP modules as compilation errors.

--- a/lib/schemes/HttpUriPlugin.js
+++ b/lib/schemes/HttpUriPlugin.js
@@ -994,6 +994,15 @@ class HttpUriPlugin {
 							} else if (contentEncoding === "deflate") {
 								stream = stream.pipe(createInflate());
 							}
+							if (stream !== res) {
+								stream.once("error", (err) => {
+									logger.log(
+										`GET ${url} [${res.statusCode}] (invalid encoding)`
+									);
+									err.message += `\nwhile decompressing ${url}`;
+									callback(err);
+								});
+							}
 
 							stream.on(
 								"data",

--- a/test/configCases/asset-modules/http-url/errors.js
+++ b/test/configCases/asset-modules/http-url/errors.js
@@ -20,5 +20,6 @@ module.exports = [
 	[/while fetching http:\/\/localhost:9990\/resolve\.js\?error/],
 	[
 		/Module not found: Error: http:\/\/localhost:9990@127\.0\.0\.1:9100\/secret\.js doesn't match the allowedUris policy/
-	]
+	],
+	[/while decompressing http:\/\/localhost:9990\/resolve\.js\?invalid-gzip/]
 ];

--- a/test/configCases/asset-modules/http-url/index.decompression-errors.js
+++ b/test/configCases/asset-modules/http-url/index.decompression-errors.js
@@ -1,0 +1,5 @@
+it("reports invalid compressed responses as module errors", () => {
+	expect(() => {
+		require("http://localhost:9990/resolve.js?invalid-gzip");
+	}).toThrow();
+});

--- a/test/configCases/asset-modules/http-url/server/index.js
+++ b/test/configCases/asset-modules/http-url/server/index.js
@@ -18,6 +18,11 @@ function createServer() {
 			/** @type {import("net").Socket} */ (res.socket).destroy();
 			return;
 		}
+		if (query === "invalid-gzip") {
+			res.setHeader("Content-Encoding", "gzip");
+			res.end("not gzip data");
+			return;
+		}
 		// must-revalidate redirect with a stable etag, to exercise the unchanged-redirect path
 		if (query === "redirect") {
 			res.statusCode = 301;

--- a/test/configCases/asset-modules/http-url/webpack.config.js
+++ b/test/configCases/asset-modules/http-url/webpack.config.js
@@ -112,5 +112,18 @@ module.exports = [
 				frozen: false
 			})
 		]
+	},
+	{
+		name: "decompression-errors",
+		...base,
+		entry: "./index.decompression-errors.js",
+		plugins: [
+			serverPlugin,
+			new HttpUriPlugin({
+				allowedUris,
+				upgrade: true,
+				frozen: false
+			})
+		]
 	}
 ];


### PR DESCRIPTION
**Summary**

Compressed HTTP module responses could emit an error on the decompressor without reaching the request error handler, leaving compilation unresolved. The selected decompression stream now forwards its first error through the normal callback with URL context.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. A real HTTP config case serves invalid gzip data and verifies compilation reports the decompression failure. The focused integration run passes 48 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. It turns a stalled/error-leaking edge case into the expected module error.

**If relevant, did you update the documentation?**

A patch changeset documents the corrected failure handling. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit the stream lifecycle and draft the fix and integration regression. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid gzip, Brotli, and deflate-compressed HTTP resources are now reported as compilation errors.
  * Decompression errors include the affected URL, making failures easier to identify.
* **Tests**
  * Added coverage for invalid gzip responses received through HTTP asset modules.
* **Release**
  * Included in a patch release of webpack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->