### PR TITLE
fix: apply cached `resolveOptions` from the factory instead of the pack

### DIFF
--- a/.changeset/015-cached-module-resolve-options.md
+++ b/.changeset/015-cached-module-resolve-options.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Refresh a cached module's `resolveOptions` from the factory instead of the persistent cache pack.

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -213,6 +213,7 @@ class ContextModule extends Module {
 	 * @returns {void}
 	 */
 	updateCacheModule(module) {
+		super.updateCacheModule(module);
 		const m = /** @type {ContextModule} */ (module);
 		this.resolveDependencies = m.resolveDependencies;
 		this.options = m.options;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1310,7 +1310,6 @@ class Module extends DependenciesBlock {
 		write(this.type);
 		write(this.layer);
 		write(this.context);
-		write(this.resolveOptions);
 		write(this.factoryMeta);
 		write(this.useSourceMap);
 		write(this.useSimpleSourceMap);
@@ -1340,7 +1339,6 @@ class Module extends DependenciesBlock {
 		this.type = read();
 		this.layer = read();
 		this.context = read();
-		this.resolveOptions = read();
 		this.factoryMeta = read();
 		this.useSourceMap = read();
 		this.useSimpleSourceMap = read();

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -2167,7 +2167,7 @@ class NormalModule extends Module {
 			parserOptions: /** @type {EXPECTED_ANY} */ (null),
 			generator: /** @type {EXPECTED_ANY} */ (null),
 			generatorOptions: /** @type {EXPECTED_ANY} */ (null),
-			resolveOptions: /** @type {EXPECTED_ANY} */ (null),
+			resolveOptions: undefined,
 			extractSourceMap: /** @type {EXPECTED_ANY} */ (null)
 		});
 		obj.deserialize(context);

--- a/lib/css/CssModule.js
+++ b/lib/css/CssModule.js
@@ -197,7 +197,7 @@ class CssModule extends NormalModule {
 			parserOptions: /** @type {EXPECTED_ANY} */ (null),
 			generator: /** @type {EXPECTED_ANY} */ (null),
 			generatorOptions: /** @type {EXPECTED_ANY} */ (null),
-			resolveOptions: /** @type {EXPECTED_ANY} */ (null),
+			resolveOptions: undefined,
 			cssLayer: /** @type {EXPECTED_ANY} */ (null),
 			supports: /** @type {EXPECTED_ANY} */ (null),
 			media: /** @type {EXPECTED_ANY} */ (null),

--- a/test/configCases/resolve/rule-resolver-plugin/dir/a-alt.js
+++ b/test/configCases/resolve/rule-resolver-plugin/dir/a-alt.js
@@ -1,0 +1,1 @@
+module.exports = "a-alt";

--- a/test/configCases/resolve/rule-resolver-plugin/dir/a.js
+++ b/test/configCases/resolve/rule-resolver-plugin/dir/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/resolve/rule-resolver-plugin/dir/b.js
+++ b/test/configCases/resolve/rule-resolver-plugin/dir/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/resolve/rule-resolver-plugin/index.js
+++ b/test/configCases/resolve/rule-resolver-plugin/index.js
@@ -1,0 +1,5 @@
+const context = require.context("./dir", false, /^\.\/[ab]\.js$/);
+
+it("should apply the issuer's rule-level resolver plugin to the context's children", () => {
+	expect(context.keys().map(context)).toEqual(["a-alt", "b"]);
+});

--- a/test/configCases/resolve/rule-resolver-plugin/webpack.config.js
+++ b/test/configCases/resolve/rule-resolver-plugin/webpack.config.js
@@ -1,0 +1,42 @@
+"use strict";
+
+/** @typedef {import("enhanced-resolve").Resolver} Resolver */
+
+class RedirectResolverPlugin {
+	/**
+	 * @param {Resolver} resolver resolver
+	 */
+	apply(resolver) {
+		const target = resolver.ensureHook("resolve");
+		resolver
+			.getHook("resolve")
+			.tapAsync(
+				"RedirectResolverPlugin",
+				(request, resolveContext, callback) => {
+					if (request.request !== "./a.js") return callback();
+					resolver.doResolve(
+						target,
+						{ ...request, request: "./a-alt.js" },
+						"redirect ./a.js",
+						resolveContext,
+						callback
+					);
+				}
+			);
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				// a plugin instance has no serializer; it must not keep the module out of the persistent cache
+				test: /index\.js$/,
+				resolve: {
+					plugins: [new RedirectResolverPlugin()]
+				}
+			}
+		]
+	}
+};

--- a/test/watchCases/resolve/context-children-rule-resolve/0/context.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/context.js
@@ -1,0 +1,3 @@
+const context = require.context("./dir", false, /^\.\/[ab]\.js$/);
+
+module.exports = context.keys().map(context);

--- a/test/watchCases/resolve/context-children-rule-resolve/0/dir/a-alt.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/dir/a-alt.js
@@ -1,0 +1,1 @@
+module.exports = "a-alt";

--- a/test/watchCases/resolve/context-children-rule-resolve/0/dir/a.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/dir/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/watchCases/resolve/context-children-rule-resolve/0/dir/b.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/dir/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/watchCases/resolve/context-children-rule-resolve/0/index.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/index.js
@@ -1,0 +1,7 @@
+const values = require("./context");
+const step = require("./trigger");
+
+it("should resolve the context's children with the issuer's rule resolve options on every build", () => {
+	expect(step).toBe(WATCH_STEP);
+	expect(values).toEqual(["a-alt", "b"]);
+});

--- a/test/watchCases/resolve/context-children-rule-resolve/0/trigger.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/0/trigger.js
@@ -1,0 +1,1 @@
+module.exports = "0";

--- a/test/watchCases/resolve/context-children-rule-resolve/1/trigger.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/1/trigger.js
@@ -1,0 +1,1 @@
+module.exports = "1";

--- a/test/watchCases/resolve/context-children-rule-resolve/webpack.config.js
+++ b/test/watchCases/resolve/context-children-rule-resolve/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				// the issuer's rule-level resolve options must reach the context's children on every build
+				test: /context\.js$/,
+				resolve: {
+					alias: {
+						"./a.js": "./a-alt.js"
+					}
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes (1) an incremental build resolves `require.context` children without the issuer's rule-level `resolveOptions`. (2) a resolver plugin instance in a rule keeps the module out of the persistent cache. 

Thanks for reports @hardfist .

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

Yes
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed persistent caching so module resolution options are refreshed correctly instead of retaining stale cached values.
  - Fixed context-created modules so they consistently inherit the issuer’s rule-level resolution settings.
  - Ensured resolver plugins and aliases continue to apply correctly to context children during watch-mode rebuilds.

- **Tests**
  - Added coverage for rule-level resolver plugins, aliases, persistent caching, and repeated watch builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->