### PR TITLE
fix: preserve literal dotenv keys in import.meta.env

### DIFF
--- a/.changeset/020-dotenv-nonidentifier-keys.md
+++ b/.changeset/020-dotenv-nonidentifier-keys.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Preserve literal dotenv keys, including dots, dashes, and `__proto__`.

--- a/lib/DotenvPlugin.js
+++ b/lib/DotenvPlugin.js
@@ -235,16 +235,18 @@ function expand(options) {
 /**
  * Format environment variables as DefinePlugin definitions
  * @param {Env} env environment variables
- * @returns {Record<string, string>} formatted definitions
+ * @returns {Record<string, string | Env>} formatted definitions
  */
 const envToDefinitions = (env) => {
-	const definitions = /** @type {Record<string, string>} */ ({});
+	const definitions = /** @type {Record<string, string | Env>} */ ({});
+	const importMetaEnv = /** @type {Env} */ (Object.create(null));
 
 	for (const [key, value] of Object.entries(env)) {
 		const defValue = JSON.stringify(value);
 		definitions[`process.env.${key}`] = defValue;
-		definitions[`import.meta.env.${key}`] = defValue;
+		importMetaEnv[key] = defValue;
 	}
+	definitions["import.meta.env"] = importMetaEnv;
 
 	return definitions;
 };

--- a/test/configCases/plugins/import-meta-env/.env.test
+++ b/test/configCases/plugins/import-meta-env/.env.test
@@ -1,1 +1,4 @@
 WEBPACK_DOTENV_VAR=from_dotenv
+WEBPACK_DOTTED.KEY=from_dotted_key
+WEBPACK_DASHED-KEY=from_dashed_key
+__proto__=from_prototype_key

--- a/test/configCases/plugins/import-meta-env/index.js
+++ b/test/configCases/plugins/import-meta-env/index.js
@@ -20,6 +20,11 @@ it("should expose variables from EnvironmentPlugin", () => {
 it("should expose variables from DotenvPlugin", () => {
 	const env = import.meta.env;
 	expect(env.WEBPACK_DOTENV_VAR).toBe("from_dotenv");
+	expect(env["WEBPACK_DOTTED.KEY"]).toBe("from_dotted_key");
+	expect(env["WEBPACK_DASHED-KEY"]).toBe("from_dashed_key");
+	expect(process.env["WEBPACK_DOTTED.KEY"]).toBe("from_dotted_key");
+	expect(process.env["WEBPACK_DASHED-KEY"]).toBe("from_dashed_key");
+	expect(env["__proto__"]).toBe("from_prototype_key");
 });
 
 it("should expose variables from DefinePlugin", () => {

--- a/test/configCases/plugins/import-meta-env/webpack.config.js
+++ b/test/configCases/plugins/import-meta-env/webpack.config.js
@@ -8,7 +8,8 @@ module.exports = {
 	mode: "production",
 	// Test 3: DotenvPlugin from .env.test file
 	dotenv: {
-		template: [".env.test"]
+		template: [".env.test"],
+		prefix: ["WEBPACK_", "__proto__"]
 	},
 	plugins: [
 		// Test 2: EnvironmentPlugin


### PR DESCRIPTION
**Summary**

Dotenv keys containing dots, dashes, or prototype-like names were emitted as chained `DefinePlugin` expressions or assigned through an inherited object setter, changing their meaning. Dotenv now defines `import.meta.env` with literal properties on a null-prototype map while retaining the existing `process.env` definitions.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The real `import.meta.env` config case covers dotted, dashed, and `__proto__` keys; the prototype regression fails before the null-prototype correction and passes afterward. The focused integration run passes 112 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. It makes valid dotenv keys behave as written.

**If relevant, did you update the documentation?**

A patch changeset documents literal-key preservation. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit dotenv definition generation and draft the fix and regression coverage. I reviewed the final diff and verification results.