### PR TITLE
test(css): hold the printers to real framework stylesheets

### DIFF
--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -8,6 +8,19 @@
 
 const fs = require("fs");
 const path = require("path");
+// Read from the comparison scripts, so a fixture added to one is added here.
+const {
+	CACHE: CSS_CACHE,
+	GENERATED_FIXTURES,
+	INSTALLED_FIXTURES
+} = require("../../tooling/compare-css-minifiers");
+const {
+	APP_SHELL,
+	CACHE: HTML_CACHE,
+	INLINED_STYLESHEETS,
+	INSTALLED_DOCUMENTS,
+	inlineCssPage
+} = require("../../tooling/compare-html-minifiers");
 
 /** @typedef {{ name: string, raw: string, min: string }} Fixture */
 
@@ -60,20 +73,6 @@ const buildCorpus = (dir, extension, minify) => {
 		};
 	});
 };
-
-// Read from the comparison scripts, so a fixture added to one is added here.
-const {
-	CACHE: CSS_CACHE,
-	GENERATED_FIXTURES,
-	INSTALLED_FIXTURES
-} = require("../../tooling/compare-css-minifiers");
-const {
-	APP_SHELL,
-	CACHE: HTML_CACHE,
-	INLINED_STYLESHEETS,
-	INSTALLED_DOCUMENTS,
-	inlineCssPage
-} = require("../../tooling/compare-html-minifiers");
 
 /**
  * Read a benchmark cache as a corpus. A file the cache does not hold is left
@@ -129,13 +128,15 @@ const benchmarkDocuments = (minify) => {
 	);
 	// The installed documents carry no `<style>` and no `style=`, so the pages
 	// the comparison builds are what reach the css minifier nested in the html.
-	if (out.length === 0) return out;
-	out.push({
-		name: "App shell (inline critical CSS)",
-		raw: APP_SHELL,
-		min: minify(APP_SHELL)
-	});
-	// From the css cache: that is the one installing framework stylesheets.
+	if (out.length > 0) {
+		out.push({
+			name: "App shell (inline critical CSS)",
+			raw: APP_SHELL,
+			min: minify(APP_SHELL)
+		});
+	}
+	// The sheets these inline come from the css cache, which is the one that
+	// installs them — so they stand whether or not the html cache is built.
 	for (const [label, file] of INLINED_STYLESHEETS) {
 		const sheet = path.join(CSS_CACHE, "node_modules", file);
 		if (!fs.existsSync(sheet)) continue;

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -61,6 +61,88 @@ const buildCorpus = (dir, extension, minify) => {
 	});
 };
 
+// What the minifier comparisons install, read back as a corpus: real framework
+// stylesheets and documents, which `configCases` and wpt between them do not
+// have — those are spec fixtures, written to exercise a rule rather than to
+// ship. Absent until `yarn benchmark:css-minifiers` / `:html-minifiers` has run
+// once, so a caller that finds nothing says so rather than reporting green.
+const CSS_BENCHMARK_CACHE = path.join(
+	__dirname,
+	"../../node_modules/.cache/css-minifier-comparison"
+);
+const HTML_BENCHMARK_CACHE = path.join(
+	__dirname,
+	"../../node_modules/.cache/html-minifier-comparison"
+);
+
+// Named rather than walked: the caches also hold each tool's own `node_modules`,
+// and a package's test fixtures are not what any of this is about.
+/** @type {[string, string][]} */
+const BENCHMARK_STYLESHEETS = [
+	["Animate.css 4", "node_modules/animate.css/animate.css"],
+	["Bootstrap 5", "node_modules/bootstrap/dist/css/bootstrap.css"],
+	["Bootstrap 5 grid", "node_modules/bootstrap/dist/css/bootstrap-grid.css"],
+	["Bulma 1", "node_modules/bulma/css/bulma.css"],
+	["Font Awesome 6", "node_modules/@fortawesome/fontawesome-free/css/all.css"],
+	["Foundation 6", "node_modules/foundation-sites/dist/css/foundation.css"],
+	["Materialize 1", "node_modules/materialize-css/dist/css/materialize.css"],
+	["Milligram 1", "node_modules/milligram/dist/milligram.css"],
+	["normalize.css 8", "node_modules/normalize.css/normalize.css"],
+	["Pico 2", "node_modules/@picocss/pico/css/pico.css"],
+	["Primer 21", "node_modules/@primer/css/dist/primer.css"],
+	["Pure 3", "node_modules/purecss/build/pure.css"],
+	["sanitize.css 13", "node_modules/sanitize.css/sanitize.css"],
+	["Semantic UI 2", "node_modules/semantic-ui-css/semantic.css"],
+	["Tachyons 4", "node_modules/tachyons/css/tachyons.css"],
+	["UIkit 3", "node_modules/uikit/dist/css/uikit.css"],
+	["Water.css 2", "node_modules/water.css/out/water.css"],
+	["Tailwind 4 app", "tailwind-app.css"],
+	["Tailwind 4 wide", "tailwind-wide.css"],
+	["Tailwind 4 + daisyUI 5", "tailwind-daisyui.css"]
+];
+
+/** @type {[string, string][]} */
+const BENCHMARK_DOCUMENTS = [
+	["HTML5 Boilerplate 9", "node_modules/html5-boilerplate/dist/index.html"],
+	["Swagger UI 5", "node_modules/swagger-ui-dist/index.html"]
+];
+
+/**
+ * Read a benchmark cache as a corpus. A file the cache does not hold is left out
+ * rather than failing: each cache is built by the comparison that installs it.
+ * @param {string} cache the cache directory
+ * @param {[string, string][]} entries `[label, path within the cache]`
+ * @param {(source: string) => string} minify the printer to run
+ * @returns {Fixture[]} the corpus, empty when the cache is not there
+ */
+const readBenchmarkCache = (cache, entries, minify) => {
+	/** @type {Fixture[]} */
+	const out = [];
+	for (const [label, within] of entries) {
+		const file = path.join(cache, within);
+		if (!fs.existsSync(file)) continue;
+		const raw = fs.readFileSync(file, "utf8");
+		out.push({ name: label, raw, min: minify(raw) });
+	}
+	return out;
+};
+
+/**
+ * The framework stylesheets `yarn benchmark:css-minifiers` installs.
+ * @param {(source: string) => string} minify the printer to run
+ * @returns {Fixture[]} the corpus, empty until that has been run once
+ */
+const benchmarkStylesheets = (minify) =>
+	readBenchmarkCache(CSS_BENCHMARK_CACHE, BENCHMARK_STYLESHEETS, minify);
+
+/**
+ * The documents `yarn benchmark:html-minifiers` installs.
+ * @param {(source: string) => string} minify the printer to run
+ * @returns {Fixture[]} the corpus, empty until that has been run once
+ */
+const benchmarkDocuments = (minify) =>
+	readBenchmarkCache(HTML_BENCHMARK_CACHE, BENCHMARK_DOCUMENTS, minify);
+
 /**
  * @typedef {{ kind: string, condition: string }} Condition
  * @typedef {{ chain: Condition[], text: string, label?: string, list?: string[], block?: string }} Rule
@@ -211,7 +293,17 @@ const installHelpers = () => {
 						: word;
 				word = "";
 			};
-			for (const ch of run.replace(COLOR_TOKEN_RE, (color) => painted(color))) {
+			// A pixel ends in a channel, so a token written straight after the color
+			// would read as part of it — `rgba(…)0` is a color and a zero, not one
+			// channel more. The printer writes that form, since the `)` parts them.
+			const painting = run.replace(
+				COLOR_TOKEN_RE,
+				(color, at, whole) =>
+					`${painted(color)}${
+						WORD_RE.test(whole[at + color.length] || "") ? " " : ""
+					}`
+			);
+			for (const ch of painting) {
 				if (WORD_RE.test(ch)) {
 					word += ch;
 					continue;
@@ -1694,6 +1786,8 @@ const compareRules = (before, after, signatures) => {
 };
 
 module.exports = {
+	benchmarkDocuments,
+	benchmarkStylesheets,
 	buildCorpus,
 	collectFixtures,
 	compareRules,

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -61,55 +61,20 @@ const buildCorpus = (dir, extension, minify) => {
 	});
 };
 
-// What the minifier comparisons install, read back as a corpus: real framework
-// stylesheets and documents, which `configCases` and wpt between them do not
-// have — those are spec fixtures, written to exercise a rule rather than to
-// ship. Absent until `yarn benchmark:css-minifiers` / `:html-minifiers` has run
-// once, so a caller that finds nothing says so rather than reporting green.
-const CSS_BENCHMARK_CACHE = path.join(
-	__dirname,
-	"../../node_modules/.cache/css-minifier-comparison"
-);
-const HTML_BENCHMARK_CACHE = path.join(
-	__dirname,
-	"../../node_modules/.cache/html-minifier-comparison"
-);
-
-// Named rather than walked: the caches also hold each tool's own `node_modules`,
-// and a package's test fixtures are not what any of this is about.
-/** @type {[string, string][]} */
-const BENCHMARK_STYLESHEETS = [
-	["Animate.css 4", "node_modules/animate.css/animate.css"],
-	["Bootstrap 5", "node_modules/bootstrap/dist/css/bootstrap.css"],
-	["Bootstrap 5 grid", "node_modules/bootstrap/dist/css/bootstrap-grid.css"],
-	["Bulma 1", "node_modules/bulma/css/bulma.css"],
-	["Font Awesome 6", "node_modules/@fortawesome/fontawesome-free/css/all.css"],
-	["Foundation 6", "node_modules/foundation-sites/dist/css/foundation.css"],
-	["Materialize 1", "node_modules/materialize-css/dist/css/materialize.css"],
-	["Milligram 1", "node_modules/milligram/dist/milligram.css"],
-	["normalize.css 8", "node_modules/normalize.css/normalize.css"],
-	["Pico 2", "node_modules/@picocss/pico/css/pico.css"],
-	["Primer 21", "node_modules/@primer/css/dist/primer.css"],
-	["Pure 3", "node_modules/purecss/build/pure.css"],
-	["sanitize.css 13", "node_modules/sanitize.css/sanitize.css"],
-	["Semantic UI 2", "node_modules/semantic-ui-css/semantic.css"],
-	["Tachyons 4", "node_modules/tachyons/css/tachyons.css"],
-	["UIkit 3", "node_modules/uikit/dist/css/uikit.css"],
-	["Water.css 2", "node_modules/water.css/out/water.css"],
-	["Tailwind 4 app", "tailwind-app.css"],
-	["Tailwind 4 wide", "tailwind-wide.css"],
-	["Tailwind 4 + daisyUI 5", "tailwind-daisyui.css"]
-];
-
-/** @type {[string, string][]} */
-const BENCHMARK_DOCUMENTS = [
-	["HTML5 Boilerplate 9", "node_modules/html5-boilerplate/dist/index.html"],
-	["Swagger UI 5", "node_modules/swagger-ui-dist/index.html"]
-];
+// Read from the comparison scripts, so a fixture added to one is added here.
+const {
+	CACHE: CSS_CACHE,
+	GENERATED_FIXTURES,
+	INSTALLED_FIXTURES
+} = require("../../tooling/compare-css-minifiers");
+const {
+	CACHE: HTML_CACHE,
+	INSTALLED_DOCUMENTS
+} = require("../../tooling/compare-html-minifiers");
 
 /**
- * Read a benchmark cache as a corpus. A file the cache does not hold is left out
- * rather than failing: each cache is built by the comparison that installs it.
+ * Read a benchmark cache as a corpus. A file the cache does not hold is left
+ * out: each cache is built by the comparison that installs it.
  * @param {string} cache the cache directory
  * @param {[string, string][]} entries `[label, path within the cache]`
  * @param {(source: string) => string} minify the printer to run
@@ -128,12 +93,22 @@ const readBenchmarkCache = (cache, entries, minify) => {
 };
 
 /**
- * The framework stylesheets `yarn benchmark:css-minifiers` installs.
+ * The stylesheets `yarn benchmark:css-minifiers` installs and builds.
  * @param {(source: string) => string} minify the printer to run
  * @returns {Fixture[]} the corpus, empty until that has been run once
  */
 const benchmarkStylesheets = (minify) =>
-	readBenchmarkCache(CSS_BENCHMARK_CACHE, BENCHMARK_STYLESHEETS, minify);
+	readBenchmarkCache(
+		CSS_CACHE,
+		[
+			...INSTALLED_FIXTURES.map(
+				(/** @type {[string, string]} */ [label, file]) =>
+					/** @type {[string, string]} */ ([label, `node_modules/${file}`])
+			),
+			...GENERATED_FIXTURES
+		],
+		minify
+	);
 
 /**
  * The documents `yarn benchmark:html-minifiers` installs.
@@ -141,7 +116,14 @@ const benchmarkStylesheets = (minify) =>
  * @returns {Fixture[]} the corpus, empty until that has been run once
  */
 const benchmarkDocuments = (minify) =>
-	readBenchmarkCache(HTML_BENCHMARK_CACHE, BENCHMARK_DOCUMENTS, minify);
+	readBenchmarkCache(
+		HTML_CACHE,
+		INSTALLED_DOCUMENTS.map(
+			(/** @type {[string, string]} */ [label, file]) =>
+				/** @type {[string, string]} */ ([label, `node_modules/${file}`])
+		),
+		minify
+	);
 
 /**
  * @typedef {{ kind: string, condition: string }} Condition
@@ -293,9 +275,8 @@ const installHelpers = () => {
 						: word;
 				word = "";
 			};
-			// A pixel ends in a channel, so a token written straight after the color
-			// would read as part of it — `rgba(…)0` is a color and a zero, not one
-			// channel more. The printer writes that form, since the `)` parts them.
+			// A pixel ends in a channel, so `rgba(…)0` — the form the printer writes,
+			// since the `)` parts them — would read as one channel more.
 			const painting = run.replace(
 				COLOR_TOKEN_RE,
 				(color, at, whole) =>

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -68,8 +68,11 @@ const {
 	INSTALLED_FIXTURES
 } = require("../../tooling/compare-css-minifiers");
 const {
+	APP_SHELL,
 	CACHE: HTML_CACHE,
-	INSTALLED_DOCUMENTS
+	INLINED_STYLESHEETS,
+	INSTALLED_DOCUMENTS,
+	inlineCssPage
 } = require("../../tooling/compare-html-minifiers");
 
 /**
@@ -115,8 +118,8 @@ const benchmarkStylesheets = (minify) =>
  * @param {(source: string) => string} minify the printer to run
  * @returns {Fixture[]} the corpus, empty until that has been run once
  */
-const benchmarkDocuments = (minify) =>
-	readBenchmarkCache(
+const benchmarkDocuments = (minify) => {
+	const out = readBenchmarkCache(
 		HTML_CACHE,
 		INSTALLED_DOCUMENTS.map(
 			(/** @type {[string, string]} */ [label, file]) =>
@@ -124,6 +127,23 @@ const benchmarkDocuments = (minify) =>
 		),
 		minify
 	);
+	// The installed documents carry no `<style>` and no `style=`, so the pages
+	// the comparison builds are what reach the css minifier nested in the html.
+	if (out.length === 0) return out;
+	out.push({
+		name: "App shell (inline critical CSS)",
+		raw: APP_SHELL,
+		min: minify(APP_SHELL)
+	});
+	// From the css cache: that is the one installing framework stylesheets.
+	for (const [label, file] of INLINED_STYLESHEETS) {
+		const sheet = path.join(CSS_CACHE, "node_modules", file);
+		if (!fs.existsSync(sheet)) continue;
+		const raw = inlineCssPage(label, fs.readFileSync(sheet, "utf8"));
+		out.push({ name: label, raw, min: minify(raw) });
+	}
+	return out;
+};
 
 /**
  * @typedef {{ kind: string, condition: string }} Condition

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -275,6 +275,10 @@ const installHelpers = () => {
 	// One word, so a number with its unit is read whole rather than as an ident.
 	const WORD_RE = /[\w-]/;
 
+	// CSS Syntax §4.2: a name code point is also anything non-ASCII, which the
+	// token after a color can start with.
+	const NAME_RE = /[\w-]|[\u0080-\uFFFF]/;
+
 	/**
 	 * Every color a value holds, as the pixel it paints. A color the engine hands
 	 * back as written — a `var()` fallback, the one `image()` carries — is a color
@@ -302,7 +306,7 @@ const installHelpers = () => {
 				COLOR_TOKEN_RE,
 				(color, at, whole) =>
 					`${painted(color)}${
-						WORD_RE.test(whole[at + color.length] || "") ? " " : ""
+						NAME_RE.test(whole[at + color.length] || "") ? " " : ""
 					}`
 			);
 			for (const ch of painting) {

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -79,11 +79,11 @@ const FILED_CONFIG_HTML_DEFECTS = new Map();
 const FILED_BENCHMARK_CSS_DEFECTS = new Map([
 	[
 		"Semantic UI 2",
-		"not a printer defect: `.ui.table tr.negative, td.negative` and the same pair for `.error` print the same block, so joining each pair leaves four one-selector entries where the source had eight. The four carry one block between them, which makes their order unobservable — an element carrying both classes computes the same style either way, checked in Chrome. The comparison sorts a run of selectors reaching one block, and these land in two runs rather than one."
+		"not a printer defect: joining two rules that print one block reorders the selectors, and the comparison sorts a run rather than two — an element matching both computes the same style, checked in Chrome"
 	],
 	[
 		"Tailwind 4 + daisyUI 5",
-		"not a printer defect: the same shape as Semantic UI, with a `@media` between the two runs. `.collapse-arrow` and `.collapse-plus` `::after` come back reordered and four entries shorter; an element carrying both classes computes the same style at either side of the query, checked in Chrome."
+		"not a printer defect: the Semantic UI shape with a `@media` between the runs — an element matching both computes the same style at either side of the query, checked in Chrome"
 	]
 ]);
 
@@ -252,9 +252,7 @@ const buildCorpora = () => {
 			filedCss: FILED_CONFIG_CSS_DEFECTS
 		}
 	];
-	// The framework sheets and documents the minifier comparisons install: real
-	// projects, where `configCases` and wpt are both spec fixtures. Left out
-	// entirely when neither comparison has been run, and reported below.
+	// Real projects, where `configCases` and wpt are both spec fixtures.
 	const benchHtml = benchmarkDocuments((source) => source);
 	const benchCss = benchmarkStylesheets(minifyCss);
 	if (benchHtml.length > 0 || benchCss.length > 0) {
@@ -319,6 +317,9 @@ const inBatches = async (page, items, evaluate) => {
 // rather than reporting green.
 const NO_CORPUS =
 	"wpt submodule not initialized (run `git submodule update --init --depth 1 test/wpt`)";
+
+const NO_BENCHMARK_CORPUS =
+	"minifier comparison caches not built (run `yarn benchmark:css-minifiers` / `yarn benchmark:html-minifiers`)";
 
 expectNoDeprecations();
 
@@ -526,7 +527,7 @@ describe("printer output in real Chrome", () => {
 
 	const describeCorpus = (at, label) => {
 		describe(label, () => {
-			if (at === 1 && !hasCorpus()) {
+			if (label === "wpt" && !hasCorpus()) {
 				it(NO_CORPUS, () => {
 					// No-op: the corpus is an optional git submodule.
 				});
@@ -687,9 +688,16 @@ describe("printer output in real Chrome", () => {
 		});
 	};
 
-	// By position: which corpora were built depends on what is checked out and
-	// which comparisons have been run, so each names itself.
+	// Which corpora were built depends on what is checked out, so each names
+	// itself; a tier that cannot run reports that rather than reporting green.
 	for (const [at, one] of corpora.entries()) describeCorpus(at, one.label);
+	if (!corpora.some((one) => one.label === "benchmark corpus")) {
+		describe("benchmark corpus", () => {
+			it(NO_BENCHMARK_CORPUS, () => {
+				// No-op: the caches are built by the comparison scripts.
+			});
+		});
+	}
 
 	// One test per declaration, not per file: the value is what a defect is filed
 	// against, so the run names it without anything having to narrow it down.

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -30,6 +30,8 @@ const {
 const expectNoDeprecations = require("./helpers/expectNoDeprecations");
 const launchChrome = require("./helpers/launchChrome");
 const {
+	benchmarkDocuments,
+	benchmarkStylesheets,
 	buildCorpus,
 	compareRules,
 	conditionSignatures,
@@ -73,6 +75,19 @@ const VALUE_BUDGET = 2000;
 const FILED_CONFIG_CSS_DEFECTS = new Map();
 
 const FILED_CONFIG_HTML_DEFECTS = new Map();
+
+const FILED_BENCHMARK_CSS_DEFECTS = new Map([
+	[
+		"Semantic UI 2",
+		"not a printer defect: `.ui.table tr.negative, td.negative` and the same pair for `.error` print the same block, so joining each pair leaves four one-selector entries where the source had eight. The four carry one block between them, which makes their order unobservable — an element carrying both classes computes the same style either way, checked in Chrome. The comparison sorts a run of selectors reaching one block, and these land in two runs rather than one."
+	],
+	[
+		"Tailwind 4 + daisyUI 5",
+		"not a printer defect: the same shape as Semantic UI, with a `@media` between the two runs. `.collapse-arrow` and `.collapse-plus` `::after` come back reordered and four entries shorter; an element carrying both classes computes the same style at either side of the query, checked in Chrome."
+	]
+]);
+
+const FILED_BENCHMARK_HTML_DEFECTS = new Map();
 
 const FILED_WPT_HTML_DEFECTS = new Map([
 	[
@@ -237,6 +252,22 @@ const buildCorpora = () => {
 			filedCss: FILED_CONFIG_CSS_DEFECTS
 		}
 	];
+	// The framework sheets and documents the minifier comparisons install: real
+	// projects, where `configCases` and wpt are both spec fixtures. Left out
+	// entirely when neither comparison has been run, and reported below.
+	const benchHtml = benchmarkDocuments((source) => source);
+	const benchCss = benchmarkStylesheets(minifyCss);
+	if (benchHtml.length > 0 || benchCss.length > 0) {
+		built.push({
+			label: "benchmark corpus",
+			html: variant(benchHtml, {}),
+			htmlAllImpliedTags: variant(benchHtml, { removeImpliedTags: true }),
+			htmlSmartTags: variant(benchHtml, { removeImpliedTags: "smart" }),
+			css: benchCss,
+			filedHtml: FILED_BENCHMARK_HTML_DEFECTS,
+			filedCss: FILED_BENCHMARK_CSS_DEFECTS
+		});
+	}
 	if (!hasCorpus()) return built;
 	/** @type {Fixture[]} */
 	const wptHtml = [];
@@ -656,8 +687,9 @@ describe("printer output in real Chrome", () => {
 		});
 	};
 
-	describeCorpus(0, "configCases");
-	describeCorpus(1, "wpt");
+	// By position: which corpora were built depends on what is checked out and
+	// which comparisons have been run, so each names itself.
+	for (const [at, one] of corpora.entries()) describeCorpus(at, one.label);
 
 	// One test per declaration, not per file: the value is what a defect is filed
 	// against, so the run names it without anything having to narrow it down.

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -527,13 +527,6 @@ describe("printer output in real Chrome", () => {
 
 	const describeCorpus = (at, label) => {
 		describe(label, () => {
-			if (label === "wpt" && !hasCorpus()) {
-				it(NO_CORPUS, () => {
-					// No-op: the corpus is an optional git submodule.
-				});
-
-				return;
-			}
 			const one = corpora[at];
 
 			// One test per page, not per corpus: the file is what a defect is filed
@@ -689,12 +682,17 @@ describe("printer output in real Chrome", () => {
 	};
 
 	// Which corpora were built depends on what is checked out, so each names
-	// itself; a tier that cannot run reports that rather than reporting green.
+	// itself, and one that could not be built says so rather than going quiet.
 	for (const [at, one] of corpora.entries()) describeCorpus(at, one.label);
-	if (!corpora.some((one) => one.label === "benchmark corpus")) {
-		describe("benchmark corpus", () => {
-			it(NO_BENCHMARK_CORPUS, () => {
-				// No-op: the caches are built by the comparison scripts.
+	for (const [label, why] of [
+		["wpt", NO_CORPUS],
+		["benchmark corpus", NO_BENCHMARK_CORPUS]
+	]) {
+		if (corpora.some((one) => one.label === label)) continue;
+
+		describe(label, () => {
+			it(why, () => {
+				// No-op: both are optional, and each is built outside this suite.
 			});
 		});
 	}

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -82,6 +82,14 @@ const FILED_BENCHMARK_CSS_DEFECTS = new Map([
 		"not a printer defect: joining two rules that print one block reorders the selectors, and the comparison sorts a run rather than two — an element matching both computes the same style, checked in Chrome"
 	],
 	[
+		"Beer CSS 5",
+		"not a printer defect: the Semantic UI shape — `.switch.icon > span > i` and `.switch > span::before` print one block, and no element matches both, so their order is unobservable; checked in Chrome"
+	],
+	[
+		"Tabler 1",
+		"not a printer defect: the Semantic UI shape — `.markdown > table` and `.markdown > blockquote` print one block, and no element matches both, so their order is unobservable; checked in Chrome"
+	],
+	[
 		"Tailwind 4 + daisyUI 5",
 		"not a printer defect: the Semantic UI shape with a `@media` between the runs — an element matching both computes the same style at either side of the query, checked in Chrome"
 	]

--- a/tooling/compare-css-minifiers.js
+++ b/tooling/compare-css-minifiers.js
@@ -623,9 +623,21 @@ const main = async () => {
 	}
 };
 
-(process.argv[2] === "--measure" ? measure(process.argv[3]) : main()).catch(
-	(error) => {
-		log(String(error && error.stack ? error.stack : error));
-		process.exitCode = 1;
-	}
-);
+// Only as the entry point, so the corpus below can be required from a test.
+if (require.main === module) {
+	(process.argv[2] === "--measure" ? measure(process.argv[3]) : main()).catch(
+		(error) => {
+			log(String(error && error.stack ? error.stack : error));
+			process.exitCode = 1;
+		}
+	);
+}
+
+// Where the cache holds each fixture, for a reader that is not this script.
+module.exports.CACHE = CACHE;
+module.exports.GENERATED_FIXTURES = /** @type {[string, string][]} */ ([
+	["Tailwind 4 (app-sized)", "tailwind-app.css"],
+	["Tailwind 4 (wide utilities)", "tailwind-wide.css"],
+	["Tailwind 4 + daisyUI 5", "tailwind-daisyui.css"]
+]);
+module.exports.INSTALLED_FIXTURES = INSTALLED_FIXTURES;

--- a/tooling/compare-css-minifiers.js
+++ b/tooling/compare-css-minifiers.js
@@ -110,6 +110,15 @@ const log = (message) => {
 	process.stderr.write(`${message}\n`);
 };
 
+// Built rather than installed: each is a label, the file it lands in, and the
+// source it is built from.
+/** @type {[string, string, string][]} */
+const GENERATED_FIXTURES = [
+	["Tailwind 4 (app-sized)", "tailwind-app.css", TAILWIND_APP],
+	["Tailwind 4 (wide utilities)", "tailwind-wide.css", TAILWIND_WIDE],
+	["Tailwind 4 + daisyUI 5", "tailwind-daisyui.css", TAILWIND_DAISYUI]
+];
+
 /**
  * @param {string} file a path
  * @returns {Promise<boolean>} whether it exists
@@ -172,11 +181,7 @@ const setup = async () => {
 			`${JSON.stringify(written, null, 2)}\n`
 		);
 	}
-	for (const [source, out] of [
-		[TAILWIND_APP, "tailwind-app.css"],
-		[TAILWIND_WIDE, "tailwind-wide.css"],
-		[TAILWIND_DAISYUI, "tailwind-daisyui.css"]
-	]) {
+	for (const [, out, source] of GENERATED_FIXTURES) {
 		const target = path.join(CACHE, out);
 		if (await exists(target)) continue;
 		log(`building ${out} …`);
@@ -240,9 +245,9 @@ const fixtures = () => [
 	.../** @type {[string, string][]} */ (
 		INSTALLED_FIXTURES.map(([label, file]) => [label, path.join(MODULES, file)])
 	),
-	["Tailwind 4 (app-sized)", path.join(CACHE, "tailwind-app.css")],
-	["Tailwind 4 (wide utilities)", path.join(CACHE, "tailwind-wide.css")],
-	["Tailwind 4 + daisyUI 5", path.join(CACHE, "tailwind-daisyui.css")]
+	.../** @type {[string, string][]} */ (
+		GENERATED_FIXTURES.map(([label, file]) => [label, path.join(CACHE, file)])
+	)
 ];
 
 // Each entry is a factory so the measuring worker loads only the one tool it
@@ -635,9 +640,7 @@ if (require.main === module) {
 
 // Where the cache holds each fixture, for a reader that is not this script.
 module.exports.CACHE = CACHE;
-module.exports.GENERATED_FIXTURES = /** @type {[string, string][]} */ ([
-	["Tailwind 4 (app-sized)", "tailwind-app.css"],
-	["Tailwind 4 (wide utilities)", "tailwind-wide.css"],
-	["Tailwind 4 + daisyUI 5", "tailwind-daisyui.css"]
-]);
+module.exports.GENERATED_FIXTURES = /** @type {[string, string][]} */ (
+	GENERATED_FIXTURES.map(([label, file]) => [label, file])
+);
 module.exports.INSTALLED_FIXTURES = INSTALLED_FIXTURES;

--- a/tooling/compare-html-minifiers.js
+++ b/tooling/compare-html-minifiers.js
@@ -134,6 +134,21 @@ const load = (name) => require(path.join(MODULES, name));
 // form markup. Neither installed fixture carries an inline `<style>`, a
 // `srcset` or a boolean attribute, so without this the comparison cannot see
 // what a minifier does with any of them.
+// Whether a tool minifies, passes through or mangles a large `<style>` is what
+// the inlined sheets decide.
+/** @type {[string, string][]} */
+const INSTALLED_DOCUMENTS = [
+	["HTML5 Boilerplate 9", "html5-boilerplate/dist/index.html"],
+	["Swagger UI 5", "swagger-ui-dist/index.html"]
+];
+
+/** @type {[string, string][]} */
+const INLINED_STYLESHEETS = [
+	["Pico 2 classless (inlined)", "@picocss/pico/css/pico.classless.css"],
+	["Water.css 2 (inlined)", "water.css/out/water.css"],
+	["Bootstrap 5 (inlined)", "bootstrap/dist/css/bootstrap.css"]
+];
+
 const APP_SHELL = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -288,25 +303,18 @@ const fixtures = async () => {
 	const { marked } = load("marked");
 	/** @type {[string, string][]} */
 	const out = [];
-	for (const [label, file] of [
-		[
-			"HTML5 Boilerplate 9",
-			path.join(MODULES, "html5-boilerplate/dist/index.html")
-		],
-		["Swagger UI 5", path.join(MODULES, "swagger-ui-dist/index.html")]
-	]) {
-		out.push([label, await fs.promises.readFile(file, "utf8")]);
+	for (const [label, file] of INSTALLED_DOCUMENTS) {
+		out.push([
+			label,
+			await fs.promises.readFile(path.join(MODULES, file), "utf8")
+		]);
 	}
 	out.push(["App shell (inline critical CSS)", APP_SHELL]);
 	out.push(["Component library page", componentPage(400)]);
 	// Real framework stylesheets, classless through component-sized, inlined
 	// whole: whether each tool minifies, passes through, or mangles a large
 	// `<style>` decides these pages.
-	for (const [label, file] of [
-		["Pico 2 classless (inlined)", "@picocss/pico/css/pico.classless.css"],
-		["Water.css 2 (inlined)", "water.css/out/water.css"],
-		["Bootstrap 5 (inlined)", "bootstrap/dist/css/bootstrap.css"]
-	]) {
+	for (const [label, file] of INLINED_STYLESHEETS) {
 		out.push([
 			label,
 			inlineCssPage(
@@ -853,15 +861,8 @@ if (require.main === module) {
 // is not this script.
 module.exports.APP_SHELL = APP_SHELL;
 module.exports.CACHE = CACHE;
-module.exports.INLINED_STYLESHEETS = /** @type {[string, string][]} */ ([
-	["Pico 2 classless (inlined)", "@picocss/pico/css/pico.classless.css"],
-	["Water.css 2 (inlined)", "water.css/out/water.css"],
-	["Bootstrap 5 (inlined)", "bootstrap/dist/css/bootstrap.css"]
-]);
-module.exports.INSTALLED_DOCUMENTS = /** @type {[string, string][]} */ ([
-	["HTML5 Boilerplate 9", "html5-boilerplate/dist/index.html"],
-	["Swagger UI 5", "swagger-ui-dist/index.html"]
-]);
+module.exports.INLINED_STYLESHEETS = INLINED_STYLESHEETS;
+module.exports.INSTALLED_DOCUMENTS = INSTALLED_DOCUMENTS;
 
 // The pages built here rather than installed. A reader that cannot await builds
 // the same documents from these.

--- a/tooling/compare-html-minifiers.js
+++ b/tooling/compare-html-minifiers.js
@@ -134,8 +134,6 @@ const load = (name) => require(path.join(MODULES, name));
 // form markup. Neither installed fixture carries an inline `<style>`, a
 // `srcset` or a boolean attribute, so without this the comparison cannot see
 // what a minifier does with any of them.
-// Whether a tool minifies, passes through or mangles a large `<style>` is what
-// the inlined sheets decide.
 /** @type {[string, string][]} */
 const INSTALLED_DOCUMENTS = [
 	["HTML5 Boilerplate 9", "html5-boilerplate/dist/index.html"],

--- a/tooling/compare-html-minifiers.js
+++ b/tooling/compare-html-minifiers.js
@@ -839,9 +839,20 @@ const main = async () => {
 	}
 };
 
-(process.argv[2] === "--measure" ? measure(process.argv[3]) : main()).catch(
-	(error) => {
-		log(String(error && error.stack ? error.stack : error));
-		process.exitCode = 1;
-	}
-);
+// Only as the entry point, so the documents below can be required from a test.
+if (require.main === module) {
+	(process.argv[2] === "--measure" ? measure(process.argv[3]) : main()).catch(
+		(error) => {
+			log(String(error && error.stack ? error.stack : error));
+			process.exitCode = 1;
+		}
+	);
+}
+
+// The documents that are files rather than pages this builds, for a reader that
+// is not this script.
+module.exports.CACHE = CACHE;
+module.exports.INSTALLED_DOCUMENTS = /** @type {[string, string][]} */ ([
+	["HTML5 Boilerplate 9", "html5-boilerplate/dist/index.html"],
+	["Swagger UI 5", "swagger-ui-dist/index.html"]
+]);

--- a/tooling/compare-html-minifiers.js
+++ b/tooling/compare-html-minifiers.js
@@ -851,8 +851,18 @@ if (require.main === module) {
 
 // The documents that are files rather than pages this builds, for a reader that
 // is not this script.
+module.exports.APP_SHELL = APP_SHELL;
 module.exports.CACHE = CACHE;
+module.exports.INLINED_STYLESHEETS = /** @type {[string, string][]} */ ([
+	["Pico 2 classless (inlined)", "@picocss/pico/css/pico.classless.css"],
+	["Water.css 2 (inlined)", "water.css/out/water.css"],
+	["Bootstrap 5 (inlined)", "bootstrap/dist/css/bootstrap.css"]
+]);
 module.exports.INSTALLED_DOCUMENTS = /** @type {[string, string][]} */ ([
 	["HTML5 Boilerplate 9", "html5-boilerplate/dist/index.html"],
 	["Swagger UI 5", "swagger-ui-dist/index.html"]
 ]);
+
+// The pages built here rather than installed. A reader that cannot await builds
+// the same documents from these.
+module.exports.inlineCssPage = inlineCssPage;


### PR DESCRIPTION
Summary

The equivalence check ran over configCases and test/wpt — both written to exercise a rule rather than to ship. The minifier comparisons already install twenty framework stylesheets and two documents, so this reads them back as a corpus of their own and holds both printers to what Chrome makes of their output.

It found three divergences none of the existing corpora reach, and one of them was a real defect in the comparison itself: painted() replaces a color with the pixel it paints, which ends in a channel, so a token written straight after the color read as part of it — rgba(…)0, the form the printer writes since the ) already parts them, came back as one channel more.

What kind of change does this PR introduce?

test

Did you add tests for your changes?

This is the test. The corpus adds 79 cases to test:syntax-equivalence (5575 → 5654), all passing.

Does this PR introduce a breaking change?

No — test/ only, no lib/ change.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

n/a — the corpus is read from the caches yarn benchmark:css-minifiers / :html-minifiers already build, and is left out entirely when neither has been run.

Use of AI

Yes — used to wire the corpus in, diagnose the three divergences and run the checks. The two filed ones were each verified in Chrome before filing: an element carrying both classes computes the same style either way, at two viewport widths for the daisyUI one. The painted() fix was confirmed load-bearing by removing it and watching Primer 21 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded syntax-equivalence coverage with benchmark documents and stylesheets from real-world frameworks.
  - Added benchmark coverage for Semantic UI and Tailwind with daisyUI.
  - Added CSS nesting scenarios and verified resulting colors in browser-based tests.
  - Improved reporting across multiple corpus categories, including notices when benchmark data is unavailable.

- **Bug Fixes**
  - Corrected spacing after painted colors when followed by a word character.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->