### PR TITLE
fix(analyzable): read a baked depth per asset where a hot update runs it elsewhere

### DIFF
--- a/.changeset/006-analyzable-repair.md
+++ b/.changeset/006-analyzable-repair.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Repair hashed names and keep baked url maps under HMR in ESM output.
+Repair hashed names, keep url maps under HMR and read depths per hot update.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -483,6 +483,8 @@ class RuntimeTemplate {
 		this._placementByChunk = new WeakMap();
 		/** @type {WeakMap<Chunk, string>} */
 		this._hotUpdateUndoByChunk = new WeakMap();
+		/** @type {string | undefined} */
+		this._hotUpdateShapeText = undefined;
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
 		/** @type {WasmGroups | undefined} */
@@ -3252,17 +3254,18 @@ class RuntimeTemplate {
 		/** @type {boolean | null} */
 		let loaded = null;
 		for (const chunk of chunks) {
-			let own = this._chunkPlacement(chunk);
-			if (hot && own.undo !== null && own.undo !== this._hotUpdateUndo(chunk)) {
-				own = { undo: null, loaded: own.loaded };
-			}
+			const own = this._chunkPlacement(chunk);
+			const ownUndo =
+				hot && own.undo !== null && own.undo !== this._hotUpdateUndo(chunk)
+					? null
+					: own.undo;
 			if (first === undefined) {
 				first = own;
-				undo = own.undo;
+				undo = ownUndo;
 				loaded = own.loaded;
 				continue;
 			}
-			if (undo !== own.undo) undo = null;
+			if (undo !== ownUndo) undo = null;
 			if (loaded !== own.loaded) loaded = null;
 		}
 		if (first === undefined) return NO_PLACEMENT;
@@ -3777,14 +3780,14 @@ class RuntimeTemplate {
 		const cached = this._hotUpdateUndoByChunk.get(chunk);
 		if (cached !== undefined) return cached;
 		const { outputOptions } = this;
+		if (this._hotUpdateShapeText === undefined) {
+			this._hotUpdateShapeText = outputOptions.hotUpdateChunkFilename.replace(
+				HASH_IN_FILENAME_GLOBAL,
+				"x"
+			);
+		}
 		const undo = getUndoPath(
-			this.compilation.getPath(
-				outputOptions.hotUpdateChunkFilename.replace(
-					HASH_IN_FILENAME_GLOBAL,
-					"x"
-				),
-				{ chunk }
-			),
+			this.compilation.getPath(this._hotUpdateShapeText, { chunk }),
 			/** @type {string} */ (outputOptions.path),
 			true
 		);

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -95,9 +95,8 @@ const getConcatenatedModule = memoize(() =>
 const getNormalModule = memoize(() => require("./NormalModule"));
 
 /**
- * Whether a hot update can re-run the module a reference is emitted into:
- * `HotModuleReplacementPlugin` marks every normal module, and a concatenated one is
- * read through its root.
+ * Whether a hot update can re-run the module a reference is emitted into: the HMR
+ * plugin marks every normal module, and a concatenated one is read through its root.
  * @param {Module | undefined} module the module a reference is emitted into
  * @returns {boolean} true under HMR
  */
@@ -3240,8 +3239,7 @@ class RuntimeTemplate {
 
 	/**
 	 * The one answer every chunk in `chunks` agrees on, with either half `null` where
-	 * they do not. A hot update re-runs a module from the update chunk as well, so under
-	 * HMR a depth that chunk does not share is `null` too, and read per asset.
+	 * they do not — under HMR the update chunk, which re-runs the module, has a say too.
 	 * @param {Iterable<Chunk>} chunks the chunks a literal is written into
 	 * @param {boolean=} hot whether a hot update can re-run what is written
 	 * @returns {Placement} where a literal in them is read from
@@ -3404,9 +3402,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The template this chunk's asset of `sourceType` is named by, as far as code
-	 * generation can resolve it: `undefined` where a function reads a hash, `null`
-	 * where nothing here names that type or the function answers nothing.
+	 * The template this chunk's asset of `sourceType` is named by: `undefined` where a
+	 * function reads a hash, `null` where nothing here names that type or it answers nothing.
 	 * @param {Chunk} chunk the chunk
 	 * @param {string} sourceType which asset of the chunk
 	 * @returns {string | undefined | null} the template
@@ -3745,9 +3742,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a url a hot update re-ships is the same text on every build until an id
-	 * joins or leaves the map: spelled here, or a stand-in reading nothing but each
-	 * asset's own depth and a name no hash moves.
+	 * Whether a url a hot update re-ships stays the same text until an id joins or leaves
+	 * the map: spelled here, or a stand-in reading only each asset's depth and a hash-free name.
 	 * @param {string} specifier the specifier already quoted
 	 * @param {Chunk} chunk the chunk it names
 	 * @param {string} sourceType which asset of the chunk it names
@@ -3770,9 +3766,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * The `../` path from a chunk's hot update file back to the output root, which is
-	 * where a hot update runs the chunk's modules from. Its hashes are neutralized as a
-	 * chunk's are; the id is the chunk's own, and one with a slash in it adds depth.
+	 * The `../` path from a chunk's hot update file, which re-runs its modules, back to
+	 * the output root. Hashes are neutralized; the chunk's own id may add a directory.
 	 * @param {Chunk} chunk the chunk being updated
 	 * @returns {string} the path back to the output root
 	 */

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -92,6 +92,21 @@ const getTemplatedPathPlugin = memoize(() => require("./TemplatedPathPlugin"));
 const getConcatenatedModule = memoize(() =>
 	require("./optimize/ConcatenatedModule")
 );
+const getNormalModule = memoize(() => require("./NormalModule"));
+
+/**
+ * Whether a hot update can re-run the module a reference is emitted into:
+ * `HotModuleReplacementPlugin` marks every normal module, and a concatenated one is
+ * read through its root.
+ * @param {Module | undefined} module the module a reference is emitted into
+ * @returns {boolean} true under HMR
+ */
+const isHotModule = (module) => {
+	if (module === undefined) return false;
+	const normal =
+		module instanceof getConcatenatedModule() ? module.rootModule : module;
+	return normal instanceof getNormalModule() && normal.hot;
+};
 
 // Any `[hash]`/`[fullhash]`/`[chunkhash]`/`[contenthash]` token, incl. a `:<length>`
 // or `:<digest>[:<length>]` suffix (e.g. `[contenthash:base64:8]`). Its value is only
@@ -209,11 +224,9 @@ const SERVED_BAILOUT =
 	'this module is in a chunk webpack loads through output.publicPath and in one it does not, so no one path back to the output root fits both (a root-absolute or absolute output.publicPath, or "auto", is read the same from both)';
 
 // Why a runtime's url map kept the runtime form under HMR: an update re-ships the
-// runtime module only when its own code changes, and runs it from the update chunk.
+// runtime module only when its own code changes.
 const HOT_NAME_BAILOUT =
 	"a hot update can move this name without changing the runtime module that spells it, so the update would not carry the new one";
-const HOT_DEPTH_BAILOUT =
-	"a hot update runs the runtime module from output.hotUpdateChunkFilename, which sits at another depth than the runtime chunk";
 
 /**
  * @import {
@@ -262,6 +275,8 @@ const FULL_HASH_PART_KINDS = new Set(["publicPath", "template", "unserved"]);
 // What the deferred pass scans for — the other half of what the class spells.
 const ANALYZABLE_TOKEN_PREFIX = "./@@webpackAnalyzableChunk:";
 const ANALYZABLE_TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
+// The same token read back out of one quoted specifier.
+const ANALYZABLE_TOKEN_PAYLOAD = /@@webpackAnalyzableChunk:([\w-]+)@@/;
 
 // Stands in for the compilation hash inside an otherwise resolved filename, with the
 // requested length when the placeholder asked for one.
@@ -466,6 +481,8 @@ class RuntimeTemplate {
 		this._publicPathClimbText = undefined;
 		/** @type {WeakMap<Chunk, Placement>} */
 		this._placementByChunk = new WeakMap();
+		/** @type {WeakMap<Chunk, string>} */
+		this._hotUpdateUndoByChunk = new WeakMap();
 		/** @type {Map<string, string | null | undefined>} */
 		this._entryBaseUriByRuntime = new Map();
 		/** @type {WasmGroups | undefined} */
@@ -3199,7 +3216,10 @@ class RuntimeTemplate {
 	 * @returns {Placement} where a literal in it is read from
 	 */
 	_modulePlacement(module, chunkGraph) {
-		return this._placementOf(this._moduleChunks(module, chunkGraph));
+		return this._placementOf(
+			this._moduleChunks(module, chunkGraph),
+			isHotModule(module)
+		);
 	}
 
 	/**
@@ -3218,11 +3238,13 @@ class RuntimeTemplate {
 
 	/**
 	 * The one answer every chunk in `chunks` agrees on, with either half `null` where
-	 * they do not.
+	 * they do not. A hot update re-runs a module from the update chunk as well, so under
+	 * HMR a depth that chunk does not share is `null` too, and read per asset.
 	 * @param {Iterable<Chunk>} chunks the chunks a literal is written into
+	 * @param {boolean=} hot whether a hot update can re-run what is written
 	 * @returns {Placement} where a literal in them is read from
 	 */
-	_placementOf(chunks) {
+	_placementOf(chunks, hot = false) {
 		/** @type {Placement | undefined} */
 		let first;
 		/** @type {string | null} */
@@ -3230,7 +3252,10 @@ class RuntimeTemplate {
 		/** @type {boolean | null} */
 		let loaded = null;
 		for (const chunk of chunks) {
-			const own = this._chunkPlacement(chunk);
+			let own = this._chunkPlacement(chunk);
+			if (hot && own.undo !== null && own.undo !== this._hotUpdateUndo(chunk)) {
+				own = { undo: null, loaded: own.loaded };
+			}
 			if (first === undefined) {
 				first = own;
 				undo = own.undo;
@@ -3288,6 +3313,7 @@ class RuntimeTemplate {
 	 * they are known without a module to read them from
 	 * @param {string=} sourceType which half of the chunk is named — its javascript by
 	 * default, or its stylesheet
+	 * @param {boolean=} hot whether a hot update can re-run what is written
 	 * @returns {string | null} a JS string literal or expression, or `null` to fall back to the runtime form
 	 */
 	_getAnalyzableChunkSpecifier(
@@ -3296,18 +3322,15 @@ class RuntimeTemplate {
 		consumingModule,
 		chunkGraph,
 		consumingChunks,
-		sourceType = JAVASCRIPT_TYPE
+		sourceType = JAVASCRIPT_TYPE,
+		hot = isHotModule(consumingModule)
 	) {
 		const { compilation } = this;
 		const { outputOptions } = compilation;
 		const naming = CHUNK_ASSET_NAMING.get(sourceType);
 		// Nothing here names this type's asset, so nothing can spell where it will be.
 		if (naming === undefined) return null;
-		const template = this._resolveChunkFilenameTemplate(
-			naming.template(chunk, outputOptions),
-			chunk,
-			sourceType
-		);
+		const template = this._chunkAssetTemplate(chunk, sourceType);
 		if (template === null) return null;
 		// A hashed name is settled long after this code is generated, so a stand-in is
 		// emitted and filled in once the hash exists.
@@ -3361,7 +3384,7 @@ class RuntimeTemplate {
 		}
 		const { publicPath } = outputOptions;
 		if (publicPath === "auto") {
-			const { undo } = this._placementOf(chunks);
+			const { undo } = this._placementOf(chunks, hot);
 			if (undo !== null) return specifier([["literal", undo]]);
 			// Different depths — no one `../` path is right for every asset the reference
 			// lands in, so the deferred pass builds each asset's own.
@@ -3370,9 +3393,29 @@ class RuntimeTemplate {
 		const prefix = this._analyzablePathPrefix(
 			consumingModule,
 			chunkGraph,
-			chunks
+			chunks,
+			undefined,
+			hot
 		);
 		return prefix === null ? null : specifier(prefix);
+	}
+
+	/**
+	 * The template this chunk's asset of `sourceType` is named by, as far as code
+	 * generation can resolve it: `undefined` where a function reads a hash, `null`
+	 * where nothing here names that type or the function answers nothing.
+	 * @param {Chunk} chunk the chunk
+	 * @param {string} sourceType which asset of the chunk
+	 * @returns {string | undefined | null} the template
+	 */
+	_chunkAssetTemplate(chunk, sourceType) {
+		const naming = CHUNK_ASSET_NAMING.get(sourceType);
+		if (naming === undefined) return null;
+		return this._resolveChunkFilenameTemplate(
+			naming.template(chunk, this.outputOptions),
+			chunk,
+			sourceType
+		);
 	}
 
 	/**
@@ -3388,9 +3431,16 @@ class RuntimeTemplate {
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {Iterable<Chunk>} chunks the chunks a stand-in would be written into
 	 * @param {string=} relativeBase an entry `baseUri` read against the output root
+	 * @param {boolean=} hot whether a hot update can re-run what is written
 	 * @returns {SpecifierPart[] | null} the parts, or `null` having recorded why not
 	 */
-	_analyzablePathPrefix(module, chunkGraph, chunks, relativeBase) {
+	_analyzablePathPrefix(
+		module,
+		chunkGraph,
+		chunks,
+		relativeBase,
+		hot = isHotModule(module)
+	) {
 		const publicPath = /** @type {PublicPath} */ (
 			this.outputOptions.publicPath
 		);
@@ -3398,7 +3448,7 @@ class RuntimeTemplate {
 		if (shape === undefined) return null;
 		const resolve = () => this._resolvePublicPathPrefix(publicPath);
 		if (isBaseIndependent(shape)) return resolve();
-		const { undo, loaded } = this._placementOf(chunks);
+		const { undo, loaded } = this._placementOf(chunks, hot);
 		// What a chunk the loader fetched climbs back out of. One of no depth leaves
 		// nothing to climb, and then both answers put the same text in front.
 		const served = this._publicPathClimb();
@@ -3664,14 +3714,11 @@ class RuntimeTemplate {
 		if (!this.supportsAnalyzable("url-runtime", chunkGraph, consumingModule)) {
 			return null;
 		}
-		// A hot update re-ships the runtime module only when its own code changes, and
-		// runs it from the update chunk: each url has to be spelled in full, from there.
+		// A hot update re-ships the runtime module only when its own code changes, so
+		// each url has to be text nothing but an id joining or leaving the map can move.
 		const hot = runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadUpdateHandlers
 		);
-		if (hot && !this._hotUpdateKeepsDepth(consumingChunks)) {
-			return this._analyzableBailout(consumingModule, HOT_DEPTH_BAILOUT, null);
-		}
 		/** @type {Map<ChunkId, string>} */
 		const urls = new Map();
 		for (const chunk of chunks) {
@@ -3682,10 +3729,11 @@ class RuntimeTemplate {
 				consumingModule,
 				chunkGraph,
 				consumingChunks,
-				sourceType
+				sourceType,
+				hot
 			);
 			if (specifier === null) return null;
-			if (hot && RuntimeTemplate._isReservedSpecifier(specifier)) {
+			if (hot && !this._settledUnderHot(specifier, chunk, sourceType)) {
 				return this._analyzableBailout(consumingModule, HOT_NAME_BAILOUT, null);
 			}
 			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);
@@ -3694,33 +3742,54 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a literal depth written into these chunks is right from the hot update
-	 * chunk too, which is where a hot update runs a re-shipped runtime module. A depth
-	 * nothing settles here is spelled per asset by the fill, so it is right anywhere.
-	 * @param {Chunk[]} chunks the chunks a runtime's url map is written into
-	 * @returns {boolean} true when the update chunk sits at the same depth
+	 * Whether a url a hot update re-ships is the same text on every build until an id
+	 * joins or leaves the map: spelled here, or a stand-in reading nothing but each
+	 * asset's own depth and a name no hash moves.
+	 * @param {string} specifier the specifier already quoted
+	 * @param {Chunk} chunk the chunk it names
+	 * @param {string} sourceType which asset of the chunk it names
+	 * @returns {boolean} true when no update changes what the fill spells
 	 */
-	_hotUpdateKeepsDepth(chunks) {
-		const { outputOptions } = this;
-		for (const chunk of chunks) {
-			const { undo } = this._chunkPlacement(chunk);
-			if (undo === null) continue;
-			// Its hashes are neutralized as a chunk's are; the id is each chunk's own, and
-			// one with a slash in it puts the update a directory down.
-			const updateUndo = getUndoPath(
-				this.compilation.getPath(
-					outputOptions.hotUpdateChunkFilename.replace(
-						HASH_IN_FILENAME_GLOBAL,
-						"x"
-					),
-					{ chunk }
-				),
-				/** @type {string} */ (outputOptions.path),
-				true
-			);
-			if (undo !== updateUndo) return false;
+	_settledUnderHot(specifier, chunk, sourceType) {
+		const match = ANALYZABLE_TOKEN_PAYLOAD.exec(specifier);
+		if (match === null) return true;
+		const parts = RuntimeTemplate._readAnalyzableSpecifier(match[1]);
+		if (parts === null) return false;
+		for (const [kind, value] of parts) {
+			if (kind === "undo") continue;
+			if (kind === "literal" && !this._hasReservedFullHash(String(value))) {
+				continue;
+			}
+			if (!CHUNK_SPECIFIER_PART_KINDS.has(kind)) return false;
 		}
-		return true;
+		const template = this._chunkAssetTemplate(chunk, sourceType);
+		return typeof template === "string" && !HASH_IN_FILENAME.test(template);
+	}
+
+	/**
+	 * The `../` path from a chunk's hot update file back to the output root, which is
+	 * where a hot update runs the chunk's modules from. Its hashes are neutralized as a
+	 * chunk's are; the id is the chunk's own, and one with a slash in it adds depth.
+	 * @param {Chunk} chunk the chunk being updated
+	 * @returns {string} the path back to the output root
+	 */
+	_hotUpdateUndo(chunk) {
+		const cached = this._hotUpdateUndoByChunk.get(chunk);
+		if (cached !== undefined) return cached;
+		const { outputOptions } = this;
+		const undo = getUndoPath(
+			this.compilation.getPath(
+				outputOptions.hotUpdateChunkFilename.replace(
+					HASH_IN_FILENAME_GLOBAL,
+					"x"
+				),
+				{ chunk }
+			),
+			/** @type {string} */ (outputOptions.path),
+			true
+		);
+		this._hotUpdateUndoByChunk.set(chunk, undo);
+		return undo;
 	}
 
 	/**
@@ -3931,16 +4000,6 @@ class RuntimeTemplate {
 			.replace(/\+/g, "-")
 			.replace(/\//g, "_")
 			.replace(/[=]/g, "")}@@`;
-	}
-
-	/**
-	 * Whether a quoted specifier is a stand-in the deferred pass still has to spell,
-	 * rather than text settled at code generation.
-	 * @param {string} specifier a specifier already quoted
-	 * @returns {boolean} true when it carries a stand-in
-	 */
-	static _isReservedSpecifier(specifier) {
-		return specifier.includes(ANALYZABLE_TOKEN_PREFIX);
 	}
 
 	/**

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/index.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/index.js
@@ -1,0 +1,33 @@
+import update from "../../update.esm";
+import { load } from "./styles";
+
+import.meta.webpackHot.accept("./styles");
+
+const hasStylesheet = (name) =>
+	[...document.getElementsByTagName("link")].some(
+		(link) => link.rel === "stylesheet" && link.href.endsWith(`/${name}`)
+	);
+
+it("should bake the stylesheet urls and follow a new one after an update", (done) => {
+	load()
+		.then(() => {
+			expect(hasStylesheet("lazy_css.chunk.css")).toBe(true);
+			// The loader reads the baked map rather than building a url from the id.
+			const loader = __webpack_require__.f.css.toString();
+			expect(loader).toContain("cssUrls[chunkId]()");
+			expect(loader).not.toContain(".k(chunkId)");
+
+			NEXT(
+				update(done, true, () => {
+					import("./styles")
+						.then((updated) => updated.load())
+						.then(() => {
+							expect(hasStylesheet("lazy2_css.chunk.css")).toBe(true);
+							done();
+						})
+						.catch(done);
+				})
+			);
+		})
+		.catch(done);
+});

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/lazy.css
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/lazy.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/lazy2.css
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/lazy2.css
@@ -1,0 +1,3 @@
+body {
+	background: blue;
+}

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/styles.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/styles.js
@@ -1,0 +1,4 @@
+export const load = () => import("./lazy.css");
+---
+export const load = () =>
+	Promise.all([import("./lazy.css"), import("./lazy2.css")]);

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/test.config.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	env: "jsdom"
+};

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/test.filter.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// A node-only build registers its css without a loader, so there is no map to read.
+module.exports = (config) =>
+	config.target === "web" || Array.isArray(config.target);

--- a/test/hotCases/esm-output/analyzable-css-urls-depth/webpack.config.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-depth/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// The runtime sits in `js/` while its hot update lands at the output root: the map a
+// re-shipped runtime module holds is read from there, so its depth is spelled per asset.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true, css: true },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "js/[name].mjs",
+		chunkFilename: "[name].chunk.mjs",
+		cssChunkFilename: "[name].chunk.css",
+		publicPath: "auto"
+	}
+};

--- a/test/hotCases/esm-output/analyzable-import-depth/a.js
+++ b/test/hotCases/esm-output/analyzable-import-depth/a.js
@@ -1,0 +1,1 @@
+export const value = "a";

--- a/test/hotCases/esm-output/analyzable-import-depth/b.js
+++ b/test/hotCases/esm-output/analyzable-import-depth/b.js
@@ -1,0 +1,1 @@
+export const value = "b";

--- a/test/hotCases/esm-output/analyzable-import-depth/index.js
+++ b/test/hotCases/esm-output/analyzable-import-depth/index.js
@@ -1,0 +1,24 @@
+import update from "../../update.esm";
+import { load } from "./lazy";
+
+import.meta.webpackHot.accept("./lazy");
+
+it("should resolve a baked import from the hot update at another depth", (done) => {
+	load()
+		.then((value) => {
+			expect(value).toBe("a");
+
+			NEXT(
+				update(done, true, () => {
+					import("./lazy")
+						.then((updated) => updated.load())
+						.then((value) => {
+							expect(value).toBe("b");
+							done();
+						})
+						.catch(done);
+				})
+			);
+		})
+		.catch(done);
+});

--- a/test/hotCases/esm-output/analyzable-import-depth/lazy.js
+++ b/test/hotCases/esm-output/analyzable-import-depth/lazy.js
@@ -1,0 +1,3 @@
+export const load = () => import("./a").then((m) => m.value);
+---
+export const load = () => import("./b").then((m) => m.value);

--- a/test/hotCases/esm-output/analyzable-import-depth/webpack.config.js
+++ b/test/hotCases/esm-output/analyzable-import-depth/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// The entry sits in `js/` while its hot update lands at the output root: an updated
+// module's baked `import()` is read from there, so its depth is spelled per asset.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	optimization: { chunkIds: "named" },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "js/[name].mjs",
+		chunkFilename: "[name].mjs",
+		publicPath: "auto"
+	}
+};

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -80,11 +80,12 @@ const CASES = {
 		expect: "analyzable",
 		contains: "cssUrls = {"
 	},
+	// The runtime chunk sits in `js/` and its update at the root, so the map is written
+	// with each asset's own `../` depth rather than the runtime chunk's.
 	"hmr-css-depth": {
 		file: "js/main.mjs",
-		expect: "partial",
-		bailout: "output.hotUpdateChunkFilename",
-		lacks: "cssUrls = {"
+		expect: "analyzable",
+		contains: 'new URL("../lazy_css.css"'
 	},
 	// The chunk `import()` bakes, the url in the chunk served both ways does not.
 	"served-both-ways": {

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -153,8 +153,8 @@ module.exports = [
 		experiments: { css: true },
 		plugins: [new webpack.HotModuleReplacementPlugin()]
 	}),
-	// And where the update chunk sits at another depth than the runtime chunk, which is
-	// where a re-shipped runtime module runs from.
+	// Also analyzable where the update chunk sits at another depth than the runtime
+	// chunk: a re-shipped runtime module runs from there, so the depth is read per asset.
 	base("hmr-css-depth", {
 		entry: "./index-css",
 		experiments: { css: true },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A hot update re-runs a module from the update chunk, and `output.hotUpdateChunkFilename` defaults to the output root, so a baked `import()` / `new URL()` literal with a fixed `../` depth (a chunk in `js/`) resolved wrong from the first update. Under HMR (`module.hot`, set on every normal module) a depth the update chunk does not share is now left to the deferred fill, which spells each asset's own, so the chunk and its update both resolve; the same lets a runtime's stylesheet/prefetch url map bake at a differing depth instead of bailing. Follow-up to #21916. Cost is counted: nothing new runs without HMR; with it, one memoized depth probe per chunk and no per-reference allocation.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes: `test/hotCases/esm-output/analyzable-import-depth` and `analyzable-css-urls-depth` (both fail on `main`), plus the `hmr-css-depth` child of `test/statsCases/analyzable-esm-fallbacks` flipped to analyzable.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to investigate the hot-update depth issue, implement the fix, write the tests, and count the added calls; every change was reviewed and verified by the author with the repository's own test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hot Module Replacement handling for analyzable imports and asset URLs when module depths change.
  * Preserved correct hashed names and CSS URL mappings across hot updates.
  * Enabled baked asset references in additional ESM output scenarios instead of falling back to runtime URL construction.

* **Tests**
  * Added coverage for depth changes involving dynamic imports and CSS assets during HMR.
  * Updated expectations for baked CSS URL references in ESM output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->