### PR TITLE
fix(dll): rebuild DelegatedModule when manifest metadata changes

### DIFF
--- a/.changeset/022-dll-manifest-delegated-rebuild.md
+++ b/.changeset/022-dll-manifest-delegated-rebuild.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Rebuild DelegatedModule when DLL manifest metadata changes.

--- a/lib/dll/DelegatedModule.js
+++ b/lib/dll/DelegatedModule.js
@@ -242,6 +242,7 @@ class DelegatedModule extends Module {
 	updateHash(hash, context) {
 		hash.update(this.delegationType);
 		hash.update(JSON.stringify(this.request));
+		hash.update(JSON.stringify(this.delegateData));
 		super.updateHash(hash, context);
 	}
 
@@ -299,7 +300,23 @@ class DelegatedModule extends Module {
 		this.delegationType = m.delegationType;
 		this.userRequest = m.userRequest;
 		this.originalRequest = m.originalRequest;
-		this.delegateData = m.delegateData;
+		const next = m.delegateData;
+		// cleanupForCache clears delegateData; compare surviving build products instead.
+		if (this.buildMeta) {
+			const nextMeta = { ...next.buildMeta };
+			const exportsDependency = this.dependencies[1];
+			const builtExports =
+				exportsDependency instanceof StaticExportsDependency
+					? exportsDependency.exports
+					: undefined;
+			if (
+				JSON.stringify(this.buildMeta) !== JSON.stringify(nextMeta) ||
+				JSON.stringify(builtExports) !== JSON.stringify(next.exports || true)
+			) {
+				this.buildMeta = undefined;
+			}
+		}
+		this.delegateData = next;
 	}
 
 	/**

--- a/test/DelegatedModulePersistentCache.test.js
+++ b/test/DelegatedModulePersistentCache.test.js
@@ -1,0 +1,302 @@
+"use strict";
+
+require("./helpers/warmup-webpack");
+
+const fs = require("fs");
+const path = require("path");
+const rimraf = require("rimraf");
+const DelegatedModule = require("../lib/dll/DelegatedModule");
+const expectNoDeprecations = require("./helpers/expectNoDeprecations");
+
+/**
+ * @param {import("../").Compiler} compiler compiler
+ * @returns {Promise<import("../").Stats>} stats
+ */
+const run = (compiler) =>
+	new Promise((resolve, reject) => {
+		compiler.run((err, stats) => {
+			if (err) return reject(err);
+			if (!stats) return reject(new Error("No stats"));
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ errors: true })));
+			}
+			resolve(stats);
+		});
+	});
+
+/**
+ * @param {import("../").Compiler} compiler compiler
+ * @returns {Promise<void>}
+ */
+const close = (compiler) =>
+	new Promise((resolve, reject) => {
+		compiler.close((err) => (err ? reject(err) : resolve()));
+	});
+
+describe("DelegatedModule persistent cache without Dll plugins", () => {
+	expectNoDeprecations();
+
+	const tempPath = path.resolve(
+		__dirname,
+		"js",
+		"delegated-module-fs-cache-no-dll"
+	);
+	const cacheDirectory = path.join(tempPath, "cache");
+	const outputPath = path.join(tempPath, "dist");
+	const manifestPath = path.join(tempPath, "manifest.json");
+
+	beforeEach((done) => {
+		rimraf(tempPath, (/** @type {Error | null | undefined} */ err) => {
+			if (err) return done(err);
+			fs.mkdirSync(tempPath, { recursive: true });
+			done();
+		});
+	});
+
+	it("should restore DelegatedModule from the filesystem cache without Dll plugins", async () => {
+		const webpack = require("..");
+
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				name: "function(id) { return { default: 'dll-default' }; }",
+				content: {
+					"./item.js": {
+						id: "./item.js",
+						buildMeta: {
+							exportsType: "namespace",
+							strictHarmonyModule: true
+						},
+						exports: ["default", "old"]
+					}
+				}
+			})
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "index.js"),
+			'import value from "dll/item"; export default value;'
+		);
+
+		/** @type {string | undefined} */
+		let delegatedIdentifier;
+		/** @type {import("../lib/dll/DelegatedModule").DelegatedModuleData | undefined} */
+		let storedDelegateData;
+
+		const first = webpack({
+			context: tempPath,
+			mode: "production",
+			entry: "./index.js",
+			target: "node",
+			devtool: false,
+			cache: {
+				type: "filesystem",
+				cacheDirectory,
+				name: "delegated-no-dll"
+			},
+			output: {
+				path: outputPath,
+				filename: "app.js",
+				library: { type: "commonjs2" }
+			},
+			optimization: {
+				concatenateModules: false,
+				minimize: false,
+				providedExports: true
+			},
+			plugins: [
+				new webpack.DllReferencePlugin({
+					scope: "dll",
+					name: "function(id) { return { default: 'dll-default' }; }",
+					manifest: manifestPath
+				}),
+				{
+					apply(compiler) {
+						compiler.hooks.compilation.tap(
+							"CaptureDelegatedModule",
+							(compilation) => {
+								compilation.hooks.finishModules.tap(
+									"CaptureDelegatedModule",
+									() => {
+										const module = [...compilation.modules].find((m) =>
+											m.identifier().startsWith("delegated ")
+										);
+										expect(module).toBeInstanceOf(DelegatedModule);
+										const delegated =
+											/** @type {InstanceType<typeof DelegatedModule>} */ (
+												/** @type {unknown} */ (module)
+											);
+										delegatedIdentifier = delegated.identifier();
+										storedDelegateData = delegated.delegateData;
+									}
+								);
+							}
+						);
+					}
+				}
+			]
+		});
+
+		try {
+			await run(first);
+		} finally {
+			await close(first);
+		}
+
+		expect(delegatedIdentifier).toBeDefined();
+		expect(storedDelegateData).toEqual({
+			id: "./item.js",
+			buildMeta: {
+				exportsType: "namespace",
+				strictHarmonyModule: true
+			},
+			exports: ["default", "old"]
+		});
+
+		// Drop the manifest so step 2 cannot re-read DLL metadata from disk.
+		fs.unlinkSync(manifestPath);
+
+		/** @type {import("../").Module | undefined} */
+		let restored;
+		/** @type {Error | null | undefined} */
+		let restoreError;
+
+		const second = webpack({
+			context: tempPath,
+			mode: "production",
+			// No import of dll/* — only probe the modules cache.
+			entry: "./empty.js",
+			target: "node",
+			devtool: false,
+			cache: {
+				type: "filesystem",
+				cacheDirectory,
+				name: "delegated-no-dll"
+			},
+			output: {
+				path: outputPath,
+				filename: "empty.js"
+			},
+			plugins: [
+				{
+					apply(compiler) {
+						compiler.hooks.compilation.tap(
+							"RestoreDelegatedModule",
+							(compilation) => {
+								compilation.hooks.finishModules.tapAsync(
+									"RestoreDelegatedModule",
+									(_modules, callback) => {
+										compilation
+											.getCache("Compilation/modules")
+											.get(
+												/** @type {string} */ (delegatedIdentifier),
+												null,
+												(err, module) => {
+													restoreError = err;
+													restored = module;
+													callback();
+												}
+											);
+									}
+								);
+							}
+						);
+					}
+				}
+			]
+		});
+
+		fs.writeFileSync(path.join(tempPath, "empty.js"), "export default 1;");
+
+		try {
+			await run(second);
+		} finally {
+			await close(second);
+		}
+
+		expect(restoreError).toBeFalsy();
+		expect(restored).toBeInstanceOf(DelegatedModule);
+		const restoredDelegated =
+			/** @type {InstanceType<typeof DelegatedModule>} */ (
+				/** @type {unknown} */ (restored)
+			);
+		expect(restoredDelegated.identifier()).toBe(delegatedIdentifier);
+		expect(restoredDelegated.delegateData).toEqual(storedDelegateData);
+		expect(restoredDelegated.buildMeta).toMatchObject({
+			exportsType: "namespace",
+			strictHarmonyModule: true
+		});
+	}, 60000);
+
+	it("should not resolve dll/* in a normal compile without DllReferencePlugin", async () => {
+		const webpack = require("..");
+
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				name: "function(id) { return { default: 'dll-default' }; }",
+				content: {
+					"./item.js": {
+						id: "./item.js",
+						buildMeta: { exportsType: "namespace" },
+						exports: ["default"]
+					}
+				}
+			})
+		);
+		fs.writeFileSync(
+			path.join(tempPath, "index.js"),
+			'import value from "dll/item"; export default value;'
+		);
+
+		const first = webpack({
+			context: tempPath,
+			mode: "production",
+			entry: "./index.js",
+			target: "node",
+			devtool: false,
+			cache: {
+				type: "filesystem",
+				cacheDirectory,
+				name: "delegated-no-dll-resolve"
+			},
+			output: {
+				path: outputPath,
+				filename: "app.js"
+			},
+			plugins: [
+				new webpack.DllReferencePlugin({
+					scope: "dll",
+					name: "function(id) { return { default: 'dll-default' }; }",
+					manifest: manifestPath
+				})
+			]
+		});
+		try {
+			await run(first);
+		} finally {
+			await close(first);
+		}
+
+		const second = webpack({
+			context: tempPath,
+			mode: "production",
+			entry: "./index.js",
+			target: "node",
+			devtool: false,
+			cache: {
+				type: "filesystem",
+				cacheDirectory,
+				name: "delegated-no-dll-resolve"
+			},
+			output: {
+				path: outputPath,
+				filename: "app2.js"
+			}
+			// Intentionally no DllReferencePlugin / DllPlugin.
+		});
+
+		await expect(run(second).finally(() => close(second))).rejects.toThrow(
+			/Can't resolve 'dll\/item'/
+		);
+	}, 60000);
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/0/index.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/0/index.js
@@ -1,0 +1,17 @@
+import value from "dll/item";
+
+const path = require("path");
+const probe = JSON.parse(
+	require("fs").readFileSync(
+		path.join(STATS_JSON.outputPath, "delegated-cache-probe.json"),
+		"utf8"
+	)
+);
+
+it("should interop the default import using the namespace DLL manifest", () => {
+	expect(value).toBe("dll-default");
+});
+
+it("should build DelegatedModule on the cold compile", () => {
+	expect(probe).toEqual({ built: 1, reused: 0 });
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/0/manifest.json
+++ b/test/watchCases/cache/dll-manifest-rebuild/0/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+  "content": {
+    "./item.js": {
+      "id": "./item.js",
+      "buildMeta": {
+        "exportsType": "namespace",
+        "strictHarmonyModule": true
+      },
+      "exports": ["default", "old"]
+    }
+  }
+}

--- a/test/watchCases/cache/dll-manifest-rebuild/1/index.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/1/index.js
@@ -1,0 +1,20 @@
+import value from "dll/item";
+
+const path = require("path");
+const probe = JSON.parse(
+	require("fs").readFileSync(
+		path.join(STATS_JSON.outputPath, "delegated-cache-probe.json"),
+		"utf8"
+	)
+);
+
+it("should rebuild DelegatedModule when the DLL manifest buildMeta changes", () => {
+	expect(value).toEqual({
+		default: "dll-default",
+		added: "dll-added"
+	});
+});
+
+it("should build DelegatedModule for the changed DLL manifest", () => {
+	expect(probe).toEqual({ built: 1, reused: 0 });
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/1/manifest.json
+++ b/test/watchCases/cache/dll-manifest-rebuild/1/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+  "content": {
+    "./item.js": {
+      "id": "./item.js",
+      "buildMeta": {
+        "exportsType": "default",
+        "defaultObject": "redirect",
+        "treatAsCommonJs": true
+      },
+      "exports": ["added", "default"]
+    }
+  }
+}

--- a/test/watchCases/cache/dll-manifest-rebuild/2/index.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/2/index.js
@@ -1,0 +1,20 @@
+import value from "dll/item";
+
+const path = require("path");
+const probe = JSON.parse(
+	require("fs").readFileSync(
+		path.join(STATS_JSON.outputPath, "delegated-cache-probe.json"),
+		"utf8"
+	)
+);
+
+it("should keep the rebuilt default-export interop", () => {
+	expect(value).toEqual({
+		default: "dll-default",
+		added: "dll-added"
+	});
+});
+
+it("should reuse DelegatedModule when the DLL manifest is unchanged", () => {
+	expect(probe).toEqual({ built: 0, reused: 1 });
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/2/manifest.json
+++ b/test/watchCases/cache/dll-manifest-rebuild/2/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+  "content": {
+    "./item.js": {
+      "id": "./item.js",
+      "buildMeta": {
+        "exportsType": "default",
+        "defaultObject": "redirect",
+        "treatAsCommonJs": true
+      },
+      "exports": ["added", "default"]
+    }
+  }
+}

--- a/test/watchCases/cache/dll-manifest-rebuild/3/index.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/3/index.js
@@ -1,0 +1,18 @@
+import value, { added } from "dll/item";
+
+const path = require("path");
+const probe = JSON.parse(
+	require("fs").readFileSync(
+		path.join(STATS_JSON.outputPath, "delegated-cache-probe.json"),
+		"utf8"
+	)
+);
+
+it("should rebuild DelegatedModule when only the DLL manifest buildMeta changes", () => {
+	expect(value).toBe("dll-default");
+	expect(added).toBe("dll-added");
+});
+
+it("should build DelegatedModule for the changed buildMeta", () => {
+	expect(probe).toEqual({ built: 1, reused: 0 });
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/3/manifest.json
+++ b/test/watchCases/cache/dll-manifest-rebuild/3/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+  "content": {
+    "./item.js": {
+      "id": "./item.js",
+      "buildMeta": {
+        "exportsType": "namespace",
+        "strictHarmonyModule": true
+      },
+      "exports": ["added", "default"]
+    }
+  }
+}

--- a/test/watchCases/cache/dll-manifest-rebuild/4/index.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/4/index.js
@@ -1,0 +1,18 @@
+import value, { added } from "dll/item";
+
+const path = require("path");
+const probe = JSON.parse(
+	require("fs").readFileSync(
+		path.join(STATS_JSON.outputPath, "delegated-cache-probe.json"),
+		"utf8"
+	)
+);
+
+it("should rebuild DelegatedModule when only the DLL manifest exports change", () => {
+	expect(value).toBe("dll-default");
+	expect(added).toBe("dll-added");
+});
+
+it("should build DelegatedModule for the changed exports", () => {
+	expect(probe).toEqual({ built: 1, reused: 0 });
+});

--- a/test/watchCases/cache/dll-manifest-rebuild/4/manifest.json
+++ b/test/watchCases/cache/dll-manifest-rebuild/4/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+  "content": {
+    "./item.js": {
+      "id": "./item.js",
+      "buildMeta": {
+        "exportsType": "namespace",
+        "strictHarmonyModule": true
+      },
+      "exports": ["default"]
+    }
+  }
+}

--- a/test/watchCases/cache/dll-manifest-rebuild/4/warnings.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/4/warnings.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// The rebuilt StaticExportsDependency no longer provides `added`; a stale one
+// would keep the import silent.
+module.exports = [[/export 'added'.+was not found in 'dll\/item'/]];

--- a/test/watchCases/cache/dll-manifest-rebuild/webpack.config.js
+++ b/test/watchCases/cache/dll-manifest-rebuild/webpack.config.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const path = require("path");
+const { RawSource } = require("webpack-sources");
+const webpack = require("../../../../");
+
+/** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration} */
+module.exports = (env, { srcPath }) => ({
+	mode: "production",
+	cache: {
+		type: "memory"
+	},
+	optimization: {
+		concatenateModules: false,
+		minimize: false,
+		providedExports: true
+	},
+	plugins: [
+		new webpack.DllReferencePlugin({
+			scope: "dll",
+			// Returns the CommonJS DLL shape; stale namespace buildMeta reads `.default`.
+			name: "function(id) { return { default: 'dll-default', added: 'dll-added' }; }",
+			manifest: path.join(srcPath, "manifest.json")
+		}),
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap(
+					"DelegatedModuleCacheProbe",
+					(compilation) => {
+						let built = 0;
+						let reused = 0;
+						compilation.hooks.buildModule.tap(
+							"DelegatedModuleCacheProbe",
+							(module) => {
+								if (module.identifier().startsWith("delegated ")) built++;
+							}
+						);
+						compilation.hooks.stillValidModule.tap(
+							"DelegatedModuleCacheProbe",
+							(module) => {
+								if (module.identifier().startsWith("delegated ")) reused++;
+							}
+						);
+						compilation.hooks.processAssets.tap(
+							{
+								name: "DelegatedModuleCacheProbe",
+								stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT
+							},
+							() => {
+								compilation.emitAsset(
+									"delegated-cache-probe.json",
+									new RawSource(`${JSON.stringify({ built, reused })}\n`)
+								);
+							}
+						);
+					}
+				);
+			}
+		}
+	]
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes https://github.com/webpack/webpack/issues/22027

DllReferencePlugin cache hits refreshed `delegateData` from the manifest but skipped `build()`, leaving stale `buildMeta`/exports and wrong interop. Rebuild when surviving build products diverge from the factory data.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/watchCases/cache/dll-manifest-rebuild/` (change rebuilds; unchanged reuses) and `test/DelegatedModulePersistentCache.test.js`.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. AI assisted root-cause analysis, the DelegatedModule cache invalidation change, regression tests, and drafting this PR description; changes were reviewed and validated locally before opening the PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * DLL-backed modules now rebuild when manifest metadata or exports change, preventing stale exports.
  * Unchanged DLL manifests continue to reuse cached modules for faster rebuilds.
  * Module hashes now account for delegated data changes.
  * Cached DLL modules are restored more reliably when DLL plugins are not active.
  * Export mismatches now produce the expected warnings.

* **Tests**
  * Added coverage for persistent caching, manifest changes, default and named exports, compatibility, and module reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->