### PR TITLE
fix(js): match acorn on regexp verdicts and on locations with ranges

### DIFF
--- a/.changeset/161-js-parser-regexp-and-locations.md
+++ b/.changeset/161-js-parser-regexp-and-locations.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Parse a regexp literal the running engine cannot build, and keep locations.

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -6499,7 +6499,10 @@ class JavascriptParser extends Parser {
 			// syntax so `auto` avoids a second full parse in the common case
 			parserOptions.moduleFallback = type === "auto";
 		}
-		const wantRanges = parserOptions.ranges === true;
+		// `locations` are acorn's to track, so the lazy path serves the callers
+		// that ask for ranges alone — which is every one inside webpack
+		const wantLazyNodes =
+			parserOptions.ranges === true && parserOptions.locations !== true;
 		/**
 		 * Returns parse result.
 		 * @param {string} code source code
@@ -6514,20 +6517,17 @@ class JavascriptParser extends Parser {
 			/** @type {Comment[]} */
 			const comments = [];
 
-			// Whenever ranges are wanted (the main parse path and the concatenation
-			// re-parse), have the parser plugin serve `range` on demand instead of
-			// eagerly. `wantRanges` is hoisted since the auto-fallback re-enters
-			// with the same (mutated) options object.
-			options.lazyNodes = wantRanges;
-			if (wantRanges) {
+			// Ranges alone (the main parse path and the concatenation re-parse) are
+			// served on demand; hoisted, since the auto-fallback re-enters here.
+			options.lazyNodes = wantLazyNodes;
+			if (wantLazyNodes) {
 				// the lazy plugin replaces acorn's native tracking — disabling it
 				// here lets WebpackParser skip its defensive options copy
-				options.locations = false;
 				options.ranges = false;
 			}
 
 			if (options.comments) {
-				if (wantRanges) {
+				if (wantLazyNodes) {
 					// the parser plugin collects the comments itself, deferring the
 					// text slice until some hook actually reads `value`
 					options.lazyComments = comments;

--- a/lib/javascript/syntax.js
+++ b/lib/javascript/syntax.js
@@ -1841,6 +1841,7 @@ class Scope {
  * checkUnreserved: (ref: Identifier) => void,
  * enterScope: (flags: number) => void,
  * readRegexp: () => void,
+ * validateRegExpPattern: (state: { start: number, source: string, flags: string }) => void,
  * potentialArrowAt: number,
  * potentialArrowInForAwait: boolean,
  * overrideContext: (tokenCtx: unknown) => void,
@@ -2706,11 +2707,13 @@ class WebpackParser extends BaseParser {
 			// eslint-disable-next-line no-constructor-return -- the explicit object return is the mechanism that skips acorn's constructor
 			return /** @type {WebpackParser} */ (/** @type {unknown} */ (self));
 		}
-		const lazy = options.lazyNodes === true;
+		// `locations` are acorn's to track, so asking for them turns the lazy
+		// path off rather than dropping them from the nodes
+		const lazy = options.lazyNodes === true && options.locations !== true;
 		// JavascriptParser._parse pre-disables acorn's tracking, so the
 		// defensive copy only runs for direct callers
-		if (lazy && (options.locations || options.ranges)) {
-			options = { ...options, locations: false, ranges: false };
+		if (lazy && options.ranges) {
+			options = { ...options, ranges: false };
 		}
 		super(options, input, startPos);
 		// acorn sets this.keywords/reservedWords in its constructor; parsing
@@ -10213,9 +10216,11 @@ class WebpackParser extends BaseParser {
 		let value = null;
 		try {
 			value = new RegExp(pattern, flags);
-		} catch (err) {
-			// V8's verdict on the pattern, like validateRegExpPattern below
-			this.raiseRecoverable(start, /** @type {Error} */ (err).message);
+		} catch (_err) {
+			// This engine cannot build it, so acorn re-reads the literal: its
+			// validator says whether the pattern is invalid or merely newer
+			this.pos = start;
+			return base.readRegexp.call(this);
 		}
 		return this.finishToken(tokTypes.regexp, { pattern, flags, value });
 	}
@@ -10224,10 +10229,11 @@ class WebpackParser extends BaseParser {
 
 	/**
 	 * Acorn constructs the literal's `RegExp` value right after this hook, so
-	 * V8 validates every pattern anyway; acorn's own JS copy of
-	 * that validation costs several percent of parse time. Raise from V8's
-	 * verdict instead — invalid patterns still fail the module build, only
-	 * exotic engine-specific message texts may differ.
+	 * V8 validates every pattern anyway and its verdict serves as the fast path;
+	 * acorn's own JS copy of that validation costs several percent of parse
+	 * time. Only a pattern V8 rejects pays for it, and acorn's verdict is the
+	 * one that counts: a pattern only this engine lacks parses on, as it does
+	 * for acorn, with a null value.
 	 * acorn source: https://github.com/acornjs/acorn/blob/8.18.0/acorn/src/regexp.js
 	 * @param {{ start: number, source: string, flags: string }} state acorn regexp validation state
 	 * @this {ParserInternals}
@@ -10236,8 +10242,8 @@ class WebpackParser extends BaseParser {
 		try {
 			// eslint-disable-next-line no-new
 			new RegExp(state.source, state.flags);
-		} catch (err) {
-			this.raiseRecoverable(state.start, /** @type {Error} */ (err).message);
+		} catch (_err) {
+			base.validateRegExpPattern.call(this, state);
 		}
 	}
 

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -1566,7 +1566,11 @@ describe("JavascriptParser", () => {
 					)
 				)
 			);
-			expect(options.ranges).toBe(true);
+			expect(options).toEqual({
+				ecmaVersion: 2022,
+				lazyNodes: true,
+				ranges: true
+			});
 			const declaration = program.body[0];
 			// lazy: `range` comes from the prototype getter, not from acorn
 			expect(

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -1555,5 +1555,25 @@ describe("JavascriptParser", () => {
 			block.range = [1, 2];
 			expect(block.range).toEqual([1, 2]);
 		});
+
+		it("serves a direct caller's `ranges` lazily, leaving its options alone", () => {
+			const options = { ecmaVersion: 2022, lazyNodes: true, ranges: true };
+			const program = /** @type {EXPECTED_ANY} */ (
+				WebpackParser.parse(
+					"var x = 1;",
+					/** @type {import("acorn").Options} */ (
+						/** @type {unknown} */ (options)
+					)
+				)
+			);
+			expect(options.ranges).toBe(true);
+			const declaration = program.body[0];
+			// lazy: `range` comes from the prototype getter, not from acorn
+			expect(
+				Object.getOwnPropertyDescriptor(declaration, "range")
+			).toBeUndefined();
+			expect(declaration.range).toEqual([0, 10]);
+			expect(declaration.range).toBe(declaration.range);
+		});
 	});
 });

--- a/test/benchmarkCases/js-parser-unit/index.bench.mjs
+++ b/test/benchmarkCases/js-parser-unit/index.bench.mjs
@@ -73,11 +73,12 @@ export default (bench) => {
 		new JavascriptParser("script").parse(typescriptSource, {});
 	});
 
-	// acorn only, no walk; same options as parse() to isolate walker changes
+	// acorn only, no walk, and the options `parse()` really passes: it derives
+	// line and column from offsets, so tracking them here measures nobody's build.
 	bench.add("unit benchmark \"js-parser-unit\", mode 'parse'", () => {
 		JavascriptParser._parse(typescriptSource, {
 			sourceType: "auto",
-			locations: true,
+			locations: false,
 			ranges: true,
 			comments: true,
 			importPhases: false

--- a/test/test262-parser.spectest.js
+++ b/test/test262-parser.spectest.js
@@ -6,7 +6,7 @@ const acorn = require("acorn");
 const JavascriptParser = require("../lib/javascript/JavascriptParser");
 
 /** @typedef {{ file: string, at: string, ours: string, acorn: string }} TreeDifference */
-/** @typedef {{ file: string, parsedBy: string, message: string }} VerdictDifference */
+/** @typedef {{ file: string, webpack: string, acorn: string }} VerdictDifference */
 /** @typedef {{ ranges?: boolean, locations?: boolean, comments?: boolean }} Mode */
 /** @typedef {import("acorn").Program} Program */
 /** @typedef {import("acorn").Comment} Comment */
@@ -22,13 +22,17 @@ const AREA_TIMEOUT = 600000;
 // Enough of a regression to see its shape without flooding the log.
 const MAX_REPORTED = 10;
 
-// The option sets a caller can hand `JavascriptParser._parse`. `ranges` is the
-// one webpack itself uses: it switches on the lazy-node path.
+// The option sets a caller can hand `JavascriptParser._parse`. Ranges alone is
+// the one webpack uses, and the only one that takes the lazy-node path.
 /** @type {[string, Mode][]} */
 const MODES = [
 	["without ranges or comments", {}],
 	["with ranges and comments", { ranges: true, comments: true }],
-	["with locations", { locations: true }]
+	["with locations", { locations: true }],
+	[
+		"with ranges, locations and comments",
+		{ ranges: true, locations: true, comments: true }
+	]
 ];
 
 /**
@@ -119,35 +123,11 @@ const firstDifference = (ours, theirs, at) => {
 };
 
 /**
- * Whether acorn only got through the file because the host engine cannot build
- * one of its regexp literals, which acorn records as a null value and webpack
- * (validating with `new RegExp`) reports as a parse error instead.
- * @param {Error} error what webpack's parser threw
- * @param {Program} ast the program acorn built
- * @returns {boolean} true when the engine, not the pattern, is the difference
- */
-const isHostRegExpLimit = (error, ast) => {
-	if (!error.message.startsWith("Invalid regular expression:")) {
-		return false;
-	}
-	/** @type {unknown[]} */
-	const queue = [ast];
-	while (queue.length > 0) {
-		const node = queue.pop();
-		if (typeof node !== "object" || node === null) continue;
-		const record = /** @type {Record<string, unknown>} */ (node);
-		if (record.regex !== undefined && record.value === null) return true;
-		for (const key of Object.keys(record)) queue.push(record[key]);
-	}
-	return false;
-};
-
-/**
  * Parse one file with both parsers and record how they disagreed.
  * @param {string} file absolute path of the test262 file
  * @param {Mode} mode the options both parsers are given
  * @param {TreeDifference[]} trees where tree differences are collected
- * @param {VerdictDifference[]} verdicts where accept/reject differences are collected
+ * @param {VerdictDifference[]} verdicts where verdicts that disagree are collected
  * @returns {void}
  */
 const compareFile = (file, mode, trees, verdicts) => {
@@ -188,20 +168,19 @@ const compareFile = (file, mode, trees, verdicts) => {
 		theirError = /** @type {Error} */ (err);
 	}
 
+	// Rejecting the same source is half of the contract; rejecting it in the
+	// same words is the other half, since webpack reports what the parser threw.
 	if (ourError !== undefined || theirError !== undefined) {
-		if (ourError !== undefined && theirError !== undefined) return;
-		if (
-			ourError !== undefined &&
-			theirs !== undefined &&
-			isHostRegExpLimit(ourError, theirs)
-		) {
-			return;
+		const webpackVerdict = ourError === undefined ? "parsed" : ourError.message;
+		const acornVerdict =
+			theirError === undefined ? "parsed" : theirError.message;
+		if (webpackVerdict !== acornVerdict) {
+			verdicts.push({
+				file: name,
+				webpack: webpackVerdict,
+				acorn: acornVerdict
+			});
 		}
-		verdicts.push({
-			file: name,
-			parsedBy: ourError === undefined ? "webpack" : "acorn",
-			message: /** @type {Error} */ (ourError || theirError).message
-		});
 		return;
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

webpack's own JavaScript parser had drifted from acorn on two points: it rejected a regexp literal the running engine cannot build, where acorn accepts it and only validates the pattern, and it dropped node locations when ranges were asked for. Both are matched to acorn again here. The comparison tooling that catches this class of divergence is #22010, split out so this stays the parser change alone.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/test262-parser.spectest.js` covers both divergences, and the cases it previously had to exempt are removed.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to find the divergences against acorn, write the fix and the test coverage, and draft this description. Each divergence was reproduced before the change and re-checked after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of regular expression literals that the runtime cannot construct, while preserving source locations.
  * Standardized regular expression validation and error reporting.
  * Improved parser behavior when source ranges, locations, and comments are requested together.
  * Ensured source ranges remain consistent and reusable when accessed repeatedly.

* **Tests**
  * Expanded parser compatibility coverage across combined parsing modes.
  * Improved reporting of differences between parser results, including cases where both parsers reject input differently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->