### PR TITLE
fix(concatenate-modules): guard a module reference against ASI

### DIFF
--- a/.changeset/017-concatenate-asi-position.md
+++ b/.changeset/017-concatenate-asi-position.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep a concatenated CommonJS reference from joining the previous statement.

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -528,7 +528,9 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 				: ids;
 			requireExpr = concatenationScope.createModuleReference(importedModule, {
 				ids: requestedIds.length > 0 ? requestedIds : undefined,
-				asiSafe: true,
+				// a used reexport keeps its assignment, so only an unused one is
+				// left standing where the original statement began
+				asiSafe: used ? true : dep.asiSafe,
 				moduleExportsAccess: true
 			});
 		} else {

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -479,6 +479,9 @@ class CommonJsExportsParserPlugin {
 					requireCall.ids,
 					!parser.isStatementLevelExpression(expr)
 				);
+				dep.asiSafe = !parser.isAsiPosition(
+					/** @type {Range} */ (expr.range)[0]
+				);
 				dep.loc = parser.getLocation(expr);
 				dep.optional = Boolean(parser.scope.inTry);
 				parser.state.module.addDependency(dep);
@@ -670,6 +673,9 @@ class CommonJsExportsParserPlugin {
 							false
 						);
 						dep.getter = reexport.getter;
+						dep.asiSafe = !parser.isAsiPosition(
+							/** @type {Range} */ (expr.range)[0]
+						);
 						dep.loc = parser.getLocation(expr);
 						dep.optional = Boolean(parser.scope.inTry);
 						parser.state.module.addDependency(dep);

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -212,6 +212,7 @@ const createRequireCallHandler = (
 				/** @type {Range} */ (expr.range)
 			);
 			if (binding) binding.dep = dep;
+			dep.asiSafe = !parser.isAsiPosition(/** @type {Range} */ (expr.range)[0]);
 			dep.loc = parser.getLocation(expr);
 			dep.optional = Boolean(parser.scope.inTry);
 			parser.state.current.addDependency(dep);

--- a/lib/dependencies/CommonJsRequireDependency.js
+++ b/lib/dependencies/CommonJsRequireDependency.js
@@ -36,8 +36,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @import { UsedByExports } from "../optimize/InnerGraph" */
 /** @import { RuntimeSpec } from "../util/runtime" */
 /** @import { DependencyGuard } from "./HarmonyImportGuard" */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectDeserializerContext */
-/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined]>} ObjectSerializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined, boolean | undefined]>} ObjectDeserializerContext */
+/** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext<[RawReferencedExports | null, Range | undefined, DependencyGuard[] | undefined, boolean, boolean, UsedByExports | undefined, boolean | undefined]>} ObjectSerializerContext */
 
 /**
  * Trims a member-access path at the first segment that is definitively not a
@@ -93,6 +93,10 @@ class CommonJsRequireDependency extends ModuleDependency {
 		// `new require(...)`; see the template for the return-value rule
 		/** @type {boolean} */
 		this.callNew = false;
+		// whether the position the call sits at cannot be joined to what precedes
+		// it by ASI; only meaningful once the call renders as a module reference
+		/** @type {boolean | undefined} */
+		this.asiSafe = undefined;
 	}
 
 	get type() {
@@ -226,7 +230,8 @@ class CommonJsRequireDependency extends ModuleDependency {
 			.write(this.branchGuards)
 			.write(this._canConcatenate)
 			.write(this.callNew)
-			.write(this.usedByExports);
+			.write(this.usedByExports)
+			.write(this.asiSafe);
 		super.serialize(context);
 	}
 
@@ -246,7 +251,9 @@ class CommonJsRequireDependency extends ModuleDependency {
 		this.callNew = c4.read();
 		const c5 = c4.rest;
 		this.usedByExports = c5.read();
-		super.deserialize(c5.rest);
+		const c6 = c5.rest;
+		this.asiSafe = c6.read();
+		super.deserialize(c6.rest);
 	}
 }
 
@@ -303,7 +310,9 @@ CommonJsRequireDependency.Template = class CommonJsRequireDependencyTemplate ext
 					ids: isRequireEsmModuleExportsModule(connection.module, moduleGraph)
 						? [ESM_MODULE_EXPORTS_NAME]
 						: undefined,
-					asiSafe: true,
+					// `new` wraps the reference in a call, so only a plain
+					// replacement inherits the original call's position
+					asiSafe: dep.callNew ? true : dep.asiSafe,
 					moduleExportsAccess: true
 				}
 			);

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -424,11 +424,12 @@ const getInteropExpr = (info, interopName) =>
  * slot, but a wrapped one only runs when its accessor is called, so dropping
  * the reference would drop the module's side effects with it.
  * @param {ConcatenatedModuleInfo} info module info
+ * @param {boolean | undefined} asiSafe asiSafe
  * @returns {string} expression evaluating to undefined
  */
-const getUnusedExportExpr = (info) =>
+const getUnusedExportExpr = (info, asiSafe) =>
 	info.wrapped
-		? `/* unused export */ (${info.namespaceObjectName}, undefined)`
+		? `${asiSafe === false ? ";" : ""}/* unused export */ (${info.namespaceObjectName}, undefined)`
 		: "/* unused export */ undefined";
 
 /**
@@ -485,7 +486,7 @@ const getFinalBinding = (
 		if (!usedName) {
 			return {
 				info,
-				rawName: getUnusedExportExpr(info),
+				rawName: getUnusedExportExpr(info, asiSafe),
 				ids: [],
 				exportName
 			};

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,549 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-require-asi-position commonjs-require-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"./a.js\\"
+/*!**************!*\\\\
+  !*** ./a.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"a\\");
+
+
+/***/ },
+
+/***/ \\"./b.js\\"
+/*!**************!*\\\\
+  !*** ./b.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"b\\");
+
+
+/***/ },
+
+/***/ \\"./order.js\\"
+/*!******************!*\\\\
+  !*** ./order.js ***!
+  \\\\******************/
+(module) {
+
+module.exports = [];
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+\\"use strict\\";
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// EXTERNAL MODULE: ./a.js
+var a_namespaceFn = () => {
+	return __webpack_require__(\\"./a.js\\");
+};
+
+// EXTERNAL MODULE: ./b.js
+var b_namespaceFn = () => {
+	return __webpack_require__(\\"./b.js\\");
+};
+
+// EXTERNAL MODULE: ./order.js
+var order = __webpack_require__(\\"./order.js\\");
+var order_default = /*#__PURE__*/__webpack_require__.n(order);
+;// ./side-effects.js
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+
+
+;// ./index.js
+
+
+it(\\"should keep adjacent bare requires as separate statements\\", () => {
+	expect((order_default())).toEqual([\\"a\\", \\"b\\"]);
+});
+
+})();
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-require-asi-position commonjs-require-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"./a.js\\"
+/*!**************!*\\\\
+  !*** ./a.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"a\\");
+
+
+/***/ },
+
+/***/ \\"./b.js\\"
+/*!**************!*\\\\
+  !*** ./b.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"b\\");
+
+
+/***/ },
+
+/***/ \\"./order.js\\"
+/*!******************!*\\\\
+  !*** ./order.js ***!
+  \\\\******************/
+(module) {
+
+module.exports = [];
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+\\"use strict\\";
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// EXTERNAL MODULE: ./a.js
+var a_namespaceFn = () => {
+	return __webpack_require__(\\"./a.js\\");
+};
+
+// EXTERNAL MODULE: ./b.js
+var b_namespaceFn = () => {
+	return __webpack_require__(\\"./b.js\\");
+};
+
+// EXTERNAL MODULE: ./order.js
+var order = __webpack_require__(\\"./order.js\\");
+var order_default = /*#__PURE__*/__webpack_require__.n(order);
+;// ./side-effects.js
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+
+
+;// ./index.js
+
+
+it(\\"should keep adjacent bare requires as separate statements\\", () => {
+	expect((order_default())).toEqual([\\"a\\", \\"b\\"]);
+});
+
+})();
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-require-asi-position commonjs-require-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"./a.js\\"
+/*!**************!*\\\\
+  !*** ./a.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"a\\");
+
+
+/***/ },
+
+/***/ \\"./b.js\\"
+/*!**************!*\\\\
+  !*** ./b.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"b\\");
+
+
+/***/ },
+
+/***/ \\"./order.js\\"
+/*!******************!*\\\\
+  !*** ./order.js ***!
+  \\\\******************/
+(module) {
+
+module.exports = [];
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+\\"use strict\\";
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// EXTERNAL MODULE: ./a.js
+var a_namespaceFn = () => {
+	return __webpack_require__(\\"./a.js\\");
+};
+
+// EXTERNAL MODULE: ./b.js
+var b_namespaceFn = () => {
+	return __webpack_require__(\\"./b.js\\");
+};
+
+// EXTERNAL MODULE: ./order.js
+var order = __webpack_require__(\\"./order.js\\");
+var order_default = /*#__PURE__*/__webpack_require__.n(order);
+;// ./side-effects.js
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+
+
+;// ./index.js
+
+
+it(\\"should keep adjacent bare requires as separate statements\\", () => {
+	expect((order_default())).toEqual([\\"a\\", \\"b\\"]);
+});
+
+})();
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-require-asi-position commonjs-require-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"./a.js\\"
+/*!**************!*\\\\
+  !*** ./a.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"a\\");
+
+
+/***/ },
+
+/***/ \\"./b.js\\"
+/*!**************!*\\\\
+  !*** ./b.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"b\\");
+
+
+/***/ },
+
+/***/ \\"./order.js\\"
+/*!******************!*\\\\
+  !*** ./order.js ***!
+  \\\\******************/
+(module) {
+
+module.exports = [];
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+\\"use strict\\";
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// EXTERNAL MODULE: ./a.js
+var a_namespaceFn = () => {
+	return __webpack_require__(\\"./a.js\\");
+};
+
+// EXTERNAL MODULE: ./b.js
+var b_namespaceFn = () => {
+	return __webpack_require__(\\"./b.js\\");
+};
+
+// EXTERNAL MODULE: ./order.js
+var order = __webpack_require__(\\"./order.js\\");
+var order_default = /*#__PURE__*/__webpack_require__.n(order);
+;// ./side-effects.js
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+
+
+;// ./index.js
+
+
+it(\\"should keep adjacent bare requires as separate statements\\", () => {
+	expect((order_default())).toEqual([\\"a\\", \\"b\\"]);
+});
+
+})();
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-require-asi-position commonjs-require-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"./a.js\\"
+/*!**************!*\\\\
+  !*** ./a.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"a\\");
+
+
+/***/ },
+
+/***/ \\"./b.js\\"
+/*!**************!*\\\\
+  !*** ./b.js ***!
+  \\\\**************/
+(__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+
+(__webpack_require__(/*! ./order */ \\"./order.js\\").push)(\\"b\\");
+
+
+/***/ },
+
+/***/ \\"./order.js\\"
+/*!******************!*\\\\
+  !*** ./order.js ***!
+  \\\\******************/
+(module) {
+
+module.exports = [];
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
+(() => {
+\\"use strict\\";
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// EXTERNAL MODULE: ./a.js
+var a_namespaceFn = () => {
+	return __webpack_require__(\\"./a.js\\");
+};
+
+// EXTERNAL MODULE: ./b.js
+var b_namespaceFn = () => {
+	return __webpack_require__(\\"./b.js\\");
+};
+
+// EXTERNAL MODULE: ./order.js
+var order = __webpack_require__(\\"./order.js\\");
+var order_default = /*#__PURE__*/__webpack_require__.n(order);
+;// ./side-effects.js
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+
+
+(a_namespaceFn())
+;(b_namespaceFn())
+
+
+
+;// ./index.js
+
+
+it(\\"should keep adjacent bare requires as separate statements\\", () => {
+	expect((order_default())).toEqual([\\"a\\", \\"b\\"]);
+});
+
+})();
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/a.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/a.js
@@ -1,0 +1,1 @@
+require("./order").push("a");

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/b.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/b.js
@@ -1,0 +1,1 @@
+require("./order").push("b");

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/index.js
@@ -1,0 +1,5 @@
+import { order } from "./side-effects";
+
+it("should keep adjacent bare requires as separate statements", () => {
+	expect(order).toEqual(["a", "b"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/order.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/order.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/side-effects.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/side-effects.js
@@ -1,0 +1,8 @@
+// semicolon-free: each require opens a statement ASI would otherwise glue to
+// the previous one
+import order from "./order";
+
+require("./a")
+require("./b")
+
+export { order };

--- a/test/configCases/concatenate-modules/commonjs-require-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-require-asi-position/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: true,
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -49,7 +49,7 @@ exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-p
 /******/ 	
 /************************************************************************/
 /*!******************************!*\\\\
-  !*** ./index.js + 5 modules ***!
+  !*** ./index.js + 7 modules ***!
   \\\\******************************/
 
 // MODULE: ./defaults.js
@@ -63,15 +63,37 @@ __webpack_unused_export__ = { name: \\"core\\" };
 
 });
 
+// MODULE: ./failsafe.js
+var failsafe_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"failsafe\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"failsafe\\")) };
+
+});
+
+// MODULE: ./json.js
+var json_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"json\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"json\\")) };
+
+});
+
 // MODULE: ./lib.js
 var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
 
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 /* unused reexport */ (type_namespaceFn())
 /* unused reexport */ ;(schema_namespaceFn())
 /* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+/* unused reexport */ ;(failsafe_namespaceFn())
+/* unused reexport */ ;(json_namespaceFn())
 module.exports.H = () => \\"loaded\\"
 
 });
@@ -128,7 +150,7 @@ it(\\"should keep an unused re-export from swallowing the next statement\\", () 
 });
 
 it(\\"should still evaluate what an unused re-export required\\", () => {
-	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\", \\"failsafe\\", \\"json\\"]);
 });
 
 /******/ })()
@@ -184,7 +206,7 @@ exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-p
 /******/ 	
 /************************************************************************/
 /*!******************************!*\\\\
-  !*** ./index.js + 5 modules ***!
+  !*** ./index.js + 7 modules ***!
   \\\\******************************/
 
 // MODULE: ./defaults.js
@@ -198,15 +220,37 @@ __webpack_unused_export__ = { name: \\"core\\" };
 
 });
 
+// MODULE: ./failsafe.js
+var failsafe_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"failsafe\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"failsafe\\")) };
+
+});
+
+// MODULE: ./json.js
+var json_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"json\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"json\\")) };
+
+});
+
 // MODULE: ./lib.js
 var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
 
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 /* unused reexport */ (type_namespaceFn())
 /* unused reexport */ ;(schema_namespaceFn())
 /* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+/* unused reexport */ ;(failsafe_namespaceFn())
+/* unused reexport */ ;(json_namespaceFn())
 module.exports.H = () => \\"loaded\\"
 
 });
@@ -263,7 +307,7 @@ it(\\"should keep an unused re-export from swallowing the next statement\\", () 
 });
 
 it(\\"should still evaluate what an unused re-export required\\", () => {
-	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\", \\"failsafe\\", \\"json\\"]);
 });
 
 /******/ })()
@@ -319,7 +363,7 @@ exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-p
 /******/ 	
 /************************************************************************/
 /*!******************************!*\\\\
-  !*** ./index.js + 5 modules ***!
+  !*** ./index.js + 7 modules ***!
   \\\\******************************/
 
 // MODULE: ./defaults.js
@@ -333,15 +377,37 @@ __webpack_unused_export__ = { name: \\"core\\" };
 
 });
 
+// MODULE: ./failsafe.js
+var failsafe_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"failsafe\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"failsafe\\")) };
+
+});
+
+// MODULE: ./json.js
+var json_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"json\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"json\\")) };
+
+});
+
 // MODULE: ./lib.js
 var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
 
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 /* unused reexport */ (type_namespaceFn())
 /* unused reexport */ ;(schema_namespaceFn())
 /* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+/* unused reexport */ ;(failsafe_namespaceFn())
+/* unused reexport */ ;(json_namespaceFn())
 module.exports.H = () => \\"loaded\\"
 
 });
@@ -398,7 +464,7 @@ it(\\"should keep an unused re-export from swallowing the next statement\\", () 
 });
 
 it(\\"should still evaluate what an unused re-export required\\", () => {
-	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\", \\"failsafe\\", \\"json\\"]);
 });
 
 /******/ })()
@@ -454,7 +520,7 @@ exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-p
 /******/ 	
 /************************************************************************/
 /*!******************************!*\\\\
-  !*** ./index.js + 5 modules ***!
+  !*** ./index.js + 7 modules ***!
   \\\\******************************/
 
 // MODULE: ./defaults.js
@@ -468,15 +534,37 @@ __webpack_unused_export__ = { name: \\"core\\" };
 
 });
 
+// MODULE: ./failsafe.js
+var failsafe_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"failsafe\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"failsafe\\")) };
+
+});
+
+// MODULE: ./json.js
+var json_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"json\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"json\\")) };
+
+});
+
 // MODULE: ./lib.js
 var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
 
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 /* unused reexport */ (type_namespaceFn())
 /* unused reexport */ ;(schema_namespaceFn())
 /* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+/* unused reexport */ ;(failsafe_namespaceFn())
+/* unused reexport */ ;(json_namespaceFn())
 module.exports.H = () => \\"loaded\\"
 
 });
@@ -533,7 +621,7 @@ it(\\"should keep an unused re-export from swallowing the next statement\\", () 
 });
 
 it(\\"should still evaluate what an unused re-export required\\", () => {
-	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\", \\"failsafe\\", \\"json\\"]);
 });
 
 /******/ })()

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,541 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-position commonjs-unused-reexport-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./defaults.js
+var defaults_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+var __webpack_unused_export__;
+
+
+(log_namespaceFn().push)(\\"defaults\\");
+
+__webpack_unused_export__ = { name: \\"core\\" };
+
+});
+
+// MODULE: ./lib.js
+var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+/* unused reexport */ (type_namespaceFn())
+/* unused reexport */ ;(schema_namespaceFn())
+/* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+module.exports.H = () => \\"loaded\\"
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./schema.js
+var schema_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"schema\\");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;
+
+});
+
+// MODULE: ./type.js
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"type\\");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./lib.js
+lib_namespaceFn();
+
+;// ./index.js
+
+
+
+it(\\"should keep an unused re-export from swallowing the next statement\\", () => {
+	expect((0,lib_namespaceFn().H)()).toBe(\\"loaded\\");
+});
+
+it(\\"should still evaluate what an unused re-export required\\", () => {
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-position commonjs-unused-reexport-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./defaults.js
+var defaults_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+var __webpack_unused_export__;
+
+
+(log_namespaceFn().push)(\\"defaults\\");
+
+__webpack_unused_export__ = { name: \\"core\\" };
+
+});
+
+// MODULE: ./lib.js
+var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+/* unused reexport */ (type_namespaceFn())
+/* unused reexport */ ;(schema_namespaceFn())
+/* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+module.exports.H = () => \\"loaded\\"
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./schema.js
+var schema_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"schema\\");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;
+
+});
+
+// MODULE: ./type.js
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"type\\");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./lib.js
+lib_namespaceFn();
+
+;// ./index.js
+
+
+
+it(\\"should keep an unused re-export from swallowing the next statement\\", () => {
+	expect((0,lib_namespaceFn().H)()).toBe(\\"loaded\\");
+});
+
+it(\\"should still evaluate what an unused re-export required\\", () => {
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-position commonjs-unused-reexport-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./defaults.js
+var defaults_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+var __webpack_unused_export__;
+
+
+(log_namespaceFn().push)(\\"defaults\\");
+
+__webpack_unused_export__ = { name: \\"core\\" };
+
+});
+
+// MODULE: ./lib.js
+var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+/* unused reexport */ (type_namespaceFn())
+/* unused reexport */ ;(schema_namespaceFn())
+/* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+module.exports.H = () => \\"loaded\\"
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./schema.js
+var schema_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"schema\\");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;
+
+});
+
+// MODULE: ./type.js
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"type\\");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./lib.js
+lib_namespaceFn();
+
+;// ./index.js
+
+
+
+it(\\"should keep an unused re-export from swallowing the next statement\\", () => {
+	expect((0,lib_namespaceFn().H)()).toBe(\\"loaded\\");
+});
+
+it(\\"should still evaluate what an unused re-export required\\", () => {
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-unused-reexport-asi-position commonjs-unused-reexport-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./defaults.js
+var defaults_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+var __webpack_unused_export__;
+
+
+(log_namespaceFn().push)(\\"defaults\\");
+
+__webpack_unused_export__ = { name: \\"core\\" };
+
+});
+
+// MODULE: ./lib.js
+var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+/* unused reexport */ (type_namespaceFn())
+/* unused reexport */ ;(schema_namespaceFn())
+/* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+module.exports.H = () => \\"loaded\\"
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./schema.js
+var schema_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"schema\\");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;
+
+});
+
+// MODULE: ./type.js
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"type\\");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./lib.js
+lib_namespaceFn();
+
+;// ./index.js
+
+
+
+it(\\"should keep an unused re-export from swallowing the next statement\\", () => {
+	expect((0,lib_namespaceFn().H)()).toBe(\\"loaded\\");
+});
+
+it(\\"should still evaluate what an unused re-export required\\", () => {
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigTest.snap
@@ -49,7 +49,7 @@ exports[`ConfigTestCases concatenate-modules commonjs-unused-reexport-asi-positi
 /******/ 	
 /************************************************************************/
 /*!******************************!*\\\\
-  !*** ./index.js + 5 modules ***!
+  !*** ./index.js + 7 modules ***!
   \\\\******************************/
 
 // MODULE: ./defaults.js
@@ -63,15 +63,37 @@ __webpack_unused_export__ = { name: \\"core\\" };
 
 });
 
+// MODULE: ./failsafe.js
+var failsafe_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"failsafe\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"failsafe\\")) };
+
+});
+
+// MODULE: ./json.js
+var json_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"json\\");
+
+module.exports = { ...(/* unused pure expression */ null && (\\"json\\")) };
+
+});
+
 // MODULE: ./lib.js
 var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
 
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 /* unused reexport */ (type_namespaceFn())
 /* unused reexport */ ;(schema_namespaceFn())
 /* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+/* unused reexport */ ;(failsafe_namespaceFn())
+/* unused reexport */ ;(json_namespaceFn())
 module.exports.H = () => \\"loaded\\"
 
 });
@@ -128,7 +150,7 @@ it(\\"should keep an unused re-export from swallowing the next statement\\", () 
 });
 
 it(\\"should still evaluate what an unused re-export required\\", () => {
-	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\", \\"failsafe\\", \\"json\\"]);
 });
 
 /******/ })()

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-unused-reexport-asi-position commonjs-unused-reexport-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./defaults.js
+var defaults_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+var __webpack_unused_export__;
+
+
+(log_namespaceFn().push)(\\"defaults\\");
+
+__webpack_unused_export__ = { name: \\"core\\" };
+
+});
+
+// MODULE: ./lib.js
+var lib_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+/* unused reexport */ (type_namespaceFn())
+/* unused reexport */ ;(schema_namespaceFn())
+/* unused reexport */ ;/* unused export */ (defaults_namespaceFn(), undefined)
+module.exports.H = () => \\"loaded\\"
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./schema.js
+var schema_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"schema\\");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;
+
+});
+
+// MODULE: ./type.js
+var type_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"type\\");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./lib.js
+lib_namespaceFn();
+
+;// ./index.js
+
+
+
+it(\\"should keep an unused re-export from swallowing the next statement\\", () => {
+	expect((0,lib_namespaceFn().H)()).toBe(\\"loaded\\");
+});
+
+it(\\"should still evaluate what an unused re-export required\\", () => {
+	expect((log_default()())).toEqual([\\"type\\", \\"schema\\", \\"defaults\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/defaults.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/defaults.js
@@ -1,0 +1,5 @@
+"use strict";
+
+require("./log").push("defaults");
+
+module.exports.core = { name: "core" };

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/failsafe.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/failsafe.js
@@ -1,0 +1,5 @@
+"use strict";
+
+require("./log").push("failsafe");
+
+module.exports = { name: "failsafe" };

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/index.js
@@ -6,5 +6,5 @@ it("should keep an unused re-export from swallowing the next statement", () => {
 });
 
 it("should still evaluate what an unused re-export required", () => {
-	expect(log).toEqual(["type", "schema", "defaults"]);
+	expect(log).toEqual(["type", "schema", "defaults", "failsafe", "json"]);
 });

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/index.js
@@ -1,0 +1,10 @@
+import log from "./log";
+import { load } from "./lib";
+
+it("should keep an unused re-export from swallowing the next statement", () => {
+	expect(load()).toBe("loaded");
+});
+
+it("should still evaluate what an unused re-export required", () => {
+	expect(log).toEqual(["type", "schema", "defaults"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/json.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/json.js
@@ -1,0 +1,5 @@
+"use strict";
+
+require("./log").push("json");
+
+module.exports = { name: "json" };

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/lib.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/lib.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// semicolon-free re-exports: dropping the unused ones must not let the
+// remaining expressions bind to the next statement
+module.exports.Type = require("./type")
+module.exports.Schema = require("./schema")
+module.exports.CORE_SCHEMA = require("./defaults").core
+module.exports.load = () => "loaded"

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/lib.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/lib.js
@@ -1,8 +1,10 @@
 "use strict";
 
-// semicolon-free re-exports: dropping the unused ones must not let the
-// remaining expressions bind to the next statement
+// semicolon-free re-exports, in every spelling: dropping the unused ones must
+// not let the remaining expressions bind to the next statement
 module.exports.Type = require("./type")
 module.exports.Schema = require("./schema")
 module.exports.CORE_SCHEMA = require("./defaults").core
+exports.FAILSAFE_SCHEMA = require("./failsafe")
+Object.defineProperty(exports, "JSON_SCHEMA", { value: require("./json") })
 module.exports.load = () => "loaded"

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/log.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/log.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [];

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/schema.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/schema.js
@@ -1,0 +1,9 @@
+"use strict";
+
+require("./log").push("schema");
+
+function Schema(types) {
+	this.types = types;
+}
+
+module.exports = Schema;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/type.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/type.js
@@ -1,0 +1,9 @@
+"use strict";
+
+require("./log").push("type");
+
+function Type(options) {
+	this.options = options;
+}
+
+module.exports = Type;

--- a/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-unused-reexport-asi-position/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: true,
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,553 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-body-asi-position commonjs-wrapped-body-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = (log_namespaceFn())
+
+log.push(\\"body\\")
+;(side_namespaceFn())
+__webpack_require__.cr((ctor_namespaceFn()))
+;(plain_namespaceFn().member)()
+
+module.exports.z = () => log
+
+});
+
+// MODULE: ./ctor.js
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"ctor\\");
+
+module.exports = function Ctor() {
+	this.tag = \\"ctor\\";
+};
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./plain.js
+var plain_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"plain\\");
+
+module.exports = { member: () => \\"member\\" };
+
+});
+
+// MODULE: ./side.js
+var side_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"side\\");
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should keep every semicolon-free require form a separate statement\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([\\"body\\", \\"side\\", \\"ctor\\", \\"plain\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-body-asi-position commonjs-wrapped-body-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = (log_namespaceFn())
+
+log.push(\\"body\\")
+;(side_namespaceFn())
+__webpack_require__.cr((ctor_namespaceFn()))
+;(plain_namespaceFn().member)()
+
+module.exports.z = () => log
+
+});
+
+// MODULE: ./ctor.js
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"ctor\\");
+
+module.exports = function Ctor() {
+	this.tag = \\"ctor\\";
+};
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./plain.js
+var plain_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"plain\\");
+
+module.exports = { member: () => \\"member\\" };
+
+});
+
+// MODULE: ./side.js
+var side_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"side\\");
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should keep every semicolon-free require form a separate statement\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([\\"body\\", \\"side\\", \\"ctor\\", \\"plain\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-body-asi-position commonjs-wrapped-body-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = (log_namespaceFn())
+
+log.push(\\"body\\")
+;(side_namespaceFn())
+__webpack_require__.cr((ctor_namespaceFn()))
+;(plain_namespaceFn().member)()
+
+module.exports.z = () => log
+
+});
+
+// MODULE: ./ctor.js
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"ctor\\");
+
+module.exports = function Ctor() {
+	this.tag = \\"ctor\\";
+};
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./plain.js
+var plain_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"plain\\");
+
+module.exports = { member: () => \\"member\\" };
+
+});
+
+// MODULE: ./side.js
+var side_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"side\\");
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should keep every semicolon-free require form a separate statement\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([\\"body\\", \\"side\\", \\"ctor\\", \\"plain\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-body-asi-position commonjs-wrapped-body-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = (log_namespaceFn())
+
+log.push(\\"body\\")
+;(side_namespaceFn())
+__webpack_require__.cr((ctor_namespaceFn()))
+;(plain_namespaceFn().member)()
+
+module.exports.z = () => log
+
+});
+
+// MODULE: ./ctor.js
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"ctor\\");
+
+module.exports = function Ctor() {
+	this.tag = \\"ctor\\";
+};
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./plain.js
+var plain_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"plain\\");
+
+module.exports = { member: () => \\"member\\" };
+
+});
+
+// MODULE: ./side.js
+var side_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"side\\");
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should keep every semicolon-free require form a separate statement\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([\\"body\\", \\"side\\", \\"ctor\\", \\"plain\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-body-asi-position commonjs-wrapped-body-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	const __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			const e = new Error(\\"Cannot find module '\\" + moduleId + \\"'\\");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/construct require */
+/******/ 	// \`new require(id)\` invokes the require function as a constructor, so a
+/******/ 	// primitive module.exports is discarded in favor of the freshly created
+/******/ 	// instance, exactly as in Node.js. A concatenated module has no require
+/******/ 	// call left, so apply that rule to its exports value instead.
+/******/ 	__webpack_require__.cr = (exports) => {
+/******/ 		const isObject =
+/******/ 			exports !== null && (typeof exports === \\"object\\" || typeof exports === \\"function\\");
+/******/ 		return isObject ? exports : Object.create(__webpack_require__.prototype);
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 5 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = (log_namespaceFn())
+
+log.push(\\"body\\")
+;(side_namespaceFn())
+__webpack_require__.cr((ctor_namespaceFn()))
+;(plain_namespaceFn().member)()
+
+module.exports.z = () => log
+
+});
+
+// MODULE: ./ctor.js
+var ctor_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"ctor\\");
+
+module.exports = function Ctor() {
+	this.tag = \\"ctor\\";
+};
+
+});
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./plain.js
+var plain_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"plain\\");
+
+module.exports = { member: () => \\"member\\" };
+
+});
+
+// MODULE: ./side.js
+var side_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+(log_namespaceFn().push)(\\"side\\");
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should keep every semicolon-free require form a separate statement\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([\\"body\\", \\"side\\", \\"ctor\\", \\"plain\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/body.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/body.js
@@ -1,0 +1,12 @@
+"use strict";
+
+// semicolon-free: every require below opens a statement ASI would otherwise
+// glue to the one above it
+const log = require("./log")
+
+log.push("body")
+require("./side")
+new require("./ctor")
+require("./plain").member()
+
+module.exports.report = () => log

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/ctor.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/ctor.js
@@ -1,0 +1,7 @@
+"use strict";
+
+require("./log").push("ctor");
+
+module.exports = function Ctor() {
+	this.tag = "ctor";
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/index.js
@@ -1,0 +1,5 @@
+import { report } from "./body";
+
+it("should keep every semicolon-free require form a separate statement", () => {
+	expect(report()).toEqual(["body", "side", "ctor", "plain"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/log.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/log.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [];

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/plain.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/plain.js
@@ -1,0 +1,5 @@
+"use strict";
+
+require("./log").push("plain");
+
+module.exports = { member: () => "member" };

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/side.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/side.js
@@ -1,0 +1,3 @@
+"use strict";
+
+require("./log").push("side");

--- a/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-body-asi-position/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,449 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-reference-asi-position commonjs-wrapped-reference-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const log = (log_namespaceFn());
+
+log.push(\\"thing\\");
+
+exports.named = () => log.push(\\"named\\");
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./user.mjs
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+
+
+
+
+function shapes() {
+	const seen = []
+	seen.push(\\"start\\")
+	;(thing_namespaceFn())
+	;(0,thing_namespaceFn().named)()
+	;(thing_namespaceFn().named)()
+	seen.push(\\"end\\")
+	return seen
+}
+
+;// ./index.js
+
+
+
+it(\\"should keep every reference into a wrapped module a separate statement\\", () => {
+	expect(shapes()).toEqual([\\"start\\", \\"end\\"]);
+});
+
+it(\\"should call the wrapped module's export once per reference\\", () => {
+	expect((log_default()())).toEqual([\\"thing\\", \\"named\\", \\"named\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-reference-asi-position commonjs-wrapped-reference-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const log = (log_namespaceFn());
+
+log.push(\\"thing\\");
+
+exports.named = () => log.push(\\"named\\");
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./user.mjs
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+
+
+
+
+function shapes() {
+	const seen = []
+	seen.push(\\"start\\")
+	;(thing_namespaceFn())
+	;(0,thing_namespaceFn().named)()
+	;(thing_namespaceFn().named)()
+	seen.push(\\"end\\")
+	return seen
+}
+
+;// ./index.js
+
+
+
+it(\\"should keep every reference into a wrapped module a separate statement\\", () => {
+	expect(shapes()).toEqual([\\"start\\", \\"end\\"]);
+});
+
+it(\\"should call the wrapped module's export once per reference\\", () => {
+	expect((log_default()())).toEqual([\\"thing\\", \\"named\\", \\"named\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-reference-asi-position commonjs-wrapped-reference-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const log = (log_namespaceFn());
+
+log.push(\\"thing\\");
+
+exports.named = () => log.push(\\"named\\");
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./user.mjs
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+
+
+
+
+function shapes() {
+	const seen = []
+	seen.push(\\"start\\")
+	;(thing_namespaceFn())
+	;(0,thing_namespaceFn().named)()
+	;(thing_namespaceFn().named)()
+	seen.push(\\"end\\")
+	return seen
+}
+
+;// ./index.js
+
+
+
+it(\\"should keep every reference into a wrapped module a separate statement\\", () => {
+	expect(shapes()).toEqual([\\"start\\", \\"end\\"]);
+});
+
+it(\\"should call the wrapped module's export once per reference\\", () => {
+	expect((log_default()())).toEqual([\\"thing\\", \\"named\\", \\"named\\"]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-reference-asi-position commonjs-wrapped-reference-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const log = (log_namespaceFn());
+
+log.push(\\"thing\\");
+
+exports.named = () => log.push(\\"named\\");
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./user.mjs
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+
+
+
+
+function shapes() {
+	const seen = []
+	seen.push(\\"start\\")
+	;(thing_namespaceFn())
+	;(0,thing_namespaceFn().named)()
+	;(thing_namespaceFn().named)()
+	seen.push(\\"end\\")
+	return seen
+}
+
+;// ./index.js
+
+
+
+it(\\"should keep every reference into a wrapped module a separate statement\\", () => {
+	expect(shapes()).toEqual([\\"start\\", \\"end\\"]);
+});
+
+it(\\"should call the wrapped module's export once per reference\\", () => {
+	expect((log_default()())).toEqual([\\"thing\\", \\"named\\", \\"named\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-reference-asi-position commonjs-wrapped-reference-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./log.js
+var log_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+module.exports = [];
+
+});
+
+// MODULE: ./thing.cjs
+var thing_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+const log = (log_namespaceFn());
+
+log.push(\\"thing\\");
+
+exports.named = () => log.push(\\"named\\");
+
+});
+
+;// ./log.js
+log_namespaceFn();
+
+function log_default() { return log_default.c || (log_default.c = __webpack_require__.n(log_namespaceFn())); }
+;// ./thing.cjs
+thing_namespaceFn();
+
+;// ./user.mjs
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+
+
+
+
+function shapes() {
+	const seen = []
+	seen.push(\\"start\\")
+	;(thing_namespaceFn())
+	;(0,thing_namespaceFn().named)()
+	;(thing_namespaceFn().named)()
+	seen.push(\\"end\\")
+	return seen
+}
+
+;// ./index.js
+
+
+
+it(\\"should keep every reference into a wrapped module a separate statement\\", () => {
+	expect(shapes()).toEqual([\\"start\\", \\"end\\"]);
+});
+
+it(\\"should call the wrapped module's export once per reference\\", () => {
+	expect((log_default()())).toEqual([\\"thing\\", \\"named\\", \\"named\\"]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/index.js
@@ -1,0 +1,10 @@
+import log from "./log";
+import { shapes } from "./user.mjs";
+
+it("should keep every reference into a wrapped module a separate statement", () => {
+	expect(shapes()).toEqual(["start", "end"]);
+});
+
+it("should call the wrapped module's export once per reference", () => {
+	expect(log).toEqual(["thing", "named", "named"]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/log.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/log.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [];

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/thing.cjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/thing.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+const log = require("./log");
+
+log.push("thing");
+
+exports.named = () => log.push("named");

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/user.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/user.mjs
@@ -1,0 +1,15 @@
+// strict ESM: each reference below resolves to the wrapper accessor call and
+// opens a statement ASI would otherwise glue to the one above it
+import thing from "./thing.cjs";
+import { named } from "./thing.cjs";
+import * as namespace from "./thing.cjs";
+
+export function shapes() {
+	const seen = []
+	seen.push("start")
+	thing
+	named()
+	namespace.named()
+	seen.push("end")
+	return seen
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-reference-asi-position/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A wrapped module's reference is emitted parenthesized, and the leading semicolon that keeps it off the previous statement is only written when the caller reports the position as unsafe. Both CommonJS call sites claimed the position was always safe, so in semicolon-free source the reference merged into the statement above it and threw while the bundle was still loading. `asiSafe` is now computed from where the original call sits, and applied to the unused-export expression, which is parenthesized as well. Closes #21955. Closes #21956.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — four semicolon-free cases under `test/configCases/concatenate-modules/`: `commonjs-require-asi-position`, `commonjs-unused-reexport-asi-position` (every re-export spelling), `commonjs-wrapped-body-asi-position` (every require form, `new require()` included), and `commonjs-wrapped-reference-asi-position`, which pins all three parenthesizing branches reached from strict ESM. The first three were confirmed to throw against unmodified `lib/`; the last already passed and is there as a pin.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code reproduced both issues, traced the cause to `asiSafe` being assumed rather than computed at two call sites, found a third unguarded site (`getUnusedExportExpr`) only after a test reached it, audited the remaining hardcoded `asiSafe: true` callers and confirmed they are correct, and wrote the regression tests. Every emitted shape was diffed against a build of the parent commit, and the results were reviewed and verified locally before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015hhLdjWFnLQjMt5EXmVZf7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CommonJS module concatenation to preserve statement boundaries in automatic semicolon insertion (ASI) positions.
  * Prevented unused re-exports and wrapped module references from being incorrectly joined with adjacent statements.
  * Preserved evaluation order and side effects for semicolon-free `require` statements.

* **Tests**
  * Added regression coverage for CommonJS requires, re-exports, wrapped module bodies, and cross-module references involving ASI-sensitive statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->