### PR TITLE
feat(css): drop a rule only an engine the target lost could read

### DIFF
--- a/.changeset/016-css-drop-what-is-already-said.md
+++ b/.changeset/016-css-drop-what-is-already-said.md
@@ -2,5 +2,4 @@
 "webpack": minor
 ---
 
-Drop what a declaration, slot or query already says and a rule only an engine
-the target lost could read, and add `lowerUnsupported`.
+Drop what is already said or only a gone engine reads, add `lowerUnsupported`.

--- a/.changeset/016-css-drop-what-is-already-said.md
+++ b/.changeset/016-css-drop-what-is-already-said.md
@@ -2,4 +2,5 @@
 "webpack": minor
 ---
 
-Drop what a declaration, slot or query already says, and add `lowerUnsupported`.
+Drop what a declaration, slot or query already says and a rule only an engine
+the target lost could read, and add `lowerUnsupported`.

--- a/cspell.json
+++ b/cspell.json
@@ -209,6 +209,7 @@
     "khtml",
     "kibibytes",
     "Kluskens",
+    "Konqueror",
     "Koppers",
     "Kumar",
     "languagetool",

--- a/cspell.json
+++ b/cspell.json
@@ -328,6 +328,7 @@
     "prefetched",
     "prefetching",
     "prefixable",
+    "prefocus",
     "preload",
     "preloaded",
     "preloading",

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -7607,8 +7607,14 @@ const _neededPrefixes = (table, name) => {
 // `-khtml-`), captured so it can be split from the construct it sits on.
 const VENDOR_PREFIX = /^(-[a-z]+-)(?=[a-z])/;
 
-// Whether each vendor prefix is one the selection still reads, kept until the
-// selection changes rather than answered again per rule.
+// The tables a prefix is looked for in, and whether each is one the selection
+// still reads — kept until the selection changes rather than answered per rule.
+/** @type {Map<string, [string, number][]>[]} */
+const _PREFIX_TABLES = [
+	PREFIXED_PROPERTIES,
+	PREFIXED_SELECTORS,
+	PREFIXED_AT_RULES
+];
 /** @type {Map<string, boolean>} */
 const _prefixLiveMemo = new Map();
 /** @type {(number[] | undefined)[] | null} */
@@ -7675,18 +7681,13 @@ const _prefixIsLive = (prefix) => {
 	}
 	const cached = _prefixLiveMemo.get(prefix);
 	if (cached !== undefined) return cached;
-	let live =
-		_tableNeedsPrefix(PREFIXED_PROPERTIES, prefix, parsed) ||
-		_tableNeedsPrefix(PREFIXED_SELECTORS, prefix, parsed) ||
-		_tableNeedsPrefix(PREFIXED_AT_RULES, prefix, parsed);
-	// A value's spellings are held per property it is read on, so this table is
-	// one level deeper than the others.
-	if (!live) {
-		for (const byProperty of PREFIXED_VALUES.values()) {
-			if (_tableNeedsPrefix(byProperty, prefix, parsed)) {
-				live = true;
-				break;
-			}
+	// Every prefix the data names sits on some property, selector or at-rule, so
+	// the value table — held one level deeper — would answer for none of its own.
+	let live = false;
+	for (const table of _PREFIX_TABLES) {
+		if (_tableNeedsPrefix(table, prefix, parsed)) {
+			live = true;
+			break;
 		}
 	}
 	_prefixLiveMemo.set(prefix, live);
@@ -7726,7 +7727,6 @@ const _needsGoneEnginePseudo = (selector) => {
 		) {
 			end++;
 		}
-		if (end === from) continue;
 		const prefix = VENDOR_PREFIX.exec(
 			toLowerCaseIfNeeded(selector.slice(from, end))
 		);
@@ -7749,7 +7749,6 @@ const _readsThroughGoneEngine = (list) => {
 	// A vendor pseudo is a `:` a `-` follows, so a list without that pair holds
 	// none — which is nearly every list, and the walk is skipped for them.
 	if (!_transforms.removeDeadRules || !list.includes(":-")) return false;
-	if (_prefixBrowsers === null) return false;
 	for (const one of _splitSelectorList(list)) {
 		if (!_needsGoneEnginePseudo(one)) return false;
 	}

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -7695,6 +7695,36 @@ const _prefixIsLive = (prefix) => {
 };
 
 /**
+ * The index of the `)` closing the `(` at `at`, stepping over an escape, a
+ * quoted run and a nested pair. The end of the text where it closes nowhere,
+ * which a parsed selector never does — an unclosed function is closed for it.
+ * @param {string} text the text to read
+ * @param {number} at the index of the opening parenthesis
+ * @returns {number} where the list it opens ends
+ */
+const _closingParenthesis = (text, at) => {
+	let depth = 0;
+	let i = at;
+	for (; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		if (code === CC_REVERSE_SOLIDUS) {
+			i++;
+		} else if (code === CC_QUOTATION_MARK || code === CC_APOSTROPHE) {
+			for (i++; i < text.length; i++) {
+				const inner = text.charCodeAt(i);
+				if (inner === CC_REVERSE_SOLIDUS) i++;
+				else if (inner === code) break;
+			}
+		} else if (code === CC_LEFT_PARENTHESIS) {
+			depth++;
+		} else if (code === CC_RIGHT_PARENTHESIS && --depth === 0) {
+			break;
+		}
+	}
+	return i;
+};
+
+/**
  * Whether a selector can only be read through a vendor pseudo whose engine the
  * selection has left behind. An escape and a quoted attribute value are stepped
  * over: the `:` of `.sm\:flex` and of `[href="a:b"]` starts no pseudo.
@@ -7728,14 +7758,36 @@ const _needsGoneEnginePseudo = (selector) => {
 			end++;
 		}
 		const name = toLowerCaseIfNeeded(selector.slice(from, end));
-		// `:is()` and `:where()` take a forgiving list, so an engine drops the one
-		// argument it cannot parse and goes on matching the rest of the selector.
-		if (name === "is" || name === "where") return false;
+		if (
+			(name === "is" || name === "where") &&
+			selector.charCodeAt(end) === CC_LEFT_PARENTHESIS
+		) {
+			// A forgiving list keeps every argument it can parse, so it matches
+			// nothing only where all of them are dead — and the rest is still read.
+			const close = _closingParenthesis(selector, end);
+			if (_everyOneGone(selector.slice(end + 1, close))) found = true;
+			i = close;
+			continue;
+		}
 		const prefix = VENDOR_PREFIX.exec(name);
 		if (prefix !== null && !_prefixIsLive(prefix[1])) found = true;
 		i = end - 1;
 	}
 	return found;
+};
+
+/**
+ * Whether every selector of a list is one no target can read. Asked of a rule's
+ * own prelude and of a forgiving list's arguments alike, which is why it takes
+ * the list rather than the rule.
+ * @param {string} list a printed selector list
+ * @returns {boolean} true when none of them can be read
+ */
+const _everyOneGone = (list) => {
+	for (const one of _splitSelectorList(list)) {
+		if (!_needsGoneEnginePseudo(one)) return false;
+	}
+	return true;
 };
 
 /**
@@ -7751,10 +7803,7 @@ const _readsThroughGoneEngine = (list) => {
 	// A vendor pseudo is a `:` a `-` follows, so a list without that pair holds
 	// none — which is nearly every list, and the walk is skipped for them.
 	if (!_transforms.removeDeadRules || !list.includes(":-")) return false;
-	for (const one of _splitSelectorList(list)) {
-		if (!_needsGoneEnginePseudo(one)) return false;
-	}
-	return true;
+	return _everyOneGone(list);
 };
 
 /**

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -5879,7 +5879,7 @@ const grammar = (input, visitors, writer, options) => {
 		writer === undefined ? undefined : writer.options.unusedSymbols;
 	_unusedSymbols =
 		unused === undefined || unused.length === 0 ? null : new Set(unused);
-	_unusedRules = _unusedSymbols === null ? null : new Set();
+	_unusedRules = writer === undefined ? null : new Set();
 	const pseudo =
 		writer === undefined ? undefined : writer.options.pseudoClasses;
 	const named = pseudo === undefined ? [] : Object.entries(pseudo);
@@ -7606,6 +7606,155 @@ const _neededPrefixes = (table, name) => {
 // A vendor prefix at the start of a name (`-webkit-`, `-moz-`, `-ms-`, `-o-`,
 // `-khtml-`), captured so it can be split from the construct it sits on.
 const VENDOR_PREFIX = /^(-[a-z]+-)(?=[a-z])/;
+
+// Whether each vendor prefix is one the selection still reads, kept until the
+// selection changes rather than answered again per rule.
+/** @type {Map<string, boolean>} */
+const _prefixLiveMemo = new Map();
+/** @type {(number[] | undefined)[] | null} */
+let _prefixLiveFor = null;
+
+/**
+ * Whether a construct's `[browser, from, to]` windows hold one the selection
+ * sits inside.
+ * @param {number} windows the windows' index into `PREFIX_WINDOW_STARTS`
+ * @param {(number[] | undefined)[]} parsed the selected versions, per browser slot
+ * @returns {boolean} true when a selected version falls in one of them
+ */
+const _windowsHitSelection = (windows, parsed) => {
+	const end = PREFIX_WINDOW_STARTS[windows + 1];
+	for (let at = PREFIX_WINDOW_STARTS[windows]; at < end; at += 3) {
+		const versions = parsed[PREFIX_WINDOWS[at]];
+		if (versions === undefined) continue;
+		const from = PREFIX_WINDOWS[at + 1];
+		const to = PREFIX_WINDOWS[at + 2];
+		for (let i = 0; i < versions.length; i++) {
+			if (versions[i] >= from && versions[i] < to) return true;
+		}
+	}
+	return false;
+};
+
+/**
+ * Whether one prefix table names a spelling carrying `prefix` that the
+ * selection still needs.
+ * @param {Map<string, [string, number][]>} table a prefix table
+ * @param {string} prefix the prefix, `-ms-` and the like
+ * @param {(number[] | undefined)[]} parsed the selected versions, per browser slot
+ * @returns {boolean} true when one of its spellings is still needed
+ */
+const _tableNeedsPrefix = (table, prefix, parsed) => {
+	for (const spellings of table.values()) {
+		for (const [spelling, windows] of spellings) {
+			if (
+				spelling.startsWith(prefix) &&
+				_windowsHitSelection(windows, parsed)
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+};
+
+/**
+ * Whether any target reads a vendor prefix at all. Asked of the tables as a
+ * whole rather than of one name, so it answers for a proprietary pseudo none of
+ * them names: a prefix nothing in the selection needs is one whose engine the
+ * selection has left behind.
+ * @param {string} prefix the prefix, `-ms-` and the like
+ * @returns {boolean} true when a target still reads it
+ */
+const _prefixIsLive = (prefix) => {
+	const parsed = _prefixBrowsers;
+	// Told no target, every prefix is assumed read: nothing is dropped for one.
+	if (parsed === null) return true;
+	if (_prefixLiveFor !== parsed) {
+		_prefixLiveMemo.clear();
+		_prefixLiveFor = parsed;
+	}
+	const cached = _prefixLiveMemo.get(prefix);
+	if (cached !== undefined) return cached;
+	let live =
+		_tableNeedsPrefix(PREFIXED_PROPERTIES, prefix, parsed) ||
+		_tableNeedsPrefix(PREFIXED_SELECTORS, prefix, parsed) ||
+		_tableNeedsPrefix(PREFIXED_AT_RULES, prefix, parsed);
+	// A value's spellings are held per property it is read on, so this table is
+	// one level deeper than the others.
+	if (!live) {
+		for (const byProperty of PREFIXED_VALUES.values()) {
+			if (_tableNeedsPrefix(byProperty, prefix, parsed)) {
+				live = true;
+				break;
+			}
+		}
+	}
+	_prefixLiveMemo.set(prefix, live);
+	return live;
+};
+
+/**
+ * Whether a selector can only be read through a vendor pseudo whose engine the
+ * selection has left behind. An escape and a quoted attribute value are stepped
+ * over: the `:` of `.sm\:flex` and of `[href="a:b"]` starts no pseudo.
+ * @param {string} selector one printed selector
+ * @returns {boolean} true when no target can read it
+ */
+const _needsGoneEnginePseudo = (selector) => {
+	let found = false;
+	for (let i = 0; i < selector.length; i++) {
+		const code = selector.charCodeAt(i);
+		if (code === CC_REVERSE_SOLIDUS) {
+			i++;
+			continue;
+		}
+		if (code === CC_QUOTATION_MARK || code === CC_APOSTROPHE) {
+			for (i++; i < selector.length; i++) {
+				const inner = selector.charCodeAt(i);
+				if (inner === CC_REVERSE_SOLIDUS) i++;
+				else if (inner === code) break;
+			}
+			continue;
+		}
+		if (code !== CC_COLON) continue;
+		let end = i + 1;
+		if (selector.charCodeAt(end) === CC_COLON) end++;
+		const from = end;
+		while (
+			end < selector.length &&
+			_isIdentCodePoint(selector.charCodeAt(end))
+		) {
+			end++;
+		}
+		if (end === from) continue;
+		const prefix = VENDOR_PREFIX.exec(
+			toLowerCaseIfNeeded(selector.slice(from, end))
+		);
+		if (prefix !== null && !_prefixIsLive(prefix[1])) found = true;
+		i = end - 1;
+	}
+	return found;
+};
+
+/**
+ * Whether a whole selector list is one no target can read, which is a rule that
+ * paints nothing anywhere it is served. Only a list every selector of which is
+ * dead: an engine drops the rule over one selector it cannot parse, so a list
+ * holding a live one already matches nothing extra, and taking the dead one out
+ * would start it matching.
+ * @param {string} list a printed selector list
+ * @returns {boolean} true when the rule may go
+ */
+const _readsThroughGoneEngine = (list) => {
+	// A vendor pseudo is a `:` a `-` follows, so a list without that pair holds
+	// none — which is nearly every list, and the walk is skipped for them.
+	if (!_transforms.removeDeadRules || !list.includes(":-")) return false;
+	if (_prefixBrowsers === null) return false;
+	for (const one of _splitSelectorList(list)) {
+		if (!_needsGoneEnginePseudo(one)) return false;
+	}
+	return true;
+};
 
 /**
  * The base an at-rule's vendor spelling belongs to. Every at-rule spelling is
@@ -14330,6 +14479,12 @@ const _rulePrelude = (path, writer, minify, outParts) => {
 				.join(",");
 		}
 		const list = _canonicalSelectorList(prelude);
+		if (_readsThroughGoneEngine(list)) {
+			/** @type {Set<Node>} */ (_unusedRules).add(
+				/** @type {Node} */ (_currentNode)
+			);
+			return list;
+		}
 		if (_unusedSymbols === null) return list;
 		const kept = _dropUnusedSelectors(list);
 		// Marked rather than dropped here: the rule's own printer takes it out, the

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -7727,9 +7727,11 @@ const _needsGoneEnginePseudo = (selector) => {
 		) {
 			end++;
 		}
-		const prefix = VENDOR_PREFIX.exec(
-			toLowerCaseIfNeeded(selector.slice(from, end))
-		);
+		const name = toLowerCaseIfNeeded(selector.slice(from, end));
+		// `:is()` and `:where()` take a forgiving list, so an engine drops the one
+		// argument it cannot parse and goes on matching the rest of the selector.
+		if (name === "is" || name === "where") return false;
+		const prefix = VENDOR_PREFIX.exec(name);
 		if (prefix !== null && !_prefixIsLive(prefix[1])) found = true;
 		i = end - 1;
 	}

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -5478,6 +5478,31 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 				expect(minify(backslash, MODERN)).toBe(backslash);
 			});
 
+			it("keeps one whose dead pseudo a forgiving list only skips", () => {
+				// Chrome parses `.a:is(.b,input::-ms-expand)` down to `.a:is(.b)` and
+				// paints with it, so the rule is not one no engine reads.
+				const is = ".a:is(.b,input::-ms-expand){color:red}";
+				expect(minify(is, MODERN)).toBe(is);
+				const where = ":where(.a,:-ms-input-placeholder){color:red}";
+				expect(minify(where, MODERN)).toBe(where);
+				// The name is matched the way an engine reads it, case and all.
+				const cased = ".a:IS(.b,:-ms-input-placeholder){color:red}";
+				expect(minify(cased, MODERN)).toBe(
+					".a:is(.b,:-ms-input-placeholder){color:red}"
+				);
+			});
+
+			it("drops one whose dead pseudo an unforgiving list keeps", () => {
+				// `:has()` and `:not()` take an unforgiving list, so Chrome drops the
+				// whole rule over the argument it cannot parse.
+				expect(
+					minify(".a:has(> :-ms-input-placeholder){color:red}", MODERN)
+				).toBe("");
+				expect(
+					minify(".a:not(:-ms-input-placeholder){color:red}", MODERN)
+				).toBe("");
+			});
+
 			it("drops one needing a prefix the data names nowhere", () => {
 				// `-khtml-` was Konqueror's: no table holds it, so every one of them
 				// is asked before the selector is read as dead.

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -5478,18 +5478,62 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 				expect(minify(backslash, MODERN)).toBe(backslash);
 			});
 
-			it("keeps one whose dead pseudo a forgiving list only skips", () => {
+			it("keeps one a forgiving list still matches with", () => {
 				// Chrome parses `.a:is(.b,input::-ms-expand)` down to `.a:is(.b)` and
 				// paints with it, so the rule is not one no engine reads.
 				const is = ".a:is(.b,input::-ms-expand){color:red}";
 				expect(minify(is, MODERN)).toBe(is);
 				const where = ":where(.a,:-ms-input-placeholder){color:red}";
 				expect(minify(where, MODERN)).toBe(where);
-				// The name is matched the way an engine reads it, case and all.
-				const cased = ".a:IS(.b,:-ms-input-placeholder){color:red}";
-				expect(minify(cased, MODERN)).toBe(
-					".a:is(.b,:-ms-input-placeholder){color:red}"
+				// A list nested in one is read the same way, so the live `.b` carries
+				// both of them.
+				const nested = ".a:is(:is(.b,::-ms-expand)){color:red}";
+				expect(minify(nested, MODERN)).toBe(nested);
+				// The `:-ms-x` sits inside a string, so no pseudo is read out of it
+				// and the `)` there closes nothing.
+				const quoted = '.a:is([href="),::-ms-x"]){color:red}';
+				expect(minify(quoted, MODERN)).toBe(quoted);
+			});
+
+			it("drops one a forgiving list leaves nothing of", () => {
+				// Every argument is dead, so the list matches nothing and neither does
+				// what it qualifies.
+				expect(minify(".a:is(input::-ms-expand){color:red}", MODERN)).toBe("");
+				expect(minify(".a:where(input::-ms-expand){color:red}", MODERN)).toBe(
+					""
 				);
+				expect(minify(".a:is(:is(::-ms-expand)){color:red}", MODERN)).toBe("");
+			});
+
+			it("reads the rest of a selector past a forgiving list", () => {
+				// The list is stepped over as one, and what follows or precedes it is
+				// still read — `.a:is(.b)::-ms-expand` parses nowhere.
+				expect(minify(".a:is(.b)::-ms-expand{color:red}", MODERN)).toBe("");
+				expect(
+					minify(".a:where(.b) :-ms-input-placeholder{color:red}", MODERN)
+				).toBe("");
+				expect(minify("::-ms-expand:is(.b){color:red}", MODERN)).toBe("");
+				// The string holds a `)`, so only the one closing the list ends it.
+				expect(
+					minify('.a:is([href="),::-ms-x"])::-ms-expand{color:red}', MODERN)
+				).toBe("");
+				// Both names are matched the way an engine reads them, case and all.
+				expect(minify(".a:IS(.b)::-MS-EXPAND{color:red}", MODERN)).toBe("");
+			});
+
+			it("finds the end of a forgiving list an escape sits in", () => {
+				// The escaped `)` closes nothing, so the list runs on to the real one
+				// and `::-ms-expand` is still read after it.
+				expect(minify(".a:is(.b\\))::-ms-expand{color:red}", MODERN)).toBe("");
+				const live = ".a:is(.b\\)){color:red}";
+				expect(minify(live, MODERN)).toBe(live);
+				// A value holding both quotes keeps its escape, and the escaped one
+				// leaves the string open so the `)` in it does not end the list.
+				const quoted = '.a:is([href="a\'\\")b"]){color:red}';
+				expect(minify(quoted, MODERN)).toBe(quoted);
+				expect(
+					minify('.a:is([href="a\'\\")b"])::-ms-expand{color:red}', MODERN)
+				).toBe("");
 			});
 
 			it("drops one whose dead pseudo an unforgiving list keeps", () => {

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -5423,6 +5423,58 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 			expect(minify(css)).toBe("a{inset:1px 2px}");
 		});
 
+		describe("a rule only a gone engine could read", () => {
+			const MODERN = { browsers: ["chrome 120", "firefox 120", "safari 17"] };
+
+			it("drops one every selector of which needs a `-ms-` pseudo", () => {
+				expect(minify("input::-ms-expand{display:none}", MODERN)).toBe("");
+				expect(minify("input:-ms-input-placeholder{color:red}", MODERN)).toBe(
+					""
+				);
+			});
+
+			it("drops one that needs an `-o-` pseudo", () => {
+				expect(
+					minify(".opera-only :-o-prefocus{word-spacing:-.43em}", MODERN)
+				).toBe("");
+			});
+
+			it("keeps it where the selection still has that engine", () => {
+				const css = "input::-ms-expand{display:none}";
+				expect(minify(css, { browsers: ["ie 11"] })).toBe(css);
+			});
+
+			it("keeps it where no target is stated", () => {
+				const css = "input::-ms-expand{display:none}";
+				expect(minify(css)).toBe(css);
+			});
+
+			it("keeps a list one live selector stands in", () => {
+				// An unknown pseudo-element invalidates the whole list, so the live
+				// half matches nothing either — dropping the dead one would start it.
+				const css = ".a,input::-ms-expand{color:red}";
+				expect(minify(css, MODERN)).toBe(css);
+			});
+
+			it("keeps a prefix an engine in the selection reads", () => {
+				const css = "input::-webkit-slider-thumb{width:1px}";
+				expect(minify(css, MODERN)).toBe(css);
+				const moz = "input::-moz-range-thumb{width:1px}";
+				expect(minify(moz, MODERN)).toBe(moz);
+			});
+
+			it("leaves it where the rewrite is turned off", () => {
+				const css = "input::-ms-expand{display:none}";
+				expect(
+					new SourceProcessor().process(css, {
+						mode: "minify",
+						environment: MODERN,
+						transforms: { removeDeadRules: false }
+					}).code
+				).toBe(css);
+			});
+		});
+
 		it("merges the four corners, matched by name rather than position", () => {
 			// `corner-shape` lists its longhands by row and `{1,4}` writes them
 			// clockwise, so a positional read would cross two of them over.

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -5463,6 +5463,27 @@ describe("CssSyntax minify — the value transforms' rejection paths", () => {
 				expect(minify(moz, MODERN)).toBe(moz);
 			});
 
+			it("reads no pseudo out of an escape or a quoted value", () => {
+				// The `:` of `.sm\\:-flex` and of `[href="a:-b"]` starts no pseudo, so
+				// neither rule is one an engine the target lost could read.
+				const escaped = ".sm\\:-flex{display:flex}";
+				expect(minify(escaped, MODERN)).toBe(escaped);
+				const quoted = '[href="a:-ms-b"]{color:red}';
+				expect(minify(quoted, MODERN)).toBe(quoted);
+				// The printer settles on one quote, so only the rule surviving is read.
+				expect(minify("[href='a:-ms-b']{color:red}", MODERN)).toBe(quoted);
+				// A `\` inside the value is stepped over with whatever it escapes, so
+				// the string still ends where it ends.
+				const backslash = '[title="a:-\\\\b"]{color:red}';
+				expect(minify(backslash, MODERN)).toBe(backslash);
+			});
+
+			it("drops one needing a prefix the data names nowhere", () => {
+				// `-khtml-` was Konqueror's: no table holds it, so every one of them
+				// is asked before the selector is read as dead.
+				expect(minify(".a :-khtml-gone{color:red}", MODERN)).toBe("");
+			});
+
 			it("leaves it where the rewrite is turned off", () => {
 				const css = "input::-ms-expand{display:none}";
 				expect(

--- a/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css minimize-drop-dead-engine-rules minimize-drop-dead-engine-rules should compile 1`] = `
+Array [
+  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.plain{color:blue}",
+]
+`;

--- a/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigCacheTest.snap
@@ -2,6 +2,6 @@
 
 exports[`ConfigCacheTestCases css minimize-drop-dead-engine-rules minimize-drop-dead-engine-rules should compile 1`] = `
 Array [
-  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.plain{color:blue}",
+  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.forgiving:is(.b,input::-ms-clear){color:teal}.plain{color:blue}",
 ]
 `;

--- a/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigTest.snap
@@ -2,6 +2,6 @@
 
 exports[`ConfigTestCases css minimize-drop-dead-engine-rules minimize-drop-dead-engine-rules should compile 1`] = `
 Array [
-  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.plain{color:blue}",
+  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.forgiving:is(.b,input::-ms-clear){color:teal}.plain{color:blue}",
 ]
 `;

--- a/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/__snapshots__/ConfigTest.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css minimize-drop-dead-engine-rules minimize-drop-dead-engine-rules should compile 1`] = `
+Array [
+  "input::-webkit-slider-thumb{width:1px}input::-moz-range-thumb{width:2px}.kept,input::-ms-track{color:green}.plain{color:blue}",
+]
+`;

--- a/test/configCases/css/minimize-drop-dead-engine-rules/index.js
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should drop a rule only an engine the target lost could read", () => {
+	// The emitted stylesheet is snapshotted in test.config.js (afterExecute);
+	// this keeps a runnable entry so the chunk and its `.css` are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-drop-dead-engine-rules/style.css
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/style.css
@@ -19,12 +19,17 @@ input::-moz-range-thumb {
 	width: 2px;
 }
 
-/* One live selector stands in this list, so the whole rule stays: an engine
-   drops it over the half it cannot parse, and taking that half out would start
-   the other one matching. */
+/* One live selector stands in this list, so the whole rule stays: taking the
+   dead half out would start the live one matching. */
 .kept,
 input::-ms-track {
 	color: green;
+}
+
+/* A forgiving list drops only the argument an engine cannot parse, so the rest
+   of this selector goes on matching. */
+.forgiving:is(.b, input::-ms-clear) {
+	color: teal;
 }
 
 .plain {

--- a/test/configCases/css/minimize-drop-dead-engine-rules/style.css
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/style.css
@@ -1,0 +1,32 @@
+/* Only Trident and EdgeHTML ever read these, so both rules go. */
+input::-ms-expand {
+	display: none;
+}
+input:-ms-input-placeholder {
+	color: red;
+}
+
+/* Only Presto read this one. */
+.opera-only :-o-prefocus {
+	word-spacing: -0.43em;
+}
+
+/* A live engine in the selection reads these, so they stay. */
+input::-webkit-slider-thumb {
+	width: 1px;
+}
+input::-moz-range-thumb {
+	width: 2px;
+}
+
+/* One live selector stands in this list, so the whole rule stays: an engine
+   drops it over the half it cannot parse, and taking that half out would start
+   the other one matching. */
+.kept,
+input::-ms-track {
+	color: green;
+}
+
+.plain {
+	color: blue;
+}

--- a/test/configCases/css/minimize-drop-dead-engine-rules/test.config.js
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/test.config.js
@@ -10,12 +10,13 @@ module.exports = {
 		const sections = readMinifiedSections(options.output.path, "bundle0.css");
 		expect(sections).toMatchSnapshot();
 		const css = sections.join("");
-		// What goes, and the three shapes that stay.
+		// What goes, and the shapes that stay.
 		expect(css).not.toContain("-ms-expand");
 		expect(css).not.toContain("-ms-input-placeholder");
 		expect(css).not.toContain("-o-prefocus");
 		expect(css).toContain("-webkit-slider-thumb");
 		expect(css).toContain("-moz-range-thumb");
 		expect(css).toContain("-ms-track");
+		expect(css).toContain("-ms-clear");
 	}
 };

--- a/test/configCases/css/minimize-drop-dead-engine-rules/test.config.js
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/test.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const readMinifiedSections = require("../../../helpers/readMinifiedSections");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		const sections = readMinifiedSections(options.output.path, "bundle0.css");
+		expect(sections).toMatchSnapshot();
+		const css = sections.join("");
+		// What goes, and the three shapes that stay.
+		expect(css).not.toContain("-ms-expand");
+		expect(css).not.toContain("-ms-input-placeholder");
+		expect(css).not.toContain("-o-prefocus");
+		expect(css).toContain("-webkit-slider-thumb");
+		expect(css).toContain("-moz-range-thumb");
+		expect(css).toContain("-ms-track");
+	}
+};

--- a/test/configCases/css/minimize-drop-dead-engine-rules/webpack.config.js
+++ b/test/configCases/css/minimize-drop-dead-engine-rules/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// A selection with no Trident, EdgeHTML or Presto in it, so a rule only one
+	// of those engines could ever have read paints nothing and goes.
+	target: "browserslist: chrome 120, firefox 120, safari 17",
+	mode: "production",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which resolves the target.
+		minimizer: ["..."]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A selector reachable only through a vendor pseudo whose engine the selection no longer holds — `::-ms-expand`, `:-ms-input-placeholder`, `:-o-prefocus` — paints nothing anywhere the sheet is served, and an engine that cannot parse it drops the rule itself. The minifier now takes those rules out when a target is stated. Found by widening the CSS minifier comparison (#21963): `lightningcss` with targets was the one tool doing this.

Only a list every selector of which is dead may go. One live selector already makes the rule match nothing extra, since an unknown pseudo-element invalidates the whole list — so taking the dead half out would *start* the live half matching, which is why `.kept, input::-ms-track` is left alone.

Which prefixes an engine in the selection still reads is read off the prefix windows already generated rather than from a version written down here, so it follows the data. Over the 20 comparison stylesheets: **−4,844 raw and −462 gzip bytes, with no sheet growing** (Water.css −134, Bulma −94, Pico −72, Semantic UI −64, Materialize −61 gzip). It only fires when the config states a target, and rides on the existing `removeDeadRules` transform, so there is no new option.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — seven cases in `test/CssSyntax.unittest.js` (each shape that goes and each that stays: a live `-webkit-`/`-moz-` prefix, a selection that still has the engine, no target stated, a mixed list, and the transform turned off), plus `test/configCases/css/minimize-drop-dead-engine-rules` driving a real build under both `ConfigTestCases` and `ConfigCacheTestCases`. `test:syntax-equivalence` passes 5641/5641 against Chrome, which is what says the dropped rules were invisible to the engine to begin with.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — a rule that goes is one no browser in the stated selection could ever have applied. Stating a selection that still holds the engine (`ie 11`, say), or stating none, keeps it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Nothing new to configure. If `removeDeadRules` is documented anywhere by what it removes, this is one more thing it removes.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code was used to find the divergence, measure it, and write the change and its tests. The measurement came first and killed three other candidates from the same investigation (folding `color-mix()` in the Lab family, reordering declarations within a block, dropping the selector-list sort) because they cost gzip bytes or had no real-world occurrences; this one was implemented because it was the one that paid with no sheet regressing. Two correctness traps found while measuring shaped the final semantics: `_pseudosReadable` could not be reused as the signal (it is also false for a pseudo merely newer than webpack's data), and the rule may only go when the whole list is dead.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CSS minification removes vendor-prefixed rules readable only by browser engines excluded from configured targets.
  * Rules remain preserved when supported by at least one target browser.
  * Selector lists are retained when they include a supported selector.
  * Forgiving selector lists discard only unsupported arguments, while invalid selectors are removed.
  * Nested lists, escaped selectors, and quoted attribute values are handled safely.
  * Unsupported selectors in non-forgiving lists are removed when they invalidate the rule.
  * Redundant declarations, slots, queries, and unsupported rules are further reduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->