### PR TITLE
fix(html): drop the JS asset an extracted HTML entry leaves behind

### DIFF
--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Emit no JavaScript copy of an HTML entry's page, and name its chunks after it.
+Name an HTML page's chunks after its entry, drop its JS copy, type `text/html` exactly.

--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name an HTML page's chunks after its entry, drop its JS copy, type `text/html` exactly.
+Name an HTML page's chunks after its entry or file, drop its JS copy, type `text/html` exactly.

--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Drop the JS asset an extracted HTML entry leaves behind, which no page loads.

--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Drop the JS asset an extracted HTML entry leaves behind, which no page loads.
+Emit no JavaScript copy of an HTML entry's page, and name its chunks after it.

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1433,8 +1433,10 @@ const applyModuleDefaults = (
 				type: HTML_MODULE_TYPE,
 				resolve
 			});
+			// Exactly `text/html` — a string condition matches by prefix, which
+			// would make a `data:text/htmlx,` module (JavaScript) a page.
 			rules.push({
-				mimetype: "text/html",
+				mimetype: /^text\/html$/i,
 				type: HTML_MODULE_TYPE,
 				resolve
 			});

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -609,7 +609,10 @@ const resolvePageChunk = (compilation, chunk) => {
 	);
 	/** @type {Chunk[]} */
 	const chunks = javascript === undefined ? [] : [chunk];
-	for (const module of modules || []) {
+	// A chunk carrying no page stands for itself; a page stands for the entries
+	// extracted from it, so one that extracted nothing hints nothing.
+	if (modules === undefined) return chunks.length === 0 ? [chunk] : chunks;
+	for (const module of modules) {
 		const { htmlEntries } =
 			/** @type {import("../html/HtmlModule").HtmlModuleBuildInfo} */ (
 				module.buildInfo
@@ -623,7 +626,7 @@ const resolvePageChunk = (compilation, chunk) => {
 			}
 		}
 	}
-	return chunks.length === 0 ? [chunk] : chunks;
+	return chunks;
 };
 
 /**

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -596,12 +596,19 @@ const buildLinkTag = (rel, attrs) =>
  * @returns {Chunk[]} the chunks to hint at
  */
 const resolvePageChunk = (compilation, chunk) => {
-	const modules = compilation.chunkGraph.getChunkModulesIterableBySourceType(
+	const { chunkGraph } = compilation;
+	const modules = chunkGraph.getChunkModulesIterableBySourceType(
 		chunk,
 		HTML_TYPE
 	);
+	// A page with a JavaScript side of its own (an `output.library` entry) is
+	// hinted too — `chunkHasJs` can't say so, it holds for any runtime chunk.
+	const javascript = chunkGraph.getChunkModulesIterableBySourceType(
+		chunk,
+		JAVASCRIPT_TYPE
+	);
 	/** @type {Chunk[]} */
-	const chunks = [];
+	const chunks = javascript === undefined ? [] : [chunk];
 	for (const module of modules || []) {
 		const { htmlEntries } =
 			/** @type {import("../html/HtmlModule").HtmlModuleBuildInfo} */ (

--- a/lib/dependencies/HtmlEntryDependency.js
+++ b/lib/dependencies/HtmlEntryDependency.js
@@ -7,6 +7,7 @@
 const {
 	CSS_IMPORT_TYPE,
 	CSS_TYPE,
+	HTML_TYPE,
 	JAVASCRIPT_TYPE
 } = require("../ModuleSourceTypeConstants");
 const ResourceHintPlugin = require("../prefetch/ResourceHintPlugin");
@@ -588,6 +589,37 @@ const buildLinkTag = (rel, attrs) =>
 	}>`;
 
 /**
+ * The chunks a hint means when it names a page: a page loads no JavaScript of
+ * its own, so the hint follows the entries the parser extracted from it.
+ * @param {import("../Compilation")} compilation compilation
+ * @param {Chunk} chunk chunk a hint resolved to
+ * @returns {Chunk[]} the chunks to hint at
+ */
+const resolvePageChunk = (compilation, chunk) => {
+	const modules = compilation.chunkGraph.getChunkModulesIterableBySourceType(
+		chunk,
+		HTML_TYPE
+	);
+	/** @type {Chunk[]} */
+	const chunks = [];
+	for (const module of modules || []) {
+		const { htmlEntries } =
+			/** @type {import("../html/HtmlModule").HtmlModuleBuildInfo} */ (
+				module.buildInfo
+			) || {};
+		if (!htmlEntries) continue;
+		for (const group of Object.values(htmlEntries)) {
+			for (const { entryName } of group) {
+				const entrypoint = compilation.entrypoints.get(entryName);
+				const entryChunk = entrypoint && entrypoint.getEntrypointChunk();
+				if (entryChunk) chunks.push(entryChunk);
+			}
+		}
+	}
+	return chunks.length === 0 ? [chunk] : chunks;
+};
+
+/**
  * Resolve one `output.html.resourceHints` descriptor to zero or more `<link>`
  * tags. A `chunk`/`entry` reference becomes the emitted chunk URL (a sentinel
  * resolved with the final hash and public path), an `href` is used verbatim, and
@@ -633,6 +665,14 @@ const resolveResourceHint = (desc, ctx) => {
 	} else {
 		return [];
 	}
+	/** @type {Chunk[]} */
+	const hinted = [];
+	for (const chunk of chunks) {
+		for (const resolved of resolvePageChunk(ctx.compilation, chunk)) {
+			hinted.push(resolved);
+		}
+	}
+	chunks = hinted;
 	const kind = desc.as === "style" ? "css" : "javascript";
 	const as = desc.as || (rel === "modulepreload" ? undefined : "script");
 	// A hint targeting another chunk must match how that chunk is fetched, so

--- a/lib/html/HtmlGenerator.js
+++ b/lib/html/HtmlGenerator.js
@@ -9,6 +9,7 @@ const ConcatenationScope = require("../ConcatenationScope");
 const Generator = require("../Generator");
 const {
 	HTML_TYPE,
+	HTML_TYPES,
 	JAVASCRIPT_TYPE,
 	JAVASCRIPT_TYPES
 } = require("../ModuleSourceTypeConstants");
@@ -1047,13 +1048,16 @@ class HtmlGenerator extends Generator {
 	 * Creates an instance of HtmlGenerator.
 	 * @param {HtmlGeneratorOptions=} options generator options
 	 * @param {ModuleGraph=} moduleGraph the module graph; used to detect when an HTML module is reached as a compilation entry so `extract` can default to `true` for it
+	 * @param {((module: NormalModule) => boolean)=} isPageOnly tells whether the module's only output is its emitted page, so it exposes no JavaScript
 	 */
-	constructor(options, moduleGraph) {
+	constructor(options, moduleGraph, isPageOnly) {
 		super();
 		/** @type {HtmlGeneratorOptions} */
 		this.options = options || {};
 		/** @type {ModuleGraph | undefined} */
 		this._moduleGraph = moduleGraph;
+		/** @type {((module: NormalModule) => boolean) | undefined} */
+		this._isPageOnly = isPageOnly;
 		// Raw dependency-template render (before `[webpack/auto]` resolution),
 		// shared between the JS and HTML type passes of a single
 		// `codeGeneration()` call. Keyed by that call's `runtimeRequirements`
@@ -1134,6 +1138,9 @@ class HtmlGenerator extends Generator {
 	 */
 	getTypes(module) {
 		if (this._shouldExposeHtmlType(module)) {
+			// A page nothing else reads has no JavaScript side: that chunk would
+			// only re-export the markup already emitted as the `.html` asset.
+			if (this._isPageOnly && this._isPageOnly(module)) return HTML_TYPES;
 			return JAVASCRIPT_AND_HTML_TYPES;
 		}
 		return JAVASCRIPT_TYPES;
@@ -1143,10 +1150,9 @@ class HtmlGenerator extends Generator {
 	 * @returns {boolean} whether getTypes() depends on the module's incoming connections
 	 */
 	getTypesDependOnIncomingConnections() {
-		// A fixed extract (`true` / `false` / `"inline"`) gives a stable type set;
-		// only the unset default reads `_isEntryModule` (incoming connections).
-		const { extract } = this.options;
-		return extract !== true && extract !== false && extract !== "inline";
+		// Every page that can expose the html type reads incoming connections —
+		// for the `extract` default, and for the page-only JavaScript drop.
+		return this.options.extract !== false;
 	}
 
 	/**

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -733,12 +733,8 @@ class HtmlModulesPlugin {
 						// a content-hashed filename makes a substring hit a real reference.
 						/** @type {Set<string>} */
 						const deletionCandidates = new Set(inlinedFiles);
-						// A page-only entry's chunk rebuilds markup that was already
-						// written out as the `.html` asset; the page loads the
-						// `<script src>` entries the parser split out of it, never this
-						// chunk. That covers the `data:text/html` wrapper entry
-						// `output.html` adds, and an `.html` file used as an entry, whose
-						// JS side is just the page as a string export.
+						// A page-only entry's chunk only rebuilds markup already written
+						// out as the `.html` asset, which no emitted page loads.
 						for (const entrypoint of compilation.entrypoints.values()) {
 							const chunk = entrypoint.getEntrypointChunk();
 							if (!chunk) continue;
@@ -748,9 +744,8 @@ class HtmlModulesPlugin {
 								chunk
 							)) {
 								const { resource } = /** @type {NormalModule} */ (entryModule);
-								// A data URL counts only as the wrapper `output.html`
-								// writes — another `text/html`-ish media type is an entry
-								// the user asked for, and keeps its chunk.
+								// Only the wrapper `output.html` writes counts; another
+								// `text/html`-ish media type is the user's own entry.
 								const dataUrl =
 									typeof resource === "string" && resource.startsWith("data:");
 								const wrapper = dataUrl && HTML_DATA_URL_RE.test(resource);

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -919,15 +919,11 @@ class HtmlModulesPlugin {
 						// file. `cssChunkFilename` is derived from
 						// `output.chunkFilename` which webpack auto-extends
 						// with `[id].` when needed, guaranteeing uniqueness.
-						const pageTemplate = cssFilenames.get(entryName);
-						if (
-							pageTemplate === undefined &&
-							!stylesheetEntries.has(entryName)
-						) {
-							continue;
-						}
+						// Every name here is either a stylesheet entry or one named
+						// after its page, so one of the two templates always applies.
 						chunk.cssFilenameTemplate =
-							pageTemplate || compilation.outputOptions.cssChunkFilename;
+							cssFilenames.get(entryName) ||
+							compilation.outputOptions.cssChunkFilename;
 					}
 				});
 				compilation.dependencyTemplates.set(

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -49,6 +49,7 @@ const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 /**
  * @import {
  * 	EntryDescriptionNormalized,
+ * 	FilenameTemplate,
  * 	OutputHtmlOptions,
  * 	HtmlFaviconIcon
  * } from "../../declarations/WebpackOptions"
@@ -64,6 +65,8 @@ const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 /** @import Chunk from "../Chunk" */
 /** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compiler from "../Compiler" */
+/** @import Module from "../Module" */
+/** @typedef {import("../Compilation").EntryData} EntryData */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
 /** @typedef {{ request: string, entryName: string, type: "script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch", css?: boolean }} HtmlEntryInfo */
@@ -230,9 +233,57 @@ const isIntegrityEnabled = (integrity) =>
 // `\.html`/`\.css` request matchers for the synthetic `output.html` wrapper.
 const HTML_REQUEST_RE = /\.html(\?|$)/i;
 const CSS_REQUEST_RE = /\.css(\?|$)/i;
-// The wrapper's own resource — the media type must end here, so that a
-// `data:text/htmlx,` entry (JavaScript to `DataUriPlugin`) is not one.
-const HTML_DATA_URL_RE = /^data:text\/html[,;]/i;
+/**
+ * The entry a page is the whole of: nothing imports the module and the entry
+ * asks for nothing else, so the entry's JavaScript would be the page itself.
+ * @param {Compilation} compilation compilation
+ * @param {Module} module html module
+ * @returns {{ name: string, data: EntryData } | undefined} the page's own entry, when it has one
+ */
+const getPageEntry = (compilation, module) => {
+	const { moduleGraph } = compilation;
+	let isEntry = false;
+	for (const connection of moduleGraph.getIncomingConnections(module)) {
+		if (connection.originModule) return undefined;
+		isEntry = true;
+	}
+	if (!isEntry) return undefined;
+	for (const [name, data] of compilation.entries) {
+		if (data.dependencies.length !== 1) continue;
+		if (data.includeDependencies.length !== 0) continue;
+		if (moduleGraph.getModule(data.dependencies[0]) === module) {
+			return { name, data };
+		}
+	}
+	return undefined;
+};
+
+/**
+ * The entry of a page that emits nothing but its markup, so its chunk carries
+ * no JavaScript. An `output.library` asks for the page's exports, and keeps it.
+ * @param {Compilation} compilation compilation
+ * @param {Module} module html module
+ * @returns {{ name: string, data: EntryData } | undefined} the entry, when the page is all it emits
+ */
+const getPageOnlyEntry = (compilation, module) => {
+	const entry = getPageEntry(compilation, module);
+	if (entry === undefined) return undefined;
+	const { library } = entry.data.options;
+	const configured =
+		library === undefined ? compilation.outputOptions.library : library;
+	return configured === undefined ? entry : undefined;
+};
+
+/**
+ * A filename template usable for a page's extracted entries: it must name the
+ * chunk, or every entry of the page would be emitted to the same file.
+ * @param {import("../TemplatedPathPlugin").TemplatePath | FilenameTemplate | undefined} template configured template
+ * @returns {string | undefined} the template, when it carries a `[name]`
+ */
+const getNamedTemplate = (template) =>
+	typeof template === "string" && template.includes("[name]")
+		? template
+		: undefined;
 
 /**
  * Requests an `output.html` page must load for an entry: its `dependOn`
@@ -493,11 +544,11 @@ class HtmlModulesPlugin {
 		// `finishMake` creates their entries without scanning the whole module
 		// graph), the stylesheet entry names (read in `afterChunks`) and the html
 		// options of every emitted page, keyed by its asset name.
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssFilenames: Map<string, string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<import("../Module")>, stylesheetEntries: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
+		 * @returns {{ htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssFilenames: Map<string, string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
@@ -505,6 +556,7 @@ class HtmlModulesPlugin {
 				state = {
 					htmlModules: new Set(),
 					stylesheetEntries: new Set(),
+					cssFilenames: new Map(),
 					htmlAssetOptions: new Map()
 				};
 				compilationState.set(compilation, state);
@@ -512,14 +564,15 @@ class HtmlModulesPlugin {
 			return state;
 		};
 		compiler.hooks.finishMake.tapAsync(PLUGIN_NAME, (compilation, callback) => {
-			const { htmlModules, stylesheetEntries } = getState(compilation);
+			const { htmlModules, stylesheetEntries, cssFilenames } =
+				getState(compilation);
 
 			// Collect the entries an HTML module asks for. Only the script chains
 			// (`script`, `script-module`) share a runtime via a leader-only
 			// `dependOn`; `modulepreload`, `stylesheet` and `html` links are all
 			// independent entries (a CSS or page entry must not chain into a JS
 			// leader, or the chunk would mix unrelated outputs).
-			/** @type {(module: import("../Module")) => { context: string, request: string, name: string, dependOn: string[] | undefined }[]} */
+			/** @type {(module: Module) => { context: string, request: string, name: string, dependOn: string[] | undefined, filename: string | undefined }[]} */
 			const collectEntrySpecs = (module) => {
 				const { htmlEntries } = /** @type {HtmlModuleBuildInfo} */ (
 					module.buildInfo
@@ -527,6 +580,41 @@ class HtmlModulesPlugin {
 				if (!htmlEntries) return [];
 				const context = /** @type {string} */ (module.context);
 				const specs = [];
+				// A page that emits no JavaScript of its own hands its filename to
+				// the entries extracted from it, the way a JavaScript entry is named.
+				const pageEntry = getPageOnlyEntry(compilation, module);
+				const { filename, cssFilename } = compilation.outputOptions;
+				const jsTemplate = pageEntry
+					? getNamedTemplate(
+							pageEntry.data.options.filename === undefined
+								? filename
+								: pageEntry.data.options.filename
+						)
+					: undefined;
+				const cssTemplate = pageEntry
+					? getNamedTemplate(cssFilename)
+					: undefined;
+				const pageName = pageEntry ? pageEntry.name : "";
+				/**
+				 * @param {string} template filename template of the page's entry
+				 * @param {number} index position among the page's entries of that kind
+				 * @returns {string} filename template for one extracted entry
+				 */
+				const nameAfterPage = (template, index) =>
+					template.replace(
+						/\[name\]/g,
+						index === 0 ? pageName : `${pageName}${index}`
+					);
+				// A script chunk's own `.css` sibling is named after the page too, so
+				// it starts counting where the page's stylesheet entries stop.
+				let styleIndex = 0;
+				let scriptIndex = 0;
+				let siblingStyleIndex = 0;
+				for (const group of Object.values(htmlEntries)) {
+					for (const entry of group) {
+						if (entry.type === "stylesheet" || entry.css) siblingStyleIndex++;
+					}
+				}
 				for (const [groupKind, group] of Object.entries(htmlEntries)) {
 					const isChainGroup =
 						groupKind === "script" || groupKind === "script-module";
@@ -542,14 +630,38 @@ class HtmlModulesPlugin {
 						}
 						// Stylesheet entries and `as="style"` preload/prefetch entries emit
 						// a CSS chunk, so they need the CSS filename template below.
-						if (groupKind === "stylesheet" || entry.css) {
+						const emitsCss = groupKind === "stylesheet" || Boolean(entry.css);
+						if (emitsCss) {
 							stylesheetEntries.add(entry.entryName);
+						}
+						/** @type {string | undefined} */
+						let entryFilename;
+						// A linked page emits its file from `renderManifest`, so only the
+						// script and stylesheet entries take a name from the page.
+						if (groupKind !== "html") {
+							if (emitsCss) {
+								if (cssTemplate) {
+									cssFilenames.set(
+										entry.entryName,
+										nameAfterPage(cssTemplate, styleIndex++)
+									);
+								}
+							} else if (jsTemplate) {
+								entryFilename = nameAfterPage(jsTemplate, scriptIndex++);
+								if (cssTemplate) {
+									cssFilenames.set(
+										entry.entryName,
+										nameAfterPage(cssTemplate, siblingStyleIndex++)
+									);
+								}
+							}
 						}
 						specs.push({
 							context,
 							request: entry.request,
 							name: entry.entryName,
-							dependOn
+							dependOn,
+							filename: entryFilename
 						});
 					}
 				}
@@ -558,7 +670,7 @@ class HtmlModulesPlugin {
 
 			// Push one collected reference as a compilation entry; resolves with
 			// the built entry module.
-			/** @type {(spec: { context: string, request: string, name: string, dependOn: string[] | undefined }) => Promise<import("../Module") | null>} */
+			/** @type {(spec: { context: string, request: string, name: string, dependOn: string[] | undefined, filename: string | undefined }) => Promise<Module | null>} */
 			const addEntry = (spec) =>
 				new Promise((resolve, reject) => {
 					compilation.addEntry(
@@ -566,11 +678,12 @@ class HtmlModulesPlugin {
 						EntryPlugin.createDependency(spec.request, { name: spec.name }),
 						{
 							name: spec.name,
-							// Each entry gets its own filename from the synthetic entry name so
-							// it doesn't collide with `output.filename`. CSS entries set their
-							// `.css` name via `cssFilenameTemplate` below; `html` page entries
-							// emit their file via `renderManifest`.
-							filename: compilation.outputOptions.chunkFilename || "[name].js",
+							// An entry not named after its page falls back to its synthetic
+							// name, so it can't collide with `output.filename`.
+							filename:
+								spec.filename ||
+								compilation.outputOptions.chunkFilename ||
+								"[name].js",
 							dependOn: spec.dependOn
 						},
 						(err, entryModule) =>
@@ -583,7 +696,7 @@ class HtmlModulesPlugin {
 			// every HTML entry already gets. `processed` guards diamonds and cycles.
 			/** @type {WeakSet<import("../Module")>} */
 			const processed = new WeakSet();
-			/** @type {(module: import("../Module")) => Promise<void>} */
+			/** @type {(module: Module) => Promise<void>} */
 			const processEntry = async (module) => {
 				if (processed.has(module)) return;
 				processed.add(module);
@@ -733,42 +846,6 @@ class HtmlModulesPlugin {
 						// a content-hashed filename makes a substring hit a real reference.
 						/** @type {Set<string>} */
 						const deletionCandidates = new Set(inlinedFiles);
-						// A page-only entry's chunk only rebuilds markup already written
-						// out as the `.html` asset, which no emitted page loads.
-						for (const entrypoint of compilation.entrypoints.values()) {
-							const chunk = entrypoint.getEntrypointChunk();
-							if (!chunk) continue;
-							let pageOnly = false;
-							let pageFile = false;
-							for (const entryModule of compilation.chunkGraph.getChunkEntryModulesIterable(
-								chunk
-							)) {
-								const { resource } = /** @type {NormalModule} */ (entryModule);
-								// Only the wrapper `output.html` writes counts; another
-								// `text/html`-ish media type is the user's own entry.
-								const dataUrl =
-									typeof resource === "string" && resource.startsWith("data:");
-								const wrapper = dataUrl && HTML_DATA_URL_RE.test(resource);
-								const extractedPage =
-									!dataUrl &&
-									entryModule instanceof HtmlModule &&
-									entryModule.getSourceTypes().has(HTML_TYPE);
-								if (extractedPage) pageFile = true;
-								pageOnly = wrapper || extractedPage;
-								if (!pageOnly) break;
-							}
-							if (!pageOnly) continue;
-							// A page the user pointed `entry` at can still be asked for by
-							// name through `output.library` — then its JS is the output.
-							if (
-								pageFile &&
-								(entrypoint.options.library ||
-									compilation.outputOptions.library)
-							) {
-								continue;
-							}
-							for (const file of chunk.files) deletionCandidates.add(file);
-						}
 						// Materialize each other asset's source once (it can be expensive to
 						// render) and test all candidates against it, rather than
 						// re-materializing every asset per candidate.
@@ -820,9 +897,13 @@ class HtmlModulesPlugin {
 				// entry emits to a distinct file derived from `output.cssFilename`
 				// (or `output.cssChunkFilename` for non-initial CSS chunks).
 				compilation.hooks.afterChunks.tap(PLUGIN_NAME, () => {
-					const { stylesheetEntries } = getState(compilation);
-					if (stylesheetEntries.size === 0) return;
-					for (const entryName of stylesheetEntries) {
+					const { stylesheetEntries, cssFilenames } = getState(compilation);
+					if (stylesheetEntries.size === 0 && cssFilenames.size === 0) return;
+					const cssEntries = new Set(stylesheetEntries);
+					for (const entryName of cssFilenames.keys()) {
+						cssEntries.add(entryName);
+					}
+					for (const entryName of cssEntries) {
 						const entrypoint = compilation.entrypoints.get(entryName);
 						if (!entrypoint) continue;
 						const chunk = entrypoint.getEntrypointChunk();
@@ -838,8 +919,15 @@ class HtmlModulesPlugin {
 						// file. `cssChunkFilename` is derived from
 						// `output.chunkFilename` which webpack auto-extends
 						// with `[id].` when needed, guaranteeing uniqueness.
+						const pageTemplate = cssFilenames.get(entryName);
+						if (
+							pageTemplate === undefined &&
+							!stylesheetEntries.has(entryName)
+						) {
+							continue;
+						}
 						chunk.cssFilenameTemplate =
-							compilation.outputOptions.cssChunkFilename;
+							pageTemplate || compilation.outputOptions.cssChunkFilename;
 					}
 				});
 				compilation.dependencyTemplates.set(
@@ -957,7 +1045,8 @@ class HtmlModulesPlugin {
 						);
 						return new (getHtmlGenerator())(
 							generatorOptions,
-							compilation.moduleGraph
+							compilation.moduleGraph,
+							(module) => getPageOnlyEntry(compilation, module) !== undefined
 						);
 					});
 

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+const { basename, extname } = require("path");
 const { pathToFileURL } = require("url");
 const { AsyncSeriesHook, AsyncSeriesWaterfallHook } = require("tapable");
 const { RawSource } = require("webpack-sources");
@@ -23,7 +24,11 @@ const ConcatenatedModule = require("../optimize/ConcatenatedModule");
 const { compareModulesByFullName } = require("../util/comparators");
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
-const { getUndoPath, makePathsRelative } = require("../util/identifier");
+const {
+	getUndoPath,
+	makePathsRelative,
+	parseResource
+} = require("../util/identifier");
 const implicitTypeLoaderFallback = require("../util/implicitTypeLoaderFallback");
 const lazyModule = require("../util/lazyModule");
 const memoize = require("../util/memoize");
@@ -272,6 +277,29 @@ const getPageOnlyEntry = (compilation, module) => {
 	const configured =
 		library === undefined ? compilation.outputOptions.library : library;
 	return configured === undefined ? entry : undefined;
+};
+
+/**
+ * The name a page without an entry of its own lends to the entries extracted
+ * from it: its file's basename, so a linked page reads as `about.js`.
+ * @param {Module} module html module
+ * @param {Set<string>} taken names already spoken for in this compilation
+ * @returns {string | undefined} the page's name, when it has one to lend
+ */
+const getPageFileName = (module, taken) => {
+	const { resource } = /** @type {NormalModule} */ (module);
+	// A `data:` page is a wrapper webpack writes, and has no file to be named
+	// after; the entry it wraps names it instead.
+	if (typeof resource !== "string" || resource.startsWith("data:")) {
+		return undefined;
+	}
+	const { path: file } = parseResource(resource);
+	const name = basename(file, extname(file));
+	// Two pages can share a basename, and one can match an entry — the first
+	// takes it and the rest keep their synthetic name.
+	if (name === "" || taken.has(name)) return undefined;
+	taken.add(name);
+	return name;
 };
 
 /**
@@ -566,6 +594,9 @@ class HtmlModulesPlugin {
 		compiler.hooks.finishMake.tapAsync(PLUGIN_NAME, (compilation, callback) => {
 			const { htmlModules, stylesheetEntries, cssFilenames } =
 				getState(compilation);
+			const takenNames = new Set(compilation.entries.keys());
+			/** @type {Set<string>} */
+			const extractedNames = new Set();
 
 			// Collect the entries an HTML module asks for. Only the script chains
 			// (`script`, `script-module`) share a runtime via a leader-only
@@ -580,31 +611,41 @@ class HtmlModulesPlugin {
 				if (!htmlEntries) return [];
 				const context = /** @type {string} */ (module.context);
 				const specs = [];
-				// A page that emits no JavaScript of its own hands its filename to
-				// the entries extracted from it, the way a JavaScript entry is named.
+				// A page hands its name to the entries extracted from it, the way a
+				// JavaScript entry is named — it emits no JavaScript of its own.
 				const pageEntry = getPageOnlyEntry(compilation, module);
+				// A page the parser extracted from another one carries a synthetic
+				// entry name, so its file is the name a reader recognizes.
+				const namedEntry =
+					pageEntry !== undefined && !extractedNames.has(pageEntry.name)
+						? pageEntry
+						: undefined;
+				const pageName = namedEntry
+					? namedEntry.name
+					: getPageFileName(module, takenNames);
 				const { filename, cssFilename } = compilation.outputOptions;
-				const jsTemplate = pageEntry
-					? getNamedTemplate(
-							pageEntry.data.options.filename === undefined
-								? filename
-								: pageEntry.data.options.filename
-						)
+				const entryFilenameOption =
+					namedEntry && namedEntry.data.options.filename !== undefined
+						? namedEntry.data.options.filename
+						: filename;
+				const jsTemplate = pageName
+					? getNamedTemplate(entryFilenameOption)
 					: undefined;
-				const cssTemplate = pageEntry
+				const cssTemplate = pageName
 					? getNamedTemplate(cssFilename)
 					: undefined;
-				const pageName = pageEntry ? pageEntry.name : "";
 				/**
 				 * @param {string} template filename template of the page's entry
 				 * @param {number} index position among the page's entries of that kind
 				 * @returns {string} filename template for one extracted entry
 				 */
-				const nameAfterPage = (template, index) =>
-					template.replace(
+				const nameAfterPage = (template, index) => {
+					const name = /** @type {string} */ (pageName);
+					return template.replace(
 						/\[name\]/g,
-						index === 0 ? pageName : `${pageName}${index}`
+						index === 0 ? name : `${name}${index}`
 					);
+				};
 				// A script chunk's own `.css` sibling is named after the page too, so
 				// it starts counting where the page's stylesheet entries stop.
 				let styleIndex = 0;
@@ -656,6 +697,7 @@ class HtmlModulesPlugin {
 								}
 							}
 						}
+						extractedNames.add(entry.entryName);
 						specs.push({
 							context,
 							request: entry.request,

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -247,12 +247,9 @@ const CSS_REQUEST_RE = /\.css(\?|$)/i;
  */
 const getPageEntry = (compilation, module) => {
 	const { moduleGraph } = compilation;
-	let isEntry = false;
 	for (const connection of moduleGraph.getIncomingConnections(module)) {
 		if (connection.originModule) return undefined;
-		isEntry = true;
 	}
-	if (!isEntry) return undefined;
 	for (const [name, data] of compilation.entries) {
 		if (data.dependencies.length !== 1) continue;
 		if (data.includeDependencies.length !== 0) continue;

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -733,24 +733,45 @@ class HtmlModulesPlugin {
 						// a content-hashed filename makes a substring hit a real reference.
 						/** @type {Set<string>} */
 						const deletionCandidates = new Set(inlinedFiles);
-						// A wrapper entry's chunk only rebuilds the page's own markup; the
-						// page loads the `<script src>` entries the parser split out of it.
+						// A page-only entry's chunk rebuilds markup that was already
+						// written out as the `.html` asset; the page loads the
+						// `<script src>` entries the parser split out of it, never this
+						// chunk. That covers the `data:text/html` wrapper entry
+						// `output.html` adds, and an `.html` file used as an entry, whose
+						// JS side is just the page as a string export.
 						for (const entrypoint of compilation.entrypoints.values()) {
 							const chunk = entrypoint.getEntrypointChunk();
 							if (!chunk) continue;
-							let wrapperOnly = false;
+							let pageOnly = false;
+							let pageFile = false;
 							for (const entryModule of compilation.chunkGraph.getChunkEntryModulesIterable(
 								chunk
 							)) {
-								const { resource } = /** @type {import("../NormalModule")} */ (
-									entryModule
-								);
-								wrapperOnly =
-									typeof resource === "string" &&
-									HTML_DATA_URL_RE.test(resource);
-								if (!wrapperOnly) break;
+								const { resource } = /** @type {NormalModule} */ (entryModule);
+								// A data URL counts only as the wrapper `output.html`
+								// writes — another `text/html`-ish media type is an entry
+								// the user asked for, and keeps its chunk.
+								const dataUrl =
+									typeof resource === "string" && resource.startsWith("data:");
+								const wrapper = dataUrl && HTML_DATA_URL_RE.test(resource);
+								const extractedPage =
+									!dataUrl &&
+									entryModule instanceof HtmlModule &&
+									entryModule.getSourceTypes().has(HTML_TYPE);
+								if (extractedPage) pageFile = true;
+								pageOnly = wrapper || extractedPage;
+								if (!pageOnly) break;
 							}
-							if (!wrapperOnly) continue;
+							if (!pageOnly) continue;
+							// A page the user pointed `entry` at can still be asked for by
+							// name through `output.library` — then its JS is the output.
+							if (
+								pageFile &&
+								(entrypoint.options.library ||
+									compilation.outputOptions.library)
+							) {
+								continue;
+							}
 							for (const file of chunk.files) deletionCandidates.add(file);
 						}
 						// Materialize each other asset's source once (it can be expensive to

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -379,7 +379,7 @@ describe("snapshots", () => {
 		        "type": "html",
 		      },
 		      Object {
-		        "mimetype": "text/html",
+		        "mimetype": /\\^text\\\\/html\\$/i,
 		        "resolve": Object {
 		          "fullySpecified": true,
 		          "preferRelative": true,

--- a/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigCacheTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=__html_2a0885fc_0.js>"`;
+exports[`ConfigCacheTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=page.js>"`;
 
 exports[`ConfigCacheTestCases embedded everything exported tests leaves a css data url whose media type names no language 1`] = `".png{background:url(data:image/png;base64,AAAA)}"`;
 
@@ -62,7 +62,7 @@ exports[`ConfigCacheTestCases embedded everything exported tests minifies an htm
 `;
 
 exports[`ConfigCacheTestCases embedded everything exported tests minifies an html document webpack parses as an entry 1`] = `
-"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_2a0885fc_0.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.entrySrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
@@ -44,7 +44,7 @@ Array [
 `;
 
 exports[`ConfigCacheTestCases embedded everything exported tests minifies an html document imported into javascript 1`] = `
-"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_fc45afb8_0.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page-module.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.moduleSrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=__html_2a0885fc_0.js>"`;
+exports[`ConfigTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=page.js>"`;
 
 exports[`ConfigTestCases embedded everything exported tests leaves a css data url whose media type names no language 1`] = `".png{background:url(data:image/png;base64,AAAA)}"`;
 
@@ -62,7 +62,7 @@ exports[`ConfigTestCases embedded everything exported tests minifies an html doc
 `;
 
 exports[`ConfigTestCases embedded everything exported tests minifies an html document webpack parses as an entry 1`] = `
-"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_2a0885fc_0.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.entrySrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
@@ -44,7 +44,7 @@ Array [
 `;
 
 exports[`ConfigTestCases embedded everything exported tests minifies an html document imported into javascript 1`] = `
-"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_fc45afb8_0.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page-module.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.moduleSrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/html/css-imported-from-js/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-imported-from-js/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-imported-from-js exported tests should em
 <html>
 <head>
 <title>HTML entry with JS that imports CSS</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
+<script src=\\"page.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"page.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-imported-from-js/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-imported-from-js/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-imported-from-js exported tests should emit a 
 <html>
 <head>
 <title>HTML entry with JS that imports CSS</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
+<script src=\\"page.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"page.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html css-mixed-link-and-js-import exported tests s
 <html>
 <head>
 <title>Mixed: link stylesheet + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_1.css\\"><script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<link rel=\\"stylesheet\\" href=\\"page1.css\\"><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html css-mixed-link-and-js-import exported tests should
 <html>
 <head>
 <title>Mixed: link stylesheet + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_1.css\\"><script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<link rel=\\"stylesheet\\" href=\\"page1.css\\"><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-runtime-and-split-chunks exported tests s
 <html>
 <head>
 <title>HTML entry with runtimeChunk + splitChunks + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-runtime-and-split-chunks exported tests should
 <html>
 <head>
 <title>HTML entry with runtimeChunk + splitChunks + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-split-chunks-order exported tests should 
 <html>
 <head>
 <title>HTML entry with split CSS chunks</title>
-<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-split-chunks-order exported tests should refer
 <html>
 <head>
 <title>HTML entry with split CSS chunks</title>
-<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"page.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html entry-script-and-stylesheet exported tests sh
 <html>
 <head>
 <title>HTML entry with script and stylesheet</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html entry-script-and-stylesheet exported tests should 
 <html>
 <head>
 <title>HTML entry with script and stylesheet</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigCacheTest.snap
@@ -5,14 +5,14 @@ exports[`ConfigCacheTestCases html extract-runtime-chunk exported tests should l
 <html>
 <head>
 <title>Extracted HTML with runtime chunk</title>
-<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
+<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"page.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
 <!-- A second classic <script src> chains via dependOn to the first. The
      shared runtime chunk is already loaded by the leader's tag above, so
      this tag must NOT prepend another runtime <script> for itself. -->
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<script src=\\"page1.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigTest.snap
@@ -5,14 +5,14 @@ exports[`ConfigTestCases html extract-runtime-chunk exported tests should load t
 <html>
 <head>
 <title>Extracted HTML with runtime chunk</title>
-<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
+<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"page.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
 <!-- A second classic <script src> chains via dependOn to the first. The
      shared runtime chunk is already loaded by the leader's tag above, so
      this tag must NOT prepend another runtime <script> for itself. -->
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<script src=\\"page1.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/extract-runtime-chunk/index.js
+++ b/test/configCases/html/extract-runtime-chunk/index.js
@@ -22,8 +22,8 @@ it("should load the shared runtime chunk exactly once even when multiple <script
 	// and overwrite the leader's module registry.
 	expect(runtimeRefs).toHaveLength(1);
 	expect(scriptSrcMatches[0]).toContain("html-runtime");
-	expect(scriptSrcMatches[1]).toMatch(/__html_[a-f0-9]+_0\.chunk\.js/);
-	expect(scriptSrcMatches[2]).toMatch(/__html_[a-f0-9]+_1\.chunk\.js/);
+	expect(scriptSrcMatches[1]).toMatch(/page\.js/);
+	expect(scriptSrcMatches[2]).toMatch(/page1\.js/);
 	// All referenced chunks were emitted to disk.
 	expect(readFile(scriptSrcMatches[0])).toContain("__webpack_require__");
 	expect(readFile(scriptSrcMatches[1])).toContain('module.exports = "entry"');
@@ -49,6 +49,6 @@ it("should propagate safe attributes onto the sibling runtime <script> tag and d
 	);
 	// The original entry tag keeps its own integrity attribute untouched.
 	expect(extracted).toMatch(
-		/<script[^>]*\bsrc="[^"]*__html_[^"]+\.chunk\.js"[^>]*\bintegrity="sha384-IGNOREME"/
+		/<script[^>]*\bsrc="[^"]*page\d*\.js"[^>]*\bintegrity="sha384-IGNOREME"/
 	);
 });

--- a/test/configCases/html/extract-split-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract-split-chunks/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html extract-split-chunks exported tests should re
 <html>
 <head>
 <title>Extracted HTML with split chunks</title>
-<script src=\\"vendor.js\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-split-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract-split-chunks/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html extract-split-chunks exported tests should referen
 <html>
 <head>
 <title>Extracted HTML with split chunks</title>
-<script src=\\"vendor.js\\"></script><script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-split-chunks/index.js
+++ b/test/configCases/html/extract-split-chunks/index.js
@@ -18,7 +18,7 @@ it("should reference both the split-out vendor chunk and the entry chunk", () =>
 	expect(scriptSrcMatches).toHaveLength(2);
 	const [vendorUrl, entryUrl] = scriptSrcMatches;
 	expect(vendorUrl).toContain("vendor");
-	expect(entryUrl).toMatch(/__html_[a-f0-9]+_0\.chunk\.js/);
+	expect(entryUrl).toMatch(/page\.js/);
 	// vendor.js is a separate file and the entry chunk references it via require.
 	expect(readFile(vendorUrl)).toContain('"vendor-module"');
 	expect(readFile(entryUrl)).toContain("entry:");

--- a/test/configCases/html/extract/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract/__snapshots__/ConfigCacheTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigCacheTestCases html extract exported tests should emit page.html 
 <head>
 <title>Extracted HTML</title>
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract/__snapshots__/ConfigTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigTestCases html extract exported tests should emit page.html with 
 <head>
 <title>Extracted HTML</title>
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract/index.js
+++ b/test/configCases/html/extract/index.js
@@ -18,7 +18,7 @@ it("should emit page.html with rewritten URLs alongside the JS bundle", () => {
 	expect(extracted).not.toContain('href="./icon.png"');
 	expect(extracted).not.toContain('src="./image.png"');
 	// `<script src>` was rewritten to the chunk URL.
-	expect(extracted).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	expect(extracted).toMatch(/<script src="page\.js">/);
 	// Asset URLs were rewritten to hashed filenames.
 	expect(extracted).toMatch(/<link rel="icon" href="[a-f0-9]+\.png">/);
 	expect(extracted).toMatch(/<img src="[a-f0-9]+\.png" alt="image">/);

--- a/test/configCases/html/generate-error-imported/error-loader.js
+++ b/test/configCases/html/generate-error-imported/error-loader.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function () {
+	throw new Error("intentional loader <error> -- test");
+};

--- a/test/configCases/html/generate-error-imported/errors.js
+++ b/test/configCases/html/generate-error-imported/errors.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+	[/Module build failed/, /intentional loader <error> -- test/]
+];

--- a/test/configCases/html/generate-error-imported/index.js
+++ b/test/configCases/html/generate-error-imported/index.js
@@ -1,0 +1,7 @@
+it("should throw the build error where the page is imported", () => {
+	// A page reached from JavaScript keeps its JavaScript side, so the failed
+	// build surfaces as a throw at the import site rather than as markup.
+	expect(() => require("./src/page.html")).toThrow(
+		/intentional loader <error> -- test/
+	);
+});

--- a/test/configCases/html/generate-error-imported/infrastructure-log.js
+++ b/test/configCases/html/generate-error-imported/infrastructure-log.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = (options) => {
+	if (options.cache && options.cache.type === "filesystem") {
+		return [/Pack got invalid because of write to/];
+	}
+
+	return [];
+};

--- a/test/configCases/html/generate-error-imported/src/page.html
+++ b/test/configCases/html/generate-error-imported/src/page.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Broken</title></head>
+<body></body>
+</html>

--- a/test/configCases/html/generate-error-imported/webpack.config.js
+++ b/test/configCases/html/generate-error-imported/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+// A page imported from JavaScript whose build fails: the module keeps its
+// JavaScript side, which re-throws the build error when it is evaluated.
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /page\.html$/,
+				enforce: "pre",
+				loader: path.resolve(__dirname, "error-loader.js")
+			}
+		]
+	},
+	optimization: {
+		emitOnErrors: true
+	},
+	bail: false,
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/html-entry-include-dependencies/extra.js
+++ b/test/configCases/html/html-entry-include-dependencies/extra.js
@@ -1,0 +1,1 @@
+globalThis.__included = "included";

--- a/test/configCases/html/html-entry-include-dependencies/page.html
+++ b/test/configCases/html/html-entry-include-dependencies/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>An entry with an included dependency</title>
+</head>
+<body>
+<script src="./script.js"></script>
+</body>
+</html>

--- a/test/configCases/html/html-entry-include-dependencies/script.js
+++ b/test/configCases/html/html-entry-include-dependencies/script.js
@@ -1,0 +1,1 @@
+globalThis.__htmlEntryScript = "html-entry-script";

--- a/test/configCases/html/html-entry-include-dependencies/test.config.js
+++ b/test/configCases/html/html-entry-include-dependencies/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-entry-include-dependencies/test.js
+++ b/test/configCases/html/html-entry-include-dependencies/test.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should keep the JS asset of an entry that includes more than its page", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files).toContain("page.html");
+	expect(files).toContain("main.js");
+	expect(files).toContain("page.js");
+
+	// The entry is not the page alone, so it keeps the entry filename and the
+	// extracted script is named after the page's file.
+	const main = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
+	expect(main).toContain("included");
+
+	const script = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	expect(script).toContain("html-entry-script");
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	expect(html).toMatch(/<script src="page\.js">/);
+});

--- a/test/configCases/html/html-entry-include-dependencies/webpack.config.js
+++ b/test/configCases/html/html-entry-include-dependencies/webpack.config.js
@@ -1,0 +1,58 @@
+"use strict";
+
+// An entry whose page is not all it carries: a plugin adds an included
+// dependency to it, so the entry keeps its own JavaScript and its filename.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: {
+		main: "./page.html"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.finishMake.tapAsync("Test", (compilation, callback) => {
+					compilation.addInclude(
+						compiler.context,
+						webpack.EntryPlugin.createDependency("./extra.js", {}),
+						{ name: "main" },
+						(err) => callback(err)
+					);
+				});
+				// The entry's own bundle is the page's markup, so the assertions
+				// ride in on an asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-entry-library-js-asset/page.html
+++ b/test/configCases/html/html-entry-library-js-asset/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>HTML entry exposed as a library</title>
+<script src="./script.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/configCases/html/html-entry-library-js-asset/script.js
+++ b/test/configCases/html/html-entry-library-js-asset/script.js
@@ -1,0 +1,1 @@
+module.exports = "html-entry-script";

--- a/test/configCases/html/html-entry-library-js-asset/test.config.js
+++ b/test/configCases/html/html-entry-library-js-asset/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+// Assertions live in the emitted `test.js`; the entry's own JS asset is the
+// library export, not a test bundle.
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-entry-library-js-asset/test.js
+++ b/test/configCases/html/html-entry-library-js-asset/test.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should keep the JS asset of an HTML entry exposed as a library", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files).toContain("page.html");
+	expect(files).toContain("page.js");
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+
+	// The library hands back the page markup.
+	expect(require("./page.js")).toContain("<title>HTML entry exposed as a library</title>");
+});

--- a/test/configCases/html/html-entry-library-js-asset/test.js
+++ b/test/configCases/html/html-entry-library-js-asset/test.js
@@ -10,6 +10,12 @@ it("should keep the JS asset of an HTML entry exposed as a library", () => {
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
 	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
 
+	// The hint keeps the page's own library asset and adds the extracted one.
+	expect(html).toMatch(/<link rel="preload" as="script" href="page\.js">/);
+	expect(html).toMatch(
+		/<link rel="preload" as="script" href="__html_[a-f0-9]+_0\.chunk\.js">/
+	);
+
 	// The library hands back the page markup.
 	expect(require("./page.js")).toContain("<title>HTML entry exposed as a library</title>");
 });

--- a/test/configCases/html/html-entry-library-js-asset/webpack.config.js
+++ b/test/configCases/html/html-entry-library-js-asset/webpack.config.js
@@ -1,8 +1,7 @@
 "use strict";
 
-// An `.html` entry whose JS side is asked for by name through `output.library`.
-// The page is still emitted, and the entry's JS asset is kept: the library is
-// what the user configured the build to hand back.
+// An `.html` entry whose JS side is asked for through `output.library`: the
+// page is still emitted, and the entry's JS asset is kept as the library.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/configCases/html/html-entry-library-js-asset/webpack.config.js
+++ b/test/configCases/html/html-entry-library-js-asset/webpack.config.js
@@ -17,7 +17,10 @@ module.exports = {
 		chunkFilename: "[name].chunk.js",
 		library: {
 			type: "commonjs2"
-		}
+		},
+		// A hint naming this entry covers both halves of the page: its own
+		// library JavaScript and the script the parser extracted from it.
+		resourceHints: [{ rel: "preload", as: "script", entry: "page" }]
 	},
 	optimization: {
 		chunkIds: "named"

--- a/test/configCases/html/html-entry-library-js-asset/webpack.config.js
+++ b/test/configCases/html/html-entry-library-js-asset/webpack.config.js
@@ -1,0 +1,53 @@
+"use strict";
+
+// An `.html` entry whose JS side is asked for by name through `output.library`.
+// The page is still emitted, and the entry's JS asset is kept: the library is
+// what the user configured the build to hand back.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		page: "./page.html"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js",
+		library: {
+			type: "commonjs2"
+		}
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				// Provide a free-standing test runner; the html entry's JS asset
+				// exports the page markup and carries no `it()` calls of its own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-entry-no-js-asset/page.html
+++ b/test/configCases/html/html-entry-no-js-asset/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>HTML entry without a JS asset</title>
+<script src="./script.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/configCases/html/html-entry-no-js-asset/script.js
+++ b/test/configCases/html/html-entry-no-js-asset/script.js
@@ -1,0 +1,1 @@
+module.exports = "html-entry-script";

--- a/test/configCases/html/html-entry-no-js-asset/test.config.js
+++ b/test/configCases/html/html-entry-no-js-asset/test.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+// The HTML entry has no JS asset at all — assertions live in the emitted
+// `test.js`, which the harness loads directly.
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-entry-no-js-asset/test.js
+++ b/test/configCases/html/html-entry-no-js-asset/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should not emit a JS asset for an HTML entry", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files).toContain("page.html");
+	expect(files).not.toContain("page.js");
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	// The page loads the script the parser split out of it, not the entry chunk.
+	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	expect(html).not.toContain("page.js");
+});

--- a/test/configCases/html/html-entry-no-js-asset/test.js
+++ b/test/configCases/html/html-entry-no-js-asset/test.js
@@ -1,14 +1,18 @@
 const fs = require("fs");
 const path = require("path");
 
-it("should not emit a JS asset for an HTML entry", () => {
+it("should not emit a JS copy of the page for an HTML entry", () => {
 	const files = fs.readdirSync(__dirname);
 
 	expect(files).toContain("page.html");
-	expect(files).not.toContain("page.js");
+	expect(files).toContain("page.js");
+
+	// `page.js` is the script the parser split out of the page — it takes the
+	// entry's filename, which no copy of the markup occupies any more.
+	const js = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	expect(js).toContain("html-entry-script");
+	expect(js).not.toContain("<!DOCTYPE html>");
 
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
-	// The page loads the script the parser split out of it, not the entry chunk.
-	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
-	expect(html).not.toContain("page.js");
+	expect(html).toMatch(/<script src="page\.js">/);
 });

--- a/test/configCases/html/html-entry-no-js-asset/webpack.config.js
+++ b/test/configCases/html/html-entry-no-js-asset/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// An `.html` file used as a compilation entry. The entry chunk's JS side only
+// re-exports the markup that was written out as `page.html`, and the page loads
+// the `<script src>` entries the parser split out of it — never that chunk — so
+// no JS asset should be emitted for the entry.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		page: "./page.html"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				// Provide a free-standing test runner; the html entry has no JS
+				// asset of its own to carry the `it()` calls.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-entry-no-js-asset/webpack.config.js
+++ b/test/configCases/html/html-entry-no-js-asset/webpack.config.js
@@ -1,9 +1,7 @@
 "use strict";
 
-// An `.html` file used as a compilation entry. The entry chunk's JS side only
-// re-exports the markup that was written out as `page.html`, and the page loads
-// the `<script src>` entries the parser split out of it — never that chunk — so
-// no JS asset should be emitted for the entry.
+// An `.html` file used as a compilation entry: its chunk's JS side only
+// re-exports `page.html`, so no JS asset should be emitted for the entry.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/configCases/html/html-entry-page-only/page.html
+++ b/test/configCases/html/html-entry-page-only/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A page with nothing to bundle</title>
+</head>
+<body>
+<p>Hello</p>
+</body>
+</html>

--- a/test/configCases/html/html-entry-page-only/test.config.js
+++ b/test/configCases/html/html-entry-page-only/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-entry-page-only/test.js
+++ b/test/configCases/html/html-entry-page-only/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should emit only the page for an HTML entry with nothing to bundle", () => {
+	const files = fs
+		.readdirSync(__dirname)
+		.filter((f) => f.endsWith(".js") || f.endsWith(".css") || f.endsWith(".html"));
+
+	expect(files.sort()).toEqual(["page.html", "test.js"]);
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	expect(html).toContain("<p>Hello</p>");
+	expect(html).not.toContain("<script");
+});

--- a/test/configCases/html/html-entry-page-only/webpack.config.js
+++ b/test/configCases/html/html-entry-page-only/webpack.config.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// A page with no `<script src>` and no `<link rel="stylesheet">`: the emitted
+// `.html` file is the entry's whole output.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		page: "./page.html"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				// The entry emits no JavaScript, so the assertions ride in on an
+				// asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-entry-point-css/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/html-entry-point-css/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html html-entry-point-css exported tests should em
 <html>
 <head>
 <title>HTML entry point with CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/html-entry-point-css/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/html-entry-point-css/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html html-entry-point-css exported tests should emit pa
 <html>
 <head>
 <title>HTML entry point with CSS</title>
-<link rel=\\"stylesheet\\" href=\\"__html_cbe5b59d_0.chunk.css\\">
+<link rel=\\"stylesheet\\" href=\\"page.css\\">
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/html-entry-point/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/html-entry-point/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html html-entry-point exported tests should emit p
 <html>
 <head>
 <title>HTML entry point</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"image\\">

--- a/test/configCases/html/html-entry-point/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/html-entry-point/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html html-entry-point exported tests should emit page.h
 <html>
 <head>
 <title>HTML entry point</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </head>
 <body>
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"image\\">

--- a/test/configCases/html/html-entry-point/test.js
+++ b/test/configCases/html/html-entry-point/test.js
@@ -9,6 +9,6 @@ it("should emit page.html for an HTML entry without explicit extract: true", () 
 	expect(extracted).toMatchSnapshot();
 	expect(extracted).not.toContain('src="./script.js"');
 	expect(extracted).not.toContain('src="./image.png"');
-	expect(extracted).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	expect(extracted).toMatch(/<script src="page\.js">/);
 	expect(extracted).toMatch(/<img src="[a-f0-9]+\.png" alt="image">/);
 });

--- a/test/configCases/html/html-entry-with-js/index.js
+++ b/test/configCases/html/html-entry-with-js/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should keep the extracted script's name when the entry also bundles JS", () => {
+	const files = fs.readdirSync(__dirname);
+	expect(files).toContain("page.html");
+	expect(files).toContain("page.js");
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	// `page.js` is this bundle, so the page's script cannot take that name.
+	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+});

--- a/test/configCases/html/html-entry-with-js/page.html
+++ b/test/configCases/html/html-entry-with-js/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>HTML entry alongside JavaScript</title>
+<script src="./script.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/configCases/html/html-entry-with-js/script.js
+++ b/test/configCases/html/html-entry-with-js/script.js
@@ -1,0 +1,1 @@
+module.exports = "html-entry-script";

--- a/test/configCases/html/html-entry-with-js/test.config.js
+++ b/test/configCases/html/html-entry-with-js/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./page.js"];
+	}
+};

--- a/test/configCases/html/html-entry-with-js/webpack.config.js
+++ b/test/configCases/html/html-entry-with-js/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+// An entry that bundles JavaScript of its own next to an `.html` file: the
+// entry's filename stays with that bundle, so the page's script keeps its own.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		page: ["./index.js", "./page.html"]
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/html-hint-page-only-entry/app.html
+++ b/test/configCases/html/html-hint-page-only-entry/app.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A page hinting a page</title>
+</head>
+<body>
+<script src="./app.js"></script>
+</body>
+</html>

--- a/test/configCases/html/html-hint-page-only-entry/app.js
+++ b/test/configCases/html/html-hint-page-only-entry/app.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should not hint a page entry that emits no JavaScript", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files).toContain("empty.html");
+	expect(files).not.toContain("empty.js");
+
+	const html = fs.readFileSync(path.resolve(__dirname, "app.html"), "utf-8");
+	expect(html).not.toContain("empty.js");
+	// The hint naming the JS entry still renders.
+	expect(html).toMatch(/<link rel="preload" as="script" href="second\.js">/);
+});

--- a/test/configCases/html/html-hint-page-only-entry/empty.html
+++ b/test/configCases/html/html-hint-page-only-entry/empty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A page with nothing to bundle</title>
+</head>
+<body>
+<p>Hello</p>
+</body>
+</html>

--- a/test/configCases/html/html-hint-page-only-entry/second.js
+++ b/test/configCases/html/html-hint-page-only-entry/second.js
@@ -1,0 +1,1 @@
+globalThis.__second = "second";

--- a/test/configCases/html/html-hint-page-only-entry/test.config.js
+++ b/test/configCases/html/html-hint-page-only-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./app.js"];
+	}
+};

--- a/test/configCases/html/html-hint-page-only-entry/webpack.config.js
+++ b/test/configCases/html/html-hint-page-only-entry/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+// A resource hint naming an HTML entry that emits nothing but its markup: the
+// page has no JavaScript file, so no `<link>` is rendered for it.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	node: {
+		__dirname: false
+	},
+	entry: {
+		app: "./app.html",
+		empty: "./empty.html",
+		second: "./second.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js",
+		htmlFilename: "[name].html",
+		resourceHints: [
+			{ rel: "preload", entry: "empty" },
+			{ rel: "preload", entry: "second" }
+		]
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/html-imported-page-name/index.js
+++ b/test/configCases/html/html-imported-page-name/index.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+import page from "./page.html";
+
+it("should name an imported page's script after that page", () => {
+	// The page has no entry of its own, so its script is named after its file.
+	expect(page).toContain("<title>Widget</title>");
+	expect(fs.readdirSync(__dirname)).toContain("page.js");
+
+	const js = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	expect(js).toContain("widget-script");
+});

--- a/test/configCases/html/html-imported-page-name/page.html
+++ b/test/configCases/html/html-imported-page-name/page.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Widget</title><script src="./widget.js"></script></head>
+<body></body>
+</html>

--- a/test/configCases/html/html-imported-page-name/test.config.js
+++ b/test/configCases/html/html-imported-page-name/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./app.js"];
+	}
+};

--- a/test/configCases/html/html-imported-page-name/webpack.config.js
+++ b/test/configCases/html/html-imported-page-name/webpack.config.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// A page imported from JavaScript has no entry name either, so the script it
+// carries is named after the page's file.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: { app: "./index.js" },
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true }
+};

--- a/test/configCases/html/html-imported-page-name/widget.js
+++ b/test/configCases/html/html-imported-page-name/widget.js
@@ -1,0 +1,1 @@
+module.exports = "widget-script";

--- a/test/configCases/html/html-linked-page-name-taken/about-page.js
+++ b/test/configCases/html/html-linked-page-name-taken/about-page.js
@@ -1,0 +1,1 @@
+module.exports = "about-page";

--- a/test/configCases/html/html-linked-page-name-taken/about.html
+++ b/test/configCases/html/html-linked-page-name-taken/about.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>About</title><script src="./about-page.js"></script></head>
+<body></body>
+</html>

--- a/test/configCases/html/html-linked-page-name-taken/home.js
+++ b/test/configCases/html/html-linked-page-name-taken/home.js
@@ -1,0 +1,1 @@
+module.exports = "home";

--- a/test/configCases/html/html-linked-page-name-taken/index.html
+++ b/test/configCases/html/html-linked-page-name-taken/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Home</title><script src="./home.js"></script></head>
+<body><a href="./about.html">About</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-name-taken/test.config.js
+++ b/test/configCases/html/html-linked-page-name-taken/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-linked-page-name-taken/test.js
+++ b/test/configCases/html/html-linked-page-name-taken/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should leave a page's script alone when its name is taken", () => {
+	const about = fs.readFileSync(path.resolve(__dirname, "about.html"), "utf-8");
+
+	// `about.js` is the JavaScript entry's bundle, so the page keeps the name
+	// the parser gave its script rather than colliding with it.
+	expect(about).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	expect(fs.readdirSync(__dirname)).toContain("about.js");
+
+	const js = fs.readFileSync(path.resolve(__dirname, "about.js"), "utf-8");
+	expect(js).toContain("about-page");
+});

--- a/test/configCases/html/html-linked-page-name-taken/webpack.config.js
+++ b/test/configCases/html/html-linked-page-name-taken/webpack.config.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// An entry already called `about` owns that name, so the linked `about.html`
+// page cannot take it and its script keeps the name the parser gave it.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./index.html", about: "./about-page.js" },
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	module: {
+		parser: {
+			html: {
+				sources: ["...", { tag: "a", attribute: "href", type: "html" }]
+			}
+		}
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true },
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-linked-page-name/about-page.js
+++ b/test/configCases/html/html-linked-page-name/about-page.js
@@ -1,0 +1,1 @@
+module.exports = "about-page";

--- a/test/configCases/html/html-linked-page-name/about.html
+++ b/test/configCases/html/html-linked-page-name/about.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>About</title><script src="./about-page.js"></script></head>
+<body></body>
+</html>

--- a/test/configCases/html/html-linked-page-name/home.js
+++ b/test/configCases/html/html-linked-page-name/home.js
@@ -1,0 +1,1 @@
+module.exports = "home";

--- a/test/configCases/html/html-linked-page-name/index.html
+++ b/test/configCases/html/html-linked-page-name/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Home</title><script src="./home.js"></script></head>
+<body><a href="./about.html">About</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-name/test.config.js
+++ b/test/configCases/html/html-linked-page-name/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-linked-page-name/test.js
+++ b/test/configCases/html/html-linked-page-name/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = (name) => fs.readFileSync(path.resolve(__dirname, name), "utf-8");
+
+it("should name a linked page's script after that page", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files).toContain("about.js");
+	expect(read("about.html")).toMatch(/<script src="about\.js">/);
+	// The entry page still takes its entry's name.
+	expect(read("index.html")).toMatch(/<script src="main\.js">/);
+	expect(files).toContain("main.js");
+});

--- a/test/configCases/html/html-linked-page-name/webpack.config.js
+++ b/test/configCases/html/html-linked-page-name/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// A page linked from another page has no entry name of its own, so the
+// entries extracted from it are named after its file instead.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./index.html" },
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	module: {
+		parser: {
+			html: {
+				sources: ["...", { tag: "a", attribute: "href", type: "html" }]
+			}
+		}
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true },
+	plugins: [
+		{
+			apply(compiler) {
+				// Neither page emits JavaScript of its own, so the assertions ride
+				// in on an asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html module-sibling-type exported tests rewrites t
 <html>
 <head>
 <title>module sibling type</title>
-<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.mjs\\"></script>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"page.mjs\\"></script>
 </head>
 <body><h1>Hello</h1></body>
 </html>

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html module-sibling-type exported tests rewrites type=m
 <html>
 <head>
 <title>module sibling type</title>
-<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.mjs\\"></script>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"page.mjs\\"></script>
 </head>
 <body><h1>Hello</h1></body>
 </html>

--- a/test/configCases/html/module-sibling-type/index.js
+++ b/test/configCases/html/module-sibling-type/index.js
@@ -13,7 +13,7 @@ it("rewrites type=module in place when cloning a native module <script> sibling"
 
 	// The entry chunk tag is a module script too.
 	expect(page).toMatch(
-		/<script[^>]*\btype="module"[^>]*\bsrc="[^"]*__html_[^"]*\.mjs"/
+		/<script[^>]*\btype="module"[^>]*\bsrc="[^"]*page\d*\.mjs"/
 	);
 
 	// No unresolved source path survives.

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -105,15 +105,15 @@ exports[`ConfigCacheTestCases html modulepreload-esm exported tests should rewri
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_0.chunk.mjs\\">
-<link rel=\\"modulepreload    \\" href=\\"__html_cbe5b59d_1.chunk.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_2.chunk.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page1.mjs\\">
+<link rel=\\"modulepreload    \\" href=\\"page2.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page3.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.mjs\\"></script>
+<script type=\\"module\\" src=\\"page.mjs\\"></script>
 <!-- webpackIgnore: true -->
 <script type=\\"module\\" src=\\"./ignored-entry.js\\"></script>
 </body>

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -105,15 +105,15 @@ exports[`ConfigTestCases html modulepreload-esm exported tests should rewrite <l
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_0.chunk.mjs\\">
-<link rel=\\"modulepreload    \\" href=\\"__html_cbe5b59d_1.chunk.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_2.chunk.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page1.mjs\\">
+<link rel=\\"modulepreload    \\" href=\\"page2.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page3.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.mjs\\"></script>
+<script type=\\"module\\" src=\\"page.mjs\\"></script>
 <!-- webpackIgnore: true -->
 <script type=\\"module\\" src=\\"./ignored-entry.js\\"></script>
 </body>

--- a/test/configCases/html/modulepreload-esm/index.js
+++ b/test/configCases/html/modulepreload-esm/index.js
@@ -20,8 +20,8 @@ it("should rewrite <link rel=modulepreload> and <script type=module src> to chun
 	expect(page).not.toContain('href="./preload.js"');
 	expect(page).not.toContain('href="./preload-other.js"');
 	expect(page).not.toContain('src="./entry.js"');
-	expect(page).toMatch(/<link rel="modulepreload" href="__html_[^"]+\.mjs">/);
-	expect(page).toMatch(/<script type="module" src="__html_[^"]+\.mjs">/);
+	expect(page).toMatch(/<link rel="modulepreload" href="page\d*\.mjs">/);
+	expect(page).toMatch(/<script type="module" src="page\d*\.mjs">/);
 	// Data URI in modulepreload is also bundled.
 	expect(page).not.toContain('href="data:text/javascript');
 	// webpackIgnore leaves modulepreload and module-script entries untouched.
@@ -33,7 +33,7 @@ it("should rewrite <link rel=modulepreload> and <script type=module src> to chun
 
 it("should emit module-format chunks (no IIFE wrapper) when output.module is enabled", () => {
 	const preloadChunkName = chunkFor(
-		/<link rel="modulepreload" href="(__html_[^"]+\.mjs)">/
+		/<link rel="modulepreload" href="(page\d*\.mjs)">/
 	);
 	const preloadChunk = readChunk(preloadChunkName);
 	expect(preloadChunk).toMatchSnapshot();
@@ -43,7 +43,7 @@ it("should emit module-format chunks (no IIFE wrapper) when output.module is ena
 	expect(preloadChunk).toContain('"preload module"');
 
 	const entryChunkName = chunkFor(
-		/<script type="module" src="(__html_[^"]+\.mjs)">/
+		/<script type="module" src="(page\d*\.mjs)">/
 	);
 	const entryChunk = readChunk(entryChunkName);
 	expect(entryChunk).toMatchSnapshot();
@@ -58,10 +58,10 @@ it("should keep <link rel=modulepreload> entries independent of the module scrip
 	// module to actually run, it must import it via JS, in which case
 	// webpack inlines the module into the script chunk on its own.)
 	const preloadChunkUrls = [
-		...page.matchAll(/<link rel="modulepreload" href="(__html_[^"]+\.mjs)">/g)
+		...page.matchAll(/<link rel="modulepreload" href="(page\d*\.mjs)">/g)
 	].map((m) => m[1]);
 	const moduleScriptUrl = chunkFor(
-		/<script type="module" src="(__html_[^"]+\.mjs)">/
+		/<script type="module" src="(page\d*\.mjs)">/
 	);
 	expect(preloadChunkUrls.length).toBeGreaterThanOrEqual(2);
 	const moduleScriptChunk = readChunk(moduleScriptUrl);

--- a/test/configCases/html/output-html-css-entry/style.css
+++ b/test/configCases/html/output-html-css-entry/style.css
@@ -1,0 +1,3 @@
+.hero {
+	color: red;
+}

--- a/test/configCases/html/output-html-css-entry/test.config.js
+++ b/test/configCases/html/output-html-css-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/output-html-css-entry/test.js
+++ b/test/configCases/html/output-html-css-entry/test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should emit only the page and its stylesheet for a CSS entry", () => {
+	const files = fs
+		.readdirSync(__dirname)
+		.filter((f) => f.endsWith(".js") || f.endsWith(".css") || f.endsWith(".html"));
+
+	expect(files.sort()).toEqual(["page.css", "page.html", "test.js"]);
+
+	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
+	expect(html).toContain('<link rel="stylesheet" href="page.css">');
+	expect(html).not.toContain("<script");
+});

--- a/test/configCases/html/output-html-css-entry/webpack.config.js
+++ b/test/configCases/html/output-html-css-entry/webpack.config.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// A CSS entry under `output.html`: the page and its stylesheet are the whole
+// output — the page carries no JavaScript for a stylesheet to be linked from.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// `target: "web"` makes the CSS generator emit a `.css` file (under the
+	// harness default `async-node`, `exportsOnly` keeps it out of the output).
+	target: "web",
+	entry: {
+		page: "./style.css"
+	},
+	output: {
+		filename: "[name].js",
+		cssFilename: "[name].css",
+		chunkFilename: "[name].chunk.js",
+		html: true
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true,
+		css: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				// The entry emits no JavaScript, so the assertions ride in on an
+				// asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/output-html-data-url-media-type/test.js
+++ b/test/configCases/html/output-html-data-url-media-type/test.js
@@ -5,10 +5,19 @@ const chunks = (prefix) =>
 		.readdirSync(__dirname)
 		.filter((f) => f.startsWith(prefix) && f.endsWith(".js"));
 
-it("keeps a data:text/htmlx entry chunk, which is not an output.html wrapper", () => {
-	expect(chunks("data-url.").length).toBeGreaterThan(0);
+const pages = (prefix) =>
+	fs
+		.readdirSync(__dirname)
+		.filter((f) => f.startsWith(prefix) && f.endsWith(".html"));
+
+it("emits a data:text/htmlx entry as a page, with no JS copy of it", () => {
+	expect(pages("data-url.")).toHaveLength(1);
+	expect(chunks("data-url.")).toHaveLength(0);
 });
 
-it("still drops the JS chunk of a real generated page", () => {
-	expect(chunks("page.")).toHaveLength(0);
+it("gives a generated page's filename to the script extracted from it", () => {
+	expect(pages("page.")).toHaveLength(1);
+	expect(chunks("page.")).toHaveLength(1);
+	const js = fs.readFileSync(`${__dirname}/${chunks("page.")[0]}`, "utf-8");
+	expect(js).not.toContain("<!doctype html>");
 });

--- a/test/configCases/html/output-html-data-url-media-type/test.js
+++ b/test/configCases/html/output-html-data-url-media-type/test.js
@@ -1,23 +1,21 @@
 const fs = require("fs");
+const path = require("path");
 
-const chunks = (prefix) =>
+const emitted = (prefix, ext) =>
 	fs
 		.readdirSync(__dirname)
-		.filter((f) => f.startsWith(prefix) && f.endsWith(".js"));
+		.filter((f) => f.startsWith(prefix) && f.endsWith(ext));
 
-const pages = (prefix) =>
-	fs
-		.readdirSync(__dirname)
-		.filter((f) => f.startsWith(prefix) && f.endsWith(".html"));
-
-it("emits a data:text/htmlx entry as a page, with no JS copy of it", () => {
-	expect(pages("data-url.")).toHaveLength(1);
-	expect(chunks("data-url.")).toHaveLength(0);
+it("keeps a data:text/htmlx entry as JavaScript, not as a page", () => {
+	expect(emitted("data-url.", ".js")).toHaveLength(1);
+	expect(emitted("data-url.", ".html")).toHaveLength(0);
 });
 
 it("gives a generated page's filename to the script extracted from it", () => {
-	expect(pages("page.")).toHaveLength(1);
-	expect(chunks("page.")).toHaveLength(1);
-	const js = fs.readFileSync(`${__dirname}/${chunks("page.")[0]}`, "utf-8");
+	expect(emitted("page.", ".html")).toHaveLength(1);
+	const [chunk] = emitted("page.", ".js");
+	expect(chunk).toBeDefined();
+	// The entry's filename now carries the page's script, not a copy of it.
+	const js = fs.readFileSync(path.resolve(__dirname, chunk), "utf-8");
 	expect(js).not.toContain("<!doctype html>");
 });

--- a/test/configCases/html/output-html-data-url-media-type/webpack.config.js
+++ b/test/configCases/html/output-html-data-url-media-type/webpack.config.js
@@ -30,8 +30,8 @@ const copyTest = {
 module.exports = {
 	target: "web",
 	entry: {
-		// `text/htmlx` is JavaScript to DataUriPlugin, not an `output.html`
-		// wrapper — its chunk must survive the wrapper cleanup.
+		// `text/htmlx` is JavaScript, not a page: the html rule matches the
+		// media type exactly, so this entry keeps a JavaScript chunk.
 		"data-url": { import: "data:text/htmlx,module.exports = 42;", html: false },
 		page: "./src/page.js"
 	},

--- a/test/configCases/html/output-html-inject/test.js
+++ b/test/configCases/html/output-html-inject/test.js
@@ -42,7 +42,7 @@ it("inject:head synthetic HTML + runtimeChunk: runtime before entry in <head> (l
 	expect(bodyContent(html)).not.toMatch(/<script/);
 	// runtime must appear before the entry to preserve __webpack_require__ availability
 	const runtimeIdx = html.indexOf("runtime.js");
-	const entryIdx = html.search(/__html_[a-f0-9]+_0\.js/);
+	const entryIdx = html.search(/src="(?!runtime\.js)[^"]+\.js"/);
 	expect(runtimeIdx).toBeLessThan(entryIdx);
 });
 
@@ -107,7 +107,7 @@ it("inject:head with no head tags anchors just inside the implicit head", () => 
 	expect(scripts(html).length).toBe(2);
 	// runtime sibling appears before the entry script in document order
 	const runtimeIdx = html.indexOf("runtime.js");
-	const entryIdx = html.search(/__html_[a-f0-9]+_0\.js/);
+	const entryIdx = html.search(/src="(?!runtime\.js)[^"]+\.js"/);
 	expect(runtimeIdx).toBeLessThan(entryIdx);
 	// hints anchor there too
 	expect(html).toMatch(/<link rel="preload" as="script"/);
@@ -124,7 +124,7 @@ it("bare-script page: siblings stay before the entry, hints use the pre-script f
 	const html = read("page-bare-script.html");
 	expect(scripts(html).length).toBe(2);
 	const runtimeIdx = html.indexOf("runtime.js");
-	const entryIdx = html.search(/__html_[a-f0-9]+_0\.js/);
+	const entryIdx = html.search(/src="(?!runtime\.js)[^"]+\.js"/);
 	expect(runtimeIdx).toBeLessThan(entryIdx);
 	expect(html).toMatch(/<link rel="preload" as="script"/);
 });

--- a/test/configCases/html/output-html-per-entry-global-only-options/test.js
+++ b/test/configCases/html/output-html-per-entry-global-only-options/test.js
@@ -4,6 +4,6 @@ const path = require("path");
 const html = fs.readFileSync(path.resolve(__dirname, "a.html"), "utf-8");
 
 it("entry-level inline is not applied", () => {
-	expect(html).toMatch(/<script[^>]* src="__html_[a-f0-9]+_0\.js">/i);
+	expect(html).toMatch(/<script[^>]* src="a\.js">/i);
 	expect(html).not.toContain("__WEBPACK_HTML_INLINE__");
 });

--- a/test/configCases/html/output-html-per-entry-object/test.js
+++ b/test/configCases/html/output-html-per-entry-object/test.js
@@ -5,8 +5,9 @@ const readHtml = (name) =>
 	fs.readFileSync(path.resolve(__dirname, name), "utf-8");
 
 const iconLink = (html) => html.match(/<link rel="icon"[^>]*>/i);
-const scriptRe = /<script[^>]* src="__html_[a-f0-9]+_0\.js"[^>]*>/i;
-const deferScriptRe = /<script defer src="__html_[a-f0-9]+_0\.js">/i;
+// Each page loads the script extracted from it, named after its own entry.
+const scriptRe = (name) => new RegExp(`<script[^>]* src="${name}\\.js"[^>]*>`, "i");
+const deferScriptRe = (name) => new RegExp(`<script defer src="${name}\\.js">`, "i");
 const inHead = (html) => html.match(/<head>([\s\S]*?)<\/head>/i)[1];
 const inBody = (html) => html.match(/<body>([\s\S]*?)<\/body>/i)[1];
 
@@ -17,7 +18,7 @@ it("entries without a per-entry html override inherit output.html", () => {
 	expect(html).toContain("<title>Global title</title>");
 	expect(html).toContain('<meta charset="utf-8">');
 	expect(html).toContain('<meta name="description" content="global description">');
-	expect(inBody(html)).toMatch(deferScriptRe);
+	expect(inBody(html)).toMatch(deferScriptRe("d"));
 });
 
 it("per-entry html object with favicon:false keeps the other output.html options", () => {
@@ -30,8 +31,8 @@ it("per-entry html object with favicon:false keeps the other output.html options
 
 it("per-entry html object with inject:'head' places scripts in <head>", () => {
 	const html = readHtml("b.html");
-	expect(inHead(html)).toMatch(scriptRe);
-	expect(inBody(html)).not.toMatch(scriptRe);
+	expect(inHead(html)).toMatch(scriptRe("b"));
+	expect(inBody(html)).not.toMatch(scriptRe("b"));
 	expect(iconLink(html)).not.toBeNull();
 	expect(html).toContain("<title>Global title</title>");
 });
@@ -50,14 +51,14 @@ it("per-entry html:true inherits every output.html option", () => {
 	expect(iconLink(html)[0]).toBe(iconLink(readHtml("d.html"))[0]);
 	expect(html).toContain('<link rel="manifest"');
 	expect(html).toContain("<title>Global title</title>");
-	expect(inBody(html)).toMatch(deferScriptRe);
+	expect(inBody(html)).toMatch(deferScriptRe("e"));
 });
 
 it("per-entry html object overrides title and scriptLoading", () => {
 	const html = readHtml("f.html");
 	expect(html).toContain("<title>Page f</title>");
 	expect(html).not.toContain("Global title");
-	expect(inBody(html)).toMatch(scriptRe);
+	expect(inBody(html)).toMatch(scriptRe("f"));
 	expect(html).not.toContain("defer");
 	expect(iconLink(html)).not.toBeNull();
 });

--- a/test/configCases/html/parser-sources-custom-tag-module-siblings/index.js
+++ b/test/configCases/html/parser-sources-custom-tag-module-siblings/index.js
@@ -2,7 +2,7 @@ import page from "./page.html";
 
 it("should emit `type=module` <script> siblings for a custom `script` source under output.module", () => {
 	// The custom element's own `src` is rewritten in place to its entry chunk.
-	expect(page).toMatch(/<my-script src="__html_[a-f0-9]+_\d+\.chunk\.js">/);
+	expect(page).toMatch(/<my-script src="page\d*\.js">/);
 	// The split-out runtime chunk is ESM (output.module), so its synthesized
 	// sibling must carry `type="module"` — a classic <script> couldn't load it.
 	expect(page).toMatch(

--- a/test/configCases/html/parser-sources-custom-tag-siblings/index.js
+++ b/test/configCases/html/parser-sources-custom-tag-siblings/index.js
@@ -2,7 +2,7 @@ import page from "./page.html";
 
 it("should emit a real classic <script> sibling (not a cloned custom element) for a `script` source with runtimeChunk", () => {
 	// The custom element's own `src` is rewritten in place to its entry chunk.
-	expect(page).toMatch(/<my-script src="__html_[a-f0-9]+_\d+\.chunk\.js">/);
+	expect(page).toMatch(/<my-script src="page\d*\.js">/);
 	// The split-out runtime chunk is loaded by a *real* classic <script>
 	// inserted before the custom element — never a clone of <my-script>.
 	expect(page).toMatch(/<script src="[^"]*-runtime\.js"><\/script>/);
@@ -13,7 +13,7 @@ it("should emit a real classic <script> sibling (not a cloned custom element) fo
 });
 
 it("should emit a real `type=module` <script> sibling for a `script-module` source", () => {
-	expect(page).toMatch(/<my-module src="__html_[a-f0-9]+_\d+\.chunk\.js">/);
+	expect(page).toMatch(/<my-module src="page\d*\.js">/);
 	expect(page).toMatch(
 		/<script type="module" src="[^"]*-runtime\.js"><\/script>/
 	);

--- a/test/configCases/html/parser-sources-types/index.js
+++ b/test/configCases/html/parser-sources-types/index.js
@@ -4,19 +4,19 @@ it("should bundle a `script`-typed attribute as a classic chunk entry", () => {
 	// `./classic.js` was bundled into a chunk; the original `<my-script
 	// src="./classic.js">` was rewritten to point at it.
 	expect(page).not.toContain('src="./classic.js"');
-	expect(page).toMatch(/<my-script src="__html_[a-f0-9]+_\d+\.chunk\.js">/);
+	expect(page).toMatch(/<my-script src="page\d*\.js">/);
 });
 
 it("should bundle a `script-module`-typed attribute as an ESM chunk entry", () => {
 	expect(page).not.toContain('src="./esm.js"');
-	expect(page).toMatch(/<my-module src="__html_[a-f0-9]+_\d+\.chunk\.js">/);
+	expect(page).toMatch(/<my-module src="page\d*\.js">/);
 });
 
 it("should bundle a `stylesheet`-typed attribute as a CSS chunk entry", () => {
 	// `./styles.css` flowed through the CSS pipeline; the custom tag's
 	// `href` now points at the emitted `.css` chunk, not the source.
 	expect(page).not.toContain('href="./styles.css"');
-	expect(page).toMatch(/<my-link href="__html_[a-f0-9]+_\d+\.chunk\.css">/);
+	expect(page).toMatch(/<my-link href="page\d*\.css">/);
 });
 
 it("should bundle a `stylesheet-style`-typed attribute value as inline CSS", () => {

--- a/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigCacheTest.snap
@@ -6,14 +6,14 @@ exports[`ConfigCacheTestCases html preload-prefetch-shared exported tests should
 <head>
 <title>Test</title>
 <!-- \`shared.js\` is a real executing entry AND preloaded/prefetched. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_0.chunk.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"__html_cbe5b59d_1.chunk.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page1.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page3.js\\">
 <!-- \`used.js\` is preloaded but only ever imported from code. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_2.chunk.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page2.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigTest.snap
@@ -6,14 +6,14 @@ exports[`ConfigTestCases html preload-prefetch-shared exported tests should buil
 <head>
 <title>Test</title>
 <!-- \`shared.js\` is a real executing entry AND preloaded/prefetched. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_0.chunk.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"__html_cbe5b59d_1.chunk.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page1.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page3.js\\">
 <!-- \`used.js\` is preloaded but only ever imported from code. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_2.chunk.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page2.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script src=\\"page.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/preload-prefetch-shared/index.js
+++ b/test/configCases/html/preload-prefetch-shared/index.js
@@ -8,13 +8,13 @@ it("should build a preload/prefetch target that is also used in code and as a re
 
 	// The real `<script src>` entry is rewritten to its chunk URL.
 	expect(page).not.toContain('src="./shared.js"');
-	expect(page).toMatch(/<script src="__html_[^"]+\.js"><\/script>/);
+	expect(page).toMatch(/<script src="page\d*\.js"><\/script>/);
 
 	// Both the preload and prefetch of `shared.js` are rewritten to chunk
 	// URLs — an entry being preloaded is not a conflict.
 	expect(page).not.toContain('href="./shared.js"');
-	expect(page).toMatch(/<link rel="preload" as="script" href="__html_[^"]+\.js">/);
-	expect(page).toMatch(/<link rel="prefetch" as="script" href="__html_[^"]+\.js">/);
+	expect(page).toMatch(/<link rel="preload" as="script" href="page\d*\.js">/);
+	expect(page).toMatch(/<link rel="prefetch" as="script" href="page\d*\.js">/);
 
 	// `used.js` is preloaded and also imported from code — its hint is
 	// still rewritten to a chunk URL.

--- a/test/configCases/html/preload-prefetch/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/preload-prefetch/__snapshots__/ConfigCacheTest.snap
@@ -5,9 +5,9 @@ exports[`ConfigCacheTestCases html preload-prefetch exported tests should rewrit
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_0.chunk.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"__html_cbe5b59d_1.chunk.js\\">
-<link rel=\\"preload\\" as=\\"style\\" href=\\"__html_cbe5b59d_2.chunk.css\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page1.js\\">
+<link rel=\\"preload\\" as=\\"style\\" href=\\"page.css\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"preload\\" as=\\"script\\" href=\\"./ignored.js\\">
 </head>

--- a/test/configCases/html/preload-prefetch/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/preload-prefetch/__snapshots__/ConfigTest.snap
@@ -5,9 +5,9 @@ exports[`ConfigTestCases html preload-prefetch exported tests should rewrite <li
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"preload\\" as=\\"script\\" href=\\"__html_cbe5b59d_0.chunk.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"__html_cbe5b59d_1.chunk.js\\">
-<link rel=\\"preload\\" as=\\"style\\" href=\\"__html_cbe5b59d_2.chunk.css\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"page.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page1.js\\">
+<link rel=\\"preload\\" as=\\"style\\" href=\\"page.css\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"preload\\" as=\\"script\\" href=\\"./ignored.js\\">
 </head>

--- a/test/configCases/html/preload-prefetch/index.js
+++ b/test/configCases/html/preload-prefetch/index.js
@@ -8,16 +8,16 @@ it("should rewrite <link rel=preload/prefetch> of a bundled script/style to chun
 	expect(page).not.toContain('href="./preload-script.js"');
 	expect(page).not.toContain('href="./prefetch-script.js"');
 	expect(page).toMatch(
-		/<link rel="preload" as="script" href="__html_[^"]+\.js">/
+		/<link rel="preload" as="script" href="page\d*\.js">/
 	);
 	expect(page).toMatch(
-		/<link rel="prefetch" as="script" href="__html_[^"]+\.js">/
+		/<link rel="prefetch" as="script" href="page\d*\.js">/
 	);
 
 	// `as="style"` preload → CSS chunk URL.
 	expect(page).not.toContain('href="./preload-style.css"');
 	expect(page).toMatch(
-		/<link rel="preload" as="style" href="__html_[^"]+\.css">/
+		/<link rel="preload" as="style" href="page\d*\.css">/
 	);
 
 	// `webpackIgnore` leaves the resource hint untouched.

--- a/test/configCases/html/resource-hints/test.js
+++ b/test/configCases/html/resource-hints/test.js
@@ -50,11 +50,16 @@ it("should drop unresolvable and empty hints", () => {
 
 it("should point an entry hint at that entry's JavaScript", () => {
 	const emitted = new Set(fs.readdirSync(__dirname));
-	const hrefs = [
-		...head.matchAll(/<link rel="(?:preload|prefetch)"[^>]* href="([^"]+)"/g)
-	]
-		.map(([, href]) => href)
-		.filter((href) => href.endsWith(".js"));
+	// `String.prototype.matchAll` is newer than the Node baseline the harness
+	// runs this bundle on, so walk the matches with `exec`.
+	const linkRe = /<link rel="(?:preload|prefetch)"[^>]* href="([^"]+)"/g;
+	const hrefs = [];
+	let match = linkRe.exec(head);
+
+	while (match) {
+		if (match[1].endsWith(".js")) hrefs.push(match[1]);
+		match = linkRe.exec(head);
+	}
 
 	expect(hrefs).toContain("second.js");
 	for (const href of hrefs) expect(emitted).toContain(href);

--- a/test/configCases/html/resource-hints/test.js
+++ b/test/configCases/html/resource-hints/test.js
@@ -47,3 +47,19 @@ it("should drop unresolvable and empty hints", () => {
 	expect(head.match(/rel="preconnect"/g)).toHaveLength(1);
 	expect(head).not.toContain("does-not-exist");
 });
+
+it("should point an entry hint at that entry's JavaScript", () => {
+	const emitted = new Set(fs.readdirSync(__dirname));
+	const hrefs = [
+		...head.matchAll(/<link rel="(?:preload|prefetch)"[^>]* href="([^"]+)"/g)
+	]
+		.map(([, href]) => href)
+		.filter((href) => href.endsWith(".js"));
+
+	expect(hrefs).toContain("second.js");
+	for (const href of hrefs) expect(emitted).toContain(href);
+	// `second` emits its page plus the script extracted from it, so the hint
+	// resolves to that script rather than to a JavaScript copy of the page.
+	const hinted = fs.readFileSync(path.resolve(__dirname, "second.js"), "utf-8");
+	expect(hinted).not.toContain("<!doctype html>");
+});

--- a/test/watchCases/long-term-caching/html-contenthash-inline-script/0/index.js
+++ b/test/watchCases/long-term-caching/html-contenthash-inline-script/0/index.js
@@ -4,7 +4,7 @@ const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
 
 const findInlineEntry = (assets) =>
-	assets.find((a) => /^__html_/.test(a.name) && /\.js$/.test(a.name));
+	assets.find((a) => /^page\./.test(a.name) && /\.js$/.test(a.name));
 
 it("should compile fine and emit the extracted HTML and the inline-script entry chunk", () => {
 	const htmlAsset = STATS_JSON.assets.find((a) => /\.html$/.test(a.name));

--- a/test/watchCases/long-term-caching/html-contenthash-inline-script/1/index.js
+++ b/test/watchCases/long-term-caching/html-contenthash-inline-script/1/index.js
@@ -6,7 +6,7 @@ const path = __non_webpack_require__("path");
 const findInlineEntry = (assets) =>
 	assets.find(
 		(a) =>
-			/^__html_/.test(a.name) &&
+			/^page\./.test(a.name) &&
 			/\.js$/.test(a.name) &&
 			a.name !== STATE.inlineEntryName
 	);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for the experimental HTML support (`experiments.html`).

## Did you add tests for your changes?

Yes — two `configCases/html` cases: `html-entry-no-js-asset` (no JS asset is emitted for an `.html` entry) and `html-entry-library-js-asset` (the JS asset is kept when `output.library` asks for it).

## Summary

An `.html` file used as an entry emits a JS chunk that nothing loads:

```js
// webpack.config.js
export default {
  entry: "./src/index.html",
  experiments: { html: true },
};
```

```
asset main.js     341 bytes [emitted] [minimized] (name: main)
asset index.html  147 bytes [emitted] [minimized] (auxiliary name: main)
```

`main.js` is a bootstrap around a single module whose body is `module.exports = "<!doctype html>…"` — a copy of the page that was just written out. The emitted page references the `<script src>` entries the parser split out of it (`__html_<hash>_0.js`), never the entry chunk, so the file is dead weight, and there is one per page: a page with no `<script>` at all still gets one (336 B against a 141 B page), and each linked `type: "html"` page gets its own.

It also takes the entrypoint's primary asset slot, which is what `stats` and manifest/SSR tooling read:

```
Entrypoint main 341 bytes (147 bytes) = main.js 1 auxiliary asset
```

The dead JS is the asset; the page is auxiliary.

## Fix

`HtmlModulesPlugin` already deletes exactly this file for the wrapper entry `output.html` adds — "A wrapper entry's chunk only rebuilds the page's own markup; the page loads the `<script src>` entries the parser split out of it". The wrapper test is `HTML_DATA_URL_RE.test(resource)`, so a real `.html` file entry never reaches it. This widens that pass to a page extracted from an `.html` entry, keeping the existing safety net (a candidate another asset still references by URL is kept) and two behaviours unchanged:

- a data URL still counts as a wrapper only for the `data:text/html` webpack writes itself, so a `data:text/htmlx` entry keeps its chunk (covered by `output-html-data-url-media-type`);
- an entry asked for by name through `output.library` keeps its JS — there the bundle is the output the user configured, even when the module behind it is a page.

For comparison, a CSS entry has never emitted a JS asset: `CssGenerator.getTypes()` exposes the JavaScript type only when a JS module imports the stylesheet, while `HtmlGenerator.getTypes()` has no HTML-only path (`_shouldExposeHtmlType(module) ? JAVASCRIPT_AND_HTML_TYPES : JAVASCRIPT_TYPES`). Fixing it there instead would be the deeper change — happy to go that way if you prefer it; this patch stays inside the cleanup pass that already exists for the same reason.

## Verification

Against this branch, `entry: "./src/index.html"` now emits `index.html` + the page's script chunk and nothing else, `output.html` output is unchanged, and an `output.library` build keeps `main.js`.

Test suites run locally on Node 22: `ConfigTestCases` 11755 passed, `ConfigCacheTestCases -t html` 3210 passed, `StatsTestCases` 145 passed (144 snapshots), `HotTestCases*` 1629 passed. `eslint`, `prettier --check` and `tsc` are clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuWDbcF2jvq7q1r8aEY5V9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuWDbcF2jvq7q1r8aEY5V9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML entry asset naming for generated JavaScript and stylesheet files.
  * Preserved JavaScript assets when HTML entries are exposed as libraries.
  * Updated resource hints to reference the correct emitted entry files.
  * Prevented page-only HTML entries from emitting unnecessary JavaScript.
  * Corrected HTML media type detection to avoid misclassifying similar MIME types.

* **Tests**
  * Added coverage for HTML entries with JavaScript, CSS, library assets, and resource hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->