### PR TITLE
fix: normalize HTTP content encoding

### DIFF
--- a/.changeset/020-http-content-encoding-case.md
+++ b/.changeset/020-http-content-encoding-case.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Handle HTTP content-encoding values case-insensitively.

--- a/lib/schemes/HttpUriPlugin.js
+++ b/lib/schemes/HttpUriPlugin.js
@@ -984,7 +984,10 @@ class HttpUriPlugin {
 							/** @type {Buffer[]} */
 							const bufferArr = [];
 
-							const contentEncoding = res.headers["content-encoding"];
+							const contentEncodingHeader = res.headers["content-encoding"];
+							const contentEncoding =
+								contentEncodingHeader &&
+								contentEncodingHeader.trim().toLowerCase();
 							/** @type {Readable} */
 							let stream = res;
 							if (contentEncoding === "gzip") {

--- a/test/configCases/asset-modules/http-url/server/index.js
+++ b/test/configCases/asset-modules/http-url/server/index.js
@@ -64,7 +64,10 @@ function createServer() {
 				? query
 				: undefined;
 		if (encoding) {
-			res.setHeader("Content-Encoding", encoding);
+			res.setHeader(
+				"Content-Encoding",
+				query === "gzip" ? "GZip" : encoding
+			);
 			const buffer = Buffer.from(file);
 			res.end(
 				encoding === "gzip"


### PR DESCRIPTION
**Summary**

`Content-Encoding` tokens are case-insensitive and may contain optional whitespace, but webpack compared them literally. The header is now trimmed and lowercased before selecting gzip, brotli, or deflate decompression.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The existing real gzip HTTP fixture now serves `GZip`, proving mixed-case decoding without adding duplicate cache artifacts. The focused integration run passes 46 tests, and all lint, generated-output, type, format, spelling, changeset, diff, and final-newline checks pass.

**Does this PR introduce a breaking change?**

No. It accepts standards-compliant header casing previously missed.

**If relevant, did you update the documentation?**

A patch changeset documents content-encoding normalization. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit HTTP decoding and draft the fix and regression coverage. I reviewed the final diff and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP content-encoding values are now handled case-insensitively.
  * Responses using mixed-case or surrounding whitespace in encoding headers are decompressed correctly, including gzip, Brotli, and deflate content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->