### PR TITLE
perf: deduplicate runtime entrypoint traversal

### DIFF
--- a/.changeset/020-runtime-entrypoint-traversal.md
+++ b/.changeset/020-runtime-entrypoint-traversal.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Deduplicate shared entrypoints during runtime dependency traversal.

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -1380,27 +1380,25 @@ class ChunkGraph {
 
 		for (const chunkGroup of chunk.groupsIterable) {
 			if (chunkGroup instanceof Entrypoint) {
+				if (entrypoints.has(chunkGroup)) continue;
+				entrypoints.add(chunkGroup);
 				const queue = [chunkGroup];
-				while (queue.length > 0) {
-					const current = queue.shift();
-					if (current) {
-						entrypoints.add(current);
-
-						let hasChildrenEntrypoint = false;
-						for (const child of current.childrenIterable) {
-							if (child instanceof Entrypoint && child.dependOn(current)) {
-								hasChildrenEntrypoint = true;
+				for (let i = 0; i < queue.length; i++) {
+					const current = queue[i];
+					let hasChildrenEntrypoint = false;
+					for (const child of current.childrenIterable) {
+						if (child instanceof Entrypoint && child.dependOn(current)) {
+							hasChildrenEntrypoint = true;
+							if (!entrypoints.has(child)) {
+								entrypoints.add(child);
 								queue.push(/** @type {Entrypoint} */ (child));
 							}
 						}
-						// entryChunkB: hasChildrenEntrypoint = true
-						// entryChunkA: dependOn = entryChunkB
-						if (hasChildrenEntrypoint) {
-							const entrypointChunk = current.getEntrypointChunk();
-							if (entrypointChunk !== chunk && !entrypointChunk.hasRuntime()) {
-								// add entryChunkB to set
-								set.add(entrypointChunk);
-							}
+					}
+					if (hasChildrenEntrypoint) {
+						const entrypointChunk = current.getEntrypointChunk();
+						if (entrypointChunk !== chunk && !entrypointChunk.hasRuntime()) {
+							set.add(entrypointChunk);
 						}
 					}
 				}

--- a/test/ChunkGraph.unittest.js
+++ b/test/ChunkGraph.unittest.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const Chunk = require("../lib/Chunk");
+const ChunkGraph = require("../lib/ChunkGraph");
+const Entrypoint = require("../lib/Entrypoint");
+const ModuleGraph = require("../lib/ModuleGraph");
+
+describe("ChunkGraph", () => {
+	it("visits shared dependent entrypoints only once", () => {
+		const chunkGraph = new ChunkGraph(new ModuleGraph());
+		const rootChunk = new Chunk("root", false);
+		const root = new Entrypoint("root");
+		root.setEntrypointChunk(rootChunk);
+		root.pushChunk(rootChunk);
+		rootChunk.addGroup(root);
+
+		const left = new Entrypoint("left");
+		const right = new Entrypoint("right");
+		const shared = new Entrypoint("shared");
+		for (const entrypoint of [left, right, shared]) {
+			const chunk = new Chunk(entrypoint.name, false);
+			entrypoint.setEntrypointChunk(chunk);
+			entrypoint.pushChunk(chunk);
+		}
+
+		root.addChild(left);
+		left.addDependOn(root);
+		root.addChild(right);
+		right.addDependOn(root);
+		left.addChild(shared);
+		shared.addDependOn(left);
+		right.addChild(shared);
+		shared.addDependOn(right);
+
+		let sharedVisits = 0;
+		Object.defineProperty(shared, "childrenIterable", {
+			get() {
+				sharedVisits++;
+				return [];
+			}
+		});
+
+		chunkGraph.getRuntimeChunkDependentChunksIterable(rootChunk);
+		expect(sharedVisits).toBe(1);
+	});
+});


### PR DESCRIPTION
**Summary**

Shared dependent entrypoints could be enqueued and traversed repeatedly, and the traversal used repeated `Array#shift()` calls. Entrypoints are now marked when enqueued and processed by index, visiting each reachable entrypoint once without front-removal costs.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes. A deterministic regression proves the shared entrypoint is visited once instead of twice. The focused test passes, the `many-chunks-esm` benchmark reports development, rebuild, and production as statistically the same, and all lint, generated-output, type, format, spelling, changeset, and diff checks pass.

**Does this PR introduce a breaking change?**

No. The resulting runtime-chunk set is unchanged; redundant traversal is removed.

**If relevant, did you update the documentation?**

A patch changeset documents the traversal optimization. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit traversal complexity and draft the optimization and deterministic regression. I reviewed the final diff, benchmark, and verification results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime dependency traversal to avoid processing shared entrypoints more than once.
  * Preserved accurate discovery of dependent chunks across complex entrypoint relationships.

* **Tests**
  * Added coverage confirming shared entrypoints are visited only once during traversal.

* **Release**
  * Included in the next patch release of webpack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->