### PR TITLE
fix: report the missing module when a code generation dependency resolved to nothing

### DIFF
--- a/.changeset/017-codegen-dependency-without-module.md
+++ b/.changeset/017-codegen-dependency-without-module.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Report a missing asset instead of a code generation deadlock.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4223,15 +4223,17 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 					const { codeGenerationDependencies } = module;
 					if (
 						codeGenerationDependencies !== undefined &&
-						(notCodeGeneratedModules === undefined ||
-							codeGenerationDependencies.some((dep) => {
-								const referencedModule = /** @type {Module} */ (
-									moduleGraph.getModule(dep)
-								);
-								return /** @type {NotCodeGeneratedModules} */ (
-									notCodeGeneratedModules
-								).has(referencedModule);
-							}))
+						codeGenerationDependencies.some((dep) => {
+							const referencedModule = moduleGraph.getModule(dep);
+							// Nothing resolved it, so it is never code-generated and
+							// waiting on it would stall instead of ordering anything.
+							if (!referencedModule) return false;
+							return (
+								notCodeGeneratedModules === undefined ||
+								/** @type {NotCodeGeneratedModules} */
+								(notCodeGeneratedModules).has(referencedModule)
+							);
+						})
 					) {
 						delayedJobs.push(job);
 						delayedModules.add(module);

--- a/test/configCases/css/missing-url/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/missing-url/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css missing-url exported tests should report a module-not-found error rather than stall code generation 1`] = `
+"/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.a {
+	background: url(data:,);
+}
+
+"
+`;

--- a/test/configCases/css/missing-url/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/missing-url/__snapshots__/ConfigTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css missing-url exported tests should report a module-not-found error rather than stall code generation 1`] = `
+"/*!***********************!*\\\\
+  !*** css ./style.css ***!
+  \\\\***********************/
+.a {
+	background: url(data:,);
+}
+
+"
+`;

--- a/test/configCases/css/missing-url/errors.js
+++ b/test/configCases/css/missing-url/errors.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [[/Can't resolve '\.\/missing\.png'/]];

--- a/test/configCases/css/missing-url/index.js
+++ b/test/configCases/css/missing-url/index.js
@@ -1,0 +1,8 @@
+import fs from "fs";
+import path from "path";
+import "./style.css";
+
+it("should report a module-not-found error rather than stall code generation", () => {
+	const name = fs.readdirSync(__dirname).find((f) => f.endsWith(".css"));
+	expect(fs.readFileSync(path.join(__dirname, name), "utf-8")).toMatchSnapshot();
+});

--- a/test/configCases/css/missing-url/style.css
+++ b/test/configCases/css/missing-url/style.css
@@ -1,0 +1,3 @@
+.a {
+	background: url("./missing.png");
+}

--- a/test/configCases/css/missing-url/webpack.config.js
+++ b/test/configCases/css/missing-url/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	experiments: {
+		css: true
+	},
+	optimization: {
+		// Production drops the bundle on a build error, so the stylesheet this
+		// case reads back would never be emitted.
+		emitOnErrors: true
+	},
+	externalsPresets: {
+		node: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/test/configCases/html/missing-asset/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/missing-asset/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html missing-asset exported tests should report a module-not-found error and render a data: placeholder 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>missing-asset</title></head>
+<body>
+<img src=\\"data:,\\">
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/missing-asset/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/missing-asset/__snapshots__/ConfigTest.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html missing-asset exported tests should report a module-not-found error and render a data: placeholder 1`] = `
+"<!DOCTYPE html>
+<html>
+<head><title>missing-asset</title></head>
+<body>
+<img src=\\"data:,\\">
+</body>
+</html>
+"
+`;

--- a/test/configCases/html/missing-asset/__snapshots__/errors.snap
+++ b/test/configCases/html/missing-asset/__snapshots__/errors.snap
@@ -2,6 +2,6 @@
 
 exports[`errors 1`] = `
 Array [
-  "Unable to make progress during code generation because of circular code generation dependency: <TEST_DIR>/index.js|87ba4eced20c49919a4cbaa62767b44c",
+  "Module not found: Error: Can't resolve './missing.png' in '<TEST_DIR>'",
 ]
 `;

--- a/test/configCases/html/missing-asset/index.js
+++ b/test/configCases/html/missing-asset/index.js
@@ -1,5 +1,5 @@
 import page from "./page.html";
 
-it("should report an error when a referenced asset is missing", () => {
-	expect(page).toBeDefined();
+it("should report a module-not-found error and render a data: placeholder", () => {
+	expect(page).toMatchSnapshot();
 });

--- a/test/configCases/html/missing-asset/webpack.config.js
+++ b/test/configCases/html/missing-asset/webpack.config.js
@@ -1,12 +1,15 @@
 "use strict";
 
-// TODO production should report the same clean "Module not found" error as
-// the missing-asset-development sibling case instead of this codegen crash
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "production",
 	target: "web",
 	experiments: {
 		html: true
+	},
+	optimization: {
+		// Production drops the bundle on a build error, so the placeholder this
+		// case is about would never be rendered for the assertion to read.
+		emitOnErrors: true
 	}
 };

--- a/test/helpers/test262StrictModeLoader.js
+++ b/test/helpers/test262StrictModeLoader.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/**
+ * Puts test262's "strict" scenario directive where webpack's parser reads it.
+ * It stays on line 1 so every diagnostic still points at the source's own line.
+ * @param {string} source the test file's source
+ * @returns {string} the same source, parsed as strict mode code
+ */
+module.exports = (source) => `"use strict";${source}`;

--- a/test/helpers/test262StrictModeLoader.js
+++ b/test/helpers/test262StrictModeLoader.js
@@ -1,9 +1,9 @@
 "use strict";
 
 /**
- * Puts test262's "strict" scenario directive where webpack's parser reads it.
- * It stays on line 1 so every diagnostic still points at the source's own line.
+ * Applies test262's strict-mode transformation, which INTERPRETING.md defines as
+ * inserting the directive plus a newline as the file's initial character sequence.
  * @param {string} source the test file's source
  * @returns {string} the same source, parsed as strict mode code
  */
-module.exports = (source) => `"use strict";${source}`;
+module.exports = (source) => `"use strict";\n${source}`;

--- a/test/hotCases/css/css-entry-mini-extract/index.js
+++ b/test/hotCases/css/css-entry-mini-extract/index.js
@@ -1,28 +1,23 @@
-const getFile = name =>
-	__non_webpack_require__("fs").readFileSync(
-		__non_webpack_require__("path").join(__dirname, name),
-		"utf-8"
-	);
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
 
-it("should work", done => {
-	try {
-		const style = getFile("css-entry.css");
-		expect(style).toContain("color: red;");
-	} catch (e) {}
+// splitChunks renames the extracted stylesheet after its cache group, so the
+// name is discovered rather than spelled out.
+const readStyles = () => {
+	const name = fs.readdirSync(__dirname).find(f => f.endsWith(".css"));
+	return fs.readFileSync(path.join(__dirname, name), "utf-8");
+};
+
+it("should apply a hot update to the extracted stylesheet", done => {
+	expect(readStyles()).toContain("color: red;");
 
 	NEXT(
 		require("../../update")(done, true, () => {
-			try {
-				const style = getFile("css-entry.css");
-				expect(style).toContain("color: blue;");
-			} catch (e) {}
+			expect(readStyles()).toContain("color: blue;");
 
 			NEXT(
 				require("../../update")(done, true, () => {
-					try {
-						const style = getFile("css-entry.css");
-						expect(style).toContain("color: green;");
-					} catch (e) {}
+					expect(readStyles()).toContain("color: green;");
 
 					done();
 				})
@@ -30,4 +25,3 @@ it("should work", done => {
 		})
 	);
 });
-

--- a/test/hotCases/css/css-entry-mini-extract/test.filter.js
+++ b/test/hotCases/css/css-entry-mini-extract/test.filter.js
@@ -2,6 +2,7 @@
 
 module.exports = (config) => {
 	const [major] = process.versions.node.split(".").map(Number);
-	// TODO: oom
+	// The case pins target "web" itself, and the other runners export no tests
+	// from the bundle it builds.
 	return config.target === "web" && major >= 18;
 };

--- a/test/hotCases/css/mini-css-extract/a.js
+++ b/test/hotCases/css/mini-css-extract/a.js
@@ -1,26 +1,21 @@
 import "./a.css";
 
-const getFile = name =>
+const readStyles = () =>
 	__non_webpack_require__("fs").readFileSync(
-		__non_webpack_require__("path").join(__dirname, name),
+		__non_webpack_require__("path").join(__dirname, "main.css"),
 		"utf-8"
 	);
 
-it("should work", async function (done) {
-	try {
-		const style = getFile("styles.css");
-		expect(style).toContain("color: red;");
-	} catch (e) {}
+it("should apply a hot update to the extracted stylesheet", function (done) {
+	expect(readStyles()).toContain("color: red;");
 
-	NEXT(require("../../update")(done, true, () => {
-		try {
-			const style = getFile("styles.css");
-			expect(style).toContain("color: blue;");
-		} catch (e) {}
+	NEXT(
+		require("../../update")(done, true, () => {
+			expect(readStyles()).toContain("color: blue;");
 
-		done();
-	}));
+			done();
+		})
+	);
 });
 
 module.hot.accept();
-

--- a/test/hotCases/css/mini-css-extract/test.filter.js
+++ b/test/hotCases/css/mini-css-extract/test.filter.js
@@ -2,6 +2,7 @@
 
 module.exports = (config) => {
 	const [major] = process.versions.node.split(".").map(Number);
-	// TODO: oom
+	// The case pins target "web" itself, so every other runner would build and
+	// run the same bundle again.
 	return config.target === "web" && major >= 18;
 };

--- a/test/hotCases/disposing/runtime-independent-filename/index.js
+++ b/test/hotCases/disposing/runtime-independent-filename/index.js
@@ -1,11 +1,13 @@
 import module from "./module";
 
-it("should not dispose shared modules when a chunk from a different runtime is removed", done => {
+it("should apply both runtimes' updates where one manifest filename serves both", done => {
 	import("./chunk1").then(chunk1 => {
 		import.meta.webpackHot.accept("./module", async () => {
 			expect(module).toBe(42);
 			expect(chunk1).toMatchObject({
-				active: false // This get incorrectly disposed, due to the runtime-independent filename
+				// Dropping [runtime] from the filename is what warnings1.js warns
+				// about: both manifests merge, so the worker's removals land here too.
+				active: false
 			});
 			done();
 		});

--- a/test/html5lib.spectest.js
+++ b/test/html5lib.spectest.js
@@ -15,9 +15,8 @@
 //    the expected one, for every tokenizer case in an initial state the public
 //    API can express (the rest are registered as skipped, with the reason).
 //
-// Both conformance suites carry a KNOWN_DIVERGENCES set (currently empty)
-// pinning intentional exceptions: a listed case is asserted to *still*
-// diverge, so accidentally fixing one flags the list as stale.
+// Both suites pin intentional exceptions in a KNOWN_DIVERGENCES set: a listed
+// case is asserted to *still* diverge, so fixing one flags the list as stale.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -23,6 +23,10 @@ const outputFileSystem = needDebug
 
 const test262Dir = path.resolve(__dirname, "./test262-cases/");
 const test262HarnessDir = path.resolve(test262Dir, "./harness");
+const strictModeLoader = path.resolve(
+	__dirname,
+	"./helpers/test262StrictModeLoader.js"
+);
 
 /* cspell:disable */
 const knownV8EvalBugs = [
@@ -644,7 +648,17 @@ const compile = async (entry, scenario, options = {}) =>
 										requireJs: false,
 										system: false
 									}
-								}
+								},
+								// The "strict" directive has to reach the parser, not only the
+								// bundle: a sloppy parse accepts what only strict mode rejects.
+								...(scenario === "strict"
+									? [
+											{
+												test: (resource) => resource === entry,
+												use: strictModeLoader
+											}
+										]
+									: [])
 							]
 			},
 			externals: [
@@ -889,9 +903,6 @@ const knownBugs = [
 	// `getOwnPropertyNames` sees webpack's `__esModule` next to `default`, so the
 	// namespace has two own keys where the spec has one.
 	"import/import-attributes/json-via-namespace.js",
-	// The "strict" scenario prepends the directive to the bundled output, not to
-	// the source, so webpack parses `yield` as a plain identifier.
-	"expressions/dynamic-import/import-attributes/2nd-param-yield-ident-invalid.js",
 	// The bundle puts `await using` inside the module wrapper's body, where it
 	// is legal, so an engine supporting the syntax raises no parse error.
 	"statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

One codegen fix, plus three test-suite corrections found while auditing the conformance suites.

- A dependency registered with `addCodeGenerationDependency` that resolved to no module can never be code-generated, so the scheduler waited on it forever. Where every remaining job waited that way it reported a circular code generation dependency instead, hiding the real error behind an internal one. An html page referencing a missing asset, and a stylesheet with a missing `url()`, both hit this in production once concatenation left a single job; both now report what is actually missing and render the same `data:,` placeholder development already rendered.
- test262's "strict" scenario prepended the directive to the assembled bundle rather than to the source webpack parses, so every strict-scenario file was read as sloppy code and a construct only strict mode rejects was accepted. A loader now applies the transformation `INTERPRETING.md` defines. That un-skips `import-attributes/2nd-param-yield-ident-invalid.js`.
- Both extracted-stylesheet HMR cases read a stylesheet under a name nothing emits, with every expectation inside an empty `catch`, so the read threw and the case passed having asserted nothing. They now read the emitted file and let the assertion through, which pins the red → blue → green sequence a hot update applies. Their filters claimed the other runners run out of memory; they do not, and the note now says why the gate is there.
- `hotCases/disposing/runtime-independent-filename` read as an unfixed defect. Dropping `[runtime]` from `output.hotUpdateMainFilename` is what the plugin warns about there, so the name and comment now say that is what the case asserts.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/missing-url` is new and `test/configCases/html/missing-asset` now asserts the rendered placeholder instead of only that the page is defined; both were confirmed to fail on unmodified `lib/` with the deadlock error. The four HMR fixtures were mutation-checked: with a deliberately wrong colour each one fails, which is what they could not do before.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to investigate the failures, write the fixes and tests, and run the verification. Every claim was measured rather than assumed: the codegen scheduler was instrumented to confirm the delayed job's dependency resolved to `null`; each new or changed test was run against unmodified `lib/` to confirm it fails; the strict-scenario change was swept across every strict case in four shards and its failures matched the pre-existing set on this machine exactly. All output was reviewed by the author before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_016q5wyknx4aqgnfnZeytnhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builds with unresolved CSS or HTML assets now report clear module-not-found errors instead of stalling during code generation.
  - When configured to emit despite errors, builds can still produce output containing the appropriate placeholder for missing assets.

- **Tests**
  - Expanded coverage for missing CSS and HTML assets.
  - Improved validation of CSS hot updates, shared runtime disposal, and strict-mode conformance scenarios.
  - Test failures now surface directly instead of being silently suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->