### PR TITLE
fix(performance): correct the fallout from the hint option rename

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -3570,7 +3570,7 @@ export interface PerformanceOptions {
 	 */
 	unusedAssets?: boolean;
 	/**
-	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched (requires 'hints' to be enabled).
+	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.
 	 * @since 5.111.0
 	 */
 	unusedConfig?: boolean;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -1100,7 +1100,7 @@ class WebpackOptionsApply extends OptionsApply {
 				new UnusedReexportsPlugin(options.performance).apply(compiler);
 			}
 
-			// Deliberately not gated on `hints`, like `unusedConfig` below: a rule
+			// Deliberately not gated on `hints`, like `unusedConfig` above: a rule
 			// that only matches on one OS is a configuration mistake, not a size.
 			if (options.performance.osDependentRules) {
 				const OsDependentRuleWarningPlugin = require("./performance/OsDependentRuleWarningPlugin");
@@ -1108,18 +1108,12 @@ class WebpackOptionsApply extends OptionsApply {
 				new OsDependentRuleWarningPlugin(options.performance).apply(compiler);
 			}
 
-			// Deliberately not gated on `hints`: an alias nothing matches is a
-			// configuration mistake, not a size.
-			// Deliberately not gated on `hints`: a key nothing reads is a
-			// configuration mistake, not a size.
 			if (options.performance.unusedAssets) {
 				const UnusedAssetsPlugin = require("./performance/UnusedAssetsPlugin");
 
 				new UnusedAssetsPlugin(options.performance).apply(compiler);
 			}
 
-			// Deliberately not gated on `hints`: a misspelled external gets bundled
-			// instead, which no size limit would explain.
 			// Deliberately not gated on `hints`: asking for both directives on one
 			// import is a configuration mistake, not a size.
 			if (options.performance.conflictingResourceHints) {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -5679,7 +5679,7 @@
           "added": "5.111.0"
         },
         "unusedConfig": {
-          "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched (requires 'hints' to be enabled).",
+          "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
           "type": "boolean",
           "added": "5.111.0"
         },

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -15959,13 +15959,13 @@ Object {
   "performance-unused-config": Object {
     "configs": Array [
       Object {
-        "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched (requires 'hints' to be enabled).",
+        "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
         "multiple": false,
         "path": "performance.unusedConfig",
         "type": "boolean",
       },
     ],
-    "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched (requires 'hints' to be enabled).",
+    "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -22393,7 +22393,7 @@ declare interface PerformanceOptions {
 	unusedAssets?: boolean;
 
 	/**
-	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched (requires 'hints' to be enabled).
+	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.
 	 * @since 5.111.0
 	 */
 	unusedConfig?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Collapsing four `unused*` gates into `unusedConfig` in #21961 left three statements behind that are now wrong. None has been released — `unusedConfig` is `added: 5.111.0` and the package is still on 5.110.3 — so this corrects them before they ship.

`unusedConfig`'s description claimed `(requires 'hints' to be enabled)`. It does not: `UnusedAliasesPlugin` and its three siblings read `hints` only to pick the severity and never return early, so they report with `hints: false` just as they did under their old names. All four of those old descriptions omitted the clause, and the other two ungated checks, `osDependentRules` and `conflictingResourceHints`, still do. The description reaches the CLI help and `types.d.ts`, so it is user-facing.

The other two are comments. The `Deliberately not gated on 'hints'` notes belonging to the deleted alias, define and externals gates were left attached to the next surviving blocks, so the source asserted that `unusedAssets` is ungated when `UnusedAssetsPlugin` opens with `if (!hints) return;`. And `osDependentRules` still pointed at "`unusedConfig` below", which the rename moved above it.

Refs #17122

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — nothing executable changed. The only behavioural surface is the schema description, which `test/__snapshots__/Cli.basictest.js.snap` already pins and which is updated here. `lint:types`, `lint:comments`, ESLint, `Defaults`/`Validation` and the 682 `configCases/performance` cases pass.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The corrected option has never appeared in a release, and no runtime behaviour changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The matching webpack.js.org change documents `unusedConfig` as ungated, alongside `osDependentRules` and `conflictingResourceHints`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used, under review at each step. The three defects were found while writing the documentation for #21961: the docs had to state which checks are gated on `hints`, and checking that against the source rather than the schema showed the two disagreeing. Which plugins gate was then confirmed per plugin rather than inferred from the surrounding comments.

No changeset: the guide says to union same-topic entries, and #21961's entry is still pending for this same release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description of the `performance.unusedConfig` option for clearer configuration guidance.
  * Removed an outdated note about requiring performance hints; the option’s behavior and schema remain unchanged.

* **Maintenance**
  * Simplified internal performance plugin wiring comments without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->