### PR TITLE
fix(css): release the printed-text store's text when it is dropped

### DIFF
--- a/.changeset/019-printer-store-release.md
+++ b/.changeset/019-printer-store-release.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Release the printed-text store's text when the CSS printer drops it.

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -261,8 +261,7 @@ class PrintContext {
 		/** @type {NodePrinter<TPath, TNode, TPrintOptions>} */
 		this._printer = printer;
 		// Printed text by node handle, in two columns rather than one `Map`: the
-		// handles are dense integers, and a stylesheet prints ~300k nodes through
-		// a store `_moveEpoch` keeps down to the few dozen live at once.
+		// handles are dense integers, and `_moveEpoch` keeps the live set small.
 		/** @type {string[]} each finished node's printed text */
 		this._storeText = [];
 		/** @type {Int32Array} the epoch each slot was written in */
@@ -432,10 +431,9 @@ class PrintContext {
 	}
 
 	/**
-	 * Move the epoch on, and let go of the text every slot written under the old
-	 * one holds. Only the range actually written is walked, so the whole run
-	 * clears as many slots as it wrote — the O(1) per node the epoch is for,
-	 * where clearing the column by its length would be O(nodes) each time.
+	 * Move the epoch on and release the text every slot written under the old one
+	 * holds. Only the range actually written is walked, so the drop stays O(1)
+	 * per node.
 	 * @returns {void}
 	 */
 	_moveEpoch() {

--- a/lib/util/SourceProcessor.js
+++ b/lib/util/SourceProcessor.js
@@ -262,13 +262,17 @@ class PrintContext {
 		this._printer = printer;
 		// Printed text by node handle, in two columns rather than one `Map`: the
 		// handles are dense integers, and a stylesheet prints ~300k nodes through
-		// a store that never holds more than a few dozen of them at once.
+		// a store `_moveEpoch` keeps down to the few dozen live at once.
 		/** @type {string[]} each finished node's printed text */
 		this._storeText = [];
 		/** @type {Int32Array} the epoch each slot was written in */
 		this._storeGen = new Int32Array(0);
 		/** @type {number} current epoch; a slot from an older one reads as absent */
 		this._gen = 1;
+		/** @type {number} lowest slot written since the epoch last moved */
+		this._storeLow = 0x7fffffff;
+		/** @type {number} highest slot written since the epoch last moved */
+		this._storeHigh = -1;
 		// Output accumulates into `_tail`, a plain string append, so printing that
 		// never takes anything back costs exactly what appending to one string
 		// costs. A piece is cut off into `_chunks` only for text that may still be
@@ -424,8 +428,26 @@ class PrintContext {
 	 * node's text.
 	 */
 	dropStore() {
-		// Bumping the epoch invalidates every slot at once, so this stays O(1) —
-		// it runs per node, and clearing a column by length would not.
+		this._moveEpoch();
+	}
+
+	/**
+	 * Move the epoch on, and let go of the text every slot written under the old
+	 * one holds. Only the range actually written is walked, so the whole run
+	 * clears as many slots as it wrote — the O(1) per node the epoch is for,
+	 * where clearing the column by its length would be O(nodes) each time.
+	 * @returns {void}
+	 */
+	_moveEpoch() {
+		const high = this._storeHigh;
+		if (high !== -1) {
+			// `""` rather than a hole: the column is packed, and a hole in it would
+			// cost every read after this one.
+			const text = this._storeText;
+			for (let i = this._storeLow; i <= high; i++) text[i] = "";
+			this._storeLow = 0x7fffffff;
+			this._storeHigh = -1;
+		}
 		this._gen++;
 	}
 
@@ -469,6 +491,8 @@ class PrintContext {
 		if (n >= this._storeText.length) this._growStore(n + 1);
 		this._storeText[n] = text;
 		this._storeGen[n] = this._gen;
+		if (n < this._storeLow) this._storeLow = n;
+		if (n > this._storeHigh) this._storeHigh = n;
 	}
 
 	/**
@@ -598,7 +622,7 @@ class PrintContext {
 		this.anchor(srcOffset, srcLine, srcCol);
 		const mapping = this._mappings.length > before ? before : -1;
 		const at = this.emitRetractable(text === undefined ? this.get(node) : text);
-		this._gen++;
+		this._moveEpoch();
 		if (mapping !== -1) {
 			if (this._retractableMappings === null) {
 				this._retractableMappings = new Map();
@@ -627,7 +651,7 @@ class PrintContext {
 		this._emit(
 			text === undefined ? this.get(/** @type {TNode} */ (node)) : text
 		);
-		this._gen++;
+		this._moveEpoch();
 	}
 
 	/**

--- a/test/SourceProcessor.unittest.js
+++ b/test/SourceProcessor.unittest.js
@@ -58,6 +58,26 @@ describe("SourceProcessor", () => {
 			expect(held(context)).toBe(8);
 		});
 
+		it("lets go of the text when a node is taken", () => {
+			const context = new PrintContext({ mode: "minify" }, () =>
+				"t".repeat(16)
+			);
+			context.printNode(1, null);
+			expect(held(context)).toBe(16);
+			context.take(1);
+			expect(held(context)).toBe(0);
+		});
+
+		it("lets go of the text when a retractable node is taken", () => {
+			const context = new PrintContext({ mode: "minify" }, () =>
+				"r".repeat(16)
+			);
+			context.printNode(1, null);
+			expect(held(context)).toBe(16);
+			context.takeRetractable(1);
+			expect(held(context)).toBe(0);
+		});
+
 		it("answers for a node printed since the drop, and no earlier one", () => {
 			const context = new PrintContext({ mode: "minify" }, () => "z");
 			context.printNode(1, null);

--- a/test/SourceProcessor.unittest.js
+++ b/test/SourceProcessor.unittest.js
@@ -8,6 +8,7 @@ const {
 	NodeType: HtmlNodeType,
 	SourceProcessor: HtmlSourceProcessor
 } = require("../lib/html/syntax");
+const { PrintContext } = require("../lib/util/SourceProcessor");
 
 const CSS = "a {\n\tcolor : #ff0000 ;\n}\n";
 const HTML = "<div   class='a'  >\n  <p>x</p>\n</div>\n";
@@ -21,6 +22,54 @@ const LANGUAGES = [
 ];
 
 describe("SourceProcessor", () => {
+	// Dropping the store has to let go of the text, not just stop answering for
+	// it: a stylesheet prints ~300k nodes, which is the output over again.
+	describe("printed-text store", () => {
+		/**
+		 * @param {InstanceType<typeof PrintContext>} context print context
+		 * @returns {number} characters the store still holds
+		 */
+		const held = (context) => {
+			let chars = 0;
+			for (let i = 0; i < context._storeText.length; i++) {
+				chars += context._storeText[i].length;
+			}
+			return chars;
+		};
+
+		it("lets go of the text when the epoch moves", () => {
+			const context = new PrintContext({ mode: "minify" }, () =>
+				"x".repeat(64)
+			);
+			for (let node = 0; node < 500; node++) context.printNode(node, null);
+			expect(held(context)).toBe(500 * 64);
+			context.dropStore();
+			expect(held(context)).toBe(0);
+		});
+
+		it("holds only what was printed since the last drop", () => {
+			const context = new PrintContext({ mode: "minify" }, () => "y".repeat(8));
+			for (let node = 0; node < 300; node++) {
+				context.printNode(node, null);
+				if (node % 10 === 9) context.dropStore();
+			}
+			expect(held(context)).toBe(0);
+			context.printNode(300, null);
+			expect(held(context)).toBe(8);
+		});
+
+		it("answers for a node printed since the drop, and no earlier one", () => {
+			const context = new PrintContext({ mode: "minify" }, () => "z");
+			context.printNode(1, null);
+			expect(context.get(1)).toBe("z");
+			context.dropStore();
+			expect(context.get(1)).toBeUndefined();
+			context.printNode(2, null);
+			expect(context.get(2)).toBe("z");
+			expect(context.get(1)).toBeUndefined();
+		});
+	});
+
 	// `mode` is the only thing that names the output, and it resolves in the
 	// shared processor — so both languages bound to it must agree.
 	describe("mode", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`PrintContext.dropStore()` moved the epoch on so the store stopped answering for a node, but left the node's text referenced in the column — so text the method documents as dropped stayed reachable until that slot happened to be reused. The epoch move now clears the range written since the last one, which keeps the drop O(1) per node and caps store occupancy at 46 KB rather than 328 KB on a 30 MB stylesheet.

Output is byte-identical on all 20 `benchmark:css-minifiers` fixtures, and neither CPU nor peak RSS moves measurably — this is a correctness fix to the store, not a performance claim.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — three cases under `printed-text store` in `test/SourceProcessor.unittest.js`; two of them fail without the change.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code was used to investigate the store's retention behaviour, write the change and the tests, and run the measurements (exact store-occupancy accounting, CPU and peak-RSS comparison over 11 stylesheets, and `yarn benchmark:css-minifiers`). An earlier framing of this as a performance improvement was dropped because the CPU and RSS deltas did not reproduce across independent runs; only the counted occupancy result is claimed above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Printed text is now released when the CSS printer drops stored content.
  - Subsequent print operations no longer retain text from earlier output.
  - Node lookups correctly reflect only content printed since the latest store reset.
  - Taking stored content or retractable content now also releases the associated printed text.

- **Tests**
  - Added coverage for text release, store reset behavior, node lookups, and content-taking operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->