### PR TITLE
fix(define): preserve non-optional property access past undefined member

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -1220,11 +1220,23 @@ class DefinePlugin {
 						};
 						parser.hooks.expressionMemberChain
 							.for(chainRoot)
-							.tap(PLUGIN_NAME, (expr, members) => {
+							.tap(PLUGIN_NAME, (expr, members, membersOptionals) => {
 								const deps = [key];
-								if (findUndefinedMemberAccess(members, deps) === -1) return;
+								const undefinedIndex = findUndefinedMemberAccess(members, deps);
+								if (undefinedIndex === -1) return;
 								for (const dep of deps) addValueDependency(dep);
-								return toConstantDependency(parser, "undefined")(expr);
+								if (
+									members.length - 1 === undefinedIndex ||
+									(membersOptionals && membersOptionals[undefinedIndex + 1])
+								) {
+									return toConstantDependency(parser, "undefined")(expr);
+								}
+								return toConstantDependency(
+									parser,
+									"undefined"
+								)(
+									dropTrailingMembers(expr, members.length - 1 - undefinedIndex)
+								);
 							});
 						// Cut the chain at the undefined member, so what follows still
 						// throws; an optional link there takes the call, arguments unevaluated.

--- a/test/configCases/plugins/define-plugin-optional-chaining/index.js
+++ b/test/configCases/plugins/define-plugin-optional-chaining/index.js
@@ -82,6 +82,22 @@ it("should keep a non-optional read after an unknown member throwing (issue 2182
 	expect(() => OBJECT.SUB1.UNKNOWN["a"]?.()).toThrow();
 	expect(() => OBJECT.SUB1.UNKNOWN.deep.method()).toThrow();
 });
+it("should keep a non-optional property access after an unknown member throwing (issue 22014)", function () {
+	const a = function () { return OBJECT.SUB1.UNKNOWN.a; };
+	const b = function () { return OBJECT.SUB1.UNKNOWN["a"]; };
+	const c = function () { return OBJECT.SUB1.UNKNOWN.a.b; };
+	const d = function () { return OBJECT.SUB1.UNKNOWN.a?.b; };
+	expect(a.toString()).toBe("function () { return undefined.a; }");
+	expect(b.toString()).toBe('function () { return undefined["a"]; }');
+	expect(c.toString()).toBe("function () { return undefined.a.b; }");
+	expect(d.toString()).toBe("function () { return undefined.a?.b; }");
+	expect(() => OBJECT.SUB1.UNKNOWN.a).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN["a"]).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN.a.b).toThrow();
+	expect(() => OBJECT.SUB1.UNKNOWN.a?.b).toThrow();
+	expect(OBJECT.SUB1.UNKNOWN?.a).toBe(undefined);
+	expect(OBJECT.SUB1.UNKNOWN).toBe(undefined);
+});
 it("should keep optional calls on defined members intact (issue 21822)", function () {
 	expect(OBJECT.SUB1.a?.toFixed(2)).toBe("1.00");
 	expect(STRING?.toUpperCase()).toBe("STRING");

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -158,7 +158,8 @@ it("should replace unknown member access with undefined (issue 15559)", function
 	expect(typeof OBJECT.UNKNOWN).toBe("undefined");
 	const a = function () { return OBJECT.UNKNOWN.A; };
 	const b = function () { return OBJECT.SUB1.UNKNOWN; };
-	expect(a.toString()).toBe("function () { return undefined; }");
+	expect(a.toString()).toBe("function () { return undefined.A; }");
+	expect(() => OBJECT.UNKNOWN.A).toThrow();
 	expect(b.toString()).toBe("function () { return undefined; }");
 	expect(OBJECT.SUB1.a).toBe(1);
 	expect(OBJECT.SUB2.a).toBe(1);


### PR DESCRIPTION
**Summary**

Follow-up to #21827. In #21827, `callMemberChain` was updated using `dropTrailingMembers` so that a non-optional call past an undefined member (e.g. `OBJ.MISSING.a?.()`) emits `undefined.a?.()` and throws at runtime as native JavaScript would.

However, `expressionMemberChain` was not updated and still unconditionally replaced the entire member expression with `undefined`. Consequently, non-optional property accesses (such as `OBJECT.SUB.UNKNOWN.a`, `OBJECT.SUB.UNKNOWN["a"]`, `OBJECT.SUB.UNKNOWN.a.b`, and `OBJECT.SUB.UNKNOWN.a?.b`) silently evaluated to `undefined` instead of throwing a `TypeError` when reading off `undefined`.

This PR brings the same chain-cutting logic to `parser.hooks.expressionMemberChain`:
1. If the member is the leaf of the access chain (`members.length - 1 === undefinedIndex`) or the next link is optional (`membersOptionals[undefinedIndex + 1]`), the expression evaluates to `undefined`.
2. Otherwise, `dropTrailingMembers` cuts the chain at `undefinedIndex`, emitting `(undefined).a` so that the non-optional property read executes against `undefined` and throws the expected `TypeError`.

Fixes #22014.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes:
- Added coverage for non-optional property reads (`.a`, `["a"]`, deep chained `.a.b`, and `.a?.b`) throwing in `test/configCases/plugins/define-plugin-optional-chaining/index.js`.
- Updated `test/configCases/plugins/define-plugin/index.js` to assert `undefined.A` and verify it throws on execution.

**Does this PR introduce a breaking change?**

No. Affected expressions previously evaluated to `undefined` instead of throwing the runtime `TypeError` mandated by ECMAScript semantics.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unknown member access in DefinePlugin expressions.
  - Non-optional property access now remains intact, preserving expected runtime errors when evaluated.
  - Optional chaining correctly resolves to `undefined` when an earlier member is unknown.
  - Added coverage for dot notation, computed properties, chained access, and mixed optional/non-optional expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->