### PR TITLE
perf(serialization): cut per-object work in the object serializer

### DIFF
--- a/.changeset/085-serialize-fewer-lookups.md
+++ b/.changeset/085-serialize-fewer-lookups.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Speed up cache serialization by cutting per-object lookups and call frames.

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -57,6 +57,7 @@ Technically any value can be used.
  * @property {number} length
  * @property {number} cycleStackSize
  * @property {number} referenceableSize
+ * @property {number} overwrittenReferencesLength
  * @property {number} currentPos
  * @property {number} objectTypeLookupSize
  * @property {number} currentPosTypeLookup
@@ -375,10 +376,21 @@ class ObjectMiddleware extends SerializerMiddleware {
 		/** @type {Map<ReferenceableItem, number>} */
 		let referenceable = new Map();
 		/**
+		 * Item and prior position, in pairs, for the positions `addReferenceable` replaced.
+		 * @type {(ReferenceableItem | number)[]}
+		 */
+		const overwrittenReferences = [];
+		/**
 		 * Adds referenceable.
 		 * @param {ReferenceableItem} item referenceable item
 		 */
 		const addReferenceable = (item) => {
+			const previous = referenceable.get(item);
+			// `setMapSize` can only drop keys added since a snapshot, so an
+			// overwritten position has to be recorded to be undone
+			if (previous !== undefined) {
+				overwrittenReferences.push(item, previous);
+			}
 			referenceable.set(item, currentPos++);
 		};
 		/** @type {Map<number, Buffer | [Buffer, Buffer] | Map<string, Buffer>>} */
@@ -735,6 +747,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 					length: result.length,
 					cycleStackSize: cycleStack.length,
 					referenceableSize: referenceable.size,
+					overwrittenReferencesLength: overwrittenReferences.length,
 					currentPos,
 					objectTypeLookupSize: objectTypeLookup.size,
 					currentPosTypeLookup
@@ -743,6 +756,19 @@ class ObjectMiddleware extends SerializerMiddleware {
 			rollback(snapshot) {
 				result.length = snapshot.length;
 				cycleStack.length = snapshot.cycleStackSize;
+				// newest first, so the oldest recorded position is the one kept,
+				// and before the truncation that drops the keys added since
+				for (
+					let i = overwrittenReferences.length - 2;
+					i >= snapshot.overwrittenReferencesLength;
+					i -= 2
+				) {
+					referenceable.set(
+						/** @type {ReferenceableItem} */ (overwrittenReferences[i]),
+						/** @type {number} */ (overwrittenReferences[i + 1])
+					);
+				}
+				overwrittenReferences.length = snapshot.overwrittenReferencesLength;
 				setMapSize(referenceable, snapshot.referenceableSize);
 				currentPos = snapshot.currentPos;
 				setMapSize(objectTypeLookup, snapshot.objectTypeLookupSize);

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -108,21 +108,6 @@ Technically any value can be used.
  */
 
 /**
- * Updates set size using the provided set.
- * @template T
- * @param {Set<T>} set set
- * @param {number} size count of items to keep
- */
-const setSetSize = (set, size) => {
-	let i = 0;
-	for (const item of set) {
-		if (i++ >= size) {
-			set.delete(item);
-		}
-	}
-};
-
-/**
  * Updates map size using the provided map.
  * @template K, X
  * @param {Map<K, X>} map map
@@ -148,6 +133,9 @@ const toHash = (buffer, hashFunction) => {
 	hash.update(buffer);
 	return hash.digest("latin1");
 };
+
+/** Marks an object whose children are still being written; never a real position. */
+const IN_PROGRESS = -1;
 
 const ESCAPE = null;
 const ESCAPE_ESCAPE_VALUE = null;
@@ -463,16 +451,22 @@ class ObjectMiddleware extends SerializerMiddleware {
 		let currentPosTypeLookup = 0;
 		/** @type {Map<SerializerConfigWithSerializer, number>} */
 		let objectTypeLookup = new Map();
-		/** @type {Set<ComplexSerializableType>} */
-		const cycleStack = new Set();
+		/**
+		 * One-entry cache in front of `objectTypeLookup`, since runs of one class are common.
+		 * @type {SerializerConfigWithSerializer | undefined}
+		 */
+		let lastConfig;
+		/** @type {number} */
+		let lastConfigIndex = 0;
+		/** @type {ComplexSerializableType[]} */
+		const cycleStack = [];
 		/**
 		 * Returns stack.
 		 * @param {ComplexSerializableType} item item to stack
 		 * @returns {string} stack
 		 */
 		const stackToString = (item) => {
-			const arr = [...cycleStack];
-			arr.push(item);
+			const arr = [...cycleStack, item];
 			return arr
 				.map((item) => {
 					if (typeof item === "string") {
@@ -528,63 +522,35 @@ class ObjectMiddleware extends SerializerMiddleware {
 		};
 		/** @type {undefined | WeakSet<Error>} */
 		let hasDebugInfoAttached;
-		/** @type {ObjectSerializerContext<EXPECTED_ANY>} */
-		let ctx = {
-			write(value) {
-				try {
-					process(/** @type {ComplexSerializableType} */ (value));
-				} catch (err) {
-					if (err !== NOT_SERIALIZABLE) {
-						if (hasDebugInfoAttached === undefined) {
-							hasDebugInfoAttached = new WeakSet();
-						}
-						if (!hasDebugInfoAttached.has(/** @type {Error} */ (err))) {
-							/** @type {Error} */
-							(err).message +=
-								`\nwhile serializing ${stackToString(/** @type {ComplexSerializableType} */ (value))}`;
-							hasDebugInfoAttached.add(/** @type {Error} */ (err));
-						}
-					}
-					throw err;
-				}
-				return ctx;
-			},
-			setCircularReference(ref) {
-				addReferenceable(ref);
-			},
-			snapshot() {
-				return {
-					length: result.length,
-					cycleStackSize: cycleStack.size,
-					referenceableSize: referenceable.size,
-					currentPos,
-					objectTypeLookupSize: objectTypeLookup.size,
-					currentPosTypeLookup
-				};
-			},
-			rollback(snapshot) {
-				result.length = snapshot.length;
-				setSetSize(cycleStack, snapshot.cycleStackSize);
-				setMapSize(referenceable, snapshot.referenceableSize);
-				currentPos = snapshot.currentPos;
-				setMapSize(objectTypeLookup, snapshot.objectTypeLookupSize);
-				currentPosTypeLookup = snapshot.currentPosTypeLookup;
-			},
-			...context
+		/**
+		 * Appends the path from the root to `item`, once per error.
+		 * @param {Error} err error thrown while writing `item`
+		 * @param {ComplexSerializableType} item item being written
+		 * @returns {Error} err
+		 */
+		const attachSerializationPath = (err, item) => {
+			if (hasDebugInfoAttached === undefined) {
+				hasDebugInfoAttached = new WeakSet();
+			}
+			if (!hasDebugInfoAttached.has(err)) {
+				err.message += `\nwhile serializing ${stackToString(item)}`;
+				hasDebugInfoAttached.add(err);
+			}
+			return err;
 		};
-		this.extendContext(ctx);
 		// Dispatched on `typeof` first: two thirds of the items are numbers,
 		// booleans and `undefined`, and only 3% are buffers.
 		/**
-		 * Processes the provided item.
+		 * Writes one item into the output; the context is returned so writes chain.
 		 * @param {ComplexSerializableType} item item to serialize
+		 * @returns {ObjectSerializerContext<EXPECTED_ANY>} context
 		 */
 		const process = (item) => {
 			switch (typeof item) {
 				case "number":
 				case "boolean":
 					result.push(item);
-					return;
+					return ctx;
 				case "string": {
 					if (item.length > 1) {
 						// short strings are shorter when not emitting a reference (this saves 1 byte per empty string)
@@ -602,10 +568,10 @@ class ObjectMiddleware extends SerializerMiddleware {
 							) {
 								// A back-reference is `null` + the offset.
 								result.push(ESCAPE, offset);
-								return;
+								return ctx;
 							}
 						}
-						addReferenceable(item);
+						referenceable.set(item, currentPos++);
 					}
 
 					if (item.length > 102400 && context.logger) {
@@ -617,87 +583,115 @@ class ObjectMiddleware extends SerializerMiddleware {
 					}
 
 					result.push(item);
-					return;
+					return ctx;
 				}
 				case "undefined":
 					result.push(ESCAPE, ESCAPE_UNDEFINED);
-					return;
+					return ctx;
 				case "object": {
 					// ESCAPE is null, so this covers null too
 					if (item === ESCAPE) {
 						result.push(ESCAPE, ESCAPE_ESCAPE_VALUE);
-						return;
+						return ctx;
+					}
+
+					// buffers and objects share one reference table, so a single
+					// lookup answers both before the costlier buffer test
+					const ref = referenceable.get(item);
+					if (ref !== undefined) {
+						if (ref === IN_PROGRESS) {
+							throw attachSerializationPath(
+								new Error(
+									"This is a circular references. To serialize circular references use 'setCircularReference' somewhere in the circle during serialize and deserialize."
+								),
+								item
+							);
+						}
+						result.push(ESCAPE, ref - currentPos);
+						return ctx;
 					}
 
 					if (Buffer.isBuffer(item)) {
-						// check if we can emit a reference
-						const ref = referenceable.get(item);
-						if (ref !== undefined) {
-							result.push(ESCAPE, ref - currentPos);
-							return;
-						}
 						const alreadyUsedBuffer = dedupeBuffer(item);
 						if (alreadyUsedBuffer !== item) {
 							const ref = referenceable.get(alreadyUsedBuffer);
 							if (ref !== undefined) {
 								referenceable.set(item, ref);
 								result.push(ESCAPE, ref - currentPos);
-								return;
+								return ctx;
 							}
 							item = alreadyUsedBuffer;
 						}
-						addReferenceable(item);
+						referenceable.set(item, currentPos++);
 
 						result.push(/** @type {Buffer} */ (item));
-						return;
-					}
-
-					// check if we can emit a reference
-					const ref = referenceable.get(item);
-					if (ref !== undefined) {
-						result.push(ESCAPE, ref - currentPos);
-						return;
-					}
-
-					if (cycleStack.has(item)) {
-						throw new Error(
-							"This is a circular references. To serialize circular references use 'setCircularReference' somewhere in the circle during serialize and deserialize."
-						);
+						return ctx;
 					}
 
 					// Keyed by the registration itself: one per class, so it stands in for
 					// `${request}/${name}` without building that string per object.
-					const config = ObjectMiddleware.getSerializerFor(
-						/** @type {Constructor} */
-						(item)
+					const proto = Object.getPrototypeOf(item);
+					const registered = serializers.get(
+						proto === null ? null : proto.constructor
 					);
+					/** @type {SerializerConfigWithSerializer} */
+					let config;
+					if (registered !== undefined && registered.serializer !== undefined) {
+						config = /** @type {SerializerConfigWithSerializer} */ (registered);
+					} else {
+						try {
+							// re-resolved so the miss reports which class is unregistered
+							config = ObjectMiddleware.getSerializerFor(
+								/** @type {Constructor} */
+								(item)
+							);
+						} catch (err) {
+							if (err === NOT_SERIALIZABLE) throw err;
+							throw attachSerializationPath(/** @type {Error} */ (err), item);
+						}
+					}
 					const { request, name, serializer } = config;
-					const lastIndex = objectTypeLookup.get(config);
+					const lastIndex =
+						config === lastConfig
+							? lastConfigIndex
+							: objectTypeLookup.get(config);
 
 					if (lastIndex === undefined) {
-						objectTypeLookup.set(config, currentPosTypeLookup++);
+						lastConfigIndex = currentPosTypeLookup++;
+						objectTypeLookup.set(config, lastConfigIndex);
 
 						result.push(ESCAPE, request, name);
 					} else {
+						lastConfigIndex = lastIndex;
 						result.push(ESCAPE, currentPosTypeLookup - lastIndex);
 					}
+					lastConfig = config;
 
-					cycleStack.add(item);
+					referenceable.set(item, IN_PROGRESS);
+					cycleStack.push(item);
 
 					try {
 						serializer.serialize(item, ctx);
-					} finally {
-						cycleStack.delete(item);
+					} catch (err) {
+						cycleStack.pop();
+						if (err !== NOT_SERIALIZABLE) {
+							attachSerializationPath(/** @type {Error} */ (err), item);
+						}
+						throw err;
 					}
+					cycleStack.pop();
 
 					result.push(ESCAPE, ESCAPE_END_OBJECT);
 
-					addReferenceable(item);
-					return;
+					referenceable.set(item, currentPos++);
+					return ctx;
 				}
 				case "function": {
 					if (!SerializerMiddleware.isLazy(item)) {
-						throw new Error(`Unexpected function ${item}`);
+						throw attachSerializationPath(
+							new Error(`Unexpected function ${item}`),
+							item
+						);
 					}
 
 					/** @type {SerializedType | undefined} */
@@ -708,10 +702,10 @@ class ObjectMiddleware extends SerializerMiddleware {
 						if (typeof serializedData === "function") {
 							result.push(serializedData);
 						} else {
-							throw new Error("Not implemented");
+							throw attachSerializationPath(new Error("Not implemented"), item);
 						}
 					} else if (SerializerMiddleware.isLazy(item, this)) {
-						throw new Error("Not implemented");
+						throw attachSerializationPath(new Error("Not implemented"), item);
 					} else {
 						const data =
 							/** @type {() => PrimitiveSerializableType[] | Promise<PrimitiveSerializableType[]>} */
@@ -723,12 +717,41 @@ class ObjectMiddleware extends SerializerMiddleware {
 						SerializerMiddleware.setLazySerializedValue(item, data);
 						result.push(data);
 					}
-					return;
+					return ctx;
 				}
 				default:
 					result.push(item);
 			}
+			return ctx;
 		};
+		/** @type {ObjectSerializerContext<EXPECTED_ANY>} */
+		let ctx = {
+			write: process,
+			setCircularReference(ref) {
+				addReferenceable(ref);
+			},
+			snapshot() {
+				return {
+					length: result.length,
+					cycleStackSize: cycleStack.length,
+					referenceableSize: referenceable.size,
+					currentPos,
+					objectTypeLookupSize: objectTypeLookup.size,
+					currentPosTypeLookup
+				};
+			},
+			rollback(snapshot) {
+				result.length = snapshot.length;
+				cycleStack.length = snapshot.cycleStackSize;
+				setMapSize(referenceable, snapshot.referenceableSize);
+				currentPos = snapshot.currentPos;
+				setMapSize(objectTypeLookup, snapshot.objectTypeLookupSize);
+				lastConfig = undefined;
+				currentPosTypeLookup = snapshot.currentPosTypeLookup;
+			},
+			...context
+		};
+		this.extendContext(ctx);
 
 		try {
 			for (const item of data) {

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -57,7 +57,6 @@ Technically any value can be used.
  * @property {number} length
  * @property {number} cycleStackSize
  * @property {number} referenceableSize
- * @property {number} overwrittenReferencesLength
  * @property {number} currentPos
  * @property {number} objectTypeLookupSize
  * @property {number} currentPosTypeLookup
@@ -376,21 +375,10 @@ class ObjectMiddleware extends SerializerMiddleware {
 		/** @type {Map<ReferenceableItem, number>} */
 		let referenceable = new Map();
 		/**
-		 * Item and prior position, in pairs, for the positions `addReferenceable` replaced.
-		 * @type {(ReferenceableItem | number)[]}
-		 */
-		const overwrittenReferences = [];
-		/**
 		 * Adds referenceable.
 		 * @param {ReferenceableItem} item referenceable item
 		 */
 		const addReferenceable = (item) => {
-			const previous = referenceable.get(item);
-			// `setMapSize` can only drop keys added since a snapshot, so an
-			// overwritten position has to be recorded to be undone
-			if (previous !== undefined) {
-				overwrittenReferences.push(item, previous);
-			}
 			referenceable.set(item, currentPos++);
 		};
 		/** @type {Map<number, Buffer | [Buffer, Buffer] | Map<string, Buffer>>} */
@@ -747,7 +735,6 @@ class ObjectMiddleware extends SerializerMiddleware {
 					length: result.length,
 					cycleStackSize: cycleStack.length,
 					referenceableSize: referenceable.size,
-					overwrittenReferencesLength: overwrittenReferences.length,
 					currentPos,
 					objectTypeLookupSize: objectTypeLookup.size,
 					currentPosTypeLookup
@@ -756,19 +743,15 @@ class ObjectMiddleware extends SerializerMiddleware {
 			rollback(snapshot) {
 				result.length = snapshot.length;
 				cycleStack.length = snapshot.cycleStackSize;
-				// newest first, so the oldest recorded position is the one kept,
-				// and before the truncation that drops the keys added since
-				for (
-					let i = overwrittenReferences.length - 2;
-					i >= snapshot.overwrittenReferencesLength;
-					i -= 2
-				) {
-					referenceable.set(
-						/** @type {ReferenceableItem} */ (overwrittenReferences[i]),
-						/** @type {number} */ (overwrittenReferences[i + 1])
-					);
+				// a `setCircularReference` since the snapshot replaced a marker on an
+				// item already keyed here, which `setMapSize` cannot undo
+				for (let i = 0; i < cycleStack.length; i++) {
+					const item = /** @type {ReferenceableItem} */ (cycleStack[i]);
+					const ref = referenceable.get(item);
+					if (ref !== undefined && ref >= snapshot.currentPos) {
+						referenceable.set(item, IN_PROGRESS);
+					}
 				}
-				overwrittenReferences.length = snapshot.overwrittenReferencesLength;
 				setMapSize(referenceable, snapshot.referenceableSize);
 				currentPos = snapshot.currentPos;
 				setMapSize(objectTypeLookup, snapshot.objectTypeLookupSize);

--- a/test/ObjectMiddleware.unittest.js
+++ b/test/ObjectMiddleware.unittest.js
@@ -13,6 +13,48 @@ const logger = new Logger(
 );
 const context = { logger };
 
+/** A node that reaches itself, so only `setCircularReference` can serialize it. */
+class Cycle {
+	/**
+	 * @param {string} name name
+	 */
+	constructor(name) {
+		/** @type {string} */
+		this.name = name;
+		/** @type {Cycle | undefined} */
+		this.next = undefined;
+	}
+}
+
+ObjectMiddleware.register(Cycle, "test/ObjectMiddleware.unittest", "Cycle", {
+	/**
+	 * @param {Cycle} item item
+	 * @param {import("../lib/serialization/ObjectMiddleware").ObjectSerializerContext} context context
+	 */
+	serialize(item, { write, setCircularReference }) {
+		setCircularReference(item);
+		write(item.name);
+		write(item.next);
+	},
+	/**
+	 * @param {import("../lib/serialization/ObjectMiddleware").ObjectDeserializerContext} context context
+	 * @returns {Cycle} item
+	 */
+	deserialize({ read, setCircularReference }) {
+		const item = new Cycle("");
+		setCircularReference(item);
+		item.name = /** @type {string} */ (read());
+		item.next = /** @type {Cycle | undefined} */ (read());
+		return item;
+	}
+});
+
+class Unregistered {}
+
+class NotSerializable {}
+
+ObjectMiddleware.registerNotSerializable(NotSerializable);
+
 /**
  * @param {EXPECTED_ANY} value the value to round-trip
  * @returns {EXPECTED_ANY} what came back
@@ -116,5 +158,35 @@ describe("ObjectMiddleware", () => {
 		expect(() => middleware.serialize([circular], context)).toThrow(
 			/circular references/
 		);
+	});
+
+	it("round-trips a cycle declared with setCircularReference", () => {
+		const first = new Cycle("first");
+		const second = new Cycle("second");
+		first.next = second;
+		second.next = first;
+		const result = roundTrip(first);
+		expect(result.name).toBe("first");
+		expect(result.next.name).toBe("second");
+		expect(result.next.next).toBe(result);
+	});
+
+	it("names the path to the value it could not serialize", () => {
+		expect(() =>
+			middleware.serialize(
+				[{ outer: { inner: /** @type {EXPECTED_ANY} */ (() => {}) } }],
+				context
+			)
+		).toThrow(/while serializing Object \{ outer \} -> Object \{ inner \}/);
+	});
+
+	it("rejects a class with no registered serializer", () => {
+		expect(() => middleware.serialize([new Unregistered()], context)).toThrow(
+			/No serializer registered for Unregistered/
+		);
+	});
+
+	it("returns null for a class registered as not serializable", () => {
+		expect(middleware.serialize([new NotSerializable()], context)).toBeNull();
 	});
 });

--- a/test/ObjectMiddleware.unittest.js
+++ b/test/ObjectMiddleware.unittest.js
@@ -49,6 +49,38 @@ ObjectMiddleware.register(Cycle, "test/ObjectMiddleware.unittest", "Cycle", {
 	}
 });
 
+/** Rolls back over its own `setCircularReference`, then writes itself again. */
+class RolledBackCycle {
+	constructor() {
+		/** @type {string} */
+		this.name = "rolled back";
+	}
+}
+
+ObjectMiddleware.register(
+	RolledBackCycle,
+	"test/ObjectMiddleware.unittest",
+	"RolledBackCycle",
+	{
+		/**
+		 * @param {RolledBackCycle} item item
+		 * @param {import("../lib/serialization/ObjectMiddleware").ObjectSerializerContext} context context
+		 */
+		serialize(item, context) {
+			const state = context.snapshot();
+			context.setCircularReference(item);
+			context.rollback(state);
+			context.write(item);
+		},
+		/**
+		 * @returns {RolledBackCycle} item
+		 */
+		deserialize() {
+			return new RolledBackCycle();
+		}
+	}
+);
+
 class Unregistered {}
 
 class NotSerializable {}
@@ -178,6 +210,12 @@ describe("ObjectMiddleware", () => {
 				context
 			)
 		).toThrow(/while serializing Object \{ outer \} -> Object \{ inner \}/);
+	});
+
+	it("forgets a rolled back setCircularReference", () => {
+		expect(() =>
+			middleware.serialize([new RolledBackCycle()], context)
+		).toThrow(/circular references/);
 	});
 
 	it("rejects a class with no registered serializer", () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -19882,7 +19882,7 @@ declare namespace ObjectDeserializerContextObjectMiddlewareObject_1 {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectDeserializerContextObjectMiddlewareObject_2<
 	T extends ReadonlyArray<any> = ReadonlyArray<any>
@@ -19893,7 +19893,7 @@ declare interface ObjectDeserializerContextObjectMiddlewareObject_2<
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectDeserializerContextObjectMiddlewareObject_3 {
 	read: () => string;
@@ -19941,7 +19941,7 @@ declare interface ObjectEncodingOptionsTypes {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectSerializer {
 	serialize: (
@@ -19954,7 +19954,7 @@ declare interface ObjectSerializer {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectSerializerContextObjectMiddlewareObject_1 {
 	write: (
@@ -19986,7 +19986,7 @@ declare namespace ObjectSerializerContextObjectMiddlewareObject_2 {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectSerializerContextObjectMiddlewareObject_3<
 	T extends ReadonlyArray<any> = ReadonlyArray<any>
@@ -20005,7 +20005,7 @@ declare interface ObjectSerializerContextObjectMiddlewareObject_3<
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectSerializerContextObjectMiddlewareObject_4 {
 	write: (
@@ -20024,7 +20024,7 @@ declare interface ObjectSerializerContextObjectMiddlewareObject_4 {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface ObjectSerializerSnapshot {
 	length: number;
@@ -27686,7 +27686,7 @@ declare abstract class StackedMap<K, V> {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface StarListDeserializerContext {
 	read: () => HarmonyExportImportedSpecifierDependency[];
@@ -27695,7 +27695,7 @@ declare interface StarListDeserializerContext {
 }
 
 /**
- * Updates set size using the provided set.
+ * Updates map size using the provided map.
  */
 declare interface StarListSerializerContext {
 	write: (

--- a/types.d.ts
+++ b/types.d.ts
@@ -20030,7 +20030,6 @@ declare interface ObjectSerializerSnapshot {
 	length: number;
 	cycleStackSize: number;
 	referenceableSize: number;
-	overwrittenReferencesLength: number;
 	currentPos: number;
 	objectTypeLookupSize: number;
 	currentPosTypeLookup: number;

--- a/types.d.ts
+++ b/types.d.ts
@@ -20030,6 +20030,7 @@ declare interface ObjectSerializerSnapshot {
 	length: number;
 	cycleStackSize: number;
 	referenceableSize: number;
+	overwrittenReferencesLength: number;
 	currentPos: number;
 	objectTypeLookupSize: number;
 	currentPosTypeLookup: number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Writing one object through `ObjectMiddleware.serialize` cost five hash-table operations — a `referenceable` lookup, three `cycleStack` set operations and an `objectTypeLookup` lookup — and every value a serializer wrote crossed two stack frames. This cuts that to three operations and one frame: cycles are detected by an `IN_PROGRESS` marker in `referenceable` (so the cycle stack is a plain array kept only for the error path), `process` is exposed as `ctx.write` with the `while serializing …` path attached at the sites that throw, buffers and objects share one reference lookup, and the registry lookup keeps a one-entry cache. The format, the `ObjectSerializerContext` contract and the diagnostics are unchanged.

Measured:

- Real cold filesystem-cache build (1398 modules), time inside `serialize`: **393.6 → 363.0 ms** (mean of 7, −7.8%); the single big pack write **285.9 → 252.8 ms** (−11.6%).
- Repeated serialization of the same pack, arms interleaved in one process: **0.88–0.92 ×** baseline.
- The emitted value stream is **byte-identical**: 2,314,143 values compared one by one with both implementations loaded in the same process.

Refs webpack/tsc#171 — that issue proposes handing serialization to `node:v8` behind a `toObject`/`fromObject` contract; this is only the "make the existing serializer faster" half and does not change the format.

Two things worth recording for that discussion, both measured on the benchmark in the issue: splitting the pipeline by stage shows `ObjectMiddleware` at ~3.8 s and `BinaryMiddleware` (which already *is* `v8.serialize`) at ~0.42 s, and webpack's encoded output is 48.2 MB where raw `v8.serialize` on the same data produces 486.6 MB. Peak RSS is 1703 MB vs 1601 MB, so memory is already at parity.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — `test/ObjectMiddleware.unittest.js` gains cases for the cycle path (`setCircularReference`), an unregistered class, a class registered as not serializable, and the path named in the `while serializing …` message. They pass unchanged on `main`, which is the point: they pin behaviour this PR must not alter.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. Claude Code was used to profile `ObjectMiddleware`, write the change and the tests, and run the before/after benchmarks. Every number above comes from a run on this branch, and the byte-identical claim is from a harness that serializes the same captured cache payload with both implementations in one process and compares the two value streams element by element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvdJaN9rHeNyc9EpqZjtb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvdJaN9rHeNyc9EpqZjtb3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved cache serialization speed by reducing repeated lookups and processing overhead.

- **Bug Fixes**
  - Improved handling of circular references during serialization and deserialization.
  - Enhanced reliability when nested serialization operations fail.
  - Correctly handles missing and explicitly non-serializable serializers.
  - Ensured rolled-back circular references do not persist and cause incorrect later results.

- **Tests**
  - Added coverage for circular objects, nested errors, rollback behavior, missing serializers, and non-serializable classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->