### PR TITLE
test(html): hold the documents the comparison builds but nothing checks

### DIFF
--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -19,7 +19,11 @@ const {
 	CACHE: HTML_CACHE,
 	INLINED_STYLESHEETS,
 	INSTALLED_DOCUMENTS,
-	inlineCssPage
+	SPRITE_WITHIN,
+	TAG_SOUP,
+	WEB_COMPONENTS,
+	inlineCssPage,
+	spritePage
 } = require("../../tooling/compare-html-tools");
 
 /** @typedef {{ name: string, raw: string, min: string }} Fixture */
@@ -112,10 +116,20 @@ const benchmarkStylesheets = (minify) =>
 		minify
 	);
 
+// Written rather than installed, each carrying a construct no shipped page
+// here reaches: recovery from malformed markup, and a declarative shadow root.
+/** @type {[string, string][]} */
+const WRITTEN_DOCUMENTS = [
+	["Tag soup", TAG_SOUP],
+	["Web components", WEB_COMPONENTS]
+];
+
 /**
  * The documents `yarn benchmark:html-tools` installs, and the pages it builds
  * around a whole framework stylesheet. Those pages are the ones carrying a
  * `<style>`, which is what reaches the css minifier nested in the html one.
+ * The comparison's bulk pages are left out: what they carry is size rather than
+ * a construct, and building them would cost that at collection time.
  * @param {(source: string) => string} minify the printer to run
  * @returns {Fixture[]} the corpus, empty until that has been run once
  */
@@ -140,6 +154,18 @@ const benchmarkDocuments = (minify) => {
 		if (!fs.existsSync(sheet)) continue;
 		const raw = inlineCssPage(label, fs.readFileSync(sheet, "utf8"));
 		out.push({ name: label, raw, min: minify(raw) });
+	}
+	// The sprite is a shipped SVG rather than a written one, so it is read out of
+	// the cache like an installed document.
+	const sprite = path.join(HTML_CACHE, "node_modules", SPRITE_WITHIN);
+	if (fs.existsSync(sprite)) {
+		const raw = spritePage(fs.readFileSync(sprite, "utf8"));
+		out.push({ name: "Icon sprite (inlined SVG)", raw, min: minify(raw) });
+	}
+	if (out.length > 0) {
+		for (const [name, raw] of WRITTEN_DOCUMENTS) {
+			out.push({ name, raw, min: minify(raw) });
+		}
 	}
 	return out;
 };

--- a/tooling/compare-html-tools.js
+++ b/tooling/compare-html-tools.js
@@ -96,6 +96,10 @@ const INSTALLED_DOCUMENTS = [
 	["Swagger UI 5", "swagger-ui-dist/index.html"]
 ];
 
+// Where the icon sprite lands in the cache: a real shipped SVG, which is the
+// only inline `<svg>` any document here carries.
+const SPRITE_WITHIN = "@fortawesome/fontawesome-free/sprites/solid.svg";
+
 // Real framework stylesheets, inlined whole into a page of their own.
 /** @type {[string, string][]} */
 const INLINED_STYLESHEETS = [
@@ -384,10 +388,7 @@ const fixtures = async () => {
 	out.push([
 		"Icon sprite (inlined SVG)",
 		spritePage(
-			await fs.promises.readFile(
-				path.join(MODULES, "@fortawesome/fontawesome-free/sprites/solid.svg"),
-				"utf8"
-			)
+			await fs.promises.readFile(path.join(MODULES, SPRITE_WITHIN), "utf8")
 		)
 	]);
 	return out;
@@ -926,11 +927,16 @@ if (require.main === module) {
 	});
 }
 
-// The documents the cache holds, and the page a reader builds the rest from.
+// The documents the cache holds, and the pages a reader builds the rest from.
+// The bulk pages stay unexported: what they carry is size, not a construct.
 module.exports = {
 	APP_SHELL,
 	CACHE,
 	INLINED_STYLESHEETS,
 	INSTALLED_DOCUMENTS,
-	inlineCssPage
+	SPRITE_WITHIN,
+	TAG_SOUP,
+	WEB_COMPONENTS,
+	inlineCssPage,
+	spritePage
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**


The equivalence check read configCases and test/wpt, which are written to exercise a rule rather than to ship. Each comparison now exports the fixtures it installs, so its 34 stylesheets and 15 documents are held to Chrome as well — a fixture added to a comparison is checked here without a second edit. CI never built those caches, so that tier reported itself skipped on every run; --setup installs and builds without measuring, which takes a minute where the comparison takes several.

Two things in the comparison had to answer for the wider corpus. A pixel written against the token after it read as one channel more, so rgba(…)0 — the form the printer writes, since the ) parts them — came back with an extra digit. And a computed box-shadow keeps whichever color function it was written with, so oklch(0 0 0 / .1) and the rgba() naming that same pixel read apart; every color a value holds is painted now, not the value as one.

**Did you add tests for your changes?**

The corpus is the test — 55 cases over 34 stylesheets and 15 documents. test/configCases/css/minimize-colors gains an oklch() shadow, which fails if the color painting is reverted. A page carrying an <iframe srcdoc> and a <noscript> goes into the HTML comparison: srcdoc minifies a whole document out of an attribute (837 → 669 bytes on that page) and no fixture reached it.
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No — test/, tooling/ and the CI workflow only

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
I found the gaps; AI wrote the wiring and the two comparison fixes under my review. Each fix was reverted on purpose to confirm the suite catches it — the pixel separator fails Primer and Open Props, the color painting fails the new oklch() fixture. The corpus is skipped rather than failed where a cache is absent, checked both ways

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded syntax-equivalence coverage with optional benchmark fixture collections.
  - Added checks for missing or incomplete benchmark data and fixture-loading failures.
  - Improved CSS color comparisons, including `oklch()` values, computed shadows, and multiple colors in declarations.
  - Added coverage for embedded HTML documents and additional CSSOM scenarios.

- **Tooling**
  - Added setup-only support for preparing CSS and HTML comparison fixtures.
  - Improved fixture processing and reuse in automated tests.
  - Added safeguards for importing comparison tools without starting measurements.
  - Updated automated test workflows to prepare comparison fixtures before testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->