### PR TITLE
fix(css): take a distant-rule merge only where it earns wire bytes

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2460,7 +2460,7 @@ export interface OptimizationMinimizeCss {
 	 */
 	lowerUnsupported?: boolean;
 	/**
-	 * Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.
+	 * Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.
 	 * @since 5.111.0
 	 */
 	mergeDistantRules?: boolean;

--- a/lib/css/syntax.js
+++ b/lib/css/syntax.js
@@ -5610,9 +5610,9 @@ const _mergeIntoDistantRule = (writer, entry) => {
 		_distantRules.delete(block);
 		return false;
 	}
-	// A block repeated at a distance already compresses on its own, so this earns
-	// only where the copy it drops outweighs the selector it writes instead.
-	if (2 * block.length <= entry.prelude) return false;
+	// A block repeated at a distance already compresses on its own, so a merge
+	// earns wire bytes only where the copy it drops is worth twice the selector.
+	if (block.length <= 2 * entry.prelude) return false;
 	const since = (/** @type {string} */ name) => {
 		const at = _distantDeclaredAt.get(name);
 		return at !== undefined && at > found.seq;
@@ -14328,9 +14328,9 @@ const _mergeDistantRules = (items, texts) => {
 			held.set(block, i);
 			continue;
 		}
-		// A block repeated at a distance already compresses well, so this earns
-		// only where the copy it drops outweighs the selector it writes instead.
-		if (2 * block.length <= entry.prelude) continue;
+		// A block repeated at a distance already compresses well, so a merge earns
+		// wire bytes only where the copy it drops is worth twice the selector.
+		if (block.length <= 2 * entry.prelude) continue;
 		const before = _ruleEntryOf(items[at], texts[at]);
 		if (
 			!_nothingBetweenShadows(

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3800,7 +3800,7 @@
           "added": "5.111.0"
         },
         "mergeDistantRules": {
-          "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.",
+          "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.",
           "type": "boolean",
           "added": "5.111.0"
         },

--- a/test/CssSyntax.unittest.js
+++ b/test/CssSyntax.unittest.js
@@ -10173,9 +10173,19 @@ describe("SourceProcessor — mergeDistantRules", () => {
 		});
 
 		it("declines a block that does not outweigh the selector it would write", () => {
+			// `{color:red}` is 11, so a selector of 6 or more is not worth the join.
 			const sheet =
-				"@media screen{.aaaaaaaaaaaaaaaaaaaaaaaaaaaa{color:red}.b{margin:0}.cccccccccccccccccccccccccccc{color:red}}";
+				"@media screen{.aaaaa{color:red}.b{margin:0}.ccccc{color:red}}";
 			expect(minify(sheet, true)).toBe(sheet);
+		});
+
+		it("joins a block worth more than twice the selector it writes", () => {
+			expect(
+				minify(
+					"@media screen{.aaaa{color:red}.b{margin:0}.cccc{color:red}}",
+					true
+				)
+			).toBe("@media screen{.aaaa,.cccc{color:red}.b{margin:0}}");
 		});
 
 		it("reads `all` between as declaring everything", () => {
@@ -10230,9 +10240,15 @@ describe("SourceProcessor — mergeDistantRules", () => {
 	});
 
 	it("declines a block that does not outweigh the selector it would write", () => {
-		// `{color:red}` is 11, so a selector of 22 or more is not worth the join.
-		const sheet = `.a{color:red}.b{margin:0}.${"x".repeat(22)}{color:red}`;
+		// `{color:red}` is 11, so a selector of 6 or more is not worth the join.
+		const sheet = `.a{color:red}.b{margin:0}.${"x".repeat(5)}{color:red}`;
 		expect(minify(sheet, true)).toBe(sheet);
+	});
+
+	it("joins a block worth more than twice the selector it writes", () => {
+		expect(
+			minify(`.a{color:red}.b{margin:0}.${"x".repeat(4)}{color:red}`, true)
+		).toBe(".a,.xxxx{color:red}.b{margin:0}");
 	});
 
 	it("does not write a selector the list already carries", () => {

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -11179,13 +11179,13 @@ Object {
   "optimization-minimize-css-merge-distant-rules": Object {
     "configs": Array [
       Object {
-        "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
+        "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
         "multiple": false,
         "path": "optimization.minimize.css.mergeDistantRules",
         "type": "boolean",
       },
     ],
-    "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
+    "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -11831,13 +11831,13 @@ Object {
   "optimization-minimize-options-css-merge-distant-rules": Object {
     "configs": Array [
       Object {
-        "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
+        "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
         "multiple": false,
         "path": "optimization.minimizeOptions.css.mergeDistantRules",
         "type": "boolean",
       },
     ],
-    "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
+    "description": "Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. \`mergeRules\` is the safe half of this, joining only what nothing stands between.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/configCases/css/minimize-merge-distant-rules/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-merge-distant-rules/__snapshots__/ConfigCacheTest.snap
@@ -2,6 +2,6 @@
 
 exports[`ConfigCacheTestCases css minimize-merge-distant-rules minimize-merge-distant-rules should compile 1`] = `
 Array [
-  ".alpha,.gamma{color:red}.spacer{margin:0}.delta{color:blue}.between{color:green}.epsilon{color:blue}.zeta{margin-top:0}.shorthand{margin:1px}.eta{margin-top:0}.theta{padding:0}@media print{.printed{width:0}}.iota{padding:0}",
+  ".alpha,.gamma{color:red;background:blue}.spacer{margin:0}.delta{color:blue}.between{color:green}.epsilon{color:blue}.zeta{margin-top:0}.shorthand{margin:1px}.eta{margin-top:0}.theta{padding:0}@media print{.printed{width:0}}.iota{padding:0}.kappa{outline:0}.spacing{margin:2px}.lambda-is-a-long-name{outline:0}",
 ]
 `;

--- a/test/configCases/css/minimize-merge-distant-rules/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-merge-distant-rules/__snapshots__/ConfigTest.snap
@@ -2,6 +2,6 @@
 
 exports[`ConfigTestCases css minimize-merge-distant-rules minimize-merge-distant-rules should compile 1`] = `
 Array [
-  ".alpha,.gamma{color:red}.spacer{margin:0}.delta{color:blue}.between{color:green}.epsilon{color:blue}.zeta{margin-top:0}.shorthand{margin:1px}.eta{margin-top:0}.theta{padding:0}@media print{.printed{width:0}}.iota{padding:0}",
+  ".alpha,.gamma{color:red;background:blue}.spacer{margin:0}.delta{color:blue}.between{color:green}.epsilon{color:blue}.zeta{margin-top:0}.shorthand{margin:1px}.eta{margin-top:0}.theta{padding:0}@media print{.printed{width:0}}.iota{padding:0}.kappa{outline:0}.spacing{margin:2px}.lambda-is-a-long-name{outline:0}",
 ]
 `;

--- a/test/configCases/css/minimize-merge-distant-rules/style.css
+++ b/test/configCases/css/minimize-merge-distant-rules/style.css
@@ -1,7 +1,7 @@
 /* Nothing between touches `color`, so the two join. */
-.alpha { color: red }
+.alpha { color: red; background: blue }
 .spacer { margin: 0 }
-.gamma { color: red }
+.gamma { color: red; background: blue }
 
 /* `color` between them, so these two stay apart. */
 .delta { color: blue }
@@ -17,3 +17,8 @@
 .theta { padding: 0 }
 @media print { .printed { width: 0 } }
 .iota { padding: 0 }
+
+/* The copy dropped is not worth twice the selector written, so these stay apart. */
+.kappa { outline: 0 }
+.spacing { margin: 2px }
+.lambda-is-a-long-name { outline: 0 }

--- a/test/configCases/css/minimize-merge-distant-rules/test.config.js
+++ b/test/configCases/css/minimize-merge-distant-rules/test.config.js
@@ -9,11 +9,12 @@ module.exports = {
 	afterExecute(options) {
 		const sections = readMinifiedSections(options.output.path, "bundle0.css");
 		expect(sections).toMatchSnapshot();
-		// What the option is for, and the three shapes it declines.
+		// What the option is for, and the four shapes it declines.
 		const css = sections.join("");
 		expect(css).toContain(".alpha,.gamma");
 		expect(css).not.toContain(".delta,.epsilon");
 		expect(css).not.toContain(".zeta,.eta");
 		expect(css).not.toContain(".theta,.iota");
+		expect(css).not.toContain(".kappa,.lambda-is-a-long-name");
 	}
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -20266,7 +20266,7 @@ declare interface OptimizationMinimizeCss {
 	lowerUnsupported?: boolean;
 
 	/**
-	 * Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default on two counts: it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does; and over the framework stylesheets it cuts raw bytes while costing gzip ones, a block repeated at a distance already compressing on its own. It is taken only where the copy of the block it drops outweighs the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.
+	 * Give a rule the selectors of a later one printing the same block, past the rules standing between them. Off by default because it reorders the cascade, so it holds only where nothing between the two declares a property the shared block does. A block repeated at a distance already compresses on its own, so the join is taken only where the copy of the block it drops is worth more than twice the selector it writes instead. `mergeRules` is the safe half of this, joining only what nothing stands between.
 	 * @since 5.111.0
 	 */
 	mergeDistantRules?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The size guard added with `optimization.minimize.css.mergeDistantRules` in #21969 reads the wrong way round — it declines only when the selector is at least twice the block, which is almost never — so the option took nearly every join it could reach. Over the `benchmark:css-minifiers` stylesheets that cut 2383 raw bytes while **adding 32 gzip ones**, growing six of the sheets (worst +31); requiring instead that the dropped copy be worth more than twice the selector written saves 1028 raw and 35 gzip bytes, with one sheet growing by a single byte. Refs #21880.

| guard | raw | gzip | sheets grown | worst |
| ----- | --- | ---- | ------------ | ----- |
| shipped | −2383 | **+32** | 6 | +31 |
| this PR | −1028 | **−35** | 1 | +1 |

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — the threshold cases in `test/CssSyntax.unittest.js` now pin both sides of the new boundary, and `test/configCases/css/minimize-merge-distant-rules` gained a fourth declining shape for it.

**Does this PR introduce a breaking change?**

No — `mergeDistantRules` is off by default and has not been released yet.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The option's schema description is updated in this PR; it no longer claims the option costs gzip bytes.

**Use of AI**

AI was used. Claude Code ran the guard-constant sweep over the 27 `benchmark:css-minifiers` fixtures at gzip level 9, wrote the patch and the tests, and ran the CSS suites and lint. Every number quoted above was measured on this branch, and the result was reviewed before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted CSS optimization so distant rules are merged only when the repeated declarations outweigh the replacement selector by more than twice its length.
  - Prevents merging rules with different property sets, preserving expected minified CSS behavior.

- **Documentation**
  - Clarified the conditions and default rationale for the distant-rule merging option.

- **Tests**
  - Expanded coverage for the updated merge threshold and cases where distant rules should remain separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->