### PR TITLE
chore: escape literal NUL bytes in Compilation.js

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4083,7 +4083,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		const text = /** @type {string} */ (source.source());
 		// Everything the hook is handed is in the key: a tap answers per language
 		// pair, so identical text offered as two of them is two questions.
-		const key = `${info.type} ${info.hostType} ${text}`;
+		const key = `${info.type}\0${info.hostType}\0${text}`;
 		const resolved = this._embeddedSources.get(info.module);
 		if (resolved !== undefined) {
 			const hit = resolved.get(key);


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<img width="702" height="134" alt="image" src="https://github.com/user-attachments/assets/e1ceb405-0a78-4434-9bcf-9345b3b40edc" />

Codex use `ripgrep` to search stuff when available. `lib/Compilation.js` contains two literal NUL and `rg` treats it as a binary file and cannot search it normally. We now escape it by `\0`. 

Thanks for report @hardfist .

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

chore
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->



**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of embedded-source cache keys without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->