### PR TITLE
fix: honor case-insensitive HTTP no-store directives

### DIFF
--- a/.changeset/020-http-cache-control-directives.md
+++ b/.changeset/020-http-cache-control-directives.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Honor case-insensitive and `no-store` HTTP cache-control directives.

--- a/lib/schemes/HttpUriPlugin.js
+++ b/lib/schemes/HttpUriPlugin.js
@@ -185,8 +185,10 @@ const parseCacheControl = (cacheControl, requestTime) => {
 	// Resource is only revalidated, after that timestamp and when upgrade is chosen
 	let validUntil = 0;
 	if (cacheControl) {
-		const parsed = parseKeyValuePairs(cacheControl);
-		if (parsed["no-cache"]) storeCache = storeLock = false;
+		const parsed = parseKeyValuePairs(cacheControl.toLowerCase());
+		if (parsed["no-cache"] || parsed["no-store"]) {
+			storeCache = storeLock = false;
+		}
 		if (parsed["max-age"] && !Number.isNaN(Number(parsed["max-age"]))) {
 			validUntil = requestTime + Number(parsed["max-age"]) * 1000;
 		}

--- a/test/configCases/asset-modules/http-url/frozen-verify.webpack.lock
+++ b/test/configCases/asset-modules/http-url/frozen-verify.webpack.lock
@@ -9,6 +9,7 @@
   "http://localhost:9990/folder/sub-dependency2.js": { "integrity": "sha512-BDZKEwlnwBabeHEwmMd02NxFEjYy+QwKAKP0S8zMMesX7dUsvh11hM7LUOPPFOS+nIEFZPtnc7kFwmnojVUw5A==", "contentType": "text/javascript" },
   "http://localhost:9990/index.css?cache": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/index.css?no-cache": "no-cache",
+  "http://localhost:9990/index.css?no-store": "no-cache",
   "http://localhost:9990/index.css?query#fragment": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/redirect": { "resolved": "http://localhost:9990/redirect.js", "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },
   "http://localhost:9990/redirect.js": { "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },

--- a/test/configCases/asset-modules/http-url/index.js
+++ b/test/configCases/asset-modules/http-url/index.js
@@ -1,5 +1,6 @@
 import cssContent from "http://localhost:9990/index.css?query#fragment";
 import noCacheCssContent from "http://localhost:9990/index.css?no-cache";
+import noStoreCssContent from "http://localhost:9990/index.css?no-store";
 import cachedCssContent from "http://localhost:9990/index.css?cache";
 import { value, value2 } from "http://localhost:9990/resolve.js";
 import { fallback } from "http://localhost:9990/fallback.js";
@@ -17,6 +18,7 @@ import { value as redirectValue } from "http://localhost:9990/resolve.js?redirec
 it("http url request should be supported", () => {
 	expect(cssContent).toBe("a {}.webpack{}");
 	expect(noCacheCssContent).toBe("a {}.webpack{}");
+	expect(noStoreCssContent).toBe("a {}.webpack{}");
 	expect(cachedCssContent).toBe("a {}.webpack{}");
 	expect(value).toBe(42);
 	expect(value2).toBe(42);

--- a/test/configCases/asset-modules/http-url/no-cache.webpack.lock
+++ b/test/configCases/asset-modules/http-url/no-cache.webpack.lock
@@ -9,6 +9,7 @@
   "http://localhost:9990/folder/sub-dependency2.js": { "integrity": "sha512-BDZKEwlnwBabeHEwmMd02NxFEjYy+QwKAKP0S8zMMesX7dUsvh11hM7LUOPPFOS+nIEFZPtnc7kFwmnojVUw5A==", "contentType": "text/javascript" },
   "http://localhost:9990/index.css?cache": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/index.css?no-cache": "no-cache",
+  "http://localhost:9990/index.css?no-store": "no-cache",
   "http://localhost:9990/index.css?query#fragment": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/redirect": { "resolved": "http://localhost:9990/redirect.js", "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },
   "http://localhost:9990/redirect.js": { "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },

--- a/test/configCases/asset-modules/http-url/prod-defaults.webpack.lock
+++ b/test/configCases/asset-modules/http-url/prod-defaults.webpack.lock
@@ -9,6 +9,7 @@
   "http://localhost:9990/folder/sub-dependency2.js": { "integrity": "sha512-BDZKEwlnwBabeHEwmMd02NxFEjYy+QwKAKP0S8zMMesX7dUsvh11hM7LUOPPFOS+nIEFZPtnc7kFwmnojVUw5A==", "contentType": "text/javascript" },
   "http://localhost:9990/index.css?cache": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/index.css?no-cache": "no-cache",
+  "http://localhost:9990/index.css?no-store": "no-cache",
   "http://localhost:9990/index.css?query#fragment": { "integrity": "sha512-sqhF9JAEi5h3ziP48SBnzQnaeei8cf/pfYJBdKL4F7xdu3v5yr71eQ0kCL11/jWRFjLG4TKOudUnS/u6WLMqYw==", "contentType": "text/css" },
   "http://localhost:9990/redirect": { "resolved": "http://localhost:9990/redirect.js", "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },
   "http://localhost:9990/redirect.js": { "integrity": "sha512-BV/MK/QTq+NHRve1XpZyQ8V6cjRP/fwbtJvENRdm5C73qNYZ4i2/fw+soj7J4qxzBXMHDbvOnA6E0ShnX2hc1w==", "contentType": "text/javascript" },

--- a/test/configCases/asset-modules/http-url/server/index.js
+++ b/test/configCases/asset-modules/http-url/server/index.js
@@ -30,6 +30,8 @@ function createServer() {
 		const pathname = "." + url.replace(/\?.*$/, "");
 		if (url.endsWith("?no-cache")) {
 			res.setHeader("Cache-Control", "no-cache, max-age=60");
+		} else if (url.endsWith("?no-store")) {
+			res.setHeader("Cache-Control", "No-Store, MAX-AGE=60");
 		} else {
 			res.setHeader("Cache-Control", "public, immutable, max-age=600");
 		}


### PR DESCRIPTION
**Summary**

HTTP cache directives are case-insensitive, but mixed-case `No-Store` was not recognized and could be overridden by `MAX-AGE`. Cache-control is now normalized before parsing, and `no-store` takes precedence over freshness directives.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The real HTTP/cache config matrix serves `No-Store, MAX-AGE=60` and verifies it is recorded as non-cacheable. The focused integration run passes 46 tests, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. It aligns caching with HTTP directive semantics.

**If relevant, did you update the documentation?**

A patch changeset documents the cache-control correction. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit HTTP cache parsing and draft the fix and regression coverage. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP resources now correctly honor cache-control directives regardless of capitalization.
  * Resources marked `no-store` are no longer saved in the cache or lockfile.
  * Existing `no-cache` handling remains supported.

* **Tests**
  * Added coverage for HTTP assets served with a `no-store` directive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->