### PR TITLE
fix(defer): evaluate async dependencies where the deferred import sits

### DIFF
--- a/.changeset/025-defer-async-evaluation-order.md
+++ b/.changeset/025-defer-async-evaluation-order.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Evaluate a deferred import's async dependencies where the import sits.

--- a/lib/async-modules/AsyncModuleHelpers.js
+++ b/lib/async-modules/AsyncModuleHelpers.js
@@ -32,16 +32,22 @@ const getOutgoingAsyncModules = (moduleGraph, module) => {
 			const outgoingConnectionMap =
 				moduleGraph.getOutgoingConnectionsByModule(module);
 			if (outgoingConnectionMap) {
-				for (const [module, connections] of outgoingConnectionMap) {
+				// Walk the imports in source order: the spec gathers these from
+				// `[[RequestedModules]]`, and their evaluation order is observable.
+				for (const dependency of module.dependencies) {
+					if (!(dependency instanceof HarmonyImportDependency)) continue;
+					const referenced = moduleGraph.getModule(dependency);
+					if (!referenced || seen.has(referenced)) continue;
+					const connections = outgoingConnectionMap.get(referenced);
 					if (
+						connections &&
 						connections.some(
 							(c) =>
 								c.dependency instanceof HarmonyImportDependency &&
 								c.isTargetActive(undefined)
-						) &&
-						module
+						)
 					) {
-						g(module);
+						g(referenced);
 					}
 				}
 			}

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -58,9 +58,8 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 									Template.indent([
 										`${cst} cache = __webpack_module_cache__[id];`,
 										"if (!cache) return true;",
-										// The deferred import starts these, so a cache entry no
-										// longer means the body finished; a rejected one is
-										// "done" but its error still has to reach the importer.
+										// A cached entry no longer means finished, and a rejected
+										// one is done but its error must still reach the importer.
 										`${cst} deps = cache.exports;`,
 										"return deps[webpackDone] !== true || deps[webpackError] !== undefined;"
 									]),

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -57,7 +57,9 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 									`${cst} hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {`,
 									Template.indent([
 										`${cst} cache = __webpack_module_cache__[id];`,
-										"return !cache || cache[webpackDone] === false;"
+										// The deferred import starts these, so a cache entry no
+										// longer means the async body has finished.
+										"return !cache || cache.exports[webpackDone] !== true;"
 									]),
 									"});",
 									"if (hasUnresolvedAsyncSubgraph) {",

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -57,9 +57,12 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 									`${cst} hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {`,
 									Template.indent([
 										`${cst} cache = __webpack_module_cache__[id];`,
+										"if (!cache) return true;",
 										// The deferred import starts these, so a cache entry no
-										// longer means the async body has finished.
-										"return !cache || cache.exports[webpackDone] !== true;"
+										// longer means the body finished; a rejected one is
+										// "done" but its error still has to reach the importer.
+										`${cst} deps = cache.exports;`,
+										"return deps[webpackDone] !== true || deps[webpackError] !== undefined;"
 									]),
 									"});",
 									"if (hasUnresolvedAsyncSubgraph) {",

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -290,24 +290,17 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 				]),
 				"};",
 				hasAsync
-					? Template.asString([
-							"if(isAsync) {",
-							Template.indent([
-								// `GatherAsynchronousTransitiveDependencies` skips a module
-								// that is already evaluating, and evaluates the rest here.
-								`${cst} started = [];`,
-								"for (var j = 0; j < asyncDeps.length; j++) {",
-								Template.indent([
-									`${cst} dep = __webpack_module_cache__[asyncDeps[j]];`,
-									"if (dep && (dep.evaluating || dep.evaluatingAsync)) continue;",
-									"r(asyncDeps[j]);",
-									"started.push(asyncDeps[j]);"
-								]),
-								"}",
-								`obj[${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol}] = started;`
-							]),
-							"}"
-						])
+					? // `GatherAsynchronousTransitiveDependencies` skips a module that is
+						// already evaluating, and evaluates the rest right here.
+						`if(isAsync) obj[${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol}] = asyncDeps.filter(${runtimeTemplate.basicFunction(
+							"id",
+							[
+								`${cst} dep = __webpack_module_cache__[id];`,
+								"if (dep && (dep.evaluating || dep.evaluatingAsync)) return false;",
+								"r(id);",
+								"return true;"
+							]
+						)});`
 					: "",
 				"return obj;"
 			]),

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -290,7 +290,24 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 				]),
 				"};",
 				hasAsync
-					? `if(isAsync) obj[${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol}] = asyncDeps;`
+					? Template.asString([
+							"if(isAsync) {",
+							Template.indent([
+								// `GatherAsynchronousTransitiveDependencies` skips a module
+								// that is already evaluating, and evaluates the rest here.
+								`${cst} started = [];`,
+								"for (var j = 0; j < asyncDeps.length; j++) {",
+								Template.indent([
+									`${cst} dep = __webpack_module_cache__[asyncDeps[j]];`,
+									"if (dep && (dep.evaluating || dep.evaluatingAsync)) continue;",
+									"r(asyncDeps[j]);",
+									"started.push(asyncDeps[j]);"
+								]),
+								"}",
+								`obj[${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol}] = started;`
+							]),
+							"}"
+						])
 					: "",
 				"return obj;"
 			]),

--- a/test/configCases/defer-import/async-dependency-rejection/boom.js
+++ b/test/configCases/defer-import/async-dependency-rejection/boom.js
@@ -1,0 +1,2 @@
+await Promise.resolve();
+throw new Error("boom");

--- a/test/configCases/defer-import/async-dependency-rejection/dep.js
+++ b/test/configCases/defer-import/async-dependency-rejection/dep.js
@@ -1,0 +1,2 @@
+import "./boom.js";
+export const value = 1;

--- a/test/configCases/defer-import/async-dependency-rejection/first.js
+++ b/test/configCases/defer-import/async-dependency-rejection/first.js
@@ -1,0 +1,2 @@
+import defer * as ns from "./dep.js";
+export const tag = "first";

--- a/test/configCases/defer-import/async-dependency-rejection/index.js
+++ b/test/configCases/defer-import/async-dependency-rejection/index.js
@@ -1,0 +1,6 @@
+// A rejected async dependency is "done", so its error must still reach every
+// deferred import of the same subgraph, not just the one that started it.
+it("should reject every importer of a failed deferred async dependency", async () => {
+	await expect(import("./first.js")).rejects.toThrow("boom");
+	await expect(import("./second.js")).rejects.toThrow("boom");
+});

--- a/test/configCases/defer-import/async-dependency-rejection/second.js
+++ b/test/configCases/defer-import/async-dependency-rejection/second.js
@@ -1,0 +1,2 @@
+import defer * as ns from "./dep.js";
+export const tag = "second";

--- a/test/configCases/defer-import/async-dependency-rejection/webpack.config.js
+++ b/test/configCases/defer-import/async-dependency-rejection/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	experiments: {
+		deferImport: true,
+		topLevelAwait: true
+	}
+};

--- a/test/configCases/defer-import/async-transitive-evaluation-order/dep-async.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/dep-async.js
@@ -1,0 +1,4 @@
+global.__configCases__deferImport__order.push("async start");
+await Promise.resolve();
+global.__configCases__deferImport__order.push("async end");
+export const value = 1;

--- a/test/configCases/defer-import/async-transitive-evaluation-order/dep.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/dep.js
@@ -1,0 +1,3 @@
+import "./dep-async.js";
+global.__configCases__deferImport__order.push("deferred body");
+export const value = 2;

--- a/test/configCases/defer-import/async-transitive-evaluation-order/entry.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/entry.js
@@ -1,0 +1,6 @@
+import defer * as ns from "./dep.js";
+import "./sibling.js";
+
+export function force() {
+	return ns.value;
+}

--- a/test/configCases/defer-import/async-transitive-evaluation-order/index.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/index.js
@@ -1,0 +1,12 @@
+it("should evaluate a deferred import's async dependencies where the import sits", async () => {
+	const order = (global.__configCases__deferImport__order = []);
+
+	// The async dependency starts before the sibling below the deferred import,
+	// and the deferred module's own body waits until the namespace is forced.
+	const { force } = await require("./entry.js");
+
+	expect(order).toEqual(["async start", "sibling", "async end"]);
+	order.length = 0;
+	expect(force()).toBe(2);
+	expect(order).toEqual(["deferred body"]);
+});

--- a/test/configCases/defer-import/async-transitive-evaluation-order/sibling.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/sibling.js
@@ -1,0 +1,1 @@
+global.__configCases__deferImport__order.push("sibling");

--- a/test/configCases/defer-import/async-transitive-evaluation-order/webpack.config.js
+++ b/test/configCases/defer-import/async-transitive-evaluation-order/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	experiments: {
+		deferImport: true,
+		topLevelAwait: true
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -892,8 +892,6 @@ const knownBugs = [
 	// Host resolution errors must be reported eagerly even for deferred imports;
 	// webpack turns a missing module into a build error resolved lazily instead.
 	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
-	// Exact interleaving of top-level-await and deferred evaluation order.
-	"import/import-defer/evaluation-top-level-await/flattening-order/main.js",
 	// A deferred module must wait for the whole strongly-connected component when a
 	// dependency's cycle root is still evaluating-async (`IsModuleSCCEvaluated`).
 	"import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

A deferred import's async transitive dependencies were only started when the importing module awaited its dependencies, so every synchronous sibling ran first. With `import defer * as ns2 from "./dep-2.js"` sitting between two plain imports:

```
before: 1, 3, 5, │ 2.1.1 start, 2.2.1, 2.2 start │ 2.1.1 end, …
after:  1, │ 2.1.1 start, 2.2.1, 2.2 start │ 3, 5, 2.1.1 end, …
```

The emitted code was already in source order — `makeOptimizedDeferredNamespaceObject` recorded the ids and `deferredModuleAsyncTransitiveDependencies` first required them from `handleDependencies`. Three things had to change together:

- **They now start at the import.** `GatherAsynchronousTransitiveDependencies` skips a module whose status is `evaluating` or `evaluated`, so a deferred import that cycles back to the module currently evaluating contributes nothing and cannot deadlock. That guard is applied where the list is built, which is the only place the two cases are distinguishable.
- **The "already finished" check had no effect.** It read `webpackDone` from the module record, but that flag is only ever set on the promise in `module.exports`, so it silently reduced to "never required". That was equivalent while nothing started these early; it is not once the import does.
- **Gathering walks the imports in source order.** `getOutgoingAsyncModules` iterated the outgoing-connections map, whose order is not the source order the spec reads from `[[RequestedModules]]` — matching in development and diverging under production ids.

Un-skips test262's `import-defer/evaluation-top-level-await/flattening-order`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `configCases/defer-import/async-transitive-evaluation-order`, which asserts the async dependency starts before the sibling below the deferred import and that the deferred module's own body still waits for the namespace. Verified failing on unmodified `lib/` and passing with the change, in both the plain and filesystem-cache suites. test262 `import-defer|top-level-await|dynamic-import` is 4022 passing with none failing, and the full `test:basic` run is clean apart from the sandbox-only failures the contributing guide names.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The same modules are evaluated eagerly as before — only the point at which they start moves, and only for a graph reached through `import defer`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used throughout: to reproduce the divergence as a standalone bundle, read the emitted runtime to locate where the dependencies were first required, and write the fix and the config case. Two intermediate attempts were rejected on evidence — starting the dependencies alone left the importer no longer awaiting them, and guarding the cycle at await time could not tell a cycle apart from a dependency the import had just started, which regressed `get-other-while-evaluating-async`. All findings and reasoning were reviewed by me before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q5wyknx4aqgnfnZeytnhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred import evaluation so asynchronous dependencies execute in source order.
  * Ensured deferred module bodies evaluate only when their namespace is accessed.
  * Prevented already-running asynchronous dependencies from being evaluated again.
  * Propagated asynchronous dependency errors consistently to all affected deferred imports.

* **Tests**
  * Added coverage for asynchronous evaluation order, dependency failures, and top-level await.
  * Enabled a previously skipped standards test now that evaluation ordering behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->