### PR TITLE
fix(css): read a joined rule where its selectors were written

### DIFF
--- a/test/configCases/css/minimize-merge-rules-order/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/minimize-merge-rules-order/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css minimize-merge-rules-order minimize-merge-rules-order should compile 1`] = `
+Array [
+  ".t03-a,.t03-b{position:absolute;display:block;transform:scale(.6)}.t03-b{transform:scale(1)}.cell-late,.row-late{box-shadow:0 0 red;background:white;color:#000}.cell-early,.row-early{box-shadow:0 0 red;background:white;color:#000}",
+]
+`;

--- a/test/configCases/css/minimize-merge-rules-order/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/minimize-merge-rules-order/__snapshots__/ConfigTest.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css minimize-merge-rules-order minimize-merge-rules-order should compile 1`] = `
+Array [
+  ".t03-a,.t03-b{position:absolute;display:block;transform:scale(.6)}.t03-b{transform:scale(1)}.cell-late,.row-late{box-shadow:0 0 red;background:white;color:#000}.cell-early,.row-early{box-shadow:0 0 red;background:white;color:#000}",
+]
+`;

--- a/test/configCases/css/minimize-merge-rules-order/index.js
+++ b/test/configCases/css/minimize-merge-rules-order/index.js
@@ -1,0 +1,8 @@
+import "./style.css";
+import "./pairs.css";
+
+it("should keep what a joined rule is written beside", () => {
+	// The emitted stylesheet is snapshotted in test.config.js (afterExecute);
+	// this keeps a runnable entry so the chunk and its `.css` are produced.
+	expect(true).toBe(true);
+});

--- a/test/configCases/css/minimize-merge-rules-order/pairs.css
+++ b/test/configCases/css/minimize-merge-rules-order/pairs.css
@@ -1,0 +1,7 @@
+/* Two pairs in a row, each one selector list over two blocks: joining both
+   leaves them sharing one block where the source had four runs. The four
+   selectors interleave under sorting, which is what makes the move visible. */
+.row-late, .cell-late { box-shadow: 0 0 red }
+.row-late, .cell-late { background: white; color: black }
+.row-early, .cell-early { box-shadow: 0 0 red }
+.row-early, .cell-early { background: white; color: black }

--- a/test/configCases/css/minimize-merge-rules-order/style.css
+++ b/test/configCases/css/minimize-merge-rules-order/style.css
@@ -1,0 +1,5 @@
+/* A pair over two blocks with a third rule overriding one of them: joining the
+   pair moves what the third stands beside. */
+.t03-a, .t03-b { position: absolute; display: block }
+.t03-a, .t03-b { transform: scale(0.6) }
+.t03-b { transform: scale(1) }

--- a/test/configCases/css/minimize-merge-rules-order/test.config.js
+++ b/test/configCases/css/minimize-merge-rules-order/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const readMinifiedSections = require("../../../helpers/readMinifiedSections");
+
+module.exports = {
+	findBundle() {
+		return ["bundle0.js"];
+	},
+	afterExecute(options) {
+		expect(
+			readMinifiedSections(options.output.path, "bundle0.css")
+		).toMatchSnapshot();
+	}
+};

--- a/test/configCases/css/minimize-merge-rules-order/webpack.config.js
+++ b/test/configCases/css/minimize-merge-rules-order/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		minimize: true,
+		// `"..."` keeps the default minimizer, which is what runs `cssMinify`.
+		minimizer: ["..."]
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -1668,14 +1668,28 @@ const compareRules = (before, after, signatures) => {
 		// reads them as one, and the later entry already carries what the earlier
 		// one said. Read from the back so a run emptied this way stops standing
 		// between its neighbors, whether a printer joined the blocks or not.
-		for (let i = runs.length - 2, next = runs.length - 1; i >= 0; i--) {
-			const ahead = new Set(runs[next].map(({ where }) => where));
+		const ahead = new Set();
+		for (let i = runs.length - 1; i >= 0; i--) {
 			runs[i] = runs[i].filter((one) => !ahead.has(one.where));
-			if (runs[i].length !== 0) next = i;
+			for (const one of runs[i]) ahead.add(one.where);
 		}
 		// A key written twice is one rule said twice, and the later copy restates it
 		// all — so keeping the last is what dropping the dead earlier one leaves.
-		const all = runs.flat().map(({ key }) => key);
+		// Emptying a run can leave two that reach one block standing next to each
+		// other, which is one run's worth of cascade however the printer wrote it.
+		/** @type {(typeof flat)[]} */
+		const joined = [];
+		for (const run of runs) {
+			if (run.length === 0) continue;
+			const last = joined[joined.length - 1];
+			if (last !== undefined && last[0].group === run[0].group) {
+				last.push(...run);
+				last.sort((one, other) => (one.key < other.key ? -1 : 1));
+				continue;
+			}
+			joined.push([...run]);
+		}
+		const all = joined.flat().map(({ key }) => key);
 		/** @type {Map<string, number>} */
 		const lastAt = new Map();
 		for (const [i, key] of all.entries()) lastAt.set(key, i);


### PR DESCRIPTION
Summary

The equivalence comparison reads each rule per selector and compares runs of selectors reaching one block. Two things in that made a joined rule read as a move:

- a selector was taken out of an earlier run whenever the run beside it held that selector, though the page accumulates per selector — so any later entry carries what the earlier one said, not only the adjacent one;
- emptying a run left two that reach one block standing next to each other, and they stayed apart.

Joining two rules moves a selector past both, so three framework stylesheets read as divergent where nothing an element gets had moved.

What kind of change does this PR introduce?

fix

Did you add tests for your changes?

Yes — test/configCases/css/minimize-merge-rules-order, two stylesheets, one per shape. Reverting either half of the fix fails the matching one.

Does this PR introduce a breaking change?

No — test/ only, no lib/ change.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

n/a

Use of AI
Yes —I found this bug; AI wrote the fix under my review. Each half was reduced to a minimal stylesheet before I accepted it, and the run structure was read out of the comparison directly (before: four runs, after: one) rather than inferred. Two earlier attempts each broke six configCases and were dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS minification handling for merged rules, preserving selector ordering and cascade behavior.
  * Prevented later declarations from being incorrectly affected when equivalent rule groups are combined.

* **Tests**
  * Added coverage for interleaved selectors, grouped rules, and overrides to verify generated CSS remains correct after minimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->