### PR TITLE
fix: expand dotenv names containing null

### DIFF
--- a/.changeset/020-dotenv-null-key-expansion.md
+++ b/.changeset/020-dotenv-null-key-expansion.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Expand dotenv references whose variable names contain `null`.

--- a/lib/DotenvPlugin.js
+++ b/lib/DotenvPlugin.js
@@ -155,8 +155,7 @@ function expandValue(value, processEnv, runningParsed) {
 		const opMatch = expression.match(opRegex);
 		const splitter = opMatch ? opMatch[0] : null;
 
-		const r = expression.split(/** @type {string} */ (splitter));
-		// const r = splitter ? expression.split(splitter) : [expression];
+		const r = splitter ? expression.split(splitter) : [expression];
 
 		/** @type {string} */
 		let defaultValue;

--- a/test/configCases/plugins/import-meta-env/.env.test
+++ b/test/configCases/plugins/import-meta-env/.env.test
@@ -1,1 +1,3 @@
 WEBPACK_DOTENV_VAR=from_dotenv
+WEBPACK_null_VALUE=expanded_value
+WEBPACK_EXPANDED_NULL=${WEBPACK_null_VALUE}

--- a/test/configCases/plugins/import-meta-env/index.js
+++ b/test/configCases/plugins/import-meta-env/index.js
@@ -20,6 +20,7 @@ it("should expose variables from EnvironmentPlugin", () => {
 it("should expose variables from DotenvPlugin", () => {
 	const env = import.meta.env;
 	expect(env.WEBPACK_DOTENV_VAR).toBe("from_dotenv");
+	expect(env.WEBPACK_EXPANDED_NULL).toBe("expanded_value");
 });
 
 it("should expose variables from DefinePlugin", () => {


### PR DESCRIPTION
**Summary**

Dotenv expansion split expressions with a null delimiter when no operator existed, so a variable name containing lowercase `null` was broken into unrelated fragments. Operator-free expressions now remain whole before lookup.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The real dotenv config case expands a reference to `WEBPACK_null_VALUE`. The focused integration run passes 112 tests, and all lint, generated-output, type, format, spelling, changeset, diff, and final-newline checks pass.

**Does this PR introduce a breaking change?**

No. Valid variable names now expand correctly.

**If relevant, did you update the documentation?**

A patch changeset documents the expansion correction. No public documentation change is required.

**Use of AI**

Significant AI assistance was used to audit dotenv expansion and draft the fix and regression coverage. I reviewed the final diff and verification results.