### PR TITLE
fix(deps): guard the lazy barrel walk on callable methods, not present keys

### DIFF
--- a/.changeset/015-cached-module-resolve-options.md
+++ b/.changeset/015-cached-module-resolve-options.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Refresh a cached module's `resolveOptions` from the factory instead of the persistent cache pack.
+Refresh a cached module's `resolveOptions` from the factory, not the pack.

--- a/.changeset/020-lazy-barrel-foreign-dependency.md
+++ b/.changeset/020-lazy-barrel-foreign-dependency.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Skip a foreign dependency whose `isLazy` is a flag when walking a lazy barrel.

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -114,7 +114,12 @@ const getDeferredExports = (module) => {
 	for (const dep of module.dependencies) {
 		// TODO remove in webpack 6
 		// These may be missing on custom dependency types not extending the base Dependency
-		if (!("getLazyUntil" in dep) || !("isLazy" in dep)) continue;
+		if (
+			typeof dep.getLazyUntil !== "function" ||
+			typeof dep.isLazy !== "function"
+		) {
+			continue;
+		}
 		if (!dep.isLazy()) continue;
 		const until = dep.getLazyUntil();
 		if (until === Dependency.LAZY_UNTIL_FALLBACK) return true;

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/index.js
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/index.js
@@ -1,0 +1,6 @@
+import { missing, value } from "./lib";
+
+it("should walk a barrel carrying a foreign dependency that spells isLazy as a flag", () => {
+	expect(value).toBe(1);
+	expect(missing).toBe(undefined);
+});

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/index.js
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/index.js
@@ -1,0 +1,1 @@
+export { value } from "./value.js";

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/package.json
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "flagged-lib",
+	"version": "1.0.0",
+	"main": "index.js",
+	"sideEffects": false
+}

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/value.js
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/lib/value.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/warnings.js
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/warnings.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [[/export 'missing'/]];

--- a/test/configCases/lazy-barrel/custom-dependency-lazy-flag/webpack.config.js
+++ b/test/configCases/lazy-barrel/custom-dependency-lazy-flag/webpack.config.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const webpack = require("../../../../");
+const makeSerializable = require("../../../../lib/util/makeSerializable");
+
+/**
+ * @import {
+ * 	ObjectDeserializerContext,
+ * 	ObjectSerializerContext
+ * } from "../../../../lib/serialization/ObjectMiddleware"
+ */
+
+const { NullDependency } = webpack.dependencies;
+
+// A dependency type of webpack's own spells `isLazy` as a method; a foreign one may
+// spell the same name as a plain flag, which the lazy-barrel walk must not call.
+class LazyFlagDependency extends NullDependency {
+	constructor() {
+		super();
+		/** @type {{ isLazy: boolean }} */ (/** @type {unknown} */ (this)).isLazy =
+			true;
+	}
+
+	/**
+	 * Serializes this instance into the provided serializer context.
+	 * @param {ObjectSerializerContext} context context
+	 */
+	serialize(context) {
+		context.write(this.isLazy);
+		super.serialize(context);
+	}
+
+	/**
+	 * Restores this instance from the provided deserializer context.
+	 * @param {ObjectDeserializerContext} context context
+	 */
+	deserialize(context) {
+		/** @type {{ isLazy: boolean }} */ (/** @type {unknown} */ (this)).isLazy =
+			/** @type {boolean} */ (context.read());
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(
+	LazyFlagDependency,
+	"test/configCases/lazy-barrel/custom-dependency-lazy-flag/webpack.config.js",
+	"LazyFlagDependency"
+);
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	target: "web",
+	devtool: false,
+	optimization: {
+		sideEffects: true,
+		providedExports: true,
+		usedExports: true,
+		moduleIds: "named",
+		minimize: false,
+		concatenateModules: false
+	},
+	plugins: [
+		(compiler) => {
+			compiler.hooks.compilation.tap("Test", (compilation) => {
+				compilation.dependencyTemplates.set(
+					LazyFlagDependency,
+					new NullDependency.Template()
+				);
+				compilation.hooks.succeedModule.tap("Test", (module) => {
+					if (/lib[/\\]index\.js$/.test(module.identifier())) {
+						module.addDependency(new LazyFlagDependency());
+					}
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The lazy-barrel walk skipped a dependency only when `isLazy`/`getLazyUntil` were absent, then called them. A foreign dependency type that spells `isLazy` as a plain flag rather than a method passes that check, so the build ends with `TypeError: dep.isLazy is not a function`. Asking whether each is callable answers the question the next line asks. Every dependency webpack itself ships defines both as methods, so nothing changes for a build using only those. Also trims a pending changeset description to the 80-character limit.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/lazy-barrel/custom-dependency-lazy-flag`, which hands a side-effect-free barrel a dependency carrying the flag and fails with that `TypeError` on the previous guard.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used: it wrote the regression case, verified it fails against the previous guard and passes with this one in both the config and cache suites, and ran lint. I reviewed the design and the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0187hRzHd96HJAoKe4bRF67Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of lazy barrel exports when dependencies use a boolean lazy flag.
  * Correctly skips unsupported dependency types during lazy export analysis.
  * Preserves valid exports while reporting warnings for missing exports.

* **Tests**
  * Added coverage for lazy barrels containing foreign dependencies with boolean lazy indicators.

* **Documentation**
  * Updated the changelog description for cached module resolution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->