### PR TITLE
feat(performance): report unused Module Federation shared keys and remotes

### DIFF
--- a/.changeset/017-performance-diagnostic-gaps.md
+++ b/.changeset/017-performance-diagnostic-gaps.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Add source-map, unused-asset, unused-module, bailout hints; group config checks.
+Add source-map, asset, module, bailout, federation hints; group config checks.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -3585,7 +3585,7 @@ export interface PerformanceOptions {
 	 */
 	unusedAssets?: boolean;
 	/**
-	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.
+	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, 'module.rules' that never matched, and Module Federation 'shared' keys or 'remotes' nothing imported.
 	 * @since 5.111.0
 	 */
 	unusedConfig?: boolean;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -1086,6 +1086,7 @@ class WebpackOptionsApply extends OptionsApply {
 				const UnusedAliasesPlugin = require("./performance/UnusedAliasesPlugin");
 				const UnusedDefinesPlugin = require("./performance/UnusedDefinesPlugin");
 				const UnusedExternalsPlugin = require("./performance/UnusedExternalsPlugin");
+				const UnusedFederationPlugin = require("./performance/UnusedFederationPlugin");
 				// Reports even where size hints are off: a dead rule is a configuration
 				// mistake either way.
 				const UnusedRuleWarningPlugin = require("./performance/UnusedRuleWarningPlugin");
@@ -1093,6 +1094,7 @@ class WebpackOptionsApply extends OptionsApply {
 				new UnusedAliasesPlugin(options.performance).apply(compiler);
 				new UnusedDefinesPlugin(options.performance).apply(compiler);
 				new UnusedExternalsPlugin(options.performance).apply(compiler);
+				new UnusedFederationPlugin(options.performance).apply(compiler);
 				new UnusedRuleWarningPlugin(options.performance).apply(compiler);
 			}
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -21,10 +21,22 @@ const { parseOptions } = require("./options");
  * 	ContainerReferencePluginOptions
  * } from "../../declarations/plugins/container/ContainerReferencePlugin"
  */
+/** @import Compilation from "../Compilation" */
 /** @import Compiler from "../Compiler" */
 
 const slashCode = "/".charCodeAt(0);
 const PLUGIN_NAME = "ContainerReferencePlugin";
+
+/** @type {WeakMap<Compilation, Set<string>>} */
+const DECLARED_REMOTES = new WeakMap();
+
+/**
+ * The remote names this build declared, for `performance.unusedConfig` to tell
+ * apart from the ones a module actually imported.
+ * @param {Compilation} compilation the compilation
+ * @returns {Set<string> | undefined} the declared names, when any were declared
+ */
+const getDeclaredRemotes = (compilation) => DECLARED_REMOTES.get(compilation);
 
 class ContainerReferencePlugin {
 	/**
@@ -91,6 +103,15 @@ class ContainerReferencePlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				let declared = DECLARED_REMOTES.get(compilation);
+
+				if (declared === undefined) {
+					declared = new Set();
+					DECLARED_REMOTES.set(compilation, declared);
+				}
+
+				for (const [key] of remotes) declared.add(key);
+
 				compilation.dependencyFactories.set(
 					RemoteToExternalDependency,
 					normalModuleFactory
@@ -156,5 +177,7 @@ class ContainerReferencePlugin {
 		);
 	}
 }
+
+ContainerReferencePlugin.getDeclaredRemotes = getDeclaredRemotes;
 
 module.exports = ContainerReferencePlugin;

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -14,6 +14,7 @@ const FallbackModuleFactory = require("./FallbackModuleFactory");
 const RemoteModule = require("./RemoteModule");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const { addDeclaredRemotes } = require("./declaredRemotes");
 const { parseOptions } = require("./options");
 
 /**
@@ -21,22 +22,10 @@ const { parseOptions } = require("./options");
  * 	ContainerReferencePluginOptions
  * } from "../../declarations/plugins/container/ContainerReferencePlugin"
  */
-/** @import Compilation from "../Compilation" */
 /** @import Compiler from "../Compiler" */
 
 const slashCode = "/".charCodeAt(0);
 const PLUGIN_NAME = "ContainerReferencePlugin";
-
-/** @type {WeakMap<Compilation, Set<string>>} */
-const DECLARED_REMOTES = new WeakMap();
-
-/**
- * The remote names this build declared, for `performance.unusedConfig` to tell
- * apart from the ones a module actually imported.
- * @param {Compilation} compilation the compilation
- * @returns {Set<string> | undefined} the declared names, when any were declared
- */
-const getDeclaredRemotes = (compilation) => DECLARED_REMOTES.get(compilation);
 
 class ContainerReferencePlugin {
 	/**
@@ -103,14 +92,10 @@ class ContainerReferencePlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
-				let declared = DECLARED_REMOTES.get(compilation);
-
-				if (declared === undefined) {
-					declared = new Set();
-					DECLARED_REMOTES.set(compilation, declared);
-				}
-
-				for (const [key] of remotes) declared.add(key);
+				addDeclaredRemotes(
+					compilation,
+					remotes.map(([key]) => key)
+				);
 
 				compilation.dependencyFactories.set(
 					RemoteToExternalDependency,
@@ -177,7 +162,5 @@ class ContainerReferencePlugin {
 		);
 	}
 }
-
-ContainerReferencePlugin.getDeclaredRemotes = getDeclaredRemotes;
 
 module.exports = ContainerReferencePlugin;

--- a/lib/container/declaredRemotes.js
+++ b/lib/container/declaredRemotes.js
@@ -1,0 +1,39 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+/** @import Compilation from "../Compilation" */
+
+/** @type {WeakMap<Compilation, Set<string>>} */
+const DECLARED_REMOTES = new WeakMap();
+
+/**
+ * The remote names this build declared, in declaration order, which is the
+ * order `factorize` resolves a request against them in.
+ * @param {Compilation} compilation the compilation
+ * @returns {Set<string> | undefined} the declared names, when any were declared
+ */
+const getDeclaredRemotes = (compilation) => DECLARED_REMOTES.get(compilation);
+
+/**
+ * Records declared names, adding to any a previous application made.
+ * @param {Compilation} compilation the compilation
+ * @param {Iterable<string>} names what this application declared
+ * @returns {void}
+ */
+const addDeclaredRemotes = (compilation, names) => {
+	let declared = DECLARED_REMOTES.get(compilation);
+
+	if (declared === undefined) {
+		declared = new Set();
+		DECLARED_REMOTES.set(compilation, declared);
+	}
+
+	for (const name of names) declared.add(name);
+};
+
+module.exports.addDeclaredRemotes = addDeclaredRemotes;
+module.exports.getDeclaredRemotes = getDeclaredRemotes;

--- a/lib/errors/UnusedFederationWarning.js
+++ b/lib/errors/UnusedFederationWarning.js
@@ -1,0 +1,35 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const WebpackError = require("./WebpackError");
+
+/**
+ * @typedef {object} UnusedFederationDetails
+ * @property {string} name the share key or remote name, as declared
+ * @property {"shared" | "remote"} kind which list declared it
+ */
+
+class UnusedFederationWarning extends WebpackError {
+	/**
+	 * Creates an instance of UnusedFederationWarning.
+	 * @param {UnusedFederationDetails[]} entries the entries nothing used
+	 */
+	constructor(entries) {
+		const list = entries
+			.map((entry) => `\n  ${entry.name} (${entry.kind})`)
+			.join("");
+
+		super(
+			`unused federation config: ${entries.length} ${entries.length === 1 ? "entry was" : "entries were"} declared but never used:${list}\nA 'shared' key nothing imports is not shared at all — each side keeps its own copy, which for a package holding state breaks at runtime rather than only costing bytes. A 'remotes' name nothing imports is dead configuration, or names a remote the code spells differently.\nFor more info visit https://webpack.js.org/concepts/module-federation/`
+		);
+
+		/** @type {string} */
+		this.name = "UnusedFederationWarning";
+	}
+}
+
+module.exports = UnusedFederationWarning;

--- a/lib/performance/UnusedFederationPlugin.js
+++ b/lib/performance/UnusedFederationPlugin.js
@@ -1,0 +1,143 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const { getDeclaredRemotes } = require("../container/ContainerReferencePlugin");
+const RemoteModule = require("../container/RemoteModule");
+const UnusedFederationWarning = require("../errors/UnusedFederationWarning");
+const ConsumeSharedModule = require("../sharing/ConsumeSharedModule");
+const { getDeclaredShared } = require("../sharing/ConsumeSharedPlugin");
+const { compareStrings } = require("../util/comparators");
+
+/** @import { PerformanceOptions } from "../../declarations/WebpackOptions" */
+/** @import Compiler from "../Compiler" */
+/** @import { UnusedFederationDetails } from "../errors/UnusedFederationWarning" */
+
+const PLUGIN_NAME = "UnusedFederationPlugin";
+
+/**
+ * @param {Set<string>} used the share keys modules were created for
+ * @param {string} prefix the declared prefix, slash included
+ * @returns {boolean} whether anything under the prefix was used
+ */
+const someUsedStartsWith = (used, prefix) => {
+	for (const shareKey of used) {
+		if (shareKey.startsWith(prefix)) return true;
+	}
+
+	return false;
+};
+
+/**
+ * Applies the rule `ContainerReferencePlugin` factorizes by, so that a remote
+ * name holding slashes is told apart from an exposed path holding them too.
+ * @param {Set<string>} requests the requests remote modules were created for
+ * @param {string} name the declared remote name
+ * @returns {boolean} whether a request named this remote
+ */
+const someRequestIsFor = (requests, name) => {
+	for (const request of requests) {
+		if (
+			request.startsWith(name) &&
+			(request.length === name.length || request[name.length] === "/")
+		) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+class UnusedFederationPlugin {
+	/**
+	 * Creates an instance of UnusedFederationPlugin.
+	 * @param {PerformanceOptions} options the plugin options
+	 */
+	constructor(options) {
+		/** @type {PerformanceOptions["hints"]} */
+		this.hints = options.hints;
+	}
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const hints = this.hints;
+
+		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+			// Reported past the hash, which folds every message into it, so a hint
+			// pushed earlier would change the build's identity.
+			compilation.hooks.afterSeal.tap(PLUGIN_NAME, () => {
+				const declaredShared = getDeclaredShared(compilation);
+				const declaredRemotes = getDeclaredRemotes(compilation);
+
+				if (declaredShared === undefined && declaredRemotes === undefined) {
+					return;
+				}
+
+				/** @type {Set<string>} */
+				const usedShared = new Set();
+				/** @type {Set<string>} */
+				const remoteRequests = new Set();
+
+				for (const module of compilation.modules) {
+					if (module instanceof ConsumeSharedModule) {
+						usedShared.add(module.options.shareKey);
+					} else if (module instanceof RemoteModule) {
+						remoteRequests.add(module.request);
+					}
+				}
+
+				/** @type {UnusedFederationDetails[]} */
+				const unused = [];
+
+				if (declaredShared !== undefined) {
+					// Keyed by share key, since that is what the module carries, but
+					// reported by the config key, which is what the config spells.
+					for (const [shareKey, name] of declaredShared) {
+						// A key ending in a slash shares everything under it, so the
+						// modules carry the remainder appended rather than the key.
+						const used = shareKey.endsWith("/")
+							? someUsedStartsWith(usedShared, shareKey)
+							: usedShared.has(shareKey);
+
+						if (!used) unused.push({ name, kind: "shared" });
+					}
+				}
+
+				if (declaredRemotes !== undefined) {
+					for (const name of declaredRemotes) {
+						if (!someRequestIsFor(remoteRequests, name)) {
+							unused.push({ name, kind: "remote" });
+						}
+					}
+				}
+
+				if (unused.length === 0) return;
+
+				// Ties break by name: declaration order is not worth preserving here.
+				unused.sort(
+					(a, b) =>
+						compareStrings(a.kind, b.kind) || compareStrings(a.name, b.name)
+				);
+
+				const warning = new UnusedFederationWarning(unused);
+
+				if (hints === "error") {
+					compilation.errors.push(warning);
+				} else if (hints === "stats") {
+					compilation.hints.push(warning);
+				} else {
+					compilation.warnings.push(warning);
+				}
+			});
+		});
+	}
+}
+
+module.exports = UnusedFederationPlugin;

--- a/lib/performance/UnusedFederationPlugin.js
+++ b/lib/performance/UnusedFederationPlugin.js
@@ -20,12 +20,12 @@ const PLUGIN_NAME = "UnusedFederationPlugin";
 
 /**
  * @param {Set<string>} used the share keys modules were created for
- * @param {string} prefix the declared prefix, slash included
- * @returns {boolean} whether anything under the prefix was used
+ * @param {string} shareKey the declared share key
+ * @returns {boolean} whether anything under the share key was used
  */
-const someUsedStartsWith = (used, prefix) => {
-	for (const shareKey of used) {
-		if (shareKey.startsWith(prefix)) return true;
+const someUsedStartsWith = (used, shareKey) => {
+	for (const usedKey of used) {
+		if (usedKey.startsWith(shareKey)) return true;
 	}
 
 	return false;
@@ -91,18 +91,14 @@ class UnusedFederationPlugin {
 				const unused = [];
 
 				if (declaredShared !== undefined) {
-					// Keyed by share key, since that is what the module carries, but
-					// reported by the config keys, which are what the config spells.
-					for (const [shareKey, names] of declaredShared) {
-						// A key ending in a slash shares everything under it, so the
-						// modules carry the remainder appended rather than the key.
-						const used = shareKey.endsWith("/")
+					// Matched on the share key, since that is what the module carries,
+					// but reported by the config key, which is what the config spells.
+					for (const { name, shareKey, prefix } of declaredShared) {
+						const used = prefix
 							? someUsedStartsWith(usedShared, shareKey)
 							: usedShared.has(shareKey);
 
-						if (used) continue;
-
-						for (const name of names) unused.push({ name, kind: "shared" });
+						if (!used) unused.push({ name, kind: "shared" });
 					}
 				}
 

--- a/lib/performance/UnusedFederationPlugin.js
+++ b/lib/performance/UnusedFederationPlugin.js
@@ -5,11 +5,11 @@
 
 "use strict";
 
-const { getDeclaredRemotes } = require("../container/ContainerReferencePlugin");
 const RemoteModule = require("../container/RemoteModule");
+const { getDeclaredRemotes } = require("../container/declaredRemotes");
 const UnusedFederationWarning = require("../errors/UnusedFederationWarning");
 const ConsumeSharedModule = require("../sharing/ConsumeSharedModule");
-const { getDeclaredShared } = require("../sharing/ConsumeSharedPlugin");
+const { getDeclaredShared } = require("../sharing/declaredShared");
 const { compareStrings } = require("../util/comparators");
 
 /** @import { PerformanceOptions } from "../../declarations/WebpackOptions" */

--- a/lib/performance/UnusedFederationPlugin.js
+++ b/lib/performance/UnusedFederationPlugin.js
@@ -34,22 +34,13 @@ const someUsedStartsWith = (used, prefix) => {
 /**
  * Applies the rule `ContainerReferencePlugin` factorizes by, so that a remote
  * name holding slashes is told apart from an exposed path holding them too.
- * @param {Set<string>} requests the requests remote modules were created for
+ * @param {string} request the request a remote module was created for
  * @param {string} name the declared remote name
- * @returns {boolean} whether a request named this remote
+ * @returns {boolean} whether the request names this remote
  */
-const someRequestIsFor = (requests, name) => {
-	for (const request of requests) {
-		if (
-			request.startsWith(name) &&
-			(request.length === name.length || request[name.length] === "/")
-		) {
-			return true;
-		}
-	}
-
-	return false;
-};
+const isRequestFor = (request, name) =>
+	request.startsWith(name) &&
+	(request.length === name.length || request[name.length] === "/");
 
 class UnusedFederationPlugin {
 	/**
@@ -80,6 +71,9 @@ class UnusedFederationPlugin {
 					return;
 				}
 
+				// Nothing was factorized, so no shared or remote module could exist.
+				if (compilation.modules.size === 0) return;
+
 				/** @type {Set<string>} */
 				const usedShared = new Set();
 				/** @type {Set<string>} */
@@ -98,23 +92,37 @@ class UnusedFederationPlugin {
 
 				if (declaredShared !== undefined) {
 					// Keyed by share key, since that is what the module carries, but
-					// reported by the config key, which is what the config spells.
-					for (const [shareKey, name] of declaredShared) {
+					// reported by the config keys, which are what the config spells.
+					for (const [shareKey, names] of declaredShared) {
 						// A key ending in a slash shares everything under it, so the
 						// modules carry the remainder appended rather than the key.
 						const used = shareKey.endsWith("/")
 							? someUsedStartsWith(usedShared, shareKey)
 							: usedShared.has(shareKey);
 
-						if (!used) unused.push({ name, kind: "shared" });
+						if (used) continue;
+
+						for (const name of names) unused.push({ name, kind: "shared" });
 					}
 				}
 
 				if (declaredRemotes !== undefined) {
-					for (const name of declaredRemotes) {
-						if (!someRequestIsFor(remoteRequests, name)) {
-							unused.push({ name, kind: "remote" });
+					/** @type {Set<string>} */
+					const usedRemotes = new Set();
+
+					// Declaration order is precedence: `factorize` takes the first
+					// name a request matches, so a later one it also matches is dead.
+					for (const request of remoteRequests) {
+						for (const name of declaredRemotes) {
+							if (isRequestFor(request, name)) {
+								usedRemotes.add(name);
+								break;
+							}
 						}
+					}
+
+					for (const name of declaredRemotes) {
+						if (!usedRemotes.has(name)) unused.push({ name, kind: "remote" });
 					}
 				}
 

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -32,6 +32,7 @@ const getModuleNotFoundError = memoize(() =>
  * 	ConsumeSharedPluginOptions
  * } from "../../declarations/plugins/sharing/ConsumeSharedPlugin"
  */
+/** @import Compilation from "../Compilation" */
 /** @import Compiler from "../Compiler" */
 /** @import { FileSystemDependencies } from "../Compilation" */
 /** @import { ResolveOptionsWithDependencyType } from "../ResolverFactory" */
@@ -42,6 +43,18 @@ const getModuleNotFoundError = memoize(() =>
 /** @type {ResolveOptionsWithDependencyType} */
 const RESOLVE_OPTIONS = { dependencyType: "esm" };
 const PLUGIN_NAME = "ConsumeSharedPlugin";
+
+/** @type {WeakMap<Compilation, Map<string, string>>} */
+const DECLARED_SHARED = new WeakMap();
+
+/**
+ * What this build declared as shared, as share key to the config key that
+ * declared it. `performance.unusedConfig` matches modules on the share key and
+ * reports the config key, which is the one written in the config.
+ * @param {Compilation} compilation the compilation
+ * @returns {Map<string, string> | undefined} the declarations, when any were made
+ */
+const getDeclaredShared = (compilation) => DECLARED_SHARED.get(compilation);
 
 class ConsumeSharedPlugin {
 	/**
@@ -136,6 +149,17 @@ class ConsumeSharedPlugin {
 					ConsumeSharedFallbackDependency,
 					normalModuleFactory
 				);
+
+				let declared = DECLARED_SHARED.get(compilation);
+
+				if (declared === undefined) {
+					declared = new Map();
+					DECLARED_SHARED.set(compilation, declared);
+				}
+
+				for (const [key, config] of consumes) {
+					declared.set(config.shareKey, key);
+				}
 
 				/** @typedef {Map<string, ConsumeOptions>} Consumes */
 
@@ -391,5 +415,7 @@ class ConsumeSharedPlugin {
 		);
 	}
 }
+
+ConsumeSharedPlugin.getDeclaredShared = getDeclaredShared;
 
 module.exports = ConsumeSharedPlugin;

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -44,16 +44,22 @@ const getModuleNotFoundError = memoize(() =>
 const RESOLVE_OPTIONS = { dependencyType: "esm" };
 const PLUGIN_NAME = "ConsumeSharedPlugin";
 
-/** @type {WeakMap<Compilation, Map<string, Set<string>>>} */
+/**
+ * @typedef {object} SharedDeclaration
+ * @property {string} name the config key, as the config spells it
+ * @property {string} shareKey the key the modules created for it carry
+ * @property {boolean} prefix whether it shares everything under the key
+ */
+
+/** @type {WeakMap<Compilation, SharedDeclaration[]>} */
 const DECLARED_SHARED = new WeakMap();
 
 /**
- * What this build declared as shared, as share key to the config keys that
- * declared it. `performance.unusedConfig` matches modules on the share key and
- * reports the config keys, which are the ones written in the config; several
- * may share one key, so each maps to a set.
+ * What this build declared as shared, one entry per config key, since several
+ * may name one share key. `performance.unusedConfig` matches modules on the
+ * share key and reports the config key.
  * @param {Compilation} compilation the compilation
- * @returns {Map<string, Set<string>> | undefined} the declarations, when any were made
+ * @returns {SharedDeclaration[] | undefined} the declarations, when any were made
  */
 const getDeclaredShared = (compilation) => DECLARED_SHARED.get(compilation);
 
@@ -154,18 +160,18 @@ class ConsumeSharedPlugin {
 				let declared = DECLARED_SHARED.get(compilation);
 
 				if (declared === undefined) {
-					declared = new Map();
+					declared = [];
 					DECLARED_SHARED.set(compilation, declared);
 				}
 
 				for (const [key, config] of consumes) {
-					const names = declared.get(config.shareKey);
-
-					if (names === undefined) {
-						declared.set(config.shareKey, new Set([key]));
-					} else {
-						names.add(key);
-					}
+					// A key ending in a slash shares everything under it, and the
+					// modules then carry the remainder appended to the share key.
+					declared.push({
+						name: key,
+						shareKey: config.shareKey,
+						prefix: key.endsWith("/")
+					});
 				}
 
 				/** @typedef {Map<string, ConsumeOptions>} Consumes */

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -44,15 +44,16 @@ const getModuleNotFoundError = memoize(() =>
 const RESOLVE_OPTIONS = { dependencyType: "esm" };
 const PLUGIN_NAME = "ConsumeSharedPlugin";
 
-/** @type {WeakMap<Compilation, Map<string, string>>} */
+/** @type {WeakMap<Compilation, Map<string, Set<string>>>} */
 const DECLARED_SHARED = new WeakMap();
 
 /**
- * What this build declared as shared, as share key to the config key that
+ * What this build declared as shared, as share key to the config keys that
  * declared it. `performance.unusedConfig` matches modules on the share key and
- * reports the config key, which is the one written in the config.
+ * reports the config keys, which are the ones written in the config; several
+ * may share one key, so each maps to a set.
  * @param {Compilation} compilation the compilation
- * @returns {Map<string, string> | undefined} the declarations, when any were made
+ * @returns {Map<string, Set<string>> | undefined} the declarations, when any were made
  */
 const getDeclaredShared = (compilation) => DECLARED_SHARED.get(compilation);
 
@@ -158,7 +159,13 @@ class ConsumeSharedPlugin {
 				}
 
 				for (const [key, config] of consumes) {
-					declared.set(config.shareKey, key);
+					const names = declared.get(config.shareKey);
+
+					if (names === undefined) {
+						declared.set(config.shareKey, new Set([key]));
+					} else {
+						names.add(key);
+					}
 				}
 
 				/** @typedef {Map<string, ConsumeOptions>} Consumes */

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -15,6 +15,7 @@ const ConsumeSharedFallbackDependency = require("./ConsumeSharedFallbackDependen
 const ConsumeSharedModule = require("./ConsumeSharedModule");
 const ConsumeSharedRuntimeModule = require("./ConsumeSharedRuntimeModule");
 const ProvideForSharedDependency = require("./ProvideForSharedDependency");
+const { addDeclaredShared } = require("./declaredShared");
 const { resolveMatchedConfigs } = require("./resolveMatchedConfigs");
 const {
 	getDescriptionFile,
@@ -32,7 +33,6 @@ const getModuleNotFoundError = memoize(() =>
  * 	ConsumeSharedPluginOptions
  * } from "../../declarations/plugins/sharing/ConsumeSharedPlugin"
  */
-/** @import Compilation from "../Compilation" */
 /** @import Compiler from "../Compiler" */
 /** @import { FileSystemDependencies } from "../Compilation" */
 /** @import { ResolveOptionsWithDependencyType } from "../ResolverFactory" */
@@ -43,25 +43,6 @@ const getModuleNotFoundError = memoize(() =>
 /** @type {ResolveOptionsWithDependencyType} */
 const RESOLVE_OPTIONS = { dependencyType: "esm" };
 const PLUGIN_NAME = "ConsumeSharedPlugin";
-
-/**
- * @typedef {object} SharedDeclaration
- * @property {string} name the config key, as the config spells it
- * @property {string} shareKey the key the modules created for it carry
- * @property {boolean} prefix whether it shares everything under the key
- */
-
-/** @type {WeakMap<Compilation, SharedDeclaration[]>} */
-const DECLARED_SHARED = new WeakMap();
-
-/**
- * What this build declared as shared, one entry per config key, since several
- * may name one share key. `performance.unusedConfig` matches modules on the
- * share key and reports the config key.
- * @param {Compilation} compilation the compilation
- * @returns {SharedDeclaration[] | undefined} the declarations, when any were made
- */
-const getDeclaredShared = (compilation) => DECLARED_SHARED.get(compilation);
 
 class ConsumeSharedPlugin {
 	/**
@@ -157,22 +138,16 @@ class ConsumeSharedPlugin {
 					normalModuleFactory
 				);
 
-				let declared = DECLARED_SHARED.get(compilation);
-
-				if (declared === undefined) {
-					declared = [];
-					DECLARED_SHARED.set(compilation, declared);
-				}
-
-				for (const [key, config] of consumes) {
-					// A key ending in a slash shares everything under it, and the
-					// modules then carry the remainder appended to the share key.
-					declared.push({
+				// A key ending in a slash shares everything under it, and the
+				// modules then carry the remainder appended to the share key.
+				addDeclaredShared(
+					compilation,
+					consumes.map(([key, config]) => ({
 						name: key,
 						shareKey: config.shareKey,
 						prefix: key.endsWith("/")
-					});
-				}
+					}))
+				);
 
 				/** @typedef {Map<string, ConsumeOptions>} Consumes */
 
@@ -428,7 +403,5 @@ class ConsumeSharedPlugin {
 		);
 	}
 }
-
-ConsumeSharedPlugin.getDeclaredShared = getDeclaredShared;
 
 module.exports = ConsumeSharedPlugin;

--- a/lib/sharing/declaredShared.js
+++ b/lib/sharing/declaredShared.js
@@ -1,0 +1,47 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+/** @import Compilation from "../Compilation" */
+
+/**
+ * @typedef {object} SharedDeclaration
+ * @property {string} name the config key, as the config spells it
+ * @property {string} shareKey the key the modules created for it carry
+ * @property {boolean} prefix whether it shares everything under the key
+ */
+
+/** @type {WeakMap<Compilation, SharedDeclaration[]>} */
+const DECLARED_SHARED = new WeakMap();
+
+/**
+ * What this build declared as shared, one entry per config key, since several
+ * may name one share key. `performance.unusedConfig` matches modules on the
+ * share key and reports the config key.
+ * @param {Compilation} compilation the compilation
+ * @returns {SharedDeclaration[] | undefined} the declarations, when any were made
+ */
+const getDeclaredShared = (compilation) => DECLARED_SHARED.get(compilation);
+
+/**
+ * Records declarations, appending when a build applies the plugin more than
+ * once, as `ModuleFederationPlugin` and `SharePlugin` do.
+ * @param {Compilation} compilation the compilation
+ * @param {SharedDeclaration[]} declarations what this application declared
+ * @returns {void}
+ */
+const addDeclaredShared = (compilation, declarations) => {
+	const declared = DECLARED_SHARED.get(compilation);
+
+	if (declared === undefined) {
+		DECLARED_SHARED.set(compilation, [...declarations]);
+	} else {
+		for (const declaration of declarations) declared.push(declaration);
+	}
+};
+
+module.exports.addDeclaredShared = addDeclaredShared;
+module.exports.getDeclaredShared = getDeclaredShared;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -5694,7 +5694,7 @@
           "added": "5.111.0"
         },
         "unusedConfig": {
-          "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
+          "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, 'module.rules' that never matched, and Module Federation 'shared' keys or 'remotes' nothing imported.",
           "type": "boolean",
           "added": "5.111.0"
         },

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -16024,13 +16024,13 @@ Object {
   "performance-unused-config": Object {
     "configs": Array [
       Object {
-        "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
+        "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, 'module.rules' that never matched, and Module Federation 'shared' keys or 'remotes' nothing imported.",
         "multiple": false,
         "path": "performance.unusedConfig",
         "type": "boolean",
       },
     ],
-    "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.",
+    "description": "Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, 'module.rules' that never matched, and Module Federation 'shared' keys or 'remotes' nothing imported.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/configCases/performance/unused-federation-clean/index.js
+++ b/test/configCases/performance/unused-federation-clean/index.js
@@ -1,0 +1,4 @@
+it("should stay quiet when every shared key is imported", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-clean/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-clean/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-clean/package.json
+++ b/test/configCases/performance/unused-federation-clean/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "used-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-clean/use.js
+++ b/test/configCases/performance/unused-federation-clean/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-clean/webpack.config.js
+++ b/test/configCases/performance/unused-federation-clean/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: { "used-lib": { requiredVersion: false } }
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-duplicate-share-key/index.js
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/index.js
@@ -1,0 +1,3 @@
+it("should report every config key sharing one share key", () => {
+	expect(1).toBe(1);
+});

--- a/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash-es/index.js
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash-es/index.js
@@ -1,0 +1,1 @@
+export default "lodash-es";

--- a/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash-es/package.json
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash-es/package.json
@@ -1,0 +1,1 @@
+{ "name": "lodash-es", "version": "4.17.21", "main": "index.js" }

--- a/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash/index.js
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash/index.js
@@ -1,0 +1,1 @@
+export default "lodash";

--- a/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash/package.json
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/node_modules/lodash/package.json
@@ -1,0 +1,1 @@
+{ "name": "lodash", "version": "4.17.21", "main": "index.js" }

--- a/test/configCases/performance/unused-federation-duplicate-share-key/package.json
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "lodash": "*",
+    "lodash-es": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-duplicate-share-key/warnings.js
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/warnings.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = [
+	[
+		/unused federation config: 2 entries were declared/,
+		/lodash \(shared\)\n {2}lodash-es \(shared\)/
+	]
+];

--- a/test/configCases/performance/unused-federation-duplicate-share-key/webpack.config.js
+++ b/test/configCases/performance/unused-federation-duplicate-share-key/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+// Both keys carry the same `shareKey`, so neither may hide the other.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				lodash: { shareKey: "lodash", requiredVersion: false },
+				"lodash-es": { shareKey: "lodash", requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-error/errors.js
+++ b/test/configCases/performance/unused-federation-error/errors.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /unused-lib \(shared\)/]
+];

--- a/test/configCases/performance/unused-federation-error/index.js
+++ b/test/configCases/performance/unused-federation-error/index.js
@@ -1,0 +1,4 @@
+it("should raise an error when hints are errors", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-error/node_modules/unused-lib.js
+++ b/test/configCases/performance/unused-federation-error/node_modules/unused-lib.js
@@ -1,0 +1,1 @@
+export default "unused-lib";

--- a/test/configCases/performance/unused-federation-error/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-error/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-error/package.json
+++ b/test/configCases/performance/unused-federation-error/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "used-lib": "*",
+    "unused-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-error/use.js
+++ b/test/configCases/performance/unused-federation-error/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-error/webpack.config.js
+++ b/test/configCases/performance/unused-federation-error/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "error",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": { requiredVersion: false },
+				"unused-lib": { requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-no-hints/index.js
+++ b/test/configCases/performance/unused-federation-no-hints/index.js
@@ -1,0 +1,4 @@
+it("should report even though hints are off", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-no-hints/node_modules/unused-lib.js
+++ b/test/configCases/performance/unused-federation-no-hints/node_modules/unused-lib.js
@@ -1,0 +1,1 @@
+export default "unused-lib";

--- a/test/configCases/performance/unused-federation-no-hints/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-no-hints/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-no-hints/package.json
+++ b/test/configCases/performance/unused-federation-no-hints/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "used-lib": "*",
+    "unused-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-no-hints/use.js
+++ b/test/configCases/performance/unused-federation-no-hints/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-no-hints/warnings.js
+++ b/test/configCases/performance/unused-federation-no-hints/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /unused-lib \(shared\)/]
+];

--- a/test/configCases/performance/unused-federation-no-hints/webpack.config.js
+++ b/test/configCases/performance/unused-federation-no-hints/webpack.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+// `hints` defaults to false outside production, so the report must not depend on it.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: false,
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": { requiredVersion: false },
+				"unused-lib": { requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-ordered/index.js
+++ b/test/configCases/performance/unused-federation-ordered/index.js
@@ -1,0 +1,4 @@
+it("should list remotes before shared keys, each by name", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-ordered/node_modules/aaa-unused.js
+++ b/test/configCases/performance/unused-federation-ordered/node_modules/aaa-unused.js
@@ -1,0 +1,1 @@
+export default "aaa-unused";

--- a/test/configCases/performance/unused-federation-ordered/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-ordered/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-ordered/node_modules/zzz-unused.js
+++ b/test/configCases/performance/unused-federation-ordered/node_modules/zzz-unused.js
@@ -1,0 +1,1 @@
+export default "zzz-unused";

--- a/test/configCases/performance/unused-federation-ordered/package.json
+++ b/test/configCases/performance/unused-federation-ordered/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "used-lib": "*",
+    "zzz-unused": "*",
+    "aaa-unused": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-ordered/use.js
+++ b/test/configCases/performance/unused-federation-ordered/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-ordered/warnings.js
+++ b/test/configCases/performance/unused-federation-ordered/warnings.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = [
+	[
+		/unused federation config: 3 entries were declared/,
+		/never-imported \(remote\)\n {2}aaa-unused \(shared\)\n {2}zzz-unused \(shared\)/
+	]
+];

--- a/test/configCases/performance/unused-federation-ordered/webpack.config.js
+++ b/test/configCases/performance/unused-federation-ordered/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { ContainerReferencePlugin } = require("../../../../").container;
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": { requiredVersion: false },
+				"zzz-unused": { requiredVersion: false },
+				"aaa-unused": { requiredVersion: false }
+			}
+		}),
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: { "never-imported": "NEVER_IMPORTED" }
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-prefix-share-key/index.js
+++ b/test/configCases/performance/unused-federation-prefix-share-key/index.js
@@ -1,0 +1,4 @@
+it("should count a prefix whose share key is spelled differently", () =>
+	import("./use").then(({ default: value }) => {
+		expect(value).toBe("pkg/subpath");
+	}));

--- a/test/configCases/performance/unused-federation-prefix-share-key/node_modules/dead/package.json
+++ b/test/configCases/performance/unused-federation-prefix-share-key/node_modules/dead/package.json
@@ -1,0 +1,1 @@
+{ "name": "dead", "version": "1.0.0" }

--- a/test/configCases/performance/unused-federation-prefix-share-key/node_modules/pkg/package.json
+++ b/test/configCases/performance/unused-federation-prefix-share-key/node_modules/pkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "pkg", "version": "1.0.0" }

--- a/test/configCases/performance/unused-federation-prefix-share-key/node_modules/pkg/subpath.js
+++ b/test/configCases/performance/unused-federation-prefix-share-key/node_modules/pkg/subpath.js
@@ -1,0 +1,1 @@
+export default "pkg/subpath";

--- a/test/configCases/performance/unused-federation-prefix-share-key/package.json
+++ b/test/configCases/performance/unused-federation-prefix-share-key/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "pkg": "*",
+    "dead": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-prefix-share-key/use.js
+++ b/test/configCases/performance/unused-federation-prefix-share-key/use.js
@@ -1,0 +1,3 @@
+import value from "pkg/subpath";
+
+export default value;

--- a/test/configCases/performance/unused-federation-prefix-share-key/warnings.js
+++ b/test/configCases/performance/unused-federation-prefix-share-key/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /dead\/ \(shared\)/]
+];

--- a/test/configCases/performance/unused-federation-prefix-share-key/webpack.config.js
+++ b/test/configCases/performance/unused-federation-prefix-share-key/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+// Whether a key is a prefix is decided by the config key, not by its
+// `shareKey`: the modules carry the remainder appended to the share key.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"pkg/": { shareKey: "shared", requiredVersion: false },
+				"dead/": { shareKey: "gone", requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-prefix/index.js
+++ b/test/configCases/performance/unused-federation-prefix/index.js
@@ -1,0 +1,4 @@
+it("should count a prefix used through anything under it", () =>
+	import("./use").then(({ default: a }) => {
+		expect(a).toBe("prefix/a");
+	}));

--- a/test/configCases/performance/unused-federation-prefix/node_modules/prefix/a.js
+++ b/test/configCases/performance/unused-federation-prefix/node_modules/prefix/a.js
@@ -1,0 +1,1 @@
+export default "prefix/a";

--- a/test/configCases/performance/unused-federation-prefix/package.json
+++ b/test/configCases/performance/unused-federation-prefix/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "prefix": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-prefix/use.js
+++ b/test/configCases/performance/unused-federation-prefix/use.js
@@ -1,0 +1,3 @@
+import a from "prefix/a";
+
+export default a;

--- a/test/configCases/performance/unused-federation-prefix/warnings.js
+++ b/test/configCases/performance/unused-federation-prefix/warnings.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = [
+	[
+		/unused federation config: 1 entry was declared/,
+		/unused-prefix\/ \(shared\)/
+	]
+];

--- a/test/configCases/performance/unused-federation-prefix/webpack.config.js
+++ b/test/configCases/performance/unused-federation-prefix/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"prefix/": { requiredVersion: false },
+				"unused-prefix/": { requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-remote-precedence/index.js
+++ b/test/configCases/performance/unused-federation-remote-precedence/index.js
@@ -1,0 +1,2 @@
+it("should report a remote an earlier declaration shadows", () =>
+	import("./module").then(({ test }) => test()));

--- a/test/configCases/performance/unused-federation-remote-precedence/module.js
+++ b/test/configCases/performance/unused-federation-remote-precedence/module.js
@@ -1,0 +1,5 @@
+import Thing from "app/foo/Thing";
+
+export function test() {
+	expect(Thing).toBe("app ./foo/Thing");
+}

--- a/test/configCases/performance/unused-federation-remote-precedence/test.config.js
+++ b/test/configCases/performance/unused-federation-remote-precedence/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		scope.APP = {
+			get(module) {
+				return Promise.resolve(() => `app ${module}`);
+			}
+		};
+	}
+};

--- a/test/configCases/performance/unused-federation-remote-precedence/warnings.js
+++ b/test/configCases/performance/unused-federation-remote-precedence/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /app\/foo \(remote\)/]
+];

--- a/test/configCases/performance/unused-federation-remote-precedence/webpack.config.js
+++ b/test/configCases/performance/unused-federation-remote-precedence/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const { ContainerReferencePlugin } = require("../../../../").container;
+
+// `factorize` takes the first name a request matches, so `app` swallows
+// everything `app/foo` would have served and leaves it dead.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: { app: "APP", "app/foo": "FOO" }
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-remotes/index.js
+++ b/test/configCases/performance/unused-federation-remotes/index.js
@@ -1,0 +1,2 @@
+it("should report a remote nothing imports", () =>
+	import("./module").then(({ test }) => test()));

--- a/test/configCases/performance/unused-federation-remotes/module.js
+++ b/test/configCases/performance/unused-federation-remotes/module.js
@@ -1,0 +1,7 @@
+import main from "abc";
+import deep from "scope/def/hello/other/world";
+
+export function test() {
+	expect(main).toBe("abc .");
+	expect(deep).toBe("def ./hello/other/world");
+}

--- a/test/configCases/performance/unused-federation-remotes/test.config.js
+++ b/test/configCases/performance/unused-federation-remotes/test.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		scope.ABC = {
+			get(module) {
+				return Promise.resolve(() => `abc ${module}`);
+			}
+		};
+		scope.DEF = {
+			get(module) {
+				return Promise.resolve(() => `def ${module}`);
+			}
+		};
+	}
+};

--- a/test/configCases/performance/unused-federation-remotes/warnings.js
+++ b/test/configCases/performance/unused-federation-remotes/warnings.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = [
+	[
+		/unused federation config: 1 entry was declared/,
+		/never-imported \(remote\)/
+	]
+];

--- a/test/configCases/performance/unused-federation-remotes/webpack.config.js
+++ b/test/configCases/performance/unused-federation-remotes/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const { ContainerReferencePlugin } = require("../../../../").container;
+
+// The declared names and the exposed paths both hold slashes, so only the rule
+// the plugin factorizes by tells one from the other.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: {
+				abc: "ABC",
+				"scope/def": "DEF",
+				"never-imported": "NEVER_IMPORTED"
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-share-key/index.js
+++ b/test/configCases/performance/unused-federation-share-key/index.js
@@ -1,0 +1,4 @@
+it("should report the config key, not the share key", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-share-key/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-share-key/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-share-key/package.json
+++ b/test/configCases/performance/unused-federation-share-key/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "used-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-share-key/use.js
+++ b/test/configCases/performance/unused-federation-share-key/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-share-key/warnings.js
+++ b/test/configCases/performance/unused-federation-share-key/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /unused-alias \(shared\)/]
+];

--- a/test/configCases/performance/unused-federation-share-key/webpack.config.js
+++ b/test/configCases/performance/unused-federation-share-key/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+// Both entries carry a `shareKey` other than their config key: the used one must
+// still count, and the unused one must be named as the config spells it.
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": {
+					shareKey: "used-under-another-name",
+					requiredVersion: false
+				},
+				"unused-alias": {
+					import: false,
+					shareKey: "unused-under-another-name",
+					requiredVersion: false
+				}
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-shared/index.js
+++ b/test/configCases/performance/unused-federation-shared/index.js
@@ -1,0 +1,4 @@
+it("should report a shared key nothing imports", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+	}));

--- a/test/configCases/performance/unused-federation-shared/node_modules/unused-lib.js
+++ b/test/configCases/performance/unused-federation-shared/node_modules/unused-lib.js
@@ -1,0 +1,1 @@
+export default "unused-lib";

--- a/test/configCases/performance/unused-federation-shared/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-shared/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-shared/package.json
+++ b/test/configCases/performance/unused-federation-shared/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "used-lib": "*",
+    "unused-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-shared/use.js
+++ b/test/configCases/performance/unused-federation-shared/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-shared/warnings.js
+++ b/test/configCases/performance/unused-federation-shared/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/unused federation config: 1 entry was declared/, /unused-lib \(shared\)/]
+];

--- a/test/configCases/performance/unused-federation-shared/webpack.config.js
+++ b/test/configCases/performance/unused-federation-shared/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "warning",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": { requiredVersion: false },
+				"unused-lib": { requiredVersion: false }
+			}
+		})
+	]
+};

--- a/test/configCases/performance/unused-federation-stats/index.js
+++ b/test/configCases/performance/unused-federation-stats/index.js
@@ -1,0 +1,10 @@
+it("should report through the stats channel", () =>
+	import("./use").then(({ default: used }) => {
+		expect(used).toBe("used-lib");
+		expect(__STATS__.hints).toHaveLength(1);
+		expect(__STATS__.hints[0].message).toMatch(
+			/unused federation config: 1 entry was declared/
+		);
+		expect(__STATS__.warnings).toHaveLength(0);
+		expect(__STATS__.errors).toHaveLength(0);
+	}));

--- a/test/configCases/performance/unused-federation-stats/node_modules/unused-lib.js
+++ b/test/configCases/performance/unused-federation-stats/node_modules/unused-lib.js
@@ -1,0 +1,1 @@
+export default "unused-lib";

--- a/test/configCases/performance/unused-federation-stats/node_modules/used-lib.js
+++ b/test/configCases/performance/unused-federation-stats/node_modules/used-lib.js
@@ -1,0 +1,1 @@
+export default "used-lib";

--- a/test/configCases/performance/unused-federation-stats/package.json
+++ b/test/configCases/performance/unused-federation-stats/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "used-lib": "*",
+    "unused-lib": "*"
+  }
+}

--- a/test/configCases/performance/unused-federation-stats/use.js
+++ b/test/configCases/performance/unused-federation-stats/use.js
@@ -1,0 +1,3 @@
+import used from "used-lib";
+
+export default used;

--- a/test/configCases/performance/unused-federation-stats/webpack.config.js
+++ b/test/configCases/performance/unused-federation-stats/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { ConsumeSharedPlugin } = require("../../../../").sharing;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	performance: {
+		hints: "stats",
+		unusedConfig: true
+	},
+	plugins: [
+		new ConsumeSharedPlugin({
+			consumes: {
+				"used-lib": { requiredVersion: false },
+				"unused-lib": { requiredVersion: false }
+			}
+		})
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -4954,6 +4954,9 @@ declare class ConsumeSharedPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
+	static getDeclaredShared: (
+		compilation: Compilation
+	) => undefined | Map<string, string>;
 }
 
 /**
@@ -5078,6 +5081,9 @@ declare class ContainerReferencePlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
+	static getDeclaredRemotes: (
+		compilation: Compilation
+	) => undefined | Set<string>;
 }
 declare interface ContainerReferencePluginOptions {
 	/**
@@ -22437,7 +22443,7 @@ declare interface PerformanceOptions {
 	unusedAssets?: boolean;
 
 	/**
-	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, and 'module.rules' that never matched.
+	 * Report configuration that no build used: 'resolve.alias' entries nothing matched, 'DefinePlugin' keys nothing referenced, 'externals' nothing imported, 'module.rules' that never matched, and Module Federation 'shared' keys or 'remotes' nothing imported.
 	 * @since 5.111.0
 	 */
 	unusedConfig?: boolean;

--- a/types.d.ts
+++ b/types.d.ts
@@ -4956,7 +4956,7 @@ declare class ConsumeSharedPlugin {
 	apply(compiler: Compiler): void;
 	static getDeclaredShared: (
 		compilation: Compilation
-	) => undefined | Map<string, Set<string>>;
+	) => undefined | SharedDeclaration[];
 }
 
 /**
@@ -26638,6 +26638,23 @@ declare interface SharedConfig {
 	 * Version of the provided module. Will replace lower matching versions, but not higher.
 	 */
 	version?: string | false;
+}
+
+declare interface SharedDeclaration {
+	/**
+	 * the config key, as the config spells it
+	 */
+	name: string;
+
+	/**
+	 * the key the modules created for it carry
+	 */
+	shareKey: string;
+
+	/**
+	 * whether it shares everything under the key
+	 */
+	prefix: boolean;
 }
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -4954,9 +4954,6 @@ declare class ConsumeSharedPlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-	static getDeclaredShared: (
-		compilation: Compilation
-	) => undefined | SharedDeclaration[];
 }
 
 /**
@@ -5081,9 +5078,6 @@ declare class ContainerReferencePlugin {
 	 * Applies the plugin by registering its hooks on the compiler.
 	 */
 	apply(compiler: Compiler): void;
-	static getDeclaredRemotes: (
-		compilation: Compilation
-	) => undefined | Set<string>;
 }
 declare interface ContainerReferencePluginOptions {
 	/**
@@ -26638,23 +26632,6 @@ declare interface SharedConfig {
 	 * Version of the provided module. Will replace lower matching versions, but not higher.
 	 */
 	version?: string | false;
-}
-
-declare interface SharedDeclaration {
-	/**
-	 * the config key, as the config spells it
-	 */
-	name: string;
-
-	/**
-	 * the key the modules created for it carry
-	 */
-	shareKey: string;
-
-	/**
-	 * whether it shares everything under the key
-	 */
-	prefix: boolean;
 }
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -4956,7 +4956,7 @@ declare class ConsumeSharedPlugin {
 	apply(compiler: Compiler): void;
 	static getDeclaredShared: (
 		compilation: Compilation
-	) => undefined | Map<string, string>;
+	) => undefined | Map<string, Set<string>>;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Extends `performance.unusedConfig` — which already names the aliases, defines, externals and rules nothing used — to Module Federation. The `shared` half catches a silent failure: an exact key matches only the exact request, so `shared: { lodash: { singleton: true } }` next to `import "lodash/debounce"` shares nothing at all, bundles the module in, and still reports `compiled successfully`; for a package holding state that is a runtime bug, not bytes. Changing the key to `"lodash/"` turns the same build into `provide shared module` + `consume shared module (singleton)`. The `remotes` half is weaker and the warning says so: a misspelled name already errors as `Module not found`, so it mostly names dead configuration, next to that error when there is one. Refs #17122.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — nine cases under `test/configCases/performance/unused-federation-*` (shared, clean, share-key alias, prefix, remotes, ordered, no-hints, error, stats), green under both `ConfigTestCases` and `ConfigCacheTestCases`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — no new option; `performance.unusedConfig` gains checks, and its schema description is updated to match.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The `performance.unusedConfig` entry on webpack.js.org should mention the two federation checks.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to implement the plugin and its tests, and to check the claims behind them against real builds. Two findings came out of that and are reflected in the diff: matching a remote name by cutting at the last `/` is wrong for names holding slashes (`remotes: { "scope/def": … }` with `import "scope/def/hello/other/world"` is falsely reported — now covered by `unused-federation-remotes`), and the original wording of the remotes warning claimed a typo would resolve elsewhere when in practice it already fails as `Module not found`. All output quoted above is from builds run locally, not recalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxbjLoCKW57MoXMHEzmruX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added diagnostics for unused Module Federation shared modules and remotes.
  - Reports unused entries as warnings, errors, or compilation hints according to performance settings.
  - Identifies affected entries, distinguishes shared modules from remotes, and links to relevant documentation.
  - Supports shared-module prefixes, duplicate configurations, remote matching, and consistent alphabetical reporting.
  - Added an option to report ESM references that prevent literal `import()` or `new URL()` output.

- **Documentation**
  - Updated performance configuration descriptions to cover unused Federation entries and analyzable bailouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->