### PR TITLE
fix: keep require() into a concatenation substituted and unmangled

### DIFF
--- a/.changeset/016-concat-require-reference-leak.md
+++ b/.changeset/016-concat-require-reference-leak.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix mangled exports read through require() and a leaked internal reference.

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -22,6 +22,8 @@ const {
 
 /** @typedef {{ start: number, end: number, name: string }} ModuleReferenceMatch */
 
+const MODULE_REFERENCE_TOKEN = "__WEBPACK_MODULE_REFERENCE__";
+
 const MODULE_REFERENCE_REGEXP =
 	/^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?(_directImport)?(_deferredImport)?(_mangleableNs)?(_moduleExportsAccess)?(?:_asiSafe(\d))?__$/;
 
@@ -228,6 +230,20 @@ class ConcatenationScope {
 	 */
 	static isModuleReference(name) {
 		return MODULE_REFERENCE_REGEXP.test(name);
+	}
+
+	/**
+	 * Checks whether an identifier buries a reference token without being a
+	 * reference itself, which a replacement overlapping a reference produces.
+	 * Nothing can resolve it, so it would reach the output as an undeclared global.
+	 * @param {string} name the identifier
+	 * @returns {boolean} true, when a reference token is buried in the identifier
+	 */
+	static isLeakedModuleReference(name) {
+		return (
+			name.includes(MODULE_REFERENCE_TOKEN) &&
+			!MODULE_REFERENCE_REGEXP.test(name)
+		);
 	}
 
 	/**

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -20,7 +20,7 @@ const {
  * } from "./optimize/ConcatenatedModule"
  */
 
-/** @typedef {{ start: number, end: number, name: string }} ModuleReferenceMatch */
+/** @typedef {{ start: number, end: number, name: string, leaked: boolean }} ModuleReferenceMatch */
 
 const MODULE_REFERENCE_TOKEN = "__WEBPACK_MODULE_REFERENCE__";
 
@@ -33,6 +33,8 @@ const MODULE_REFERENCE_SCAN_REGEXP = new RegExp(
 	MODULE_REFERENCE_REGEXP.source.slice(1, -1),
 	"g"
 );
+
+const IDENTIFIER_CHARACTER_REGEXP = /[\w$]/;
 
 /** @type {WeakMap<Source, ModuleReferenceMatch[]>} */
 const moduleReferencesCache = new WeakMap();
@@ -247,7 +249,9 @@ class ConcatenationScope {
 	}
 
 	/**
-	 * Finds all encoded module references in a generated source.
+	 * Finds all encoded module references in a generated source. A match that
+	 * continues an identifier is reported as `leaked`: it is a token a wider
+	 * replacement swallowed, so substituting it would rewrite the middle of a name.
 	 * @param {Source} source generated source
 	 * @returns {ModuleReferenceMatch[]} reference token positions (end is exclusive, excludes the appended "._")
 	 */
@@ -263,7 +267,10 @@ class ConcatenationScope {
 			result.push({
 				start: match.index,
 				end: match.index + match[0].length,
-				name: match[0]
+				name: match[0],
+				leaked:
+					match.index > 0 &&
+					IDENTIFIER_CHARACTER_REGEXP.test(code[match.index - 1])
 			});
 			match = MODULE_REFERENCE_SCAN_REGEXP.exec(code);
 		}

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -235,9 +235,8 @@ class ConcatenationScope {
 	}
 
 	/**
-	 * Checks whether an identifier buries a reference token without being a
-	 * reference itself, which a replacement overlapping a reference produces.
-	 * Nothing can resolve it, so it would reach the output as an undeclared global.
+	 * Checks whether an identifier buries a reference token without being one,
+	 * which nothing can resolve: it would reach the output as an undeclared global.
 	 * @param {string} name the identifier
 	 * @returns {boolean} true, when a reference token is buried in the identifier
 	 */

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -345,10 +345,16 @@ class FlagDependencyUsagePlugin {
 											if (oldItem === undefined || Array.isArray(oldItem)) {
 												exportsMap.set(key, item);
 											} else {
+												// An unset flag means "allowed", so merge on `!== false`:
+												// `undefined && false` reads back as allowed.
 												exportsMap.set(key, {
 													name: item.name,
-													canMangle: item.canMangle && oldItem.canMangle,
-													canInline: item.canInline && oldItem.canInline
+													canMangle:
+														item.canMangle !== false &&
+														oldItem.canMangle !== false,
+													canInline:
+														item.canInline !== false &&
+														oldItem.canInline !== false
 												});
 											}
 										}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1866,6 +1866,13 @@ class ConcatenatedModule extends Module {
 					for (const reference of ConcatenationScope.findModuleReferences(
 						/** @type {Source} */ (info.internalSource)
 					)) {
+						if (reference.leaked) {
+							throw new Error(
+								`Unsubstituted module reference "${reference.name}" in ${info.module.readableIdentifier(
+									requestShortener
+								)}`
+							);
+						}
 						if (visitedReferences.has(reference.name)) continue;
 						visitedReferences.add(reference.name);
 						const match = ConcatenationScope.matchModuleReference(

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1959,6 +1959,13 @@ class ConcatenatedModule extends Module {
 									ignoredScopes
 								);
 							} else {
+								if (ConcatenationScope.isLeakedModuleReference(name)) {
+									throw new Error(
+										`Unsubstituted module reference "${name}" in ${info.module.readableIdentifier(
+											requestShortener
+										)}`
+									);
+								}
 								allUsedNames.add(name);
 								freeNames.add(name);
 							}

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/consumer.js
@@ -1,0 +1,5 @@
+const sync = require("./target");
+
+export const syncExports = sync;
+export const syncValue = sync.value;
+export const loadAsync = () => import("./target");

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/index.js
@@ -1,0 +1,16 @@
+import { loadAsync, syncExports, syncValue } from "./consumer";
+
+it("should read a require() of a module that is also imported dynamically", () => {
+	expect(syncValue).toBe("target");
+});
+
+it("should give the dynamic import the same instance the require() got", async () => {
+	const namespace = await loadAsync();
+	expect(namespace.default).toBe(syncExports);
+	expect(namespace.value).toBe("target");
+});
+
+it("should evaluate that module exactly once", async () => {
+	await loadAsync();
+	expect(global.__targetEvaluations).toBe(1);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/index.js
@@ -1,3 +1,4 @@
+import { evaluations } from "./registry";
 import { loadAsync, syncExports, syncValue } from "./consumer";
 
 it("should read a require() of a module that is also imported dynamically", () => {
@@ -12,5 +13,5 @@ it("should give the dynamic import the same instance the require() got", async (
 
 it("should evaluate that module exactly once", async () => {
 	await loadAsync();
-	expect(global.__targetEvaluations).toBe(1);
+	expect(evaluations).toEqual(["target"]);
 });

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/registry.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/registry.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Counted through webpack's module cache rather than a host global, so the
+// count is per bundle run whatever runtime executes it.
+exports.evaluations = [];

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/target.js
@@ -1,5 +1,5 @@
 "use strict";
 
-global.__targetEvaluations = (global.__targetEvaluations || 0) + 1;
+require("./registry").evaluations.push("target");
 
 exports.value = "target";

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/target.js
@@ -1,0 +1,5 @@
+"use strict";
+
+global.__targetEvaluations = (global.__targetEvaluations || 0) + 1;
+
+exports.value = "target";

--- a/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-and-dynamic-import/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/consumer.js
@@ -1,0 +1,7 @@
+// A whole-namespace capture reads properties under their written names, so the
+// mangler must leave them alone — even though the tracked access below allows it.
+const whole = require("./target");
+
+export const name = whole.NAME;
+export const other = whole.OTHER;
+export const direct = require("./target").NAME;

--- a/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/index.js
@@ -1,0 +1,10 @@
+import { direct, name, other } from "./consumer";
+
+it("should not mangle exports read through a whole-namespace require(esm)", () => {
+	expect(name).toBe("target");
+	expect(other).toBe("other");
+});
+
+it("should keep a tracked access on the same module working", () => {
+	expect(direct).toBe("target");
+});

--- a/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/target.js
@@ -1,0 +1,2 @@
+export const NAME = "target";
+export const OTHER = "other";

--- a/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/test.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["split.js", "main.js"];
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-esm-namespace-mangling/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		mangleExports: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		splitChunks: {
+			cacheGroups: {
+				split: {
+					test: /target\.js$/,
+					name: "split",
+					chunks: "all",
+					enforce: true,
+					minSize: 0
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/consumer.js
@@ -1,0 +1,38 @@
+// Concatenation replaces the whole `require(...)` call, so every position below
+// has to survive the substituted expression — ASI hazards included.
+
+export const afterReturn = () => require("./values").value;
+
+export const inTemplate = () => `${require("./values").value}!`;
+
+export const tagged = () => require("./tag")`literal`;
+
+export const computedMember = () => require("./values")["value"];
+
+export const optionalChain = () => require("./values")?.value;
+
+export const spreadArgument = () => Math.max(...require("./list").items);
+
+export const forOfSubject = () => {
+	const seen = [];
+	for (const item of require("./list").items) seen.push(item);
+	return seen;
+};
+
+export const voidResult = () => void require("./values");
+
+export const typeofResult = () => typeof require("./values");
+
+export const conditionalOperand = (flag) =>
+	(flag ? require("./values") : require("./other")).value;
+
+export const renamedDestructure = () => {
+	const { value: renamed, missing = "fallback" } = require("./values");
+	return [renamed, missing];
+};
+
+export const statementStart = () => {
+	const previous = "before";
+	require("./recorder").record(previous);
+	return require("./recorder").records.slice();
+};

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/index.js
@@ -1,0 +1,57 @@
+import {
+	afterReturn,
+	computedMember,
+	conditionalOperand,
+	forOfSubject,
+	inTemplate,
+	optionalChain,
+	renamedDestructure,
+	spreadArgument,
+	statementStart,
+	tagged,
+	typeofResult,
+	voidResult
+} from "./consumer";
+
+it("should substitute a require() in return and template positions", () => {
+	expect(afterReturn()).toBe("value");
+	expect(inTemplate()).toBe("value!");
+});
+
+it("should substitute a require() used as a template tag", () => {
+	expect(tagged()).toBe("tagged:literal:");
+});
+
+it("should substitute a require() read with a computed member", () => {
+	expect(computedMember()).toBe("value");
+});
+
+it("should substitute a require() behind optional chaining", () => {
+	expect(optionalChain()).toBe("value");
+});
+
+it("should substitute a require() spread into a call", () => {
+	expect(spreadArgument()).toBe(3);
+});
+
+it("should substitute a require() as the subject of for...of", () => {
+	expect(forOfSubject()).toEqual([1, 2, 3]);
+});
+
+it("should substitute a require() under void and typeof", () => {
+	expect(voidResult()).toBe(undefined);
+	expect(typeofResult()).toBe("object");
+});
+
+it("should substitute both operands of a conditional", () => {
+	expect(conditionalOperand(true)).toBe("value");
+	expect(conditionalOperand(false)).toBe("other");
+});
+
+it("should substitute a require() destructured with a rename and a default", () => {
+	expect(renamedDestructure()).toEqual(["value", "fallback"]);
+});
+
+it("should substitute a require() opening a statement", () => {
+	expect(statementStart()).toEqual(["before"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/list.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/list.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.items = [1, 2, 3];

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/other.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/other.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "other";

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/recorder.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/recorder.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const records = [];
+
+module.exports = {
+	records,
+	record(entry) {
+		records.push(entry);
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/tag.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/tag.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = (strings, ...values) => `tagged:${strings.raw.join("|")}:${values.join(",")}`;

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/values.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/values.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "value";

--- a/test/configCases/concatenate-modules/commonjs-require-expression-positions/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-expression-positions/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/branch-a.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/branch-a.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "branch-a";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/branch-b.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/branch-b.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "branch-b";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/callable.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/callable.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = () => "called";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/destructured.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/destructured.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.first = "first";
+exports.second = "second";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/index.js
@@ -1,0 +1,30 @@
+import {
+	loadAlsoImported,
+	loadCalled,
+	loadConditional,
+	loadDestructured,
+	loadResolved
+} from "./route";
+
+it("should read a destructured require() inside require.ensure", async () => {
+	await expect(loadDestructured()).resolves.toEqual(["first", "second"]);
+});
+
+it("should call the result of a require() inside require.ensure", async () => {
+	await expect(loadCalled()).resolves.toBe("called");
+});
+
+it("should keep both branches of a conditional require() inside require.ensure", async () => {
+	await expect(loadConditional(true)).resolves.toBe("branch-a");
+	await expect(loadConditional(false)).resolves.toBe("branch-b");
+});
+
+it("should keep require.resolve() inside require.ensure working", async () => {
+	const [id, value] = await loadResolved();
+	expect(id).toBeDefined();
+	expect(value).toBe("resolved");
+});
+
+it("should share one instance with a module-level import of the same module", async () => {
+	await expect(loadAlsoImported()).resolves.toEqual(["shared", "shared"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/resolved.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/resolved.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "resolved";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/route.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/route.js
@@ -1,6 +1,5 @@
-// The require forms whose dependency renders in an async block while the
-// `require`/`require.resolve` callee it sits in is a presentational dependency
-// of the module, so the two are applied out of source order.
+// Each callee below is a presentational dependency of the module while its call
+// renders in an async block, so the two are applied out of source order.
 import { value as sharedFromImport } from "./shared";
 
 export function loadDestructured() {

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/route.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/route.js
@@ -1,0 +1,66 @@
+// The require forms whose dependency renders in an async block while the
+// `require`/`require.resolve` callee it sits in is a presentational dependency
+// of the module, so the two are applied out of source order.
+import { value as sharedFromImport } from "./shared";
+
+export function loadDestructured() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				const { first, second } = require("./destructured");
+				resolve([first, second]);
+			},
+			"destructured"
+		);
+	});
+}
+
+export function loadCalled() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				resolve(require("./callable")());
+			},
+			"called"
+		);
+	});
+}
+
+export function loadConditional(useA) {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				resolve(require(useA ? "./branch-a" : "./branch-b").value);
+			},
+			"conditional"
+		);
+	});
+}
+
+export function loadResolved() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				const id = require.resolve("./resolved");
+				resolve([id, require("./resolved").value]);
+			},
+			"resolved"
+		);
+	});
+}
+
+export function loadAlsoImported() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				resolve([sharedFromImport, require("./shared").value]);
+			},
+			"also-imported"
+		);
+	});
+}

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/shared.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/shared.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "shared";

--- a/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-forms-in-async-block/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/amd-dep.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/amd-dep.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "amd-dep";

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/amd-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/amd-target.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "amd-target";

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/cjs.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/cjs.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "cjs";

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/esm.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/esm.js
@@ -1,0 +1,2 @@
+export const NAME = "esm";
+export default { isDefault: true };

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/index.js
@@ -1,0 +1,32 @@
+import {
+	loadAmd,
+	loadCommonJs,
+	loadConstructed,
+	loadMember,
+	loadNamespace,
+	loadNested
+} from "./route";
+
+it("should substitute a whole-namespace require(esm) inside require.ensure", async () => {
+	await expect(loadNamespace()).resolves.toEqual(["esm", { isDefault: true }]);
+});
+
+it("should substitute a member access on require(esm) inside require.ensure", async () => {
+	await expect(loadMember()).resolves.toBe("esm");
+});
+
+it("should substitute a `new require()` inside require.ensure", async () => {
+	await expect(loadConstructed()).resolves.toBe("constructed");
+});
+
+it("should substitute a require() of a CommonJS module inside require.ensure", async () => {
+	await expect(loadCommonJs()).resolves.toBe("cjs");
+});
+
+it("should substitute a require() inside a nested require.ensure", async () => {
+	await expect(loadNested()).resolves.toBe("nested");
+});
+
+it("should substitute a require() inside an AMD require block", async () => {
+	await expect(loadAmd()).resolves.toEqual(["amd-dep", "amd-target"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/nested.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/nested.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "nested";

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/object-exports.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/object-exports.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { value: "constructed" };

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/route.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/route.js
@@ -1,0 +1,82 @@
+// Every require() below sits in an async block, so its dependency renders after
+// the module's presentational ones — the order that leaked a reference in #21903.
+
+export function loadNamespace() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				const whole = require("./esm");
+				resolve([whole.NAME, whole.default]);
+			},
+			"namespace"
+		);
+	});
+}
+
+export function loadMember() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				resolve(require("./esm").NAME);
+			},
+			"member"
+		);
+	});
+}
+
+export function loadConstructed() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				// `new require(id)` passes an object module.exports through unchanged
+				const constructed = new require("./object-exports");
+				resolve(constructed.value);
+			},
+			"constructed"
+		);
+	});
+}
+
+export function loadCommonJs() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				const cjs = require("./cjs");
+				resolve(cjs.value);
+			},
+			"cjs"
+		);
+	});
+}
+
+export function loadNested() {
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				require.ensure(
+					[],
+					(require) => {
+						const nested = require("./nested");
+						resolve(nested.value);
+					},
+					"nested-inner"
+				);
+			},
+			"nested-outer"
+		);
+	});
+}
+
+export function loadAmd() {
+	return new Promise((resolve) => {
+		require(["./amd-dep"], (amdDep) => {
+			const target = require("./amd-target");
+			resolve([amdDep.value, target.value]);
+		});
+	});
+}

--- a/test/configCases/concatenate-modules/commonjs-require-in-async-block/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-async-block/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/async-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/async-target.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "async";

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/cjs-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/cjs-target.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "cjs";

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/esm-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/esm-target.js
@@ -1,0 +1,2 @@
+export const NAME = "esm";
+export default "default";

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/index.js
@@ -1,0 +1,33 @@
+import wrapped from "./wrapped";
+
+it("should read a whole-namespace require(esm) from a wrapped body", () => {
+	expect(wrapped.whole.NAME).toBe("esm");
+	expect(wrapped.whole.default).toBe("default");
+	expect(wrapped.whole.__esModule).toBe(true);
+});
+
+it("should read a member of a require() from a wrapped body", () => {
+	expect(wrapped.member).toBe("cjs");
+});
+
+it("should pass an object module.exports through `new require()` in a wrapped body", () => {
+	expect(wrapped.constructed).toEqual({ value: "object" });
+});
+
+it("should substitute a require() inside an async block of a wrapped body", async () => {
+	await expect(wrapped.loadAsync()).resolves.toBe("async");
+});
+
+// The async target sits in its own chunk, so it stays outside — the reference
+// to it resolves through the concatenation's external accessor.
+it("should concatenate every require() target sharing the chunk", () => {
+	const concatModules = __STATS__.modules.filter((m) => m.modules);
+	expect(concatModules.length).toBe(1);
+	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual([
+		"./cjs-target.js",
+		"./esm-target.js",
+		"./index.js",
+		"./object-target.js",
+		"./wrapped.js"
+	]);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/object-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/object-target.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { value: "object" };

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/wrapped.js
+++ b/test/configCases/concatenate-modules/commonjs-require-in-wrapped-module/wrapped.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// A reassigned module.exports wraps this body, so its concatenation references
+// are substituted textually instead of through scope analysis.
+const whole = require("./esm-target");
+const member = require("./cjs-target").value;
+const constructed = new require("./object-target");
+
+module.exports = {
+	whole,
+	member,
+	constructed,
+	loadAsync() {
+		return new Promise((resolve) => {
+			require.ensure(
+				[],
+				(require) => {
+					resolve(require("./async-target").value);
+				},
+				"wrapped-async"
+			);
+		});
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-inlined-const/constants.js
+++ b/test/configCases/concatenate-modules/commonjs-require-inlined-const/constants.js
@@ -1,0 +1,2 @@
+export const NUMBER = 42;
+export const TEXT = "text";

--- a/test/configCases/concatenate-modules/commonjs-require-inlined-const/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-inlined-const/consumer.js
@@ -1,0 +1,9 @@
+// The import may be inlined as a literal; the require() reads the same names off
+// the exports object, so they have to stay properties of it.
+import { NUMBER } from "./constants";
+
+const whole = require("./constants");
+
+export const fromImport = NUMBER;
+export const fromRequire = whole.NUMBER;
+export const textFromRequire = whole.TEXT;

--- a/test/configCases/concatenate-modules/commonjs-require-inlined-const/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-inlined-const/index.js
@@ -1,0 +1,10 @@
+import { fromImport, fromRequire, textFromRequire } from "./consumer";
+
+it("should read an inlinable constant through the import", () => {
+	expect(fromImport).toBe(42);
+});
+
+it("should keep the same constant readable off the required exports object", () => {
+	expect(fromRequire).toBe(42);
+	expect(textFromRequire).toBe("text");
+});

--- a/test/configCases/concatenate-modules/commonjs-require-inlined-const/test.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-inlined-const/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["split.js", "main.js"];
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-inlined-const/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-inlined-const/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		mangleExports: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		splitChunks: {
+			cacheGroups: {
+				split: {
+					test: /constants\.js$/,
+					name: "split",
+					chunks: "all",
+					enforce: true,
+					minSize: 0
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/cjs-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/cjs-target.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.gamma = "gamma";
+exports.delta = "delta";

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/consumer.js
@@ -1,0 +1,16 @@
+// None of these reads name an export statically, so the exports objects must
+// keep their written names: a mangled one silently answers `undefined` here.
+const esm = require("./esm-target");
+const cjs = require("./cjs-target");
+
+export const esmKeys = Object.keys(esm).sort();
+export const cjsKeys = Object.keys(cjs).sort();
+export const spread = { ...cjs };
+export const looped = (() => {
+	const names = [];
+	for (const name in cjs) names.push(name);
+	return names.sort();
+})();
+export const byComputedName = (name) => cjs[name];
+export const stringified = JSON.stringify(cjs);
+export const esmMarker = esm.__esModule;

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/esm-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/esm-target.js
@@ -1,0 +1,2 @@
+export const alpha = "alpha";
+export const beta = "beta";

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/index.js
@@ -1,0 +1,35 @@
+import {
+	byComputedName,
+	cjsKeys,
+	esmKeys,
+	esmMarker,
+	looped,
+	spread,
+	stringified
+} from "./consumer";
+
+it("should keep the export names of a required ESM module readable", () => {
+	expect(esmKeys).toEqual(["alpha", "beta"]);
+	expect(esmMarker).toBe(true);
+});
+
+it("should keep the export names of a required CommonJS module readable", () => {
+	expect(cjsKeys).toEqual(["delta", "gamma"]);
+});
+
+it("should spread the required exports object under its written names", () => {
+	expect(spread).toEqual({ delta: "delta", gamma: "gamma" });
+});
+
+it("should enumerate the required exports object", () => {
+	expect(looped).toEqual(["delta", "gamma"]);
+});
+
+it("should answer a computed property read", () => {
+	expect(byComputedName("gamma")).toBe("gamma");
+	expect(byComputedName("delta")).toBe("delta");
+});
+
+it("should serialize the required exports object", () => {
+	expect(JSON.parse(stringified)).toEqual({ delta: "delta", gamma: "gamma" });
+});

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/test.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["split.js", "main.js"];
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-namespace-escape/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-namespace-escape/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		mangleExports: true,
+		moduleIds: "named",
+		chunkIds: "named",
+		splitChunks: {
+			cacheGroups: {
+				split: {
+					test: /-target\.js$/,
+					name: "split",
+					chunks: "all",
+					enforce: true,
+					minSize: 0
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/cjs-target.cjs
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/cjs-target.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.value = "cjs";

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/consumer.js
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/consumer.js
@@ -1,0 +1,5 @@
+const whole = require("./esm-target.mjs");
+const member = require("./cjs-target.cjs").value;
+const constructed = new require("./object-target.cjs");
+
+export { constructed, member, whole };

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/esm-target.mjs
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/esm-target.mjs
@@ -1,0 +1,2 @@
+export const NAME = "esm";
+export default "default";

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/index.js
@@ -1,0 +1,14 @@
+import { constructed, member, whole } from "./consumer";
+
+it("should read a whole-namespace require(esm) in an ESM output bundle", () => {
+	expect(whole.NAME).toBe("esm");
+	expect(whole.default).toBe("default");
+});
+
+it("should read a member of a require() in an ESM output bundle", () => {
+	expect(member).toBe("cjs");
+});
+
+it("should pass an object module.exports through `new require()` in an ESM output bundle", () => {
+	expect(constructed).toEqual({ value: "object" });
+});

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/object-target.cjs
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/object-target.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = { value: "object" };

--- a/test/configCases/concatenate-modules/commonjs-require-output-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-output-module/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/errors.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/errors.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = [
+	[
+		/Unsubstituted module reference "__WEBPACK_MODULE_REFERENCE__0_ns__" in \.\/leak\.js/
+	]
+];

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/index.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/index.js
@@ -1,0 +1,7 @@
+import leak from "./leak";
+
+// The build fails, so the case only checks its error (test.config.js sets
+// noTests); the import keeps `leak.js` from being tree-shaken away.
+it("should not run", () => {
+	expect(leak.value).toBe(undefined);
+});

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/leak.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/leak.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// A reassigned module.exports wraps this body, whose reference tokens are found
+// textually: one buried in a wider identifier would be substituted mid-name.
+module.exports = { value: leaked__WEBPACK_MODULE_REFERENCE__0_ns__._ };

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/test.config.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/test.config.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.noTests = true;

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/webpack.config.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference-wrapped/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference/errors.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference/errors.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = [
+	[
+		/Unsubstituted module reference "leaked__WEBPACK_MODULE_REFERENCE__0_ns__" in \.\/leak\.js/
+	]
+];

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference/index.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference/index.js
@@ -1,0 +1,7 @@
+import { value } from "./leak";
+
+// The build fails, so the case only checks its error (test.config.js sets
+// noTests); the import keeps `leak.js` from being tree-shaken away.
+it("should not run", () => {
+	expect(value).toBe(undefined);
+});

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference/leak.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference/leak.js
@@ -1,0 +1,3 @@
+// A free identifier burying webpack's reference token: nothing can resolve it,
+// so the build must fail instead of emitting an undeclared global.
+export const value = leaked__WEBPACK_MODULE_REFERENCE__0_ns__;

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference/test.config.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference/test.config.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.noTests = true;

--- a/test/configCases/concatenate-modules/unsubstituted-module-reference/webpack.config.js
+++ b/test/configCases/concatenate-modules/unsubstituted-module-reference/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: true,
+		minimize: false,
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -4585,7 +4585,9 @@ declare class ConcatenationScope {
 	static isLeakedModuleReference(name: string): boolean;
 
 	/**
-	 * Finds all encoded module references in a generated source.
+	 * Finds all encoded module references in a generated source. A match that
+	 * continues an identifier is reported as `leaked`: it is a token a wider
+	 * replacement swallowed, so substituting it would rewrite the middle of a name.
 	 */
 	static findModuleReferences(source: Source): ModuleReferenceMatch[];
 
@@ -18213,6 +18215,7 @@ declare interface ModuleReferenceMatch {
 	start: number;
 	end: number;
 	name: string;
+	leaked: boolean;
 }
 declare interface ModuleReferenceOptions {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -4578,9 +4578,8 @@ declare class ConcatenationScope {
 	static isModuleReference(name: string): boolean;
 
 	/**
-	 * Checks whether an identifier buries a reference token without being a
-	 * reference itself, which a replacement overlapping a reference produces.
-	 * Nothing can resolve it, so it would reach the output as an undeclared global.
+	 * Checks whether an identifier buries a reference token without being one,
+	 * which nothing can resolve: it would reach the output as an undeclared global.
 	 */
 	static isLeakedModuleReference(name: string): boolean;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -4578,6 +4578,13 @@ declare class ConcatenationScope {
 	static isModuleReference(name: string): boolean;
 
 	/**
+	 * Checks whether an identifier buries a reference token without being a
+	 * reference itself, which a replacement overlapping a reference produces.
+	 * Nothing can resolve it, so it would reach the output as an undeclared global.
+	 */
+	static isLeakedModuleReference(name: string): boolean;
+
+	/**
 	 * Finds all encoded module references in a generated source.
 	 */
 	static findModuleReferences(source: Source): ModuleReferenceMatch[];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #21903. A `require()` inside an async block renders after the module's presentational dependencies, so `RequireHeaderDependency` replaced the callee of a call the paired dependency had not yet replaced as a whole, leaving `__WEBPACK_MODULE_REFERENCE__…__` in the output as an undeclared global; the header now asks the paired dependency instead of a range it registered, which no longer depends on template order. Two related fixes came out of the new tests: merging referenced exports dropped a `canMangle`/`canInline` of `false` against an unset one (`undefined && false` reads back as allowed), so a whole-namespace `require(esm)` read mangled export names; and concatenation now fails the build on an identifier burying an unsubstituted reference token instead of shipping it.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/concatenate-modules/commonjs-require-in-async-block`, `.../commonjs-require-esm-namespace-mangling` and `.../unsubstituted-module-reference`; each fails without its fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to reproduce the issue, locate the ordering bug, write the tests and draft the patch; every change was reviewed and verified locally against the reproduction and the test suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgwT91iM1y7awUy5s1a927)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CommonJS `require()` handling so exported names are not incorrectly mangled or altered.
  - Prevented internal module-reference tokens from leaking into generated bundles.
  - Improved export analysis so unspecified optimization flags remain usable unless explicitly disabled.
  - Preserved correct module identity and single evaluation when synchronous `require()` and dynamic imports target the same module.
  - Improved support for `require()` in expressions, async blocks, wrapped modules, namespace access, and output modules.

- **Tests**
  - Added comprehensive coverage for CommonJS and ES module interoperability, including failure detection for unresolved references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->