### PR TITLE
fix: concatenated `require()` in `require.ensure` or computed target

### DIFF
--- a/.changeset/015-concat-require-async-callback.md
+++ b/.changeset/015-concat-require-async-callback.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix concatenated `require()` in a `require.ensure` callback or a computed request.

--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -19,7 +19,6 @@ const {
  * 	ExportName as Ids
  * } from "./optimize/ConcatenatedModule"
  */
-/** @import { Range } from "./javascript/JavascriptParser" */
 
 /** @typedef {{ start: number, end: number, name: string }} ModuleReferenceMatch */
 
@@ -76,10 +75,6 @@ class ConcatenationScope {
 		this.usedNames = usedNames;
 		/** @type {Map<Module, ModuleInfo>} */
 		this._modulesMap = modulesMap;
-		// written and read by dependency templates within a single code
-		// generation pass, never across passes
-		/** @type {Range[] | undefined} */
-		this._replacedRequireRanges = undefined;
 	}
 
 	/**
@@ -119,33 +114,6 @@ class ConcatenationScope {
 	 */
 	isWrapped() {
 		return this._currentModule.wrapped;
-	}
-
-	/**
-	 * Records a `require(...)` call that was replaced as a whole by a
-	 * concatenation reference, so nothing else rewrites a range inside it.
-	 * @param {Range} range source range of the replaced call
-	 */
-	registerReplacedRequire(range) {
-		if (this._replacedRequireRanges === undefined) {
-			this._replacedRequireRanges = [];
-		}
-		this._replacedRequireRanges.push(range);
-	}
-
-	/**
-	 * Checks whether an offset sits inside an already-replaced `require(...)` call.
-	 * Containment, not exact match: `new require(...)` is replaced from `new`.
-	 * @param {number} start start offset to test
-	 * @returns {boolean} true, when the offset was replaced already
-	 */
-	isInsideReplacedRequire(start) {
-		const ranges = this._replacedRequireRanges;
-		if (ranges === undefined) return false;
-		for (const [rangeStart, rangeEnd] of ranges) {
-			if (start >= rangeStart && start < rangeEnd) return true;
-		}
-		return false;
 	}
 
 	/**

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -20,6 +20,7 @@ const HarmonyImportGuard = require("./HarmonyImportGuard");
 const ModuleDependency = require("./ModuleDependency");
 
 /** @import { ReplaceSource } from "webpack-sources" */
+/** @import ConcatenationScope from "../ConcatenationScope" */
 /**
  * @import {
  * 	GetConditionFn,
@@ -30,6 +31,7 @@ const ModuleDependency = require("./ModuleDependency");
 /** @import { DependencyTemplateContext } from "../DependencyTemplate" */
 /** @import Module from "../Module" */
 /** @import ModuleGraph from "../ModuleGraph" */
+/** @import ModuleGraphConnection from "../ModuleGraphConnection" */
 /** @import { Range } from "../javascript/JavascriptParser" */
 /** @import { UsedByExports } from "../optimize/InnerGraph" */
 /** @import { RuntimeSpec } from "../util/runtime" */
@@ -201,6 +203,19 @@ class CommonJsRequireDependency extends ModuleDependency {
 	}
 
 	/**
+	 * @param {ModuleGraphConnection} connection the active connection of this dependency
+	 * @param {ConcatenationScope} concatenationScope the concatenation scope
+	 * @returns {boolean} true when the call becomes a module reference
+	 */
+	rendersAsConcatenatedReference(connection, concatenationScope) {
+		return (
+			this._canConcatenate &&
+			this.valueRange !== undefined &&
+			concatenationScope.isModuleInScope(connection.module)
+		);
+	}
+
+	/**
 	 * Serializes this instance into the provided serializer context.
 	 * @param {ObjectSerializerContext} context context
 	 */
@@ -278,9 +293,9 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 		if (
 			connection &&
 			concatenationScope !== undefined &&
-			dep.valueRange !== undefined &&
-			concatenationScope.isModuleInScope(connection.module)
+			dep.rendersAsConcatenatedReference(connection, concatenationScope)
 		) {
+			const valueRange = /** @type {Range} */ (dep.valueRange);
 			let content = concatenationScope.createModuleReference(
 				connection.module,
 				{
@@ -300,8 +315,7 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 				);
 				content = `${RuntimeGlobals.constructRequire}(${content})`;
 			}
-			source.replace(dep.valueRange[0], dep.valueRange[1] - 1, content);
-			concatenationScope.registerReplacedRequire(dep.valueRange);
+			source.replace(valueRange[0], valueRange[1] - 1, content);
 			return;
 		}
 		const importedModule = /** @type {Module} */ (moduleGraph.getModule(dep));

--- a/lib/dependencies/RequireHeaderDependency.js
+++ b/lib/dependencies/RequireHeaderDependency.js
@@ -76,30 +76,29 @@ RequireHeaderDependency.Template = class RequireHeaderDependencyTemplate extends
 		{ moduleGraph, runtime, runtimeRequirements, concatenationScope }
 	) {
 		const dep = /** @type {RequireHeaderDependency} */ (dependency);
-
-		// the paired require dependency already replaced the whole call
-		if (
-			concatenationScope !== undefined &&
-			concatenationScope.isInsideReplacedRequire(dep.range[0])
-		) {
-			return;
-		}
-
 		const requireDep = dep.requireDependency;
-		// Skip when the paired call became `0`; dead-branch still needs the header.
 		if (requireDep) {
 			const connection = moduleGraph.getConnection(requireDep);
-			if (
-				connection &&
-				!connection.isTargetActive(runtime) &&
-				requireDep.isEvaluationOnly()
-			) {
-				const guards = requireDep.branchGuards;
-				if (
-					guards === undefined ||
-					!HarmonyImportGuard.isDeadByGuards(guards, moduleGraph, runtime)
-				) {
-					return;
+			if (connection) {
+				if (connection.isTargetActive(runtime)) {
+					if (
+						concatenationScope !== undefined &&
+						requireDep.rendersAsConcatenatedReference(
+							connection,
+							concatenationScope
+						)
+					) {
+						return;
+					}
+				} else if (requireDep.isEvaluationOnly()) {
+					// Skip when the paired call became `0`; dead-branch still needs the header.
+					const guards = requireDep.branchGuards;
+					if (
+						guards === undefined ||
+						!HarmonyImportGuard.isDeadByGuards(guards, moduleGraph, runtime)
+					) {
+						return;
+					}
 				}
 			}
 		}

--- a/test/configCases/concatenate-modules/commonjs-require-call-sites/amd-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-call-sites/amd-target.js
@@ -1,0 +1,5 @@
+"use strict";
+
+global.__bailoutOrder = (global.__bailoutOrder || []).concat("amd-target");
+
+exports.v = "amd-target";

--- a/test/configCases/concatenate-modules/commonjs-require-call-sites/ensure-target.js
+++ b/test/configCases/concatenate-modules/commonjs-require-call-sites/ensure-target.js
@@ -1,0 +1,4 @@
+global.__bailoutOrder = (global.__bailoutOrder || []).concat("ensure-target");
+
+export const NAME = "ensure-target";
+export default { isDefault: true };

--- a/test/configCases/concatenate-modules/commonjs-require-call-sites/imported-branch.js
+++ b/test/configCases/concatenate-modules/commonjs-require-call-sites/imported-branch.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.v = "imported-branch";

--- a/test/configCases/concatenate-modules/commonjs-require-call-sites/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-call-sites/index.js
@@ -1,6 +1,8 @@
 // the ESM import gives this entry a concatenation; each require() below decides
 // whether its target is absorbed into it
 import { tag } from "./member";
+// also a branch of the computed requests below, so it sits in the scope
+import importedBranch from "./imported-branch";
 
 function getLazy() {
 	return require("./lazy").v;
@@ -15,6 +17,12 @@ try {
 	tryV = "failed";
 }
 const argM = require(global.__notSet ? "./arg-a" : "./arg-b");
+const importedBranchM = require(
+	global.__notSet ? "./imported-branch" : "./arg-b"
+);
+const importedBranchTakenM = require(
+	global.__notSet ? "./arg-b" : "./imported-branch"
+);
 
 require("./written-direct").p = "set";
 const writtenDirect = require("./written-direct");
@@ -26,7 +34,12 @@ const resolveId = require.resolve("./resolve-target");
 const ORDER_AT_LOAD = global.__bailoutOrder.slice();
 
 // no single target for a computed request; require.resolve() cannot concatenate
-const BAILED_OUT = ["./arg-a.js", "./arg-b.js", "./resolve-target.js"];
+const BAILED_OUT = [
+	"./arg-a.js",
+	"./arg-b.js",
+	"./imported-branch.js",
+	"./resolve-target.js"
+];
 // absorbed targets render as wrapped members, so they evaluate at their
 // require() instead of at their position in the concatenation
 const ABSORBED = [
@@ -62,6 +75,12 @@ it("should resolve a require() with a computed request at runtime", () => {
 	expect(ORDER_AT_LOAD).not.toContain("arg-a");
 });
 
+it("should keep a computed request working when a branch is also imported", () => {
+	expect(importedBranch.v).toBe("imported-branch");
+	expect(importedBranchM.v).toBe("arg-b");
+	expect(importedBranchTakenM.v).toBe("imported-branch");
+});
+
 it("should keep a member-assigned require() target writable", () => {
 	expect(writtenDirect.p).toBe("set");
 	expect(writtenDirect.v).toBe("written-direct");
@@ -90,6 +109,34 @@ it("should absorb every require() target that can be wrapped", () => {
 	expect(concatModules.length).toBe(1);
 	expect(concatModules[0].modules.map((m) => m.name).sort()).toEqual(ABSORBED);
 });
+
+// an async callback moves the require() into a child block, which renders
+// after the module's own `require` header
+it("should read a whole module object required in a require.ensure callback", () => {
+	expect(ORDER_AT_LOAD).not.toContain("ensure-target");
+	return new Promise((resolve) => {
+		require.ensure(
+			[],
+			(require) => {
+				resolve(require("./ensure-target"));
+			},
+			"ensure"
+		);
+	}).then((whole) => {
+		expect(whole.NAME).toBe("ensure-target");
+		expect(whole.default).toEqual({ isDefault: true });
+		expect(global.__bailoutOrder).toContain("ensure-target");
+	});
+});
+
+it("should read a whole module object required in an AMD require callback", () =>
+	new Promise((resolve) => {
+		require(["./amd-target"], function () {
+			resolve(require("./amd-target"));
+		});
+	}).then((whole) => {
+		expect(whole.v).toBe("amd-target");
+	}));
 
 it("should evaluate the absorbed targets at their require(), in source order", () => {
 	// a bailed-out target is reached through a lazy accessor too, so it keeps its

--- a/types.d.ts
+++ b/types.d.ts
@@ -4535,18 +4535,6 @@ declare class ConcatenationScope {
 	isWrapped(): boolean;
 
 	/**
-	 * Records a `require(...)` call that was replaced as a whole by a
-	 * concatenation reference, so nothing else rewrites a range inside it.
-	 */
-	registerReplacedRequire(range: [number, number]): void;
-
-	/**
-	 * Checks whether an offset sits inside an already-replaced `require(...)` call.
-	 * Containment, not exact match: `new require(...)` is replaced from `new`.
-	 */
-	isInsideReplacedRequire(start: number): boolean;
-
-	/**
 	 * Records the symbol that should be used when the current module exports a
 	 * named binding.
 	 */


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes https://github.com/webpack/webpack/issues/21903.

In concatenation, `RequireHeaderDependency` skipped rendering `require` callee only after the paired CJS require dependency had replaced the whole call and `registerReplacedRequire`.

But inside a `require.ensure` and AMD callback, the CJS require dependency sits in the async block, which `JavascriptGenerator` renders it after the module's presentational dependencies, so the rendering `RequireHeaderDependency` can't be skipped, which cause module reference error.

Now `RequireHeaderDependency` rely on `CommonJsRequireDependnecy#rendersAsConcatenatedReference` directly, it won't introduce order issues.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of concatenated `require()` calls inside asynchronous loading callbacks and computed module requests.
  - Improved replacement behavior for active and inactive module branches.
  - Preserved correct module evaluation order and exported values in affected scenarios.

- **Tests**
  - Added coverage for AMD and asynchronous loading callbacks.
  - Added tests for computed requests and conditional branches involving concatenated CommonJS modules.

- **Release**
  - Included in a patch release of webpack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->