### PR TITLE
test(benchmark): port the webpack/benchmark scenarios

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The only trigger that measures the `-on-schedule` cases; every other one
+  # filters them out as too expensive to run per pull request.
+  schedule:
+    - cron: "0 4 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -60,7 +64,7 @@ jobs:
           mode: "simulation"
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: on-schedule
+          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.
@@ -106,7 +110,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: on-schedule
+          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,6 +30,9 @@ jobs:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
+    # The harness has no deadline of its own and a watch bench waits on a
+    # rebuild callback; main's slowest shard is ~55m, so this only trips on a hang.
+    timeout-minutes: 120
     permissions:
       issues: write
       pull-requests: write
@@ -75,6 +78,9 @@ jobs:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
+    # The harness has no deadline of its own and a watch bench waits on a
+    # rebuild callback; main's slowest shard is ~55m, so this only trips on a hang.
+    timeout-minutes: 120
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ jobs:
           mode: "simulation"
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
+          NEGATIVE_FILTER: ${{ github.event_name != 'schedule' && 'on-schedule' || '' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.
@@ -110,7 +110,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
           LAST_COMMIT: 1
-          NEGATIVE_FILTER: ${{ github.event_name == 'schedule' && '' || 'on-schedule' }}
+          NEGATIVE_FILTER: ${{ github.event_name != 'schedule' && 'on-schedule' || '' }}
           SHARD: ${{ matrix.shard }}
           # Single libuv thread → deterministic fs-completion order, removing the
           # last I/O race that perturbs allocation counts between runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,7 +757,6 @@
 - Fix `RangeError: Maximum call stack size exceeded` thrown from `HarmonyImportSideEffectDependency.getModuleEvaluationSideEffectsState` on long linear chains of side-effect-free imports. `NormalModule.getSideEffectsConnectionState` previously descended through `HarmonyImportSideEffectDependency.getModuleEvaluationSideEffectsState` recursively, adding two stack frames per module, which overflowed V8's stack at a few thousand modules deep. The traversal is now iterative. (by [@alexander-akait](https://github.com/alexander-akait) in [#20993](https://github.com/webpack/webpack/pull/20993))
 
 - Fix `NormalModuleFactory` parser/generator types: (by [@alexander-akait](https://github.com/alexander-akait) in [#20999](https://github.com/webpack/webpack/pull/20999))
-
   - `module.generator.html` now uses `HtmlGeneratorOptions` instead of `EmptyGeneratorOptions` (the `extract` option was hidden from the `createGenerator` / `generator` hook types).
   - WebAssembly (`webassembly/async`, `webassembly/sync`) generator hooks now use `EmptyGeneratorOptions` instead of `EmptyParserOptions`.
   - `NormalModuleFactory#getParser` / `createParser` / `getGenerator` / `createGenerator` are now generic over the module-type string, returning the specific parser/generator class for known types (e.g. `JavascriptParser` for `"javascript/auto"`, `CssGenerator` for `"css"`, etc.) instead of always returning the base `Parser` / `Generator`.
@@ -900,7 +899,6 @@
 - Add `exportType: "style"` for CSS modules to inject styles into DOM via HTMLStyleElement, similar to style-loader functionality. (by [@xiaoxiaojx](https://github.com/xiaoxiaojx) in [#20579](https://github.com/webpack/webpack/pull/20579))
 
 - Add `context` option support for VirtualUrlPlugin (by [@xiaoxiaojx](https://github.com/xiaoxiaojx) in [#20449](https://github.com/webpack/webpack/pull/20449))
-
   - The context for the virtual module. A string path. Defaults to 'auto', which will try to resolve the context from the module id.
   - Support custom context path for resolving relative imports in virtual modules
   - Add examples demonstrating context usage and filename customization

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -294,9 +294,8 @@ class BenchmarkRunner {
 	 * @returns {Promise<string[]>} benchmark names
 	 */
 	async discoverBenchmarks() {
-		// Empty means unset: a workflow expression that resolves to "" would
-		// otherwise compile to `new RegExp("")`, which matches every case and so
-		// excludes all of them.
+		// Empty means unset: `new RegExp("")` matches every case, so an empty
+		// NEGATIVE_FILTER would exclude all of them.
 		const FILTER = process.env.FILTER
 			? new RegExp(process.env.FILTER)
 			: undefined;

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -294,15 +294,16 @@ class BenchmarkRunner {
 	 * @returns {Promise<string[]>} benchmark names
 	 */
 	async discoverBenchmarks() {
-		const FILTER =
-			typeof process.env.FILTER !== "undefined"
-				? new RegExp(process.env.FILTER)
-				: undefined;
+		// Empty means unset: a workflow expression that resolves to "" would
+		// otherwise compile to `new RegExp("")`, which matches every case and so
+		// excludes all of them.
+		const FILTER = process.env.FILTER
+			? new RegExp(process.env.FILTER)
+			: undefined;
 
-		const NEGATIVE_FILTER =
-			typeof process.env.NEGATIVE_FILTER !== "undefined"
-				? new RegExp(process.env.NEGATIVE_FILTER)
-				: undefined;
+		const NEGATIVE_FILTER = process.env.NEGATIVE_FILTER
+			? new RegExp(process.env.NEGATIVE_FILTER)
+			: undefined;
 
 		/** @type {string[]} */
 		const allBenchmarks = (await fs.readdir(this.casesPath))
@@ -463,12 +464,20 @@ class BenchmarkRunner {
 		const benchmarkResults = [];
 		/** @type {string[]} */
 		const failedTasks = [];
+		/** @type {unknown} */
+		let firstFailure;
 
 		for (const [index, settled] of settledResults.entries()) {
 			if (settled.status === "fulfilled") {
 				benchmarkResults.push(settled.value);
 			} else {
-				failedTasks.push(benchmarkTasks[index].id);
+				const { id } = benchmarkTasks[index];
+
+				failedTasks.push(id);
+				// The rejection is the only description of what broke; without it a
+				// failing case reports a task id and nothing else.
+				console.error(`Failed: ${id}`, settled.reason);
+				if (failedTasks.length === 1) firstFailure = settled.reason;
 			}
 		}
 
@@ -478,7 +487,8 @@ class BenchmarkRunner {
 
 		if (failedTasks.length > 0) {
 			throw new Error(
-				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(", ")}`
+				`${failedTasks.length} benchmark task(s) failed: ${failedTasks.join(", ")}`,
+				{ cause: firstFailure }
 			);
 		}
 	}

--- a/test/BenchmarkTestCases.benchmark.mjs
+++ b/test/BenchmarkTestCases.benchmark.mjs
@@ -406,12 +406,20 @@ class BenchmarkRunner {
 			);
 
 			try {
-				const options = await import(`${pathToFileURL(optionsPath)}`);
-				if (typeof options.setup !== "undefined") {
-					await options.setup();
+				await fs.stat(optionsPath);
+			} catch (err) {
+				// Only a missing options.mjs is optional; anything else would
+				// otherwise measure a fixture that never got built.
+				if (/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOENT") {
+					throw err;
 				}
-			} catch (_err) {
-				// Ignore — benchmark has no options.mjs
+				continue;
+			}
+
+			const options = await import(`${pathToFileURL(optionsPath)}`);
+
+			if (typeof options.setup !== "undefined") {
+				await options.setup();
 			}
 		}
 	}

--- a/test/benchmarkCases/cache-filesystem-cold/index.js
+++ b/test/benchmarkCases/cache-filesystem-cold/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/cache-filesystem-cold/options.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/options.mjs
@@ -13,12 +13,11 @@ export async function setup() {
 }
 
 /**
- * Drop the pack so each iteration builds from nothing and serializes a fresh
- * one — the store path `cache-filesystem` never reaches, since it restores.
+ * Drops the pack so each iteration measures the store path, not the restore one.
  * @param {import("../../..").Configuration} config built configuration
  * @returns {Promise<void>}
  */
-export async function beforeEach(config) {
+export async function beforeEachIteration(config) {
 	const { cache } = config;
 
 	if (

--- a/test/benchmarkCases/cache-filesystem-cold/options.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/options.mjs
@@ -1,0 +1,34 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}
+
+/**
+ * Drop the pack so each iteration builds from nothing and serializes a fresh
+ * one — the store path `cache-filesystem` never reaches, since it restores.
+ * @param {import("../../..").Configuration} config built configuration
+ * @returns {Promise<void>}
+ */
+export async function beforeEach(config) {
+	const { cache } = config;
+
+	if (
+		!cache ||
+		typeof cache === "boolean" ||
+		cache.type !== "filesystem" ||
+		!cache.cacheDirectory
+	) {
+		throw new Error("Expected a filesystem cache with a resolved directory");
+	}
+
+	await fs.rm(cache.cacheDirectory, { recursive: true, force: true });
+}

--- a/test/benchmarkCases/cache-filesystem-cold/webpack.config.mjs
+++ b/test/benchmarkCases/cache-filesystem-cold/webpack.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	cache: {
+		type: "filesystem",
+		// For benchmark stability
+		maxMemoryGenerations: 0,
+		idleTimeoutForInitialStore: 0
+	}
+};

--- a/test/benchmarkCases/common-libs/index.js
+++ b/test/benchmarkCases/common-libs/index.js
@@ -1,0 +1,8 @@
+import * as mod1 from "react";
+export { mod1 };
+import * as mod2 from "react-dom";
+export { mod2 };
+import * as mod3 from "lodash-es";
+export { mod3 };
+import * as mod4 from "date-fns";
+export { mod4 };

--- a/test/benchmarkCases/common-libs/webpack.config.mjs
+++ b/test/benchmarkCases/common-libs/webpack.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index"
+};

--- a/test/benchmarkCases/hmr/index.js
+++ b/test/benchmarkCases/hmr/index.js
@@ -1,0 +1,7 @@
+import * as mod from "./generated/module.js";
+
+export { mod };
+
+if (import.meta.webpackHot) {
+	import.meta.webpackHot.accept();
+}

--- a/test/benchmarkCases/hmr/options.mjs
+++ b/test/benchmarkCases/hmr/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/hmr/webpack.config.mjs
+++ b/test/benchmarkCases/hmr/webpack.config.mjs
@@ -1,0 +1,15 @@
+/** @import Webpack, { WebpackPluginInstance } from "../../.." */
+
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	target: "web"
+};
+
+/**
+ * @param {Webpack} webpack the baseline's webpack
+ * @returns {WebpackPluginInstance[]} plugins
+ */
+export function createPlugins(webpack) {
+	return [new webpack.HotModuleReplacementPlugin()];
+}

--- a/test/benchmarkCases/loader-babel/index.js
+++ b/test/benchmarkCases/loader-babel/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/loader-babel/options.mjs
+++ b/test/benchmarkCases/loader-babel/options.mjs
@@ -1,0 +1,67 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+// Small in simulation/walltime mode: every module pays a full babel parse,
+// transform and print, so the count buys build time quickly.
+const count = memoryScaledCount(30, 90);
+
+/**
+ * @param {number} i index
+ * @returns {string} generated component source
+ */
+function generateComponent(i) {
+	return `import h from "./h.js";
+
+export const title${i} = "component-${i}";
+
+export default function Component${i}({ items, title }) {
+	const rows = items.map((item, index) => (
+		<li className="row" data-index={index} key={item.id}>
+			<span className="label">{item.label}</span>
+			<em className="value">{item.value * ${i}}</em>
+		</li>
+	));
+
+	return (
+		<section className="component component-${i}">
+			<h2 className="heading">{title || title${i}}</h2>
+			<ul className="rows">{rows}</ul>
+			{items.length > 0 ? <footer className="count">{items.length}</footer> : null}
+		</section>
+	);
+}
+`;
+}
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await fs.mkdir(generated, { recursive: true });
+
+	// The JSX factory, so the transformed output resolves without pulling a
+	// runtime package into the measured graph.
+	await fs.writeFile(
+		resolve(generated, "h.js"),
+		`export default function h(type, props, ...children) {
+	return { type, props, children };
+}
+`
+	);
+
+	let code = "";
+
+	for (let i = 0; i < count; i++) {
+		await fs.writeFile(
+			resolve(generated, `component-${i}.jsx`),
+			generateComponent(i)
+		);
+
+		code += `import Component${i} from "./component-${i}.jsx";\nconsole.log(Component${i});\nexport { Component${i} };\n`;
+	}
+
+	await fs.writeFile(resolve(generated, "module.js"), code);
+}

--- a/test/benchmarkCases/loader-babel/webpack.config.mjs
+++ b/test/benchmarkCases/loader-babel/webpack.config.mjs
@@ -1,0 +1,22 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	module: {
+		rules: [
+			{
+				test: /\.jsx$/,
+				loader: "babel-loader",
+				options: {
+					// Hermetic: no repo or user babel config leaks into the numbers,
+					// and no cache turns later iterations into a different benchmark.
+					babelrc: false,
+					configFile: false,
+					cacheDirectory: false,
+					presets: [
+						["@babel/preset-react", { runtime: "classic", pragma: "h" }]
+					]
+				}
+			}
+		]
+	}
+};

--- a/test/benchmarkCases/module-unsafe-cache/index.js
+++ b/test/benchmarkCases/module-unsafe-cache/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/module-unsafe-cache/options.mjs
+++ b/test/benchmarkCases/module-unsafe-cache/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/module-unsafe-cache/webpack.config.mjs
+++ b/test/benchmarkCases/module-unsafe-cache/webpack.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	module: {
+		unsafeCache: true
+	}
+};

--- a/test/benchmarkCases/no-concatenation/index.js
+++ b/test/benchmarkCases/no-concatenation/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/no-concatenation/options.mjs
+++ b/test/benchmarkCases/no-concatenation/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/no-concatenation/webpack.config.mjs
+++ b/test/benchmarkCases/no-concatenation/webpack.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	optimization: {
+		concatenateModules: false
+	}
+};

--- a/test/benchmarkCases/no-exports-analysis/index.js
+++ b/test/benchmarkCases/no-exports-analysis/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/no-exports-analysis/options.mjs
+++ b/test/benchmarkCases/no-exports-analysis/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/no-exports-analysis/webpack.config.mjs
+++ b/test/benchmarkCases/no-exports-analysis/webpack.config.mjs
@@ -1,0 +1,11 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	optimization: {
+		providedExports: false,
+		usedExports: false,
+		sideEffects: false,
+		mangleExports: false,
+		innerGraph: false
+	}
+};

--- a/test/benchmarkCases/no-minimize/index.js
+++ b/test/benchmarkCases/no-minimize/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/no-minimize/options.mjs
+++ b/test/benchmarkCases/no-minimize/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/no-minimize/webpack.config.mjs
+++ b/test/benchmarkCases/no-minimize/webpack.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/benchmarkCases/resolve-unsafe-cache/index.js
+++ b/test/benchmarkCases/resolve-unsafe-cache/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/resolve-unsafe-cache/options.mjs
+++ b/test/benchmarkCases/resolve-unsafe-cache/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/resolve-unsafe-cache/webpack.config.mjs
+++ b/test/benchmarkCases/resolve-unsafe-cache/webpack.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	resolve: {
+		unsafeCache: true
+	}
+};

--- a/test/benchmarkCases/unsafe-cache/index.js
+++ b/test/benchmarkCases/unsafe-cache/index.js
@@ -1,0 +1,3 @@
+import * as mod from "./generated/module.js";
+
+export { mod };

--- a/test/benchmarkCases/unsafe-cache/options.mjs
+++ b/test/benchmarkCases/unsafe-cache/options.mjs
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(75, 200));
+}

--- a/test/benchmarkCases/unsafe-cache/webpack.config.mjs
+++ b/test/benchmarkCases/unsafe-cache/webpack.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index",
+	module: {
+		unsafeCache: true
+	},
+	resolve: {
+		unsafeCache: true
+	}
+};

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -59,6 +59,12 @@ import { Bench, hrtimeNow } from "tinybench";
 /** @typedef {{ run: (seed: number) => unknown }} RuntimeBundleExports */
 /** @typedef {{ taskName: string, collectBy: string }} TaskNames */
 
+/**
+ * @typedef {object} CaseOptions
+ * @property {(() => Promise<void>)=} setup one-time fixture generation, run once by the orchestrator
+ * @property {((config: Configuration) => Promise<void> | void)=} beforeEach reset run before every iteration, outside the measured region
+ */
+
 const GENERATE_PROFILE = typeof process.env.PROFILE !== "undefined";
 const codspeedRunnerMode = getCodspeedRunnerMode();
 
@@ -827,9 +833,17 @@ function buildConfiguration(test, baseline, realConfig, scenario, testDirectory)
  * @param {string} params.collectBy collect-by key
  * @param {Webpack} params.webpack webpack
  * @param {Configuration} params.config config
+ * @param {((config: Configuration) => Promise<void> | void)=} params.beforeEachIteration per-iteration reset
  * @returns {void}
  */
-function addBuildBench({ bench, taskName, collectBy, webpack, config }) {
+function addBuildBench({
+	bench,
+	taskName,
+	collectBy,
+	webpack,
+	config,
+	beforeEachIteration
+}) {
 	bench.add(
 		taskName,
 		async () => {
@@ -838,7 +852,9 @@ function addBuildBench({ bench, taskName, collectBy, webpack, config }) {
 				: runWebpack(webpack, config));
 		},
 		{
-			beforeEach(mode) {
+			async beforeEach(mode) {
+				// Before the timer: the reset is setup, not part of the build.
+				if (beforeEachIteration) await beforeEachIteration(config);
 				console.time(`Time (${mode} mode): ${taskName}`);
 			},
 			afterEach(mode) {
@@ -1246,6 +1262,24 @@ function attachResultCollector(bench, results) {
 }
 
 /**
+ * @param {string} testDirectory benchmark case directory
+ * @returns {Promise<CaseOptions | undefined>} case options, or undefined when the case has none
+ */
+async function importCaseOptions(testDirectory) {
+	const optionsPath = path.resolve(testDirectory, "options.mjs");
+
+	try {
+		await fs.stat(optionsPath);
+	} catch (_err) {
+		return undefined;
+	}
+
+	// Imported outside the existence check so a broken `options.mjs` throws
+	// instead of reading as a case that has none.
+	return import(`${pathToFileURL(optionsPath)}`);
+}
+
+/**
  * Register one benchmark task's benches onto `bench`. `-unit` benchmarks
  * register their own tasks against the current lib, `-runtime` benchmarks
  * measure the compiled output; others add one build/watch bench per baseline.
@@ -1274,11 +1308,23 @@ async function registerBenchmark(bench, task, casesPath) {
 		throw new Error(`Missing scenario for benchmark "${benchmark}"`);
 	}
 
-	const realConfig = (
-		await import(
-			`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
-		)
-	).default;
+	const configModule = await import(
+		`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
+	);
+	const realConfig = configModule.default;
+	// `buildConfiguration` structuredClones the config, which strips a plugin's
+	// prototype (and with it `apply`) without erroring. A case declares plugins
+	// through this factory instead, so each baseline instantiates them from the
+	// webpack copy it is measuring.
+	const { createPlugins } = configModule;
+
+	if (realConfig.plugins && realConfig.plugins.length > 0) {
+		throw new Error(
+			`Benchmark "${benchmark}" declares \`plugins\` in its configuration, which cloning would silently empty. Export \`createPlugins(webpack)\` from its webpack.config.mjs instead.`
+		);
+	}
+
+	const caseOptions = await importCaseOptions(testDirectory);
 
 	// Register HEAD then BASE sequentially so task order in `bench.tasks` is
 	// deterministic; parallel registration would leak Promise-resolution order
@@ -1297,6 +1343,10 @@ async function registerBenchmark(bench, task, casesPath) {
 			scenario,
 			testDirectory
 		);
+
+		if (createPlugins) {
+			config.plugins = createPlugins(webpack);
+		}
 
 		const stringifiedScenario = JSON.stringify(scenario);
 
@@ -1324,7 +1374,12 @@ async function registerBenchmark(bench, task, casesPath) {
 
 		const params = { bench, ...createNames(""), webpack, config };
 
-		await (scenario.watch ? addWatchBench(params) : addBuildBench(params));
+		await (scenario.watch
+			? addWatchBench(params)
+			: addBuildBench({
+					...params,
+					beforeEachIteration: caseOptions?.beforeEach
+				}));
 	}
 }
 

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -1270,7 +1270,11 @@ async function importCaseOptions(testDirectory) {
 
 	try {
 		await fs.stat(optionsPath);
-	} catch (_err) {
+	} catch (err) {
+		// Only a missing options.mjs is optional; a permission error is real.
+		if (/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOENT") {
+			throw err;
+		}
 		return undefined;
 	}
 

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -62,7 +62,7 @@ import { Bench, hrtimeNow } from "tinybench";
 /**
  * @typedef {object} CaseOptions
  * @property {(() => Promise<void>)=} setup one-time fixture generation, run once by the orchestrator
- * @property {((config: Configuration) => Promise<void> | void)=} beforeEach reset run before every iteration, outside the measured region
+ * @property {((config: Configuration) => Promise<void> | void)=} beforeEachIteration reset run before every iteration, outside the measured region
  */
 
 const GENERATE_PROFILE = typeof process.env.PROFILE !== "undefined";
@@ -1312,10 +1312,8 @@ async function registerBenchmark(bench, task, casesPath) {
 		`${pathToFileURL(path.join(testDirectory, "webpack.config.mjs"))}`
 	);
 	const realConfig = configModule.default;
-	// `buildConfiguration` structuredClones the config, which strips a plugin's
-	// prototype (and with it `apply`) without erroring. A case declares plugins
-	// through this factory instead, so each baseline instantiates them from the
-	// webpack copy it is measuring.
+	// Cloning the config strips a plugin's prototype, and with it `apply`, so a
+	// case declares plugins here instead — bound to the baseline being measured.
 	const { createPlugins } = configModule;
 
 	if (realConfig.plugins && realConfig.plugins.length > 0) {
@@ -1378,7 +1376,7 @@ async function registerBenchmark(bench, task, casesPath) {
 			? addWatchBench(params)
 			: addBuildBench({
 					...params,
-					beforeEachIteration: caseOptions?.beforeEach
+					beforeEachIteration: caseOptions?.beforeEachIteration
 				}));
 	}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

[webpack/benchmark](https://github.com/webpack/benchmark) is deprecated (webpack/benchmark#13), so what it measured has to live here. This supersedes #21858 and #21864, unioning them into one change: ten new cases under `test/benchmarkCases/`, plus the harness and workflow fixes three of them needed.

Of the 21 addon scenarios that repository carried, this repository already covered eight. The ten added here:

- **Loader pipeline, cold cache, HMR** — `loader-babel` (babel-loader over generated JSX, so the loader-runner and the source round trip are measured), `cache-filesystem-cold` (drops the pack each iteration, measuring the store path beside `cache-filesystem`'s restore) and `hmr` (`HotModuleReplacementPlugin`, which the rebuild scenario turns into an update round trip).
- **Optimizations off, so their cost becomes measurable** — `no-minimize`, `no-concatenation`, `no-exports-analysis` (following the original addon in also dropping `sideEffects`, `mangleExports` and `innerGraph`).
- **Caching widened past the node_modules-only default** — `module-unsafe-cache`, `resolve-unsafe-cache`, `unsafe-cache`.
- **`common-libs`**, replacing the fixture of that name, which pinned Material-UI 4, Vue 2, moment and jQuery as of 2021. It builds a graph from `react`, `react-dom`, `lodash-es` and `date-fns` at the versions already in `devDependencies`.

Two harness gaps blocked the first group. A config's `plugins` never survived `structuredClone` — it strips the prototype and with it `apply` — so a case now declares them via `createPlugins(webpack)`, bound to the baseline being measured, and declaring them directly throws instead of silently building without them. A case's `options.mjs` may export `beforeEachIteration`, run before every iteration and outside the measured region, which is what lets the cold case reset its pack.

Also here: `-on-schedule` cases ran nowhere, since `benchmarks.yml` filtered them out and had no `schedule` to run them on, so `typescript-long-on-schedule` was measured by no trigger at all. It gets a weekly one — say if a different cadence is wanted. Neither benchmark job set `timeout-minutes`, so both inherited the 6-hour default while the harness has no deadline of its own; they are now bounded at 120 minutes against a ~55-minute slowest shard on `main`. A failed task also reports the rejection it failed with rather than only its id.

**Deliberately not ported**, so the gap is on the record rather than silent:

| Scenario | Why |
| --- | --- |
| `swc-env`, `swc-env-minimize`, `swc-minimize` | `minimizer-webpack-plugin` already ships `swcMinify`, so no extra plugin is needed — but adding `@swc/core` to `devDependencies` makes `test/cases/large/big-assets` fail: it bundles that plugin, so webpack follows into swc's native binding and reports the platform binary as an unparseable module plus an unresolvable `@swc/wasm`. Those errors differ per runner OS, so no single snapshot matches across the ubuntu/macOS/Windows matrix. Verified against a clean baseline: the case passes with `@swc/core` absent and fails with it present. |
| babel `preset-env` | needs `@babel/preset-env`; `loader-babel` uses `preset-react` |
| `pnp` | needs a Yarn PnP install layout the harness cannot produce |
| `no-cache` | inexpressible here — the watch scenario overrides `cache`, and every iteration builds a fresh compiler, so a memory cache never carries over between them |

The `cases/` fixtures are not ported either: `rome` is an archived project whose case no longer builds, and `atlaskit-editor` pins React 16 with `@atlaskit/editor-core` 120.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

The change is tests: ten cases under `test/benchmarkCases/`, plus `test/BenchmarkTestCases.benchmark.mjs` and `test/harness/benchmark/benchmark.worker.mjs`. All ten were run locally across the three scenarios and pass, and the numbers separate rather than collapsing together — production is 121 ms for `no-minimize` against ~850 ms for the others, and the three cache variants land at 854 / 714 / 579 ms. The HMR runtime was verified present in the `hmr` bundle and absent in a control case, and the per-iteration hook verified to fire on every iteration and find a pack to drop on all but the first.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — test-only, so no changeset.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to audit webpack/benchmark's addons against this repository's cases, write the ones that were missing, run them locally, and measure the `@swc/core` fallout recorded above. All output was reviewed before committing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFVaJ3E5Xf3udz53yMbyNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFVaJ3E5Xf3udz53yMbyNm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmark scenarios covering filesystem caching, hot module replacement, loaders, module resolution, optimization settings, and common libraries.
  - Benchmarks can now perform setup actions before each measured iteration.

- **Bug Fixes**
  - Improved benchmark filtering when filters are empty.
  - Benchmark failures now include clearer rejection details and preserve the first failure cause.

- **Changelog**
  - Documented parser and generator type fixes and the new `context` option for `VirtualUrlPlugin`.

- **Chores**
  - Benchmarks now run weekly with extended time limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->