### PR TITLE
fix(css): settle a css chunk load without a DOM where the stylesheet cannot be read

### DIFF
--- a/.changeset/014-css-chunk-load-without-dom.md
+++ b/.changeset/014-css-chunk-load-without-dom.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Settle a css chunk load without a DOM where its stylesheet cannot be read.

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -385,6 +385,10 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 																		]
 																	)});`
 																]
+																// No fs to import, or a url `readFile` rejects on sight (a CDN public
+																// path): nothing to collect, which is what a missing file already means.
+															)}).catch(${runtimeTemplate.expressionFunction(
+																"loadingEnded({ type: 'load' })"
 															)});`
 														]),
 														"}"

--- a/test/configCases/css/universal-cdn-public-path/index.js
+++ b/test/configCases/css/universal-cdn-public-path/index.js
@@ -1,0 +1,4 @@
+it("should settle a css chunk load where the stylesheet is not on disk", () =>
+	import("./lazy.css").then(() => {
+		expect(__webpack_css_server_styles__).not.toContain("rebeccapurple");
+	}));

--- a/test/configCases/css/universal-cdn-public-path/lazy.css
+++ b/test/configCases/css/universal-cdn-public-path/lazy.css
@@ -1,0 +1,3 @@
+.lazy {
+	color: rebeccapurple;
+}

--- a/test/configCases/css/universal-cdn-public-path/test.config.js
+++ b/test/configCases/css/universal-cdn-public-path/test.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const path = require("path");
+
+const CDN = "https://cdn.example/assets/";
+
+module.exports = {
+	// No DOM: the server side of the universal bundle.
+	moduleScope(scope) {
+		delete scope.window;
+		delete scope.document;
+		delete scope.self;
+	},
+	// The chunk's script is read from disk in its place; its stylesheet url is not.
+	resolveModule(module) {
+		return module.startsWith(CDN) ? `./${path.basename(module)}` : module;
+	}
+};

--- a/test/configCases/css/universal-cdn-public-path/webpack.config.js
+++ b/test/configCases/css/universal-cdn-public-path/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	experiments: {
+		css: true,
+		outputModule: true
+	},
+	output: {
+		module: true,
+		uniqueName: "universal-cdn-public-path",
+		// Not a file url, so the stylesheet is not on disk to be read.
+		publicPath: "https://cdn.example/assets/"
+	}
+};

--- a/test/configCases/css/universal-no-fs/index.js
+++ b/test/configCases/css/universal-no-fs/index.js
@@ -1,0 +1,4 @@
+it("should settle a css chunk load where the stylesheet cannot be read", () =>
+	import("./lazy.css").then(() => {
+		expect(__webpack_css_server_styles__).not.toContain("rebeccapurple");
+	}));

--- a/test/configCases/css/universal-no-fs/lazy.css
+++ b/test/configCases/css/universal-no-fs/lazy.css
@@ -1,0 +1,3 @@
+.lazy {
+	color: rebeccapurple;
+}

--- a/test/configCases/css/universal-no-fs/test.config.js
+++ b/test/configCases/css/universal-no-fs/test.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+	// No DOM and no file system: a worker running the universal bundle.
+	moduleScope(scope) {
+		delete scope.window;
+		delete scope.document;
+		delete scope.self;
+	},
+	modules: {
+		get fs() {
+			throw new Error("Cannot find module 'fs'");
+		}
+	}
+};

--- a/test/configCases/css/universal-no-fs/webpack.config.js
+++ b/test/configCases/css/universal-no-fs/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: ["web", "node"],
+	mode: "development",
+	experiments: {
+		css: true,
+		outputModule: true
+	},
+	output: {
+		module: true,
+		uniqueName: "universal-no-fs"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The no-DOM branch of the css chunk loader chained the `fs` and `url` imports into a `then` with no rejection handler. Where the import rejects (a universal bundle in a worker), or `readFile` throws on sight because the public path is not a file url (a CDN), nothing called `loadingEnded`: the chunk promise never settled, and on Node 15+ the unhandled rejection ended the server process. A rejection now settles the load the way a missing file already does, with nothing collected. The `catch` costs 46 raw / ~11 gzip bytes per universal-target css bundle and nothing elsewhere.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/universal-no-fs` (the `fs` import rejects) and `test/configCases/css/universal-cdn-public-path` (`readFile` throws on an `https:` url); both failed before the fix.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used: it surfaced the gap while auditing earlier review threads, found the second (CDN) shape while reading the branch, wrote the failing cases first and confirmed them against unmodified `main`, then the fix, and measured the size delta and ran the targeted suites and lint. I reviewed the diff and the emitted runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CSS chunk loading now completes reliably in server-side or DOM-free environments when stylesheet files are unavailable or unreadable.
  - Prevents CSS loading operations from remaining unresolved when filesystem access or stylesheet retrieval fails.
  - Improved handling for applications using universal builds and CDN-hosted assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->