### PR TITLE
fix(concatenate-modules): compute asiSafe for unused reexports and bare requires

### DIFF
--- a/.changeset/017-asi-safe-concatenated-accessor-calls.md
+++ b/.changeset/017-asi-safe-concatenated-accessor-calls.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix ASI for unused reexports and bare requires in concatenated modules.

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -528,7 +528,9 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 				: ids;
 			requireExpr = concatenationScope.createModuleReference(importedModule, {
 				ids: requestedIds.length > 0 ? requestedIds : undefined,
-				asiSafe: true,
+				// an unused reexport drops the assignment, so the reference can
+				// end up starting its own statement instead of an RHS
+				asiSafe: Boolean(used),
 				moduleExportsAccess: true
 			});
 		} else {

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -212,6 +212,7 @@ const createRequireCallHandler = (
 				/** @type {Range} */ (expr.range)
 			);
 			if (binding) binding.dep = dep;
+			dep.asiSafe = !parser.isAsiPosition(/** @type {Range} */ (expr.range)[0]);
 			dep.loc = parser.getLocation(expr);
 			dep.optional = Boolean(parser.scope.inTry);
 			parser.state.current.addDependency(dep);

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -36,8 +36,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @import { UsedByExports } from "../optimize/InnerGraph" */
 /** @import { RuntimeSpec } from "../util/runtime" */
 /** @import { DependencyGuard } from "./HarmonyImportGuard" */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined, undefined | boolean]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined, undefined | boolean]>} ObjectSerializerContext */
 
 /**
  * Trims a member-access path at the first segment that is definitively not a
@@ -93,6 +93,8 @@ class CommonJsRequireDependency extends ModuleDependency {
 		// `new require(...)`; see the template for the return-value rule
 		/** @type {boolean} */
 		this.callNew = false;
+		/** @type {undefined | boolean} */
+		this.asiSafe = undefined;
 	}
 
 	get type() {
@@ -226,7 +228,8 @@ class CommonJsRequireDependency extends ModuleDependency {
 			.write(this.branchGuards)
 			.write(this._canConcatenate)
 			.write(this.callNew)
-			.write(this.usedByExports);
+			.write(this.usedByExports)
+			.write(this.asiSafe);
 		super.serialize(context);
 	}
 
@@ -246,7 +249,9 @@ class CommonJsRequireDependency extends ModuleDependency {
 		this.callNew = c4.read();
 		const c5 = c4.rest;
 		this.usedByExports = c5.read();
-		super.deserialize(c5.rest);
+		const c6 = c5.rest;
+		this.asiSafe = c6.read();
+		super.deserialize(c6.rest);
 	}
 }
 
@@ -296,6 +301,7 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 			dep.rendersAsConcatenatedReference(connection, concatenationScope)
 		) {
 			const valueRange = /** @type {Range} */ (dep.valueRange);
+			// `new require(...)`: guard the wrapper call, not the reference inside it.
 			let content = concatenationScope.createModuleReference(
 				connection.module,
 				{
@@ -303,7 +309,7 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 					ids: isRequireEsmModuleExportsModule(connection.module, moduleGraph)
 						? [ESM_MODULE_EXPORTS_NAME]
 						: undefined,
-					asiSafe: true,
+					asiSafe: dep.callNew ? true : dep.asiSafe,
 					moduleExportsAccess: true
 				}
 			);
@@ -313,7 +319,7 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 				templateContext.runtimeRequirements.add(
 					RuntimeGlobals.constructRequire
 				);
-				content = `${RuntimeGlobals.constructRequire}(${content})`;
+				content = `${dep.asiSafe === false ? ";" : ""}${RuntimeGlobals.constructRequire}(${content})`;
 			}
 			source.replace(valueRange[0], valueRange[1] - 1, content);
 			return;

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,529 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-bare-require-asi commonjs-bare-require-asi should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./a.cjs
+var a_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./b.cjs
+var b_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./ctor.cjs
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Ctor() {
+	this.ran = true;
+};
+
+});
+
+;// ./x.js
+function X() {
+	return 42;
+}
+
+;// ./entry.js
+
+
+const value = X();
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+;__webpack_require__.cr((ctor_namespaceFn()))
+
+;// ./index.js
+
+
+const a = (a_namespaceFn());
+const b = (b_namespaceFn());
+const index_Ctor = (ctor_namespaceFn());
+
+it(\\"should not merge adjacent require() statements via ASI\\", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it(\\"should not merge a \`new require()\` statement via ASI\\", () => {
+	const instance = new index_Ctor();
+	expect(instance.ran).toBe(true);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-bare-require-asi commonjs-bare-require-asi should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./a.cjs
+var a_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./b.cjs
+var b_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./ctor.cjs
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Ctor() {
+	this.ran = true;
+};
+
+});
+
+;// ./x.js
+function X() {
+	return 42;
+}
+
+;// ./entry.js
+
+
+const value = X();
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+;__webpack_require__.cr((ctor_namespaceFn()))
+
+;// ./index.js
+
+
+const a = (a_namespaceFn());
+const b = (b_namespaceFn());
+const index_Ctor = (ctor_namespaceFn());
+
+it(\\"should not merge adjacent require() statements via ASI\\", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it(\\"should not merge a \`new require()\` statement via ASI\\", () => {
+	const instance = new index_Ctor();
+	expect(instance.ran).toBe(true);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-bare-require-asi commonjs-bare-require-asi should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./a.cjs
+var a_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./b.cjs
+var b_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./ctor.cjs
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Ctor() {
+	this.ran = true;
+};
+
+});
+
+;// ./x.js
+function X() {
+	return 42;
+}
+
+;// ./entry.js
+
+
+const value = X();
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+;__webpack_require__.cr((ctor_namespaceFn()))
+
+;// ./index.js
+
+
+const a = (a_namespaceFn());
+const b = (b_namespaceFn());
+const index_Ctor = (ctor_namespaceFn());
+
+it(\\"should not merge adjacent require() statements via ASI\\", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it(\\"should not merge a \`new require()\` statement via ASI\\", () => {
+	const instance = new index_Ctor();
+	expect(instance.ran).toBe(true);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-bare-require-asi commonjs-bare-require-asi should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./a.cjs
+var a_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./b.cjs
+var b_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./ctor.cjs
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Ctor() {
+	this.ran = true;
+};
+
+});
+
+;// ./x.js
+function X() {
+	return 42;
+}
+
+;// ./entry.js
+
+
+const value = X();
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+;__webpack_require__.cr((ctor_namespaceFn()))
+
+;// ./index.js
+
+
+const a = (a_namespaceFn());
+const b = (b_namespaceFn());
+const index_Ctor = (ctor_namespaceFn());
+
+it(\\"should not merge adjacent require() statements via ASI\\", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it(\\"should not merge a \`new require()\` statement via ASI\\", () => {
+	const instance = new index_Ctor();
+	expect(instance.ran).toBe(true);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/__snapshots__/ConfigTest.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-bare-require-asi commonjs-bare-require-asi should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./a.cjs
+var a_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./b.cjs
+var b_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.ran = true;
+
+});
+
+// MODULE: ./ctor.cjs
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Ctor() {
+	this.ran = true;
+};
+
+});
+
+;// ./x.js
+function X() {
+	return 42;
+}
+
+;// ./entry.js
+
+
+const value = X();
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+;__webpack_require__.cr((ctor_namespaceFn()))
+
+;// ./index.js
+
+
+const a = (a_namespaceFn());
+const b = (b_namespaceFn());
+const index_Ctor = (ctor_namespaceFn());
+
+it(\\"should not merge adjacent require() statements via ASI\\", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it(\\"should not merge a \`new require()\` statement via ASI\\", () => {
+	const instance = new index_Ctor();
+	expect(instance.ran).toBe(true);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/a.cjs
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/a.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.ran = true;

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/b.cjs
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/b.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports.ran = true;

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/ctor.cjs
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/ctor.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function Ctor() {
+	this.ran = true;
+};

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/entry.js
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/entry.js
@@ -1,0 +1,8 @@
+import X from "./x.js";
+
+export const value = X();
+
+require("./a.cjs")
+require("./b.cjs")
+
+new require("./ctor.cjs")

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/index.js
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/index.js
@@ -1,0 +1,16 @@
+import { value } from "./entry.js";
+
+const a = require("./a.cjs");
+const b = require("./b.cjs");
+const Ctor = require("./ctor.cjs");
+
+it("should not merge adjacent require() statements via ASI", () => {
+	expect(value).toBe(42);
+	expect(a.ran).toBe(true);
+	expect(b.ran).toBe(true);
+});
+
+it("should not merge a `new require()` statement via ASI", () => {
+	const instance = new Ctor();
+	expect(instance.ran).toBe(true);
+});

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-bare-require-asi/x.js
+++ b/test/configCases/concatenate-modules/commonjs-bare-require-asi/x.js
@@ -1,0 +1,3 @@
+export default function X() {
+	return 42;
+}

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,329 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi commonjs-unused-reexport-asi should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./loader.cjs
+var loader_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.Sub = function Sub() {
+	this.marker = \\"sub\\";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};
+
+});
+
+// MODULE: ./reexport-lib.cjs
+var reexport_lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+/* unused reexport */ ;(type_namespaceFn())
+/* unused reexport */ ;(loader_namespaceFn().Sub)
+module.exports.load = (loader_namespaceFn().load)
+
+});
+
+// MODULE: ./type.cjs
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Type() {
+	this.marker = \\"type\\";
+};
+
+});
+
+;// ./reexport-lib.cjs
+reexport_lib_namespaceFn();
+
+;// ./entry.mjs
+
+
+const entry_load = (loader_namespaceFn().load);
+
+;// ./index.js
+
+
+it(\\"should not merge an unused reexport's dropped assignment into the previous statement\\", () => {
+	expect(entry_load(1)).toBe(2);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi commonjs-unused-reexport-asi should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./loader.cjs
+var loader_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.Sub = function Sub() {
+	this.marker = \\"sub\\";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};
+
+});
+
+// MODULE: ./reexport-lib.cjs
+var reexport_lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+/* unused reexport */ ;(type_namespaceFn())
+/* unused reexport */ ;(loader_namespaceFn().Sub)
+module.exports.load = (loader_namespaceFn().load)
+
+});
+
+// MODULE: ./type.cjs
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Type() {
+	this.marker = \\"type\\";
+};
+
+});
+
+;// ./reexport-lib.cjs
+reexport_lib_namespaceFn();
+
+;// ./entry.mjs
+
+
+const entry_load = (loader_namespaceFn().load);
+
+;// ./index.js
+
+
+it(\\"should not merge an unused reexport's dropped assignment into the previous statement\\", () => {
+	expect(entry_load(1)).toBe(2);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi commonjs-unused-reexport-asi should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./loader.cjs
+var loader_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.Sub = function Sub() {
+	this.marker = \\"sub\\";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};
+
+});
+
+// MODULE: ./reexport-lib.cjs
+var reexport_lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+/* unused reexport */ ;(type_namespaceFn())
+/* unused reexport */ ;(loader_namespaceFn().Sub)
+module.exports.load = (loader_namespaceFn().load)
+
+});
+
+// MODULE: ./type.cjs
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Type() {
+	this.marker = \\"type\\";
+};
+
+});
+
+;// ./reexport-lib.cjs
+reexport_lib_namespaceFn();
+
+;// ./entry.mjs
+
+
+const entry_load = (loader_namespaceFn().load);
+
+;// ./index.js
+
+
+it(\\"should not merge an unused reexport's dropped assignment into the previous statement\\", () => {
+	expect(entry_load(1)).toBe(2);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi commonjs-unused-reexport-asi should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./loader.cjs
+var loader_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.Sub = function Sub() {
+	this.marker = \\"sub\\";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};
+
+});
+
+// MODULE: ./reexport-lib.cjs
+var reexport_lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+/* unused reexport */ ;(type_namespaceFn())
+/* unused reexport */ ;(loader_namespaceFn().Sub)
+module.exports.load = (loader_namespaceFn().load)
+
+});
+
+// MODULE: ./type.cjs
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Type() {
+	this.marker = \\"type\\";
+};
+
+});
+
+;// ./reexport-lib.cjs
+reexport_lib_namespaceFn();
+
+;// ./entry.mjs
+
+
+const entry_load = (loader_namespaceFn().load);
+
+;// ./index.js
+
+
+it(\\"should not merge an unused reexport's dropped assignment into the previous statement\\", () => {
+	expect(entry_load(1)).toBe(2);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/__snapshots__/ConfigTest.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-unused-reexport-asi commonjs-unused-reexport-asi should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 4 modules ***!
+  \\\\******************************/
+
+// MODULE: ./loader.cjs
+var loader_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports.Sub = function Sub() {
+	this.marker = \\"sub\\";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};
+
+});
+
+// MODULE: ./reexport-lib.cjs
+var reexport_lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+/* unused reexport */ ;(type_namespaceFn())
+/* unused reexport */ ;(loader_namespaceFn().Sub)
+module.exports.load = (loader_namespaceFn().load)
+
+});
+
+// MODULE: ./type.cjs
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = function Type() {
+	this.marker = \\"type\\";
+};
+
+});
+
+;// ./reexport-lib.cjs
+reexport_lib_namespaceFn();
+
+;// ./entry.mjs
+
+
+const entry_load = (loader_namespaceFn().load);
+
+;// ./index.js
+
+
+it(\\"should not merge an unused reexport's dropped assignment into the previous statement\\", () => {
+	expect(entry_load(1)).toBe(2);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/entry.mjs
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/entry.mjs
@@ -1,0 +1,3 @@
+import lib from "./reexport-lib.cjs";
+
+export const load = lib.load;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/index.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/index.js
@@ -1,0 +1,5 @@
+import { load } from "./entry.mjs";
+
+it("should not merge an unused reexport's dropped assignment into the previous statement", () => {
+	expect(load(1)).toBe(2);
+});

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/loader.cjs
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/loader.cjs
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports.Sub = function Sub() {
+	this.marker = "sub";
+};
+
+module.exports.load = function load(value) {
+	return value + 1;
+};

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/reexport-lib.cjs
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/reexport-lib.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports.Type = require('./type.cjs')
+module.exports.Sub = require('./loader.cjs').Sub
+module.exports.load = require('./loader.cjs').load

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/type.cjs
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/type.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function Type() {
+	this.marker = "type";
+};

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "node",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The ASI guard for a wrapped module's accessor call only fires when the caller reports the position unsafe; two call sites always reported safe, so ASI could merge it into the previous statement and throw. Fixes #21955. Fixes #21956.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new configCases cases, both failing on unmodified lib/ before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes, Claude Code — it found the fix, wrote the tests, and verified locally before pushing.
