### PR TITLE
chore: add new tsc member

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ For information about the governance of the webpack project, see [GOVERNANCE.md]
   **Even Stensberg** <<evenstensberg@gmail.com>> (he/him)
 - [thelarkinn](https://github.com/thelarkinn) -
   **Sean Larkin** <<selarkin@microsoft.com>> (he/him)
+- [hai-x](https://github.com/hai-x) -
+  **Haijie Xie** <<haijie0619@gmail.com>> (he/him)
 
 ### Maintenance
 


### PR DESCRIPTION
from internal tsc meeting with majority of present members +1'ing I'm submitting a formal vote to add Hai to the tsc (+1 from me)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the TSC member list in the README to include Haijie Xie and their GitHub handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->