### PR TITLE
fix(esm): await an async entry that runs behind its chunks

### DIFF
--- a/.changeset/010-top-level-await.md
+++ b/.changeset/010-top-level-await.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Add `output.environment.topLevelAwait` and await async ESM entries.
+Add `output.environment.topLevelAwait` and await every async ESM entry.

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -19,7 +19,10 @@ const {
 	getChunkFilenameTemplate,
 	getCompilationHooks
 } = require("../javascript/JavascriptModulesPlugin");
-const { entryModuleIdExpression } = require("../javascript/StartupHelpers");
+const {
+	entryModuleIdExpression,
+	renderAwaitedEntries
+} = require("../javascript/StartupHelpers");
 const { getUndoPath } = require("../util/identifier");
 
 /** @import { Source } from "webpack-sources" */
@@ -186,7 +189,8 @@ class ModuleChunkFormatPlugin {
 				}
 			);
 			hooks.renderChunk.tap(PLUGIN_NAME, (modules, renderContext) => {
-				const { chunk, chunkGraph, runtimeTemplate } = renderContext;
+				const { chunk, chunkGraph, moduleGraph, runtimeTemplate } =
+					renderContext;
 				const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
 				const source = new ConcatSource();
 				const cst = runtimeTemplate.renderConst();
@@ -239,6 +243,17 @@ class ModuleChunkFormatPlugin {
 						);
 					}
 
+					const entryOptions = chunk.getEntryOptions();
+					const library =
+						entryOptions && entryOptions.library !== undefined
+							? entryOptions.library
+							: runtimeTemplate.outputOptions.library;
+					// A module library awaits the entry itself, in `ModuleLibraryPlugin`.
+					const canAwaitEntry =
+						runtimeTemplate.supportsTopLevelAwait() &&
+						!(library !== undefined && library.type === "module");
+					/** @type {string[]} */
+					const awaitedEntries = [];
 					/** @type {Set<Chunk>} */
 					const loadedChunks = new Set();
 					let ownInstalled = false;
@@ -296,12 +311,22 @@ class ModuleChunkFormatPlugin {
 							startupSource.add(inlinedEntrySource);
 							startupSource.add("\n");
 						} else {
+							// An async entry nobody awaits settles after the bundle did,
+							// which orphans its rejection.
+							const awaitEntry = canAwaitEntry && moduleGraph.isAsync(module);
+							const target = final
+								? RuntimeGlobals.exports
+								: `${RuntimeGlobals.exports}_${i}`;
 							startupSource.add(
 								`${
-									final ? `var ${RuntimeGlobals.exports} = ` : ""
+									final || awaitEntry ? `var ${target} = ` : ""
 								}__webpack_exec__(${JSON.stringify(moduleId)});\n`
 							);
+							if (awaitEntry) awaitedEntries.push(target);
 						}
+					}
+					for (const line of renderAwaitedEntries(awaitedEntries)) {
+						startupSource.add(`${line}\n`);
 					}
 
 					entrySource.add(

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -57,6 +57,7 @@ const JavascriptGenerator = require("./JavascriptGenerator");
 const JavascriptModule = require("./JavascriptModule");
 const JavascriptParser = require("./JavascriptParser");
 const analyzeScope = require("./ScopeAnalyzer");
+const { renderAwaitedEntries } = require("./StartupHelpers");
 
 /**
  * @import {
@@ -1817,15 +1818,26 @@ class JavascriptModulesPlugin {
 					// reassignment is allowed.
 					const exportsDecl = runtimeTemplate.renderLet();
 					if (chunks.length > 0) {
+						const awaitEntry =
+							canAwaitEntry && moduleGraph.isAsync(entryModule);
+						const target =
+							i === 0
+								? RuntimeGlobals.exports
+								: `${RuntimeGlobals.exports}_${i}`;
+						// The wrapper hands back nothing until the flush below runs the
+						// entry, so an awaited one is caught by the entry call itself.
+						if (awaitEntry && i !== 0) buf2.push(`${exportsDecl} ${target};`);
+						const entryCall = `${RuntimeGlobals.require}(${moduleIdExpr})`;
 						buf2.push(
 							`${i === 0 ? `${exportsDecl} ${RuntimeGlobals.exports} = ` : ""}${
 								RuntimeGlobals.onChunksLoaded
 							}(undefined, ${JSON.stringify(
 								chunks.map((c) => c.id)
 							)}, ${runtimeTemplate.returningFunction(
-								`${RuntimeGlobals.require}(${moduleIdExpr})`
+								awaitEntry ? `(${target} = ${entryCall})` : entryCall
 							)})`
 						);
+						if (awaitEntry) awaitedEntries.push(target);
 					} else if (useRequire) {
 						// An async entry nobody awaits settles after the bundle did,
 						// which orphans its rejection.
@@ -1882,14 +1894,7 @@ class JavascriptModulesPlugin {
 						`${RuntimeGlobals.exports} = ${RuntimeGlobals.onChunksLoaded}(${RuntimeGlobals.exports});`
 					);
 				}
-				// Several need one `Promise.all`, so an entry rejecting first still
-				// leaves the others observed. A single one has nothing to orphan.
-				if (awaitedEntries.length === 1) {
-					buf2.push(`${awaitedEntries[0]} = await ${awaitedEntries[0]};`);
-				} else if (awaitedEntries.length > 1) {
-					const list = awaitedEntries.join(", ");
-					buf2.push(`[${list}] = await Promise.all([${list}]);`);
-				}
+				buf2.push(...renderAwaitedEntries(awaitedEntries));
 				if (
 					runtimeRequirements.has(RuntimeGlobals.startup) ||
 					(runtimeRequirements.has(RuntimeGlobals.startupOnlyBefore) &&

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -199,6 +199,21 @@ module.exports.getInitialChunkIds = (chunk, chunkGraph, filterFn) => {
 };
 
 /**
+ * The top-level `await` settling the async entries of an ESM chunk, so one rejecting
+ * rejects the bundle instead of going unobserved.
+ * @param {string[]} targets the bindings each holding one entry's promise
+ * @returns {string[]} the lines, none without a target
+ */
+module.exports.renderAwaitedEntries = (targets) => {
+	if (targets.length === 0) return [];
+	// Several need one `Promise.all`, so an entry rejecting first still
+	// leaves the others observed. A single one has nothing to orphan.
+	if (targets.length === 1) return [`${targets[0]} = await ${targets[0]};`];
+	const list = targets.join(", ");
+	return [`[${list}] = await Promise.all([${list}]);`];
+};
+
+/**
  * Processes the provided hash.
  * @param {Hash} hash the hash to update
  * @param {ChunkGraph} chunkGraph chunkGraph

--- a/test/configCases/module/async-entry-await-depend-on/a.js
+++ b/test/configCases/module/async-entry-await-depend-on/a.js
@@ -1,0 +1,9 @@
+import { base } from "./shared.js";
+
+const value = await new Promise((resolve) => {
+	setTimeout(() => resolve(base + 1), 0);
+});
+
+it("should settle the bundle only after the first async entry finished", () => {
+	expect(value).toBe(42);
+});

--- a/test/configCases/module/async-entry-await-depend-on/b.js
+++ b/test/configCases/module/async-entry-await-depend-on/b.js
@@ -1,0 +1,9 @@
+import { base } from "./shared.js";
+
+const value = await new Promise((resolve) => {
+	setTimeout(() => resolve(base + 2), 0);
+});
+
+it("should settle the bundle only after the last async entry finished", () => {
+	expect(value).toBe(43);
+});

--- a/test/configCases/module/async-entry-await-depend-on/shared.js
+++ b/test/configCases/module/async-entry-await-depend-on/shared.js
@@ -1,0 +1,1 @@
+export const base = 41;

--- a/test/configCases/module/async-entry-await-depend-on/test.config.js
+++ b/test/configCases/module/async-entry-await-depend-on/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "./app.mjs";
+	}
+};

--- a/test/configCases/module/async-entry-await-depend-on/test.filter.js
+++ b/test/configCases/module/async-entry-await-depend-on/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The entries and the generated startup both use top-level `await`, which the
+// runner's `vm.SourceTextModule` cannot parse before Node.js 14.8.
+module.exports = function filter() {
+	const [major, minor] = process.versions.node.split(".").map(Number);
+	return major > 14 || (major === 14 && minor >= 8);
+};

--- a/test/configCases/module/async-entry-await-depend-on/vendors.js
+++ b/test/configCases/module/async-entry-await-depend-on/vendors.js
@@ -1,0 +1,1 @@
+import "./shared.js";

--- a/test/configCases/module/async-entry-await-depend-on/webpack.config.js
+++ b/test/configCases/module/async-entry-await-depend-on/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	// The runtime lives in the entry depended on, so the async entries run through
+	// the chunk format's own startup rather than the runtime chunk's.
+	entry: {
+		app: { import: ["./a.js", "./b.js"], dependOn: "vendors" },
+		vendors: "./vendors.js"
+	},
+	output: {
+		module: true,
+		filename: "[name].mjs"
+	}
+};

--- a/test/configCases/module/async-entry-await-split/a.js
+++ b/test/configCases/module/async-entry-await-split/a.js
@@ -1,0 +1,9 @@
+import { base } from "./shared.js";
+
+const value = await new Promise((resolve) => {
+	setTimeout(() => resolve(base + 1), 0);
+});
+
+it("should settle the bundle only after the first async entry finished", () => {
+	expect(value).toBe(42);
+});

--- a/test/configCases/module/async-entry-await-split/b.js
+++ b/test/configCases/module/async-entry-await-split/b.js
@@ -1,0 +1,9 @@
+import { base } from "./shared.js";
+
+const value = await new Promise((resolve) => {
+	setTimeout(() => resolve(base + 2), 0);
+});
+
+it("should settle the bundle only after the last async entry finished", () => {
+	expect(value).toBe(43);
+});

--- a/test/configCases/module/async-entry-await-split/shared.js
+++ b/test/configCases/module/async-entry-await-split/shared.js
@@ -1,0 +1,1 @@
+export const base = 41;

--- a/test/configCases/module/async-entry-await-split/test.config.js
+++ b/test/configCases/module/async-entry-await-split/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "./main.mjs";
+	}
+};

--- a/test/configCases/module/async-entry-await-split/test.filter.js
+++ b/test/configCases/module/async-entry-await-split/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The entries and the generated startup both use top-level `await`, which the
+// runner's `vm.SourceTextModule` cannot parse before Node.js 14.8.
+module.exports = function filter() {
+	const [major, minor] = process.versions.node.split(".").map(Number);
+	return major > 14 || (major === 14 && minor >= 8);
+};

--- a/test/configCases/module/async-entry-await-split/webpack.config.js
+++ b/test/configCases/module/async-entry-await-split/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	experiments: { outputModule: true },
+	// Two async entry modules, so the one the bundle exports and the one it does not
+	// are both awaited behind the chunk the split carries out of them.
+	entry: { main: ["./a.js", "./b.js"] },
+	output: {
+		module: true,
+		filename: "[name].mjs"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				shared: {
+					test: /shared\.js$/,
+					name: "shared",
+					chunks: "all",
+					minSize: 0,
+					enforce: true
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The `await` of an async ESM entry (#21867) covered only the startup that calls the entry straight. An entry whose entrypoint carries other initial chunks runs through the `onChunksLoaded` wrapper, and one behind `dependOn` through the chunk format's own startup, and neither awaited the promise: the bundle settled before the entry did and a rejection went unobserved. Both sites now capture the entry's promise and await it at the chunk's top level, under the same gate as before, with the await line rendered by one shared helper.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/module/async-entry-await-split` and `test/configCases/module/async-entry-await-depend-on`, each with two async entry modules so both the exported and the discarded entry slot are awaited; both failed before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used: it surfaced the gap while auditing earlier review threads, reproduced both shapes with a scratch build, wrote the failing cases first, then the fix, and ran the targeted suites and lint. I reviewed the diff and the emitted startup code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Async ES module entries now wait for dependent asynchronous entries to finish before resolving.
  - Improved handling of multiple asynchronous entries, including entries split across chunks or configured with dependencies.
  - Top-level `await` behavior is now consistently supported where applicable.

- **Tests**
  - Added coverage for dependent and split asynchronous entry scenarios.
  - Added compatibility filtering for environments supporting top-level `await`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->