### PR TITLE
docs(examples): add an example that adds exports to a module that has none

### DIFF
--- a/examples/add-exports/README.md
+++ b/examples/add-exports/README.md
@@ -1,10 +1,12 @@
 # Adding exports to a module
 
-Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own, so they take part in tree shaking, mangling, const inlining and scope hoisting exactly like an `export` written in the source.
+Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own.
 
 No loader is needed for that. `NormalModule`'s `processResult` hook hands a plugin what the loaders produced — source, source map and any preparsed AST — and takes back a replacement.
 
-Which format to append is the module's own: a script takes `module.exports = …`, an ES module takes `export { … }` — and appending an `export` is itself what makes a file an ES module, as it would be in the source. Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
+Which format to append is the module's own, and the two are not equivalent. `export { … }` is what makes a file an ES module, exactly as it would be in the source, so those exports are analyzable: below, `math.js` has its `PI` inlined into the call site and its `add` hoisted into the entry, like any `export` webpack reads. `module.exports = …` keeps the file the script it is, and webpack treats it as it treats any module whose whole exports object is assigned a value — `legacy-global.js` below keeps runtime-defined exports and is not analyzed that way. Prefer the ES module form where the file tolerates it.
+
+Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
 
 # internals/add-exports-plugin.js
 
@@ -42,6 +44,9 @@ class AddExportsPlugin {
 				(result, module) => {
 					const [source, sourceMap] = result;
 					for (const [test, code] of this.exports) {
+						// a global or sticky pattern keeps its lastIndex between calls,
+						// which would skip the next module it is tested against
+						test.lastIndex = 0;
 						if (!module.resource || !test.test(module.resource)) continue;
 						// appending moves nothing before it, so the source map still fits;
 						// a preparsed ast would be parsed instead of the appended code

--- a/examples/add-exports/README.md
+++ b/examples/add-exports/README.md
@@ -1,0 +1,282 @@
+# Adding exports to a module
+
+Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own, so they take part in tree shaking, mangling, const inlining and scope hoisting exactly like an `export` written in the source.
+
+No loader is needed for that. `NormalModule`'s `processResult` hook hands a plugin what the loaders produced — source, source map and any preparsed AST — and takes back a replacement.
+
+Which format to append is the module's own: a script takes `module.exports = …`, an ES module takes `export { … }` — and appending an `export` is itself what makes a file an ES module, as it would be in the source. Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
+
+# internals/add-exports-plugin.js
+
+```javascript
+"use strict";
+
+const { NormalModule } = require("../../../");
+
+/** @import { Compiler } from "webpack" */
+
+const PLUGIN_NAME = "AddExportsPlugin";
+
+/**
+ * Appends exports to modules which have none, before webpack parses them, so
+ * the exports are read as the module's own.
+ */
+class AddExportsPlugin {
+	/**
+	 * Creates an instance of AddExportsPlugin.
+	 * @param {[RegExp, string][]} exports pairs of a resource condition and the code to append
+	 */
+	constructor(exports) {
+		this.exports = exports;
+	}
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+			NormalModule.getCompilationHooks(compilation).processResult.tap(
+				PLUGIN_NAME,
+				(result, module) => {
+					const [source, sourceMap] = result;
+					for (const [test, code] of this.exports) {
+						if (!module.resource || !test.test(module.resource)) continue;
+						// appending moves nothing before it, so the source map still fits;
+						// a preparsed ast would be parsed instead of the appended code
+						return [`${source}\n${code}`, sourceMap, undefined];
+					}
+					return result;
+				}
+			);
+		});
+	}
+}
+
+module.exports = AddExportsPlugin;
+```
+
+# webpack.config.js
+
+```javascript
+"use strict";
+
+const AddExportsPlugin = require("./internals/add-exports-plugin");
+
+/** @type {import("webpack").Configuration} */
+module.exports = {
+	plugins: [
+		new AddExportsPlugin([
+			// a script, so CommonJs exports
+			[/legacy-global\.js$/, "module.exports = Legacy;"],
+			// `export` makes the module an ES module, as it would in the source
+			[/math\.js$/, "export { add, PI };"]
+		])
+	]
+};
+```
+
+# example.js
+
+```javascript
+import Legacy from "./legacy-global";
+import { add, PI } from "./math";
+
+console.log(new Legacy().version, add(PI, 1));
+```
+
+# legacy-global.js
+
+```javascript
+// A legacy script — it defines a constructor and exports nothing.
+function Legacy() {
+	this.version = "1.0.0";
+}
+```
+
+# math.js
+
+```javascript
+// A vendored file — it defines values and exports nothing.
+const PI = 3.14;
+
+function add(first, second) {
+	return first + second;
+}
+```
+
+# dist/output.js
+
+```javascript
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ([
+/* 0 */,
+/* 1 */
+/*!**************************!*\
+  !*** ./legacy-global.js ***!
+  \**************************/
+/*! unknown exports (runtime-defined) */
+/*! runtime requirements: module */
+/*! CommonJS bailout: module.exports is used directly at 6:0-14 */
+/***/ ((module) => {
+
+// A legacy script — it defines a constructor and exports nothing.
+function Legacy() {
+	this.version = "1.0.0";
+}
+
+module.exports = Legacy;
+
+/***/ }),
+/* 2 */
+/*!*****************!*\
+  !*** ./math.js ***!
+  \*****************/
+/*! namespace exports */
+/*! export PI [provided] [no usage info] [missing usage info prevents renaming] */
+/*! export add [provided] [no usage info] [missing usage info prevents renaming] */
+/*! other exports [not provided] [no usage info] */
+/*! runtime requirements: __webpack_require__.r, __webpack_exports__, __webpack_require__.d, __webpack_require__.* */
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   PI: () => (/* binding */ PI),
+/* harmony export */   add: () => (/* binding */ add)
+/* harmony export */ });
+// A vendored file — it defines values and exports nothing.
+const PI = 3.14;
+
+function add(first, second) {
+	return first + second;
+}
+
+
+
+/***/ })
+/******/ 	]);
+```
+
+<details><summary><code>/* webpack runtime code */</code></summary>
+
+``` js
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = (exports) => {
+/******/ 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/ 	
+/************************************************************************/
+```
+
+</details>
+
+``` js
+let __webpack_exports__ = {};
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+"use strict";
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! namespace exports */
+/*! exports [not provided] [no usage info] */
+/*! runtime requirements: __webpack_require__, __webpack_require__.n, __webpack_require__.r, __webpack_exports__, __webpack_require__.* */
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _legacy_global__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./legacy-global */ 1);
+/* harmony import */ var _legacy_global__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_legacy_global__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _math__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./math */ 2);
+
+
+
+console.log(new (_legacy_global__WEBPACK_IMPORTED_MODULE_0___default())().version, (0,_math__WEBPACK_IMPORTED_MODULE_1__.add)(_math__WEBPACK_IMPORTED_MODULE_1__.PI, 1));
+
+})();
+
+/******/ })()
+;
+```
+
+# Info
+
+## Unoptimized
+
+```
+asset output.js 4.85 KiB [emitted] (name: main)
+chunk (runtime: main) output.js (main) 417 bytes (javascript) 883 bytes (runtime) [entry] [rendered]
+  > ./example.js main
+  runtime modules 883 bytes 4 modules
+  dependent modules 297 bytes [dependent] 2 modules
+  ./example.js 120 bytes [built] [code generated]
+    [no exports]
+    [used exports unknown]
+    entry ./example.js main
+webpack X.X.X compiled successfully
+```
+
+## Production mode
+
+```
+asset output.js 514 bytes [emitted] [minimized] (name: main)
+chunk (runtime: main) output.js (main) 417 bytes (javascript) 672 bytes (runtime) [entry] [rendered]
+  > ./example.js main
+  runtime modules 672 bytes 3 modules
+  dependent modules 141 bytes [dependent] 1 module
+  ./example.js + 1 modules 276 bytes [built] [code generated]
+    [no exports]
+    [no exports used]
+    entry ./example.js main
+webpack X.X.X compiled successfully
+```

--- a/examples/add-exports/build.js
+++ b/examples/add-exports/build.js
@@ -1,0 +1,1 @@
+require("../build-common");

--- a/examples/add-exports/example.js
+++ b/examples/add-exports/example.js
@@ -1,0 +1,4 @@
+import Legacy from "./legacy-global";
+import { add, PI } from "./math";
+
+console.log(new Legacy().version, add(PI, 1));

--- a/examples/add-exports/internals/add-exports-plugin.js
+++ b/examples/add-exports/internals/add-exports-plugin.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const { NormalModule } = require("../../../");
+
+/** @import { Compiler } from "webpack" */
+
+const PLUGIN_NAME = "AddExportsPlugin";
+
+/**
+ * Appends exports to modules which have none, before webpack parses them, so
+ * the exports are read as the module's own.
+ */
+class AddExportsPlugin {
+	/**
+	 * Creates an instance of AddExportsPlugin.
+	 * @param {[RegExp, string][]} exports pairs of a resource condition and the code to append
+	 */
+	constructor(exports) {
+		this.exports = exports;
+	}
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+			NormalModule.getCompilationHooks(compilation).processResult.tap(
+				PLUGIN_NAME,
+				(result, module) => {
+					const [source, sourceMap] = result;
+					for (const [test, code] of this.exports) {
+						if (!module.resource || !test.test(module.resource)) continue;
+						// appending moves nothing before it, so the source map still fits;
+						// a preparsed ast would be parsed instead of the appended code
+						return [`${source}\n${code}`, sourceMap, undefined];
+					}
+					return result;
+				}
+			);
+		});
+	}
+}
+
+module.exports = AddExportsPlugin;

--- a/examples/add-exports/internals/add-exports-plugin.js
+++ b/examples/add-exports/internals/add-exports-plugin.js
@@ -31,6 +31,9 @@ class AddExportsPlugin {
 				(result, module) => {
 					const [source, sourceMap] = result;
 					for (const [test, code] of this.exports) {
+						// a global or sticky pattern keeps its lastIndex between calls,
+						// which would skip the next module it is tested against
+						test.lastIndex = 0;
 						if (!module.resource || !test.test(module.resource)) continue;
 						// appending moves nothing before it, so the source map still fits;
 						// a preparsed ast would be parsed instead of the appended code

--- a/examples/add-exports/legacy-global.js
+++ b/examples/add-exports/legacy-global.js
@@ -1,0 +1,4 @@
+// A legacy script — it defines a constructor and exports nothing.
+function Legacy() {
+	this.version = "1.0.0";
+}

--- a/examples/add-exports/math.js
+++ b/examples/add-exports/math.js
@@ -1,0 +1,6 @@
+// A vendored file — it defines values and exports nothing.
+const PI = 3.14;
+
+function add(first, second) {
+	return first + second;
+}

--- a/examples/add-exports/template.md
+++ b/examples/add-exports/template.md
@@ -1,0 +1,57 @@
+# Adding exports to a module
+
+Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own, so they take part in tree shaking, mangling, const inlining and scope hoisting exactly like an `export` written in the source.
+
+No loader is needed for that. `NormalModule`'s `processResult` hook hands a plugin what the loaders produced — source, source map and any preparsed AST — and takes back a replacement.
+
+Which format to append is the module's own: a script takes `module.exports = …`, an ES module takes `export { … }` — and appending an `export` is itself what makes a file an ES module, as it would be in the source. Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
+
+# internals/add-exports-plugin.js
+
+```javascript
+_{{internals/add-exports-plugin.js}}_
+```
+
+# webpack.config.js
+
+```javascript
+_{{webpack.config.js}}_
+```
+
+# example.js
+
+```javascript
+_{{example.js}}_
+```
+
+# legacy-global.js
+
+```javascript
+_{{legacy-global.js}}_
+```
+
+# math.js
+
+```javascript
+_{{math.js}}_
+```
+
+# dist/output.js
+
+```javascript
+_{{dist/output.js}}_
+```
+
+# Info
+
+## Unoptimized
+
+```
+_{{stdout}}_
+```
+
+## Production mode
+
+```
+_{{production:stdout}}_
+```

--- a/examples/add-exports/template.md
+++ b/examples/add-exports/template.md
@@ -1,10 +1,12 @@
 # Adding exports to a module
 
-Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own, so they take part in tree shaking, mangling, const inlining and scope hoisting exactly like an `export` written in the source.
+Some files export nothing: a legacy script that only defines globals, a vendored file, a bundle that was never written as a module. Appending the exports before webpack parses the file is enough — the parser reads them as the module's own.
 
 No loader is needed for that. `NormalModule`'s `processResult` hook hands a plugin what the loaders produced — source, source map and any preparsed AST — and takes back a replacement.
 
-Which format to append is the module's own: a script takes `module.exports = …`, an ES module takes `export { … }` — and appending an `export` is itself what makes a file an ES module, as it would be in the source. Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
+Which format to append is the module's own, and the two are not equivalent. `export { … }` is what makes a file an ES module, exactly as it would be in the source, so those exports are analyzable: below, `math.js` has its `PI` inlined into the call site and its `add` hoisted into the entry, like any `export` webpack reads. `module.exports = …` keeps the file the script it is, and webpack treats it as it treats any module whose whole exports object is assigned a value — `legacy-global.js` below keeps runtime-defined exports and is not analyzed that way. Prefer the ES module form where the file tolerates it.
+
+Appending moves nothing before it, so the source map is still valid; a preparsed AST is dropped, because webpack would otherwise parse that instead of the appended code.
 
 # internals/add-exports-plugin.js
 

--- a/examples/add-exports/webpack.config.js
+++ b/examples/add-exports/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const AddExportsPlugin = require("./internals/add-exports-plugin");
+
+/** @type {import("webpack").Configuration} */
+module.exports = {
+	plugins: [
+		new AddExportsPlugin([
+			// a script, so CommonJs exports
+			[/legacy-global\.js$/, "module.exports = Legacy;"],
+			// `export` makes the module an ES module, as it would in the source
+			[/math\.js$/, "export { add, PI };"]
+		])
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Adds `examples/add-exports`: appending exports to a file that has none — a legacy script, a vendored file — is a plugin over `NormalModule`'s `processResult` hook, not something that needs a loader or a config option. Webpack parses the appended code, so the exports are the module's own: the example's `math.js` gets its `PI` const-inlined and scope-hoisted. This is the recipe `exports-loader`'s deprecation notice points at (webpack/exports-loader#190).

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — the example is built by `yarn build:examples`, and its `README.md` is the generated output.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the example's `README.md` is generated from `template.md` and documents itself.

**Use of AI**

Claude Code wrote the example and its prose. Every claim in it was checked against a real build: the emitted bundle, the const-inlining, and the source map naming the original files. Two details in the plugin come from that checking rather than from the docs — the preparsed AST has to be dropped or webpack parses it instead of the appended code, and the incoming source map can be passed through unchanged because appending never moves what came before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj4FVR7z3fkmwde9nqVVyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj4FVR7z3fkmwde9nqVVyc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a runnable example showing how to append CommonJS or ES module exports to legacy and vendored files that originally export nothing.
  - Demonstrates that appended ES module exports can support optimization, while CommonJS exports remain runtime-defined.
  - Added an example application using the resulting legacy and mathematical exports.

- **Bug Fixes**
  - Improved matching reliability for repeated use of global or sticky patterns.

- **Documentation**
  - Added setup instructions, source examples, generated bundle output, and build statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->