### PR TITLE
refactor(html): minify inline CSS and JSON through renderEmbeddedSource alone

### DIFF
--- a/.changeset/008-builtin-embedded-renderer.md
+++ b/.changeset/008-builtin-embedded-renderer.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Minify inline CSS and JSON via `renderEmbeddedSource`, exporting webpack's own.

--- a/lib/html/builtinEmbeddedRenderer.js
+++ b/lib/html/builtinEmbeddedRenderer.js
@@ -24,11 +24,9 @@ let _cssSyntax;
 let _htmlSyntax;
 
 /**
- * Strip the whitespace between a JSON body's tokens. Every literal is copied
- * byte for byte — re-serializing would reorder nothing but would round numbers
- * through a double, drop a duplicate key and rewrite escapes, none of which is
- * this transform's to do. Escapes are also the security case: unescaping a
- * `<` lets a string close the `<script>` early.
+ * Strip the whitespace between a JSON body's tokens, every literal copied byte
+ * for byte. Re-serializing would round numbers, drop a duplicate key and rewrite
+ * the escapes that keep a string from closing the `<script>` early.
  * @param {string} json a `<script>` body
  * @returns {string} the stripped body, or the body as written where it is not JSON
  */

--- a/lib/html/builtinEmbeddedRenderer.js
+++ b/lib/html/builtinEmbeddedRenderer.js
@@ -1,0 +1,109 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+const { CSS_TYPE } = require("../ModuleSourceTypeConstants");
+
+/** @import { CssProcessOptions } from "../css/syntax" */
+/** @import { EmbeddedSourceRenderer } from "./syntax" */
+
+/**
+ * What this minifies inline CSS with: the CSS minifier's own options, so an
+ * inline declaration is held to the rules a `.css` asset is.
+ * @typedef {Pick<CssProcessOptions, "environment" | "convertLengthUnits" | "rewriteCustomProperties" | "transforms" | "unusedSymbols" | "pseudoClasses">} BuiltinEmbeddedRendererOptions
+ */
+
+// Both are loaded on first render rather than at module load: a document that
+// embeds no CSS and no JSON pays for neither.
+/** @type {typeof import("../css/syntax") | undefined} */
+let _cssSyntax;
+/** @type {typeof import("./syntax") | undefined} */
+let _htmlSyntax;
+
+/**
+ * Strip the whitespace between a JSON body's tokens. Every literal is copied
+ * byte for byte — re-serializing would reorder nothing but would round numbers
+ * through a double, drop a duplicate key and rewrite escapes, none of which is
+ * this transform's to do. Escapes are also the security case: unescaping a
+ * `<` lets a string close the `<script>` early.
+ * @param {string} json a `<script>` body
+ * @returns {string} the stripped body, or the body as written where it is not JSON
+ */
+const stripJsonWhitespace = (json) => {
+	try {
+		JSON.parse(json);
+	} catch (_err) {
+		// Not JSON after all (a template, a placeholder) — not ours to touch.
+		return json;
+	}
+	let out = "";
+	let inString = false;
+	let escaped = false;
+	for (let i = 0; i < json.length; i++) {
+		const c = json.charCodeAt(i);
+		if (inString) {
+			out += json[i];
+			if (escaped) escaped = false;
+			else if (c === 0x5c) escaped = true;
+			else if (c === 0x22) inString = false;
+			continue;
+		}
+		if (c === 0x22) {
+			inString = true;
+			out += json[i];
+			continue;
+		}
+		// JSON whitespace (RFC 8259): tab, LF, CR, space.
+		if (c === 0x09 || c === 0x0a || c === 0x0d || c === 0x20) continue;
+		out += json[i];
+	}
+	return out;
+};
+
+/**
+ * The renderer webpack ships for what a document embeds: its own CSS minifier
+ * for a `<style>` or `style=""` and `stripJsonWhitespace` for JSON, declining
+ * every other language. A caller passes it where it has no renderer of its own,
+ * or behind one for the languages that one declines — the HTML printer minifies
+ * none of this itself.
+ * @param {BuiltinEmbeddedRendererOptions=} options the CSS minifier's options, so an inline declaration is minified as the `.css` assets are
+ * @returns {EmbeddedSourceRenderer} the renderer
+ */
+const builtinEmbeddedRenderer = (options = {}) => {
+	const { BLOCK_CONTENTS, JSON_TYPE } =
+		_htmlSyntax || (_htmlSyntax = require("./syntax"));
+	const sheet = { mode: /** @type {"minify"} */ ("minify"), ...options };
+	const block = { ...sheet, as: BLOCK_CONTENTS };
+	// A `style=""` repeats across a document far more often than it varies.
+	/** @type {Map<string, string>} */
+	const blocks = new Map();
+	return (source, info) => {
+		if (info.type === JSON_TYPE) return stripJsonWhitespace(source);
+		if (info.type !== CSS_TYPE) return undefined;
+		const isBlock = info.as === BLOCK_CONTENTS;
+		if (isBlock) {
+			const memoized = blocks.get(source);
+			if (memoized !== undefined) return memoized;
+		}
+		const { SourceProcessor } =
+			_cssSyntax || (_cssSyntax = require("../css/syntax"));
+		let code;
+		try {
+			code = new SourceProcessor().process(
+				source,
+				isBlock ? block : sheet
+			).code;
+		} catch (_err) {
+			// Text the minifier cannot read is left as written, by declining.
+			return undefined;
+		}
+		if (isBlock) blocks.set(source, code);
+		return code;
+	};
+};
+
+module.exports.builtinEmbeddedRenderer = builtinEmbeddedRenderer;
+module.exports.stripJsonWhitespace = stripJsonWhitespace;

--- a/lib/html/htmlMinify.js
+++ b/lib/html/htmlMinify.js
@@ -6,6 +6,7 @@
 "use strict";
 
 /** @import { DeferredEmbeddedSource, HtmlPrintOptions } from "../html/syntax" */
+/** @import { CssEnvironment } from "../css/syntax" */
 
 /**
  * What a renderer made of one embedded body: the minified text, and anything it
@@ -34,7 +35,7 @@
  * re-resolves in the worker — via the installed package, or the dev self-link.
  * @param {{ [file: string]: string | Buffer }} input a single `{ filename: code }` entry; a `Buffer` is read as UTF-8
  * @param {(RawSourceMap | undefined)=} sourceMap input source map (unused: safe serialize keeps positions token-coarse, so no map is produced yet)
- * @param {Omit<HtmlPrintOptions, "renderEmbeddedSource" | "deferEmbeddedSource"> & { css?: { convertLengthUnits?: boolean, rewriteCustomProperties?: boolean, unusedSymbols?: string[], pseudoClasses?: { [name: string]: string } }, minifyConditionalComments?: boolean, renderEmbeddedSource?: AsyncEmbeddedSourceRenderer }=} minimizerOptions minimizer options — `environment` and `css` (`optimization.minimize.css`, whole) reach the CSS minifier this runs over inline CSS; the rest is `optimization.minimize.html`. The two stand apart rather than merged: both languages name a `quotes` and a `comments`, and one flat object would hand each the other's answer. `renderEmbeddedSource` minifies source this document embeds and may be asynchronous — one parse serves both it and the output. What it declines this minifies itself, for the languages webpack ships a minifier for
+ * @param {Omit<HtmlPrintOptions, "renderEmbeddedSource" | "deferEmbeddedSource"> & { environment?: CssEnvironment, css?: { convertLengthUnits?: boolean, rewriteCustomProperties?: boolean, unusedSymbols?: string[], pseudoClasses?: { [name: string]: string } }, minifyConditionalComments?: boolean, renderEmbeddedSource?: AsyncEmbeddedSourceRenderer }=} minimizerOptions minimizer options — `environment` and `css` (`optimization.minimize.css`, whole) reach the CSS minifier this runs over inline CSS; the rest is `optimization.minimize.html`. The two stand apart rather than merged: both languages name a `quotes` and a `comments`, and one flat object would hand each the other's answer. `renderEmbeddedSource` minifies source this document embeds and may be asynchronous — one parse serves both it and the output. What it declines this minifies itself, for the languages webpack ships a minifier for
  * @returns {Promise<{ code: string, warnings?: (Error | string)[], errors?: (Error | string)[] }>} the minified HTML, and what a renderer reported over what it embeds
  */
 const htmlMinify = async (input, sourceMap, minimizerOptions = {}) => {
@@ -47,6 +48,7 @@ const htmlMinify = async (input, sourceMap, minimizerOptions = {}) => {
 	// value the spec does not name.
 	const {
 		askEmbeddedRenderer,
+		builtinEmbeddedRenderer,
 		collectEmbeddedDiagnostics,
 		embeddedText,
 		SourceProcessor,
@@ -78,17 +80,20 @@ const htmlMinify = async (input, sourceMap, minimizerOptions = {}) => {
 	// the top rather than lost at the level that heard it.
 	/** @type {EmbeddedSourceResult[]} */
 	const reported = [];
+	// Webpack's own renderer, handed the CSS minifier's options so an inline
+	// declaration agrees with the `.css` asset; each language picks its switches.
+	const builtin = builtinEmbeddedRenderer({
+		environment,
+		convertLengthUnits: css.convertLengthUnits,
+		rewriteCustomProperties: css.rewriteCustomProperties,
+		unusedSymbols: css.unusedSymbols,
+		pseudoClasses: css.pseudoClasses,
+		transforms: webpack.css.syntax.pickTransforms(css)
+	});
 	// One set of options, handed to the document pass and to each conditional
 	// comment's body below.
 	const printOptions = {
 		mode: /** @type {"minify"} */ ("minify"),
-		environment,
-		convertLengthUnits: css.convertLengthUnits,
-		rewriteCustomProperties: css.rewriteCustomProperties,
-		cssUnusedSymbols: css.unusedSymbols,
-		cssPseudoClasses: css.pseudoClasses,
-		// Each language picks its own switches out of its own options object.
-		cssTransforms: webpack.css.syntax.pickTransforms(css),
 		transforms: pickTransforms(minimizerOptions),
 		collapseWhitespace,
 		mergeStyles,
@@ -117,8 +122,10 @@ const htmlMinify = async (input, sourceMap, minimizerOptions = {}) => {
 			if (typeof answered === "string") return answered;
 		}
 
-		// A nested document is a document, so it is minified the same way. The
-		// built-in CSS and JSON minifiers already reach every other body.
+		// Webpack's own answers for what the caller's left: CSS and JSON, and a
+		// nested document, which is a document minified the same way.
+		const own = builtin(source, hole);
+		if (own !== undefined) return own;
 		return hole.type === "html" ? minifyDocument(source) : undefined;
 	};
 	/**
@@ -217,9 +224,7 @@ htmlMinify.getTypes = () => ["html"];
  * The languages this can offer a caller through `renderEmbeddedSource` — an
  * inline `<style>`, a `<script>`, every event handler attribute (as the
  * function body it is), an `<svg>` subtree and the document an
- * `<iframe srcdoc>` holds. A `style=""` is not among them: how the attribute is
- * written is decided by reading the minified text back, so it stays with the
- * built-in CSS minifier, which is webpack's own `cssMinify`.
+ * `<iframe srcdoc>` holds, and every `style=""` as the block's contents it is.
  * @returns {string[]} the languages
  */
 htmlMinify.getEmbeddedTypes = () => {

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -9563,28 +9563,66 @@ const _writeQuotedAttribute = (name, value, source) => {
 let _deferSrcdoc = true;
 
 /**
- * Hand one nested body to the caller's renderer, which must be present.
- * Anything it throws is a renderer that did not answer: a document must not
- * fail to serialize because something inside it did not parse.
+ * The renderer webpack ships: its own CSS and JSON minifiers, standing where a
+ * caller passed no renderer and behind one that declines a body.
+ * @type {EmbeddedSourceRenderer}
+ */
+const _builtinRenderer = (source, info) => {
+	if (info.type === CSS_TYPE) {
+		const minified = _builtinStyleBody(
+			source,
+			info.as === BLOCK_CONTENTS ? BLOCK_CONTENTS : undefined
+		);
+		return minified === null ? undefined : minified;
+	}
+	if (info.type === JSON_TYPE) return _builtinInlineJson(source);
+	return undefined;
+};
+
+/**
+ * What webpack's own renderer makes of one nested body, for a site that must
+ * read text back before the caller's answer can arrive.
  * @param {string} source the nested body
  * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
  * @param {string=} as which production of that language it is, for one with more than one
- * @returns {string | null} the rendered body, or null when it declined
+ * @returns {string | null} the rendered body, or null when webpack ships no minifier for it
+ */
+const _renderBuiltinOrNull = (source, type, as) => {
+	const rendered = _builtinRenderer(source, {
+		type,
+		hostType: HTML_TYPE,
+		...(as === undefined ? undefined : { as })
+	});
+	return rendered === undefined ? null : rendered;
+};
+
+/**
+ * Hand one nested body to the caller's renderer, then to webpack's own where
+ * there is none or it declined. Anything the caller's throws is a renderer that
+ * did not answer: a document must not fail to serialize because something inside
+ * it did not parse.
+ * @param {string} source the nested body
+ * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
+ * @param {string=} as which production of that language it is, for one with more than one
+ * @returns {string | null} the rendered body, or null when both declined
  */
 const _renderEmbeddedOrNull = (source, type, as) => {
-	try {
-		const rendered = /** @type {EmbeddedSourceRenderer} */ (
-			_renderEmbeddedSource
-		)(source, {
-			type,
-			hostType: HTML_TYPE,
-			...(as === undefined ? undefined : { as })
-		});
-		// Anything but text is a renderer that did not answer, not a body to write.
-		return typeof rendered === "string" ? rendered : null;
-	} catch (_err) {
-		return null;
+	const info = {
+		type,
+		hostType: HTML_TYPE,
+		...(as === undefined ? undefined : { as })
+	};
+	if (_renderEmbeddedSource !== undefined) {
+		try {
+			const rendered = _renderEmbeddedSource(source, info);
+			// Anything but text is a renderer that did not answer, not a body to write.
+			if (typeof rendered === "string") return rendered;
+		} catch (_err) {
+			// Declined.
+		}
 	}
+	const rendered = _builtinRenderer(source, info);
+	return rendered === undefined ? null : rendered;
 };
 
 /**
@@ -9613,8 +9651,8 @@ const _deferEmbedded = (source, type, build, as) => {
 };
 
 /**
- * `_renderEmbeddedOrNull` for a body webpack has no minifier of its own for, so
- * a renderer that declines leaves it exactly as written.
+ * `_renderEmbeddedOrNull` with the body left exactly as written where every
+ * renderer declines it, deferred to the caller's where one collects.
  * @param {string} source the nested body
  * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
  * @param {string=} as which production of that language it is, for one with more than one
@@ -9625,7 +9663,11 @@ const _renderEmbedded = (source, type, as) => {
 		return _deferEmbedded(
 			source,
 			type,
-			(rendered) => (typeof rendered === "string" ? rendered : source),
+			(rendered) => {
+				if (typeof rendered === "string") return rendered;
+				const builtin = _renderBuiltinOrNull(source, type, as);
+				return builtin === null ? source : builtin;
+			},
 			as
 		);
 	}
@@ -9846,29 +9888,17 @@ const _canOmitStartTag = (path, name, node, open) => {
  */
 const _minifyStyleBody = (css, decided) => {
 	if (css.trim() === "") return css;
-	try {
-		if (_deferEmbeddedSource !== undefined) {
-			// The built-in still runs: what this print does next is decided by
-			// reading the minified text back (whether a run merges), and a marker
-			// cannot be read. Only the text that reaches the output is the caller's,
-			// and `decided` carries the readable text to whoever needs it.
-			const builtin = _builtinStyleBody(css);
-			if (builtin === null) return null;
-			if (decided !== undefined) decided.text = builtin;
-			return _deferEmbedded(css, CSS_TYPE, (rendered) =>
-				typeof rendered === "string" ? rendered : builtin
-			);
-		}
-		if (_renderEmbeddedSource !== undefined) {
-			// Declining falls back to the built-in, so a renderer that covers some
-			// languages does not turn the ones it does not cover off.
-			const rendered = _renderEmbeddedOrNull(css, CSS_TYPE);
-			if (rendered !== null) return rendered;
-		}
-		return _builtinStyleBody(css);
-	} catch (_err) {
-		return null;
+	if (_deferEmbeddedSource !== undefined) {
+		// The built-in still runs: what this print does next reads the minified
+		// text back, which a marker cannot be, and `decided` carries that text.
+		const builtin = _renderBuiltinOrNull(css, CSS_TYPE);
+		if (builtin === null) return null;
+		if (decided !== undefined) decided.text = builtin;
+		return _deferEmbedded(css, CSS_TYPE, (rendered) =>
+			typeof rendered === "string" ? rendered : builtin
+		);
 	}
+	return _renderEmbeddedOrNull(css, CSS_TYPE);
 };
 
 /**
@@ -9994,18 +10024,12 @@ const _minifyStyleAttributeUncached = (raw) => {
 	// declaration list needs for the transforms a block's contents get is the CSS
 	// layer's own business. The deferring path offers it at the attribute
 	// instead, where the shape an answer has to land in is known.
-	if (
-		_renderEmbeddedSource !== undefined &&
+	const rendered =
 		_deferEmbeddedSource === undefined
-	) {
-		const rendered = _renderEmbeddedOrNull(raw, CSS_TYPE, BLOCK_CONTENTS);
+			? _renderEmbeddedOrNull(raw, CSS_TYPE, BLOCK_CONTENTS)
+			: _renderBuiltinOrNull(raw, CSS_TYPE, BLOCK_CONTENTS);
 
-		if (rendered !== null) return rendered;
-	}
-
-	const out = _builtinStyleBody(raw, BLOCK_CONTENTS);
-
-	return out === null ? raw : out;
+	return rendered === null ? raw : rendered;
 };
 
 /**
@@ -10525,19 +10549,8 @@ const _JSON_SUBTYPE_REGEXP =
  * @param {string} json a `<script>` body
  * @returns {string} the stripped body
  */
-const _minifyInlineJson = (json) => {
-	if (json.trim() === "") return json;
-	if (_deferEmbeddedSource !== undefined) {
-		return _deferEmbedded(json, JSON_TYPE, (rendered) =>
-			typeof rendered === "string" ? rendered : _builtinInlineJson(json)
-		);
-	}
-	if (_renderEmbeddedSource !== undefined) {
-		const rendered = _renderEmbeddedOrNull(json, JSON_TYPE);
-		if (rendered !== null) return rendered;
-	}
-	return _builtinInlineJson(json);
-};
+const _minifyInlineJson = (json) =>
+	json.trim() === "" ? json : _renderEmbedded(json, JSON_TYPE);
 
 /**
  * The JSON strip webpack ships, for a body no caller's renderer answered for.
@@ -12429,14 +12442,9 @@ const printer = (path, writer) => {
 						if (_absorbed !== null && _absorbed.has(parent)) return "";
 						body = _mergedScriptRun(path, parent, data);
 					}
-					// No built-in: webpack ships no JS minifier, so an inline script is
-					// touched only by a caller's renderer.
-					if (
-						(_renderEmbeddedSource !== undefined ||
-							_deferEmbeddedSource !== undefined) &&
-						JAVASCRIPT_SCRIPT_TYPES.has(type) &&
-						body.trim() !== ""
-					) {
+					// Webpack ships no JS minifier, so an inline script is touched only
+					// by a caller's renderer; the built-in declines it.
+					if (JAVASCRIPT_SCRIPT_TYPES.has(type) && body.trim() !== "") {
 						return _renderEmbedded(
 							body,
 							JAVASCRIPT_TYPE,

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -14,7 +14,7 @@ const GenericSourceProcessor = require("../util/SourceProcessor");
 
 const { deferredWrite, declineDeferredWrites } = GenericSourceProcessor;
 
-/** @import { CssEnvironment, CssProcessOptions, CssTransformOptions } from "../css/syntax" */
+/** @import { CssProcessOptions } from "../css/syntax" */
 /** @import { OutputHtmlOptions } from "../../declarations/WebpackOptions" */
 
 /**
@@ -300,6 +300,12 @@ const CC_GREATER_THAN = 0x3e;
 const CC_QUESTION_MARK = 0x3f;
 const CC_LEFT_SQUARE_BRACKET = 0x5b;
 const CC_RIGHT_SQUARE_BRACKET = 0x5d;
+const CC_LEFT_PARENTHESIS = 0x28;
+const CC_RIGHT_PARENTHESIS = 0x29;
+const CC_ASTERISK = 0x2a;
+const CC_REVERSE_SOLIDUS = 0x5c;
+const CC_LEFT_CURLY_BRACKET = 0x7b;
+const CC_RIGHT_CURLY_BRACKET = 0x7d;
 const CC_LOW_LINE = 0x5f;
 const CC_GRAVE_ACCENT = 0x60;
 const CC_NO_BREAK_SPACE = 0xa0;
@@ -8939,12 +8945,6 @@ const mirrorSelectedContent = (node, select) => {
  * @property {string=} fragmentContext context element tag name for fragment parsing (see `parseHtml`); the HTML analog of the CSS parser's `as` parse-mode option
  * @property {HtmlAstSkip=} skip node kinds to omit from the AST for speed/memory (see `HtmlAstSkip`)
  * @property {boolean=} minimize print the safely-minified serialization (nodes rebuilt from source, inert comments dropped, opening-tag whitespace collapsed) as `process` walks, and return it (default false = walk only, return `""`)
- * @property {CssEnvironment=} environment CSS's, not HTML's: handed to the CSS minifier that runs over an inline `<style>` and every `style=""`, so the inline copy of a declaration agrees with the `.css` asset
- * @property {boolean=} convertLengthUnits CSS's too, handed over with `environment` (see `HtmlPrintOptions`)
- * @property {boolean=} rewriteCustomProperties CSS's too, handed over with `environment` (see `HtmlPrintOptions`)
- * @property {CssTransformOptions=} cssTransforms CSS's per-transform switches too, handed over with `environment` (see `HtmlPrintOptions`)
- * @property {string[]=} cssUnusedSymbols CSS's `unusedSymbols` too, handed over with `environment` (see `HtmlPrintOptions`)
- * @property {{ [name: string]: string }=} cssPseudoClasses CSS's `pseudoClasses` too, handed over with `environment` (see `HtmlPrintOptions`)
  * @property {HtmlTransformOptions=} transforms which of the meaning-preserving rewrites the minifying print makes; each is on unless it is `false`
  * @property {(boolean | "conservative" | "smart" | "all")=} collapseWhitespace collapse each run of whitespace in text to a single space, except where an ancestor renders it verbatim; `"smart"` also drops what sits against a block edge and `"all"` drops every edge (default false)
  * @property {boolean=} removeEmptyAttributes drop an attribute whose empty value leaves it in the state its absence gives (default false)
@@ -8956,17 +8956,22 @@ const mirrorSelectedContent = (node, select) => {
  * @property {(boolean | "smart" | "all")=} removeRedundantAttributes drop an attribute whose value is the element's own default; `true` is `"smart"`, and `"all"` also drops the spec defaults a selector can match (default false)
  * @property {(boolean | "smart" | "all")=} removeImpliedTags how much of the `<html>` / `<head>` / `<body>` shell §13.1.2.4 lets the parser imply may be left out: `"smart"` leaves out only the `<html>` start tag, `true` (or `"all"`) all six, `false` none (default `"smart"`)
  * @property {boolean=} deferSrcdoc whether an `<iframe srcdoc>` is among what `deferEmbeddedSource` collects (default true); false for a caller that minifies them itself, which keeps the attribute on the normal path and its shorter delimiter
- * @property {DeferredEmbeddedSource[]=} deferEmbeddedSource collects what `renderEmbeddedSource` would be offered instead of offering it, for a caller whose renderer is asynchronous: the print leaves a marker for each and `finish` puts the answers in their place, so one parse serves both. A `style=""` stays with the built-in CSS minifier, whose text this print reads back to decide how the attribute is written. Takes precedence over `renderEmbeddedSource`
- * @property {EmbeddedSourceRenderer=} renderEmbeddedSource renders each nested body this document embeds — an inline `<style>`, every `style=""` (handed over as a whole stylesheet, SVG's and MathML's included), a `<script>` holding JSON or JavaScript (with `as` naming which production of it the body is — `"module"` for a `<script type=module>`, `"script"` for a classic one), every event handler attribute, with `as: "event-handler"` saying it is a function body rather than a script — the production a `return` at its top level is in, which a renderer whose engine takes only whole scripts wraps before it reads — an `<svg>` subtree, and the document an `<iframe srcdoc>` holds (decoded, and written back escaped). Replaces the built-in CSS and JSON minifiers wherever it answers, and returning anything but text falls back to them; it is the only way inline JavaScript, SVG and a nested document are reached at all
+ * @property {DeferredEmbeddedSource[]=} deferEmbeddedSource collects what `renderEmbeddedSource` would be offered instead of offering it, for a caller whose renderer is asynchronous: the print leaves a marker for each and `finish` puts the answers in their place, so one parse serves both. Takes precedence over `renderEmbeddedSource`
+ * @property {EmbeddedSourceRenderer=} renderEmbeddedSource renders each nested body this document embeds — an inline `<style>`, every `style=""` (as the block's contents it is, SVG's and MathML's included), a `<script>` holding JSON or JavaScript (with `as` naming which production of it the body is — `"module"` for a `<script type=module>`, `"script"` for a classic one), every event handler attribute, with `as: "event-handler"` saying it is a function body rather than a script — the production a `return` at its top level is in, which a renderer whose engine takes only whole scripts wraps before it reads — an `<svg>` subtree, and the document an `<iframe srcdoc>` holds (decoded, and written back escaped). The only way any of them is minified: webpack minifies nothing here itself, and `builtinEmbeddedRenderer` is its own CSS and JSON minifiers for a caller to pass; returning anything but text leaves a body as written
  */
 
 /**
- * What the HTML printer may be told, on top of the `mode` every language has.
- * The first two are not HTML's own: an inline `<style>` and every `style=""` run
- * through the CSS minifier, so `optimization.minimize.css` rides along to reach
- * it (see `lib/config/defaults.js`) and the two must not disagree about what the
- * target can read. The rest is `optimization.minimize.html`.
- * @typedef {Pick<CssProcessOptions, "environment" | "convertLengthUnits" | "rewriteCustomProperties"> & { cssTransforms?: CssTransformOptions, cssUnusedSymbols?: string[], cssPseudoClasses?: { [name: string]: string }, transforms?: HtmlTransformOptions, collapseWhitespace?: boolean | "conservative" | "smart" | "all", mergeStyles?: boolean, mergeScripts?: boolean, removeEmptyAttributes?: boolean, removeEmptyElements?: boolean, removeRedundantAttributes?: boolean | "smart" | "all", sortAttributes?: boolean, sortTokenLists?: boolean, removeImpliedTags?: boolean | "smart" | "all", renderEmbeddedSource?: EmbeddedSourceRenderer, deferEmbeddedSource?: DeferredEmbeddedSource[], deferSrcdoc?: boolean }} HtmlPrintOptions
+ * What the HTML printer may be told, on top of the `mode` every language has:
+ * `optimization.minimize.html`, and the renderer every nested body goes through.
+ * `optimization.minimize.css` reaches inline CSS through `builtinEmbeddedRenderer`,
+ * which `htmlMinify` passes (see `lib/config/defaults.js`).
+ * @typedef {{ transforms?: HtmlTransformOptions, collapseWhitespace?: boolean | "conservative" | "smart" | "all", mergeStyles?: boolean, mergeScripts?: boolean, removeEmptyAttributes?: boolean, removeEmptyElements?: boolean, removeRedundantAttributes?: boolean | "smart" | "all", sortAttributes?: boolean, sortTokenLists?: boolean, removeImpliedTags?: boolean | "smart" | "all", renderEmbeddedSource?: EmbeddedSourceRenderer, deferEmbeddedSource?: DeferredEmbeddedSource[], deferSrcdoc?: boolean }} HtmlPrintOptions
+ */
+
+/**
+ * What `builtinEmbeddedRenderer` minifies inline CSS with: the CSS minifier's
+ * own options, so an inline declaration is held to the rules a `.css` asset is.
+ * @typedef {Pick<CssProcessOptions, "environment" | "convertLengthUnits" | "rewriteCustomProperties" | "transforms" | "unusedSymbols" | "pseudoClasses">} BuiltinEmbeddedRendererOptions
  */
 
 /** @typedef {import("../util/SourceProcessor").PrintContext<HtmlPath, HtmlNodeRef, HtmlPrintOptions>} PrintContext */
@@ -9397,28 +9402,6 @@ const _canOmitColgroupStart = (path, node) => {
 	return !_canOmitEndTag(path, "colgroup", previous);
 };
 
-// The CSS abilities of the target, forwarded into the nested CSS minifier so an
-// inline `<style>` or `style=""` is gated exactly like a `.css` asset. Set per
-// print, since the printer is the only place the options are in scope.
-/** @type {CssEnvironment | undefined} */
-let _cssEnvironment;
-
-// Whether the nested CSS minifier may rewrite a length's unit — forwarded like
-// `_cssEnvironment` so inline CSS agrees with the `.css` assets.
-let _cssConvertLengthUnits = false;
-
-// And whether it may shorten a custom property's value, forwarded the same way.
-let _cssRewriteCustomProperties = false;
-
-// And which of its rewrites it makes at all, forwarded the same way — inline CSS
-// is minified by the same switches a `.css` asset is.
-/** @type {CssTransformOptions | undefined} */
-let _cssTransforms;
-/** @type {string[] | undefined} */
-let _cssUnusedSymbols;
-/** @type {{ [name: string]: string } | undefined} */
-let _cssPseudoClasses;
-
 // Every rewrite on, which is what a print with no `transforms` option makes and
 // what the walk-only passes hold. Frozen, since it is shared rather than copied.
 /** @type {Required<HtmlTransformOptions>} */
@@ -9510,13 +9493,8 @@ const pickTransforms = (options) => {
 	return out;
 };
 
-// Minified `style` attributes by raw text — a pure function of the value and
-// the options above, which a document repeats far more often than it adds one.
-/** @type {Map<string, string>} */
-const _styleAttributeCache = new Map();
-
 // How far text whitespace may be collapsed (see `HtmlProcessOptions`) — set per
-// print, like `_cssEnvironment`. "none" is off; the rest name how much of the
+// print, like `_minifying`. "none" is off; the rest name how much of the
 // whitespace against a boundary no line box reaches goes with it.
 /** @type {"none" | "conservative" | "smart" | "all"} */
 let _collapseWhitespace = "none";
@@ -9525,16 +9503,13 @@ let _collapseWhitespace = "none";
 // have to predict what it will drop.
 let _minifying = false;
 
-// The caller's renderer for source nested in this document, set per print. It
-// replaces the built-in CSS/JSON minifiers and is the only way inline
-// JavaScript and SVG are reached — webpack ships no minifier for either.
+// The caller's renderer for source nested in this document, set per print: the
+// only way any of it is minified, `builtinEmbeddedRenderer` being webpack's own.
 /** @type {EmbeddedSourceRenderer | undefined} */
 let _renderEmbeddedSource;
 
 // Where an asynchronous caller's embedded sources are recorded instead of
-// rendered, set per print. A body whose text this print reads back to decide
-// what to emit is still minified by the built-in for that decision — only the
-// text that reaches the output is deferred.
+// rendered, set per print; what the print decides from a body reads its source.
 /** @type {DeferredEmbeddedSource[] | undefined} */
 let _deferEmbeddedSource;
 
@@ -9563,66 +9538,27 @@ const _writeQuotedAttribute = (name, value, source) => {
 let _deferSrcdoc = true;
 
 /**
- * The renderer webpack ships: its own CSS and JSON minifiers, standing where a
- * caller passed no renderer and behind one that declines a body.
- * @type {EmbeddedSourceRenderer}
- */
-const _builtinRenderer = (source, info) => {
-	if (info.type === CSS_TYPE) {
-		const minified = _builtinStyleBody(
-			source,
-			info.as === BLOCK_CONTENTS ? BLOCK_CONTENTS : undefined
-		);
-		return minified === null ? undefined : minified;
-	}
-	if (info.type === JSON_TYPE) return _builtinInlineJson(source);
-	return undefined;
-};
-
-/**
- * What webpack's own renderer makes of one nested body, for a site that must
- * read text back before the caller's answer can arrive.
+ * Hand one nested body to the caller's renderer. Anything it throws is a
+ * renderer that did not answer: a document must not fail to serialize because
+ * something inside it did not parse.
  * @param {string} source the nested body
  * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
  * @param {string=} as which production of that language it is, for one with more than one
- * @returns {string | null} the rendered body, or null when webpack ships no minifier for it
- */
-const _renderBuiltinOrNull = (source, type, as) => {
-	const rendered = _builtinRenderer(source, {
-		type,
-		hostType: HTML_TYPE,
-		...(as === undefined ? undefined : { as })
-	});
-	return rendered === undefined ? null : rendered;
-};
-
-/**
- * Hand one nested body to the caller's renderer, then to webpack's own where
- * there is none or it declined. Anything the caller's throws is a renderer that
- * did not answer: a document must not fail to serialize because something inside
- * it did not parse.
- * @param {string} source the nested body
- * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
- * @param {string=} as which production of that language it is, for one with more than one
- * @returns {string | null} the rendered body, or null when both declined
+ * @returns {string | null} the rendered body, or null when there is no renderer or it declined
  */
 const _renderEmbeddedOrNull = (source, type, as) => {
-	const info = {
-		type,
-		hostType: HTML_TYPE,
-		...(as === undefined ? undefined : { as })
-	};
-	if (_renderEmbeddedSource !== undefined) {
-		try {
-			const rendered = _renderEmbeddedSource(source, info);
-			// Anything but text is a renderer that did not answer, not a body to write.
-			if (typeof rendered === "string") return rendered;
-		} catch (_err) {
-			// Declined.
-		}
+	if (_renderEmbeddedSource === undefined) return null;
+	try {
+		const rendered = _renderEmbeddedSource(source, {
+			type,
+			hostType: HTML_TYPE,
+			...(as === undefined ? undefined : { as })
+		});
+		// Anything but text is a renderer that did not answer, not a body to write.
+		return typeof rendered === "string" ? rendered : null;
+	} catch (_err) {
+		return null;
 	}
-	const rendered = _builtinRenderer(source, info);
-	return rendered === undefined ? null : rendered;
 };
 
 /**
@@ -9651,7 +9587,7 @@ const _deferEmbedded = (source, type, build, as) => {
 };
 
 /**
- * `_renderEmbeddedOrNull` with the body left exactly as written where every
+ * `_renderEmbeddedOrNull` with the body left exactly as written where the
  * renderer declines it, deferred to the caller's where one collects.
  * @param {string} source the nested body
  * @param {string} type its language, e.g. `"css"` / `"javascript"` / `"svg"`
@@ -9663,11 +9599,7 @@ const _renderEmbedded = (source, type, as) => {
 		return _deferEmbedded(
 			source,
 			type,
-			(rendered) => {
-				if (typeof rendered === "string") return rendered;
-				const builtin = _renderBuiltinOrNull(source, type, as);
-				return builtin === null ? source : builtin;
-			},
+			(rendered) => (typeof rendered === "string" ? rendered : source),
 			as
 		);
 	}
@@ -9877,68 +9809,14 @@ const _canOmitStartTag = (path, name, node, open) => {
 };
 
 /**
- * Minify a `<style>` body with webpack's own CSS minifier — the one that runs on
- * CSS assets, so an inline sheet is held to the same rules. `null` when it
- * declines the text, which a caller joining two sheets has to tell apart from a
- * sheet that was already minimal: text the minifier cannot parse may be
- * unterminated, and then it swallows whatever is concatenated after it.
+ * Offer a `<style>` body to the renderer, blank text kept as written. Webpack
+ * minifies no CSS here itself: `builtinEmbeddedRenderer` is what a caller
+ * passes for that.
  * @param {string} css the element's text
- * @param {{ text: string }=} decided filled with the text this print may read back, which is the built-in's rather than the marker when the caller's renderer is deferred
- * @returns {string | null} the minified text, or null
+ * @returns {string} the rendered text, the marker standing for it, or the text as written
  */
-const _minifyStyleBody = (css, decided) => {
-	if (css.trim() === "") return css;
-	if (_deferEmbeddedSource !== undefined) {
-		// The built-in still runs: what this print does next reads the minified
-		// text back, which a marker cannot be, and `decided` carries that text.
-		const builtin = _renderBuiltinOrNull(css, CSS_TYPE);
-		if (builtin === null) return null;
-		if (decided !== undefined) decided.text = builtin;
-		return _deferEmbedded(css, CSS_TYPE, (rendered) =>
-			typeof rendered === "string" ? rendered : builtin
-		);
-	}
-	return _renderEmbeddedOrNull(css, CSS_TYPE);
-};
-
-/**
- * The CSS minify webpack ships, for a body no caller's renderer answered for.
- * @param {string} css the element's text
- * @param {("stylesheet" | "block-contents")=} as which production it is — a `style=""` holds a block's contents, an element a stylesheet
- * @returns {string | null} the minified text, or null
- */
-const _builtinStyleBody = (css, as) => {
-	try {
-		const cssSyntax = _cssSyntax || (_cssSyntax = require("../css/syntax"));
-		const options = {
-			environment: _cssEnvironment,
-			convertLengthUnits: _cssConvertLengthUnits,
-			rewriteCustomProperties: _cssRewriteCustomProperties,
-			transforms: _cssTransforms,
-			unusedSymbols: _cssUnusedSymbols,
-			pseudoClasses: _cssPseudoClasses
-		};
-
-		return new cssSyntax.SourceProcessor().process(css, {
-			mode: "minify",
-			...options,
-			as
-		}).code;
-	} catch (_err) {
-		return null;
-	}
-};
-
-/**
- * `_minifyStyleBody`, with text it rejects handed back untouched rather than
- * failing the build.
- * @param {string} css the element's text
- * @returns {string} the minified text
- */
-const _minifyInlineCss = (css) => {
-	const minified = _minifyStyleBody(css);
-	return minified === null ? css : minified;
-};
+const _minifyStyleBody = (css) =>
+	css.trim() === "" ? css : _renderEmbedded(css, CSS_TYPE);
 
 // The throwaway rule a `style` attribute's declaration list is minified inside.
 // The selector is only ever written and read back here, so it is the shortest
@@ -9991,44 +9869,16 @@ const _writeAttribute = (attributeName, value, rawValue, decoded) => {
 };
 
 /**
- * Minify a `style` attribute's declaration list with webpack's CSS minifier, as
- * the block-contents production it is — which is what gives the list the
- * duplicate-drop and shorthand merges a rule's block gets.
+ * Offer a `style` attribute's declaration list to the renderer as the
+ * block-contents production it is, which gives it the merges a rule's block
+ * gets. The deferring path offers it at the attribute instead, where the shape
+ * an answer has to land in is known.
  * @param {string} raw raw (undecoded) attribute value
- * @returns {string} the minified declarations
+ * @returns {string} the rendered declarations, or the value as written
  */
 const _minifyStyleAttribute = (raw) => {
-	// A caller's renderer is handed every `style=""` the document holds, so it is
-	// not a function of the value alone and nothing about it may be reused.
-	if (_renderEmbeddedSource !== undefined) {
-		return _minifyStyleAttributeUncached(raw);
-	}
-	const memoized = _styleAttributeCache.get(raw);
-	if (memoized !== undefined) return memoized;
-	const minified = _minifyStyleAttributeUncached(raw);
-	_styleAttributeCache.set(raw, minified);
-	return minified;
-};
-
-/**
- * `_minifyStyleAttribute` without the memo — every path here runs the CSS
- * minifier, and every return is safe to keep, none of them reading state the
- * print goes on to change.
- * @param {string} raw raw (undecoded) attribute value
- * @returns {string} the minified declarations
- */
-const _minifyStyleAttributeUncached = (raw) => {
-	if (raw.trim() === "") return raw;
-
-	// Offered as the CSS it is, with `as` saying which production — the wrapper a
-	// declaration list needs for the transforms a block's contents get is the CSS
-	// layer's own business. The deferring path offers it at the attribute
-	// instead, where the shape an answer has to land in is known.
-	const rendered =
-		_deferEmbeddedSource === undefined
-			? _renderEmbeddedOrNull(raw, CSS_TYPE, BLOCK_CONTENTS)
-			: _renderBuiltinOrNull(raw, CSS_TYPE, BLOCK_CONTENTS);
-
+	if (_deferEmbeddedSource !== undefined || raw.trim() === "") return raw;
+	const rendered = _renderEmbeddedOrNull(raw, CSS_TYPE, BLOCK_CONTENTS);
 	return rendered === null ? raw : rendered;
 };
 
@@ -10541,23 +10391,24 @@ const _JSON_SUBTYPE_REGEXP =
 	/^[!#$%&'*+.^_`|~\w-]+\/[!#$%&'*+.^_`|~\w-]*\+json$/;
 
 /**
+ * Offer a JSON `<script>` body to the renderer, blank text kept as written;
+ * `stripJsonWhitespace` is what webpack's own answers with.
+ * @param {string} json a `<script>` body
+ * @returns {string} the rendered body, the marker standing for it, or the body as written
+ */
+const _minifyInlineJson = (json) =>
+	json.trim() === "" ? json : _renderEmbedded(json, JSON_TYPE);
+
+/**
  * Strip the whitespace between a JSON body's tokens. Every literal is copied
  * byte for byte — re-serializing would reorder nothing but would round numbers
  * through a double, drop a duplicate key and rewrite escapes, none of which is
  * this transform's to do. Escapes are also the security case: unescaping a
  * `<` lets a string close the `<script>` early.
  * @param {string} json a `<script>` body
- * @returns {string} the stripped body
+ * @returns {string} the stripped body, or the body as written where it is not JSON
  */
-const _minifyInlineJson = (json) =>
-	json.trim() === "" ? json : _renderEmbedded(json, JSON_TYPE);
-
-/**
- * The JSON strip webpack ships, for a body no caller's renderer answered for.
- * @param {string} json a `<script>` body
- * @returns {string} the stripped body
- */
-const _builtinInlineJson = (json) => {
+const stripJsonWhitespace = (json) => {
 	try {
 		JSON.parse(json);
 	} catch (_err) {
@@ -10682,43 +10533,75 @@ const _mergeableStyleAfter = (path, element) => {
 };
 
 /**
- * The text the first `<style>` of a run prints: every sheet in it, each minified
- * on its own and then joined. Marks the rest of the run absorbed, which is what
- * makes their tags and text print as nothing — it runs first because a run's
- * first element prints before any of the others in both print paths.
- *
- * Each sheet is minified before it is joined, never after: only text the
- * minifier accepted is known to be terminated, and appending to a sheet that is
- * not makes the next one part of the last rule of this one. A sheet after the
- * first carrying `@import` (or `@charset` / `@namespace`) is not folded either —
- * those only apply at the top of a sheet, and would silently stop applying.
+ * Whether a sheet ends outside every string, comment and bracket, so a sheet
+ * appended to it starts rules of its own rather than finishing this one's last.
+ * @param {string} css the sheet's text
+ * @returns {boolean} true when another sheet may follow it
+ */
+const _sheetEndsCleanly = (css) => {
+	let depth = 0;
+	for (let i = 0; i < css.length; i++) {
+		const c = css.charCodeAt(i);
+		if (c === CC_REVERSE_SOLIDUS) {
+			i++;
+		} else if (c === CC_SOLIDUS && css.charCodeAt(i + 1) === CC_ASTERISK) {
+			const close = css.indexOf("*/", i + 2);
+			if (close === -1) return false;
+			i = close + 1;
+		} else if (c === CC_QUOTATION_MARK || c === CC_APOSTROPHE) {
+			// A string ends at its quote, or at a newline as a bad string does.
+			for (i++; i < css.length; i++) {
+				const d = css.charCodeAt(i);
+				if (d === CC_REVERSE_SOLIDUS) i++;
+				else if (d === c || d === CC_LF) break;
+			}
+			if (i >= css.length) return false;
+		} else if (
+			c === CC_LEFT_CURLY_BRACKET ||
+			c === CC_LEFT_PARENTHESIS ||
+			c === CC_LEFT_SQUARE_BRACKET
+		) {
+			depth++;
+		} else if (
+			depth !== 0 &&
+			(c === CC_RIGHT_CURLY_BRACKET ||
+				c === CC_RIGHT_PARENTHESIS ||
+				c === CC_RIGHT_SQUARE_BRACKET)
+		) {
+			depth--;
+		}
+	}
+	return depth === 0;
+};
+
+/**
+ * The text the first `<style>` of a run prints: every sheet in it, each offered
+ * on its own and then joined, the rest of the run marked absorbed so their tags
+ * and text print as nothing. Whether a sheet joins is read off its source, since
+ * an answer may be a marker: one not ending cleanly would swallow the next, and
+ * one after the first carrying `@import` (or `@charset` / `@namespace`) would
+ * silently stop applying those.
  * @param {HtmlPath} path the accessor
  * @param {HtmlElement} element the run's first `<style>`
  * @param {string} css its own text
  * @returns {string} the run's text
  */
 const _mergedStyleRun = (path, element, css) => {
-	const head = _minifyStyleBody(css);
-	if (head === null) return css;
-	let out = head;
+	let out = _minifyStyleBody(css);
+	if (!_sheetEndsCleanly(css)) return out;
 	for (
 		let next = _mergeableStyleAfter(path, element);
 		next !== 0;
 		next = _mergeableStyleAfter(path, next)
 	) {
-		const decided = { text: "" };
-		const body = _minifyStyleBody(
-			_nodeStrings[/** @type {HtmlNodeRef} */ (_onlyTextChild(next))],
-			decided
-		);
-		if (body === null) break;
-		// Read the built-in's text, not the marker: whether this sheet may be
-		// absorbed decides what its own element prints, so it cannot wait for an
-		// answer.
-		if (_SHEET_LEADING_AT_RULE_REGEXP.test(decided.text || body)) break;
+		const text =
+			_nodeStrings[/** @type {HtmlNodeRef} */ (_onlyTextChild(next))];
+		if (!_sheetEndsCleanly(text) || _SHEET_LEADING_AT_RULE_REGEXP.test(text)) {
+			break;
+		}
 		if (_absorbed === null) _absorbed = new Set();
 		_absorbed.add(next);
-		out += body;
+		out += _minifyStyleBody(text);
 	}
 	return out;
 };
@@ -13097,20 +12980,6 @@ const grammar = (input, visitors, writer, options) => {
 		writer !== undefined && writer.options.removeEmptyAttributes === true;
 	_removeEmptyElements =
 		writer !== undefined && writer.options.removeEmptyElements === true;
-	// With the rest rather than in `printer`: they are the print's, not the
-	// node's, and that runs once per node.
-	_cssEnvironment =
-		writer === undefined ? undefined : writer.options.environment;
-	_cssConvertLengthUnits =
-		writer !== undefined && writer.options.convertLengthUnits === true;
-	_cssRewriteCustomProperties =
-		writer !== undefined && writer.options.rewriteCustomProperties === true;
-	_cssTransforms =
-		writer === undefined ? undefined : writer.options.cssTransforms;
-	_cssUnusedSymbols =
-		writer === undefined ? undefined : writer.options.cssUnusedSymbols;
-	_cssPseudoClasses =
-		writer === undefined ? undefined : writer.options.cssPseudoClasses;
 	_transforms = _transformsFrom(
 		writer === undefined ? undefined : writer.options.transforms
 	);
@@ -13202,8 +13071,6 @@ const grammar = (input, visitors, writer, options) => {
 		// Keyed by this parse's interned names, so it must not outlive it.
 		_attributeFrequencies = null;
 		_attributeRanks = null;
-		// Keyed by this print's options, and holding slices of its input.
-		_styleAttributeCache.clear();
 		_emptyElements.clear();
 		_streamEligible = false;
 		_streaming = false;
@@ -13674,6 +13541,45 @@ const parseMsapplicationTask = (input) => {
 let _cssSyntax;
 
 /**
+ * The renderer webpack ships for what a document embeds: its own CSS minifier
+ * for a `<style>` or `style=""` and `stripJsonWhitespace` for JSON, declining
+ * every other language. A caller passes it where it has no renderer of its own,
+ * or behind one for the languages that one declines.
+ * @param {BuiltinEmbeddedRendererOptions=} options the CSS minifier's options, so an inline declaration is minified as the `.css` assets are
+ * @returns {EmbeddedSourceRenderer} the renderer
+ */
+const builtinEmbeddedRenderer = (options = {}) => {
+	const sheet = { mode: /** @type {"minify"} */ ("minify"), ...options };
+	const block = { ...sheet, as: BLOCK_CONTENTS };
+	// A `style=""` repeats across a document far more often than it varies.
+	/** @type {Map<string, string>} */
+	const blocks = new Map();
+	return (source, info) => {
+		if (info.type === JSON_TYPE) return stripJsonWhitespace(source);
+		if (info.type !== CSS_TYPE) return undefined;
+		const isBlock = info.as === BLOCK_CONTENTS;
+		if (isBlock) {
+			const memoized = blocks.get(source);
+			if (memoized !== undefined) return memoized;
+		}
+		const { SourceProcessor: CssSourceProcessor } =
+			_cssSyntax || (_cssSyntax = require("../css/syntax"));
+		let code;
+		try {
+			code = new CssSourceProcessor().process(
+				source,
+				isBlock ? block : sheet
+			).code;
+		} catch (_err) {
+			// Text the minifier cannot read is left as written, by declining.
+			return undefined;
+		}
+		if (isBlock) blocks.set(source, code);
+		return code;
+	};
+};
+
+/**
  * Extracts `url(...)` references from a CSS value (an SVG presentation
  * attribute). Reuses webpack's CSS lexer so quoting/escaping match the CSS
  * spec; returns the `parseSrc` shape so the shared emit path maps and rewrites
@@ -14118,6 +14024,7 @@ module.exports.SourceProcessor = SourceProcessor;
 module.exports.askEmbeddedRenderer = askEmbeddedRenderer;
 module.exports.baseTag = baseTag;
 module.exports.buildHeadTags = buildHeadTags;
+module.exports.builtinEmbeddedRenderer = builtinEmbeddedRenderer;
 module.exports.collectEmbeddedDiagnostics = collectEmbeddedDiagnostics;
 module.exports.decodeEntities = decodeEntities;
 module.exports.embeddedText = embeddedText;
@@ -14135,4 +14042,5 @@ module.exports.parseSrc = parseSrc;
 module.exports.parseSrcset = parseSrcset;
 module.exports.pickTransforms = pickTransforms;
 module.exports.printer = printer;
+module.exports.stripJsonWhitespace = stripJsonWhitespace;
 module.exports.tokenize = tokenize;

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -14,7 +14,6 @@ const GenericSourceProcessor = require("../util/SourceProcessor");
 
 const { deferredWrite, declineDeferredWrites } = GenericSourceProcessor;
 
-/** @import { CssProcessOptions } from "../css/syntax" */
 /** @import { OutputHtmlOptions } from "../../declarations/WebpackOptions" */
 
 /**
@@ -74,6 +73,10 @@ const EMBEDDED_LANGUAGES = [
 	HTML_TYPE
 ];
 
+const {
+	builtinEmbeddedRenderer,
+	stripJsonWhitespace
+} = require("./builtinEmbeddedRenderer");
 const {
 	ADDRESS_DIV_P,
 	APPLET_MARQUEE_OBJECT,
@@ -8968,12 +8971,6 @@ const mirrorSelectedContent = (node, select) => {
  * @typedef {{ transforms?: HtmlTransformOptions, collapseWhitespace?: boolean | "conservative" | "smart" | "all", mergeStyles?: boolean, mergeScripts?: boolean, removeEmptyAttributes?: boolean, removeEmptyElements?: boolean, removeRedundantAttributes?: boolean | "smart" | "all", sortAttributes?: boolean, sortTokenLists?: boolean, removeImpliedTags?: boolean | "smart" | "all", renderEmbeddedSource?: EmbeddedSourceRenderer, deferEmbeddedSource?: DeferredEmbeddedSource[], deferSrcdoc?: boolean }} HtmlPrintOptions
  */
 
-/**
- * What `builtinEmbeddedRenderer` minifies inline CSS with: the CSS minifier's
- * own options, so an inline declaration is held to the rules a `.css` asset is.
- * @typedef {Pick<CssProcessOptions, "environment" | "convertLengthUnits" | "rewriteCustomProperties" | "transforms" | "unusedSymbols" | "pseudoClasses">} BuiltinEmbeddedRendererOptions
- */
-
 /** @typedef {import("../util/SourceProcessor").PrintContext<HtmlPath, HtmlNodeRef, HtmlPrintOptions>} PrintContext */
 
 // Whether the text ends inside an unterminated character reference, so the next
@@ -10398,46 +10395,6 @@ const _JSON_SUBTYPE_REGEXP =
  */
 const _minifyInlineJson = (json) =>
 	json.trim() === "" ? json : _renderEmbedded(json, JSON_TYPE);
-
-/**
- * Strip the whitespace between a JSON body's tokens. Every literal is copied
- * byte for byte — re-serializing would reorder nothing but would round numbers
- * through a double, drop a duplicate key and rewrite escapes, none of which is
- * this transform's to do. Escapes are also the security case: unescaping a
- * `<` lets a string close the `<script>` early.
- * @param {string} json a `<script>` body
- * @returns {string} the stripped body, or the body as written where it is not JSON
- */
-const stripJsonWhitespace = (json) => {
-	try {
-		JSON.parse(json);
-	} catch (_err) {
-		// Not JSON after all (a template, a placeholder) — not ours to touch.
-		return json;
-	}
-	let out = "";
-	let inString = false;
-	let escaped = false;
-	for (let i = 0; i < json.length; i++) {
-		const c = json.charCodeAt(i);
-		if (inString) {
-			out += json[i];
-			if (escaped) escaped = false;
-			else if (c === 0x5c) escaped = true;
-			else if (c === 0x22) inString = false;
-			continue;
-		}
-		if (c === 0x22) {
-			inString = true;
-			out += json[i];
-			continue;
-		}
-		// JSON whitespace (RFC 8259): tab, LF, CR, space.
-		if (c === 0x09 || c === 0x0a || c === 0x0d || c === 0x20) continue;
-		out += json[i];
-	}
-	return out;
-};
 
 /**
  * Whether a `<style>` element's body is CSS: the attribute is optional, and the
@@ -13535,49 +13492,10 @@ const parseMsapplicationTask = (input) => {
 };
 
 // CSS syntax is loaded on first `parseCssUrls` call, not at module load —
-// `HtmlGenerator` deliberately defers it the same way, and most documents
-// never carry a URL-bearing SVG presentation attribute.
+// `HtmlGenerator` defers it the same way, and most documents carry no
+// URL-bearing SVG presentation attribute.
 /** @type {typeof import("../css/syntax") | undefined} */
 let _cssSyntax;
-
-/**
- * The renderer webpack ships for what a document embeds: its own CSS minifier
- * for a `<style>` or `style=""` and `stripJsonWhitespace` for JSON, declining
- * every other language. A caller passes it where it has no renderer of its own,
- * or behind one for the languages that one declines.
- * @param {BuiltinEmbeddedRendererOptions=} options the CSS minifier's options, so an inline declaration is minified as the `.css` assets are
- * @returns {EmbeddedSourceRenderer} the renderer
- */
-const builtinEmbeddedRenderer = (options = {}) => {
-	const sheet = { mode: /** @type {"minify"} */ ("minify"), ...options };
-	const block = { ...sheet, as: BLOCK_CONTENTS };
-	// A `style=""` repeats across a document far more often than it varies.
-	/** @type {Map<string, string>} */
-	const blocks = new Map();
-	return (source, info) => {
-		if (info.type === JSON_TYPE) return stripJsonWhitespace(source);
-		if (info.type !== CSS_TYPE) return undefined;
-		const isBlock = info.as === BLOCK_CONTENTS;
-		if (isBlock) {
-			const memoized = blocks.get(source);
-			if (memoized !== undefined) return memoized;
-		}
-		const { SourceProcessor: CssSourceProcessor } =
-			_cssSyntax || (_cssSyntax = require("../css/syntax"));
-		let code;
-		try {
-			code = new CssSourceProcessor().process(
-				source,
-				isBlock ? block : sheet
-			).code;
-		} catch (_err) {
-			// Text the minifier cannot read is left as written, by declining.
-			return undefined;
-		}
-		if (isBlock) blocks.set(source, code);
-		return code;
-	};
-};
 
 /**
  * Extracts `url(...)` references from a CSS value (an SVG presentation
@@ -14000,6 +13918,9 @@ const A = {
 };
 
 module.exports.A = A;
+// The `as` a `style=""` is offered under: a block's contents rather than a
+// whole stylesheet, which is what gives it a rule block's merges.
+module.exports.BLOCK_CONTENTS = BLOCK_CONTENTS;
 // The `as` a classic `<script>` is offered under — the production every
 // JavaScript engine reads by default.
 module.exports.CLASSIC_SCRIPT = CLASSIC_SCRIPT;
@@ -14007,6 +13928,9 @@ module.exports.EMBEDDED_LANGUAGES = EMBEDDED_LANGUAGES;
 // The `as` an event handler attribute is offered under, read by a renderer
 // whose engine takes only whole scripts.
 module.exports.EVENT_HANDLER = EVENT_HANDLER;
+// Neither a JSON `<script>` body nor an `<svg>` subtree is a module source
+// type, so both name themselves here.
+module.exports.JSON_TYPE = JSON_TYPE;
 // The `as` a `<script type=module>` is offered under: the goal symbol decides
 // what parses, so a renderer cannot read it off the body.
 module.exports.MODULE_SCRIPT = MODULE_SCRIPT;

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -4033,11 +4033,8 @@ describe("SourceProcessor — collapseWhitespace", () => {
 	});
 });
 
-// The two conditions that decline a fold cannot be reached through a build:
-// webpack's CSS pipeline resolves an `@import` away long before the HTML
-// minifier sees the sheet, and the minifier only refuses text that overflows
-// its own parser. The rest of the transform is covered by the
-// `configCases/html/minimize-merge-styles` case.
+// The shapes a fold is declined for, which a build does not reach: webpack
+// resolves an `@import` away long before the HTML minifier sees the sheet.
 describe("SourceProcessor — merging adjacent <style>", () => {
 	const { SourceProcessor } = require("../lib/html/syntax");
 
@@ -4083,6 +4080,46 @@ describe("SourceProcessor — merging adjacent <style>", () => {
 				"<style>@import url(x.css);a{color:red}</style><style>b{color:#00f}</style>"
 			)
 		).toBe("<style>@import url(x.css);a{color:red}b{color:#00f}</style>");
+	});
+
+	it("declines a sheet ending inside a comment", () => {
+		// Appending to text the comment swallows would comment the next sheet out.
+		expect(
+			minify("<style>a{color:red}/*x</style><style>b{color:#00f}</style>")
+		).toBe("<style>a{color:red}</style><style>b{color:#00f}</style>");
+		expect(
+			minify("<style>a{color:red}/*x*/</style><style>b{color:#00f}</style>")
+		).toBe("<style>a{color:red}b{color:#00f}</style>");
+	});
+
+	it("declines a sheet ending inside a string", () => {
+		expect(
+			minify('<style>a{content:"x</style><style>b{color:#00f}</style>')
+		).toBe('<style>a{content:"x"}</style><style>b{color:#00f}</style>');
+		// A newline ends a bad string, so this one is over where the sheet is.
+		expect(
+			minify('<style>a{content:"x\n}</style><style>b{color:#00f}</style>')
+		).toBe('<style>a{content:"x\n}b{color:#00f}</style>');
+		// An escaped quote is a character of the string, not its end.
+		expect(
+			minify('<style>a{content:"x\\"y"}</style><style>b{color:#00f}</style>')
+		).toBe("<style>a{content:'x\"y'}b{color:#00f}</style>");
+	});
+
+	it("reads an escape outside a string as one too", () => {
+		// Were the quote not escaped it would open a string running to the end.
+		expect(
+			minify('<style>a{color:red}\\"</style><style>b{color:#00f}</style>')
+		).toBe("<style>a{color:red}b{color:#00f}</style>");
+	});
+
+	it("declines a sheet left inside a bracket", () => {
+		expect(
+			minify("<style>a{color:red</style><style>b{color:#00f}</style>")
+		).toBe("<style>a{color:red}</style><style>b{color:#00f}</style>");
+		expect(
+			minify("<style>a{color:rgb(1,2,3}</style><style>b{color:#00f}</style>")
+		).toBe("<style>a{color:rgb(1,2,3})}</style><style>b{color:#00f}</style>");
 	});
 
 	it("declines a sheet the CSS minifier could not read", () => {

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -19,6 +19,7 @@ const {
 	QUOTE_DOUBLE,
 	QUOTE_NONE,
 	QUOTE_SINGLE,
+	builtinEmbeddedRenderer,
 	decodeEntities,
 	escapeAttribute,
 	escapeText,
@@ -4045,8 +4046,11 @@ describe("SourceProcessor — merging adjacent <style>", () => {
 	 * @returns {string} the minified serialization
 	 */
 	const minify = (html) =>
-		new SourceProcessor().process(html, { mode: "minify", mergeStyles: true })
-			.code;
+		new SourceProcessor().process(html, {
+			mode: "minify",
+			mergeStyles: true,
+			renderEmbeddedSource: builtinEmbeddedRenderer()
+		}).code;
 
 	it("folds a run into one element", () => {
 		expect(
@@ -4057,9 +4061,12 @@ describe("SourceProcessor — merging adjacent <style>", () => {
 	it("keeps every element, minified, unless asked to fold", () => {
 		const html =
 			"<style>a {color: red}</style><style>b {color: #0000ff}</style>";
-		expect(new SourceProcessor().process(html, { mode: "minify" }).code).toBe(
-			"<style>a{color:red}</style><style>b{color:#00f}</style>"
-		);
+		expect(
+			new SourceProcessor().process(html, {
+				mode: "minify",
+				renderEmbeddedSource: builtinEmbeddedRenderer()
+			}).code
+		).toBe("<style>a{color:red}</style><style>b{color:#00f}</style>");
 	});
 
 	it("declines a sheet whose `@import` would stop applying", () => {
@@ -4415,7 +4422,10 @@ describe("SourceProcessor — JSON <script> bodies", () => {
 	 * @returns {string} the minified serialization
 	 */
 	const minify = (html) =>
-		new SourceProcessor().process(html, { mode: "minify" }).code;
+		new SourceProcessor().process(html, {
+			mode: "minify",
+			renderEmbeddedSource: builtinEmbeddedRenderer()
+		}).code;
 
 	/**
 	 * @param {string} type the `<script type>` value
@@ -4518,7 +4528,7 @@ describe("SourceProcessor — inline <script> type", () => {
 	const minifyBody = (type, body) => {
 		const out = new SourceProcessor().process(
 			`<script type="${type}">${body}</script>`,
-			{ mode: "minify" }
+			{ mode: "minify", renderEmbeddedSource: builtinEmbeddedRenderer() }
 		).code;
 		return out.slice(out.indexOf(">") + 1, out.lastIndexOf("</script>"));
 	};
@@ -5611,7 +5621,7 @@ describe("SourceProcessor — renderEmbeddedSource", () => {
 		);
 	});
 
-	it("offers a `style` attribute to a deferring caller, and falls back to the built-in", async () => {
+	it("offers a `style` attribute to a deferring caller, and keeps it as written when declined", async () => {
 		const declined = await deferred(
 			'<p style="  color : #ff0000 ; margin : 0px  ">x</p>',
 			() => undefined
@@ -5622,12 +5632,21 @@ describe("SourceProcessor — renderEmbeddedSource", () => {
 			// `module.parser.css.as` uses.
 			["css", "block-contents", "  color : #ff0000 ; margin : 0px  "]
 		]);
-		// Nothing answered, so webpack's own minifier wrote it — byte for byte what
-		// a run with no renderer at all writes.
-		expect(declined.code).toBe("<p style=color:red;margin:0>x");
+		// Nothing answered and the printer minifies no CSS itself — byte for byte
+		// what a run with no renderer at all writes.
+		expect(declined.code).toBe(
+			'<p style="  color : #ff0000 ; margin : 0px  ">x'
+		);
 		expect(declined.code).toBe(
 			minify('<p style="  color : #ff0000 ; margin : 0px  ">x</p>')
 		);
+		// Webpack's own renderer, put behind a declining one, is what answers.
+		expect(
+			minify(
+				'<p style="  color : #ff0000 ; margin : 0px  ">x</p>',
+				builtinEmbeddedRenderer()
+			)
+		).toBe("<p style=color:red;margin:0>x");
 	});
 
 	it("writes a deferred `style` attribute back in whatever shape its answer needs", async () => {
@@ -5648,37 +5667,39 @@ describe("SourceProcessor — renderEmbeddedSource", () => {
 	});
 
 	it("gives a `style` attribute the transforms a block's contents get", () => {
-		// The printer composes a block-contents list the way it composes a rule's
-		// block, so it gets the same transforms — merging longhands into the
-		// shorthand they imply.
-		expect(minify('<p style="top:0;right:0;bottom:0;left:0">x</p>')).toBe(
+		// Webpack's own renderer composes a block-contents list the way the CSS
+		// printer composes a rule's block: longhands merge into their shorthand.
+		const own = builtinEmbeddedRenderer();
+		expect(minify('<p style="top:0;right:0;bottom:0;left:0">x</p>', own)).toBe(
 			"<p style=inset:0>x"
 		);
 		expect(
 			minify(
-				'<p style="margin-top:1px;margin-right:1px;margin-bottom:1px;margin-left:1px">x</p>'
+				'<p style="margin-top:1px;margin-right:1px;margin-bottom:1px;margin-left:1px">x</p>',
+				own
 			)
 		).toBe("<p style=margin:1px>x");
 		// Foreign content is the same declaration list.
 		expect(
 			minify(
-				'<svg><rect style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"/></svg>'
+				'<svg><rect style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"/></svg>',
+				own
 			)
 		).toBe("<svg><rect style=padding:0 /></svg>");
 		// Nothing opened a block, so a `}` closes none: it is a parse error whose
 		// bad declaration runs to the next `;` — two properties, so both survive it.
-		expect(minify('<p style="color:red;};background:blue">x</p>')).toBe(
+		expect(minify('<p style="color:red;};background:blue">x</p>', own)).toBe(
 			"<p style=color:red;background:blue>x"
 		);
 		// No `;` after it, so the bad declaration runs to the end.
-		expect(minify('<p style="background:red;}background:blue">x</p>')).toBe(
-			"<p style=background:red>x"
-		);
+		expect(
+			minify('<p style="background:red;}background:blue">x</p>', own)
+		).toBe("<p style=background:red>x");
 		// Inside a value it is a token like any other, leaving a declaration a
 		// browser drops — so it is handed back exactly as written.
-		expect(minify('<p style="background:red};background:blue">x</p>')).toBe(
-			"<p style=background:red};background:blue>x"
-		);
+		expect(
+			minify('<p style="background:red};background:blue">x</p>', own)
+		).toBe("<p style=background:red};background:blue>x");
 	});
 
 	it("minifies and offers a `style` attribute carrying character references", () => {
@@ -5690,9 +5711,10 @@ describe("SourceProcessor — renderEmbeddedSource", () => {
 		expect(offered(html)).toEqual([
 			["css", "block-contents", 'content: "x" ; color : red']
 		]);
-		expect(minify(html)).toBe("<p style='content:\"x\";color:red'>y");
+		const own = builtinEmbeddedRenderer();
+		expect(minify(html, own)).toBe("<p style='content:\"x\";color:red'>y");
 		// Foreign content too: SVG and MathML `style` is the same declaration list.
-		expect(minify('<svg><rect style="fill : &quot;a&quot;"/></svg>')).toBe(
+		expect(minify('<svg><rect style="fill : &quot;a&quot;"/></svg>', own)).toBe(
 			"<svg><rect style='fill:\"a\"'/></svg>"
 		);
 	});
@@ -6172,7 +6194,12 @@ describe("SourceProcessor — inline CSS honors the target's abilities", () => {
 	const minifyFor = (browser) =>
 		new SourceProcessor().process(
 			'<p style="color:rgba(255,0,0,.5)">x</p><style>.a{color:rgba(255,0,0,.5)}</style>',
-			{ mode: "minify", environment: { browsers: [browser] } }
+			{
+				mode: "minify",
+				renderEmbeddedSource: builtinEmbeddedRenderer({
+					environment: { browsers: [browser] }
+				})
+			}
 		).code;
 
 	it("shortens both the attribute and the element when the target reads it", () => {
@@ -9389,7 +9416,8 @@ describe("SourceProcessor — minifying what the round-trip guard checks", () =>
 			removeEmptyElements: true,
 			removeRedundantAttributes: /** @type {"all"} */ ("all"),
 			sortAttributes: true,
-			sortTokenLists: true
+			sortTokenLists: true,
+			renderEmbeddedSource: builtinEmbeddedRenderer()
 		}).code;
 
 	/** @type {[string, string][]} */
@@ -9469,11 +9497,13 @@ describe("SourceProcessor — reusing work across a print", () => {
 		new SourceProcessor().process(html, { mode: "minify", ...options }).code;
 
 	it("minifies a repeated style attribute to the same declarations", () => {
-		// The same raw value twice, which is what the memo is keyed on — a value
-		// that merely minifies to the same text is a different entry.
-		expect(minify('<p style="color: #ff0000"><b style="color: #ff0000">')).toBe(
-			"<p style=color:red><b style=color:red></b>"
-		);
+		// The same raw value twice, which is what webpack's own renderer keys its
+		// memo on — a value that merely minifies to the same text is another entry.
+		expect(
+			minify('<p style="color: #ff0000"><b style="color: #ff0000">', {
+				renderEmbeddedSource: builtinEmbeddedRenderer()
+			})
+		).toBe("<p style=color:red><b style=color:red></b>");
 	});
 
 	it("runs a caller's renderer for every style attribute, repeats included", () => {
@@ -9489,13 +9519,18 @@ describe("SourceProcessor — reusing work across a print", () => {
 		expect(code).toBe("<p style=--call:1><b style=--call:2></b>");
 	});
 
-	it("does not carry a style attribute's result into a print with other options", () => {
+	it("does not carry a style attribute's result into a renderer with other options", () => {
 		const html = '<p style="width: 16px">';
-		expect(minify(html)).toBe("<p style=width:16px>");
-		expect(minify(html, { convertLengthUnits: true })).toBe(
-			"<p style=width:1pc>"
-		);
-		expect(minify(html)).toBe("<p style=width:16px>");
+		const plain = { renderEmbeddedSource: builtinEmbeddedRenderer() };
+		expect(minify(html, plain)).toBe("<p style=width:16px>");
+		expect(
+			minify(html, {
+				renderEmbeddedSource: builtinEmbeddedRenderer({
+					convertLengthUnits: true
+				})
+			})
+		).toBe("<p style=width:1pc>");
+		expect(minify(html, plain)).toBe("<p style=width:16px>");
 	});
 
 	/**
@@ -9670,12 +9705,18 @@ describe("htmlMinify — an answered `style` attribute that changes its quoting"
 
 	it("declines an answer that would change a foreign `/>`", async () => {
 		// Whether a space must precede a foreign `/>` is decided when the tag
-		// closes, too early to wait for the answer, so the built-in's text stands.
+		// closes, too early to wait for the answer, so the source's spelling stands.
+		expect(
+			await min("<svg><rect style=color:red /></svg>", (source, info) =>
+				info.type === "css" ? "margin:0 auto" : undefined
+			)
+		).toBe("<svg><rect style=color:red /></svg>");
+		// An answer that keeps the tag ending as the source had it is taken.
 		expect(
 			await min('<svg><rect style="color: red" /></svg>', (source, info) =>
 				info.type === "css" ? "margin:0 auto" : undefined
 			)
-		).toBe("<svg><rect style=color:red /></svg>");
+		).toBe('<svg><rect style="margin:0 auto"/></svg>');
 	});
 });
 
@@ -9842,8 +9883,8 @@ describe("SourceProcessor — attribute rewrites as switches", () => {
 	};
 
 	it("keeps one a deferred renderer hands straight back", async () => {
-		// The answer arrives after the attribute is written, so the built-in's
-		// text stood here until the answer was read for what it says.
+		// The answer arrives after the attribute is written, so the source's
+		// spelling stood here until the answer was read for what it says.
 		expect(
 			await deferredStyle(
 				'<p style="color:  #ff0000 ;">x</p>',
@@ -9913,10 +9954,10 @@ describe("SourceProcessor — attribute rewrites as switches", () => {
 		).toBe('<p style="margin:0 auto">x');
 	});
 
-	it("minifies one a deferred renderer declines", async () => {
+	it("keeps one a deferred renderer declines as written", async () => {
 		expect(
 			await deferredStyle('<p style="color:  #ff0000 ;">x</p>', () => undefined)
-		).toBe("<p style=color:red>x");
+		).toBe('<p style="color:  #ff0000 ;">x');
 	});
 
 	it("trims the whitespace around a URL, until told not to", () => {

--- a/test/configCases/css/minify-embedded-svg/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minify-embedded-svg/__snapshots__/ConfigCacheTest.snap
@@ -2,7 +2,7 @@
 
 exports[`ConfigCacheTestCases css minify-embedded-svg exported tests should reach an inline svg subtree in embedded HTML 1`] = `
 "<div>
-	<svg viewBox=\\"0 0 2 2\\"> <rect style=\\" fill : red ; \\"/> </svg>
+	<svg viewBox=\\"0 0 2 2\\"> <rect style=fill:red /> </svg>
 </div>
 "
 `;

--- a/test/configCases/css/minify-embedded-svg/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minify-embedded-svg/__snapshots__/ConfigTest.snap
@@ -2,7 +2,7 @@
 
 exports[`ConfigTestCases css minify-embedded-svg exported tests should reach an inline svg subtree in embedded HTML 1`] = `
 "<div>
-	<svg viewBox=\\"0 0 2 2\\"> <rect style=\\" fill : red ; \\"/> </svg>
+	<svg viewBox=\\"0 0 2 2\\"> <rect style=fill:red /> </svg>
 </div>
 "
 `;

--- a/test/configCases/css/minify-embedded-svg/webpack.config.js
+++ b/test/configCases/css/minify-embedded-svg/webpack.config.js
@@ -4,9 +4,10 @@ const SampleEmbeddedMinifyPlugin = require("../../../helpers/SampleEmbeddedMinif
 
 // Stands in for an SVG minifier: collapsing runs of whitespace is enough to
 // show the payload was reached and put back in the form it was written in.
+// Every other language is declined, which is what leaves it to webpack's own.
 /** @type {import("../../../../lib/html/syntax").EmbeddedSourceRenderer} */
 const renderEmbeddedSource = (source, { type }) =>
-	type === "svg" ? source.replace(/\s+/g, " ").trim() : source;
+	type === "svg" ? source.replace(/\s+/g, " ").trim() : undefined;
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/helpers/SampleEmbeddedMinifyPlugin.js
+++ b/test/helpers/SampleEmbeddedMinifyPlugin.js
@@ -52,6 +52,17 @@ class SampleEmbeddedMinifyPlugin {
 			renderEmbeddedSource === undefined ? null : String(renderEmbeddedSource)
 		]);
 
+		// Webpack's own CSS and JSON minifiers stand behind the sample's renderer
+		// for what it declines, as `htmlMinify` puts them behind a caller's.
+		const builtin = htmlSyntax.builtinEmbeddedRenderer();
+		/** @type {EmbeddedSourceRenderer} */
+		const renderer = (source, info) => {
+			const answered =
+				renderEmbeddedSource === undefined
+					? undefined
+					: renderEmbeddedSource(source, info);
+			return answered === undefined ? builtin(source, info) : answered;
+		};
 		compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
 			// One tap per language pair — `info.type` says which arrived. Async on
 			// purpose: a real minifier may only be loadable that way.
@@ -79,9 +90,8 @@ class SampleEmbeddedMinifyPlugin {
 									typeof markup === "string" ? markup : markup.toString("utf8"),
 									{
 										mode: "minify",
-										// What the document itself embeds. Absent, the serializer
-										// falls back to its own CSS and JSON minifiers.
-										renderEmbeddedSource,
+										// What the document itself embeds.
+										renderEmbeddedSource: renderer,
 										...minimizerOptions
 									}
 								).code,

--- a/types.d.ts
+++ b/types.d.ts
@@ -30920,9 +30920,11 @@ declare namespace exports {
 				parentOf(n?: number): number;
 				children(n?: number): number[];
 			};
+			export let BLOCK_CONTENTS: "block-contents";
 			export let CLASSIC_SCRIPT: "script";
 			export let EMBEDDED_LANGUAGES: string[];
 			export let EVENT_HANDLER: "event-handler";
+			export let JSON_TYPE: "json";
 			export let MODULE_SCRIPT: "module";
 			export let NS_HTML: 0;
 			export let NS_MATHML: 1;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1285,6 +1285,37 @@ type BuildDependencyItem =
 	  };
 type BuildInfo = KnownBuildInfo & Record<string, any>;
 type BuildMeta = KnownBuildMeta & Record<string, any>;
+declare interface BuiltinEmbeddedRendererOptions {
+	/**
+	 * what the target can read (the CSS entries of `output.environment`), so a spelling it would not understand is never reached for; only read while printing, and an absent entry means the modern spelling is available
+	 */
+	environment?: CssEnvironment;
+
+	/**
+	 * rewrite a length into a shorter unit it is exactly equal in (`16px` -> `1pc`); off by default because it earns nothing once the asset is compressed, and only read while printing. A time is always rewritten
+	 */
+	convertLengthUnits?: boolean;
+
+	/**
+	 * shorten a custom property's value the way any other value is shortened (`--x:#ffffff` -> `#fff`); off by default because `getPropertyValue()` hands that text back, and only read while printing. What it may rewrite is what any other value's tokens may be, a color in a substitution's fallback included — that being the property's value rather than the function's own argument
+	 */
+	rewriteCustomProperties?: boolean;
+
+	/**
+	 * which of the meaning-preserving rewrites the minifying print makes; each is on unless it is `false`
+	 */
+	transforms?: CssTransformOptions;
+
+	/**
+	 * names a whole-project analysis found unused, which the print takes out: a bare name is a class, an id and an `@keyframes` name, and a `--`-prefixed one is a custom property. Only read while printing
+	 */
+	unusedSymbols?: string[];
+
+	/**
+	 * each pseudo-class to write as a class instead (`{ "focus-visible": "focus-visible" }`), so a script can apply it where the engine does not. Only read while printing
+	 */
+	pseudoClasses?: { [index: string]: string };
+}
 declare abstract class ByTypeGenerator extends Generator {
 	map: { [index: string]: undefined | Generator };
 	generateError?: (
@@ -10457,13 +10488,7 @@ declare interface HtmlParserOptions {
 	 */
 	urlHints?: UrlHintRule[];
 }
-type HtmlPrintOptions = Pick<
-	CssProcessOptions,
-	"environment" | "convertLengthUnits" | "rewriteCustomProperties"
-> & {
-	cssTransforms?: CssTransformOptions;
-	cssUnusedSymbols?: string[];
-	cssPseudoClasses?: { [index: string]: string };
+declare interface HtmlPrintOptions {
 	transforms?: HtmlTransformOptions;
 	collapseWhitespace?: boolean | "all" | "conservative" | "smart";
 	mergeStyles?: boolean;
@@ -10480,7 +10505,7 @@ type HtmlPrintOptions = Pick<
 	) => undefined | string;
 	deferEmbeddedSource?: DeferredEmbeddedSource[];
 	deferSrcdoc?: boolean;
-};
+}
 declare interface HtmlProcessOptions {
 	/**
 	 * context element tag name for fragment parsing (see `parseHtml`); the HTML analog of the CSS parser's `as` parse-mode option
@@ -10496,36 +10521,6 @@ declare interface HtmlProcessOptions {
 	 * print the safely-minified serialization (nodes rebuilt from source, inert comments dropped, opening-tag whitespace collapsed) as `process` walks, and return it (default false = walk only, return `""`)
 	 */
 	minimize?: boolean;
-
-	/**
-	 * CSS's, not HTML's: handed to the CSS minifier that runs over an inline `<style>` and every `style=""`, so the inline copy of a declaration agrees with the `.css` asset
-	 */
-	environment?: CssEnvironment;
-
-	/**
-	 * CSS's too, handed over with `environment` (see `HtmlPrintOptions`)
-	 */
-	convertLengthUnits?: boolean;
-
-	/**
-	 * CSS's too, handed over with `environment` (see `HtmlPrintOptions`)
-	 */
-	rewriteCustomProperties?: boolean;
-
-	/**
-	 * CSS's per-transform switches too, handed over with `environment` (see `HtmlPrintOptions`)
-	 */
-	cssTransforms?: CssTransformOptions;
-
-	/**
-	 * CSS's `unusedSymbols` too, handed over with `environment` (see `HtmlPrintOptions`)
-	 */
-	cssUnusedSymbols?: string[];
-
-	/**
-	 * CSS's `pseudoClasses` too, handed over with `environment` (see `HtmlPrintOptions`)
-	 */
-	cssPseudoClasses?: { [index: string]: string };
 
 	/**
 	 * which of the meaning-preserving rewrites the minifying print makes; each is on unless it is `false`
@@ -10583,12 +10578,12 @@ declare interface HtmlProcessOptions {
 	deferSrcdoc?: boolean;
 
 	/**
-	 * collects what `renderEmbeddedSource` would be offered instead of offering it, for a caller whose renderer is asynchronous: the print leaves a marker for each and `finish` puts the answers in their place, so one parse serves both. A `style=""` stays with the built-in CSS minifier, whose text this print reads back to decide how the attribute is written. Takes precedence over `renderEmbeddedSource`
+	 * collects what `renderEmbeddedSource` would be offered instead of offering it, for a caller whose renderer is asynchronous: the print leaves a marker for each and `finish` puts the answers in their place, so one parse serves both. Takes precedence over `renderEmbeddedSource`
 	 */
 	deferEmbeddedSource?: DeferredEmbeddedSource[];
 
 	/**
-	 * renders each nested body this document embeds — an inline `<style>`, every `style=""` (handed over as a whole stylesheet, SVG's and MathML's included), a `<script>` holding JSON or JavaScript (with `as` naming which production of it the body is — `"module"` for a `<script type=module>`, `"script"` for a classic one), every event handler attribute, with `as: "event-handler"` saying it is a function body rather than a script — the production a `return` at its top level is in, which a renderer whose engine takes only whole scripts wraps before it reads — an `<svg>` subtree, and the document an `<iframe srcdoc>` holds (decoded, and written back escaped). Replaces the built-in CSS and JSON minifiers wherever it answers, and returning anything but text falls back to them; it is the only way inline JavaScript, SVG and a nested document are reached at all
+	 * renders each nested body this document embeds — an inline `<style>`, every `style=""` (as the block's contents it is, SVG's and MathML's included), a `<script>` holding JSON or JavaScript (with `as` naming which production of it the body is — `"module"` for a `<script type=module>`, `"script"` for a classic one), every event handler attribute, with `as: "event-handler"` saying it is a function body rather than a script — the production a `return` at its top level is in, which a renderer whose engine takes only whole scripts wraps before it reads — an `<svg>` subtree, and the document an `<iframe srcdoc>` holds (decoded, and written back escaped). The only way any of them is minified: webpack minifies nothing here itself, and `builtinEmbeddedRenderer` is its own CSS and JSON minifiers for a caller to pass; returning anything but text leaves a body as written
 	 */
 	renderEmbeddedSource?: (
 		source: string,
@@ -30972,6 +30967,12 @@ declare namespace exports {
 					  }
 			) => string;
 			export let buildHeadTags: (opts: OutputHtmlOptions) => string;
+			export let builtinEmbeddedRenderer: (
+				options?: BuiltinEmbeddedRendererOptions
+			) => (
+				source: string,
+				info: { type: string; hostType: string; as?: string }
+			) => undefined | string;
 			export let collectEmbeddedDiagnostics: (
 				reported: {
 					warnings?: (string | Error)[];
@@ -30995,6 +30996,7 @@ declare namespace exports {
 					HtmlPrintOptions,
 					"renderEmbeddedSource" | "deferEmbeddedSource"
 				> & {
+					environment?: CssEnvironment;
 					css?: {
 						convertLengthUnits?: boolean;
 						rewriteCustomProperties?: boolean;
@@ -31178,6 +31180,7 @@ declare namespace exports {
 					HtmlPrintOptions
 				>
 			) => string;
+			export let stripJsonWhitespace: (json: string) => string;
 			export let tokenize: (
 				input: string,
 				pos?: number,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

The HTML printer ran its own CSS and JSON minifiers for an inline `<style>`, a `style=""` and a JSON `<script>`, so a caller's `renderEmbeddedSource` could not own those bodies — a custom minimizer had no way to minify them itself. Now the printer minifies nothing: every nested body is offered to the renderer and a declined one is left as written. `builtinEmbeddedRenderer` exports webpack's own CSS and JSON minifiers as such a renderer, and `htmlMinify` composes it behind the caller's, so a custom minimizer answers for the languages it claims and webpack's own answers for the rest.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/HtmlSyntax.unittest.js` covers the renderer-only path and webpack's own renderer passed behind a declining one; `test/helpers/SampleEmbeddedMinifyPlugin.js` composes it the way `htmlMinify` does, so the `html` and `css` `configCases` exercise it in a real build.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `htmlMinify` and `optimization.minimize.html` produce the same output; the printer's CSS options (`environment`, `convertLengthUnits`, `rewriteCustomProperties`, `cssTransforms`, `cssUnusedSymbols`, `cssPseudoClasses`) move to `builtinEmbeddedRenderer`, which a direct `html.syntax` caller passes as `renderEmbeddedSource`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

`html.syntax.builtinEmbeddedRenderer` and `html.syntax.stripJsonWhitespace` are new exports worth a line where `renderEmbeddedSource` is documented.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to write the change and its tests under my direction and review, and to run the unit suites, the `html` and `css` `configCases` in both the plain and filesystem-cache runs, and the lint chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rendering for embedded CSS, JSON, JavaScript, SVG, event handlers, and nested documents.
  * Added built-in minification for embedded CSS and JSON, including inline styles.
  * Added support for configuring CSS processing options for embedded content.

* **Bug Fixes**
  * Preserved original embedded content when rendering is unavailable, declined, or fails.
  * Improved handling of style merging, malformed declarations, character references, and foreign content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->