### PR TITLE
test(js): compare the parser's tree with acorn's over all of test262

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,41 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # Parses all of test262 with webpack's parser and with acorn, and compares the
+  # trees. Coverage instrumentation makes the parser ~5x slower, so this one job
+  # runs without it — every line it reaches is covered by the suites that upload.
+  test262-parser:
+    needs: basic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check out the test262 corpus
+        run: git submodule update --init --depth 1 test/test262-cases
+
+      - name: Use Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          cache: yarn
+
+      - run: yarn --frozen-lockfile
+
+      - run: yarn link --frozen-lockfile || true
+
+      - run: yarn link webpack --frozen-lockfile
+
+      - name: Cache jest result
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .jest-cache
+          key: jest-test262-parser-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-${{ github.sha }}
+          restore-keys: |
+            jest-test262-parser-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/jest.config.js') }}-
+            jest-test262-parser-${{ runner.os }}-
+
+      - run: yarn test:test262-parser --ci --cacheDirectory .jest-cache
+
   html5lib:
     needs: basic
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,9 @@ jobs:
   test262-parser:
     needs: basic
     runs-on: ubuntu-latest
+    # Bounded: the suite allows ten minutes per area per mode, so a stall
+    # would otherwise hold a runner for the 6h default.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:integration:a": "yarn test:base --testMatch \"<rootDir>/test/*.{basictest,test}.js\"",
     "test:integration:b": "yarn test:base --testMatch \"<rootDir>/test/*.longtest.js\"",
     "test:test262": "yarn test:base --testMatch \"<rootDir>/test/test262.spectest.js\"",
+    "test:test262-parser": "yarn test:base --testMatch \"<rootDir>/test/test262-parser.spectest.js\"",
     "test:html5lib": "yarn test:base --testMatch \"<rootDir>/test/html5lib.spectest.js\"",
     "test:syntax-equivalence": "yarn test:base --testMatch \"<rootDir>/test/syntaxEquivalence.spectest.js\"",
     "test:css-parsing": "yarn test:base --testMatch \"<rootDir>/test/cssParsing-webpack.spectest.js\"",

--- a/test/test262-parser.spectest.js
+++ b/test/test262-parser.spectest.js
@@ -1,0 +1,278 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const acorn = require("acorn");
+const JavascriptParser = require("../lib/javascript/JavascriptParser");
+
+/** @typedef {{ file: string, at: string, ours: string, acorn: string }} TreeDifference */
+/** @typedef {{ file: string, parsedBy: string, message: string }} VerdictDifference */
+/** @typedef {{ ranges?: boolean, locations?: boolean, comments?: boolean }} Mode */
+/** @typedef {import("acorn").Program} Program */
+/** @typedef {import("acorn").Comment} Comment */
+/** @typedef {import("../lib/javascript/JavascriptParser").ParseResult} ParseResult */
+
+const corpusDir = path.resolve(__dirname, "./test262-cases/test");
+const hasCorpus =
+	fs.existsSync(corpusDir) && fs.readdirSync(corpusDir).length > 0;
+
+// Every area is parsed twice per mode, and coverage instrumentation makes the
+// parser several times slower, so jest's default 30s is far too tight.
+const AREA_TIMEOUT = 600000;
+// Enough of a regression to see its shape without flooding the log.
+const MAX_REPORTED = 10;
+
+// The option sets a caller can hand `JavascriptParser._parse`. `ranges` is the
+// one webpack itself uses: it switches on the lazy-node path.
+/** @type {[string, Mode][]} */
+const MODES = [
+	["without ranges or comments", {}],
+	["with ranges and comments", { ranges: true, comments: true }],
+	["with locations", { locations: true }]
+];
+
+/**
+ * The `sourceType` a test262 file is written for, which its `flags` declare.
+ * @param {string} code the file's source
+ * @returns {"module" | "script"} the goal symbol to parse it as
+ */
+const sourceTypeOf = (code) => {
+	const meta = /\/\*---([\s\S]*?)---\*\//.exec(code);
+	if (!meta) return "script";
+	const flags = /flags:\s*\[([^\]]*)\]/.exec(meta[1]);
+	if (!flags) return "script";
+	return flags[1].split(",").some((flag) => flag.trim() === "module")
+		? "module"
+		: "script";
+};
+
+/**
+ * A value as it reads in a difference report, kept short enough to scan.
+ * @param {unknown} value either parser's value at the differing path
+ * @returns {string} how the value prints
+ */
+const show = (value) => {
+	if (typeof value === "bigint") return `${value}n`;
+	if (value instanceof RegExp) return String(value);
+	if (typeof value === "object" && value !== null) {
+		return Array.isArray(value)
+			? `[${value.length} items]`
+			: `{${Object.keys(value).sort().join(",")}}`;
+	}
+	return JSON.stringify(value) || String(value);
+};
+
+/**
+ * The first place two parse trees disagree, or null when they match. Key
+ * presence is asked with `in`, since the lazy path serves `range` from a
+ * prototype getter rather than an own property.
+ * @param {unknown} ours what webpack's parser built
+ * @param {unknown} theirs what acorn built
+ * @param {string} at the path walked so far
+ * @returns {{ at: string, ours: string, acorn: string } | null} the difference
+ */
+const firstDifference = (ours, theirs, at) => {
+	if (ours === theirs) return null;
+	const report = { at, ours: show(ours), acorn: show(theirs) };
+	if (typeof ours !== typeof theirs) return report;
+	if (typeof ours === "number") {
+		return Number.isNaN(ours) && Number.isNaN(/** @type {number} */ (theirs))
+			? null
+			: report;
+	}
+	if (typeof ours === "bigint") {
+		return String(ours) === String(theirs) ? null : report;
+	}
+	if (typeof ours !== "object" || ours === null || theirs === null) {
+		return report;
+	}
+	if (ours instanceof RegExp || theirs instanceof RegExp) {
+		return String(ours) === String(theirs) ? null : report;
+	}
+	if (Array.isArray(ours) !== Array.isArray(theirs)) return report;
+	if (Array.isArray(ours)) {
+		const other = /** @type {unknown[]} */ (theirs);
+		if (ours.length !== other.length) return report;
+		for (let i = 0; i < ours.length; i++) {
+			const difference = firstDifference(ours[i], other[i], `${at}[${i}]`);
+			if (difference) return difference;
+		}
+		return null;
+	}
+	const left = /** @type {Record<string, unknown>} */ (ours);
+	const right = /** @type {Record<string, unknown>} */ (theirs);
+	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+	for (const key of [...keys].sort()) {
+		if (!(key in left)) {
+			return { at: `${at}.${key}`, ours: "absent", acorn: show(right[key]) };
+		}
+		if (!(key in right)) {
+			return { at: `${at}.${key}`, ours: show(left[key]), acorn: "absent" };
+		}
+		const difference = firstDifference(left[key], right[key], `${at}.${key}`);
+		if (difference) return difference;
+	}
+	return null;
+};
+
+/**
+ * Whether acorn only got through the file because the host engine cannot build
+ * one of its regexp literals, which acorn records as a null value and webpack
+ * (validating with `new RegExp`) reports as a parse error instead.
+ * @param {Error} error what webpack's parser threw
+ * @param {Program} ast the program acorn built
+ * @returns {boolean} true when the engine, not the pattern, is the difference
+ */
+const isHostRegExpLimit = (error, ast) => {
+	if (!error.message.startsWith("Invalid regular expression:")) {
+		return false;
+	}
+	/** @type {unknown[]} */
+	const queue = [ast];
+	while (queue.length > 0) {
+		const node = queue.pop();
+		if (typeof node !== "object" || node === null) continue;
+		const record = /** @type {Record<string, unknown>} */ (node);
+		if (record.regex !== undefined && record.value === null) return true;
+		for (const key of Object.keys(record)) queue.push(record[key]);
+	}
+	return false;
+};
+
+/**
+ * Parse one file with both parsers and record how they disagreed.
+ * @param {string} file absolute path of the test262 file
+ * @param {Mode} mode the options both parsers are given
+ * @param {TreeDifference[]} trees where tree differences are collected
+ * @param {VerdictDifference[]} verdicts where accept/reject differences are collected
+ * @returns {void}
+ */
+const compareFile = (file, mode, trees, verdicts) => {
+	const code = fs.readFileSync(file, "utf8");
+	const sourceType = sourceTypeOf(code);
+	const name = path.relative(corpusDir, file);
+	const options = {
+		sourceType,
+		ecmaVersion: /** @type {const} */ ("latest"),
+		allowHashBang: true,
+		...mode
+	};
+
+	/** @type {ParseResult | undefined} */
+	let ours;
+	/** @type {Error | undefined} */
+	let ourError;
+	try {
+		ours = JavascriptParser._parse(code, { ...options });
+	} catch (err) {
+		ourError = /** @type {Error} */ (err);
+	}
+
+	/** @type {Comment[]} */
+	const comments = [];
+	/** @type {Program | undefined} */
+	let theirs;
+	/** @type {Error | undefined} */
+	let theirError;
+	try {
+		theirs = acorn.parse(code, {
+			...options,
+			// `_parse` sets this from the goal symbol, so acorn has to match
+			allowReturnOutsideFunction: sourceType === "script",
+			...(mode.comments === true ? { onComment: comments } : {})
+		});
+	} catch (err) {
+		theirError = /** @type {Error} */ (err);
+	}
+
+	if (ourError !== undefined || theirError !== undefined) {
+		if (ourError !== undefined && theirError !== undefined) return;
+		if (
+			ourError !== undefined &&
+			theirs !== undefined &&
+			isHostRegExpLimit(ourError, theirs)
+		) {
+			return;
+		}
+		verdicts.push({
+			file: name,
+			parsedBy: ourError === undefined ? "webpack" : "acorn",
+			message: /** @type {Error} */ (ourError || theirError).message
+		});
+		return;
+	}
+
+	const tree = firstDifference(
+		/** @type {ParseResult} */ (ours).ast,
+		theirs,
+		"program"
+	);
+	if (tree) trees.push({ file: name, ...tree });
+	if (mode.comments !== true) return;
+	const commentDifference = firstDifference(
+		/** @type {ParseResult} */ (ours).comments,
+		comments,
+		"comments"
+	);
+	if (commentDifference) trees.push({ file: name, ...commentDifference });
+};
+
+/**
+ * The first few differences, with a count when more were found.
+ * @template T
+ * @param {T[]} differences everything the run collected
+ * @returns {(T | string)[]} what the assertion prints
+ */
+const reportable = (differences) =>
+	differences.length > MAX_REPORTED
+		? [
+				...differences.slice(0, MAX_REPORTED),
+				`…and ${differences.length - MAX_REPORTED} more`
+			]
+		: differences;
+
+const areas = hasCorpus
+	? fs
+			.readdirSync(corpusDir, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort()
+	: [];
+
+describe("test262 parser parity", () => {
+	if (!hasCorpus) {
+		it("submodule not initialized (run `git submodule update --init --depth 1 test/test262-cases`)", () => {
+			// No-op: the conformance corpus is an optional git submodule.
+		});
+
+		return;
+	}
+
+	for (const area of areas) {
+		describe(area, () => {
+			const files = fs
+				.globSync(`${corpusDir}/${area}/**/*.js`)
+				.filter((file) => !/_FIXTURE\.js$/i.test(file))
+				.sort();
+
+			for (const [modeName, mode] of MODES) {
+				it(
+					`builds acorn's tree ${modeName}`,
+					() => {
+						/** @type {TreeDifference[]} */
+						const trees = [];
+						/** @type {VerdictDifference[]} */
+						const verdicts = [];
+						for (const file of files) {
+							compareFile(file, mode, trees, verdicts);
+						}
+						expect(files.length).toBeGreaterThan(0);
+						expect(reportable(trees)).toEqual([]);
+						expect(reportable(verdicts)).toEqual([]);
+					},
+					AREA_TIMEOUT
+				);
+			}
+		});
+	}
+});

--- a/test/test262-parser.spectest.js
+++ b/test/test262-parser.spectest.js
@@ -101,8 +101,11 @@ const firstDifference = (ours, theirs, at) => {
 	}
 	const left = /** @type {Record<string, unknown>} */ (ours);
 	const right = /** @type {Record<string, unknown>} */ (theirs);
-	const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
-	for (const key of [...keys].sort()) {
+	const ourKeys = Object.keys(left);
+	const theirKeys = Object.keys(right);
+	// Whichever side owns more keys covers the other: two same-sized key sets
+	// that differ must each hold a key the other lacks.
+	for (const key of ourKeys.length >= theirKeys.length ? ourKeys : theirKeys) {
 		if (!(key in left)) {
 			return { at: `${at}.${key}`, ours: "absent", acorn: show(right[key]) };
 		}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The rewritten JavaScript parser is an acorn subclass that reimplements most of the tokenizer and much of the parser, so its contract is that the tree it builds is acorn's — but nothing checked that wholesale. This parses each of the 53,580 test262 files with both parsers, in each option set a caller can ask `_parse` for (no ranges, ranges and comments, locations), and reports the first node that differs; it also checks that both accept or reject the same file. There are no differences today.

Key presence is asked with `in` rather than own keys, because the lazy-node path serves `range` from a prototype getter — an own-key comparison would skip exactly the values most likely to drift. One divergence is tolerated by mechanism rather than by a file list: where the host engine cannot build a regexp literal, acorn records a null value and webpack raises, so a pattern acorn accepted while recording a null value is not counted (on Node 22 that is 87 valid ES2025 patterns; on a newer engine, none).

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — the change is the test: `test/test262-parser.spectest.js`, with `yarn test:test262-parser` and its own CI job. I verified it is not vacuous by injecting a one-line regression (a `bigint` literal keeping its trailing `n`), which it caught with the file, the AST path and both values.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — it adds a test suite and its job; no shipped code changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a. The suite runs in a job of its own rather than in the existing `test262` job because that one runs under coverage, and instrumentation makes the parser about five times slower (27 minutes for the corpus against 4.6 without); it skips with a placeholder when the submodule is not checked out.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to write the suite and its wiring under my direction and review, to measure the run cost with and without coverage, and to run the suite, the injected-regression check and the lint chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tNx7sU4SbnKFhFeofDVr5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated parser compatibility testing against the Test262 JavaScript corpus.
  - Parser behavior is compared across multiple configuration modes, including syntax results, AST output, and comments.
  - Test reporting identifies and limits differences while accounting for unsupported regular expression features.

- **Chores**
  - Added continuous integration coverage for the Test262 parser suite.
  - Added a dedicated command for running the parser compatibility tests locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->