### PR TITLE
fix(html): reset duplicate-attr flag at every tag boundary

### DIFF
--- a/.changeset/182-html-pend-attr-dropped-reset.md
+++ b/.changeset/182-html-pend-attr-dropped-reset.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix stale duplicate-attribute flag bleeding into subsequent HTML start tags.

--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8619,6 +8619,7 @@ const handleStartTagToken = (
 	if (eofInTag) {
 		// Any attribute slots already allocated for it are orphaned.
 		pendAttrStart = 0;
+		pendAttrDropped = false;
 		return end;
 	}
 	const name = internLowerName(TAG_NAME_INTERN, input, nameStart, nameEnd);
@@ -8640,6 +8641,7 @@ const handleStartTagToken = (
 		}
 	}
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	tok.selfClosing = selfClosing;
 	tok.swallowNewline = false;
 	tok.pos.start = start;
@@ -8669,6 +8671,7 @@ const handleEndTagToken = (input, start, end, nameStart, nameEnd) => {
 	}
 	// End tags drop any parsed attributes (the slots are orphaned).
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	tok.type = TOKEN_END_TAG;
 	tok.name = name;
 	tok.pos.start = start;
@@ -8754,6 +8757,7 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	form = 0;
 	framesetOk = true;
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	fosterParenting = false;
 	_fosteredLog = null;
 	_printFromSource = false;

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -10247,3 +10247,36 @@ describe("SourceProcessor — reflected attributes are read per element", () => 
 		expect(minify('<div vspace="008">x</div>')).toBe("<div vspace=008>x</div>");
 	});
 });
+
+describe("SourceProcessor — duplicate-attr state reset between tags", () => {
+	const { SourceProcessor } = require("../lib/html/syntax");
+
+	/**
+	 * @param {string} html input markup
+	 * @returns {string} the minified serialization
+	 */
+	const minify = (html) =>
+		new SourceProcessor().process(html, { mode: "minify" }).code;
+
+	it("does not misidentify a zero-attribute tag as foreign-syntax after a dup-attr tag", () => {
+		// <div {%if%} {%if%}> has a duplicate foreign delimiter and is written back
+		// verbatim. The next <br> (zero attributes) must not inherit the dropped-attr
+		// flag and must be processed normally.
+		const result = minify("<div {%if%} {%if%}><br><p id=\"x\">text</p>");
+		expect(result).toContain("<div {%if%} {%if%}>");
+		expect(result).toContain("<br>");
+		expect(result).toContain("<p id=x>");
+	});
+
+	it("does not carry duplicate-attr state across consecutive parse calls", () => {
+		// A document whose last start-tag had a duplicate attribute leaves
+		// `pendAttrDropped=true` at module level; the next `parseHtml` call must
+		// reset it during init so zero-attribute tags in the new document are not
+		// scanned with stale state (which can crash when the attr columns are
+		// empty after a large-document release).
+		const firstResult = minify("<div {%if%} {%if%}>");
+		expect(firstResult).toContain("<div {%if%} {%if%}>");
+		const secondResult = minify("<p id=\"a\">x</p><br>");
+		expect(secondResult).toBe("<p id=a>x<br>");
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`pendAttrDropped` (the flag that records whether the current start-tag
dropped a duplicate attribute per §13.2.5.33) was never co-reset alongside
`pendAttrStart = 0`. A zero-attribute tag following a dup-attr tag inherited
stale `true`, causing `handleStartTagToken` to scan attribute slots from the
previous tag. In the worst case — after a parse with >65 536 attributes
shrinks `_attrNames` to empty — the next small-document parse crashes with
`TypeError: Cannot read properties of undefined (reading 'length')`.

Fix: add `pendAttrDropped = false` at all four `pendAttrStart = 0` sites —
the eof-in-tag early return and normal finish in `handleStartTagToken`,
`handleEndTagToken`, and the `parseHtml` init block.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes — `test/HtmlSyntax.unittest.js`: two cases under
`"SourceProcessor — duplicate-attr state reset between tags"` verify that a
zero-attribute tag after a dup-attr tag is not misidentified as a
foreign-syntax tag, and that state does not bleed across consecutive
`parseHtml` calls.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This fix was identified and implemented with the assistance of Claude Code
(Anthropic). Root cause analysis, code change, regression test, and commit
were AI-assisted and reviewed by the author before submission, in accordance
with the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale duplicate-attribute state affecting subsequent HTML tags.
  - Corrected foreign-syntax handling for tags following duplicate attributes.
  - Ensured parsing state is reset between separate parsing operations.

- **Tests**
  - Added regression coverage for duplicate attributes and parser state isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->