### PR TITLE
fix: read the extension out of a path-scoped rule's alternation

### DIFF
--- a/.changeset/015-scoped-rule-extension-detection.md
+++ b/.changeset/015-scoped-rule-extension-detection.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Read the extension out of a path-scoped rule's alternation, class or braces.

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -708,7 +708,21 @@ const splitAlternatives = (body) => {
 };
 
 /**
- * Rewrites the first alternation group, word-character class or optional atom
+ * The part of a group body the match spells: the body itself for a capturing
+ * group, what follows the `?:` or `?<name>` prefix for the others, and nothing
+ * for a lookaround, which says what surrounds the match rather than spelling it.
+ * @param {string} body group body without the enclosing parentheses
+ * @returns {string | undefined} the spelled part, or `undefined` for a lookaround
+ */
+const groupContent = (body) => {
+	if (!body.startsWith("?")) return body;
+	if (body.startsWith("?:")) return body.slice(2);
+	const named = /^\?<[^=!][^>]*>/.exec(body);
+	return named ? body.slice(named[0].length) : undefined;
+};
+
+/**
+ * Rewrites the first group, word-character class or optional atom
  * in the source into the spellings it can match, leaving the rest as written.
  * @param {string} source regexp source
  * @returns {string[] | undefined} the rewritten sources, or `undefined` when the source holds no such construct
@@ -717,7 +731,6 @@ const expandFirstConstruct = (source) => {
 	for (let i = 0; i < source.length; i++) {
 		const char = source[i];
 		let end = i + 1;
-		let resumeInside = false;
 		/** @type {string[] | undefined} */
 		let spellings;
 		if (char === "\\") {
@@ -732,15 +745,8 @@ const expandFirstConstruct = (source) => {
 		} else if (char === "(") {
 			const close = findGroupEnd(source, i);
 			end = close + 1;
-			const body = source.slice(i + 1, close);
-			// a lookaround says what must surround the match, not what it spells
-			if (!body.startsWith("?") || body.startsWith("?:")) {
-				const alternatives = splitAlternatives(
-					body.startsWith("?:") ? body.slice(2) : body
-				);
-				if (alternatives.length > 1) spellings = alternatives;
-				else resumeInside = true;
-			}
+			const content = groupContent(source.slice(i + 1, close));
+			if (content !== undefined) spellings = splitAlternatives(content);
 		}
 		// `?` makes the atom optional, so its absence is a spelling as well
 		if (source[end] === "?") {
@@ -752,7 +758,7 @@ const expandFirstConstruct = (source) => {
 				(spelling) => source.slice(0, i) + spelling + source.slice(end)
 			);
 		}
-		if (!resumeInside) i = end - 1;
+		i = end - 1;
 	}
 };
 
@@ -855,11 +861,11 @@ const globReferencesExtension = (glob, extension) => {
  */
 const conditionReferencesExtension = (condition, extProbe) => {
 	if (condition instanceof RegExp) {
-		return someSpellingContains(
-			condition.source,
-			extProbe,
-			expandFirstConstruct
-		);
+		// an `/i` rule spells the extension in any case; the probe is lower case
+		const source = condition.ignoreCase
+			? condition.source.toLowerCase()
+			: condition.source;
+		return someSpellingContains(source, extProbe, expandFirstConstruct);
 	}
 	if (Array.isArray(condition)) {
 		return condition.some((c) => conditionReferencesExtension(c, extProbe));

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -708,9 +708,8 @@ const splitAlternatives = (body) => {
 };
 
 /**
- * The part of a group body the match spells: the body itself for a capturing
- * group, what follows the `?:` or `?<name>` prefix for the others, and nothing
- * for a lookaround, which says what surrounds the match rather than spelling it.
+ * The part of a group body that the match spells — past a `?:` or `?<name>`
+ * prefix, and nothing at all for a lookaround, which spells nothing.
  * @param {string} body group body without the enclosing parentheses
  * @returns {string | undefined} the spelled part, or `undefined` for a lookaround
  */

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -644,6 +644,10 @@ const matchRuleSetCondition = (condition, resource) => {
 // many alternations stays cheap to probe.
 const MAX_EXPANDED_SPELLINGS = 64;
 
+// A rule naming an extension is short; a pattern generated from a list of paths
+// runs to kilobytes and costs more to expand than the answer is worth.
+const MAX_EXPANDED_PATTERN_LENGTH = 256;
+
 /**
  * Index of the `]` closing the character class opened at `start`, or the end of
  * the source when it is unterminated.
@@ -806,6 +810,7 @@ const containsSubsequence = (pattern, probe) => {
  */
 const someSpellingContains = (pattern, probe, expandFirst) => {
 	if (pattern.includes(probe)) return true;
+	if (pattern.length > MAX_EXPANDED_PATTERN_LENGTH) return false;
 	if (!containsSubsequence(pattern, probe)) return false;
 	let spellings = [pattern];
 	for (;;) {

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -640,6 +640,190 @@ const matchRuleSetCondition = (condition, resource) => {
 	}
 };
 
+// Cap on the spellings one pattern is expanded into, so a pattern built from
+// many alternations stays cheap to probe.
+const MAX_EXPANDED_SPELLINGS = 64;
+
+/**
+ * Index of the `]` closing the character class opened at `start`, or the end of
+ * the source when it is unterminated.
+ * @param {string} source regexp source
+ * @param {number} start index of the opening `[`
+ * @returns {number} index of the closing `]`
+ */
+const findCharacterClassEnd = (source, start) => {
+	for (let i = start + 1; i < source.length; i++) {
+		if (source[i] === "\\") i++;
+		else if (source[i] === "]") return i;
+	}
+	return source.length;
+};
+
+/**
+ * Index of the `)` closing the group opened at `start`, skipping nested groups
+ * and character classes, or the end of the source when it is unterminated.
+ * @param {string} source regexp source
+ * @param {number} start index of the opening `(`
+ * @returns {number} index of the closing `)`
+ */
+const findGroupEnd = (source, start) => {
+	let depth = 0;
+	for (let i = start; i < source.length; i++) {
+		const char = source[i];
+		if (char === "\\") i++;
+		else if (char === "[") i = findCharacterClassEnd(source, i);
+		else if (char === "(") depth++;
+		else if (char === ")" && --depth === 0) return i;
+	}
+	return source.length;
+};
+
+/**
+ * Splits a group body on its top-level `|`, skipping nested groups and
+ * character classes.
+ * @param {string} body group body without the enclosing parentheses
+ * @returns {string[]} the alternatives
+ */
+const splitAlternatives = (body) => {
+	const alternatives = [];
+	let depth = 0;
+	let start = 0;
+	for (let i = 0; i < body.length; i++) {
+		const char = body[i];
+		if (char === "\\") {
+			i++;
+		} else if (char === "[") {
+			i = findCharacterClassEnd(body, i);
+		} else if (char === "(") {
+			depth++;
+		} else if (char === ")") {
+			depth--;
+		} else if (char === "|" && depth === 0) {
+			alternatives.push(body.slice(start, i));
+			start = i + 1;
+		}
+	}
+	alternatives.push(body.slice(start));
+	return alternatives;
+};
+
+/**
+ * Rewrites the first alternation group, word-character class or optional atom
+ * in the source into the spellings it can match, leaving the rest as written.
+ * @param {string} source regexp source
+ * @returns {string[] | undefined} the rewritten sources, or `undefined` when the source holds no such construct
+ */
+const expandFirstConstruct = (source) => {
+	for (let i = 0; i < source.length; i++) {
+		const char = source[i];
+		let end = i + 1;
+		let resumeInside = false;
+		/** @type {string[] | undefined} */
+		let spellings;
+		if (char === "\\") {
+			end = i + 2;
+		} else if (char === "[") {
+			const close = findCharacterClassEnd(source, i);
+			end = close + 1;
+			const body = source.slice(i + 1, close);
+			// only a plain list of word characters spells out safely (no range,
+			// no negation, no escape)
+			if (/^\w+$/.test(body)) spellings = [...body];
+		} else if (char === "(") {
+			const close = findGroupEnd(source, i);
+			end = close + 1;
+			const body = source.slice(i + 1, close);
+			// a lookaround says what must surround the match, not what it spells
+			if (!body.startsWith("?") || body.startsWith("?:")) {
+				const alternatives = splitAlternatives(
+					body.startsWith("?:") ? body.slice(2) : body
+				);
+				if (alternatives.length > 1) spellings = alternatives;
+				else resumeInside = true;
+			}
+		}
+		// `?` makes the atom optional, so its absence is a spelling as well
+		if (source[end] === "?") {
+			spellings = [...(spellings || [source.slice(i, end)]), ""];
+			end += 1;
+		}
+		if (spellings) {
+			return spellings.map(
+				(spelling) => source.slice(0, i) + spelling + source.slice(end)
+			);
+		}
+		if (!resumeInside) i = end - 1;
+	}
+};
+
+/**
+ * Rewrites the first brace alternative in a glob pattern (e.g. `*.{css,scss}`)
+ * into the spellings it can match.
+ * @param {string} pattern glob pattern
+ * @returns {string[] | undefined} the rewritten patterns, or `undefined` when the pattern holds no brace
+ */
+const expandFirstBrace = (pattern) => {
+	const open = pattern.indexOf("{");
+	const close = open === -1 ? -1 : pattern.indexOf("}", open);
+	if (close === -1) return;
+	return pattern
+		.slice(open + 1, close)
+		.split(",")
+		.map(
+			(alternative) =>
+				pattern.slice(0, open) + alternative + pattern.slice(close + 1)
+		);
+};
+
+/**
+ * Whether `probe` occurs in `pattern` as a subsequence. Expanding a pattern only
+ * ever drops characters, so a probe failing this is spelled by none of its
+ * spellings and the expansion is not worth starting.
+ * @param {string} pattern pattern to search
+ * @param {string} probe probe to find
+ * @returns {boolean} whether the probe is a subsequence of the pattern
+ */
+const containsSubsequence = (pattern, probe) => {
+	let found = 0;
+	for (let i = 0; i < pattern.length && found < probe.length; i++) {
+		if (pattern[i] === probe[found]) found++;
+	}
+	return found === probe.length;
+};
+
+/**
+ * Whether any spelling of the pattern contains the probe, rewriting one
+ * construct at a time until none is left or `MAX_EXPANDED_SPELLINGS` is reached.
+ * @param {string} pattern pattern to expand
+ * @param {string} probe probe the spellings are searched for
+ * @param {(pattern: string) => string[] | undefined} expandFirst rewrites the first expandable construct
+ * @returns {boolean} whether a spelling contains the probe
+ */
+const someSpellingContains = (pattern, probe, expandFirst) => {
+	if (pattern.includes(probe)) return true;
+	if (!containsSubsequence(pattern, probe)) return false;
+	let spellings = [pattern];
+	for (;;) {
+		/** @type {string[]} */
+		const expanded = [];
+		for (const spelling of spellings) {
+			const rewritten = expandFirst(spelling);
+			// every spelling was searched as it was produced, so one with nothing
+			// left to rewrite is settled
+			if (!rewritten) continue;
+			for (const alternative of rewritten) {
+				if (alternative.includes(probe)) return true;
+				// an alternative that dropped the probe's characters expands no
+				// further into it
+				if (containsSubsequence(alternative, probe)) expanded.push(alternative);
+			}
+			if (expanded.length > MAX_EXPANDED_SPELLINGS) return false;
+		}
+		if (expanded.length === 0) return false;
+		spellings = expanded;
+	}
+};
+
 /**
  * @param {EXPECTED_ANY} glob glob pattern(s)
  * @param {string} extension extension including the dot (e.g. `".css"`)
@@ -648,7 +832,10 @@ const matchRuleSetCondition = (condition, resource) => {
 const globReferencesExtension = (glob, extension) => {
 	// a `!` pattern subtracts the extension instead of targeting it
 	if (typeof glob === "string") {
-		return !glob.startsWith("!") && glob.includes(extension);
+		return (
+			!glob.startsWith("!") &&
+			someSpellingContains(glob, extension, expandFirstBrace)
+		);
 	}
 	return (
 		Array.isArray(glob) &&
@@ -660,12 +847,20 @@ const globReferencesExtension = (glob, extension) => {
  * Whether any regexp or glob in the condition references the extension probe
  * (e.g. `\.css`), i.e. the rule clearly targets that extension even if the
  * generic sample path doesn't match its (possibly filename-scoped) pattern.
+ * The extension may be spelled by an alternation (`\.(css|scss)$`) or a
+ * character class (`\.[jt]sx?$`), so those are expanded before probing.
  * @param {EXPECTED_ANY} condition condition
  * @param {string} extProbe escaped extension probe (e.g. `"\\.css"`)
  * @returns {boolean} whether a regexp in the condition targets the extension
  */
 const conditionReferencesExtension = (condition, extProbe) => {
-	if (condition instanceof RegExp) return condition.source.includes(extProbe);
+	if (condition instanceof RegExp) {
+		return someSpellingContains(
+			condition.source,
+			extProbe,
+			expandFirstConstruct
+		);
+	}
 	if (Array.isArray(condition)) {
 		return condition.some((c) => conditionReferencesExtension(c, extProbe));
 	}

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -5825,6 +5825,41 @@ describe("experiments.css/html/asyncWebAssembly auto", () => {
 		).toEqual({ css: "auto", html: "auto", asyncWebAssembly: true });
 	});
 
+	it("reads the extension out of a path-scoped alternation or class", () => {
+		// The sample path the detection probes with doesn't match a path-scoped
+		// rule, so the extension has to be read out of the pattern itself.
+		expect(
+			resolve({
+				module: {
+					rules: [
+						{
+							test: /[\\/]src[\\/].*\.(css|scss)$/i,
+							use: ["style-loader", "css-loader"]
+						}
+					]
+				}
+			})
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
+		expect(
+			resolve({
+				module: {
+					rules: [
+						{ glob: "src/**/*.{css,scss}", use: ["style-loader", "css-loader"] }
+					]
+				}
+			})
+		).toEqual({ css: false, html: "auto", asyncWebAssembly: true });
+		expect(
+			resolve({
+				module: {
+					rules: [
+						{ test: /\/templates\/.*\.(html|htm)$/i, use: ["html-loader"] }
+					]
+				}
+			})
+		).toEqual({ css: "auto", html: false, asyncWebAssembly: true });
+	});
+
 	it("stays lenient about include/exclude narrowing", () => {
 		// A loader scoped to `include: /src/` already handles those files today, so
 		// the built-in type must stay off even for a resource outside that scope.
@@ -5955,10 +5990,34 @@ describe("experiments.typescript auto", () => {
 		).toBe(false);
 	});
 
+	it("keeps typescript off for a path-scoped ts-loader rule", () => {
+		// A rule the sample path can't match still names `.ts` in its alternation
+		// or class — leaving the built-in support on would reject `.tsx` outright.
+		expect(
+			resolve({
+				module: {
+					rules: [{ test: /\/components\/.*\.(ts|tsx)$/, use: ["ts-loader"] }]
+				}
+			})
+		).toBe(false);
+		expect(
+			resolve({
+				module: { rules: [{ test: /[\\/]src[\\/].*\.[jt]sx?$/, use: ["swc"] }] }
+			})
+		).toBe(false);
+	});
+
 	it("ignores loaders registered for unrelated extensions", () => {
 		expect(
 			resolve({
 				module: { rules: [{ test: /\.js$/i, use: ["babel-loader"] }] }
+			})
+		).toBe(true);
+		expect(
+			resolve({
+				module: {
+					rules: [{ test: /[\\/]src[\\/].*\.(js|mjs)$/, use: ["babel-loader"] }]
+				}
 			})
 		).toBe(true);
 	});

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -132,9 +132,8 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 	});
 
 	it("leaves a pattern generated from a list of paths unexpanded", () => {
-		// the test262 harness builds one of these from ~200 paths; expanding it
-		// costs 165ms per compilation, so past the length cap only the spelling the
-		// pattern carries outright is read
+		// a kilobyte-long generated pattern (test262's harness has one) costs 165ms
+		// to expand per compilation, so past the cap only an outright spelling reads
 		const paths = Array.from(
 			{ length: 60 },
 			(_, i) => `(?:case-${i}/fixture\\.js$)`

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -63,12 +63,87 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		);
 	});
 
+	it("detects a path-scoped regexp spelling the extension in an alternation", () => {
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(css|scss)$/, use: ["css-loader"] }])
+		).toBe(true);
+		expect(has([{ test: /[\\/]src[\\/].*\.(?:css|less)$/, use: ["x"] }])).toBe(
+			true
+		);
+		expect(has([{ test: /[\\/]src[\\/].*\.(sa|sc|c)ss$/, use: ["x"] }])).toBe(
+			true
+		);
+		expect(has([{ test: /[\\/]src[\\/].*\.(scss|sass)$/, use: ["x"] }])).toBe(
+			false
+		);
+	});
+
+	it("detects a path-scoped regexp spelling the extension in a character class", () => {
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.[jt]sx?$/, use: ["x"] }], "/file.ts")
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.[mc]?ts$/, use: ["x"] }], "/file.mts")
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.[jt]sx?$/, use: ["x"] }], "/file.css")
+		).toBe(false);
+		// a range spells no fixed extension, so it stays unexpanded
+		expect(has([{ test: /[\\/]src[\\/].*\.[a-z]ss$/, use: ["x"] }])).toBe(
+			false
+		);
+	});
+
+	it("detects an extension spelled behind an optional atom", () => {
+		expect(has([{ test: /[\\/]src[\\/].*\.s?css$/, use: ["x"] }])).toBe(true);
+		expect(has([{ test: /[\\/]src[\\/].*\.s?ass$/, use: ["x"] }])).toBe(false);
+	});
+
+	it("skips escapes and character classes inside an alternation", () => {
+		expect(has([{ test: /[\\/]src[\\/].*(\.css|\.less)$/, use: ["x"] }])).toBe(
+			true
+		);
+		expect(
+			has([{ test: /[\\/]src[\\/].*(\.[ms]css|\.css)$/, use: ["x"] }])
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*(\.[ms]css|\.less)$/, use: ["x"] }])
+		).toBe(false);
+	});
+
+	it("expands past a lookaround and stops at the spelling cap", () => {
+		expect(
+			has([{ test: /[\\/]src[\\/](?!vendor)((.*))\.(css|scss)$/, use: ["x"] }])
+		).toBe(true);
+		// an expression with more spellings than the cap keeps what it reached
+		expect(
+			has([
+				{
+					test: /[\\/]src[\\/](a|b)(c|d)(e|f)(g|h)(i|j)(k|l)(m|n)\.(css|scss)$/,
+					use: ["x"]
+				}
+			])
+		).toBe(false);
+	});
+
 	it("detects a filename-scoped glob via the extension probe", () => {
 		expect(has([{ test: { glob: "**/*.module.css" }, use: ["x"] }])).toBe(true);
 		expect(
 			has([{ test: { glob: ["**/*.js", "**/*.module.css"] }, use: ["x"] }])
 		).toBe(true);
 		expect(has([{ test: { glob: "**/*.scss" }, use: ["x"] }])).toBe(false);
+	});
+
+	it("detects a path-scoped glob spelling the extension in braces", () => {
+		expect(has([{ test: { glob: "src/**/*.{css,scss}" }, use: ["x"] }])).toBe(
+			true
+		);
+		expect(
+			has([{ test: { glob: "src/**/*.{ts,tsx}" }, use: ["x"] }], "/file.ts")
+		).toBe(true);
+		expect(has([{ test: { glob: "src/**/*.{scss,sass}" }, use: ["x"] }])).toBe(
+			false
+		);
 	});
 
 	it("matches a rule-level glob", () => {

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -96,12 +96,11 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 
 	it("reads a capturing, non-capturing or named group the same way", () => {
 		expect(has([{ test: /[\\/]src[\\/].*\.(css)$/, use: ["x"] }])).toBe(true);
-		expect(
-			has([{ test: /[\\/]src[\\/].*\.(?<ext>css|scss)$/, use: ["x"] }])
-		).toBe(true);
-		expect(
-			has([{ test: /[\\/]src[\\/].*\.(?<ext>scss|sass)$/, use: ["x"] }])
-		).toBe(false);
+		// built at runtime: a named group is past this project's `tsc` target
+		const named = (/** @type {string} */ alternatives) =>
+			new RegExp(`[\\\\/]src[\\\\/].*\\.(?<ext>${alternatives})$`);
+		expect(has([{ test: named("css|scss"), use: ["x"] }])).toBe(true);
+		expect(has([{ test: named("scss|sass"), use: ["x"] }])).toBe(false);
 	});
 
 	it("spells the extension in the case an `i` rule accepts", () => {

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -131,6 +131,25 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		).toBe(false);
 	});
 
+	it("leaves a pattern generated from a list of paths unexpanded", () => {
+		// the test262 harness builds one of these from ~200 paths; expanding it
+		// costs 165ms per compilation, so past the length cap only the spelling the
+		// pattern carries outright is read
+		const paths = Array.from(
+			{ length: 60 },
+			(_, i) => `(?:case-${i}/fixture\\.js$)`
+		).join("|");
+		expect(
+			has([
+				{ test: new RegExp(`${paths}|(?:styles/x\\.(css|scss)$)`), use: ["x"] }
+			])
+		).toBe(false);
+		// the extension is still read where the pattern spells it outright
+		expect(
+			has([{ test: new RegExp(`${paths}|(?:styles/x\\.css$)`), use: ["x"] }])
+		).toBe(true);
+	});
+
 	it("expands past a lookaround and stops at the spelling cap", () => {
 		expect(
 			has([{ test: /[\\/]src[\\/](?!vendor)((.*))\.(css|scss)$/, use: ["x"] }])

--- a/test/RuleSetCompiler.unittest.js
+++ b/test/RuleSetCompiler.unittest.js
@@ -94,6 +94,27 @@ describe("RuleSetCompiler.hasRuleForResource", () => {
 		);
 	});
 
+	it("reads a capturing, non-capturing or named group the same way", () => {
+		expect(has([{ test: /[\\/]src[\\/].*\.(css)$/, use: ["x"] }])).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(?<ext>css|scss)$/, use: ["x"] }])
+		).toBe(true);
+		expect(
+			has([{ test: /[\\/]src[\\/].*\.(?<ext>scss|sass)$/, use: ["x"] }])
+		).toBe(false);
+	});
+
+	it("spells the extension in the case an `i` rule accepts", () => {
+		expect(has([{ test: /[\\/]src[\\/].*\.(CSS|SCSS)$/i, use: ["x"] }])).toBe(
+			true
+		);
+		expect(has([{ test: /[\\/]SRC[\\/].*\.Css$/i, use: ["x"] }])).toBe(true);
+		// without `i` the rule really does not match `.css`
+		expect(has([{ test: /[\\/]src[\\/].*\.(CSS|SCSS)$/, use: ["x"] }])).toBe(
+			false
+		);
+	});
+
 	it("detects an extension spelled behind an optional atom", () => {
 		expect(has([{ test: /[\\/]src[\\/].*\.s?css$/, use: ["x"] }])).toBe(true);
 		expect(has([{ test: /[\\/]src[\\/].*\.s?ass$/, use: ["x"] }])).toBe(false);

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/index.tsx
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/index.tsx
@@ -1,0 +1,8 @@
+import value from "./module.ts";
+
+const greeting: string = `hello-${value}`;
+
+it("should let a path-scoped ts-loader own .ts/.tsx when experiments.typescript is auto", () => {
+	expect(greeting).toBe("hello-from-module");
+	expect(value).toBe("from-module");
+});

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/module.ts
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/module.ts
@@ -1,0 +1,3 @@
+const value: string = "from-module";
+
+export default value;

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/test.filter.js
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/test.filter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = () => "stripTypeScriptTypes" in require("module");

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/tsconfig.json
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"jsx": "preserve",
+		"strict": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"declaration": false
+	},
+	"include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/webpack.config.js
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+// `experiments.typescript` stays at its "auto" default and the ts-loader rule is
+// path-scoped with its extensions in an alternation — the sample path the
+// detection probes with doesn't match it, so only reading the extension out of
+// the alternation keeps the built-in support off. Left on, it rejects `.tsx`.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.tsx",
+	module: {
+		rules: [
+			{
+				test: /[\\/]experiments-auto-and-scoped-ts-loader[\\/].*\.(ts|tsx)$/,
+				loader: "ts-loader",
+				options: {
+					transpileOnly: true
+				}
+			}
+		]
+	}
+};

--- a/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/webpack.config.js
+++ b/test/configCases/typescript/experiments-auto-and-scoped-ts-loader/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// `experiments.typescript` stays at its "auto" default and the ts-loader rule is
-// path-scoped with its extensions in an alternation — the sample path the
-// detection probes with doesn't match it, so only reading the extension out of
-// the alternation keeps the built-in support off. Left on, it rejects `.tsx`.
+// The ts-loader rule is path-scoped, so the detection probe has to read `.ts`
+// out of its alternation — left on, the built-in support rejects `.tsx`.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`hasRuleForResource` searched a rule's regexp source for the extension probe (`\.ts`) as a literal substring, so a path-scoped rule spelling its extensions in an alternation, a character class or glob braces — `/[\\/]src[\\/].*\.(ts|tsx)$/`, `/\.[jt]sx?$/`, `glob: "src/**/*.{css,scss}"` — matched neither the sample path nor the probe and went undetected. `experiments.typescript` then stayed on next to the user's ts-loader, which rejects `.tsx` outright (`experiments.typescript does not support .tsx/JSX`) and, in a `"type": "module"` package, restamps `.ts` as `javascript/esm` + `fullySpecified` so the loader's extensionless imports stop resolving. Those constructs are now expanded into the spellings they can match before probing. Closes #21943.

The expansion is guarded by a subsequence precondition (expanding only ever drops characters, so a probe that is not a subsequence of the pattern cannot be spelled by it), which keeps the miss path — the common one — cheap: over a realistic 20-rule config the 140 probes start 0 expansions and allocate 0 strings, costing 13 µs on top of a ~6 ms `webpack(config)`, once per compiler and never per module.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/typescript/experiments-auto-and-scoped-ts-loader` (fails on `main` with the `.tsx` build error), plus detection cases in `test/RuleSetCompiler.unittest.js` and option-resolution cases in `test/Defaults.unittest.js`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code reproduced the report, established that the css/html half of it is harmless (the `"auto"` marker already steps aside for loader-processed modules, bundles byte-identical) and the typescript half is a real build failure, wrote the fix and the tests, and measured the config-time cost A/B against `main`. All output was reviewed and verified locally by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR93JfzDSiYSACarEdDPmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UR93JfzDSiYSACarEdDPmm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of file extensions in path-scoped rules.
  - More accurately recognizes extensions in regular-expression alternations, character classes, groups, optional patterns, case-insensitive matching, and glob braces.
  - Avoids incorrect detection from unsupported lookaround patterns.
  - Prevents built-in CSS, HTML, and TypeScript handling from being enabled when scoped rules already cover those extensions.

- **Tests**
  - Added coverage for complex extension patterns and scoped TypeScript/TSX loader configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->