### PR TITLE
fix: propagate dotenv read errors

### DIFF
--- a/.changeset/020-dotenv-read-errors.md
+++ b/.changeset/020-dotenv-read-errors.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Report dotenv read errors instead of treating every failure as a missing file.

--- a/lib/DotenvPlugin.js
+++ b/lib/DotenvPlugin.js
@@ -369,7 +369,13 @@ class DotenvPlugin {
 						fileDependencies.push(filePath);
 						return content;
 					},
-					() => {
+					(err) => {
+						if (
+							/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOENT" &&
+							/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOTDIR"
+						) {
+							throw err;
+						}
 						// File doesn't exist, add to missingDependencies (this is normal)
 						missingDependencies.push(filePath);
 						return "";

--- a/test/DotenvPlugin.unittest.js
+++ b/test/DotenvPlugin.unittest.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const DotenvPlugin = require("../lib/DotenvPlugin");
+
+const inputFileSystem = /** @type {EXPECTED_ANY} */ ({});
+
+describe("DotenvPlugin", () => {
+	it.each(["ENOENT", "ENOTDIR"])(
+		"tracks %s errors as missing dotenv files",
+		async (code) => {
+			const error = Object.assign(new Error("missing"), { code });
+			const plugin = /** @type {EXPECTED_ANY} */ (
+				new DotenvPlugin({ template: [".env"] })
+			);
+			plugin._loadFile = () => Promise.reject(error);
+
+			await expect(
+				plugin._getParsed(inputFileSystem, "/project", "development")
+			).resolves.toMatchObject({
+				missingDependencies: ["/project/.env"],
+				parsed: {}
+			});
+		}
+	);
+
+	it("propagates errors reading configured dotenv files", async () => {
+		const error = Object.assign(new Error("permission denied"), {
+			code: "EACCES"
+		});
+		const plugin = /** @type {EXPECTED_ANY} */ (
+			new DotenvPlugin({ template: [".env"] })
+		);
+		plugin._loadFile = () => Promise.reject(error);
+
+		await expect(
+			plugin._getParsed(inputFileSystem, "/project", "development")
+		).rejects.toBe(error);
+	});
+});


### PR DESCRIPTION
**Summary**

Dotenv treated every file read failure as a missing optional file, silently swallowing permission errors and other I/O faults. Only `ENOENT` and `ENOTDIR` are now recorded as missing dependencies; all other errors reject compilation.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. Unit regressions cover both expected missing-file codes and `EACCES` propagation. The focused suite passes 3 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. Real configuration I/O failures are now reported instead of silently ignored.

**If relevant, did you update the documentation?**

A patch changeset documents the error-handling correction. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit dotenv loading and draft the fix and regression tests. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dotenv file error handling.
  * Missing or invalid paths continue to be handled as absent files.
  * Other read errors are now reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->