### PR TITLE
fix(cache): invalidate consumer codegen when inlined exports change

### DIFF
--- a/.changeset/021-inline-exports-cache-invalidation.md
+++ b/.changeset/021-inline-exports-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Invalidate consumer codegen when an inlined export value changes.

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -9,6 +9,7 @@ const util = require("util");
 const Entrypoint = require("./Entrypoint");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 const { DEFAULTS } = require("./config/defaults");
+const { isExportInlined } = require("./optimize/InlineExports");
 const { first } = require("./util/SetHelpers");
 const SortableSet = require("./util/SortableSet");
 const {
@@ -21,6 +22,7 @@ const {
 } = require("./util/comparators");
 const createHash = require("./util/createHash");
 const findGraphRoots = require("./util/findGraphRoots");
+const memoize = require("./util/memoize");
 const {
 	RuntimeSpecMap,
 	RuntimeSpecSet,
@@ -28,6 +30,10 @@ const {
 	mergeRuntime,
 	runtimeToString
 } = require("./util/runtime");
+
+const getHarmonyImportSpecifierDependency = memoize(() =>
+	require("./dependencies/HarmonyImportSpecifierDependency")
+);
 
 /** @import AsyncDependenciesBlock from "./AsyncDependenciesBlock" */
 /** @import Chunk, { Chunks, Entrypoints, ChunkId } from "./Chunk" */
@@ -67,6 +73,23 @@ const activeStateToString = (state) => {
 	if (state === true) return "T";
 	if (state === ModuleGraphConnection.TRANSITIVE_ONLY) return "O";
 	throw new Error("Not implemented active state");
+};
+
+/**
+ * True when an inactive connection still embeds an inlined export literal
+ * in the referencing module's generated code (must stay in its hash).
+ * @param {ModuleGraph} moduleGraph module graph
+ * @param {ModuleGraphConnection} connection connection
+ * @param {RuntimeSpec} runtime runtime
+ * @returns {boolean} true when the connection contributes an inlined literal
+ */
+const connectionInactiveDueToInlining = (moduleGraph, connection, runtime) => {
+	const module = connection.module;
+	if (!module) return false;
+	const dep = connection.dependency;
+	// Lazy: top-level require cycles Module → ChunkGraph → dependency → Module.
+	if (!(dep instanceof getHarmonyImportSpecifierDependency())) return false;
+	return isExportInlined(moduleGraph, module, dep.getIds(moduleGraph), runtime);
 };
 
 const compareModuleIterables = compareIterables(compareModulesByIdentifier);
@@ -1885,7 +1908,20 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 			if (runtime === undefined || typeof runtime === "string") {
 				for (const connection of connections) {
 					const state = connection.getActiveState(runtime);
-					if (state === false) continue;
+					if (state === false) {
+						// Keep inlined imports in the hash: their literals are
+						// embedded in this module's codegen (#22019).
+						if (
+							connectionInactiveDueToInlining(
+								this.moduleGraph,
+								connection,
+								runtime
+							)
+						) {
+							processConnection(connection, "I");
+						}
+						continue;
+					}
 					processConnection(connection, state === true ? "T" : "O");
 				}
 			} else {
@@ -1905,7 +1941,18 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 					);
 					if (states.size === 1) {
 						const state = first(states);
-						if (state === false) continue;
+						if (state === false) {
+							if (
+								connectionInactiveDueToInlining(
+									this.moduleGraph,
+									connection,
+									runtime
+								)
+							) {
+								processConnection(connection, "I");
+							}
+							continue;
+						}
 						stateInfo = activeStateToString(
 							/** @type {ConnectionState} */
 							(state)

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -44,7 +44,7 @@ const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
 	const hasValueDependencies =
 		valueDependencies !== undefined && valueDependencies.size > 0;
 	if (!lazyRequests && !hasValueDependencies) return "";
-	/** @type {(string | string[] | null)[][]} */
+	/** @type {(string | string[] | undefined)[][]} */
 	const valueEntries = [];
 	if (hasValueDependencies) {
 		const versions =
@@ -52,13 +52,10 @@ const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
 			(valueDependencies);
 		for (const key of [...versions.keys()].sort()) {
 			const value = versions.get(key);
+			// An absent version serializes as null, distinct from both other shapes
 			valueEntries.push([
 				key,
-				value === undefined
-					? null
-					: typeof value === "string"
-						? value
-						: [...value].sort()
+				value instanceof Set ? [...value].sort() : value
 			]);
 		}
 	}

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -30,67 +30,47 @@ const PLUGIN_LOGGER_NAME = `webpack.${PLUGIN_NAME}`;
 /** @typedef {{ etag: string, data: InstanceType<RestoreProvidedData> }} MemCacheEntry */
 
 /**
+ * Cache key fragment for what changes provided exports without changing the
+ * module's source: still-lazy barrel requests and DefinePlugin value versions.
  * @param {Module} module the module
  * @param {LazyBarrelController} lazyBarrelController the compilation's lazy barrel controller
  * @param {HashFunction} hashFunction hash function for long keys
- * @returns {string} the hash
- */
-const getLazyRequestsHash = (module, lazyBarrelController, hashFunction) => {
-	const lazyKeys = lazyBarrelController.getLazyRequests(module);
-	if (!lazyKeys) return "";
-	const joined = [...lazyKeys].join("|");
-	if (joined.length < 100) return joined;
-	const hash = createHash(hashFunction);
-	hash.update(joined);
-	return /** @type {string} */ (hash.digest("hex"));
-};
-
-/**
- * DefinePlugin (and similar) can change provided exports without changing the
- * source hash; fold valueDependencies into the provided-exports cache key.
- * @param {Module} module the module
- * @param {HashFunction} hashFunction hash function for long keys
- * @returns {string} key fragment, or "" when absent
- */
-const getValueDependenciesHash = (module, hashFunction) => {
-	const valueDependencies =
-		/** @type {BuildInfo | undefined} */
-		(module.buildInfo) &&
-		/** @type {BuildInfo} */
-		(module.buildInfo).valueDependencies;
-	if (!valueDependencies || valueDependencies.size === 0) return "";
-	const parts = [];
-	for (const key of [...valueDependencies.keys()].sort()) {
-		const value = valueDependencies.get(key);
-		parts.push(
-			`${key}=${
-				typeof value === "string"
-					? value
-					: value === undefined
-						? ""
-						: `[${[...value].sort().join(",")}]`
-			}`
-		);
-	}
-	const joined = parts.join("|");
-	if (joined.length < 100) return joined;
-	const hash = createHash(hashFunction);
-	hash.update(joined);
-	return /** @type {string} */ (hash.digest("hex"));
-};
-
-/**
- * @param {Module} module the module
- * @param {LazyBarrelController} lazyBarrelController the compilation's lazy barrel controller
- * @param {HashFunction} hashFunction hash function for long keys
- * @returns {string} etag for provided-exports mem/persistent cache
+ * @returns {string} etag for provided-exports mem/persistent cache, "" when neither applies
  */
 const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
-	const lazy = getLazyRequestsHash(module, lazyBarrelController, hashFunction);
-	const valueDeps = getValueDependenciesHash(module, hashFunction);
-	if (!lazy) return valueDeps;
-	if (!valueDeps) return lazy;
-	return `${lazy}|${valueDeps}`;
+	const lazyRequests = lazyBarrelController.getLazyRequests(module);
+	const buildInfo = /** @type {BuildInfo | undefined} */ (module.buildInfo);
+	const valueDependencies = buildInfo && buildInfo.valueDependencies;
+	const hasValueDependencies =
+		valueDependencies !== undefined && valueDependencies.size > 0;
+	if (!lazyRequests && !hasValueDependencies) return "";
+	/** @type {(string | string[] | null)[][]} */
+	const valueEntries = [];
+	if (hasValueDependencies) {
+		const versions =
+			/** @type {NonNullable<BuildInfo["valueDependencies"]>} */
+			(valueDependencies);
+		for (const key of [...versions.keys()].sort()) {
+			const value = versions.get(key);
+			valueEntries.push([
+				key,
+				value === undefined
+					? null
+					: typeof value === "string"
+						? value
+						: [...value].sort()
+			]);
+		}
+	}
+	// JSON, so a separator inside a request or a version cannot forge another entry
+	const joined = JSON.stringify([
+		lazyRequests ? [...lazyRequests] : [],
+		valueEntries
+	]);
+	if (joined.length < 100) return joined;
+	const hash = createHash(hashFunction);
+	hash.update(joined);
+	return /** @type {string} */ (hash.digest("hex"));
 };
 
 class FlagDependencyExportsPlugin {

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -45,6 +45,54 @@ const getLazyRequestsHash = (module, lazyBarrelController, hashFunction) => {
 	return /** @type {string} */ (hash.digest("hex"));
 };
 
+/**
+ * DefinePlugin (and similar) can change provided exports without changing the
+ * source hash; fold valueDependencies into the provided-exports cache key.
+ * @param {Module} module the module
+ * @param {HashFunction} hashFunction hash function for long keys
+ * @returns {string} key fragment, or "" when absent
+ */
+const getValueDependenciesHash = (module, hashFunction) => {
+	const valueDependencies =
+		/** @type {BuildInfo | undefined} */
+		(module.buildInfo) &&
+		/** @type {BuildInfo} */
+		(module.buildInfo).valueDependencies;
+	if (!valueDependencies || valueDependencies.size === 0) return "";
+	const parts = [];
+	for (const key of [...valueDependencies.keys()].sort()) {
+		const value = valueDependencies.get(key);
+		parts.push(
+			`${key}=${
+				typeof value === "string"
+					? value
+					: value === undefined
+						? ""
+						: `[${[...value].sort().join(",")}]`
+			}`
+		);
+	}
+	const joined = parts.join("|");
+	if (joined.length < 100) return joined;
+	const hash = createHash(hashFunction);
+	hash.update(joined);
+	return /** @type {string} */ (hash.digest("hex"));
+};
+
+/**
+ * @param {Module} module the module
+ * @param {LazyBarrelController} lazyBarrelController the compilation's lazy barrel controller
+ * @param {HashFunction} hashFunction hash function for long keys
+ * @returns {string} etag for provided-exports mem/persistent cache
+ */
+const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
+	const lazy = getLazyRequestsHash(module, lazyBarrelController, hashFunction);
+	const valueDeps = getValueDependenciesHash(module, hashFunction);
+	if (!lazy) return valueDeps;
+	if (!valueDeps) return lazy;
+	return `${lazy}|${valueDeps}`;
+};
+
 class FlagDependencyExportsPlugin {
 	/**
 	 * Applies the plugin by registering its hooks on the compiler.
@@ -107,7 +155,7 @@ class FlagDependencyExportsPlugin {
 							const memCache = moduleMemCaches && moduleMemCaches.get(module);
 							/** @type {MemCacheEntry | undefined} */
 							const memCacheEntry = memCache && memCache.get(this);
-							const hash = getLazyRequestsHash(
+							const etag = getProvidedExportsEtag(
 								module,
 								lazyBarrelController,
 								hashFunction
@@ -116,7 +164,7 @@ class FlagDependencyExportsPlugin {
 							// detection cannot invalidate the mem cache when the un-lazied
 							// connections are unsafe-cached (they are skipped when comparing
 							// references)
-							if (memCacheEntry !== undefined && memCacheEntry.etag === hash) {
+							if (memCacheEntry !== undefined && memCacheEntry.etag === etag) {
 								statRestoredFromMemCache++;
 								exportsInfo.restoreProvided(memCacheEntry.data);
 								return callback();
@@ -126,7 +174,7 @@ class FlagDependencyExportsPlugin {
 							);
 							cache.get(
 								module.identifier(),
-								hash ? `${buildHash}|${hash}` : buildHash,
+								etag ? `${buildHash}|${etag}` : buildHash,
 								(err, result) => {
 									if (err) return callback(err);
 
@@ -349,12 +397,13 @@ class FlagDependencyExportsPlugin {
 												changed = true;
 											}
 
-											if (
-												inlined !== undefined &&
-												exportInfo.canInlineProvide === undefined
-											) {
-												exportInfo.canInlineProvide = inlined;
-												changed = true;
+											if (inlined !== undefined) {
+												const prev = exportInfo.canInlineProvide;
+												// Watch rebuilds keep ExportInfo; refresh when the constant changes
+												if (prev === undefined || !prev.equals(inlined)) {
+													exportInfo.canInlineProvide = inlined;
+													changed = true;
+												}
 											}
 
 											if (terminalBinding && !exportInfo.terminalBinding) {
@@ -511,7 +560,7 @@ class FlagDependencyExportsPlugin {
 										.getRestoreProvidedData();
 									const memCache =
 										moduleMemCaches && moduleMemCaches.get(module);
-									const hash = getLazyRequestsHash(
+									const etag = getProvidedExportsEtag(
 										module,
 										lazyBarrelController,
 										hashFunction
@@ -519,7 +568,7 @@ class FlagDependencyExportsPlugin {
 									if (memCache) {
 										/** @type {MemCacheEntry} */
 										const entry = {
-											etag: hash,
+											etag,
 											data: cachedData
 										};
 										memCache.set(this, entry);
@@ -529,7 +578,7 @@ class FlagDependencyExportsPlugin {
 									);
 									cache.store(
 										module.identifier(),
-										hash ? `${buildHash}|${hash}` : buildHash,
+										etag ? `${buildHash}|${etag}` : buildHash,
 										cachedData,
 										callback
 									);

--- a/lib/optimize/ConstExportsPlugin.js
+++ b/lib/optimize/ConstExportsPlugin.js
@@ -189,13 +189,23 @@ class ConstExportsPlugin {
 							}
 							for (const exportInfo of exportsInfo.ownedExports) {
 								const inlined = exportInfo.canInline();
-								const doInline =
-									!exportInfo.hasUsedName() &&
-									inlined !== undefined &&
-									exportInfo.provided === true;
-								if (doInline) {
-									exportInfo.setUsedName(new InlinedUsedName(inlined));
-									exportsInfo.markInlinedExports();
+								if (inlined !== undefined && exportInfo.provided === true) {
+									if (!exportInfo.hasUsedName()) {
+										exportInfo.setUsedName(new InlinedUsedName(inlined));
+										exportsInfo.markInlinedExports();
+									} else {
+										// Watch rebuilds keep ExportInfo; refresh a stale literal
+										const usedName = exportInfo.getUsedName(
+											exportInfo.name,
+											undefined
+										);
+										if (
+											usedName instanceof InlinedUsedName &&
+											!usedName.value.equals(inlined)
+										) {
+											exportInfo.setUsedName(new InlinedUsedName(inlined));
+										}
+									}
 								}
 								if (exportInfo.exportsInfoOwned && exportInfo.exportsInfo) {
 									const used = exportInfo.getUsed(undefined);

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -61,6 +61,14 @@ class InlinedValue {
 	}
 
 	/**
+	 * @param {InlinedValue} other other inlined value
+	 * @returns {boolean} true when kind and value match
+	 */
+	equals(other) {
+		return this.kind === other.kind && this.value === other.value;
+	}
+
+	/**
 	 * @param {ObjectSerializerContext} context context
 	 */
 	serialize({ write }) {

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -512,4 +512,77 @@ export const FLAG = "off";
 		expect(second).toContain("inlined export .NUM */6");
 		expect(second).toContain('inlined export .FLAG */"off"');
 	}, 100000);
+
+	// A DefinePlugin value changes the inlined literal without touching the
+	// module source, so its build hash alone cannot key the provided exports.
+	it("should invalidate consumer codegen when a plugin-provided inlined export changes", async () => {
+		const { DefinePlugin } = require("../");
+
+		const configFor = (/** @type {string} */ flag) => ({
+			mode: "production",
+			optimization: { minimize: false },
+			output: {
+				...config.output,
+				pathinfo: true
+			},
+			plugins: [new DefinePlugin({ "process.env.FLAG": JSON.stringify(flag) })]
+		});
+		await updateSrc({
+			"index.js": `import { FLAG } from "./env.js";
+export default FLAG;
+`,
+			"env.js": "export const FLAG = process.env.FLAG;\n"
+		});
+		await compile(configFor("on"));
+		expect(execute()).toBe("on");
+		const first = await readFile(path.resolve(outputPath, "main.js"), "utf8");
+		expect(first).toContain('inlined export .FLAG */"on"');
+
+		await compile(configFor("off"));
+		expect(execute()).toBe("off");
+		const second = await readFile(path.resolve(outputPath, "main.js"), "utf8");
+		expect(second).toContain('inlined export .FLAG */"off"');
+	}, 100000);
+
+	// A value version is user-supplied text; spelling out the encoding's own
+	// separators must not forge another key's entry in the cache key.
+	it("should key value dependencies whose versions contain the separators", async () => {
+		const { DefinePlugin } = require("../");
+
+		const keyB = `${DefinePlugin.VALUE_DEP_PREFIX}process.env.B`;
+		const configFor = (
+			/** @type {string} */ suffix,
+			/** @type {string} */ versionA,
+			/** @type {string} */ versionB
+		) => ({
+			mode: "production",
+			optimization: { minimize: false },
+			plugins: [
+				new DefinePlugin({
+					"process.env.A": DefinePlugin.runtimeValue(
+						() => JSON.stringify(`a${suffix}`),
+						{ version: versionA }
+					),
+					"process.env.B": DefinePlugin.runtimeValue(
+						() => JSON.stringify(`b${suffix}`),
+						{ version: versionB }
+					)
+				})
+			]
+		});
+		await updateSrc({
+			"index.js": `import { A, B } from "./env.js";
+export default [A, B];
+`,
+			"env.js": `export const A = process.env.A;
+export const B = process.env.B;
+`
+		});
+		await compile(configFor("1", `1|${keyB}=2`, "3"));
+		expect(execute()).toEqual(["a1", "b1"]);
+
+		// The two version sets concatenate to the same "key=value|…" text
+		await compile(configFor("2", "1", `2|${keyB}=3`));
+		expect(execute()).toEqual(["a2", "b2"]);
+	}, 100000);
 });

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -473,4 +473,43 @@ export default 40 + file;
 		await compile(configAdditions);
 		await expect(getCacheFileTimes()).resolves.toEqual(firstCacheFileTimes);
 	}, 20000);
+
+	// An inlined export embeds its literal in the consumer's codegen; the
+	// filesystem cache must invalidate that consumer when the value changes.
+	it("should invalidate consumer codegen when an inlined export value changes", async () => {
+		const configAdditions = {
+			mode: "production",
+			optimization: { minimize: false },
+			output: {
+				...config.output,
+				pathinfo: true
+			}
+		};
+		await updateSrc({
+			"index.js": `import { FLAG, NUM } from "./env.js";
+export default [NUM, FLAG];
+`,
+			"env.js": `export const NUM = 5;
+export const FLAG = "on";
+`
+		});
+		await compile(configAdditions);
+		expect(execute()).toEqual([5, "on"]);
+		const first = await readFile(path.resolve(outputPath, "main.js"), "utf8");
+		expect(first).toContain("inlined export .NUM */5");
+		expect(first).toContain('inlined export .FLAG */"on"');
+
+		// Both values stay within the ≤6-byte inline limit so a yes→no
+		// boundary change cannot mask the stale-hash bug (#22019).
+		await updateSrc({
+			"env.js": `export const NUM = 6;
+export const FLAG = "off";
+`
+		});
+		await compile(configAdditions);
+		expect(execute()).toEqual([6, "off"]);
+		const second = await readFile(path.resolve(outputPath, "main.js"), "utf8");
+		expect(second).toContain("inlined export .NUM */6");
+		expect(second).toContain('inlined export .FLAG */"off"');
+	}, 100000);
 });

--- a/test/watchCases/cache/inline-exports-value-change/0/env.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/env.js
@@ -1,0 +1,2 @@
+export const FLAG = process.env.FLAG;
+export const NUM = 5;

--- a/test/watchCases/cache/inline-exports-value-change/0/index.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/index.js
@@ -1,0 +1,22 @@
+import { FLAG, NUM } from "./env";
+import { REEXPORTED_NUM } from "./reexport";
+import "./trigger";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+it("should refresh the inlined constants a cached build baked into consumers", () => {
+	const source = fs.readFileSync(
+		path.join(STATS_JSON.outputPath, "bundle.js"),
+		"utf8"
+	);
+	const expectedFlag = WATCH_STEP === "0" ? "on" : "off";
+	const expectedNum = WATCH_STEP === "2" ? 6 : 5;
+	expect(FLAG).toBe(expectedFlag);
+	expect(NUM).toBe(expectedNum);
+	expect(REEXPORTED_NUM).toBe(expectedNum);
+	expect(source).toContain(
+		`(/* inlined export .FLAG */${JSON.stringify(expectedFlag)})`
+	);
+	expect(source).toContain(`(/* inlined export .NUM */${expectedNum})`);
+});

--- a/test/watchCases/cache/inline-exports-value-change/0/reexport.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/reexport.js
@@ -1,0 +1,1 @@
+export { NUM as REEXPORTED_NUM } from "./env";

--- a/test/watchCases/cache/inline-exports-value-change/0/trigger.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/trigger.js
@@ -1,0 +1,2 @@
+// Changed at every step so the watcher rebuilds while the consumer stays as it was
+module.exports = 0;

--- a/test/watchCases/cache/inline-exports-value-change/1/trigger.js
+++ b/test/watchCases/cache/inline-exports-value-change/1/trigger.js
@@ -1,0 +1,2 @@
+// Changed at every step so the watcher rebuilds while the consumer stays as it was
+module.exports = 1;

--- a/test/watchCases/cache/inline-exports-value-change/2/env.js
+++ b/test/watchCases/cache/inline-exports-value-change/2/env.js
@@ -1,0 +1,2 @@
+export const FLAG = process.env.FLAG;
+export const NUM = 6;

--- a/test/watchCases/cache/inline-exports-value-change/2/trigger.js
+++ b/test/watchCases/cache/inline-exports-value-change/2/trigger.js
@@ -1,0 +1,2 @@
+// Changed at every step so the watcher rebuilds while the consumer stays as it was
+module.exports = 2;

--- a/test/watchCases/cache/inline-exports-value-change/webpack.config.js
+++ b/test/watchCases/cache/inline-exports-value-change/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { DefinePlugin } = require("../../../../");
+const currentWatchStep = require("../../../helpers/currentWatchStep");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	cache: {
+		type: "filesystem"
+	},
+	optimization: {
+		minimize: false,
+		inlineExports: true
+	},
+	plugins: [
+		new DefinePlugin({
+			"process.env.FLAG": DefinePlugin.runtimeValue(
+				() =>
+					JSON.stringify(
+						Number(currentWatchStep.step || 0) === 0 ? "on" : "off"
+					),
+				{ version: () => String(currentWatchStep.step || 0) }
+			)
+		})
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -11694,6 +11694,7 @@ declare abstract class InlinedValue {
 	value?: null | string | number | boolean;
 	renderLiteral(): string;
 	render(comment: string): string;
+	equals(other: InlinedValue): boolean;
 	serialize(__0: ObjectSerializerContextObjectMiddlewareObject_3): void;
 	deserialize(__0: ObjectDeserializerContextObjectMiddlewareObject_2): void;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #22019: when `optimization.inlineExports` is on, changing an inlined constant no longer left consumers with a stale filesystem-cache codegen. Inactive-but-inlined import connections are included in the module graph hash again.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/PersistentCaching.test.js` (filesystem cache rebuild with a changed inlined constant).

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. AI assisted root-cause analysis, the ChunkGraph hash fix, the PersistentCaching regression, and PR preparation. The failing case and the fix were verified locally before opening this PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persistent caching now invalidates consumer code generation when inlined export values change.
  * Cached builds correctly refresh updated inlined constants during watch-mode rebuilds.
  * Cache keys now reliably distinguish export values containing special separator characters.

* **Tests**
  * Added regression coverage for persistent-cache invalidation across changing inlined exports.
  * Added watch-mode coverage for updated environment-based and numeric export values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->