### PR TITLE
fix: reject cache files truncated after stat

### DIFF
--- a/.changeset/020-truncated-cache-file.md
+++ b/.changeset/020-truncated-cache-file.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reject cache files truncated after their size is read.

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -793,6 +793,14 @@ class FileMiddleware extends SerializerMiddleware {
 										});
 										return;
 									}
+									if (bytesRead === 0 && remaining > 0) {
+										this.fs.close(fd, (err) => {
+											reject(
+												err || new Error(`Unexpected end of file ${file}`)
+											);
+										});
+										return;
+									}
 									/** @type {number} */
 									(currentBufferUsed) += bytesRead;
 									remaining -= bytesRead;

--- a/test/FileMiddleware.unittest.js
+++ b/test/FileMiddleware.unittest.js
@@ -42,6 +42,37 @@ describe("FileMiddleware deserialize", () => {
 		expect(result).toHaveLength(1);
 		expect(Buffer.from(/** @type {Buffer} */ (result[0]))).toEqual(content);
 	});
+
+	it("rejects when a cache file is truncated after stat", async () => {
+		const content = buildHeader([]);
+		let position = 0;
+		let reads = 0;
+		const fs = /** @type {EXPECTED_ANY} */ ({
+			stat: jest.fn((_file, callback) =>
+				process.nextTick(() => callback(null, { size: content.length + 1 }))
+			),
+			open: jest.fn((_file, _flags, callback) =>
+				process.nextTick(() => callback(null, 1))
+			),
+			read: jest.fn((_fd, buffer, offset, length, _position, callback) => {
+				reads++;
+				if (reads > 2) {
+					process.nextTick(() => callback(new Error("read retried after EOF")));
+					return;
+				}
+				const slice = content.subarray(position, position + length);
+				slice.copy(buffer, offset);
+				position += slice.length;
+				process.nextTick(() => callback(null, slice.length));
+			}),
+			close: jest.fn((_fd, callback) => process.nextTick(() => callback(null)))
+		});
+
+		await expect(
+			new FileMiddleware(fs).deserialize(true, { filename: "cache.pack" })
+		).rejects.toThrow(/Unexpected end of file/);
+		expect(reads).toBe(2);
+	});
 });
 
 describe("FileMiddleware getReferencedFilenames", () => {


### PR DESCRIPTION
**Summary**

If a cache file shrank after `stat`, positional reads could repeatedly return zero bytes while the original size still indicated remaining data. The reader now treats zero bytes before the expected end as truncation and rejects instead of looping indefinitely.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. A bounded fake filesystem simulates truncation after metadata lookup and verifies an EOF error after two reads. The focused unit suite passes 13 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. Corrupt cache input now fails promptly instead of hanging.

**If relevant, did you update the documentation?**

A patch changeset documents truncated-cache rejection. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit cache I/O and draft the fix and regression test. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated cache files.
  * Cache reads now fail promptly with an “Unexpected end of file” error instead of continuing with incomplete data or hanging.

* **Tests**
  * Added coverage for cache files whose reported size exceeds their actual contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->