### PR TITLE
fix: reject a fulfilled async cycle member with the cycle's evaluation error

### DIFF
--- a/.changeset/013-errored-cycle-member.md
+++ b/.changeset/013-errored-cycle-member.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reject a fulfilled async cycle member with the cycle's evaluation error.

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -402,7 +402,11 @@ class RuntimePlugin {
 					compilation.addLazyRuntimeModule(
 						chunk,
 						getAsyncModuleRuntimeModule,
-						(Ctor) => new Ctor(experiments.deferImport)
+						(Ctor) =>
+							new Ctor(
+								experiments.deferImport,
+								compilation.outputOptions.strictModuleErrorHandling
+							)
 					);
 					return true;
 				});

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -17,11 +17,18 @@ const NullDependency = require("./NullDependency");
 const getJavascriptModulesPlugin = memoize(() =>
 	require("../javascript/JavascriptModulesPlugin")
 );
+// Same reason: the deferred-namespace runtime imports dependencies from here.
+const getDeferredCycleHelpers = memoize(() =>
+	require("../runtime/MakeDeferredNamespaceObjectRuntime")
+);
 
 /** @import { ReplaceSource } from "webpack-sources" */
 /** @import Dependency from "../Dependency" */
 /** @import { DependencyTemplateContext } from "../DependencyTemplate" */
 /** @import { BuildMeta } from "../Module" */
+/** @import Module from "../Module" */
+/** @import ModuleGraph from "../ModuleGraph" */
+/** @import ChunkGraph, { ModuleId } from "../ChunkGraph" */
 /**
  * @import {
  * 	JavascriptModuleBuildInfo
@@ -38,6 +45,30 @@ makeSerializable(
 	HarmonyCompatibilityDependency,
 	"webpack/lib/dependencies/HarmonyCompatibilityDependency"
 );
+
+/**
+ * Ids of the async modules sharing a strongly-connected component with `module`.
+ * The spec records one `[[EvaluationError]]` for a whole component, so a member
+ * that already fulfilled still has to report the root's error afterwards.
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {Module} module the async module
+ * @returns {ModuleId[] | null} peer ids, or null when it is not in a cycle
+ */
+const getAsyncCyclePeerIds = (moduleGraph, chunkGraph, module) => {
+	const { getDeferredCycleModuleIds, getDeferredCycleModules } =
+		getDeferredCycleHelpers();
+	const peers = getDeferredCycleModules(moduleGraph, module);
+	if (peers === null) return null;
+	const asyncPeers = new Set();
+	for (const peer of peers) {
+		if (moduleGraph.isAsync(peer)) asyncPeers.add(peer);
+	}
+	if (asyncPeers.size === 0) return null;
+	return getDeferredCycleModuleIds(asyncPeers, (m) =>
+		chunkGraph.getModuleId(m)
+	);
+};
 
 HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate extends (
 	NullDependency.Template
@@ -56,6 +87,7 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 			module,
 			runtimeTemplate,
 			moduleGraph,
+			chunkGraph,
 			initFragments,
 			runtimeRequirements,
 			runtime,
@@ -99,9 +131,17 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 		}
 		if (moduleGraph.isAsync(module)) {
 			runtimeRequirements.add(RuntimeGlobals.module);
-			const hasAwait = /** @type {BuildMeta} */ (module.buildMeta).async
-				? ", 1"
-				: "";
+			// Only `strictModuleErrorHandling` keeps a recorded error for later
+			// requires, so the component's peers are worth naming only then.
+			const cyclePeers = runtimeTemplate.outputOptions.strictModuleErrorHandling
+				? getAsyncCyclePeerIds(moduleGraph, chunkGraph, module)
+				: null;
+			const isAsyncBody = /** @type {BuildMeta} */ (module.buildMeta).async;
+			const hasAwait = cyclePeers
+				? `, ${isAsyncBody ? 1 : 0}, ${JSON.stringify(cyclePeers)}`
+				: isAsyncBody
+					? ", 1"
+					: "";
 			// A module-scope `await using` is disposed when its scope ends, so the body
 			// needs a block that closes before the module reports completion —
 			// otherwise dependents run before disposal is awaited.

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -47,27 +47,36 @@ makeSerializable(
 );
 
 /**
- * Ids of the async modules sharing a strongly-connected component with `module`.
- * The spec records one `[[EvaluationError]]` for a whole component, so a member
- * that already fulfilled still has to report the root's error afterwards.
+ * Key shared by the async modules of one strongly-connected component. The spec
+ * records one `[[EvaluationError]]` per component, so a member that already
+ * fulfilled still has to report the root's error afterwards.
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {ChunkGraph} chunkGraph the chunk graph
  * @param {Module} module the async module
- * @returns {ModuleId[] | null} peer ids, or null when it is not in a cycle
+ * @returns {ModuleId | null} the group key, or null when it is not in an async cycle
  */
-const getAsyncCyclePeerIds = (moduleGraph, chunkGraph, module) => {
-	const { getDeferredCycleModuleIds, getDeferredCycleModules } =
-		getDeferredCycleHelpers();
+const getAsyncCycleGroupId = (moduleGraph, chunkGraph, module) => {
+	const { getDeferredCycleModules } = getDeferredCycleHelpers();
 	const peers = getDeferredCycleModules(moduleGraph, module);
 	if (peers === null) return null;
-	const asyncPeers = new Set();
+	// The component's smallest async member id names the group, so every member
+	// emits the same key and none has to carry the whole peer list.
+	let groupId = null;
+	let asyncPeerCount = 0;
 	for (const peer of peers) {
-		if (moduleGraph.isAsync(peer)) asyncPeers.add(peer);
+		if (!moduleGraph.isAsync(peer)) continue;
+		asyncPeerCount++;
+		const id = chunkGraph.getModuleId(peer);
+		if (id !== null && (groupId === null || `${id}` < `${groupId}`)) {
+			groupId = id;
+		}
 	}
-	if (asyncPeers.size === 0) return null;
-	return getDeferredCycleModuleIds(asyncPeers, (m) =>
-		chunkGraph.getModuleId(m)
-	);
+	if (asyncPeerCount === 0) return null;
+	const ownId = chunkGraph.getModuleId(module);
+	if (ownId !== null && (groupId === null || `${ownId}` < `${groupId}`)) {
+		groupId = ownId;
+	}
+	return groupId;
 };
 
 HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate extends (
@@ -133,15 +142,17 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 			runtimeRequirements.add(RuntimeGlobals.module);
 			// Only `strictModuleErrorHandling` keeps a recorded error for later
 			// requires, so the component's peers are worth naming only then.
-			const cyclePeers = runtimeTemplate.outputOptions.strictModuleErrorHandling
-				? getAsyncCyclePeerIds(moduleGraph, chunkGraph, module)
+			const cycleGroupId = runtimeTemplate.outputOptions
+				.strictModuleErrorHandling
+				? getAsyncCycleGroupId(moduleGraph, chunkGraph, module)
 				: null;
 			const isAsyncBody = /** @type {BuildMeta} */ (module.buildMeta).async;
-			const hasAwait = cyclePeers
-				? `, ${isAsyncBody ? 1 : 0}, ${JSON.stringify(cyclePeers)}`
-				: isAsyncBody
-					? ", 1"
-					: "";
+			const hasAwait =
+				cycleGroupId === null
+					? isAsyncBody
+						? ", 1"
+						: ""
+					: `, ${isAsyncBody ? 1 : 0}, ${JSON.stringify(cycleGroupId)}`;
 			// A module-scope `await using` is disposed when its scope ends, so the body
 			// needs a block that closes before the module reports completion —
 			// otherwise dependents run before disposal is awaited.

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -146,6 +146,10 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 				.strictModuleErrorHandling
 				? getAsyncCycleGroupId(moduleGraph, chunkGraph, module)
 				: null;
+			// The group is keyed by module id, so the runtime needs `module.id`.
+			if (cycleGroupId !== null) {
+				runtimeRequirements.add(RuntimeGlobals.moduleId);
+			}
 			const isAsyncBody = /** @type {BuildMeta} */ (module.buildMeta).async;
 			const hasAwait =
 				cycleGroupId === null

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -216,11 +216,16 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 					...(strictErrors
 						? [
 								`${cst} group = cycleGroup === undefined ? undefined : (cycleGroups[cycleGroup] = cycleGroups[cycleGroup] || []);`,
-								"group && group.push(module);",
+								// Ids, not module objects: hot replacement swaps a member for a
+								// new object under the same id, and the error belongs to that one.
+								"group && group.indexOf(module.id) < 0 && group.push(module.id);",
 								`${cst} markCycle = ${runtimeTemplate.expressionFunction(
-									`group && group.forEach(${runtimeTemplate.expressionFunction(
-										"peer.error === undefined && (peer.error = err)",
-										"peer"
+									`group && group.forEach(${runtimeTemplate.basicFunction(
+										"id",
+										[
+											`${cst} peer = __webpack_module_cache__[id];`,
+											"if (peer && peer.error === undefined) peer.error = err;"
+										]
 									)})`,
 									"err"
 								)};`

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -33,6 +33,10 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 		const fn = RuntimeGlobals.asyncModule;
 		const defer = this._deferInterop;
 		const strictErrors = this._strictModuleErrorHandling;
+		const rejectCall = "reject(promise[webpackError] = err)";
+		const rejectExpression = strictErrors
+			? `(markCycle(err), ${rejectCall})`
+			: rejectCall;
 		const cst = runtimeTemplate.renderConst();
 		const lt = runtimeTemplate.renderLet();
 		const supportsSymbol = runtimeTemplate.supportsSymbol();
@@ -50,6 +54,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 				defer ? `${RuntimeGlobals.asyncModuleExportSymbol}= ` : ""
 			}${renderSymbol("webpack exports", RuntimeGlobals.exports)};`,
 			`${cst} webpackError = ${renderSymbol("webpack error", "__webpack_error__")};`,
+			...(strictErrors ? [`${cst} cycleGroups = {};`] : []),
 			defer
 				? Template.asString([
 						`${cst} webpackDone = ${RuntimeGlobals.asyncModuleDoneSymbol} = ${renderSymbol("webpack done", "__webpack_done__")};`,
@@ -154,7 +159,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 			)};`,
 			`${fn} = ${runtimeTemplate.basicFunction(
 				strictErrors
-					? "module, body, hasAwait, cyclePeers"
+					? "module, body, hasAwait, cycleGroup"
 					: "module, body, hasAwait",
 				[
 					`${lt} queue;`,
@@ -208,20 +213,21 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 					])}`,
 					// One `[[EvaluationError]]` is recorded for a whole strongly-connected
 					// component, so a peer that already fulfilled must report it too.
-					strictErrors
-						? `${cst} markCycle = ${runtimeTemplate.expressionFunction(
-								`cyclePeers && cyclePeers.forEach(${runtimeTemplate.basicFunction(
-									"id",
-									[
-										`${cst} peer = __webpack_module_cache__[id];`,
-										"if (peer && peer.error === undefined) peer.error = err;"
-									]
-								)})`,
-								"err"
-							)};`
-						: "",
+					...(strictErrors
+						? [
+								`${cst} group = cycleGroup === undefined ? undefined : (cycleGroups[cycleGroup] = cycleGroups[cycleGroup] || []);`,
+								"group && group.push(module);",
+								`${cst} markCycle = ${runtimeTemplate.expressionFunction(
+									`group && group.forEach(${runtimeTemplate.expressionFunction(
+										"peer.error === undefined && (peer.error = err)",
+										"peer"
+									)})`,
+									"err"
+								)};`
+							]
+						: []),
 					`${cst} done = ${runtimeTemplate.expressionFunction(
-						`(err ? (${strictErrors ? "markCycle(err), " : ""}reject(promise[webpackError] = err)) : outerResolve(exports)), resolveQueue(queue)${
+						`(err ? ${rejectExpression} : outerResolve(exports)), resolveQueue(queue)${
 							defer
 								? ", promise[webpackDone] = true, module.evaluatingAsync = false"
 								: ""

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -13,11 +13,14 @@ const HelperRuntimeModule = require("./HelperRuntimeModule");
 class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 	/**
 	 * @param {boolean=} deferInterop if defer import is used.
+	 * @param {boolean=} strictModuleErrorHandling if a recorded evaluation error is kept.
 	 */
-	constructor(deferInterop = false) {
+	constructor(deferInterop = false, strictModuleErrorHandling = false) {
 		super("async module");
 		/** @type {boolean} */
 		this._deferInterop = deferInterop;
+		/** @type {boolean} */
+		this._strictModuleErrorHandling = strictModuleErrorHandling;
 	}
 
 	/**
@@ -29,6 +32,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 		const { runtimeTemplate } = compilation;
 		const fn = RuntimeGlobals.asyncModule;
 		const defer = this._deferInterop;
+		const strictErrors = this._strictModuleErrorHandling;
 		const cst = runtimeTemplate.renderConst();
 		const lt = runtimeTemplate.renderLet();
 		const supportsSymbol = runtimeTemplate.supportsSymbol();
@@ -148,73 +152,92 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 				])})`,
 				"deps"
 			)};`,
-			`${fn} = ${runtimeTemplate.basicFunction("module, body, hasAwait", [
-				`${lt} queue;`,
-				"hasAwait && ((queue = []).d = -1);",
-				`${cst} depQueues = new Set();`,
-				`${cst} exports = module.exports;`,
-				`${lt} currentDeps;`,
-				`${lt} outerResolve;`,
-				`${lt} reject;`,
-				`${cst} promise = new Promise(${runtimeTemplate.basicFunction(
-					"resolve, rej",
-					["reject = rej;", "outerResolve = resolve;"]
-				)});`,
-				"promise[webpackExports] = exports;",
-				`promise[webpackQueues] = ${runtimeTemplate.expressionFunction(
-					`queue && fn(queue), depQueues.forEach(fn), promise["catch"](${runtimeTemplate.emptyFunction()})`,
-					"fn"
-				)};`,
-				"module.exports = promise;",
-				`${cst} handle = ${runtimeTemplate.basicFunction("deps", [
-					"currentDeps = wrapDeps(deps);",
-					`${lt} fn;`,
-					`${cst} getResult = ${runtimeTemplate.returningFunction(
-						`currentDeps.map(${runtimeTemplate.basicFunction("d", [
-							defer ? "if(d[webpackDefer]) return d;" : "",
-							"if(d[webpackError]) throw d[webpackError];",
-							"return d[webpackExports];"
-						])})`
-					)}`,
+			`${fn} = ${runtimeTemplate.basicFunction(
+				strictErrors
+					? "module, body, hasAwait, cyclePeers"
+					: "module, body, hasAwait",
+				[
+					`${lt} queue;`,
+					"hasAwait && ((queue = []).d = -1);",
+					`${cst} depQueues = new Set();`,
+					`${cst} exports = module.exports;`,
+					`${lt} currentDeps;`,
+					`${lt} outerResolve;`,
+					`${lt} reject;`,
 					`${cst} promise = new Promise(${runtimeTemplate.basicFunction(
-						"resolve",
-						[
-							`fn = ${runtimeTemplate.expressionFunction(
-								"resolve(getResult)",
-								""
-							)};`,
-							"fn.r = 0;",
-							`${cst} fnQueue = ${runtimeTemplate.expressionFunction(
-								"q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn)))",
-								"q"
-							)};`,
-							`currentDeps.forEach(${runtimeTemplate.expressionFunction(
-								`${
-									defer ? "dep[webpackDefer]||" : ""
-								}dep[webpackQueues](fnQueue)`,
-								"dep"
-							)});`
-						]
+						"resolve, rej",
+						["reject = rej;", "outerResolve = resolve;"]
 					)});`,
-					"return fn.r ? promise : getResult();"
-				])}`,
-				`${cst} done = ${runtimeTemplate.expressionFunction(
-					`(err ? reject(promise[webpackError] = err) : outerResolve(exports)), resolveQueue(queue)${
-						defer
-							? ", promise[webpackDone] = true, module.evaluatingAsync = false"
-							: ""
-					}`,
-					"err"
-				)}`,
-				// Track the async body's whole lifetime (evaluating +
-				// evaluating-async states) with a dedicated flag — the sync require
-				// wrapper clears `module.evaluating` as soon as `.a` returns, so a
-				// deferred namespace reaching this module through a cycle relies on
-				// `evaluatingAsync` to keep throwing until it is fully evaluated.
-				defer ? "module.evaluatingAsync = true;" : "",
-				"body(handle, done);",
-				`${runtimeTemplate.optionalChaining("queue", "d < 0")} && (queue.d = 0);`
-			])};`
+					"promise[webpackExports] = exports;",
+					`promise[webpackQueues] = ${runtimeTemplate.expressionFunction(
+						`queue && fn(queue), depQueues.forEach(fn), promise["catch"](${runtimeTemplate.emptyFunction()})`,
+						"fn"
+					)};`,
+					"module.exports = promise;",
+					`${cst} handle = ${runtimeTemplate.basicFunction("deps", [
+						"currentDeps = wrapDeps(deps);",
+						`${lt} fn;`,
+						`${cst} getResult = ${runtimeTemplate.returningFunction(
+							`currentDeps.map(${runtimeTemplate.basicFunction("d", [
+								defer ? "if(d[webpackDefer]) return d;" : "",
+								"if(d[webpackError]) throw d[webpackError];",
+								"return d[webpackExports];"
+							])})`
+						)}`,
+						`${cst} promise = new Promise(${runtimeTemplate.basicFunction(
+							"resolve",
+							[
+								`fn = ${runtimeTemplate.expressionFunction(
+									"resolve(getResult)",
+									""
+								)};`,
+								"fn.r = 0;",
+								`${cst} fnQueue = ${runtimeTemplate.expressionFunction(
+									"q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn)))",
+									"q"
+								)};`,
+								`currentDeps.forEach(${runtimeTemplate.expressionFunction(
+									`${
+										defer ? "dep[webpackDefer]||" : ""
+									}dep[webpackQueues](fnQueue)`,
+									"dep"
+								)});`
+							]
+						)});`,
+						"return fn.r ? promise : getResult();"
+					])}`,
+					// One `[[EvaluationError]]` is recorded for a whole strongly-connected
+					// component, so a peer that already fulfilled must report it too.
+					strictErrors
+						? `${cst} markCycle = ${runtimeTemplate.expressionFunction(
+								`cyclePeers && cyclePeers.forEach(${runtimeTemplate.basicFunction(
+									"id",
+									[
+										`${cst} peer = __webpack_module_cache__[id];`,
+										"if (peer && peer.error === undefined) peer.error = err;"
+									]
+								)})`,
+								"err"
+							)};`
+						: "",
+					`${cst} done = ${runtimeTemplate.expressionFunction(
+						`(err ? (${strictErrors ? "markCycle(err), " : ""}reject(promise[webpackError] = err)) : outerResolve(exports)), resolveQueue(queue)${
+							defer
+								? ", promise[webpackDone] = true, module.evaluatingAsync = false"
+								: ""
+						}`,
+						"err"
+					)}`,
+					// Track the async body's whole lifetime (evaluating +
+					// evaluating-async states) with a dedicated flag — the sync require
+					// wrapper clears `module.evaluating` as soon as `.a` returns, so a
+					// deferred namespace reaching this module through a cycle relies on
+					// `evaluatingAsync` to keep throwing until it is fully evaluated.
+					defer ? "module.evaluatingAsync = true;" : "",
+					"body(handle, done);",
+					`${runtimeTemplate.optionalChaining("queue", "d < 0")} && (queue.d = 0);`
+				]
+			)};`
 		]);
 	}
 }

--- a/test/configCases/async-module/errored-cycle-deferred-member/a.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/a.js
@@ -1,0 +1,3 @@
+import "./c.js";
+await Promise.resolve(0);
+export const a = "a";

--- a/test/configCases/async-module/errored-cycle-deferred-member/b.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/b.js
@@ -1,0 +1,3 @@
+import "./a.js";
+await Promise.resolve(0);
+throw new Error("async error in B");

--- a/test/configCases/async-module/errored-cycle-deferred-member/c.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/c.js
@@ -1,0 +1,3 @@
+import "./b.js";
+await Promise.resolve(0);
+export const c = "c";

--- a/test/configCases/async-module/errored-cycle-deferred-member/deferred.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/deferred.js
@@ -1,0 +1,3 @@
+import defer * as ns from "./c.js";
+
+export const readC = () => ns.c;

--- a/test/configCases/async-module/errored-cycle-deferred-member/index.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/index.js
@@ -1,0 +1,23 @@
+it("should throw the cycle's evaluation error from a deferred member reached afterwards", async () => {
+	// The component records one `[[EvaluationError]]`, so reaching C through a
+	// deferred namespace after B failed must report it instead of C's exports.
+	let errorFromB = null;
+	try {
+		await import("./b.js");
+	} catch (err) {
+		errorFromB = err;
+	}
+	expect(errorFromB).toBeInstanceOf(Error);
+	expect(errorFromB.message).toBe("async error in B");
+
+	// Deferring an async module still gathers its async dependencies, so both
+	// the import and the namespace access can carry the component's error.
+	let errorFromDeferred = null;
+	try {
+		const { readC } = await import("./deferred.js");
+		readC();
+	} catch (err) {
+		errorFromDeferred = err;
+	}
+	expect(errorFromDeferred).toBe(errorFromB);
+});

--- a/test/configCases/async-module/errored-cycle-deferred-member/webpack.config.js
+++ b/test/configCases/async-module/errored-cycle-deferred-member/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	target: "node",
+	output: {
+		strictModuleErrorHandling: true
+	},
+	experiments: {
+		topLevelAwait: true,
+		deferImport: true
+	}
+};

--- a/test/configCases/async-module/errored-cycle-member/a.js
+++ b/test/configCases/async-module/errored-cycle-member/a.js
@@ -1,0 +1,3 @@
+import "./b.js";
+await Promise.resolve(0);
+export const a = "a";

--- a/test/configCases/async-module/errored-cycle-member/b.js
+++ b/test/configCases/async-module/errored-cycle-member/b.js
@@ -1,0 +1,3 @@
+import "./c.js";
+await Promise.resolve(0);
+throw new Error("async error in B");

--- a/test/configCases/async-module/errored-cycle-member/c.js
+++ b/test/configCases/async-module/errored-cycle-member/c.js
@@ -1,0 +1,3 @@
+import "./a.js";
+await Promise.resolve(0);
+export const c = "c";

--- a/test/configCases/async-module/errored-cycle-member/index.js
+++ b/test/configCases/async-module/errored-cycle-member/index.js
@@ -1,0 +1,20 @@
+it("should reject a fulfilled cycle member with the cycle's evaluation error", async () => {
+	// One `[[EvaluationError]]` is recorded for the whole strongly-connected
+	// component, so C reports B's error even though C's own body completed.
+	let errorFromB = null;
+	try {
+		await import("./b.js");
+	} catch (err) {
+		errorFromB = err;
+	}
+	expect(errorFromB).toBeInstanceOf(Error);
+	expect(errorFromB.message).toBe("async error in B");
+
+	let errorFromC = null;
+	try {
+		await import("./c.js");
+	} catch (err) {
+		errorFromC = err;
+	}
+	expect(errorFromC).toBe(errorFromB);
+});

--- a/test/configCases/async-module/errored-cycle-member/webpack.config.js
+++ b/test/configCases/async-module/errored-cycle-member/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	target: "node",
+	output: {
+		strictModuleErrorHandling: true
+	},
+	experiments: {
+		topLevelAwait: true
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -1007,10 +1007,6 @@ const knownBugs = [
 	// `.then` is expected not to be called on the deferred namespace's promise.
 	"expressions/dynamic-import/import-defer/import-defer-transitive-async-module/promise-prototype-then-not-called.js",
 
-	// Dynamic import of a fulfilled member of an errored TLA cycle must reject
-	// with the cycle root's evaluation error; webpack fulfills it instead.
-	"expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js",
-
 	// Same root cause as the postfix variants above: getter on a global `this`
 	// property must run before the increment writes back, but webpack scopes
 	// bare `x` to its module wrapper rather than the realm global.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A strongly-connected component of async modules records one `[[EvaluationError]]` for all of its members, so a member that already fulfilled before a peer threw must still report that error to a later import. webpack settled each async module on its own, so importing the fulfilled member resolved with a half-evaluated namespace instead of rejecting.

Async modules in a cycle now emit a group key (the component's smallest async member id) and the runtime marks the group's members on rejection. Both the key and the marker are emitted only under `output.strictModuleErrorHandling`, which is what makes a recorded error observable to a later require. This un-skips `expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js` in the test262 suite.

Measured on a 301-module build where every async module sits in a cycle: with the option off the output is byte-identical to `main` (306169 bytes both) and the new code path is never entered (0 calls, confirmed by counting); with the option on it costs +2126 bytes (+0.7%). Build CPU and retained heap were unchanged in both configurations — every delta fell well inside the run-to-run spread.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/async-module/errored-cycle-member/`, plus the test262 case un-skipped in `test/test262.spectest.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. A build without `output.strictModuleErrorHandling` emits identical output.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no new option; this only changes behaviour under the existing `output.strictModuleErrorHandling`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used to root-cause the divergence from the spec's per-component `[[EvaluationError]]`, draft the fix and the test case, and run the size/CPU/memory measurements quoted above. Every claim here was verified by running the tests and the measurements rather than taken from the model's output.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q5wyknx4aqgnfnZeytnhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async module cycle error handling so fulfilled or deferred members of an errored cycle now reject with the cycle’s evaluation error.
  * Ensured the same error is consistently propagated across all modules in an async dependency cycle.
  * Improved error reporting for cyclic dependencies when strict module error handling is enabled.
* **Tests**
  * Added coverage for errored async cycles, including deferred members.
  * Enabled a previously skipped standards-compliance test for this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->