### PR TITLE
fix(defer): await an async dependency that is evaluating-async

### DIFF
--- a/.changeset/014-defer-async-cycle-gather.md
+++ b/.changeset/014-defer-async-cycle-gather.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Await a deferred import's async dependency that is evaluating-async.

--- a/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
+++ b/lib/runtime/MakeDeferredNamespaceObjectRuntime.js
@@ -290,13 +290,13 @@ class MakeOptimizedDeferredNamespaceObjectRuntimeModule extends HelperRuntimeMod
 				]),
 				"};",
 				hasAsync
-					? // `GatherAsynchronousTransitiveDependencies` skips a module that is
-						// already evaluating, and evaluates the rest right here.
+					? // `evaluating` is on the stack, so awaiting it would deadlock;
+						// `evaluating-async` is suspended and must still be awaited.
 						`if(isAsync) obj[${RuntimeGlobals.deferredModuleAsyncTransitiveDependenciesSymbol}] = asyncDeps.filter(${runtimeTemplate.basicFunction(
 							"id",
 							[
 								`${cst} dep = __webpack_module_cache__[id];`,
-								"if (dep && (dep.evaluating || dep.evaluatingAsync)) return false;",
+								"if (dep && dep.evaluating) return false;",
 								"r(id);",
 								"return true;"
 							]

--- a/test/configCases/defer-import/harmony-import-mixed/entry.js
+++ b/test/configCases/defer-import/harmony-import-mixed/entry.js
@@ -1,0 +1,12 @@
+import { value as directValue } from "./shared.js"; // non-defer import
+import * as deferredShared from /* webpackDefer: true */ "./shared.js"; // defer import
+
+import { value as directValueAsync } from "./shared-async.js"; // non-defer import
+import * as deferredSharedAsync from /* webpackDefer: true */ "./shared-async.js"; // defer import
+
+export {
+	directValue,
+	deferredShared,
+	directValueAsync,
+	deferredSharedAsync
+};

--- a/test/configCases/defer-import/harmony-import-mixed/index.js
+++ b/test/configCases/defer-import/harmony-import-mixed/index.js
@@ -1,29 +1,26 @@
-import { value as directValue } from "./shared.js";  // non-defer import
-import * as deferredShared from /* webpackDefer: true */ "./shared.js";  // defer import
+// The imports live in `entry.js` so this module stays synchronous: an async
+// index registers its tests where the runner cannot await them.
+it("should handle mixed defer/non-defer targets correctly", async () => {
+	const { directValue, deferredShared } = await require("./entry.js");
 
-import { value as directValueAsync } from "./shared-async.js";  // non-defer import
-import * as deferredSharedAsync from /* webpackDefer: true */ "./shared-async.js"; // defer import
-
-it("should handle mixed defer/non-defer targets correctly", () => {
-	// Test direct non-defer access
 	expect(typeof directValue).toBe("string");
 	expect(directValue).toBe("shared-value");
-	
-	// Test deferred access
+
 	expect(typeof deferredShared).toBe("object");
 	expect(deferredShared).not.toBe(null);
 	expect(deferredShared.value).toBe("shared-value");
-	
+
 	// Both should access the same underlying value
 	expect(directValue).toBe(deferredShared.value);
 });
 
-it("should handle mixed defer/non-defer targets with async correctly", () => {
-	// Test direct non-defer access
+it("should handle mixed defer/non-defer targets with async correctly", async () => {
+	const { directValueAsync, deferredSharedAsync } =
+		await require("./entry.js");
+
 	expect(typeof directValueAsync).toBe("string");
 	expect(directValueAsync).toBe("shared-value-async");
 
-	// Test deferred access
 	expect(deferredSharedAsync).not.toBeInstanceOf(Promise);
 	((m) => {
 		expect(m.value).toBe("shared-value-async");

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -894,10 +894,7 @@ const knownBugs = [
 	// `#mark in obj` needs `isExtensible() === false` without evaluating, so the
 	// target must be sealed with every export name on it, and a mismatch loses one.
 	"import/import-defer/evaluation-triggers/ignore-private-name-access.js",
-	// A deferred module must wait for the whole strongly-connected component when a
-	// dependency's cycle root is still evaluating-async (`IsModuleSCCEvaluated`).
-	"import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js",
-	// It also wants `ownKeys` to be the sorted exports plus `@@toStringTag`, so
+	// It wants `ownKeys` to be the sorted exports plus `@@toStringTag`, so
 	// `__esModule` would have to go — the namespace trade-off, not a defer fix.
 	"import/import-defer/deferred-namespace-object/exotic-object-behavior.js",
 	// Improvement- bug with `delete` and `ns[0] = something` when using `import * as ns from "...";`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`GatherAsynchronousTransitiveDependencies` skips a module whose status is `evaluating` — it is on the stack, so awaiting it would deadlock — but not one that is `evaluating-async`, which is suspended and must still be awaited. The deferred-namespace runtime skipped both, so a deferred import could resolve before a suspended async dependency had finished. This un-skips `import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js` in the test262 suite.

`defer-import/harmony-import-mixed` is restructured alongside: awaiting the extra dependency delays the entry body by one microtask, and that case registered its `it()` blocks from an async `index.js`, so the runner had nothing to await. The imports move to an `entry.js` that `index.js` awaits inside each test, which registers them synchronously. The case still passes without the runtime change, so it is not weakened by the move.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — the test262 case above is un-skipped, and `test/configCases/defer-import/harmony-import-mixed/` covers the same path. Verified that the un-skipped case fails without the runtime change and passes with it.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. It only affects builds using `experiments.deferImport` with an async dependency, where the previous behaviour was to under-await.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no option or API change.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used to root-cause the divergence from `GatherAsynchronousTransitiveDependencies`, draft the fix, and diagnose why the mixed-import config case needed restructuring. Every claim was checked by running the tests, including confirming the un-skipped case fails without the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q5wyknx4aqgnfnZeytnhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred imports now correctly wait for asynchronous dependencies during evaluation, including dependencies involved in async cycles.
  * Improved behavior for modules that combine deferred and non-deferred imports.

* **Tests**
  * Added coverage for deferred imports involving asynchronous shared modules.
  * Removed a previously skipped test covering deferred modules waiting on async cycle dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->