### PR TITLE
fix(rules): read a grouped extension alternative as targeting that extension

### DIFF
--- a/.changeset/015-rule-extension-probe-alternatives.md
+++ b/.changeset/015-rule-extension-probe-alternatives.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Read a rule's grouped extension alternatives when matching a resource.
+Read grouped and case-insensitive extension tests when matching a resource.

--- a/.changeset/015-rule-extension-probe-alternatives.md
+++ b/.changeset/015-rule-extension-probe-alternatives.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Read a rule's grouped extension alternatives when deciding if a resource is handled.

--- a/.changeset/015-rule-extension-probe-alternatives.md
+++ b/.changeset/015-rule-extension-probe-alternatives.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Read a rule's grouped extension alternatives when deciding if a resource is handled.
+Read a rule's grouped extension alternatives when matching a resource.

--- a/.changeset/015-rule-extension-probe-alternatives.md
+++ b/.changeset/015-rule-extension-probe-alternatives.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Read grouped and case-insensitive extension tests when matching a resource.
+Match a rule's extension test exactly, including groups and the `i` flag.

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -669,7 +669,15 @@ const EXTENSION_GROUP_REGEXP = /\\\.\((?:\?:)?([^()]*)\)/g;
 const sourceReferencesExtension = (source, extProbe, ignoreCase) => {
 	const target = ignoreCase ? source.toLowerCase() : source;
 	const probe = ignoreCase ? extProbe.toLowerCase() : extProbe;
-	if (target.includes(probe)) return true;
+	let index = target.indexOf(probe);
+	while (index !== -1) {
+		const end = index + probe.length;
+		// `\.tsx` does not target `.ts`, unlike the optional `x` in `\.tsx?`
+		if (!/\w/.test(target.charAt(end)) || target.charAt(end + 1) === "?") {
+			return true;
+		}
+		index = target.indexOf(probe, end);
+	}
 	// `\.css` → `css`
 	const extensionName = probe.slice(2);
 	// `RegExp.exec` loop rather than `String.matchAll` (Node.js 12+) so this

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -656,6 +656,8 @@ const globReferencesExtension = (glob, extension) => {
 	);
 };
 
+const EXTENSION_GROUP_REGEXP = /\\\.\((?:\?:)?([^()]*)\)/g;
+
 /**
  * Whether a regexp source targets the extension, either spelled out or as one
  * alternative of a group (e.g. `\.(css|scss)` or `\.(?:ts|tsx)`).
@@ -666,9 +668,15 @@ const globReferencesExtension = (glob, extension) => {
 const sourceReferencesExtension = (source, extProbe) => {
 	if (source.includes(extProbe)) return true;
 	// `\.css` → `css`
-	const extension = extProbe.slice(2);
-	for (const [, alternatives] of source.matchAll(/\\\.\((?:\?:)?([^()]*)\)/g)) {
-		if (alternatives.split("|").includes(extension)) return true;
+	const extensionName = extProbe.slice(2);
+	// `RegExp.exec` loop rather than `String.matchAll` (Node.js 12+) so this
+	// stays compatible with the supported Node.js 10 range.
+	EXTENSION_GROUP_REGEXP.lastIndex = 0;
+	/** @type {RegExpExecArray | null} */
+	let match;
+	while ((match = EXTENSION_GROUP_REGEXP.exec(source)) !== null) {
+		const alternatives = /** @type {string} */ (match[1]);
+		if (alternatives.split("|").includes(extensionName)) return true;
 	}
 	return false;
 };

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -663,18 +663,21 @@ const EXTENSION_GROUP_REGEXP = /\\\.\((?:\?:)?([^()]*)\)/g;
  * alternative of a group (e.g. `\.(css|scss)` or `\.(?:ts|tsx)`).
  * @param {string} source regexp source
  * @param {string} extProbe escaped extension probe (e.g. `"\\.css"`)
+ * @param {boolean} ignoreCase whether the regexp carries the `i` flag
  * @returns {boolean} whether the source targets the extension
  */
-const sourceReferencesExtension = (source, extProbe) => {
-	if (source.includes(extProbe)) return true;
+const sourceReferencesExtension = (source, extProbe, ignoreCase) => {
+	const target = ignoreCase ? source.toLowerCase() : source;
+	const probe = ignoreCase ? extProbe.toLowerCase() : extProbe;
+	if (target.includes(probe)) return true;
 	// `\.css` → `css`
-	const extensionName = extProbe.slice(2);
+	const extensionName = probe.slice(2);
 	// `RegExp.exec` loop rather than `String.matchAll` (Node.js 12+) so this
 	// stays compatible with the supported Node.js 10 range.
 	EXTENSION_GROUP_REGEXP.lastIndex = 0;
 	/** @type {RegExpExecArray | null} */
 	let match;
-	while ((match = EXTENSION_GROUP_REGEXP.exec(source)) !== null) {
+	while ((match = EXTENSION_GROUP_REGEXP.exec(target)) !== null) {
 		const alternatives = /** @type {string} */ (match[1]);
 		if (alternatives.split("|").includes(extensionName)) return true;
 	}
@@ -691,7 +694,11 @@ const sourceReferencesExtension = (source, extProbe) => {
  */
 const conditionReferencesExtension = (condition, extProbe) => {
 	if (condition instanceof RegExp) {
-		return sourceReferencesExtension(condition.source, extProbe);
+		return sourceReferencesExtension(
+			condition.source,
+			extProbe,
+			condition.ignoreCase
+		);
 	}
 	if (Array.isArray(condition)) {
 		return condition.some((c) => conditionReferencesExtension(c, extProbe));

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -657,6 +657,23 @@ const globReferencesExtension = (glob, extension) => {
 };
 
 /**
+ * Whether a regexp source targets the extension, either spelled out or as one
+ * alternative of a group (e.g. `\.(css|scss)` or `\.(?:ts|tsx)`).
+ * @param {string} source regexp source
+ * @param {string} extProbe escaped extension probe (e.g. `"\\.css"`)
+ * @returns {boolean} whether the source targets the extension
+ */
+const sourceReferencesExtension = (source, extProbe) => {
+	if (source.includes(extProbe)) return true;
+	// `\.css` → `css`
+	const extension = extProbe.slice(2);
+	for (const [, alternatives] of source.matchAll(/\\\.\((?:\?:)?([^()]*)\)/g)) {
+		if (alternatives.split("|").includes(extension)) return true;
+	}
+	return false;
+};
+
+/**
  * Whether any regexp or glob in the condition references the extension probe
  * (e.g. `\.css`), i.e. the rule clearly targets that extension even if the
  * generic sample path doesn't match its (possibly filename-scoped) pattern.
@@ -665,7 +682,9 @@ const globReferencesExtension = (glob, extension) => {
  * @returns {boolean} whether a regexp in the condition targets the extension
  */
 const conditionReferencesExtension = (condition, extProbe) => {
-	if (condition instanceof RegExp) return condition.source.includes(extProbe);
+	if (condition instanceof RegExp) {
+		return sourceReferencesExtension(condition.source, extProbe);
+	}
 	if (Array.isArray(condition)) {
 		return condition.some((c) => conditionReferencesExtension(c, extProbe));
 	}

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -76,6 +76,18 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		).toBe(true);
 	});
 
+	it("reads the extension probe case-insensitively behind an `i` flag", () => {
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(CSS|SCSS)$/i, use: ["css-loader"] }])
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.CSS$/i, loader: "css-loader" }])
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(CSS|SCSS)$/, use: ["css-loader"] }])
+		).toBe(false);
+	});
+
 	it("detects a filename-scoped glob via the extension probe", () => {
 		expect(has([{ test: { glob: "**/*.module.css" }, use: ["x"] }])).toBe(true);
 		expect(

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -76,6 +76,22 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		).toBe(true);
 	});
 
+	it("does not read a longer extension as the probed one", () => {
+		expect(has([{ test: /\.tsx$/, loader: "ts-loader" }], "/file.ts")).toBe(
+			false
+		);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.tsx$/, loader: "ts-loader" }], "/file.ts")
+		).toBe(false);
+		expect(has([{ test: /\.html$/, use: ["x"] }], "/file.htm")).toBe(false);
+		expect(has([{ test: /\.tsx$/, loader: "ts-loader" }], "/file.tsx")).toBe(
+			true
+		);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.tsx?$/, loader: "ts-loader" }], "/file.ts")
+		).toBe(true);
+	});
+
 	it("reads the extension probe case-insensitively behind an `i` flag", () => {
 		expect(
 			has([{ test: /[\\/]src[\\/].*\.(CSS|SCSS)$/i, use: ["css-loader"] }])

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -63,6 +63,19 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		);
 	});
 
+	it("detects grouped extension alternatives via the extension probe", () => {
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(css|scss)$/, use: ["css-loader"] }])
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(?:scss|css)$/, use: ["css-loader"] }])
+		).toBe(true);
+		expect(has([{ test: /\.(scss|less)$/, use: ["sass-loader"] }])).toBe(false);
+		expect(
+			has([{ test: /\/src\/.*\.(ts|tsx)$/, loader: "ts-loader" }], "/file.ts")
+		).toBe(true);
+	});
+
 	it("detects a filename-scoped glob via the extension probe", () => {
 		expect(has([{ test: { glob: "**/*.module.css" }, use: ["x"] }])).toBe(true);
 		expect(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

A rule whose `test` puts the extension inside a group, such as `/[\\/]src[\\/].*\.(css|scss)$/`, was not counted as handling `.css`: the extension probe searched the regexp source for the literal `\.css`, which a grouped alternative never spells out. `experiments.css`, and the same for html and typescript, then stayed `"auto"`, so webpack's built-in handling ran next to the loaders the user had already configured. The probe now also reads the alternatives of a `\.(…)` group. Fixes #21943.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes, a new case in `test/RuleSetCompiler.unittest.js` covering `(css|scss)`, `(?:scss|css)` and `(ts|tsx)` groups, plus a group that targets other extensions only.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code traced the probe from `applyExperimentsDefaults` down to `conditionReferencesExtension` and drafted the fix and the test; I confirmed the test fails on `main`, passes with the change, and that lint is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource matching for regular expressions with grouped file-extension alternatives, including case-insensitive patterns.
  * Extension checks now require complete extension tokens, preventing rules for extensions such as `.tsx` from incorrectly matching `.ts` resources while preserving valid optional-extension patterns.

* **Tests**
  * Added coverage for grouped, case-insensitive, exact-extension, and positive/negative matching scenarios across CSS, SCSS, TypeScript, TSX, and HTML patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->