### PR TITLE
test(html): cover the inline module script the minifier cannot read

### DIFF
--- a/test/configCases/html/minimize-inline-script/errors.js
+++ b/test/configCases/html/minimize-inline-script/errors.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// The body is offered to a renderer by language, and the dispatcher reads a
+// language alone, so the parse goal `as` names never reaches the JS minifier.
+module.exports = [[/Unexpected token: name \(Promise\)/]];

--- a/test/configCases/html/minimize-inline-script/index.js
+++ b/test/configCases/html/minimize-inline-script/index.js
@@ -1,0 +1,5 @@
+it("should report a `<script type=module>` it could not read as a classic script", () => {
+	// The expectation is `errors.js`: the minifier is handed the body's language
+	// but not its parse goal, so a top-level `await` is read as a syntax error.
+	expect(true).toBe(true);
+});

--- a/test/configCases/html/minimize-inline-script/webpack.config.js
+++ b/test/configCases/html/minimize-inline-script/webpack.config.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+// An HTML asset webpack emits without parsing it: the only shape whose
+// `<script>` bodies stay inline, since one it parses has each extracted.
+const PAGE = `<!doctype html>
+<html lang="en">
+	<head><title>inline script</title></head>
+	<body>
+		<script>
+			function sharedFn(a, b) {
+				const result = a + b;
+				return result;
+			}
+			window.sharedResult = sharedFn(1, 2);
+		</script>
+		<script type="text/javascript">
+			window.essenceRan = true;
+		</script>
+		<script type="module">
+			const unusedTop = "dropped";
+			window.moduleRan = true;
+			await Promise.resolve();
+		</script>
+		<script>
+			window.closer = "</scr" + "ipt>";
+		</script>
+		<script type="text/template">
+			{{  each   item  }}
+		</script>
+		<script type="text/javascript; charset=utf-8">
+			var   notAnEssence   =   1 ;
+		</script>
+		<script></script>
+	</body>
+</html>
+`;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		filename: "[name].js",
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which hands the JS minifier's own
+		// options to `htmlMinify` for an inline `<script>` too.
+		minimizer: ["..."]
+	},
+	experiments: {
+		html: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("EmitPage", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "EmitPage",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							compilation.emitAsset(
+								"page.html",
+								new webpack.sources.RawSource(PAGE)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

An inline `<script type="module">` holding a top-level `await` is minified as a classic script, where `await` is a syntax error — so the build reports `Unexpected token: name (Promise)` and the body is left as written. Reproduced deterministically on `main`; this pins it as an expected diagnostic so the fix has a landing test.

The parse goal is what is missing, not a minifier: a body is offered to `renderEmbeddedSource` with its language, and `minimizer-webpack-plugin` dispatches on that language alone, so the `as` a body is offered with never reaches terser. It cannot be given as a blanket option either — module parsing implies strict mode, so `with`, legacy octal literals, duplicate parameters and `delete x` all stop parsing where they minify today. The goal has to travel per body, which is what `as` already does for a `style=""`.

Supersedes #21607, which added this before `renderEmbeddedSource` existed: an inline `<script>` is already minified through it, so only the module goal is still open.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — this PR is only a test: `test/configCases/html/minimize-inline-script`, an HTML asset emitted without webpack parsing it (what `html-webpack-plugin` produces, and the only shape whose `<script>` bodies stay inline — one webpack parses has each extracted into its own asset). `errors.js` pins the diagnostic.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — no `lib/` change.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code was used to investigate and write the case. Three candidate fixes were built and each abandoned on evidence rather than reported around: calling terser from `htmlMinify` (duplicates the embedded mechanism), offering `as` for every script (terser rejects an unknown option, regressing scripts that minify today), and `parse: { module: true }` as a default (never reached terser, and implies strict mode — measured against `with`, `010`, duplicate params and `delete x`). What is left is the reproduction, and the fix belongs to the dispatcher.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for minimizing inline scripts in HTML, including classic, module, template, typed, empty, and closing-tag-splitting script elements.
  * Added validation for syntax errors when unreadable module scripts contain top-level `await`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->