### PR TITLE
fix: await compressed cache output completion

### DIFF
--- a/.changeset/020-compressed-cache-write-completion.md
+++ b/.changeset/020-compressed-cache-write-completion.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Wait for compressed cache files to finish writing before replacing them.

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -549,9 +549,11 @@ class FileMiddleware extends SerializerMiddleware {
 								});
 							}
 							if (compression) {
-								pipeline(compression, stream, reject);
+								pipeline(compression, stream, (err) => {
+									if (err) return reject(err);
+									resolve();
+								});
 								stream = compression;
-								stream.on("finish", () => resolve());
 							} else {
 								stream.on("error", (err) => reject(err));
 								stream.on("finish", () => resolve());

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { Writable } = require("stream");
 const FileMiddleware = require("../lib/serialization/FileMiddleware");
 
 // Internal `deserialize(middleware, name, readFile)` exposed for this test.
@@ -41,6 +42,39 @@ describe("FileMiddleware deserialize", () => {
 
 		expect(result).toHaveLength(1);
 		expect(Buffer.from(/** @type {Buffer} */ (result[0]))).toEqual(content);
+	});
+});
+
+describe("FileMiddleware serialize", () => {
+	it("waits for compressed output before replacing the cache file", async () => {
+		const output = new Writable({
+			write(_chunk, _encoding, callback) {
+				setTimeout(callback, 25);
+			}
+		});
+		let finishedWhenReplaced = false;
+		const fs = /** @type {EXPECTED_ANY} */ ({
+			mkdir: jest.fn((_path, callback) => callback()),
+			createWriteStream: () => output,
+			rename: jest.fn((from, _to, callback) => {
+				if (from.endsWith("_")) {
+					finishedWhenReplaced = output.writableFinished;
+				}
+				callback();
+			})
+		});
+		const middleware = new FileMiddleware(fs);
+
+		await middleware.serialize([Buffer.from("content")], {
+			filename: "/cache/index.pack.gz"
+		});
+
+		if (!output.writableFinished) {
+			await new Promise((resolve) => {
+				output.once("finish", () => resolve(undefined));
+			});
+		}
+		expect(finishedWhenReplaced).toBe(true);
 	});
 });
 


### PR DESCRIPTION
**Summary**

Compressed persistent-cache serialization resolved after the gzip/brotli transform finished reading, before the destination writable necessarily flushed. The pipeline now includes the output stream, so webpack replaces the cache file only after the complete compressed write succeeds.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The regression uses a delayed writable and asserts replacement observes `writableFinished`. The focused unit suite passes 13 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. It strengthens completion ordering for compressed cache writes.

**If relevant, did you update the documentation?**

A patch changeset documents the lifecycle correction. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit the stream pipeline and draft the fix and regression test. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compressed cache files are now fully written before being replaced, preventing incomplete cache updates.

* **Tests**
  * Added coverage to verify cache replacement waits for compressed output to finish successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->