### PR TITLE
perf(html): skip JS sentinel scans on chunks without HTML

### DIFF
--- a/.changeset/025-html-chunk-has-html.md
+++ b/.changeset/025-html-chunk-has-html.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip JS render sentinel scans on chunks without HTML.

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -19,6 +19,7 @@ const ConstDependency = require("../dependencies/ConstDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
 const WebpackError = require("../errors/WebpackError");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
+const ConcatenatedModule = require("../optimize/ConcatenatedModule");
 const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
@@ -55,6 +56,8 @@ const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions["favicon"]} FaviconOption */
 /** @typedef {import("../../declarations/WebpackOptions").OutputHtmlOptions["manifest"]} ManifestOption */
 /** @typedef {Exclude<HtmlFaviconIcon, string>} FaviconIcon */
+/** @import Chunk from "../Chunk" */
+/** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compiler from "../Compiler" */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
@@ -1211,6 +1214,16 @@ class HtmlModulesPlugin {
 				jsHooks.render.tap(PLUGIN_NAME, (source, renderContext) => {
 					// No HTML modules ⇒ no sentinels; skip materializing the JS source.
 					if (htmlModules.size === 0) return source;
+					// Chunks without HTML modules can't carry HTML sentinels — avoid
+					// ConcatSource.source() on the common pure-JS chunk path.
+					if (
+						!HtmlModulesPlugin.chunkHasHtml(
+							renderContext.chunk,
+							compilation.chunkGraph
+						)
+					) {
+						return source;
+					}
 					const raw = source.source();
 					if (typeof raw !== "string") return source;
 					// Every sentinel shares this prefix — one scan answers the common
@@ -1280,6 +1293,29 @@ class HtmlModulesPlugin {
 				});
 			}
 		);
+	}
+
+	/**
+	 * Returns true, when the chunk has html.
+	 * @param {Chunk} chunk chunk
+	 * @param {ChunkGraph} chunkGraph chunk graph
+	 * @returns {boolean} true, when the chunk has html
+	 */
+	static chunkHasHtml(chunk, chunkGraph) {
+		if (chunkGraph.getChunkModulesIterableBySourceType(chunk, HTML_TYPE)) {
+			return true;
+		}
+		// Scope-hoisted HTML loses HTML_TYPE on the ConcatenatedModule, but its
+		// JS export can still carry unresolved sentinels that need this path.
+		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
+			if (module instanceof HtmlModule) return true;
+			if (module instanceof ConcatenatedModule) {
+				for (const inner of module.modules) {
+					if (inner instanceof HtmlModule) return true;
+				}
+			}
+		}
+		return false;
 	}
 }
 

--- a/test/benchmarkCases/html-many-chunks/index.html
+++ b/test/benchmarkCases/html-many-chunks/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+	<body>
+		<script type="module" src="./main.js"></script>
+	</body>
+</html>
+<!-- watch test --><!-- watch test --><!-- watch test --><!-- watch test --><!-- watch test -->

--- a/test/benchmarkCases/html-many-chunks/main.js
+++ b/test/benchmarkCases/html-many-chunks/main.js
@@ -1,0 +1,2 @@
+import * as mod from "./generated/module.js";
+export { mod };

--- a/test/benchmarkCases/html-many-chunks/options.mjs
+++ b/test/benchmarkCases/html-many-chunks/options.mjs
@@ -1,0 +1,15 @@
+import fs from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import createTree from "../../harness/benchmark/create-tree.mjs";
+import memoryScaledCount from "../../harness/benchmark/scale.mjs";
+
+// HTML entry + many async JS chunks: htmlModules is non-empty while most chunks
+// lack HTML_TYPE, so chunkHasHtml can skip ConcatSource.source() on them.
+export async function setup() {
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const generated = resolve(__dirname, "./generated");
+
+	await fs.rm(generated, { recursive: true, force: true });
+	await createTree(generated, false, memoryScaledCount(50, 150), 0);
+}

--- a/test/benchmarkCases/html-many-chunks/webpack.config.mjs
+++ b/test/benchmarkCases/html-many-chunks/webpack.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import("../../..").Configuration} */
+export default {
+	entry: "./index.html",
+	target: "web",
+	experiments: {
+		html: true
+	},
+	// Leave minify off so HtmlModulesPlugin's jsHooks.render isn't drowned by terser.
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/harness/benchmark/benchmark.worker.mjs
+++ b/test/harness/benchmark/benchmark.worker.mjs
@@ -792,7 +792,10 @@ function buildConfiguration(test, baseline, realConfig, scenario, testDirectory)
 			? path.resolve(
 					testDirectory,
 					config.entry
-						? /\.(?:c|m)?js$/.test(config.entry)
+						? // Keep entries that already have an extension (JS or HTML).
+							// Bare names still get `.js` — the historical default entry shape.
+							/\.(?:c|m)?js$/i.test(config.entry) ||
+							/\.html$/i.test(config.entry)
 							? config.entry
 							: `${config.entry}.js`
 						: "./index.js"
@@ -869,6 +872,51 @@ function addBuildBench({
 }
 
 /**
+ * Resolve the on-disk file the watch scenario rewrites to trigger a rebuild.
+ * @param {NonNullable<Configuration["entry"]>} entry webpack entry
+ * @returns {string} absolute path of one entry file
+ */
+const resolveWatchEntryPath = (entry) => {
+	if (typeof entry === "string") return path.resolve(entry);
+	if (Array.isArray(entry)) {
+		const first = entry.find((item) => typeof item === "string");
+		if (typeof first === "string") return path.resolve(first);
+	} else if (entry && typeof entry === "object") {
+		for (const value of Object.values(entry)) {
+			if (typeof value === "string") return path.resolve(value);
+			if (Array.isArray(value)) {
+				const first = value.find((item) => typeof item === "string");
+				if (typeof first === "string") return path.resolve(first);
+			} else if (
+				value &&
+				typeof value === "object" &&
+				"import" in value &&
+				value.import
+			) {
+				const imp = value.import;
+				if (typeof imp === "string") return path.resolve(imp);
+				if (Array.isArray(imp)) {
+					const first = imp.find((item) => typeof item === "string");
+					if (typeof first === "string") return path.resolve(first);
+				}
+			}
+		}
+	}
+	throw new Error("Watch bench needs a string path in `entry`.");
+};
+
+/**
+ * Append a no-op change that keeps the entry parseable (JS statement or HTML comment).
+ * @param {string} entryPath entry file path
+ * @param {string} originalContent original file contents
+ * @returns {string} mutated contents
+ */
+const mutateWatchEntryContent = (entryPath, originalContent) =>
+	/\.html$/i.test(entryPath)
+		? `${originalContent}<!-- watch test -->`
+		: `${originalContent};console.log('watch test')`;
+
+/**
  * @param {object} params params
  * @param {Bench} params.bench bench
  * @param {string} params.taskName task name
@@ -882,7 +930,7 @@ async function addWatchBench({ bench, taskName, collectBy, webpack, config }) {
 		throw new Error(`No entry for "${taskName}" bench.`);
 	}
 
-	const entry = path.resolve(/** @type {string} */ (config.entry));
+	const entry = resolveWatchEntryPath(config.entry);
 	const originalEntryContent = await fs.readFile(entry, "utf8");
 
 	/** @type {Watching | undefined} */
@@ -937,7 +985,7 @@ async function addWatchBench({ bench, taskName, collectBy, webpack, config }) {
 				(resolve, reject) => {
 					writeFile(
 						entry,
-						`${originalEntryContent};console.log('watch test')`,
+						mutateWatchEntryContent(entry, originalEntryContent),
 						(err) => {
 							if (err) {
 								reject(err);

--- a/types.d.ts
+++ b/types.d.ts
@@ -10310,6 +10310,11 @@ declare class HtmlModulesPlugin {
 	): ChunkFilenameTemplate;
 
 	/**
+	 * Returns true, when the chunk has html.
+	 */
+	static chunkHasHtml(chunk: Chunk, chunkGraph: ChunkGraph): boolean;
+
+	/**
 	 * Per-compilation hooks for the experimental HTML support.
 	 */
 	static getCompilationHooks: (compilation: Compilation) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Skip `ConcatSource.source()` in HtmlModulesPlugin's JS `render` tap when the chunk has no HTML modules (`chunkHasHtml`), so HTML builds do not scan every pure-JS chunk for sentinels.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — `test/benchmarkCases/html-many-chunks` (HTML entry + many async JS chunks); harness supports `.html` entries.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. AI assisted implementing `chunkHasHtml` / render early-exit, the benchmark case, harness HTML-entry support, and drafting this PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML chunk processing by skipping JavaScript render-sentinel scans for chunks that do not contain HTML.
  - Added support for detecting HTML content in scope-hoisted and nested modules, improving build accuracy.

- **Performance**
  - Reduced unnecessary processing for builds containing many asynchronous JavaScript chunks.

- **Tests**
  - Added benchmark coverage for HTML entry points with many generated chunks.
  - Improved watch-mode benchmark handling for HTML and JavaScript entry files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->