### PR TITLE
test(test262): assert two more errors webpack reports at build time

### DIFF
--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -838,6 +838,11 @@ const baseDir = path.posix.resolve(test262Dir, "./test/language/");
 // The spec rejects `import()` for these link errors; webpack, like rollup,
 // esbuild and bun, resolves linking at build time and reports them there.
 const linkErrorsAtBuildTime = new Set([
+	// A module that fails to resolve is a build error, deferred or not.
+	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
+	// Assigning to a namespace import is a build error, earlier than the
+	// spec's runtime TypeError.
+	"module-code/instn-star-binding.js",
 	// ambiguous star re-export
 	"expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-ambiguous-import.js",
 	"expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.js",
@@ -889,18 +894,12 @@ const knownBugs = [
 	// `#mark in obj` needs `isExtensible() === false` without evaluating, so the
 	// target must be sealed with every export name on it, and a mismatch loses one.
 	"import/import-defer/evaluation-triggers/ignore-private-name-access.js",
-	// Host resolution errors must be reported eagerly even for deferred imports;
-	// webpack turns a missing module into a build error resolved lazily instead.
-	"import/import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js",
 	// A deferred module must wait for the whole strongly-connected component when a
 	// dependency's cycle root is still evaluating-async (`IsModuleSCCEvaluated`).
 	"import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js",
 	// It also wants `ownKeys` to be the sorted exports plus `@@toStringTag`, so
 	// `__esModule` would have to go — the namespace trade-off, not a defer fix.
 	"import/import-defer/deferred-namespace-object/exotic-object-behavior.js",
-	// Reported as a build error, earlier than the spec's runtime TypeError: the
-	// binding stays a `var`, which a runtime condition and HMR accept both need.
-	"module-code/instn-star-binding.js",
 	// Improvement- bug with `delete` and `ns[0] = something` when using `import * as ns from "...";`
 	"module-code/export-expname-binding-index.js",
 	// `String(ns)`/`Number(ns)` rely on `ns`'s prototype being `null` (a real


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Two entries in the test262 skip lists no longer describe what webpack does, so the suite was skipping behaviour it already has.

`import-defer-of-missing-module-fails.js` and `module-code/instn-star-binding.js` move from `knownBugs` to `linkErrorsAtBuildTime`, the existing list for cases where webpack — like rollup, esbuild and bun — resolves linking at build time and reports there rather than throwing at runtime. A module that fails to resolve is a build error whether or not the import is deferred, and assigning to a namespace import has been one since #21867. The suite now asserts webpack reports both instead of skipping them.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

This PR is only test changes — `test/test262.spectest.js`. Both cases pass on this branch, across the development and production scenarios. Because membership of `linkErrorsAtBuildTime` is itself what turns on `exportsPresence: "error"`, the classification would be self-confirming if checked through the suite alone, so both were also built with a real `webpack()` under default options, where they error on their own: `Module not found: Error: Can't resolve './missing.js'` and `Assignment to the imported binding 'ns'. A namespace import is immutable, …`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Nothing outside `test/` changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to re-probe the remaining skip-list entries with their filter removed, and to check each candidate against a real build rather than against the suite alone — which matters here, since the harness enables `exportsPresence: "error"` for `linkErrorsAtBuildTime` members and would otherwise make that classification self-confirming. Several candidates the first sweep called green were rejected on exactly that ground, and one further candidate — un-skipping the top-level `await using` Script-goal case — was proposed, pushed, then reverted after CI disproved it: the local run had scored a host `SyntaxError` from an older Node as the expected parse error. All findings and reasoning were reviewed by me before committing.