### PR TITLE
fix: keep code generation data per result instead of per NormalModule

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -109,7 +109,6 @@ const getModuleBuildError = memoize(() => require("./errors/ModuleBuildError"));
  * 	BuildMeta,
  * 	CodeGenerationContext,
  * 	CodeGenerationResult,
- * 	CodeGenerationResultData,
  * 	ConcatenationBailoutReasonContext,
  * 	KnownBuildInfo,
  * 	LibIdentOptions,
@@ -119,7 +118,6 @@ const getModuleBuildError = memoize(() => require("./errors/ModuleBuildError"));
  * 	NeedBuildCallback,
  * 	BuildCallback,
  * 	RuntimeRequirements,
- * 	Sources,
  * 	SourceType,
  * 	SourceTypes
  * } from "./Module"
@@ -728,11 +726,6 @@ class NormalModule extends Module {
 		this._sideEffectsStateGraph = undefined;
 		/** @type {ConnectionState | undefined} */
 		this._sideEffectsStateValue = undefined;
-		/**
-		 * @private
-		 * @type {CodeGenerationResultData}
-		 */
-		this._codeGeneratorData = new Map();
 	}
 
 	/**
@@ -1892,10 +1885,19 @@ class NormalModule extends Module {
 			runtimeRequirements.add(RuntimeGlobals.thisAsExports);
 		}
 
-		const getData = () => this._codeGeneratorData;
+		/** @type {CodeGenerationResult} */
+		const resultEntry = {
+			sources: new Map(),
+			runtimeRequirements,
+			data: undefined,
+			hash: undefined
+		};
 
-		/** @type {Sources} */
-		const sources = new Map();
+		const getData = () => {
+			if (resultEntry.data === undefined) resultEntry.data = new Map();
+			return resultEntry.data;
+		};
+
 		for (const type of sourceTypes || chunkGraph.getModuleSourceTypes(this)) {
 			// TODO webpack@6 make generateError required
 			const generator =
@@ -1930,17 +1932,10 @@ class NormalModule extends Module {
 					});
 
 			if (source) {
-				sources.set(type, new CachedSource(source));
+				resultEntry.sources.set(type, new CachedSource(source));
 			}
 		}
 
-		/** @type {CodeGenerationResult} */
-		const resultEntry = {
-			sources,
-			runtimeRequirements,
-			data: this._codeGeneratorData,
-			hash: undefined
-		};
 		return resultEntry;
 	}
 
@@ -2116,7 +2111,6 @@ class NormalModule extends Module {
 		write(this.error);
 		write(this._lastSuccessfulBuildMeta);
 		write(this._forceBuild);
-		write(this._codeGeneratorData);
 		write(this.hot);
 		super.serialize(context);
 	}
@@ -2160,7 +2154,6 @@ class NormalModule extends Module {
 		this.error = read();
 		this._lastSuccessfulBuildMeta = read();
 		this._forceBuild = read();
-		this._codeGeneratorData = read();
 		this.hot = read();
 		super.deserialize(context);
 	}

--- a/test/watchCases/cache/stale-chunk-init-fragments/0/index.js
+++ b/test/watchCases/cache/stale-chunk-init-fragments/0/index.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+import { value } from "./shared";
+
+// The import the `__dirname` replacement pulls in; line-anchored so this file's own source never matches.
+const FILE_URL_TO_PATH_IMPORT =
+	/^import \{[^}]*fileURLToPath[^}]*\} from "(?:node:)?url";/m;
+
+it("should drop the init fragments of a removed dependency", () => {
+	const source = fs.readFileSync(
+		path.join(STATS_JSON.outputPath, "bundle.mjs"),
+		"utf8"
+	);
+	if (WATCH_STEP === "0") {
+		expect(typeof value).toBe("string");
+		expect(source).toMatch(FILE_URL_TO_PATH_IMPORT);
+	} else {
+		expect(value).toBe("static");
+		expect(source).not.toMatch(FILE_URL_TO_PATH_IMPORT);
+	}
+});

--- a/test/watchCases/cache/stale-chunk-init-fragments/0/shared.js
+++ b/test/watchCases/cache/stale-chunk-init-fragments/0/shared.js
@@ -1,0 +1,1 @@
+export const value = __dirname;

--- a/test/watchCases/cache/stale-chunk-init-fragments/1/shared.js
+++ b/test/watchCases/cache/stale-chunk-init-fragments/1/shared.js
@@ -1,0 +1,1 @@
+export const value = "static";

--- a/test/watchCases/cache/stale-chunk-init-fragments/webpack.config.js
+++ b/test/watchCases/cache/stale-chunk-init-fragments/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// A module rebuilt in place must not carry the previous build's init fragments.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	devtool: false,
+	experiments: { outputModule: true },
+	output: { module: true },
+	node: { __dirname: "node-module" }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

#16703 introduced one module-level `_codeGeneratorData` to solve the shared issue between JS and asset source type when enabling cache. 

But now `AssetGenerator` have already records data for every source type, so the per code generation result map already is enough and the module-level data is no need more.

This PR also fixes stale code generation caused by `_codeGeneratorData`. A later code generation could reuse `chunkInitFragments` which is added in the earlier generation because `data.chunkInitFragments` was retained in the module-level map.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fix
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed watch-mode rebuilds that could retain initialization fragments from removed dependencies.
  - Generated bundles now correctly remove outdated imports and reflect the latest module content after changes.

- **Tests**
  - Added coverage for repeated watch updates to ensure stale bundle fragments are cleared and rebuilt output remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->