### PR TITLE
fix(hmr): carry a hashed stylesheet name in the update, and bake it into the url map

### DIFF
--- a/.changeset/006-analyzable-repair.md
+++ b/.changeset/006-analyzable-repair.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Repair hashed names, bake hashed url maps under HMR and read depths per update.
+Repair hashed names; under HMR bake hashed url maps and reload moved css names.

--- a/.changeset/006-analyzable-repair.md
+++ b/.changeset/006-analyzable-repair.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Repair hashed names, keep url maps under HMR and read depths per hot update.
+Repair hashed names, bake hashed url maps under HMR and read depths per update.

--- a/.changeset/007-hmr-css-hashed-names.md
+++ b/.changeset/007-hmr-css-hashed-names.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Reload a stylesheet whose hashed name moved at the name the hot update gives it.

--- a/.changeset/007-hmr-css-hashed-names.md
+++ b/.changeset/007-hmr-css-hashed-names.md
@@ -1,5 +1,0 @@
----
-"webpack": patch
----
-
-Reload a stylesheet whose hashed name moved at the name the hot update gives it.

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -17,7 +17,11 @@ const {
 } = require("./ModuleTypeConstants");
 const NormalModule = require("./NormalModule");
 const RuntimeGlobals = require("./RuntimeGlobals");
-const { chunkHasCss } = require("./css/CssModulesPlugin");
+const { getPresentKinds } = require("./TemplatedPathPlugin");
+const {
+	chunkHasCss,
+	getChunkFilenameTemplate: getCssChunkFilenameTemplate
+} = require("./css/CssModulesPlugin");
 const ConstDependency = require("./dependencies/ConstDependency");
 const ImportMetaHotAcceptDependency = require("./dependencies/ImportMetaHotAcceptDependency");
 const ImportMetaHotDeclineDependency = require("./dependencies/ImportMetaHotDeclineDependency");
@@ -71,6 +75,22 @@ const {
 
 /** @typedef {{ updatedChunkIds: ChunkIds, removedChunkIds: ChunkIds, removedModules: ModuleSet, forceLoadChunkIds: ChunkIds, filename: string, assetInfo: AssetInfo }} HotUpdateMainContentByRuntimeItem */
 /** @typedef {Map<string, HotUpdateMainContentByRuntimeItem>} HotUpdateMainContentByRuntime */
+
+/**
+ * Whether a filename template reads any hash, so the name it gives a chunk can move
+ * between two builds.
+ * @param {string} template the filename template
+ * @returns {boolean} true when a hash is part of the name
+ */
+const templateReadsHash = (template) => {
+	const kinds = getPresentKinds(template);
+	return (
+		kinds.has("hash") ||
+		kinds.has("fullhash") ||
+		kinds.has("chunkhash") ||
+		kinds.has("contenthash")
+	);
+};
 
 const PLUGIN_NAME = "HotModuleReplacementPlugin";
 
@@ -856,7 +876,7 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 								assetInfo
 							}
 						] of hotUpdateMainContentByFilename) {
-							/** @type {{ c: ChunkId[], r: ChunkId[], m: ModuleId[], f?: ChunkId[], css?: { r: ChunkId[] } }} */
+							/** @type {{ c: ChunkId[], r: ChunkId[], m: ModuleId[], f?: ChunkId[], css?: { r: ChunkId[], n?: Record<ChunkId, string> } }} */
 							const hotUpdateMainJson = {
 								c: [...updatedChunkIds],
 								r: [...removedChunkIds],
@@ -882,21 +902,47 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 							// Build CSS removed chunks list (chunks in updatedChunkIds that no longer have CSS)
 							/** @type {ChunkId[]} */
 							const cssRemovedChunkIds = [];
+							/** @type {Record<ChunkId, string> | undefined} */
+							let cssChunkNames;
 							if (compilation.options.experiments.css) {
 								for (const chunkId of updatedChunkIds) {
 									for (const /** @type {Chunk} */ chunk of compilation.chunks) {
-										if (chunk.id === chunkId) {
-											if (!chunkHasCss(chunk, chunkGraph)) {
-												cssRemovedChunkIds.push(chunkId);
-											}
+										if (chunk.id !== chunkId) continue;
+										if (!chunkHasCss(chunk, chunkGraph)) {
+											cssRemovedChunkIds.push(chunkId);
 											break;
 										}
+										// The runtime's name map is refreshed only by the update chunk
+										// itself, so a name that moved with the content travels here.
+										const template = getCssChunkFilenameTemplate(
+											chunk,
+											compilation.outputOptions
+										);
+										if (
+											typeof template !== "string" ||
+											templateReadsHash(template)
+										) {
+											if (cssChunkNames === undefined) cssChunkNames = {};
+											cssChunkNames[chunkId] = compilation.getPath(template, {
+												hash: compilation.hash,
+												runtime: chunk.runtime,
+												chunk,
+												contentHashType: "css"
+											});
+										}
+										break;
 									}
 								}
 							}
 
-							if (cssRemovedChunkIds.length > 0) {
+							if (
+								cssRemovedChunkIds.length > 0 ||
+								cssChunkNames !== undefined
+							) {
 								hotUpdateMainJson.css = { r: cssRemovedChunkIds };
+								if (cssChunkNames !== undefined) {
+									hotUpdateMainJson.css.n = cssChunkNames;
+								}
 							}
 
 							const source = new RawSource(

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2792,6 +2792,17 @@ class RuntimeTemplate {
 			const late = this._settlesLate(chunk);
 			if (late !== this._settlesLate(target)) return !late;
 		}
+		return this._hashRoundBefore(chunk, target);
+	}
+
+	/**
+	 * Whether the four rounds alone settle `chunk` before `target`, leaving out what the
+	 * full-hash marks move: the order a runtime module generated in its chunk's round sees.
+	 * @param {Chunk} chunk the chunk whose hash would be read
+	 * @param {Chunk} target the chunk reading it
+	 * @returns {boolean} true when the hash exists by the time the target is hashed
+	 */
+	_hashRoundBefore(chunk, target) {
 		const chunkGraph = /** @type {ChunkGraph} */ (this.compilation.chunkGraph);
 		const round = hashRound(chunk, chunkGraph);
 		const targetRound = hashRound(target, chunkGraph);
@@ -2811,6 +2822,43 @@ class RuntimeTemplate {
 				/** @type {ChunkId} */ (chunk.id),
 				/** @type {ChunkId} */ (target.id)
 			) < 0
+		);
+	}
+
+	/**
+	 * Whether a name reading `[chunkhash]` or `[contenthash]` is settled before every
+	 * chunk it is written into. A runtime module is generated in its chunk's round, so
+	 * such a name is spelled into it rather than deferred, and moves its hash with it.
+	 * @param {Chunk} chunk the chunk named
+	 * @param {string} template what names it
+	 * @param {Iterable<Chunk>} targets the chunks the name is written into
+	 * @returns {boolean} true when the hashes it reads exist by then
+	 */
+	_hashedNameSettledBefore(chunk, template, targets) {
+		const kinds = getTemplatedPathPlugin().getPresentKinds(template);
+		// The compilation hash exists in no round a chunk is hashed in.
+		if (kinds.has("fullhash") || kinds.has("hash")) return false;
+		for (const target of targets) {
+			if (!this._hashRoundBefore(chunk, target)) return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Whether the hashes a name reads are on the chunk now, which they are only once its
+	 * round of `createHash` has run — never while modules are being generated.
+	 * @param {Chunk} chunk the chunk named
+	 * @param {string} template what names it
+	 * @param {string} sourceType which asset of the chunk it names
+	 * @returns {boolean} true when the name can be resolved here
+	 */
+	_hashedNamePresent(chunk, template, sourceType) {
+		const kinds = getTemplatedPathPlugin().getPresentKinds(template);
+		return (
+			!kinds.has("fullhash") &&
+			!kinds.has("hash") &&
+			(!kinds.has("chunkhash") || chunk.hash !== undefined) &&
+			(!kinds.has("contenthash") || chunk.contentHash[sourceType] !== undefined)
 		);
 	}
 
@@ -3350,25 +3398,33 @@ class RuntimeTemplate {
 		// An id names the chunk in the stand-in; `blockPromise` drops an id-less chunk
 		// before asking, so the guard only keeps `null` out of a name.
 		if (chunk.id === null) return null;
+		// A runtime module is generated in its chunk's round of `createHash`, where a
+		// hashed name settled earlier exists: spelled, so a hot update carries the new one.
+		const settled =
+			deferred &&
+			template !== undefined &&
+			this._hashedNamePresent(chunk, template, sourceType) &&
+			this._namesBeforeAll(chunk, chunks);
 		const canReserve = this._canDeferAnalyzableName(chunks);
 		// A content-named consumer folds this name into its hash when it settles first;
 		// what the fold cannot cover is repaired instead.
 		const canFold = !canReserve && this._namesBeforeAll(chunk, chunks);
-		const filename = deferred
-			? ""
-			: compilation.getPath(/** @type {string} */ (template), {
-					chunk,
-					// Matches what names the asset, or a placeholder resolved here would
-					// not be the one on disk.
-					runtime: chunk.runtime,
-					contentHashType: sourceType
-				});
+		const filename =
+			deferred && !settled
+				? ""
+				: compilation.getPath(/** @type {string} */ (template), {
+						chunk,
+						// Matches what names the asset, or a placeholder resolved here would
+						// not be the one on disk.
+						runtime: chunk.runtime,
+						contentHashType: sourceType
+					});
 		/**
 		 * @param {SpecifierPart[]} prefix what goes in front of the chunk's filename
 		 * @returns {string} the specifier already quoted
 		 */
 		const specifier = (prefix) => {
-			if (!deferred) {
+			if (!deferred || settled) {
 				const text = literalText(prefix);
 				if (text !== null) return toJsStringLiteral(text + filename);
 			}
@@ -3378,7 +3434,11 @@ class RuntimeTemplate {
 				this._reserveAnalyzableSpecifier(
 					this._markedForRepair(repair, [
 						...prefix,
-						[naming.standIn, /** @type {ChunkId} */ (chunk.id)]
+						// A settled name is carried as text: the fill would spell the same,
+						// but only text of its own moves the runtime module's hash.
+						settled
+							? ["literal", filename]
+							: [naming.standIn, /** @type {ChunkId} */ (chunk.id)]
 					])
 				)
 			);
@@ -3737,7 +3797,10 @@ class RuntimeTemplate {
 				hot
 			);
 			if (specifier === null) return null;
-			if (hot && !this._settledUnderHot(specifier, chunk, sourceType)) {
+			if (
+				hot &&
+				!this._settledUnderHot(specifier, chunk, sourceType, consumingChunks)
+			) {
 				return this._analyzableBailout(consumingModule, HOT_NAME_BAILOUT, null);
 			}
 			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);
@@ -3746,14 +3809,16 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a url a hot update re-ships stays the same text until an id joins or leaves
-	 * the map: spelled here, or a stand-in reading only each asset's depth and a hash-free name.
+	 * Whether a url a hot update re-ships moves only with the runtime module's own text:
+	 * spelled here, or a stand-in reading only each asset's depth and a name that is
+	 * hash-free or settled before the chunks the map is written into.
 	 * @param {string} specifier the specifier already quoted
 	 * @param {Chunk} chunk the chunk it names
 	 * @param {string} sourceType which asset of the chunk it names
-	 * @returns {boolean} true when no update changes what the fill spells
+	 * @param {Chunk[]} consumingChunks the chunks the map is written into
+	 * @returns {boolean} true when no update moves what the fill spells
 	 */
-	_settledUnderHot(specifier, chunk, sourceType) {
+	_settledUnderHot(specifier, chunk, sourceType, consumingChunks) {
 		const match = ANALYZABLE_TOKEN_PAYLOAD.exec(specifier);
 		if (match === null) return true;
 		const parts = RuntimeTemplate._readAnalyzableSpecifier(match[1]);
@@ -3766,7 +3831,11 @@ class RuntimeTemplate {
 			if (!CHUNK_SPECIFIER_PART_KINDS.has(kind)) return false;
 		}
 		const template = this._chunkAssetTemplate(chunk, sourceType);
-		return typeof template === "string" && !HASH_IN_FILENAME.test(template);
+		return (
+			typeof template === "string" &&
+			(!HASH_IN_FILENAME.test(template) ||
+				this._hashedNameSettledBefore(chunk, template, consumingChunks))
+		);
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2826,9 +2826,8 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether a name reading `[chunkhash]` or `[contenthash]` is settled before every
-	 * chunk it is written into. A runtime module is generated in its chunk's round, so
-	 * such a name is spelled into it rather than deferred, and moves its hash with it.
+	 * Whether a `[chunkhash]`/`[contenthash]` name is settled before every chunk it is
+	 * written into, so a runtime module generated in its chunk's round can spell it.
 	 * @param {Chunk} chunk the chunk named
 	 * @param {string} template what names it
 	 * @param {Iterable<Chunk>} targets the chunks the name is written into
@@ -3810,8 +3809,7 @@ class RuntimeTemplate {
 
 	/**
 	 * Whether a url a hot update re-ships moves only with the runtime module's own text:
-	 * spelled here, or a stand-in reading only each asset's depth and a name that is
-	 * hash-free or settled before the chunks the map is written into.
+	 * spelled here, or a stand-in of each asset's depth and a hash-free or settled name.
 	 * @param {string} specifier the specifier already quoted
 	 * @param {Chunk} chunk the chunk it names
 	 * @param {string} sourceType which asset of the chunk it names

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -542,6 +542,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 											Template.indent([
 												// node SSR: refresh the server style registry from the re-emitted CSS instead of touching the DOM
 												`${cst} cssRemovedChunks = css && css.r;`,
+												`${cst} cssNames = css && css.n;`,
 												`${cst} registry = ${runtimeTemplate.cssServerStyleRegistry()};`,
 												`chunkIds.forEach(${runtimeTemplate.basicFunction(
 													"chunkId",
@@ -551,7 +552,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 															"cssRemovedChunks",
 															"indexOf(chunkId)"
 														)} >= 0) { delete registry[key]; return; }`,
-														`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
+														`${cst} url = ${RuntimeGlobals.publicPath} + (cssNames && cssNames[chunkId] || ${RuntimeGlobals.getChunkCssFilename}(chunkId));`,
 														`promises.push(Promise.all([import('fs'), import('url')]).then(${runtimeTemplate.basicFunction(
 															"[{ readFile }, { URL }]",
 															[
@@ -584,9 +585,14 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 								"applyHandlers.push(applyHandler);",
 								"// Read CSS removed chunks from update manifest",
 								`${cst} cssRemovedChunks = css && css.r;`,
+								// The name map this runtime holds is refreshed by the update chunk, which
+								// has not run yet, so a name that moved is read off the manifest.
+								`${cst} cssNames = css && css.n;`,
 								`chunkIds.forEach(${runtimeTemplate.basicFunction("chunkId", [
-									`${cst} url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId);`,
-									`${cst} oldTag = loadStylesheet(chunkId, url);`,
+									`${cst} url = ${RuntimeGlobals.publicPath} + (cssNames && cssNames[chunkId] || ${RuntimeGlobals.getChunkCssFilename}(chunkId));`,
+									// The stylesheet in the document was loaded at the name this runtime
+									// still holds, so that is the name it is found by.
+									`${cst} oldTag = loadStylesheet(chunkId, ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkCssFilename}(chunkId));`,
 									`if(!oldTag && !${withHmr} ) return;`,
 									"// Skip if CSS was removed",
 									`if(${runtimeTemplate.optionalChaining(

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -26,14 +26,20 @@
 
 /** @typedef {(options: ApplyOptions) => ApplyResult} ApplyHandler */
 /** @typedef {(moduleId: ModuleId, applyHandlers: ApplyHandler[]) => void} InvalidateModuleHandler */
-/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<unknown>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: ModuleId[] | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
+/**
+ * @typedef {object} CssUpdateManifest
+ * @property {ModuleId[]} r updated chunk ids that no longer have a stylesheet
+ * @property {Record<string, string>=} n the stylesheet name of each updated chunk whose name moved with its content
+ */
+
+/** @typedef {(chunkIds: ModuleId[], removedChunks: ModuleId[], removedModules: ModuleId[], promises: Promise<unknown>[], applyHandlers: ApplyHandler[], updatedModulesList: ModuleId[], css: CssUpdateManifest | undefined, forceLoadChunks: ModuleId[] | undefined) => void} DownloadUpdateHandler */
 
 /**
  * @typedef {object} HMRManifest
  * @property {ModuleId[]} c updated chunk ids
  * @property {ModuleId[]} r removed chunk ids
  * @property {ModuleId[]} m removed module ids
- * @property {ModuleId[]=} css updated css chunk ids
+ * @property {CssUpdateManifest=} css what the stylesheet loader needs to know about the update
  * @property {ModuleId[]=} f chunk ids to force-load
  */
 

--- a/test/hotCases/css/hashed-chunk-name/index.js
+++ b/test/hotCases/css/hashed-chunk-name/index.js
@@ -1,0 +1,27 @@
+const stylesheets = () =>
+	[...document.getElementsByTagName("link")].filter(
+		(link) =>
+			link.rel === "stylesheet" && /\/lazy_css\.[0-9a-f]+\.css/.test(link.href)
+	);
+
+it("should reload a lazily loaded stylesheet at the name the update gave it", (done) => {
+	import("./lazy.css")
+		.then(() => {
+			const [link] = stylesheets();
+			expect(link.sheet.css).toContain("red");
+			NEXT(
+				require("../../update")(done, true, () => {
+					// The update swapped the stylesheet for one holding the new content, at
+					// the name that content has now.
+					const active = stylesheets().filter((l) => !l.sheet.disabled);
+					expect(active).toHaveLength(1);
+					expect(active[0].href).not.toBe(link.href.split("?")[0]);
+					expect(active[0].sheet.css).toContain("blue");
+					done();
+				})
+			);
+		})
+		.catch(done);
+});
+
+module.hot.accept();

--- a/test/hotCases/css/hashed-chunk-name/index.js
+++ b/test/hotCases/css/hashed-chunk-name/index.js
@@ -15,7 +15,7 @@ it("should reload a lazily loaded stylesheet at the name the update gave it", (d
 					// the name that content has now.
 					const active = stylesheets().filter((l) => !l.sheet.disabled);
 					expect(active).toHaveLength(1);
-					expect(active[0].href).not.toBe(link.href.split("?")[0]);
+					expect(active[0].href.split("?")[0]).not.toBe(link.href);
 					expect(active[0].sheet.css).toContain("blue");
 					done();
 				})

--- a/test/hotCases/css/hashed-chunk-name/lazy.css
+++ b/test/hotCases/css/hashed-chunk-name/lazy.css
@@ -1,0 +1,7 @@
+.class {
+	color: red;
+}
+---
+.class {
+	color: blue;
+}

--- a/test/hotCases/css/hashed-chunk-name/test.config.js
+++ b/test/hotCases/css/hashed-chunk-name/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	env: "jsdom"
+};

--- a/test/hotCases/css/hashed-chunk-name/test.filter.js
+++ b/test/hotCases/css/hashed-chunk-name/test.filter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = (config) => config.target === "web";

--- a/test/hotCases/css/hashed-chunk-name/webpack.config.js
+++ b/test/hotCases/css/hashed-chunk-name/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+// A stylesheet named by its content moves with every change to it: the update has to
+// carry the new name, since the runtime's own name map is refreshed only afterwards.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	output: {
+		cssChunkFilename: "[name].[contenthash].css"
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/index.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/index.js
@@ -21,12 +21,11 @@ it("should bake hashed stylesheet urls and carry a moved one in the update", (do
 				update(done, true, () => {
 					loadMore()
 						.then(() => {
-							// The map the update re-shipped spells the name the stylesheet has
-							// now, so the loader attaches the updated one.
-							const link = stylesheets("lazy2_css").find(
-								(candidate) => !candidate.href.includes("?")
-							);
-							expect(link.sheet.css).toContain("orange");
+							// The map the update re-shipped spells the name the update loaded the
+							// stylesheet at, so the loader reuses that one instead of adding another.
+							const links = stylesheets("lazy2_css");
+							expect(links).toHaveLength(1);
+							expect(links[0].sheet.css).toContain("orange");
 							done();
 						})
 						.catch(done);

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/index.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/index.js
@@ -1,0 +1,37 @@
+import update from "../../update.esm";
+import { load, loadMore } from "./styles";
+
+const stylesheets = (name) =>
+	[...document.getElementsByTagName("link")].filter(
+		(link) =>
+			link.rel === "stylesheet" &&
+			new RegExp(`/${name}\\.[0-9a-f]+\\.css`).test(link.href)
+	);
+
+it("should bake hashed stylesheet urls and carry a moved one in the update", (done) => {
+	load()
+		.then(() => {
+			expect(stylesheets("lazy_css")).toHaveLength(1);
+			// The names settle before the runtime chunk, so the loader reads the map.
+			const loader = __webpack_require__.f.css.toString();
+			expect(loader).toContain("cssUrls[chunkId]()");
+			expect(loader).not.toContain(".k(chunkId)");
+
+			NEXT(
+				update(done, true, () => {
+					loadMore()
+						.then(() => {
+							// The map the update re-shipped spells the name the stylesheet has
+							// now, so the loader attaches the updated one.
+							const link = stylesheets("lazy2_css").find(
+								(candidate) => !candidate.href.includes("?")
+							);
+							expect(link.sheet.css).toContain("orange");
+							done();
+						})
+						.catch(done);
+				})
+			);
+		})
+		.catch(done);
+});

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/lazy.css
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/lazy.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/lazy2.css
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/lazy2.css
@@ -1,0 +1,7 @@
+body {
+	background: blue;
+}
+---
+body {
+	background: orange;
+}

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/styles.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/styles.js
@@ -1,0 +1,2 @@
+export const load = () => import("./lazy.css");
+export const loadMore = () => import("./lazy2.css");

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/test.config.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	env: "jsdom"
+};

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/test.filter.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// A node-only build registers its css without a loader, so there is no map to read.
+module.exports = (config) =>
+	config.target === "web" || Array.isArray(config.target);

--- a/test/hotCases/esm-output/analyzable-css-urls-hashed/webpack.config.js
+++ b/test/hotCases/esm-output/analyzable-css-urls-hashed/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+// A hashed stylesheet name settles before the runtime chunk is hashed, so the map
+// spells it and an update that moves the name re-ships the runtime module with it.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true, css: true },
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		chunkFilename: "[name].chunk.mjs",
+		cssChunkFilename: "[name].[contenthash].css"
+	}
+};

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -211,6 +211,31 @@ hmr-hashed-css-entry:
     css ./lazy.css X bytes (javascript) X bytes (css) [built] [code generated]
   hmr-hashed-css-entry (webpack x.x.x) compiled successfully in X ms
 
+hmr-fullhash-css:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset lazy_css.mjs X bytes [emitted] [javascript module]
+  asset async_js.mjs X bytes [emitted] [javascript module]
+  asset lazy_css.XXXXXXXXXXXXXXXXXXXX.css X bytes [emitted] [immutable]
+  runtime modules X KiB 13 modules
+  cacheable modules X bytes (javascript) X bytes (css)
+    ./index-css.js X bytes [built] [code generated]
+    css ./lazy.css X bytes (javascript) X bytes (css) [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  hmr-fullhash-css (webpack x.x.x) compiled successfully in X ms
+
+hmr-hashed-css-depth:
+  assets by path *.mjs X KiB
+    asset lazy_css.mjs X bytes [emitted] [javascript module]
+    asset async_js.mjs X bytes [emitted] [javascript module]
+  asset js/main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset lazy_css.XXXXXXXXXXXXXXXXXXXX.css X bytes [emitted] [immutable]
+  runtime modules X KiB 13 modules
+  cacheable modules X bytes (javascript) X bytes (css)
+    ./index-css.js X bytes [built] [code generated]
+    css ./lazy.css X bytes (javascript) X bytes (css) [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  hmr-hashed-css-depth (webpack x.x.x) compiled successfully in X ms
+
 hmr-hashed-prefetch:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset mid_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -196,6 +196,32 @@ hmr-hashed-css:
     ./async.js X bytes [built] [code generated]
   hmr-hashed-css (webpack x.x.x) compiled successfully in X ms
 
+hmr-hashed-css-entry:
+  assets by path *.mjs X KiB
+    asset main.mjs X KiB [emitted] [javascript module] (name: main)
+    asset lazy_css.mjs X bytes [emitted] [javascript module]
+  assets by path *.css X bytes
+    asset lazy_css.XXXXXXXXXXXXXXXXXXXX.css X bytes [emitted] [immutable]
+    asset main.XXXXXXXXXXXXXXXXXXXX.css X bytes [emitted] [immutable] (name: main)
+  Entrypoint main X KiB = main.mjs X KiB main.XXXXXXXXXXXXXXXXXXXX.css X bytes
+  runtime modules X KiB 13 modules
+  cacheable modules X bytes (javascript) X bytes (css)
+    ./index-css-own.js X bytes [built] [code generated]
+    css ./own.css X bytes [built] [code generated]
+    css ./lazy.css X bytes (javascript) X bytes (css) [built] [code generated]
+  hmr-hashed-css-entry (webpack x.x.x) compiled successfully in X ms
+
+hmr-hashed-prefetch:
+  asset main.mjs X KiB [emitted] [javascript module] (name: main)
+  asset mid_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
+  asset async_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
+  runtime modules X KiB 13 modules
+  cacheable modules X bytes
+    ./index-prefetch.js X bytes [built] [code generated]
+    ./mid.js X bytes [built] [code generated]
+    ./async.js X bytes [built] [code generated]
+  hmr-hashed-prefetch (webpack x.x.x) compiled successfully in X ms
+
 hmr-css-two-depths:
   assets by path *.mjs X KiB
     asset main.mjs X KiB [emitted] [javascript module] (name: main)

--- a/test/statsCases/analyzable-esm-fallbacks/index-css-own.js
+++ b/test/statsCases/analyzable-esm-fallbacks/index-css-own.js
@@ -1,0 +1,4 @@
+// The entry's own stylesheet is in the runtime chunk, whose hashes settle last.
+import "./own.css";
+
+export const style = () => import("./lazy.css");

--- a/test/statsCases/analyzable-esm-fallbacks/own.css
+++ b/test/statsCases/analyzable-esm-fallbacks/own.css
@@ -1,0 +1,3 @@
+body {
+	margin: 0;
+}

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -69,11 +69,22 @@ const CASES = {
 		expect: "analyzable",
 		contains: "cssUrls = {"
 	},
+	// The name settles a round before the runtime chunk, so the map spells it.
 	"hmr-hashed-css": {
+		file: "main.mjs",
+		expect: "analyzable",
+		contains: /cssUrls = \{[^}]*"\.\/lazy_css\.[0-9a-f]+\.css"/
+	},
+	"hmr-hashed-css-entry": {
 		file: "main.mjs",
 		expect: "partial",
 		bailout: "a hot update can move this name",
 		lacks: "cssUrls = {"
+	},
+	"hmr-hashed-prefetch": {
+		file: "main.mjs",
+		expect: "analyzable",
+		contains: /chunkUrls = \{[^}]*"\.\/async_js\.[0-9a-f]+\.mjs"/
 	},
 	"hmr-css-two-depths": {
 		file: "nested/side.mjs",
@@ -132,7 +143,9 @@ module.exports = {
 					if (bailout.startsWith(BAILOUT)) bailouts.push(bailout);
 				}
 			}
-			if (testCase.contains) expect(output).toContain(testCase.contains);
+			if (testCase.contains) {
+				expect(output).toMatch(testCase.contains);
+			}
 			if (testCase.lacks) expect(output).not.toContain(testCase.lacks);
 			if (testCase.expect === "analyzable") {
 				expect(output).toContain(HELPER);

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -81,6 +81,17 @@ const CASES = {
 		bailout: "a hot update can move this name",
 		lacks: "cssUrls = {"
 	},
+	"hmr-fullhash-css": {
+		file: "main.mjs",
+		expect: "partial",
+		bailout: "a hot update can move this name",
+		lacks: "cssUrls = {"
+	},
+	"hmr-hashed-css-depth": {
+		file: "js/main.mjs",
+		expect: "analyzable",
+		contains: /new URL\("\.\.\/lazy_css\.[0-9a-f]+\.css"/
+	},
 	"hmr-hashed-prefetch": {
 		file: "main.mjs",
 		expect: "analyzable",

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -157,6 +157,25 @@ module.exports = [
 			cssChunkFilename: "[name].[contenthash].css"
 		}
 	}),
+	// A name built from the compilation hash exists in no round a chunk is hashed in, so
+	// nothing settles it before the runtime module: the map keeps the runtime form.
+	base("hmr-fullhash-css", {
+		entry: "./index-css",
+		experiments: { css: true },
+		plugins: [new webpack.HotModuleReplacementPlugin()],
+		output: { cssChunkFilename: "[name].[fullhash].css" }
+	}),
+	// Also analyzable: the runtime chunk sits in `js/` and its update at the root, so the
+	// settled name is carried as text behind each asset's own `../` depth.
+	base("hmr-hashed-css-depth", {
+		entry: "./index-css",
+		experiments: { css: true },
+		plugins: [new webpack.HotModuleReplacementPlugin()],
+		output: {
+			filename: "js/[name].mjs",
+			cssChunkFilename: "[name].[contenthash].css"
+		}
+	}),
 	// Also analyzable: the hinted script names are read off the chunk hash the same way.
 	base("hmr-hashed-prefetch", {
 		entry: "./index-prefetch",

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -138,13 +138,30 @@ module.exports = [
 		experiments: { css: true },
 		plugins: [new webpack.HotModuleReplacementPlugin()]
 	}),
-	// The map keeps the runtime form under HMR where a name is settled only by the fill:
-	// an update could move it without touching the module the map is written into.
+	// Also analyzable: a hashed name settled in a round before the runtime chunk's is
+	// spelled into the runtime module, so an update that moves it re-ships the map.
 	base("hmr-hashed-css", {
 		entry: "./index-css",
 		experiments: { css: true },
 		plugins: [new webpack.HotModuleReplacementPlugin()],
 		output: { cssChunkFilename: "[name].[contenthash].css" }
+	}),
+	// The entry's own stylesheet is hashed after its runtime module is generated, so no
+	// update could carry that name: the map keeps the runtime form.
+	base("hmr-hashed-css-entry", {
+		entry: "./index-css-own",
+		experiments: { css: true },
+		plugins: [new webpack.HotModuleReplacementPlugin()],
+		output: {
+			cssFilename: "[name].[contenthash].css",
+			cssChunkFilename: "[name].[contenthash].css"
+		}
+	}),
+	// Also analyzable: the hinted script names are read off the chunk hash the same way.
+	base("hmr-hashed-prefetch", {
+		entry: "./index-prefetch",
+		plugins: [new webpack.HotModuleReplacementPlugin()],
+		output: { chunkFilename: "[name].[chunkhash].mjs" }
 	}),
 	// Also analyzable: each runtime is measured against its own update chunk, so one
 	// whose id puts that chunk a directory down bakes beside one at the root.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Two fixes for a stylesheet named by its content under HMR. The css update handler built the url from the runtime's own name map, which the update chunk refreshes only after the handler has run, so under a hashed `cssChunkFilename` it re-fetched the old file, found it unchanged and dropped the update; the manifest now carries the name of each updated stylesheet whose name reads a hash, and the handler loads that one while still finding the stylesheet in the document by the name the runtime holds. Separately, under `output.module` a runtime's baked url map kept the runtime form for such names because the deferred fill settled them without changing the runtime module: a runtime module is generated in its chunk's round of `createHash`, where a `[chunkhash]`/`[contenthash]` name settled earlier already exists, so it is now spelled there and moves the module's hash with it, which lets HMR re-ship the map. Follow-up to #21922. Cost is counted: hash-free names add no calls; a hashed one adds one cached placeholder-kind lookup and one round comparison per chunk in the map, and one `getPath` per updated stylesheet on the manifest, with no new allocation beyond the names object. `test:size` over the css/hmr/hot cases: the handler grows by 206 B raw / 40 B gzip on the one development-only runtime that ships css loading under HMR, no runtime gained or lost a module, and the url-map change moves no bytes.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes: `test/hotCases/css/hashed-chunk-name` and `test/hotCases/esm-output/analyzable-css-urls-hashed` (both fail on `main`), plus the `hmr-hashed-css`, `hmr-hashed-css-entry` and `hmr-hashed-prefetch` children of `test/statsCases/analyzable-esm-fallbacks`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to investigate both problems, implement the fixes, write the tests, and count the added calls and bytes; every change was reviewed and verified by the author with the repository's own test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot module replacement for content-hashed CSS files.
  * Updated stylesheets now reload correctly when hashed filenames change.
  * CSS updates now use the correct stylesheet names for changed chunks.
  * Improved generation of hashed CSS and JavaScript URLs in runtime output.

* **Tests**
  * Added coverage for hashed CSS updates, lazy-loaded stylesheets, prefetches, and entry stylesheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->