### PR TITLE
refactor(javascript): use webpack's own parser and types outside the parser core

### DIFF
--- a/.changeset/180-own-parser-outside-syntax.md
+++ b/.changeset/180-own-parser-outside-syntax.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Use webpack's own parser and types instead of acorn outside the parser core.

--- a/lib/asset/WebManifestParser.js
+++ b/lib/asset/WebManifestParser.js
@@ -5,15 +5,15 @@
 
 "use strict";
 
-const { parse } = require("acorn");
 const Parser = require("../Parser");
 const HtmlSourceDependency = require("../dependencies/HtmlSourceDependency");
+const { parse } = require("../javascript/syntax");
 
 /** @import { Expression, ObjectExpression, Program, Property } from "estree" */
 /** @import { BuildInfo } from "../Module" */
 /** @import { ParserState, PreparsedAst } from "../Parser" */
 
-// acorn decorates every node with numeric source offsets (absent from the estree types).
+// the parser decorates every node with numeric source offsets (absent from the estree types).
 /** @typedef {{ start: number, end: number }} Positioned */
 
 // A URL carrying its own scheme (`https:`, `data:`, …) is external; it is only
@@ -70,9 +70,11 @@ class WebManifestParser extends Parser {
 		let ast;
 		try {
 			// Wrap in parens so the top-level object is an expression, not a block.
-			ast = /** @type {Program} */ (
-				/** @type {unknown} */ (parse(`(${source})`, { ecmaVersion: "latest" }))
-			);
+			ast = parse(`(${source})`, {
+				ecmaVersion: "latest",
+				sourceType: "script",
+				lazyNodes: true
+			});
 		} catch (_err) {
 			// Not valid JSON — leave the file untouched (still emitted as-is).
 			ast = undefined;

--- a/lib/errors/ModuleParseError.js
+++ b/lib/errors/ModuleParseError.js
@@ -101,7 +101,8 @@ class ModuleParseError extends WebpackError {
 				}
 			}
 
-			loc = { start: err.loc };
+			// a plain copy: a parser's own position class must not reach the cache
+			loc = { start: { line: lineNumber, column: err.loc.column } };
 		} else if (err && err.stack) {
 			message += `\n${err.stack}`;
 		}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -26,13 +26,7 @@ const {
 	positionAt
 } = require("./syntax");
 
-/** @typedef {typeof import("acorn").Parser} AcornParser */
-/**
- * @import {
- * 	Options as AcornOptions,
- * 	ecmaVersion as EcmaVersion
- * } from "acorn"
- */
+/** @import { EcmaVersion, ParserOptions, ParserPlugin } from "./syntax" */
 /**
  * @import {
  * 	AssignmentExpression,
@@ -184,7 +178,7 @@ const RETURN_FALSE = () => false;
 const RETURN_EMPTY_ARRAY = () => [];
 
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
-let parser = /** @type {AcornParser} */ (WebpackParser);
+let parser = WebpackParser;
 
 /** @typedef {Record<string, string> & { _isLegacyAssert?: boolean }} ImportAttributes */
 
@@ -327,7 +321,7 @@ class VariableInfo {
  * @property {boolean=} ranges
  * @property {boolean=} allowHashBang
  * @property {boolean=} allowReturnOutsideFunction
- * @property {boolean=} lazyNodes internal: serve `range` lazily and skip acorn's location/range tracking
+ * @property {boolean=} lazyNodes internal: serve `range` lazily and skip the parser's location/range tracking
  * @property {Comment[]=} lazyComments internal: collect comments here without slicing their text eagerly
  * @property {boolean=} importPhases enable parsing of the import phase proposals (import defer / import source)
  * @property {boolean=} moduleFallback internal: for `auto`, let the parser downgrade module->script in place instead of re-parsing
@@ -5877,7 +5871,15 @@ class JavascriptParser extends Parser {
 				};
 			}
 		}
-		return /** @type {DependencyLocation} */ (node.loc);
+		const loc = node.loc;
+		if (!loc) {
+			return /** @type {DependencyLocation} */ (/** @type {unknown} */ (loc));
+		}
+		// a plain copy: a foreign parser's location class must not reach the cache
+		return {
+			start: { line: loc.start.line, column: loc.start.column },
+			end: { line: loc.end.line, column: loc.end.column }
+		};
 	}
 
 	/**
@@ -6530,16 +6532,12 @@ class JavascriptParser extends Parser {
 					// text slice until some hook actually reads `value`
 					options.lazyComments = comments;
 				} else {
-					/** @type {AcornOptions} */
-					(options).onComment =
-						/** @type {import("acorn").Comment[]} */
-						(/** @type {unknown} */ (comments));
+					/** @type {ParserOptions} */
+					(options).onComment = comments;
 				}
 			}
 
-			const ast =
-				/** @type {Program} */
-				(parser.parse(code, /** @type {AcornOptions} */ (options)));
+			const ast = /** @type {Program} */ (parser.parse(code, options));
 
 			return { ast, comments };
 		};
@@ -6575,7 +6573,7 @@ class JavascriptParser extends Parser {
 		// release per-parse state retained on the (possibly reused) options
 		// object — the comments array retains source text slices
 		parserOptions.lazyComments = undefined;
-		/** @type {AcornOptions} */
+		/** @type {ParserOptions} */
 		(parserOptions).onComment = undefined;
 
 		if (threw) {
@@ -6587,7 +6585,7 @@ class JavascriptParser extends Parser {
 
 	/**
 	 * Returns parser.
-	 * @param {((BaseParser: AcornParser) => AcornParser)[]} plugins parser plugin
+	 * @param {ParserPlugin[]} plugins parser plugin
 	 * @returns {typeof JavascriptParser} parser
 	 */
 	static extend(...plugins) {

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -94,6 +94,11 @@ const stringToBigInt = (str) => BigInt(str.replace(/_/g, ""));
 /** @typedef {[number, number]} Range */
 /** @typedef {"defer" | "source"} ImportPhase */
 /** @typedef {import("estree").Comment & { start: number, end: number }} CollectedComment comment as JavascriptParser exposes it */
+/** @typedef {import("acorn").ecmaVersion} EcmaVersion the ECMAScript versions the parser accepts */
+/** @typedef {typeof import("acorn").Parser} ParserClass the parser class itself, the one place its acorn base is still part of a public signature */
+/** @typedef {(BaseParser: ParserClass) => ParserClass} ParserPlugin a plugin: receives the parser class, returns an extended one */
+/** @typedef {CollectedComment[] | ((isBlock: boolean, text: string, start: number, end: number) => void)} CommentSink where comments are collected, as an array or a callback */
+/** @typedef {Omit<Options, "onComment"> & { onComment?: CommentSink, lazyNodes?: boolean, lazyComments?: CollectedComment[], importPhases?: boolean, moduleFallback?: boolean }} ParserOptions the parser's options, carrying webpack's own comment type plus its lazy-node and import-phase switches */
 
 // Symbol-keyed so they stay out of for-in, Object.keys and JSON.stringify
 // over AST nodes.
@@ -2523,6 +2528,17 @@ const getFastConstructionShape = (options, input, startPos) => {
  * `!forNew` guard, unlike the former `acorn-import-phases` package).
  */
 class WebpackParser extends BaseParser {
+	/**
+	 * Applies parser plugins, keeping the result typed as this parser.
+	 * @param {...ParserPlugin} plugins parser plugins
+	 * @returns {typeof WebpackParser} the extended parser class
+	 */
+	static extend(...plugins) {
+		return /** @type {typeof WebpackParser} */ (
+			/** @type {unknown} */ (super.extend(...plugins))
+		);
+	}
+
 	/**
 	 * @param {Options & { lazyNodes?: boolean, lazyComments?: CollectedComment[], importPhases?: boolean, moduleFallback?: boolean }} options options
 	 * @param {string} input source code
@@ -11672,6 +11688,23 @@ const collectCjsRequireSpecifiers = (source) => {
 	return specifiers;
 };
 
+/**
+ * Parses `input` into an estree program. The entry point for everything outside
+ * this module, so no caller needs the parser class or its underlying types.
+ * @param {string} input source code
+ * @param {ParserOptions} options parser options
+ * @returns {import("estree").Program} the parsed program
+ */
+const parse = (input, options) =>
+	/** @type {import("estree").Program} */ (
+		/** @type {unknown} */ (
+			WebpackParser.parse(
+				input,
+				/** @type {Options} */ (/** @type {unknown} */ (options))
+			)
+		)
+	);
+
 module.exports.LEGACY_ASSERT_ATTRIBUTES = LEGACY_ASSERT_ATTRIBUTES;
 module.exports.ParserPosition = ParserPosition;
 module.exports.WebpackParser = WebpackParser;
@@ -11679,5 +11712,6 @@ module.exports.buildLineStarts = buildLineStarts;
 module.exports.collectCjsRequireSpecifiers = collectCjsRequireSpecifiers;
 module.exports.hasOctalEscape = hasOctalEscape;
 module.exports.isIdentifierChar = isIdentifierChar;
+module.exports.parse = parse;
 module.exports.positionAt = positionAt;
 module.exports.releaseParserCaches = releaseParserCaches;

--- a/lib/util/registerExternalSerializer.js
+++ b/lib/util/registerExternalSerializer.js
@@ -5,8 +5,6 @@
 
 "use strict";
 
-const Position = require("acorn").Position;
-const SourceLocation = require("acorn").SourceLocation;
 const ValidationError = require("schema-utils").ValidationError;
 const {
 	CachedSource,
@@ -20,7 +18,7 @@ const {
 const ParserPosition = require("../javascript/syntax").ParserPosition;
 const { register } = require("./serialization");
 
-/** @import { RealDependencyLocation, SourcePosition } from "../Dependency" */
+/** @import { SourcePosition } from "../Dependency" */
 /**
  * @import {
  * 	ObjectDeserializerContext,
@@ -225,74 +223,6 @@ register(
 			const buffer = read();
 			const name = read();
 			return new OriginalSource(buffer, name);
-		}
-	})()
-);
-
-register(
-	SourceLocation,
-	CURRENT_MODULE,
-	"acorn/SourceLocation",
-	new (class SourceLocationSerializer {
-		/**
-		 * Serializes this instance into the provided serializer context.
-		 * @param {SourceLocation} loc the location to be serialized
-		 * @param {import("../serialization/ObjectMiddleware").ObjectSerializerContext<number[]>} context context
-		 * @returns {void}
-		 */
-		serialize(loc, { write }) {
-			write(loc.start.line);
-			write(loc.start.column);
-			write(loc.end.line);
-			write(loc.end.column);
-		}
-
-		/**
-		 * Restores this instance from the provided deserializer context.
-		 * @param {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<number[]>} context context
-		 * @returns {RealDependencyLocation} location
-		 */
-		deserialize({ read }) {
-			return {
-				start: {
-					line: read(),
-					column: read()
-				},
-				end: {
-					line: read(),
-					column: read()
-				}
-			};
-		}
-	})()
-);
-
-register(
-	Position,
-	CURRENT_MODULE,
-	"acorn/Position",
-	new (class PositionSerializer {
-		/**
-		 * Serializes this instance into the provided serializer context.
-		 * @param {Position} pos the position to be serialized
-		 * @param {import("../serialization/ObjectMiddleware").ObjectSerializerContext<number[]>} context context
-		 * @returns {void}
-		 */
-		serialize(pos, { write }) {
-			write(pos.line);
-			write(pos.column);
-		}
-
-		/**
-		 * Restores this instance from the provided deserializer context.
-		 * @param {import("../serialization/ObjectMiddleware").ObjectDeserializerContext<number[]>} context context
-		 * @returns {SourcePosition} position
-		 */
-		deserialize({ read }) {
-			return {
-				line: read(),
-				column: read()
-			};
 		}
 	})()
 );

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -1165,22 +1165,31 @@ describe("JavascriptParser", () => {
 			});
 		});
 
-		it("should fall back to `loc` without source text", () => {
+		it("should fall back to a copy of `loc` without source text", () => {
 			const parser = new JavascriptParser("module");
 			const loc = {
 				start: { line: 1, column: 0 },
 				end: { line: 1, column: 1 }
 			};
-			expect(parser.getLocation({ start: 0, end: 1, loc })).toBe(loc);
+			const location = parser.getLocation({ start: 0, end: 1, loc });
+			expect(location).toEqual(loc);
+			expect(location).not.toBe(loc);
 		});
 
-		it("should fall back to `loc` for nodes without offsets", () => {
+		it("should fall back to a copy of `loc` for nodes without offsets", () => {
 			const parser = parserFor("a;");
 			const loc = {
 				start: { line: 1, column: 0 },
 				end: { line: 1, column: 1 }
 			};
-			expect(parser.getLocation({ loc })).toBe(loc);
+			const location = parser.getLocation({ loc });
+			expect(location).toEqual(loc);
+			expect(location).not.toBe(loc);
+		});
+
+		it("should leave a missing `loc` alone without source text", () => {
+			const parser = new JavascriptParser("module");
+			expect(parser.getLocation({ start: 0, end: 1 })).toBeUndefined();
 		});
 
 		// `buildLineStarts` serves LF-only and CRLF sources from a native

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2324,6 +2324,10 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 	});
 
 	describe("acorn boundary", () => {
+		// Either quote style, and the name must end there: a sibling package like
+		// `acorn-import-phases` is not the dependency this boundary is about.
+		const ACORN_REQUIRE_REGEXP = /\brequire\s*\(\s*["']acorn["'/]/;
+
 		// the parser core owns the acorn dependency; every other file uses
 		// webpack's own `parse`, so a new `require("acorn")` is a regression
 		it("keeps acorn out of every lib file but the parser core", () => {
@@ -2346,7 +2350,7 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 					} else if (entry.name.endsWith(".js")) {
 						const relative = path.relative(dir, file).replace(/\\/g, "/");
 						if (relative === "javascript/syntax.js") continue;
-						if (/require\(\s*"acorn/.test(fs.readFileSync(file, "utf8"))) {
+						if (ACORN_REQUIRE_REGEXP.test(fs.readFileSync(file, "utf8"))) {
 							offenders.push(relative);
 						}
 					}

--- a/test/WebpackParser.unittest.js
+++ b/test/WebpackParser.unittest.js
@@ -2322,4 +2322,38 @@ describe("WebpackParser acorn-override fast-path gates", () => {
 			expect(count).toBeGreaterThan(10);
 		});
 	});
+
+	describe("acorn boundary", () => {
+		// the parser core owns the acorn dependency; every other file uses
+		// webpack's own `parse`, so a new `require("acorn")` is a regression
+		it("keeps acorn out of every lib file but the parser core", () => {
+			const fs = require("fs");
+			const path = require("path");
+
+			const dir = path.resolve(__dirname, "../lib");
+			/** @type {string[]} */
+			const offenders = [];
+			/**
+			 * @param {string} directory directory to scan
+			 */
+			const walk = (directory) => {
+				for (const entry of fs.readdirSync(directory, {
+					withFileTypes: true
+				})) {
+					const file = path.join(directory, entry.name);
+					if (entry.isDirectory()) {
+						walk(file);
+					} else if (entry.name.endsWith(".js")) {
+						const relative = path.relative(dir, file).replace(/\\/g, "/");
+						if (relative === "javascript/syntax.js") continue;
+						if (/require\(\s*"acorn/.test(fs.readFileSync(file, "utf8"))) {
+							offenders.push(relative);
+						}
+					}
+				}
+			};
+			walk(dir);
+			expect(offenders).toEqual([]);
+		});
+	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -21987,7 +21987,7 @@ declare interface ParseOptionsJavascriptParser {
 	allowReturnOutsideFunction?: boolean;
 
 	/**
-	 * internal: serve `range` lazily and skip acorn's location/range tracking
+	 * internal: serve `range` lazily and skip the parser's location/range tracking
 	 */
 	lazyNodes?: boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`lib/javascript/syntax.js` owns the acorn dependency, but three other `lib/` files still reached for acorn directly; they now use a new `parse` export and the `EcmaVersion` / `ParserOptions` / `ParserPlugin` typedefs that `syntax.js` declares, so acorn is named in exactly one file under `lib/`. Dropping the acorn `Position` / `SourceLocation` serializers needs a compensating change: `getLocation` and `ModuleParseError` now copy a foreign parser's location into a plain object, so an AST supplied by a loader cannot put a class the registry does not know into the persistent cache.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — a tripwire in `test/WebpackParser.unittest.js` fails if any `lib/` file but `syntax.js` requires acorn again, and `test/JavascriptParser.unittest.js` covers the copied and missing `loc` paths. The cache path is covered by `parsing/precreated-ast` under `TestCasesCachePack`, whose loader still builds its AST with acorn and asks for locations.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `types.d.ts` is unchanged apart from one reworded doc line — the public `JavascriptParser.extend` signature still names acorn's `Parser`, because that plugin hook hands out the parser class itself.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

This PR was developed with Claude (AI assistant) under human direction: it performed the analysis, implementation and verification; the requester reviewed and directed the work.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo1cHj5Asx24LuVcz2CqT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo1cHj5Asx24LuVcz2CqT6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and web manifest parsing for more consistent syntax handling.
  * Improved error location handling to preserve accurate source positions during caching and serialization.
  * Increased compatibility when processing parser-generated location data.

* **Refactor**
  * Standardized parser integration across supported parsing workflows.

* **Tests**
  * Added coverage to verify parser boundaries and location-copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->