### PR TITLE
feat: export cssMinify and htmlMinify on css.syntax and html.syntax

### DIFF
--- a/.changeset/009-export-css-and-html-minifiers.md
+++ b/.changeset/009-export-css-and-html-minifiers.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Export `cssMinify` and `htmlMinify` on `css.syntax` and `html.syntax`.

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -22,6 +22,7 @@ const {
 	parseDataURI
 } = require("../util/dataURL");
 const { makeCacheable } = require("../util/identifier");
+const cssMinify = require("./cssMinify");
 
 /**
  * Renders source this stylesheet embeds — a `data:` URL's payload today.
@@ -16642,6 +16643,7 @@ module.exports.TokenStream = TokenStream;
 module.exports.askEmbeddedRenderer = askEmbeddedRenderer;
 module.exports.buildSkipSet = buildSkipSet;
 module.exports.collectEmbeddedDiagnostics = collectEmbeddedDiagnostics;
+module.exports.cssMinify = cssMinify;
 module.exports.embeddedText = embeddedText;
 module.exports.equalsLowerCase = equalsLowerCase;
 module.exports.escapeIdentifier = escapeIdentifier;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -149,6 +149,7 @@ const {
 	VOID,
 	VOID_FORMATTING
 } = require("./data");
+const htmlMinify = require("./htmlMinify");
 
 // cspell:ignore apos notpre noncharacter noncharacters DFFF FFFE CCLS ALNUM
 
@@ -13766,6 +13767,7 @@ module.exports.decodeEntities = decodeEntities;
 module.exports.embeddedText = embeddedText;
 module.exports.escapeAttribute = escapeAttribute;
 module.exports.escapeText = escapeText;
+module.exports.htmlMinify = htmlMinify;
 module.exports.isAsciiWhitespace = isSpace;
 module.exports.metaTag = metaTag;
 // WHATWG "ASCII whitespace" (tab / LF / FF / CR / space) — the tokenizer's

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -9907,6 +9907,6 @@ describe("cssMinify export", () => {
 
 		const { code } = await cssMinify({ "a.css": "a {\n\tcolor: red;\n}\n" });
 
-		expect(code).toBe("a{color:red}");
+		expect(code).toMatchInlineSnapshot('"a{color:red}"');
 	});
 });

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -9880,3 +9880,33 @@ describe("CssSyntax minify — a `color-mix()` the target cannot read", () => {
 		);
 	});
 });
+
+describe("cssMinify export", () => {
+	it("is the minifier itself, reachable from the public entry", () => {
+		const webpack = require("../");
+
+		expect(webpack.css.syntax.cssMinify).toBe(require("../lib/css/cssMinify"));
+	});
+
+	it("carries the minimizer contract minimizer-webpack-plugin dispatches on", () => {
+		const webpack = require("../");
+
+		const { cssMinify } = webpack.css.syntax;
+
+		expect(cssMinify.getTypes()).toEqual(["css"]);
+		expect(cssMinify.getEmbeddedTypes()).toContain("css");
+		expect(cssMinify.supportsWorkerThreads()).toBe(true);
+		expect(cssMinify.filter("a.css")).toBe(true);
+		expect(cssMinify.filter("a.html")).toBe(false);
+	});
+
+	it("minifies through the public entry", async () => {
+		const webpack = require("../");
+
+		const { cssMinify } = webpack.css.syntax;
+
+		const { code } = await cssMinify({ "a.css": "a {\n\tcolor: red;\n}\n" });
+
+		expect(code).toBe("a{color:red}");
+	});
+});

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -9094,6 +9094,6 @@ describe("htmlMinify export", () => {
 		});
 
 		// `</p>` is an optional end tag, so minifying drops it.
-		expect(code).toBe("<p class=x>  a  ");
+		expect(code).toMatchInlineSnapshot('"<p class=x>  a  "');
 	});
 });

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -9062,3 +9062,38 @@ describe("htmlMinify — an answered `style` attribute that changes its quoting"
 		).toBe("<svg><rect style=color:red /></svg>");
 	});
 });
+
+describe("htmlMinify export", () => {
+	it("is the minifier itself, reachable from the public entry", () => {
+		const webpack = require("../");
+
+		expect(webpack.html.syntax.htmlMinify).toBe(
+			require("../lib/html/htmlMinify")
+		);
+	});
+
+	it("carries the minimizer contract minimizer-webpack-plugin dispatches on", () => {
+		const webpack = require("../");
+
+		const { htmlMinify } = webpack.html.syntax;
+
+		expect(htmlMinify.getTypes()).toEqual(["html"]);
+		expect(htmlMinify.getEmbeddedTypes()).toContain("css");
+		expect(htmlMinify.supportsWorkerThreads()).toBe(true);
+		expect(htmlMinify.filter("a.html")).toBe(true);
+		expect(htmlMinify.filter("a.css")).toBe(false);
+	});
+
+	it("minifies through the public entry", async () => {
+		const webpack = require("../");
+
+		const { htmlMinify } = webpack.html.syntax;
+
+		const { code } = await htmlMinify({
+			"a.html": "<p class='x'>  a  </p>"
+		});
+
+		// `</p>` is an optional end tag, so minifying drops it.
+		expect(code).toBe("<p class=x>  a  ");
+	});
+});

--- a/test/configCases/css/minimize-bad-string/webpack.config.js
+++ b/test/configCases/css/minimize-bad-string/webpack.config.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const MinimizerPlugin = require("minimizer-webpack-plugin");
-const cssMinify = require("../../../../lib/css/cssMinify");
+const webpack = require("../../../../");
+
+const { cssMinify } = webpack.css.syntax;
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/html/minimize/webpack.config.js
+++ b/test/configCases/html/minimize/webpack.config.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const MinimizerPlugin = require("minimizer-webpack-plugin");
-const htmlMinify = require("../../../../lib/html/htmlMinify");
+const webpack = require("../../../../");
+
+const { htmlMinify } = webpack.html.syntax;
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -30556,6 +30556,37 @@ declare namespace exports {
 					errors?: (string | Error)[];
 				}[]
 			) => { warnings?: (string | Error)[]; errors?: (string | Error)[] };
+			export function cssMinify(
+				input: { [index: string]: string },
+				sourceMap?: object,
+				minimizerOptions?: {
+					as?: "stylesheet" | "block-contents";
+					environment?: CssEnvironment;
+					convertLengthUnits?: boolean;
+					rewriteCustomProperties?: boolean;
+					unusedSymbols?: string[];
+					pseudoClasses?: { [index: string]: string };
+					renderEmbeddedSource?: (
+						source: string,
+						info: { type: string; hostType: string }
+					) =>
+						| undefined
+						| string
+						| EmbeddedSourceResult
+						| Promise<undefined | string | EmbeddedSourceResult>;
+				} & CssTransformOptions
+			): Promise<{
+				code: string;
+				map?: SourceMap;
+				warnings?: (string | Error)[];
+				errors?: (string | Error)[];
+			}>;
+			export namespace cssMinify {
+				export let supportsWorkerThreads: () => boolean;
+				export let getTypes: () => string[];
+				export let getEmbeddedTypes: () => string[];
+				export let filter: (name: string) => boolean;
+			}
 			export let embeddedText: (
 				answer?: string | { code?: string }
 			) => undefined | string;
@@ -30868,6 +30899,40 @@ declare namespace exports {
 				minimal?: boolean
 			) => string;
 			export let escapeText: (s: string) => string;
+			export function htmlMinify(
+				input: { [index: string]: string },
+				sourceMap?: RawSourceMap,
+				minimizerOptions?: Omit<
+					HtmlPrintOptions,
+					"renderEmbeddedSource" | "deferEmbeddedSource"
+				> & {
+					css?: {
+						convertLengthUnits?: boolean;
+						rewriteCustomProperties?: boolean;
+						unusedSymbols?: string[];
+						pseudoClasses?: { [index: string]: string };
+					};
+					minifyConditionalComments?: boolean;
+					renderEmbeddedSource?: (
+						source: string,
+						info: { type: string; hostType: string; as?: string }
+					) =>
+						| undefined
+						| string
+						| EmbeddedSourceResult
+						| Promise<undefined | string | EmbeddedSourceResult>;
+				}
+			): Promise<{
+				code: string;
+				warnings?: (string | Error)[];
+				errors?: (string | Error)[];
+			}>;
+			export namespace htmlMinify {
+				export let supportsWorkerThreads: () => boolean;
+				export let getTypes: () => string[];
+				export let getEmbeddedTypes: () => string[];
+				export let filter: (name: string) => boolean;
+			}
 			export let isAsciiWhitespace: (cc: number) => boolean;
 			export let metaTag: (name: string, content: string) => string;
 			export let parseCssUrls: (input: string) => [string, number, number][];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`lib/css/cssMinify.js` and `lib/html/htmlMinify.js` are written as `minify` functions for `minimizer-webpack-plugin`, but neither was reachable from webpack's public surface — both are absent from `lib/index.js` and from `types.d.ts` — so the only way to pass one to the plugin was a deep require into `lib/`. This exports them on the `css.syntax` / `html.syntax` namespaces they already read their parser back out of at call time. Needed by webpack/minimizer-webpack-plugin#718, which documents them.

Neither minify file requires anything at module scope (the `require("webpack")` resolving the parser sits inside the function body, so it survives being shipped to the plugin's worker pool as source), so this adds no cycle and no load-order constraint — every module still loads standalone in any order.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/CssSyntax.unittest.js` and `test/HtmlSyntax.unittest.js` each assert the export is the minifier itself, carries the contract the plugin dispatches on (`getTypes` / `getEmbeddedTypes` / `filter` / `supportsWorkerThreads`), and minifies through the public entry. For integration coverage, `configCases/css/minimize-bad-string` and `configCases/html/minimize` now reach the minifier through the new export instead of a deep require, so a real build exercises it.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — purely additive. The deep require keeps working.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

`webpack.css.syntax.cssMinify` and `webpack.html.syntax.htmlMinify` as the supported way to pass webpack's own minifiers to `minimizer-webpack-plugin`; webpack/minimizer-webpack-plugin#718 documents this and is waiting on this PR.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code wrote the change and the tests. It verified the export surface empirically rather than from the JSDoc — enumerating `webpack.css.syntax` / `webpack.html.syntax` at runtime to confirm the minifiers were genuinely absent, and loading each module first in its own process to confirm the new requires introduce no cycle. The `types.d.ts` hunk is the generator's own output: `yarn fix:special` also produced unrelated churn from a local `mdn-data` version older than CI's, so only the generated region for these two symbols was kept and then diffed against the generator's full output to confirm it matches byte for byte.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQeNpahUSDUjD2Crugy5H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS and HTML minifiers are now available through the public `css.syntax` and `html.syntax` APIs.
  * CSS minification now supports additional target-aware transformations, including nesting, direction selectors, custom rules, escape rewriting, and color fallbacks.
  * Public minifier exports support stylesheet and HTML optimization workflows, including worker-thread compatibility.

* **Tests**
  * Added coverage for public exports, supported file types, plugin compatibility, target-aware CSS output, and expected minified results.
  * Updated configuration examples to use the public minifier exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->